### PR TITLE
v0.4.3: clap CLI, record destructuring fix, codegen refactor

### DIFF
--- a/.codopsyrc.json
+++ b/.codopsyrc.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "no-println": false,
+    "max-complexity": { "severity": "warning", "max": 30 },
+    "max-cognitive-complexity": { "severity": "warning", "max": 30 },
+    "max-lines": { "severity": "warning", "max": 300 },
+    "max-depth": { "severity": "info", "max": 6 },
+    "max-params": { "severity": "info", "max": 8 }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ almide run app.almd              # Compile + execute
 almide build app.almd -o app     # Build binary
 almide build app.almd --target wasm  # Build WASM
 almide test                      # Run tests/ directory
+almide test --run "pattern"      # Filter tests by name
 almide check app.almd            # Type check only
 almide fmt app.almd              # Format source
 almide clean                     # Clear dependency cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,10 +6,119 @@ version = 4
 name = "almide"
 version = "0.4.2"
 dependencies = [
+ "clap",
  "semver",
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -22,6 +131,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "proc-macro2"
@@ -91,6 +206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +227,27 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "almide"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 semver = "1"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -210,6 +210,8 @@ pub struct MatchArm {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LambdaParam {
     pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tuple_names: Option<Vec<String>>,
     #[serde(rename = "type")]
     pub ty: Option<TypeExpr>,
 }
@@ -218,7 +220,7 @@ pub struct LambdaParam {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Stmt {
     Let { name: String, #[serde(rename = "type")] ty: Option<TypeExpr>, value: Expr, #[serde(skip)] span: Option<Span> },
-    LetDestructure { fields: Vec<String>, #[serde(default)] is_tuple: bool, value: Expr, #[serde(skip)] span: Option<Span> },
+    LetDestructure { pattern: Pattern, value: Expr, #[serde(skip)] span: Option<Span> },
     Var { name: String, #[serde(rename = "type")] ty: Option<TypeExpr>, value: Expr, #[serde(skip)] span: Option<Span> },
     Assign { name: String, value: Expr, #[serde(skip)] span: Option<Span> },
     Guard { cond: Expr, else_: Expr, #[serde(skip)] span: Option<Span> },

--- a/src/check/expressions.rs
+++ b/src/check/expressions.rs
@@ -245,9 +245,18 @@ impl Checker {
             ast::Expr::Lambda { params, body, .. } => {
                 self.env.push_scope();
                 let pts: Vec<Ty> = params.iter().map(|p| {
-                    let ty = p.ty.as_ref().map(|te| self.resolve_type_expr(te)).unwrap_or(Ty::Unknown);
-                    self.env.define_var(&p.name, ty.clone());
-                    ty
+                    if let Some(names) = &p.tuple_names {
+                        let tuple_ty = p.ty.as_ref().map(|te| self.resolve_type_expr(te)).unwrap_or(Ty::Unknown);
+                        let tys = self.resolve_tuple_elements(&tuple_ty, names.len(), format!("fn({}) => ...", p.name));
+                        for (name, ty) in names.iter().zip(tys.iter()) {
+                            self.env.define_var(name, ty.clone());
+                        }
+                        Ty::Tuple(tys)
+                    } else {
+                        let ty = p.ty.as_ref().map(|te| self.resolve_type_expr(te)).unwrap_or(Ty::Unknown);
+                        self.env.define_var(&p.name, ty.clone());
+                        ty
+                    }
                 }).collect();
                 let ret = self.check_expr(body);
                 self.env.pop_scope();

--- a/src/check/statements.rs
+++ b/src/check/statements.rs
@@ -55,43 +55,10 @@ impl Checker {
                 } else { vt };
                 self.env.define_var(name, dt);
             }
-            ast::Stmt::LetDestructure { fields, is_tuple, value, .. } => {
+            ast::Stmt::LetDestructure { pattern, value, .. } => {
                 let vt = self.check_expr(value);
                 let resolved = self.env.resolve_named(&vt);
-                if *is_tuple {
-                    let tys = self.resolve_tuple_elements(&resolved, fields.len(), format!("let ({}) = ...", fields.join(", ")));
-                    for (fname, ft) in fields.iter().zip(tys) {
-                        self.env.define_var(fname, ft);
-                    }
-                } else {
-                    match &resolved {
-                        Ty::Record { fields: rec_fields } => {
-                            for fname in &**fields {
-                                let ft = rec_fields.iter().find(|(n, _)| n == fname)
-                                    .map(|(_, t)| t.clone())
-                                    .unwrap_or_else(|| {
-                                        let avail = rec_fields.iter().map(|(n, _)| n.as_str()).collect::<Vec<_>>().join(", ");
-                                        self.push_diagnostic(err(
-                                            format!("record has no field '{}'", fname),
-                                            format!("Available fields: {}", avail),
-                                            format!("let {{ {} }} = ...", fields.join(", ")),
-                                        ));
-                                        Ty::Unknown
-                                    });
-                                self.env.define_var(fname, ft);
-                            }
-                        }
-                        Ty::Unknown => { for f in fields { self.env.define_var(f, Ty::Unknown); } }
-                        _ => {
-                            self.push_diagnostic(err(
-                                format!("cannot destructure type {}", vt.display()),
-                                "Destructuring only works on record types",
-                                format!("let {{ {} }} = ...", fields.join(", ")),
-                            ));
-                            for f in fields { self.env.define_var(f, Ty::Unknown); }
-                        }
-                    }
-                }
+                self.check_pattern(pattern, &resolved);
             }
             ast::Stmt::Assign { name, value, .. } => {
                 let vt = self.check_expr(value);
@@ -156,10 +123,27 @@ impl Checker {
                     self.check_pattern(pat, ty);
                 }
             }
-            ast::Pattern::RecordPattern { fields, .. } => {
+            ast::Pattern::RecordPattern { name, fields } => {
+                // Look up field types from variant constructor or subject record type
+                let field_type_map: Vec<(String, Ty)> = if !name.is_empty() {
+                    if let Some((_, case)) = self.env.constructors.get(name).cloned() {
+                        if let VariantPayload::Record(rec_fields) = case.payload {
+                            rec_fields
+                        } else { vec![] }
+                    } else { vec![] }
+                } else if let Ty::Record { fields: rec_fields } = subject_ty {
+                    rec_fields.clone()
+                } else { vec![] };
                 for field in fields {
-                    if let Some(ref pat) = field.pattern { self.check_pattern(pat, &Ty::Unknown); }
-                    else { self.env.define_var(&field.name, Ty::Unknown); }
+                    let ft = field_type_map.iter()
+                        .find(|(n, _)| n == &field.name)
+                        .map(|(_, t)| t.clone())
+                        .unwrap_or(Ty::Unknown);
+                    if let Some(ref pat) = field.pattern {
+                        self.check_pattern(pat, &ft);
+                    } else {
+                        self.env.define_var(&field.name, ft);
+                    }
                 }
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -146,26 +146,13 @@ pub fn cmd_test(file: &str, no_check: bool, run_filter: Option<&str>) {
     eprintln!("\nAll {} test file(s) passed", test_files.len());
 }
 
-pub fn cmd_build(args: &[String], no_check: bool) {
-    let file = if args.len() >= 3 && !args[2].starts_with('-') {
-        args[2].clone()
-    } else if std::path::Path::new("almide.toml").exists() && std::path::Path::new("src/main.almd").exists() {
-        "src/main.almd".to_string()
-    } else {
-        eprintln!("No file specified and no almide.toml found.");
-        eprintln!("Run 'almide init' to create a project, or specify a file: almide build <file.almd>");
-        std::process::exit(1);
-    };
-    let build_target = args.iter()
-        .position(|a| a == "--target")
-        .and_then(|i| args.get(i + 1))
-        .map(|s| s.as_str());
-
-    let is_npm = matches!(build_target, Some("npm"));
-    let is_wasm = matches!(build_target, Some("wasm" | "wasm32" | "wasi"));
+pub fn cmd_build(file: &str, output: Option<&str>, target: Option<&str>, release: bool, no_check: bool) {
+    let is_npm = matches!(target, Some("npm"));
+    let is_wasm = matches!(target, Some("wasm" | "wasm32" | "wasi"));
 
     if is_npm {
-        cmd_build_npm(&file, &args, no_check);
+        let out_dir = output.unwrap_or("dist");
+        cmd_build_npm(file, out_dir, no_check);
         return;
     }
 
@@ -181,28 +168,22 @@ pub fn cmd_build(args: &[String], no_check: bool) {
     } else {
         file.strip_suffix(".almd").unwrap_or("a.out").to_string()
     };
-    let output = args.iter()
-        .position(|a| a == "-o")
-        .and_then(|i| args.get(i + 1))
-        .map(|s| s.to_string())
-        .unwrap_or(default_output);
+    let output = output.unwrap_or(&default_output);
 
     let emit_options = emit_rust::EmitOptions { no_thread_wrap: is_wasm };
     let wasm_target = if is_wasm { Some("wasm") } else { None };
-    let rs_code = compile_with_options(&file, no_check, &emit_options, wasm_target);
+    let rs_code = compile_with_options(file, no_check, &emit_options, wasm_target);
 
-    let tmp_rs = format!("{}.rs", output.strip_suffix(".wasm").unwrap_or(&output));
+    let tmp_rs = format!("{}.rs", output.strip_suffix(".wasm").unwrap_or(output));
     if let Err(e) = std::fs::write(&tmp_rs, &rs_code) {
         eprintln!("Failed to write {}: {}", tmp_rs, e);
         std::process::exit(1);
     }
 
-    let is_release = args.iter().any(|a| a == "--release");
-
     let mut rustc_cmd = Command::new(&find_rustc());
     rustc_cmd.arg(&tmp_rs)
         .arg("-o")
-        .arg(&output)
+        .arg(output)
         .arg("-C").arg("overflow-checks=no")
         .arg("--edition").arg("2021");
 
@@ -210,7 +191,7 @@ pub fn cmd_build(args: &[String], no_check: bool) {
         rustc_cmd.arg("--target").arg("wasm32-wasip1")
             .arg("-C").arg("opt-level=s")
             .arg("-C").arg("lto=yes");
-    } else if is_release {
+    } else if release {
         rustc_cmd.arg("-C").arg("opt-level=2");
     }
 
@@ -228,7 +209,7 @@ pub fn cmd_build(args: &[String], no_check: bool) {
     eprintln!("Built {}", output);
 }
 
-fn cmd_build_npm(file: &str, args: &[String], no_check: bool) {
+fn cmd_build_npm(file: &str, out_dir: &str, no_check: bool) {
     let mut program = parse_file(file);
     let source_text = std::fs::read_to_string(file).unwrap_or_default();
 
@@ -288,15 +269,8 @@ fn cmd_build_npm(file: &str, args: &[String], no_check: bool) {
 
     let output = emit_ts::emit_npm_package(&program, &legacy_modules, &config);
 
-    // Output directory
-    let out_dir = args.iter()
-        .position(|a| a == "-o")
-        .and_then(|i| args.get(i + 1))
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| "dist".to_string());
-
     // Write files
-    let out_path = std::path::Path::new(&out_dir);
+    let out_path = std::path::Path::new(out_dir);
     std::fs::create_dir_all(out_path).unwrap_or_else(|e| {
         eprintln!("Failed to create {}: {}", out_dir, e);
         std::process::exit(1);
@@ -366,7 +340,7 @@ pub fn cmd_emit(file: &str, target: &str, emit_ast: bool, no_check: bool) {
             if let Some(a) = alias {
                 Some((a.clone(), path.join(".")))
             } else if path.len() > 1 && path.first().map(|s| s.as_str()) != Some("self") {
-                let last = path.last().unwrap().clone();
+                let last = path.last().expect("path.len() > 1 checked above").clone();
                 Some((last, path.join(".")))
             } else {
                 None

--- a/src/emit_rust/blocks.rs
+++ b/src/emit_rust/blocks.rs
@@ -254,8 +254,19 @@ impl Emitter {
                 }
                 format!("let {} = {};", name, val)
             }
-            Stmt::LetDestructure { fields, value, .. } => {
-                format!("let ({}) = {};", fields.join(", "), self.gen_expr(value))
+            Stmt::LetDestructure { pattern, value, .. } => {
+                // Record destructure: emit field-access bindings (Rust has no anonymous record destructuring)
+                if let Pattern::RecordPattern { fields, .. } = pattern {
+                    let val = self.gen_expr(value);
+                    let tmp = "__ds";
+                    let mut lines = vec![format!("let {} = {};", tmp, val)];
+                    for f in fields {
+                        lines.push(format!("let {} = {}.{}.clone();", f.name, tmp, f.name));
+                    }
+                    lines.join("\n    ")
+                } else {
+                    format!("let {} = {};", self.gen_pattern(pattern), self.gen_expr(value))
+                }
             }
             Stmt::Var { name, value, .. } => {
                 format!("let mut {} = {};", name, self.gen_expr(value))

--- a/src/emit_rust/calls.rs
+++ b/src/emit_rust/calls.rs
@@ -213,337 +213,20 @@ impl Emitter {
             return call;
         }
         match module {
-            "fs" => match func {
-                "read_text" => format!("almide_rt_fs_read_text(&*{})?", args_str[0]),
-                "write" => format!("almide_rt_fs_write(&*{}, &*{})?", args_str[0], args_str[1]),
-                "write_bytes" => format!("almide_rt_fs_write_bytes(&*{}, &{})?", args_str[0], args_str[1]),
-                "read_bytes" => format!("almide_rt_fs_read_bytes(&*{})?", args_str[0]),
-                "exists?" | "exists_hdlm_qm_" => format!("almide_rt_fs_exists(&*{})", args_str[0]),
-                "mkdir_p" => format!("almide_rt_fs_mkdir_p(&*{})?", args_str[0]),
-                "append" => format!("almide_rt_fs_append(&*{}, &*{})?", args_str[0], args_str[1]),
-                "read_lines" => format!("almide_rt_fs_read_lines(&*{})?", args_str[0]),
-                "remove" => format!("almide_rt_fs_remove(&*{})?", args_str[0]),
-                "list_dir" => format!("almide_rt_fs_list_dir(&*{})?", args_str[0]),
-                "is_dir?" | "is_dir_hdlm_qm_" => format!("almide_rt_fs_is_dir(&*{})", args_str[0]),
-                "is_file?" | "is_file_hdlm_qm_" => format!("almide_rt_fs_is_file(&*{})", args_str[0]),
-                "copy" => format!("almide_rt_fs_copy(&*{}, &*{})?", args_str[0], args_str[1]),
-                "rename" => format!("almide_rt_fs_rename(&*{}, &*{})?", args_str[0], args_str[1]),
-                "walk" => format!("almide_rt_fs_walk(&*{})?", args_str[0]),
-                "stat" => format!("almide_rt_fs_stat(&*{})?", args_str[0]),
-                _ => { eprintln!("internal error: no Rust codegen for fs.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
-            "string" => match func {
-                "trim" => format!("almide_rt_string_trim(&*{})", args_str[0]),
-                "split" => format!("almide_rt_string_split(&*{}, &*{})", args_str[0], args_str[1]),
-                "join" => format!("almide_rt_string_join(&{}, &*{})", args_str[0], args_str[1]),
-                "len" => format!("almide_rt_string_len(&*{})", args_str[0]),
-                "contains" | "contains?" | "contains_hdlm_qm_" => format!("almide_rt_string_contains(&*{}, &*{})", args_str[0], args_str[1]),
-                "starts_with?" | "starts_with_hdlm_qm_" | "starts_with" => format!("almide_rt_string_starts_with(&*{}, &*{})", args_str[0], args_str[1]),
-                "ends_with?" | "ends_with_hdlm_qm_" | "ends_with" => format!("almide_rt_string_ends_with(&*{}, &*{})", args_str[0], args_str[1]),
-                "slice" => {
-                    if args_str.len() == 3 {
-                        format!("almide_rt_string_slice(&*{}, {}, Some({}))", args_str[0], args_str[1], args_str[2])
-                    } else {
-                        format!("almide_rt_string_slice(&*{}, {}, None)", args_str[0], args_str[1])
-                    }
-                }
-                "pad_left" => format!("almide_rt_string_pad_left(&*{}, {})", args_str[0], args_str[1]),
-                "to_bytes" => format!("almide_rt_string_to_bytes(&*{})", args_str[0]),
-                "to_upper" => format!("almide_rt_string_to_upper(&*{})", args_str[0]),
-                "to_lower" => format!("almide_rt_string_to_lower(&*{})", args_str[0]),
-                "to_int" => format!("almide_rt_string_to_int(&*{})?", args_str[0]),
-                "replace" => format!("almide_rt_string_replace(&*{}, &*{}, &*{})", args_str[0], args_str[1], args_str[2]),
-                "char_at" => format!("almide_rt_string_char_at(&*{}, {})", args_str[0], args_str[1]),
-                "lines" => format!("almide_rt_string_lines(&*{})", args_str[0]),
-                "chars" => format!("almide_rt_string_chars(&*{})", args_str[0]),
-                "index_of" => format!("almide_rt_string_index_of(&*{}, &*{})", args_str[0], args_str[1]),
-                "repeat" => format!("almide_rt_string_repeat(&*{}, {})", args_str[0], args_str[1]),
-                "from_bytes" => format!("almide_rt_string_from_bytes(&{{ let __bytes: Vec<i64> = {}; __bytes }})", args_str[0]),
-                "is_digit?" | "is_digit_hdlm_qm_" => format!("almide_rt_string_is_digit(&*{})", args_str[0]),
-                "is_alpha?" | "is_alpha_hdlm_qm_" => format!("almide_rt_string_is_alpha(&*{})", args_str[0]),
-                "is_alphanumeric?" | "is_alphanumeric_hdlm_qm_" => format!("almide_rt_string_is_alphanumeric(&*{})", args_str[0]),
-                "is_whitespace?" | "is_whitespace_hdlm_qm_" => format!("almide_rt_string_is_whitespace(&*{})", args_str[0]),
-                "pad_right" => format!("almide_rt_string_pad_right({}, {}, &*{})", args_str[0], args_str[1], args_str[2]),
-                "trim_start" => format!("almide_rt_string_trim_start(&*{})", args_str[0]),
-                "trim_end" => format!("almide_rt_string_trim_end(&*{})", args_str[0]),
-                "count" => format!("almide_rt_string_count(&*{}, &*{})", args_str[0], args_str[1]),
-                "is_empty?" | "is_empty_hdlm_qm_" => format!("almide_rt_string_is_empty(&*{})", args_str[0]),
-                "reverse" => format!("almide_rt_string_reverse(&*{})", args_str[0]),
-                "strip_prefix" => format!("almide_rt_string_strip_prefix(&*{}, &*{})", args_str[0], args_str[1]),
-                "strip_suffix" => format!("almide_rt_string_strip_suffix(&*{}, &*{})", args_str[0], args_str[1]),
-                "replace_first" => format!("almide_rt_string_replace_first(&*{}, &*{}, &*{})", args_str[0], args_str[1], args_str[2]),
-                "last_index_of" => format!("almide_rt_string_last_index_of(&*{}, &*{})", args_str[0], args_str[1]),
-                "to_float" => format!("almide_rt_string_to_float(&*{})?", args_str[0]),
-                _ => { eprintln!("internal error: no Rust codegen for string.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
-            "list" => {
-                match func {
-                    "len" => format!("almide_rt_list_len(&{})", args_str[0]),
-                    "get" => format!("almide_rt_list_get(&{}, {})", args_str[0], args_str[1]),
-                    "get_or" => format!("almide_rt_list_get_or(&{}, {}, {})", args_str[0], args_str[1], args_str[2]),
-                    "sort" => format!("almide_rt_list_sort(&{})", args_str[0]),
-                    "reverse" => format!("almide_rt_list_reverse(&{})", args_str[0]),
-                    "any" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        format!("almide_rt_list_any(&{}, |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
-                    }
-                    "all" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        format!("almide_rt_list_all(&{}, |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
-                    }
-                    "contains" => format!("almide_rt_list_contains(&{}, &{})", args_str[0], args_str[1]),
-                    "each" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        format!("almide_rt_list_each(&{}, |{}| {{ {} ; }})", args_str[0], names[0], body)
-                    }
-                    "map" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        if self.in_effect && body.contains("?") {
-                            format!("almide_rt_list_map_effect(({}).clone(), |{}| -> Result<_, String> {{ Ok({{ {} }}) }})?", args_str[0], names[0], body)
-                        } else {
-                            format!("almide_rt_list_map(({}).clone(), |{}| {{ {} }})", args_str[0], names[0], body)
-                        }
-                    }
-                    "filter" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        format!("almide_rt_list_filter(({}).clone(), |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
-                    }
-                    "find" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        format!("almide_rt_list_find(({}).clone(), |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
-                    }
-                    "fold" => {
-                        let (names, body) = self.inline_lambda(&args[2], 2);
-                        let init = &args_str[1];
-                        if self.in_effect && body.contains("?") {
-                            format!("almide_rt_list_fold_effect(({}).clone(), {}, |{}, {}| -> Result<_, String> {{ Ok({{ {} }}) }})?", args_str[0], init, names[0], names[1], body)
-                        } else {
-                            let acc_typed = if init.starts_with("Ok(") || init.starts_with("Err(") {
-                                format!("{}: Result<_, String>", names[0])
-                            } else {
-                                names[0].clone()
-                            };
-                            format!("almide_rt_list_fold(({}).clone(), {}, |{}, {}| {{ {} }})", args_str[0], init, acc_typed, names[1], body)
-                        }
-                    }
-                    "enumerate" => format!("almide_rt_list_enumerate(({}).clone())", args_str[0]),
-                    "zip" => format!("almide_rt_list_zip(({}).clone(), ({}).clone())", args_str[0], args_str[1]),
-                    "flatten" => format!("almide_rt_list_flatten(({}).clone())", args_str[0]),
-                    "take" => format!("almide_rt_list_take(({}).clone(), {})", args_str[0], args_str[1]),
-                    "drop" => format!("almide_rt_list_drop(({}).clone(), {})", args_str[0], args_str[1]),
-                    "sort_by" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        format!("almide_rt_list_sort_by(({}).clone(), |{}| {{ {} }})", args_str[0], names[0], body)
-                    }
-                    "unique" => format!("almide_rt_list_unique(&{})", args_str[0]),
-                    "index_of" => format!("almide_rt_list_index_of(&{}, &{})", args_str[0], args_str[1]),
-                    "last" => format!("almide_rt_list_last(&{})", args_str[0]),
-                    "chunk" => format!("almide_rt_list_chunk(&{}, {})", args_str[0], args_str[1]),
-                    "sum" => format!("almide_rt_list_sum(&{})", args_str[0]),
-                    "product" => format!("almide_rt_list_product(&{})", args_str[0]),
-                    "first" => format!("almide_rt_list_first(&{})", args_str[0]),
-                    "is_empty?" | "is_empty_hdlm_qm_" => format!("almide_rt_list_is_empty(&{})", args_str[0]),
-                    "flat_map" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        if self.in_effect && body.contains("?") {
-                            format!("almide_rt_list_flat_map_effect(({}).clone(), |{}| -> Result<Vec<_>, String> {{ Ok({{ {} }}) }})?", args_str[0], names[0], body)
-                        } else {
-                            format!("almide_rt_list_flat_map(({}).clone(), |{}| {{ {} }})", args_str[0], names[0], body)
-                        }
-                    }
-                    "min" => format!("almide_rt_list_min(&{})", args_str[0]),
-                    "max" => format!("almide_rt_list_max(&{})", args_str[0]),
-                    "join" => format!("almide_rt_list_join(&{}, &*{})", args_str[0], args_str[1]),
-                    "filter_map" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        format!("almide_rt_list_filter_map(({}).clone(), |{}| {{ {} }})", args_str[0], names[0], body)
-                    }
-                    "take_while" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        format!("almide_rt_list_take_while(({}).clone(), |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
-                    }
-                    "drop_while" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        format!("almide_rt_list_drop_while(({}).clone(), |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
-                    }
-                    "count" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        format!("almide_rt_list_count(&{}, |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
-                    }
-                    "partition" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        format!("almide_rt_list_partition(({}).clone(), |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
-                    }
-                    "reduce" => {
-                        let (names, body) = self.inline_lambda(&args[1], 2);
-                        format!("almide_rt_list_reduce(({}).clone(), |{}, {}| {{ {} }})", args_str[0], names[0], names[1], body)
-                    }
-                    "group_by" => {
-                        let (names, body) = self.inline_lambda(&args[1], 1);
-                        format!("almide_rt_list_group_by(({}).clone(), |{}| {{ {} }})", args_str[0], names[0], body)
-                    }
-                    _ => { eprintln!("internal error: no Rust codegen for list.{}() — this is a compiler bug", func); std::process::exit(70); },
-                }
-            },
-            "map" => match func {
-                "new" => "almide_rt_map_new()".to_string(),
-                "get" => format!("almide_rt_map_get(&{}, &{})", args_str[0], args_str[1]),
-                "get_or" => format!("almide_rt_map_get_or(&{}, &{}, {})", args_str[0], args_str[1], args_str[2]),
-                "set" => format!("almide_rt_map_set(&{}, {}, {})", args_str[0], args_str[1], args_str[2]),
-                "contains" => format!("almide_rt_map_contains(&{}, &{})", args_str[0], args_str[1]),
-                "remove" => format!("almide_rt_map_remove(&{}, &{})", args_str[0], args_str[1]),
-                "keys" => format!("almide_rt_map_keys(&{})", args_str[0]),
-                "values" => format!("almide_rt_map_values(&{})", args_str[0]),
-                "len" => format!("almide_rt_map_len(&{})", args_str[0]),
-                "entries" => format!("almide_rt_map_entries(&{})", args_str[0]),
-                "from_list" => {
-                    let (names, body) = self.inline_lambda(&args[1], 1);
-                    format!("almide_rt_map_from_list(({}).clone(), |{}| {{ {} }})", args_str[0], names[0], body)
-                }
-                "merge" => format!("almide_rt_map_merge(&{}, &{})", args_str[0], args_str[1]),
-                "is_empty?" | "is_empty_hdlm_qm_" => format!("almide_rt_map_is_empty(&{})", args_str[0]),
-                "map_values" => {
-                    let (names, body) = self.inline_lambda(&args[1], 1);
-                    format!("almide_rt_map_map_values(&{}, |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
-                }
-                "filter" => {
-                    let (names, body) = self.inline_lambda(&args[1], 2);
-                    format!("almide_rt_map_filter(&{}, |{}, {}| {{ let {} = {}.clone(); let {} = {}.clone(); {} }})", args_str[0], names[0], names[1], names[0], names[0], names[1], names[1], body)
-                }
-                "from_entries" => format!("almide_rt_map_from_entries(({}).clone())", args_str[0]),
-                _ => { eprintln!("internal error: no Rust codegen for map.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
-            "int" => match func {
-                "to_hex" => format!("almide_rt_int_to_hex({})", args_str[0]),
-                "to_string" => format!("almide_rt_int_to_string({})", args_str[0]),
-                "parse" => format!("almide_rt_int_parse(&*{})", args_str[0]),
-                "parse_hex" => format!("almide_rt_int_parse_hex(&*{})", args_str[0]),
-                "abs" => format!("almide_rt_int_abs({})", args_str[0]),
-                "min" => format!("almide_rt_int_min({}, {})", args_str[0], args_str[1]),
-                "max" => format!("almide_rt_int_max({}, {})", args_str[0], args_str[1]),
-                // bitwise operations
-                "band" => format!("almide_rt_int_band({}, {})", args_str[0], args_str[1]),
-                "bor" => format!("almide_rt_int_bor({}, {})", args_str[0], args_str[1]),
-                "bxor" => format!("almide_rt_int_bxor({}, {})", args_str[0], args_str[1]),
-                "bshl" => format!("almide_rt_int_bshl({}, {})", args_str[0], args_str[1]),
-                "bshr" => format!("almide_rt_int_bshr({}, {})", args_str[0], args_str[1]),
-                "bnot" => format!("almide_rt_int_bnot({})", args_str[0]),
-                // wrapping arithmetic
-                "wrap_add" => format!("almide_rt_int_wrap_add({}, {}, {})", args_str[0], args_str[1], args_str[2]),
-                "wrap_mul" => format!("almide_rt_int_wrap_mul({}, {}, {})", args_str[0], args_str[1], args_str[2]),
-                "rotate_right" => format!("almide_rt_int_rotate_right({}, {}, {})", args_str[0], args_str[1], args_str[2]),
-                "rotate_left" => format!("almide_rt_int_rotate_left({}, {}, {})", args_str[0], args_str[1], args_str[2]),
-                "to_u32" => format!("almide_rt_int_to_u32({})", args_str[0]),
-                "to_u8" => format!("almide_rt_int_to_u8({})", args_str[0]),
-                "clamp" => format!("almide_rt_int_clamp({}, {}, {})", args_str[0], args_str[1], args_str[2]),
-                _ => { eprintln!("internal error: no Rust codegen for int.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
-            "float" => match func {
-                "to_string" => format!("almide_rt_float_to_string({})", args_str[0]),
-                "to_int" => format!("almide_rt_float_to_int({})", args_str[0]),
-                "round" => format!("almide_rt_float_round({})", args_str[0]),
-                "floor" => format!("almide_rt_float_floor({})", args_str[0]),
-                "ceil" => format!("almide_rt_float_ceil({})", args_str[0]),
-                "abs" => format!("almide_rt_float_abs({})", args_str[0]),
-                "sqrt" => format!("almide_rt_float_sqrt({})", args_str[0]),
-                "parse" => format!("almide_rt_float_parse(&*{})?", args_str[0]),
-                "from_int" => format!("almide_rt_float_from_int({})", args_str[0]),
-                "min" => format!("almide_rt_float_min({}, {})", args_str[0], args_str[1]),
-                "max" => format!("almide_rt_float_max({}, {})", args_str[0], args_str[1]),
-                "clamp" => format!("almide_rt_float_clamp({}, {}, {})", args_str[0], args_str[1], args_str[2]),
-                _ => { eprintln!("internal error: no Rust codegen for float.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
-            "env" => match func {
-                "unix_timestamp" => "almide_rt_env_unix_timestamp()".to_string(),
-                "args" => "almide_rt_env_args()".to_string(),
-                "get" => format!("almide_rt_env_get(&*{})", args_str[0]),
-                "set" => format!("almide_rt_env_set(&*{}, &*{})", args_str[0], args_str[1]),
-                "cwd" => "almide_rt_env_cwd()?".to_string(),
-                "millis" => "almide_rt_env_millis()".to_string(),
-                "sleep_ms" => format!("almide_rt_env_sleep_ms({})", args_str[0]),
-                _ => { eprintln!("internal error: no Rust codegen for env.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
-            "process" => match func {
-                "exec" => format!("almide_rt_process_exec(&*{}, &{{ let __a: Vec<String> = {}; __a }})", args_str[0], args_str[1]),
-                "exit" => format!("almide_rt_process_exit({})", args_str[0]),
-                "stdin_lines" => "almide_rt_process_stdin_lines()?".to_string(),
-                "exec_status" => format!("almide_rt_process_exec_status(&*{}, &{{ let __a: Vec<String> = {}; __a }})?", args_str[0], args_str[1]),
-                _ => { eprintln!("internal error: no Rust codegen for process.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
-            "io" => match func {
-                "read_line" => "almide_rt_io_read_line()?".to_string(),
-                "print" => format!("almide_rt_io_print(&*{})?", args_str[0]),
-                "read_all" => "almide_rt_io_read_all()?".to_string(),
-                _ => { eprintln!("internal error: no Rust codegen for io.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
-            "json" => match func {
-                "parse" => format!("almide_json_parse(&{})?", args_str[0]),
-                "stringify" => format!("almide_json_stringify(&{})", args_str[0]),
-                "get" => format!("almide_json_get(&{}, &{})", args_str[0], args_str[1]),
-                "get_string" => format!("almide_json_get_string(&{}, &{})", args_str[0], args_str[1]),
-                "get_int" => format!("almide_json_get_int(&{}, &{})", args_str[0], args_str[1]),
-                "get_bool" => format!("almide_json_get_bool(&{}, &{})", args_str[0], args_str[1]),
-                "get_array" => format!("almide_json_get_array(&{}, &{})", args_str[0], args_str[1]),
-                "keys" => format!("almide_json_keys(&{})", args_str[0]),
-                "to_string" => format!("almide_json_to_string(&{})", args_str[0]),
-                "to_int" => format!("almide_json_to_int(&{})", args_str[0]),
-                "from_string" => format!("JStr({})", args_str[0]),
-                "from_int" => format!("JInt({})", args_str[0]),
-                "from_bool" => format!("JBool({})", args_str[0]),
-                "null" => "JNull".to_string(),
-                "array" => format!("JArray({})", args_str[0]),
-                "from_map" => format!("JObject({})", args_str[0]),
-                "get_float" => format!("almide_json_get_float(&{}, &{})", args_str[0], args_str[1]),
-                "from_float" => format!("almide_json_from_float({})", args_str[0]),
-                "stringify_pretty" => format!("almide_json_stringify_pretty(&{})", args_str[0]),
-                _ => { eprintln!("internal error: no Rust codegen for json.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
-            "http" => match func {
-                "serve" => {
-                    let (names, body) = self.inline_lambda(&args[1], 1);
-                    // serve returns Result<(), String> which matches effect fn main's return type
-                    format!("{{ almide_http_serve({}, |{}| -> Result<AlmideHttpResponse, String> {{ Ok({{ {} }}) }})?; Ok(()) }}", args_str[0], names[0], body)
-                }
-                "response" => format!("AlmideHttpResponse::new({}, {}.to_string())", args_str[0], args_str[1]),
-                "json" => format!("AlmideHttpResponse::json({}, {}.to_string())", args_str[0], args_str[1]),
-                "with_headers" => format!("AlmideHttpResponse::with_headers({}, {}.to_string(), {})", args_str[0], args_str[1], args_str[2]),
-                "get" => format!("almide_http_get(&{})?", args_str[0]),
-                "post" => format!("almide_http_post(&{}, &{})?", args_str[0], args_str[1]),
-                _ => { eprintln!("internal error: no Rust codegen for http.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
-            "math" => match func {
-                "min" => format!("almide_rt_math_min({}, {})", args_str[0], args_str[1]),
-                "max" => format!("almide_rt_math_max({}, {})", args_str[0], args_str[1]),
-                "abs" => format!("almide_rt_math_abs({})", args_str[0]),
-                "pow" => format!("almide_rt_math_pow({}, {})", args_str[0], args_str[1]),
-                "pi" => "almide_rt_math_pi()".to_string(),
-                "e" => "almide_rt_math_e()".to_string(),
-                "sin" => format!("almide_rt_math_sin({} as f64)", args_str[0]),
-                "cos" => format!("almide_rt_math_cos({} as f64)", args_str[0]),
-                "tan" => format!("almide_rt_math_tan({} as f64)", args_str[0]),
-                "log" => format!("almide_rt_math_log({} as f64)", args_str[0]),
-                "exp" => format!("almide_rt_math_exp({} as f64)", args_str[0]),
-                "sqrt" => format!("almide_rt_math_sqrt({} as f64)", args_str[0]),
-                _ => { eprintln!("internal error: no Rust codegen for math.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
-            "random" => match func {
-                "int" => format!("almide_rt_random_int({}, {})?", args_str[0], args_str[1]),
-                "float" => "almide_rt_random_float()?".to_string(),
-                "choice" => format!("almide_rt_random_choice(&{})?", args_str[0]),
-                "shuffle" => format!("almide_rt_random_shuffle(({}).clone())?", args_str[0]),
-                _ => { eprintln!("internal error: no Rust codegen for random.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
-            "regex" => match func {
-                "match?" | "match_hdlm_qm_" => format!("almide_regex_is_match(&{}, &{})", args_str[0], args_str[1]),
-                "full_match?" | "full_match_hdlm_qm_" => format!("almide_regex_full_match(&{}, &{})", args_str[0], args_str[1]),
-                "find" => format!("almide_regex_find(&{}, &{})", args_str[0], args_str[1]),
-                "find_all" => format!("almide_regex_find_all(&{}, &{})", args_str[0], args_str[1]),
-                "replace" => format!("almide_regex_replace(&{}, &{}, &{})", args_str[0], args_str[1], args_str[2]),
-                "replace_first" => format!("almide_regex_replace_first(&{}, &{}, &{})", args_str[0], args_str[1], args_str[2]),
-                "split" => format!("almide_regex_split(&{}, &{})", args_str[0], args_str[1]),
-                "captures" => format!("almide_regex_captures(&{}, &{})", args_str[0], args_str[1]),
-                _ => { eprintln!("internal error: no Rust codegen for regex.{}() — this is a compiler bug", func); std::process::exit(70); },
-            },
+            "fs" => self.gen_fs_call(func, &args_str),
+            "string" => self.gen_string_call(func, &args_str),
+            "list" => self.gen_list_call(func, args, &args_str),
+            "map" => self.gen_map_call(func, args, &args_str),
+            "int" => self.gen_int_call(func, &args_str),
+            "float" => self.gen_float_call(func, &args_str),
+            "env" => self.gen_env_call(func, &args_str),
+            "process" => self.gen_process_call(func, &args_str),
+            "io" => self.gen_io_call(func, &args_str),
+            "json" => self.gen_json_call(func, &args_str),
+            "http" => self.gen_http_call(func, args, &args_str),
+            "math" => self.gen_math_call(func, &args_str),
+            "random" => self.gen_random_call(func, &args_str),
+            "regex" => self.gen_regex_call(func, &args_str),
             _ => {
                 let resolved = self.module_aliases.get(module)
                     .cloned()
@@ -557,6 +240,377 @@ impl Emitter {
                     call
                 }
             }
+        }
+    }
+
+    fn gen_fs_call(&self, func: &str, args_str: &[String]) -> String {
+        match func {
+            "read_text" => format!("almide_rt_fs_read_text(&*{})?", args_str[0]),
+            "write" => format!("almide_rt_fs_write(&*{}, &*{})?", args_str[0], args_str[1]),
+            "write_bytes" => format!("almide_rt_fs_write_bytes(&*{}, &{})?", args_str[0], args_str[1]),
+            "read_bytes" => format!("almide_rt_fs_read_bytes(&*{})?", args_str[0]),
+            "exists?" | "exists_hdlm_qm_" => format!("almide_rt_fs_exists(&*{})", args_str[0]),
+            "mkdir_p" => format!("almide_rt_fs_mkdir_p(&*{})?", args_str[0]),
+            "append" => format!("almide_rt_fs_append(&*{}, &*{})?", args_str[0], args_str[1]),
+            "read_lines" => format!("almide_rt_fs_read_lines(&*{})?", args_str[0]),
+            "remove" => format!("almide_rt_fs_remove(&*{})?", args_str[0]),
+            "list_dir" => format!("almide_rt_fs_list_dir(&*{})?", args_str[0]),
+            "is_dir?" | "is_dir_hdlm_qm_" => format!("almide_rt_fs_is_dir(&*{})", args_str[0]),
+            "is_file?" | "is_file_hdlm_qm_" => format!("almide_rt_fs_is_file(&*{})", args_str[0]),
+            "copy" => format!("almide_rt_fs_copy(&*{}, &*{})?", args_str[0], args_str[1]),
+            "rename" => format!("almide_rt_fs_rename(&*{}, &*{})?", args_str[0], args_str[1]),
+            "walk" => format!("almide_rt_fs_walk(&*{})?", args_str[0]),
+            "stat" => format!("almide_rt_fs_stat(&*{})?", args_str[0]),
+            _ => { eprintln!("internal error: no Rust codegen for fs.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_string_call(&self, func: &str, args_str: &[String]) -> String {
+        match func {
+            "trim" => format!("almide_rt_string_trim(&*{})", args_str[0]),
+            "split" => format!("almide_rt_string_split(&*{}, &*{})", args_str[0], args_str[1]),
+            "join" => format!("almide_rt_string_join(&{}, &*{})", args_str[0], args_str[1]),
+            "len" => format!("almide_rt_string_len(&*{})", args_str[0]),
+            "contains" | "contains?" | "contains_hdlm_qm_" => format!("almide_rt_string_contains(&*{}, &*{})", args_str[0], args_str[1]),
+            "starts_with?" | "starts_with_hdlm_qm_" | "starts_with" => format!("almide_rt_string_starts_with(&*{}, &*{})", args_str[0], args_str[1]),
+            "ends_with?" | "ends_with_hdlm_qm_" | "ends_with" => format!("almide_rt_string_ends_with(&*{}, &*{})", args_str[0], args_str[1]),
+            "slice" => {
+                if args_str.len() == 3 {
+                    format!("almide_rt_string_slice(&*{}, {}, Some({}))", args_str[0], args_str[1], args_str[2])
+                } else {
+                    format!("almide_rt_string_slice(&*{}, {}, None)", args_str[0], args_str[1])
+                }
+            }
+            "pad_left" => format!("almide_rt_string_pad_left(&*{}, {})", args_str[0], args_str[1]),
+            "to_bytes" => format!("almide_rt_string_to_bytes(&*{})", args_str[0]),
+            "to_upper" => format!("almide_rt_string_to_upper(&*{})", args_str[0]),
+            "to_lower" => format!("almide_rt_string_to_lower(&*{})", args_str[0]),
+            "to_int" => format!("almide_rt_string_to_int(&*{})?", args_str[0]),
+            "replace" => format!("almide_rt_string_replace(&*{}, &*{}, &*{})", args_str[0], args_str[1], args_str[2]),
+            "char_at" => format!("almide_rt_string_char_at(&*{}, {})", args_str[0], args_str[1]),
+            "lines" => format!("almide_rt_string_lines(&*{})", args_str[0]),
+            "chars" => format!("almide_rt_string_chars(&*{})", args_str[0]),
+            "index_of" => format!("almide_rt_string_index_of(&*{}, &*{})", args_str[0], args_str[1]),
+            "repeat" => format!("almide_rt_string_repeat(&*{}, {})", args_str[0], args_str[1]),
+            "from_bytes" => format!("almide_rt_string_from_bytes(&{{ let __bytes: Vec<i64> = {}; __bytes }})", args_str[0]),
+            "is_digit?" | "is_digit_hdlm_qm_" => format!("almide_rt_string_is_digit(&*{})", args_str[0]),
+            "is_alpha?" | "is_alpha_hdlm_qm_" => format!("almide_rt_string_is_alpha(&*{})", args_str[0]),
+            "is_alphanumeric?" | "is_alphanumeric_hdlm_qm_" => format!("almide_rt_string_is_alphanumeric(&*{})", args_str[0]),
+            "is_whitespace?" | "is_whitespace_hdlm_qm_" => format!("almide_rt_string_is_whitespace(&*{})", args_str[0]),
+            "pad_right" => format!("almide_rt_string_pad_right({}, {}, &*{})", args_str[0], args_str[1], args_str[2]),
+            "trim_start" => format!("almide_rt_string_trim_start(&*{})", args_str[0]),
+            "trim_end" => format!("almide_rt_string_trim_end(&*{})", args_str[0]),
+            "count" => format!("almide_rt_string_count(&*{}, &*{})", args_str[0], args_str[1]),
+            "is_empty?" | "is_empty_hdlm_qm_" => format!("almide_rt_string_is_empty(&*{})", args_str[0]),
+            "reverse" => format!("almide_rt_string_reverse(&*{})", args_str[0]),
+            "strip_prefix" => format!("almide_rt_string_strip_prefix(&*{}, &*{})", args_str[0], args_str[1]),
+            "strip_suffix" => format!("almide_rt_string_strip_suffix(&*{}, &*{})", args_str[0], args_str[1]),
+            "replace_first" => format!("almide_rt_string_replace_first(&*{}, &*{}, &*{})", args_str[0], args_str[1], args_str[2]),
+            "last_index_of" => format!("almide_rt_string_last_index_of(&*{}, &*{})", args_str[0], args_str[1]),
+            "to_float" => format!("almide_rt_string_to_float(&*{})?", args_str[0]),
+            _ => { eprintln!("internal error: no Rust codegen for string.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_list_call(&self, func: &str, args: &[Expr], args_str: &[String]) -> String {
+        match func {
+            "len" => format!("almide_rt_list_len(&{})", args_str[0]),
+            "get" => format!("almide_rt_list_get(&{}, {})", args_str[0], args_str[1]),
+            "get_or" => format!("almide_rt_list_get_or(&{}, {}, {})", args_str[0], args_str[1], args_str[2]),
+            "sort" => format!("almide_rt_list_sort(&{})", args_str[0]),
+            "reverse" => format!("almide_rt_list_reverse(&{})", args_str[0]),
+            "any" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_list_any(&{}, |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
+            }
+            "all" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_list_all(&{}, |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
+            }
+            "contains" => format!("almide_rt_list_contains(&{}, &{})", args_str[0], args_str[1]),
+            "each" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_list_each(&{}, |{}| {{ {} ; }})", args_str[0], names[0], body)
+            }
+            "map" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                if self.in_effect && body.contains("?") {
+                    format!("almide_rt_list_map_effect(({}).clone(), |{}| -> Result<_, String> {{ Ok({{ {} }}) }})?", args_str[0], names[0], body)
+                } else {
+                    format!("almide_rt_list_map(({}).clone(), |{}| {{ {} }})", args_str[0], names[0], body)
+                }
+            }
+            "filter" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_list_filter(({}).clone(), |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
+            }
+            "find" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_list_find(({}).clone(), |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
+            }
+            "fold" => {
+                let (names, body) = self.inline_lambda(&args[2], 2);
+                let init = &args_str[1];
+                if self.in_effect && body.contains("?") {
+                    format!("almide_rt_list_fold_effect(({}).clone(), {}, |{}, {}| -> Result<_, String> {{ Ok({{ {} }}) }})?", args_str[0], init, names[0], names[1], body)
+                } else {
+                    let acc_typed = if init.starts_with("Ok(") || init.starts_with("Err(") {
+                        format!("{}: Result<_, String>", names[0])
+                    } else {
+                        names[0].clone()
+                    };
+                    format!("almide_rt_list_fold(({}).clone(), {}, |{}, {}| {{ {} }})", args_str[0], init, acc_typed, names[1], body)
+                }
+            }
+            "enumerate" => format!("almide_rt_list_enumerate(({}).clone())", args_str[0]),
+            "zip" => format!("almide_rt_list_zip(({}).clone(), ({}).clone())", args_str[0], args_str[1]),
+            "flatten" => format!("almide_rt_list_flatten(({}).clone())", args_str[0]),
+            "take" => format!("almide_rt_list_take(({}).clone(), {})", args_str[0], args_str[1]),
+            "drop" => format!("almide_rt_list_drop(({}).clone(), {})", args_str[0], args_str[1]),
+            "sort_by" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_list_sort_by(({}).clone(), |{}| {{ {} }})", args_str[0], names[0], body)
+            }
+            "unique" => format!("almide_rt_list_unique(&{})", args_str[0]),
+            "index_of" => format!("almide_rt_list_index_of(&{}, &{})", args_str[0], args_str[1]),
+            "last" => format!("almide_rt_list_last(&{})", args_str[0]),
+            "chunk" => format!("almide_rt_list_chunk(&{}, {})", args_str[0], args_str[1]),
+            "sum" => format!("almide_rt_list_sum(&{})", args_str[0]),
+            "product" => format!("almide_rt_list_product(&{})", args_str[0]),
+            "first" => format!("almide_rt_list_first(&{})", args_str[0]),
+            "is_empty?" | "is_empty_hdlm_qm_" => format!("almide_rt_list_is_empty(&{})", args_str[0]),
+            "flat_map" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                if self.in_effect && body.contains("?") {
+                    format!("almide_rt_list_flat_map_effect(({}).clone(), |{}| -> Result<Vec<_>, String> {{ Ok({{ {} }}) }})?", args_str[0], names[0], body)
+                } else {
+                    format!("almide_rt_list_flat_map(({}).clone(), |{}| {{ {} }})", args_str[0], names[0], body)
+                }
+            }
+            "min" => format!("almide_rt_list_min(&{})", args_str[0]),
+            "max" => format!("almide_rt_list_max(&{})", args_str[0]),
+            "join" => format!("almide_rt_list_join(&{}, &*{})", args_str[0], args_str[1]),
+            "filter_map" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_list_filter_map(({}).clone(), |{}| {{ {} }})", args_str[0], names[0], body)
+            }
+            "take_while" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_list_take_while(({}).clone(), |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
+            }
+            "drop_while" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_list_drop_while(({}).clone(), |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
+            }
+            "count" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_list_count(&{}, |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
+            }
+            "partition" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_list_partition(({}).clone(), |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
+            }
+            "reduce" => {
+                let (names, body) = self.inline_lambda(&args[1], 2);
+                format!("almide_rt_list_reduce(({}).clone(), |{}, {}| {{ {} }})", args_str[0], names[0], names[1], body)
+            }
+            "group_by" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_list_group_by(({}).clone(), |{}| {{ {} }})", args_str[0], names[0], body)
+            }
+            _ => { eprintln!("internal error: no Rust codegen for list.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_map_call(&self, func: &str, args: &[Expr], args_str: &[String]) -> String {
+        match func {
+            "new" => "almide_rt_map_new()".to_string(),
+            "get" => format!("almide_rt_map_get(&{}, &{})", args_str[0], args_str[1]),
+            "get_or" => format!("almide_rt_map_get_or(&{}, &{}, {})", args_str[0], args_str[1], args_str[2]),
+            "set" => format!("almide_rt_map_set(&{}, {}, {})", args_str[0], args_str[1], args_str[2]),
+            "contains" => format!("almide_rt_map_contains(&{}, &{})", args_str[0], args_str[1]),
+            "remove" => format!("almide_rt_map_remove(&{}, &{})", args_str[0], args_str[1]),
+            "keys" => format!("almide_rt_map_keys(&{})", args_str[0]),
+            "values" => format!("almide_rt_map_values(&{})", args_str[0]),
+            "len" => format!("almide_rt_map_len(&{})", args_str[0]),
+            "entries" => format!("almide_rt_map_entries(&{})", args_str[0]),
+            "from_list" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_map_from_list(({}).clone(), |{}| {{ {} }})", args_str[0], names[0], body)
+            }
+            "merge" => format!("almide_rt_map_merge(&{}, &{})", args_str[0], args_str[1]),
+            "is_empty?" | "is_empty_hdlm_qm_" => format!("almide_rt_map_is_empty(&{})", args_str[0]),
+            "map_values" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                format!("almide_rt_map_map_values(&{}, |{}| {{ let {} = {}.clone(); {} }})", args_str[0], names[0], names[0], names[0], body)
+            }
+            "filter" => {
+                let (names, body) = self.inline_lambda(&args[1], 2);
+                format!("almide_rt_map_filter(&{}, |{}, {}| {{ let {} = {}.clone(); let {} = {}.clone(); {} }})", args_str[0], names[0], names[1], names[0], names[0], names[1], names[1], body)
+            }
+            "from_entries" => format!("almide_rt_map_from_entries(({}).clone())", args_str[0]),
+            _ => { eprintln!("internal error: no Rust codegen for map.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_int_call(&self, func: &str, args_str: &[String]) -> String {
+        match func {
+            "to_hex" => format!("almide_rt_int_to_hex({})", args_str[0]),
+            "to_string" => format!("almide_rt_int_to_string({})", args_str[0]),
+            "parse" => format!("almide_rt_int_parse(&*{})", args_str[0]),
+            "parse_hex" => format!("almide_rt_int_parse_hex(&*{})", args_str[0]),
+            "abs" => format!("almide_rt_int_abs({})", args_str[0]),
+            "min" => format!("almide_rt_int_min({}, {})", args_str[0], args_str[1]),
+            "max" => format!("almide_rt_int_max({}, {})", args_str[0], args_str[1]),
+            // bitwise operations
+            "band" => format!("almide_rt_int_band({}, {})", args_str[0], args_str[1]),
+            "bor" => format!("almide_rt_int_bor({}, {})", args_str[0], args_str[1]),
+            "bxor" => format!("almide_rt_int_bxor({}, {})", args_str[0], args_str[1]),
+            "bshl" => format!("almide_rt_int_bshl({}, {})", args_str[0], args_str[1]),
+            "bshr" => format!("almide_rt_int_bshr({}, {})", args_str[0], args_str[1]),
+            "bnot" => format!("almide_rt_int_bnot({})", args_str[0]),
+            // wrapping arithmetic
+            "wrap_add" => format!("almide_rt_int_wrap_add({}, {}, {})", args_str[0], args_str[1], args_str[2]),
+            "wrap_mul" => format!("almide_rt_int_wrap_mul({}, {}, {})", args_str[0], args_str[1], args_str[2]),
+            "rotate_right" => format!("almide_rt_int_rotate_right({}, {}, {})", args_str[0], args_str[1], args_str[2]),
+            "rotate_left" => format!("almide_rt_int_rotate_left({}, {}, {})", args_str[0], args_str[1], args_str[2]),
+            "to_u32" => format!("almide_rt_int_to_u32({})", args_str[0]),
+            "to_u8" => format!("almide_rt_int_to_u8({})", args_str[0]),
+            "clamp" => format!("almide_rt_int_clamp({}, {}, {})", args_str[0], args_str[1], args_str[2]),
+            _ => { eprintln!("internal error: no Rust codegen for int.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_float_call(&self, func: &str, args_str: &[String]) -> String {
+        match func {
+            "to_string" => format!("almide_rt_float_to_string({})", args_str[0]),
+            "to_int" => format!("almide_rt_float_to_int({})", args_str[0]),
+            "round" => format!("almide_rt_float_round({})", args_str[0]),
+            "floor" => format!("almide_rt_float_floor({})", args_str[0]),
+            "ceil" => format!("almide_rt_float_ceil({})", args_str[0]),
+            "abs" => format!("almide_rt_float_abs({})", args_str[0]),
+            "sqrt" => format!("almide_rt_float_sqrt({})", args_str[0]),
+            "parse" => format!("almide_rt_float_parse(&*{})?", args_str[0]),
+            "from_int" => format!("almide_rt_float_from_int({})", args_str[0]),
+            "min" => format!("almide_rt_float_min({}, {})", args_str[0], args_str[1]),
+            "max" => format!("almide_rt_float_max({}, {})", args_str[0], args_str[1]),
+            "clamp" => format!("almide_rt_float_clamp({}, {}, {})", args_str[0], args_str[1], args_str[2]),
+            _ => { eprintln!("internal error: no Rust codegen for float.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_env_call(&self, func: &str, args_str: &[String]) -> String {
+        match func {
+            "unix_timestamp" => "almide_rt_env_unix_timestamp()".to_string(),
+            "args" => "almide_rt_env_args()".to_string(),
+            "get" => format!("almide_rt_env_get(&*{})", args_str[0]),
+            "set" => format!("almide_rt_env_set(&*{}, &*{})", args_str[0], args_str[1]),
+            "cwd" => "almide_rt_env_cwd()?".to_string(),
+            "millis" => "almide_rt_env_millis()".to_string(),
+            "sleep_ms" => format!("almide_rt_env_sleep_ms({})", args_str[0]),
+            _ => { eprintln!("internal error: no Rust codegen for env.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_process_call(&self, func: &str, args_str: &[String]) -> String {
+        match func {
+            "exec" => format!("almide_rt_process_exec(&*{}, &{{ let __a: Vec<String> = {}; __a }})", args_str[0], args_str[1]),
+            "exit" => format!("almide_rt_process_exit({})", args_str[0]),
+            "stdin_lines" => "almide_rt_process_stdin_lines()?".to_string(),
+            "exec_status" => format!("almide_rt_process_exec_status(&*{}, &{{ let __a: Vec<String> = {}; __a }})?", args_str[0], args_str[1]),
+            _ => { eprintln!("internal error: no Rust codegen for process.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_io_call(&self, func: &str, args_str: &[String]) -> String {
+        match func {
+            "read_line" => "almide_rt_io_read_line()?".to_string(),
+            "print" => format!("almide_rt_io_print(&*{})?", args_str[0]),
+            "read_all" => "almide_rt_io_read_all()?".to_string(),
+            _ => { eprintln!("internal error: no Rust codegen for io.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_json_call(&self, func: &str, args_str: &[String]) -> String {
+        match func {
+            "parse" => format!("almide_json_parse(&{})?", args_str[0]),
+            "stringify" => format!("almide_json_stringify(&{})", args_str[0]),
+            "get" => format!("almide_json_get(&{}, &{})", args_str[0], args_str[1]),
+            "get_string" => format!("almide_json_get_string(&{}, &{})", args_str[0], args_str[1]),
+            "get_int" => format!("almide_json_get_int(&{}, &{})", args_str[0], args_str[1]),
+            "get_bool" => format!("almide_json_get_bool(&{}, &{})", args_str[0], args_str[1]),
+            "get_array" => format!("almide_json_get_array(&{}, &{})", args_str[0], args_str[1]),
+            "keys" => format!("almide_json_keys(&{})", args_str[0]),
+            "to_string" => format!("almide_json_to_string(&{})", args_str[0]),
+            "to_int" => format!("almide_json_to_int(&{})", args_str[0]),
+            "from_string" => format!("JStr({})", args_str[0]),
+            "from_int" => format!("JInt({})", args_str[0]),
+            "from_bool" => format!("JBool({})", args_str[0]),
+            "null" => "JNull".to_string(),
+            "array" => format!("JArray({})", args_str[0]),
+            "from_map" => format!("JObject({})", args_str[0]),
+            "get_float" => format!("almide_json_get_float(&{}, &{})", args_str[0], args_str[1]),
+            "from_float" => format!("almide_json_from_float({})", args_str[0]),
+            "stringify_pretty" => format!("almide_json_stringify_pretty(&{})", args_str[0]),
+            _ => { eprintln!("internal error: no Rust codegen for json.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_http_call(&self, func: &str, args: &[Expr], args_str: &[String]) -> String {
+        match func {
+            "serve" => {
+                let (names, body) = self.inline_lambda(&args[1], 1);
+                // serve returns Result<(), String> which matches effect fn main's return type
+                format!("{{ almide_http_serve({}, |{}| -> Result<AlmideHttpResponse, String> {{ Ok({{ {} }}) }})?; Ok(()) }}", args_str[0], names[0], body)
+            }
+            "response" => format!("AlmideHttpResponse::new({}, {}.to_string())", args_str[0], args_str[1]),
+            "json" => format!("AlmideHttpResponse::json({}, {}.to_string())", args_str[0], args_str[1]),
+            "with_headers" => format!("AlmideHttpResponse::with_headers({}, {}.to_string(), {})", args_str[0], args_str[1], args_str[2]),
+            "get" => format!("almide_http_get(&{})?", args_str[0]),
+            "post" => format!("almide_http_post(&{}, &{})?", args_str[0], args_str[1]),
+            _ => { eprintln!("internal error: no Rust codegen for http.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_math_call(&self, func: &str, args_str: &[String]) -> String {
+        match func {
+            "min" => format!("almide_rt_math_min({}, {})", args_str[0], args_str[1]),
+            "max" => format!("almide_rt_math_max({}, {})", args_str[0], args_str[1]),
+            "abs" => format!("almide_rt_math_abs({})", args_str[0]),
+            "pow" => format!("almide_rt_math_pow({}, {})", args_str[0], args_str[1]),
+            "pi" => "almide_rt_math_pi()".to_string(),
+            "e" => "almide_rt_math_e()".to_string(),
+            "sin" => format!("almide_rt_math_sin({} as f64)", args_str[0]),
+            "cos" => format!("almide_rt_math_cos({} as f64)", args_str[0]),
+            "tan" => format!("almide_rt_math_tan({} as f64)", args_str[0]),
+            "log" => format!("almide_rt_math_log({} as f64)", args_str[0]),
+            "exp" => format!("almide_rt_math_exp({} as f64)", args_str[0]),
+            "sqrt" => format!("almide_rt_math_sqrt({} as f64)", args_str[0]),
+            _ => { eprintln!("internal error: no Rust codegen for math.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_random_call(&self, func: &str, args_str: &[String]) -> String {
+        match func {
+            "int" => format!("almide_rt_random_int({}, {})?", args_str[0], args_str[1]),
+            "float" => "almide_rt_random_float()?".to_string(),
+            "choice" => format!("almide_rt_random_choice(&{})?", args_str[0]),
+            "shuffle" => format!("almide_rt_random_shuffle(({}).clone())?", args_str[0]),
+            _ => { eprintln!("internal error: no Rust codegen for random.{}() — this is a compiler bug", func); std::process::exit(70); },
+        }
+    }
+
+    fn gen_regex_call(&self, func: &str, args_str: &[String]) -> String {
+        match func {
+            "match?" | "match_hdlm_qm_" => format!("almide_regex_is_match(&{}, &{})", args_str[0], args_str[1]),
+            "full_match?" | "full_match_hdlm_qm_" => format!("almide_regex_full_match(&{}, &{})", args_str[0], args_str[1]),
+            "find" => format!("almide_regex_find(&{}, &{})", args_str[0], args_str[1]),
+            "find_all" => format!("almide_regex_find_all(&{}, &{})", args_str[0], args_str[1]),
+            "replace" => format!("almide_regex_replace(&{}, &{}, &{})", args_str[0], args_str[1], args_str[2]),
+            "replace_first" => format!("almide_regex_replace_first(&{}, &{}, &{})", args_str[0], args_str[1], args_str[2]),
+            "split" => format!("almide_regex_split(&{}, &{})", args_str[0], args_str[1]),
+            "captures" => format!("almide_regex_captures(&{}, &{})", args_str[0], args_str[1]),
+            _ => { eprintln!("internal error: no Rust codegen for regex.{}() — this is a compiler bug", func); std::process::exit(70); },
         }
     }
 }

--- a/src/emit_rust/calls.rs
+++ b/src/emit_rust/calls.rs
@@ -10,7 +10,13 @@ impl Emitter {
     /// Extract lambda parameter names and body code from a lambda expression or function reference.
     pub(crate) fn inline_lambda(&self, lambda_arg: &Expr, arity: usize) -> (Vec<String>, String) {
         if let Expr::Lambda { params, body, .. } = lambda_arg {
-            let names: Vec<String> = params.iter().map(|p| p.name.clone()).collect();
+            let names: Vec<String> = params.iter().map(|p| {
+                if let Some(tuple_names) = &p.tuple_names {
+                    format!("({})", tuple_names.join(", "))
+                } else {
+                    p.name.clone()
+                }
+            }).collect();
             let body_str = self.gen_expr(body);
             (names, body_str)
         } else {

--- a/src/emit_rust/expressions.rs
+++ b/src/emit_rust/expressions.rs
@@ -167,7 +167,13 @@ impl Emitter {
             }
 
             Expr::Lambda { params, body, .. } => {
-                let ps: Vec<String> = params.iter().map(|p| p.name.clone()).collect();
+                let ps: Vec<String> = params.iter().map(|p| {
+                    if let Some(names) = &p.tuple_names {
+                        format!("({})", names.join(", "))
+                    } else {
+                        p.name.clone()
+                    }
+                }).collect();
                 let b = self.gen_expr(body);
                 format!("|{}| {{ {} }}", ps.join(", "), b)
             }

--- a/src/emit_rust/mod.rs
+++ b/src/emit_rust/mod.rs
@@ -98,10 +98,6 @@ impl Emitter {
     }
 }
 
-pub fn emit(program: &Program, modules: &[(String, Program, Option<crate::project::PkgId>, bool)]) -> String {
-    emit_with_options(program, modules, &EmitOptions::default(), &[])
-}
-
 pub fn emit_with_options(program: &Program, modules: &[(String, Program, Option<crate::project::PkgId>, bool)], options: &EmitOptions, import_aliases: &[(String, String)]) -> String {
     let mut emitter = Emitter::new(options);
     // Register user-level import aliases (import pkg as alias)

--- a/src/emit_rust/platform_runtime.txt
+++ b/src/emit_rust/platform_runtime.txt
@@ -1,6 +1,14 @@
 // Almide platform runtime — fs, env, process, io, random
 // Functions extracted from inline codegen for @extern migration.
 
+// ---- record types ----
+
+#[derive(Clone)]
+struct AlmideStatResult { size: i64, is_dir: bool, is_file: bool, modified: i64 }
+
+#[derive(Clone)]
+struct AlmideExecResult { code: i64, stdout: String, stderr: String }
+
 // ---- fs ----
 
 fn almide_rt_fs_read_text(path: &str) -> Result<String, String> {
@@ -93,13 +101,13 @@ fn almide_rt_fs_walk(dir: &str) -> Result<Vec<String>, String> {
     Ok(results)
 }
 
-fn almide_rt_fs_stat(path: &str) -> Result<(i64, bool, bool, i64), String> {
+fn almide_rt_fs_stat(path: &str) -> Result<AlmideStatResult, String> {
     let meta = std::fs::metadata(path).map_err(|e| e.to_string())?;
     let modified = meta.modified().ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
-    Ok((meta.len() as i64, meta.is_dir(), meta.is_file(), modified))
+    Ok(AlmideStatResult { size: meta.len() as i64, is_dir: meta.is_dir(), is_file: meta.is_file(), modified })
 }
 
 // ---- env ----
@@ -156,13 +164,13 @@ fn almide_rt_process_stdin_lines() -> Result<Vec<String>, String> {
     std::io::stdin().lock().lines().collect::<Result<Vec<String>, _>>().map_err(|e| e.to_string())
 }
 
-fn almide_rt_process_exec_status(cmd: &str, args: &[String]) -> Result<(i64, String, String), String> {
+fn almide_rt_process_exec_status(cmd: &str, args: &[String]) -> Result<AlmideExecResult, String> {
     match std::process::Command::new(cmd).args(args).output() {
-        Ok(out) => Ok((
-            out.status.code().unwrap_or(-1) as i64,
-            String::from_utf8_lossy(&out.stdout).to_string(),
-            String::from_utf8_lossy(&out.stderr).to_string(),
-        )),
+        Ok(out) => Ok(AlmideExecResult {
+            code: out.status.code().unwrap_or(-1) as i64,
+            stdout: String::from_utf8_lossy(&out.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+        }),
         Err(e) => Err(e.to_string()),
     }
 }

--- a/src/emit_ts/blocks.rs
+++ b/src/emit_ts/blocks.rs
@@ -228,12 +228,8 @@ impl TsEmitter {
                 // Use `var` to allow Almide's let-shadowing (const/let disallow re-declaration)
                 format!("var {} = {};", Self::sanitize(name), self.gen_expr(value))
             }
-            Stmt::LetDestructure { fields, is_tuple, value, .. } => {
-                if *is_tuple {
-                    format!("var [{}] = {};", fields.join(", "), self.gen_expr(value))
-                } else {
-                    format!("var {{ {} }} = {};", fields.join(", "), self.gen_expr(value))
-                }
+            Stmt::LetDestructure { pattern, value, .. } => {
+                format!("var {} = {};", self.gen_destructure_pattern(pattern), self.gen_expr(value))
             }
             Stmt::Var { name, value, .. } => {
                 format!("let {} = {};", Self::sanitize(name), self.gen_expr(value))
@@ -272,6 +268,24 @@ impl TsEmitter {
                 format!("if (!({})) {{\n{}\n}}", cond, body)
             }
             _ => format!("if (!({})) {{ return {}; }}", cond, self.gen_expr(else_)),
+        }
+    }
+
+    /// Convert a destructure Pattern to JS destructuring syntax.
+    /// Tuple → `[a, b]`, Record → `{ a, b }`, nested → `[[a, b], c]`
+    pub(crate) fn gen_destructure_pattern(&self, pattern: &Pattern) -> String {
+        match pattern {
+            Pattern::Ident { name } => name.clone(),
+            Pattern::Wildcard => "_".to_string(),
+            Pattern::Tuple { elements } => {
+                let ps: Vec<String> = elements.iter().map(|p| self.gen_destructure_pattern(p)).collect();
+                format!("[{}]", ps.join(", "))
+            }
+            Pattern::RecordPattern { fields, .. } => {
+                let fs: Vec<String> = fields.iter().map(|f| f.name.clone()).collect();
+                format!("{{ {} }}", fs.join(", "))
+            }
+            _ => "_".to_string(),
         }
     }
 }

--- a/src/emit_ts/expressions.rs
+++ b/src/emit_ts/expressions.rs
@@ -129,7 +129,13 @@ impl TsEmitter {
                 }
             }
             Expr::Lambda { params, body, .. } => {
-                let ps: Vec<String> = params.iter().map(|p| p.name.clone()).collect();
+                let ps: Vec<String> = params.iter().map(|p| {
+                    if let Some(names) = &p.tuple_names {
+                        format!("[{}]", names.join(", "))
+                    } else {
+                        p.name.clone()
+                    }
+                }).collect();
                 format!("(({}) => {})", ps.join(", "), self.gen_expr(body))
             }
             Expr::Binary { op, left, right, .. } => self.gen_binary(op, left, right),

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -529,7 +529,13 @@ fn format_expr(out: &mut String, expr: &Expr, depth: usize) {
             out.push_str("fn(");
             for (i, p) in params.iter().enumerate() {
                 if i > 0 { out.push_str(", "); }
-                out.push_str(&p.name);
+                if let Some(names) = &p.tuple_names {
+                    out.push('(');
+                    out.push_str(&names.join(", "));
+                    out.push(')');
+                } else {
+                    out.push_str(&p.name);
+                }
                 if let Some(ref ty) = p.ty {
                     out.push_str(": ");
                     format_type_expr(out, ty, depth);
@@ -555,17 +561,11 @@ fn format_stmt(out: &mut String, stmt: &Stmt, depth: usize) {
             out.push_str(" = ");
             format_expr(out, value, depth);
         }
-        Stmt::LetDestructure { fields, is_tuple, value, .. } => {
+        Stmt::LetDestructure { pattern, value, .. } => {
             out.push_str(&ind);
-            if *is_tuple {
-                out.push_str("let (");
-                out.push_str(&fields.join(", "));
-                out.push_str(") = ");
-            } else {
-                out.push_str("let { ");
-                out.push_str(&fields.join(", "));
-                out.push_str(" } = ");
-            }
+            out.push_str("let ");
+            format_destructure_pattern(out, pattern);
+            out.push_str(" = ");
             format_expr(out, value, depth);
         }
         Stmt::Var { name, ty, value, .. } => {
@@ -604,6 +604,31 @@ fn format_stmt(out: &mut String, stmt: &Stmt, depth: usize) {
         }
     }
     out.push_str(";\n");
+}
+
+/// Format a destructure pattern for `let` statements.
+/// Differs from `format_pattern` in that record patterns omit the constructor name.
+fn format_destructure_pattern(out: &mut String, pat: &Pattern) {
+    match pat {
+        Pattern::Tuple { elements } => {
+            out.push('(');
+            for (i, e) in elements.iter().enumerate() {
+                if i > 0 { out.push_str(", "); }
+                format_destructure_pattern(out, e);
+            }
+            out.push(')');
+        }
+        Pattern::RecordPattern { fields, .. } => {
+            out.push_str("{ ");
+            for (i, f) in fields.iter().enumerate() {
+                if i > 0 { out.push_str(", "); }
+                out.push_str(&f.name);
+            }
+            out.push_str(" }");
+        }
+        Pattern::Ident { name } => out.push_str(name),
+        _ => format_pattern(out, pat),
+    }
 }
 
 fn format_pattern(out: &mut String, pat: &Pattern) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,105 @@ mod project;
 mod resolve;
 
 use std::process::Command;
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "almide", version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Create a new Almide project
+    Init,
+    /// Compile and execute
+    Run {
+        /// Source file (default: src/main.almd)
+        file: Option<String>,
+        /// Skip type checking
+        #[arg(long)]
+        no_check: bool,
+        /// Arguments passed to the program (use -- to separate)
+        #[arg(last = true)]
+        program_args: Vec<String>,
+    },
+    /// Build a binary
+    Build {
+        /// Source file (default: src/main.almd)
+        file: Option<String>,
+        /// Output file name
+        #[arg(short)]
+        o: Option<String>,
+        /// Build target (wasm, npm)
+        #[arg(long)]
+        target: Option<String>,
+        /// Optimize for performance (opt-level=2)
+        #[arg(long)]
+        release: bool,
+        /// Skip type checking
+        #[arg(long)]
+        no_check: bool,
+    },
+    /// Run tests
+    Test {
+        /// Test file
+        file: Option<String>,
+        /// Filter test names by pattern
+        #[arg(short = 'r', long)]
+        run: Option<String>,
+        /// Skip type checking
+        #[arg(long)]
+        no_check: bool,
+    },
+    /// Type check only
+    Check {
+        /// Source file (default: src/main.almd)
+        file: Option<String>,
+    },
+    /// Format source files
+    Fmt {
+        /// Files to format (default: src/**/*.almd)
+        files: Vec<String>,
+        /// Check formatting without writing
+        #[arg(long)]
+        check: bool,
+        /// Check formatting without writing
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Clear dependency cache
+    Clean,
+    /// Add a dependency
+    Add {
+        /// Package specifier
+        pkg: String,
+        /// Git repository URL
+        #[arg(long)]
+        git: Option<String>,
+        /// Git tag
+        #[arg(long)]
+        tag: Option<String>,
+    },
+    /// List dependencies
+    Deps,
+    /// Emit source code or AST
+    #[command(hide = true)]
+    Emit {
+        /// Source file
+        file: String,
+        /// Target language (rust, ts, js)
+        #[arg(long, default_value = "rust")]
+        target: String,
+        /// Emit AST as JSON
+        #[arg(long)]
+        emit_ast: bool,
+        /// Skip type checking
+        #[arg(long)]
+        no_check: bool,
+    },
+}
 
 fn find_rustc() -> String {
     if Command::new("rustc").arg("--version").output().is_ok() {
@@ -78,15 +177,12 @@ fn compile_with_options(file: &str, no_check: bool, emit_options: &emit_rust::Em
     let resolved = resolve::resolve_imports_with_deps(file, &program, &dep_paths)
         .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
 
-    // Extract user-level import aliases (import pkg as alias, or implicit aliases for multi-segment imports)
     let import_aliases: Vec<(String, String)> = program.imports.iter().filter_map(|imp| {
         if let ast::Decl::Import { path, alias, .. } = imp {
             if let Some(a) = alias {
-                // Explicit alias: import pkg as alias
                 Some((a.clone(), path.join(".")))
             } else if path.len() > 1 && path.first().map(|s| s.as_str()) != Some("self") {
-                // Implicit alias: import pkg.sub → "sub" maps to "pkg.sub"
-                let last = path.last().unwrap().clone();
+                let last = path.last().expect("path.len() > 1 checked above").clone();
                 Some((last, path.join(".")))
             } else {
                 None
@@ -106,7 +202,6 @@ fn compile_with_options(file: &str, no_check: bool, emit_options: &emit_rust::Em
         for (name, mod_prog, pkg_id, is_self) in &resolved.modules {
             checker.register_module(name, mod_prog, pkg_id.as_ref(), *is_self);
         }
-        // Register user-level import aliases
         for (alias, target) in &import_aliases {
             checker.register_alias(alias, target);
         }
@@ -144,224 +239,109 @@ fn collect_almd_files(dir: &std::path::Path, out: &mut Vec<String>) {
     }
 }
 
-fn print_help() {
-    println!("almide {}", env!("CARGO_PKG_VERSION"));
-    println!();
-    println!("Usage: almide <command> [options]");
-    println!();
-    println!("Commands:");
-    println!("  init                        Create a new Almide project");
-    println!("  run [file.almd] [args...]   Compile and execute (default: src/main.almd)");
-    println!("  build [file.almd] [opts]    Build a binary");
-    println!("  test [file.almd] [-run pat] Run tests");
-    println!("  check [file.almd]           Type check only");
-    println!("  fmt [files...] [--check]    Format source files (default: src/**/*.almd)");
-    println!("  clean                       Clear dependency cache");
-    println!("  add <pkg> [--git url]       Add a dependency");
-    println!("  deps                        List dependencies");
-    println!();
-    println!("Build options:");
-    println!("  -o <output>                 Output file name");
-    println!("  --target wasm               Build for WebAssembly");
-    println!("  --release                   Optimize for performance (opt-level=2)");
-    println!("  --no-check                  Skip type checking");
-    println!();
-    println!("Emit options:");
-    println!("  almide <file> --target rust  Emit Rust source");
-    println!("  almide <file> --target ts    Emit TypeScript source");
-    println!("  almide <file> --emit-ast     Emit AST as JSON");
-    println!();
-    println!("Examples:");
-    println!("  almide init");
-    println!("  almide run");
-    println!("  almide run hello.almd");
-    println!("  almide build --release");
-    println!("  almide build app.almd --target wasm -o app.wasm");
-    println!("  almide test -run \"parser\"");
-    println!("  almide fmt");
-    println!("  almide fmt src/main.almd --check");
-}
-
-fn main() {
-    let args: Vec<String> = std::env::args().collect();
-
-    if args.len() >= 2 && (args[1] == "--version" || args[1] == "-V") {
-        println!("almide {}", env!("CARGO_PKG_VERSION"));
-        return;
-    }
-
-    if args.len() >= 2 && (args[1] == "--help" || args[1] == "-h" || args[1] == "help") {
-        print_help();
-        return;
-    }
-
-    let no_check = args.iter().any(|a| a == "--no-check");
-
-    if args.len() >= 3 && args[1] == "add" {
-        let spec = &args[2];
-        let (name, git_url, tag) = if args.iter().any(|a| a == "--git") {
-            let git = args.iter().position(|a| a == "--git")
-                .and_then(|i| args.get(i + 1))
-                .unwrap_or_else(|| { eprintln!("--git requires a URL"); std::process::exit(1); });
-            let tag = args.iter().position(|a| a == "--tag")
-                .and_then(|i| args.get(i + 1))
-                .map(|s| s.to_string());
-            (spec.to_string(), git.to_string(), tag)
-        } else {
-            project::resolve_package_spec(spec)
-        };
-        project::add_dep_to_toml(&name, &git_url, tag.as_deref())
-            .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
-        let dep = project::Dependency {
-            name: name.clone(),
-            git: git_url,
-            tag,
-            branch: None,
-            version: None,
-        };
-        project::fetch_dep(&dep)
-            .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
-        return;
-    }
-
-    if args.len() >= 2 && args[1] == "deps" {
-        if std::path::Path::new("almide.toml").exists() {
-            let proj = project::parse_toml(std::path::Path::new("almide.toml"))
-                .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
-            if proj.dependencies.is_empty() {
-                println!("No dependencies");
-            } else {
-                for dep in &proj.dependencies {
-                    let ref_name = dep.tag.as_deref().or(dep.branch.as_deref()).unwrap_or("main");
-                    println!("{} = {} ({})", dep.name, dep.git, ref_name);
-                }
-            }
-        } else {
-            eprintln!("No almide.toml found");
-        }
-        return;
-    }
-
-    if args.len() >= 2 && args[1] == "init" {
-        cli::cmd_init();
-        return;
-    }
-
-    if args.len() >= 2 && args[1] == "test" {
-        let mut file = "";
-        let mut run_filter = None;
-        let mut i = 2;
-        while i < args.len() {
-            if args[i] == "-run" || args[i] == "--run" {
-                if i + 1 < args.len() {
-                    run_filter = Some(args[i + 1].clone());
-                    i += 2;
-                    continue;
-                }
-            } else if !args[i].starts_with('-') && file.is_empty() {
-                file = &args[i];
-            }
-            i += 1;
-        }
-        cli::cmd_test(file, no_check, run_filter.as_deref());
-        return;
-    }
-
-    if args.len() >= 2 && args[1] == "run" {
-        let (file, arg_start) = if args.len() >= 3 && !args[2].starts_with('-') {
-            (args[2].clone(), 3)
-        } else if std::path::Path::new("almide.toml").exists() && std::path::Path::new("src/main.almd").exists() {
-            ("src/main.almd".to_string(), 2)
-        } else {
-            eprintln!("No file specified and no almide.toml found.");
-            eprintln!("Run 'almide init' to create a project, or specify a file: almide run <file.almd>");
-            std::process::exit(1);
-        };
-        let program_args: Vec<String> = if let Some(pos) = args.iter().position(|a| a == "--") {
-            args[pos + 1..].to_vec()
-        } else {
-            // Filter out compiler flags that shouldn't be passed to the program
-            let mut filtered = Vec::new();
-            let mut skip_next = false;
-            for a in &args[arg_start..] {
-                if skip_next { skip_next = false; continue; }
-                if a == "--no-check" { continue; }
-                if a == "--target" || a == "-o" { skip_next = true; continue; }
-                if a.starts_with("--target=") || a.starts_with("-o=") { continue; }
-                filtered.push(a.clone());
-            }
-            filtered
-        };
-        cli::cmd_run(&file, &program_args, no_check);
-        return;
-    }
-
-    if args.len() >= 2 && args[1] == "build" {
-        cli::cmd_build(&args, no_check);
-        return;
-    }
-
-    if args.len() >= 2 && args[1] == "check" {
-        let file = if args.len() >= 3 && !args[2].starts_with('-') {
-            args[2].clone()
-        } else if std::path::Path::new("almide.toml").exists() && std::path::Path::new("src/main.almd").exists() {
+fn resolve_file(file: Option<String>) -> String {
+    file.unwrap_or_else(|| {
+        if std::path::Path::new("almide.toml").exists() && std::path::Path::new("src/main.almd").exists() {
             "src/main.almd".to_string()
         } else {
             eprintln!("No file specified and no almide.toml found.");
+            eprintln!("Run 'almide init' to create a project, or specify a file.");
             std::process::exit(1);
-        };
-        cli::cmd_check(&file);
+        }
+    })
+}
+
+fn main() {
+    // Legacy mode: `almide file.almd [--target X]` → rewrite as `almide emit file.almd [--target X]`
+    let raw_args: Vec<String> = std::env::args().collect();
+    if raw_args.len() >= 2
+        && !raw_args[1].starts_with('-')
+        && (raw_args[1].ends_with(".almd") || raw_args[1].ends_with(".json"))
+    {
+        let mut new_args = vec![raw_args[0].clone(), "emit".to_string()];
+        new_args.extend_from_slice(&raw_args[1..]);
+        let cli = Cli::parse_from(new_args);
+        dispatch(cli);
         return;
     }
 
-    if args.len() >= 2 && args[1] == "fmt" {
-        let write_back = !args.iter().any(|a| a == "--check" || a == "--dry-run");
-        let fmt_files: Vec<String> = args.iter().skip(2)
-            .filter(|a| !a.starts_with("--"))
-            .cloned()
-            .collect();
-        if fmt_files.is_empty() {
-            // No files specified — format all src/**/*.almd recursively
-            let mut files = Vec::new();
-            if std::path::Path::new("src").is_dir() {
-                collect_almd_files(std::path::Path::new("src"), &mut files);
-            }
-            if files.is_empty() {
-                eprintln!("No .almd files found in src/");
-                std::process::exit(1);
-            }
-            cli::cmd_fmt(&files, write_back);
-        } else {
+    let cli = Cli::parse();
+    dispatch(cli);
+}
+
+fn dispatch(cli: Cli) {
+    match cli.command {
+        Commands::Init => cli::cmd_init(),
+        Commands::Run { file, no_check, program_args } => {
+            let file = resolve_file(file);
+            cli::cmd_run(&file, &program_args, no_check);
+        }
+        Commands::Build { file, o, target, release, no_check } => {
+            let file = resolve_file(file);
+            cli::cmd_build(&file, o.as_deref(), target.as_deref(), release, no_check);
+        }
+        Commands::Test { file, run, no_check } => {
+            let file_str = file.as_deref().unwrap_or("");
+            cli::cmd_test(file_str, no_check, run.as_deref());
+        }
+        Commands::Check { file } => {
+            let file = resolve_file(file);
+            cli::cmd_check(&file);
+        }
+        Commands::Fmt { files, check, dry_run } => {
+            let write_back = !check && !dry_run;
+            let fmt_files = if files.is_empty() {
+                let mut found = Vec::new();
+                if std::path::Path::new("src").is_dir() {
+                    collect_almd_files(std::path::Path::new("src"), &mut found);
+                }
+                if found.is_empty() {
+                    eprintln!("No .almd files found in src/");
+                    std::process::exit(1);
+                }
+                found
+            } else {
+                files
+            };
             cli::cmd_fmt(&fmt_files, write_back);
         }
-        return;
+        Commands::Clean => cli::cmd_clean(),
+        Commands::Add { pkg, git, tag } => {
+            let (name, git_url, tag) = if let Some(git_url) = git {
+                (pkg, git_url, tag)
+            } else {
+                project::resolve_package_spec(&pkg)
+            };
+            project::add_dep_to_toml(&name, &git_url, tag.as_deref())
+                .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
+            let dep = project::Dependency {
+                name: name.clone(),
+                git: git_url,
+                tag,
+                branch: None,
+                version: None,
+            };
+            project::fetch_dep(&dep)
+                .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
+        }
+        Commands::Deps => {
+            if std::path::Path::new("almide.toml").exists() {
+                let proj = project::parse_toml(std::path::Path::new("almide.toml"))
+                    .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
+                if proj.dependencies.is_empty() {
+                    println!("No dependencies");
+                } else {
+                    for dep in &proj.dependencies {
+                        let ref_name = dep.tag.as_deref().or(dep.branch.as_deref()).unwrap_or("main");
+                        println!("{} = {} ({})", dep.name, dep.git, ref_name);
+                    }
+                }
+            } else {
+                eprintln!("No almide.toml found");
+            }
+        }
+        Commands::Emit { file, target, emit_ast, no_check } => {
+            cli::cmd_emit(&file, &target, emit_ast, no_check);
+        }
     }
-
-    if args.len() >= 2 && args[1] == "clean" {
-        cli::cmd_clean();
-        return;
-    }
-
-    // Legacy: almide file.almd [--target rust|ts] [--emit-ast]
-    let files: Vec<&str> = args.iter().skip(1)
-        .filter(|a| !a.starts_with("--"))
-        .map(|s| s.as_str())
-        .collect();
-
-    if files.is_empty() {
-        eprintln!("Usage: almide <command> [options]");
-        eprintln!();
-        eprintln!("Run 'almide --help' for detailed usage.");
-        std::process::exit(1);
-    }
-
-    let file = files[0];
-    let emit_ast = args.iter().any(|a| a == "--emit-ast");
-    let target = args.iter()
-        .position(|a| a == "--target")
-        .and_then(|i| args.get(i + 1))
-        .map(|s| s.as_str())
-        .unwrap_or("rust");
-
-    cli::cmd_emit(file, target, emit_ast, no_check);
 }

--- a/src/parser/compounds.rs
+++ b/src/parser/compounds.rs
@@ -109,13 +109,26 @@ impl Parser {
     }
 
     fn parse_lambda_param(&mut self) -> Result<LambdaParam, String> {
+        if self.check(TokenType::LParen) {
+            self.advance();
+            let mut names = Vec::new();
+            while !self.check(TokenType::RParen) {
+                names.push(self.expect_ident()?);
+                if self.check(TokenType::Comma) {
+                    self.advance();
+                }
+            }
+            self.expect(TokenType::RParen)?;
+            let first = names.first().cloned().unwrap_or_default();
+            return Ok(LambdaParam { name: first, tuple_names: Some(names), ty: None });
+        }
         let name = self.expect_ident()?;
         let mut ty: Option<TypeExpr> = None;
         if self.check(TokenType::Colon) {
             self.advance();
             ty = Some(self.parse_type_expr()?);
         }
-        Ok(LambdaParam { name, ty })
+        Ok(LambdaParam { name, tuple_names: None, ty })
     }
 
     pub(crate) fn parse_do_block(&mut self) -> Result<Expr, String> {

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -207,7 +207,7 @@ impl Parser {
         }
         self.expect(TokenType::Fn)?;
         let name = self.expect_any_fn_name()?;
-        let generics = self.try_parse_generic_params()?;
+        let _generics = self.try_parse_generic_params()?;
         self.expect(TokenType::LParen)?;
         let params = self.parse_param_list()?;
         self.expect(TokenType::RParen)?;

--- a/src/parser/statements.rs
+++ b/src/parser/statements.rs
@@ -32,9 +32,9 @@ impl Parser {
 
         if self.check(TokenType::LBrace) {
             self.advance();
-            let mut fields = Vec::new();
+            let mut names = Vec::new();
             while !self.check(TokenType::RBrace) {
-                fields.push(self.expect_ident()?);
+                names.push(self.expect_ident()?);
                 if self.check(TokenType::Comma) {
                     self.advance();
                     self.skip_newlines();
@@ -44,24 +44,21 @@ impl Parser {
             self.expect(TokenType::Eq)?;
             self.skip_newlines();
             let value = self.parse_expr()?;
-            return Ok(Stmt::LetDestructure { fields, is_tuple: false, value, span: Some(span) });
+            let fields = names.into_iter()
+                .map(|n| FieldPattern { name: n, pattern: None })
+                .collect();
+            return Ok(Stmt::LetDestructure {
+                pattern: Pattern::RecordPattern { name: String::new(), fields },
+                value, span: Some(span),
+            });
         }
 
         if self.check(TokenType::LParen) {
-            self.advance();
-            let mut fields = Vec::new();
-            while !self.check(TokenType::RParen) {
-                fields.push(self.expect_ident()?);
-                if self.check(TokenType::Comma) {
-                    self.advance();
-                    self.skip_newlines();
-                }
-            }
-            self.expect(TokenType::RParen)?;
+            let pattern = self.parse_destructure_tuple()?;
             self.expect(TokenType::Eq)?;
             self.skip_newlines();
             let value = self.parse_expr()?;
-            return Ok(Stmt::LetDestructure { fields, is_tuple: true, value, span: Some(span) });
+            return Ok(Stmt::LetDestructure { pattern, value, span: Some(span) });
         }
 
         // Detect `let mut` (Rust style) — hint to use `var` instead
@@ -118,5 +115,26 @@ impl Parser {
         self.skip_newlines();
         let value = self.parse_expr()?;
         Ok(Stmt::Assign { name, value, span: Some(span) })
+    }
+
+    /// Parse a destructure pattern for tuples: `(a, b)` or `((a, b), c)`
+    fn parse_destructure_tuple(&mut self) -> Result<Pattern, String> {
+        self.expect(TokenType::LParen)?;
+        let mut elements = Vec::new();
+        while !self.check(TokenType::RParen) {
+            if self.check(TokenType::LParen) {
+                // Nested tuple
+                elements.push(self.parse_destructure_tuple()?);
+            } else {
+                let name = self.expect_ident()?;
+                elements.push(Pattern::Ident { name });
+            }
+            if self.check(TokenType::Comma) {
+                self.advance();
+                self.skip_newlines();
+            }
+        }
+        self.expect(TokenType::RParen)?;
+        Ok(Pattern::Tuple { elements })
     }
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,7 +1,6 @@
 /// Project configuration (almide.toml) and dependency management.
 
 use std::path::{Path, PathBuf};
-use std::collections::HashMap;
 use std::process::Command;
 
 /// Package identity for diamond dependency resolution.
@@ -34,10 +33,6 @@ impl PkgId {
         format!("{}_v{}", self.name, self.major)
     }
 
-    /// The import name users write: "json"
-    pub fn import_name(&self) -> &str {
-        &self.name
-    }
 }
 
 impl std::fmt::Display for PkgId {
@@ -49,7 +44,6 @@ impl std::fmt::Display for PkgId {
 #[derive(Debug, Clone)]
 pub struct FetchedDep {
     pub pkg_id: PkgId,
-    pub version: String,
     pub source_dir: PathBuf,
 }
 
@@ -244,16 +238,6 @@ pub fn fetch_all_deps(project: &Project) -> Result<Vec<FetchedDep>, String> {
     Ok(fetched)
 }
 
-/// Legacy API: returns HashMap<String, PathBuf> for backward compatibility.
-pub fn fetch_all_deps_flat(project: &Project) -> Result<HashMap<String, PathBuf>, String> {
-    let fetched = fetch_all_deps(project)?;
-    let mut paths = HashMap::new();
-    for dep in fetched {
-        paths.insert(dep.pkg_id.name.clone(), dep.source_dir);
-    }
-    Ok(paths)
-}
-
 fn fetch_deps_recursive(
     deps: &[Dependency],
     fetched: &mut Vec<FetchedDep>,
@@ -293,7 +277,6 @@ fn fetch_deps_recursive(
         let actual_pkg_id = PkgId::from_version_str(&module_name, &version_str);
         fetched.push(FetchedDep {
             pkg_id: actual_pkg_id,
-            version: version_str,
             source_dir,
         });
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -16,10 +16,6 @@ pub struct ResolvedModules {
     pub modules: Vec<(String, ast::Program, Option<project::PkgId>, bool)>,
 }
 
-pub fn resolve_imports(source_file: &str, program: &ast::Program) -> Result<ResolvedModules, String> {
-    resolve_imports_with_deps(source_file, program, &[])
-}
-
 /// Find the project root (directory containing almide.toml), searching upward from base_dir.
 fn find_project_root(base_dir: &Path) -> Option<PathBuf> {
     let mut dir = base_dir.to_path_buf();


### PR DESCRIPTION
## Summary
- **clap CLI**: Replace hand-rolled argument parsing with clap derive for proper help, validation, and subcommand handling
- **Record destructuring fix**: `fs.stat` and `process.exec_status` now return named structs instead of tuples, fixing `let { size, is_dir, ... }` destructuring (CI 2-test failure)
- **Codegen refactor**: Split `gen_module_call` (CC 246) into 14 per-module functions for maintainability
- **codopsy config**: Add `.codopsyrc.json` with adjusted thresholds

## Test plan
- [x] All 46 exercises pass on Rust target (0 failures)
- [x] All 46 exercises pass on TS target (0 failures)
- [x] Legacy emit syntax (`almide file.almd --target rust`) still works
- [x] `--help`, `--version` work via clap
- [x] `fs_process_test` and `fs_walk_stat_test` now pass (previously failing in CI)