### PR TITLE
WASM: list closure ops, error.context, compile error fixes (56→58 pass)

### DIFF
--- a/src/codegen/emit_wasm/calls.rs
+++ b/src/codegen/emit_wasm/calls.rs
@@ -1039,6 +1039,40 @@ impl FuncCompiler<'_> {
                             end;
                         });
                     }
+                    ("error", "context") => {
+                        // error.context(result, msg) → Result[T, String]
+                        // If err: wrap error message with context. If ok: pass through.
+                        let s = self.match_i32_base + self.match_depth;
+                        self.emit_expr(&args[0]);
+                        wasm!(self.func, {
+                            local_set(s);
+                            local_get(s); i32_load(0); i32_eqz; // tag == 0 (ok)?
+                            if_i32;
+                              local_get(s); // pass ok through
+                            else_;
+                              // Build new err with context: "msg: original_err"
+                              local_get(s); i32_load(4); local_set(s + 1); // original err string
+                        });
+                        self.emit_expr(&args[1]); // context msg
+                        wasm!(self.func, {
+                              local_set(s + 2);
+                              // Build ": " separator
+                              i32_const(6); call(self.emitter.rt.alloc); local_set(s + 3);
+                              local_get(s + 3); i32_const(2); i32_store(0);
+                              local_get(s + 3); i32_const(58); i32_store8(4);
+                              local_get(s + 3); i32_const(32); i32_store8(5);
+                              // concat: msg + ": " + original
+                              local_get(s + 2); local_get(s + 3); call(self.emitter.rt.concat_str);
+                              local_get(s + 1); call(self.emitter.rt.concat_str);
+                              local_set(s + 1);
+                              // Build new err Result
+                              i32_const(8); call(self.emitter.rt.alloc); local_set(s);
+                              local_get(s); i32_const(1); i32_store(0);
+                              local_get(s); local_get(s + 1); i32_store(4);
+                              local_get(s);
+                            end;
+                        });
+                    }
                     ("error", "chain") => {
                         // error.chain(outer, cause) → "outer: cause"
                         self.emit_expr(&args[0]);

--- a/src/codegen/emit_wasm/calls_list.rs
+++ b/src/codegen/emit_wasm/calls_list.rs
@@ -861,10 +861,111 @@ impl FuncCompiler<'_> {
                 });
             }
             "unique" => {
-                // unique(xs) → List[A]: O(n²) dedup
-                // For now, stub — needs element equality which is complex
                 self.emit_stub_call(args);
                 return true;
+            }
+            "take_end" => {
+                // take_end(xs, n) = drop(xs, max(0, len-n))
+                let elem_ty = self.list_elem_ty(&args[0].ty);
+                let es = values::byte_size(&elem_ty) as i32;
+                let s = self.match_i32_base + self.match_depth;
+                wasm!(self.func, { i32_const(0); });
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { i32_store(0); });
+                self.emit_expr(&args[1]);
+                wasm!(self.func, {
+                    i32_wrap_i64; local_set(s); // n
+                    // start = max(0, len - n)
+                    i32_const(0); i32_load(0); i32_load(0); local_get(s); i32_sub;
+                    local_set(s + 1);
+                    local_get(s + 1); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(0); local_set(s + 1); end;
+                    // new_len = len - start
+                    i32_const(0); i32_load(0); i32_load(0); local_get(s + 1); i32_sub;
+                    local_set(s + 2);
+                    i32_const(4); local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(s + 3);
+                    local_get(s + 3); local_get(s + 2); i32_store(0);
+                    i32_const(0); local_set(s); // reuse as i
+                    block_empty; loop_empty;
+                      local_get(s); local_get(s + 2); i32_ge_u; br_if(1);
+                      local_get(s + 3); i32_const(4); i32_add;
+                      local_get(s); i32_const(es); i32_mul; i32_add;
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s + 1); local_get(s); i32_add;
+                      i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_elem_copy(&elem_ty);
+                wasm!(self.func, {
+                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      br(0);
+                    end; end;
+                    local_get(s + 3);
+                });
+            }
+            "drop_end" => {
+                // drop_end(xs, n) = take(xs, max(0, len-n))
+                let elem_ty = self.list_elem_ty(&args[0].ty);
+                let es = values::byte_size(&elem_ty) as i32;
+                let s = self.match_i32_base + self.match_depth;
+                wasm!(self.func, { i32_const(0); });
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { i32_store(0); });
+                self.emit_expr(&args[1]);
+                wasm!(self.func, {
+                    i32_wrap_i64; local_set(s); // n
+                    i32_const(0); i32_load(0); i32_load(0); local_get(s); i32_sub;
+                    local_set(s + 1); // new_len
+                    local_get(s + 1); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(0); local_set(s + 1); end;
+                    i32_const(4); local_get(s + 1); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(s + 2);
+                    local_get(s + 2); local_get(s + 1); i32_store(0);
+                    i32_const(0); local_set(s); // i
+                    block_empty; loop_empty;
+                      local_get(s); local_get(s + 1); i32_ge_u; br_if(1);
+                      local_get(s + 2); i32_const(4); i32_add;
+                      local_get(s); i32_const(es); i32_mul; i32_add;
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_elem_copy(&elem_ty);
+                wasm!(self.func, {
+                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      br(0);
+                    end; end;
+                    local_get(s + 2);
+                });
+            }
+            "repeat" => {
+                // repeat(val, n) → List[A]
+                let elem_ty = self.list_elem_ty(&args[0].ty);
+                let es = values::byte_size(&elem_ty) as i32;
+                let s = self.match_i32_base + self.match_depth;
+                wasm!(self.func, { i32_const(0); });
+                self.emit_expr(&args[0]); // val
+                self.emit_store_at(&elem_ty, 0); // mem[0] = val
+                self.emit_expr(&args[1]); // n
+                wasm!(self.func, {
+                    i32_wrap_i64; local_set(s); // n
+                    i32_const(4); local_get(s); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(s + 1);
+                    local_get(s + 1); local_get(s); i32_store(0);
+                    i32_const(0); local_set(s + 2); // i
+                    block_empty; loop_empty;
+                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
+                      local_get(s + 1); i32_const(4); i32_add;
+                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                      i32_const(0);
+                });
+                self.emit_load_at(&elem_ty, 0);
+                self.emit_store_at(&elem_ty, 0);
+                wasm!(self.func, {
+                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      br(0);
+                    end; end;
+                    local_get(s + 1);
+                });
             }
             _ => return false,
         }

--- a/src/codegen/emit_wasm/calls_list.rs
+++ b/src/codegen/emit_wasm/calls_list.rs
@@ -864,6 +864,191 @@ impl FuncCompiler<'_> {
                 self.emit_stub_call(args);
                 return true;
             }
+            "find" => {
+                // find(xs, pred) → Option[A]: first element where pred(x) is true
+                let elem_ty = self.list_elem_ty(&args[0].ty);
+                let es = values::byte_size(&elem_ty) as i32;
+                let s = self.match_i32_base + self.match_depth;
+                // mem[0]=xs, mem[4]=closure (store before closure emit)
+                wasm!(self.func, { i32_const(0); });
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { i32_store(0); i32_const(4); });
+                self.emit_expr(&args[1]);
+                wasm!(self.func, {
+                    i32_store(0); // mem[4]=closure
+                    i32_const(0); local_set(s); // i=0
+                    block_empty; loop_empty;
+                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
+                      // Call pred(xs[i])
+                      i32_const(4); i32_load(0); i32_load(4); // env
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_load_at(&elem_ty, 0);
+                wasm!(self.func, {
+                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                });
+                {
+                    let mut ct = vec![ValType::I32];
+                    if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
+                    let ti = self.emitter.register_type(ct, vec![ValType::I32]);
+                    wasm!(self.func, { call_indirect(ti, 0); });
+                }
+                wasm!(self.func, {
+                      if_empty;
+                        // Found: alloc some(xs[i])
+                        i32_const(es); call(self.emitter.rt.alloc); local_set(s + 1);
+                        local_get(s + 1);
+                        i32_const(0); i32_load(0); i32_const(4); i32_add;
+                        local_get(s); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_elem_copy(&elem_ty);
+                wasm!(self.func, {
+                        local_get(s + 1); return_;
+                      end;
+                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      br(0);
+                    end; end;
+                    i32_const(0); // none
+                });
+            }
+            "find_index" if args.len() == 2 && matches!(&args[1].ty, Ty::Fn { .. }) => {
+                // find_index(xs, pred) → Option[Int]
+                let elem_ty = self.list_elem_ty(&args[0].ty);
+                let es = values::byte_size(&elem_ty) as i32;
+                let s = self.match_i32_base + self.match_depth;
+                wasm!(self.func, { i32_const(0); });
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { i32_store(0); i32_const(4); });
+                self.emit_expr(&args[1]);
+                wasm!(self.func, {
+                    i32_store(0);
+                    i32_const(0); local_set(s);
+                    block_empty; loop_empty;
+                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(4); i32_load(0); i32_load(4); // env
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_load_at(&elem_ty, 0);
+                wasm!(self.func, { i32_const(4); i32_load(0); i32_load(0); });
+                {
+                    let mut ct = vec![ValType::I32];
+                    if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
+                    let ti = self.emitter.register_type(ct, vec![ValType::I32]);
+                    wasm!(self.func, { call_indirect(ti, 0); });
+                }
+                wasm!(self.func, {
+                      if_empty;
+                        i32_const(8); call(self.emitter.rt.alloc); local_set(s + 1);
+                        local_get(s + 1); local_get(s); i64_extend_i32_u; i64_store(0);
+                        local_get(s + 1); return_;
+                      end;
+                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      br(0);
+                    end; end;
+                    i32_const(0); // none
+                });
+            }
+            "any" => {
+                // any(xs, pred) → Bool
+                let elem_ty = self.list_elem_ty(&args[0].ty);
+                let es = values::byte_size(&elem_ty) as i32;
+                let s = self.match_i32_base + self.match_depth;
+                wasm!(self.func, { i32_const(0); });
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { i32_store(0); i32_const(4); });
+                self.emit_expr(&args[1]);
+                wasm!(self.func, {
+                    i32_store(0);
+                    i32_const(0); local_set(s);
+                    block_empty; loop_empty;
+                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(4); i32_load(0); i32_load(4);
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_load_at(&elem_ty, 0);
+                wasm!(self.func, { i32_const(4); i32_load(0); i32_load(0); });
+                {
+                    let mut ct = vec![ValType::I32];
+                    if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
+                    let ti = self.emitter.register_type(ct, vec![ValType::I32]);
+                    wasm!(self.func, { call_indirect(ti, 0); });
+                }
+                wasm!(self.func, {
+                      if_empty; i32_const(1); return_; end;
+                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      br(0);
+                    end; end;
+                    i32_const(0); // false
+                });
+            }
+            "all" => {
+                let elem_ty = self.list_elem_ty(&args[0].ty);
+                let es = values::byte_size(&elem_ty) as i32;
+                let s = self.match_i32_base + self.match_depth;
+                wasm!(self.func, { i32_const(0); });
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { i32_store(0); i32_const(4); });
+                self.emit_expr(&args[1]);
+                wasm!(self.func, {
+                    i32_store(0);
+                    i32_const(0); local_set(s);
+                    block_empty; loop_empty;
+                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(4); i32_load(0); i32_load(4);
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_load_at(&elem_ty, 0);
+                wasm!(self.func, { i32_const(4); i32_load(0); i32_load(0); });
+                {
+                    let mut ct = vec![ValType::I32];
+                    if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
+                    let ti = self.emitter.register_type(ct, vec![ValType::I32]);
+                    wasm!(self.func, { call_indirect(ti, 0); });
+                }
+                wasm!(self.func, {
+                      i32_eqz;
+                      if_empty; i32_const(0); return_; end;
+                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      br(0);
+                    end; end;
+                    i32_const(1); // true
+                });
+            }
+            "each" => {
+                let elem_ty = self.list_elem_ty(&args[0].ty);
+                let es = values::byte_size(&elem_ty) as i32;
+                let s = self.match_i32_base + self.match_depth;
+                wasm!(self.func, { i32_const(0); });
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { i32_store(0); i32_const(4); });
+                self.emit_expr(&args[1]);
+                wasm!(self.func, {
+                    i32_store(0);
+                    i32_const(0); local_set(s);
+                    block_empty; loop_empty;
+                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(4); i32_load(0); i32_load(4);
+                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(s); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_load_at(&elem_ty, 0);
+                wasm!(self.func, { i32_const(4); i32_load(0); i32_load(0); });
+                {
+                    let mut ct = vec![ValType::I32];
+                    if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
+                    let ti = self.emitter.register_type(ct, vec![]);
+                    wasm!(self.func, { call_indirect(ti, 0); });
+                }
+                wasm!(self.func, {
+                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      br(0);
+                    end; end;
+                });
+            }
             "take_end" => {
                 // take_end(xs, n) = drop(xs, max(0, len-n))
                 let elem_ty = self.list_elem_ty(&args[0].ty);


### PR DESCRIPTION
Add list.find/find_index/any/all/each/take_end/drop_end/repeat, error.context. Fix do-block return, scratch depth, intersperse type store. 56→58 pass, compile errors 19→10.