### PR TITLE
v0.4.2: Tuple destructuring and arity checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "almide"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -218,7 +218,7 @@ pub struct LambdaParam {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Stmt {
     Let { name: String, #[serde(rename = "type")] ty: Option<TypeExpr>, value: Expr, #[serde(skip)] span: Option<Span> },
-    LetDestructure { fields: Vec<String>, value: Expr, #[serde(skip)] span: Option<Span> },
+    LetDestructure { fields: Vec<String>, #[serde(default)] is_tuple: bool, value: Expr, #[serde(skip)] span: Option<Span> },
     Var { name: String, #[serde(rename = "type")] ty: Option<TypeExpr>, value: Expr, #[serde(skip)] span: Option<Span> },
     Assign { name: String, value: Expr, #[serde(skip)] span: Option<Span> },
     Guard { cond: Expr, else_: Expr, #[serde(skip)] span: Option<Span> },

--- a/src/check/expressions.rs
+++ b/src/check/expressions.rs
@@ -230,19 +230,9 @@ impl Checker {
                     }
                 };
                 if let Some(names) = var_tuple {
-                    // Tuple destructuring: define each name
-                    match &elem_ty {
-                        Ty::Tuple(tys) => {
-                            for (i, name) in names.iter().enumerate() {
-                                let ty = tys.get(i).cloned().unwrap_or(Ty::Unknown);
-                                self.env.define_var(name, ty);
-                            }
-                        }
-                        _ => {
-                            for name in names {
-                                self.env.define_var(name, Ty::Unknown);
-                            }
-                        }
+                    let tys = self.resolve_tuple_elements(&elem_ty, names.len(), format!("for ({}) in ...", names.join(", ")));
+                    for (name, ty) in names.iter().zip(tys) {
+                        self.env.define_var(name, ty);
                     }
                 } else {
                     self.env.define_var(var, elem_ty);

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -511,6 +511,26 @@ impl Checker {
         }
     }
 
+    /// Validate tuple arity and return element types.
+    /// Returns a Vec of types matching `expected` count.
+    /// Emits a diagnostic if the tuple has a different number of elements.
+    /// For non-tuple / Unknown types, returns `vec![Ty::Unknown; expected]` silently.
+    pub(crate) fn resolve_tuple_elements(&mut self, ty: &Ty, expected: usize, context: impl Into<String>) -> Vec<Ty> {
+        match ty {
+            Ty::Tuple(elements) => {
+                if elements.len() != expected {
+                    self.push_diagnostic(err(
+                        format!("tuple has {} elements but {} expected", elements.len(), expected),
+                        format!("The value has type {}", ty.display()),
+                        context,
+                    ));
+                }
+                (0..expected).map(|i| elements.get(i).cloned().unwrap_or(Ty::Unknown)).collect()
+            }
+            _ => vec![Ty::Unknown; expected],
+        }
+    }
+
     fn register_stdlib(&mut self) {
         for name in stdlib::builtin_effect_fns() {
             self.env.effect_fns.insert(name.to_string());

--- a/src/check/statements.rs
+++ b/src/check/statements.rs
@@ -55,34 +55,41 @@ impl Checker {
                 } else { vt };
                 self.env.define_var(name, dt);
             }
-            ast::Stmt::LetDestructure { fields, value, .. } => {
+            ast::Stmt::LetDestructure { fields, is_tuple, value, .. } => {
                 let vt = self.check_expr(value);
                 let resolved = self.env.resolve_named(&vt);
-                match &resolved {
-                    Ty::Record { fields: rec_fields } => {
-                        for fname in &**fields {
-                            let ft = rec_fields.iter().find(|(n, _)| n == fname)
-                                .map(|(_, t)| t.clone())
-                                .unwrap_or_else(|| {
-                                    let avail = rec_fields.iter().map(|(n, _)| n.as_str()).collect::<Vec<_>>().join(", ");
-                                    self.push_diagnostic(err(
-                                        format!("record has no field '{}'", fname),
-                                        format!("Available fields: {}", avail),
-                                        format!("let {{ {} }} = ...", fields.join(", ")),
-                                    ));
-                                    Ty::Unknown
-                                });
-                            self.env.define_var(fname, ft);
-                        }
+                if *is_tuple {
+                    let tys = self.resolve_tuple_elements(&resolved, fields.len(), format!("let ({}) = ...", fields.join(", ")));
+                    for (fname, ft) in fields.iter().zip(tys) {
+                        self.env.define_var(fname, ft);
                     }
-                    Ty::Unknown => { for f in fields { self.env.define_var(f, Ty::Unknown); } }
-                    _ => {
-                        self.push_diagnostic(err(
-                            format!("cannot destructure type {}", vt.display()),
-                            "Destructuring only works on record types",
-                            format!("let {{ {} }} = ...", fields.join(", ")),
-                        ));
-                        for f in fields { self.env.define_var(f, Ty::Unknown); }
+                } else {
+                    match &resolved {
+                        Ty::Record { fields: rec_fields } => {
+                            for fname in &**fields {
+                                let ft = rec_fields.iter().find(|(n, _)| n == fname)
+                                    .map(|(_, t)| t.clone())
+                                    .unwrap_or_else(|| {
+                                        let avail = rec_fields.iter().map(|(n, _)| n.as_str()).collect::<Vec<_>>().join(", ");
+                                        self.push_diagnostic(err(
+                                            format!("record has no field '{}'", fname),
+                                            format!("Available fields: {}", avail),
+                                            format!("let {{ {} }} = ...", fields.join(", ")),
+                                        ));
+                                        Ty::Unknown
+                                    });
+                                self.env.define_var(fname, ft);
+                            }
+                        }
+                        Ty::Unknown => { for f in fields { self.env.define_var(f, Ty::Unknown); } }
+                        _ => {
+                            self.push_diagnostic(err(
+                                format!("cannot destructure type {}", vt.display()),
+                                "Destructuring only works on record types",
+                                format!("let {{ {} }} = ...", fields.join(", ")),
+                            ));
+                            for f in fields { self.env.define_var(f, Ty::Unknown); }
+                        }
                     }
                 }
             }
@@ -144,10 +151,7 @@ impl Checker {
                 }
             }
             ast::Pattern::Tuple { elements } => {
-                let tys = match subject_ty {
-                    Ty::Tuple(ts) => ts.clone(),
-                    _ => vec![Ty::Unknown; elements.len()],
-                };
+                let tys = self.resolve_tuple_elements(subject_ty, elements.len(), "tuple pattern");
                 for (pat, ty) in elements.iter().zip(tys.iter()) {
                     self.check_pattern(pat, ty);
                 }

--- a/src/emit_ts/blocks.rs
+++ b/src/emit_ts/blocks.rs
@@ -228,8 +228,12 @@ impl TsEmitter {
                 // Use `var` to allow Almide's let-shadowing (const/let disallow re-declaration)
                 format!("var {} = {};", Self::sanitize(name), self.gen_expr(value))
             }
-            Stmt::LetDestructure { fields, value, .. } => {
-                format!("var {{ {} }} = {};", fields.join(", "), self.gen_expr(value))
+            Stmt::LetDestructure { fields, is_tuple, value, .. } => {
+                if *is_tuple {
+                    format!("var [{}] = {};", fields.join(", "), self.gen_expr(value))
+                } else {
+                    format!("var {{ {} }} = {};", fields.join(", "), self.gen_expr(value))
+                }
             }
             Stmt::Var { name, value, .. } => {
                 format!("let {} = {};", Self::sanitize(name), self.gen_expr(value))

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -555,11 +555,17 @@ fn format_stmt(out: &mut String, stmt: &Stmt, depth: usize) {
             out.push_str(" = ");
             format_expr(out, value, depth);
         }
-        Stmt::LetDestructure { fields, value, .. } => {
+        Stmt::LetDestructure { fields, is_tuple, value, .. } => {
             out.push_str(&ind);
-            out.push_str("let { ");
-            out.push_str(&fields.join(", "));
-            out.push_str(" } = ");
+            if *is_tuple {
+                out.push_str("let (");
+                out.push_str(&fields.join(", "));
+                out.push_str(") = ");
+            } else {
+                out.push_str("let { ");
+                out.push_str(&fields.join(", "));
+                out.push_str(" } = ");
+            }
             format_expr(out, value, depth);
         }
         Stmt::Var { name, ty, value, .. } => {

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -44,7 +44,24 @@ impl Parser {
             self.expect(TokenType::Eq)?;
             self.skip_newlines();
             let value = self.parse_expr()?;
-            return Ok(Stmt::LetDestructure { fields, value, span: Some(span) });
+            return Ok(Stmt::LetDestructure { fields, is_tuple: false, value, span: Some(span) });
+        }
+
+        if self.check(TokenType::LParen) {
+            self.advance();
+            let mut fields = Vec::new();
+            while !self.check(TokenType::RParen) {
+                fields.push(self.expect_ident()?);
+                if self.check(TokenType::Comma) {
+                    self.advance();
+                    self.skip_newlines();
+                }
+            }
+            self.expect(TokenType::RParen)?;
+            self.expect(TokenType::Eq)?;
+            self.skip_newlines();
+            let value = self.parse_expr()?;
+            return Ok(Stmt::LetDestructure { fields, is_tuple: true, value, span: Some(span) });
         }
 
         // Detect `let mut` (Rust style) — hint to use `var` instead


### PR DESCRIPTION
## Summary
- Add `let (a, b) = expr` tuple destructuring across the full pipeline (parser, type checker, Rust/TS emitters, formatter)
- Consolidate tuple element count validation into a single `resolve_tuple_elements()` helper, used by let-destructure, for-loop, and match pattern checks
- Emit `var [a, b]` for TS target, `let (a, b)` for Rust target

## Test plan
- [x] All exercises pass (`for f in exercises/*/*.almd; do almide run "$f"; done`)
- [x] nbody test produces identical output on both Rust and TS targets
- [x] Tuple arity mismatch correctly reports diagnostic errors