### PR TITLE
Fix WASM compile errors: do-block, scratch depth, intersperse (53→56)

### DIFF
--- a/src/codegen/emit_wasm/calls_list.rs
+++ b/src/codegen/emit_wasm/calls_list.rs
@@ -607,8 +607,8 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { i32_store(0); i32_const(4); });
                 self.emit_expr(&args[1]); // sep
+                self.emit_store_at(&elem_ty, 0); // mem[4] = sep (type-aware)
                 wasm!(self.func, {
-                    i32_store(0); // mem[4] = sep (i32 ptr)
                     i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
                     // new_len = max(0, 2*len - 1)
                     local_get(s); i32_eqz;
@@ -641,9 +641,10 @@ impl FuncCompiler<'_> {
                         if_empty;
                           local_get(s + 1); i32_const(4); i32_add;
                           local_get(s + 4); i32_const(elem_size as i32); i32_mul; i32_add;
-                          i32_const(4); i32_load(0); // sep
+                          i32_const(4);
                 });
-                self.emit_elem_store(&elem_ty);
+                self.emit_load_at(&elem_ty, 0); // load sep from mem[4]
+                self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
                           local_get(s + 4); i32_const(1); i32_add; local_set(s + 4);
                         end;

--- a/src/codegen/emit_wasm/expressions.rs
+++ b/src/codegen/emit_wasm/expressions.rs
@@ -137,8 +137,21 @@ impl FuncCompiler<'_> {
 
             // ── DoBlock (with guard → loop) ──
             IrExprKind::DoBlock { stmts, expr: tail } => {
-                // do block with guards: block { loop { stmts; br 0 (continue) } }
-                // Guard breaks out of the outer block
+                // do block with guards: block { loop { stmts; tail?; br 0 } }
+                // Guard breaks out via br to outer block.
+                // Tail expr (if any) is stored in a scratch local, then break exits the loop.
+                let has_tail = tail.is_some();
+                let tail_vt = tail.as_ref().and_then(|e| values::ty_to_valtype(&e.ty));
+                let result_local = if has_tail && tail_vt.is_some() {
+                    // Use i64 scratch for i64/f64, i32 scratch for i32
+                    match tail_vt {
+                        Some(ValType::I64) | Some(ValType::F64) =>
+                            Some(self.match_i64_base + self.match_depth),
+                        _ =>
+                            Some(self.match_i32_base + self.match_depth),
+                    }
+                } else { None };
+
                 let break_depth = self.depth;
                 wasm!(self.func, { block_empty; });
                 self.depth += 1;
@@ -154,21 +167,27 @@ impl FuncCompiler<'_> {
                 }
                 if let Some(e) = tail {
                     self.emit_expr(e);
-                    // Tail expr is the return value — exit via return
-                    wasm!(self.func, { return_; });
+                    if let Some(rl) = result_local {
+                        // Save result to local, break out of loop+block
+                        wasm!(self.func, { local_set(rl); });
+                    }
+                    // Break out of block (depth 1 from loop = to block)
+                    wasm!(self.func, { br(self.depth - break_depth - 1); });
+                } else {
+                    // No tail: continue looping
+                    wasm!(self.func, { br(self.depth - continue_depth - 1); });
                 }
-
-                // Fallback: continue (loop back) — only reached if no tail expr
-                wasm!(self.func, { br(self.depth - continue_depth - 1); });
 
                 self.loop_stack.pop();
                 self.depth -= 1;
                 wasm!(self.func, { end; }); // end loop
                 self.depth -= 1;
                 wasm!(self.func, { end; }); // end block
-                // All do-block paths exit via return/guard.
-                // unreachable tells the validator no value is needed here.
-                wasm!(self.func, { unreachable; });
+
+                // After block: load saved result (if any)
+                if let Some(rl) = result_local {
+                    wasm!(self.func, { local_get(rl); });
+                }
             }
 
             // ── While loop ──

--- a/src/codegen/emit_wasm/statements.rs
+++ b/src/codegen/emit_wasm/statements.rs
@@ -212,18 +212,18 @@ fn count_scratch_depth(expr: &IrExpr) -> usize {
         }
         IrExprKind::BinOp { op, left, right } => {
             let inner = count_scratch_depth(left).max(count_scratch_depth(right));
-            // PowInt/PowFloat use 2 i64 + 1 i32 scratch
-            if matches!(op, crate::ir::BinOp::PowInt | crate::ir::BinOp::PowFloat) {
-                2 + inner
-            } else {
-                inner
+            match op {
+                crate::ir::BinOp::PowInt | crate::ir::BinOp::PowFloat => 4 + inner,
+                // Eq/Neq: deep equality uses up to 3 scratch locals (list_eq_deep, option_eq_deep, etc.)
+                crate::ir::BinOp::Eq | crate::ir::BinOp::Neq => 3 + inner,
+                _ => inner,
             }
         }
         IrExprKind::UnOp { operand, .. } => count_scratch_depth(operand),
         IrExprKind::Call { args, target, .. } => {
-            // Calls may use scratch: variant constructors (1), stdlib like list.filter/fold (2), computed calls (1)
+            // Calls may use scratch: option/result ops (3), list ops (4), variant constructors (1), computed calls (1)
             let inner = args.iter().map(|a| count_scratch_depth(a)).max().unwrap_or(0);
-            2 + inner
+            4 + inner
         }
         // SpreadRecord needs 2 i32 scratch (result + base ptrs) + 1 i64 scratch (copy counter)
         IrExprKind::SpreadRecord { base, fields, .. } => {


### PR DESCRIPTION
Fix do-block return, scratch depth for equality/calls, intersperse type-aware store. Compile errors 19→10.