### PR TITLE
v0.5.9: Built-in protocols, universal string interpolation, Map literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "almide"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "clap",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Verify the installation:
 
 ```bash
 almide --version
-# almide 0.5.8
+# almide 0.5.9
 ```
 
 ### Hello World

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ almide run hello.almd
 - **Generics** — Functions, records, variant types, recursive variants with auto Box wrapping
 - **Pattern matching** — Exhaustive match with variant destructuring
 - **Effect functions** — `effect fn` for explicit error propagation (`Result` auto-wrapping)
+- **Bidirectional type inference** — Type annotations flow into expressions (`let xs: List[Int] = []`)
+- **Map literals** — `["key": value]` syntax with `m[key]` access and `for (k, v) in m` iteration
 - **Top-level constants** — `let PI = 3.14` at module scope, compile-time evaluated
 - **Pipeline operator** — `data |> transform |> output`
 - **Module system** — Packages, sub-namespaces, visibility control, diamond dependency resolution

--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -117,9 +117,12 @@ for x in xs {
   println(x)
 }
 
-for key in map.keys(config) {
-  let val = match map.get(config, key) { some(v) => v, none => "" }
-  println(key ++ " = " ++ val)
+for (k, v) in config {
+  println(k ++ " = " ++ v)
+}
+
+for key in m {
+  println(key)           // iterates keys only
 }
 ```
 **Prefer `for...in` over `do { guard ... }` for iterating lists.**
@@ -182,8 +185,17 @@ create_user("alice", age: 30)          // mixed positional + named
 ```
 [1, 2, 3]
 []                         // empty list (there is NO list.new())
-xs[0]                      // index read (returns Option[T])
+xs[0]                      // index read
 xs[i] = value              // index write (var only)
+```
+
+### Map
+```
+["a": 1, "b": 2]          // map literal
+[:]                        // empty map (requires type annotation)
+let m: Map[String, Int] = [:]
+m["key"]                   // index read (returns Option[V])
+m["key"] = value           // index write (var only)
 ```
 
 ### String interpolation
@@ -364,7 +376,7 @@ The runtime calls `main(args)` where `args` includes the program name at index 0
 - No null — use `Option[T]`
 - No inheritance — use trait + impl
 - No macros, no operator overloading, no implicit conversions
-- Empty list = `[]` (no `list.new()` or `list.empty()`), empty map = `map.new()`
+- Empty list = `[]`, empty map = `[:]` (with type annotation)
 - `_` is ONLY for match wildcard patterns, never as a variable name
 - The stdlib functions listed above are exhaustive — no other functions exist
 - Use `for x in xs { ... }` for iteration, NOT `do { var i = 0; guard ... }`
@@ -372,8 +384,9 @@ The runtime calls `main(args)` where `args` includes the program name at index 0
 ## Common mistakes (DO NOT)
 - `list[1, 2, 3]` → **WRONG**. Write `[1, 2, 3]`. `list` is a module, not a type constructor
 - `each(xs, f)` → **WRONG**. Write `list.each(xs, f)`. All stdlib functions need module prefix
-- `map[K, V]` as a value → **WRONG**. Write `map.new()` to create an empty map
+- `map[K, V]` as a value → **WRONG**. Write `[:]` with type annotation to create an empty map
 - `List.new()` → **WRONG**. Write `[]`. There is no `new()` for List
+- `{"a": 1}` as a map → **WRONG**. Write `["a": 1]`. Braces `{}` are for records/blocks, brackets `[]` for lists and maps
 - `string.length(s)` → **WRONG**. Write `string.len(s)`. No synonyms
 - `println(x)` where x is Int → **WRONG**. Write `println(int.to_string(x))`. No implicit conversion
 - `1 :: 2 :: []` → **WRONG**. Write `[1, 2]`. There is no cons operator `::`

--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -10,7 +10,7 @@ fn_decl     = ["effect"] "fn" IDENT "(" params ")" "->" type "=" expr
 top_let     = "let" IDENT [":" type] "=" expr       (* module-scope constant *)
 type        = "Int" | "String" | "Bool" | "Unit" | IDENT | IDENT "[" type ("," type)* "]"
 expr        = block | if_expr | match_expr | for_in | while_expr | do_expr | guard | let | var | assign | binary | call | literal
-for_in      = "for" IDENT "in" expr "{" stmt* "}"  (* iterate over list/collection *)
+for_in      = "for" (IDENT | "(" IDENT "," IDENT ")") "in" expr "{" stmt* "}"
 while_expr  = "while" expr "{" stmt* "}"            (* loop while condition is true *)
 block       = "{" stmt* expr "}"
 if_expr     = "if" expr "then" expr "else" expr       (* else is MANDATORY *)
@@ -26,7 +26,11 @@ binary      = expr OP expr    (* OP: + - * / % ^ == != < > <= >= ++ and or *)
                                (* ++ for string/list concat, ^ for XOR, not for boolean neg *)
 call        = IDENT "(" args ")" | IDENT "." IDENT "(" args ")"
 lambda      = "fn" "(" params ")" "=>" expr
+list_lit    = "[" (expr ("," expr)*)? "]"            (* list: [1, 2, 3] or [] *)
+map_lit     = "[" expr ":" expr ("," expr ":" expr)* "]"  (* map: ["a": 1, "b": 2] *)
+              | "[" ":" "]"                          (* empty map: [:] *)
 literal     = INT | STRING | "true" | "false" | "ok" "(" expr ")" | "err" "(" expr ")"
+              | list_lit | map_lit
                                (* string interpolation: "hello ${name}" *)
 ```
 
@@ -43,7 +47,8 @@ See [CHEATSHEET.md](./CHEATSHEET.md) for the complete stdlib function reference 
 
 - `int`, `string`, `list`, `map`, `path`, and `env` are auto-imported — no `import` needed. `fs` and `json` require explicit import.
 - No `return`, `class`, `null`, `!` — use Almide alternatives
-- `for x in xs { ... }` for iterating lists; `while cond { ... }` for condition-based loops; `do { guard ... }` for dynamic break with values
+- `for x in xs { ... }` for iterating lists; `for (k, v) in m { ... }` for maps; `while cond { ... }` for condition-based loops; `do { guard ... }` for dynamic break with values
+- Map literal: `["key": value]`, empty map: `[:]` (with type annotation)
 - `if` always requires `else`
 - `effect fn` marks functions with side effects
 - All errors via `Result[T, E]`, all optionals via `Option[T]`

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -23,7 +23,7 @@
 - [Syntax Sugar](on-hold/syntax-sugar.md) — range, raw strings, exhaustiveness done; comprehensions pending
 - [Tooling](on-hold/tooling.md)
 - [Trailing Lambda / Builder DSL](on-hold/trailing-lambda-builder.md) — won't do, solve with stdlib instead
-- [Built-in Protocols](on-hold/trait-impl.md) — Show, Hash remaining; no user-defined traits
+- [Built-in Protocols](on-hold/trait-impl.md) — Show (`show(x)`), Hash (Map key constraint) remaining; all automatic
 - [Type System Extensions](on-hold/type-system.md)
 
 ## Done

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -63,5 +63,5 @@
 - [Tuple & Record](done/tuple-record.md)
 - [Typed IR](done/typed-ir.md) — IR-based codegen, AST-direct codegen removed
 - [Variant Record Fields](done/variant-record-fields.md) — named fields on enum variants, `..` rest pattern
-- [Map Literal](done/map-literal.md) — Swift-style `[:]` / `["key": value]` syntax
+- [Map Literal](done/map-literal.md) — `[:]` / `["key": value]` syntax, index access, direct iteration
 - [While Loop](done/while-loop.md) — `while condition { }`, universal loop syntax

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -23,7 +23,7 @@
 - [Syntax Sugar](on-hold/syntax-sugar.md) — range, raw strings, exhaustiveness done; comprehensions pending
 - [Tooling](on-hold/tooling.md)
 - [Trailing Lambda / Builder DSL](on-hold/trailing-lambda-builder.md) — won't do, solve with stdlib instead
-- [trait / impl](on-hold/trait-impl.md) — parser done, checker/emitter partial
+- [Built-in Protocols](on-hold/trait-impl.md) — Show, Hash remaining; no user-defined traits
 - [Type System Extensions](on-hold/type-system.md)
 
 ## Done
@@ -64,4 +64,5 @@
 - [Typed IR](done/typed-ir.md) — IR-based codegen, AST-direct codegen removed
 - [Variant Record Fields](done/variant-record-fields.md) — named fields on enum variants, `..` rest pattern
 - [Map Literal](done/map-literal.md) — `[:]` / `["key": value]` syntax, index access, direct iteration
+- [Eq Protocol](on-hold/trait-impl.md) — automatic `==` for all value types, `Fn` types rejected
 - [While Loop](done/while-loop.md) — `while condition { }`, universal loop syntax

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -63,4 +63,5 @@
 - [Tuple & Record](done/tuple-record.md)
 - [Typed IR](done/typed-ir.md) — IR-based codegen, AST-direct codegen removed
 - [Variant Record Fields](done/variant-record-fields.md) — named fields on enum variants, `..` rest pattern
+- [Map Literal](done/map-literal.md) — Swift-style `[:]` / `["key": value]` syntax
 - [While Loop](done/while-loop.md) — `while condition { }`, universal loop syntax

--- a/docs/roadmap/done/map-literal.md
+++ b/docs/roadmap/done/map-literal.md
@@ -1,0 +1,49 @@
+# Map Literal Syntax
+
+## Goal
+
+Add Swift-style Map literal syntax to the language, enabling bidirectional type inference for empty Maps.
+
+## Syntax
+
+```almide
+let m: Map[String, Int] = [:]                    // empty Map (type from annotation)
+let m = ["name": "Alice", "age": "30"]           // non-empty Map
+let m = [
+  "host": "localhost",
+  "port": "8080",
+]                                                 // multi-line
+```
+
+## Design Decisions
+
+- **Swift `[:]` style** — `[]` is already List, `[k: v]` is a natural extension
+- No conflict with records (`{ field = value }` uses `=`, not `:`)
+- Parser disambiguation: `[` then `]` → empty List, `[` then `:` then `]` → empty Map, expr then `:` → Map, expr then `,` or `]` → List
+
+## Implementation Steps
+
+### 1. Lexer/Parser
+- Parse `[:]` as `Expr::EmptyMap`
+- Parse `[expr: expr, ...]` as `Expr::MapLiteral { entries: Vec<(Expr, Expr)> }`
+- Disambiguation logic after `[`
+
+### 2. Type Checker
+- `EmptyMap` with `expected: Some(Ty::Map(k, v))` → `Ty::Map(k, v)`
+- `EmptyMap` without expected → error: "cannot infer Map type, add annotation"
+- `MapLiteral` → infer K/V from first entry, unify all entries
+
+### 3. IR Lowering
+- `IrExprKind::EmptyMap`
+- `IrExprKind::MapLiteral { entries }`
+
+### 4. Codegen
+- **Rust**: `EmptyMap` → `almide_rt_map_new()`, `MapLiteral` → chain of `almide_rt_map_set`
+- **TS**: `EmptyMap` → `__almd_map.new()`, `MapLiteral` → `new Map([...entries])`
+
+### 5. Tests
+- Empty Map with type annotation
+- Non-empty Map literal
+- Nested Map
+- Map literal in function arguments
+- Bidirectional type flow through if/match/block

--- a/docs/roadmap/done/map-literal.md
+++ b/docs/roadmap/done/map-literal.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Add Swift-style Map literal syntax to the language, enabling bidirectional type inference for empty Maps.
+Add Map literal syntax to the language, enabling bidirectional type inference for empty Maps.
 
 ## Syntax
 

--- a/docs/roadmap/on-hold/cross-target-aot.md
+++ b/docs/roadmap/on-hold/cross-target-aot.md
@@ -1,0 +1,115 @@
+# Cross-Target AOT Compilation [PLANNED]
+
+## Motivation
+
+Almide は既に複数の emit ターゲット（Rust / TS / JS / 将来 WASM）を持ち、`@extern` でターゲット別の実装を宣言的に切り替えられる。この構造を活かし、`almide build` 一発で複数ターゲットの成果物を同時に生成する AOT クロスコンパイルシステムを構築する。
+
+## 現状の土台
+
+Almide のコンパイルパイプラインは既にクロスターゲット対応の構造:
+
+```
+Source (.almd)
+  → Lexer → Parser → AST
+  → Checker → IR (共通)
+  → emit_rust/  (native CLI / cargo crate)
+  → emit_ts/    (TS/JS / npm パッケージ)
+  → emit_wasm/  (将来: WASM 直接出力 + JS グルー)
+```
+
+- チェッカー・IR は全ターゲット共通
+- `@extern(rs, ...)` / `@extern(ts, ...)` でターゲット別の実装を言語レベルでサポート
+- ターゲット固有のコードは emit レイヤーに閉じている
+
+## ゴール
+
+```bash
+almide build --target all
+```
+
+```
+dist/
+├── native/     Rust → バイナリ (macOS / Linux / Windows)
+├── web/        WASM + JS グルー (ブラウザ向け)
+├── npm/        JS パッケージ (npm publish 可能)
+└── deno/       TS モジュール (Deno / Bun 向け)
+```
+
+## 他言語との比較
+
+| 言語/フレームワーク | クロスターゲット戦略 | Almide との違い |
+|---|---|---|
+| **Kotlin Multiplatform** | `commonMain` → JVM / iOS / JS / WASM | `expect`/`actual` でターゲット分岐。Almide の `@extern` と同じ設計思想 |
+| **Rust** | `#[cfg(target)]` + cross-compile | 条件コンパイルは強力だが、JS/TS ターゲットはない |
+| **Go** | `GOOS`/`GOARCH` でクロスコンパイル | ネイティブのみ。Web ターゲットは TinyGo 経由 |
+| **Dart (Flutter)** | AOT (iOS/Android) + JIT (dev) | プラットフォームチャネルで分岐。言語レベルではない |
+| **Zig** | `comptime` + ターゲット判定 | ゼロコスト抽象化。ただし Web ターゲットは限定的 |
+
+**Almide の優位性**: `@extern` が言語の第一級機能であるため、ターゲット分岐がアドホックな条件分岐ではなく、型安全かつ宣言的。さらに、ネイティブ (Rust) と Web (TS/JS/WASM) の両方を一級ターゲットとして持つ言語は稀。
+
+## Implementation Phases
+
+### Phase 1: `almide build --target` の拡張
+
+- [ ] `--target all` で全ターゲットを順次ビルド
+- [ ] `--target native,npm` のようなカンマ区切り複数指定
+- [ ] `almide.toml` の `[build]` セクションでデフォルトターゲットを設定
+
+```toml
+[build]
+targets = ["native", "npm"]
+```
+
+### Phase 2: ターゲット別最適化
+
+各ターゲットに特化した最適化パスを IR → emit 間に挿入:
+
+| ターゲット | 最適化 |
+|-----------|--------|
+| Rust (native) | borrow analysis、ライフタイム推論、ゼロコピー最適化 |
+| TS/JS (web) | tree shaking、minification-friendly な命名 |
+| WASM (direct) | サイズ最適化、線形メモリレイアウト最適化 |
+| npm (package) | 使用 stdlib のみバンドル、ESM/CJS デュアル出力 |
+
+### Phase 3: 成果物パッケージング
+
+- [ ] `dist/` ディレクトリへの統一出力
+- [ ] npm: `package.json` 自動生成（既に `emit_npm_package` で部分実装済み）
+- [ ] WASM: `.wasm` + `.js` グルーの同梱（emit-wasm-direct.md 参照）
+- [ ] native: ターゲットトリプル別バイナリ（`x86_64-apple-darwin` 等）
+
+### Phase 4: CI/CD 統合
+
+```yaml
+# GitHub Actions で全ターゲットビルド
+- run: almide build --target all
+- uses: actions/upload-artifact@v4
+  with:
+    path: dist/
+```
+
+- [ ] `almide publish` コマンドで npm + crates.io + GitHub Release を一括公開
+- [ ] GitHub Actions テンプレート提供
+
+## @extern とクロスターゲットの関係
+
+`@extern` はこのシステムの中核。ターゲット分岐を型安全に宣言する:
+
+```almide
+// ネイティブは OS API、Web は fetch API を使う
+@extern(rs, "reqwest", "get")
+@extern(ts, "fetch_wrapper", "get")
+fn http_get(url: String) -> Result[String, String]
+
+// 共通ロジックはそのまま全ターゲットで使える
+fn parse_response(body: String) -> Data =
+  json.parse(body) |> unwrap_or(default_data())
+```
+
+クロスターゲットの難しさは「どこでターゲット分岐するか」だが、Almide では `@extern` 境界が明確なので、共通コードとターゲット固有コードの切り分けがコンパイラレベルで保証される。
+
+## 依存関係
+
+- emit-wasm-direct.md: WASM ターゲットが Phase 3 以降の前提
+- package-registry.md: `almide publish` は registry が必要
+- stdlib-architecture-3-layer-design.md: platform 分離がクロスターゲットの安全性を担保

--- a/docs/roadmap/on-hold/trait-impl.md
+++ b/docs/roadmap/on-hold/trait-impl.md
@@ -1,38 +1,59 @@
-# trait / impl [IN PROGRESS]
+# Built-in Protocols
 
-Parser support is complete (`trait` / `impl` declarations are parsed and stored in AST). Checker and emitter are not yet implemented.
+## Design Decision
 
-### Syntax (parser-complete)
+**No user-defined traits.** Almide provides built-in protocols that the compiler understands. User-defined `trait` / `impl` syntax is intentionally excluded.
+
+**Eq is automatic.** All value types support `==` by default. Only function types cannot be compared. No `deriving Eq` needed — the compiler determines comparability from the type structure. This follows Almide's principle: "write it the obvious way and it works."
+
+**Why no user traits:** User-defined traits increase abstraction depth, break locality (LLMs need to understand all impls to modify one callsite), and create expression branching (function vs method). This hurts modification survival rate.
+
+## Built-in Protocols
+
+| Protocol | Behavior | Status |
+|----------|----------|--------|
+| `Eq` | All value types are comparable. `Fn` types are not. Automatic — no annotation needed | **Done** |
+| `Show` | Universal `show(x)` → String for displayable types | Planned |
+| `Hash` | Enables use as Map key. Requires `deriving Hash` (opt-in) | Planned |
+| `From` | Error type conversions via `deriving From` | **Done** |
+
+## Eq Protocol (Done)
 
 ```almide
-trait Show {
-  fn show(self) -> String
-}
+type Color = | Red | Green | Blue
 
-impl Show for Color {
-  fn show(self) -> String = match self {
-    Red => "red"
-    Green => "green"
-    Blue => "blue"
-  }
-}
+// Just works — no deriving needed
+fn same_color?(a: Color, b: Color) -> Bool = a == b
+
+// Function types are rejected at compile time:
+// let f = fn(x: Int) => x + 1
+// f == f  // error: function types are not comparable
 ```
 
-### Implementation Steps
+What is Eq:
+- Primitives: Int, Float, String, Bool, Unit
+- Containers: List[T], Option[T], Result[T, E], Map[K, V], Tuple — if contents are Eq
+- Records: if all fields are Eq
+- Variants: if all payloads are Eq
+- Recursive types: handled (e.g. `Tree[T]` with `Node(Tree[T], Tree[T])`)
 
-- [ ] checker: register trait method signatures, type-check impl bodies
-- [ ] checker: verify that impl provides all methods required by the trait
-- [ ] Rust emitter: output `impl Trait for Type { ... }` directly
-- [ ] TS emitter: output traits as interfaces, dispatch method calls
-- [ ] `self` parameter handling: UFCS (both `show(color)` and `color.show()` work)
+What is NOT Eq:
+- `Fn` types (function values cannot be compared)
 
-### Design Notes
+## Planned: Show
 
-- Almide has no classes. trait + impl + pattern matching is how type behavior is defined
-- `self` is exclusively the receiver in trait methods, not a class instance reference
-- `self` in `import self.xxx` is a separate use (distinguishable by context: import statement vs parameter list)
-- `deriving` is already parser-complete (`type Color = ... deriving Show, Eq`)
+Universal `show()` function for all displayable types. Eliminates the need for per-module `int.to_string()`, `float.to_string()`, etc.
 
----
+## Planned: Hash (opt-in via `deriving Hash`)
 
----
+Unlike Eq, Hash requires explicit opt-in because:
+- Float cannot be hashed (NaN)
+- Map key constraint: `Map[K, V]` will require K to be Hash
+- Checked at Almide level, not deferred to Rust compiler
+
+## What NOT To Do
+
+- No user-defined traits
+- No `impl` blocks (all behavior is standalone functions or `deriving`)
+- No associated types, default methods, orphan rules, trait objects
+- No `deriving Eq` — Eq is automatic based on type structure

--- a/docs/roadmap/on-hold/trait-impl.md
+++ b/docs/roadmap/on-hold/trait-impl.md
@@ -1,59 +1,100 @@
 # Built-in Protocols
 
-## Design Decision
+## Design Principle
 
-**No user-defined traits.** Almide provides built-in protocols that the compiler understands. User-defined `trait` / `impl` syntax is intentionally excluded.
+**All protocols are automatic.** The compiler determines protocol support from the type structure. No `deriving` annotations needed (except `From` for error conversions). This follows Almide's principle: "write it the obvious way and it works." Rust's trait system must never leak into user-facing semantics.
 
-**Eq is automatic.** All value types support `==` by default. Only function types cannot be compared. No `deriving Eq` needed — the compiler determines comparability from the type structure. This follows Almide's principle: "write it the obvious way and it works."
-
-**Why no user traits:** User-defined traits increase abstraction depth, break locality (LLMs need to understand all impls to modify one callsite), and create expression branching (function vs method). This hurts modification survival rate.
+**No user-defined traits.** User-defined traits increase abstraction depth, break locality, and create expression branching. This hurts modification survival rate.
 
 ## Built-in Protocols
 
 | Protocol | Behavior | Status |
 |----------|----------|--------|
-| `Eq` | All value types are comparable. `Fn` types are not. Automatic — no annotation needed | **Done** |
-| `Show` | Universal `show(x)` → String for displayable types | Planned |
-| `Hash` | Enables use as Map key. Requires `deriving Hash` (opt-in) | Planned |
+| `Eq` | `==` / `!=` on all value types. `Fn` rejected | **Done** |
+| `Show` | `show(x)` → String for all value types. `Fn` rejected | Planned |
+| `Hash` | Map key constraint. `Fn` and `Float` rejected | Planned |
 | `From` | Error type conversions via `deriving From` | **Done** |
 
 ## Eq Protocol (Done)
 
+Automatic. All value types support `==`. Only `Fn` types are rejected.
+
+```almide
+type Color = | Red | Green | Blue
+fn same_color?(a: Color, b: Color) -> Bool = a == b  // just works
+```
+
+- Primitives: Int, Float, String, Bool, Unit — always Eq
+- Containers: List[T], Option[T], Result[T, E], Map[K, V], Tuple — Eq if contents are Eq
+- Records, Variants — Eq if all fields/payloads are Eq
+- Recursive types — handled (cycle detection)
+- `Fn` types — compile error
+
+## Show Protocol (Planned)
+
+**Automatic.** All value types can be converted to String. Replaces per-module `int.to_string()`, `float.to_string()`, etc.
+
+```almide
+show(42)              // "42"
+show(3.14)            // "3.14"
+show(true)            // "true"
+show(Red)             // "Red"
+show([1, 2, 3])       // "[1, 2, 3]"
+show(some(42))        // "some(42)"
+show({ x: 1, y: 2 }) // "{ x: 1, y: 2 }"
+```
+
+What is Show:
+- Primitives: Int → digits, Float → digits, String → itself, Bool → "true"/"false", Unit → "()"
+- Containers: List → "[elem, ...]", Option → "some(x)" / "none", Result → "ok(x)" / "err(e)"
+- Records: "{ field: value, ... }"
+- Variants: "Name" / "Name(payload)" / "Name { field: value }"
+- Tuple: "(a, b, c)"
+- `Fn` types — compile error (or return something like `"<function>"`)
+
+### Implementation
+
+- Add built-in `show` function: `fn show[T: Show](x: T) -> String`
+- Checker: all types except `Fn` are Show (same pattern as `is_eq`)
+- Rust codegen: generate `Display` impl for user-defined types, use `format!("{:?}", x)` or custom formatting
+- TS codegen: generate `toString()` or use JSON.stringify-based approach
+- Existing `int.to_string()` etc. remain for backward compatibility but `show()` becomes the recommended way
+
+### Open Questions
+
+- String interpolation: should `"value is ${x}"` auto-call `show(x)` for non-String types? Currently requires explicit conversion. If yes, this massively improves ergonomics
+- Debug vs display: should `show(Red)` produce `"Red"` (debug-style) or allow user customization? Almide answer: always debug-style, no customization. One way to do things
+
+## Hash Protocol (Planned)
+
+**Automatic.** The compiler determines hashability from the type structure. No `deriving Hash` needed.
+
 ```almide
 type Color = | Red | Green | Blue
 
-// Just works — no deriving needed
-fn same_color?(a: Color, b: Color) -> Bool = a == b
-
-// Function types are rejected at compile time:
-// let f = fn(x: Int) => x + 1
-// f == f  // error: function types are not comparable
+let m: Map[Color, String] = [:]  // OK: Color is hashable
+let n: Map[Float, String] = [:]  // error: Float cannot be used as Map key
 ```
 
-What is Eq:
-- Primitives: Int, Float, String, Bool, Unit
-- Containers: List[T], Option[T], Result[T, E], Map[K, V], Tuple — if contents are Eq
-- Records: if all fields are Eq
-- Variants: if all payloads are Eq
-- Recursive types: handled (e.g. `Tree[T]` with `Node(Tree[T], Tree[T])`)
+What is Hash:
+- Int, String, Bool, Unit — hashable
+- **Float — NOT hashable** (NaN != NaN makes hashing unsound)
+- List[T], Option[T], Tuple — hashable if contents are Hash
+- Records, Variants — hashable if all fields are Hash (and no Float fields)
+- `Fn` types — not hashable
 
-What is NOT Eq:
-- `Fn` types (function values cannot be compared)
+### Implementation
 
-## Planned: Show
-
-Universal `show()` function for all displayable types. Eliminates the need for per-module `int.to_string()`, `float.to_string()`, etc.
-
-## Planned: Hash (opt-in via `deriving Hash`)
-
-Unlike Eq, Hash requires explicit opt-in because:
-- Float cannot be hashed (NaN)
-- Map key constraint: `Map[K, V]` will require K to be Hash
-- Checked at Almide level, not deferred to Rust compiler
+- Add `is_hash()` to TypeEnv (same pattern as `is_eq()` with cycle detection)
+- Checker: `Map[K, V]` requires K to be Hash at type-check time
+- Error message: "Map key type Float is not hashable — use String or Int as keys"
+- Rust codegen: emit `#[derive(Hash)]` for types that are Hash
+- No user-facing syntax change — just better compile errors
 
 ## What NOT To Do
 
 - No user-defined traits
-- No `impl` blocks (all behavior is standalone functions or `deriving`)
+- No `impl` blocks
 - No associated types, default methods, orphan rules, trait objects
-- No `deriving Eq` — Eq is automatic based on type structure
+- No `deriving Eq` / `deriving Show` / `deriving Hash` — all automatic from type structure
+- Only exception: `deriving From` (genuinely opt-in for error type conversions)

--- a/spec/lang/bidirectional_type_test.almd
+++ b/spec/lang/bidirectional_type_test.almd
@@ -1,0 +1,83 @@
+// Bidirectional type inference tests
+
+// --- Empty container with type annotation ---
+
+test "empty list with type annotation" {
+  let xs: List[Int] = []
+  assert_eq(xs.len(), 0)
+  let ys = xs ++ [1, 2, 3]
+  assert_eq(ys, [1, 2, 3])
+}
+
+test "empty list of strings" {
+  let xs: List[String] = []
+  let result = xs ++ ["hello"]
+  assert_eq(result, ["hello"])
+}
+
+// --- Structured error types ---
+
+type MathError =
+  | DivideByZero
+  | Overflow(String)
+  | NegativeInput(Int)
+
+effect fn safe_div(a: Int, b: Int) -> Result[Int, MathError] = {
+  guard b != 0 else err(DivideByZero)
+  ok(a / b)
+}
+
+effect fn safe_sqrt(x: Int) -> Result[Int, MathError] = {
+  guard x >= 0 else err(NegativeInput(x))
+  ok(x)
+}
+
+test "structured error - ok path" {
+  assert_eq(safe_div(10, 2), ok(5))
+}
+
+test "structured error - divide by zero" {
+  assert_eq(safe_div(10, 0), err(DivideByZero))
+}
+
+test "structured error - negative input" {
+  assert_eq(safe_sqrt(-5), err(NegativeInput(-5)))
+}
+
+test "structured error - overflow variant" {
+  let e: Result[Int, MathError] = err(Overflow("too big"))
+  match e {
+    ok(_) => assert(false),
+    err(Overflow(msg)) => assert_eq(msg, "too big"),
+    err(_) => assert(false),
+  }
+}
+
+// --- Match on structured errors ---
+
+effect fn compute(a: Int, b: Int) -> Result[String, MathError] = {
+  match safe_div(a, b) {
+    ok(v) => ok(int.to_string(v)),
+    err(DivideByZero) => ok("infinity"),
+    err(e) => err(e),
+  }
+}
+
+test "match on structured error" {
+  assert_eq(compute(10, 2), ok("5"))
+  assert_eq(compute(10, 0), ok("infinity"))
+}
+
+// --- Expected type flows through if/match/block ---
+
+effect fn classify(x: Int) -> Result[String, MathError] = {
+  if x > 0 then ok("positive")
+  else if x == 0 then ok("zero")
+  else err(NegativeInput(x))
+}
+
+test "expected type through if branches" {
+  assert_eq(classify(5), ok("positive"))
+  assert_eq(classify(0), ok("zero"))
+  assert_eq(classify(-3), err(NegativeInput(-3)))
+}

--- a/spec/lang/eq_protocol_test.almd
+++ b/spec/lang/eq_protocol_test.almd
@@ -1,0 +1,65 @@
+// Eq protocol: all value types support ==, function types do not
+
+type Color =
+  | Red
+  | Green
+  | Blue
+
+type Point = { x: Int, y: Int }
+
+type Tree[T] =
+  | Leaf(T)
+  | Node(Tree[T], Tree[T])
+
+test "primitives are comparable" {
+  assert_eq(1 == 1, true)
+  assert_eq(1 != 2, true)
+  assert_eq("a" == "a", true)
+  assert_eq(true == true, true)
+  assert_eq(1.5 == 1.5, true)
+}
+
+test "lists are comparable" {
+  assert_eq([1, 2, 3] == [1, 2, 3], true)
+  assert_eq([1, 2] != [1, 3], true)
+}
+
+test "options are comparable" {
+  assert_eq(some(1) == some(1), true)
+  assert_eq(some(1) != none, true)
+}
+
+test "results are comparable" {
+  let a: Result[Int, String] = ok(1)
+  let b: Result[Int, String] = ok(1)
+  assert_eq(a == b, true)
+  assert_eq(a != err("fail"), true)
+}
+
+test "tuples are comparable" {
+  assert_eq((1, "a") == (1, "a"), true)
+  assert_eq((1, 2, 3) != (1, 2, 4), true)
+}
+
+test "records are comparable" {
+  let p1 = { x: 1, y: 2 }
+  let p2 = { x: 1, y: 2 }
+  assert_eq(p1 == p2, true)
+}
+
+test "variant types are comparable" {
+  assert_eq(Red == Red, true)
+  assert_eq(Red != Green, true)
+}
+
+test "recursive variant types are comparable" {
+  let t1 = Node(Leaf(1), Leaf(2))
+  let t2 = Node(Leaf(1), Leaf(2))
+  assert_eq(t1 == t2, true)
+}
+
+test "nested containers are comparable" {
+  let a: List[Option[Int]] = [some(1), none, some(3)]
+  let b: List[Option[Int]] = [some(1), none, some(3)]
+  assert_eq(a == b, true)
+}

--- a/spec/lang/hash_protocol_test.almd
+++ b/spec/lang/hash_protocol_test.almd
@@ -1,0 +1,23 @@
+// Hash protocol: Map keys must be hashable (no Float, no Fn)
+
+test "string keys work" {
+  let m = ["a": 1, "b": 2]
+  assert_eq(m["a"], some(1))
+}
+
+test "int keys work" {
+  let m = [1: "one", 2: "two"]
+  assert_eq(m[1], some("one"))
+}
+
+test "bool keys work" {
+  let m = [true: "yes", false: "no"]
+  assert_eq(m[true], some("yes"))
+}
+
+test "option keys work" {
+  let m: Map[String, Int] = [:]
+  var m2 = m
+  m2["x"] = 10
+  assert_eq(m2["x"], some(10))
+}

--- a/spec/lang/map_literal_test.almd
+++ b/spec/lang/map_literal_test.almd
@@ -1,0 +1,87 @@
+// Map literal syntax tests
+
+test "empty map with type annotation" {
+  let m: Map[String, Int] = [:]
+  assert_eq(m.len(), 0)
+  assert(m.is_empty?())
+}
+
+test "map literal with entries" {
+  let m = ["a": 1, "b": 2, "c": 3]
+  assert_eq(m.len(), 3)
+  assert_eq(m.get("a"), some(1))
+  assert_eq(m.get("b"), some(2))
+  assert_eq(m.get("c"), some(3))
+}
+
+test "map literal single entry" {
+  let m = ["key": "value"]
+  assert_eq(m.get("key"), some("value"))
+}
+
+test "map set on empty map" {
+  let m: Map[String, Int] = [:]
+  let m2 = m.set("x", 42)
+  assert_eq(m2.get("x"), some(42))
+}
+
+test "map literal with trailing comma" {
+  let m = [
+    "host": "localhost",
+    "port": "8080",
+  ]
+  assert_eq(m.get("host"), some("localhost"))
+  assert_eq(m.get("port"), some("8080"))
+}
+
+test "map keys and values" {
+  let m = ["a": 1, "b": 2]
+  let ks = m.keys()
+  assert_eq(ks.len(), 2)
+  assert(ks.contains("a"))
+  assert(ks.contains("b"))
+}
+
+// --- Index access: m[key] returns Option[V] ---
+
+test "map index access returns some" {
+  let m = ["x": 10, "y": 20]
+  assert_eq(m["x"], some(10))
+  assert_eq(m["y"], some(20))
+}
+
+test "map index access returns none for missing key" {
+  let m = ["a": 1]
+  assert_eq(m["z"], none)
+}
+
+// --- Direct iteration: for (k, v) in m ---
+
+test "for (k, v) in map" {
+  let m = ["a": 1, "b": 2]
+  var sum = 0
+  for (k, v) in m {
+    sum = sum + v
+  }
+  assert_eq(sum, 3)
+}
+
+test "for key in map iterates keys" {
+  let m = ["x": 10, "y": 20]
+  var count = 0
+  for k in m {
+    count = count + 1
+  }
+  assert_eq(count, 2)
+}
+
+// --- Mutable index assignment: m[key] = val ---
+
+test "map index assign on var" {
+  var m = ["a": 1]
+  m["b"] = 2
+  m["a"] = 10
+  assert_eq(m["a"], some(10))
+  assert_eq(m["b"], some(2))
+  assert_eq(m.len(), 2)
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -96,6 +96,8 @@ pub enum Expr {
     Ident { name: String, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
     TypeName { name: String, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
     List { elements: Vec<Expr>, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
+    MapLiteral { entries: Vec<(Expr, Expr)>, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
+    EmptyMap { #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
     Record { name: Option<String>, fields: Vec<FieldInit>, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
     SpreadRecord { base: Box<Expr>, fields: Vec<FieldInit>, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
     Call { callee: Box<Expr>, args: Vec<Expr>, #[serde(default)] type_args: Option<Vec<TypeExpr>>, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
@@ -135,7 +137,8 @@ impl Expr {
             Expr::Int { span, .. } | Expr::Float { span, .. } | Expr::String { span, .. }
             | Expr::InterpolatedString { span, .. } | Expr::Bool { span, .. }
             | Expr::Ident { span, .. } | Expr::TypeName { span, .. }
-            | Expr::List { span, .. } | Expr::Record { span, .. }
+            | Expr::List { span, .. } | Expr::MapLiteral { span, .. } | Expr::EmptyMap { span, .. }
+            | Expr::Record { span, .. }
             | Expr::SpreadRecord { span, .. } | Expr::Call { span, .. }
             | Expr::Member { span, .. } | Expr::TupleIndex { span, .. } | Expr::IndexAccess { span, .. } | Expr::Pipe { span, .. }
             | Expr::If { span, .. } | Expr::Match { span, .. }
@@ -158,7 +161,8 @@ impl Expr {
             Expr::Int { resolved_type, .. } | Expr::Float { resolved_type, .. } | Expr::String { resolved_type, .. }
             | Expr::InterpolatedString { resolved_type, .. } | Expr::Bool { resolved_type, .. }
             | Expr::Ident { resolved_type, .. } | Expr::TypeName { resolved_type, .. }
-            | Expr::List { resolved_type, .. } | Expr::Record { resolved_type, .. }
+            | Expr::List { resolved_type, .. } | Expr::MapLiteral { resolved_type, .. } | Expr::EmptyMap { resolved_type, .. }
+            | Expr::Record { resolved_type, .. }
             | Expr::SpreadRecord { resolved_type, .. } | Expr::Call { resolved_type, .. }
             | Expr::Member { resolved_type, .. } | Expr::TupleIndex { resolved_type, .. } | Expr::IndexAccess { resolved_type, .. } | Expr::Pipe { resolved_type, .. }
             | Expr::If { resolved_type, .. } | Expr::Match { resolved_type, .. }
@@ -181,7 +185,8 @@ impl Expr {
             Expr::Int { resolved_type, .. } | Expr::Float { resolved_type, .. } | Expr::String { resolved_type, .. }
             | Expr::InterpolatedString { resolved_type, .. } | Expr::Bool { resolved_type, .. }
             | Expr::Ident { resolved_type, .. } | Expr::TypeName { resolved_type, .. }
-            | Expr::List { resolved_type, .. } | Expr::Record { resolved_type, .. }
+            | Expr::List { resolved_type, .. } | Expr::MapLiteral { resolved_type, .. } | Expr::EmptyMap { resolved_type, .. }
+            | Expr::Record { resolved_type, .. }
             | Expr::SpreadRecord { resolved_type, .. } | Expr::Call { resolved_type, .. }
             | Expr::Member { resolved_type, .. } | Expr::TupleIndex { resolved_type, .. } | Expr::IndexAccess { resolved_type, .. } | Expr::Pipe { resolved_type, .. }
             | Expr::If { resolved_type, .. } | Expr::Match { resolved_type, .. }

--- a/src/check/expressions.rs
+++ b/src/check/expressions.rs
@@ -150,6 +150,42 @@ impl Checker {
                 Ty::List(Box::new(first_ty))
             }
 
+            ast::Expr::EmptyMap { .. } => {
+                if let Some(Ty::Map(k, v)) = expected {
+                    Ty::Map(k.clone(), v.clone())
+                } else {
+                    self.push_diagnostic(err(
+                        "cannot infer Map type from empty literal [:]",
+                        "Add a type annotation: let m: Map[K, V] = [:]",
+                        "empty map literal",
+                    ));
+                    Ty::Map(Box::new(Ty::Unknown), Box::new(Ty::Unknown))
+                }
+            }
+
+            ast::Expr::MapLiteral { entries, .. } => {
+                let (first_key, first_val) = &mut entries[0];
+                let key_ty = self.check_expr(first_key);
+                let val_ty = self.check_expr(first_val);
+                for (i, (k, v)) in entries.iter_mut().enumerate().skip(1) {
+                    let kt = self.check_expr(k);
+                    let vt = self.check_expr(v);
+                    if !key_ty.compatible(&kt) {
+                        self.push_diagnostic(err(
+                            format!("map key at index {} has type {} but expected {}", i, kt.display(), key_ty.display()),
+                            "All map keys must have the same type", "map literal",
+                        ));
+                    }
+                    if !val_ty.compatible(&vt) {
+                        self.push_diagnostic(err(
+                            format!("map value at index {} has type {} but expected {}", i, vt.display(), val_ty.display()),
+                            "All map values must have the same type", "map literal",
+                        ));
+                    }
+                }
+                Ty::Map(Box::new(key_ty), Box::new(val_ty))
+            }
+
             ast::Expr::Record { name, fields, .. } => {
                 // Check if this is a variant record constructor
                 if let Some(cname) = name.as_ref() {
@@ -339,7 +375,13 @@ impl Checker {
                 self.env.push_scope();
                 let elem_ty = match &it {
                     Ty::List(inner) => *inner.clone(),
-                    Ty::Map(k, _) => *k.clone(),
+                    Ty::Map(k, v) => {
+                        if var_tuple.is_some() {
+                            Ty::Tuple(vec![*k.clone(), *v.clone()])
+                        } else {
+                            *k.clone()
+                        }
+                    }
                     _ if matches!(it, Ty::Unknown) => Ty::Unknown,
                     _ => {
                         self.push_diagnostic(err(
@@ -500,21 +542,33 @@ impl Checker {
             ast::Expr::IndexAccess { object, index, .. } => {
                 let ot = self.check_expr(object);
                 let it = self.check_expr(index);
-                if !matches!(it, Ty::Int | Ty::Unknown) {
-                    self.push_diagnostic(err(
-                        format!("index must be Int, got {}", it.display()),
-                        "Use an Int value for list indexing",
-                        "xs[i]",
-                    ));
-                }
                 match &ot {
-                    Ty::List(inner) => *inner.clone(),
+                    Ty::List(inner) => {
+                        if !matches!(it, Ty::Int | Ty::Unknown) {
+                            self.push_diagnostic(err(
+                                format!("list index must be Int, got {}", it.display()),
+                                "Use an Int value for list indexing",
+                                "xs[i]",
+                            ));
+                        }
+                        *inner.clone()
+                    }
+                    Ty::Map(k, v) => {
+                        if !it.compatible(k) && !matches!(it, Ty::Unknown) {
+                            self.push_diagnostic(err(
+                                format!("map key type is {} but got {}", k.display(), it.display()),
+                                "Key type must match the Map's key type",
+                                "m[key]",
+                            ));
+                        }
+                        Ty::Option(v.clone())
+                    }
                     Ty::Unknown => Ty::Unknown,
                     _ => {
                         self.push_diagnostic(err(
                             format!("cannot index into type {}", ot.display()),
-                            "Indexing with [] is only supported for List[T]",
-                            "xs[i]",
+                            "Indexing with [] is supported for List[T] and Map[K, V]",
+                            "xs[i] or m[key]",
                         ));
                         Ty::Unknown
                     }

--- a/src/check/expressions.rs
+++ b/src/check/expressions.rs
@@ -152,6 +152,13 @@ impl Checker {
 
             ast::Expr::EmptyMap { .. } => {
                 if let Some(Ty::Map(k, v)) = expected {
+                    if !self.env.is_hash(k) {
+                        self.push_diagnostic(err(
+                            format!("Map key type {} is not hashable", k.display()),
+                            "Use String, Int, or Bool as Map keys — Float and function types cannot be keys",
+                            "empty map literal",
+                        ));
+                    }
                     Ty::Map(k.clone(), v.clone())
                 } else {
                     self.push_diagnostic(err(
@@ -182,6 +189,13 @@ impl Checker {
                             "All map values must have the same type", "map literal",
                         ));
                     }
+                }
+                if !self.env.is_hash(&key_ty) {
+                    self.push_diagnostic(err(
+                        format!("Map key type {} is not hashable", key_ty.display()),
+                        "Use String, Int, or Bool as Map keys — Float and function types cannot be keys",
+                        "map literal",
+                    ));
                 }
                 Ty::Map(Box::new(key_ty), Box::new(val_ty))
             }

--- a/src/check/expressions.rs
+++ b/src/check/expressions.rs
@@ -25,6 +25,10 @@ fn ty_to_resolved(ty: &Ty) -> ResolvedType {
 
 impl Checker {
     pub(crate) fn check_expr(&mut self, expr: &mut ast::Expr) -> Ty {
+        self.check_expr_with(expr, None)
+    }
+
+    pub(crate) fn check_expr_with(&mut self, expr: &mut ast::Expr, expected: Option<&Ty>) -> Ty {
         // Update current line/col from expression span for precise error positions
         let prev_line = self.current_decl_line;
         let prev_col = self.current_decl_col;
@@ -32,7 +36,7 @@ impl Checker {
             self.current_decl_line = Some(span.line);
             self.current_decl_col = Some(span.col);
         }
-        let ty = self.check_expr_inner(expr);
+        let ty = self.check_expr_inner(expr, expected);
         expr.set_resolved_type(ty_to_resolved(&ty));
         if let Some(span) = expr.span() {
             self.expr_types.insert((span.line, span.col), ty.clone());
@@ -42,7 +46,7 @@ impl Checker {
         ty
     }
 
-    fn check_expr_inner(&mut self, expr: &mut ast::Expr) -> Ty {
+    fn check_expr_inner(&mut self, expr: &mut ast::Expr, expected: Option<&Ty>) -> Ty {
         match expr {
             ast::Expr::Int { .. } => Ty::Int,
             ast::Expr::Float { .. } => Ty::Float,
@@ -53,7 +57,13 @@ impl Checker {
             }
             ast::Expr::Bool { .. } => Ty::Bool,
             ast::Expr::Unit { .. } => Ty::Unit,
-            ast::Expr::None { .. } => Ty::Option(Box::new(Ty::Unknown)),
+            ast::Expr::None { .. } => {
+                if let Some(Ty::Option(inner)) = expected {
+                    Ty::Option(inner.clone())
+                } else {
+                    Ty::Option(Box::new(Ty::Unknown))
+                }
+            }
             ast::Expr::Hole { .. } | ast::Expr::Todo { .. } | ast::Expr::Placeholder { .. } => Ty::Unknown,
             ast::Expr::Some { expr: inner, .. } => Ty::Option(Box::new(self.check_expr(inner))),
             ast::Expr::Ok { expr: inner, .. } => {
@@ -61,10 +71,23 @@ impl Checker {
                 if !self.env.in_effect && matches!(inner_ty, Ty::Unit) {
                     Ty::Unit
                 } else {
-                    Ty::Result(Box::new(inner_ty), Box::new(Ty::Unknown))
+                    // Use expected type to infer error half
+                    let err_ty = match expected {
+                        Some(Ty::Result(_, e)) => *e.clone(),
+                        _ => Ty::Unknown,
+                    };
+                    Ty::Result(Box::new(inner_ty), Box::new(err_ty))
                 }
             }
-            ast::Expr::Err { expr: inner, .. } => Ty::Result(Box::new(Ty::Unknown), Box::new(self.check_expr(inner))),
+            ast::Expr::Err { expr: inner, .. } => {
+                let err_ty = self.check_expr(inner);
+                // Use expected type to infer ok half
+                let ok_ty = match expected {
+                    Some(Ty::Result(o, _)) => *o.clone(),
+                    _ => Ty::Unknown,
+                };
+                Ty::Result(Box::new(ok_ty), Box::new(err_ty))
+            }
 
             ast::Expr::Ident { name, .. } => {
                 if let Some(ty) = self.env.lookup_var(name).cloned() {
@@ -107,7 +130,13 @@ impl Checker {
             }
 
             ast::Expr::List { elements, .. } => {
-                if elements.is_empty() { return Ty::List(Box::new(Ty::Unknown)); }
+                if elements.is_empty() {
+                    return if let Some(Ty::List(inner)) = expected {
+                        Ty::List(inner.clone())
+                    } else {
+                        Ty::List(Box::new(Ty::Unknown))
+                    };
+                }
                 let first_ty = self.check_expr(&mut elements[0]);
                 for (i, elem) in elements.iter_mut().enumerate().skip(1) {
                     let et = self.check_expr(elem);
@@ -188,8 +217,8 @@ impl Checker {
                         "The condition must be a Bool expression", "if expression",
                     ));
                 }
-                let tt = self.check_expr(then);
-                let et = self.check_expr(else_);
+                let tt = self.check_expr_with(then, expected);
+                let et = self.check_expr_with(else_, expected);
                 if !tt.compatible(&et) {
                     let mut diag = err(
                         format!("if branches have different types: then is {}, else is {}", tt.display(), et.display()),
@@ -229,7 +258,7 @@ impl Checker {
                             ));
                         }
                     }
-                    let at = self.check_expr(&mut arm.body);
+                    let at = self.check_expr_with(&mut arm.body, expected);
                     if let Some(ref mut prev) = result_ty {
                         let compat = prev.compatible(&at)
                             || match (prev.clone(), &at) {
@@ -267,7 +296,7 @@ impl Checker {
             ast::Expr::Block { stmts, expr, .. } => {
                 self.env.push_scope();
                 for s in stmts.iter_mut() { self.check_stmt(s); }
-                let ty = expr.as_mut().map(|e| self.check_expr(e)).unwrap_or(Ty::Unit);
+                let ty = expr.as_mut().map(|e| self.check_expr_with(e, expected)).unwrap_or(Ty::Unit);
                 self.warn_unused_vars_in_scope("block");
                 self.env.pop_scope();
                 ty
@@ -278,7 +307,7 @@ impl Checker {
                 let prev_do = self.env.in_do_block;
                 self.env.in_do_block = true;
                 for s in stmts.iter_mut() { self.check_stmt(s); }
-                let _ty = expr.as_mut().map(|e| self.check_expr(e)).unwrap_or(Ty::Unit);
+                let _ty = expr.as_mut().map(|e| self.check_expr_with(e, expected)).unwrap_or(Ty::Unit);
                 self.warn_unused_vars_in_scope("do block");
                 self.env.in_do_block = prev_do;
                 self.env.pop_scope();
@@ -439,7 +468,7 @@ impl Checker {
                 }
             }
 
-            ast::Expr::Paren { expr: inner, .. } => self.check_expr(inner),
+            ast::Expr::Paren { expr: inner, .. } => self.check_expr_with(inner, expected),
             ast::Expr::Tuple { elements, .. } => {
                 let tys: Vec<Ty> = elements.iter_mut().map(|e| self.check_expr(e)).collect();
                 Ty::Tuple(tys)

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -474,7 +474,7 @@ impl Checker {
                     let prev_effect = self.env.in_effect;
                     self.env.current_ret = Some(ret_ty.clone());
                     self.env.in_effect = effect.unwrap_or(false);
-                    let body_ty = self.check_expr(body);
+                    let body_ty = self.check_expr_with(body, Some(&ret_ty));
                     let is_effect = effect.unwrap_or(false);
                     let effective_ret = if is_effect {
                         match &ret_ty {

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -17,6 +17,7 @@ fn is_const_expr(expr: &ast::Expr) -> bool {
         ast::Expr::Int { .. } | ast::Expr::Float { .. } | ast::Expr::String { .. }
         | ast::Expr::Bool { .. } | ast::Expr::Unit { .. } | ast::Expr::None { .. } => true,
         ast::Expr::List { elements, .. } => elements.is_empty(),
+        ast::Expr::EmptyMap { .. } => true,
         ast::Expr::Unary { op, operand, .. } if op == "-" => is_const_expr(operand),
         _ => false,
     }
@@ -30,6 +31,7 @@ fn is_top_let_const_expr(expr: &ast::Expr, known_consts: &std::collections::Hash
         ast::Expr::Int { .. } | ast::Expr::Float { .. } | ast::Expr::String { .. }
         | ast::Expr::Bool { .. } | ast::Expr::Unit { .. } | ast::Expr::None { .. } => true,
         ast::Expr::List { elements, .. } => elements.is_empty(),
+        ast::Expr::EmptyMap { .. } => true,
         ast::Expr::Unary { op, operand, .. } if op == "-" => is_top_let_const_expr(operand, known_consts),
         ast::Expr::Ident { name, .. } | ast::Expr::TypeName { name, .. } => known_consts.contains(name),
         ast::Expr::Binary { op, left, right, .. } => {
@@ -266,6 +268,7 @@ impl Checker {
             ast::Expr::Unit { .. } => Ty::Unit,
             ast::Expr::None { .. } => Ty::Option(Box::new(Ty::Unknown)),
             ast::Expr::List { .. } => Ty::List(Box::new(Ty::Unknown)),
+            ast::Expr::EmptyMap { .. } => Ty::Map(Box::new(Ty::Unknown), Box::new(Ty::Unknown)),
             ast::Expr::Unary { op, operand, .. } if op == "-" => self.infer_const_type(operand),
             ast::Expr::Ident { name, .. } | ast::Expr::TypeName { name, .. } => {
                 // Reference to another top-level let
@@ -886,6 +889,13 @@ impl Checker {
                     Self::find_list_mutations(e, list_params, out);
                 }
             }
+            ast::Expr::MapLiteral { entries, .. } => {
+                for (k, v) in entries {
+                    Self::find_list_mutations(k, list_params, out);
+                    Self::find_list_mutations(v, list_params, out);
+                }
+            }
+            ast::Expr::EmptyMap { .. } => {}
             ast::Expr::Member { object, .. } | ast::Expr::TupleIndex { object, .. } => {
                 Self::find_list_mutations(object, list_params, out);
             }

--- a/src/check/operators.rs
+++ b/src/check/operators.rs
@@ -49,7 +49,24 @@ impl Checker {
                     Ty::Unknown
                 }
             }
-            "==" | "!=" | "<" | ">" | "<=" | ">=" => Ty::Bool,
+            "==" | "!=" => {
+                if !self.env.is_eq(left) {
+                    self.push_diagnostic(err(
+                        format!("'{}' cannot compare type {} — function types are not comparable", op, left.display()),
+                        "Only value types (Int, String, List, records, variants, ...) support equality",
+                        format!("operator '{}'", op),
+                    ));
+                }
+                if !self.env.is_eq(right) {
+                    self.push_diagnostic(err(
+                        format!("'{}' cannot compare type {} — function types are not comparable", op, right.display()),
+                        "Only value types (Int, String, List, records, variants, ...) support equality",
+                        format!("operator '{}'", op),
+                    ));
+                }
+                Ty::Bool
+            }
+            "<" | ">" | "<=" | ">=" => Ty::Bool,
             "and" | "or" => {
                 if !left.compatible(&Ty::Bool) {
                     self.push_diagnostic(err(

--- a/src/check/statements.rs
+++ b/src/check/statements.rs
@@ -24,7 +24,8 @@ impl Checker {
         }
         match stmt {
             ast::Stmt::Let { name, ty, value, span, .. } => {
-                let vt = self.check_expr(value);
+                let expected_ty = ty.as_ref().map(|te| self.resolve_type_expr(te));
+                let vt = self.check_expr_with(value, expected_ty.as_ref());
                 let vt = if self.env.in_do_block {
                     match vt {
                         Ty::Result(ok, _) => *ok,
@@ -32,7 +33,7 @@ impl Checker {
                     }
                 } else { vt };
                 let dt = if let Some(te) = ty {
-                    let t = self.resolve_type_expr(te);
+                    let t = expected_ty.clone().unwrap_or_else(|| self.resolve_type_expr(te));
                     // Resolve Named types (e.g., Container[Int] → Record { items: List[Int], label: String })
                     // so structural comparison works with anonymous record literals
                     let t_resolved = self.env.resolve_named(&t);
@@ -52,9 +53,10 @@ impl Checker {
                 }
             }
             ast::Stmt::Var { name, ty, value, span, .. } => {
-                let vt = self.check_expr(value);
+                let expected_ty = ty.as_ref().map(|te| self.resolve_type_expr(te));
+                let vt = self.check_expr_with(value, expected_ty.as_ref());
                 let dt = if let Some(te) = ty {
-                    let t = self.resolve_type_expr(te);
+                    let t = expected_ty.clone().unwrap_or_else(|| self.resolve_type_expr(te));
                     let t_resolved = self.env.resolve_named(&t);
                     if !t_resolved.compatible(&vt) {
                         self.push_diagnostic(err(

--- a/src/emit_rust/borrow.rs
+++ b/src/emit_rust/borrow.rs
@@ -182,6 +182,15 @@ fn check_escape_expr(
             for (_, e) in fields { mark_all(e, heap_vars, escaped); }
         }
 
+        IrExprKind::MapLiteral { entries } => {
+            for (k, v) in entries {
+                mark_all(k, heap_vars, escaped);
+                mark_all(v, heap_vars, escaped);
+            }
+        }
+
+        IrExprKind::EmptyMap => {}
+
         // Binary ops: Concat consumes ownership; others are OK
         IrExprKind::BinOp { op, left, right } => {
             if matches!(op, BinOp::ConcatStr | BinOp::ConcatList) {
@@ -381,6 +390,13 @@ fn mark_all_filtered(expr: &IrExpr, vars: &HashSet<VarId>, escaped: &mut HashSet
             mark_all_filtered(base, vars, escaped);
             for (_, e) in fields { mark_all_filtered(e, vars, escaped); }
         }
+        IrExprKind::MapLiteral { entries } => {
+            for (k, v) in entries {
+                mark_all_filtered(k, vars, escaped);
+                mark_all_filtered(v, vars, escaped);
+            }
+        }
+        IrExprKind::EmptyMap => {}
         IrExprKind::BinOp { left, right, .. } => {
             mark_all_filtered(left, vars, escaped);
             mark_all_filtered(right, vars, escaped);

--- a/src/emit_rust/ir_blocks.rs
+++ b/src/emit_rust/ir_blocks.rs
@@ -52,7 +52,10 @@ impl Emitter {
                 let name = self.ir_var_table().get(*target).name.clone();
                 let idx = self.gen_ir_expr(index);
                 let val = self.gen_ir_expr(value);
-                if self.fast_mode {
+                let target_ty = &self.ir_var_table().get(*target).ty;
+                if matches!(target_ty, almide::types::Ty::Map(_, _)) {
+                    format!("{}.insert({}, {});", name, idx, val)
+                } else if self.fast_mode {
                     format!("unsafe {{ *{}.get_unchecked_mut({} as usize) = {}; }}", name, idx, val)
                 } else {
                     format!("{}[{} as usize] = {};", name, idx, val)
@@ -319,6 +322,7 @@ impl Emitter {
         use almide::types::Ty;
         let is_empty_collection = value.map_or(false, |v| match &v.kind {
             IrExprKind::List { elements } => elements.is_empty(),
+            IrExprKind::EmptyMap => true,
             IrExprKind::Call { target: CallTarget::Module { func, .. }, args, .. } => {
                 func == "new" && args.is_empty()
             }

--- a/src/emit_rust/ir_expressions.rs
+++ b/src/emit_rust/ir_expressions.rs
@@ -1,4 +1,5 @@
 use almide::ir::*;
+use almide::types::Ty;
 use super::Emitter;
 
 impl Emitter {
@@ -220,7 +221,15 @@ impl Emitter {
                             }
                         }
                         IrStringPart::Expr { expr } => {
-                            fmt.push_str("{}");
+                            // Use Debug ({:?}) only for compound types that lack Display:
+                            // List, Option, Result, Map, Tuple, Record, Variant
+                            // Everything else uses Display ({}) — including String, Int, Float, Bool, Unknown
+                            let use_debug = Self::needs_debug_format(&expr.ty);
+                            if use_debug {
+                                fmt.push_str("{:?}");
+                            } else {
+                                fmt.push_str("{}");
+                            }
                             args.push(self.gen_ir_expr(expr));
                         }
                     }
@@ -943,6 +952,19 @@ impl Emitter {
             if *count == 1 && !param_ids.contains(id) {
                 self.single_use_vars.insert(var_table.get(*id).name.clone());
             }
+        }
+    }
+
+    fn needs_debug_format(ty: &Ty) -> bool {
+        match ty {
+            Ty::List(_) | Ty::Option(_) | Ty::Result(_, _) |
+            Ty::Map(_, _) | Ty::Tuple(_) | Ty::Record { .. } |
+            Ty::Variant { .. } => true,
+            Ty::Named(name, _) => {
+                // Built-in type names use Display, user-defined types use Debug
+                !matches!(name.as_str(), "String" | "Int" | "Float" | "Bool")
+            }
+            _ => false,
         }
     }
 }

--- a/src/emit_rust/ir_expressions.rs
+++ b/src/emit_rust/ir_expressions.rs
@@ -94,6 +94,19 @@ impl Emitter {
                 format!("vec![{}]", elems.join(", "))
             }
 
+            IrExprKind::EmptyMap => {
+                "HashMap::new()".to_string()
+            }
+
+            IrExprKind::MapLiteral { entries } => {
+                let pairs: Vec<String> = entries.iter().map(|(k, v)| {
+                    let kc = self.gen_ir_arg(k);
+                    let vc = self.gen_ir_arg(v);
+                    format!("({}, {})", kc, vc)
+                }).collect();
+                format!("vec![{}].into_iter().collect::<HashMap<_, _>>()", pairs.join(", "))
+            }
+
             IrExprKind::Record { name, fields } => {
                 if let Some(struct_name) = name {
                     let fs: Vec<String> = fields.iter().map(|(fname, fval)| {
@@ -172,7 +185,10 @@ impl Emitter {
             IrExprKind::IndexAccess { object, index } => {
                 let obj = self.gen_ir_expr(object);
                 let idx = self.gen_ir_expr(index);
-                if self.fast_mode {
+                if matches!(object.ty, almide::types::Ty::Map(_, _)) {
+                    // Map index: m[key] → map.get(m, key) → Option<V>
+                    format!("almide_rt_map_get(&{}, &{})", obj, idx)
+                } else if self.fast_mode {
                     format!("unsafe {{ *{}.get_unchecked({} as usize) }}", obj, idx)
                 } else {
                     format!("{}[{} as usize]", obj, idx)
@@ -574,6 +590,12 @@ impl Emitter {
             IrExprKind::Record { fields, .. } => {
                 for (_, v) in fields { Self::count_vars_in_expr(v, counts); }
             }
+            IrExprKind::MapLiteral { entries } => {
+                for (k, v) in entries {
+                    Self::count_vars_in_expr(k, counts);
+                    Self::count_vars_in_expr(v, counts);
+                }
+            }
             _ => {}
         }
     }
@@ -585,7 +607,8 @@ impl Emitter {
             IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. } |
             IrExprKind::LitBool { .. } | IrExprKind::LitStr { .. } |
             IrExprKind::Unit | IrExprKind::Hole | IrExprKind::Todo { .. } |
-            IrExprKind::Break | IrExprKind::Continue | IrExprKind::OptionNone => 0,
+            IrExprKind::Break | IrExprKind::Continue | IrExprKind::OptionNone |
+            IrExprKind::EmptyMap => 0,
             IrExprKind::BinOp { left, right, .. } => {
                 Self::count_var_uses(var, left) + Self::count_var_uses(var, right)
             }
@@ -598,6 +621,9 @@ impl Emitter {
             }
             IrExprKind::Record { fields, .. } | IrExprKind::SpreadRecord { fields, .. } => {
                 fields.iter().map(|(_, v)| Self::count_var_uses(var, v)).sum()
+            }
+            IrExprKind::MapLiteral { entries } => {
+                entries.iter().map(|(k, v)| Self::count_var_uses(var, k) + Self::count_var_uses(var, v)).sum()
             }
             IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
                 Self::count_var_uses(var, object)
@@ -790,7 +816,8 @@ impl Emitter {
             IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. } | IrExprKind::LitStr { .. }
             | IrExprKind::LitBool { .. } | IrExprKind::Unit | IrExprKind::OptionNone
             | IrExprKind::Hole | IrExprKind::Todo { .. }
-            | IrExprKind::Break | IrExprKind::Continue => {}
+            | IrExprKind::Break | IrExprKind::Continue
+            | IrExprKind::EmptyMap => {}
 
             IrExprKind::BinOp { left, right, .. } => {
                 Self::count_ir_var_uses(left, counts);
@@ -831,6 +858,12 @@ impl Emitter {
             IrExprKind::SpreadRecord { base, fields } => {
                 Self::count_ir_var_uses(base, counts);
                 for (_, e) in fields { Self::count_ir_var_uses(e, counts); }
+            }
+            IrExprKind::MapLiteral { entries } => {
+                for (k, v) in entries {
+                    Self::count_ir_var_uses(k, counts);
+                    Self::count_ir_var_uses(v, counts);
+                }
             }
             IrExprKind::Range { start, end, .. } => {
                 Self::count_ir_var_uses(start, counts);

--- a/src/emit_ts/ir_blocks.rs
+++ b/src/emit_ts/ir_blocks.rs
@@ -9,7 +9,7 @@ impl TsEmitter {
                 let val = self.gen_ir_expr(value);
                 let is_call = matches!(&value.kind, IrExprKind::Call { .. });
                 if self.in_test.get() && !self.in_effect.get() && is_call {
-                    format!("var {}; try {{ {} = {}; }} catch (__e) {{ {} = new __Err(__e instanceof Error ? __e.message : String(__e)); }}", name, name, val, name)
+                    format!("var {}; try {{ {} = {}; }} catch (__e) {{ {} = new __Err(__e instanceof Error ? __e.message : String(__e), __e.__almd_value); }}", name, name, val, name)
                 } else if *mutability == Mutability::Var {
                     format!("let {} = {};", name, val)
                 } else {
@@ -47,8 +47,23 @@ impl TsEmitter {
             IrExprKind::Break => format!("if (!({})) {{ break; }}", cond),
             IrExprKind::Continue => format!("if (!({})) {{ continue; }}", cond),
             IrExprKind::ResultErr { expr } => {
+                // Check if this is a structured error (variant constructor)
+                let is_variant = match &expr.kind {
+                    IrExprKind::Call { target: CallTarget::Named { name }, .. } =>
+                        name.chars().next().map_or(false, |c| c.is_uppercase()),
+                    IrExprKind::Var { id } => {
+                        let name = &self.ir_var_table().get(*id).name;
+                        name.chars().next().map_or(false, |c| c.is_uppercase())
+                    }
+                    _ => false,
+                };
                 let msg = self.gen_ir_err_msg(expr);
-                format!("if (!({})) {{ throw new Error({}); }}", cond, msg)
+                if is_variant {
+                    let val = self.gen_ir_expr(expr);
+                    format!("if (!({})) {{ const __e = new Error({}); __e.__almd_value = {}; throw __e; }}", cond, msg, val)
+                } else {
+                    format!("if (!({})) {{ throw new Error({}); }}", cond, msg)
+                }
             }
             IrExprKind::Block { stmts, expr } | IrExprKind::DoBlock { stmts, expr } => {
                 let body_stmts: Vec<String> = stmts.iter()
@@ -71,26 +86,19 @@ impl TsEmitter {
 
         let err_arm = arms.iter().find(|a| matches!(&a.pattern, IrPattern::Err { .. }));
 
-        if let Some(err_arm) = err_arm {
+        if let Some(_err_arm) = err_arm {
             let ok_arms: Vec<&IrMatchArm> = arms.iter().filter(|a| !matches!(&a.pattern, IrPattern::Err { .. })).collect();
-            let err_body = self.gen_ir_expr_value(&err_arm.body);
-            let err_binding = if let IrPattern::Err { inner } = &err_arm.pattern {
-                if let IrPattern::Bind { var } = inner.as_ref() {
-                    Some(self.ir_var_table().get(*var).name.clone())
-                } else { None }
-            } else { None };
+            let err_arms: Vec<&IrMatchArm> = arms.iter().filter(|a| matches!(&a.pattern, IrPattern::Err { .. })).collect();
 
-            let catch_convert = format!("{} = new __Err(__e instanceof Error ? __e.message : String(__e));", tmp);
-            let err_return = if let Some(ref binding) = err_binding {
-                format!("const {} = {}.message; return {};", binding, tmp, err_body)
-            } else {
-                format!("return {};", err_body)
-            };
+            let catch_convert = format!("{} = new __Err(__e instanceof Error ? __e.message : String(__e), __e.__almd_value);", tmp);
+
+            // Build err handling with multiple err arms
+            let err_handling = self.gen_err_arm_chain(&err_arms, tmp);
 
             let type_ann = if self.js_mode { "" } else { ": any" };
             let mut lines = vec![format!(
                 "(() => {{ let {}{}; try {{ {} = {}; }} catch (__e) {{ {} }} if ({} instanceof __Err) {{ {} }}",
-                tmp, type_ann, tmp, subj, catch_convert, tmp, err_return
+                tmp, type_ann, tmp, subj, catch_convert, tmp, err_handling
             )];
             for arm in &ok_arms {
                 self.emit_ir_match_arm(&mut lines, tmp, arm);
@@ -111,6 +119,47 @@ impl TsEmitter {
         }
         lines.push(format!("}})({})", subj));
         lines.join("\n")
+    }
+
+    /// Generate chained if-else for multiple err arms in a match
+    fn gen_err_arm_chain(&self, err_arms: &[&IrMatchArm], tmp: &str) -> String {
+        let val_expr = format!("{}.value", tmp);
+        let mut parts = Vec::new();
+
+        for arm in err_arms {
+            if let IrPattern::Err { inner } = &arm.pattern {
+                let body_str = self.gen_ir_expr_value(&arm.body);
+                match inner.as_ref() {
+                    IrPattern::Wildcard => {
+                        parts.push(format!("return {};", body_str));
+                    }
+                    IrPattern::Bind { var } => {
+                        let name = self.ir_var_table().get(*var).name.clone();
+                        parts.push(format!("{{ const {} = {}; return {}; }}", name, val_expr, body_str));
+                    }
+                    _ => {
+                        // Constructor pattern or nested — use gen_ir_pattern_cond on .value
+                        let (cond, bindings) = self.gen_ir_pattern_cond(&val_expr, inner);
+                        let bind_str: String = bindings.iter()
+                            .map(|b| format!("const {} = {};", b.0, b.1))
+                            .collect::<Vec<_>>().join(" ");
+                        if cond == "true" {
+                            if bind_str.is_empty() {
+                                parts.push(format!("return {};", body_str));
+                            } else {
+                                parts.push(format!("{{ {} return {}; }}", bind_str, body_str));
+                            }
+                        } else if bind_str.is_empty() {
+                            parts.push(format!("if ({}) return {};", cond, body_str));
+                        } else {
+                            parts.push(format!("if ({}) {{ {} return {}; }}", cond, bind_str, body_str));
+                        }
+                    }
+                }
+            }
+        }
+
+        parts.join(" ")
     }
 
     fn ir_is_unconditional_pattern(pat: &IrPattern) -> bool {
@@ -258,7 +307,7 @@ impl TsEmitter {
             // Auto-propagate __Err in do blocks
             if let IrStmtKind::Bind { var, .. } = &stmt.kind {
                 let san = Self::sanitize(&self.ir_var_table().get(*var).name);
-                lines.push(format!("{}if ({} instanceof __Err) throw new Error({}.message);", ind, san, san));
+                lines.push(format!("{}if ({} instanceof __Err) {{ const __re = new Error({}.message); __re.__almd_value = {}.value; throw __re; }}", ind, san, san, san));
             }
         }
 

--- a/src/emit_ts/ir_blocks.rs
+++ b/src/emit_ts/ir_blocks.rs
@@ -25,7 +25,12 @@ impl TsEmitter {
             }
             IrStmtKind::IndexAssign { target, index, value } => {
                 let name = Self::sanitize(&self.ir_var_table().get(*target).name);
-                format!("{}[{}] = {};", name, self.gen_ir_expr(index), self.gen_ir_expr(value))
+                let target_ty = &self.ir_var_table().get(*target).ty;
+                if matches!(target_ty, crate::types::Ty::Map(_, _)) {
+                    format!("{}.set({}, {});", name, self.gen_ir_expr(index), self.gen_ir_expr(value))
+                } else {
+                    format!("{}[{}] = {};", name, self.gen_ir_expr(index), self.gen_ir_expr(value))
+                }
             }
             IrStmtKind::FieldAssign { target, field, value } => {
                 let name = Self::sanitize(&self.ir_var_table().get(*target).name);

--- a/src/emit_ts/ir_expressions.rs
+++ b/src/emit_ts/ir_expressions.rs
@@ -80,6 +80,15 @@ impl TsEmitter {
                 format!("[{}]", elems.join(", "))
             }
 
+            IrExprKind::EmptyMap => "__almd_map.new()".to_string(),
+
+            IrExprKind::MapLiteral { entries } => {
+                let pairs: Vec<String> = entries.iter().map(|(k, v)| {
+                    format!("[{}, {}]", self.gen_ir_expr(k), self.gen_ir_expr(v))
+                }).collect();
+                format!("new Map([{}])", pairs.join(", "))
+            }
+
             IrExprKind::Record { name, fields } => {
                 let fs: Vec<String> = fields.iter()
                     .map(|(fname, fval)| format!("{}: {}", fname, self.gen_ir_expr(fval)))
@@ -131,7 +140,11 @@ impl TsEmitter {
             }
 
             IrExprKind::IndexAccess { object, index } => {
-                format!("{}[{}]", self.gen_ir_expr(object), self.gen_ir_expr(index))
+                if matches!(object.ty, crate::types::Ty::Map(_, _)) {
+                    format!("__almd_map.get({}, {})", self.gen_ir_expr(object), self.gen_ir_expr(index))
+                } else {
+                    format!("{}[{}]", self.gen_ir_expr(object), self.gen_ir_expr(index))
+                }
             }
 
             IrExprKind::Lambda { params, body } => {

--- a/src/emit_ts/ir_expressions.rs
+++ b/src/emit_ts/ir_expressions.rs
@@ -170,15 +170,43 @@ impl TsEmitter {
     }
 
     fn gen_ir_err(&self, expr: &IrExpr) -> String {
-        let msg = self.gen_ir_err_msg(expr);
-        if self.in_effect.get() {
-            format!("__throw({})", msg)
+        // Check if this is a structured error (variant constructor)
+        let is_variant = match &expr.kind {
+            IrExprKind::Call { target: CallTarget::Named { name }, .. } =>
+                name.chars().next().map_or(false, |c| c.is_uppercase()),
+            IrExprKind::Var { id } => {
+                let name = &self.ir_var_table().get(*id).name;
+                name.chars().next().map_or(false, |c| c.is_uppercase())
+            }
+            _ => false,
+        };
+
+        if is_variant {
+            // Structured error: preserve variant object
+            let val = self.gen_ir_expr(expr);
+            let msg = self.gen_ir_err_msg_string(expr);
+            if self.in_effect.get() {
+                // Throw an Error with message, but attach value for catch handlers
+                format!("(() => {{ const __e = new Error({}); __e.__almd_value = {}; throw __e; }})()", msg, val)
+            } else {
+                format!("new __Err({}, {})", msg, val)
+            }
         } else {
-            format!("new __Err({})", msg)
+            // Simple string error
+            let msg = self.gen_ir_err_msg_string(expr);
+            if self.in_effect.get() {
+                format!("__throw({})", msg)
+            } else {
+                format!("new __Err({})", msg)
+            }
         }
     }
 
     pub(crate) fn gen_ir_err_msg(&self, expr: &IrExpr) -> String {
+        self.gen_ir_err_msg_string(expr)
+    }
+
+    fn gen_ir_err_msg_string(&self, expr: &IrExpr) -> String {
         match &expr.kind {
             IrExprKind::LitStr { value } => Self::json_string(value),
             IrExprKind::Call { target: CallTarget::Named { name }, args, .. } => {
@@ -247,12 +275,12 @@ impl TsEmitter {
                     if matches!(&args[1].kind, IrExprKind::ResultErr { .. }) {
                         let other = self.gen_ir_expr(&args[0]);
                         let err_val = self.gen_ir_expr(&args[1]);
-                        return format!("(() => {{ let __v; try {{ __v = {}; }} catch (__e) {{ __v = new __Err(__e instanceof Error ? __e.message : String(__e)); }} assert_eq(__v, {}); }})()", other, err_val);
+                        return format!("(() => {{ let __v; try {{ __v = {}; }} catch (__e) {{ __v = new __Err(__e instanceof Error ? __e.message : String(__e), __e.__almd_value); }} assert_eq(__v, {}); }})()", other, err_val);
                     }
                     if matches!(&args[0].kind, IrExprKind::ResultErr { .. }) {
                         let other = self.gen_ir_expr(&args[1]);
                         let err_val = self.gen_ir_expr(&args[0]);
-                        return format!("(() => {{ let __v; try {{ __v = {}; }} catch (__e) {{ __v = new __Err(__e instanceof Error ? __e.message : String(__e)); }} assert_eq({}, __v); }})()", other, err_val);
+                        return format!("(() => {{ let __v; try {{ __v = {}; }} catch (__e) {{ __v = new __Err(__e instanceof Error ? __e.message : String(__e), __e.__almd_value); }} assert_eq({}, __v); }})()", other, err_val);
                     }
                 }
                 // Unit variants (no payload) are const values, not functions — emit bare identifier

--- a/src/emit_ts_runtime.rs
+++ b/src/emit_ts_runtime.rs
@@ -732,10 +732,10 @@ function __div(a: any, b: any): any {
 }
 function println(s: string): void { console.log(s); }
 function eprintln(s: string): void { console.error(s); }
-class __Err { constructor(public message: string) {} }
+class __Err { constructor(public message: string, public value?: any) {} }
 function __deep_eq(a: any, b: any): boolean {
   if (a === b) return true;
-  if (a instanceof __Err && b instanceof __Err) return a.message === b.message;
+  if (a instanceof __Err && b instanceof __Err) return __deep_eq(a.value, b.value);
   if (a instanceof __Err || b instanceof __Err) return false;
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) return false;
@@ -791,10 +791,10 @@ function __div(a, b) {
 }
 function println(s) { console.log(s); }
 function eprintln(s) { console.error(s); }
-class __Err { constructor(message) { this.message = message; } }
+class __Err { constructor(message, value) { this.message = message; this.value = value !== undefined ? value : message; } }
 function __deep_eq(a, b) {
   if (a === b) return true;
-  if (a instanceof __Err && b instanceof __Err) return a.message === b.message;
+  if (a instanceof __Err && b instanceof __Err) return __deep_eq(a.value, b.value);
   if (a instanceof __Err || b instanceof __Err) return false;
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) return false;

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -336,6 +336,36 @@ fn format_expr(out: &mut String, expr: &Expr, depth: usize) {
             }
         }
 
+        Expr::EmptyMap { .. } => {
+            out.push_str("[:]");
+        }
+
+        Expr::MapLiteral { entries, .. } => {
+            let short = entries.len() <= 3 && entries.iter().all(|(k, v)| is_short_expr(k) && is_short_expr(v));
+            if short {
+                out.push('[');
+                for (i, (k, v)) in entries.iter().enumerate() {
+                    if i > 0 { out.push_str(", "); }
+                    format_expr(out, k, depth);
+                    out.push_str(": ");
+                    format_expr(out, v, depth);
+                }
+                out.push(']');
+            } else {
+                out.push_str("[\n");
+                for (i, (k, v)) in entries.iter().enumerate() {
+                    out.push_str(&indent(depth + 1));
+                    format_expr(out, k, depth + 1);
+                    out.push_str(": ");
+                    format_expr(out, v, depth + 1);
+                    if i < entries.len() - 1 { out.push(','); }
+                    out.push('\n');
+                }
+                out.push_str(&indent(depth));
+                out.push(']');
+            }
+        }
+
         Expr::Record { name, fields, .. } => {
             if let Some(n) = name {
                 out.push_str(n);

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -181,6 +181,8 @@ pub enum IrExprKind {
 
     // ── Collections ──
     List { elements: Vec<IrExpr> },
+    MapLiteral { entries: Vec<(IrExpr, IrExpr)> },
+    EmptyMap,
     Record { name: Option<String>, fields: Vec<(String, IrExpr)> },
     SpreadRecord { base: Box<IrExpr>, fields: Vec<(String, IrExpr)> },
     Tuple { elements: Vec<IrExpr> },

--- a/src/lower.rs
+++ b/src/lower.rs
@@ -263,7 +263,13 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
             ctx.push_scope();
             let elem_ty = match &iterable_ir.ty {
                 Ty::List(inner) => *inner.clone(),
-                Ty::Map(k, _) => *k.clone(),
+                Ty::Map(k, v) => {
+                    if var_tuple.is_some() {
+                        Ty::Tuple(vec![*k.clone(), *v.clone()])
+                    } else {
+                        *k.clone()
+                    }
+                }
                 _ => Ty::Unknown,
             };
             let var_tuple_ids = if let Some(names) = var_tuple {
@@ -312,6 +318,17 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
         ast::Expr::List { elements, .. } => {
             let elems: Vec<IrExpr> = elements.iter().map(|e| lower_expr(ctx, e)).collect();
             ctx.mk(IrExprKind::List { elements: elems }, ty, span)
+        }
+
+        ast::Expr::EmptyMap { .. } => {
+            ctx.mk(IrExprKind::EmptyMap, ty, span)
+        }
+
+        ast::Expr::MapLiteral { entries, .. } => {
+            let ir_entries: Vec<(IrExpr, IrExpr)> = entries.iter()
+                .map(|(k, v)| (lower_expr(ctx, k), lower_expr(ctx, v)))
+                .collect();
+            ctx.mk(IrExprKind::MapLiteral { entries: ir_entries }, ty, span)
         }
 
         ast::Expr::Record { name, fields, .. } => {

--- a/src/lower.rs
+++ b/src/lower.rs
@@ -273,14 +273,26 @@ fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
                 _ => Ty::Unknown,
             };
             let var_tuple_ids = if let Some(names) = var_tuple {
-                let ids: Vec<VarId> = names.iter().map(|n|
-                    ctx.define_var(n, Ty::Unknown, Mutability::Let, None)
+                // Extract element types from the tuple type for each destructured variable
+                let tuple_inner = match &elem_ty {
+                    Ty::Tuple(tys) => tys.clone(),
+                    _ => vec![Ty::Unknown; names.len()],
+                };
+                let ids: Vec<VarId> = names.iter().enumerate().map(|(i, n)|
+                    ctx.define_var(n, tuple_inner.get(i).cloned().unwrap_or(Ty::Unknown), Mutability::Let, None)
                 ).collect();
                 Some(ids)
             } else {
                 None
             };
-            let var_id = ctx.define_var(var, elem_ty, Mutability::Let, None);
+            // For tuple destructuring, use a synthetic name to avoid shadowing
+            // the first destructured variable (var == first tuple element name)
+            let var_name = if var_tuple.is_some() {
+                format!("__for_tuple_{}", var)
+            } else {
+                var.clone()
+            };
+            let var_id = ctx.define_var(&var_name, elem_ty, Mutability::Let, None);
             let body_ir: Vec<IrStmt> = body.iter().map(|s| lower_stmt(ctx, s)).collect();
             ctx.pop_scope();
             ctx.mk(IrExprKind::ForIn {
@@ -830,7 +842,13 @@ fn lower_string_interp(ctx: &mut LowerCtx, raw: &str) -> Vec<IrStringPart> {
             let tokens = crate::lexer::Lexer::tokenize(&expr_str);
             let mut parser = crate::parser::Parser::new(tokens);
             if let Ok(parsed) = parser.parse_single_expr() {
-                let ir_expr = lower_expr(ctx, &parsed);
+                let mut ir_expr = lower_expr(ctx, &parsed);
+                // Fix type: re-parsed expressions have bogus spans (1,1) which
+                // cause expr_types lookup to return wrong types. For Var nodes,
+                // use the authoritative type from VarTable instead.
+                if let IrExprKind::Var { id } = &ir_expr.kind {
+                    ir_expr.ty = ctx.var_table.get(*id).ty.clone();
+                }
                 parts.push(IrStringPart::Expr { expr: ir_expr });
             } else {
                 // Parse failed — keep as literal

--- a/src/parser/compounds.rs
+++ b/src/parser/compounds.rs
@@ -310,14 +310,55 @@ impl Parser {
         let span = Some(self.current_span());
         self.expect(TokenType::LBracket)?;
         self.skip_newlines();
-        let mut elements = Vec::new();
-        while !self.check(TokenType::RBracket) {
-            elements.push(self.parse_expr()?);
+
+        // [] → empty List
+        if self.check(TokenType::RBracket) {
+            self.advance();
+            return Ok(Expr::List { elements: vec![], span, resolved_type: None });
+        }
+
+        // [:] → empty Map
+        if self.check(TokenType::Colon) {
+            self.advance();
+            self.expect(TokenType::RBracket)?;
+            return Ok(Expr::EmptyMap { span, resolved_type: None });
+        }
+
+        // Parse first expression, then decide List vs Map
+        let first = self.parse_expr()?;
+        self.skip_newlines();
+
+        if self.check(TokenType::Colon) {
+            // Map literal: [key: value, ...]
+            self.advance();
             self.skip_newlines();
-            if self.check(TokenType::Comma) {
+            let first_value = self.parse_expr()?;
+            self.skip_newlines();
+            let mut entries = vec![(first, first_value)];
+            while self.check(TokenType::Comma) {
                 self.advance();
                 self.skip_newlines();
+                if self.check(TokenType::RBracket) { break; } // trailing comma
+                let key = self.parse_expr()?;
+                self.skip_newlines();
+                self.expect(TokenType::Colon)?;
+                self.skip_newlines();
+                let value = self.parse_expr()?;
+                self.skip_newlines();
+                entries.push((key, value));
             }
+            self.expect(TokenType::RBracket)?;
+            return Ok(Expr::MapLiteral { entries, span, resolved_type: None });
+        }
+
+        // List literal: [expr, ...]
+        let mut elements = vec![first];
+        while self.check(TokenType::Comma) {
+            self.advance();
+            self.skip_newlines();
+            if self.check(TokenType::RBracket) { break; }
+            elements.push(self.parse_expr()?);
+            self.skip_newlines();
         }
         self.expect(TokenType::RBracket)?;
         Ok(Expr::List { elements, span, resolved_type: None })

--- a/src/types.rs
+++ b/src/types.rs
@@ -114,6 +114,8 @@ pub struct TypeEnv {
     pub var_decl_locs: std::collections::HashMap<std::string::String, (usize, usize)>,
     /// Top-level `let` constants: name -> type
     pub top_lets: std::collections::HashMap<std::string::String, Ty>,
+    /// Types that implement the Eq protocol (via `deriving Eq`)
+    pub eq_types: std::collections::HashSet<std::string::String>,
 }
 
 impl Ty {
@@ -288,6 +290,51 @@ impl TypeEnv {
             param_vars: std::collections::HashSet::new(),
             var_decl_locs: std::collections::HashMap::new(),
             top_lets: std::collections::HashMap::new(),
+            eq_types: std::collections::HashSet::new(),
+        }
+    }
+
+    /// Check if a type implements the Eq protocol.
+    /// Primitives are implicitly Eq. Container types are Eq if their elements are.
+    /// User-defined types require `deriving Eq`. Function types are never Eq.
+    /// Check if a type supports equality (`==`, `!=`).
+    /// All value types are Eq by default. Only function types are not.
+    pub fn is_eq(&self, ty: &Ty) -> bool {
+        let mut seen = std::collections::HashSet::new();
+        self.is_eq_inner(ty, &mut seen)
+    }
+
+    fn is_eq_inner(&self, ty: &Ty, seen: &mut std::collections::HashSet<std::string::String>) -> bool {
+        match ty {
+            Ty::Int | Ty::Float | Ty::String | Ty::Bool | Ty::Unit => true,
+            Ty::List(inner) | Ty::Option(inner) => self.is_eq_inner(inner, seen),
+            Ty::Result(ok, err) => self.is_eq_inner(ok, seen) && self.is_eq_inner(err, seen),
+            Ty::Map(k, v) => self.is_eq_inner(k, seen) && self.is_eq_inner(v, seen),
+            Ty::Tuple(tys) => tys.iter().all(|t| self.is_eq_inner(t, seen)),
+            Ty::Record { fields } => fields.iter().all(|(_, t)| self.is_eq_inner(t, seen)),
+            Ty::Variant { name, cases, .. } => {
+                if !seen.insert(name.clone()) {
+                    return true; // Recursive type — assume Eq to break cycle
+                }
+                cases.iter().all(|c| match &c.payload {
+                    crate::types::VariantPayload::Unit => true,
+                    crate::types::VariantPayload::Tuple(tys) => tys.iter().all(|t| self.is_eq_inner(t, seen)),
+                    crate::types::VariantPayload::Record(fs) => fs.iter().all(|(_, t, _)| self.is_eq_inner(t, seen)),
+                })
+            }
+            Ty::Named(name, _) => {
+                if !seen.insert(name.clone()) {
+                    return true; // Recursive type
+                }
+                if let Some(resolved) = self.types.get(name) {
+                    self.is_eq_inner(resolved, seen)
+                } else {
+                    true
+                }
+            }
+            Ty::Fn { .. } => false,
+            Ty::TypeVar(_) => true,
+            Ty::Unknown => true,
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -338,6 +338,48 @@ impl TypeEnv {
         }
     }
 
+    /// Check if a type is hashable (can be used as a Map key).
+    /// All value types except Float and Fn are hashable.
+    pub fn is_hash(&self, ty: &Ty) -> bool {
+        let mut seen = std::collections::HashSet::new();
+        self.is_hash_inner(ty, &mut seen)
+    }
+
+    fn is_hash_inner(&self, ty: &Ty, seen: &mut std::collections::HashSet<std::string::String>) -> bool {
+        match ty {
+            Ty::Int | Ty::String | Ty::Bool | Ty::Unit => true,
+            Ty::Float => false,
+            Ty::List(inner) | Ty::Option(inner) => self.is_hash_inner(inner, seen),
+            Ty::Result(ok, err) => self.is_hash_inner(ok, seen) && self.is_hash_inner(err, seen),
+            Ty::Map(_, _) => false, // Maps themselves are not hashable
+            Ty::Tuple(tys) => tys.iter().all(|t| self.is_hash_inner(t, seen)),
+            Ty::Record { fields } => fields.iter().all(|(_, t)| self.is_hash_inner(t, seen)),
+            Ty::Variant { name, cases, .. } => {
+                if !seen.insert(name.clone()) {
+                    return true;
+                }
+                cases.iter().all(|c| match &c.payload {
+                    crate::types::VariantPayload::Unit => true,
+                    crate::types::VariantPayload::Tuple(tys) => tys.iter().all(|t| self.is_hash_inner(t, seen)),
+                    crate::types::VariantPayload::Record(fs) => fs.iter().all(|(_, t, _)| self.is_hash_inner(t, seen)),
+                })
+            }
+            Ty::Named(name, _) => {
+                if !seen.insert(name.clone()) {
+                    return true;
+                }
+                if let Some(resolved) = self.types.get(name) {
+                    self.is_hash_inner(resolved, seen)
+                } else {
+                    true
+                }
+            }
+            Ty::Fn { .. } => false,
+            Ty::TypeVar(_) => true,
+            Ty::Unknown => true,
+        }
+    }
+
     pub fn push_scope(&mut self) {
         self.scopes.push(std::collections::HashMap::new());
     }


### PR DESCRIPTION
## Summary

- Add Map literal syntax `[k: v]`, index access `m[k]`, and direct iteration
- Add Eq protocol: reject `==` on function types, allow all value types automatically
- Add Hash protocol: reject Float and Fn types as Map keys
- Universal string interpolation: `${x}` works for all types (Display for primitives, Debug for compound types)
- Fix for-in tuple destructuring type propagation in IR lowering
- Add bidirectional type inference and structured error types
- Add cross-target AOT compilation roadmap
- Add Rainbow FFI and LLM integration roadmaps

## Test plan

- [x] All 63 test files pass (`almide test`)
- [x] Eq protocol tests pass (`spec/lang/eq_protocol_test.almd`)
- [x] Hash protocol tests pass (`spec/lang/hash_protocol_test.almd`)
- [x] String interpolation tests pass (`spec/lang/string_test.almd`, `spec/lang/operator_test.almd`)
- [x] For-in tuple destructuring tests pass (`spec/lang/control_flow_test.almd`)