### PR TITLE
Fix generic variant unit constructors in TS/JS emitter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Verify the installation:
 
 ```bash
 almide --version
-# almide 0.4.0
+# almide 0.4.1
 ```
 
 ### Hello World

--- a/src/emit_ts/declarations.rs
+++ b/src/emit_ts/declarations.rs
@@ -3,7 +3,26 @@ use crate::emit_ts_runtime;
 use super::TsEmitter;
 
 impl TsEmitter {
+    /// Pre-collect generic variant unit constructors from declarations.
+    fn collect_generic_variant_info(&mut self, decls: &[Decl]) {
+        for decl in decls {
+            if let Decl::Type { ty: TypeExpr::Variant { cases }, generics: Some(gs), .. } = decl {
+                if !gs.is_empty() {
+                    for case in cases {
+                        if let VariantCase::Unit { name } = case {
+                            self.generic_variant_unit_ctors.insert(name.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     pub(crate) fn emit_program(&mut self, prog: &Program, modules: &[(String, Program)]) {
+        self.collect_generic_variant_info(&prog.decls);
+        for (_, mod_prog) in modules {
+            self.collect_generic_variant_info(&mod_prog.decls);
+        }
         self.out.push_str(&emit_ts_runtime::full_runtime(self.js_mode));
         self.out.push('\n');
 
@@ -171,11 +190,17 @@ impl TsEmitter {
                 format!("interface {}{} {{\n{}\n}}", name, generic_str, fs.join("\n"))
             }
             TypeExpr::Variant { cases } => {
+                let is_generic = matches!(generics, Some(gs) if !gs.is_empty());
                 let mut lines = vec![format!("// variant type {}", name)];
                 for case in cases {
                     match case {
                         VariantCase::Unit { name: cname } => {
-                            lines.push(format!("const {} = {{ tag: {} }};", cname, Self::json_string(cname)));
+                            if is_generic {
+                                // Generic unit constructors must be functions so they can be called: Nothing()
+                                lines.push(format!("function {}() {{ return {{ tag: {} }}; }}", cname, Self::json_string(cname)));
+                            } else {
+                                lines.push(format!("const {} = {{ tag: {} }};", cname, Self::json_string(cname)));
+                            }
                         }
                         VariantCase::Tuple { name: cname, fields } => {
                             let params: Vec<String> = fields.iter().enumerate()
@@ -313,6 +338,10 @@ impl TsEmitter {
     /// Emit user code for npm target: no inlined runtime, `export` for public functions,
     /// no entry point, no test blocks.
     pub(crate) fn emit_npm_program(&mut self, prog: &Program, modules: &[(String, Program)]) {
+        self.collect_generic_variant_info(&prog.decls);
+        for (_, mod_prog) in modules {
+            self.collect_generic_variant_info(&mod_prog.decls);
+        }
         // Register user modules
         for (mod_name, _) in modules {
             self.user_modules.push(mod_name.clone());

--- a/src/emit_ts/expressions.rs
+++ b/src/emit_ts/expressions.rs
@@ -44,7 +44,13 @@ impl TsEmitter {
             }
             Expr::Bool { value, .. } => format!("{}", value),
             Expr::Ident { name, .. } => Self::sanitize(name),
-            Expr::TypeName { name, .. } => name.clone(),
+            Expr::TypeName { name, .. } => {
+                if self.generic_variant_unit_ctors.contains(name) {
+                    format!("{}()", name)
+                } else {
+                    name.clone()
+                }
+            }
             Expr::Unit { .. } => "undefined".to_string(),
             Expr::None { .. } => "null".to_string(),
             Expr::Some { expr, .. } => self.gen_expr(expr),
@@ -334,7 +340,12 @@ impl TsEmitter {
             }
         }
 
-        let callee_str = self.gen_expr(callee);
+        // For generic unit constructors used as callees, use raw name to avoid double-call
+        let callee_str = match callee {
+            Expr::TypeName { name, .. } if self.generic_variant_unit_ctors.contains(name) => name.clone(),
+            Expr::Ident { name, .. } if self.generic_variant_unit_ctors.contains(name) => Self::sanitize(name),
+            _ => self.gen_expr(callee),
+        };
         // Special case: assert_eq(x, err(e))
         if callee_str == "assert_eq" && args.len() == 2 {
             if let Expr::Err { expr: err_expr, .. } = &args[1] {

--- a/src/emit_ts/mod.rs
+++ b/src/emit_ts/mod.rs
@@ -13,6 +13,8 @@ pub(crate) struct TsEmitter {
     pub(crate) user_modules: Vec<String>,
     /// Tracks which stdlib modules (`__almd_*`) are referenced during codegen.
     pub(crate) used_stdlib: RefCell<HashSet<String>>,
+    /// Generic variant unit constructors — need `()` when used as standalone expressions
+    pub(crate) generic_variant_unit_ctors: HashSet<String>,
 }
 
 impl TsEmitter {
@@ -23,6 +25,7 @@ impl TsEmitter {
             npm_mode: false,
             user_modules: Vec::new(),
             used_stdlib: RefCell::new(HashSet::new()),
+            generic_variant_unit_ctors: HashSet::new(),
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix CI failure: generic variant unit constructors (e.g. `Nothing`) were emitted as `const` objects in TS/JS, causing `Nothing()` calls to fail with "not a function"
- Now emitted as functions for generic enums: `function Nothing() { return { tag: "Nothing" }; }`
- Prevent double-call issue (`Nothing()()`) when unit ctors are used as callees

## Test plan
- [x] `generics_variant_test.almd` passes on JS/Node target
- [x] All Rust target exercises pass
- [x] No regressions