### PR TITLE
v0.3.0: Add --target npm for ESM package output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1030,6 +1030,111 @@ Goal: get `.almd` recognized as "Almide" on GitHub (language bar, syntax highlig
 
 **Interim workaround:** `.gitattributes` with `*.almd linguist-language=OCaml` for approximate highlighting.
 
+## npm Package Target (`--target npm`)
+
+Compile Almide code into a publish-ready npm package. Write libraries in Almide and distribute them to the JS ecosystem via `almide build --target npm`.
+
+### Current Limitations
+
+- `--target ts` / `--target js` inline ~300 lines of runtime at the top of the output
+- Output is a single file (stdout) with no package structure
+- Entry point code is included when `main()` exists
+- Visibility (`Public`/`Mod`/`Local`) exists in the AST but is not reflected in exports
+
+### Output Structure
+
+```
+dist/
+  package.json        — name, version, type: "module", exports
+  index.js            — ESM: import runtime + export public functions
+  index.d.ts          — TypeScript type declarations
+  _runtime/           — only stdlib modules actually used
+    helpers.js         — __bigop, __div, __deep_eq, __concat, println
+    list.js            — __almd_list
+    string.js          — __almd_string
+    ...
+```
+
+### Phase 1: Runtime Separation
+
+Split monolithic RUNTIME/RUNTIME_JS into individual module files.
+
+- [ ] Extract each `__almd_*` object in `emit_ts_runtime.rs` as an individually emittable string
+- [ ] Separate helper functions (`__bigop`, `__div`, `__deep_eq`, `__concat`, `println`, etc.)
+- [ ] Track which stdlib modules are used during codegen (compile-time tree-shaking)
+- [ ] Emit each module as a standalone JS file with ESM `export`
+
+### Phase 2: ESM Export Output
+
+npm mode in `src/emit_ts/declarations.rs`:
+
+- [ ] Skip entry point emission (`// ---- Entry Point ----`)
+- [ ] `Visibility::Public` → `export function`, `Mod`/`Local` → no export
+- [ ] `Decl::Type` (Public) → `export type` (d.ts)
+- [ ] Import runtime via relative paths: `import { __almd_list } from "./_runtime/list.js";`
+- [ ] Consider clean re-exports for sanitized names (`is_empty_hdlm_qm_` → `isEmpty` etc.)
+
+### Phase 3: Package Scaffolding
+
+- [ ] Output to a directory (`-o dist/` or default `dist/`)
+- [ ] Generate `package.json`: read name/version from `almide.toml`, set `type: "module"`
+- [ ] `index.js` — compiled user code (ESM import/export)
+- [ ] `index.d.ts` — TypeScript type declarations for all exported functions
+- [ ] `_runtime/*.js` — only modules actually used
+
+### Phase 4: CLI Integration
+
+- [ ] Add `"npm"` target to `src/cli.rs`
+- [ ] `emit_ts::emit_npm_package()` — emit multiple files to a directory
+- [ ] `-o <dir>` for directory output (file writes, not stdout)
+- [ ] Existing `--target ts` / `--target js` remain unchanged (backwards compatible)
+
+### Example
+
+```almide
+fn greet(name: String) -> String = "Hello, ${name}!"
+
+fn fibonacci(n: Int) -> List[Int] = {
+  list.take(
+    list.fold(0..n, [0, 1], fn(acc, _i) => {
+      let a = list.get_or(acc, list.len(acc) - 2, 0)
+      let b = list.get_or(acc, list.len(acc) - 1, 0)
+      acc ++ [a + b]
+    }),
+    n
+  )
+}
+```
+
+Output `dist/index.js`:
+```javascript
+import { __almd_list } from "./_runtime/list.js";
+import { __concat } from "./_runtime/helpers.js";
+
+export function greet(name) {
+  return `Hello, ${name}!`;
+}
+
+export function fibonacci(n) {
+  return __almd_list.take(/* ... */);
+}
+```
+
+Output `dist/index.d.ts`:
+```typescript
+export declare function greet(name: string): string;
+export declare function fibonacci(n: number): number[];
+```
+
+### Constraints
+
+- Node.js 22+ (LTS) / modern bundlers (Vite, esbuild, Rollup)
+- `__almd_` prefix is internal only — never exposed in the public API
+- `_runtime/` is internal (conventional `_` prefix marks it as private)
+- Int is i64 — BigInt handling (`__bigop`, `__div`) must be considered
+
+---
+
 ## Other
 
 - [ ] Package registry (to be considered in the future)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,7 +151,13 @@ pub fn cmd_build(args: &[String], no_check: bool) {
         .and_then(|i| args.get(i + 1))
         .map(|s| s.as_str());
 
+    let is_npm = matches!(build_target, Some("npm"));
     let is_wasm = matches!(build_target, Some("wasm" | "wasm32" | "wasi"));
+
+    if is_npm {
+        cmd_build_npm(&file, &args, no_check);
+        return;
+    }
 
     let default_output = if is_wasm {
         format!("{}.wasm", file.strip_suffix(".almd").unwrap_or("a.out"))
@@ -210,6 +216,117 @@ pub fn cmd_build(args: &[String], no_check: bool) {
     }
 
     eprintln!("Built {}", output);
+}
+
+fn cmd_build_npm(file: &str, args: &[String], no_check: bool) {
+    let mut program = parse_file(file);
+    let source_text = std::fs::read_to_string(file).unwrap_or_default();
+
+    // Resolve dependencies
+    let dep_paths: Vec<(project::PkgId, std::path::PathBuf)> = if std::path::Path::new("almide.toml").exists() {
+        if let Ok(proj) = project::parse_toml(std::path::Path::new("almide.toml")) {
+            project::fetch_all_deps(&proj)
+                .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); })
+                .into_iter()
+                .map(|fd| (fd.pkg_id, fd.source_dir))
+                .collect()
+        } else {
+            vec![]
+        }
+    } else {
+        vec![]
+    };
+
+    let resolved = resolve::resolve_imports_with_deps(file, &program, &dep_paths)
+        .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
+
+    // Type check unless --no-check
+    if !no_check {
+        let mut checker = check::Checker::new();
+        checker.set_source(file, &source_text);
+        for (name, mod_prog, pkg_id, is_self) in &resolved.modules {
+            checker.register_module(name, mod_prog, pkg_id.as_ref(), *is_self);
+        }
+        let diagnostics = checker.check_program(&mut program);
+        if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
+            for d in &diagnostics {
+                eprintln!("{}", d.display_with_source(&source_text));
+            }
+            std::process::exit(1);
+        }
+    }
+
+    // Read package metadata from almide.toml (or use defaults)
+    let (pkg_name, pkg_version) = if std::path::Path::new("almide.toml").exists() {
+        if let Ok(proj) = project::parse_toml(std::path::Path::new("almide.toml")) {
+            (proj.package.name, proj.package.version)
+        } else {
+            (file.strip_suffix(".almd").unwrap_or("my-package").to_string(), "0.1.0".to_string())
+        }
+    } else {
+        (file.strip_suffix(".almd").unwrap_or("my-package").to_string(), "0.1.0".to_string())
+    };
+
+    let config = emit_ts::NpmConfig {
+        name: pkg_name,
+        version: pkg_version,
+    };
+
+    let legacy_modules: Vec<(String, crate::ast::Program)> = resolved.modules.iter()
+        .map(|(n, p, _, _)| (n.clone(), p.clone()))
+        .collect();
+
+    let output = emit_ts::emit_npm_package(&program, &legacy_modules, &config);
+
+    // Output directory
+    let out_dir = args.iter()
+        .position(|a| a == "-o")
+        .and_then(|i| args.get(i + 1))
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "dist".to_string());
+
+    // Write files
+    let out_path = std::path::Path::new(&out_dir);
+    std::fs::create_dir_all(out_path).unwrap_or_else(|e| {
+        eprintln!("Failed to create {}: {}", out_dir, e);
+        std::process::exit(1);
+    });
+
+    std::fs::write(out_path.join("package.json"), &output.package_json).unwrap_or_else(|e| {
+        eprintln!("Failed to write package.json: {}", e);
+        std::process::exit(1);
+    });
+    std::fs::write(out_path.join("index.js"), &output.index_js).unwrap_or_else(|e| {
+        eprintln!("Failed to write index.js: {}", e);
+        std::process::exit(1);
+    });
+    std::fs::write(out_path.join("index.d.ts"), &output.index_dts).unwrap_or_else(|e| {
+        eprintln!("Failed to write index.d.ts: {}", e);
+        std::process::exit(1);
+    });
+
+    // Write runtime files
+    for (path, content) in &output.runtime_files {
+        let full_path = out_path.join(path);
+        if let Some(parent) = full_path.parent() {
+            std::fs::create_dir_all(parent).unwrap_or_else(|e| {
+                eprintln!("Failed to create directory: {}", e);
+                std::process::exit(1);
+            });
+        }
+        std::fs::write(&full_path, content).unwrap_or_else(|e| {
+            eprintln!("Failed to write {}: {}", path, e);
+            std::process::exit(1);
+        });
+    }
+
+    eprintln!("Built npm package in {}/", out_dir);
+    eprintln!("  package.json");
+    eprintln!("  index.js");
+    eprintln!("  index.d.ts");
+    for (path, _) in &output.runtime_files {
+        eprintln!("  {}", path);
+    }
 }
 
 pub fn cmd_emit(file: &str, target: &str, emit_ast: bool, no_check: bool) {

--- a/src/emit_common.rs
+++ b/src/emit_common.rs
@@ -6,3 +6,31 @@
 pub fn sanitize(name: &str) -> String {
     name.replace('?', "_hdlm_qm_")
 }
+
+/// Convert a sanitized or snake_case name to a clean camelCase export name
+/// for npm packages. Examples:
+///   `is_empty_hdlm_qm_` → `isEmpty`
+///   `pangram_hdlm_qm_`  → `pangram`
+///   `has_letter`         → `hasLetter`
+///   `roman`              → `roman`
+pub fn to_clean_export_name(sanitized: &str) -> String {
+    // Strip the _hdlm_qm_ suffix (restores original name minus `?`)
+    let base = sanitized.strip_suffix("_hdlm_qm_").unwrap_or(sanitized);
+    snake_to_camel(base)
+}
+
+fn snake_to_camel(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut capitalize_next = false;
+    for c in s.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.push(c.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}

--- a/src/emit_ts/blocks.rs
+++ b/src/emit_ts/blocks.rs
@@ -10,11 +10,7 @@ impl TsEmitter {
 
         if let Some(err_arm) = err_arm {
             let ok_arms: Vec<&MatchArm> = arms.iter().filter(|a| !matches!(&a.pattern, Pattern::Err { .. })).collect();
-            let err_body = if Self::needs_iife(&err_arm.body) {
-                format!("(() => {})()", self.gen_expr(&err_arm.body))
-            } else {
-                self.gen_expr(&err_arm.body)
-            };
+            let err_body = self.gen_expr_value(&err_arm.body);
             let err_binding = if let Pattern::Err { inner } = &err_arm.pattern {
                 if let Pattern::Ident { name } = inner.as_ref() {
                     Some(name.clone())
@@ -60,11 +56,7 @@ impl TsEmitter {
             .map(|b| format!("    const {} = {};", b.0, b.1))
             .collect::<Vec<_>>()
             .join("\n");
-        let body_str = if Self::needs_iife(&arm.body) {
-            format!("(() => {})()", self.gen_expr(&arm.body))
-        } else {
-            self.gen_expr(&arm.body)
-        };
+        let body_str = self.gen_expr_value(&arm.body);
 
         if let Some(guard) = &arm.guard {
             let guard_str = self.gen_expr(guard);

--- a/src/emit_ts/declarations.rs
+++ b/src/emit_ts/declarations.rs
@@ -1,14 +1,10 @@
 use crate::ast::*;
-use crate::emit_ts_runtime::{RUNTIME, RUNTIME_JS};
+use crate::emit_ts_runtime;
 use super::TsEmitter;
 
 impl TsEmitter {
     pub(crate) fn emit_program(&mut self, prog: &Program, modules: &[(String, Program)]) {
-        if self.js_mode {
-            self.out.push_str(RUNTIME_JS);
-        } else {
-            self.out.push_str(RUNTIME);
-        }
+        self.out.push_str(&emit_ts_runtime::full_runtime(self.js_mode));
         self.out.push('\n');
 
         // Register and emit imported modules as namespace objects

--- a/src/emit_ts/declarations.rs
+++ b/src/emit_ts/declarations.rs
@@ -285,4 +285,199 @@ impl TsEmitter {
             format!("{}function {}({}){} {{\n  throw new Error(\"no body and no @extern for ts target\");\n}}", async_, sname, params_str.join(", "), ret_str)
         }
     }
+
+    // ── npm package emission ──
+
+    /// Emit user code for npm target: no inlined runtime, `export` for public functions,
+    /// no entry point, no test blocks.
+    pub(crate) fn emit_npm_program(&mut self, prog: &Program, modules: &[(String, Program)]) {
+        // Register user modules
+        for (mod_name, _) in modules {
+            self.user_modules.push(mod_name.clone());
+        }
+
+        // Pre-declare namespace objects for parent modules
+        let module_names: std::collections::HashSet<String> = modules.iter().map(|(n, _)| n.clone()).collect();
+        let mut emitted_ns: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (mod_name, _) in modules {
+            if mod_name.contains('.') {
+                let parts: Vec<&str> = mod_name.split('.').collect();
+                for i in 1..parts.len() {
+                    let ancestor = parts[..i].join(".");
+                    if !module_names.contains(&ancestor) && !emitted_ns.contains(&ancestor) {
+                        emitted_ns.insert(ancestor.clone());
+                        if ancestor.contains('.') {
+                            self.out.push_str(&format!("{} = {{}};\n", ancestor));
+                        } else {
+                            self.out.push_str(&format!("const {} = {{}};\n", ancestor));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Emit user modules
+        for (mod_name, mod_prog) in modules {
+            self.emit_user_module(mod_name, mod_prog);
+        }
+
+        // Emit import aliases
+        for imp in &prog.imports {
+            if let Decl::Import { path, alias, .. } = imp {
+                let full_path = path.join(".");
+                if let Some(alias_name) = alias {
+                    self.out.push_str(&format!("var {} = {};\n", alias_name, full_path));
+                } else if path.len() > 1 {
+                    let short_name = path.last().unwrap();
+                    self.out.push_str(&format!("var {} = {};\n", short_name, full_path));
+                }
+            }
+        }
+        self.out.push('\n');
+
+        // Emit declarations: export public fns, skip tests and entry point
+        for decl in &prog.decls {
+            match decl {
+                Decl::Test { .. } => continue,
+                Decl::Fn { name, visibility, .. } => {
+                    if name == "main" {
+                        // Still emit main, but don't generate entry point invocation
+                        let code = self.gen_decl(decl);
+                        if *visibility == Visibility::Public {
+                            self.out.push_str(&format!("export {}\n\n", code));
+                        } else {
+                            self.out.push_str(&code);
+                            self.out.push_str("\n\n");
+                        }
+                    } else if *visibility == Visibility::Public {
+                        let code = self.gen_decl(decl);
+                        self.out.push_str(&format!("export {}\n\n", code));
+                    } else {
+                        self.out.push_str(&self.gen_decl(decl));
+                        self.out.push_str("\n\n");
+                    }
+                }
+                Decl::Type { name, ty, visibility, .. } => {
+                    if *visibility == Visibility::Public {
+                        if let TypeExpr::Variant { cases } = ty {
+                            // Export variant constructors
+                            self.out.push_str(&format!("// variant type {}\n", name));
+                            for case in cases {
+                                match case {
+                                    VariantCase::Unit { name: cname } => {
+                                        self.out.push_str(&format!("export const {} = {{ tag: {} }};\n", cname, Self::json_string(cname)));
+                                    }
+                                    VariantCase::Tuple { name: cname, fields } => {
+                                        let params: Vec<String> = fields.iter().enumerate()
+                                            .map(|(i, _)| format!("_{}", i))
+                                            .collect();
+                                        let obj_fields: Vec<String> = fields.iter().enumerate()
+                                            .map(|(i, _)| format!("_{}: _{}", i, i))
+                                            .collect();
+                                        self.out.push_str(&format!("export function {}({}) {{ return {{ tag: {}, {} }}; }}\n",
+                                            cname, params.join(", "), Self::json_string(cname), obj_fields.join(", ")));
+                                    }
+                                    VariantCase::Record { name: cname, fields } => {
+                                        let params: Vec<String> = fields.iter()
+                                            .map(|f| f.name.clone())
+                                            .collect();
+                                        let obj_fields: Vec<String> = fields.iter()
+                                            .map(|f| format!("{}: {}", f.name, f.name))
+                                            .collect();
+                                        self.out.push_str(&format!("export function {}({}) {{ return {{ tag: {}, {} }}; }}\n",
+                                            cname, params.join(", "), Self::json_string(cname), obj_fields.join(", ")));
+                                    }
+                                }
+                            }
+                            self.out.push('\n');
+                        } else {
+                            self.out.push_str(&self.gen_decl(decl));
+                            self.out.push_str("\n\n");
+                        }
+                    } else {
+                        self.out.push_str(&self.gen_decl(decl));
+                        self.out.push_str("\n\n");
+                    }
+                }
+                _ => {
+                    self.out.push_str(&self.gen_decl(decl));
+                    self.out.push_str("\n\n");
+                }
+            }
+        }
+    }
+
+    /// Generate TypeScript declaration file (index.d.ts) for public functions and types.
+    pub(crate) fn generate_dts(&self, prog: &Program) -> String {
+        let mut dts = String::new();
+        for decl in &prog.decls {
+            match decl {
+                Decl::Fn { name, params, return_type, visibility, r#async, .. } => {
+                    if *visibility != Visibility::Public {
+                        continue;
+                    }
+                    let async_ = if r#async.unwrap_or(false) { "async " } else { "" };
+                    let _ = async_; // For now, use Promise<T> for async
+                    let sname = Self::sanitize(name);
+                    let ps: Vec<String> = params.iter()
+                        .filter(|p| p.name != "self")
+                        .map(|p| format!("{}: {}", Self::sanitize(&p.name), self.gen_type_expr(&p.ty)))
+                        .collect();
+                    let ret = self.gen_type_expr(return_type);
+                    let ret_str = if r#async.unwrap_or(false) {
+                        format!("Promise<{}>", ret)
+                    } else {
+                        ret
+                    };
+                    dts.push_str(&format!("export declare function {}({}): {};\n", sname, ps.join(", "), ret_str));
+                }
+                Decl::Type { name, ty, visibility, .. } => {
+                    if *visibility != Visibility::Public {
+                        continue;
+                    }
+                    match ty {
+                        TypeExpr::Record { fields } => {
+                            let fs: Vec<String> = fields.iter()
+                                .map(|f| format!("  {}: {};", f.name, self.gen_type_expr(&f.ty)))
+                                .collect();
+                            dts.push_str(&format!("export interface {} {{\n{}\n}}\n", name, fs.join("\n")));
+                        }
+                        TypeExpr::Variant { cases } => {
+                            // Export variant constructor type declarations
+                            for case in cases {
+                                match case {
+                                    VariantCase::Unit { name: cname } => {
+                                        dts.push_str(&format!("export declare const {}: {{ tag: \"{}\" }};\n", cname, cname));
+                                    }
+                                    VariantCase::Tuple { name: cname, fields } => {
+                                        let ps: Vec<String> = fields.iter().enumerate()
+                                            .map(|(i, f)| format!("_{}: {}", i, self.gen_type_expr(f)))
+                                            .collect();
+                                        let ret_fields: Vec<String> = std::iter::once(format!("tag: \"{}\"", cname))
+                                            .chain(fields.iter().enumerate().map(|(i, f)| format!("_{}: {}", i, self.gen_type_expr(f))))
+                                            .collect();
+                                        dts.push_str(&format!("export declare function {}({}): {{ {} }};\n", cname, ps.join(", "), ret_fields.join(", ")));
+                                    }
+                                    VariantCase::Record { name: cname, fields } => {
+                                        let ps: Vec<String> = fields.iter()
+                                            .map(|f| format!("{}: {}", f.name, self.gen_type_expr(&f.ty)))
+                                            .collect();
+                                        let ret_fields: Vec<String> = std::iter::once(format!("tag: \"{}\"", cname))
+                                            .chain(fields.iter().map(|f| format!("{}: {}", f.name, self.gen_type_expr(&f.ty))))
+                                            .collect();
+                                        dts.push_str(&format!("export declare function {}({}): {{ {} }};\n", cname, ps.join(", "), ret_fields.join(", ")));
+                                    }
+                                }
+                            }
+                        }
+                        _ => {
+                            dts.push_str(&format!("export type {} = {};\n", name, self.gen_type_expr(ty)));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        dts
+    }
 }

--- a/src/emit_ts/declarations.rs
+++ b/src/emit_ts/declarations.rs
@@ -335,37 +335,30 @@ impl TsEmitter {
         }
         self.out.push('\n');
 
-        // Emit declarations: export public fns, skip tests and entry point
+        // Emit declarations: all functions without export keyword, skip tests
+        // Collect public names for clean export at the end
+        let mut public_fns: Vec<(String, String)> = Vec::new(); // (sanitized, original)
+        let mut public_variants: Vec<String> = Vec::new(); // variant constructor names
+
         for decl in &prog.decls {
             match decl {
                 Decl::Test { .. } => continue,
                 Decl::Fn { name, visibility, .. } => {
-                    if name == "main" {
-                        // Still emit main, but don't generate entry point invocation
-                        let code = self.gen_decl(decl);
-                        if *visibility == Visibility::Public {
-                            self.out.push_str(&format!("export {}\n\n", code));
-                        } else {
-                            self.out.push_str(&code);
-                            self.out.push_str("\n\n");
-                        }
-                    } else if *visibility == Visibility::Public {
-                        let code = self.gen_decl(decl);
-                        self.out.push_str(&format!("export {}\n\n", code));
-                    } else {
-                        self.out.push_str(&self.gen_decl(decl));
-                        self.out.push_str("\n\n");
+                    self.out.push_str(&self.gen_decl(decl));
+                    self.out.push_str("\n\n");
+                    if *visibility == Visibility::Public {
+                        public_fns.push((Self::sanitize(name), name.clone()));
                     }
                 }
                 Decl::Type { name, ty, visibility, .. } => {
                     if *visibility == Visibility::Public {
                         if let TypeExpr::Variant { cases } = ty {
-                            // Export variant constructors
                             self.out.push_str(&format!("// variant type {}\n", name));
                             for case in cases {
                                 match case {
                                     VariantCase::Unit { name: cname } => {
-                                        self.out.push_str(&format!("export const {} = {{ tag: {} }};\n", cname, Self::json_string(cname)));
+                                        self.out.push_str(&format!("const {} = {{ tag: {} }};\n", cname, Self::json_string(cname)));
+                                        public_variants.push(cname.clone());
                                     }
                                     VariantCase::Tuple { name: cname, fields } => {
                                         let params: Vec<String> = fields.iter().enumerate()
@@ -374,8 +367,9 @@ impl TsEmitter {
                                         let obj_fields: Vec<String> = fields.iter().enumerate()
                                             .map(|(i, _)| format!("_{}: _{}", i, i))
                                             .collect();
-                                        self.out.push_str(&format!("export function {}({}) {{ return {{ tag: {}, {} }}; }}\n",
+                                        self.out.push_str(&format!("function {}({}) {{ return {{ tag: {}, {} }}; }}\n",
                                             cname, params.join(", "), Self::json_string(cname), obj_fields.join(", ")));
+                                        public_variants.push(cname.clone());
                                     }
                                     VariantCase::Record { name: cname, fields } => {
                                         let params: Vec<String> = fields.iter()
@@ -384,8 +378,9 @@ impl TsEmitter {
                                         let obj_fields: Vec<String> = fields.iter()
                                             .map(|f| format!("{}: {}", f.name, f.name))
                                             .collect();
-                                        self.out.push_str(&format!("export function {}({}) {{ return {{ tag: {}, {} }}; }}\n",
+                                        self.out.push_str(&format!("function {}({}) {{ return {{ tag: {}, {} }}; }}\n",
                                             cname, params.join(", "), Self::json_string(cname), obj_fields.join(", ")));
+                                        public_variants.push(cname.clone());
                                     }
                                 }
                             }
@@ -405,9 +400,28 @@ impl TsEmitter {
                 }
             }
         }
+
+        // Emit clean camelCase exports
+        if !public_fns.is_empty() || !public_variants.is_empty() {
+            self.out.push_str("// ---- Exports ----\n");
+            let mut exports = Vec::new();
+            for (sanitized, _original) in &public_fns {
+                let clean = crate::emit_common::to_clean_export_name(sanitized);
+                if clean == *sanitized {
+                    exports.push(sanitized.clone());
+                } else {
+                    exports.push(format!("{} as {}", sanitized, clean));
+                }
+            }
+            for vname in &public_variants {
+                exports.push(vname.clone());
+            }
+            self.out.push_str(&format!("export {{ {} }};\n", exports.join(", ")));
+        }
     }
 
     /// Generate TypeScript declaration file (index.d.ts) for public functions and types.
+    /// Uses clean camelCase names matching the export aliases in index.js.
     pub(crate) fn generate_dts(&self, prog: &Program) -> String {
         let mut dts = String::new();
         for decl in &prog.decls {
@@ -416,12 +430,14 @@ impl TsEmitter {
                     if *visibility != Visibility::Public {
                         continue;
                     }
-                    let async_ = if r#async.unwrap_or(false) { "async " } else { "" };
-                    let _ = async_; // For now, use Promise<T> for async
                     let sname = Self::sanitize(name);
+                    let clean = crate::emit_common::to_clean_export_name(&sname);
                     let ps: Vec<String> = params.iter()
                         .filter(|p| p.name != "self")
-                        .map(|p| format!("{}: {}", Self::sanitize(&p.name), self.gen_type_expr(&p.ty)))
+                        .map(|p| {
+                            let pname = crate::emit_common::to_clean_export_name(&Self::sanitize(&p.name));
+                            format!("{}: {}", pname, self.gen_type_expr(&p.ty))
+                        })
                         .collect();
                     let ret = self.gen_type_expr(return_type);
                     let ret_str = if r#async.unwrap_or(false) {
@@ -429,7 +445,7 @@ impl TsEmitter {
                     } else {
                         ret
                     };
-                    dts.push_str(&format!("export declare function {}({}): {};\n", sname, ps.join(", "), ret_str));
+                    dts.push_str(&format!("export declare function {}({}): {};\n", clean, ps.join(", "), ret_str));
                 }
                 Decl::Type { name, ty, visibility, .. } => {
                     if *visibility != Visibility::Public {

--- a/src/emit_ts/expressions.rs
+++ b/src/emit_ts/expressions.rs
@@ -82,16 +82,8 @@ impl TsEmitter {
             }
             Expr::Pipe { left, right, .. } => self.gen_pipe(left, right),
             Expr::If { cond, then, else_, .. } => {
-                let t = if Self::needs_iife(then) {
-                    format!("(() => {})()", self.gen_expr(then))
-                } else {
-                    self.gen_expr(then)
-                };
-                let e = if Self::needs_iife(else_) {
-                    format!("(() => {})()", self.gen_expr(else_))
-                } else {
-                    self.gen_expr(else_)
-                };
+                let t = self.gen_expr_value(then);
+                let e = self.gen_expr_value(else_);
                 format!("({} ? {} : {})", self.gen_expr(cond), t, e)
             }
             Expr::Match { subject, arms, .. } => self.gen_match(subject, arms),
@@ -150,7 +142,7 @@ impl TsEmitter {
             Expr::Try { expr, .. } => self.gen_expr(expr),
             Expr::Await { expr, .. } => format!("await {}", self.gen_expr(expr)),
             Expr::Hole { .. } => if self.js_mode { "null /* hole */".to_string() } else { "null as any /* hole */".to_string() },
-            Expr::Todo { message, .. } => format!("(() => {{ throw new Error({}); }})()", Self::json_string(message)),
+            Expr::Todo { message, .. } => format!("__throw({})", Self::json_string(message)),
             Expr::Placeholder { .. } => "__placeholder__".to_string(),
         }
     }
@@ -164,18 +156,32 @@ impl TsEmitter {
                     self.gen_expr(callee)
                 };
                 let arg = if !args.is_empty() { self.gen_expr(&args[0]) } else { "\"\"".to_string() };
-                format!("(() => {{ throw new Error({} + \": \" + {}); }})()", Self::json_string(&callee_str), arg)
+                format!("__throw({} + \": \" + {})", Self::json_string(&callee_str), arg)
             }
             Expr::TypeName { name, .. } => {
                 let msg = Self::pascal_to_message(name);
-                format!("(() => {{ throw new Error({}); }})()", Self::json_string(&msg))
+                format!("__throw({})", Self::json_string(&msg))
             }
             Expr::String { value, .. } => {
-                format!("(() => {{ throw new Error({}); }})()", Self::json_string(value))
+                format!("__throw({})", Self::json_string(value))
             }
             _ => {
-                format!("(() => {{ throw new Error(String({})); }})()", self.gen_expr(expr))
+                format!("__throw(String({}))", self.gen_expr(expr))
             }
+        }
+    }
+
+    /// Generate an expression as a value, unwrapping simple blocks to avoid unnecessary IIFEs.
+    /// A block with no statements and just a final expression can be inlined directly.
+    pub(crate) fn gen_expr_value(&self, expr: &Expr) -> String {
+        match expr {
+            Expr::Block { stmts, expr: Some(final_expr), .. } if stmts.is_empty() => {
+                self.gen_expr_value(final_expr)
+            }
+            other if Self::needs_iife(other) => {
+                format!("(() => {})()", self.gen_expr(other))
+            }
+            _ => self.gen_expr(expr),
         }
     }
 

--- a/src/emit_ts/mod.rs
+++ b/src/emit_ts/mod.rs
@@ -122,7 +122,7 @@ pub fn emit_npm_package(program: &Program, modules: &[(String, Program)], config
     // Build import preamble
     let mut imports = String::new();
     // Helpers are always needed (operators, deep_eq, etc.)
-    imports.push_str("import { __bigop, __div, __deep_eq, __concat, println, eprintln, assert_eq, assert_ne, assert, unwrap_or, __assert_throws } from \"./_runtime/helpers.js\";\n");
+    imports.push_str("import { __bigop, __div, __deep_eq, __concat, __throw, println, eprintln, assert_eq, assert_ne, assert, unwrap_or, __assert_throws } from \"./_runtime/helpers.js\";\n");
     let mut sorted_modules: Vec<&String> = used.iter().collect();
     sorted_modules.sort();
     for mod_name in &sorted_modules {

--- a/src/emit_ts/mod.rs
+++ b/src/emit_ts/mod.rs
@@ -2,17 +2,26 @@ mod declarations;
 mod expressions;
 mod blocks;
 
+use std::cell::RefCell;
+use std::collections::HashSet;
 use crate::ast::*;
 
 pub(crate) struct TsEmitter {
     pub(crate) out: String,
     pub(crate) js_mode: bool,
     pub(crate) user_modules: Vec<String>,
+    /// Tracks which stdlib modules (`__almd_*`) are referenced during codegen.
+    pub(crate) used_stdlib: RefCell<HashSet<String>>,
 }
 
 impl TsEmitter {
     fn new() -> Self {
-        Self { out: String::new(), js_mode: false, user_modules: Vec::new() }
+        Self {
+            out: String::new(),
+            js_mode: false,
+            user_modules: Vec::new(),
+            used_stdlib: RefCell::new(HashSet::new()),
+        }
     }
 
     // Helpers
@@ -38,6 +47,7 @@ impl TsEmitter {
         if self.user_modules.contains(&name.to_string()) {
             name.to_string()
         } else if crate::stdlib::is_stdlib_module(name) {
+            self.used_stdlib.borrow_mut().insert(name.to_string());
             format!("__almd_{}", name)
         } else {
             name.to_string()

--- a/src/emit_ts/mod.rs
+++ b/src/emit_ts/mod.rs
@@ -9,6 +9,7 @@ use crate::ast::*;
 pub(crate) struct TsEmitter {
     pub(crate) out: String,
     pub(crate) js_mode: bool,
+    pub(crate) npm_mode: bool,
     pub(crate) user_modules: Vec<String>,
     /// Tracks which stdlib modules (`__almd_*`) are referenced during codegen.
     pub(crate) used_stdlib: RefCell<HashSet<String>>,
@@ -19,6 +20,7 @@ impl TsEmitter {
         Self {
             out: String::new(),
             js_mode: false,
+            npm_mode: false,
             user_modules: Vec::new(),
             used_stdlib: RefCell::new(HashSet::new()),
         }
@@ -85,4 +87,125 @@ pub fn emit_js_with_modules(program: &Program, modules: &[(String, Program)]) ->
     emitter.js_mode = true;
     emitter.emit_program(program, modules);
     emitter.out
+}
+
+/// Output from the npm package emitter.
+pub struct NpmOutput {
+    /// `index.js` — ESM user code with runtime imports and exports.
+    pub index_js: String,
+    /// `index.d.ts` — TypeScript type declarations for public functions.
+    pub index_dts: String,
+    /// Runtime files: `(relative_path, content)` pairs (e.g. `("_runtime/list.js", "...")`)
+    pub runtime_files: Vec<(String, String)>,
+    /// `package.json` content.
+    pub package_json: String,
+}
+
+/// Configuration for npm package generation.
+pub struct NpmConfig {
+    pub name: String,
+    pub version: String,
+}
+
+/// Emit an npm-publishable package from an Almide program.
+pub fn emit_npm_package(program: &Program, modules: &[(String, Program)], config: &NpmConfig) -> NpmOutput {
+    use crate::emit_ts_runtime;
+
+    let mut emitter = TsEmitter::new();
+    emitter.js_mode = true;
+    emitter.npm_mode = true;
+    emitter.emit_npm_program(program, modules);
+    let user_code = std::mem::take(&mut emitter.out);
+
+    let used = emitter.used_stdlib.borrow();
+
+    // Build import preamble
+    let mut imports = String::new();
+    // Helpers are always needed (operators, deep_eq, etc.)
+    imports.push_str("import { __bigop, __div, __deep_eq, __concat, println, eprintln, assert_eq, assert_ne, assert, unwrap_or, __assert_throws } from \"./_runtime/helpers.js\";\n");
+    let mut sorted_modules: Vec<&String> = used.iter().collect();
+    sorted_modules.sort();
+    for mod_name in &sorted_modules {
+        imports.push_str(&format!(
+            "import {{ __almd_{name} }} from \"./_runtime/{name}.js\";\n",
+            name = mod_name
+        ));
+    }
+    imports.push('\n');
+
+    let index_js = format!("{}{}", imports, user_code);
+
+    // Generate index.d.ts
+    let index_dts = emitter.generate_dts(program);
+
+    // Generate runtime files
+    let mut runtime_files = Vec::new();
+
+    // helpers.js
+    let helpers_src = emit_ts_runtime::get_helpers_source(true);
+    let helpers_esm = convert_helpers_to_esm(helpers_src);
+    runtime_files.push(("_runtime/helpers.js".to_string(), helpers_esm));
+
+    // Individual stdlib modules
+    for mod_name in &sorted_modules {
+        if let Some(src) = emit_ts_runtime::get_module_source(mod_name, true) {
+            let esm_src = convert_module_to_esm(mod_name, src);
+            runtime_files.push((format!("_runtime/{}.js", mod_name), esm_src));
+        }
+    }
+
+    // package.json
+    let package_json = format!(
+        r#"{{
+  "name": "{}",
+  "version": "{}",
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {{
+    ".": {{
+      "import": "./index.js",
+      "types": "./index.d.ts"
+    }}
+  }},
+  "engines": {{
+    "node": ">=22"
+  }}
+}}
+"#,
+        config.name, config.version
+    );
+
+    NpmOutput {
+        index_js,
+        index_dts,
+        runtime_files,
+        package_json,
+    }
+}
+
+/// Convert a `const __almd_X = { ... };` block to an ESM export.
+fn convert_module_to_esm(name: &str, src: &str) -> String {
+    // The source starts with `const __almd_X = {` — replace `const` with `export const`
+    let prefix = format!("const __almd_{}", name);
+    if let Some(rest) = src.strip_prefix(&prefix) {
+        format!("export const __almd_{}{}", name, rest)
+    } else {
+        format!("export {}", src)
+    }
+}
+
+/// Convert helper functions to ESM exports.
+fn convert_helpers_to_esm(src: &str) -> String {
+    let mut out = String::with_capacity(src.len() + 200);
+    for line in src.lines() {
+        if line.starts_with("function ") {
+            out.push_str("export ");
+            out.push_str(line);
+        } else {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+    out
 }

--- a/src/emit_ts/mod.rs
+++ b/src/emit_ts/mod.rs
@@ -119,21 +119,30 @@ pub fn emit_npm_package(program: &Program, modules: &[(String, Program)], config
 
     let used = emitter.used_stdlib.borrow();
 
-    // Build import preamble
+    // Post-process: rename __almd_X → __X in user code for cleaner output.
+    // Safe because __almd_ prefix is compiler-generated and never appears in user identifiers.
+    let mut clean_code = user_code;
+    for mod_name in used.iter() {
+        clean_code = clean_code.replace(
+            &format!("__almd_{}", mod_name),
+            &format!("__{}", mod_name),
+        );
+    }
+
+    // Build import preamble with aliased imports: __almd_X as __X
     let mut imports = String::new();
-    // Helpers are always needed (operators, deep_eq, etc.)
     imports.push_str("import { __bigop, __div, __deep_eq, __concat, __throw, println, eprintln, assert_eq, assert_ne, assert, unwrap_or, __assert_throws } from \"./_runtime/helpers.js\";\n");
     let mut sorted_modules: Vec<&String> = used.iter().collect();
     sorted_modules.sort();
     for mod_name in &sorted_modules {
         imports.push_str(&format!(
-            "import {{ __almd_{name} }} from \"./_runtime/{name}.js\";\n",
+            "import {{ __almd_{name} as __{name} }} from \"./_runtime/{name}.js\";\n",
             name = mod_name
         ));
     }
     imports.push('\n');
 
-    let index_js = format!("{}{}", imports, user_code);
+    let index_js = format!("{}{}", imports, clean_code);
 
     // Generate index.d.ts
     let index_dts = emitter.generate_dts(program);

--- a/src/emit_ts_runtime.rs
+++ b/src/emit_ts_runtime.rs
@@ -704,6 +704,7 @@ function assert_ne<T>(a: T, b: T, msg?: string): void { if (__deep_eq(a, b)) { c
 function assert(c: boolean, msg?: string): void { if (!c) throw new Error(msg ? msg : "assertion failed"); }
 function unwrap_or<T>(x: T | null, d: T): T { return x !== null ? x : d; }
 function __concat(a: any, b: any): any { return typeof a === "string" ? a + b : [...a, ...b]; }
+function __throw(msg: string): never { throw new Error(msg); }
 function __assert_throws(fn: () => any, expectedMsg: string): void {
   try { fn(); throw new Error("Expected error but succeeded with: " + fn); }
   catch (e) { if (e instanceof Error && e.message === expectedMsg) return; throw e; }
@@ -759,6 +760,7 @@ function assert_ne(a, b, msg) { if (__deep_eq(a, b)) { var m = msg ? msg + ": " 
 function assert(c, msg) { if (!c) throw new Error(msg ? msg : "assertion failed"); }
 function unwrap_or(x, d) { return x !== null ? x : d; }
 function __concat(a, b) { return typeof a === "string" ? a + b : [...a, ...b]; }
+function __throw(msg) { throw new Error(msg); }
 function __assert_throws(fn, expectedMsg) {
   try { fn(); throw new Error("Expected error but succeeded with: " + fn); }
   catch (e) { if (e instanceof Error && e.message === expectedMsg) return; throw e; }

--- a/src/emit_ts_runtime.rs
+++ b/src/emit_ts_runtime.rs
@@ -1,6 +1,24 @@
-/// TypeScript runtime (Deno) for emitted code.
-pub const RUNTIME: &str = r#"// ---- Almide Runtime ----
-const __almd_fs = {
+/// Runtime modules for Almide TypeScript/JavaScript code generation.
+///
+/// Each stdlib module (`__almd_*`) is defined as a separate constant pair
+/// (TS for Deno, JS for Node.js). The `full_runtime()` function composes them
+/// into the monolithic runtime string used by `--target ts` and `--target js`.
+/// Individual modules can be retrieved via `get_module_source()` for the
+/// `--target npm` output.
+
+// ──────────────────────────────── Preambles ────────────────────────────────
+
+const PREAMBLE_TS: &str = "// ---- Almide Runtime ----\n";
+const PREAMBLE_JS: &str = "\
+// ---- Almide Runtime (JS) ----
+const __node_process = globalThis.process || {};
+";
+
+const EPILOGUE: &str = "// ---- End Runtime ----\n";
+
+// ──────────────────────────────── fs ────────────────────────────────
+
+const MOD_FS_TS: &str = r#"const __almd_fs = {
   exists(p: string): boolean { try { Deno.statSync(p); return true; } catch { return false; } },
   read_text(p: string): string { return Deno.readTextFileSync(p); },
   read_bytes(p: string): Uint8Array { return Deno.readFileSync(p); },
@@ -33,7 +51,49 @@ const __almd_fs = {
   copy(src: string, dst: string): void { Deno.copyFileSync(src, dst); },
   rename(src: string, dst: string): void { Deno.renameSync(src, dst); },
 };
-const __almd_string = {
+"#;
+
+const MOD_FS_JS: &str = r#"const __almd_fs = {
+  exists(p) { const fs = require("fs"); try { fs.statSync(p); return true; } catch { return false; } },
+  read_text(p) { return require("fs").readFileSync(p, "utf-8"); },
+  read_bytes(p) { return Array.from(require("fs").readFileSync(p)); },
+  write(p, s) { require("fs").writeFileSync(p, s); },
+  write_bytes(p, b) { require("fs").writeFileSync(p, Buffer.from(b)); },
+  append(p, s) { require("fs").appendFileSync(p, s); },
+  mkdir_p(p) { require("fs").mkdirSync(p, { recursive: true }); },
+  exists_hdlm_qm_(p) { const fs = require("fs"); try { fs.statSync(p); return true; } catch { return false; } },
+  read_lines(p) { return require("fs").readFileSync(p, "utf-8").split("\n").filter(l => l.length > 0); },
+  remove(p) { const fs = require("fs"); try { const s = fs.statSync(p); if (s.isDirectory()) fs.rmSync(p, { recursive: true }); else fs.unlinkSync(p); } catch(e) { throw e; } },
+  list_dir(p) { return require("fs").readdirSync(p).sort(); },
+  walk(dir) {
+    const fs = require("fs");
+    const results = [];
+    function inner(d) {
+      const entries = fs.readdirSync(d, { withFileTypes: true });
+      for (const entry of entries) {
+        const p = d + "/" + entry.name;
+        results.push(p);
+        if (entry.isDirectory()) inner(p);
+      }
+    }
+    inner(dir);
+    return results.sort();
+  },
+  stat(path) {
+    const fs = require("fs");
+    const s = fs.statSync(path);
+    return { size: s.size, is_dir: s.isDirectory(), is_file: s.isFile(), modified: Math.floor(s.mtimeMs / 1000) };
+  },
+  is_dir_hdlm_qm_(p) { try { return require("fs").statSync(p).isDirectory(); } catch { return false; } },
+  is_file_hdlm_qm_(p) { try { return require("fs").statSync(p).isFile(); } catch { return false; } },
+  copy(src, dst) { require("fs").copyFileSync(src, dst); },
+  rename(src, dst) { require("fs").renameSync(src, dst); },
+};
+"#;
+
+// ──────────────────────────────── string ────────────────────────────────
+
+const MOD_STRING_TS: &str = r#"const __almd_string = {
   trim(s: string): string { return s.trim(); },
   split(s: string, sep: string): string[] { return s.split(sep); },
   join(arr: string[], sep: string): string { return arr.join(sep); },
@@ -72,7 +132,52 @@ const __almd_string = {
   strip_suffix(s: string, suffix: string): string | null { return s.endsWith(suffix) ? s.slice(0, -suffix.length) : null; },
   ends_with(s: string, suffix: string): boolean { return s.endsWith(suffix); },
 };
-const __almd_list = {
+"#;
+
+const MOD_STRING_JS: &str = r#"const __almd_string = {
+  trim(s) { return s.trim(); },
+  split(s, sep) { return s.split(sep); },
+  join(arr, sep) { return arr.join(sep); },
+  len(s) { return s.length; },
+  pad_left(s, n, ch) { return s.padStart(n, ch); },
+  starts_with(s, prefix) { return s.startsWith(prefix); },
+  slice(s, start, end) { return end !== undefined ? s.slice(start, end) : s.slice(start); },
+  to_bytes(s) { return Array.from(new TextEncoder().encode(s)); },
+  contains(s, sub) { return s.includes(sub); },
+  starts_with_hdlm_qm_(s, prefix) { return s.startsWith(prefix); },
+  ends_with_hdlm_qm_(s, suffix) { return s.endsWith(suffix); },
+  to_upper(s) { return s.toUpperCase(); },
+  to_lower(s) { return s.toLowerCase(); },
+  to_int(s) { const n = parseInt(s, 10); if (isNaN(n)) throw new Error("invalid integer: " + s); return n; },
+  replace(s, from, to) { return s.split(from).join(to); },
+  char_at(s, i) { return i < s.length ? s[i] : null; },
+  lines(s) { return s.split("\n").filter(l => l.length > 0); },
+  chars(s) { return [...s]; },
+  index_of(s, needle) { const i = s.indexOf(needle); return i >= 0 ? i : null; },
+  repeat(s, n) { return s.repeat(n); },
+  from_bytes(bytes) { return new TextDecoder().decode(new Uint8Array(bytes)); },
+  is_digit_hdlm_qm_(s) { return s.length > 0 && /^[0-9]+$/.test(s); },
+  is_alpha_hdlm_qm_(s) { return s.length > 0 && /^[a-zA-Z]+$/.test(s); },
+  is_alphanumeric_hdlm_qm_(s) { return s.length > 0 && /^[a-zA-Z0-9]+$/.test(s); },
+  is_whitespace_hdlm_qm_(s) { return s.length > 0 && /^\s+$/.test(s); },
+  replace_first(s, from, to) { const i = s.indexOf(from); return i < 0 ? s : s.slice(0, i) + to + s.slice(i + from.length); },
+  last_index_of(s, needle) { const i = s.lastIndexOf(needle); return i >= 0 ? i : null; },
+  to_float(s) { const n = parseFloat(s); if (isNaN(n)) throw new Error("invalid float number: " + s); return n; },
+  pad_right(s, n, ch) { return s.padEnd(n, ch); },
+  trim_start(s) { return s.trimStart(); },
+  trim_end(s) { return s.trimEnd(); },
+  count(s, sub) { if (!sub) return 0; let c = 0, i = 0; while ((i = s.indexOf(sub, i)) >= 0) { c++; i += sub.length; } return c; },
+  is_empty_hdlm_qm_(s) { return s.length === 0; },
+  reverse(s) { return [...s].reverse().join(""); },
+  strip_prefix(s, prefix) { return s.startsWith(prefix) ? s.slice(prefix.length) : null; },
+  strip_suffix(s, suffix) { return s.endsWith(suffix) ? s.slice(0, -suffix.length) : null; },
+  ends_with(s, suffix) { return s.endsWith(suffix); },
+};
+"#;
+
+// ──────────────────────────────── list ────────────────────────────────
+
+const MOD_LIST_TS: &str = r#"const __almd_list = {
   len<T>(xs: T[]): number { return xs.length; },
   get<T>(xs: T[], i: number): T | null { return i < xs.length ? xs[i] : null; },
   get_or<T>(xs: T[], i: number, d: T): T { return i < xs.length ? xs[i] : d; },
@@ -113,7 +218,54 @@ const __almd_list = {
   max<T>(xs: T[]): T | null { return xs.length === 0 ? null : xs.reduce((a, b) => a > b ? a : b); },
   join(xs: string[], sep: string): string { return xs.join(sep); },
 };
-const __almd_map = {
+"#;
+
+const MOD_LIST_JS: &str = r#"const __almd_list = {
+  len(xs) { return xs.length; },
+  get(xs, i) { return i < xs.length ? xs[i] : null; },
+  get_or(xs, i, d) { return i < xs.length ? xs[i] : d; },
+  sort(xs) { return [...xs].sort(); },
+  reverse(xs) { return [...xs].reverse(); },
+  any(xs, f) { return xs.some(f); },
+  all(xs, f) { return xs.every(f); },
+  contains(xs, x) { return xs.includes(x); },
+  each(xs, f) { xs.forEach(f); },
+  map(xs, f) { return xs.map(f); },
+  filter(xs, f) { return xs.filter(f); },
+  find(xs, f) { return xs.find(f) ?? null; },
+  fold(xs, init, f) { return xs.reduce(f, init); },
+  enumerate(xs) { return xs.map((x, i) => [i, x]); },
+  zip(a, b) { return a.slice(0, Math.min(a.length, b.length)).map((x, i) => [x, b[i]]); },
+  flatten(xss) { return xss.flat(); },
+  take(xs, n) { return xs.slice(0, n); },
+  drop(xs, n) { return xs.slice(n); },
+  sort_by(xs, f) { return [...xs].sort((a, b) => { const ka = f(a), kb = f(b); return ka < kb ? -1 : ka > kb ? 1 : 0; }); },
+  unique(xs) { const seen = []; return xs.filter(x => { if (seen.includes(x)) return false; seen.push(x); return true; }); },
+  index_of(xs, x) { const i = xs.indexOf(x); return i >= 0 ? i : null; },
+  chunk(xs, n) { const r = []; for (let i = 0; i < xs.length; i += n) r.push(xs.slice(i, i + n)); return r; },
+  filter_map(xs, f) { const r = []; for (const x of xs) { const v = f(x); if (v !== null) r.push(v); } return r; },
+  take_while(xs, f) { const r = []; for (const x of xs) { if (!f(x)) break; r.push(x); } return r; },
+  drop_while(xs, f) { let dropping = true; const r = []; for (const x of xs) { if (dropping && f(x)) continue; dropping = false; r.push(x); } return r; },
+  count(xs, f) { return xs.filter(f).length; },
+  partition(xs, f) { const a = [], b = []; for (const x of xs) { if (f(x)) a.push(x); else b.push(x); } return [a, b]; },
+  reduce(xs, f) { if (xs.length === 0) return null; return xs.reduce(f); },
+  group_by(xs, f) { const m = new Map(); for (const x of xs) { const k = f(x); if (!m.has(k)) m.set(k, []); m.get(k).push(x); } return m; },
+  last(xs) { return xs.length > 0 ? xs[xs.length - 1] : null; },
+  first(xs) { return xs.length > 0 ? xs[0] : null; },
+  sum(xs) { return xs.reduce((a, b) => a + b, 0); },
+  product(xs) { return xs.reduce((a, b) => a * b, 1); },
+  is_empty(xs) { return xs.length === 0; },
+  is_empty_hdlm_qm_(xs) { return xs.length === 0; },
+  flat_map(xs, f) { return xs.flatMap(f); },
+  min(xs) { return xs.length === 0 ? null : xs.reduce((a, b) => a < b ? a : b); },
+  max(xs) { return xs.length === 0 ? null : xs.reduce((a, b) => a > b ? a : b); },
+  join(xs, sep) { return xs.join(sep); },
+};
+"#;
+
+// ──────────────────────────────── map ────────────────────────────────
+
+const MOD_MAP_TS: &str = r#"const __almd_map = {
   new<K, V>(): Map<K, V> { return new Map(); },
   get<K, V>(m: Map<K, V>, k: K): V | null { return m.has(k) ? m.get(k)! : null; },
   get_or<K, V>(m: Map<K, V>, k: K, d: V): V { return m.has(k) ? m.get(k)! : d; },
@@ -132,7 +284,32 @@ const __almd_map = {
   is_empty<K, V>(m: Map<K, V>): boolean { return m.size === 0; },
   is_empty_hdlm_qm_<K, V>(m: Map<K, V>): boolean { return m.size === 0; },
 };
-const __almd_int = {
+"#;
+
+const MOD_MAP_JS: &str = r#"const __almd_map = {
+  new() { return new Map(); },
+  get(m, k) { return m.has(k) ? m.get(k) : null; },
+  get_or(m, k, d) { return m.has(k) ? m.get(k) : d; },
+  set(m, k, v) { const r = new Map(m); r.set(k, v); return r; },
+  contains(m, k) { return m.has(k); },
+  remove(m, k) { const r = new Map(m); r.delete(k); return r; },
+  keys(m) { return [...m.keys()].sort(); },
+  values(m) { return [...m.values()]; },
+  len(m) { return m.size; },
+  entries(m) { return [...m.entries()]; },
+  from_list(xs, f) { const r = new Map(); for (const x of xs) { const [k, v] = f(x); r.set(k, v); } return r; },
+  map_values(m, f) { const r = new Map(); m.forEach((v, k) => r.set(k, f(v))); return r; },
+  filter(m, f) { const r = new Map(); m.forEach((v, k) => { if (f(k, v)) r.set(k, v); }); return r; },
+  from_entries(entries) { const r = new Map(); for (const [k, v] of entries) r.set(k, v); return r; },
+  merge(a, b) { const r = new Map(a); b.forEach((v, k) => r.set(k, v)); return r; },
+  is_empty(m) { return m.size === 0; },
+  is_empty_hdlm_qm_(m) { return m.size === 0; },
+};
+"#;
+
+// ──────────────────────────────── int ────────────────────────────────
+
+const MOD_INT_TS: &str = r#"const __almd_int = {
   to_hex(n: bigint): string { return (n >= 0n ? n : n + (1n << 64n)).toString(16); },
   to_string(n: number): string { return String(n); },
   band(a: number, b: number): number { return (a & b) >>> 0; },
@@ -154,7 +331,35 @@ const __almd_int = {
   min(a: number, b: number): number { return Math.min(a, b); },
   max(a: number, b: number): number { return Math.max(a, b); },
 };
-const __almd_float = {
+"#;
+
+const MOD_INT_JS: &str = r#"const __almd_int = {
+  to_hex(n) { return (typeof n === "bigint" ? (n >= 0n ? n : n + (1n << 64n)).toString(16) : n.toString(16)); },
+  to_string(n) { return String(n); },
+  band(a, b) { return (a & b) >>> 0; },
+  bor(a, b) { return (a | b) >>> 0; },
+  bxor(a, b) { return (a ^ b) >>> 0; },
+  bshl(a, n) { return (a << n) >>> 0; },
+  bshr(a, n) { return a >>> n; },
+  bnot(a) { return ~a; },
+  wrap_add(a, b, bits) { const mask = bits === 32 ? 0xFFFFFFFF : (1 << bits) - 1; return ((a + b) & mask) >>> 0; },
+  wrap_mul(a, b, bits) { const mask = bits === 32 ? 0xFFFFFFFF : (1 << bits) - 1; return (Math.imul(a, b) & mask) >>> 0; },
+  rotate_right(a, n, bits) { const mask = bits === 32 ? 0xFFFFFFFF : (1 << bits) - 1; const v = a & mask; n = n % bits; return (((v >>> n) | (v << (bits - n))) & mask) >>> 0; },
+  rotate_left(a, n, bits) { const mask = bits === 32 ? 0xFFFFFFFF : (1 << bits) - 1; const v = a & mask; n = n % bits; return (((v << n) | (v >>> (bits - n))) & mask) >>> 0; },
+  to_u32(a) { return a >>> 0; },
+  to_u8(a) { return a & 0xFF; },
+  clamp(n, lo, hi) { return Math.max(lo, Math.min(hi, n)); },
+  parse(s) { var n = parseInt(s, 10); if (isNaN(n) || !/^-?\d+$/.test(s.trim())) throw new Error("invalid digit found in string"); return n; },
+  parse_hex(s) { var h = s.startsWith("0x") || s.startsWith("0X") ? s.slice(2) : s; var n = parseInt(h, 16); if (isNaN(n)) throw new Error("invalid digit found in string"); return n; },
+  abs(n) { return Math.abs(n); },
+  min(a, b) { return Math.min(a, b); },
+  max(a, b) { return Math.max(a, b); },
+};
+"#;
+
+// ──────────────────────────────── float ────────────────────────────────
+
+const MOD_FLOAT_TS: &str = r#"const __almd_float = {
   to_string(n: number): string { return String(n); },
   to_int(n: number): number { return Math.trunc(n); },
   round(n: number): number { return Math.round(n); },
@@ -168,14 +373,47 @@ const __almd_float = {
   max(a: number, b: number): number { return Math.max(a, b); },
   clamp(n: number, lo: number, hi: number): number { return Math.max(lo, Math.min(hi, n)); },
 };
-const __almd_path = {
+"#;
+
+const MOD_FLOAT_JS: &str = r#"const __almd_float = {
+  to_string(n) { return String(n); },
+  to_int(n) { return Math.trunc(n); },
+  round(n) { return Math.round(n); },
+  floor(n) { return Math.floor(n); },
+  ceil(n) { return Math.ceil(n); },
+  abs(n) { return Math.abs(n); },
+  sqrt(n) { return Math.sqrt(n); },
+  parse(s) { const n = parseFloat(s); if (isNaN(n)) throw new Error("invalid float: " + s); return n; },
+  from_int(n) { return n; },
+  min(a, b) { return Math.min(a, b); },
+  max(a, b) { return Math.max(a, b); },
+  clamp(n, lo, hi) { return Math.max(lo, Math.min(hi, n)); },
+};
+"#;
+
+// ──────────────────────────────── path ────────────────────────────────
+
+const MOD_PATH_TS: &str = r#"const __almd_path = {
   join(base: string, child: string): string { return base.replace(/\/+$/, "") + "/" + child; },
   dirname(p: string): string { const i = p.lastIndexOf("/"); return i >= 0 ? p.substring(0, i) : "."; },
   basename(p: string): string { const i = p.lastIndexOf("/"); return i >= 0 ? p.substring(i + 1) : p; },
   extension(p: string): string | null { const b = __almd_path.basename(p); const i = b.lastIndexOf("."); return i > 0 ? b.substring(i + 1) : null; },
   is_absolute_hdlm_qm_(p: string): boolean { return p.startsWith("/"); },
 };
-const __almd_json = {
+"#;
+
+const MOD_PATH_JS: &str = r#"const __almd_path = {
+  join(base, child) { return base.replace(/\/+$/, "") + "/" + child; },
+  dirname(p) { const i = p.lastIndexOf("/"); return i >= 0 ? p.substring(0, i) : "."; },
+  basename(p) { const i = p.lastIndexOf("/"); return i >= 0 ? p.substring(i + 1) : p; },
+  extension(p) { const b = __almd_path.basename(p); const i = b.lastIndexOf("."); return i > 0 ? b.substring(i + 1) : null; },
+  is_absolute_hdlm_qm_(p) { return p.startsWith("/"); },
+};
+"#;
+
+// ──────────────────────────────── json ────────────────────────────────
+
+const MOD_JSON_TS: &str = r#"const __almd_json = {
   parse(text: string): any { return JSON.parse(text); },
   stringify(j: any): string { return JSON.stringify(j); },
   get(j: any, key: string): any | null { return (j && typeof j === "object" && !Array.isArray(j) && key in j) ? j[key] : null; },
@@ -196,7 +434,34 @@ const __almd_json = {
   from_float(n: number): any { return n; },
   stringify_pretty(j: any): string { return JSON.stringify(j, null, 2); },
 };
-const __almd_env = {
+"#;
+
+const MOD_JSON_JS: &str = r#"const __almd_json = {
+  parse(text) { return JSON.parse(text); },
+  stringify(j) { return JSON.stringify(j); },
+  get(j, key) { return (j && typeof j === "object" && !Array.isArray(j) && key in j) ? j[key] : null; },
+  get_string(j, key) { const v = __almd_json.get(j, key); return typeof v === "string" ? v : null; },
+  get_int(j, key) { const v = __almd_json.get(j, key); return typeof v === "number" ? v : null; },
+  get_bool(j, key) { const v = __almd_json.get(j, key); return typeof v === "boolean" ? v : null; },
+  get_array(j, key) { const v = __almd_json.get(j, key); return Array.isArray(v) ? v : null; },
+  keys(j) { return (j && typeof j === "object" && !Array.isArray(j)) ? Object.keys(j).sort() : []; },
+  to_string(j) { return typeof j === "string" ? j : null; },
+  to_int(j) { return typeof j === "number" ? j : null; },
+  from_string(s) { return s; },
+  from_int(n) { return n; },
+  from_bool(b) { return b; },
+  null_() { return null; },
+  array(items) { return items; },
+  from_map(m) { if (m instanceof Map) { const o = {}; m.forEach((v, k) => { o[k] = v; }); return o; } return m; },
+  get_float(j, key) { const v = __almd_json.get(j, key); return typeof v === "number" ? v : null; },
+  from_float(n) { return n; },
+  stringify_pretty(j) { return JSON.stringify(j, null, 2); },
+};
+"#;
+
+// ──────────────────────────────── env ────────────────────────────────
+
+const MOD_ENV_TS: &str = r#"const __almd_env = {
   unix_timestamp(): number { return Math.floor(Date.now() / 1000); },
   args(): string[] { return Deno.args; },
   get(name: string): string | null { const v = Deno.env.get(name); return v !== undefined ? v : null; },
@@ -205,13 +470,40 @@ const __almd_env = {
   millis(): number { return Date.now(); },
   sleep_ms(ms: number): void { const end = Date.now() + ms; while (Date.now() < end) {} },
 };
-const __almd_process = {
+"#;
+
+const MOD_ENV_JS: &str = r#"const __almd_env = {
+  unix_timestamp() { return Math.floor(Date.now() / 1000); },
+  args() { return __node_process.argv.slice(2); },
+  get(name) { const v = __node_process.env[name]; return v !== undefined ? v : null; },
+  set(name, value) { __node_process.env[name] = value; },
+  cwd() { return __node_process.cwd(); },
+  millis() { return Date.now(); },
+  sleep_ms(ms) { const end = Date.now() + ms; while (Date.now() < end) {} },
+};
+"#;
+
+// ──────────────────────────────── process ────────────────────────────────
+
+const MOD_PROCESS_TS: &str = r#"const __almd_process = {
   exec(cmd: string, args: string[]): string { try { const p = new Deno.Command(cmd, { args, stdout: "piped", stderr: "piped" }); const out = p.outputSync(); if (out.success) { return new TextDecoder().decode(out.stdout); } else { const msg = new TextDecoder().decode(out.stderr); throw new Error(msg || "command failed"); } } catch (e) { if (e instanceof Error) throw e; throw new Error(String(e)); } },
   exec_status(cmd: string, args: string[]): {code: number, stdout: string, stderr: string} { try { const p = new Deno.Command(cmd, { args, stdout: "piped", stderr: "piped" }); const out = p.outputSync(); return { code: out.code, stdout: new TextDecoder().decode(out.stdout), stderr: new TextDecoder().decode(out.stderr) }; } catch (e) { throw e instanceof Error ? e : new Error(String(e)); } },
   exit(code: number): void { Deno.exit(code); },
   stdin_lines(): string[] { const buf = new Uint8Array(1024 * 1024); const n = Deno.stdin.readSync(buf); return n ? new TextDecoder().decode(buf.subarray(0, n)).split("\n").filter(l => l.length > 0) : []; },
 };
-const __almd_math = {
+"#;
+
+const MOD_PROCESS_JS: &str = r#"const __almd_process = {
+  exec(cmd, args) { const { execFileSync } = require("child_process"); try { return execFileSync(cmd, args, { encoding: "utf-8" }); } catch (e) { const msg = e.stderr ? String(e.stderr) : e.message; throw new Error(msg || "command failed"); } },
+  exec_status(cmd, args) { const { spawnSync } = require("child_process"); const r = spawnSync(cmd, args, { encoding: "utf-8" }); if (r.error) throw r.error; return { code: r.status ?? 1, stdout: r.stdout || "", stderr: r.stderr || "" }; },
+  exit(code) { __node_process.exit(code); },
+  stdin_lines() { return require("fs").readFileSync(0, "utf-8").split("\n").filter(l => l.length > 0); },
+};
+"#;
+
+// ──────────────────────────────── math ────────────────────────────────
+
+const MOD_MATH_TS: &str = r#"const __almd_math = {
   min(a: number, b: number): number { return Math.min(a, b); },
   max(a: number, b: number): number { return Math.max(a, b); },
   abs(n: number): number { return Math.abs(n); },
@@ -225,13 +517,45 @@ const __almd_math = {
   exp(x: number): number { return Math.exp(x); },
   sqrt(x: number): number { return Math.sqrt(x); },
 };
-const __almd_random = {
+"#;
+
+const MOD_MATH_JS: &str = r#"const __almd_math = {
+  min(a, b) { return Math.min(a, b); },
+  max(a, b) { return Math.max(a, b); },
+  abs(n) { return Math.abs(n); },
+  pow(base, exp) { return Math.pow(base, exp); },
+  pi() { return Math.PI; },
+  e() { return Math.E; },
+  sin(x) { return Math.sin(x); },
+  cos(x) { return Math.cos(x); },
+  tan(x) { return Math.tan(x); },
+  log(x) { return Math.log(x); },
+  exp(x) { return Math.exp(x); },
+  sqrt(x) { return Math.sqrt(x); },
+};
+"#;
+
+// ──────────────────────────────── random ────────────────────────────────
+
+const MOD_RANDOM_TS: &str = r#"const __almd_random = {
   int(min: number, max: number): number { return Math.floor(Math.random() * (max - min + 1)) + min; },
   float(): number { return Math.random(); },
   choice<T>(xs: T[]): T | null { return xs.length > 0 ? xs[Math.floor(Math.random() * xs.length)] : null; },
   shuffle<T>(xs: T[]): T[] { const a = [...xs]; for (let i = a.length - 1; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); [a[i], a[j]] = [a[j], a[i]]; } return a; },
 };
-const __almd_regex = {
+"#;
+
+const MOD_RANDOM_JS: &str = r#"const __almd_random = {
+  int(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; },
+  float() { return Math.random(); },
+  choice(xs) { return xs.length > 0 ? xs[Math.floor(Math.random() * xs.length)] : null; },
+  shuffle(xs) { const a = [...xs]; for (let i = a.length - 1; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); [a[i], a[j]] = [a[j], a[i]]; } return a; },
+};
+"#;
+
+// ──────────────────────────────── regex ────────────────────────────────
+
+const MOD_REGEX_TS: &str = r#"const __almd_regex = {
   match_hdlm_qm_(pat: string, s: string): boolean { return new RegExp(pat).test(s); },
   full_match_hdlm_qm_(pat: string, s: string): boolean { return new RegExp(`^(?:${pat})$`).test(s); },
   find(pat: string, s: string): string | null { const m = s.match(new RegExp(pat)); return m ? m[0] : null; },
@@ -241,12 +565,39 @@ const __almd_regex = {
   split(pat: string, s: string): string[] { return s.split(new RegExp(pat)); },
   captures(pat: string, s: string): string[] | null { const m = s.match(new RegExp(pat)); return m && m.length > 1 ? m.slice(1) : null; },
 };
-const __almd_io = {
+"#;
+
+const MOD_REGEX_JS: &str = r#"const __almd_regex = {
+  match_hdlm_qm_(pat, s) { return new RegExp(pat).test(s); },
+  full_match_hdlm_qm_(pat, s) { return new RegExp(`^(?:${pat})$`).test(s); },
+  find(pat, s) { const m = s.match(new RegExp(pat)); return m ? m[0] : null; },
+  find_all(pat, s) { const m = s.match(new RegExp(pat, 'g')); return m ? [...m] : []; },
+  replace(pat, s, rep) { return s.replace(new RegExp(pat, 'g'), rep); },
+  replace_first(pat, s, rep) { return s.replace(new RegExp(pat), rep); },
+  split(pat, s) { return s.split(new RegExp(pat)); },
+  captures(pat, s) { const m = s.match(new RegExp(pat)); return m && m.length > 1 ? m.slice(1) : null; },
+};
+"#;
+
+// ──────────────────────────────── io ────────────────────────────────
+
+const MOD_IO_TS: &str = r#"const __almd_io = {
   read_line(): string { return prompt("") ?? ""; },
   print(s: string): void { const buf = new TextEncoder().encode(s); Deno.stdout.writeSync(buf); },
   read_all(): string { const d = new TextDecoder(); let r = ""; const buf = new Uint8Array(4096); let n: number | null; while ((n = Deno.stdin.readSync(buf)) !== null && n > 0) { r += d.decode(buf.subarray(0, n)); } return r; },
 };
-const __almd_time = {
+"#;
+
+const MOD_IO_JS: &str = r#"const __almd_io = {
+  read_line() { const buf = Buffer.alloc(1024); let s = ""; while (true) { const n = require("fs").readSync(0, buf, 0, 1, null); if (n === 0) break; const ch = buf.toString("utf-8", 0, n); s += ch; if (ch === "\n") break; } return s.replace(/\r?\n$/, ""); },
+  print(s) { __node_process.stdout.write(s); },
+  read_all() { return require("fs").readFileSync(0, "utf-8"); },
+};
+"#;
+
+// ──────────────────────────────── time ────────────────────────────────
+
+const MOD_TIME_TS: &str = r#"const __almd_time = {
   now(): number { return Math.floor(Date.now() / 1000); },
   millis(): number { return Date.now(); },
   sleep(ms: number): void { /* Deno */ if (typeof Deno !== "undefined") { const end = Date.now() + ms; while (Date.now() < end) {} } },
@@ -261,7 +612,28 @@ const __almd_time = {
   to_iso(ts: number): string { const [y, m, d, h, mi, s] = __almd_time._parts(ts); return `${String(y).padStart(4,"0")}-${String(m).padStart(2,"0")}-${String(d).padStart(2,"0")}T${String(h).padStart(2,"0")}:${String(mi).padStart(2,"0")}:${String(s).padStart(2,"0")}Z`; },
   from_parts(y: number, m: number, d: number, h: number, min: number, s: number): number { return Math.floor(Date.UTC(y, m - 1, d, h, min, s) / 1000); },
 };
-const __almd_http = {
+"#;
+
+const MOD_TIME_JS: &str = r#"const __almd_time = {
+  now() { return Math.floor(Date.now() / 1000); },
+  millis() { return Date.now(); },
+  sleep(ms) { const end = Date.now() + ms; while (Date.now() < end) {} },
+  _parts(ts) { const d = new Date(ts * 1000); return [d.getUTCFullYear(), d.getUTCMonth() + 1, d.getUTCDate(), d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds()]; },
+  year(ts) { return new Date(ts * 1000).getUTCFullYear(); },
+  month(ts) { return new Date(ts * 1000).getUTCMonth() + 1; },
+  day(ts) { return new Date(ts * 1000).getUTCDate(); },
+  hour(ts) { return new Date(ts * 1000).getUTCHours(); },
+  minute(ts) { return new Date(ts * 1000).getUTCMinutes(); },
+  second(ts) { return new Date(ts * 1000).getUTCSeconds(); },
+  weekday(ts) { const d = new Date(ts * 1000).getUTCDay(); return d === 0 ? 6 : d - 1; },
+  to_iso(ts) { const [y, m, d, h, mi, s] = __almd_time._parts(ts); return `${String(y).padStart(4,"0")}-${String(m).padStart(2,"0")}-${String(d).padStart(2,"0")}T${String(h).padStart(2,"0")}:${String(mi).padStart(2,"0")}:${String(s).padStart(2,"0")}Z`; },
+  from_parts(y, m, d, h, min, s) { return Math.floor(Date.UTC(y, m - 1, d, h, min, s) / 1000); },
+};
+"#;
+
+// ──────────────────────────────── http ────────────────────────────────
+
+const MOD_HTTP_TS: &str = r#"const __almd_http = {
   async serve(port: number, handler: (req: any) => any): Promise<void> { const server = Deno.serve({ port }, async (request: Request) => { const url = new URL(request.url); const method = request.method; const path = url.pathname; const body = method === "POST" || method === "PUT" ? await request.text() : ""; const headers: Record<string, string> = {}; request.headers.forEach((v: string, k: string) => { headers[k] = v; }); const req = { method, path, body, headers }; const res = handler(req); return new Response(res.body, { status: res.status, headers: res.headers || {} }); }); },
   response(status: number, body: string): any { return { status, body, headers: { "content-type": "text/plain" } }; },
   json(status: number, body: string): any { return { status, body, headers: { "content-type": "application/json" } }; },
@@ -269,7 +641,21 @@ const __almd_http = {
   async get(url: string): Promise<string> { const r = await fetch(url); if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.text(); },
   async post(url: string, body: string): Promise<string> { const r = await fetch(url, { method: "POST", body, headers: { "content-type": "application/json" } }); if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.text(); },
 };
-function __bigop(op: string, a: any, b: any): any {
+"#;
+
+const MOD_HTTP_JS: &str = r#"const __almd_http = {
+  async serve(port, handler) { const http = require("http"); const server = http.createServer(async (req, res) => { let body = ""; req.on("data", (c) => { body += c; }); req.on("end", () => { const r = handler({ method: req.method, path: req.url, body, headers: req.headers || {} }); const headers = r.headers || {}; res.writeHead(r.status, headers); res.end(r.body); }); }); server.listen(port); },
+  response(status, body) { return { status, body, headers: { "content-type": "text/plain" } }; },
+  json(status, body) { return { status, body, headers: { "content-type": "application/json" } }; },
+  with_headers(status, body, headers) { const h = {}; if (headers instanceof Map) { headers.forEach((v, k) => { h[k] = v; }); } else { Object.assign(h, headers); } return { status, body, headers: h }; },
+  async get(url) { return new Promise((resolve, reject) => { const m = url.startsWith("https") ? require("https") : require("http"); m.get(url, (r) => { let d = ""; r.on("data", (c) => d += c); r.on("end", () => r.statusCode >= 400 ? reject(new Error("HTTP " + r.statusCode)) : resolve(d)); }).on("error", reject); }); },
+  async post(url, body) { return new Promise((resolve, reject) => { const u = new URL(url); const m = u.protocol === "https:" ? require("https") : require("http"); const req = m.request({ hostname: u.hostname, port: u.port, path: u.pathname + u.search, method: "POST", headers: { "content-type": "application/json", "content-length": Buffer.byteLength(body) } }, (r) => { let d = ""; r.on("data", (c) => d += c); r.on("end", () => r.statusCode >= 400 ? reject(new Error("HTTP " + r.statusCode)) : resolve(d)); }); req.on("error", reject); req.write(body); req.end(); }); },
+};
+"#;
+
+// ──────────────────────────────── helpers ────────────────────────────────
+
+const HELPERS_TS: &str = r#"function __bigop(op: string, a: any, b: any): any {
   if (typeof a === "bigint" || typeof b === "bigint") {
     const ba = typeof a === "bigint" ? a : BigInt(a);
     const bb = typeof b === "bigint" ? b : BigInt(b);
@@ -322,285 +708,9 @@ function __assert_throws(fn: () => any, expectedMsg: string): void {
   try { fn(); throw new Error("Expected error but succeeded with: " + fn); }
   catch (e) { if (e instanceof Error && e.message === expectedMsg) return; throw e; }
 }
-// ---- End Runtime ----
 "#;
 
-/// JavaScript runtime (Node.js) for emitted code.
-pub const RUNTIME_JS: &str = r#"// ---- Almide Runtime (JS) ----
-const __node_process = globalThis.process || {};
-const __almd_fs = {
-  exists(p) { const fs = require("fs"); try { fs.statSync(p); return true; } catch { return false; } },
-  read_text(p) { return require("fs").readFileSync(p, "utf-8"); },
-  read_bytes(p) { return Array.from(require("fs").readFileSync(p)); },
-  write(p, s) { require("fs").writeFileSync(p, s); },
-  write_bytes(p, b) { require("fs").writeFileSync(p, Buffer.from(b)); },
-  append(p, s) { require("fs").appendFileSync(p, s); },
-  mkdir_p(p) { require("fs").mkdirSync(p, { recursive: true }); },
-  exists_hdlm_qm_(p) { const fs = require("fs"); try { fs.statSync(p); return true; } catch { return false; } },
-  read_lines(p) { return require("fs").readFileSync(p, "utf-8").split("\n").filter(l => l.length > 0); },
-  remove(p) { const fs = require("fs"); try { const s = fs.statSync(p); if (s.isDirectory()) fs.rmSync(p, { recursive: true }); else fs.unlinkSync(p); } catch(e) { throw e; } },
-  list_dir(p) { return require("fs").readdirSync(p).sort(); },
-  walk(dir) {
-    const fs = require("fs");
-    const results = [];
-    function inner(d) {
-      const entries = fs.readdirSync(d, { withFileTypes: true });
-      for (const entry of entries) {
-        const p = d + "/" + entry.name;
-        results.push(p);
-        if (entry.isDirectory()) inner(p);
-      }
-    }
-    inner(dir);
-    return results.sort();
-  },
-  stat(path) {
-    const fs = require("fs");
-    const s = fs.statSync(path);
-    return { size: s.size, is_dir: s.isDirectory(), is_file: s.isFile(), modified: Math.floor(s.mtimeMs / 1000) };
-  },
-  is_dir_hdlm_qm_(p) { try { return require("fs").statSync(p).isDirectory(); } catch { return false; } },
-  is_file_hdlm_qm_(p) { try { return require("fs").statSync(p).isFile(); } catch { return false; } },
-  copy(src, dst) { require("fs").copyFileSync(src, dst); },
-  rename(src, dst) { require("fs").renameSync(src, dst); },
-};
-const __almd_string = {
-  trim(s) { return s.trim(); },
-  split(s, sep) { return s.split(sep); },
-  join(arr, sep) { return arr.join(sep); },
-  len(s) { return s.length; },
-  pad_left(s, n, ch) { return s.padStart(n, ch); },
-  starts_with(s, prefix) { return s.startsWith(prefix); },
-  slice(s, start, end) { return end !== undefined ? s.slice(start, end) : s.slice(start); },
-  to_bytes(s) { return Array.from(new TextEncoder().encode(s)); },
-  contains(s, sub) { return s.includes(sub); },
-  starts_with_hdlm_qm_(s, prefix) { return s.startsWith(prefix); },
-  ends_with_hdlm_qm_(s, suffix) { return s.endsWith(suffix); },
-  to_upper(s) { return s.toUpperCase(); },
-  to_lower(s) { return s.toLowerCase(); },
-  to_int(s) { const n = parseInt(s, 10); if (isNaN(n)) throw new Error("invalid integer: " + s); return n; },
-  replace(s, from, to) { return s.split(from).join(to); },
-  char_at(s, i) { return i < s.length ? s[i] : null; },
-  lines(s) { return s.split("\n").filter(l => l.length > 0); },
-  chars(s) { return [...s]; },
-  index_of(s, needle) { const i = s.indexOf(needle); return i >= 0 ? i : null; },
-  repeat(s, n) { return s.repeat(n); },
-  from_bytes(bytes) { return new TextDecoder().decode(new Uint8Array(bytes)); },
-  is_digit_hdlm_qm_(s) { return s.length > 0 && /^[0-9]+$/.test(s); },
-  is_alpha_hdlm_qm_(s) { return s.length > 0 && /^[a-zA-Z]+$/.test(s); },
-  is_alphanumeric_hdlm_qm_(s) { return s.length > 0 && /^[a-zA-Z0-9]+$/.test(s); },
-  is_whitespace_hdlm_qm_(s) { return s.length > 0 && /^\s+$/.test(s); },
-  replace_first(s, from, to) { const i = s.indexOf(from); return i < 0 ? s : s.slice(0, i) + to + s.slice(i + from.length); },
-  last_index_of(s, needle) { const i = s.lastIndexOf(needle); return i >= 0 ? i : null; },
-  to_float(s) { const n = parseFloat(s); if (isNaN(n)) throw new Error("invalid float number: " + s); return n; },
-  pad_right(s, n, ch) { return s.padEnd(n, ch); },
-  trim_start(s) { return s.trimStart(); },
-  trim_end(s) { return s.trimEnd(); },
-  count(s, sub) { if (!sub) return 0; let c = 0, i = 0; while ((i = s.indexOf(sub, i)) >= 0) { c++; i += sub.length; } return c; },
-  is_empty_hdlm_qm_(s) { return s.length === 0; },
-  reverse(s) { return [...s].reverse().join(""); },
-  strip_prefix(s, prefix) { return s.startsWith(prefix) ? s.slice(prefix.length) : null; },
-  strip_suffix(s, suffix) { return s.endsWith(suffix) ? s.slice(0, -suffix.length) : null; },
-  ends_with(s, suffix) { return s.endsWith(suffix); },
-};
-const __almd_list = {
-  len(xs) { return xs.length; },
-  get(xs, i) { return i < xs.length ? xs[i] : null; },
-  get_or(xs, i, d) { return i < xs.length ? xs[i] : d; },
-  sort(xs) { return [...xs].sort(); },
-  reverse(xs) { return [...xs].reverse(); },
-  any(xs, f) { return xs.some(f); },
-  all(xs, f) { return xs.every(f); },
-  contains(xs, x) { return xs.includes(x); },
-  each(xs, f) { xs.forEach(f); },
-  map(xs, f) { return xs.map(f); },
-  filter(xs, f) { return xs.filter(f); },
-  find(xs, f) { return xs.find(f) ?? null; },
-  fold(xs, init, f) { return xs.reduce(f, init); },
-  enumerate(xs) { return xs.map((x, i) => [i, x]); },
-  zip(a, b) { return a.slice(0, Math.min(a.length, b.length)).map((x, i) => [x, b[i]]); },
-  flatten(xss) { return xss.flat(); },
-  take(xs, n) { return xs.slice(0, n); },
-  drop(xs, n) { return xs.slice(n); },
-  sort_by(xs, f) { return [...xs].sort((a, b) => { const ka = f(a), kb = f(b); return ka < kb ? -1 : ka > kb ? 1 : 0; }); },
-  unique(xs) { const seen = []; return xs.filter(x => { if (seen.includes(x)) return false; seen.push(x); return true; }); },
-  index_of(xs, x) { const i = xs.indexOf(x); return i >= 0 ? i : null; },
-  chunk(xs, n) { const r = []; for (let i = 0; i < xs.length; i += n) r.push(xs.slice(i, i + n)); return r; },
-  filter_map(xs, f) { const r = []; for (const x of xs) { const v = f(x); if (v !== null) r.push(v); } return r; },
-  take_while(xs, f) { const r = []; for (const x of xs) { if (!f(x)) break; r.push(x); } return r; },
-  drop_while(xs, f) { let dropping = true; const r = []; for (const x of xs) { if (dropping && f(x)) continue; dropping = false; r.push(x); } return r; },
-  count(xs, f) { return xs.filter(f).length; },
-  partition(xs, f) { const a = [], b = []; for (const x of xs) { if (f(x)) a.push(x); else b.push(x); } return [a, b]; },
-  reduce(xs, f) { if (xs.length === 0) return null; return xs.reduce(f); },
-  group_by(xs, f) { const m = new Map(); for (const x of xs) { const k = f(x); if (!m.has(k)) m.set(k, []); m.get(k).push(x); } return m; },
-  last(xs) { return xs.length > 0 ? xs[xs.length - 1] : null; },
-  first(xs) { return xs.length > 0 ? xs[0] : null; },
-  sum(xs) { return xs.reduce((a, b) => a + b, 0); },
-  product(xs) { return xs.reduce((a, b) => a * b, 1); },
-  is_empty(xs) { return xs.length === 0; },
-  is_empty_hdlm_qm_(xs) { return xs.length === 0; },
-  flat_map(xs, f) { return xs.flatMap(f); },
-  min(xs) { return xs.length === 0 ? null : xs.reduce((a, b) => a < b ? a : b); },
-  max(xs) { return xs.length === 0 ? null : xs.reduce((a, b) => a > b ? a : b); },
-  join(xs, sep) { return xs.join(sep); },
-};
-const __almd_map = {
-  new() { return new Map(); },
-  get(m, k) { return m.has(k) ? m.get(k) : null; },
-  get_or(m, k, d) { return m.has(k) ? m.get(k) : d; },
-  set(m, k, v) { const r = new Map(m); r.set(k, v); return r; },
-  contains(m, k) { return m.has(k); },
-  remove(m, k) { const r = new Map(m); r.delete(k); return r; },
-  keys(m) { return [...m.keys()].sort(); },
-  values(m) { return [...m.values()]; },
-  len(m) { return m.size; },
-  entries(m) { return [...m.entries()]; },
-  from_list(xs, f) { const r = new Map(); for (const x of xs) { const [k, v] = f(x); r.set(k, v); } return r; },
-  map_values(m, f) { const r = new Map(); m.forEach((v, k) => r.set(k, f(v))); return r; },
-  filter(m, f) { const r = new Map(); m.forEach((v, k) => { if (f(k, v)) r.set(k, v); }); return r; },
-  from_entries(entries) { const r = new Map(); for (const [k, v] of entries) r.set(k, v); return r; },
-  merge(a, b) { const r = new Map(a); b.forEach((v, k) => r.set(k, v)); return r; },
-  is_empty(m) { return m.size === 0; },
-  is_empty_hdlm_qm_(m) { return m.size === 0; },
-};
-const __almd_int = {
-  to_hex(n) { return (typeof n === "bigint" ? (n >= 0n ? n : n + (1n << 64n)).toString(16) : n.toString(16)); },
-  to_string(n) { return String(n); },
-  band(a, b) { return (a & b) >>> 0; },
-  bor(a, b) { return (a | b) >>> 0; },
-  bxor(a, b) { return (a ^ b) >>> 0; },
-  bshl(a, n) { return (a << n) >>> 0; },
-  bshr(a, n) { return a >>> n; },
-  bnot(a) { return ~a; },
-  wrap_add(a, b, bits) { const mask = bits === 32 ? 0xFFFFFFFF : (1 << bits) - 1; return ((a + b) & mask) >>> 0; },
-  wrap_mul(a, b, bits) { const mask = bits === 32 ? 0xFFFFFFFF : (1 << bits) - 1; return (Math.imul(a, b) & mask) >>> 0; },
-  rotate_right(a, n, bits) { const mask = bits === 32 ? 0xFFFFFFFF : (1 << bits) - 1; const v = a & mask; n = n % bits; return (((v >>> n) | (v << (bits - n))) & mask) >>> 0; },
-  rotate_left(a, n, bits) { const mask = bits === 32 ? 0xFFFFFFFF : (1 << bits) - 1; const v = a & mask; n = n % bits; return (((v << n) | (v >>> (bits - n))) & mask) >>> 0; },
-  to_u32(a) { return a >>> 0; },
-  to_u8(a) { return a & 0xFF; },
-  clamp(n, lo, hi) { return Math.max(lo, Math.min(hi, n)); },
-  parse(s) { var n = parseInt(s, 10); if (isNaN(n) || !/^-?\d+$/.test(s.trim())) throw new Error("invalid digit found in string"); return n; },
-  parse_hex(s) { var h = s.startsWith("0x") || s.startsWith("0X") ? s.slice(2) : s; var n = parseInt(h, 16); if (isNaN(n)) throw new Error("invalid digit found in string"); return n; },
-  abs(n) { return Math.abs(n); },
-  min(a, b) { return Math.min(a, b); },
-  max(a, b) { return Math.max(a, b); },
-};
-const __almd_float = {
-  to_string(n) { return String(n); },
-  to_int(n) { return Math.trunc(n); },
-  round(n) { return Math.round(n); },
-  floor(n) { return Math.floor(n); },
-  ceil(n) { return Math.ceil(n); },
-  abs(n) { return Math.abs(n); },
-  sqrt(n) { return Math.sqrt(n); },
-  parse(s) { const n = parseFloat(s); if (isNaN(n)) throw new Error("invalid float: " + s); return n; },
-  from_int(n) { return n; },
-  min(a, b) { return Math.min(a, b); },
-  max(a, b) { return Math.max(a, b); },
-  clamp(n, lo, hi) { return Math.max(lo, Math.min(hi, n)); },
-};
-const __almd_path = {
-  join(base, child) { return base.replace(/\/+$/, "") + "/" + child; },
-  dirname(p) { const i = p.lastIndexOf("/"); return i >= 0 ? p.substring(0, i) : "."; },
-  basename(p) { const i = p.lastIndexOf("/"); return i >= 0 ? p.substring(i + 1) : p; },
-  extension(p) { const b = __almd_path.basename(p); const i = b.lastIndexOf("."); return i > 0 ? b.substring(i + 1) : null; },
-  is_absolute_hdlm_qm_(p) { return p.startsWith("/"); },
-};
-const __almd_json = {
-  parse(text) { return JSON.parse(text); },
-  stringify(j) { return JSON.stringify(j); },
-  get(j, key) { return (j && typeof j === "object" && !Array.isArray(j) && key in j) ? j[key] : null; },
-  get_string(j, key) { const v = __almd_json.get(j, key); return typeof v === "string" ? v : null; },
-  get_int(j, key) { const v = __almd_json.get(j, key); return typeof v === "number" ? v : null; },
-  get_bool(j, key) { const v = __almd_json.get(j, key); return typeof v === "boolean" ? v : null; },
-  get_array(j, key) { const v = __almd_json.get(j, key); return Array.isArray(v) ? v : null; },
-  keys(j) { return (j && typeof j === "object" && !Array.isArray(j)) ? Object.keys(j).sort() : []; },
-  to_string(j) { return typeof j === "string" ? j : null; },
-  to_int(j) { return typeof j === "number" ? j : null; },
-  from_string(s) { return s; },
-  from_int(n) { return n; },
-  from_bool(b) { return b; },
-  null_() { return null; },
-  array(items) { return items; },
-  from_map(m) { if (m instanceof Map) { const o = {}; m.forEach((v, k) => { o[k] = v; }); return o; } return m; },
-  get_float(j, key) { const v = __almd_json.get(j, key); return typeof v === "number" ? v : null; },
-  from_float(n) { return n; },
-  stringify_pretty(j) { return JSON.stringify(j, null, 2); },
-};
-const __almd_env = {
-  unix_timestamp() { return Math.floor(Date.now() / 1000); },
-  args() { return __node_process.argv.slice(2); },
-  get(name) { const v = __node_process.env[name]; return v !== undefined ? v : null; },
-  set(name, value) { __node_process.env[name] = value; },
-  cwd() { return __node_process.cwd(); },
-  millis() { return Date.now(); },
-  sleep_ms(ms) { const end = Date.now() + ms; while (Date.now() < end) {} },
-};
-const __almd_process = {
-  exec(cmd, args) { const { execFileSync } = require("child_process"); try { return execFileSync(cmd, args, { encoding: "utf-8" }); } catch (e) { const msg = e.stderr ? String(e.stderr) : e.message; throw new Error(msg || "command failed"); } },
-  exec_status(cmd, args) { const { spawnSync } = require("child_process"); const r = spawnSync(cmd, args, { encoding: "utf-8" }); if (r.error) throw r.error; return { code: r.status ?? 1, stdout: r.stdout || "", stderr: r.stderr || "" }; },
-  exit(code) { __node_process.exit(code); },
-  stdin_lines() { return require("fs").readFileSync(0, "utf-8").split("\n").filter(l => l.length > 0); },
-};
-const __almd_math = {
-  min(a, b) { return Math.min(a, b); },
-  max(a, b) { return Math.max(a, b); },
-  abs(n) { return Math.abs(n); },
-  pow(base, exp) { return Math.pow(base, exp); },
-  pi() { return Math.PI; },
-  e() { return Math.E; },
-  sin(x) { return Math.sin(x); },
-  cos(x) { return Math.cos(x); },
-  tan(x) { return Math.tan(x); },
-  log(x) { return Math.log(x); },
-  exp(x) { return Math.exp(x); },
-  sqrt(x) { return Math.sqrt(x); },
-};
-const __almd_random = {
-  int(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; },
-  float() { return Math.random(); },
-  choice(xs) { return xs.length > 0 ? xs[Math.floor(Math.random() * xs.length)] : null; },
-  shuffle(xs) { const a = [...xs]; for (let i = a.length - 1; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); [a[i], a[j]] = [a[j], a[i]]; } return a; },
-};
-const __almd_regex = {
-  match_hdlm_qm_(pat, s) { return new RegExp(pat).test(s); },
-  full_match_hdlm_qm_(pat, s) { return new RegExp(`^(?:${pat})$`).test(s); },
-  find(pat, s) { const m = s.match(new RegExp(pat)); return m ? m[0] : null; },
-  find_all(pat, s) { const m = s.match(new RegExp(pat, 'g')); return m ? [...m] : []; },
-  replace(pat, s, rep) { return s.replace(new RegExp(pat, 'g'), rep); },
-  replace_first(pat, s, rep) { return s.replace(new RegExp(pat), rep); },
-  split(pat, s) { return s.split(new RegExp(pat)); },
-  captures(pat, s) { const m = s.match(new RegExp(pat)); return m && m.length > 1 ? m.slice(1) : null; },
-};
-const __almd_io = {
-  read_line() { const buf = Buffer.alloc(1024); let s = ""; while (true) { const n = require("fs").readSync(0, buf, 0, 1, null); if (n === 0) break; const ch = buf.toString("utf-8", 0, n); s += ch; if (ch === "\n") break; } return s.replace(/\r?\n$/, ""); },
-  print(s) { __node_process.stdout.write(s); },
-  read_all() { return require("fs").readFileSync(0, "utf-8"); },
-};
-const __almd_time = {
-  now() { return Math.floor(Date.now() / 1000); },
-  millis() { return Date.now(); },
-  sleep(ms) { const end = Date.now() + ms; while (Date.now() < end) {} },
-  _parts(ts) { const d = new Date(ts * 1000); return [d.getUTCFullYear(), d.getUTCMonth() + 1, d.getUTCDate(), d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds()]; },
-  year(ts) { return new Date(ts * 1000).getUTCFullYear(); },
-  month(ts) { return new Date(ts * 1000).getUTCMonth() + 1; },
-  day(ts) { return new Date(ts * 1000).getUTCDate(); },
-  hour(ts) { return new Date(ts * 1000).getUTCHours(); },
-  minute(ts) { return new Date(ts * 1000).getUTCMinutes(); },
-  second(ts) { return new Date(ts * 1000).getUTCSeconds(); },
-  weekday(ts) { const d = new Date(ts * 1000).getUTCDay(); return d === 0 ? 6 : d - 1; },
-  to_iso(ts) { const [y, m, d, h, mi, s] = __almd_time._parts(ts); return `${String(y).padStart(4,"0")}-${String(m).padStart(2,"0")}-${String(d).padStart(2,"0")}T${String(h).padStart(2,"0")}:${String(mi).padStart(2,"0")}:${String(s).padStart(2,"0")}Z`; },
-  from_parts(y, m, d, h, min, s) { return Math.floor(Date.UTC(y, m - 1, d, h, min, s) / 1000); },
-};
-const __almd_http = {
-  async serve(port, handler) { const http = require("http"); const server = http.createServer(async (req, res) => { let body = ""; req.on("data", (c) => { body += c; }); req.on("end", () => { const r = handler({ method: req.method, path: req.url, body, headers: req.headers || {} }); const headers = r.headers || {}; res.writeHead(r.status, headers); res.end(r.body); }); }); server.listen(port); },
-  response(status, body) { return { status, body, headers: { "content-type": "text/plain" } }; },
-  json(status, body) { return { status, body, headers: { "content-type": "application/json" } }; },
-  with_headers(status, body, headers) { const h = {}; if (headers instanceof Map) { headers.forEach((v, k) => { h[k] = v; }); } else { Object.assign(h, headers); } return { status, body, headers: h }; },
-  async get(url) { return new Promise((resolve, reject) => { const m = url.startsWith("https") ? require("https") : require("http"); m.get(url, (r) => { let d = ""; r.on("data", (c) => d += c); r.on("end", () => r.statusCode >= 400 ? reject(new Error("HTTP " + r.statusCode)) : resolve(d)); }).on("error", reject); }); },
-  async post(url, body) { return new Promise((resolve, reject) => { const u = new URL(url); const m = u.protocol === "https:" ? require("https") : require("http"); const req = m.request({ hostname: u.hostname, port: u.port, path: u.pathname + u.search, method: "POST", headers: { "content-type": "application/json", "content-length": Buffer.byteLength(body) } }, (r) => { let d = ""; r.on("data", (c) => d += c); r.on("end", () => r.statusCode >= 400 ? reject(new Error("HTTP " + r.statusCode)) : resolve(d)); }); req.on("error", reject); req.write(body); req.end(); }); },
-};
-function __bigop(op, a, b) {
+const HELPERS_JS: &str = r#"function __bigop(op, a, b) {
   if (typeof a === "bigint" || typeof b === "bigint") {
     const ba = typeof a === "bigint" ? a : BigInt(a);
     const bb = typeof b === "bigint" ? b : BigInt(b);
@@ -653,5 +763,62 @@ function __assert_throws(fn, expectedMsg) {
   try { fn(); throw new Error("Expected error but succeeded with: " + fn); }
   catch (e) { if (e instanceof Error && e.message === expectedMsg) return; throw e; }
 }
-// ---- End Runtime ----
 "#;
+
+// ──────────────────────────────── Registry ────────────────────────────────
+
+/// A runtime module with TS (Deno) and JS (Node.js) source variants.
+pub struct RuntimeModule {
+    pub name: &'static str,
+    pub ts_source: &'static str,
+    pub js_source: &'static str,
+}
+
+/// All stdlib runtime modules in emit order.
+pub static ALL_MODULES: &[RuntimeModule] = &[
+    RuntimeModule { name: "fs",      ts_source: MOD_FS_TS,      js_source: MOD_FS_JS },
+    RuntimeModule { name: "string",  ts_source: MOD_STRING_TS,  js_source: MOD_STRING_JS },
+    RuntimeModule { name: "list",    ts_source: MOD_LIST_TS,    js_source: MOD_LIST_JS },
+    RuntimeModule { name: "map",     ts_source: MOD_MAP_TS,     js_source: MOD_MAP_JS },
+    RuntimeModule { name: "int",     ts_source: MOD_INT_TS,     js_source: MOD_INT_JS },
+    RuntimeModule { name: "float",   ts_source: MOD_FLOAT_TS,   js_source: MOD_FLOAT_JS },
+    RuntimeModule { name: "path",    ts_source: MOD_PATH_TS,    js_source: MOD_PATH_JS },
+    RuntimeModule { name: "json",    ts_source: MOD_JSON_TS,    js_source: MOD_JSON_JS },
+    RuntimeModule { name: "env",     ts_source: MOD_ENV_TS,     js_source: MOD_ENV_JS },
+    RuntimeModule { name: "process", ts_source: MOD_PROCESS_TS, js_source: MOD_PROCESS_JS },
+    RuntimeModule { name: "math",    ts_source: MOD_MATH_TS,    js_source: MOD_MATH_JS },
+    RuntimeModule { name: "random",  ts_source: MOD_RANDOM_TS,  js_source: MOD_RANDOM_JS },
+    RuntimeModule { name: "regex",   ts_source: MOD_REGEX_TS,   js_source: MOD_REGEX_JS },
+    RuntimeModule { name: "io",      ts_source: MOD_IO_TS,      js_source: MOD_IO_JS },
+    RuntimeModule { name: "time",    ts_source: MOD_TIME_TS,    js_source: MOD_TIME_JS },
+    RuntimeModule { name: "http",    ts_source: MOD_HTTP_TS,    js_source: MOD_HTTP_JS },
+];
+
+/// Compose the full runtime string (backwards compatible with --target ts/js).
+pub fn full_runtime(js_mode: bool) -> String {
+    let mut out = String::with_capacity(if js_mode { 16384 } else { 20480 });
+    out.push_str(if js_mode { PREAMBLE_JS } else { PREAMBLE_TS });
+    for m in ALL_MODULES {
+        out.push_str(if js_mode { m.js_source } else { m.ts_source });
+    }
+    out.push_str(if js_mode { HELPERS_JS } else { HELPERS_TS });
+    out.push_str(EPILOGUE);
+    out
+}
+
+/// Get the source for a single stdlib module.
+pub fn get_module_source(name: &str, js_mode: bool) -> Option<&'static str> {
+    ALL_MODULES.iter().find(|m| m.name == name).map(|m| {
+        if js_mode { m.js_source } else { m.ts_source }
+    })
+}
+
+/// Get the helpers source (always needed).
+pub fn get_helpers_source(js_mode: bool) -> &'static str {
+    if js_mode { HELPERS_JS } else { HELPERS_TS }
+}
+
+/// Get the preamble (platform-specific setup code).
+pub fn get_preamble(js_mode: bool) -> &'static str {
+    if js_mode { PREAMBLE_JS } else { PREAMBLE_TS }
+}


### PR DESCRIPTION
## Summary

- **`--target npm`**: Compile Almide code into a publish-ready npm package with `almide build app.almd --target npm`
- **Runtime separation**: Split monolithic 600-line runtime into 16 individual ESM modules with compile-time tree-shaking
- **Clean exports**: Public functions exported as camelCase (`is_empty?` → `isEmpty`), with auto-generated `index.d.ts`
- **IIFE reduction**: Replace throw-IIFEs with `__throw()` helper, unwrap simple blocks
- **Clean `__almd_` prefix**: npm output uses `__string.contains()` instead of `__almd_string.contains()` (existing targets unchanged)

## Output example

```js
import { __almd_string as __string } from "./_runtime/string.js";

function pangram_hdlm_qm_(sentence) {
  return __string.contains(sentence, "a") && ...;
}

export { pangram_hdlm_qm_ as pangram };
```

```typescript
// index.d.ts
export declare function pangram(sentence: string): boolean;
```

## Test plan

- [x] 42/42 exercises pass on Rust target
- [x] 42/42 exercises pass on TS/Deno target
- [x] 42/42 exercises pass on JS/Node target
- [x] npm output tested with Node.js (pangram, roman-numerals)
- [x] Clean camelCase imports verified (`import { pangram } from "./index.js"`)
- [x] Tree-shaking verified (pangram only includes `_runtime/string.js`)