### PR TITLE
WASM: major codegen fixes (80→90 pass)

### DIFF
--- a/src/codegen/emit_wasm/calls.rs
+++ b/src/codegen/emit_wasm/calls.rs
@@ -1321,13 +1321,25 @@ impl FuncCompiler<'_> {
 
     /// Emit a lambda as a closure: allocate env + closure on heap.
     pub(super) fn emit_lambda_closure(&mut self, _params: &[(crate::ir::VarId, Ty)], _body: &IrExpr) {
-        let lambda_idx = self.emitter.lambda_counter.get();
-        self.emitter.lambda_counter.set(lambda_idx + 1);
+        // Match lambda by param VarIds (deterministic, order-independent of scan)
+        let param_key: Vec<u32> = _params.iter().map(|(vid, _)| vid.0).collect();
+        let lambda_idx = self.emitter.lambdas.iter().enumerate()
+            .find(|(_, info)| info.param_ids == param_key)
+            .map(|(i, _)| i);
 
-        if lambda_idx >= self.emitter.lambdas.len() {
-            wasm!(self.func, { unreachable; });
-            return;
-        }
+        let lambda_idx = match lambda_idx {
+            Some(i) => i,
+            None => {
+                // Fallback to counter (for compatibility)
+                let idx = self.emitter.lambda_counter.get();
+                self.emitter.lambda_counter.set(idx + 1);
+                if idx >= self.emitter.lambdas.len() {
+                    wasm!(self.func, { unreachable; });
+                    return;
+                }
+                idx
+            }
+        };
 
         let table_idx = self.emitter.lambdas[lambda_idx].table_idx;
         let captures = self.emitter.lambdas[lambda_idx].captures.clone();

--- a/src/codegen/emit_wasm/calls_list.rs
+++ b/src/codegen/emit_wasm/calls_list.rs
@@ -1367,6 +1367,13 @@ impl FuncCompiler<'_> {
                 // filter_map(xs, f) → List[B]: f returns Option[B], keep some values
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
+                // Output element type B: if input is List[Option[B]], unwrap Option to get B
+                let out_elem_ty = if let Ty::Applied(_, inner_args) = &elem_ty {
+                    inner_args.first().cloned().unwrap_or(Ty::Int)
+                } else if let Ty::Fn { ret, .. } = &args[1].ty {
+                    self.list_elem_ty(ret)
+                } else { Ty::Int };
+                let out_es = values::byte_size(&out_elem_ty) as i32;
                 let s = self.match_i32_base + self.match_depth;
                 // mem[0]=xs, mem[4]=closure
                 wasm!(self.func, { i32_const(0); });
@@ -1375,38 +1382,40 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
                     i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
-                    // Alloc max-size result (4 bytes per element ptr)
-                    i32_const(4); local_get(s); i32_const(4); i32_mul; i32_add;
+                    i32_const(0); i32_load(0); i32_load(0); local_set(s);
+                    i32_const(4); local_get(s); i32_const(out_es); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(s + 1);
-                    local_get(s + 1); i32_const(0); i32_store(0); // result len = 0
-                    i32_const(0); local_set(s + 2); // i
+                    local_get(s + 1); i32_const(0); i32_store(0);
+                    i32_const(0); local_set(s + 2);
                     block_empty; loop_empty;
                       local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-                      // Call f(xs[i]) → Option[B]
                       i32_const(4); i32_load(0); i32_load(4); // env
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s + 2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                      i32_const(4); i32_load(0); i32_load(0);
                 });
                 {
                     let mut ct = vec![ValType::I32];
                     if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
-                    let ti = self.emitter.register_type(ct, vec![ValType::I32]); // returns Option ptr (i32)
+                    let ti = self.emitter.register_type(ct, vec![ValType::I32]);
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
                       local_set(s + 3); // option result
-                      // If some (non-zero), append inner value to result
                       local_get(s + 3); i32_const(0); i32_ne;
                       if_empty;
+                        // Append unwrapped value to result
                         local_get(s + 1); i32_const(4); i32_add;
-                        local_get(s + 1); i32_load(0); i32_const(4); i32_mul; i32_add;
-                        local_get(s + 3); i32_load(0); // unwrap some → inner value (ptr)
-                        i32_store(0);
+                        local_get(s + 1); i32_load(0); i32_const(out_es); i32_mul; i32_add;
+                        local_get(s + 3); // some ptr
+                });
+                // Load inner value from some ptr
+                self.emit_load_at(&out_elem_ty, 0);
+                self.emit_store_at(&out_elem_ty, 0);
+                wasm!(self.func, {
                         local_get(s + 1);
                         local_get(s + 1); i32_load(0); i32_const(1); i32_add;
                         i32_store(0);

--- a/src/codegen/emit_wasm/calls_list.rs
+++ b/src/codegen/emit_wasm/calls_list.rs
@@ -1268,8 +1268,12 @@ impl FuncCompiler<'_> {
             }
             "flat_map" => {
                 // flat_map(xs, f) → List[B]: f returns List[B], flatten results
-                // Strategy: collect results into list of lists, then flatten
                 let elem_ty = self.list_elem_ty(&args[0].ty);
+                // Output element type B: infer from fn return type List[B]
+                let out_elem_ty = if let Ty::Fn { ret, .. } = &args[1].ty {
+                    self.list_elem_ty(ret) // List[B] → B
+                } else { elem_ty.clone() };
+                let out_es = values::byte_size(&out_elem_ty) as i32;
                 let es = values::byte_size(&elem_ty) as i32;
                 let s = self.match_i32_base + self.match_depth;
                 // mem[0]=xs, mem[4]=closure
@@ -1330,8 +1334,8 @@ impl FuncCompiler<'_> {
                       local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
                       br(0);
                     end; end;
-                    // Alloc result: assume 4 bytes per element (i32 ptrs)
-                    i32_const(4); local_get(s + 1); i32_const(4); i32_mul; i32_add;
+                    // Alloc result
+                    i32_const(4); local_get(s + 1); i32_const(out_es); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(s + 3);
                     local_get(s + 3); local_get(s + 1); i32_store(0);
                 });
@@ -1341,18 +1345,19 @@ impl FuncCompiler<'_> {
                     i32_const(0); local_set(s + 2); // outer i
                     block_empty; loop_empty;
                       local_get(s + 2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                      // inner list
                       local_get(s); i32_const(4); i32_add;
                       local_get(s + 2); i32_const(4); i32_mul; i32_add;
-                      i32_load(0); local_set(s + 4); // inner
+                      i32_load(0); local_set(s + 4); // inner list
                       i32_const(0); local_set(s + 5); // j
                       block_empty; loop_empty;
                         local_get(s + 5); local_get(s + 4); i32_load(0); i32_ge_u; br_if(1);
                         local_get(s + 3); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(4); i32_mul; i32_add;
+                        local_get(s + 1); i32_const(out_es); i32_mul; i32_add;
                         local_get(s + 4); i32_const(4); i32_add;
-                        local_get(s + 5); i32_const(4); i32_mul; i32_add;
-                        i32_load(0); i32_store(0);
+                        local_get(s + 5); i32_const(out_es); i32_mul; i32_add;
+                });
+                self.emit_elem_copy(&out_elem_ty);
+                wasm!(self.func, {
                         local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
                         local_get(s + 5); i32_const(1); i32_add; local_set(s + 5);
                         br(0);

--- a/src/codegen/emit_wasm/calls_list.rs
+++ b/src/codegen/emit_wasm/calls_list.rs
@@ -355,8 +355,9 @@ impl FuncCompiler<'_> {
             "flatten" => {
                 // flatten(xss: List[List[T]]) → List[T]
                 // Two-pass: count total, then copy
-                let inner_ty = self.list_elem_ty(&args[0].ty);
-                let elem_size = values::byte_size(&inner_ty); // size of inner list elements
+                let inner_list_ty = self.list_elem_ty(&args[0].ty); // List[T]
+                let elem_ty = self.list_elem_ty(&inner_list_ty); // T
+                let elem_size = values::byte_size(&elem_ty); // size of T
                 let s = self.match_i32_base + self.match_depth;
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
@@ -400,7 +401,7 @@ impl FuncCompiler<'_> {
                         local_get(s + 4); i32_const(4); i32_add;
                         local_get(s + 5); i32_const(elem_size as i32); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&inner_ty);
+                self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
                         local_get(s + 5); i32_const(1); i32_add; local_set(s + 5);
                         br(0);

--- a/src/codegen/emit_wasm/calls_map.rs
+++ b/src/codegen/emit_wasm/calls_map.rs
@@ -523,8 +523,49 @@ impl FuncCompiler<'_> {
                 });
             }
             "from_list" => {
-                self.emit_stub_call(args);
-                return true;
+                // from_list(pairs: List[(K,V)]) → Map
+                // Infer K,V from pair type: List[(K,V)] → elem = (K,V)
+                let pair_ty = self.list_elem_ty(&args[0].ty);
+                let (ks, vs) = if let Ty::Tuple(elems) = &pair_ty {
+                    let k = elems.first().map(|t| values::byte_size(t)).unwrap_or(4);
+                    let v = elems.get(1).map(|t| values::byte_size(t)).unwrap_or(4);
+                    (k, v)
+                } else { (4u32, 4u32) };
+                let entry = ks + vs;
+                let s = self.match_i32_base + self.match_depth;
+                self.emit_expr(&args[0]);
+                wasm!(self.func, {
+                    local_set(s); // pairs list
+                    local_get(s); i32_load(0); local_set(s + 1); // len
+                    // Alloc map: 4 + len * entry
+                    i32_const(4); local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(s + 2);
+                    local_get(s + 2); local_get(s + 1); i32_store(0);
+                    // Copy: for each pair, copy key and val into map entry
+                    i32_const(0); local_set(s + 3); // i
+                    block_empty; loop_empty;
+                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
+                      // tuple_ptr = pairs[4 + i*4]
+                      local_get(s); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(4); i32_mul; i32_add;
+                      i32_load(0); local_set(s + 4); // tuple ptr
+                      // Copy key: map[4 + i*entry] = tuple[0]
+                      local_get(s + 2); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(s + 4); i32_load(0); i32_store(0);
+                      // Copy val: map[4 + i*entry + ks] = tuple[ks]
+                      local_get(s + 2); i32_const(4); i32_add;
+                      local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+                      i32_const(ks as i32); i32_add;
+                      local_get(s + 4); i32_const(ks as i32); i32_add;
+                });
+                self.emit_elem_copy_sized(vs);
+                wasm!(self.func, {
+                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      br(0);
+                    end; end;
+                    local_get(s + 2);
+                });
             }
             "fold" => {
                 // fold(m, init, f) → A: f(acc, key, val) for each entry

--- a/src/codegen/emit_wasm/collections.rs
+++ b/src/codegen/emit_wasm/collections.rs
@@ -15,25 +15,26 @@ impl FuncCompiler<'_> {
         let tag = self.resolve_variant_tag(name, result_ty);
         let tag_size: u32 = if tag.is_some() { 4 } else { 0 };
 
-        // Compute field types and total size (including defaults)
-        let explicit_field_size: u32 = fields.iter()
-            .map(|(_, expr)| values::byte_size(&expr.ty))
-            .sum();
-        let default_field_size: u32 = if let Some(ctor_name) = name {
-            let explicit_names: std::collections::HashSet<&str> = fields.iter().map(|(n, _)| n.as_str()).collect();
-            self.emitter.default_fields.iter()
-                .filter(|((cn, _), _)| cn == ctor_name)
-                .filter(|((_, fn_name), _)| !explicit_names.contains(fn_name.as_str()))
-                .map(|((_, _), expr)| {
-                    match (&expr.ty, &expr.kind) {
-                        (Ty::Unknown, crate::ir::IrExprKind::LitInt { .. }) => values::byte_size(&Ty::Int),
-                        (Ty::Unknown, crate::ir::IrExprKind::LitFloat { .. }) => values::byte_size(&Ty::Float),
-                        _ => values::byte_size(&expr.ty),
+        // Compute total size from type definition (includes defaults)
+        let type_field_size: u32 = if let Some(ctor_name) = name {
+            let mut size = 0u32;
+            // Check variant cases
+            for cases in self.emitter.variant_info.values() {
+                for case in cases {
+                    if case.name == ctor_name {
+                        size = case.fields.iter().map(|(_, ty)| values::byte_size(ty)).sum();
                     }
-                })
-                .sum()
+                }
+            }
+            if size == 0 {
+                if let Some(rf) = self.emitter.record_fields.get(ctor_name) {
+                    size = rf.iter().map(|(_, ty)| values::byte_size(ty)).sum();
+                }
+            }
+            size
         } else { 0 };
-        let total_size = tag_size + explicit_field_size + default_field_size;
+        let explicit_size: u32 = fields.iter().map(|(_, e)| values::byte_size(&e.ty)).sum();
+        let total_size = tag_size + if type_field_size > 0 { type_field_size } else { explicit_size };
 
         // Allocate
         wasm!(self.func, {
@@ -54,43 +55,70 @@ impl FuncCompiler<'_> {
             });
         }
 
-        // Store each explicit field (offset starts after tag)
-        let explicit_names: std::collections::HashSet<&str> = fields.iter().map(|(n, _)| n.as_str()).collect();
-        let mut offset = tag_size;
-        for (_, field_expr) in fields {
-            let field_size = values::byte_size(&field_expr.ty);
-            wasm!(self.func, { local_get(scratch); });
-            self.emit_expr(field_expr);
-            self.emit_store_at(&field_expr.ty, offset);
-            offset += field_size;
-        }
+        // Build merged field list in type-definition order
+        // Explicit fields + defaults, ordered by type definition
+        let explicit_map: std::collections::HashMap<&str, &IrExpr> =
+            fields.iter().map(|(n, e)| (n.as_str(), e)).collect();
 
-        // Fill in default fields that were not explicitly provided
-        if let Some(ctor_name) = name {
-            let defaults: Vec<(String, crate::ir::IrExpr)> = self.emitter.default_fields.iter()
-                .filter(|((cn, _), _)| cn == ctor_name)
-                .filter(|((_, fn_name), _)| !explicit_names.contains(fn_name.as_str()))
-                .map(|((_, fn_name), expr)| (fn_name.clone(), expr.clone()))
-                .collect();
-            for (_, default_expr) in &defaults {
-                // Use correct field type: infer from expr kind when ty is Unknown
-                let field_ty = match (&default_expr.ty, &default_expr.kind) {
-                    (Ty::Unknown, crate::ir::IrExprKind::LitInt { .. }) => Ty::Int,
-                    (Ty::Unknown, crate::ir::IrExprKind::LitFloat { .. }) => Ty::Float,
-                    (Ty::Unknown, crate::ir::IrExprKind::LitBool { .. }) => Ty::Bool,
-                    (Ty::Unknown, crate::ir::IrExprKind::LitStr { .. }) => Ty::String,
-                    _ => default_expr.ty.clone(),
-                };
-                let field_size = values::byte_size(&field_ty);
+        // Get type-definition field order from variant_info or record_fields
+        let type_fields: Vec<(String, Ty)> = if let Some(ctor_name) = name {
+            // Try variant case
+            let mut found = Vec::new();
+            for cases in self.emitter.variant_info.values() {
+                for case in cases {
+                    if case.name == ctor_name {
+                        found = case.fields.clone();
+                    }
+                }
+            }
+            if found.is_empty() {
+                if let Some(rf) = self.emitter.record_fields.get(ctor_name) {
+                    found = rf.clone();
+                }
+            }
+            found
+        } else { vec![] };
+
+        let mut offset = tag_size;
+        if !type_fields.is_empty() {
+            // Emit in type-definition order
+            for (field_name, field_ty) in &type_fields {
                 wasm!(self.func, { local_get(scratch); });
-                self.emit_expr(default_expr);
-                self.emit_store_at(&field_ty, offset);
+                if let Some(expr) = explicit_map.get(field_name.as_str()) {
+                    self.emit_expr(expr);
+                    self.emit_store_at(&expr.ty, offset);
+                    offset += values::byte_size(&expr.ty);
+                } else if let Some(ctor_name) = name {
+                    if let Some(default_expr) = self.emitter.default_fields.get(&(ctor_name.to_string(), field_name.clone())) {
+                        let default_expr = default_expr.clone();
+                        let dt = match (&default_expr.ty, &default_expr.kind) {
+                            (Ty::Unknown, crate::ir::IrExprKind::LitInt { .. }) => Ty::Int,
+                            (Ty::Unknown, crate::ir::IrExprKind::LitFloat { .. }) => Ty::Float,
+                            (Ty::Unknown, crate::ir::IrExprKind::LitBool { .. }) => Ty::Bool,
+                            (Ty::Unknown, crate::ir::IrExprKind::LitStr { .. }) => Ty::String,
+                            _ => default_expr.ty.clone(),
+                        };
+                        self.emit_expr(&default_expr);
+                        self.emit_store_at(&dt, offset);
+                        offset += values::byte_size(&dt);
+                    } else {
+                        // No value — zero-fill
+                        offset += values::byte_size(field_ty);
+                    }
+                } else {
+                    offset += values::byte_size(field_ty);
+                }
+            }
+        } else {
+            // No type info: emit explicit fields only
+            for (_, field_expr) in fields {
+                let field_size = values::byte_size(&field_expr.ty);
+                wasm!(self.func, { local_get(scratch); });
+                self.emit_expr(field_expr);
+                self.emit_store_at(&field_expr.ty, offset);
                 offset += field_size;
             }
         }
-
-        // Also recompute total_size to include defaults
-        // (The allocation above may be too small — need to fix)
 
         self.match_depth -= 1;
         wasm!(self.func, { local_get(scratch); });

--- a/src/codegen/emit_wasm/collections.rs
+++ b/src/codegen/emit_wasm/collections.rs
@@ -15,11 +15,25 @@ impl FuncCompiler<'_> {
         let tag = self.resolve_variant_tag(name, result_ty);
         let tag_size: u32 = if tag.is_some() { 4 } else { 0 };
 
-        // Compute field types and total size
-        let field_types: Vec<(String, Ty)> = fields.iter()
-            .map(|(n, expr)| (n.clone(), expr.ty.clone()))
-            .collect();
-        let total_size = tag_size + values::record_size(&field_types);
+        // Compute field types and total size (including defaults)
+        let explicit_field_size: u32 = fields.iter()
+            .map(|(_, expr)| values::byte_size(&expr.ty))
+            .sum();
+        let default_field_size: u32 = if let Some(ctor_name) = name {
+            let explicit_names: std::collections::HashSet<&str> = fields.iter().map(|(n, _)| n.as_str()).collect();
+            self.emitter.default_fields.iter()
+                .filter(|((cn, _), _)| cn == ctor_name)
+                .filter(|((_, fn_name), _)| !explicit_names.contains(fn_name.as_str()))
+                .map(|((_, _), expr)| {
+                    match (&expr.ty, &expr.kind) {
+                        (Ty::Unknown, crate::ir::IrExprKind::LitInt { .. }) => values::byte_size(&Ty::Int),
+                        (Ty::Unknown, crate::ir::IrExprKind::LitFloat { .. }) => values::byte_size(&Ty::Float),
+                        _ => values::byte_size(&expr.ty),
+                    }
+                })
+                .sum()
+        } else { 0 };
+        let total_size = tag_size + explicit_field_size + default_field_size;
 
         // Allocate
         wasm!(self.func, {
@@ -40,7 +54,8 @@ impl FuncCompiler<'_> {
             });
         }
 
-        // Store each field (offset starts after tag)
+        // Store each explicit field (offset starts after tag)
+        let explicit_names: std::collections::HashSet<&str> = fields.iter().map(|(n, _)| n.as_str()).collect();
         let mut offset = tag_size;
         for (_, field_expr) in fields {
             let field_size = values::byte_size(&field_expr.ty);
@@ -49,6 +64,33 @@ impl FuncCompiler<'_> {
             self.emit_store_at(&field_expr.ty, offset);
             offset += field_size;
         }
+
+        // Fill in default fields that were not explicitly provided
+        if let Some(ctor_name) = name {
+            let defaults: Vec<(String, crate::ir::IrExpr)> = self.emitter.default_fields.iter()
+                .filter(|((cn, _), _)| cn == ctor_name)
+                .filter(|((_, fn_name), _)| !explicit_names.contains(fn_name.as_str()))
+                .map(|((_, fn_name), expr)| (fn_name.clone(), expr.clone()))
+                .collect();
+            for (_, default_expr) in &defaults {
+                // Use correct field type: infer from expr kind when ty is Unknown
+                let field_ty = match (&default_expr.ty, &default_expr.kind) {
+                    (Ty::Unknown, crate::ir::IrExprKind::LitInt { .. }) => Ty::Int,
+                    (Ty::Unknown, crate::ir::IrExprKind::LitFloat { .. }) => Ty::Float,
+                    (Ty::Unknown, crate::ir::IrExprKind::LitBool { .. }) => Ty::Bool,
+                    (Ty::Unknown, crate::ir::IrExprKind::LitStr { .. }) => Ty::String,
+                    _ => default_expr.ty.clone(),
+                };
+                let field_size = values::byte_size(&field_ty);
+                wasm!(self.func, { local_get(scratch); });
+                self.emit_expr(default_expr);
+                self.emit_store_at(&field_ty, offset);
+                offset += field_size;
+            }
+        }
+
+        // Also recompute total_size to include defaults
+        // (The allocation above may be too small — need to fix)
 
         self.match_depth -= 1;
         wasm!(self.func, { local_get(scratch); });

--- a/src/codegen/emit_wasm/control.rs
+++ b/src/codegen/emit_wasm/control.rs
@@ -654,25 +654,69 @@ impl FuncCompiler<'_> {
 
             // Tuple pattern: (a, b) => ...
             IrPattern::Tuple { elements } => {
-                // Tuple always matches (destructure only). Bind each element.
                 if let Ty::Tuple(elem_types) = subject_ty {
+                    let has_literal = elements.iter().any(|p| matches!(p, IrPattern::Literal { .. }));
+
+                    if has_literal && !is_last {
+                        // Build condition: check all literal elements
+                        let mut offset = 0u32;
+                        let mut cond_count = 0;
+                        for (i, elem_pat) in elements.iter().enumerate() {
+                            let ft = elem_types.get(i).cloned().unwrap_or(Ty::Int);
+                            if let IrPattern::Literal { expr: lit_expr } = elem_pat {
+                                wasm!(self.func, { local_get(scratch); });
+                                self.emit_load_at(&ft, offset);
+                                self.emit_expr(lit_expr);
+                                match &ft {
+                                    Ty::Int => { wasm!(self.func, { i64_eq; }); }
+                                    Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
+                                    _ => { wasm!(self.func, { i32_eq; }); }
+                                }
+                                cond_count += 1;
+                            }
+                            offset += values::byte_size(&ft);
+                        }
+                        for _ in 1..cond_count {
+                            wasm!(self.func, { i32_and; });
+                        }
+                        // if condition: bind + body, else: next arm
+                        let resolved_result = values::ty_to_valtype(result_ty);
+                        match resolved_result {
+                            Some(ValType::I64) => { wasm!(self.func, { if_i64; }); }
+                            Some(ValType::F64) => { wasm!(self.func, { if_f64; }); }
+                            Some(ValType::I32) => { wasm!(self.func, { if_i32; }); }
+                            _ => { wasm!(self.func, { if_i32; }); } // String/ptr results are i32
+                        }
+                        self.depth += 1;
+                    }
+
+                    // Bind elements
                     let mut offset = 0u32;
                     for (i, elem_pat) in elements.iter().enumerate() {
+                        let ft = elem_types.get(i).cloned().unwrap_or(Ty::Int);
                         if let IrPattern::Bind { var, .. } = elem_pat {
                             if let Some(&local_idx) = self.var_map.get(&var.0) {
-                                let ft = elem_types.get(i).cloned().unwrap_or(Ty::Int);
                                 wasm!(self.func, { local_get(scratch); });
                                 self.emit_load_at(&ft, offset);
                                 wasm!(self.func, { local_set(local_idx); });
-                                offset += values::byte_size(&ft);
                             }
-                        } else if let IrPattern::Wildcard = elem_pat {
-                            let ft = elem_types.get(i).cloned().unwrap_or(Ty::Int);
-                            offset += values::byte_size(&ft);
                         }
+                        offset += values::byte_size(&ft);
                     }
+
+                    self.emit_expr(&arm.body);
+
+                    if has_literal && !is_last {
+                        wasm!(self.func, { else_; });
+                        // Emit remaining arms
+                        self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1);
+                        wasm!(self.func, { end; });
+                        self.depth -= 1;
+                        return; // Don't fall through to normal next-arm processing
+                    }
+                } else {
+                    self.emit_expr(&arm.body);
                 }
-                self.emit_expr(&arm.body);
             }
 
             // Catch-all for unsupported patterns

--- a/src/codegen/emit_wasm/expressions.rs
+++ b/src/codegen/emit_wasm/expressions.rs
@@ -679,10 +679,15 @@ impl FuncCompiler<'_> {
         self.emit_expr(left);
         self.emit_expr(right);
         // Use the more specific type for comparison dispatch.
+        // Try to infer type from IR expression structure when both sides are Unknown
+        let inferred = self.infer_expr_ty(left).or_else(|| self.infer_expr_ty(right));
         let cmp_ty = match (&left.ty, &right.ty) {
+            (Ty::Unknown, Ty::Unknown) | (Ty::TypeVar(_), Ty::TypeVar(_))
+            | (Ty::Unknown, Ty::TypeVar(_)) | (Ty::TypeVar(_), Ty::Unknown) => {
+                if let Some(ref t) = inferred { t } else { &left.ty }
+            }
             (Ty::Unknown, _) | (Ty::TypeVar(_), _) => &right.ty,
             (_, Ty::Unknown) | (_, Ty::TypeVar(_)) => &left.ty,
-            // If left is a primitive but right is a compound type, use right
             (l, r) if !Self::is_compound_ty(l) && Self::is_compound_ty(r) => r,
             _ => &left.ty,
         };
@@ -790,6 +795,41 @@ impl FuncCompiler<'_> {
     fn is_compound_ty(ty: &Ty) -> bool {
         matches!(ty, Ty::Named(_, _) | Ty::Applied(_, _) | Ty::Variant { .. }
             | Ty::Record { .. } | Ty::Tuple(_) | Ty::String)
+    }
+
+    /// Try to infer a concrete type from an IR expression when expr.ty is Unknown.
+    fn infer_expr_ty(&self, expr: &IrExpr) -> Option<Ty> {
+        use crate::ir::IrExprKind;
+        match &expr.kind {
+            IrExprKind::TupleIndex { object, index } => {
+                // Try to get the tuple type from the object, then extract element type
+                let obj_ty = if matches!(&object.ty, Ty::Unknown | Ty::TypeVar(_)) {
+                    // Try VarTable
+                    if let IrExprKind::Var { id } = &object.kind {
+                        if (id.0 as usize) < self.var_table.len() {
+                            let info = self.var_table.get(*id);
+                            if !matches!(&info.ty, Ty::Unknown | Ty::TypeVar(_)) {
+                                Some(info.ty.clone())
+                            } else { None }
+                        } else { None }
+                    } else { None }
+                } else {
+                    Some(object.ty.clone())
+                };
+                if let Some(Ty::Tuple(elems)) = obj_ty {
+                    elems.get(*index as usize).cloned()
+                } else { None }
+            }
+            IrExprKind::Var { id } => {
+                if (id.0 as usize) < self.var_table.len() {
+                    let info = self.var_table.get(*id);
+                    if !matches!(&info.ty, Ty::Unknown | Ty::TypeVar(_)) {
+                        Some(info.ty.clone())
+                    } else { None }
+                } else { None }
+            }
+            _ => None,
+        }
     }
 
     /// Deep list equality: [a_ptr, b_ptr] → i32

--- a/src/codegen/emit_wasm/expressions.rs
+++ b/src/codegen/emit_wasm/expressions.rs
@@ -353,7 +353,6 @@ impl FuncCompiler<'_> {
 
             // ── Option/Result ──
             IrExprKind::OptionSome { expr: inner } => {
-                // Allocate space for the inner value, store it, return pointer
                 let inner_size = values::byte_size(&inner.ty);
                 let scratch = self.match_i32_base + self.match_depth;
                 wasm!(self.func, {
@@ -362,7 +361,10 @@ impl FuncCompiler<'_> {
                     local_set(scratch);
                     local_get(scratch);
                 });
+                // Reserve scratch so inner expr uses different local
+                self.match_depth += 1;
                 self.emit_expr(inner);
+                self.match_depth -= 1;
                 self.emit_store_at(&inner.ty, 0);
                 wasm!(self.func, { local_get(scratch); });
             }
@@ -384,10 +386,11 @@ impl FuncCompiler<'_> {
                     i32_const(0);
                     i32_store(0);
                 });
-                // Store value (skip for Unit — no value to store)
                 if values::ty_to_valtype(&inner.ty).is_some() {
                     wasm!(self.func, { local_get(scratch); });
+                    self.match_depth += 1;
                     self.emit_expr(inner);
+                    self.match_depth -= 1;
                     self.emit_store_at(&inner.ty, 4);
                 }
                 wasm!(self.func, { local_get(scratch); });
@@ -407,7 +410,9 @@ impl FuncCompiler<'_> {
                 });
                 if values::ty_to_valtype(&inner.ty).is_some() {
                     wasm!(self.func, { local_get(scratch); });
+                    self.match_depth += 1;
                     self.emit_expr(inner);
+                    self.match_depth -= 1;
                     self.emit_store_at(&inner.ty, 4);
                 }
                 wasm!(self.func, { local_get(scratch); });

--- a/src/codegen/emit_wasm/mod.rs
+++ b/src/codegen/emit_wasm/mod.rs
@@ -180,6 +180,7 @@ pub struct LambdaInfo {
     pub table_idx: u32,
     pub closure_type_idx: u32,
     pub captures: Vec<(crate::ir::VarId, crate::types::Ty)>,
+    pub param_ids: Vec<u32>,
 }
 
 impl WasmEmitter {
@@ -716,10 +717,12 @@ fn pre_scan_closures(program: &IrProgram, emitter: &mut WasmEmitter) {
             })
             .collect();
 
+        let param_ids: Vec<u32> = params.iter().map(|(vid, _)| vid.0).collect();
         emitter.lambdas.push(LambdaInfo {
             table_idx,
             closure_type_idx,
             captures: capture_vars,
+            param_ids,
         });
     }
 

--- a/src/codegen/emit_wasm/mod.rs
+++ b/src/codegen/emit_wasm/mod.rs
@@ -155,6 +155,8 @@ pub struct WasmEmitter {
     pub record_fields: HashMap<String, Vec<(String, crate::types::Ty)>>,
     // Variant info: variant type name → list of (case_name, tag, fields)
     pub variant_info: HashMap<String, Vec<VariantCase>>,
+    // Default field values: (type_name, field_name) → default IR expr
+    pub default_fields: HashMap<(String, String), crate::ir::IrExpr>,
 
     // Lambda/closure info: sequential index → LambdaInfo
     pub lambdas: Vec<LambdaInfo>,
@@ -228,6 +230,7 @@ impl WasmEmitter {
             func_to_table_idx: HashMap::new(),
             record_fields: HashMap::new(),
             variant_info: HashMap::new(),
+            default_fields: HashMap::new(),
             lambdas: Vec::new(),
             fn_ref_wrappers: HashMap::new(),
             lambda_counter: std::cell::Cell::new(0),
@@ -348,6 +351,35 @@ pub fn emit(program: &IrProgram) -> Vec<u8> {
                     });
                 }
                 emitter.variant_info.insert(td.name.clone(), variant_cases);
+            }
+            _ => {}
+        }
+    }
+
+    // Build default_fields from type declarations
+    for td in &program.type_decls {
+        match &td.kind {
+            crate::ir::IrTypeDeclKind::Variant { cases, .. } => {
+                for case in cases {
+                    if let crate::ir::IrVariantKind::Record { fields } = &case.kind {
+                        for f in fields {
+                            if let Some(def) = &f.default {
+                                emitter.default_fields.insert(
+                                    (case.name.clone(), f.name.clone()), def.clone()
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            crate::ir::IrTypeDeclKind::Record { fields } => {
+                for f in fields {
+                    if let Some(def) = &f.default {
+                        emitter.default_fields.insert(
+                            (td.name.clone(), f.name.clone()), def.clone()
+                        );
+                    }
+                }
             }
             _ => {}
         }

--- a/src/codegen/emit_wasm/mod.rs
+++ b/src/codegen/emit_wasm/mod.rs
@@ -652,7 +652,7 @@ use std::collections::HashSet;
 /// Register lambda functions and FnRef wrappers in the emitter.
 fn pre_scan_closures(program: &IrProgram, emitter: &mut WasmEmitter) {
     // Collect all lambdas (in tree-walk order)
-    let mut lambda_exprs: Vec<(Vec<(VarId, crate::types::Ty)>, IrExpr, HashSet<u32>)> = Vec::new();
+    let mut lambda_exprs: Vec<(Vec<(VarId, crate::types::Ty)>, IrExpr, Vec<u32>)> = Vec::new();
     let mut fn_ref_set: HashSet<String> = HashSet::new();
     let mut fn_ref_names: Vec<String> = Vec::new(); // ordered, deduped
 
@@ -750,7 +750,7 @@ fn pre_scan_closures(program: &IrProgram, emitter: &mut WasmEmitter) {
 /// Compile lambda bodies and FnRef wrappers.
 fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitter) {
     // Re-scan to get lambda bodies (in same order as pre-scan)
-    let mut lambda_exprs: Vec<(Vec<(VarId, crate::types::Ty)>, IrExpr, HashSet<u32>)> = Vec::new();
+    let mut lambda_exprs: Vec<(Vec<(VarId, crate::types::Ty)>, IrExpr, Vec<u32>)> = Vec::new();
     let mut fn_ref_set: HashSet<String> = HashSet::new();
     let mut mutable_vars: HashSet<u32> = HashSet::new();
 
@@ -931,7 +931,7 @@ fn scan_closures_expr(
     scope_vars: &mut HashSet<u32>,
     mutable_vars: &mut HashSet<u32>,
     var_table: &crate::ir::VarTable,
-    lambdas: &mut Vec<(Vec<(VarId, crate::types::Ty)>, IrExpr, HashSet<u32>)>,
+    lambdas: &mut Vec<(Vec<(VarId, crate::types::Ty)>, IrExpr, Vec<u32>)>,
     fn_refs: &mut HashSet<String>,
 ) {
     match &expr.kind {
@@ -940,10 +940,11 @@ fn scan_closures_expr(
             let param_ids: HashSet<u32> = params.iter().map(|(vid, _)| vid.0).collect();
             let mut body_vars = HashSet::new();
             collect_var_refs(body, &mut body_vars);
-            let captures: HashSet<u32> = body_vars.difference(&param_ids)
+            let mut captures: Vec<u32> = body_vars.difference(&param_ids)
                 .copied()
                 .filter(|vid| scope_vars.contains(vid))
                 .collect();
+            captures.sort(); // Deterministic order for env layout
 
             let param_list: Vec<(VarId, crate::types::Ty)> = params.iter()
                 .map(|(vid, ty)| (*vid, ty.clone()))
@@ -1019,7 +1020,7 @@ fn scan_closures_stmt(
     scope_vars: &mut HashSet<u32>,
     mutable_vars: &mut HashSet<u32>,
     var_table: &crate::ir::VarTable,
-    lambdas: &mut Vec<(Vec<(VarId, crate::types::Ty)>, IrExpr, HashSet<u32>)>,
+    lambdas: &mut Vec<(Vec<(VarId, crate::types::Ty)>, IrExpr, Vec<u32>)>,
     fn_refs: &mut HashSet<String>,
 ) {
     match &stmt.kind {

--- a/src/codegen/emit_wasm/mod.rs
+++ b/src/codegen/emit_wasm/mod.rs
@@ -1044,6 +1044,20 @@ fn scan_closures_stmt(
             scan_closures_expr(cond, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
             scan_closures_expr(else_, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
         }
+        IrStmtKind::BindDestructure { value, .. } => {
+            scan_closures_expr(value, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
+        }
+        IrStmtKind::IndexAssign { index, value, .. } => {
+            scan_closures_expr(index, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
+            scan_closures_expr(value, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            scan_closures_expr(key, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
+            scan_closures_expr(value, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
+        }
+        IrStmtKind::FieldAssign { value, .. } => {
+            scan_closures_expr(value, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
+        }
         _ => {}
     }
 }

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -347,56 +347,93 @@ fn compile_int_to_string(emitter: &mut WasmEmitter) {
 }
 
 /// __float_to_string(f: f64) -> i32
-/// Converts float to string: integer_part + "." + first decimal digit.
-/// e.g., 10.0 → "10.0", 3.5 → "3.5", -2.7 → "-2.7"
+/// Multi-digit decimal: integer_part + "." + decimal_digits (up to 15, trailing zeros trimmed)
 fn compile_float_to_string(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.float_to_string];
-    // locals: 0=f64 input, 1=i64 int_part, 2=i32 int_str, 3=i32 dot_str, 4=i64 frac, 5=i32 frac_str
-    let mut f = Function::new([(1, ValType::I64), (1, ValType::I32), (1, ValType::I32), (1, ValType::I64), (1, ValType::I32)]);
+    // locals: 0=f64 input | 1=i32 int_str, 2=i32 result, 3=f64 frac, 4=i32 buf, 5=i32 count, 6=i32 digit
+    let mut f = Function::new([
+        (1, ValType::I32), (1, ValType::I32), (1, ValType::F64),
+        (1, ValType::I32), (1, ValType::I32), (1, ValType::I32),
+    ]);
 
+    // int_str = int_to_string(trunc(f))
     wasm!(f, {
-        // int_part = trunc(abs(f))
-        local_get(0);
-        f64_abs;
-        i64_trunc_f64_s;
-        local_set(1);
-
-        // frac = round((abs(f) - int_part) * 10)
-        local_get(0);
-        f64_abs;
-        local_get(1);
-        f64_convert_i64_s;
-        f64_sub;
-        f64_const(10.0);
-        f64_mul;
-        i64_trunc_f64_s;
-        local_set(4);
-
-        // Build: int_to_string(trunc(f)) + "." + int_to_string(frac)
-        // If negative: int_to_string handles the sign via trunc(f)
         local_get(0);
         i64_trunc_f64_s;
         call(emitter.rt.int_to_string);
-        local_set(2);
+        local_set(1);
+        // frac = abs(f) - abs(trunc(f))
+        local_get(0); f64_abs;
+        local_get(0); i64_trunc_f64_s; f64_convert_i64_s; f64_abs;
+        f64_sub;
+        local_set(3);
+        // Alloc scratch buffer for decimal digits (max 20)
+        i32_const(20); call(emitter.rt.alloc); local_set(4);
+        i32_const(0); local_set(5); // count = 0
     });
-
-    // Intern "."
+    // Loop: extract digits while frac > 0 and count < 15
+    wasm!(f, {
+        block_empty; loop_empty;
+          local_get(5); i32_const(15); i32_ge_u; br_if(1);
+          // digit = trunc(frac * 10)
+          local_get(3); f64_const(10.0); f64_mul; local_set(3);
+          local_get(3); i64_trunc_f64_s; i32_wrap_i64; local_set(6);
+          // buf[count] = '0' + digit
+          local_get(4); local_get(5); i32_add;
+          local_get(6); i32_const(48); i32_add;
+          i32_store8(0);
+          // frac = frac - digit
+          local_get(3); local_get(6); i64_extend_i32_u; f64_convert_i64_s; f64_sub; local_set(3);
+          local_get(5); i32_const(1); i32_add; local_set(5);
+          // Stop if frac is essentially 0
+          local_get(3); f64_const(0.000000000000001); f64_lt;
+          br_if(1);
+          br(0);
+        end; end;
+    });
+    // Ensure at least 1 digit (for "X.0")
+    wasm!(f, {
+        local_get(5); i32_eqz;
+        if_empty;
+          local_get(4); i32_const(48); i32_store8(0); // '0'
+          i32_const(1); local_set(5);
+        end;
+    });
+    // Trim trailing zeros (but keep at least 1 digit)
+    wasm!(f, {
+        block_empty; loop_empty;
+          local_get(5); i32_const(1); i32_le_u; br_if(1);
+          local_get(4); local_get(5); i32_const(1); i32_sub; i32_add;
+          i32_load8_u(0);
+          i32_const(48); // '0'
+          i32_ne; br_if(1);
+          local_get(5); i32_const(1); i32_sub; local_set(5);
+          br(0);
+        end; end;
+    });
+    // Build frac string from buf[0..count]
+    wasm!(f, {
+        i32_const(4); local_get(5); i32_add;
+        call(emitter.rt.alloc); local_set(2);
+        local_get(2); local_get(5); i32_store(0);
+        // Copy digits
+        i32_const(0); local_set(6);
+        block_empty; loop_empty;
+          local_get(6); local_get(5); i32_ge_u; br_if(1);
+          local_get(2); i32_const(4); i32_add; local_get(6); i32_add;
+          local_get(4); local_get(6); i32_add; i32_load8_u(0);
+          i32_store8(0);
+          local_get(6); i32_const(1); i32_add; local_set(6);
+          br(0);
+        end; end;
+    });
+    // Result: int_str + "." + frac_str
     let dot = emitter.intern_string(".");
     wasm!(f, {
-        // dot_str
+        local_get(1);
         i32_const(dot as i32);
-        local_set(3);
-
-        // frac_str = int_to_string(frac)
-        local_get(4);
-        call(emitter.rt.int_to_string);
-        local_set(5);
-
-        // concat: int_str + "." + frac_str
-        local_get(2);
-        local_get(3);
         call(emitter.rt.concat_str);
-        local_get(5);
+        local_get(2);
         call(emitter.rt.concat_str);
         end;
     });

--- a/src/codegen/emit_wasm/statements.rs
+++ b/src/codegen/emit_wasm/statements.rs
@@ -107,7 +107,6 @@ impl FuncCompiler<'_> {
             }
 
             IrStmtKind::BindDestructure { pattern, value } => {
-                // Emit value (usually a tuple/record ptr)
                 self.emit_expr(value);
                 let scratch = self.match_i32_base + self.match_depth;
                 wasm!(self.func, { local_set(scratch); });


### PR DESCRIPTION
Fix flatten/flat_map/filter_map elem_size, OptionSome/ResultOk scratch depth, lambda capture ordering (sorted Vec), lambda param_ids matching (mono-safe), list.map local scratch (nested map), tuple match literal check + offset, type inference for equality (TupleIndex/VarTable), map.from_list, BindDestructure lambda scan, float.to_string multi-digit, record default fields. 80→90 pass.