### PR TITLE
Refactor deep nesting to functional style

### DIFF
--- a/src/check/calls.rs
+++ b/src/check/calls.rs
@@ -108,18 +108,7 @@ impl Checker {
                     }
                 }
                 // Convention method: dog.repr() → Dog.repr(dog)
-                let type_name_opt = match &obj_concrete {
-                    Ty::Named(name, _) => Some(name.clone()),
-                    Ty::Record { .. } | Ty::Variant { .. } => {
-                        // Reverse lookup: find type name whose definition matches this structure
-                        self.env.types.iter().find_map(|(name, ty)| {
-                            if ty == &obj_concrete && name.chars().next().map_or(false, |c| c.is_uppercase()) {
-                                Some(name.clone())
-                            } else { None }
-                        })
-                    }
-                    _ => None,
-                };
+                let type_name_opt = self.resolve_type_name(&obj_concrete);
                 if let Some(type_name) = type_name_opt {
                     let convention_key = format!("{}.{}", type_name, field);
                     if self.env.functions.contains_key(&convention_key) {
@@ -144,6 +133,19 @@ impl Checker {
                 self.constrain(ct, Ty::Fn { params: arg_tys.to_vec(), ret: Box::new(ret.clone()) }, "function call");
                 ret
             }
+        }
+    }
+
+    /// Resolve a concrete type to its declared type name.
+    fn resolve_type_name(&self, ty: &Ty) -> Option<String> {
+        match ty {
+            Ty::Named(name, _) => Some(name.clone()),
+            Ty::Record { .. } | Ty::Variant { .. } => {
+                self.env.types.iter().find_map(|(name, def)| {
+                    (def == ty && name.starts_with(|c: char| c.is_uppercase())).then(|| name.clone())
+                })
+            }
+            _ => None,
         }
     }
 

--- a/src/check/calls.rs
+++ b/src/check/calls.rs
@@ -2,6 +2,45 @@
 
 use std::collections::HashMap;
 use crate::ast;
+/// Extract the effective return type from a function type, auto-unwrapping Result.
+fn unwrap_fn_return(fn_ty: &Ty) -> Option<Ty> {
+    if let Ty::Fn { ret, .. } = fn_ty {
+        Some(match ret.as_ref() {
+            Ty::Applied(TypeConstructorId::Result, args) if args.len() == 2 => args[0].clone(),
+            other => other.clone(),
+        })
+    } else {
+        None
+    }
+}
+
+/// Extract the Result type from List[Fn() -> Result[T, E]] → Result[T, E]
+fn unwrap_list_fn_result_ty(list_ty: &Ty) -> Ty {
+    match list_ty {
+        Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 => {
+            match &args[0] {
+                Ty::Fn { ret, .. } => match ret.as_ref() {
+                    r @ Ty::Applied(TypeConstructorId::Result, _) => r.clone(),
+                    other => Ty::result(other.clone(), Ty::String),
+                },
+                _ => Ty::Unknown,
+            }
+        }
+        _ => Ty::Unknown,
+    }
+}
+
+/// Extract the element's effective return type from List[Fn() -> Result[T, E]] → T
+fn unwrap_list_fn_return(list_ty: &Ty) -> Ty {
+    match list_ty {
+        Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 => {
+            unwrap_fn_return(&args[0]).unwrap_or(Ty::Unknown)
+        }
+        _ => Ty::Unknown,
+    }
+}
+
+
 use crate::types::{Ty, TypeConstructorId};
 use super::types::resolve_vars;
 use super::Checker;
@@ -366,21 +405,7 @@ impl Checker {
                             return Some(Ty::Unknown);
                         }
                         let list_ty = resolve_vars(&arg_tys[0], &self.solutions);
-                        let result_ty = match &list_ty {
-                            Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 => {
-                                match &args[0] {
-                                    Ty::Fn { ret, .. } => {
-                                        match ret.as_ref() {
-                                            Ty::Applied(TypeConstructorId::Result, rargs) if rargs.len() == 2 => rargs[0].clone(),
-                                            other => other.clone(),
-                                        }
-                                    }
-                                    _ => Ty::Unknown,
-                                }
-                            }
-                            _ => Ty::Unknown,
-                        };
-                        return Some(result_ty);
+                        return Some(unwrap_list_fn_return(&list_ty));
                     }
                     "any" => {
                         // fan.any(thunks) -> T — first success, all fail = error
@@ -392,17 +417,7 @@ impl Checker {
                             return Some(Ty::Unknown);
                         }
                         let list_ty = resolve_vars(&arg_tys[0], &self.solutions);
-                        let result_ty = match &list_ty {
-                            Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 => match &args[0] {
-                                Ty::Fn { ret, .. } => match ret.as_ref() {
-                                    Ty::Applied(TypeConstructorId::Result, rargs) if rargs.len() == 2 => rargs[0].clone(),
-                                    other => other.clone(),
-                                },
-                                _ => Ty::Unknown,
-                            },
-                            _ => Ty::Unknown,
-                        };
-                        return Some(result_ty);
+                        return Some(unwrap_list_fn_return(&list_ty));
                     }
                     "settle" => {
                         // fan.settle(thunks) -> List[Result[T, String]]
@@ -414,16 +429,7 @@ impl Checker {
                             return Some(Ty::Unknown);
                         }
                         let list_ty = resolve_vars(&arg_tys[0], &self.solutions);
-                        let inner_result = match &list_ty {
-                            Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 => match &args[0] {
-                                Ty::Fn { ret, .. } => match ret.as_ref() {
-                                    Ty::Applied(TypeConstructorId::Result, rargs) if rargs.len() == 2 => Ty::result(rargs[0].clone(), rargs[1].clone()),
-                                    other => Ty::result(other.clone(), Ty::String),
-                                },
-                                _ => Ty::Unknown,
-                            },
-                            _ => Ty::Unknown,
-                        };
+                        let inner_result = unwrap_list_fn_result_ty(&list_ty);
                         return Some(Ty::list(inner_result));
                     }
                     "timeout" => {

--- a/src/check/calls.rs
+++ b/src/check/calls.rs
@@ -211,15 +211,13 @@ impl Checker {
                         return Ty::Named(type_name, generic_args);
                     }
                     if let Some(ty) = self.env.lookup_var(name).cloned() {
-                        return match &ty {
-                            Ty::Fn { params, ret } => {
-                                for (aty, pty) in arg_tys.iter().zip(params.iter()) {
-                                    self.constrain(pty.clone(), aty.clone(), format!("call to {}()", name));
-                                }
-                                ret.as_ref().clone()
-                            }
-                            _ => ty
-                        };
+                        if let Ty::Fn { params, ret } = &ty {
+                            arg_tys.iter().zip(params.iter()).for_each(|(aty, pty)| {
+                                self.constrain(pty.clone(), aty.clone(), format!("call to {}()", name));
+                            });
+                            return ret.as_ref().clone();
+                        }
+                        return ty;
                     }
                     self.emit(super::err(format!("undefined function '{}'", name), "Check the function name", format!("call to {}()", name)).with_code("E002"));
                     return Ty::Unknown;
@@ -376,23 +374,13 @@ impl Checker {
                         };
                         // Infer return type from f's return type
                         let fn_ty = resolve_vars(&arg_tys[1], &self.solutions);
-                        let result_elem = match &fn_ty {
-                            Ty::Fn { ret, .. } => {
-                                // Auto-unwrap Result
-                                match ret.as_ref() {
-                                    Ty::Applied(TypeConstructorId::Result, args) if args.len() == 2 => args[0].clone(),
-                                    other => other.clone(),
-                                }
-                            }
-                            _ => {
-                                // If fn type unknown, constrain it
-                                let ret_var = self.fresh_var();
-                                self.constrain(arg_tys[1].clone(),
-                                    Ty::Fn { params: vec![elem_ty], ret: Box::new(ret_var.clone()) },
-                                    "fan.map callback");
-                                resolve_vars(&ret_var, &self.solutions)
-                            }
-                        };
+                        let result_elem = unwrap_fn_return(&fn_ty).unwrap_or_else(|| {
+                            let ret_var = self.fresh_var();
+                            self.constrain(arg_tys[1].clone(),
+                                Ty::Fn { params: vec![elem_ty], ret: Box::new(ret_var.clone()) },
+                                "fan.map callback");
+                            resolve_vars(&ret_var, &self.solutions)
+                        });
                         return Some(Ty::list(result_elem));
                     }
                     "race" => {

--- a/src/check/infer.rs
+++ b/src/check/infer.rs
@@ -231,17 +231,16 @@ impl Checker {
                         "fan block".to_string()).with_code("E007"));
                 }
                 // Check for mutable variable capture
-                for e in exprs.iter() {
+                let mutable_captures: Vec<String> = exprs.iter().flat_map(|e| {
                     let mut idents = Vec::new();
                     collect_idents(e, &mut idents);
-                    for name in &idents {
-                        if self.env.mutable_vars.contains(name) {
-                            self.emit(super::err(
-                                format!("cannot capture mutable variable '{}' inside fan block", name),
-                                "Use a `let` binding instead of `var` for values shared across fan expressions",
-                                "fan block".to_string()).with_code("E008"));
-                        }
-                    }
+                    idents.into_iter().filter(|name| self.env.mutable_vars.contains(name)).collect::<Vec<_>>()
+                }).collect();
+                for name in &mutable_captures {
+                    self.emit(super::err(
+                        format!("cannot capture mutable variable '{}' inside fan block", name),
+                        "Use a `let` binding instead of `var` for values shared across fan expressions",
+                        "fan block".to_string()).with_code("E008"));
                 }
                 let tys: Vec<Ty> = exprs.iter_mut().map(|e| {
                     let ty = self.infer_expr(e);

--- a/src/check/infer.rs
+++ b/src/check/infer.rs
@@ -366,15 +366,9 @@ impl Checker {
                 match callee.as_mut() {
                     ast::Expr::Ident { name, .. } => self.check_named_call(name, &all_arg_tys),
                     ast::Expr::Member { object, field, .. } => {
-                        if let ast::Expr::Ident { name: module, .. } = object.as_ref() {
-                            if crate::stdlib::is_stdlib_module(module) || self.env.user_modules.contains(module.as_str()) {
-                                let key = format!("{}.{}", module, field);
-                                return self.check_named_call(&key, &all_arg_tys);
-                            }
-                            if let Some(target) = self.env.module_aliases.get(module.as_str()).cloned() {
-                                let key = format!("{}.{}", target, field);
-                                return self.check_named_call(&key, &all_arg_tys);
-                            }
+                        let module_key = self.resolve_module_call(object, field);
+                        if let Some(key) = module_key {
+                            return self.check_named_call(&key, &all_arg_tys);
                         }
                         let ct = self.infer_expr(callee);
                         let ret = self.fresh_var();
@@ -397,15 +391,8 @@ impl Checker {
             // Pipe RHS is a module-qualified function (e.g. `5 |> int.abs`)
             ast::Expr::Member { object, field, .. } => {
                 let all_arg_tys = vec![left_ty];
-                if let ast::Expr::Ident { name: module, .. } = object.as_ref() {
-                    if crate::stdlib::is_stdlib_module(module) || self.env.user_modules.contains(module.as_str()) {
-                        let key = format!("{}.{}", module, field);
-                        return self.check_named_call(&key, &all_arg_tys);
-                    }
-                    if let Some(target) = self.env.module_aliases.get(module.as_str()).cloned() {
-                        let key = format!("{}.{}", target, field);
-                        return self.check_named_call(&key, &all_arg_tys);
-                    }
+                if let Some(key) = self.resolve_module_call(object, field) {
+                    return self.check_named_call(&key, &all_arg_tys);
                 }
                 let ct = self.infer_expr(right);
                 let ret = self.fresh_var();
@@ -550,6 +537,19 @@ impl Checker {
             ast::Pattern::Err { inner } => { let it = match ty { Ty::Applied(TypeConstructorId::Result, args) if args.len() == 2 => args[1].clone(), _ => Ty::Unknown }; self.bind_pattern(inner, &it); }
             ast::Pattern::None | ast::Pattern::Literal { .. } => {}
         }
+    }
+
+    /// Resolve a module.func Member expression to a qualified call key.
+    fn resolve_module_call(&self, object: &ast::Expr, field: &str) -> Option<String> {
+        if let ast::Expr::Ident { name: module, .. } = object {
+            if crate::stdlib::is_stdlib_module(module) || self.env.user_modules.contains(module.as_str()) {
+                return Some(format!("{}.{}", module, field));
+            }
+            if let Some(target) = self.env.module_aliases.get(module.as_str()) {
+                return Some(format!("{}.{}", target, field));
+            }
+        }
+        None
     }
 }
 

--- a/src/check/infer.rs
+++ b/src/check/infer.rs
@@ -127,24 +127,7 @@ impl Checker {
                     "+" => {
                         let lc = resolve_vars(&lt, &self.solutions);
                         let rc = resolve_vars(&rt, &self.solutions);
-                        // + works for: String+String, List+List (concat), numeric+numeric (add)
-                        let l_concat = matches!(&lc, Ty::String | Ty::Applied(TypeConstructorId::List, _));
-                        let r_concat = matches!(&rc, Ty::String | Ty::Applied(TypeConstructorId::List, _));
-                        let l_unknown = matches!(&lc, Ty::Unknown | Ty::TypeVar(_));
-                        let r_unknown = matches!(&rc, Ty::Unknown | Ty::TypeVar(_));
-                        let is_concat = (l_concat && (r_concat || r_unknown))
-                            || (r_concat && l_unknown);
-                        if is_concat {
-                            lt // concat: return same type
-                        } else {
-                            let is_numeric = |t: &Ty| matches!(t, Ty::Int | Ty::Float | Ty::Unknown | Ty::TypeVar(_));
-                            if !is_numeric(&lc) || !is_numeric(&rc) {
-                                self.emit(super::err(
-                                    format!("operator '+' requires numeric, String, or List types but got {} and {}", lc.display(), rc.display()),
-                                    "Use + with numeric types, String, or List", format!("operator +")));
-                            }
-                            if lc == Ty::Float || rc == Ty::Float { Ty::Float } else { lt }
-                        }
+                        self.infer_plus_op(&lc, &rc, lt)
                     }
                     "-" | "*" | "/" | "%" => {
                         let lc = resolve_vars(&lt, &self.solutions);
@@ -537,6 +520,23 @@ impl Checker {
             ast::Pattern::Err { inner } => { let it = match ty { Ty::Applied(TypeConstructorId::Result, args) if args.len() == 2 => args[1].clone(), _ => Ty::Unknown }; self.bind_pattern(inner, &it); }
             ast::Pattern::None | ast::Pattern::Literal { .. } => {}
         }
+    }
+
+    /// Infer the result type of the + operator (numeric add or string/list concat).
+    fn infer_plus_op(&mut self, lc: &Ty, rc: &Ty, lt: Ty) -> Ty {
+        let is_concat_ty = |t: &Ty| matches!(t, Ty::String | Ty::Applied(TypeConstructorId::List, _));
+        let is_unknown_ty = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_));
+        if (is_concat_ty(lc) && (is_concat_ty(rc) || is_unknown_ty(rc)))
+            || (is_concat_ty(rc) && is_unknown_ty(lc)) {
+            return lt; // concat: return same type
+        }
+        let is_numeric = |t: &Ty| matches!(t, Ty::Int | Ty::Float | Ty::Unknown | Ty::TypeVar(_));
+        if !is_numeric(lc) || !is_numeric(rc) {
+            self.emit(super::err(
+                format!("operator '+' requires numeric, String, or List types but got {} and {}", lc.display(), rc.display()),
+                "Use + with numeric types, String, or List", format!("operator +")));
+        }
+        if *lc == Ty::Float || *rc == Ty::Float { Ty::Float } else { lt }
     }
 
     /// Resolve a module.func Member expression to a qualified call key.

--- a/src/check/types.rs
+++ b/src/check/types.rs
@@ -44,13 +44,10 @@ fn resolve_inner(ty: &Ty, solutions: &HashMap<TyVarId, Ty>, seen: &mut HashSet<u
                 let terminal = loop {
                     if !chain.insert(current.0) { break None; }
                     match solutions.get(&current) {
-                        Some(Ty::TypeVar(n)) if n.starts_with('?') => {
-                            if let Ok(next_id) = n[1..].parse::<u32>() {
-                                current = TyVarId(next_id);
-                            } else {
-                                break Some(Ty::TypeVar(n.clone()));
-                            }
-                        }
+                        Some(Ty::TypeVar(n)) if n.starts_with('?') => match n[1..].parse::<u32>() {
+                            Ok(next_id) => current = TyVarId(next_id),
+                            Err(_) => break Some(Ty::TypeVar(n.clone())),
+                        },
                         Some(other) => break Some(other.clone()),
                         None => break None,
                     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -85,58 +85,47 @@ pub fn emit(program: &mut IrProgram, target: Target) -> String {
         }
         ann.recursive_enums = recursive.clone();
         // Build boxed_fields: for each recursive enum, find which variant fields reference the enum
-        for td in &program.type_decls {
-            if recursive.contains(&td.name) {
-                if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
-                    for c in cases {
-                        if let IrVariantKind::Record { fields } = &c.kind {
-                            for f in fields {
-                                if walker::ty_contains_name(&f.ty, &td.name) {
-                                    ann.boxed_fields.insert((c.name.clone(), f.name.clone()));
-                                }
-                            }
-                        }
-                        if let IrVariantKind::Tuple { fields } = &c.kind {
-                            for (i, t) in fields.iter().enumerate() {
-                                if walker::ty_contains_name(t, &td.name) {
-                                    ann.boxed_fields.insert((c.name.clone(), format!("{}", i)));
-                                }
-                            }
-                        }
+        ann.boxed_fields = program.type_decls.iter()
+            .filter(|td| recursive.contains(&td.name))
+            .filter_map(|td| match &td.kind {
+                IrTypeDeclKind::Variant { cases, .. } => Some((td, cases)),
+                _ => None,
+            })
+            .flat_map(|(td, cases)| {
+                cases.iter().flat_map(move |c| {
+                    let name = &td.name;
+                    match &c.kind {
+                        IrVariantKind::Record { fields } => fields.iter()
+                            .filter(|f| walker::ty_contains_name(&f.ty, name))
+                            .map(|f| (c.name.clone(), f.name.clone()))
+                            .collect::<Vec<_>>(),
+                        IrVariantKind::Tuple { fields } => fields.iter().enumerate()
+                            .filter(|(_, t)| walker::ty_contains_name(t, name))
+                            .map(|(i, _)| (c.name.clone(), format!("{}", i)))
+                            .collect::<Vec<_>>(),
+                        _ => vec![],
                     }
-                }
-            }
-        }
+                })
+            })
+            .collect();
         // Build default_fields: for each variant/record constructor with default field values
-        for td in &program.type_decls {
-            match &td.kind {
-                IrTypeDeclKind::Variant { cases, .. } => {
-                    for c in cases {
-                        if let IrVariantKind::Record { fields } = &c.kind {
-                            for f in fields {
-                                if let Some(ref def) = f.default {
-                                    ann.default_fields.insert(
-                                        (c.name.clone(), f.name.clone()),
-                                        def.clone(),
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-                IrTypeDeclKind::Record { fields } => {
-                    for f in fields {
-                        if let Some(ref def) = f.default {
-                            ann.default_fields.insert(
-                                (td.name.clone(), f.name.clone()),
-                                def.clone(),
-                            );
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
+        ann.default_fields = program.type_decls.iter()
+            .flat_map(|td| match &td.kind {
+                IrTypeDeclKind::Variant { cases, .. } => cases.iter()
+                    .filter_map(|c| match &c.kind {
+                        IrVariantKind::Record { fields } => Some(fields.iter()
+                            .filter_map(|f| f.default.as_ref().map(|def| ((c.name.clone(), f.name.clone()), def.clone())))
+                            .collect::<Vec<_>>()),
+                        _ => None,
+                    })
+                    .flatten()
+                    .collect::<Vec<_>>(),
+                IrTypeDeclKind::Record { fields } => fields.iter()
+                    .filter_map(|f| f.default.as_ref().map(|def| ((td.name.clone(), f.name.clone()), def.clone())))
+                    .collect(),
+                _ => vec![],
+            })
+            .collect();
     }
 
     // Layer 2: Run Nanopass pipeline (semantic rewrites — modifies IR)

--- a/src/codegen/pass_box_deref.rs
+++ b/src/codegen/pass_box_deref.rs
@@ -282,51 +282,38 @@ fn collect_from_stmt(stmt: &IrStmt, recursive_enums: &HashSet<String>, type_decl
 }
 
 /// Given a pattern matching a recursive enum, find Bind vars in recursive positions.
+/// Look up a variant case from a type decl by constructor name.
+fn find_variant_case<'a>(td: Option<&'a IrTypeDecl>, ctor_name: &str) -> Option<&'a IrVariantKind> {
+    let td = td?;
+    let cases = match &td.kind {
+        IrTypeDeclKind::Variant { cases, .. } => cases,
+        _ => return None,
+    };
+    cases.iter().find(|c| c.name == ctor_name).map(|c| &c.kind)
+}
+
 fn collect_deref_from_pattern(pattern: &IrPattern, enum_name: &str, td: Option<&IrTypeDecl>, name_to_var: &std::collections::HashMap<String, Vec<VarId>>, deref_vars: &mut HashSet<VarId>) {
     match pattern {
         IrPattern::Constructor { name, args } => {
-            // Find the variant in the type decl
-            if let Some(td) = td {
-                if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
-                    if let Some(case) = cases.iter().find(|c| &c.name == name) {
-                        if let IrVariantKind::Tuple { fields } = &case.kind {
-                            for (i, arg) in args.iter().enumerate() {
-                                if let Some(field_ty) = fields.get(i) {
-                                    if ty_contains_name(field_ty, enum_name) {
-                                        // This field is Box'd — any Bind in this pattern position needs deref
-                                        collect_bind_vars(arg, deref_vars);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            let Some(IrVariantKind::Tuple { fields }) = find_variant_case(td, name) else { return };
+            args.iter().enumerate()
+                .filter(|(i, _)| fields.get(*i).map_or(false, |ft| ty_contains_name(ft, enum_name)))
+                .for_each(|(_, arg)| collect_bind_vars(arg, deref_vars));
         }
         IrPattern::RecordPattern { name, fields, .. } => {
-            if let Some(td) = td {
-                if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
-                    if let Some(case) = cases.iter().find(|c| &c.name == name) {
-                        if let IrVariantKind::Record { fields: case_fields } = &case.kind {
-                            for field_pat in fields {
-                                if let Some(case_field) = case_fields.iter().find(|f| f.name == field_pat.name) {
-                                    if ty_contains_name(&case_field.ty, enum_name) {
-                                        if let Some(ref p) = field_pat.pattern {
-                                            collect_bind_vars(p, deref_vars);
-                                        } else {
-                                            // Shorthand: lookup VarId by name, but only if unambiguous
-                                            if let Some(var_ids) = name_to_var.get(&field_pat.name) {
-                                                if var_ids.len() == 1 {
-                                                    deref_vars.insert(var_ids[0]);
-                                                }
-                                                // If ambiguous (multiple vars with same name), skip —
-                                                // we can't tell which one is the pattern binding
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+            let Some(IrVariantKind::Record { fields: case_fields }) = find_variant_case(td, name) else { return };
+            for field_pat in fields {
+                let is_recursive = case_fields.iter()
+                    .find(|f| f.name == field_pat.name)
+                    .map_or(false, |f| ty_contains_name(&f.ty, enum_name));
+                if !is_recursive { continue; }
+
+                if let Some(ref p) = field_pat.pattern {
+                    collect_bind_vars(p, deref_vars);
+                } else if let Some(var_ids) = name_to_var.get(&field_pat.name) {
+                    // Shorthand: lookup VarId by name, only if unambiguous
+                    if var_ids.len() == 1 {
+                        deref_vars.insert(var_ids[0]);
                     }
                 }
             }

--- a/src/codegen/pass_box_deref.rs
+++ b/src/codegen/pass_box_deref.rs
@@ -36,54 +36,21 @@ pub fn collect_deref_vars(program: &IrProgram) -> (HashSet<VarId>, HashSet<Strin
     let mut deref_vars = HashSet::new();
     let mut recursive_enums = HashSet::new();
 
-    // Step 1: Find recursive enums
-    for td in &program.type_decls {
+    // Step 1: Find recursive enums (type declarations that reference themselves)
+    let all_type_decls = program.type_decls.iter()
+        .chain(program.modules.iter().flat_map(|m| m.type_decls.iter()));
+    for td in all_type_decls {
         if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
-            for case in cases {
+            let is_recursive = cases.iter().any(|case| {
+                let fields_contain_self = |tys: &[Ty]| tys.iter().any(|t| ty_contains_name(t, &td.name));
                 match &case.kind {
-                    IrVariantKind::Tuple { fields } => {
-                        for f in fields {
-                            if ty_contains_name(f, &td.name) {
-                                recursive_enums.insert(td.name.clone());
-                            }
-                        }
-                    }
-                    IrVariantKind::Record { fields } => {
-                        for f in fields {
-                            if ty_contains_name(&f.ty, &td.name) {
-                                recursive_enums.insert(td.name.clone());
-                            }
-                        }
-                    }
-                    _ => {}
+                    IrVariantKind::Tuple { fields } => fields_contain_self(fields),
+                    IrVariantKind::Record { fields } => fields.iter().any(|f| ty_contains_name(&f.ty, &td.name)),
+                    _ => false,
                 }
-            }
-        }
-    }
-
-    // Also check module type_decls for recursive enums
-    for module in &program.modules {
-        for td in &module.type_decls {
-            if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
-                for case in cases {
-                    match &case.kind {
-                        IrVariantKind::Tuple { fields } => {
-                            for f in fields {
-                                if ty_contains_name(f, &td.name) {
-                                    recursive_enums.insert(td.name.clone());
-                                }
-                            }
-                        }
-                        IrVariantKind::Record { fields } => {
-                            for f in fields {
-                                if ty_contains_name(&f.ty, &td.name) {
-                                    recursive_enums.insert(td.name.clone());
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
+            });
+            if is_recursive {
+                recursive_enums.insert(td.name.clone());
             }
         }
     }

--- a/src/codegen/pass_box_deref.rs
+++ b/src/codegen/pass_box_deref.rs
@@ -23,6 +23,24 @@ impl NanoPass for BoxDerefPass {
     }
 }
 
+/// Find recursive enums from a set of type declarations.
+fn find_recursive_enums<'a>(type_decls: impl Iterator<Item = &'a IrTypeDecl>) -> HashSet<String> {
+    let mut recursive = HashSet::new();
+    for td in type_decls {
+        if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
+            let is_recursive = cases.iter().any(|case| match &case.kind {
+                IrVariantKind::Tuple { fields } => fields.iter().any(|f| ty_contains_name(f, &td.name)),
+                IrVariantKind::Record { fields } => fields.iter().any(|f| ty_contains_name(&f.ty, &td.name)),
+                _ => false,
+            });
+            if is_recursive {
+                recursive.insert(td.name.clone());
+            }
+        }
+    }
+    recursive
+}
+
 /// Find which enums have recursive variants and collect
 /// VarIds that are bound from Box'd fields in match patterns.
 pub fn collect_deref_vars(program: &IrProgram) -> (HashSet<VarId>, HashSet<String>) {
@@ -34,26 +52,11 @@ pub fn collect_deref_vars(program: &IrProgram) -> (HashSet<VarId>, HashSet<Strin
         name_to_var.entry(info.name.clone()).or_default().push(id);
     }
     let mut deref_vars = HashSet::new();
-    let mut recursive_enums = HashSet::new();
 
     // Step 1: Find recursive enums (type declarations that reference themselves)
-    let all_type_decls = program.type_decls.iter()
-        .chain(program.modules.iter().flat_map(|m| m.type_decls.iter()));
-    for td in all_type_decls {
-        if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
-            let is_recursive = cases.iter().any(|case| {
-                let fields_contain_self = |tys: &[Ty]| tys.iter().any(|t| ty_contains_name(t, &td.name));
-                match &case.kind {
-                    IrVariantKind::Tuple { fields } => fields_contain_self(fields),
-                    IrVariantKind::Record { fields } => fields.iter().any(|f| ty_contains_name(&f.ty, &td.name)),
-                    _ => false,
-                }
-            });
-            if is_recursive {
-                recursive_enums.insert(td.name.clone());
-            }
-        }
-    }
+    let recursive_enums = find_recursive_enums(
+        program.type_decls.iter().chain(program.modules.iter().flat_map(|m| m.type_decls.iter()))
+    );
 
     // Step 2: Walk all match expressions and find Bind vars in recursive positions
     for func in &program.functions {
@@ -83,30 +86,7 @@ pub fn collect_module_deref_vars(module: &IrModule, all_type_decls: &[IrTypeDecl
         name_to_var.entry(info.name.clone()).or_default().push(id);
     }
     let mut deref_vars = HashSet::new();
-    let mut recursive_enums = HashSet::new();
-    for td in all_type_decls {
-        if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
-            for case in cases {
-                match &case.kind {
-                    IrVariantKind::Tuple { fields } => {
-                        for f in fields {
-                            if ty_contains_name(f, &td.name) {
-                                recursive_enums.insert(td.name.clone());
-                            }
-                        }
-                    }
-                    IrVariantKind::Record { fields } => {
-                        for f in fields {
-                            if ty_contains_name(&f.ty, &td.name) {
-                                recursive_enums.insert(td.name.clone());
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
-    }
+    let recursive_enums = find_recursive_enums(all_type_decls.iter());
     for func in &module.functions {
         collect_from_expr(&func.body, &recursive_enums, all_type_decls, &name_to_var, &mut deref_vars);
     }

--- a/src/codegen/pass_builtin_lowering.rs
+++ b/src/codegen/pass_builtin_lowering.rs
@@ -101,10 +101,8 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
                             }, ty, span };
                         } else {
                             // Custom type: use generic encode/decode
-                            let func_ref = format!("{}_{}",
-                                type_name,
-                                if name.starts_with("__encode") { "encode" } else { "decode" }
-                            );
+                            let codec_op = if name.starts_with("__encode") { "encode" } else { "decode" };
+                            let func_ref = format!("{}_{}", type_name, codec_op);
                             let mut new_args = args;
                             new_args.push(IrExpr {
                                 kind: IrExprKind::FnRef { name: func_ref },

--- a/src/codegen/pass_stdlib_lowering.rs
+++ b/src/codegen/pass_stdlib_lowering.rs
@@ -133,29 +133,26 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
                     // UFCS: "module.func" method → convert to Module call and process
                     // Only if the module.func exists in stdlib (arg_transforms table)
                     if method.contains('.') && !method.ends_with(".encode") && !method.ends_with(".decode") {
-                        if let Some(dot_pos) = method.find('.') {
-                            let mod_name = &method[..dot_pos];
-                            let func_name = &method[dot_pos+1..];
-                            // Check if this is a real stdlib function
-                            if arg_transforms::lookup(mod_name, func_name).is_none() {
+                        let dot_pos = method.find('.').unwrap();
+                        let (mod_name, func_name) = (&method[..dot_pos], &method[dot_pos+1..]);
+                        // Check if this is a real stdlib function
+                        if arg_transforms::lookup(mod_name, func_name).is_none() {
                                 // Not a stdlib function — leave as Method call for BuiltinLoweringPass
                                 return IrExpr { kind: IrExprKind::Call {
                                     target: CallTarget::Method { object, method },
                                     args, type_args,
                                 }, ty, span };
                             }
-                            let mut call_args = vec![*object];
-                            call_args.extend(args);
-                            // Recursively process as Module call
-                            let module_call = IrExpr {
-                                kind: IrExprKind::Call {
-                                    target: CallTarget::Module { module: mod_name.to_string(), func: func_name.to_string() },
-                                    args: call_args, type_args,
-                                },
-                                ty: ty.clone(), span,
-                            };
-                            return rewrite_expr(module_call);
-                        }
+                        let mut call_args = vec![*object];
+                        call_args.extend(args);
+                        let module_call = IrExpr {
+                            kind: IrExprKind::Call {
+                                target: CallTarget::Module { module: mod_name.to_string(), func: func_name.to_string() },
+                                args: call_args, type_args,
+                            },
+                            ty: ty.clone(), span,
+                        };
+                        return rewrite_expr(module_call);
                     }
                     CallTarget::Method { object, method }
                 }

--- a/src/codegen/pass_stream_fusion.rs
+++ b/src/codegen/pass_stream_fusion.rs
@@ -135,14 +135,15 @@ fn detect_pipe_chains_inner(
                 let mut current = args.first().map(|a| unwrap_decorators(a));
 
                 while let Some(arg) = current {
-                    if let Some(iname) = extract_call_name(arg) {
-                        if let Some(inner_op) = classify_stdlib_op(iname) {
-                            if let IrExprKind::Call { args: inner_args, .. } = &arg.kind {
-                                chain_ops.push(inner_op);
-                                current = inner_args.first().map(|a| unwrap_decorators(a));
-                                continue;
-                            }
-                        }
+                    let inner_op = extract_call_name(arg).and_then(classify_stdlib_op);
+                    let inner_args_opt = match &arg.kind {
+                        IrExprKind::Call { args, .. } => Some(args),
+                        _ => None,
+                    };
+                    if let (Some(op), Some(inner_args)) = (inner_op, inner_args_opt) {
+                        chain_ops.push(op);
+                        current = inner_args.first().map(|a| unwrap_decorators(a));
+                        continue;
                     }
                     break;
                 }

--- a/src/codegen/pass_stream_fusion.rs
+++ b/src/codegen/pass_stream_fusion.rs
@@ -135,12 +135,7 @@ fn detect_pipe_chains_inner(
                 let mut current = args.first().map(|a| unwrap_decorators(a));
 
                 while let Some(arg) = current {
-                    let inner_name = match &arg.kind {
-                        IrExprKind::Call { target: CallTarget::Named { name }, .. } => Some(name.as_str()),
-                        IrExprKind::Call { target: CallTarget::Module { func, .. }, .. } => Some(func.as_str()),
-                        _ => None,
-                    };
-                    if let Some(iname) = inner_name {
+                    if let Some(iname) = extract_call_name(arg) {
                         if let Some(inner_op) = classify_stdlib_op(iname) {
                             if let IrExprKind::Call { args: inner_args, .. } = &arg.kind {
                                 chain_ops.push(inner_op);

--- a/src/codegen/pass_stream_fusion.rs
+++ b/src/codegen/pass_stream_fusion.rs
@@ -173,87 +173,29 @@ fn detect_pipe_chains_inner(
         }
 
         // Detect let-binding chains: let a = map(x); let b = filter(a); fold(b)
-        // This is how |> desugars in Almide's IR
         IrExprKind::Block { stmts, expr: body } => {
-            // Collect sequential let bindings that are pipe operations
             let mut let_chain: Vec<(VarId, PipeOp, &IrExpr)> = Vec::new();
             for stmt in stmts {
-                match &stmt.kind {
-                    IrStmtKind::Bind { var, value, .. } => {
-                        let call_name = match &value.kind {
-                            IrExprKind::Call { target: CallTarget::Module { func, .. }, .. } => Some(func.as_str()),
-                            IrExprKind::Call { target: CallTarget::Named { name }, .. } => Some(name.as_str()),
-                            _ => None,
-                        };
-                        if let Some(name) = call_name {
-                            if let Some(op) = classify_stdlib_op(name) {
-                                // Check if first arg references the previous let binding
-                                let is_chained = if let Some((prev_var, _, _)) = let_chain.last() {
-                                    first_arg_is_var(value, *prev_var)
-                                } else {
-                                    true // First in chain
-                                };
-                                if is_chained {
-                                    let_chain.push((*var, op, value));
-                                    continue;
-                                }
-                            }
-                        }
-                        // Not a chain op — flush and reset
-                        flush_let_chain(&let_chain, registry, chains);
-                        let_chain.clear();
-                        detect_pipe_chains_inner(value, registry, chains);
-                    }
-                    IrStmtKind::Expr { expr } => {
-                        // Check if this expression continues the chain
-                        let call_name = match &expr.kind {
-                            IrExprKind::Call { target: CallTarget::Module { func, .. }, .. } => Some(func.as_str()),
-                            IrExprKind::Call { target: CallTarget::Named { name }, .. } => Some(name.as_str()),
-                            _ => None,
-                        };
-                        if let Some(name) = call_name {
-                            if let Some(op) = classify_stdlib_op(name) {
-                                if let Some((prev_var, _, _)) = let_chain.last() {
-                                    if first_arg_is_var(expr, *prev_var) {
-                                        let_chain.push((VarId(0), op, expr)); // VarId doesn't matter for last
-                                        continue;
-                                    }
-                                }
-                            }
-                        }
-                        flush_let_chain(&let_chain, registry, chains);
-                        let_chain.clear();
-                        detect_pipe_chains_inner(expr, registry, chains);
-                    }
-                    _ => {
-                        flush_let_chain(&let_chain, registry, chains);
-                        let_chain.clear();
+                let extended = match &stmt.kind {
+                    IrStmtKind::Bind { var, value, .. } => try_extend_chain(value, *var, &mut let_chain),
+                    IrStmtKind::Expr { expr } => try_extend_chain(expr, VarId(0), &mut let_chain),
+                    _ => false,
+                };
+                if !extended {
+                    flush_let_chain(&let_chain, registry, chains);
+                    let_chain.clear();
+                    match &stmt.kind {
+                        IrStmtKind::Bind { value, .. } => detect_pipe_chains_inner(value, registry, chains),
+                        IrStmtKind::Expr { expr } => detect_pipe_chains_inner(expr, registry, chains),
+                        _ => {}
                     }
                 }
             }
-            // Also check if body expr continues the chain
+            let body_appended = body.as_ref()
+                .map_or(false, |e| try_extend_chain(e, VarId(0), &mut let_chain));
+            flush_let_chain(&let_chain, registry, chains);
             if let Some(e) = body {
-                let call_name = match &e.kind {
-                    IrExprKind::Call { target: CallTarget::Module { func, .. }, .. } => Some(func.as_str()),
-                    IrExprKind::Call { target: CallTarget::Named { name }, .. } => Some(name.as_str()),
-                    _ => None,
-                };
-                let appended = if let Some(name) = call_name {
-                    if let Some(op) = classify_stdlib_op(name) {
-                        if let Some((prev_var, _, _)) = let_chain.last() {
-                            if first_arg_is_var(e, *prev_var) {
-                                let_chain.push((VarId(0), op, e));
-                                true
-                            } else { false }
-                        } else { false }
-                    } else { false }
-                } else { false };
-                flush_let_chain(&let_chain, registry, chains);
-                if !appended {
-                    detect_pipe_chains_inner(e, registry, chains);
-                }
-            } else {
-                flush_let_chain(&let_chain, registry, chains);
+                if !body_appended { detect_pipe_chains_inner(e, registry, chains); }
             }
         }
         IrExprKind::If { cond, then, else_ } => {
@@ -268,6 +210,34 @@ fn detect_pipe_chains_inner(
     }
 }
 
+
+
+/// Extract the function name from a call expression (Module or Named).
+fn extract_call_name(expr: &IrExpr) -> Option<&str> {
+    match &expr.kind {
+        IrExprKind::Call { target: CallTarget::Module { func, .. }, .. } => Some(func.as_str()),
+        IrExprKind::Call { target: CallTarget::Named { name }, .. } => Some(name.as_str()),
+        _ => None,
+    }
+}
+
+/// Try to extend a let-binding chain with an expression. Returns true if appended.
+fn try_extend_chain<'a>(
+    expr: &'a IrExpr,
+    var: VarId,
+    let_chain: &mut Vec<(VarId, PipeOp, &'a IrExpr)>,
+) -> bool {
+    let Some(name) = extract_call_name(expr) else { return false };
+    let Some(op) = classify_stdlib_op(name) else { return false };
+    let is_chained = let_chain.last()
+        .map_or(true, |(prev_var, _, _)| first_arg_is_var(expr, *prev_var));
+    if is_chained {
+        let_chain.push((var, op, expr));
+        true
+    } else {
+        false
+    }
+}
 
 /// Check if the first argument of a call expression is a variable reference.
 fn first_arg_is_var(expr: &IrExpr, var: VarId) -> bool {

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -423,18 +423,14 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                 .cloned()
                 .collect();
             for (_, field_name) in &default_keys {
-                if !explicit_names.contains(field_name.as_str()) {
-                    if let Some(default_expr) = ctx.ann.default_fields.get(&(ctor_name_str.to_string(), field_name.clone())) {
-                        let mut val_str = render_expr(ctx, default_expr);
-                        if let Some(cn) = name {
-                            if ctx.ann.boxed_fields.contains(&(cn.clone(), field_name.clone())) {
-                                val_str = format!("Box::new({})", val_str);
-                            }
-                        }
-                        field_strs.push(ctx.templates.render_with("record_field", None, &[], &[("name", field_name.as_str()), ("value", val_str.as_str())])
-                            .unwrap_or_else(|| format!("{}: {}", field_name, val_str)));
-                    }
-                }
+                if explicit_names.contains(field_name.as_str()) { continue; }
+                let Some(default_expr) = ctx.ann.default_fields.get(&(ctor_name_str.to_string(), field_name.clone())) else { continue; };
+                let mut val_str = render_expr(ctx, default_expr);
+                let needs_box = name.as_ref()
+                    .map_or(false, |cn| ctx.ann.boxed_fields.contains(&(cn.clone(), field_name.clone())));
+                if needs_box { val_str = format!("Box::new({})", val_str); }
+                field_strs.push(ctx.templates.render_with("record_field", None, &[], &[("name", field_name.as_str()), ("value", val_str.as_str())])
+                    .unwrap_or_else(|| format!("{}: {}", field_name, val_str)));
             }
             let fields_str = field_strs.join(", ");
             // Resolve type name: explicit name, or from expr.ty

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -1368,13 +1368,10 @@ fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                             .unwrap_or_else(|| v.name.clone())
                     }
                     IrVariantKind::Tuple { fields } => {
+                        let is_recursive = ctx.ann.recursive_enums.contains(&td.name);
                         let types: Vec<String> = fields.iter().map(|t| {
                             let rendered = render_type(ctx, t);
-                            if ctx.ann.recursive_enums.contains(&td.name) && ty_contains_name(t, &td.name) {
-                                format!("Box<{}>", rendered)
-                            } else {
-                                rendered
-                            }
+                            if is_recursive && ty_contains_name(t, &td.name) { format!("Box<{}>", rendered) } else { rendered }
                         }).collect();
                         let fields_str = types.join(", ");
                         // Named params via fn_param template (respects JS/TS)

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -371,37 +371,7 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                     ctx.templates.render_with("module_call", None, &[], &[("module", module.as_str()), ("func", func.as_str()), ("args", args_str.as_str())])
                         .unwrap_or_else(|| format!("__almd_{}.{}()", module, func))
                 }
-                _ => {
-                    let callee = match target {
-                        CallTarget::Named { name } => {
-                            // Qualify enum constructors (Red → Color::Red)
-                            if let Some(enum_name) = ctx.ann.ctor_to_enum.get(name.as_str()) {
-                                return render_enum_constructor(ctx, name, enum_name, args);
-                            }
-                            name.clone()
-                        }
-                        CallTarget::Method { object, method } => {
-                            // UFCS and module.func calls return the full expression
-                            if let Some(full) = render_method_call_full(ctx, object, method, args) {
-                                return full;
-                            }
-                            format!("{}.{}", render_expr(ctx, object), method)
-                        }
-                        CallTarget::Computed { callee } => {
-                            let s = render_expr(ctx, callee);
-                            // Lambdas need parens when immediately invoked
-                            if matches!(&callee.kind, IrExprKind::Lambda { .. }) {
-                                format!("({})", s)
-                            } else {
-                                s
-                            }
-                        }
-                        CallTarget::Module { .. } => unreachable!(),
-                    };
-                    let args_str = args.iter().map(|a| render_expr(ctx, a)).collect::<Vec<_>>().join(", ");
-                    ctx.templates.render_with("call_expr", None, &[], &[("callee", callee.as_str()), ("args", args_str.as_str())])
-                        .unwrap_or_else(|| format!("call(...)"))
-                }
+                _ => render_generic_call(ctx, target, args)
             }
         }
 
@@ -1280,6 +1250,32 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
     }
 
     parts.join("\n\n")
+}
+
+/// Render a generic call expression (Named, Method, or Computed target).
+fn render_generic_call(ctx: &RenderContext, target: &CallTarget, args: &[IrExpr]) -> String {
+    let callee = match target {
+        CallTarget::Named { name } => {
+            if let Some(enum_name) = ctx.ann.ctor_to_enum.get(name.as_str()) {
+                return render_enum_constructor(ctx, name, enum_name, args);
+            }
+            name.clone()
+        }
+        CallTarget::Method { object, method } => {
+            if let Some(full) = render_method_call_full(ctx, object, method, args) {
+                return full;
+            }
+            format!("{}.{}", render_expr(ctx, object), method)
+        }
+        CallTarget::Computed { callee } => {
+            let s = render_expr(ctx, callee);
+            if matches!(&callee.kind, IrExprKind::Lambda { .. }) { format!("({})", s) } else { s }
+        }
+        CallTarget::Module { .. } => unreachable!(),
+    };
+    let args_str = args.iter().map(|a| render_expr(ctx, a)).collect::<Vec<_>>().join(", ");
+    ctx.templates.render_with("call_expr", None, &[], &[("callee", callee.as_str()), ("args", args_str.as_str())])
+        .unwrap_or_else(|| format!("call(...)"))
 }
 
 /// Render a method call as a full expression for UFCS and module.func patterns.

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -376,60 +376,14 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                         CallTarget::Named { name } => {
                             // Qualify enum constructors (Red → Color::Red)
                             if let Some(enum_name) = ctx.ann.ctor_to_enum.get(name.as_str()) {
-                                // Box-wrap args for recursive enum constructors
-                                let boxed_args: Vec<String> = args.iter().map(|a| {
-                                    let rendered = render_expr(ctx, a);
-                                    if ctx.ann.recursive_enums.contains(enum_name) && ty_contains_name(&a.ty, enum_name) {
-                                        format!("Box::new({})", rendered)
-                                    } else {
-                                        rendered
-                                    }
-                                }).collect();
-                                let args_str = boxed_args.join(", ");
-                                if args.is_empty() {
-                                    return ctx.templates.render_with("ctor_unit", None, &[], &[("enum_name", enum_name.as_str()), ("ctor_name", name.as_str()), ("args", args_str.as_str())])
-                                        .unwrap_or_else(|| format!("{}::{}", enum_name, name));
-                                } else {
-                                    return ctx.templates.render_with("ctor_call", None, &[], &[("enum_name", enum_name.as_str()), ("ctor_name", name.as_str()), ("args", args_str.as_str())])
-                                        .unwrap_or_else(|| format!("{}::{}({})", enum_name, name, args_str));
-                                }
+                                return render_enum_constructor(ctx, name, enum_name, args);
                             }
                             name.clone()
                         }
                         CallTarget::Method { object, method } => {
-                            // User-defined UFCS: plain method name (no dots) that isn't
-                            // a Rust intrinsic method → convert to func(object, args)
-                            let is_rust_intrinsic = matches!(method.as_str(),
-                                "clone" | "is_some" | "is_none" | "unwrap" | "unwrap_or"
-                                | "to_string" | "len" | "push" | "pop" | "insert" | "remove"
-                                | "contains" | "iter" | "into_iter" | "collect" | "map"
-                                | "filter" | "to_vec" | "join" | "split" | "trim"
-                                | "starts_with" | "ends_with" | "replace" | "chars"
-                                | "as_str" | "get" | "keys" | "values" | "abs" | "powi"
-                                | "is_empty" | "contains_key" | "entry" | "or_insert"
-                                | "expect" | "ok" | "err" | "and_then" | "map_err"
-                                | "unwrap_or_else" | "ok_or" | "flatten" | "as_ref"
-                            );
-                            if !method.contains('.') && !is_rust_intrinsic {
-                                // User-defined function: f(obj, args)
-                                let obj_str = render_expr(ctx, object);
-                                let mut all_args = vec![obj_str];
-                                all_args.extend(args.iter().map(|a| render_expr(ctx, a)));
-                                let all_args_str = all_args.join(", ");
-                                return format!("{}({})", method, all_args_str);
-                            }
-                            // Module.func UFCS: render via module_call template
-                            if method.contains('.') {
-                                let obj_str = render_expr(ctx, object);
-                                let mut all_args = vec![obj_str];
-                                all_args.extend(args.iter().map(|a| render_expr(ctx, a)));
-                                let all_args_str = all_args.join(", ");
-                                if let Some(dot_pos) = method.find('.') {
-                                    let module = &method[..dot_pos];
-                                    let func = &method[dot_pos+1..];
-                                    return ctx.templates.render_with("module_call", None, &[], &[("module", module), ("func", func), ("args", all_args_str.as_str())])
-                                        .unwrap_or_else(|| format!("{}.{}()", module, func));
-                                }
+                            // UFCS and module.func calls return the full expression
+                            if let Some(full) = render_method_call_full(ctx, object, method, args) {
+                                return full;
                             }
                             format!("{}.{}", render_expr(ctx, object), method)
                         }
@@ -1327,6 +1281,61 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
 
     parts.join("\n\n")
 }
+
+/// Render a method call as a full expression for UFCS and module.func patterns.
+/// Returns Some(full_expr) if the method call was handled, None for normal obj.method calls.
+fn render_method_call_full(ctx: &RenderContext, object: &IrExpr, method: &str, args: &[IrExpr]) -> Option<String> {
+    let is_rust_intrinsic = matches!(method,
+        "clone" | "is_some" | "is_none" | "unwrap" | "unwrap_or"
+        | "to_string" | "len" | "push" | "pop" | "insert" | "remove"
+        | "contains" | "iter" | "into_iter" | "collect" | "map"
+        | "filter" | "to_vec" | "join" | "split" | "trim"
+        | "starts_with" | "ends_with" | "replace" | "chars"
+        | "as_str" | "get" | "keys" | "values" | "abs" | "powi"
+        | "is_empty" | "contains_key" | "entry" | "or_insert"
+        | "expect" | "ok" | "err" | "and_then" | "map_err"
+        | "unwrap_or_else" | "ok_or" | "flatten" | "as_ref"
+    );
+    // User-defined UFCS: plain method name (no dots) → func(object, args)
+    if !method.contains('.') && !is_rust_intrinsic {
+        let obj_str = render_expr(ctx, object);
+        let mut all_args = vec![obj_str];
+        all_args.extend(args.iter().map(|a| render_expr(ctx, a)));
+        return Some(format!("{}({})", method, all_args.join(", ")));
+    }
+    // Module.func UFCS: render via module_call template
+    if let Some(dot_pos) = method.find('.') {
+        let obj_str = render_expr(ctx, object);
+        let mut all_args = vec![obj_str];
+        all_args.extend(args.iter().map(|a| render_expr(ctx, a)));
+        let module = &method[..dot_pos];
+        let func = &method[dot_pos+1..];
+        return Some(ctx.templates.render_with("module_call", None, &[], &[("module", module), ("func", func), ("args", all_args.join(", ").as_str())])
+            .unwrap_or_else(|| format!("{}.{}()", module, func)));
+    }
+    None
+}
+
+/// Render an enum constructor call with optional Box wrapping for recursive types.
+fn render_enum_constructor(ctx: &RenderContext, ctor_name: &str, enum_name: &str, args: &[IrExpr]) -> String {
+    let boxed_args: Vec<String> = args.iter().map(|a| {
+        let rendered = render_expr(ctx, a);
+        if ctx.ann.recursive_enums.contains(enum_name) && ty_contains_name(&a.ty, enum_name) {
+            format!("Box::new({})", rendered)
+        } else {
+            rendered
+        }
+    }).collect();
+    let args_str = boxed_args.join(", ");
+    if args.is_empty() {
+        ctx.templates.render_with("ctor_unit", None, &[], &[("enum_name", enum_name), ("ctor_name", ctor_name), ("args", args_str.as_str())])
+            .unwrap_or_else(|| format!("{}::{}", enum_name, ctor_name))
+    } else {
+        ctx.templates.render_with("ctor_call", None, &[], &[("enum_name", enum_name), ("ctor_name", ctor_name), ("args", args_str.as_str())])
+            .unwrap_or_else(|| format!("{}::{}({})", enum_name, ctor_name, args_str))
+    }
+}
+
 
 fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
     // Build generics string e.g. "<T>" or "<T, U>"

--- a/src/lower/calls.rs
+++ b/src/lower/calls.rs
@@ -57,26 +57,24 @@ pub(super) fn lower_call(ctx: &mut LowerCtx, callee: &ast::Expr, args: &[ast::Ex
             .unwrap_or_default();
         let defaults = ctx.fn_defaults.get(name).cloned();
         let positional_count = ir_args.len();
-        for i in positional_count..param_names.len() {
-            let param_name = &param_names[i];
-            if let Some((_, expr)) = named_args.iter().find(|(n, _)| n == param_name) {
-                ir_args.push(lower_expr(ctx, expr));
-            } else if let Some(ref defs) = defaults
-                && let Some(Some(default_expr)) = defs.get(i)
-            {
-                ir_args.push(lower_expr(ctx, default_expr));
-            }
-        }
+        ir_args.extend(param_names[positional_count..].iter().filter_map(|param_name| {
+            named_args.iter()
+                .find(|(n, _)| n == param_name)
+                .map(|(_, expr)| lower_expr(ctx, expr))
+                .or_else(|| defaults.as_ref()
+                    .and_then(|defs| defs.get(positional_count + param_names[positional_count..].iter().position(|p| p == param_name).unwrap_or(0)))
+                    .and_then(|d| d.as_ref())
+                    .map(|default_expr| lower_expr(ctx, default_expr)))
+        }));
     }
 
     // Default args: fill in remaining defaults (for calls without named args)
     if let (true, CallTarget::Named { name }) = (named_args.is_empty(), &target) {
         if let Some(defaults) = ctx.fn_defaults.get(name).cloned() {
-            for i in ir_args.len()..defaults.len() {
-                if let Some(Some(default_expr)) = defaults.get(i) {
-                    ir_args.push(lower_expr(ctx, &default_expr));
-                }
-            }
+            ir_args.extend(
+                defaults.iter().skip(ir_args.len())
+                    .filter_map(|d| d.as_ref().map(|expr| lower_expr(ctx, expr)))
+            );
         }
     }
 

--- a/src/mono.rs
+++ b/src/mono.rs
@@ -85,19 +85,15 @@ fn find_structurally_bounded_fns(functions: &[IrFunction], type_decls: &[IrTypeD
         let mut bounded = Vec::new();
         // パターン A: generic + structural bound (fn f[T: { name: String, .. }](x: T))
         if let Some(ref generics) = func.generics {
-            for g in generics {
-                if g.structural_bound.is_some() {
-                    for (i, param) in func.params.iter().enumerate() {
-                        let is_match = ty_contains_typevar(&param.ty, &g.name);
-                        if is_match {
-                            bounded.push(BoundedParam {
-                                param_idx: i,
-                                type_var: g.name.clone(),
-                            });
-                        }
-                    }
-                }
-            }
+            bounded.extend(
+                generics.iter()
+                    .filter(|g| g.structural_bound.is_some())
+                    .flat_map(|g| {
+                        func.params.iter().enumerate()
+                            .filter(|(_, param)| ty_contains_typevar(&param.ty, &g.name))
+                            .map(|(i, _)| BoundedParam { param_idx: i, type_var: g.name.clone() })
+                    })
+            );
         }
         // パターン B: 直接 OpenRecord パラメータ、または OpenRecord エイリアス
         for (i, param) in func.params.iter().enumerate() {

--- a/src/mono.rs
+++ b/src/mono.rs
@@ -117,6 +117,25 @@ fn find_structurally_bounded_fns(functions: &[IrFunction], type_decls: &[IrTypeD
     result
 }
 
+
+/// Collect type variable bindings for a monomorphization call site.
+fn collect_mono_bindings(
+    bounded_params: &[BoundedParam],
+    args: &[IrExpr],
+    param_types: &[Ty],
+) -> HashMap<String, Ty> {
+    bounded_params.iter()
+        .filter(|bp| bp.param_idx < args.len())
+        .map(|bp| {
+            let arg_ty = &args[bp.param_idx].ty;
+            let binding = param_types.get(bp.param_idx)
+                .map(|pt| extract_typevar_binding(pt, arg_ty, &bp.type_var))
+                .unwrap_or_else(|| arg_ty.clone());
+            (bp.type_var.clone(), binding)
+        })
+        .collect()
+}
+
 /// Discover all concrete instantiations of structurally-bounded functions.
 fn discover_instances(
     program: &IrProgram,
@@ -151,18 +170,7 @@ fn discover_in_expr(
                         .map(|f| f.params.iter().map(|p| p.ty.clone()).collect())
                         .unwrap_or_default();
 
-                    let mut bindings: HashMap<String, Ty> = HashMap::new();
-                    for bp in bounded_params {
-                        if bp.param_idx < args.len() {
-                            let arg_ty = &args[bp.param_idx].ty;
-                            if let Some(param_ty) = param_types.get(bp.param_idx) {
-                                let extracted = extract_typevar_binding(param_ty, arg_ty, &bp.type_var);
-                                bindings.insert(bp.type_var.clone(), extracted);
-                            } else {
-                                bindings.insert(bp.type_var.clone(), arg_ty.clone());
-                            }
-                        }
-                    }
+                    let bindings = collect_mono_bindings(bounded_params, args, &param_types);
                     // Skip bindings with Unknown or unresolved inference vars
                     let all_concrete = !bindings.is_empty() && bindings.values().all(|ty|
                         !matches!(ty, Ty::Unknown) && !ty.contains_unknown()
@@ -508,17 +516,8 @@ fn rewrite_expr_calls(
             if let CallTarget::Named { name } = target {
                 if let Some(bounded_params) = bound_fns.get(name.as_str()) {
                     let param_types = fn_param_types.get(name.as_str());
-                    let mut bindings: HashMap<String, Ty> = HashMap::new();
-                    for bp in bounded_params {
-                        if bp.param_idx < args.len() {
-                            let arg_ty = &args[bp.param_idx].ty;
-                            if let Some(pt) = param_types.and_then(|pts| pts.get(bp.param_idx)) {
-                                bindings.insert(bp.type_var.clone(), extract_typevar_binding(pt, arg_ty, &bp.type_var));
-                            } else {
-                                bindings.insert(bp.type_var.clone(), arg_ty.clone());
-                            }
-                        }
-                    }
+                    let pt = param_types.map(|pts| pts.as_slice()).unwrap_or(&[]);
+                    let bindings = collect_mono_bindings(bounded_params, args, pt);
                     if !bindings.is_empty() {
                         let suffix = mangle_suffix(&bindings);
                         if instances.contains_key(&(name.clone(), suffix.clone())) {

--- a/src/project.rs
+++ b/src/project.rs
@@ -119,17 +119,13 @@ pub fn parse_toml(path: &Path) -> Result<Project, String> {
                 }
             }
             "permissions" => {
-                if let Some((key, val)) = parse_kv(line) {
-                    if key == "allow" {
-                        // Parse array: allow = ["IO", "Net"]
-                        let val = val.trim_matches(|c| c == '[' || c == ']');
-                        for item in val.split(',') {
-                            let item = item.trim().trim_matches('"').trim_matches('\'');
-                            if !item.is_empty() {
-                                permissions.push(item.to_string());
-                            }
-                        }
-                    }
+                if let Some(("allow", val)) = parse_kv(line) {
+                    permissions.extend(
+                        val.trim_matches(|c| c == '[' || c == ']')
+                            .split(',')
+                            .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                            .filter(|s| !s.is_empty())
+                    );
                 }
             }
             _ => {}

--- a/src/types/env.rs
+++ b/src/types/env.rs
@@ -196,17 +196,11 @@ impl TypeEnv {
                         // Extract generic param names from the resolved type's TypeVars
                         let mut param_names = Vec::new();
                         Self::collect_typevars(resolved, &mut param_names);
-                        let mut bindings = std::collections::HashMap::new();
-                        for (i, arg) in args.iter().enumerate() {
-                            if let Some(name) = param_names.get(i) {
-                                bindings.insert(name.clone(), arg.clone());
-                            }
-                        }
-                        if bindings.is_empty() {
-                            resolved.clone()
-                        } else {
-                            substitute(resolved, &bindings)
-                        }
+                        let bindings: std::collections::HashMap<_, _> = param_names.iter()
+                            .zip(args.iter())
+                            .map(|(name, arg)| (name.clone(), arg.clone()))
+                            .collect();
+                        if bindings.is_empty() { resolved.clone() } else { substitute(resolved, &bindings) }
                     }
                 } else {
                     ty.clone()


### PR DESCRIPTION
## Summary

Deep nesting (indent >= 28) in control flow: **56 → 2 (97% reduction)**

Remaining 2 are single-line ifs inside map closures — structural minimum.

### Refactoring techniques used
- **Helper function extraction**: render_enum_constructor, render_method_call_full, render_generic_call, find_recursive_enums, find_variant_case, collect_mono_bindings, resolve_module_call, resolve_type_name, infer_plus_op, extract_call_name, try_extend_chain, unwrap_fn_return, unwrap_list_fn_return
- **Iterator chains**: flat_map, filter, filter_map, extend, zip, for_each, and_then
- **Early return/continue**: let-else, guard clauses
- **Code deduplication**: 4 cases of identical blocks merged into shared helpers

### Files changed (12)
- check/infer.rs, check/calls.rs, check/types.rs
- codegen/walker.rs, codegen/mod.rs, codegen/pass_box_deref.rs, codegen/pass_builtin_lowering.rs, codegen/pass_stream_fusion.rs, codegen/pass_stdlib_lowering.rs
- lower/calls.rs
- mono.rs
- project.rs, types/env.rs

## Test plan

- [x] 617+ Rust unit tests pass
- [x] 142/142 almide test files pass
- [x] 0 warnings