### PR TITLE
IR verification pass and PowInt operator

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -7,6 +7,7 @@
 | 項目 | 説明 | Grand Plan |
 |---|---|---|
 | [Effect System](active/effect-system.md) | Phase 3-4 残: Dependency制限, 内部型レベル統合 | Phase 3 |
+| [IR Verification](active/ir-verification.md) | Debug-only IR整合性検証 (VarId, 型一貫性, ループ文脈, 型宣言) | Compiler Internals |
 
 ## 1.0 Remaining
 

--- a/docs/roadmap/active/ir-verification.md
+++ b/docs/roadmap/active/ir-verification.md
@@ -1,0 +1,46 @@
+# IR Verification Pass [ACTIVE]
+
+Debug-only integrity checks on the typed IR. Runs after optimization, before monomorphization. Catches internal compiler errors before they reach codegen or rustc.
+
+## Implemented (Phase 1)
+
+### Structural integrity
+- [x] **VarId bounds** — every `Var { id }`, `Bind { var }`, parameter, and pattern binding references a valid VarTable entry
+- [x] **Parameter VarId uniqueness** — no two parameters in a function share the same VarId
+- [x] **Loop context** — `Break`/`Continue` only inside `ForIn`, `While`, or `DoBlock` (guard-loop)
+- [x] **Pattern variable validation** — all VarIds in match patterns are within VarTable bounds
+
+### Type consistency
+- [x] **BinOp type dispatch** — `AddInt` requires Int operands, `AddFloat` requires Float, etc. (all 20 variants)
+- [x] **UnOp type dispatch** — `NegInt` requires Int, `NegFloat` requires Float, `Not` requires Bool
+- [x] **Unknown/TypeVar tolerance** — unresolved types are skipped (error recovery / generics)
+
+### Type declaration integrity
+- [x] **Duplicate record fields** — no two fields in a record type share the same name
+- [x] **Duplicate variant cases** — no two cases in a variant type share the same name
+
+### Module coverage
+- [x] All checks apply to both main program and imported user modules
+
+## Planned (Phase 2)
+
+| Check | Purpose |
+|-------|---------|
+| **Use-count cross-check** | Independent variable reference count vs VarTable.use_count — catches bugs in loop bumping / lambda capture logic |
+| **CallTarget validity** | Named function calls reference functions that exist in the program or stdlib |
+| **Exhaustive IrExprKind walk** | Ensure new IR node variants added in the future don't bypass verification |
+
+## Design
+
+- **Debug-only**: `#[cfg(debug_assertions)]` — zero cost in release builds
+- **Pipeline position**: Lower → optimize → **verify** → mono → codegen
+- **Error type**: `IrVerifyError` with message, function name, and span — printed as `internal compiler error:`
+- **Pattern**: Same walk-based post-pass as `unknown.rs` and `use_count.rs`
+
+## Affected files
+
+| File | Role |
+|------|------|
+| `src/ir/verify.rs` | Verification logic and tests (16 tests) |
+| `src/ir/mod.rs` | Module registration |
+| `src/main.rs` | Pipeline insertion point |

--- a/docs/roadmap/active/ir-verification.md
+++ b/docs/roadmap/active/ir-verification.md
@@ -1,46 +1,56 @@
-# IR Verification Pass [ACTIVE]
+# IR Verification & Self-Describing IR [ACTIVE]
 
-Debug-only integrity checks on the typed IR. Runs after optimization, before monomorphization. Catches internal compiler errors before they reach codegen or rustc.
+Debug-only integrity checks + IR self-description improvements. Verification runs after optimization, before monomorphization. Self-describing IR ensures every node's meaning is unambiguous without type inspection.
 
-## Implemented (Phase 1)
+## Implemented
 
-### Structural integrity
-- [x] **VarId bounds** — every `Var { id }`, `Bind { var }`, parameter, and pattern binding references a valid VarTable entry
-- [x] **Parameter VarId uniqueness** — no two parameters in a function share the same VarId
-- [x] **Loop context** — `Break`/`Continue` only inside `ForIn`, `While`, or `DoBlock` (guard-loop)
-- [x] **Pattern variable validation** — all VarIds in match patterns are within VarTable bounds
+### IR Verification (19 tests)
 
-### Type consistency
-- [x] **BinOp type dispatch** — `AddInt` requires Int operands, `AddFloat` requires Float, etc. (all 20 variants)
-- [x] **UnOp type dispatch** — `NegInt` requires Int, `NegFloat` requires Float, `Not` requires Bool
-- [x] **Unknown/TypeVar tolerance** — unresolved types are skipped (error recovery / generics)
+- [x] **VarId bounds** — every variable reference maps to a valid VarTable entry
+- [x] **Parameter VarId uniqueness** — no two params in a function share the same VarId
+- [x] **Loop context** — Break/Continue only inside ForIn, While, or DoBlock
+- [x] **BinOp/UnOp type dispatch** — operator variant matches operand types (all 22 variants)
+- [x] **MapAccess/IndexAccess type constraints** — MapAccess only on Map, IndexAccess not on Map
+- [x] **Duplicate record fields** — no two fields share the same name
+- [x] **Duplicate variant cases** — no two cases share the same name
+- [x] **Module coverage** — all checks apply to imported user modules
 
-### Type declaration integrity
-- [x] **Duplicate record fields** — no two fields in a record type share the same name
-- [x] **Duplicate variant cases** — no two cases in a variant type share the same name
+### Self-Describing IR
 
-### Module coverage
-- [x] All checks apply to both main program and imported user modules
+- [x] **PowInt** — split from PowFloat. Lowerer dispatches `**` by operand type (like all other arithmetic ops)
+- [x] **MapAccess / MapInsert** — split from IndexAccess / IndexAssign. Map key lookup vs list index access are distinct IR nodes
+- [x] **MatchSubjectPass** — `.as_str()` / `.as_deref()` insertion moved from walker to nanopass. Walker no longer checks types for match subjects
+
+### Infrastructure
+
+- [x] **IrVisitor trait** (`src/ir/visit.rs`) — shared walker for read-only IR passes. verify.rs and unknown.rs migrated
+- [x] **ExprId** — already complete (HashMap<ExprId, Ty>, parser-allocated IDs)
 
 ## Planned (Phase 2)
 
 | Check | Purpose |
 |-------|---------|
-| **Use-count cross-check** | Independent variable reference count vs VarTable.use_count — catches bugs in loop bumping / lambda capture logic |
-| **CallTarget validity** | Named function calls reference functions that exist in the program or stdlib |
-| **Exhaustive IrExprKind walk** | Ensure new IR node variants added in the future don't bypass verification |
+| **Use-count cross-check** | Independent reference count vs VarTable.use_count |
+| **CallTarget validity** | Named function calls reference existing functions |
+| **Migrate use_count.rs to IrVisitor** | Reduce walker duplication further |
+| **Migrate remaining codegen type dispatches to nanopass** | ResultErr inner type, OptionNone type hint |
 
-## Design
+## Design Principles
 
-- **Debug-only**: `#[cfg(debug_assertions)]` — zero cost in release builds
-- **Pipeline position**: Lower → optimize → **verify** → mono → codegen
-- **Error type**: `IrVerifyError` with message, function name, and span — printed as `internal compiler error:`
-- **Pattern**: Same walk-based post-pass as `unknown.rs` and `use_count.rs`
+1. **IR self-description**: Every IR node's meaning is determined by its variant, not by runtime type inspection
+2. **Walker = pure renderer**: The template walker (Layer 3) reads IR and annotations, never checks types
+3. **Nanopass = semantic transform**: Type-dependent decisions happen in nanopass passes (Layer 2)
+4. **Verification = feedback loop**: Self-describing IR enables type constraint verification
 
 ## Affected files
 
 | File | Role |
 |------|------|
-| `src/ir/verify.rs` | Verification logic and tests (16 tests) |
-| `src/ir/mod.rs` | Module registration |
-| `src/main.rs` | Pipeline insertion point |
+| `src/ir/verify.rs` | Verification logic (19 tests) |
+| `src/ir/visit.rs` | IrVisitor trait + walk functions |
+| `src/ir/mod.rs` | PowInt, MapAccess, MapInsert, module registration |
+| `src/codegen/pass_match_subject.rs` | MatchSubject nanopass (Rust-only) |
+| `src/codegen/walker.rs` | Type dispatch removal |
+| `src/lower/expressions.rs` | PowInt/MapAccess lowering |
+| `src/lower/statements.rs` | MapInsert lowering |
+| `src/main.rs` | Verification pipeline insertion |

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -26,6 +26,7 @@ pub mod pass_builtin_lowering;
 pub mod pass_clone;
 pub mod pass_fan_lowering;
 pub mod pass_match_lowering;
+pub mod pass_match_subject;
 pub mod pass_result_erasure;
 pub mod pass_result_propagation;
 pub mod pass_shadow_resolve;

--- a/src/codegen/pass_builtin_lowering.rs
+++ b/src/codegen/pass_builtin_lowering.rs
@@ -254,6 +254,10 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
             object: Box::new(rewrite_expr(*object)),
             index: Box::new(rewrite_expr(*index)),
         },
+        IrExprKind::MapAccess { object, key } => IrExprKind::MapAccess {
+            object: Box::new(rewrite_expr(*object)),
+            key: Box::new(rewrite_expr(*key)),
+        },
         IrExprKind::TupleIndex { object, index } => IrExprKind::TupleIndex {
             object: Box::new(rewrite_expr(*object)), index,
         },

--- a/src/codegen/pass_clone.rs
+++ b/src/codegen/pass_clone.rs
@@ -156,6 +156,10 @@ fn insert_clones(expr: IrExpr, clone_ids: &HashSet<VarId>) -> IrExpr {
             object: Box::new(insert_clones(*object, clone_ids)),
             index: Box::new(insert_clones(*index, clone_ids)),
         },
+        IrExprKind::MapAccess { object, key } => IrExprKind::MapAccess {
+            object: Box::new(insert_clones(*object, clone_ids)),
+            key: Box::new(insert_clones(*key, clone_ids)),
+        },
         IrExprKind::Range { start, end, inclusive } => IrExprKind::Range {
             start: Box::new(insert_clones(*start, clone_ids)),
             end: Box::new(insert_clones(*end, clone_ids)),

--- a/src/codegen/pass_effect_inference.rs
+++ b/src/codegen/pass_effect_inference.rs
@@ -353,6 +353,11 @@ fn collect_effects_inner(expr: &IrExpr, effects: &mut HashSet<Effect>) {
             collect_effects_inner(index, effects);
         }
 
+        IrExprKind::MapAccess { object, key } => {
+            collect_effects_inner(object, effects);
+            collect_effects_inner(key, effects);
+        }
+
         // Leaf nodes — no effects
         _ => {}
     }

--- a/src/codegen/pass_match_subject.rs
+++ b/src/codegen/pass_match_subject.rs
@@ -1,0 +1,170 @@
+//! MatchSubject Nanopass: insert ownership transforms on match subjects.
+//!
+//! Target: Rust only.
+//!
+//! Rust's `match` on `String` requires `.as_str()` to match against `&str` literals.
+//! `Option<String>` requires `.as_deref()` to match `Some("literal")` patterns.
+//!
+//! This pass inserts `Borrow { as_str: true }` or `Call { Method "as_deref" }` IR nodes
+//! on match subjects, so the walker never needs to check types.
+
+use crate::ir::*;
+use crate::types::{Ty, TypeConstructorId};
+use super::pass::{NanoPass, Target};
+
+#[derive(Debug)]
+pub struct MatchSubjectPass;
+
+impl NanoPass for MatchSubjectPass {
+    fn name(&self) -> &str { "MatchSubject" }
+
+    fn targets(&self) -> Option<Vec<Target>> {
+        Some(vec![Target::Rust])
+    }
+
+    fn run(&self, program: &mut IrProgram, _target: Target) {
+        for func in &mut program.functions {
+            rewrite_expr(&mut func.body);
+        }
+        for tl in &mut program.top_lets {
+            rewrite_expr(&mut tl.value);
+        }
+        for module in &mut program.modules {
+            for func in &mut module.functions {
+                rewrite_expr(&mut func.body);
+            }
+            for tl in &mut module.top_lets {
+                rewrite_expr(&mut tl.value);
+            }
+        }
+    }
+}
+
+fn rewrite_expr(expr: &mut IrExpr) {
+    // Recurse into children first (bottom-up)
+    match &mut expr.kind {
+        IrExprKind::BinOp { left, right, .. } => { rewrite_expr(left); rewrite_expr(right); }
+        IrExprKind::UnOp { operand, .. } => rewrite_expr(operand),
+        IrExprKind::If { cond, then, else_ } => { rewrite_expr(cond); rewrite_expr(then); rewrite_expr(else_); }
+        IrExprKind::Block { stmts, expr } | IrExprKind::DoBlock { stmts, expr } => {
+            for s in stmts { rewrite_stmt(s); }
+            if let Some(e) = expr { rewrite_expr(e); }
+        }
+        IrExprKind::Call { target, args, .. } => {
+            match target {
+                CallTarget::Method { object, .. } | CallTarget::Computed { callee: object } => rewrite_expr(object),
+                _ => {}
+            }
+            for a in args { rewrite_expr(a); }
+        }
+        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
+        | IrExprKind::Fan { exprs: elements } => {
+            for e in elements { rewrite_expr(e); }
+        }
+        IrExprKind::Record { fields, .. } => { for (_, v) in fields { rewrite_expr(v); } }
+        IrExprKind::SpreadRecord { base, fields } => {
+            rewrite_expr(base);
+            for (_, v) in fields { rewrite_expr(v); }
+        }
+        IrExprKind::MapLiteral { entries } => { for (k, v) in entries { rewrite_expr(k); rewrite_expr(v); } }
+        IrExprKind::Range { start, end, .. } => { rewrite_expr(start); rewrite_expr(end); }
+        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => rewrite_expr(object),
+        IrExprKind::IndexAccess { object, index } => { rewrite_expr(object); rewrite_expr(index); }
+        IrExprKind::MapAccess { object, key } => { rewrite_expr(object); rewrite_expr(key); }
+        IrExprKind::Lambda { body, .. } => rewrite_expr(body),
+        IrExprKind::StringInterp { parts } => {
+            for p in parts { if let IrStringPart::Expr { expr } = p { rewrite_expr(expr); } }
+        }
+        IrExprKind::ForIn { iterable, body, .. } => {
+            rewrite_expr(iterable);
+            for s in body { rewrite_stmt(s); }
+        }
+        IrExprKind::While { cond, body } => {
+            rewrite_expr(cond);
+            for s in body { rewrite_stmt(s); }
+        }
+        IrExprKind::ResultOk { expr: e } | IrExprKind::ResultErr { expr: e }
+        | IrExprKind::OptionSome { expr: e } | IrExprKind::Try { expr: e }
+        | IrExprKind::Await { expr: e } | IrExprKind::Clone { expr: e }
+        | IrExprKind::Deref { expr: e } | IrExprKind::Borrow { expr: e, .. }
+        | IrExprKind::BoxNew { expr: e } | IrExprKind::ToVec { expr: e } => rewrite_expr(e),
+        IrExprKind::RustMacro { args, .. } => { for a in args { rewrite_expr(a); } }
+        // Match — handled below after recursion
+        IrExprKind::Match { subject, arms } => {
+            rewrite_expr(subject);
+            for arm in arms {
+                if let Some(g) = &mut arm.guard { rewrite_expr(g); }
+                rewrite_expr(&mut arm.body);
+            }
+        }
+        _ => {}
+    }
+
+    // Transform match subjects after children are rewritten
+    if let IrExprKind::Match { subject, arms } = &mut expr.kind {
+        transform_match_subject(subject, arms);
+    }
+}
+
+fn rewrite_stmt(stmt: &mut IrStmt) {
+    match &mut stmt.kind {
+        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
+        | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => rewrite_expr(value),
+        IrStmtKind::IndexAssign { index, value, .. } => { rewrite_expr(index); rewrite_expr(value); }
+        IrStmtKind::MapInsert { key, value, .. } => { rewrite_expr(key); rewrite_expr(value); }
+        IrStmtKind::Guard { cond, else_ } => { rewrite_expr(cond); rewrite_expr(else_); }
+        IrStmtKind::Expr { expr } => rewrite_expr(expr),
+        IrStmtKind::Comment { .. } => {}
+    }
+}
+
+/// Insert `.as_str()` or `.as_deref()` on match subjects when needed.
+fn transform_match_subject(subject: &mut Box<IrExpr>, arms: &[IrMatchArm]) {
+    // String subject with string literal patterns → wrap with Borrow { as_str: true }
+    if matches!(&subject.ty, Ty::String) {
+        let has_str_pat = arms.iter().any(|a| {
+            matches!(&a.pattern, IrPattern::Literal { expr } if matches!(&expr.kind, IrExprKind::LitStr { .. }))
+        });
+        if has_str_pat {
+            let inner = std::mem::replace(
+                subject.as_mut(),
+                IrExpr { kind: IrExprKind::Unit, ty: Ty::Unit, span: None },
+            );
+            **subject = IrExpr {
+                kind: IrExprKind::Borrow { expr: Box::new(inner), as_str: true },
+                ty: Ty::String, // type is still String for downstream
+                span: subject.span,
+            };
+        }
+    }
+
+    // Option<String> subject with Some("literal") patterns → wrap with method call .as_deref()
+    if let Ty::Applied(TypeConstructorId::Option, args) = &subject.ty {
+        if args.len() == 1 && matches!(&args[0], Ty::String) {
+            let has_some_str_pat = arms.iter().any(|a| {
+                if let IrPattern::Some { inner } = &a.pattern {
+                    matches!(inner.as_ref(), IrPattern::Literal { expr } if matches!(&expr.kind, IrExprKind::LitStr { .. }))
+                } else { false }
+            });
+            if has_some_str_pat {
+                let inner = std::mem::replace(
+                    subject.as_mut(),
+                    IrExpr { kind: IrExprKind::Unit, ty: Ty::Unit, span: None },
+                );
+                let deref_ty = Ty::Applied(TypeConstructorId::Option, vec![Ty::String]);
+                **subject = IrExpr {
+                    kind: IrExprKind::Call {
+                        target: CallTarget::Method {
+                            object: Box::new(inner),
+                            method: "as_deref".into(),
+                        },
+                        args: vec![],
+                        type_args: vec![],
+                    },
+                    ty: deref_ty,
+                    span: subject.span,
+                };
+            }
+        }
+    }
+}

--- a/src/codegen/pass_result_erasure.rs
+++ b/src/codegen/pass_result_erasure.rs
@@ -161,6 +161,10 @@ fn erase_expr(expr: IrExpr) -> IrExpr {
             object: Box::new(erase_expr(*object)),
             index: Box::new(erase_expr(*index)),
         },
+        IrExprKind::MapAccess { object, key } => IrExprKind::MapAccess {
+            object: Box::new(erase_expr(*object)),
+            key: Box::new(erase_expr(*key)),
+        },
         IrExprKind::Range { start, end, inclusive } => IrExprKind::Range {
             start: Box::new(erase_expr(*start)),
             end: Box::new(erase_expr(*end)),

--- a/src/codegen/pass_stdlib_lowering.rs
+++ b/src/codegen/pass_stdlib_lowering.rs
@@ -240,6 +240,10 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
             object: Box::new(rewrite_expr(*object)),
             index: Box::new(rewrite_expr(*index)),
         },
+        IrExprKind::MapAccess { object, key } => IrExprKind::MapAccess {
+            object: Box::new(rewrite_expr(*object)),
+            key: Box::new(rewrite_expr(*key)),
+        },
         IrExprKind::Fan { exprs } => IrExprKind::Fan {
             // FanLoweringPass will strip auto-try from these later
             exprs: exprs.into_iter().map(|e| rewrite_expr(e)).collect(),

--- a/src/codegen/target.rs
+++ b/src/codegen/target.rs
@@ -20,6 +20,7 @@ use super::pass_result_erasure::ResultErasurePass;
 use super::pass_result_propagation::ResultPropagationPass;
 use super::pass_shadow_resolve::ShadowResolvePass;
 use super::pass_stdlib_lowering::StdlibLoweringPass;
+use super::pass_match_subject::MatchSubjectPass;
 use super::pass_effect_inference::EffectInferencePass;
 use super::pass_stream_fusion::StreamFusionPass;
 use super::template::TemplateSet;
@@ -49,6 +50,8 @@ fn build_pipeline(target: Target) -> Pipeline {
             .add(TypeConcretizationPass)
             .add(BorrowInsertionPass)
             .add(CloneInsertionPass)
+            // Match subject transforms: String → .as_str(), Option<String> → .as_deref()
+            .add(MatchSubjectPass)
             // Analysis passes (before lowering, while Module calls still visible)
             .add(EffectInferencePass)
             .add(StreamFusionPass)

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -585,13 +585,14 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         IrExprKind::IndexAccess { object, index } => {
             let obj_str = render_expr(ctx, object);
             let idx = render_expr(ctx, index);
-            if object.ty.is_map() {
-                ctx.templates.render_with("map_get", None, &[], &[("object", obj_str.as_str()), ("key", idx.as_str())])
-                    .unwrap_or_else(|| "map_get(...)".into())
-            } else {
-                ctx.templates.render_with("index_access", None, &[], &[("object", obj_str.as_str()), ("index", idx.as_str())])
-                    .unwrap_or_else(|| "idx[...]".into())
-            }
+            ctx.templates.render_with("index_access", None, &[], &[("object", obj_str.as_str()), ("index", idx.as_str())])
+                .unwrap_or_else(|| "idx[...]".into())
+        }
+        IrExprKind::MapAccess { object, key } => {
+            let obj_str = render_expr(ctx, object);
+            let key_str = render_expr(ctx, key);
+            ctx.templates.render_with("map_get", None, &[], &[("object", obj_str.as_str()), ("key", key_str.as_str())])
+                .unwrap_or_else(|| "map_get(...)".into())
         }
 
         // ── Map ──
@@ -938,14 +939,15 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             let target_str = ctx.var_name(*target).to_string();
             let idx_str = render_expr(ctx, index);
             let val_str = render_expr(ctx, value);
-            let target_ty = &ctx.var_table.get(*target).ty;
-            if target_ty.is_map() {
-                ctx.templates.render_with("map_insert", None, &[], &[("target", target_str.as_str()), ("key", idx_str.as_str()), ("value", val_str.as_str())])
-                    .unwrap_or_else(|| "map_set(...)".into())
-            } else {
-                ctx.templates.render_with("index_assign", None, &[], &[("target", target_str.as_str()), ("index", idx_str.as_str()), ("value", val_str.as_str())])
-                    .unwrap_or_else(|| "idx[...] = ...;".into())
-            }
+            ctx.templates.render_with("index_assign", None, &[], &[("target", target_str.as_str()), ("index", idx_str.as_str()), ("value", val_str.as_str())])
+                .unwrap_or_else(|| "idx[...] = ...;".into())
+        }
+        IrStmtKind::MapInsert { target, key, value } => {
+            let target_str = ctx.var_name(*target).to_string();
+            let key_str = render_expr(ctx, key);
+            let val_str = render_expr(ctx, value);
+            ctx.templates.render_with("map_insert", None, &[], &[("target", target_str.as_str()), ("key", key_str.as_str()), ("value", val_str.as_str())])
+                .unwrap_or_else(|| "map_set(...)".into())
         }
         IrStmtKind::FieldAssign { target, field, value } => {
             let target_str = ctx.var_name(*target).to_string();

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -246,29 +246,9 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         }
 
         IrExprKind::Match { subject, arms } => {
-            let mut subj = render_expr(ctx, subject);
-            // String subjects may need transformation for pattern matching (e.g., .as_str() in Rust)
-            if matches!(&subject.ty, Ty::String) {
-                let has_str_pat = arms.iter().any(|a| matches!(&a.pattern, IrPattern::Literal { expr } if matches!(&expr.kind, IrExprKind::LitStr { .. })));
-                if has_str_pat {
-                    subj = ctx.templates.render_with("string_match_subject", None, &[], &[("subject", subj.as_str())])
-                        .unwrap_or_else(|| subj.clone());
-                }
-            }
-            // Option<String> subjects → .as_deref() so Some("literal") patterns match
-            if let Ty::Applied(TypeConstructorId::Option, args) = &subject.ty {
-                if args.len() == 1 && matches!(&args[0], Ty::String) {
-                    let has_some_str_pat = arms.iter().any(|a| {
-                        if let IrPattern::Some { inner } = &a.pattern {
-                            matches!(inner.as_ref(), IrPattern::Literal { expr } if matches!(&expr.kind, IrExprKind::LitStr { .. }))
-                        } else { false }
-                    });
-                    if has_some_str_pat {
-                        subj = ctx.templates.render_with("option_string_match_subject", None, &[], &[("subject", subj.as_str())])
-                            .unwrap_or_else(|| format!("{}.as_deref()", subj));
-                    }
-                }
-            }
+            // Match subject transforms (.as_str(), .as_deref()) are handled by
+            // MatchSubjectPass nanopass — walker just renders what's in the IR.
+            let subj = render_expr(ctx, subject);
             let arms_str = arms.iter()
                 .map(|arm| render_match_arm(ctx, arm))
                 .collect::<Vec<_>>()

--- a/src/codegen/walker.rs
+++ b/src/codegen/walker.rs
@@ -754,12 +754,12 @@ fn render_binop(ctx: &RenderContext, op: BinOp, left: &IrExpr, right: &IrExpr, _
             ctx.templates.render_with("ne_expr", None, &[], &[("left", l.as_str()), ("right", r.as_str())])
                 .unwrap_or_else(|| format!("_ != _"))
         }
+        BinOp::PowInt => {
+            ctx.templates.render_with("power_expr", Some("Int"), &[], &[("left", l.as_str()), ("right", r.as_str())])
+                .unwrap_or_else(|| format!("pow(_, _)"))
+        }
         BinOp::PowFloat => {
-            let ty_tag = match &left.ty {
-                Ty::Int => "Int",
-                _ => "Float",
-            };
-            ctx.templates.render_with("power_expr", Some(ty_tag), &[], &[("left", l.as_str()), ("right", r.as_str())])
+            ctx.templates.render_with("power_expr", Some("Float"), &[], &[("left", l.as_str()), ("right", r.as_str())])
                 .unwrap_or_else(|| format!("pow(_, _)"))
         }
         _ => {

--- a/src/ir/fold.rs
+++ b/src/ir/fold.rs
@@ -63,6 +63,10 @@ fn fold_expr(expr: &mut IrExpr) {
             fold_expr(object);
             fold_expr(index);
         }
+        IrExprKind::MapAccess { object, key } => {
+            fold_expr(object);
+            fold_expr(key);
+        }
         IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => fold_expr(object),
         IrExprKind::MapLiteral { entries } => {
             for (k, v) in entries { fold_expr(k); fold_expr(v); }
@@ -136,6 +140,10 @@ fn fold_stmt(stmt: &mut IrStmt) {
         | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => fold_expr(value),
         IrStmtKind::IndexAssign { index, value, .. } => {
             fold_expr(index);
+            fold_expr(value);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            fold_expr(key);
             fold_expr(value);
         }
         IrStmtKind::Guard { cond, else_ } => {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -44,7 +44,7 @@ pub enum BinOp {
     MulInt, MulFloat,
     DivInt, DivFloat,
     ModInt, ModFloat,
-    PowFloat,
+    PowInt, PowFloat,
     XorInt,
     ConcatStr, ConcatList,
     Eq, Neq,

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -226,6 +226,8 @@ pub enum IrExprKind {
     Member { object: Box<IrExpr>, field: String },
     TupleIndex { object: Box<IrExpr>, index: usize },
     IndexAccess { object: Box<IrExpr>, index: Box<IrExpr> },
+    /// Map key lookup: `map[key]` → returns Option<V>. Distinct from IndexAccess (list).
+    MapAccess { object: Box<IrExpr>, key: Box<IrExpr> },
 
     // ── Functions ──
     Lambda { params: Vec<(VarId, Ty)>, body: Box<IrExpr> },
@@ -281,6 +283,8 @@ pub enum IrStmtKind {
     BindDestructure { pattern: IrPattern, value: IrExpr },
     Assign { var: VarId, value: IrExpr },
     IndexAssign { target: VarId, index: IrExpr, value: IrExpr },
+    /// Map key insertion: `map[key] = value`. Distinct from IndexAssign (list).
+    MapInsert { target: VarId, key: IrExpr, value: IrExpr },
     FieldAssign { target: VarId, field: String, value: IrExpr },
     Guard { cond: IrExpr, else_: IrExpr },
     Expr { expr: IrExpr },

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -19,12 +19,14 @@ use crate::types::Ty;
 mod unknown;
 mod fold;
 mod use_count;
+mod verify;
 pub mod result;
 
 pub use unknown::*;
 pub use fold::*;
 pub use use_count::*;
 pub use result::is_ir_result_expr;
+pub use verify::{verify_program, IrVerifyError};
 
 // ── Identifiers ─────────────────────────────────────────────────
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -20,6 +20,7 @@ mod unknown;
 mod fold;
 mod use_count;
 mod verify;
+pub mod visit;
 pub mod result;
 
 pub use unknown::*;
@@ -27,6 +28,7 @@ pub use fold::*;
 pub use use_count::*;
 pub use result::is_ir_result_expr;
 pub use verify::{verify_program, IrVerifyError};
+pub use visit::{IrVisitor, walk_expr, walk_stmt, walk_pattern};
 
 // ── Identifiers ─────────────────────────────────────────────────
 

--- a/src/ir/unknown.rs
+++ b/src/ir/unknown.rs
@@ -1,6 +1,7 @@
 // ── Unknown type detection (post-pass) ──────────────────────────
 
 use super::*;
+use super::visit::{IrVisitor, walk_expr, walk_stmt};
 
 /// A warning about Ty::Unknown surviving into the IR.
 #[derive(Debug)]
@@ -11,12 +12,53 @@ pub struct UnknownTypeWarning {
     pub context: &'static str,
 }
 
+struct UnknownChecker {
+    fn_name: String,
+    warnings: Vec<UnknownTypeWarning>,
+}
+
+impl IrVisitor for UnknownChecker {
+    fn visit_expr(&mut self, expr: &IrExpr) {
+        if expr.ty.contains_unknown() {
+            self.warnings.push(UnknownTypeWarning {
+                fn_name: self.fn_name.clone(),
+                span: expr.span,
+                ty: expr.ty.clone(),
+                context: "expression",
+            });
+            // Don't recurse into children — one warning per subtree is enough
+            return;
+        }
+        walk_expr(self, expr);
+    }
+
+    fn visit_stmt(&mut self, stmt: &IrStmt) {
+        if let IrStmtKind::Bind { ty, .. } = &stmt.kind {
+            if ty.contains_unknown() {
+                self.warnings.push(UnknownTypeWarning {
+                    fn_name: self.fn_name.clone(),
+                    span: stmt.span,
+                    ty: ty.clone(),
+                    context: "let binding",
+                });
+            }
+        }
+        walk_stmt(self, stmt);
+    }
+}
+
 /// Scan an IR program for any Ty::Unknown that survived lowering.
 /// Returns a list of warnings (not errors) for diagnostic reporting.
 pub fn collect_unknown_warnings(program: &IrProgram) -> Vec<UnknownTypeWarning> {
     let mut warnings = Vec::new();
     for f in &program.functions {
-        check_expr_for_unknown(&f.body, &f.name, &mut warnings);
+        let mut checker = UnknownChecker {
+            fn_name: f.name.clone(),
+            warnings: Vec::new(),
+        };
+        checker.visit_expr(&f.body);
+        warnings.append(&mut checker.warnings);
+
         for p in &f.params {
             if p.ty.contains_unknown() {
                 warnings.push(UnknownTypeWarning {
@@ -47,159 +89,4 @@ pub fn collect_unknown_warnings(program: &IrProgram) -> Vec<UnknownTypeWarning> 
         }
     }
     warnings
-}
-
-fn check_expr_for_unknown(expr: &IrExpr, fn_name: &str, warnings: &mut Vec<UnknownTypeWarning>) {
-    if expr.ty.contains_unknown() {
-        warnings.push(UnknownTypeWarning {
-            fn_name: fn_name.to_string(),
-            span: expr.span,
-            ty: expr.ty.clone(),
-            context: "expression",
-        });
-        // Don't recurse into children — one warning per subtree is enough
-        return;
-    }
-    // Recurse into children
-    match &expr.kind {
-        IrExprKind::Block { stmts, expr: tail } | IrExprKind::DoBlock { stmts, expr: tail } => {
-            for s in stmts { check_stmt_for_unknown(s, fn_name, warnings); }
-            if let Some(t) = tail { check_expr_for_unknown(t, fn_name, warnings); }
-        }
-        IrExprKind::Call { target, args, .. } => {
-            if let CallTarget::Computed { callee } = target {
-                check_expr_for_unknown(callee, fn_name, warnings);
-            }
-            if let CallTarget::Method { object, .. } = target {
-                check_expr_for_unknown(object, fn_name, warnings);
-            }
-            for a in args { check_expr_for_unknown(a, fn_name, warnings); }
-        }
-        IrExprKind::If { cond, then, else_ } => {
-            check_expr_for_unknown(cond, fn_name, warnings);
-            check_expr_for_unknown(then, fn_name, warnings);
-            check_expr_for_unknown(else_, fn_name, warnings);
-        }
-        IrExprKind::BinOp { left, right, .. } => {
-            check_expr_for_unknown(left, fn_name, warnings);
-            check_expr_for_unknown(right, fn_name, warnings);
-        }
-        IrExprKind::UnOp { operand, .. } => {
-            check_expr_for_unknown(operand, fn_name, warnings);
-        }
-        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
-        | IrExprKind::Fan { exprs: elements } => {
-            for e in elements { check_expr_for_unknown(e, fn_name, warnings); }
-        }
-        IrExprKind::Lambda { body, .. } => {
-            check_expr_for_unknown(body, fn_name, warnings);
-        }
-        IrExprKind::Match { subject, arms } => {
-            check_expr_for_unknown(subject, fn_name, warnings);
-            for a in arms { check_expr_for_unknown(&a.body, fn_name, warnings); }
-        }
-        IrExprKind::IndexAccess { object, index } => {
-            check_expr_for_unknown(object, fn_name, warnings);
-            check_expr_for_unknown(index, fn_name, warnings);
-        }
-        IrExprKind::MapAccess { object, key } => {
-            check_expr_for_unknown(object, fn_name, warnings);
-            check_expr_for_unknown(key, fn_name, warnings);
-        }
-        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
-            check_expr_for_unknown(object, fn_name, warnings);
-        }
-        IrExprKind::Try { expr } | IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
-        | IrExprKind::OptionSome { expr } | IrExprKind::Await { expr } => {
-            check_expr_for_unknown(expr, fn_name, warnings);
-        }
-        IrExprKind::Record { fields, .. } => {
-            for (_, v) in fields { check_expr_for_unknown(v, fn_name, warnings); }
-        }
-        IrExprKind::SpreadRecord { base, fields } => {
-            check_expr_for_unknown(base, fn_name, warnings);
-            for (_, v) in fields { check_expr_for_unknown(v, fn_name, warnings); }
-        }
-        IrExprKind::MapLiteral { entries } => {
-            for (k, v) in entries {
-                check_expr_for_unknown(k, fn_name, warnings);
-                check_expr_for_unknown(v, fn_name, warnings);
-            }
-        }
-        IrExprKind::StringInterp { parts } => {
-            for p in parts {
-                match p {
-                    IrStringPart::Expr { expr } => check_expr_for_unknown(expr, fn_name, warnings),
-                    IrStringPart::Lit { .. } => {}
-                }
-            }
-        }
-        IrExprKind::Range { start, end, .. } => {
-            check_expr_for_unknown(start, fn_name, warnings);
-            check_expr_for_unknown(end, fn_name, warnings);
-        }
-        IrExprKind::ForIn { iterable, body, .. } => {
-            check_expr_for_unknown(iterable, fn_name, warnings);
-            for s in body { check_stmt_for_unknown(s, fn_name, warnings); }
-        }
-        IrExprKind::While { cond, body } => {
-            check_expr_for_unknown(cond, fn_name, warnings);
-            for s in body { check_stmt_for_unknown(s, fn_name, warnings); }
-        }
-        // Leaf nodes — no children
-        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. } | IrExprKind::LitStr { .. }
-        | IrExprKind::LitBool { .. } | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
-        | IrExprKind::EmptyMap | IrExprKind::OptionNone | IrExprKind::Break
-        | IrExprKind::Continue | IrExprKind::Hole | IrExprKind::Todo { .. } => {}
-        // Codegen-specific nodes (not present in type-checked IR)
-        IrExprKind::Clone { expr } | IrExprKind::Deref { expr } | IrExprKind::Borrow { expr, .. }
-        | IrExprKind::BoxNew { expr } | IrExprKind::ToVec { expr } => {
-            check_expr_for_unknown(expr, fn_name, warnings);
-        }
-        IrExprKind::RustMacro { args, .. } => {
-            for a in args { check_expr_for_unknown(a, fn_name, warnings); }
-        }
-        IrExprKind::RenderedCall { .. } => {}
-    }
-}
-
-fn check_stmt_for_unknown(stmt: &IrStmt, fn_name: &str, warnings: &mut Vec<UnknownTypeWarning>) {
-    match &stmt.kind {
-        IrStmtKind::Bind { value, ty, .. } => {
-            if ty.contains_unknown() {
-                warnings.push(UnknownTypeWarning {
-                    fn_name: fn_name.to_string(),
-                    span: stmt.span,
-                    ty: ty.clone(),
-                    context: "let binding",
-                });
-            }
-            check_expr_for_unknown(value, fn_name, warnings);
-        }
-        IrStmtKind::BindDestructure { value, .. } => {
-            check_expr_for_unknown(value, fn_name, warnings);
-        }
-        IrStmtKind::Assign { value, .. } => {
-            check_expr_for_unknown(value, fn_name, warnings);
-        }
-        IrStmtKind::IndexAssign { index, value, .. } => {
-            check_expr_for_unknown(index, fn_name, warnings);
-            check_expr_for_unknown(value, fn_name, warnings);
-        }
-        IrStmtKind::MapInsert { key, value, .. } => {
-            check_expr_for_unknown(key, fn_name, warnings);
-            check_expr_for_unknown(value, fn_name, warnings);
-        }
-        IrStmtKind::FieldAssign { value, .. } => {
-            check_expr_for_unknown(value, fn_name, warnings);
-        }
-        IrStmtKind::Guard { cond, else_ } => {
-            check_expr_for_unknown(cond, fn_name, warnings);
-            check_expr_for_unknown(else_, fn_name, warnings);
-        }
-        IrStmtKind::Expr { expr } => {
-            check_expr_for_unknown(expr, fn_name, warnings);
-        }
-        IrStmtKind::Comment { .. } => {}
-    }
 }

--- a/src/ir/unknown.rs
+++ b/src/ir/unknown.rs
@@ -102,6 +102,10 @@ fn check_expr_for_unknown(expr: &IrExpr, fn_name: &str, warnings: &mut Vec<Unkno
             check_expr_for_unknown(object, fn_name, warnings);
             check_expr_for_unknown(index, fn_name, warnings);
         }
+        IrExprKind::MapAccess { object, key } => {
+            check_expr_for_unknown(object, fn_name, warnings);
+            check_expr_for_unknown(key, fn_name, warnings);
+        }
         IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
             check_expr_for_unknown(object, fn_name, warnings);
         }
@@ -180,6 +184,10 @@ fn check_stmt_for_unknown(stmt: &IrStmt, fn_name: &str, warnings: &mut Vec<Unkno
         }
         IrStmtKind::IndexAssign { index, value, .. } => {
             check_expr_for_unknown(index, fn_name, warnings);
+            check_expr_for_unknown(value, fn_name, warnings);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            check_expr_for_unknown(key, fn_name, warnings);
             check_expr_for_unknown(value, fn_name, warnings);
         }
         IrStmtKind::FieldAssign { value, .. } => {

--- a/src/ir/use_count.rs
+++ b/src/ir/use_count.rs
@@ -92,6 +92,10 @@ fn count_uses_in_expr(expr: &IrExpr, table: &mut VarTable) {
             count_uses_in_expr(object, table);
             count_uses_in_expr(index, table);
         }
+        IrExprKind::MapAccess { object, key } => {
+            count_uses_in_expr(object, table);
+            count_uses_in_expr(key, table);
+        }
         IrExprKind::ForIn { iterable, body, .. } => {
             count_uses_in_expr(iterable, table);
             // Collect vars defined inside the loop body
@@ -147,6 +151,10 @@ fn count_uses_in_stmt(stmt: &IrStmt, table: &mut VarTable) {
         }
         IrStmtKind::IndexAssign { index, value, .. } => {
             count_uses_in_expr(index, table);
+            count_uses_in_expr(value, table);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            count_uses_in_expr(key, table);
             count_uses_in_expr(value, table);
         }
         IrStmtKind::FieldAssign { value, .. } => {
@@ -234,6 +242,10 @@ fn bump_vars_in_expr(expr: &IrExpr, locals: &HashSet<u32>, table: &mut VarTable)
             bump_vars_in_expr(object, locals, table);
             bump_vars_in_expr(index, locals, table);
         }
+        IrExprKind::MapAccess { object, key } => {
+            bump_vars_in_expr(object, locals, table);
+            bump_vars_in_expr(key, locals, table);
+        }
         IrExprKind::List { elements } | IrExprKind::Tuple { elements } => {
             for e in elements { bump_vars_in_expr(e, locals, table); }
         }
@@ -250,6 +262,10 @@ fn bump_vars_in_stmt(stmt: &IrStmt, locals: &HashSet<u32>, table: &mut VarTable)
         | IrStmtKind::Assign { value, .. } => bump_vars_in_expr(value, locals, table),
         IrStmtKind::IndexAssign { index, value, .. } => {
             bump_vars_in_expr(index, locals, table);
+            bump_vars_in_expr(value, locals, table);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            bump_vars_in_expr(key, locals, table);
             bump_vars_in_expr(value, locals, table);
         }
         IrStmtKind::FieldAssign { value, .. } => bump_vars_in_expr(value, locals, table),
@@ -315,6 +331,11 @@ fn collect_assigned_vars_stmt(stmt: &IrStmt, assigned: &mut HashSet<u32>) {
         IrStmtKind::IndexAssign { target, index, value } => {
             assigned.insert(target.0);
             collect_assigned_vars(index, assigned);
+            collect_assigned_vars(value, assigned);
+        }
+        IrStmtKind::MapInsert { target, key, value } => {
+            assigned.insert(target.0);
+            collect_assigned_vars(key, assigned);
             collect_assigned_vars(value, assigned);
         }
         IrStmtKind::FieldAssign { target, value, .. } => {

--- a/src/ir/verify.rs
+++ b/src/ir/verify.rs
@@ -67,19 +67,12 @@ impl<'a> VerifyCtx<'a> {
 pub fn verify_program(program: &IrProgram) -> Vec<IrVerifyError> {
     let mut errors = Vec::new();
 
-    // Verify main module
+    // Verify type declarations
+    verify_type_decls(&program.type_decls, "", &mut errors);
+
+    // Verify main module functions
     for f in &program.functions {
-        let mut ctx = VerifyCtx {
-            var_table: &program.var_table,
-            fn_name: f.name.clone(),
-            in_loop: false,
-            errors: Vec::new(),
-        };
-        for p in &f.params {
-            ctx.check_var_id(p.var, None);
-        }
-        verify_expr(&f.body, &mut ctx);
-        errors.append(&mut ctx.errors);
+        verify_function(f, &program.var_table, &f.name, &mut errors);
     }
     for tl in &program.top_lets {
         let mut ctx = VerifyCtx {
@@ -95,18 +88,10 @@ pub fn verify_program(program: &IrProgram) -> Vec<IrVerifyError> {
 
     // Verify imported modules
     for m in &program.modules {
+        verify_type_decls(&m.type_decls, &m.name, &mut errors);
         for f in &m.functions {
-            let mut ctx = VerifyCtx {
-                var_table: &m.var_table,
-                fn_name: format!("{}.{}", m.name, f.name),
-                in_loop: false,
-                errors: Vec::new(),
-            };
-            for p in &f.params {
-                ctx.check_var_id(p.var, None);
-            }
-            verify_expr(&f.body, &mut ctx);
-            errors.append(&mut ctx.errors);
+            let qual_name = format!("{}.{}", m.name, f.name);
+            verify_function(f, &m.var_table, &qual_name, &mut errors);
         }
         for tl in &m.top_lets {
             let mut ctx = VerifyCtx {
@@ -122,6 +107,60 @@ pub fn verify_program(program: &IrProgram) -> Vec<IrVerifyError> {
     }
 
     errors
+}
+
+fn verify_function(f: &IrFunction, var_table: &VarTable, name: &str, errors: &mut Vec<IrVerifyError>) {
+    let mut ctx = VerifyCtx {
+        var_table,
+        fn_name: name.to_string(),
+        in_loop: false,
+        errors: Vec::new(),
+    };
+
+    // Check parameter VarIds are valid and unique
+    let mut seen_param_ids = std::collections::HashSet::new();
+    for p in &f.params {
+        ctx.check_var_id(p.var, None);
+        if !seen_param_ids.insert(p.var.0) {
+            ctx.err(format!("duplicate parameter VarId({}) for '{}'", p.var.0, p.name), None);
+        }
+    }
+
+    verify_expr(&f.body, &mut ctx);
+    errors.append(&mut ctx.errors);
+}
+
+fn verify_type_decls(decls: &[IrTypeDecl], module: &str, errors: &mut Vec<IrVerifyError>) {
+    for decl in decls {
+        let loc = if module.is_empty() { decl.name.clone() } else { format!("{}.{}", module, decl.name) };
+        match &decl.kind {
+            IrTypeDeclKind::Record { fields } => {
+                let mut seen = std::collections::HashSet::new();
+                for f in fields {
+                    if !seen.insert(&f.name) {
+                        errors.push(IrVerifyError {
+                            message: format!("duplicate field '{}' in record type", f.name),
+                            fn_name: loc.clone(),
+                            span: None,
+                        });
+                    }
+                }
+            }
+            IrTypeDeclKind::Variant { cases, .. } => {
+                let mut seen = std::collections::HashSet::new();
+                for c in cases {
+                    if !seen.insert(&c.name) {
+                        errors.push(IrVerifyError {
+                            message: format!("duplicate variant case '{}'", c.name),
+                            fn_name: loc.clone(),
+                            span: None,
+                        });
+                    }
+                }
+            }
+            IrTypeDeclKind::Alias { .. } => {}
+        }
+    }
 }
 
 fn verify_expr(expr: &IrExpr, ctx: &mut VerifyCtx) {
@@ -329,11 +368,10 @@ fn verify_binop_types(op: BinOp, left: &IrExpr, right: &IrExpr, ctx: &mut Verify
 
     let expected = match op {
         BinOp::AddInt | BinOp::SubInt | BinOp::MulInt
-        | BinOp::DivInt | BinOp::ModInt | BinOp::XorInt => Some(Ty::Int),
+        | BinOp::DivInt | BinOp::ModInt | BinOp::PowInt | BinOp::XorInt => Some(Ty::Int),
         BinOp::AddFloat | BinOp::SubFloat | BinOp::MulFloat
-        | BinOp::DivFloat => Some(Ty::Float),
+        | BinOp::DivFloat | BinOp::PowFloat => Some(Ty::Float),
         BinOp::ConcatStr => Some(Ty::String),
-        // PowFloat: used for both Int**Int and Float**Float (codegen handles conversion)
         // ConcatList, Eq, Neq, comparisons, And, Or — operand types vary
         _ => None,
     };
@@ -645,5 +683,143 @@ mod tests {
         let errors = verify_program(&prog);
         assert_eq!(errors.len(), 1);
         assert!(errors[0].message.contains("NegInt"));
+    }
+
+    #[test]
+    fn detects_duplicate_record_fields() {
+        let vt = VarTable::new();
+        let prog = IrProgram {
+            functions: vec![],
+            top_lets: vec![],
+            type_decls: vec![IrTypeDecl {
+                name: "Bad".into(),
+                kind: IrTypeDeclKind::Record {
+                    fields: vec![
+                        IrFieldDecl { name: "x".into(), ty: Ty::Int, default: None, alias: None },
+                        IrFieldDecl { name: "x".into(), ty: Ty::String, default: None, alias: None },
+                    ],
+                },
+                deriving: None,
+                generics: None,
+                visibility: IrVisibility::Public,
+            }],
+            var_table: vt,
+            modules: vec![],
+            type_registry: Default::default(),
+            effect_map: Default::default(),
+        };
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("duplicate field 'x'"));
+    }
+
+    #[test]
+    fn detects_duplicate_variant_cases() {
+        let vt = VarTable::new();
+        let prog = IrProgram {
+            functions: vec![],
+            top_lets: vec![],
+            type_decls: vec![IrTypeDecl {
+                name: "Bad".into(),
+                kind: IrTypeDeclKind::Variant {
+                    cases: vec![
+                        IrVariantDecl { name: "A".into(), kind: IrVariantKind::Unit },
+                        IrVariantDecl { name: "A".into(), kind: IrVariantKind::Unit },
+                    ],
+                    is_generic: false,
+                    boxed_args: HashSet::new(),
+                    boxed_record_fields: HashSet::new(),
+                },
+                deriving: None,
+                generics: None,
+                visibility: IrVisibility::Public,
+            }],
+            var_table: vt,
+            modules: vec![],
+            type_registry: Default::default(),
+            effect_map: Default::default(),
+        };
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("duplicate variant case 'A'"));
+    }
+
+    #[test]
+    fn detects_duplicate_param_var_ids() {
+        let mut vt = VarTable::new();
+        let x = vt.alloc("x".into(), Ty::Int, Mutability::Let, None);
+        let f = IrFunction {
+            name: "bad".into(),
+            params: vec![
+                IrParam { var: x, ty: Ty::Int, name: "a".into(), borrow: ParamBorrow::Own, open_record: None, default: None },
+                IrParam { var: x, ty: Ty::Int, name: "b".into(), borrow: ParamBorrow::Own, open_record: None, default: None },
+            ],
+            ret_ty: Ty::Int,
+            body: lit_int(0),
+            is_effect: false,
+            is_async: false,
+            is_test: false,
+            generics: None,
+            extern_attrs: vec![],
+            visibility: IrVisibility::Public,
+        };
+        let prog = make_program(vec![f], vt);
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("duplicate parameter VarId"));
+    }
+
+    #[test]
+    fn allows_break_inside_do_block() {
+        let vt = VarTable::new();
+        let body = IrExpr {
+            kind: IrExprKind::DoBlock {
+                stmts: vec![IrStmt {
+                    kind: IrStmtKind::Expr {
+                        expr: IrExpr { kind: IrExprKind::Break, ty: Ty::Unit, span: None },
+                    },
+                    span: None,
+                }],
+                expr: None,
+            },
+            ty: Ty::Unit,
+            span: None,
+        };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn pow_int_type_consistency() {
+        let vt = VarTable::new();
+        // PowInt with Int operands — should pass
+        let body = IrExpr {
+            kind: IrExprKind::BinOp {
+                op: BinOp::PowInt,
+                left: Box::new(lit_int(2)),
+                right: Box::new(lit_int(3)),
+            },
+            ty: Ty::Int,
+            span: None,
+        };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        assert!(verify_program(&prog).is_empty());
+
+        // PowInt with Float operand — should fail
+        let vt2 = VarTable::new();
+        let body2 = IrExpr {
+            kind: IrExprKind::BinOp {
+                op: BinOp::PowInt,
+                left: Box::new(IrExpr { kind: IrExprKind::LitFloat { value: 2.0 }, ty: Ty::Float, span: None }),
+                right: Box::new(lit_int(3)),
+            },
+            ty: Ty::Int,
+            span: None,
+        };
+        let prog2 = make_program(vec![make_fn("main", body2)], vt2);
+        let errors = verify_program(&prog2);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("PowInt"));
     }
 }

--- a/src/ir/verify.rs
+++ b/src/ir/verify.rs
@@ -10,6 +10,7 @@
 //   4. Operator–type consistency — BinOp variant matches operand types
 
 use super::*;
+use super::visit::{IrVisitor, walk_expr, walk_stmt, walk_pattern};
 use crate::types::Ty;
 
 /// An internal compiler error detected by IR verification.
@@ -30,14 +31,14 @@ impl std::fmt::Display for IrVerifyError {
     }
 }
 
-struct VerifyCtx<'a> {
+struct Verifier<'a> {
     var_table: &'a VarTable,
     fn_name: String,
     in_loop: bool,
     errors: Vec<IrVerifyError>,
 }
 
-impl<'a> VerifyCtx<'a> {
+impl<'a> Verifier<'a> {
     fn err(&mut self, message: String, span: Option<Span>) {
         self.errors.push(IrVerifyError {
             message,
@@ -62,6 +63,126 @@ impl<'a> VerifyCtx<'a> {
     // after optimization would produce false positives.
 }
 
+impl<'a> IrVisitor for Verifier<'a> {
+    fn visit_expr(&mut self, expr: &IrExpr) {
+        match &expr.kind {
+            // ── Variables ──
+            IrExprKind::Var { id } => {
+                self.check_var_id(*id, expr.span);
+            }
+
+            // ── Operators: check type consistency ──
+            IrExprKind::BinOp { op, left, right } => {
+                verify_binop_types(*op, left, right, self, expr.span);
+            }
+            IrExprKind::UnOp { op, operand } => {
+                verify_unop_types(*op, operand, self, expr.span);
+            }
+
+            // ── Loop context ──
+            IrExprKind::Break | IrExprKind::Continue => {
+                if !self.in_loop {
+                    let kind = if matches!(expr.kind, IrExprKind::Break) { "break" } else { "continue" };
+                    self.err(format!("{} outside of loop", kind), expr.span);
+                }
+            }
+
+            // ── ForIn: check var ids, then walk with in_loop=true ──
+            IrExprKind::ForIn { var, var_tuple, .. } => {
+                self.check_var_id(*var, expr.span);
+                if let Some(tuple_vars) = var_tuple {
+                    for v in tuple_vars {
+                        self.check_var_id(*v, expr.span);
+                    }
+                }
+                let prev = self.in_loop;
+                self.in_loop = true;
+                walk_expr(self, expr);
+                self.in_loop = prev;
+                return; // already walked
+            }
+
+            // ── While: walk with in_loop=true ──
+            IrExprKind::While { .. } => {
+                let prev = self.in_loop;
+                self.in_loop = true;
+                walk_expr(self, expr);
+                self.in_loop = prev;
+                return;
+            }
+
+            // ── DoBlock with guards acts as a loop (break is valid) ──
+            IrExprKind::DoBlock { .. } => {
+                let prev = self.in_loop;
+                self.in_loop = true;
+                walk_expr(self, expr);
+                self.in_loop = prev;
+                return;
+            }
+
+            // ── Lambda: check param VarIds before walking body ──
+            IrExprKind::Lambda { params, .. } => {
+                for (var, _) in params {
+                    self.check_var_id(*var, expr.span);
+                }
+            }
+
+            // ── Access: type constraints ──
+            IrExprKind::IndexAccess { object, .. } => {
+                if !is_unresolved(&object.ty) && object.ty.is_map() {
+                    self.err("IndexAccess used on Map type (should be MapAccess)".into(), expr.span);
+                }
+            }
+            IrExprKind::MapAccess { object, .. } => {
+                if !is_unresolved(&object.ty) && !object.ty.is_map() {
+                    self.err(
+                        format!("MapAccess used on non-Map type '{}'", object.ty.display()),
+                        expr.span,
+                    );
+                }
+            }
+
+            _ => {}
+        }
+
+        walk_expr(self, expr);
+    }
+
+    fn visit_stmt(&mut self, stmt: &IrStmt) {
+        match &stmt.kind {
+            IrStmtKind::Bind { var, .. } => {
+                self.check_var_id(*var, stmt.span);
+            }
+            IrStmtKind::Assign { var, .. } => {
+                self.check_var_id(*var, stmt.span);
+            }
+            IrStmtKind::IndexAssign { target, .. } => {
+                self.check_var_id(*target, stmt.span);
+            }
+            IrStmtKind::MapInsert { target, .. } => {
+                self.check_var_id(*target, stmt.span);
+            }
+            IrStmtKind::FieldAssign { target, .. } => {
+                self.check_var_id(*target, stmt.span);
+            }
+            _ => {}
+        }
+
+        walk_stmt(self, stmt);
+    }
+
+    fn visit_pattern(&mut self, pat: &IrPattern) {
+        match pat {
+            IrPattern::Bind { var } => {
+                self.check_var_id(*var, None);
+            }
+            _ => {}
+        }
+
+        walk_pattern(self, pat);
+    }
+}
+
 /// Verify IR integrity for the main program. Returns errors found.
 /// Intended for debug builds — call after optimization, before monomorphization.
 pub fn verify_program(program: &IrProgram) -> Vec<IrVerifyError> {
@@ -75,15 +196,15 @@ pub fn verify_program(program: &IrProgram) -> Vec<IrVerifyError> {
         verify_function(f, &program.var_table, &f.name, &mut errors);
     }
     for tl in &program.top_lets {
-        let mut ctx = VerifyCtx {
+        let mut v = Verifier {
             var_table: &program.var_table,
             fn_name: "<top-level>".into(),
             in_loop: false,
             errors: Vec::new(),
         };
-        ctx.check_var_id(tl.var, None);
-        verify_expr(&tl.value, &mut ctx);
-        errors.append(&mut ctx.errors);
+        v.check_var_id(tl.var, None);
+        v.visit_expr(&tl.value);
+        errors.append(&mut v.errors);
     }
 
     // Verify imported modules
@@ -94,15 +215,15 @@ pub fn verify_program(program: &IrProgram) -> Vec<IrVerifyError> {
             verify_function(f, &m.var_table, &qual_name, &mut errors);
         }
         for tl in &m.top_lets {
-            let mut ctx = VerifyCtx {
+            let mut v = Verifier {
                 var_table: &m.var_table,
                 fn_name: format!("{}.<top-level>", m.name),
                 in_loop: false,
                 errors: Vec::new(),
             };
-            ctx.check_var_id(tl.var, None);
-            verify_expr(&tl.value, &mut ctx);
-            errors.append(&mut ctx.errors);
+            v.check_var_id(tl.var, None);
+            v.visit_expr(&tl.value);
+            errors.append(&mut v.errors);
         }
     }
 
@@ -110,7 +231,7 @@ pub fn verify_program(program: &IrProgram) -> Vec<IrVerifyError> {
 }
 
 fn verify_function(f: &IrFunction, var_table: &VarTable, name: &str, errors: &mut Vec<IrVerifyError>) {
-    let mut ctx = VerifyCtx {
+    let mut v = Verifier {
         var_table,
         fn_name: name.to_string(),
         in_loop: false,
@@ -120,14 +241,14 @@ fn verify_function(f: &IrFunction, var_table: &VarTable, name: &str, errors: &mu
     // Check parameter VarIds are valid and unique
     let mut seen_param_ids = std::collections::HashSet::new();
     for p in &f.params {
-        ctx.check_var_id(p.var, None);
+        v.check_var_id(p.var, None);
         if !seen_param_ids.insert(p.var.0) {
-            ctx.err(format!("duplicate parameter VarId({}) for '{}'", p.var.0, p.name), None);
+            v.err(format!("duplicate parameter VarId({}) for '{}'", p.var.0, p.name), None);
         }
     }
 
-    verify_expr(&f.body, &mut ctx);
-    errors.append(&mut ctx.errors);
+    v.visit_expr(&f.body);
+    errors.append(&mut v.errors);
 }
 
 fn verify_type_decls(decls: &[IrTypeDecl], module: &str, errors: &mut Vec<IrVerifyError>) {
@@ -163,221 +284,11 @@ fn verify_type_decls(decls: &[IrTypeDecl], module: &str, errors: &mut Vec<IrVeri
     }
 }
 
-fn verify_expr(expr: &IrExpr, ctx: &mut VerifyCtx) {
-    match &expr.kind {
-        // ── Variables ──
-        IrExprKind::Var { id } => {
-            ctx.check_var_id(*id, expr.span);
-        }
-
-        // ── Operators: check type consistency ──
-        IrExprKind::BinOp { op, left, right } => {
-            verify_binop_types(*op, left, right, ctx, expr.span);
-            verify_expr(left, ctx);
-            verify_expr(right, ctx);
-        }
-        IrExprKind::UnOp { op, operand } => {
-            verify_unop_types(*op, operand, ctx, expr.span);
-            verify_expr(operand, ctx);
-        }
-
-        // ── Loop context ──
-        IrExprKind::Break | IrExprKind::Continue => {
-            if !ctx.in_loop {
-                let kind = if matches!(expr.kind, IrExprKind::Break) { "break" } else { "continue" };
-                ctx.err(format!("{} outside of loop", kind), expr.span);
-            }
-        }
-        IrExprKind::ForIn { var, var_tuple, iterable, body } => {
-            ctx.check_var_id(*var, expr.span);
-            if let Some(tuple_vars) = var_tuple {
-                for v in tuple_vars {
-                    ctx.check_var_id(*v, expr.span);
-                }
-            }
-            verify_expr(iterable, ctx);
-            let prev = ctx.in_loop;
-            ctx.in_loop = true;
-            for s in body { verify_stmt(s, ctx); }
-            ctx.in_loop = prev;
-        }
-        IrExprKind::While { cond, body } => {
-            verify_expr(cond, ctx);
-            let prev = ctx.in_loop;
-            ctx.in_loop = true;
-            for s in body { verify_stmt(s, ctx); }
-            ctx.in_loop = prev;
-        }
-
-        // ── Recursive cases ──
-        IrExprKind::If { cond, then, else_ } => {
-            verify_expr(cond, ctx);
-            verify_expr(then, ctx);
-            verify_expr(else_, ctx);
-        }
-        IrExprKind::Block { stmts, expr: tail } => {
-            for s in stmts { verify_stmt(s, ctx); }
-            if let Some(t) = tail { verify_expr(t, ctx); }
-        }
-        // DoBlock with guards acts as a loop (break is valid for early exit)
-        IrExprKind::DoBlock { stmts, expr: tail } => {
-            let prev = ctx.in_loop;
-            ctx.in_loop = true;
-            for s in stmts { verify_stmt(s, ctx); }
-            if let Some(t) = tail { verify_expr(t, ctx); }
-            ctx.in_loop = prev;
-        }
-        IrExprKind::Match { subject, arms } => {
-            verify_expr(subject, ctx);
-            for arm in arms {
-                verify_pattern(&arm.pattern, ctx, expr.span);
-                if let Some(g) = &arm.guard { verify_expr(g, ctx); }
-                verify_expr(&arm.body, ctx);
-            }
-        }
-        IrExprKind::Call { target, args, .. } => {
-            match target {
-                CallTarget::Method { object, .. } => verify_expr(object, ctx),
-                CallTarget::Computed { callee } => verify_expr(callee, ctx),
-                _ => {}
-            }
-            for a in args { verify_expr(a, ctx); }
-        }
-        IrExprKind::Lambda { params, body } => {
-            for (var, _) in params {
-                ctx.check_var_id(*var, expr.span);
-            }
-            verify_expr(body, ctx);
-        }
-        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
-        | IrExprKind::Fan { exprs: elements } => {
-            for e in elements { verify_expr(e, ctx); }
-        }
-        IrExprKind::Record { fields, .. } => {
-            for (_, v) in fields { verify_expr(v, ctx); }
-        }
-        IrExprKind::SpreadRecord { base, fields } => {
-            verify_expr(base, ctx);
-            for (_, v) in fields { verify_expr(v, ctx); }
-        }
-        IrExprKind::MapLiteral { entries } => {
-            for (k, v) in entries { verify_expr(k, ctx); verify_expr(v, ctx); }
-        }
-        IrExprKind::Range { start, end, .. } => {
-            verify_expr(start, ctx);
-            verify_expr(end, ctx);
-        }
-        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
-            verify_expr(object, ctx);
-        }
-        IrExprKind::IndexAccess { object, index } => {
-            if !is_unresolved(&object.ty) && object.ty.is_map() {
-                ctx.err("IndexAccess used on Map type (should be MapAccess)".into(), expr.span);
-            }
-            verify_expr(object, ctx);
-            verify_expr(index, ctx);
-        }
-        IrExprKind::MapAccess { object, key } => {
-            if !is_unresolved(&object.ty) && !object.ty.is_map() {
-                ctx.err(
-                    format!("MapAccess used on non-Map type '{}'", object.ty.display()),
-                    expr.span,
-                );
-            }
-            verify_expr(object, ctx);
-            verify_expr(key, ctx);
-        }
-        IrExprKind::StringInterp { parts } => {
-            for p in parts {
-                if let IrStringPart::Expr { expr } = p { verify_expr(expr, ctx); }
-            }
-        }
-        IrExprKind::ResultOk { expr: e } | IrExprKind::ResultErr { expr: e }
-        | IrExprKind::OptionSome { expr: e } | IrExprKind::Try { expr: e }
-        | IrExprKind::Await { expr: e }
-        | IrExprKind::Clone { expr: e } | IrExprKind::Deref { expr: e }
-        | IrExprKind::Borrow { expr: e, .. } | IrExprKind::BoxNew { expr: e }
-        | IrExprKind::ToVec { expr: e } => {
-            verify_expr(e, ctx);
-        }
-        IrExprKind::RustMacro { args, .. } => {
-            for a in args { verify_expr(a, ctx); }
-        }
-
-        // Leaf nodes
-        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. } | IrExprKind::LitStr { .. }
-        | IrExprKind::LitBool { .. } | IrExprKind::Unit | IrExprKind::FnRef { .. }
-        | IrExprKind::EmptyMap | IrExprKind::OptionNone | IrExprKind::Hole
-        | IrExprKind::Todo { .. } | IrExprKind::RenderedCall { .. } => {}
-    }
-}
-
-fn verify_stmt(stmt: &IrStmt, ctx: &mut VerifyCtx) {
-    match &stmt.kind {
-        IrStmtKind::Bind { var, value, .. } => {
-            ctx.check_var_id(*var, stmt.span);
-            verify_expr(value, ctx);
-        }
-        IrStmtKind::BindDestructure { pattern, value } => {
-            verify_pattern(pattern, ctx, stmt.span);
-            verify_expr(value, ctx);
-        }
-        IrStmtKind::Assign { var, value } => {
-            ctx.check_var_id(*var, stmt.span);
-            verify_expr(value, ctx);
-        }
-        IrStmtKind::IndexAssign { target, index, value } => {
-            ctx.check_var_id(*target, stmt.span);
-            verify_expr(index, ctx);
-            verify_expr(value, ctx);
-        }
-        IrStmtKind::MapInsert { target, key, value } => {
-            ctx.check_var_id(*target, stmt.span);
-            verify_expr(key, ctx);
-            verify_expr(value, ctx);
-        }
-        IrStmtKind::FieldAssign { target, value, .. } => {
-            ctx.check_var_id(*target, stmt.span);
-            verify_expr(value, ctx);
-        }
-        IrStmtKind::Guard { cond, else_ } => {
-            verify_expr(cond, ctx);
-            verify_expr(else_, ctx);
-        }
-        IrStmtKind::Expr { expr } => {
-            verify_expr(expr, ctx);
-        }
-        IrStmtKind::Comment { .. } => {}
-    }
-}
-
-fn verify_pattern(pat: &IrPattern, ctx: &mut VerifyCtx, span: Option<Span>) {
-    match pat {
-        IrPattern::Bind { var } => ctx.check_var_id(*var, span),
-        IrPattern::Constructor { args, .. } => {
-            for a in args { verify_pattern(a, ctx, span); }
-        }
-        IrPattern::RecordPattern { fields, .. } => {
-            for f in fields {
-                if let Some(p) = &f.pattern { verify_pattern(p, ctx, span); }
-            }
-        }
-        IrPattern::Tuple { elements } => {
-            for e in elements { verify_pattern(e, ctx, span); }
-        }
-        IrPattern::Some { inner } | IrPattern::Ok { inner } | IrPattern::Err { inner } => {
-            verify_pattern(inner, ctx, span);
-        }
-        IrPattern::Literal { expr } => verify_expr(expr, ctx),
-        IrPattern::Wildcard | IrPattern::None => {}
-    }
-}
-
 // ── Operator–type consistency ─────────────────────────────────────
 
 /// Check that a BinOp variant is consistent with its operand types.
 /// Only flags clear contradictions (e.g., AddInt on String operands).
-fn verify_binop_types(op: BinOp, left: &IrExpr, right: &IrExpr, ctx: &mut VerifyCtx, span: Option<Span>) {
+fn verify_binop_types(op: BinOp, left: &IrExpr, right: &IrExpr, v: &mut Verifier, span: Option<Span>) {
     let lt = &left.ty;
     let rt = &right.ty;
 
@@ -396,7 +307,7 @@ fn verify_binop_types(op: BinOp, left: &IrExpr, right: &IrExpr, ctx: &mut Verify
 
     if let Some(expected_ty) = expected {
         if !ty_matches(lt, &expected_ty) || !ty_matches(rt, &expected_ty) {
-            ctx.err(
+            v.err(
                 format!(
                     "{:?} expects {} operands, got {} and {}",
                     op, expected_ty.display(), lt.display(), rt.display()
@@ -409,7 +320,7 @@ fn verify_binop_types(op: BinOp, left: &IrExpr, right: &IrExpr, ctx: &mut Verify
     // And/Or require Bool
     if matches!(op, BinOp::And | BinOp::Or) {
         if !ty_matches(lt, &Ty::Bool) || !ty_matches(rt, &Ty::Bool) {
-            ctx.err(
+            v.err(
                 format!(
                     "{:?} expects Bool operands, got {} and {}",
                     op, lt.display(), rt.display()
@@ -420,7 +331,7 @@ fn verify_binop_types(op: BinOp, left: &IrExpr, right: &IrExpr, ctx: &mut Verify
     }
 }
 
-fn verify_unop_types(op: UnOp, operand: &IrExpr, ctx: &mut VerifyCtx, span: Option<Span>) {
+fn verify_unop_types(op: UnOp, operand: &IrExpr, v: &mut Verifier, span: Option<Span>) {
     let t = &operand.ty;
     if is_unresolved(t) { return; }
 
@@ -432,7 +343,7 @@ fn verify_unop_types(op: UnOp, operand: &IrExpr, ctx: &mut VerifyCtx, span: Opti
 
     if let Some(expected_ty) = expected {
         if !ty_matches(t, &expected_ty) {
-            ctx.err(
+            v.err(
                 format!(
                     "{:?} expects {} operand, got {}",
                     op, expected_ty.display(), t.display()

--- a/src/ir/verify.rs
+++ b/src/ir/verify.rs
@@ -271,10 +271,19 @@ fn verify_expr(expr: &IrExpr, ctx: &mut VerifyCtx) {
             verify_expr(object, ctx);
         }
         IrExprKind::IndexAccess { object, index } => {
+            if !is_unresolved(&object.ty) && object.ty.is_map() {
+                ctx.err("IndexAccess used on Map type (should be MapAccess)".into(), expr.span);
+            }
             verify_expr(object, ctx);
             verify_expr(index, ctx);
         }
         IrExprKind::MapAccess { object, key } => {
+            if !is_unresolved(&object.ty) && !object.ty.is_map() {
+                ctx.err(
+                    format!("MapAccess used on non-Map type '{}'", object.ty.display()),
+                    expr.span,
+                );
+            }
             verify_expr(object, ctx);
             verify_expr(key, ctx);
         }
@@ -797,6 +806,58 @@ mod tests {
         let prog = make_program(vec![make_fn("main", body)], vt);
         let errors = verify_program(&prog);
         assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn detects_index_access_on_map() {
+        let vt = VarTable::new();
+        let map_ty = Ty::Applied(crate::types::TypeConstructorId::Map, vec![Ty::String, Ty::Int]);
+        let body = IrExpr {
+            kind: IrExprKind::IndexAccess {
+                object: Box::new(IrExpr { kind: IrExprKind::EmptyMap, ty: map_ty, span: None }),
+                index: Box::new(IrExpr { kind: IrExprKind::LitStr { value: "k".into() }, ty: Ty::String, span: None }),
+            },
+            ty: Ty::Int,
+            span: None,
+        };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("IndexAccess used on Map"));
+    }
+
+    #[test]
+    fn detects_map_access_on_non_map() {
+        let vt = VarTable::new();
+        let list_ty = Ty::Applied(crate::types::TypeConstructorId::List, vec![Ty::Int]);
+        let body = IrExpr {
+            kind: IrExprKind::MapAccess {
+                object: Box::new(IrExpr { kind: IrExprKind::List { elements: vec![] }, ty: list_ty, span: None }),
+                key: Box::new(lit_int(0)),
+            },
+            ty: Ty::Int,
+            span: None,
+        };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("MapAccess used on non-Map"));
+    }
+
+    #[test]
+    fn allows_map_access_on_map() {
+        let vt = VarTable::new();
+        let map_ty = Ty::Applied(crate::types::TypeConstructorId::Map, vec![Ty::String, Ty::Int]);
+        let body = IrExpr {
+            kind: IrExprKind::MapAccess {
+                object: Box::new(IrExpr { kind: IrExprKind::EmptyMap, ty: map_ty, span: None }),
+                key: Box::new(IrExpr { kind: IrExprKind::LitStr { value: "k".into() }, ty: Ty::String, span: None }),
+            },
+            ty: Ty::Int,
+            span: None,
+        };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        assert!(verify_program(&prog).is_empty());
     }
 
     #[test]

--- a/src/ir/verify.rs
+++ b/src/ir/verify.rs
@@ -1,0 +1,649 @@
+// ── IR integrity verification (post-pass) ───────────────────────
+//
+// Debug-only pass that catches internal compiler errors before codegen.
+// Runs after lowering + optimization, before monomorphization.
+//
+// Checks:
+//   1. VarId bounds — every referenced VarId exists in VarTable
+//   2. Mutability — only `var` variables appear in Assign/IndexAssign/FieldAssign
+//   3. Loop context — Break/Continue only inside ForIn/While
+//   4. Operator–type consistency — BinOp variant matches operand types
+
+use super::*;
+use crate::types::Ty;
+
+/// An internal compiler error detected by IR verification.
+#[derive(Debug)]
+pub struct IrVerifyError {
+    pub message: String,
+    pub fn_name: String,
+    pub span: Option<Span>,
+}
+
+impl std::fmt::Display for IrVerifyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "IR verify: {} (in {})", self.message, self.fn_name)?;
+        if let Some(s) = &self.span {
+            write!(f, " at line {}", s.line)?;
+        }
+        Ok(())
+    }
+}
+
+struct VerifyCtx<'a> {
+    var_table: &'a VarTable,
+    fn_name: String,
+    in_loop: bool,
+    errors: Vec<IrVerifyError>,
+}
+
+impl<'a> VerifyCtx<'a> {
+    fn err(&mut self, message: String, span: Option<Span>) {
+        self.errors.push(IrVerifyError {
+            message,
+            fn_name: self.fn_name.clone(),
+            span,
+        });
+    }
+
+    fn check_var_id(&mut self, id: VarId, span: Option<Span>) {
+        if (id.0 as usize) >= self.var_table.len() {
+            self.err(
+                format!("VarId({}) out of bounds (table size: {})", id.0, self.var_table.len()),
+                span,
+            );
+        }
+    }
+
+    // Note: mutability checking is intentionally omitted here.
+    // The optimizer's `demote_unused_mut` pass may have already
+    // demoted `Var` to `Let` for variables that are assigned but
+    // whose assignments were eliminated by DCE. Checking mutability
+    // after optimization would produce false positives.
+}
+
+/// Verify IR integrity for the main program. Returns errors found.
+/// Intended for debug builds — call after optimization, before monomorphization.
+pub fn verify_program(program: &IrProgram) -> Vec<IrVerifyError> {
+    let mut errors = Vec::new();
+
+    // Verify main module
+    for f in &program.functions {
+        let mut ctx = VerifyCtx {
+            var_table: &program.var_table,
+            fn_name: f.name.clone(),
+            in_loop: false,
+            errors: Vec::new(),
+        };
+        for p in &f.params {
+            ctx.check_var_id(p.var, None);
+        }
+        verify_expr(&f.body, &mut ctx);
+        errors.append(&mut ctx.errors);
+    }
+    for tl in &program.top_lets {
+        let mut ctx = VerifyCtx {
+            var_table: &program.var_table,
+            fn_name: "<top-level>".into(),
+            in_loop: false,
+            errors: Vec::new(),
+        };
+        ctx.check_var_id(tl.var, None);
+        verify_expr(&tl.value, &mut ctx);
+        errors.append(&mut ctx.errors);
+    }
+
+    // Verify imported modules
+    for m in &program.modules {
+        for f in &m.functions {
+            let mut ctx = VerifyCtx {
+                var_table: &m.var_table,
+                fn_name: format!("{}.{}", m.name, f.name),
+                in_loop: false,
+                errors: Vec::new(),
+            };
+            for p in &f.params {
+                ctx.check_var_id(p.var, None);
+            }
+            verify_expr(&f.body, &mut ctx);
+            errors.append(&mut ctx.errors);
+        }
+        for tl in &m.top_lets {
+            let mut ctx = VerifyCtx {
+                var_table: &m.var_table,
+                fn_name: format!("{}.<top-level>", m.name),
+                in_loop: false,
+                errors: Vec::new(),
+            };
+            ctx.check_var_id(tl.var, None);
+            verify_expr(&tl.value, &mut ctx);
+            errors.append(&mut ctx.errors);
+        }
+    }
+
+    errors
+}
+
+fn verify_expr(expr: &IrExpr, ctx: &mut VerifyCtx) {
+    match &expr.kind {
+        // ── Variables ──
+        IrExprKind::Var { id } => {
+            ctx.check_var_id(*id, expr.span);
+        }
+
+        // ── Operators: check type consistency ──
+        IrExprKind::BinOp { op, left, right } => {
+            verify_binop_types(*op, left, right, ctx, expr.span);
+            verify_expr(left, ctx);
+            verify_expr(right, ctx);
+        }
+        IrExprKind::UnOp { op, operand } => {
+            verify_unop_types(*op, operand, ctx, expr.span);
+            verify_expr(operand, ctx);
+        }
+
+        // ── Loop context ──
+        IrExprKind::Break | IrExprKind::Continue => {
+            if !ctx.in_loop {
+                let kind = if matches!(expr.kind, IrExprKind::Break) { "break" } else { "continue" };
+                ctx.err(format!("{} outside of loop", kind), expr.span);
+            }
+        }
+        IrExprKind::ForIn { var, var_tuple, iterable, body } => {
+            ctx.check_var_id(*var, expr.span);
+            if let Some(tuple_vars) = var_tuple {
+                for v in tuple_vars {
+                    ctx.check_var_id(*v, expr.span);
+                }
+            }
+            verify_expr(iterable, ctx);
+            let prev = ctx.in_loop;
+            ctx.in_loop = true;
+            for s in body { verify_stmt(s, ctx); }
+            ctx.in_loop = prev;
+        }
+        IrExprKind::While { cond, body } => {
+            verify_expr(cond, ctx);
+            let prev = ctx.in_loop;
+            ctx.in_loop = true;
+            for s in body { verify_stmt(s, ctx); }
+            ctx.in_loop = prev;
+        }
+
+        // ── Recursive cases ──
+        IrExprKind::If { cond, then, else_ } => {
+            verify_expr(cond, ctx);
+            verify_expr(then, ctx);
+            verify_expr(else_, ctx);
+        }
+        IrExprKind::Block { stmts, expr: tail } => {
+            for s in stmts { verify_stmt(s, ctx); }
+            if let Some(t) = tail { verify_expr(t, ctx); }
+        }
+        // DoBlock with guards acts as a loop (break is valid for early exit)
+        IrExprKind::DoBlock { stmts, expr: tail } => {
+            let prev = ctx.in_loop;
+            ctx.in_loop = true;
+            for s in stmts { verify_stmt(s, ctx); }
+            if let Some(t) = tail { verify_expr(t, ctx); }
+            ctx.in_loop = prev;
+        }
+        IrExprKind::Match { subject, arms } => {
+            verify_expr(subject, ctx);
+            for arm in arms {
+                verify_pattern(&arm.pattern, ctx, expr.span);
+                if let Some(g) = &arm.guard { verify_expr(g, ctx); }
+                verify_expr(&arm.body, ctx);
+            }
+        }
+        IrExprKind::Call { target, args, .. } => {
+            match target {
+                CallTarget::Method { object, .. } => verify_expr(object, ctx),
+                CallTarget::Computed { callee } => verify_expr(callee, ctx),
+                _ => {}
+            }
+            for a in args { verify_expr(a, ctx); }
+        }
+        IrExprKind::Lambda { params, body } => {
+            for (var, _) in params {
+                ctx.check_var_id(*var, expr.span);
+            }
+            verify_expr(body, ctx);
+        }
+        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
+        | IrExprKind::Fan { exprs: elements } => {
+            for e in elements { verify_expr(e, ctx); }
+        }
+        IrExprKind::Record { fields, .. } => {
+            for (_, v) in fields { verify_expr(v, ctx); }
+        }
+        IrExprKind::SpreadRecord { base, fields } => {
+            verify_expr(base, ctx);
+            for (_, v) in fields { verify_expr(v, ctx); }
+        }
+        IrExprKind::MapLiteral { entries } => {
+            for (k, v) in entries { verify_expr(k, ctx); verify_expr(v, ctx); }
+        }
+        IrExprKind::Range { start, end, .. } => {
+            verify_expr(start, ctx);
+            verify_expr(end, ctx);
+        }
+        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
+            verify_expr(object, ctx);
+        }
+        IrExprKind::IndexAccess { object, index } => {
+            verify_expr(object, ctx);
+            verify_expr(index, ctx);
+        }
+        IrExprKind::StringInterp { parts } => {
+            for p in parts {
+                if let IrStringPart::Expr { expr } = p { verify_expr(expr, ctx); }
+            }
+        }
+        IrExprKind::ResultOk { expr: e } | IrExprKind::ResultErr { expr: e }
+        | IrExprKind::OptionSome { expr: e } | IrExprKind::Try { expr: e }
+        | IrExprKind::Await { expr: e }
+        | IrExprKind::Clone { expr: e } | IrExprKind::Deref { expr: e }
+        | IrExprKind::Borrow { expr: e, .. } | IrExprKind::BoxNew { expr: e }
+        | IrExprKind::ToVec { expr: e } => {
+            verify_expr(e, ctx);
+        }
+        IrExprKind::RustMacro { args, .. } => {
+            for a in args { verify_expr(a, ctx); }
+        }
+
+        // Leaf nodes
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. } | IrExprKind::LitStr { .. }
+        | IrExprKind::LitBool { .. } | IrExprKind::Unit | IrExprKind::FnRef { .. }
+        | IrExprKind::EmptyMap | IrExprKind::OptionNone | IrExprKind::Hole
+        | IrExprKind::Todo { .. } | IrExprKind::RenderedCall { .. } => {}
+    }
+}
+
+fn verify_stmt(stmt: &IrStmt, ctx: &mut VerifyCtx) {
+    match &stmt.kind {
+        IrStmtKind::Bind { var, value, .. } => {
+            ctx.check_var_id(*var, stmt.span);
+            verify_expr(value, ctx);
+        }
+        IrStmtKind::BindDestructure { pattern, value } => {
+            verify_pattern(pattern, ctx, stmt.span);
+            verify_expr(value, ctx);
+        }
+        IrStmtKind::Assign { var, value } => {
+            ctx.check_var_id(*var, stmt.span);
+            verify_expr(value, ctx);
+        }
+        IrStmtKind::IndexAssign { target, index, value } => {
+            ctx.check_var_id(*target, stmt.span);
+            verify_expr(index, ctx);
+            verify_expr(value, ctx);
+        }
+        IrStmtKind::FieldAssign { target, value, .. } => {
+            ctx.check_var_id(*target, stmt.span);
+            verify_expr(value, ctx);
+        }
+        IrStmtKind::Guard { cond, else_ } => {
+            verify_expr(cond, ctx);
+            verify_expr(else_, ctx);
+        }
+        IrStmtKind::Expr { expr } => {
+            verify_expr(expr, ctx);
+        }
+        IrStmtKind::Comment { .. } => {}
+    }
+}
+
+fn verify_pattern(pat: &IrPattern, ctx: &mut VerifyCtx, span: Option<Span>) {
+    match pat {
+        IrPattern::Bind { var } => ctx.check_var_id(*var, span),
+        IrPattern::Constructor { args, .. } => {
+            for a in args { verify_pattern(a, ctx, span); }
+        }
+        IrPattern::RecordPattern { fields, .. } => {
+            for f in fields {
+                if let Some(p) = &f.pattern { verify_pattern(p, ctx, span); }
+            }
+        }
+        IrPattern::Tuple { elements } => {
+            for e in elements { verify_pattern(e, ctx, span); }
+        }
+        IrPattern::Some { inner } | IrPattern::Ok { inner } | IrPattern::Err { inner } => {
+            verify_pattern(inner, ctx, span);
+        }
+        IrPattern::Literal { expr } => verify_expr(expr, ctx),
+        IrPattern::Wildcard | IrPattern::None => {}
+    }
+}
+
+// ── Operator–type consistency ─────────────────────────────────────
+
+/// Check that a BinOp variant is consistent with its operand types.
+/// Only flags clear contradictions (e.g., AddInt on String operands).
+fn verify_binop_types(op: BinOp, left: &IrExpr, right: &IrExpr, ctx: &mut VerifyCtx, span: Option<Span>) {
+    let lt = &left.ty;
+    let rt = &right.ty;
+
+    // Skip if either side is Unknown (error recovery) or TypeVar (generic)
+    if is_unresolved(lt) || is_unresolved(rt) { return; }
+
+    let expected = match op {
+        BinOp::AddInt | BinOp::SubInt | BinOp::MulInt
+        | BinOp::DivInt | BinOp::ModInt | BinOp::XorInt => Some(Ty::Int),
+        BinOp::AddFloat | BinOp::SubFloat | BinOp::MulFloat
+        | BinOp::DivFloat => Some(Ty::Float),
+        BinOp::ConcatStr => Some(Ty::String),
+        // PowFloat: used for both Int**Int and Float**Float (codegen handles conversion)
+        // ConcatList, Eq, Neq, comparisons, And, Or — operand types vary
+        _ => None,
+    };
+
+    if let Some(expected_ty) = expected {
+        if !ty_matches(lt, &expected_ty) || !ty_matches(rt, &expected_ty) {
+            ctx.err(
+                format!(
+                    "{:?} expects {} operands, got {} and {}",
+                    op, expected_ty.display(), lt.display(), rt.display()
+                ),
+                span,
+            );
+        }
+    }
+
+    // And/Or require Bool
+    if matches!(op, BinOp::And | BinOp::Or) {
+        if !ty_matches(lt, &Ty::Bool) || !ty_matches(rt, &Ty::Bool) {
+            ctx.err(
+                format!(
+                    "{:?} expects Bool operands, got {} and {}",
+                    op, lt.display(), rt.display()
+                ),
+                span,
+            );
+        }
+    }
+}
+
+fn verify_unop_types(op: UnOp, operand: &IrExpr, ctx: &mut VerifyCtx, span: Option<Span>) {
+    let t = &operand.ty;
+    if is_unresolved(t) { return; }
+
+    let expected = match op {
+        UnOp::NegInt => Some(Ty::Int),
+        UnOp::NegFloat => Some(Ty::Float),
+        UnOp::Not => Some(Ty::Bool),
+    };
+
+    if let Some(expected_ty) = expected {
+        if !ty_matches(t, &expected_ty) {
+            ctx.err(
+                format!(
+                    "{:?} expects {} operand, got {}",
+                    op, expected_ty.display(), t.display()
+                ),
+                span,
+            );
+        }
+    }
+}
+
+fn is_unresolved(ty: &Ty) -> bool {
+    matches!(ty, Ty::Unknown | Ty::TypeVar(_))
+}
+
+fn ty_matches(actual: &Ty, expected: &Ty) -> bool {
+    if is_unresolved(actual) { return true; }
+    std::mem::discriminant(actual) == std::mem::discriminant(expected)
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_program(functions: Vec<IrFunction>, var_table: VarTable) -> IrProgram {
+        IrProgram {
+            functions,
+            top_lets: vec![],
+            type_decls: vec![],
+            var_table,
+            modules: vec![],
+            type_registry: Default::default(),
+            effect_map: Default::default(),
+        }
+    }
+
+    fn lit_int(v: i64) -> IrExpr {
+        IrExpr { kind: IrExprKind::LitInt { value: v }, ty: Ty::Int, span: None }
+    }
+
+    fn var_expr(id: VarId, ty: Ty) -> IrExpr {
+        IrExpr { kind: IrExprKind::Var { id }, ty, span: None }
+    }
+
+    fn make_fn(name: &str, body: IrExpr) -> IrFunction {
+        IrFunction {
+            name: name.into(),
+            params: vec![],
+            ret_ty: body.ty.clone(),
+            body,
+            is_effect: false,
+            is_async: false,
+            is_test: false,
+            generics: None,
+            extern_attrs: vec![],
+            visibility: IrVisibility::Public,
+        }
+    }
+
+    #[test]
+    fn valid_program_no_errors() {
+        let mut vt = VarTable::new();
+        let x = vt.alloc("x".into(), Ty::Int, Mutability::Let, None);
+        let body = IrExpr {
+            kind: IrExprKind::Block {
+                stmts: vec![IrStmt {
+                    kind: IrStmtKind::Bind { var: x, mutability: Mutability::Let, ty: Ty::Int, value: lit_int(1) },
+                    span: None,
+                }],
+                expr: Some(Box::new(var_expr(x, Ty::Int))),
+            },
+            ty: Ty::Int,
+            span: None,
+        };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert!(errors.is_empty(), "expected no errors, got: {:?}", errors);
+    }
+
+    #[test]
+    fn detects_var_id_out_of_bounds() {
+        let vt = VarTable::new(); // empty table
+        let body = var_expr(VarId(99), Ty::Int);
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("VarId(99)"));
+    }
+
+    #[test]
+    fn assign_checks_var_id_bounds() {
+        let vt = VarTable::new(); // empty
+        let body = IrExpr {
+            kind: IrExprKind::Block {
+                stmts: vec![IrStmt {
+                    kind: IrStmtKind::Assign { var: VarId(99), value: lit_int(2) },
+                    span: None,
+                }],
+                expr: None,
+            },
+            ty: Ty::Unit,
+            span: None,
+        };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("VarId(99)"));
+    }
+
+    #[test]
+    fn detects_break_outside_loop() {
+        let vt = VarTable::new();
+        let body = IrExpr { kind: IrExprKind::Break, ty: Ty::Unit, span: None };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("break outside of loop"));
+    }
+
+    #[test]
+    fn allows_break_inside_loop() {
+        let mut vt = VarTable::new();
+        let i = vt.alloc("i".into(), Ty::Int, Mutability::Let, None);
+        let body = IrExpr {
+            kind: IrExprKind::ForIn {
+                var: i,
+                var_tuple: None,
+                iterable: Box::new(IrExpr {
+                    kind: IrExprKind::Range {
+                        start: Box::new(lit_int(0)),
+                        end: Box::new(lit_int(10)),
+                        inclusive: false,
+                    },
+                    ty: Ty::Int, // simplified
+                    span: None,
+                }),
+                body: vec![IrStmt {
+                    kind: IrStmtKind::Expr {
+                        expr: IrExpr { kind: IrExprKind::Break, ty: Ty::Unit, span: None },
+                    },
+                    span: None,
+                }],
+            },
+            ty: Ty::Unit,
+            span: None,
+        };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn detects_binop_type_mismatch() {
+        let vt = VarTable::new();
+        let body = IrExpr {
+            kind: IrExprKind::BinOp {
+                op: BinOp::AddInt,
+                left: Box::new(IrExpr { kind: IrExprKind::LitStr { value: "a".into() }, ty: Ty::String, span: None }),
+                right: Box::new(lit_int(1)),
+            },
+            ty: Ty::Int,
+            span: None,
+        };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("AddInt"));
+    }
+
+    #[test]
+    fn skips_unknown_types_in_binop() {
+        let vt = VarTable::new();
+        let body = IrExpr {
+            kind: IrExprKind::BinOp {
+                op: BinOp::AddInt,
+                left: Box::new(IrExpr { kind: IrExprKind::Hole, ty: Ty::Unknown, span: None }),
+                right: Box::new(lit_int(1)),
+            },
+            ty: Ty::Int,
+            span: None,
+        };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn detects_continue_outside_loop() {
+        let vt = VarTable::new();
+        let body = IrExpr { kind: IrExprKind::Continue, ty: Ty::Unit, span: None };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("continue outside of loop"));
+    }
+
+    #[test]
+    fn verifies_pattern_var_ids() {
+        let mut vt = VarTable::new();
+        let _x = vt.alloc("x".into(), Ty::Int, Mutability::Let, None);
+        // Pattern references VarId(99) which doesn't exist
+        let body = IrExpr {
+            kind: IrExprKind::Match {
+                subject: Box::new(lit_int(1)),
+                arms: vec![IrMatchArm {
+                    pattern: IrPattern::Bind { var: VarId(99) },
+                    guard: None,
+                    body: lit_int(2),
+                }],
+            },
+            ty: Ty::Int,
+            span: None,
+        };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("VarId(99)"));
+    }
+
+    #[test]
+    fn verifies_module_functions() {
+        let mut main_vt = VarTable::new();
+        let _x = main_vt.alloc("x".into(), Ty::Int, Mutability::Let, None);
+
+        let mod_vt = VarTable::new(); // empty
+        let mod_body = var_expr(VarId(99), Ty::Int); // out of bounds in module table
+
+        let prog = IrProgram {
+            functions: vec![make_fn("main", lit_int(0))],
+            top_lets: vec![],
+            type_decls: vec![],
+            var_table: main_vt,
+            modules: vec![IrModule {
+                name: "mymod".into(),
+                versioned_name: None,
+                type_decls: vec![],
+                functions: vec![make_fn("helper", mod_body)],
+                top_lets: vec![],
+                var_table: mod_vt,
+            }],
+            type_registry: Default::default(),
+            effect_map: Default::default(),
+        };
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].fn_name == "mymod.helper");
+    }
+
+    #[test]
+    fn detects_unop_type_mismatch() {
+        let vt = VarTable::new();
+        let body = IrExpr {
+            kind: IrExprKind::UnOp {
+                op: UnOp::NegInt,
+                operand: Box::new(IrExpr {
+                    kind: IrExprKind::LitBool { value: true },
+                    ty: Ty::Bool,
+                    span: None,
+                }),
+            },
+            ty: Ty::Int,
+            span: None,
+        };
+        let prog = make_program(vec![make_fn("main", body)], vt);
+        let errors = verify_program(&prog);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("NegInt"));
+    }
+}

--- a/src/ir/verify.rs
+++ b/src/ir/verify.rs
@@ -274,6 +274,10 @@ fn verify_expr(expr: &IrExpr, ctx: &mut VerifyCtx) {
             verify_expr(object, ctx);
             verify_expr(index, ctx);
         }
+        IrExprKind::MapAccess { object, key } => {
+            verify_expr(object, ctx);
+            verify_expr(key, ctx);
+        }
         IrExprKind::StringInterp { parts } => {
             for p in parts {
                 if let IrStringPart::Expr { expr } = p { verify_expr(expr, ctx); }
@@ -316,6 +320,11 @@ fn verify_stmt(stmt: &IrStmt, ctx: &mut VerifyCtx) {
         IrStmtKind::IndexAssign { target, index, value } => {
             ctx.check_var_id(*target, stmt.span);
             verify_expr(index, ctx);
+            verify_expr(value, ctx);
+        }
+        IrStmtKind::MapInsert { target, key, value } => {
+            ctx.check_var_id(*target, stmt.span);
+            verify_expr(key, ctx);
             verify_expr(value, ctx);
         }
         IrStmtKind::FieldAssign { target, value, .. } => {

--- a/src/ir/visit.rs
+++ b/src/ir/visit.rs
@@ -1,0 +1,192 @@
+// ── IR Visitor trait (read-only) ─────────────────────────────────
+//
+// Centralizes IR tree walking. Each analysis pass implements IrVisitor
+// and overrides only the visit_* methods it needs. The walk_* functions
+// handle exhaustive recursion into child nodes.
+//
+// Adding a new IrExprKind variant requires updating only walk_expr —
+// all passes automatically traverse the new node's children.
+
+use super::*;
+
+/// Read-only visitor for IR trees.
+///
+/// Override `visit_expr` / `visit_stmt` / `visit_pattern` to add custom logic.
+/// Call the corresponding `walk_*` function inside your override to recurse.
+pub trait IrVisitor: Sized {
+    fn visit_expr(&mut self, expr: &IrExpr) { walk_expr(self, expr); }
+    fn visit_stmt(&mut self, stmt: &IrStmt) { walk_stmt(self, stmt); }
+    fn visit_pattern(&mut self, pat: &IrPattern) { walk_pattern(self, pat); }
+}
+
+/// Walk all child expressions/statements/patterns of an expression.
+pub fn walk_expr<V: IrVisitor>(v: &mut V, expr: &IrExpr) {
+    match &expr.kind {
+        // ── Leaf nodes ──
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. } | IrExprKind::LitStr { .. }
+        | IrExprKind::LitBool { .. } | IrExprKind::Unit | IrExprKind::Var { .. }
+        | IrExprKind::FnRef { .. } | IrExprKind::EmptyMap | IrExprKind::OptionNone
+        | IrExprKind::Break | IrExprKind::Continue | IrExprKind::Hole
+        | IrExprKind::Todo { .. } | IrExprKind::RenderedCall { .. } => {}
+
+        // ── Operators ──
+        IrExprKind::BinOp { left, right, .. } => {
+            v.visit_expr(left);
+            v.visit_expr(right);
+        }
+        IrExprKind::UnOp { operand, .. } => {
+            v.visit_expr(operand);
+        }
+
+        // ── Control flow ──
+        IrExprKind::If { cond, then, else_ } => {
+            v.visit_expr(cond);
+            v.visit_expr(then);
+            v.visit_expr(else_);
+        }
+        IrExprKind::Match { subject, arms } => {
+            v.visit_expr(subject);
+            for arm in arms {
+                v.visit_pattern(&arm.pattern);
+                if let Some(g) = &arm.guard { v.visit_expr(g); }
+                v.visit_expr(&arm.body);
+            }
+        }
+        IrExprKind::Block { stmts, expr } | IrExprKind::DoBlock { stmts, expr } => {
+            for s in stmts { v.visit_stmt(s); }
+            if let Some(e) = expr { v.visit_expr(e); }
+        }
+
+        // ── Loops ──
+        IrExprKind::ForIn { iterable, body, .. } => {
+            v.visit_expr(iterable);
+            for s in body { v.visit_stmt(s); }
+        }
+        IrExprKind::While { cond, body } => {
+            v.visit_expr(cond);
+            for s in body { v.visit_stmt(s); }
+        }
+
+        // ── Calls ──
+        IrExprKind::Call { target, args, .. } => {
+            match target {
+                CallTarget::Method { object, .. } => v.visit_expr(object),
+                CallTarget::Computed { callee } => v.visit_expr(callee),
+                _ => {}
+            }
+            for a in args { v.visit_expr(a); }
+        }
+
+        // ── Collections ──
+        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
+        | IrExprKind::Fan { exprs: elements } => {
+            for e in elements { v.visit_expr(e); }
+        }
+        IrExprKind::Record { fields, .. } => {
+            for (_, val) in fields { v.visit_expr(val); }
+        }
+        IrExprKind::SpreadRecord { base, fields } => {
+            v.visit_expr(base);
+            for (_, val) in fields { v.visit_expr(val); }
+        }
+        IrExprKind::MapLiteral { entries } => {
+            for (k, val) in entries { v.visit_expr(k); v.visit_expr(val); }
+        }
+        IrExprKind::Range { start, end, .. } => {
+            v.visit_expr(start);
+            v.visit_expr(end);
+        }
+
+        // ── Access ──
+        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
+            v.visit_expr(object);
+        }
+        IrExprKind::IndexAccess { object, index } => {
+            v.visit_expr(object);
+            v.visit_expr(index);
+        }
+        IrExprKind::MapAccess { object, key } => {
+            v.visit_expr(object);
+            v.visit_expr(key);
+        }
+
+        // ── Functions ──
+        IrExprKind::Lambda { body, .. } => {
+            v.visit_expr(body);
+        }
+
+        // ── Strings ──
+        IrExprKind::StringInterp { parts } => {
+            for p in parts {
+                if let IrStringPart::Expr { expr } = p { v.visit_expr(expr); }
+            }
+        }
+
+        // ── Wrappers (single child) ──
+        IrExprKind::ResultOk { expr: e } | IrExprKind::ResultErr { expr: e }
+        | IrExprKind::OptionSome { expr: e } | IrExprKind::Try { expr: e }
+        | IrExprKind::Await { expr: e }
+        | IrExprKind::Clone { expr: e } | IrExprKind::Deref { expr: e }
+        | IrExprKind::Borrow { expr: e, .. } | IrExprKind::BoxNew { expr: e }
+        | IrExprKind::ToVec { expr: e } => {
+            v.visit_expr(e);
+        }
+        IrExprKind::RustMacro { args, .. } => {
+            for a in args { v.visit_expr(a); }
+        }
+    }
+}
+
+/// Walk all child expressions/patterns of a statement.
+pub fn walk_stmt<V: IrVisitor>(v: &mut V, stmt: &IrStmt) {
+    match &stmt.kind {
+        IrStmtKind::Bind { value, .. } => {
+            v.visit_expr(value);
+        }
+        IrStmtKind::BindDestructure { pattern, value } => {
+            v.visit_pattern(pattern);
+            v.visit_expr(value);
+        }
+        IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => {
+            v.visit_expr(value);
+        }
+        IrStmtKind::IndexAssign { index, value, .. } => {
+            v.visit_expr(index);
+            v.visit_expr(value);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            v.visit_expr(key);
+            v.visit_expr(value);
+        }
+        IrStmtKind::Guard { cond, else_ } => {
+            v.visit_expr(cond);
+            v.visit_expr(else_);
+        }
+        IrStmtKind::Expr { expr } => {
+            v.visit_expr(expr);
+        }
+        IrStmtKind::Comment { .. } => {}
+    }
+}
+
+/// Walk all child patterns of a pattern.
+pub fn walk_pattern<V: IrVisitor>(v: &mut V, pat: &IrPattern) {
+    match pat {
+        IrPattern::Wildcard | IrPattern::Bind { .. } | IrPattern::None => {}
+        IrPattern::Literal { expr } => v.visit_expr(expr),
+        IrPattern::Constructor { args, .. } => {
+            for a in args { v.visit_pattern(a); }
+        }
+        IrPattern::RecordPattern { fields, .. } => {
+            for f in fields {
+                if let Some(p) = &f.pattern { v.visit_pattern(p); }
+            }
+        }
+        IrPattern::Tuple { elements } => {
+            for e in elements { v.visit_pattern(e); }
+        }
+        IrPattern::Some { inner } | IrPattern::Ok { inner } | IrPattern::Err { inner } => {
+            v.visit_pattern(inner);
+        }
+    }
+}

--- a/src/lower/expressions.rs
+++ b/src/lower/expressions.rs
@@ -274,7 +274,11 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
         ast::Expr::IndexAccess { object, index, .. } => {
             let obj = lower_expr(ctx, object);
             let idx = lower_expr(ctx, index);
-            ctx.mk(IrExprKind::IndexAccess { object: Box::new(obj), index: Box::new(idx) }, ty, span)
+            if obj.ty.is_map() {
+                ctx.mk(IrExprKind::MapAccess { object: Box::new(obj), key: Box::new(idx) }, ty, span)
+            } else {
+                ctx.mk(IrExprKind::IndexAccess { object: Box::new(obj), index: Box::new(idx) }, ty, span)
+            }
         }
 
         // ── String interpolation ──

--- a/src/lower/expressions.rs
+++ b/src/lower/expressions.rs
@@ -111,7 +111,7 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
                 ("*", Ty::Float, _) | ("*", _, Ty::Float) => BinOp::MulFloat, ("*", _, _) => BinOp::MulInt,
                 ("/", Ty::Float, _) | ("/", _, Ty::Float) => BinOp::DivFloat, ("/", _, _) => BinOp::DivInt,
                 ("%", Ty::Float, _) | ("%", _, Ty::Float) => BinOp::ModFloat, ("%", _, _) => BinOp::ModInt,
-                ("**", _, _) => BinOp::PowFloat,
+                ("**", Ty::Float, _) | ("**", _, Ty::Float) => BinOp::PowFloat, ("**", _, _) => BinOp::PowInt,
                 ("^", _, _) => BinOp::XorInt,
                 ("++", Ty::String, _) => BinOp::ConcatStr, // legacy
                 ("++", _, _) => BinOp::ConcatList,         // legacy

--- a/src/lower/statements.rs
+++ b/src/lower/statements.rs
@@ -43,7 +43,12 @@ pub(super) fn lower_stmt(ctx: &mut LowerCtx, stmt: &ast::Stmt) -> IrStmt {
             let var = ctx.lookup_var(target).unwrap_or(VarId(0));
             let ir_idx = lower_expr(ctx, index);
             let ir_val = lower_expr(ctx, value);
-            IrStmtKind::IndexAssign { target: var, index: ir_idx, value: ir_val }
+            let var_ty = &ctx.var_table.get(var).ty;
+            if var_ty.is_map() {
+                IrStmtKind::MapInsert { target: var, key: ir_idx, value: ir_val }
+            } else {
+                IrStmtKind::IndexAssign { target: var, index: ir_idx, value: ir_val }
+            }
         }
         ast::Stmt::FieldAssign { target, field, value, .. } => {
             let var = ctx.lookup_var(target).unwrap_or(VarId(0));

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,6 +283,18 @@ fn try_compile_with_ir(file: &str, no_check: bool) -> Result<(String, Option<alm
         almide::optimize::optimize_program(ir);
     }
 
+    // Verify IR integrity (debug builds only)
+    #[cfg(debug_assertions)]
+    if let Some(ref ir) = ir_program {
+        let verify_errors = almide::ir::verify_program(ir);
+        if !verify_errors.is_empty() {
+            for e in &verify_errors {
+                eprintln!("internal compiler error: {}", e);
+            }
+            return Err(format!("{} IR verification error(s)", verify_errors.len()));
+        }
+    }
+
     // Monomorphize row-polymorphic functions (Rust target only)
     if let Some(ref mut ir) = ir_program {
         almide::mono::monomorphize(ir);

--- a/src/mono.rs
+++ b/src/mono.rs
@@ -246,6 +246,10 @@ fn discover_in_expr(
             discover_in_expr(object, bound_fns, program_functions, instances);
             discover_in_expr(index, bound_fns, program_functions, instances);
         }
+        IrExprKind::MapAccess { object, key } => {
+            discover_in_expr(object, bound_fns, program_functions, instances);
+            discover_in_expr(key, bound_fns, program_functions, instances);
+        }
         IrExprKind::Lambda { body, .. } => discover_in_expr(body, bound_fns, program_functions, instances),
         IrExprKind::StringInterp { parts } => {
             for part in parts {
@@ -272,6 +276,10 @@ fn discover_in_stmt(
         | IrStmtKind::Assign { value, .. } => discover_in_expr(value, bound_fns, program_functions, instances),
         IrStmtKind::IndexAssign { index, value, .. } => {
             discover_in_expr(index, bound_fns, program_functions, instances);
+            discover_in_expr(value, bound_fns, program_functions, instances);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            discover_in_expr(key, bound_fns, program_functions, instances);
             discover_in_expr(value, bound_fns, program_functions, instances);
         }
         IrStmtKind::FieldAssign { value, .. } => discover_in_expr(value, bound_fns, program_functions, instances),
@@ -435,6 +443,10 @@ fn substitute_expr_types(expr: &mut IrExpr, bindings: &HashMap<String, Ty>) {
             substitute_expr_types(object, bindings);
             substitute_expr_types(index, bindings);
         }
+        IrExprKind::MapAccess { object, key } => {
+            substitute_expr_types(object, bindings);
+            substitute_expr_types(key, bindings);
+        }
         IrExprKind::ForIn { iterable, body, .. } => {
             substitute_expr_types(iterable, bindings);
             for s in body { substitute_stmt_types(s, bindings); }
@@ -472,6 +484,10 @@ fn substitute_stmt_types(stmt: &mut IrStmt, bindings: &HashMap<String, Ty>) {
         }
         IrStmtKind::IndexAssign { index, value, .. } => {
             substitute_expr_types(index, bindings);
+            substitute_expr_types(value, bindings);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            substitute_expr_types(key, bindings);
             substitute_expr_types(value, bindings);
         }
         IrStmtKind::FieldAssign { value, .. } => substitute_expr_types(value, bindings),
@@ -589,6 +605,10 @@ fn rewrite_expr_calls(
             rewrite_expr_calls(object, bound_fns, instances, fn_param_types);
             rewrite_expr_calls(index, bound_fns, instances, fn_param_types);
         }
+        IrExprKind::MapAccess { object, key } => {
+            rewrite_expr_calls(object, bound_fns, instances, fn_param_types);
+            rewrite_expr_calls(key, bound_fns, instances, fn_param_types);
+        }
         IrExprKind::Lambda { body, .. } => rewrite_expr_calls(body, bound_fns, instances, fn_param_types),
         IrExprKind::StringInterp { parts } => {
             for part in parts {
@@ -615,6 +635,10 @@ fn rewrite_stmt_calls(
         | IrStmtKind::Assign { value, .. } => rewrite_expr_calls(value, bound_fns, instances, fn_param_types),
         IrStmtKind::IndexAssign { index, value, .. } => {
             rewrite_expr_calls(index, bound_fns, instances, fn_param_types);
+            rewrite_expr_calls(value, bound_fns, instances, fn_param_types);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            rewrite_expr_calls(key, bound_fns, instances, fn_param_types);
             rewrite_expr_calls(value, bound_fns, instances, fn_param_types);
         }
         IrStmtKind::FieldAssign { value, .. } => rewrite_expr_calls(value, bound_fns, instances, fn_param_types),

--- a/src/optimize/mod.rs
+++ b/src/optimize/mod.rs
@@ -109,6 +109,10 @@ fn fold_expr(expr: &mut IrExpr) {
             fold_expr(object);
             fold_expr(index);
         }
+        IrExprKind::MapAccess { object, key } => {
+            fold_expr(object);
+            fold_expr(key);
+        }
         IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
             fold_expr(object);
         }
@@ -212,6 +216,10 @@ fn fold_stmt(stmt: &mut IrStmt) {
         | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => fold_expr(value),
         IrStmtKind::IndexAssign { index, value, .. } => {
             fold_expr(index);
+            fold_expr(value);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            fold_expr(key);
             fold_expr(value);
         }
         IrStmtKind::Guard { cond, else_ } => {

--- a/src/optimize/propagate.rs
+++ b/src/optimize/propagate.rs
@@ -114,6 +114,10 @@ fn propagate_expr(expr: &mut IrExpr, constants: &HashMap<VarId, IrExpr>) {
             propagate_expr(object, constants);
             propagate_expr(index, constants);
         }
+        IrExprKind::MapAccess { object, key } => {
+            propagate_expr(object, constants);
+            propagate_expr(key, constants);
+        }
         IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
             propagate_expr(object, constants);
         }
@@ -143,6 +147,10 @@ fn propagate_stmt(stmt: &mut IrStmt, constants: &HashMap<VarId, IrExpr>) {
         | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => propagate_expr(value, constants),
         IrStmtKind::IndexAssign { index, value, .. } => {
             propagate_expr(index, constants);
+            propagate_expr(value, constants);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            propagate_expr(key, constants);
             propagate_expr(value, constants);
         }
         IrStmtKind::Guard { cond, else_ } => {


### PR DESCRIPTION
## Summary

- Add `src/ir/verify.rs` — debug-only IR integrity verification pass that runs after optimization, before monomorphization
- Add `BinOp::PowInt` to fix type-dispatch inconsistency discovered by the verification pass
- Add roadmap document for IR verification

## IR Verification Checks (16 tests)

| Check | Description |
|-------|-------------|
| VarId bounds | Every variable reference maps to a valid VarTable entry |
| Parameter uniqueness | No two params in a function share the same VarId |
| Loop context | Break/Continue only inside ForIn, While, or DoBlock |
| BinOp type consistency | AddInt requires Int operands, AddFloat requires Float, etc. |
| UnOp type consistency | NegInt requires Int, Not requires Bool |
| Record field uniqueness | No duplicate field names in type declarations |
| Variant case uniqueness | No duplicate case names in variant types |
| Pattern VarId validation | All VarIds in match patterns are valid |
| Module coverage | All checks apply to imported user modules |

## PowInt Operator

The BinOp enum had AddInt/AddFloat, SubInt/SubFloat, etc. for every arithmetic operator — except power, which only had `PowFloat`. The codegen was compensating by checking `left.ty` at render time. This violated the design principle that operators are type-dispatched at lowering time.

**Before:** `("**", _, _) => BinOp::PowFloat` → codegen checks `left.ty` to pick template
**After:** `("**", Ty::Float, _) => BinOp::PowFloat, ("**", _, _) => BinOp::PowInt` → codegen uses the correct variant directly

## Test plan

- [x] `cargo test` — 84 tests pass (including 16 new verify tests)
- [x] `almide test spec/` — all 110 test files pass
- [x] No IR verification errors on any existing test