### PR TITLE
v0.8.3: Add Target::JavaScript, build artifact cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "almide"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "clap",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Verify the installation:
 
 ```bash
 almide --version
-# almide 0.8.2
+# almide 0.8.3
 ```
 
 ### Hello World

--- a/codegen/templates/javascript.toml
+++ b/codegen/templates/javascript.toml
@@ -1,0 +1,397 @@
+# JavaScript target syntax templates
+# Identical to TypeScript but with all type annotations removed.
+
+# ── Expressions ──
+
+[if_expr]
+template = "(({cond}) ? ({then}) : ({else}))"
+
+[call_expr]
+template = "{callee}({args})"
+
+# ── Stdlib module calls ──
+
+[module_call]
+template = "__almd_{module}.{func}({args})"
+
+[binary_op]
+template = "({left} {op} {right})"
+
+[field_access]
+template = "{expr}.{field}"
+
+[index_access]
+template = "{object}[{index}]"
+
+[pipe_call]
+template = "{callee}({pipe_arg}, {args})"
+
+# ── Concat ──
+
+[[concat_expr]]
+when_type = "String"
+template = "{left} + {right}"
+
+[[concat_expr]]
+when_type = "List"
+template = "[...{left}, ...{right}]"
+
+# ── Equality ──
+
+[eq_expr]
+template = "__deep_eq({left}, {right})"
+
+[ne_expr]
+template = "!__deep_eq({left}, {right})"
+
+# ── Power ──
+
+[power_expr]
+template = "{left} ** {right}"
+
+# ── Option / Result ──
+
+[some_expr]
+template = "{inner}"
+
+[none_expr]
+template = "null"
+
+[ok_expr]
+template = "{{ ok: true, value: {inner} }}"
+
+[err_expr]
+template = "{{ ok: false, error: {inner} }}"
+
+[unwrap_or_expr]
+template = "__almd_unwrap_or({expr}, {default})"
+
+# ── Match ──
+
+[match_expr]
+template = "(() => {{ {arms} }})()"
+
+[match_arm]
+template = "if ({condition}) {{ return {body}; }}"
+
+[match_arm_default]
+template = "return {body};"
+
+[pattern_some]
+template = "({binding} !== null)"
+
+[pattern_none]
+template = "({subject} === null)"
+
+[pattern_ok]
+template = "({subject}.ok === true)"
+
+[pattern_err]
+template = "({subject}.ok === false)"
+
+[pattern_wildcard]
+template = "true"
+
+[pattern_literal]
+template = "(__deep_eq({subject}, {value}))"
+
+# ── Literals ──
+
+[int_literal]
+template = "{value}"
+
+[float_literal]
+template = "{value}"
+
+[string_literal]
+template = "\"{value}\""
+
+[bool_literal_true]
+template = "true"
+
+[bool_literal_false]
+template = "false"
+
+[list_literal]
+template = "[{elements}]"
+
+[record_literal]
+template = "{{ {fields} }}"
+
+[record_field]
+template = "{name}: {value}"
+
+# ── String Interpolation ──
+
+[string_interp]
+template = "`{template_str}`"
+
+# ── Statements (no type annotations) ──
+
+[let_binding]
+template = "let {name} = {value};"
+
+[var_binding]
+template = "let {name} = {value};"
+
+[assignment]
+template = "{target} = {value};"
+
+[return_expr]
+template = "{value}"
+
+# ── Declarations (no type annotations) ──
+
+[fn_decl]
+template = "function {name}({params}) {{ {body} }}"
+
+[effect_fn_decl]
+template = "function {name}({params}) {{ {body} }}"
+
+[fn_param]
+template = "{name}"
+
+# ── Type annotations (not emitted, but walker may query them) ──
+
+[type_int]
+template = ""
+
+[type_float]
+template = ""
+
+[type_string]
+template = ""
+
+[type_bool]
+template = ""
+
+[type_unit]
+template = ""
+
+[type_list]
+template = ""
+
+[type_option]
+template = ""
+
+[type_result]
+template = ""
+
+[type_map]
+template = ""
+
+[type_set]
+template = ""
+
+[type_fn]
+template = ""
+
+# ── Loops ──
+
+[for_loop]
+template = "for (const {var} of {iter}) {{ {body} }}"
+
+[while_loop]
+template = "while ({cond}) {{ {body} }}"
+
+[break_stmt]
+template = "break;"
+
+[continue_stmt]
+template = "continue;"
+
+# ── Lambda ──
+
+[lambda]
+template = "({params}) => {{ {body} }}"
+
+[lambda_single]
+template = "({params}) => {body}"
+
+# ── Type declarations (JS: no interface/type, just constructors) ──
+
+[type_alias]
+template = ""
+
+[struct_decl]
+template = ""
+
+[struct_field]
+template = "{name};"
+
+[enum_decl]
+template = "// type {name} = variant union\n{variants}"
+
+[enum_variant]
+template = "function {name}({params}) {{ return {{ tag: \"{name}\", value: [{param_names}] }}; }}"
+
+[enum_variant_unit]
+template = "const {name} = {{ tag: \"{name}\" }};"
+
+[type_tuple]
+template = ""
+
+[tuple_literal]
+template = "[{elements}]"
+
+[tuple_index]
+template = "{object}[{index}]"
+
+[enum_variant_sep]
+template = "\n"
+
+[enum_variant_record]
+template = "function {name}({fields}) {{ return {{ tag: \"{name}\", {field_names} }}; }}"
+
+[interface_decl]
+template = ""
+
+[interface_field]
+template = "{name};"
+
+# ── Imports ──
+
+[import]
+template = "import {{ {names} }} from \"{module}\";"
+
+# ── Test ──
+
+[unit_literal]
+template = "undefined"
+
+[deref_lazy]
+template = "{name}"
+
+[deref_var]
+template = "{name}"
+
+[clone_expr]
+template = "{expr}"
+
+[range_expr]
+template = "Array.from({{ length: ({end}) - ({start}) }}, (_, i) => ({start}) + i)"
+
+[range_inclusive]
+template = "Array.from({{ length: ({end}) - ({start}) + 1 }}, (_, i) => ({start}) + i)"
+
+[for_tuple_destructure]
+template = "[{vars}]"
+
+[ctor_unit]
+template = "{ctor_name}"
+
+[ctor_call]
+template = "{ctor_name}({args})"
+
+[ctor_qualify]
+template = "{ctor_name}"
+
+[ctor_record]
+template = "{{ tag: \"{ctor_name}\", {fields} }}"
+
+[destructure_pattern]
+template = "{{ {fields} }}"
+
+[bind_destructure]
+template = "const {pattern} = {value};"
+
+[block_expr]
+template = "(() => {{\n{body}\n}})()"
+
+[block_result_expr]
+template = "return {expr};"
+
+[test_module]
+template = "{tests}"
+
+[test_block]
+template = "// test: {name}\n(function() {{ {body} }})();"
+
+[assert_eq]
+template = "if (!__deep_eq({left}, {right})) throw new Error(`assertion failed`);"
+
+# ── Target-agnostic constructs ──
+
+[typevar_infer]
+template = ""
+
+[unknown_type]
+template = ""
+
+[empty_map]
+template = "new Map()"
+
+[try_expr]
+template = "{inner}"
+
+[await_expr]
+template = "await {inner}"
+
+[keyword_escape]
+template = "_{name}"
+
+[map_literal]
+template = "new Map([{entries}])"
+
+[map_entry]
+template = "[{key}, {value}]"
+
+[map_get]
+template = "{object}.get({key})"
+
+[map_insert]
+template = "{target}.set({key}, {value});"
+
+[index_assign]
+template = "{target}[{index}] = {value};"
+
+[stmt_terminator]
+template = ";"
+
+[spread_record]
+template = "{{ ...{base}, {fields} }}"
+
+[string_match_subject]
+template = "{subject}"
+
+[guard_negate]
+template = "(!({cond}))"
+
+[empty_list]
+template = "[]"
+
+[fan_expr]
+template = "await Promise.all([{exprs}])"
+
+[fan_effect]
+template = "await Promise.all([{exprs}])"
+
+[extern_fn]
+template = "// extern: {module}.{function} as {name}"
+
+[loop_block]
+template = "(() => {{ while (true) {{\n{body}\n}} }})()"
+
+[err_inner_string]
+template = "(() => {{ throw new Error({inner}) }})()"
+
+[err_inner_other]
+template = "(() => {{ throw new Error(String({inner})) }})()"
+
+[record_pattern_rest]
+template = "{name}"
+
+[record_pattern_rest_empty]
+template = "{name}"
+
+[top_let_const]
+template = "const {name} = {value};"
+
+[top_let_lazy]
+template = "const {name} = {value};"
+
+[generic_bound]
+template = "{name}"
+
+[generic_bound_full]
+template = "{name}"

--- a/src/cli/emit.rs
+++ b/src/cli/emit.rs
@@ -125,7 +125,7 @@ pub fn cmd_emit(file: &str, target: &str, emit_ast: bool, emit_ir: bool, no_chec
             }
             "js" | "javascript" => {
                 let ir = ir_program.as_mut().expect("IR required for codegen");
-                codegen::emit(ir, codegen::pass::Target::TypeScript)
+                codegen::emit(ir, codegen::pass::Target::JavaScript)
             }
             other => { eprintln!("Unknown target: {}. Use rust, ts, js.", other); std::process::exit(1); }
         };

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -165,6 +165,11 @@ pub fn emit(program: &mut IrProgram, target: Target) -> String {
             output.push_str(&crate::emit_ts_runtime::full_runtime(false));
             output.push('\n');
         }
+        Target::JavaScript => {
+            // Embed the JS runtime (no type annotations)
+            output.push_str(&crate::emit_ts_runtime::full_runtime(true));
+            output.push('\n');
+        }
         _ => {}
     }
     output.push_str(&user_code);

--- a/src/codegen/pass.rs
+++ b/src/codegen/pass.rs
@@ -32,6 +32,7 @@ pub struct ScopeContext {
 pub enum Target {
     Rust,
     TypeScript,
+    JavaScript,
     Go,
     Python,
 }
@@ -121,7 +122,7 @@ pub struct OptionErasurePass;
 impl NanoPass for OptionErasurePass {
     fn name(&self) -> &str { "OptionErasure" }
     fn targets(&self) -> Option<Vec<Target>> {
-        Some(vec![Target::TypeScript, Target::Python])
+        Some(vec![Target::TypeScript, Target::JavaScript, Target::Python])
     }
     fn run(&self, _program: &mut IrProgram, _target: Target) {
         // TS/Python: some(x) → x, none → null/None

--- a/src/codegen/pass_match_lowering.rs
+++ b/src/codegen/pass_match_lowering.rs
@@ -22,7 +22,7 @@ impl NanoPass for MatchLoweringPass {
     fn name(&self) -> &str { "MatchLowering" }
 
     fn targets(&self) -> Option<Vec<Target>> {
-        Some(vec![Target::TypeScript, Target::Python, Target::Go])
+        Some(vec![Target::TypeScript, Target::JavaScript, Target::Python, Target::Go])
     }
 
     fn run(&self, program: &mut IrProgram, _target: Target) {

--- a/src/codegen/pass_result_erasure.rs
+++ b/src/codegen/pass_result_erasure.rs
@@ -21,7 +21,7 @@ pub struct ResultErasurePass;
 impl NanoPass for ResultErasurePass {
     fn name(&self) -> &str { "ResultErasure" }
     fn targets(&self) -> Option<Vec<Target>> {
-        Some(vec![Target::TypeScript, Target::Python])
+        Some(vec![Target::TypeScript, Target::JavaScript, Target::Python])
     }
     fn run(&self, program: &mut IrProgram, _target: Target) {
         for func in &mut program.functions {

--- a/src/codegen/pass_shadow_resolve.rs
+++ b/src/codegen/pass_shadow_resolve.rs
@@ -16,7 +16,7 @@ pub struct ShadowResolvePass;
 impl NanoPass for ShadowResolvePass {
     fn name(&self) -> &str { "ShadowResolve" }
     fn targets(&self) -> Option<Vec<Target>> {
-        Some(vec![Target::TypeScript, Target::Python])
+        Some(vec![Target::TypeScript, Target::JavaScript, Target::Python])
     }
     fn run(&self, program: &mut IrProgram, _target: Target) {
         for func in &mut program.functions {

--- a/src/codegen/target.rs
+++ b/src/codegen/target.rs
@@ -57,7 +57,7 @@ fn build_pipeline(target: Target) -> Pipeline {
             // Shared passes
             .add(FanLoweringPass),
 
-        Target::TypeScript => Pipeline::new()
+        Target::TypeScript | Target::JavaScript => Pipeline::new()
             // Semantic lowering
             .add(MatchLoweringPass)
             // Result/Option erasure: ok(x)→x, err(e)→throw, some(x)→x, none→null
@@ -85,7 +85,7 @@ fn build_templates(target: Target) -> TemplateSet {
     match target {
         Target::Rust => super::template::rust_templates(),
         Target::TypeScript => super::template::typescript_templates(),
-        // TODO: load from TOML files once template loader is implemented
+        Target::JavaScript => super::template::javascript_templates(),
         Target::Go => TemplateSet::new("go"),
         Target::Python => TemplateSet::new("python"),
     }

--- a/src/codegen/template.rs
+++ b/src/codegen/template.rs
@@ -235,6 +235,11 @@ pub fn typescript_templates() -> TemplateSet {
     load_from_toml("typescript", include_str!("../../codegen/templates/typescript.toml"))
 }
 
+/// Load JavaScript templates from embedded TOML
+pub fn javascript_templates() -> TemplateSet {
+    load_from_toml("javascript", include_str!("../../codegen/templates/javascript.toml"))
+}
+
 /// Load built-in Rust templates (inline fallback — kept for reference)
 pub fn rust_templates_inline() -> TemplateSet {
     let mut ts = TemplateSet::new("rust");

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -1063,7 +1063,7 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
     if !func.extern_attrs.is_empty() {
         let target_str = match ctx.target {
             Target::Rust => "rs",
-            Target::TypeScript => "ts",
+            Target::TypeScript | Target::JavaScript => "ts",
             _ => "",
         };
         for attr in &func.extern_attrs {
@@ -1344,9 +1344,13 @@ fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                             }
                         }).collect();
                         let fields_str = types.join(", ");
-                        // Named params for TS: v0: type0, v1: type1
+                        // Named params via fn_param template (respects JS/TS)
                         let params_str = types.iter().enumerate()
-                            .map(|(i, t)| format!("v{}: {}", i, t))
+                            .map(|(i, t)| {
+                                let name = format!("v{}", i);
+                                ctx.templates.render_with("fn_param", None, &[], &[("name", name.as_str()), ("type", t.as_str())])
+                                    .unwrap_or(name)
+                            })
                             .collect::<Vec<_>>().join(", ");
                         let param_names = (0..types.len()).map(|i| format!("v{}", i))
                             .collect::<Vec<_>>().join(", ");
@@ -1363,7 +1367,8 @@ fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                                 } else {
                                     rendered
                                 };
-                                format!("{}: {}", f.name, boxed)
+                                ctx.templates.render_with("fn_param", None, &[], &[("name", f.name.as_str()), ("type", boxed.as_str())])
+                                    .unwrap_or_else(|| format!("{}: {}", f.name, boxed))
                             })
                             .collect::<Vec<_>>()
                             .join(", ");


### PR DESCRIPTION
## Summary

- **Add `Target::JavaScript`**: `--target js` now emits proper JavaScript without TypeScript type annotations. Separate TOML template set (`javascript.toml`), JS runtime via `full_runtime(true)`, all nanopass passes enabled for JS
- **Fix variant constructor codegen**: enum variant params now use `fn_param` template (prevents `v0: , v1: ` in JS output)
- **Route rustc incremental cache**: build artifacts go to `.almide/cache/incremental/` instead of polluting project root
- **Simplify `.gitignore`**: remove 8 obsolete patterns
- **Fix ResultPropagationPass**: skip lambda bodies in `insert_try`

## Test plan

- [x] `almide test` — 110/110 pass
- [x] `cargo test --lib` — 37/37 pass
- [x] JS output runs in Node.js without syntax errors
- [x] TS output unchanged (no regression)
- [x] No artifact directories in project root