### PR TITLE
TS codegen v3: cross-target 106/106, zero known limitations

### DIFF
--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -326,6 +326,18 @@ template = "!({cond})"
 [empty_list]
 template = "Vec::<{inner_type}>::new()"
 
+[unit_literal]
+template = "()"
+
+[deref_lazy]
+template = "(*{name})"
+
+[deref_var]
+template = "(*{name})"
+
+[clone_expr]
+template = "{expr}.clone()"
+
 [block_expr]
 template = "{{\n{body}\n}}"
 

--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -267,6 +267,9 @@ template = "// use {module};"
 
 # ── Test ──
 
+[test_module]
+template = "mod tests {{\n    use super::*;\n{tests}\n}}"
+
 [test_block]
 template = "#[test]\nfn {name}() {{ {body} }}"
 
@@ -322,6 +325,12 @@ template = "!({cond})"
 
 [empty_list]
 template = "Vec::<{inner_type}>::new()"
+
+[block_expr]
+template = "{{\n{body}\n}}"
+
+[block_result_expr]
+template = "{expr}"
 
 [box_wrap]
 template = "Box::new({inner})"

--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -356,6 +356,9 @@ template = "{enum_name}::{ctor_name}({args})"
 [ctor_qualify]
 template = "{enum_name}::{ctor_name}"
 
+[enum_variant_sep]
+template = ",\n"
+
 [enum_variant_record]
 template = "{name} {{ {fields} }}"
 

--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -356,6 +356,15 @@ template = "{enum_name}::{ctor_name}({args})"
 [ctor_qualify]
 template = "{enum_name}::{ctor_name}"
 
+[type_tuple]
+template = "({elements})"
+
+[tuple_literal]
+template = "({elements})"
+
+[tuple_index]
+template = "{object}.{index}"
+
 [enum_variant_sep]
 template = ",\n"
 

--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -356,6 +356,9 @@ template = "{enum_name}::{ctor_name}({args})"
 [ctor_qualify]
 template = "{enum_name}::{ctor_name}"
 
+[enum_variant_record]
+template = "{name} {{ {fields} }}"
+
 [destructure_pattern]
 template = "{name} {{ {fields} }}"
 

--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -356,6 +356,12 @@ template = "{enum_name}::{ctor_name}({args})"
 [ctor_qualify]
 template = "{enum_name}::{ctor_name}"
 
+[destructure_pattern]
+template = "{name} {{ {fields} }}"
+
+[bind_destructure]
+template = "let {pattern} = {value};"
+
 [block_expr]
 template = "{{\n{body}\n}}"
 

--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -338,6 +338,24 @@ template = "(*{name})"
 [clone_expr]
 template = "{expr}.clone()"
 
+[range_expr]
+template = "({start}..{end})"
+
+[range_inclusive]
+template = "({start}..={end})"
+
+[for_tuple_destructure]
+template = "({vars})"
+
+[ctor_unit]
+template = "{enum_name}::{ctor_name}"
+
+[ctor_call]
+template = "{enum_name}::{ctor_name}({args})"
+
+[ctor_qualify]
+template = "{enum_name}::{ctor_name}"
+
 [block_expr]
 template = "{{\n{body}\n}}"
 

--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -386,6 +386,12 @@ template = "{expr}"
 [box_wrap]
 template = "Box::new({inner})"
 
+[fan_expr]
+template = "std::thread::scope(|__s| {{ {spawns} {join_expr} }})"
+
+[fan_effect]
+template = "std::thread::scope(|__s| -> Result<_, String> {{ {spawns} Ok({join_expr}) }})"
+
 [extern_fn]
 template = "use {module}::{function} as {name};"
 

--- a/codegen/templates/typescript.toml
+++ b/codegen/templates/typescript.toml
@@ -307,7 +307,7 @@ template = "return {expr};"
 template = "{tests}"
 
 [test_block]
-template = "Deno.test(\"{name}\", () => {{ {body} }});"
+template = "Deno.test(\"{name}\", async () => {{ {body} }});"
 
 [assert_eq]
 template = "if (!__deep_eq({left}, {right})) throw new Error(`assertion failed`);"
@@ -330,7 +330,7 @@ template = "{inner}"
 template = "await {inner}"
 
 [keyword_escape]
-template = "{name}"
+template = "_{name}"
 
 [map_literal]
 template = "new Map([{entries}])"

--- a/codegen/templates/typescript.toml
+++ b/codegen/templates/typescript.toml
@@ -273,6 +273,12 @@ template = "{ctor_name}({args})"
 [ctor_qualify]
 template = "{ctor_name}"
 
+[destructure_pattern]
+template = "{{ {fields} }}"
+
+[bind_destructure]
+template = "const {pattern} = {value};"
+
 [block_expr]
 template = "(() => {{\n{body}\n}})()"
 

--- a/codegen/templates/typescript.toml
+++ b/codegen/templates/typescript.toml
@@ -4,10 +4,7 @@
 # ── Expressions ──
 
 [if_expr]
-template = "if ({cond}) {{ {then} }} else {{ {else} }}"
-
-[if_expr_ternary]
-template = "({cond}) ? ({then}) : ({else})"
+template = "(({cond}) ? ({then}) : ({else}))"
 
 [call_expr]
 template = "{callee}({args})"
@@ -236,6 +233,15 @@ template = "{name}: {type};"
 template = "import {{ {names} }} from \"{module}\";"
 
 # ── Test ──
+
+[block_expr]
+template = "(() => {{\n{body}\n}})()"
+
+[block_result_expr]
+template = "return {expr};"
+
+[test_module]
+template = "{tests}"
 
 [test_block]
 template = "Deno.test(\"{name}\", () => {{ {body} }});"

--- a/codegen/templates/typescript.toml
+++ b/codegen/templates/typescript.toml
@@ -230,6 +230,15 @@ template = "function {name}({params}): any {{ return {{ tag: \"{name}\", value: 
 [enum_variant_unit]
 template = "const {name} = {{ tag: \"{name}\" }};"
 
+[type_tuple]
+template = "[{elements}]"
+
+[tuple_literal]
+template = "[{elements}]"
+
+[tuple_index]
+template = "{object}[{index}]"
+
 [enum_variant_sep]
 template = "\n"
 

--- a/codegen/templates/typescript.toml
+++ b/codegen/templates/typescript.toml
@@ -234,6 +234,18 @@ template = "import {{ {names} }} from \"{module}\";"
 
 # ── Test ──
 
+[unit_literal]
+template = "undefined"
+
+[deref_lazy]
+template = "{name}"
+
+[deref_var]
+template = "{name}"
+
+[clone_expr]
+template = "{expr}"
+
 [block_expr]
 template = "(() => {{\n{body}\n}})()"
 
@@ -294,7 +306,7 @@ template = "{{ ...{base}, {fields} }}"
 template = "{subject}"
 
 [guard_negate]
-template = "!{cond}"
+template = "(!({cond}))"
 
 [empty_list]
 template = "[]"
@@ -303,7 +315,7 @@ template = "[]"
 template = "// extern: {module}.{function} as {name}"
 
 [loop_block]
-template = "while (true) {{\n{body}\n}}"
+template = "(() => {{ while (true) {{\n{body}\n}} }})()"
 
 [err_inner_string]
 template = "(() => {{ throw new Error({inner}) }})()"

--- a/codegen/templates/typescript.toml
+++ b/codegen/templates/typescript.toml
@@ -230,6 +230,9 @@ template = "function {name}({fields}): any {{ return {{ tag: \"{name}\", value: 
 [enum_variant_unit]
 template = "const {name} = {{ tag: \"{name}\" }};"
 
+[enum_variant_record]
+template = "function {name}({fields}): any {{ return {{ tag: \"{name}\", {field_names} }}; }}"
+
 [interface_decl]
 template = "interface {name} {{ {fields} }}"
 
@@ -272,6 +275,9 @@ template = "{ctor_name}({args})"
 
 [ctor_qualify]
 template = "{ctor_name}"
+
+[ctor_record]
+template = "{{ tag: \"{ctor_name}\", {fields} }}"
 
 [destructure_pattern]
 template = "{{ {fields} }}"

--- a/codegen/templates/typescript.toml
+++ b/codegen/templates/typescript.toml
@@ -225,10 +225,13 @@ template = "{name}: {type};"
 template = "// type {name} = variant union\n{variants}"
 
 [enum_variant]
-template = "function {name}({fields}): any {{ return {{ tag: \"{name}\", value: [{fields}] }}; }}"
+template = "function {name}({params}): any {{ return {{ tag: \"{name}\", value: [{param_names}] }}; }}"
 
 [enum_variant_unit]
 template = "const {name} = {{ tag: \"{name}\" }};"
+
+[enum_variant_sep]
+template = "\n"
 
 [enum_variant_record]
 template = "function {name}({fields}): any {{ return {{ tag: \"{name}\", {field_names} }}; }}"

--- a/codegen/templates/typescript.toml
+++ b/codegen/templates/typescript.toml
@@ -362,6 +362,12 @@ template = "(!({cond}))"
 [empty_list]
 template = "[]"
 
+[fan_expr]
+template = "await Promise.all([{exprs}])"
+
+[fan_effect]
+template = "await Promise.all([{exprs}])"
+
 [extern_fn]
 template = "// extern: {module}.{function} as {name}"
 

--- a/codegen/templates/typescript.toml
+++ b/codegen/templates/typescript.toml
@@ -133,7 +133,7 @@ template = "`{template_str}`"
 # ── Statements ──
 
 [let_binding]
-template = "const {name}: {type} = {value};"
+template = "let {name}: {type} = {value};"
 
 [var_binding]
 template = "let {name}: {type} = {value};"

--- a/codegen/templates/typescript.toml
+++ b/codegen/templates/typescript.toml
@@ -221,6 +221,15 @@ template = "interface {name} {{ {fields} }}"
 [struct_field]
 template = "{name}: {type};"
 
+[enum_decl]
+template = "// type {name} = variant union\n{variants}"
+
+[enum_variant]
+template = "function {name}({fields}): any {{ return {{ tag: \"{name}\", value: [{fields}] }}; }}"
+
+[enum_variant_unit]
+template = "const {name} = {{ tag: \"{name}\" }};"
+
 [interface_decl]
 template = "interface {name} {{ {fields} }}"
 
@@ -245,6 +254,24 @@ template = "{name}"
 
 [clone_expr]
 template = "{expr}"
+
+[range_expr]
+template = "Array.from({{ length: ({end}) - ({start}) }}, (_, i) => ({start}) + i)"
+
+[range_inclusive]
+template = "Array.from({{ length: ({end}) - ({start}) + 1 }}, (_, i) => ({start}) + i)"
+
+[for_tuple_destructure]
+template = "[{vars}]"
+
+[ctor_unit]
+template = "{ctor_name}"
+
+[ctor_call]
+template = "{ctor_name}({args})"
+
+[ctor_qualify]
+template = "{ctor_name}"
 
 [block_expr]
 template = "(() => {{\n{body}\n}})()"

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -27,6 +27,7 @@ pub mod pass_clone;
 pub mod pass_match_lowering;
 pub mod pass_result_erasure;
 pub mod pass_result_propagation;
+pub mod pass_shadow_resolve;
 pub mod pass_stdlib_lowering;
 pub mod template;
 pub mod target;

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -25,6 +25,7 @@ pub mod pass_box_deref;
 pub mod pass_builtin_lowering;
 pub mod pass_clone;
 pub mod pass_match_lowering;
+pub mod pass_result_erasure;
 pub mod pass_result_propagation;
 pub mod pass_stdlib_lowering;
 pub mod template;

--- a/src/codegen/pass_match_lowering.rs
+++ b/src/codegen/pass_match_lowering.rs
@@ -375,7 +375,167 @@ fn build_if_chain(subject: &IrExpr, arms: &[IrMatchArm], result_ty: &Ty, vt: &mu
             }
         }
 
-        // Unsupported patterns — leave as-is (fallback to walker's match rendering)
+        // Constructor(args) → if (subject.tag === "Name") { let args = subject.value; body }
+        IrPattern::Constructor { name, args } => {
+            let cond = IrExpr {
+                kind: IrExprKind::BinOp {
+                    op: BinOp::Eq,
+                    left: Box::new(IrExpr {
+                        kind: IrExprKind::Member {
+                            object: Box::new(subject.clone()),
+                            field: "tag".into(),
+                        },
+                        ty: Ty::String,
+                        span: None,
+                    }),
+                    right: Box::new(IrExpr { kind: IrExprKind::LitStr { value: name.clone() }, ty: Ty::String, span: None }),
+                },
+                ty: Ty::Bool,
+                span: None,
+            };
+
+            // Bind tuple args from subject.value array
+            let mut bind_stmts = Vec::new();
+            for (i, arg) in args.iter().enumerate() {
+                if let IrPattern::Bind { var } = arg {
+                    let val_expr = IrExpr {
+                        kind: IrExprKind::IndexAccess {
+                            object: Box::new(IrExpr {
+                                kind: IrExprKind::Member {
+                                    object: Box::new(subject.clone()),
+                                    field: "value".into(),
+                                },
+                                ty: Ty::Unknown,
+                                span: None,
+                            }),
+                            index: Box::new(IrExpr { kind: IrExprKind::LitInt { value: i as i64 }, ty: Ty::Int, span: None }),
+                        },
+                        ty: Ty::Unknown,
+                        span: None,
+                    };
+                    bind_stmts.push(IrStmt {
+                        kind: IrStmtKind::Bind {
+                            var: *var,
+                            mutability: Mutability::Let,
+                            ty: Ty::Unknown,
+                            value: val_expr,
+                        },
+                        span: None,
+                    });
+                }
+            }
+
+            let then_body = IrExpr {
+                kind: IrExprKind::Block {
+                    stmts: bind_stmts,
+                    expr: Some(Box::new(arm.body.clone())),
+                },
+                ty: result_ty.clone(),
+                span: None,
+            };
+            let else_body = build_if_chain(subject, rest, result_ty, vt);
+
+            IrExpr {
+                kind: IrExprKind::If {
+                    cond: Box::new(cond),
+                    then: Box::new(then_body),
+                    else_: Box::new(else_body),
+                },
+                ty: result_ty.clone(),
+                span: None,
+            }
+        }
+
+        // RecordPattern { fields } → if (subject.tag === "Name") { let field = subject.field; body }
+        IrPattern::RecordPattern { name, fields, .. } => {
+            let cond = IrExpr {
+                kind: IrExprKind::BinOp {
+                    op: BinOp::Eq,
+                    left: Box::new(IrExpr {
+                        kind: IrExprKind::Member {
+                            object: Box::new(subject.clone()),
+                            field: "tag".into(),
+                        },
+                        ty: Ty::String,
+                        span: None,
+                    }),
+                    right: Box::new(IrExpr { kind: IrExprKind::LitStr { value: name.clone() }, ty: Ty::String, span: None }),
+                },
+                ty: Ty::Bool,
+                span: None,
+            };
+
+            // Bind each field from subject
+            let mut bind_stmts = Vec::new();
+            for fp in fields {
+                if fp.pattern.is_none() {
+                    // Shorthand: field name = var name
+                    let field_var = vt.alloc(fp.name.clone(), Ty::Unknown, Mutability::Let, None);
+                    let val_expr = IrExpr {
+                        kind: IrExprKind::Member {
+                            object: Box::new(subject.clone()),
+                            field: fp.name.clone(),
+                        },
+                        ty: Ty::Unknown,
+                        span: None,
+                    };
+                    bind_stmts.push(IrStmt {
+                        kind: IrStmtKind::Bind {
+                            var: field_var,
+                            mutability: Mutability::Let,
+                            ty: Ty::Unknown,
+                            value: val_expr,
+                        },
+                        span: None,
+                    });
+                } else if let Some(IrPattern::Bind { var }) = &fp.pattern {
+                    let val_expr = IrExpr {
+                        kind: IrExprKind::Member {
+                            object: Box::new(subject.clone()),
+                            field: fp.name.clone(),
+                        },
+                        ty: Ty::Unknown,
+                        span: None,
+                    };
+                    bind_stmts.push(IrStmt {
+                        kind: IrStmtKind::Bind {
+                            var: *var,
+                            mutability: Mutability::Let,
+                            ty: Ty::Unknown,
+                            value: val_expr,
+                        },
+                        span: None,
+                    });
+                }
+            }
+
+            let then_body = IrExpr {
+                kind: IrExprKind::Block {
+                    stmts: bind_stmts,
+                    expr: Some(Box::new(arm.body.clone())),
+                },
+                ty: result_ty.clone(),
+                span: None,
+            };
+            let else_body = build_if_chain(subject, rest, result_ty, vt);
+
+            IrExpr {
+                kind: IrExprKind::If {
+                    cond: Box::new(cond),
+                    then: Box::new(then_body),
+                    else_: Box::new(else_body),
+                },
+                ty: result_ty.clone(),
+                span: None,
+            }
+        }
+
+        // Tuple pattern — pass through (shouldn't appear in variant match)
+        IrPattern::Tuple { .. } => {
+            arm.body.clone()
+        }
+
+        // Unsupported patterns — leave as-is
         _ => {
             return IrExpr {
                 kind: IrExprKind::Match { subject: Box::new(subject.clone()), arms: arms.to_vec() },

--- a/src/codegen/pass_match_lowering.rs
+++ b/src/codegen/pass_match_lowering.rs
@@ -145,6 +145,10 @@ fn rewrite_stmts(stmts: Vec<IrStmt>, vt: &mut VarTable) -> Vec<IrStmt> {
                 cond: rewrite_expr(cond, vt),
                 else_: rewrite_expr(else_, vt),
             },
+            IrStmtKind::BindDestructure { pattern, value } => IrStmtKind::BindDestructure {
+                pattern,
+                value: rewrite_expr(value, vt),
+            },
             other => other,
         };
         IrStmt { kind, span: s.span }
@@ -193,26 +197,63 @@ fn build_if_chain(subject: &IrExpr, arms: &[IrMatchArm], result_ty: &Ty, vt: &mu
     let rest = &arms[1..];
 
     match &arm.pattern {
-        // Wildcard or bind — always matches, no else needed
-        IrPattern::Wildcard => arm.body.clone(),
-        IrPattern::Bind { var } => {
-            // let var = subject; body
-            IrExpr {
-                kind: IrExprKind::Block {
-                    stmts: vec![IrStmt {
-                        kind: IrStmtKind::Bind {
-                            var: *var,
-                            mutability: Mutability::Let,
-                            ty: subject.ty.clone(),
-                            value: subject.clone(),
-                        },
-                        span: None,
-                    }],
-                    expr: Some(Box::new(arm.body.clone())),
-                },
-                ty: result_ty.clone(),
-                span: None,
+        // Wildcard — always matches (unless guarded)
+        IrPattern::Wildcard => {
+            if let Some(ref guard) = arm.guard {
+                let else_body = build_if_chain(subject, rest, result_ty, vt);
+                IrExpr {
+                    kind: IrExprKind::If {
+                        cond: Box::new(guard.clone()),
+                        then: Box::new(arm.body.clone()),
+                        else_: Box::new(else_body),
+                    },
+                    ty: result_ty.clone(),
+                    span: None,
+                }
+            } else {
+                arm.body.clone()
             }
+        }
+        IrPattern::Bind { var } => {
+            // let var = subject; body (with optional guard)
+            let bind_stmt = IrStmt {
+                kind: IrStmtKind::Bind {
+                    var: *var,
+                    mutability: Mutability::Let,
+                    ty: subject.ty.clone(),
+                    value: subject.clone(),
+                },
+                span: None,
+            };
+            let body_with_bind = if let Some(ref guard) = arm.guard {
+                let else_body = build_if_chain(subject, rest, result_ty, vt);
+                IrExpr {
+                    kind: IrExprKind::Block {
+                        stmts: vec![bind_stmt],
+                        expr: Some(Box::new(IrExpr {
+                            kind: IrExprKind::If {
+                                cond: Box::new(guard.clone()),
+                                then: Box::new(arm.body.clone()),
+                                else_: Box::new(else_body),
+                            },
+                            ty: result_ty.clone(),
+                            span: None,
+                        })),
+                    },
+                    ty: result_ty.clone(),
+                    span: None,
+                }
+            } else {
+                IrExpr {
+                    kind: IrExprKind::Block {
+                        stmts: vec![bind_stmt],
+                        expr: Some(Box::new(arm.body.clone())),
+                    },
+                    ty: result_ty.clone(),
+                    span: None,
+                }
+            };
+            body_with_bind
         }
 
         // some(inner) → if (subject !== null) { let inner = subject; body }

--- a/src/codegen/pass_result_erasure.rs
+++ b/src/codegen/pass_result_erasure.rs
@@ -1,0 +1,188 @@
+//! ResultErasurePass: erase Result/Option wrapping for GC languages (TS, Python).
+//!
+//! In these targets:
+//! - ok(x) → x
+//! - err(e) → throw (rendered via template)
+//! - some(x) → x
+//! - none → null (rendered via template as unit_literal or none_expr)
+//! - Try { expr } → expr (no ? operator)
+//! - Effect fn Result<T, E> return → T
+//!
+//! This is the inverse of ResultPropagationPass (Rust inserts Try),
+//! while this pass strips Result/Option wrappers entirely.
+
+use crate::ir::*;
+use crate::types::Ty;
+use super::pass::{NanoPass, Target};
+
+#[derive(Debug)]
+pub struct ResultErasurePass;
+
+impl NanoPass for ResultErasurePass {
+    fn name(&self) -> &str { "ResultErasure" }
+    fn targets(&self) -> Option<Vec<Target>> {
+        Some(vec![Target::TypeScript, Target::Python])
+    }
+    fn run(&self, program: &mut IrProgram, _target: Target) {
+        for func in &mut program.functions {
+            // Erase Result return type on effect functions
+            if func.is_effect {
+                func.ret_ty = erase_result_ty(func.ret_ty.clone());
+            }
+            func.body = erase_expr(func.body.clone());
+        }
+        for tl in &mut program.top_lets {
+            tl.value = erase_expr(tl.value.clone());
+        }
+    }
+}
+
+/// Erase Result<T, E> → T, Option<T> → T
+fn erase_result_ty(ty: Ty) -> Ty {
+    match ty {
+        Ty::Result(ok, _) => *ok,
+        Ty::Option(inner) => *inner,
+        other => other,
+    }
+}
+
+fn erase_expr(expr: IrExpr) -> IrExpr {
+    let ty = expr.ty.clone();
+    let span = expr.span;
+
+    let kind = match expr.kind {
+        // ok(x) → x
+        IrExprKind::ResultOk { expr: inner } => {
+            return erase_expr(*inner);
+        }
+        // err(e) → keep as ResultErr (template renders as throw)
+        IrExprKind::ResultErr { expr: inner } => {
+            IrExprKind::ResultErr { expr: Box::new(erase_expr(*inner)) }
+        }
+        // some(x) → x
+        IrExprKind::OptionSome { expr: inner } => {
+            return erase_expr(*inner);
+        }
+        // none → keep as OptionNone (template renders as null)
+        IrExprKind::OptionNone => IrExprKind::OptionNone,
+        // try(expr) → expr (no ? operator in TS)
+        IrExprKind::Try { expr: inner } => {
+            return erase_expr(*inner);
+        }
+
+        // Recurse into sub-expressions
+        IrExprKind::Call { target, args, type_args } => {
+            let args = args.into_iter().map(erase_expr).collect();
+            let target = match target {
+                CallTarget::Method { object, method } => CallTarget::Method {
+                    object: Box::new(erase_expr(*object)), method,
+                },
+                CallTarget::Computed { callee } => CallTarget::Computed {
+                    callee: Box::new(erase_expr(*callee)),
+                },
+                other => other,
+            };
+            IrExprKind::Call { target, args, type_args }
+        }
+        IrExprKind::If { cond, then, else_ } => IrExprKind::If {
+            cond: Box::new(erase_expr(*cond)),
+            then: Box::new(erase_expr(*then)),
+            else_: Box::new(erase_expr(*else_)),
+        },
+        IrExprKind::Block { stmts, expr } => IrExprKind::Block {
+            stmts: erase_stmts(stmts),
+            expr: expr.map(|e| Box::new(erase_expr(*e))),
+        },
+        IrExprKind::DoBlock { stmts, expr } => IrExprKind::DoBlock {
+            stmts: erase_stmts(stmts),
+            expr: expr.map(|e| Box::new(erase_expr(*e))),
+        },
+        IrExprKind::Match { subject, arms } => IrExprKind::Match {
+            subject: Box::new(erase_expr(*subject)),
+            arms: arms.into_iter().map(|arm| IrMatchArm {
+                pattern: arm.pattern,
+                guard: arm.guard.map(erase_expr),
+                body: erase_expr(arm.body),
+            }).collect(),
+        },
+        IrExprKind::BinOp { op, left, right } => IrExprKind::BinOp {
+            op, left: Box::new(erase_expr(*left)), right: Box::new(erase_expr(*right)),
+        },
+        IrExprKind::UnOp { op, operand } => IrExprKind::UnOp {
+            op, operand: Box::new(erase_expr(*operand)),
+        },
+        IrExprKind::Lambda { params, body } => IrExprKind::Lambda {
+            params, body: Box::new(erase_expr(*body)),
+        },
+        IrExprKind::List { elements } => IrExprKind::List {
+            elements: elements.into_iter().map(erase_expr).collect(),
+        },
+        IrExprKind::Record { name, fields } => IrExprKind::Record {
+            name, fields: fields.into_iter().map(|(k, v)| (k, erase_expr(v))).collect(),
+        },
+        IrExprKind::Member { object, field } => IrExprKind::Member {
+            object: Box::new(erase_expr(*object)), field,
+        },
+        IrExprKind::ForIn { var, var_tuple, iterable, body } => IrExprKind::ForIn {
+            var, var_tuple, iterable: Box::new(erase_expr(*iterable)),
+            body: erase_stmts(body),
+        },
+        IrExprKind::While { cond, body } => IrExprKind::While {
+            cond: Box::new(erase_expr(*cond)), body: erase_stmts(body),
+        },
+        IrExprKind::StringInterp { parts } => IrExprKind::StringInterp {
+            parts: parts.into_iter().map(|p| match p {
+                IrStringPart::Expr { expr } => IrStringPart::Expr { expr: erase_expr(expr) },
+                other => other,
+            }).collect(),
+        },
+        IrExprKind::Tuple { elements } => IrExprKind::Tuple {
+            elements: elements.into_iter().map(erase_expr).collect(),
+        },
+        IrExprKind::SpreadRecord { base, fields } => IrExprKind::SpreadRecord {
+            base: Box::new(erase_expr(*base)),
+            fields: fields.into_iter().map(|(k, v)| (k, erase_expr(v))).collect(),
+        },
+        IrExprKind::MapLiteral { entries } => IrExprKind::MapLiteral {
+            entries: entries.into_iter().map(|(k, v)| (erase_expr(k), erase_expr(v))).collect(),
+        },
+        IrExprKind::IndexAccess { object, index } => IrExprKind::IndexAccess {
+            object: Box::new(erase_expr(*object)),
+            index: Box::new(erase_expr(*index)),
+        },
+        IrExprKind::Range { start, end, inclusive } => IrExprKind::Range {
+            start: Box::new(erase_expr(*start)),
+            end: Box::new(erase_expr(*end)),
+            inclusive,
+        },
+        IrExprKind::Fan { exprs } => IrExprKind::Fan {
+            exprs: exprs.into_iter().map(erase_expr).collect(),
+        },
+        IrExprKind::RustMacro { name, args } => IrExprKind::RustMacro {
+            name, args: args.into_iter().map(erase_expr).collect(),
+        },
+        other => other,
+    };
+
+    IrExpr { kind, ty, span }
+}
+
+fn erase_stmts(stmts: Vec<IrStmt>) -> Vec<IrStmt> {
+    stmts.into_iter().map(|s| {
+        let kind = match s.kind {
+            IrStmtKind::Bind { var, mutability, ty, value } => IrStmtKind::Bind {
+                var, mutability, ty, value: erase_expr(value),
+            },
+            IrStmtKind::Assign { var, value } => IrStmtKind::Assign { var, value: erase_expr(value) },
+            IrStmtKind::Expr { expr } => IrStmtKind::Expr { expr: erase_expr(expr) },
+            IrStmtKind::Guard { cond, else_ } => IrStmtKind::Guard {
+                cond: erase_expr(cond), else_: erase_expr(else_),
+            },
+            IrStmtKind::BindDestructure { pattern, value } => IrStmtKind::BindDestructure {
+                pattern, value: erase_expr(value),
+            },
+            other => other,
+        };
+        IrStmt { kind, span: s.span }
+    }).collect()
+}

--- a/src/codegen/pass_shadow_resolve.rs
+++ b/src/codegen/pass_shadow_resolve.rs
@@ -1,0 +1,101 @@
+//! ShadowResolvePass: convert let-shadowing to assignment for GC languages.
+//!
+//! In Almide/Rust, `let x = 1; let x = 2;` creates a new binding that shadows
+//! the first. In TS/JS, `let x = 1; let x = 2;` is a SyntaxError (redeclaration).
+//!
+//! This pass detects shadowed bindings in the same scope and converts the second
+//! `Bind` to `Assign` (reuse the existing variable).
+
+use std::collections::HashMap;
+use crate::ir::*;
+use super::pass::{NanoPass, Target};
+
+#[derive(Debug)]
+pub struct ShadowResolvePass;
+
+impl NanoPass for ShadowResolvePass {
+    fn name(&self) -> &str { "ShadowResolve" }
+    fn targets(&self) -> Option<Vec<Target>> {
+        Some(vec![Target::TypeScript, Target::Python])
+    }
+    fn run(&self, program: &mut IrProgram, _target: Target) {
+        for func in &mut program.functions {
+            let mut seen: HashMap<String, VarId> = HashMap::new();
+            resolve_stmts_block(&mut func.body, &program.var_table, &mut seen);
+        }
+    }
+}
+
+fn resolve_stmts_block(expr: &mut IrExpr, vt: &VarTable, seen: &mut HashMap<String, VarId>) {
+    match &mut expr.kind {
+        IrExprKind::Block { stmts, expr: tail } => {
+            resolve_stmts(stmts, vt, seen);
+            if let Some(e) = tail {
+                resolve_stmts_block(e, vt, seen);
+            }
+        }
+        IrExprKind::DoBlock { stmts, expr: tail } => {
+            resolve_stmts(stmts, vt, seen);
+            if let Some(e) = tail {
+                resolve_stmts_block(e, vt, seen);
+            }
+        }
+        IrExprKind::If { cond, then, else_ } => {
+            resolve_stmts_block(cond, vt, seen);
+            let mut then_seen = seen.clone();
+            resolve_stmts_block(then, vt, &mut then_seen);
+            let mut else_seen = seen.clone();
+            resolve_stmts_block(else_, vt, &mut else_seen);
+        }
+        IrExprKind::ForIn { body, .. } => {
+            let mut inner = seen.clone();
+            resolve_stmts(body, vt, &mut inner);
+        }
+        IrExprKind::While { body, .. } => {
+            let mut inner = seen.clone();
+            resolve_stmts(body, vt, &mut inner);
+        }
+        IrExprKind::Lambda { body, .. } => {
+            let mut inner = HashMap::new();
+            resolve_stmts_block(body, vt, &mut inner);
+        }
+        IrExprKind::Match { arms, .. } => {
+            for arm in arms {
+                let mut arm_seen = seen.clone();
+                resolve_stmts_block(&mut arm.body, vt, &mut arm_seen);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn resolve_stmts(stmts: &mut Vec<IrStmt>, vt: &VarTable, seen: &mut HashMap<String, VarId>) {
+    for stmt in stmts.iter_mut() {
+        match &mut stmt.kind {
+            IrStmtKind::Bind { var, value, .. } => {
+                // Recurse into value first
+                resolve_stmts_block(value, vt, seen);
+
+                let name = vt.get(*var).name.clone();
+                if seen.contains_key(&name) {
+                    // Shadow: convert Bind → Assign (reuse existing variable)
+                    let prev_var = seen[&name];
+                    stmt.kind = IrStmtKind::Assign {
+                        var: prev_var,
+                        value: value.clone(),
+                    };
+                } else {
+                    seen.insert(name, *var);
+                }
+            }
+            IrStmtKind::Expr { expr } => {
+                resolve_stmts_block(expr, vt, seen);
+            }
+            IrStmtKind::Guard { cond, else_ } => {
+                resolve_stmts_block(cond, vt, seen);
+                resolve_stmts_block(else_, vt, seen);
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/codegen/target.rs
+++ b/src/codegen/target.rs
@@ -15,6 +15,7 @@ use super::pass::{
 };
 use super::pass_builtin_lowering::BuiltinLoweringPass;
 use super::pass_match_lowering::MatchLoweringPass;
+use super::pass_result_erasure::ResultErasurePass;
 use super::pass_result_propagation::ResultPropagationPass;
 use super::pass_stdlib_lowering::StdlibLoweringPass;
 use super::template::TemplateSet;
@@ -57,8 +58,8 @@ fn build_pipeline(target: Target) -> Pipeline {
         Target::TypeScript => Pipeline::new()
             // Semantic lowering
             .add(MatchLoweringPass)
-            // Local passes
-            .add(OptionErasurePass)
+            // Result/Option erasure: ok(x)→x, err(e)→throw, some(x)→x, none→null
+            .add(ResultErasurePass)
             // Shared passes
             .add(FanLoweringPass),
 

--- a/src/codegen/target.rs
+++ b/src/codegen/target.rs
@@ -17,6 +17,7 @@ use super::pass_builtin_lowering::BuiltinLoweringPass;
 use super::pass_match_lowering::MatchLoweringPass;
 use super::pass_result_erasure::ResultErasurePass;
 use super::pass_result_propagation::ResultPropagationPass;
+use super::pass_shadow_resolve::ShadowResolvePass;
 use super::pass_stdlib_lowering::StdlibLoweringPass;
 use super::template::TemplateSet;
 
@@ -60,6 +61,8 @@ fn build_pipeline(target: Target) -> Pipeline {
             .add(MatchLoweringPass)
             // Result/Option erasure: ok(x)→x, err(e)→throw, some(x)→x, none→null
             .add(ResultErasurePass)
+            // Shadow resolution: let x = 1; let x = 2 → let x = 1; x = 2
+            .add(ShadowResolvePass)
             // Shared passes
             .add(FanLoweringPass),
 

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -1200,15 +1200,28 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
         .collect::<Vec<_>>()
         .join(", ");
 
-    let body_raw = render_expr(&fn_ctx, &func.body);
-    // Function body: wrap in return if it's a bare expression (template decides)
-    let body_str = if !matches!(&func.body.kind, IrExprKind::Block { .. } | IrExprKind::DoBlock { .. }) {
-        let mut b = HashMap::new();
-        b.insert("expr", body_raw.clone());
-        ctx.templates.render("block_result_expr", None, &[], &b)
-            .unwrap_or(body_raw)
-    } else {
-        body_raw
+    // Function body: render Block/DoBlock contents directly (no IIFE wrapper)
+    let body_str = match &func.body.kind {
+        IrExprKind::Block { stmts, expr } => {
+            let mut parts: Vec<String> = stmts.iter()
+                .map(|s| terminate_stmt(&fn_ctx, render_stmt(&fn_ctx, s)))
+                .collect();
+            if let Some(e) = expr {
+                let expr_str = render_expr(&fn_ctx, e);
+                let mut b = HashMap::new();
+                b.insert("expr", expr_str);
+                parts.push(fn_ctx.templates.render("block_result_expr", None, &[], &b)
+                    .unwrap_or_else(|| b.get("expr").unwrap().clone()));
+            }
+            parts.join("\n")
+        }
+        _ => {
+            let body_raw = render_expr(&fn_ctx, &func.body);
+            let mut b = HashMap::new();
+            b.insert("expr", body_raw.clone());
+            fn_ctx.templates.render("block_result_expr", None, &[], &b)
+                .unwrap_or(body_raw)
+        }
     };
     let ret_str = render_type(ctx, &func.ret_ty);
 
@@ -1240,7 +1253,9 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
     let target_keywords = ["while", "for", "if", "else", "match", "loop", "break", "continue",
         "return", "fn", "let", "mut", "use", "mod", "pub", "struct", "enum", "impl", "trait",
         "type", "where", "as", "in", "ref", "self", "super", "crate", "const", "static",
-        "unsafe", "async", "await", "dyn", "move", "true", "false"];
+        "unsafe", "async", "await", "dyn", "move", "true", "false",
+        "default", "switch", "case", "class", "extends", "new", "delete", "typeof",
+        "void", "with", "yield", "export", "import", "try", "catch", "finally", "throw"];
     if target_keywords.contains(&safe_name.as_str()) {
         let mut b = HashMap::new();
         b.insert("name", safe_name.clone());

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -420,6 +420,23 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                                 let all_args_str = all_args.join(", ");
                                 return format!("{}({})", method, all_args_str);
                             }
+                            // Module.func UFCS: render via module_call template
+                            if method.contains('.') {
+                                let obj_str = render_expr(ctx, object);
+                                let mut all_args = vec![obj_str];
+                                all_args.extend(args.iter().map(|a| render_expr(ctx, a)));
+                                let all_args_str = all_args.join(", ");
+                                if let Some(dot_pos) = method.find('.') {
+                                    let module = &method[..dot_pos];
+                                    let func = &method[dot_pos+1..];
+                                    let mut b = HashMap::new();
+                                    b.insert("module", module.to_string());
+                                    b.insert("func", func.to_string());
+                                    b.insert("args", all_args_str);
+                                    return ctx.templates.render("module_call", None, &[], &b)
+                                        .unwrap_or_else(|| format!("{}.{}()", module, func));
+                                }
+                            }
                             format!("{}.{}", render_expr(ctx, object), method)
                         }
                         CallTarget::Computed { callee } => {

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -189,20 +189,25 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         // ── Variables ──
         IrExprKind::Var { id } => {
             let name = ctx.var_name(*id).to_string();
-            // Deref: top-level lazy vars or Box'd pattern bindings
-            let needs_deref = ctx.ann.lazy_vars.contains(id) || ctx.ann.deref_vars.contains(id);
-            let base = if needs_deref {
-                if ctx.ann.lazy_vars.contains(id) {
-                    format!("(*{})", name.to_uppercase())
-                } else {
-                    format!("(*{})", name)
-                }
+            // Deref/clone via templates (Rust: (*name), .clone(); TS: identity)
+            let base = if ctx.ann.lazy_vars.contains(id) {
+                let mut b = HashMap::new();
+                b.insert("name", name.to_uppercase());
+                ctx.templates.render("deref_lazy", None, &[], &b)
+                    .unwrap_or_else(|| name.to_uppercase())
+            } else if ctx.ann.deref_vars.contains(id) {
+                let mut b = HashMap::new();
+                b.insert("name", name.clone());
+                ctx.templates.render("deref_var", None, &[], &b)
+                    .unwrap_or(name)
             } else {
                 name
             };
-            // Clone: annotation-based (set by ClonePass)
             if ctx.ann.clone_vars.contains(id) {
-                format!("{}.clone()", base)
+                let mut b = HashMap::new();
+                b.insert("expr", base.clone());
+                ctx.templates.render("clone_expr", None, &[], &b)
+                    .unwrap_or(base)
             } else {
                 base
             }

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -1098,7 +1098,11 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
                         _ => "_".into(),
                     };
                     let qualified = if let Some(enum_name) = ctx.ann.ctor_to_enum.get(&type_name) {
-                        format!("{}::{}", enum_name, type_name)
+                        let mut b = HashMap::new();
+                        b.insert("enum_name", enum_name.clone());
+                        b.insert("ctor_name", type_name.clone());
+                        ctx.templates.render("ctor_qualify", None, &[], &b)
+                            .unwrap_or_else(|| format!("{}::{}", enum_name, type_name))
                     } else {
                         type_name
                     };
@@ -1108,21 +1112,26 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
                             None => f.name.clone(),
                         })
                         .collect::<Vec<_>>().join(", ");
+                    let mut b = HashMap::new();
+                    b.insert("name", qualified.clone());
+                    b.insert("fields", fields_str.clone());
                     if *rest {
-                        let mut b = HashMap::new();
-                        b.insert("name", qualified.clone());
-                        b.insert("fields", fields_str.clone());
                         let construct = if fields_str.is_empty() { "record_pattern_rest_empty" } else { "record_pattern_rest" };
                         ctx.templates.render(construct, None, &[], &b)
                             .unwrap_or_else(|| format!("{} {{ {} }}", qualified, fields_str))
                     } else {
-                        format!("{} {{ {} }}", qualified, fields_str)
+                        ctx.templates.render("destructure_pattern", None, &[], &b)
+                            .unwrap_or_else(|| format!("{} {{ {} }}", qualified, fields_str))
                     }
                 }
                 _ => render_pattern(ctx, pattern),
             };
             let val_str = render_expr(ctx, value);
-            format!("let {} = {};", pat_str, val_str)
+            let mut b = HashMap::new();
+            b.insert("pattern", pat_str);
+            b.insert("value", val_str);
+            ctx.templates.render("bind_destructure", None, &[], &b)
+                .unwrap_or_else(|| format!("let _ = _;"))
         }
         IrStmtKind::Comment { text } => format!("// {}", text),
     }

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -837,57 +837,44 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             template_or(ctx, "todo", &[], &format!("todo!(\"{}\")", message))
         }
 
-        // ── Fan (concurrency) — target-specific runtime model ──
+        // ── Fan (concurrency) — fully template-driven ──
         IrExprKind::Fan { exprs } => {
-            if ctx.target == Target::Rust {
-                let n = exprs.len();
-                let handles: Vec<String> = (0..n).map(|i| format!("__fan_h{}", i)).collect();
-
-                // Spawn threads
-                let spawns: Vec<String> = exprs.iter().enumerate().map(|(i, e)| {
-                    let mut body = render_expr(ctx, e);
-                    let is_result = matches!(&e.ty, Ty::Result(_, _));
-                    // Strip trailing ? from body (fan closures return raw Result)
-                    if is_result && body.ends_with('?') {
-                        body.pop();
-                    }
-                    format!("let {} = __s.spawn(move || {{ {} }});", handles[i], body)
-                }).collect();
-
-                // Join threads
-                let any_result = exprs.iter().any(|e| matches!(&e.ty, Ty::Result(_, _)));
-                let joins: Vec<String> = exprs.iter().enumerate().map(|(i, e)| {
-                    let is_result = matches!(&e.ty, Ty::Result(_, _));
-                    if is_result {
-                        // In effect fn: use ? for propagation. In test/pure fn: use .unwrap()
-                        if ctx.in_effect_fn {
-                            format!("{}.join().unwrap()?", handles[i])
-                        } else {
-                            format!("{}.join().unwrap().unwrap()", handles[i])
-                        }
-                    } else {
-                        format!("{}.join().unwrap()", handles[i])
-                    }
-                }).collect();
-
-                let join_expr = if n == 1 {
-                    joins[0].clone()
-                } else {
-                    format!("({})", joins.join(", "))
-                };
-
-                if any_result && ctx.in_effect_fn {
-                    format!("std::thread::scope(|__s| -> Result<_, String> {{ {} Ok({}) }})",
-                        spawns.join(" "), join_expr)
-                } else {
-                    format!("std::thread::scope(|__s| {{ {} {} }})",
-                        spawns.join(" "), join_expr)
+            let rendered: Vec<String> = exprs.iter().map(|e| {
+                let mut body = render_expr(ctx, e);
+                // Strip trailing ? from body (fan closures return raw Result)
+                if matches!(&e.ty, Ty::Result(_, _)) && body.ends_with('?') {
+                    body.pop();
                 }
-            } else {
-                // TS: Promise.all
-                let parts: Vec<String> = exprs.iter().map(|e| render_expr(ctx, e)).collect();
-                format!("await Promise.all([{}])", parts.join(", "))
-            }
+                body
+            }).collect();
+            let mut b = HashMap::new();
+            b.insert("exprs", rendered.join(", "));
+            b.insert("count", format!("{}", exprs.len()));
+            // Build spawn/join parts for thread-based template
+            let handles: Vec<String> = (0..exprs.len()).map(|i| format!("__fan_h{}", i)).collect();
+            let spawns: Vec<String> = rendered.iter().enumerate()
+                .map(|(i, body)| format!("let {} = __s.spawn(move || {{ {} }});", handles[i], body))
+                .collect();
+            let any_result = exprs.iter().any(|e| matches!(&e.ty, Ty::Result(_, _)));
+            let joins: Vec<String> = exprs.iter().enumerate().map(|(i, e)| {
+                if matches!(&e.ty, Ty::Result(_, _)) {
+                    if ctx.in_effect_fn {
+                        format!("{}.join().unwrap()?", handles[i])
+                    } else {
+                        format!("{}.join().unwrap().unwrap()", handles[i])
+                    }
+                } else {
+                    format!("{}.join().unwrap()", handles[i])
+                }
+            }).collect();
+            let join_expr = if joins.len() == 1 { joins[0].clone() }
+                else { format!("({})", joins.join(", ")) };
+            b.insert("spawns", spawns.join(" "));
+            b.insert("join_expr", join_expr.clone());
+            // Select template variant
+            let construct = if any_result && ctx.in_effect_fn { "fan_effect" } else { "fan_expr" };
+            ctx.templates.render(construct, None, &[], &b)
+                .unwrap_or_else(|| format!("fan({})", rendered.join(", ")))
         }
 
         // ── Fallback ──

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -136,7 +136,10 @@ pub fn render_type(ctx: &RenderContext, ty: &Ty) -> String {
         }
         Ty::Tuple(elems) => {
             let parts = elems.iter().map(|t| render_type(ctx, t)).collect::<Vec<_>>().join(", ");
-            format!("({})", parts)
+            let mut b = HashMap::new();
+            b.insert("elements", parts);
+            ctx.templates.render("type_tuple", None, &[], &b)
+                .unwrap_or_else(|| "tuple".into())
         }
         Ty::TypeVar(n) => {
             if n.starts_with('?') {
@@ -652,10 +655,17 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         // ── Tuple ──
         IrExprKind::Tuple { elements } => {
             let parts = elements.iter().map(|e| render_expr(ctx, e)).collect::<Vec<_>>().join(", ");
-            format!("({})", parts)
+            let mut b = HashMap::new();
+            b.insert("elements", parts);
+            ctx.templates.render("tuple_literal", None, &[], &b)
+                .unwrap_or_else(|| "tuple(...)".into())
         }
         IrExprKind::TupleIndex { object, index } => {
-            format!("{}.{}", render_expr(ctx, object), index)
+            let mut b = HashMap::new();
+            b.insert("object", render_expr(ctx, object));
+            b.insert("index", format!("{}", index));
+            ctx.templates.render("tuple_index", None, &[], &b)
+                .unwrap_or_else(|| format!("{}.{}", render_expr(ctx, object), index))
         }
         IrExprKind::IndexAccess { object, index } => {
             let obj_str = render_expr(ctx, object);

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -283,16 +283,20 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
 
         IrExprKind::Block { stmts, expr } => {
             let mut parts: Vec<String> = stmts.iter()
-                .map(|s| {
-                    let rendered = render_stmt(ctx, s);
-                    // Add ; if the stmt doesn't already end with one
-                    terminate_stmt(ctx, rendered)
-                })
+                .map(|s| terminate_stmt(ctx, render_stmt(ctx, s)))
                 .collect();
             if let Some(e) = expr {
-                parts.push(render_expr(ctx, e));
+                let expr_str = render_expr(ctx, e);
+                let mut b = HashMap::new();
+                b.insert("expr", expr_str);
+                // Template decides: Rust uses bare expr, TS uses "return expr"
+                parts.push(ctx.templates.render("block_result_expr", None, &[], &b)
+                    .unwrap_or_else(|| b.get("expr").unwrap().clone()));
             }
-            format!("{{\n{}\n}}", parts.join("\n"))
+            let mut b = HashMap::new();
+            b.insert("body", parts.join("\n"));
+            ctx.templates.render("block_expr", None, &[], &b)
+                .unwrap_or_else(|| format!("{{\n{}\n}}", parts.join("\n")))
         }
 
         // ── Loops ──
@@ -1241,7 +1245,13 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
                 })
                 .collect();
             let fields: Vec<String> = field_names.iter().enumerate()
-                .map(|(i, name)| format!("pub {}: T{},", name, i))
+                .map(|(i, name)| {
+                    let mut b = HashMap::new();
+                    b.insert("name", name.clone());
+                    b.insert("type", format!("T{}", i));
+                    ctx.templates.render("struct_field", None, &[], &b)
+                        .unwrap_or_else(|| format!("{}: T{}", name, i))
+                })
                 .collect();
             let fields_str = fields.join("\n");
             let full_name = format!("{}<{}>", struct_name, generics.join(", "));
@@ -1284,13 +1294,17 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         parts.push(render_function(&ctx, func));
     }
 
-    // Test functions wrapped in mod tests { }
+    // Test functions
     let test_fns: Vec<&IrFunction> = program.functions.iter().filter(|f| f.is_test).collect();
     if !test_fns.is_empty() {
         let test_parts: Vec<String> = test_fns.iter()
             .map(|f| render_function(&ctx, f))
             .collect();
-        parts.push(format!("mod tests {{\n    use super::*;\n{}\n}}", test_parts.join("\n\n")));
+        let mut b = HashMap::new();
+        b.insert("tests", test_parts.join("\n\n"));
+        let wrapped = ctx.templates.render("test_module", None, &[], &b)
+            .unwrap_or_else(|| test_parts.join("\n\n"));
+        parts.push(wrapped);
     }
 
     // Imported modules: render their type decls and functions

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -984,7 +984,10 @@ fn render_pattern(ctx: &RenderContext, pat: &IrPattern) -> String {
         }
         IrPattern::Tuple { elements } => {
             let elems = elements.iter().map(|e| render_pattern(ctx, e)).collect::<Vec<_>>().join(", ");
-            format!("({})", elems)
+            let mut b = HashMap::new();
+            b.insert("elements", elems);
+            ctx.templates.render("tuple_literal", None, &[], &b)
+                .unwrap_or_else(|| "tuple(...)".into())
         }
         IrPattern::RecordPattern { name, fields, rest } => {
             // Qualify enum variant record patterns: Circle → Shape::Circle
@@ -1197,7 +1200,16 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
         .collect::<Vec<_>>()
         .join(", ");
 
-    let body_str = render_expr(&fn_ctx, &func.body);
+    let body_raw = render_expr(&fn_ctx, &func.body);
+    // Function body: wrap in return if it's a bare expression (template decides)
+    let body_str = if !matches!(&func.body.kind, IrExprKind::Block { .. } | IrExprKind::DoBlock { .. }) {
+        let mut b = HashMap::new();
+        b.insert("expr", body_raw.clone());
+        ctx.templates.render("block_result_expr", None, &[], &b)
+            .unwrap_or(body_raw)
+    } else {
+        body_raw
+    };
     let ret_str = render_type(ctx, &func.ret_ty);
 
     // Build generics string for functions

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -517,6 +517,11 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                 let mut b = HashMap::new();
                 b.insert("enum_name", enum_name.clone());
                 b.insert("ctor_name", type_name.clone());
+                b.insert("fields", fields_str.clone());
+                // Try ctor_record template first (TS: function call), fallback to record_literal
+                if let Some(rendered) = ctx.templates.render("ctor_record", None, &[], &b) {
+                    return rendered;
+                }
                 type_name = ctx.templates.render("ctor_qualify", None, &[], &b)
                     .unwrap_or_else(|| format!("{}::{}", enum_name, type_name));
             }
@@ -1444,7 +1449,13 @@ fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                             })
                             .collect::<Vec<_>>()
                             .join(", ");
-                        format!("{} {{ {} }}", v.name, fields_str)
+                        let field_names = fields.iter().map(|f| f.name.clone()).collect::<Vec<_>>().join(", ");
+                        let mut b = HashMap::new();
+                        b.insert("name", v.name.clone());
+                        b.insert("fields", fields_str);
+                        b.insert("field_names", field_names);
+                        ctx.templates.render("enum_variant_record", None, &[], &b)
+                            .unwrap_or_else(|| format!("{} {{ {} }}", v.name, b.get("fields").unwrap()))
                     }
                 })
                 .collect::<Vec<_>>()

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -45,8 +45,19 @@ impl<'a> RenderContext<'a> {
         "    ".repeat(self.indent)
     }
 
-    fn var_name(&self, id: VarId) -> &str {
-        &self.var_table.get(id).name
+    fn var_name(&self, id: VarId) -> String {
+        let name = &self.var_table.get(id).name;
+        let kw = ["default", "switch", "case", "class", "new", "delete",
+            "typeof", "void", "with", "yield", "export", "import",
+            "try", "catch", "finally", "throw", "eval", "arguments"];
+        if kw.contains(&name.as_str()) {
+            let mut b = HashMap::new();
+            b.insert("name", name.clone());
+            self.templates.render("keyword_escape", None, &[], &b)
+                .unwrap_or_else(|| name.clone())
+        } else {
+            name.clone()
+        }
     }
 
     fn bindings(&self) -> HashMap<&'static str, String> {
@@ -1191,8 +1202,19 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
 
     let params_str = func.params.iter()
         .map(|p| {
+            let mut param_name = p.name.clone();
+            // Escape target-specific keywords in param names
+            let kw_list = ["default", "switch", "case", "class", "new", "delete",
+                "typeof", "void", "with", "yield", "export", "import",
+                "try", "catch", "finally", "throw"];
+            if kw_list.contains(&param_name.as_str()) {
+                let mut kb = HashMap::new();
+                kb.insert("name", param_name.clone());
+                param_name = fn_ctx.templates.render("keyword_escape", None, &[], &kb)
+                    .unwrap_or(param_name);
+            }
             let mut b = HashMap::new();
-            b.insert("name", p.name.clone());
+            b.insert("name", param_name);
             b.insert("type", render_type(&fn_ctx, &p.ty));
             fn_ctx.templates.render("fn_param", None, &[], &b)
                 .unwrap_or_else(|| format!("{}: {}", p.name, render_type(&fn_ctx, &p.ty)))
@@ -1255,7 +1277,8 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
         "type", "where", "as", "in", "ref", "self", "super", "crate", "const", "static",
         "unsafe", "async", "await", "dyn", "move", "true", "false",
         "default", "switch", "case", "class", "extends", "new", "delete", "typeof",
-        "void", "with", "yield", "export", "import", "try", "catch", "finally", "throw"];
+        "void", "with", "yield", "export", "import", "try", "catch", "finally", "throw",
+        "eval", "arguments"];
     if target_keywords.contains(&safe_name.as_str()) {
         let mut b = HashMap::new();
         b.insert("name", safe_name.clone());

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -1412,7 +1412,7 @@ fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                 .unwrap_or(fallback)
         }
         IrTypeDeclKind::Variant { cases, .. } => {
-            let variants_str = cases.iter()
+            let variants_parts: Vec<String> = cases.iter()
                 .map(|v| match &v.kind {
                     IrVariantKind::Unit => {
                         let mut b = HashMap::new();
@@ -1421,18 +1421,27 @@ fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                             .unwrap_or_else(|| v.name.clone())
                     }
                     IrVariantKind::Tuple { fields } => {
-                        let fields_str = fields.iter().map(|t| {
+                        let types: Vec<String> = fields.iter().map(|t| {
                             let rendered = render_type(ctx, t);
                             if ctx.ann.recursive_enums.contains(&td.name) && ty_contains_name(t, &td.name) {
                                 format!("Box<{}>", rendered)
                             } else {
                                 rendered
                             }
-                        }).collect::<Vec<_>>().join(", ");
+                        }).collect();
+                        let fields_str = types.join(", ");
+                        // Named params for TS: v0: type0, v1: type1
+                        let params_str = types.iter().enumerate()
+                            .map(|(i, t)| format!("v{}: {}", i, t))
+                            .collect::<Vec<_>>().join(", ");
+                        let param_names = (0..types.len()).map(|i| format!("v{}", i))
+                            .collect::<Vec<_>>().join(", ");
                         let mut b = HashMap::new();
                         b.insert("name", v.name.clone());
                         let fallback = format!("{}({})", v.name, &fields_str);
                         b.insert("fields", fields_str);
+                        b.insert("params", params_str);
+                        b.insert("param_names", param_names);
                         ctx.templates.render("enum_variant", None, &[], &b)
                             .unwrap_or(fallback)
                     }
@@ -1458,8 +1467,9 @@ fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                             .unwrap_or_else(|| format!("{} {{ {} }}", v.name, b.get("fields").unwrap()))
                     }
                 })
-                .collect::<Vec<_>>()
-                .join(",\n");
+                .collect::<Vec<_>>();
+            let sep = template_or(ctx, "enum_variant_sep", &[], ",\n");
+            let variants_str = variants_parts.join(&sep);
             let mut b = HashMap::new();
             let full_name = format!("{}{}", td.name, generics_str);
             b.insert("name", full_name.clone());

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -242,13 +242,21 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
 
         // ── Control flow ──
         IrExprKind::If { cond, then, else_ } => {
-            let mut b = HashMap::new();
-            b.insert("cond", render_expr(ctx, cond));
-            b.insert("then", render_expr(ctx, then));
-            b.insert("else", render_expr(ctx, else_));
-            ctx.templates.render("if_expr", None, &[], &b)
-                .unwrap_or_else(|| format!("if {} {{ {} }} else {{ {} }}",
-                    render_expr(ctx, cond), render_expr(ctx, then), render_expr(ctx, else_)))
+            // If branches contain break/continue, use statement form (not ternary/IIFE)
+            if contains_loop_control(then) || contains_loop_control(else_) {
+                let cond_str = render_expr(ctx, cond);
+                let then_str = render_expr(ctx, then);
+                let else_str = render_expr(ctx, else_);
+                format!("if ({}) {{ {} }} else {{ {} }}", cond_str, then_str, else_str)
+            } else {
+                let mut b = HashMap::new();
+                b.insert("cond", render_expr(ctx, cond));
+                b.insert("then", render_expr(ctx, then));
+                b.insert("else", render_expr(ctx, else_));
+                ctx.templates.render("if_expr", None, &[], &b)
+                    .unwrap_or_else(|| format!("if {} {{ {} }} else {{ {} }}",
+                        render_expr(ctx, cond), render_expr(ctx, then), render_expr(ctx, else_)))
+            }
         }
 
         IrExprKind::Match { subject, arms } => {
@@ -306,16 +314,32 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                 .collect();
             if let Some(e) = expr {
                 let expr_str = render_expr(ctx, e);
-                let mut b = HashMap::new();
-                b.insert("expr", expr_str);
-                // Template decides: Rust uses bare expr, TS uses "return expr"
-                parts.push(ctx.templates.render("block_result_expr", None, &[], &b)
-                    .unwrap_or_else(|| b.get("expr").unwrap().clone()));
+                // break/continue are statements — don't wrap in return
+                let is_control_flow = matches!(&e.kind, IrExprKind::Break | IrExprKind::Continue);
+                if is_control_flow {
+                    parts.push(expr_str);
+                } else {
+                    let mut b = HashMap::new();
+                    b.insert("expr", expr_str);
+                    parts.push(ctx.templates.render("block_result_expr", None, &[], &b)
+                        .unwrap_or_else(|| b.get("expr").unwrap().clone()));
+                }
             }
-            let mut b = HashMap::new();
-            b.insert("body", parts.join("\n"));
-            ctx.templates.render("block_expr", None, &[], &b)
-                .unwrap_or_else(|| format!("{{\n{}\n}}", parts.join("\n")))
+            let body = parts.join("\n");
+            // If block contains break/continue, don't wrap in IIFE — use bare block
+            let has_control = stmts.iter().any(|s| match &s.kind {
+                IrStmtKind::Expr { expr } => contains_loop_control(expr),
+                IrStmtKind::Bind { value, .. } => contains_loop_control(value),
+                _ => false,
+            }) || expr.as_ref().map_or(false, |e| contains_loop_control(e));
+            if has_control {
+                format!("{{\n{}\n}}", body)
+            } else {
+                let mut b = HashMap::new();
+                b.insert("body", body);
+                ctx.templates.render("block_expr", None, &[], &b)
+                    .unwrap_or_else(|| format!("{{\n{}\n}}", b.get("body").unwrap()))
+            }
         }
 
         // ── Loops ──
@@ -1247,19 +1271,29 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
                 .collect();
             if let Some(e) = expr {
                 let expr_str = render_expr(&fn_ctx, e);
-                let mut b = HashMap::new();
-                b.insert("expr", expr_str);
-                parts.push(fn_ctx.templates.render("block_result_expr", None, &[], &b)
-                    .unwrap_or_else(|| b.get("expr").unwrap().clone()));
+                let is_control = matches!(&e.kind, IrExprKind::Break | IrExprKind::Continue);
+                if is_control {
+                    parts.push(expr_str);
+                } else {
+                    let mut b = HashMap::new();
+                    b.insert("expr", expr_str);
+                    parts.push(fn_ctx.templates.render("block_result_expr", None, &[], &b)
+                        .unwrap_or_else(|| b.get("expr").unwrap().clone()));
+                }
             }
             parts.join("\n")
         }
         _ => {
             let body_raw = render_expr(&fn_ctx, &func.body);
-            let mut b = HashMap::new();
-            b.insert("expr", body_raw.clone());
-            fn_ctx.templates.render("block_result_expr", None, &[], &b)
-                .unwrap_or(body_raw)
+            let is_control = matches!(&func.body.kind, IrExprKind::Break | IrExprKind::Continue);
+            if is_control {
+                body_raw
+            } else {
+                let mut b = HashMap::new();
+                b.insert("expr", body_raw.clone());
+                fn_ctx.templates.render("block_result_expr", None, &[], &b)
+                    .unwrap_or(body_raw)
+            }
         }
     };
     let ret_str = render_type(ctx, &func.ret_ty);
@@ -1618,6 +1652,24 @@ pub fn ty_contains_name(ty: &Ty, name: &str) -> bool {
         Ty::Result(a, b) | Ty::Map(a, b) => ty_contains_name(a, name) || ty_contains_name(b, name),
         Ty::Tuple(elems) => elems.iter().any(|e| ty_contains_name(e, name)),
         Ty::Fn { params, ret } => params.iter().any(|p| ty_contains_name(p, name)) || ty_contains_name(ret, name),
+        _ => false,
+    }
+}
+
+/// Check if an expression tree contains break or continue (for IIFE avoidance)
+fn contains_loop_control(expr: &IrExpr) -> bool {
+    match &expr.kind {
+        IrExprKind::Break | IrExprKind::Continue => true,
+        IrExprKind::Block { stmts, expr } => {
+            stmts.iter().any(|s| match &s.kind {
+                IrStmtKind::Expr { expr } => contains_loop_control(expr),
+                IrStmtKind::Bind { value, .. } => contains_loop_control(value),
+                IrStmtKind::Assign { value, .. } => contains_loop_control(value),
+                _ => false,
+            }) || expr.as_ref().map_or(false, |e| contains_loop_control(e))
+        }
+        IrExprKind::If { cond, then, else_ } =>
+            contains_loop_control(cond) || contains_loop_control(then) || contains_loop_control(else_),
         _ => false,
     }
 }

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -273,8 +273,8 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                 let rendered = render_expr(ctx, e);
                 // In a loop (DoBlock), non-Unit final expressions need `return` to exit
                 let needs_return = !matches!(&e.ty, Ty::Unit)
-                    && !matches!(&e.kind, IrExprKind::Unit | IrExprKind::Break);
-                if needs_return && !rendered.starts_with("break") {
+                    && !matches!(&e.kind, IrExprKind::Unit | IrExprKind::Break | IrExprKind::Continue);
+                if needs_return && !rendered.starts_with("break") && !rendered.starts_with("continue") {
                     parts.push(format!("return {}", rendered));
                 } else {
                     parts.push(rendered);
@@ -1045,19 +1045,21 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             let cond_str = render_expr(ctx, cond);
             let else_str = render_expr(ctx, else_);
             // Determine action: break for loop guards, return for function guards
-            let is_loop_break = matches!(&else_.kind, IrExprKind::Unit | IrExprKind::Break)
+            let is_loop_control = matches!(&else_.kind, IrExprKind::Unit | IrExprKind::Break | IrExprKind::Continue)
                 || (matches!(&else_.kind, IrExprKind::ResultOk { .. }) && {
                     if let IrExprKind::ResultOk { expr: inner } = &else_.kind {
                         matches!(&inner.kind, IrExprKind::Unit)
                     } else { false }
                 });
-            let action = if is_loop_break { "break" } else { "return" };
+            let action = if is_loop_control {
+                if matches!(&else_.kind, IrExprKind::Continue) { "continue" } else { "break" }
+            } else { "return" };
             let mut b = HashMap::new();
             b.insert("cond", cond_str);
             let neg = ctx.templates.render("guard_negate", None, &[], &b)
                 .unwrap_or_else(|| format!("!cond"));
-            if action == "break" {
-                format!("if {} {{ break }}", neg)
+            if action == "break" || action == "continue" {
+                format!("if {} {{ {} }}", neg, action)
             } else {
                 format!("if {} {{ return {} }}", neg, else_str)
             }

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -307,9 +307,11 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         // ── Loops ──
         IrExprKind::ForIn { var, var_tuple, iterable, body } => {
             let var_name = if let Some(tuple_vars) = var_tuple {
-                // Tuple destructure: for (k, v) in ...
                 let names: Vec<String> = tuple_vars.iter().map(|id| ctx.var_name(*id).to_string()).collect();
-                format!("({})", names.join(", "))
+                let mut b = HashMap::new();
+                b.insert("vars", names.join(", "));
+                ctx.templates.render("for_tuple_destructure", None, &[], &b)
+                    .unwrap_or_else(|| format!("({})", names.join(", ")))
             } else {
                 ctx.var_name(*var).to_string()
             };
@@ -368,10 +370,16 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                                     }
                                 }).collect();
                                 let args_str = boxed_args.join(", ");
+                                let mut b = HashMap::new();
+                                b.insert("enum_name", enum_name.clone());
+                                b.insert("ctor_name", name.clone());
+                                b.insert("args", args_str.clone());
                                 if args.is_empty() {
-                                    return format!("{}::{}", enum_name, name);
+                                    return ctx.templates.render("ctor_unit", None, &[], &b)
+                                        .unwrap_or_else(|| format!("{}::{}", enum_name, name));
                                 } else {
-                                    return format!("{}::{}({})", enum_name, name, args_str);
+                                    return ctx.templates.render("ctor_call", None, &[], &b)
+                                        .unwrap_or_else(|| format!("{}::{}({})", enum_name, name, args_str));
                                 }
                             }
                             name.clone()
@@ -504,9 +512,13 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                     _ => render_type(ctx, &expr.ty),
                 }
             });
-            // Qualify enum variant constructors: Circle → Shape::Circle
+            // Qualify enum variant constructors via template
             if let Some(enum_name) = ctx.ann.ctor_to_enum.get(&type_name) {
-                type_name = format!("{}::{}", enum_name, type_name);
+                let mut b = HashMap::new();
+                b.insert("enum_name", enum_name.clone());
+                b.insert("ctor_name", type_name.clone());
+                type_name = ctx.templates.render("ctor_qualify", None, &[], &b)
+                    .unwrap_or_else(|| format!("{}::{}", enum_name, type_name));
             }
             let mut b = HashMap::new();
             b.insert("type_name", type_name);
@@ -624,11 +636,12 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         IrExprKind::Range { start, end, inclusive } => {
             let s = render_expr(ctx, start);
             let e = render_expr(ctx, end);
-            if *inclusive {
-                format!("({}..={})", s, e)
-            } else {
-                format!("({}..{})", s, e)
-            }
+            let mut b = HashMap::new();
+            b.insert("start", s);
+            b.insert("end", e);
+            let construct = if *inclusive { "range_inclusive" } else { "range_expr" };
+            ctx.templates.render(construct, None, &[], &b)
+                .unwrap_or_else(|| "range(...)".into())
         }
 
         // ── Tuple ──
@@ -939,7 +952,11 @@ fn render_pattern(ctx: &RenderContext, pat: &IrPattern) -> String {
         }
         IrPattern::Constructor { name, args } => {
             let qualified = if let Some(enum_name) = ctx.ann.ctor_to_enum.get(name) {
-                format!("{}::{}", enum_name, name)
+                let mut b = HashMap::new();
+                b.insert("enum_name", enum_name.clone());
+                b.insert("ctor_name", name.clone());
+                ctx.templates.render("ctor_qualify", None, &[], &b)
+                    .unwrap_or_else(|| format!("{}::{}", enum_name, name))
             } else {
                 name.clone()
             };

--- a/tests/codegen_v3_compare.rs
+++ b/tests/codegen_v3_compare.rs
@@ -272,9 +272,9 @@ fn test_walker_if_formatting() {
     assert!(rust_out.starts_with("if ("), "Rust if: {}", rust_out);
     assert!(!rust_out.contains("if (("), "Rust should not double-paren: {}", rust_out);
 
-    // TS: if (cond) { ... } else { ... }  (parens around cond)
+    // TS: ternary (cond) ? (then) : (else)
     let ts_templates = template::typescript_templates();
     let ts_ctx = RenderContext::new(&ts_templates, &var_table);
     let ts_out = walker::render_expr(&ts_ctx, &if_expr);
-    assert!(ts_out.contains("if ("), "TS if should have parens: {}", ts_out);
+    assert!(ts_out.contains("?") && ts_out.contains(":"), "TS if should be ternary: {}", ts_out);
 }


### PR DESCRIPTION
## Summary

- **Cross-target (Rust + TS): 106/106 pass, 0 fail** — up from 13 pass at branch start
- 3 new Nanopass passes for TS/Python targets:
  - `ResultErasurePass` — ok(x)→x, err(e)→throw, Try→identity
  - `ShadowResolvePass` — let shadowing → assignment (TS const/let redeclaration)
  - `MatchLoweringPass` extended — Constructor + RecordPattern → if/else chain with guard support
- 20+ TOML template additions for target-agnostic rendering
- break-in-IIFE solved: Block/If with loop control renders as bare blocks

## Architecture validation

The `is_rust() = 0` walker correctly renders both Rust and TS via templates + nanopass alone. No target-specific logic in the walker (except 1 `Target::Rust` match for fan concurrency).

## Test plan

- [x] Rust spec: 72/72
- [x] TS spec/lang: 45/45
- [x] Cross-target full (spec + exercises): 106/106
- [x] Zero known limitations