### PR TITLE
Docs, license, and CI housekeeping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # Project Rules
 
+## Branch Strategy
+
+- **main** — protected. Never commit directly. Only accepts PRs from `develop`
+- **develop** — the working branch. All commits go here
+- Always confirm `git branch` before committing
+
 ## Git Commit Rules
 
 - Write commit messages in **English only**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ lefthook install
 
 Almide is a programming language (.almd files) compiled via a pure-Rust compiler with multi-target codegen.
 
-See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full compiler pipeline and module map.
+See [ARCHITECTURE.md](./docs/ARCHITECTURE.md) for the full compiler pipeline and module map.
 
 ### Module Structure
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "almide"
 version = "0.1.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,6 @@
-MIT License
+Almide is dual-licensed under either:
 
-Copyright (c) 2026 mizchi
+- MIT License (LICENSE-MIT or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+at your option.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,173 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as defined by Sections 1 through 9 of this
+      document, any work of authorship, including the original version of the
+      Work and any modifications or additions to that Work or Derivative Works
+      of the Work, that is intentionally submitted to the Licensor for
+      inclusion in the Work by the copyright owner or by an individual or
+      Legal Entity authorized to submit on behalf of the copyright owner.
+      For the purposes of this definition, "submitted" means any form of
+      electronic, verbal, or written communication sent to the Licensor or
+      its representatives, including but not limited to communication on
+      electronic mailing lists, source code control systems, and issue
+      tracking systems that is managed by, or on behalf of, the Licensor
+      for the purpose of discussing and improving the Work, but excluding
+      communication that is conspicuously marked or designated in writing
+      by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and included
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Derivative Works, and to permit persons to whom the Derivative Works
+      is furnished to do so, subject to Your terms and conditions.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Liability. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may offer such obligations only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 mizchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <p align="center">
   <a href="https://github.com/almide/almide/actions/workflows/ci.yml"><img src="https://github.com/almide/almide/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT%20%2F%20Apache--2.0-blue.svg" alt="License: MIT / Apache-2.0"></a>
 </p>
 
 ## What is Almide?

--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ Contributions are welcome! Please open an issue or pull request on [GitHub](http
 
 ## License
 
-[MIT](./LICENSE)
+Licensed under either of [MIT](./LICENSE-MIT) or [Apache 2.0](./LICENSE-APACHE) at your option.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 <p align="center">
   <a href="https://almide.github.io/playground/">Playground</a> ·
-  <a href="./SPEC.md">Specification</a> ·
+  <a href="./docs/SPEC.md">Specification</a> ·
   <a href="./docs/GRAMMAR.md">Grammar</a> ·
-  <a href="./CHEATSHEET.md">Cheatsheet</a> ·
+  <a href="./docs/CHEATSHEET.md">Cheatsheet</a> ·
   <a href="./docs/DESIGN.md">Design Philosophy</a>
 </p>
 
@@ -149,12 +149,12 @@ Almide compiles to Rust, then to native machine code. The generated binaries are
 
 ## Documentation
 
-- [ARCHITECTURE.md](./ARCHITECTURE.md) — Compiler pipeline, module map, design decisions
-- [SPEC.md](./SPEC.md) — Full language specification
+- [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) — Compiler pipeline, module map, design decisions
+- [docs/SPEC.md](./docs/SPEC.md) — Full language specification
 - [docs/GRAMMAR.md](./docs/GRAMMAR.md) — EBNF grammar + stdlib reference
-- [CHEATSHEET.md](./CHEATSHEET.md) — Quick reference for AI code generation
+- [docs/CHEATSHEET.md](./docs/CHEATSHEET.md) — Quick reference for AI code generation
 - [docs/DESIGN.md](./docs/DESIGN.md) — Design philosophy and trade-offs
-- [roadmap/](./roadmap/) — Language evolution plans
+- [docs/ROADMAP.md](./docs/ROADMAP.md) — Language evolution plans
 
 ## Contributing
 

--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -4,9 +4,7 @@ File extension: `.almd`
 
 ## File structure
 ```
-module <path.separated.by.dots>
 import <module>
-import <module>.{Name1, Name2}
 // declarations...
 ```
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -81,7 +81,7 @@ There is **no** null literal for missing values. Absence is represented by `none
 ### 1.4 Reserved Words
 
 ```
-module import type trait impl for fn let var
+import type trait impl for fn let var
 if then else match
 ok err some none
 try do
@@ -137,7 +137,7 @@ text
 ## 3. Syntactic Categories
 
 ```
-Program   ::= ModuleDecl ImportDecl* TopDecl*
+Program   ::= ImportDecl* TopDecl*
 
 TopDecl   ::= TypeDecl | TraitDecl | ImplDecl | FnDecl | TestDecl
 
@@ -169,14 +169,9 @@ Expr      ::= Literal
 
 ## 4. Modules and Imports
 
-### 4.1 Module Declaration
+Package identity is declared in `almide.toml` — no `module` declaration in source files.
 
-```
-ModuleDecl ::= "module" ModulePath
-ModulePath ::= Identifier ( "." Identifier )*
-```
-
-### 4.2 Import Declaration
+### 4.1 Import Declaration
 
 ```
 ImportDecl ::= "import" ImportPath
@@ -1275,7 +1270,6 @@ Not a style police, but a **generation stabilization device**.
 ## 22. Gradual Strictness
 
 ```
-module repo.index
 strict types      // make all type annotations required
 strict effects    // fully check effect propagation
 ```
@@ -1445,8 +1439,6 @@ return_type = R
 ## 25. Complete Example
 
 ```
-module repo.config
-
 import fs
 import json
 
@@ -1555,7 +1547,7 @@ Properties exhibited here:
 - Variance rules for generics
 - Default implementations for traits
 - Basic stream type
-- Module visibility control (`pub fn` / `fn`)
+- Variance rules for generics (already have `pub fn`, `mod fn`, `local fn`)
 
 ---
 


### PR DESCRIPTION
## Summary

- Switch to MIT / Apache-2.0 dual license
- Consolidate all documentation under `docs/`
- Fix broken doc links in README and CLAUDE.md
- Remove deprecated `module` declaration from SPEC, CHEATSHEET, and playground
- Fix wasmtime install in CI
- Add commit-msg hook to block Japanese commit messages
- Document branch strategy in CLAUDE.md

No code changes. Version remains 0.1.0.