### PR TITLE
v0.6.2: Fix playground lambda param naming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "almide"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clap",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Verify the installation:
 
 ```bash
 almide --version
-# almide 0.6.1
+# almide 0.6.2
 ```
 
 ### Hello World

--- a/src/emit_ts/lower_ts.rs
+++ b/src/emit_ts/lower_ts.rs
@@ -62,7 +62,7 @@ impl<'a> LowerCtx<'a> {
             if *count == 0 {
                 var_names.insert(vid, base);
             } else {
-                var_names.insert(vid, format!("{}${}", base, count));
+                var_names.insert(vid, format!("{}_v{}", base, count));
             }
             *count += 1;
         }

--- a/src/emit_ts/lower_ts.rs
+++ b/src/emit_ts/lower_ts.rs
@@ -269,7 +269,7 @@ impl<'a> LowerCtx<'a> {
             }
 
             IrExprKind::Lambda { params, body } => Expr::Arrow {
-                params: params.iter().map(|(v, _)| self.vt().get(*v).name.clone()).collect(),
+                params: params.iter().map(|(v, _)| self.var_name(*v)).collect(),
                 body: Box::new(self.lower_expr(body, ie, it)),
             },
             IrExprKind::StringInterp { parts } => Expr::Template { parts: parts.iter().map(|p| match p {


### PR DESCRIPTION
## Summary

Hotfix for playground runtime error `line$1 is not defined`.

- Fix lambda param names to use `var_name()` (VarId-unique names)
- Change var shadowing suffix from `$` to `_v` (avoids template literal conflicts)
- Fix auto-try for stdlib Result functions (check rendered output for existing `?`)

## Test plan
- [x] CI green on develop
- [x] Cross-target CI green
- [x] Playground rebuild needed after merge