### PR TITLE
WASM: map module, list.unique, fix return/contains bugs (59→65 pass)

### DIFF
--- a/src/codegen/emit_wasm/calls.rs
+++ b/src/codegen/emit_wasm/calls.rs
@@ -928,81 +928,68 @@ impl FuncCompiler<'_> {
                     }
                     ("list", "contains") => {
                         // list.contains(list, elem) -> Bool (i32)
-                        // Linear scan: compare each element
+                        // Uses only scratch locals — no mem[] to avoid nested call conflicts
                         let elem_ty = if let Ty::Applied(_, a) = &args[0].ty {
                             a.first().cloned().unwrap_or(Ty::Int)
                         } else { Ty::Int };
                         let elem_size = values::byte_size(&elem_ty);
                         let s = self.match_i32_base + self.match_depth;
-                        let len_local = s;
-                        let idx_local = s + 1;
-
-                        // Store list → mem[0], elem → mem[4]
-                        wasm!(self.func, { i32_const(0); });
+                        // s=list_ptr, s+1=idx, s+2=result
                         self.emit_expr(&args[0]);
-                        wasm!(self.func, {
-                            i32_store(0);
-                            i32_const(0);
-                            i32_load(0);
-                            i32_load(0); // len
-                            local_set(len_local);
-                            i32_const(0);
-                            local_set(idx_local);
-                        });
-                        // Save target elem
-                        wasm!(self.func, { i32_const(8); });
-                        self.emit_expr(&args[1]);
-                        self.emit_store_at(&elem_ty, 0);
-
-                        let saved = self.depth;
-                        wasm!(self.func, {
-                            // Loop: check each element
-                            block_empty;
-                            loop_empty;
-                        });
-                        self.depth += 2;
-                        wasm!(self.func, {
-                            local_get(idx_local);
-                            local_get(len_local);
-                            i32_ge_u;
-                            br_if(1); // break if done → not found
-                            // Load element
-                            i32_const(0);
-                            i32_load(0); // list
-                            i32_const(4);
-                            i32_add;
-                            local_get(idx_local);
-                            i32_const(elem_size as i32);
-                            i32_mul;
-                            i32_add;
-                        });
-                        self.emit_load_at(&elem_ty, 0);
-                        // Load target
-                        wasm!(self.func, { i32_const(8); });
-                        self.emit_load_at(&elem_ty, 0);
-                        // Compare
-                        match &elem_ty {
-                            Ty::Int => { wasm!(self.func, { i64_eq; }); }
-                            Ty::Float => { wasm!(self.func, { f64_eq; }); }
-                            Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
-                            _ => { wasm!(self.func, { i32_eq; }); }
+                        wasm!(self.func, { local_set(s); });
+                        // Save target to i64 scratch or i32 scratch depending on type
+                        match values::ty_to_valtype(&elem_ty) {
+                            Some(ValType::I64) => {
+                                let t = self.match_i64_base + self.match_depth;
+                                self.emit_expr(&args[1]);
+                                wasm!(self.func, {
+                                    local_set(t); // target in i64 local
+                                    i32_const(0); local_set(s + 1); // idx
+                                    i32_const(0); local_set(s + 2); // result = false
+                                    block_empty; loop_empty;
+                                      local_get(s + 1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
+                                      local_get(s); i32_const(4); i32_add;
+                                      local_get(s + 1); i32_const(elem_size as i32); i32_mul; i32_add;
+                                      i64_load(0);
+                                      local_get(t); i64_eq;
+                                      if_empty;
+                                        i32_const(1); local_set(s + 2); br(2);
+                                      end;
+                                      local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                                      br(0);
+                                    end; end;
+                                    local_get(s + 2);
+                                });
+                            }
+                            _ => {
+                                // i32 types: String, Option, etc.
+                                self.emit_expr(&args[1]);
+                                wasm!(self.func, {
+                                    local_set(s + 3); // target in i32 local
+                                    i32_const(0); local_set(s + 1);
+                                    i32_const(0); local_set(s + 2);
+                                    block_empty; loop_empty;
+                                      local_get(s + 1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
+                                      local_get(s); i32_const(4); i32_add;
+                                      local_get(s + 1); i32_const(elem_size as i32); i32_mul; i32_add;
+                                      i32_load(0);
+                                      local_get(s + 3);
+                                });
+                                match &elem_ty {
+                                    Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
+                                    _ => { wasm!(self.func, { i32_eq; }); }
+                                }
+                                wasm!(self.func, {
+                                      if_empty;
+                                        i32_const(1); local_set(s + 2); br(2);
+                                      end;
+                                      local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                                      br(0);
+                                    end; end;
+                                    local_get(s + 2);
+                                });
+                            }
                         }
-                        wasm!(self.func, {
-                            if_empty;
-                            i32_const(1);
-                            return_;
-                            end;
-                            local_get(idx_local);
-                            i32_const(1);
-                            i32_add;
-                            local_set(idx_local);
-                            br(0);
-                            end; // loop
-                            end; // block
-                        });
-                        self.depth = saved;
-                        // Not found
-                        wasm!(self.func, { i32_const(0); });
                     }
                     _ if module == "map" => {
                         if !self.emit_map_call(func, args) {

--- a/src/codegen/emit_wasm/calls_list.rs
+++ b/src/codegen/emit_wasm/calls_list.rs
@@ -862,8 +862,59 @@ impl FuncCompiler<'_> {
                 });
             }
             "unique" => {
-                self.emit_stub_call(args);
-                return true;
+                // unique(xs) → List[A]: O(n²) dedup, String elements
+                let elem_ty = self.list_elem_ty(&args[0].ty);
+                let es = values::byte_size(&elem_ty) as i32;
+                let s = self.match_i32_base + self.match_depth;
+                self.emit_expr(&args[0]);
+                wasm!(self.func, {
+                    local_set(s);
+                    local_get(s); i32_load(0); local_set(s + 1); // src_len
+                    i32_const(4); local_get(s + 1); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(s + 2); // dst
+                    local_get(s + 2); i32_const(0); i32_store(0);
+                    i32_const(0); local_set(s + 3); // i
+                    block_empty; loop_empty;
+                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
+                      // Check if src[i] already in dst
+                      i32_const(0); local_set(s + 4); // j
+                      i32_const(0); local_set(s + 5); // found
+                      block_empty; loop_empty;
+                        local_get(s + 4); local_get(s + 2); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(s); i32_const(4); i32_add;
+                        local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                        i32_load(0);
+                        local_get(s + 2); i32_const(4); i32_add;
+                        local_get(s + 4); i32_const(es); i32_mul; i32_add;
+                        i32_load(0);
+                });
+                match &elem_ty {
+                    Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
+                    _ => { wasm!(self.func, { i32_eq; }); }
+                }
+                wasm!(self.func, {
+                        if_empty; i32_const(1); local_set(s + 5); br(2); end;
+                        local_get(s + 4); i32_const(1); i32_add; local_set(s + 4);
+                        br(0);
+                      end; end;
+                      local_get(s + 5); i32_eqz;
+                      if_empty;
+                        local_get(s + 2); i32_const(4); i32_add;
+                        local_get(s + 2); i32_load(0); i32_const(es); i32_mul; i32_add;
+                        local_get(s); i32_const(4); i32_add;
+                        local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                });
+                self.emit_elem_copy(&elem_ty);
+                wasm!(self.func, {
+                        local_get(s + 2);
+                        local_get(s + 2); i32_load(0); i32_const(1); i32_add;
+                        i32_store(0);
+                      end;
+                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      br(0);
+                    end; end;
+                    local_get(s + 2);
+                });
             }
             "find" => {
                 // find(xs, pred) → Option[A]: first element where pred(x) is true

--- a/src/codegen/emit_wasm/calls_list.rs
+++ b/src/codegen/emit_wasm/calls_list.rs
@@ -506,6 +506,7 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                     i32_const(0); local_set(s); // i
+                    i32_const(0); local_set(s + 2); // result (default: none)
                     block_empty; loop_empty;
                       local_get(s);
                       i32_const(0); i32_load(0); i32_load(0); // len
@@ -520,10 +521,10 @@ impl FuncCompiler<'_> {
                             i64_load(0);
                             local_get(s64); i64_eq;
                             if_empty;
-                              // Found: return some(i)
+                              // Found: store some(i) and break
                               i32_const(8); call(self.emitter.rt.alloc); local_set(s + 1);
                               local_get(s + 1); local_get(s); i64_extend_i32_u; i64_store(0);
-                              local_get(s + 1); return_;
+                              local_get(s + 1); local_set(s + 2); br(2);
                             end;
                         });
                     }
@@ -544,7 +545,7 @@ impl FuncCompiler<'_> {
                             if_empty;
                               i32_const(8); call(self.emitter.rt.alloc); local_set(s + 1);
                               local_get(s + 1); local_get(s); i64_extend_i32_u; i64_store(0);
-                              local_get(s + 1); return_;
+                              local_get(s + 1); local_set(s + 2); br(2);
                             end;
                         });
                     }
@@ -553,7 +554,7 @@ impl FuncCompiler<'_> {
                       local_get(s); i32_const(1); i32_add; local_set(s);
                       br(0);
                     end; end;
-                    i32_const(0); // none
+                    local_get(s + 2); // result (none if not found)
                 });
             }
             "min" | "max" => {
@@ -877,6 +878,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     i32_store(0); // mem[4]=closure
                     i32_const(0); local_set(s); // i=0
+                    i32_const(0); local_set(s + 2); // result (default: none)
                     block_empty; loop_empty;
                       local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
                       // Call pred(xs[i])
@@ -904,12 +906,12 @@ impl FuncCompiler<'_> {
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 1); return_;
+                        local_get(s + 1); local_set(s + 2); br(2);
                       end;
                       local_get(s); i32_const(1); i32_add; local_set(s);
                       br(0);
                     end; end;
-                    i32_const(0); // none
+                    local_get(s + 2); // result (none if not found)
                 });
             }
             "find_index" if args.len() == 2 && matches!(&args[1].ty, Ty::Fn { .. }) => {
@@ -924,6 +926,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     i32_store(0);
                     i32_const(0); local_set(s);
+                    i32_const(0); local_set(s + 2); // result (default: none)
                     block_empty; loop_empty;
                       local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
                       i32_const(4); i32_load(0); i32_load(4); // env
@@ -942,12 +945,12 @@ impl FuncCompiler<'_> {
                       if_empty;
                         i32_const(8); call(self.emitter.rt.alloc); local_set(s + 1);
                         local_get(s + 1); local_get(s); i64_extend_i32_u; i64_store(0);
-                        local_get(s + 1); return_;
+                        local_get(s + 1); local_set(s + 2); br(2);
                       end;
                       local_get(s); i32_const(1); i32_add; local_set(s);
                       br(0);
                     end; end;
-                    i32_const(0); // none
+                    local_get(s + 2); // result (none if not found)
                 });
             }
             "any" => {
@@ -962,6 +965,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     i32_store(0);
                     i32_const(0); local_set(s);
+                    i32_const(0); local_set(s + 1); // result (default: false)
                     block_empty; loop_empty;
                       local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
                       i32_const(4); i32_load(0); i32_load(4);
@@ -977,11 +981,11 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      if_empty; i32_const(1); return_; end;
+                      if_empty; i32_const(1); local_set(s + 1); br(2); end;
                       local_get(s); i32_const(1); i32_add; local_set(s);
                       br(0);
                     end; end;
-                    i32_const(0); // false
+                    local_get(s + 1); // result
                 });
             }
             "all" => {
@@ -995,6 +999,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     i32_store(0);
                     i32_const(0); local_set(s);
+                    i32_const(1); local_set(s + 1); // result (default: true)
                     block_empty; loop_empty;
                       local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
                       i32_const(4); i32_load(0); i32_load(4);
@@ -1011,11 +1016,11 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                       i32_eqz;
-                      if_empty; i32_const(0); return_; end;
+                      if_empty; i32_const(0); local_set(s + 1); br(2); end;
                       local_get(s); i32_const(1); i32_add; local_set(s);
                       br(0);
                     end; end;
-                    i32_const(1); // true
+                    local_get(s + 1); // result
                 });
             }
             "each" => {


### PR DESCRIPTION
Map module (10 ops), list.unique, fix inline return_ to block+br, fix list.contains mem[] conflicts. 59→65 pass.