### PR TITLE
WASM compile failures: 0 — fix checker RecordPattern and mono VarId sharing

### DIFF
--- a/docs/roadmap/active/wasm-runtime-traps.md
+++ b/docs/roadmap/active/wasm-runtime-traps.md
@@ -31,13 +31,17 @@ List iteration は実装済み。Map iteration は Map runtime に依存。
 
 **Fix**: Map runtime 後に実装。
 
-### Fan/async [4 files]
+### Fan (sequential fallback) [4 files]
 fan basic, fan.map, fan.race, fan.any
 
-**Root**: fan (並行実行) は WASM の single-thread model と根本的に非互換。
-WASM には thread/coroutine がない。
+**Root**: fan (並行実行) の WASM codegen が未実装。
+WASM は single-thread だが、fan の semantics は「複数の式を実行して結果を集める」。
+sequential に実行すれば同じ結果が得られる。
 
-**Fix**: skip (wasm:skip マーカー)。WASM target では fan は使えない。
+**Fix**: fan を sequential fallback で実装。
+- `fan { a, b, c }` → `(a(), b(), c())`
+- `fan.map(list, fn)` → `list.map(list, fn)`
+- `fan.race(list, fn)` → 先頭要素を返す
 
 ### Deep equality [3 files]
 nested list equality, deep equality on nested structures, recursive variant types
@@ -92,7 +96,7 @@ structured error, string keys, tco deep recursion, variant roundtrip
 
 | Priority | Category | Files | Impact | Effort |
 |----------|----------|-------|--------|--------|
-| 1 | Fan skip | 4 | -4 traps | 5 min |
+| 1 | Fan sequential fallback | 4 | -4 traps | Low |
 | 2 | Protocol dispatch | 8 | -8 traps, 大量のテスト unblock | Medium |
 | 3 | Record/Variant features | 3 | -3 traps | Medium |
 | 4 | Type features | 5 | -5 traps | Medium (個別) |
@@ -108,7 +112,7 @@ structured error, string keys, tco deep recursion, variant roundtrip
 | After step | Pass | Traps |
 |------------|------|-------|
 | 現状 | 21 | 44 |
-| 1 (fan skip) | 21 | 40 |
+| 1 (fan) | 25 | 40 |
 | 2 (protocol) | 29+ | 32 |
 | 3-5 (features) | 41+ | 20 |
 | 6-8 (equality/string/codec) | 50+ | 11 |

--- a/docs/roadmap/active/wasm-runtime-traps.md
+++ b/docs/roadmap/active/wasm-runtime-traps.md
@@ -1,0 +1,115 @@
+# WASM Runtime Traps [ACTIVE]
+
+## Status: 21 pass, 44 runtime traps, 8 skipped, 0 compile failures
+
+## Trap Categories (44 files)
+
+### Protocol/Convention dispatch [8 files]
+basic protocol method, basic protocol satisfaction, builder pattern via protocol,
+convention method resolution, convention method via UFCS, diamond protocol,
+generic function with protocol bound, protocol methods chained via pipe
+
+**Root**: protocol メソッド呼び出しが `unreachable` に落ちる。
+WASM codegen で convention/protocol dispatch が未実装。
+Rust codegen は `TypeName.method(self)` の直接呼び出しに変換するが、WASM ではテーブル間接呼び出しか名前解決が必要。
+
+**Fix**: emit_call で protocol method を Named call に解決する。
+
+### Map operations [4 files]
+map basic operations, map creation and get, empty map operations, empty map with type annotation
+
+**Root**: Map 型の WASM runtime が未実装。
+List は linear memory + length header で実装済みだが、Map はハッシュテーブルが必要。
+
+**Fix**: Map runtime を実装（hash + bucket array）。大工事。
+
+### Map iteration [3 files]
+for over map, for with map tuple destructure, for with zip
+
+**Root**: `for k, v in map` の WASM codegen が未実装。
+List iteration は実装済み。Map iteration は Map runtime に依存。
+
+**Fix**: Map runtime 後に実装。
+
+### Fan/async [4 files]
+fan basic, fan.map, fan.race, fan.any
+
+**Root**: fan (並行実行) は WASM の single-thread model と根本的に非互換。
+WASM には thread/coroutine がない。
+
+**Fix**: skip (wasm:skip マーカー)。WASM target では fan は使えない。
+
+### Deep equality [3 files]
+nested list equality, deep equality on nested structures, recursive variant types
+
+**Root**: `assert_eq` で nested containers (List[List[T]], variant with payloads) の
+deep equality が incomplete。`option_eq_i64` / `list_eq` が shallow comparison のみ。
+
+**Fix**: runtime の eq 関数を recursive にする。型情報に基づいた dispatch が必要。
+
+### Record/Variant features [3 files]
+let record destructure, nested open record, basic variant record construction
+
+**Root**: record destructure (`let { name, age } = person`) と variant record
+construction の WASM codegen が incomplete。
+
+**Fix**: emit_stmt の BindDestructure と emit_record の variant record case を実装。
+
+### Type features [5 files]
+match constructor with payload, match nested option, default fields - omit all defaults,
+comparison on type variable, multi type param generic
+
+**Root**: 個別のパターンマッチや generic 関数の codegen edge case。
+各テストで最初に trap する箇所を特定して個別修正。
+
+**Fix**: 各ケースを調査して修正。
+
+### String operations [2 files]
+string split and join, json stringify
+
+**Root**: `string.split`, `string.join` の WASM runtime が未実装 (stub)。
+
+**Fix**: runtime に string split/join を実装。
+
+### Import/Codec [4 files]
+encode/decode roundtrip, result.map, naming strategy, unit variant encode
+
+**Root**: Codec 系 + module import の WASM 対応。
+
+**Fix**: 大部分は skip 対象。result.map は stdlib runtime に追加。
+
+### Misc codegen [4 files]
+UFCS basic, pipe into list function, nested closure, do guard
+
+**Root**: 個別の codegen パターン。UFCS 変換、pipe desugar、closure の nested capture 等。
+
+**Fix**: 各ケースを調査して修正。
+
+### Other [4 files]
+structured error, string keys, tco deep recursion, variant roundtrip
+
+## Priority Order
+
+| Priority | Category | Files | Impact | Effort |
+|----------|----------|-------|--------|--------|
+| 1 | Fan skip | 4 | -4 traps | 5 min |
+| 2 | Protocol dispatch | 8 | -8 traps, 大量のテスト unblock | Medium |
+| 3 | Record/Variant features | 3 | -3 traps | Medium |
+| 4 | Type features | 5 | -5 traps | Medium (個別) |
+| 5 | Misc codegen | 4 | -4 traps | Medium (個別) |
+| 6 | Deep equality | 3 | -3 traps | Medium |
+| 7 | String operations | 2 | -2 traps | Low |
+| 8 | Import/Codec skip | 4 | -4 traps | 5 min |
+| 9 | Map runtime | 7 | -7 traps | High (hash table) |
+| 10 | TCO | 1 | -1 trap | High |
+
+## Expected Progress
+
+| After step | Pass | Traps |
+|------------|------|-------|
+| 現状 | 21 | 44 |
+| 1 (fan skip) | 21 | 40 |
+| 2 (protocol) | 29+ | 32 |
+| 3-5 (features) | 41+ | 20 |
+| 6-8 (equality/string/codec) | 50+ | 11 |
+| 9 (map) | 57+ | 4 |

--- a/src/check/calls.rs
+++ b/src/check/calls.rs
@@ -318,6 +318,9 @@ impl Checker {
                         final_bindings.insert(g.clone(), self.fresh_var());
                     }
                 }
+                if name.contains("either_map_right") || name.contains("map_right") {
+                    eprintln!("[CHECKER CALL] {} bindings={:?} final_bindings={:?}", name, bindings, final_bindings);
+                }
                 let ret = if final_bindings.is_empty() { sig.ret.clone() } else { crate::types::substitute(&sig.ret, &final_bindings) };
                 ret
             }

--- a/src/check/infer.rs
+++ b/src/check/infer.rs
@@ -523,14 +523,20 @@ impl Checker {
                     self.bind_pattern(arg, payload_tys.get(i).unwrap_or(&Ty::Unknown));
                 }
             }
-            ast::Pattern::RecordPattern { fields, .. } => {
+            ast::Pattern::RecordPattern { name, fields, .. } => {
                 let resolved = self.env.resolve_named(ty);
                 let field_tys: Vec<(String, Ty)> = match &resolved {
                     Ty::Record { fields } | Ty::OpenRecord { fields } => fields.clone(),
-                    Ty::Variant { cases, .. } => cases.iter().find_map(|c| match &c.payload {
-                        VariantPayload::Record(fs) => Some(fs.iter().map(|(n, t, _)| (n.clone(), t.clone())).collect()),
-                        _ => None,
-                    }).unwrap_or_default(),
+                    Ty::Variant { cases, .. } => {
+                        // Find the specific case matching the pattern name
+                        cases.iter()
+                            .find(|c| c.name == *name)
+                            .and_then(|c| match &c.payload {
+                                VariantPayload::Record(fs) => Some(fs.iter().map(|(n, t, _)| (n.clone(), t.clone())).collect()),
+                                _ => None,
+                            })
+                            .unwrap_or_default()
+                    }
                     _ => vec![],
                 };
                 for f in fields {

--- a/src/codegen/emit_wasm/statements.rs
+++ b/src/codegen/emit_wasm/statements.rs
@@ -455,12 +455,13 @@ fn scan_pattern(pattern: &crate::ir::IrPattern, subject_ty: &crate::types::Ty, l
                 crate::types::Ty::Named(_, args) if !args.is_empty() => args.clone(),
                 crate::types::Ty::Applied(_, args) if !args.is_empty() => args.clone(),
                 crate::types::Ty::Variant { .. } => {
-                    // For inline Variant types, use VarTable (updated by mono propagate)
-                    // as the source of truth for field types.
+                    // Use pattern.ty (set by mono substitute_pattern_types) — no VarTable
                     for arg in args.iter() {
-                        if let crate::ir::IrPattern::Bind { var, .. } = arg {
-                            let vt_ty = &vt.get(*var).ty;
-                            if let Some(val_type) = values::ty_to_valtype(vt_ty) {
+                        if let crate::ir::IrPattern::Bind { var, ty } = arg {
+                            let effective_ty = if matches!(ty, crate::types::Ty::Unknown | crate::types::Ty::TypeVar(_)) {
+                                &vt.get(*var).ty // fallback only
+                            } else { ty };
+                            if let Some(val_type) = values::ty_to_valtype(effective_ty) {
                                 locals.push((*var, val_type));
                             }
                         }
@@ -470,19 +471,20 @@ fn scan_pattern(pattern: &crate::ir::IrPattern, subject_ty: &crate::types::Ty, l
                 _ => vec![],
             };
             for (i, arg) in args.iter().enumerate() {
-                if let crate::ir::IrPattern::Bind { var, .. } = arg {
-                    let var_ty = vt.get(*var).ty.clone();
-                    if var.0 == 107 || (ctor_name == "Right" && vt.get(*var).name == "v") {
-                        eprintln!("[SCAN RIGHT] {}[{}] var={:?} '{}' vt_ty={:?} subject={:?} type_args={:?}",
-                            ctor_name, i, var, vt.get(*var).name, var_ty, subject_ty, subject_type_args);
-                    }
-                    let resolved = if !subject_type_args.is_empty() {
+                if let crate::ir::IrPattern::Bind { var, ty: pat_ty } = arg {
+                    // Use pattern.ty first (set by mono), fall back to VarTable + substitution
+                    let resolved = if !matches!(pat_ty, crate::types::Ty::Unknown | crate::types::Ty::TypeVar(_))
+                        && !matches!(pat_ty, crate::types::Ty::Named(n, a) if a.is_empty() && n.len() <= 2 && n.chars().next().map_or(false, |c| c.is_uppercase()))
+                    {
+                        pat_ty.clone()
+                    } else if !subject_type_args.is_empty() {
+                        let var_ty = vt.get(*var).ty.clone();
                         let mut gnames = Vec::new();
                         super::expressions::collect_type_param_names(&var_ty, &mut gnames);
                         if gnames.is_empty() { var_ty } else {
                             super::expressions::substitute_type_params(&var_ty, &gnames, &subject_type_args)
                         }
-                    } else { var_ty };
+                    } else { vt.get(*var).ty.clone() };
                     if let Some(val_type) = values::ty_to_valtype(&resolved) {
                         locals.push((*var, val_type));
                     }


### PR DESCRIPTION
## Summary

- WASM compile failures: **1→0** (type_system_test + default_fields_test 解消)
- Rust 153/153 維持

## Root Causes Fixed

### 1. Mono VarId sharing (type_system_test)
`tree_value__Int` と `tree_value__String` が VarTable の同じ VarId を共有。
最後に走った mono が VarTable を上書き → scan が間違った型で local を宣言。

**Fix**: scan_pattern の Constructor handler で VarTable ではなく `pattern.ty` を使用。
`IrPattern::Bind { var, ty }` の `ty` は IR ノード内蔵で関数ごとに独立。

### 2. Checker RecordPattern bind (default_fields_test)
`bind_pattern` で `Variant { cases }` の `find_map` が**最初の Record case** を返していた。
`Rect { width, .. }` パターンなのに Circle の fields を参照 → `width: Unknown`。

**Fix**: `find_map` → `find(|c| c.name == *name)` でパターン名に一致する case を検索。

## Test plan
- [x] `almide test` — 153/153 pass
- [x] `almide test spec/lang/ --target wasm` — 0 compile failures, 21 pass, 44 runtime traps, 8 skipped