### PR TITLE
WASM deep equality, do-block return, list.zip/slice/insert/remove_at

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -48,7 +48,7 @@
 | [Almide Shell](on-hold/almide-shell.md) | AI-native REPL |
 | [LLM Integration](on-hold/llm-integration.md) | `almide forge`, `almide fix` |
 | [LLM → IR Generation](on-hold/llm-ir-generation.md) | Parser bypass |
-| [Self-Hosting](on-hold/self-hosting.md) | |
+| [Self-Hosting](on-hold/self-hosting.md) | 350KB WASM bootstrap compiler → LLM 自律進化ループ |
 
 ## On Hold — Compiler Internals
 

--- a/docs/roadmap/on-hold/self-hosting.md
+++ b/docs/roadmap/on-hold/self-hosting.md
@@ -1,30 +1,82 @@
-# Self-Hosting
+# Self-Hosting: Autonomous Bootstrap Compiler
 
-**Status**: Far Future
-**Priority**: Low
-**Prerequisite**: Language spec stabilization, benchmark parity with Python/Go
+**Status**: On Hold (Phase 3+ prerequisite)
+**Priority**: Strategic — ミッション直結
+**Prerequisite**: 言語仕様安定, WASM direct emit 完成, Protocol/Generics 成熟
 
-## Summary
+## なぜやるのか
 
-Rewrite the Almide compiler in Almide itself, replacing the current Rust implementation.
+Almide のミッションは **modification survival rate** — LLM が最も正確に書ける言語であること。
 
-## Why Not Now
+セルフホスティングはこのミッションの論理的帰結になる:
 
-- Language spec is still evolving (generics Phase 1, no trait/impl yet, no recursive generic variants)
-- Every spec change would create a bootstrapping problem (need old compiler to build new compiler)
-- Development velocity would drop significantly
-- Almide's mission is **modification survival rate**, not self-proof — effort is better spent on benchmarks and stdlib
+1. **コンパイラのソースが Almide で書かれている** → LLM が最も正確に読み書きできるコンパイラになる
+2. **WASM direct emit で 350KB 級の全部入りバイナリが出せる** → compiler + formatter + test runner + type checker が単一バイナリに収まる
+3. **1 + 2 の組み合わせ** → LLM がコンパイラ自体を改変 → 再コンパイル → 改変されたコンパイラでさらに改変、というループが自己完結する
 
-## Prerequisites Before Starting
+つまり: **dev container に 350KB の WASM バイナリを 1 つ置くだけで、LLM が自分の道具を自分で研ぐループが回り始める。**
 
-- [ ] type system extensions complete (row polymorphism, container protocols — see [Type System Extensions](../active/type-system.md))
-- [ ] Type system extensions done
-- [ ] Generics fully stable (recursive variants, trait bounds)
-- [ ] Benchmark results competitive with Python/Go across multiple tasks
-- [ ] Language spec freeze (or near-freeze)
+普通の言語でこれは成立しない:
+- ソースが複雑すぎて LLM が壊す → 修正生存率が低い
+- ツールチェーンの依存関係で環境構築に失敗する → セットアップコストが高い
+- バイナリが大きすぎて配布が重い → 起動コストが高い
 
-## When It Makes Sense
+Almide は 3 つとも解決できる位置にいる。
 
-- Language spec is stable enough that bootstrap breakage is rare
-- Need to demonstrate "Almide can build real systems" for adoption
-- Dogfooding value outweighs development cost
+## ゴール像
+
+```
+350KB WASM バイナリ 1 つ:
+  almide compile  — セルフコンパイル可能
+  almide fmt      — フォーマッタ内蔵
+  almide test     — テストランナー内蔵
+  almide check    — 型チェッカー内蔵
+
+実行環境:
+  wasmtime / wasmer / ブラウザ / エッジ — どこでも同じバイナリが動く
+
+LLM ループ:
+  LLM がソースを読む → 修正 → almide test → almide compile → 新しいコンパイラ
+  ↑ このループが外部依存ゼロで回る
+```
+
+## 段階的移行
+
+| Phase | 対象 | 理由 |
+|-------|------|------|
+| 0 | formatter | 文字列処理中心、壊れても被害が限定的 |
+| 1 | test runner | コンパイラ本体への依存が少ない |
+| 2 | lexer | 文字列処理中心、依存が少ない |
+| 3 | parser | 再帰下降、データ構造操作 |
+| 4 | type checker | 最も複雑、言語機能をフルに使う |
+| 5 | lowering + codegen | IR 変換、WASM emit |
+| 6 | bootstrap | 古い Almide コンパイラで新しい Almide コンパイラをコンパイル |
+
+Phase 0-1 は言語機能の成熟度テストを兼ねる。ここで足りない機能が見つかれば言語側にフィードバックする。
+
+## 前提条件
+
+- [ ] WASM direct emit が stdlib 含めて完成している
+- [ ] Protocol / Generics が安定している（コンパイラの内部データ構造に必要）
+- [ ] ファイル I/O が WASI 経由で動く
+- [ ] 言語仕様がほぼ凍結されている（bootstrap breakage を最小化）
+- [ ] テストカバレッジがコンパイラの正しさを十分に保証している
+
+## 技術的課題
+
+- **Bootstrap 信頼チェーン**: 最初の 1 回は Rust 版からビルドする必要がある
+- **WASM 上でのファイル I/O**: WASI で解決可能だが、コンパイラのファイルアクセスパターンとの整合が要る
+- **コンパイラの複雑さ**: 型推論・パターンマッチ・IR 変換はAlmide の言語機能を限界まで使う。足りなければ言語を拡張する必要がある
+- **バイナリサイズ**: 350KB 目標を維持するために、コンパイラ自体のコードサイズを意識した設計が必要
+
+## 成功したとき何が起きるか
+
+**Almide は「LLM が最も正確に書ける言語」から「LLM が自律的に進化させられるツールチェーン」になる。**
+
+350KB の WASM バイナリが dev container に 1 つあれば、外部依存なしに:
+- コンパイラ自体のバグを LLM が修正できる
+- 新しい最適化パスを LLM が追加できる
+- 新しいターゲットを LLM が実装できる
+- これらすべてをテスト付きで検証できる
+
+コンパイラが小さく、ソースが LLM に読みやすく、ツールが自己完結している — この 3 つが揃ったとき、コンパイラは **ソフトウェアではなくエージェントの一部** になる。

--- a/src/codegen/emit_wasm/calls_list.rs
+++ b/src/codegen/emit_wasm/calls_list.rs
@@ -642,6 +642,65 @@ impl FuncCompiler<'_> {
                     end;
                 });
             }
+            "zip" => {
+                // zip(xs, ys) → List[(A, B)]
+                // Each tuple is heap-allocated: [a_value, b_value]
+                let a_ty = self.list_elem_ty(&args[0].ty);
+                let b_ty = self.list_elem_ty(&args[1].ty);
+                let a_size = values::byte_size(&a_ty);
+                let b_size = values::byte_size(&b_ty);
+                let tuple_size = a_size + b_size;
+                let s = self.match_i32_base + self.match_depth;
+                // mem[0]=xs, mem[4]=ys
+                wasm!(self.func, { i32_const(0); });
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { i32_store(0); i32_const(4); });
+                self.emit_expr(&args[1]);
+                wasm!(self.func, {
+                    i32_store(0);
+                    // len = min(xs.len, ys.len)
+                    i32_const(0); i32_load(0); i32_load(0);
+                    i32_const(4); i32_load(0); i32_load(0);
+                    i32_lt_u;
+                    if_i32;
+                      i32_const(0); i32_load(0); i32_load(0);
+                    else_;
+                      i32_const(4); i32_load(0); i32_load(0);
+                    end;
+                    local_set(s); // len
+                    // Alloc result: list of ptrs to tuples
+                    i32_const(4); local_get(s); i32_const(4); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(s + 1);
+                    local_get(s + 1); local_get(s); i32_store(0);
+                    i32_const(0); local_set(s + 2); // i
+                    block_empty; loop_empty;
+                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
+                      // Alloc tuple
+                      i32_const(tuple_size as i32); call(self.emitter.rt.alloc); local_set(s + 3);
+                      // Copy a: tuple[0] = xs[i]
+                      local_get(s + 3);
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s + 2); i32_const(a_size as i32); i32_mul; i32_add;
+                });
+                self.emit_elem_copy(&a_ty);
+                // Copy b: tuple[a_size] = ys[i]
+                wasm!(self.func, {
+                      local_get(s + 3); i32_const(a_size as i32); i32_add;
+                      i32_const(4); i32_load(0); i32_const(4); i32_add;
+                      local_get(s + 2); i32_const(b_size as i32); i32_mul; i32_add;
+                });
+                self.emit_elem_copy(&b_ty);
+                wasm!(self.func, {
+                      // result[i] = tuple_ptr
+                      local_get(s + 1); i32_const(4); i32_add;
+                      local_get(s + 2); i32_const(4); i32_mul; i32_add;
+                      local_get(s + 3); i32_store(0);
+                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      br(0);
+                    end; end;
+                    local_get(s + 1);
+                });
+            }
             _ => return false,
         }
         true

--- a/src/codegen/emit_wasm/calls_list.rs
+++ b/src/codegen/emit_wasm/calls_list.rs
@@ -158,28 +158,40 @@ impl FuncCompiler<'_> {
                 });
             }
             "slice" => {
+                // slice(xs, start, end) → List[A]
                 let elem_ty = self.list_elem_ty(&args[0].ty);
-                let elem_size = values::byte_size(&elem_ty);
+                let es = values::byte_size(&elem_ty) as i32;
                 let s = self.match_i32_base + self.match_depth;
-                // xs → mem[0], start, end
+                // mem[0]=xs
                 wasm!(self.func, { i32_const(0); });
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { i32_store(0); });
-                self.emit_expr(&args[1]); // start: i64
-                wasm!(self.func, { i32_wrap_i64; local_set(s); }); // s = start
-                self.emit_expr(&args[2]); // end: i64
+                self.emit_expr(&args[1]); // start
+                wasm!(self.func, { i32_wrap_i64; local_set(s); });
+                self.emit_expr(&args[2]); // end
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s + 1); // s+1 = end
-                    // new_len = end - start
-                    local_get(s + 1); local_get(s); i32_sub; local_set(s + 2);
-                    // alloc: 4 + new_len * elem_size
-                    i32_const(4); local_get(s + 2); i32_const(elem_size as i32); i32_mul; i32_add;
+                    i32_wrap_i64; local_set(s + 1);
+                    local_get(s + 1); local_get(s); i32_sub; local_set(s + 2); // new_len
+                    i32_const(4); local_get(s + 2); i32_const(es); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(s + 3);
                     local_get(s + 3); local_get(s + 2); i32_store(0);
+                    // copy loop
+                    i32_const(0); local_set(s + 2); // reuse as i
+                    block_empty; loop_empty;
+                      local_get(s + 2); local_get(s + 1); local_get(s); i32_sub; i32_ge_u; br_if(1);
+                      local_get(s + 3); i32_const(4); i32_add;
+                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s); local_get(s + 2); i32_add;
+                      i32_const(es); i32_mul; i32_add;
                 });
-                // memcpy: dst[4..] = src[4 + start*elem_size ..]
-                self.emit_memcpy_loop(s + 4, s + 3, s, elem_size as usize);
-                wasm!(self.func, { local_get(s + 3); });
+                self.emit_elem_copy(&elem_ty);
+                wasm!(self.func, {
+                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      br(0);
+                    end; end;
+                    local_get(s + 3);
+                });
             }
             "reverse" => {
                 let elem_ty = self.list_elem_ty(&args[0].ty);
@@ -700,6 +712,158 @@ impl FuncCompiler<'_> {
                     end; end;
                     local_get(s + 1);
                 });
+            }
+            "set" => {
+                // set(xs, i, val) → List[A]: copy + replace element at i
+                let elem_ty = self.list_elem_ty(&args[0].ty);
+                let es = values::byte_size(&elem_ty) as i32;
+                let s = self.match_i32_base + self.match_depth;
+                // mem[0]=xs
+                wasm!(self.func, { i32_const(0); });
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { i32_store(0); });
+                self.emit_expr(&args[1]); // i: i64
+                wasm!(self.func, {
+                    i32_wrap_i64; local_set(s); // s = idx
+                    i32_const(0); i32_load(0); i32_load(0); local_set(s + 1); // len
+                    // Alloc copy
+                    i32_const(4); local_get(s + 1); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(s + 2);
+                    local_get(s + 2); local_get(s + 1); i32_store(0);
+                    // Copy all elements
+                    i32_const(0); local_set(s + 3);
+                    block_empty; loop_empty;
+                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
+                      local_get(s + 2); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_elem_copy(&elem_ty);
+                wasm!(self.func, {
+                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      br(0);
+                    end; end;
+                });
+                // Overwrite dst[idx] with val
+                wasm!(self.func, {
+                    local_get(s + 2); i32_const(4); i32_add;
+                    local_get(s); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_expr(&args[2]);
+                self.emit_elem_store(&elem_ty);
+                wasm!(self.func, { local_get(s + 2); });
+            }
+            "insert" => {
+                // insert(xs, i, val) → List[A]: copy with element inserted at i
+                let elem_ty = self.list_elem_ty(&args[0].ty);
+                let es = values::byte_size(&elem_ty) as i32;
+                let s = self.match_i32_base + self.match_depth;
+                wasm!(self.func, { i32_const(0); });
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { i32_store(0); });
+                self.emit_expr(&args[1]);
+                wasm!(self.func, {
+                    i32_wrap_i64; local_set(s); // idx
+                    i32_const(0); i32_load(0); i32_load(0); local_set(s + 1); // old_len
+                    // new_len = old_len + 1
+                    i32_const(4); local_get(s + 1); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(s + 2);
+                    local_get(s + 2); local_get(s + 1); i32_const(1); i32_add; i32_store(0);
+                    // Copy [0..idx)
+                    i32_const(0); local_set(s + 3);
+                    block_empty; loop_empty;
+                      local_get(s + 3); local_get(s); i32_ge_u; br_if(1);
+                      local_get(s + 2); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_elem_copy(&elem_ty);
+                wasm!(self.func, {
+                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      br(0);
+                    end; end;
+                });
+                // Insert val at idx
+                wasm!(self.func, {
+                    local_get(s + 2); i32_const(4); i32_add;
+                    local_get(s); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_expr(&args[2]);
+                self.emit_elem_store(&elem_ty);
+                // Copy [idx..old_len)
+                wasm!(self.func, {
+                    local_get(s); local_set(s + 3);
+                    block_empty; loop_empty;
+                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
+                      local_get(s + 2); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_elem_copy(&elem_ty);
+                wasm!(self.func, {
+                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      br(0);
+                    end; end;
+                    local_get(s + 2);
+                });
+            }
+            "remove_at" => {
+                // remove_at(xs, i) → List[A]
+                let elem_ty = self.list_elem_ty(&args[0].ty);
+                let es = values::byte_size(&elem_ty) as i32;
+                let s = self.match_i32_base + self.match_depth;
+                wasm!(self.func, { i32_const(0); });
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { i32_store(0); });
+                self.emit_expr(&args[1]);
+                wasm!(self.func, {
+                    i32_wrap_i64; local_set(s); // idx
+                    i32_const(0); i32_load(0); i32_load(0); local_set(s + 1); // old_len
+                    // new_len = old_len - 1
+                    i32_const(4); local_get(s + 1); i32_const(1); i32_sub; i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(s + 2);
+                    local_get(s + 2); local_get(s + 1); i32_const(1); i32_sub; i32_store(0);
+                    // Copy [0..idx)
+                    i32_const(0); local_set(s + 3);
+                    block_empty; loop_empty;
+                      local_get(s + 3); local_get(s); i32_ge_u; br_if(1);
+                      local_get(s + 2); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_elem_copy(&elem_ty);
+                wasm!(self.func, {
+                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      br(0);
+                    end; end;
+                });
+                // Copy [idx+1..old_len)
+                wasm!(self.func, {
+                    local_get(s); i32_const(1); i32_add; local_set(s + 3);
+                    block_empty; loop_empty;
+                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
+                      local_get(s + 2); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(1); i32_sub; i32_const(es); i32_mul; i32_add;
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_elem_copy(&elem_ty);
+                wasm!(self.func, {
+                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      br(0);
+                    end; end;
+                    local_get(s + 2);
+                });
+            }
+            "unique" => {
+                // unique(xs) → List[A]: O(n²) dedup
+                // For now, stub — needs element equality which is complex
+                self.emit_stub_call(args);
+                return true;
             }
             _ => return false,
         }

--- a/src/codegen/emit_wasm/calls_numeric.rs
+++ b/src/codegen/emit_wasm/calls_numeric.rs
@@ -45,15 +45,16 @@ impl FuncCompiler<'_> {
             }
             "sign" => {
                 // sign(n) → -1.0, 0.0, or 1.0
-                let s = self.match_i64_base + self.match_depth;
+                // Store f64 in mem[0] (as 8 bytes) since no f64 scratch local
+                wasm!(self.func, { i32_const(0); });
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s); // f64 local
-                    local_get(s); f64_const(0.0); f64_lt;
+                    f64_store(0);
+                    i32_const(0); f64_load(0); f64_const(0.0); f64_lt;
                     if_f64;
                       f64_const(-1.0);
                     else_;
-                      local_get(s); f64_const(0.0); f64_gt;
+                      i32_const(0); f64_load(0); f64_const(0.0); f64_gt;
                       if_f64;
                         f64_const(1.0);
                       else_;
@@ -81,10 +82,15 @@ impl FuncCompiler<'_> {
                 self.func.instruction(&Instruction::F64Max); // max(lo, min(n, hi))
             }
             "is_nan" => {
-                // NaN != NaN
+                // NaN != NaN. Store in mem to avoid double eval.
+                wasm!(self.func, { i32_const(0); });
                 self.emit_expr(&args[0]);
-                self.emit_expr(&args[0]);
-                wasm!(self.func, { f64_ne; }); // n != n → true iff NaN
+                wasm!(self.func, {
+                    f64_store(0);
+                    i32_const(0); f64_load(0);
+                    i32_const(0); f64_load(0);
+                    f64_ne;
+                });
             }
             "is_infinite" => {
                 self.emit_expr(&args[0]);

--- a/src/codegen/emit_wasm/expressions.rs
+++ b/src/codegen/emit_wasm/expressions.rs
@@ -639,76 +639,257 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_eq(&mut self, left: &IrExpr, right: &IrExpr, negate: bool) {
         self.emit_expr(left);
         self.emit_expr(right);
-        // Use the more concrete type for comparison dispatch
         let cmp_ty = if matches!(&left.ty, Ty::Unknown | Ty::TypeVar(_)) { &right.ty } else { &left.ty };
-        match cmp_ty {
+        self.emit_eq_typed(cmp_ty);
+        if negate {
+            wasm!(self.func, { i32_eqz; });
+        }
+    }
+
+    /// Emit type-aware equality for two values on stack. Consumes [a, b], produces i32.
+    /// Recursive: handles nested containers correctly.
+    pub(super) fn emit_eq_typed(&mut self, ty: &Ty) {
+        use crate::types::constructor::TypeConstructorId;
+        match ty {
             Ty::Int => { wasm!(self.func, { i64_eq; }); }
             Ty::Float => { wasm!(self.func, { f64_eq; }); }
             Ty::Bool => { wasm!(self.func, { i32_eq; }); }
             Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
-            Ty::Applied(crate::types::constructor::TypeConstructorId::List, args) => {
-                let elem_size = args.first().map(|t| values::byte_size(t)).unwrap_or(8);
-                wasm!(self.func, {
-                    i32_const(elem_size as i32);
-                    call(self.emitter.rt.list_eq);
-                });
+
+            Ty::Applied(TypeConstructorId::List, args) => {
+                let elem_ty = args.first().cloned().unwrap_or(Ty::Int);
+                // If elem is a value type (no pointers), use byte comparison
+                if self.is_value_type(&elem_ty) {
+                    let elem_size = values::byte_size(&elem_ty);
+                    wasm!(self.func, {
+                        i32_const(elem_size as i32);
+                        call(self.emitter.rt.list_eq);
+                    });
+                } else {
+                    // Deep list equality: compare element by element
+                    self.emit_list_eq_deep(&elem_ty);
+                }
             }
-            // Record: byte-compare the entire struct
+
+            Ty::Applied(TypeConstructorId::Option, args) => {
+                let inner_ty = args.first().cloned().unwrap_or(Ty::Int);
+                self.emit_option_eq_deep(&inner_ty);
+            }
+
+            Ty::Applied(TypeConstructorId::Result, args) => {
+                let ok_ty = args.first().cloned().unwrap_or(Ty::Int);
+                let err_ty = args.get(1).cloned().unwrap_or(Ty::String);
+                self.emit_result_eq_deep(&ok_ty, &err_ty);
+            }
+
+            Ty::Tuple(elems) => {
+                if elems.iter().all(|t| self.is_value_type(t)) {
+                    let size: u32 = elems.iter().map(|t| values::byte_size(t)).sum();
+                    wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
+                } else {
+                    self.emit_tuple_eq_deep(elems);
+                }
+            }
+
             Ty::Record { fields } => {
-                let size = values::record_size(fields);
-                wasm!(self.func, {
-                    i32_const(size as i32);
-                    call(self.emitter.rt.mem_eq);
-                });
+                if fields.iter().all(|(_, t)| self.is_value_type(t)) {
+                    let size = values::record_size(fields);
+                    wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
+                } else {
+                    // Field-by-field deep equality
+                    self.emit_record_eq_deep(fields);
+                }
             }
-            // Named types (records/variants): compute size from registered fields
+
             Ty::Named(name, _) => {
                 if let Some(cases) = self.emitter.variant_info.get(name.as_str()) {
-                    // Variant: tag(4) + max payload size across all constructors
                     let max_payload = cases.iter()
                         .map(|c| values::record_size(&c.fields))
                         .max().unwrap_or(0);
                     let size = 4 + max_payload;
-                    wasm!(self.func, {
-                        i32_const(size as i32);
-                        call(self.emitter.rt.mem_eq);
-                    });
+                    wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
                 } else {
                     let fields = self.emitter.record_fields.get(name.as_str()).cloned().unwrap_or_default();
                     let size = values::record_size(&fields);
                     if size > 0 {
-                        wasm!(self.func, {
-                            i32_const(size as i32);
-                            call(self.emitter.rt.mem_eq);
-                        });
+                        wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
                     } else {
                         wasm!(self.func, { i32_eq; });
                     }
                 }
             }
-            // Tuple: byte-compare all elements
-            Ty::Tuple(elems) => {
-                let size: u32 = elems.iter().map(|t| values::byte_size(t)).sum();
-                wasm!(self.func, {
-                    i32_const(size as i32);
-                    call(self.emitter.rt.mem_eq);
-                });
-            }
-            // Option: deep equality via runtime
-            Ty::Applied(crate::types::constructor::TypeConstructorId::Option, args) => {
-                match args.first() {
-                    Some(Ty::String) => { wasm!(self.func, { call(self.emitter.rt.option_eq_str); }); }
-                    _ => { wasm!(self.func, { call(self.emitter.rt.option_eq_i64); }); }
-                }
-            }
-            // Result: deep equality via runtime
-            Ty::Applied(crate::types::constructor::TypeConstructorId::Result, _) => {
-                wasm!(self.func, { call(self.emitter.rt.result_eq_i64_str); });
-            }
+
             _ => { wasm!(self.func, { i32_eq; }); }
         }
-        if negate {
-            wasm!(self.func, { i32_eqz; });
+    }
+
+    /// True if type is stored inline (no heap pointers that need deep comparison).
+    fn is_value_type(&self, ty: &Ty) -> bool {
+        matches!(ty, Ty::Int | Ty::Float | Ty::Bool | Ty::Unit)
+    }
+
+    /// Deep list equality: [a_ptr, b_ptr] → i32
+    fn emit_list_eq_deep(&mut self, elem_ty: &Ty) {
+        let s = self.match_i32_base + self.match_depth;
+        let elem_size = values::byte_size(elem_ty);
+        wasm!(self.func, {
+            local_set(s + 1); // b
+            local_set(s);     // a
+            // Same pointer → true
+            local_get(s); local_get(s + 1); i32_eq;
+            if_i32; i32_const(1);
+            else_;
+              // Different lengths → false
+              local_get(s); i32_load(0);
+              local_get(s + 1); i32_load(0);
+              i32_ne;
+              if_i32; i32_const(0);
+              else_;
+                // Compare element by element
+                i32_const(0); local_set(s + 2); // i
+                block_empty; loop_empty;
+                  local_get(s + 2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
+                  // Load a[i]
+                  local_get(s); i32_const(4); i32_add;
+                  local_get(s + 2); i32_const(elem_size as i32); i32_mul; i32_add;
+        });
+        self.emit_load_at(elem_ty, 0);
+        // Load b[i]
+        wasm!(self.func, {
+                  local_get(s + 1); i32_const(4); i32_add;
+                  local_get(s + 2); i32_const(elem_size as i32); i32_mul; i32_add;
+        });
+        self.emit_load_at(elem_ty, 0);
+        // Compare elements (recursive)
+        let elem_ty_clone = elem_ty.clone();
+        self.emit_eq_typed(&elem_ty_clone);
+        wasm!(self.func, {
+                  i32_eqz; // not equal?
+                  if_empty;
+                    i32_const(0); return_;
+                  end;
+                  local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                  br(0);
+                end; end;
+                // All elements matched
+                i32_const(1);
+              end;
+            end;
+        });
+    }
+
+    /// Deep option equality: [a_ptr, b_ptr] → i32
+    fn emit_option_eq_deep(&mut self, inner_ty: &Ty) {
+        let s = self.match_i32_base + self.match_depth;
+        wasm!(self.func, {
+            local_set(s + 1); // b
+            local_set(s);     // a
+            // Both none → true
+            local_get(s); i32_eqz; local_get(s + 1); i32_eqz; i32_and;
+            if_i32; i32_const(1);
+            else_;
+              // One none → false
+              local_get(s); i32_eqz; local_get(s + 1); i32_eqz; i32_or;
+              if_i32; i32_const(0);
+              else_;
+                // Both some: compare inner values
+                local_get(s);
+        });
+        self.emit_load_at(inner_ty, 0);
+        wasm!(self.func, { local_get(s + 1); });
+        self.emit_load_at(inner_ty, 0);
+        let inner_clone = inner_ty.clone();
+        self.emit_eq_typed(&inner_clone);
+        wasm!(self.func, {
+              end;
+            end;
+        });
+    }
+
+    /// Deep result equality: [a_ptr, b_ptr] → i32
+    fn emit_result_eq_deep(&mut self, ok_ty: &Ty, err_ty: &Ty) {
+        let s = self.match_i32_base + self.match_depth;
+        wasm!(self.func, {
+            local_set(s + 1); // b
+            local_set(s);     // a
+            // Tags must match
+            local_get(s); i32_load(0);
+            local_get(s + 1); i32_load(0);
+            i32_ne;
+            if_i32; i32_const(0);
+            else_;
+              // Same tag. If tag==0 (ok): compare ok values
+              local_get(s); i32_load(0); i32_eqz;
+              if_i32;
+                local_get(s);
+        });
+        self.emit_load_at(ok_ty, 4);
+        wasm!(self.func, { local_get(s + 1); });
+        self.emit_load_at(ok_ty, 4);
+        let ok_clone = ok_ty.clone();
+        self.emit_eq_typed(&ok_clone);
+        wasm!(self.func, {
+              else_;
+                // tag==1 (err): compare err values
+                local_get(s);
+        });
+        self.emit_load_at(err_ty, 4);
+        wasm!(self.func, { local_get(s + 1); });
+        self.emit_load_at(err_ty, 4);
+        let err_clone = err_ty.clone();
+        self.emit_eq_typed(&err_clone);
+        wasm!(self.func, {
+              end;
+            end;
+        });
+    }
+
+    /// Deep tuple equality: [a_ptr, b_ptr] → i32
+    fn emit_tuple_eq_deep(&mut self, elems: &[Ty]) {
+        let s = self.match_i32_base + self.match_depth;
+        wasm!(self.func, {
+            local_set(s + 1); // b
+            local_set(s);     // a
+        });
+        // Compare each field, short-circuit on mismatch
+        let mut offset: u32 = 0;
+        for (i, elem_ty) in elems.iter().enumerate() {
+            let elem_size = values::byte_size(elem_ty);
+            wasm!(self.func, { local_get(s); });
+            self.emit_load_at(elem_ty, offset);
+            wasm!(self.func, { local_get(s + 1); });
+            self.emit_load_at(elem_ty, offset);
+            let elem_clone = elem_ty.clone();
+            self.emit_eq_typed(&elem_clone);
+            if i < elems.len() - 1 {
+                // Short-circuit: if not equal, return 0
+                wasm!(self.func, { i32_eqz; if_empty; i32_const(0); return_; end; });
+            }
+            offset += elem_size;
+        }
+        // If we reach here, all fields matched. Last comparison result is on stack.
+    }
+
+    /// Deep record equality: [a_ptr, b_ptr] → i32
+    fn emit_record_eq_deep(&mut self, fields: &[(std::string::String, Ty)]) {
+        let s = self.match_i32_base + self.match_depth;
+        wasm!(self.func, {
+            local_set(s + 1);
+            local_set(s);
+        });
+        let mut offset: u32 = 0;
+        for (i, (_, field_ty)) in fields.iter().enumerate() {
+            let field_size = values::byte_size(field_ty);
+            wasm!(self.func, { local_get(s); });
+            self.emit_load_at(field_ty, offset);
+            wasm!(self.func, { local_get(s + 1); });
+            self.emit_load_at(field_ty, offset);
+            let field_clone = field_ty.clone();
+            self.emit_eq_typed(&field_clone);
+            if i < fields.len() - 1 {
+                wasm!(self.func, { i32_eqz; if_empty; i32_const(0); return_; end; });
+            }
+            offset += field_size;
         }
     }
 

--- a/src/codegen/emit_wasm/expressions.rs
+++ b/src/codegen/emit_wasm/expressions.rs
@@ -154,13 +154,11 @@ impl FuncCompiler<'_> {
                 }
                 if let Some(e) = tail {
                     self.emit_expr(e);
-                    // Drop tail value if non-Unit (do blocks in stmt position)
-                    if values::ty_to_valtype(&e.ty).is_some() {
-                        wasm!(self.func, { drop; });
-                    }
+                    // Tail expr is the return value — exit via return
+                    wasm!(self.func, { return_; });
                 }
 
-                // Continue (loop back)
+                // Fallback: continue (loop back) — only reached if no tail expr
                 wasm!(self.func, { br(self.depth - continue_depth - 1); });
 
                 self.loop_stack.pop();
@@ -168,6 +166,9 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { end; }); // end loop
                 self.depth -= 1;
                 wasm!(self.func, { end; }); // end block
+                // All do-block paths exit via return/guard.
+                // unreachable tells the validator no value is needed here.
+                wasm!(self.func, { unreachable; });
             }
 
             // ── While loop ──


### PR DESCRIPTION
## Summary
- Recursive deep equality for List, Option, Result, Tuple, Record (fixes nested container comparison)
- Fix do-block tail expression: return instead of drop+loop (fixes effect fn codegen)
- Fix float.sign/is_nan: use mem[] scratch instead of wrong-type locals
- Implement list.zip, list.slice, list.insert, list.remove_at, list.set
- WASM test pass: 45 → 53 (+8)

## Key fixes
- **Deep equality**: `emit_eq_typed` recursively dispatches based on inner element types. `[[1,2],[3,4]] == [[1,2],[3,4]]` now works correctly instead of comparing pointers.
- **Do-block return**: `do { guard ...; ok(value) }` now emits `return` for the tail expression instead of `drop; br 0` which caused infinite loops.
- **Float scratch**: `float.sign` and `float.is_nan` now use `mem[0]` scratch memory instead of i64 locals (f64/i64 type mismatch).

## Remaining: 101 fail (20 compile error + 81 trap)
- Compile errors: mostly stub-related type mismatches and scratch local overflow
- Traps: unimplemented functions (map/set/json) and some codegen edge cases

## Test plan
- [x] `cargo test` — all Rust unit tests pass
- [x] `almide test` — all 153 non-WASM tests pass  
- [x] `almide test --target wasm` — 53 pass, 101 fail, 28 skip