### PR TITLE
v0.8.2: generic fn lambda fix, build artifact cleanup, test architecture redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,17 +8,9 @@ tools/stdlib-crawler/data/
 __pycache__/
 *.pyc
 
-# Test compilation cache (almide test generates these)
+# Test compilation cache (almide test/run generates these)
 _tmp_*
 _dev_stdin-*/
 main-*/
 test_inc-*/
-__exercises_*/
-__spec_*/
-exercises_*-*/
-exercises_*_almd-*/
-examples_*_almd-*/
-spec_*_almd-*/
-spec_*-*/
-spec__*_almd-*/
-tools_stdlib_*/
+*_almd-*/

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,3 @@ codopsy-report.json
 tools/stdlib-crawler/data/
 __pycache__/
 *.pyc
-
-# Test compilation cache (almide test/run generates these)
-_tmp_*
-_dev_stdin-*/
-main-*/
-test_inc-*/
-*_almd-*/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "almide"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "clap",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Verify the installation:
 
 ```bash
 almide --version
-# almide 0.8.1
+# almide 0.8.2
 ```
 
 ### Hello World

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -43,7 +43,7 @@ pub fn cmd_run_inner(file: &str, program_args: &[String], no_check: bool, test_m
             .arg(&bin_path)
             .arg("-C").arg("overflow-checks=no")
             .arg("-C").arg("opt-level=1")
-            .arg("-C").arg("incremental=")
+            .arg("-C").arg(format!("incremental={}", incremental_cache_dir().join("incremental").display()))
             .arg("--edition").arg("2021");
         if use_test_harness {
             rustc_cmd.arg("--test");

--- a/src/codegen/pass_result_propagation.rs
+++ b/src/codegen/pass_result_propagation.rs
@@ -139,9 +139,11 @@ fn insert_try(expr: IrExpr, in_match_subject: bool) -> IrExpr {
             args: args.into_iter().map(|a| insert_try(a, false)).collect(),
             type_args,
         },
+        // Don't recurse into lambdas — they are independent scopes,
+        // not part of the effect fn's error propagation chain.
         IrExprKind::Lambda { params, body } => IrExprKind::Lambda {
             params,
-            body: Box::new(insert_try(*body, false)),
+            body,
         },
         IrExprKind::List { elements } => IrExprKind::List {
             elements: elements.into_iter().map(|e| insert_try(e, false)).collect(),


### PR DESCRIPTION
## Summary

330 commits since last release. Key changes in this release:

- **Fix ResultPropagationPass lambda recursion**: `insert_try` no longer recurses into lambda bodies, fixing the generic adapter pattern (`fn fetch[T]` with decoder callbacks)
- **Route rustc incremental cache to `.almide/cache/incremental`**: eliminates ~200 artifact directories polluting the project root
- **Simplify `.gitignore`**: remove 8 obsolete patterns, down to 9 lines
- **Test architecture redesign**: split `in_effect` into `can_call_effect` + `auto_unwrap`, eliminate `in_test` flag
- **Codegen v3 complete**: Rust 72/72, TS 106/106, `is_rust()` = 0
- **Stdlib verb reform**: all 7 steps complete (282 functions across 15 modules)
- **Fan concurrency**: `fan { }`, `fan.map`, `fan.race`, `fan.any`, `fan.settle`, `fan.timeout`
- **5 showcases**: almide-grep, csv-to-json, md2html, dotenv-check, todo-api
- **24 exercises**: 230+ tests across Tier 1-6
- **Cross-target CI**: 91/91 spec+exercise tests pass on both Rust and TS (Deno)
- **Error codes**: E001-E010, `almide check --json`, `almide check --explain`
- **Single-quote strings**, `+` concat (replacing `++`), security model, stability contract
- **Codec system**: `Type.decode`/`Type.encode` convention, auto-derive
- **110/110 all tests pass**, ICE = 0

## Test plan

- [x] `almide test` — 110/110 pass
- [x] `almide test spec/integration/generics/generics_test.almd` — 10/10
- [x] No artifact directories in project root after full test run
- [x] `cargo build --release` clean