### PR TITLE
v0.4.6: Braceless let-chain, immutable binding check, empty block fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "almide"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "clap",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/src/check/statements.rs
+++ b/src/check/statements.rs
@@ -56,6 +56,7 @@ impl Checker {
                     t
                 } else { vt };
                 self.env.define_var(name, dt);
+                self.env.mutable_vars.insert(name.clone());
             }
             ast::Stmt::LetDestructure { pattern, value, .. } => {
                 let vt = self.check_expr(value);
@@ -65,7 +66,13 @@ impl Checker {
             ast::Stmt::Assign { name, value, .. } => {
                 let vt = self.check_expr(value);
                 if let Some(var_ty) = self.env.lookup_var(name).cloned() {
-                    if !var_ty.compatible(&vt) {
+                    if !self.env.mutable_vars.contains(name) {
+                        self.push_diagnostic(err(
+                            format!("cannot reassign immutable binding '{}'", name),
+                            "Use 'var' instead of 'let' to declare a mutable variable, or use a different name",
+                            format!("{} = ...", name),
+                        ));
+                    } else if !var_ty.compatible(&vt) {
                         self.push_diagnostic(err(
                             format!("cannot assign {} to variable '{}' of type {}", vt.display(), name, var_ty.display()),
                             "Assignment must match the variable's declared type",

--- a/src/parser/compounds.rs
+++ b/src/parser/compounds.rs
@@ -177,7 +177,13 @@ impl Parser {
         self.skip_newlines_into_stmts(&mut initial_comments);
         if self.check(TokenType::RBrace) {
             self.advance();
-            return Ok(Expr::Record { name: None, fields: Vec::new(), span, resolved_type: None });
+            // Empty braces `{}` are an empty block (Unit), not an empty record.
+            return Ok(Expr::Block {
+                stmts: Vec::new(),
+                expr: None,
+                span,
+                resolved_type: None,
+            });
         }
         if self.check(TokenType::DotDotDot) {
             self.advance();
@@ -261,6 +267,37 @@ impl Parser {
             }
         }
         self.expect(TokenType::RBrace)?;
+        Ok(Expr::Block {
+            stmts,
+            expr: final_expr,
+            span,
+            resolved_type: None,
+        })
+    }
+
+    /// Parse a braceless block: a sequence of let/var statements ending in an expression.
+    /// Used for `fn foo() = let x = 1; let y = 2; x + y` without braces.
+    pub(crate) fn parse_braceless_block(&mut self) -> Result<Expr, String> {
+        let span = Some(self.current_span());
+        let mut stmts = Vec::new();
+        let mut final_expr: Option<Box<Expr>> = None;
+
+        loop {
+            if self.check(TokenType::Let) || self.check(TokenType::Var) {
+                let stmt = self.parse_stmt()?;
+                stmts.push(stmt);
+                self.skip_newlines();
+                if self.check(TokenType::Semicolon) {
+                    self.advance();
+                    self.skip_newlines();
+                }
+            } else {
+                let expr = self.parse_expr()?;
+                final_expr = Some(Box::new(expr));
+                break;
+            }
+        }
+
         Ok(Expr::Block {
             stmts,
             expr: final_expr,

--- a/src/parser/declarations.rs
+++ b/src/parser/declarations.rs
@@ -305,7 +305,11 @@ impl Parser {
         let body = if self.check(TokenType::Eq) {
             self.advance();
             self.skip_newlines();
-            let mut body = self.parse_expr()?;
+            let mut body = if self.check(TokenType::Let) || self.check(TokenType::Var) {
+                self.parse_braceless_block()?
+            } else {
+                self.parse_expr()?
+            };
 
             let returns_result = matches!(&return_type,
                 TypeExpr::Generic { name, .. } if name == "Result"

--- a/src/types.rs
+++ b/src/types.rs
@@ -91,6 +91,8 @@ pub struct TypeEnv {
     pub local_symbols: std::collections::HashSet<std::string::String>,
     /// Temporarily suppress auto-unwrap of Result (for match on ok/err)
     pub skip_auto_unwrap: bool,
+    /// Variables declared with `var` (mutable). Parameters and `let` are immutable.
+    pub mutable_vars: std::collections::HashSet<std::string::String>,
 }
 
 impl Ty {
@@ -182,6 +184,7 @@ impl TypeEnv {
             module_aliases: std::collections::HashMap::new(),
             local_symbols: std::collections::HashSet::new(),
             skip_auto_unwrap: false,
+            mutable_vars: std::collections::HashSet::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

- **Braceless let-chain in fn body**: `fn foo() = let x = 1; let y = 2; x + y` now works without braces — LLMs naturally write this pattern
- **Empty `{}` is now Unit (empty block)**: Previously parsed as empty record, causing `else {}` type errors
- **Immutable binding check**: Reassigning function parameters or `let` bindings now produces a clear Almide-level error (`cannot reassign immutable binding 'x'`) instead of failing at Rust compile time

## Test plan

- [x] All 42 test files pass (`almide test`)
- [x] `cargo build --release` succeeds
- [x] Parameter reassignment correctly detected with actionable hint
- [x] Braceless let-chain parses and executes correctly
- [x] `else {}` no longer causes type mismatch