### PR TITLE
v0.6.3: Fix AnonRecord codegen for empty typed lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "almide"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "clap",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Verify the installation:
 
 ```bash
 almide --version
-# almide 0.6.2
+# almide 0.6.3
 ```
 
 ### Hello World

--- a/src/emit_rust/lower_rust_expr.rs
+++ b/src/emit_rust/lower_rust_expr.rs
@@ -513,10 +513,15 @@ impl<'a> LowerCtx<'a> {
                 if matches!(inner.as_ref(), Ty::Unknown | Ty::TypeVar(_)) {
                     return Expr::Vec(vec![]); // fallback: let Rust infer
                 }
-                let rt = super::lower_types::lower_ty(inner);
+                // Use lower_ty_with to resolve Record types to their named type
+                let rt = super::lower_types::lower_ty_with(self.anon, self.named, inner);
                 let mut s = String::new();
                 super::render::render_type(&mut s, &rt);
-                Expr::Raw(format!("Vec::<{}>::new()", s))
+                if s == "AnonRecord" {
+                    Expr::Vec(vec![]) // fallback: let Rust infer
+                } else {
+                    Expr::Raw(format!("Vec::<{}>::new()", s))
+                }
             }
             IrExprKind::MapLiteral { entries } => Expr::HashMap(entries.iter().map(|(k, v)| (self.lower_expr(k), self.lower_expr(v))).collect()),
             IrExprKind::EmptyMap => self.lower_empty_map(e),


### PR DESCRIPTION
## Summary

- **Fix AnonRecord codegen**: Empty list `[]` with record type annotation (e.g., `let ps: List[Product] = []`) now generates correct Rust code instead of `Vec::<AnonRecord>::new()`
- Uses `lower_ty_with` (with anon/named maps) to resolve Record types to their named struct
- Falls back to untyped `vec![]` if type is still unresolvable

### Impact
- Fixes Grammar Lab t07/t08/t10 failures (30% of optional-handling tasks)
- Unblocks common pattern: `let xs: List[MyRecord] = []`

## Test plan
- [x] CI green (both CI and Cross-Target CI)
- [x] `let items: List[Item] = []` compiles and passes
- [x] `let ps: List[Product] = [] ++ [Product { ... }]` works
- [x] All 102 checker tests + 49 emit_ts tests pass