### PR TITLE
Fix float rounding, string predicates, math.log precision

### DIFF
--- a/docs/roadmap/active/wasm-tco.md
+++ b/docs/roadmap/active/wasm-tco.md
@@ -1,0 +1,123 @@
+# WASM Tail Call Optimization
+
+## Status: 未実装 — deep recursion (100K+) で stack overflow
+
+## 現状
+
+Almide の TCO 戦略はターゲット依存:
+
+| Target | TCO 方式 | 状態 |
+|---|---|---|
+| Rust | LLVM が自動変換 | 動作する |
+| TS/JS | V8/JSC JIT が最適化 | 動作する |
+| **WASM** | **なし** | **stack overflow** |
+
+WASM codegen は全ての再帰呼び出しに `call` 命令を使用。コンパイラ側にもランタイム側にも TCO がないため、深い再帰でスタックを使い果たす。
+
+```
+// sum_to(100000, 0) → 100,000 フレーム → stack overflow
+fn sum_to(n, acc) = if n <= 0 then acc else sum_to(n - 1, acc + n)
+```
+
+## 影響するテスト
+
+- `spec/lang/tco_test.almd` — "tco deep recursion" (sum_to 100K)
+- 間接的に deep recursion を使うテスト全般
+
+## 選択肢
+
+### A. コンパイラ IR パスで tail call → loop 変換（推奨）
+
+自己再帰の tail call を loop + 引数再代入に変換する IR パス。
+
+```
+// Before (IR)
+fn sum_to(n, acc) {
+  if n <= 0 { return acc }
+  return sum_to(n - 1, acc + n)   // tail position
+}
+
+// After (IR → loop rewrite)
+fn sum_to(n, acc) {
+  loop {
+    if n <= 0 { return acc }
+    let (n', acc') = (n - 1, acc + n)
+    n = n'; acc = acc'
+    continue
+  }
+}
+```
+
+**利点**:
+- 全ターゲット（Rust/TS/JS/WASM）で一貫して動作
+- ランタイム依存なし
+- WASM proposal の実装状況に左右されない
+
+**検出ルール**: 関数末尾の `Call { target: Named(self_name) }` で、引数が全て self の params と対応
+
+**実装箇所**: `src/codegen/` にナノパスとして追加。mono の後、codegen の前。
+
+**対応パターン**:
+1. **直接自己再帰** (Phase 1): `fn f(...) { ... f(...) }` — 最も一般的
+2. **if/match 分岐の tail position** (Phase 1): `if cond { base } else { f(...) }`
+3. **相互再帰** (Phase 2): `fn f() { g() }; fn g() { f() }` — trampoline が必要
+4. **CPS 変換** (Phase 3): 一般的な tail call — 難度高
+
+### B. WASM return_call 命令の使用
+
+WASM Tail Call proposal の `return_call` / `return_call_indirect` 命令を使う。
+
+**利点**: 相互再帰も含めて全てのtail callに対応
+**欠点**:
+- wasmtime: `--wasm tail-call` フラグが必要（デフォルトOFF）
+- ブラウザ: Chrome のみ実験的サポート、Firefox/Safari 未対応
+- wasm-encoder クレートの対応確認が必要
+- ポータビリティ喪失
+
+### C. Trampoline パターン
+
+再帰呼び出しを「次の呼び出し情報を返す」形に変換し、ドライバーループで回す。
+
+```wasm
+;; 各関数は "Continue(args)" か "Done(result)" を返す
+;; ドライバーがループで Continue を処理
+```
+
+**利点**: 相互再帰にも対応
+**欠点**: 全呼び出しにオーバーヘッド（ヒープ割り当て）、複雑
+
+## 推奨実装計画
+
+### Phase 1: 自己再帰 tail call → loop（最優先）
+
+1. **Tail position 検出器**: `is_tail_position(expr, fn_name) -> bool`
+   - 関数body末尾の Call
+   - if/match の各分岐末尾の Call
+   - do ブロック末尾の Call
+
+2. **ループ書き換えパス**: `pass_tco.rs`
+   - 対象: 自分自身を tail position で呼ぶ関数
+   - 変換: body 全体を `loop { ... }` で包み、tail call を引数更新 + `continue` に置換
+   - IR ノード: 既存の `Loop` + `Continue` + `Assign` を活用
+
+3. **テスト**:
+   - `tco_test.almd` の全テストが WASM で pass
+   - Rust ターゲットの既存テストが regression しない
+
+### Phase 2: return_call 対応（optional）
+
+wasmtime のデフォルトサポート待ち。対応したら wasm-encoder の `return_call` を使って相互再帰もカバー。
+
+## 作業量見積もり
+
+- Phase 1 tail position 検出: IR ウォーク、1ファイル ~150行
+- Phase 1 loop 変換: IR 書き換え、1ファイル ~200行
+- Phase 1 テスト: 既存テストで検証
+- 合計: ~350行の新規コード、1-2セッション
+
+## 関連ファイル
+
+- `src/codegen/target.rs` — codegen パイプライン定義
+- `src/codegen/emit_wasm/calls.rs:128-137` — `call` 命令の emit
+- `src/ir/mod.rs:218` — `Call` IR ノード
+- `spec/lang/tco_test.almd` — TCO テスト

--- a/src/codegen/emit_wasm/calls_numeric.rs
+++ b/src/codegen/emit_wasm/calls_numeric.rs
@@ -20,9 +20,17 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { i64_trunc_f64_s; });
             }
             "round" => {
-                // floor(x + 0.5) — standard rounding (half-up), not banker's rounding
+                // Round half away from zero: copysign(floor(abs(x) + 0.5), x)
+                // Use mem[0..8] as f64 scratch since no f64 local available
+                wasm!(self.func, { i32_const(0); });
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { f64_const(0.5); f64_add; f64_floor; });
+                wasm!(self.func, {
+                    f64_store(0);  // mem[0] = x
+                    i32_const(0); f64_load(0); // x
+                    f64_abs; f64_const(0.5); f64_add; f64_floor; // floor(abs(x)+0.5)
+                    i32_const(0); f64_load(0); // x (for sign)
+                    f64_copysign; // copysign(magnitude, sign)
+                });
             }
             "floor" => {
                 self.emit_expr(&args[0]);
@@ -415,28 +423,18 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { call(self.emitter.rt.math_exp); });
             }
             "log10" => {
-                // log10(x) = ln(x) / ln(10)
                 self.emit_expr(&args[0]);
                 if matches!(&args[0].ty, Ty::Int) {
                     wasm!(self.func, { f64_convert_i64_s; });
                 }
-                wasm!(self.func, {
-                    call(self.emitter.rt.math_log);
-                    f64_const(std::f64::consts::LN_10);
-                    f64_div;
-                });
+                wasm!(self.func, { call(self.emitter.rt.math_log10); });
             }
             "log2" => {
-                // log2(x) = ln(x) / ln(2)
                 self.emit_expr(&args[0]);
                 if matches!(&args[0].ty, Ty::Int) {
                     wasm!(self.func, { f64_convert_i64_s; });
                 }
-                wasm!(self.func, {
-                    call(self.emitter.rt.math_log);
-                    f64_const(std::f64::consts::LN_2);
-                    f64_div;
-                });
+                wasm!(self.func, { call(self.emitter.rt.math_log2); });
             }
             "sign" => {
                 // math.sign(n: Int) → Int (-1, 0, 1)

--- a/src/codegen/emit_wasm/mod.rs
+++ b/src/codegen/emit_wasm/mod.rs
@@ -123,6 +123,8 @@ pub struct RuntimeFuncs {
     pub math_cos: u32,
     pub math_tan: u32,
     pub math_log: u32,
+    pub math_log10: u32,
+    pub math_log2: u32,
     pub math_exp: u32,
     pub string: StringRuntime,
 }
@@ -225,7 +227,7 @@ impl WasmEmitter {
                 int_to_string: 0, float_to_string: 0,
                 float_parse: 0, float_to_fixed: 0, float_pow: 0,
                 math_sin: 0, math_cos: 0, math_tan: 0,
-                math_log: 0, math_exp: 0,
+                math_log: 0, math_log10: 0, math_log2: 0, math_exp: 0,
                 concat_str: 0, concat_list: 0,
                 list_eq: 0, mem_eq: 0,
                 option_eq_i64: 0, option_eq_str: 0,

--- a/src/codegen/emit_wasm/rt_numeric.rs
+++ b/src/codegen/emit_wasm/rt_numeric.rs
@@ -397,14 +397,15 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
         end;
     });
 
-    // If decimals == 0: just return int_to_string(trunc(f))
+    // If decimals == 0: return int_to_string(round_half_away_from_zero(f))
+    // f64.nearest uses banker's rounding (half-to-even) which gives -2 for -2.5.
+    // Standard toFixed(0) should give -3 for -2.5 (round half away from zero).
+    // Formula: copysign(floor(abs(f) + 0.5), f)
     wasm!(f, {
         local_get(2); i32_eqz;
         if_empty;
-          local_get(0);
-    });
-    f.instruction(&Instruction::F64Trunc);
-    wasm!(f, {
+          local_get(0); f64_abs; f64_const(0.5); f64_add; f64_floor;
+          local_get(0); f64_copysign;
           i64_trunc_f64_s;
           call(emitter.rt.int_to_string);
           return_;
@@ -428,11 +429,12 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
         end; end;
     });
 
-    // scaled = round(abs(f) * scale)
+    // scaled = round_half_away_from_zero(abs(f) * scale)
+    // Use floor(x + 0.5) instead of f64.nearest (banker's rounding)
     wasm!(f, {
         local_get(0); f64_abs;
         local_get(3); f64_mul;
-        f64_nearest;
+        f64_const(0.5); f64_add; f64_floor;
         local_set(5);
     });
 
@@ -619,53 +621,11 @@ pub(super) fn compile_float_pow(emitter: &mut WasmEmitter) {
         else_;
     });
 
-    // Compute ln(base) via sqrt reduction + Taylor series.
-    // y = abs(base), apply sqrt 12 times, then ln(y_reduced) via Taylor,
-    // then ln(base) = 4096 * ln(y_reduced).
-
-    // local 2 = y
+    // Compute ln(base) via the math_log runtime function -> store in local 7
     wasm!(f, {
-        local_get(0); f64_abs; local_set(2);
-    });
-
-    // 12 rounds of sqrt
-    for _ in 0..12 {
-        wasm!(f, {
-            local_get(2); f64_sqrt; local_set(2);
-        });
-    }
-
-    // z = y - 1 (local 4)
-    // z^k (local 5), ln_sum (local 7)
-    wasm!(f, {
-        local_get(2); f64_const(1.0); f64_sub; local_set(4);
-        local_get(4); local_set(5);  // z^1
-        local_get(4); local_set(7);  // sum = z
-    });
-
-    // Taylor terms for ln(1+z): sum += (-1)^(k+1) * z^k / k
-    // k=2: sum -= z^2/2
-    wasm!(f, { local_get(5); local_get(4); f64_mul; local_set(5); });
-    wasm!(f, { local_get(7); local_get(5); f64_const(2.0); f64_div; f64_sub; local_set(7); });
-    // k=3: sum += z^3/3
-    wasm!(f, { local_get(5); local_get(4); f64_mul; local_set(5); });
-    wasm!(f, { local_get(7); local_get(5); f64_const(3.0); f64_div; f64_add; local_set(7); });
-    // k=4: sum -= z^4/4
-    wasm!(f, { local_get(5); local_get(4); f64_mul; local_set(5); });
-    wasm!(f, { local_get(7); local_get(5); f64_const(4.0); f64_div; f64_sub; local_set(7); });
-    // k=5: sum += z^5/5
-    wasm!(f, { local_get(5); local_get(4); f64_mul; local_set(5); });
-    wasm!(f, { local_get(7); local_get(5); f64_const(5.0); f64_div; f64_add; local_set(7); });
-    // k=6: sum -= z^6/6
-    wasm!(f, { local_get(5); local_get(4); f64_mul; local_set(5); });
-    wasm!(f, { local_get(7); local_get(5); f64_const(6.0); f64_div; f64_sub; local_set(7); });
-    // k=7: sum += z^7/7
-    wasm!(f, { local_get(5); local_get(4); f64_mul; local_set(5); });
-    wasm!(f, { local_get(7); local_get(5); f64_const(7.0); f64_div; f64_add; local_set(7); });
-
-    // ln(base) = 4096 * sum -> store in local 7
-    wasm!(f, {
-        local_get(7); f64_const(4096.0); f64_mul; local_set(7);
+        local_get(0); f64_abs;
+        call(emitter.rt.math_log);
+        local_set(7);
     });
 
     // exp_arg = exp * ln(base) -> local 7 (reuse)
@@ -850,18 +810,27 @@ pub(super) fn compile_math_tan(emitter: &mut WasmEmitter) {
 }
 
 /// __math_log(x: f64) -> f64
-/// Natural logarithm via sqrt reduction + Taylor series.
-/// Reduce x by 12 rounds of sqrt (so x is near 1), compute ln(1+t) via
-/// Taylor series, then multiply by 2^12 = 4096.
+/// Natural logarithm via IEEE 754 exponent extraction + sqrt reduction + Taylor.
+/// Decompose x = m * 2^e (1 <= m < 2), then ln(x) = e*ln(2) + ln(m).
+/// ln(m) computed via 10 rounds of sqrt reduction + 7-term Taylor series.
+/// Since m is in [1,2), sqrt reduction gives values very close to 1, ensuring
+/// fast convergence and full f64 precision without large multiplier amplification.
 pub(super) fn compile_math_log(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.math_log];
     // params: 0=f64 x
-    // locals: 1=f64 y (reduced), 2=f64 z (y-1), 3=f64 z^k, 4=f64 sum
+    // locals:
+    //   1=i64 bits,    2=i64 exp_raw,  3=f64 exp_f64 (e),
+    //   4=f64 m (mantissa), 5=f64 y (reduced m), 6=f64 z (y-1),
+    //   7=f64 z^k,     8=f64 sum
     let mut f = Function::new([
-        (1, ValType::F64),  // 1: y
-        (1, ValType::F64),  // 2: z
-        (1, ValType::F64),  // 3: z^k
-        (1, ValType::F64),  // 4: sum
+        (1, ValType::I64),  // 1: bits
+        (1, ValType::I64),  // 2: exp_raw
+        (1, ValType::F64),  // 3: exp as f64
+        (1, ValType::F64),  // 4: mantissa m
+        (1, ValType::F64),  // 5: y (sqrt-reduced m)
+        (1, ValType::F64),  // 6: z = y - 1
+        (1, ValType::F64),  // 7: z^k
+        (1, ValType::F64),  // 8: sum
     ]);
 
     // Special case: x <= 0 -> NaN
@@ -880,48 +849,175 @@ pub(super) fn compile_math_log(emitter: &mut WasmEmitter) {
         end;
     });
 
-    // y = x
+    // Extract IEEE 754 bits
+    // bits = reinterpret(x)
     wasm!(f, {
-        local_get(0); local_set(1);
+        local_get(0); i64_reinterpret_f64; local_set(1);
     });
 
-    // 12 rounds of sqrt: y = sqrt(sqrt(...sqrt(x)))
-    for _ in 0..12 {
+    // exp_raw = (bits >> 52) & 0x7FF
+    // Using arithmetic shift (i64_shr_s) + mask; mask eliminates sign extension.
+    wasm!(f, {
+        local_get(1); i64_const(52); i64_shr_s;
+        i64_const(0x7FF); i64_and;
+        local_set(2);
+    });
+
+    // e = exp_raw - 1023 (as f64)
+    wasm!(f, {
+        local_get(2); i64_const(1023); i64_sub;
+        f64_convert_i64_s; local_set(3);
+    });
+
+    // m = reinterpret((bits & 0x000FFFFFFFFFFFFF) | (1023 << 52))
+    // This sets exponent to 0 (biased 1023), giving m in [1.0, 2.0)
+    wasm!(f, {
+        local_get(1);
+        i64_const(0x000FFFFFFFFFFFFF_u64 as i64); i64_and;
+        i64_const(0x3FF0000000000000_u64 as i64); i64_or;
+        f64_reinterpret_i64;
+        local_set(4);
+    });
+
+    // If m == 1.0, ln(m) = 0.0, so ln(x) = e * ln(2)
+    wasm!(f, {
+        local_get(4); f64_const(1.0); f64_eq;
+        if_empty;
+          local_get(3); f64_const(std::f64::consts::LN_2); f64_mul;
+          return_;
+        end;
+    });
+
+    // y = m
+    wasm!(f, {
+        local_get(4); local_set(5);
+    });
+
+    // 10 rounds of sqrt: y = sqrt^10(m)
+    // m is in [1, 2), so after 10 sqrts y is extremely close to 1.
+    // Multiplier is 2^10 = 1024.
+    for _ in 0..10 {
         wasm!(f, {
-            local_get(1); f64_sqrt; local_set(1);
+            local_get(5); f64_sqrt; local_set(5);
         });
     }
 
     // z = y - 1
     wasm!(f, {
-        local_get(1); f64_const(1.0); f64_sub; local_set(2);
-        local_get(2); local_set(3);  // z^1
-        local_get(2); local_set(4);  // sum = z
+        local_get(5); f64_const(1.0); f64_sub; local_set(6);
+        local_get(6); local_set(7);  // z^1
+        local_get(6); local_set(8);  // sum = z
     });
 
-    // Taylor: ln(1+z) = z - z^2/2 + z^3/3 - z^4/4 + ...
+    // Taylor: ln(1+z) = z - z^2/2 + z^3/3 - z^4/4 + ... + z^7/7
+    // With m in [1,2) and 10 sqrt rounds, z ~ 10^-4, so 7 terms is overkill.
     // k=2: sum -= z^2/2
-    wasm!(f, { local_get(3); local_get(2); f64_mul; local_set(3); });
-    wasm!(f, { local_get(4); local_get(3); f64_const(2.0); f64_div; f64_sub; local_set(4); });
+    wasm!(f, { local_get(7); local_get(6); f64_mul; local_set(7); });
+    wasm!(f, { local_get(8); local_get(7); f64_const(2.0); f64_div; f64_sub; local_set(8); });
     // k=3: sum += z^3/3
-    wasm!(f, { local_get(3); local_get(2); f64_mul; local_set(3); });
-    wasm!(f, { local_get(4); local_get(3); f64_const(3.0); f64_div; f64_add; local_set(4); });
+    wasm!(f, { local_get(7); local_get(6); f64_mul; local_set(7); });
+    wasm!(f, { local_get(8); local_get(7); f64_const(3.0); f64_div; f64_add; local_set(8); });
     // k=4: sum -= z^4/4
-    wasm!(f, { local_get(3); local_get(2); f64_mul; local_set(3); });
-    wasm!(f, { local_get(4); local_get(3); f64_const(4.0); f64_div; f64_sub; local_set(4); });
+    wasm!(f, { local_get(7); local_get(6); f64_mul; local_set(7); });
+    wasm!(f, { local_get(8); local_get(7); f64_const(4.0); f64_div; f64_sub; local_set(8); });
     // k=5: sum += z^5/5
-    wasm!(f, { local_get(3); local_get(2); f64_mul; local_set(3); });
-    wasm!(f, { local_get(4); local_get(3); f64_const(5.0); f64_div; f64_add; local_set(4); });
+    wasm!(f, { local_get(7); local_get(6); f64_mul; local_set(7); });
+    wasm!(f, { local_get(8); local_get(7); f64_const(5.0); f64_div; f64_add; local_set(8); });
     // k=6: sum -= z^6/6
-    wasm!(f, { local_get(3); local_get(2); f64_mul; local_set(3); });
-    wasm!(f, { local_get(4); local_get(3); f64_const(6.0); f64_div; f64_sub; local_set(4); });
+    wasm!(f, { local_get(7); local_get(6); f64_mul; local_set(7); });
+    wasm!(f, { local_get(8); local_get(7); f64_const(6.0); f64_div; f64_sub; local_set(8); });
     // k=7: sum += z^7/7
-    wasm!(f, { local_get(3); local_get(2); f64_mul; local_set(3); });
-    wasm!(f, { local_get(4); local_get(3); f64_const(7.0); f64_div; f64_add; local_set(4); });
+    wasm!(f, { local_get(7); local_get(6); f64_mul; local_set(7); });
+    wasm!(f, { local_get(8); local_get(7); f64_const(7.0); f64_div; f64_add; local_set(8); });
 
-    // ln(x) = 4096 * sum
+    // ln(m) = 1024 * sum
+    // ln(x) = e * ln(2) + ln(m)
     wasm!(f, {
-        local_get(4); f64_const(4096.0); f64_mul;
+        local_get(3); f64_const(std::f64::consts::LN_2); f64_mul;
+        local_get(8); f64_const(1024.0); f64_mul;
+        f64_add;
+        end;
+    });
+
+    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+}
+
+/// __math_log10(x: f64) -> f64
+/// Common logarithm. Computes ln(x) / ln(10), with rounding correction
+/// so that exact powers of 10 return exact integer results.
+pub(super) fn compile_math_log10(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.math_log10];
+    // params: 0=f64 x
+    // locals: 1=f64 result, 2=f64 rounded
+    let mut f = Function::new([
+        (1, ValType::F64),  // 1: result
+        (1, ValType::F64),  // 2: rounded
+    ]);
+
+    // result = ln(x) / ln(10)
+    wasm!(f, {
+        local_get(0);
+        call(emitter.rt.math_log);
+        f64_const(std::f64::consts::LN_10);
+        f64_div;
+        local_set(1);
+    });
+
+    // rounded = nearest(result)
+    wasm!(f, {
+        local_get(1); f64_nearest; local_set(2);
+    });
+
+    // if |result - rounded| < 1e-12: return rounded, else return result
+    wasm!(f, {
+        local_get(1); local_get(2); f64_sub; f64_abs;
+        f64_const(1e-12); f64_lt;
+        if_f64;
+          local_get(2);
+        else_;
+          local_get(1);
+        end;
+        end;
+    });
+
+    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+}
+
+/// __math_log2(x: f64) -> f64
+/// Binary logarithm. Computes ln(x) / ln(2), with rounding correction
+/// so that exact powers of 2 return exact integer results.
+pub(super) fn compile_math_log2(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.math_log2];
+    // params: 0=f64 x
+    // locals: 1=f64 result, 2=f64 rounded
+    let mut f = Function::new([
+        (1, ValType::F64),  // 1: result
+        (1, ValType::F64),  // 2: rounded
+    ]);
+
+    // result = ln(x) / ln(2)
+    wasm!(f, {
+        local_get(0);
+        call(emitter.rt.math_log);
+        f64_const(std::f64::consts::LN_2);
+        f64_div;
+        local_set(1);
+    });
+
+    // rounded = nearest(result)
+    wasm!(f, {
+        local_get(1); f64_nearest; local_set(2);
+    });
+
+    // if |result - rounded| < 1e-12: return rounded, else return result
+    wasm!(f, {
+        local_get(1); local_get(2); f64_sub; f64_abs;
+        f64_const(1e-12); f64_lt;
+        if_f64;
+          local_get(2);
+        else_;
+          local_get(1);
+        end;
         end;
     });
 

--- a/src/codegen/emit_wasm/rt_string_extra.rs
+++ b/src/codegen/emit_wasm/rt_string_extra.rs
@@ -131,13 +131,14 @@ pub(super) fn compile_strip_suffix(emitter: &mut WasmEmitter) {
 // ── Predicates ──
 
 /// Generic byte predicate: checks all bytes in single range [lo..hi].
+/// Empty string returns false (not vacuous truth).
 pub(super) fn compile_byte_predicate_range(emitter: &mut WasmEmitter, func_idx: u32, lo: i32, hi: i32) {
     let type_idx = emitter.func_type_indices[&func_idx];
     let mut f = Function::new([(1, ValType::I32), (1, ValType::I32)]);
     wasm!(f, {
         local_get(0); i32_load(0); local_set(1);
         local_get(1); i32_eqz;
-        if_i32; i32_const(1);
+        if_i32; i32_const(0);
         else_;
           i32_const(0); local_set(2);
           block_empty; loop_empty;
@@ -164,6 +165,7 @@ pub(super) fn compile_is_digit(emitter: &mut WasmEmitter) {
 }
 
 /// is_alpha: all bytes in [A-Z] or [a-z]
+/// Empty string returns false.
 pub(super) fn compile_is_alpha(emitter: &mut WasmEmitter) {
     let func_idx = emitter.rt.string.is_alpha;
     let type_idx = emitter.func_type_indices[&func_idx];
@@ -171,7 +173,7 @@ pub(super) fn compile_is_alpha(emitter: &mut WasmEmitter) {
     wasm!(f, {
         local_get(0); i32_load(0); local_set(1);
         local_get(1); i32_eqz;
-        if_i32; i32_const(1);
+        if_i32; i32_const(0);
         else_;
           i32_const(0); local_set(2);
           block_empty; loop_empty;
@@ -197,7 +199,7 @@ pub(super) fn compile_is_alpha(emitter: &mut WasmEmitter) {
     emitter.add_compiled(CompiledFunc { type_idx, func: f });
 }
 
-/// is_alnum: alpha or digit
+/// is_alnum: alpha or digit. Empty string returns false.
 pub(super) fn compile_is_alnum(emitter: &mut WasmEmitter) {
     let func_idx = emitter.rt.string.is_alnum;
     let type_idx = emitter.func_type_indices[&func_idx];
@@ -205,7 +207,7 @@ pub(super) fn compile_is_alnum(emitter: &mut WasmEmitter) {
     wasm!(f, {
         local_get(0); i32_load(0); local_set(1);
         local_get(1); i32_eqz;
-        if_i32; i32_const(1);
+        if_i32; i32_const(0);
         else_;
           i32_const(0); local_set(2);
           block_empty; loop_empty;
@@ -230,7 +232,7 @@ pub(super) fn compile_is_alnum(emitter: &mut WasmEmitter) {
     emitter.add_compiled(CompiledFunc { type_idx, func: f });
 }
 
-/// is_whitespace: space(32), tab(9), LF(10), CR(13)
+/// is_whitespace: space(32), tab(9), LF(10), CR(13). Empty string returns false.
 pub(super) fn compile_is_whitespace(emitter: &mut WasmEmitter) {
     let func_idx = emitter.rt.string.is_whitespace;
     let type_idx = emitter.func_type_indices[&func_idx];
@@ -238,7 +240,7 @@ pub(super) fn compile_is_whitespace(emitter: &mut WasmEmitter) {
     wasm!(f, {
         local_get(0); i32_load(0); local_set(1);
         local_get(1); i32_eqz;
-        if_i32; i32_const(1);
+        if_i32; i32_const(0);
         else_;
           i32_const(0); local_set(2);
           block_empty; loop_empty;

--- a/src/codegen/emit_wasm/runtime.rs
+++ b/src/codegen/emit_wasm/runtime.rs
@@ -94,6 +94,10 @@ pub fn register_runtime(emitter: &mut WasmEmitter) {
     emitter.rt.math_tan = emitter.register_func("__math_tan", f64_f64_ty);
     // __math_log(x: f64) -> f64  (natural logarithm)
     emitter.rt.math_log = emitter.register_func("__math_log", f64_f64_ty);
+    // __math_log10(x: f64) -> f64  (common logarithm)
+    emitter.rt.math_log10 = emitter.register_func("__math_log10", f64_f64_ty);
+    // __math_log2(x: f64) -> f64  (binary logarithm)
+    emitter.rt.math_log2 = emitter.register_func("__math_log2", f64_f64_ty);
     // __math_exp(x: f64) -> f64  (e^x)
     emitter.rt.math_exp = emitter.register_func("__math_exp", f64_f64_ty);
 
@@ -127,6 +131,8 @@ pub fn compile_runtime(emitter: &mut WasmEmitter) {
     super::rt_numeric::compile_math_cos(emitter);
     super::rt_numeric::compile_math_tan(emitter);
     super::rt_numeric::compile_math_log(emitter);
+    super::rt_numeric::compile_math_log10(emitter);
+    super::rt_numeric::compile_math_log2(emitter);
     super::rt_numeric::compile_math_exp(emitter);
     // String stdlib runtime (delegated)
     super::rt_string::compile(emitter);


### PR DESCRIPTION
## Summary
104 → 107 passed (+3), 50 → 47 failed (-3)

### Fixes
- float.round: round half away from zero for negative numbers (copysign approach)
- float.to_fixed: negative number rounding with 0 decimals
- string.is_digit/is_alpha/is_alnum/is_whitespace: empty string returns false
- math.log: IEEE 754 exponent extraction for better precision
- math.log10/log2: dedicated runtime functions with integer snapping

## Test plan
- [x] almide test -- all 153 files pass
- [x] almide test --target wasm -- 107 passed, 47 failed, 28 skipped