### PR TITLE
Fix map Int/Bool keys, list.map TypeVar resolution, lambda call_indirect types

### DIFF
--- a/src/codegen/emit_wasm/calls_list_closure2.rs
+++ b/src/codegen/emit_wasm/calls_list_closure2.rs
@@ -5,7 +5,7 @@
 
 use super::FuncCompiler;
 use super::values;
-use crate::ir::IrExpr;
+use crate::ir::{IrExpr, IrExprKind};
 use crate::types::Ty;
 use wasm_encoder::ValType;
 
@@ -828,9 +828,28 @@ impl FuncCompiler<'_> {
         let in_elem_ty = if let Ty::Applied(_, args) = &list_arg.ty {
             args.first().cloned().unwrap_or(Ty::Int)
         } else { Ty::Int };
-        let out_elem_ty = if let Ty::Applied(_, args) = ret_ty {
+        let mut out_elem_ty = if let Ty::Applied(_, args) = ret_ty {
             args.first().cloned().unwrap_or(Ty::Int)
         } else { Ty::Int };
+        // When the return type is unresolved (TypeVar/Unknown), derive the output
+        // element type from the lambda body.  The call-site ret_ty can remain
+        // unresolved when the map result is unused or only used in a type-agnostic
+        // context, but the lambda body always carries the concrete type.
+        if matches!(&out_elem_ty, Ty::TypeVar(_) | Ty::Unknown) {
+            if let IrExprKind::Lambda { body, .. } = &fn_arg.kind {
+                if !matches!(&body.ty, Ty::TypeVar(_) | Ty::Unknown) {
+                    out_elem_ty = body.ty.clone();
+                }
+            }
+            // Also try fn_arg.ty.ret as a secondary source
+            if matches!(&out_elem_ty, Ty::TypeVar(_) | Ty::Unknown) {
+                if let Ty::Fn { ret, .. } = &fn_arg.ty {
+                    if !matches!(ret.as_ref(), Ty::TypeVar(_) | Ty::Unknown) {
+                        out_elem_ty = *ret.clone();
+                    }
+                }
+            }
+        }
         let in_size = values::byte_size(&in_elem_ty);
         let out_size = values::byte_size(&out_elem_ty);
 

--- a/src/codegen/emit_wasm/calls_list_closure2.rs
+++ b/src/codegen/emit_wasm/calls_list_closure2.rs
@@ -642,12 +642,15 @@ impl FuncCompiler<'_> {
                     i32_load(0);
                     i32_load(0);
                 });
-                // call_indirect
-                if let Ty::Fn { params, ret } = &args[1].ty {
-                    let mut ct = vec![ValType::I32];
-                    for p in params { if let Some(vt) = values::ty_to_valtype(p) { ct.push(vt); } }
-                    let rt = values::ret_type(ret);
-                    let ti = self.emitter.register_type(ct, rt);
+                // call_indirect — predicate always returns Bool (i32)
+                {
+                    let mut ct = vec![ValType::I32]; // env
+                    if let Ty::Fn { params, .. } = &args[1].ty {
+                        for p in params { if let Some(vt) = values::ty_to_valtype(p) { ct.push(vt); } }
+                    } else {
+                        if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
+                    }
+                    let ti = self.emitter.register_type(ct, vec![ValType::I32]);
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 // If true, copy element to dst
@@ -776,10 +779,19 @@ impl FuncCompiler<'_> {
                     i32_load(0);
                     i32_load(0);
                 });
-                if let Ty::Fn { params, ret } = &args[2].ty {
-                    let mut ct = vec![ValType::I32];
-                    for p in params { if let Some(vt) = values::ty_to_valtype(p) { ct.push(vt); } }
-                    let rt = values::ret_type(ret);
+                // Use fn params for parameter types, but derive the return
+                // type from the init value (args[1]) since fn_arg.ty.ret may
+                // be Ty::Unknown when the lambda wasn't fully inferred.
+                {
+                    let acc_ty = &args[1].ty;
+                    let mut ct = vec![ValType::I32]; // env
+                    if let Ty::Fn { params, .. } = &args[2].ty {
+                        for p in params { if let Some(vt) = values::ty_to_valtype(p) { ct.push(vt); } }
+                    } else {
+                        if let Some(vt) = values::ty_to_valtype(acc_ty) { ct.push(vt); }
+                        if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
+                    }
+                    let rt = values::ret_type(acc_ty);
                     let ti = self.emitter.register_type(ct, rt);
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
@@ -896,22 +908,21 @@ impl FuncCompiler<'_> {
         // Stack: [dst_elem_addr, env_ptr, element, table_idx]
 
         // call_indirect (env, element) → result
-        // Use fn_arg.ty (Fn type) if available for accurate param/ret types,
-        // otherwise fall back to element types
+        // Use fn_arg.ty params for accurate parameter types when available,
+        // but always derive the return type from out_elem_ty (the call-site
+        // return type) because fn_arg.ty.ret can be Ty::Unknown when the
+        // lambda's return type wasn't fully inferred.
         {
-            let ti = if let Ty::Fn { params, ret } = &fn_arg.ty {
-                let mut ct = vec![ValType::I32]; // env
+            let mut ct = vec![ValType::I32]; // env
+            if let Ty::Fn { params, .. } = &fn_arg.ty {
                 for p in params {
                     if let Some(vt) = values::ty_to_valtype(p) { ct.push(vt); }
                 }
-                let rt = values::ret_type(ret);
-                self.emitter.register_type(ct, rt)
             } else {
-                let mut ct = vec![ValType::I32];
                 if let Some(vt) = values::ty_to_valtype(&in_elem_ty) { ct.push(vt); }
-                let rt = values::ret_type(&out_elem_ty);
-                self.emitter.register_type(ct, rt)
-            };
+            }
+            let rt = values::ret_type(&out_elem_ty);
+            let ti = self.emitter.register_type(ct, rt);
             wasm!(self.func, { call_indirect(ti, 0); });
         }
         // Stack: [dst_elem_addr, result]

--- a/src/codegen/emit_wasm/calls_map.rs
+++ b/src/codegen/emit_wasm/calls_map.rs
@@ -1,7 +1,7 @@
 //! Map stdlib call dispatch for WASM codegen.
 //!
 //! Map layout: [len:i32][key0:K][val0:V][key1:K][val1:V]...
-//! Keys are compared with string.eq (Map[String, V] is the common case).
+//! Key comparison is type-aware: string.eq for String, i64_eq for Int, i32_eq for Bool.
 
 use super::FuncCompiler;
 use super::values;
@@ -32,25 +32,33 @@ impl FuncCompiler<'_> {
             "get" => {
                 // get(m, key) → Option[V]
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
+                let s64 = self.match_i64_base + self.match_depth;
                 // mem[0]=map
                 wasm!(self.func, { i32_const(0); });
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { i32_store(0); });
+                // Store search key
+                if !matches!(key_ty, Ty::Int) {
+                    wasm!(self.func, { i32_const(4); });
+                }
                 self.emit_expr(&args[1]); // key
+                self.emit_search_key_store(&key_ty, 4, s64);
                 wasm!(self.func, {
-                    i32_store(0); // mem[4]=key
                     i32_const(0); local_set(s); // i
                     block_empty; loop_empty;
                       local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
                       // Compare map_key[i] with search key
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0); // key_ptr at entry offset 0
-                      i32_const(4); i32_load(0); // search key
-                      call(self.emitter.rt.string.eq);
+                });
+                self.emit_key_load(&key_ty, 0);
+                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_key_eq(&key_ty);
+                wasm!(self.func, {
                       if_empty;
                         // Found: return some(val)
                         i32_const(vs as i32); call(self.emitter.rt.alloc); local_set(s + 1);
@@ -71,24 +79,31 @@ impl FuncCompiler<'_> {
             }
             "get_or" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
+                let s64 = self.match_i64_base + self.match_depth;
                 let vt = values::ty_to_valtype(&val_ty).unwrap_or(ValType::I32);
                 wasm!(self.func, { i32_const(0); });
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { i32_store(0); });
+                if !matches!(key_ty, Ty::Int) {
+                    wasm!(self.func, { i32_const(4); });
+                }
                 self.emit_expr(&args[1]); // key
+                self.emit_search_key_store(&key_ty, 4, s64);
                 wasm!(self.func, {
-                    i32_store(0);
                     i32_const(0); local_set(s);
                     block_empty; loop_empty;
                       local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0);
-                      i32_const(4); i32_load(0);
-                      call(self.emitter.rt.string.eq);
+                });
+                self.emit_key_load(&key_ty, 0);
+                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_key_eq(&key_ty);
+                wasm!(self.func, {
                       if_empty;
                         i32_const(0); i32_load(0); i32_const(4); i32_add;
                         local_get(s); i32_const(entry as i32); i32_mul; i32_add;
@@ -107,22 +122,29 @@ impl FuncCompiler<'_> {
             }
             "contains" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
+                let s64 = self.match_i64_base + self.match_depth;
                 wasm!(self.func, { i32_const(0); });
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { i32_store(0); });
+                if !matches!(key_ty, Ty::Int) {
+                    wasm!(self.func, { i32_const(4); });
+                }
                 self.emit_expr(&args[1]);
+                self.emit_search_key_store(&key_ty, 4, s64);
                 wasm!(self.func, {
-                    i32_store(0);
                     i32_const(0); local_set(s);
                     block_empty; loop_empty;
                       local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0);
-                      i32_const(4); i32_load(0);
-                      call(self.emitter.rt.string.eq);
+                });
+                self.emit_key_load(&key_ty, 0);
+                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_key_eq(&key_ty);
+                wasm!(self.func, {
                       if_empty; i32_const(1); return_; end;
                       local_get(s); i32_const(1); i32_add; local_set(s);
                       br(0);
@@ -134,17 +156,24 @@ impl FuncCompiler<'_> {
                 // set(m, key, value) → new Map
                 // Copy existing entries, update if key exists, append if new
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
-                // mem[0]=map, mem[4]=key
+                let s64 = self.match_i64_base + self.match_depth;
+                // mem[0]=map
                 wasm!(self.func, { i32_const(0); });
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
-                self.emit_expr(&args[1]); // key
                 wasm!(self.func, { i32_store(0); });
-                // Store value to mem[8..8+vs]
-                wasm!(self.func, { i32_const(8); });
+                // Store search key
+                if !matches!(key_ty, Ty::Int) {
+                    wasm!(self.func, { i32_const(4); });
+                }
+                self.emit_expr(&args[1]); // key
+                self.emit_search_key_store(&key_ty, 4, s64);
+                // Store value to mem[8..8+vs] (safe: Int key uses i64 local, not mem[4..12])
+                let val_mem_offset = if matches!(key_ty, Ty::Int) { 4u32 } else { 8u32 };
+                wasm!(self.func, { i32_const(val_mem_offset as i32); });
                 self.emit_expr(&args[2]); // value
                 self.emit_store_at(&val_ty, 0);
                 wasm!(self.func, {
@@ -156,9 +185,11 @@ impl FuncCompiler<'_> {
                       local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0);
-                      i32_const(4); i32_load(0);
-                      call(self.emitter.rt.string.eq);
+                });
+                self.emit_key_load(&key_ty, 0);
+                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_key_eq(&key_ty);
+                wasm!(self.func, {
                       if_empty;
                         local_get(s + 2); local_set(s + 1); // found
                       end;
@@ -179,16 +210,14 @@ impl FuncCompiler<'_> {
                     i32_const(0); local_set(s + 2); // i
                     block_empty; loop_empty;
                       local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-                      // dst entry addr
+                      // Copy key: dst entry, src entry
                       local_get(s + 3); i32_const(4); i32_add;
                       local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
-                      // src entry addr
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
-                      // Copy key
-                      i32_load(0); i32_store(0);
                 });
-                // Copy value: if this is the found_idx, use new value from mem[8]
+                self.emit_elem_copy_sized(ks);
+                // Copy value: if this is the found_idx, use new value from mem
                 wasm!(self.func, {
                       local_get(s + 2); local_get(s + 1); i32_eq;
                       if_empty;
@@ -196,7 +225,7 @@ impl FuncCompiler<'_> {
                         local_get(s + 3); i32_const(4); i32_add;
                         local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(ks as i32); i32_add;
-                        i32_const(8);
+                        i32_const(val_mem_offset as i32);
                 });
                 self.emit_elem_copy_sized(vs);
                 wasm!(self.func, {
@@ -220,15 +249,18 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_get(s + 1); i32_const(0); i32_lt_s;
                     if_empty;
-                      // Append: dst[old_len] = (key, value)
+                      // Append key: dst[old_len]
                       local_get(s + 3); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_const(4); i32_load(0); // key
-                      i32_store(0);
+                });
+                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_key_store(&key_ty, 0);
+                // Append value
+                wasm!(self.func, {
                       local_get(s + 3); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
-                      i32_const(8);
+                      i32_const(val_mem_offset as i32);
                 });
                 self.emit_elem_copy_sized(vs);
                 wasm!(self.func, {
@@ -238,14 +270,19 @@ impl FuncCompiler<'_> {
             }
             "remove" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
+                let s64 = self.match_i64_base + self.match_depth;
                 wasm!(self.func, { i32_const(0); });
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { i32_store(0); });
+                if !matches!(key_ty, Ty::Int) {
+                    wasm!(self.func, { i32_const(4); });
+                }
                 self.emit_expr(&args[1]);
+                self.emit_search_key_store(&key_ty, 4, s64);
                 wasm!(self.func, {
-                    i32_store(0);
                     i32_const(0); i32_load(0); i32_load(0); local_set(s); // old_len
                     // Find key index
                     i32_const(-1); local_set(s + 1);
@@ -254,9 +291,11 @@ impl FuncCompiler<'_> {
                       local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0);
-                      i32_const(4); i32_load(0);
-                      call(self.emitter.rt.string.eq);
+                });
+                self.emit_key_load(&key_ty, 0);
+                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_key_eq(&key_ty);
+                wasm!(self.func, {
                       if_empty; local_get(s + 2); local_set(s + 1); end;
                       local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
                       br(0);
@@ -297,23 +336,28 @@ impl FuncCompiler<'_> {
             }
             "keys" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(s);
                     local_get(s); i32_load(0); local_set(s + 1); // len
-                    i32_const(4); local_get(s + 1); i32_const(4); i32_mul; i32_add;
+                    i32_const(4); local_get(s + 1); i32_const(ks as i32); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(s + 2);
                     local_get(s + 2); local_get(s + 1); i32_store(0);
                     i32_const(0); local_set(s + 3);
                     block_empty; loop_empty;
                       local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
+                      // dst: result[4 + i*ks]
                       local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(4); i32_mul; i32_add;
+                      local_get(s + 3); i32_const(ks as i32); i32_mul; i32_add;
+                      // src: map[4 + i*entry]
                       local_get(s); i32_const(4); i32_add;
                       local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0); i32_store(0); // key ptr
+                });
+                self.emit_elem_copy_sized(ks);
+                wasm!(self.func, {
                       local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
                       br(0);
                     end; end;
@@ -495,8 +539,8 @@ impl FuncCompiler<'_> {
                       local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0); i32_store(0);
                 });
+                self.emit_elem_copy_sized(ks);
                 // Copy val
                 self.emit_merge_copy_val(entry, ks, vs);
                 wasm!(self.func, {
@@ -512,8 +556,8 @@ impl FuncCompiler<'_> {
                       i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(4); i32_load(0); i32_const(4); i32_add;
                       local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0); i32_store(0);
                 });
+                self.emit_elem_copy_sized(ks);
                 self.emit_merge_copy_val2(entry, ks, vs);
                 wasm!(self.func, {
                       local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
@@ -552,7 +596,10 @@ impl FuncCompiler<'_> {
                       // Copy key: map[4 + i*entry] = tuple[0]
                       local_get(s + 2); i32_const(4); i32_add;
                       local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
-                      local_get(s + 4); i32_load(0); i32_store(0);
+                      local_get(s + 4);
+                });
+                self.emit_elem_copy_sized(ks);
+                wasm!(self.func, {
                       // Copy val: map[4 + i*entry + ks] = tuple[ks]
                       local_get(s + 2); i32_const(4); i32_add;
                       local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
@@ -586,6 +633,75 @@ impl FuncCompiler<'_> {
         if let Ty::Applied(_, args) = ty {
             args.get(1).cloned().unwrap_or(Ty::Int)
         } else { Ty::Int }
+    }
+
+    pub(super) fn map_key_ty(&self, ty: &Ty) -> Ty {
+        if let Ty::Applied(_, args) = ty {
+            args.first().cloned().unwrap_or(Ty::String)
+        } else { Ty::String }
+    }
+
+    /// Load a key from memory at [addr_on_stack + offset].
+    /// For Int keys: i64_load. For String/Bool/other: i32_load.
+    pub(super) fn emit_key_load(&mut self, key_ty: &Ty, offset: u32) {
+        match key_ty {
+            Ty::Int => { wasm!(self.func, { i64_load(offset); }); }
+            _ => { wasm!(self.func, { i32_load(offset); }); }
+        }
+    }
+
+    /// Store a key to memory at [addr_on_stack, val_on_stack].
+    /// For Int keys: i64_store. For String/Bool/other: i32_store.
+    pub(super) fn emit_key_store(&mut self, key_ty: &Ty, offset: u32) {
+        match key_ty {
+            Ty::Int => { wasm!(self.func, { i64_store(offset); }); }
+            _ => { wasm!(self.func, { i32_store(offset); }); }
+        }
+    }
+
+    /// Emit key comparison: consumes [key_a, key_b], produces i32 (1=equal).
+    pub(super) fn emit_key_eq(&mut self, key_ty: &Ty) {
+        match key_ty {
+            Ty::Int => { wasm!(self.func, { i64_eq; }); }
+            Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
+            Ty::Bool => { wasm!(self.func, { i32_eq; }); }
+            _ => { wasm!(self.func, { i32_eq; }); } // pointer equality for other types
+        }
+    }
+
+    /// Store search key to scratch. For Int keys, stores to i64 scratch local.
+    /// For other keys, stores to mem[mem_offset]. Returns true if an i64 local was used.
+    pub(super) fn emit_search_key_store(&mut self, key_ty: &Ty, mem_offset: u32, scratch_i64: u32) {
+        match key_ty {
+            Ty::Int => {
+                // Store search key in i64 scratch local (8 bytes don't fit in mem[4..8] safely)
+                wasm!(self.func, { local_set(scratch_i64); });
+            }
+            _ => {
+                wasm!(self.func, { i32_store(0); }); // mem[mem_offset] already on stack
+            }
+        }
+    }
+
+    /// Load search key from scratch. For Int keys, loads from i64 scratch local.
+    /// For other keys, loads from mem[mem_offset].
+    pub(super) fn emit_search_key_load(&mut self, key_ty: &Ty, mem_offset: u32, scratch_i64: u32) {
+        match key_ty {
+            Ty::Int => {
+                wasm!(self.func, { local_get(scratch_i64); });
+            }
+            _ => {
+                wasm!(self.func, { i32_const(mem_offset as i32); i32_load(0); });
+            }
+        }
+    }
+
+    /// Key ValType for call_indirect signatures.
+    pub(super) fn key_valtype(key_ty: &Ty) -> ValType {
+        match key_ty {
+            Ty::Int => ValType::I64,
+            _ => ValType::I32,
+        }
     }
 
     fn emit_merge_copy_val(&mut self, entry: u32, ks: u32, vs: u32) {

--- a/src/codegen/emit_wasm/calls_map_closure.rs
+++ b/src/codegen/emit_wasm/calls_map_closure.rs
@@ -14,6 +14,7 @@ impl FuncCompiler<'_> {
             "fold" => {
                 // fold(m, init, f) → A: f(acc, key, val) for each entry
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
@@ -38,7 +39,9 @@ impl FuncCompiler<'_> {
                       // key = map[4 + i*entry]
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0); // key (String ptr)
+                });
+                self.emit_key_load(&key_ty, 0);
+                wasm!(self.func, {
                       // val = map[4 + i*entry + ks]
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
@@ -51,7 +54,8 @@ impl FuncCompiler<'_> {
                 // call_indirect (env, acc, key, val) → acc
                 {
                     let acc_vt = ValType::I64; // assume Int acc
-                    let mut ct = vec![ValType::I32, acc_vt, ValType::I32]; // env, acc, key
+                    let key_vt = Self::key_valtype(&key_ty);
+                    let mut ct = vec![ValType::I32, acc_vt, key_vt]; // env, acc, key
                     if let Some(vt) = values::ty_to_valtype(&val_ty) { ct.push(vt); }
                     let ti = self.emitter.register_type(ct, vec![acc_vt]);
                     wasm!(self.func, { call_indirect(ti, 0); });
@@ -66,6 +70,7 @@ impl FuncCompiler<'_> {
             }
             "each" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
@@ -81,7 +86,9 @@ impl FuncCompiler<'_> {
                       i32_const(4); i32_load(0); i32_load(4); // env
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0); // key
+                });
+                self.emit_key_load(&key_ty, 0);
+                wasm!(self.func, {
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
@@ -91,7 +98,8 @@ impl FuncCompiler<'_> {
                       i32_const(4); i32_load(0); i32_load(0);
                 });
                 {
-                    let mut ct = vec![ValType::I32, ValType::I32]; // env, key
+                    let key_vt = Self::key_valtype(&key_ty);
+                    let mut ct = vec![ValType::I32, key_vt]; // env, key
                     if let Some(vt) = values::ty_to_valtype(&val_ty) { ct.push(vt); }
                     let ti = self.emitter.register_type(ct, vec![]);
                     wasm!(self.func, { call_indirect(ti, 0); });
@@ -104,6 +112,7 @@ impl FuncCompiler<'_> {
             }
             "any" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
@@ -120,7 +129,9 @@ impl FuncCompiler<'_> {
                       i32_const(4); i32_load(0); i32_load(4);
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0); // key
+                });
+                self.emit_key_load(&key_ty, 0);
+                wasm!(self.func, {
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
@@ -130,7 +141,8 @@ impl FuncCompiler<'_> {
                       i32_const(4); i32_load(0); i32_load(0);
                 });
                 {
-                    let mut ct = vec![ValType::I32, ValType::I32]; // env, key
+                    let key_vt = Self::key_valtype(&key_ty);
+                    let mut ct = vec![ValType::I32, key_vt]; // env, key
                     if let Some(vt) = values::ty_to_valtype(&val_ty) { ct.push(vt); }
                     let ti = self.emitter.register_type(ct, vec![ValType::I32]);
                     wasm!(self.func, { call_indirect(ti, 0); });
@@ -147,6 +159,7 @@ impl FuncCompiler<'_> {
             }
             "all" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
@@ -163,7 +176,9 @@ impl FuncCompiler<'_> {
                       i32_const(4); i32_load(0); i32_load(4);
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0);
+                });
+                self.emit_key_load(&key_ty, 0);
+                wasm!(self.func, {
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
@@ -173,7 +188,8 @@ impl FuncCompiler<'_> {
                       i32_const(4); i32_load(0); i32_load(0);
                 });
                 {
-                    let mut ct = vec![ValType::I32, ValType::I32];
+                    let key_vt = Self::key_valtype(&key_ty);
+                    let mut ct = vec![ValType::I32, key_vt];
                     if let Some(vt) = values::ty_to_valtype(&val_ty) { ct.push(vt); }
                     let ti = self.emitter.register_type(ct, vec![ValType::I32]);
                     wasm!(self.func, { call_indirect(ti, 0); });
@@ -191,6 +207,7 @@ impl FuncCompiler<'_> {
             }
             "count" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
@@ -208,7 +225,9 @@ impl FuncCompiler<'_> {
                       i32_const(4); i32_load(0); i32_load(4);
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0);
+                });
+                self.emit_key_load(&key_ty, 0);
+                wasm!(self.func, {
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
@@ -218,7 +237,8 @@ impl FuncCompiler<'_> {
                       i32_const(4); i32_load(0); i32_load(0);
                 });
                 {
-                    let mut ct = vec![ValType::I32, ValType::I32];
+                    let key_vt = Self::key_valtype(&key_ty);
+                    let mut ct = vec![ValType::I32, key_vt];
                     if let Some(vt) = values::ty_to_valtype(&val_ty) { ct.push(vt); }
                     let ti = self.emitter.register_type(ct, vec![ValType::I32]);
                     wasm!(self.func, { call_indirect(ti, 0); });
@@ -236,6 +256,7 @@ impl FuncCompiler<'_> {
             "filter" => {
                 // filter(m, pred) → Map: keep entries where pred(k, v) is true
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
@@ -256,7 +277,9 @@ impl FuncCompiler<'_> {
                       i32_const(4); i32_load(0); i32_load(4);
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0);
+                });
+                self.emit_key_load(&key_ty, 0);
+                wasm!(self.func, {
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
@@ -266,20 +289,21 @@ impl FuncCompiler<'_> {
                       i32_const(4); i32_load(0); i32_load(0);
                 });
                 {
-                    let mut ct = vec![ValType::I32, ValType::I32];
+                    let key_vt = Self::key_valtype(&key_ty);
+                    let mut ct = vec![ValType::I32, key_vt];
                     if let Some(vt) = values::ty_to_valtype(&val_ty) { ct.push(vt); }
                     let ti = self.emitter.register_type(ct, vec![ValType::I32]);
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
                       if_empty;
-                        // Copy entry to result[result.len]
+                        // Copy key to result[result.len]
                         local_get(s); i32_const(4); i32_add;
                         local_get(s); i32_load(0); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(0); i32_load(0); i32_const(4); i32_add;
                         local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
-                        i32_load(0); i32_store(0); // key
                 });
+                self.emit_elem_copy_sized(ks);
                 // Copy val
                 wasm!(self.func, {
                         local_get(s); i32_const(4); i32_add;
@@ -326,7 +350,9 @@ impl FuncCompiler<'_> {
                       local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0); i32_store(0); // key
+                });
+                self.emit_elem_copy_sized(ks);
+                wasm!(self.func, {
                       // Call f(val) → new val
                       local_get(s + 1); i32_const(4); i32_add;
                       local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
@@ -360,6 +386,7 @@ impl FuncCompiler<'_> {
             "find" => {
                 // find(m, pred) → Option[(K, V)]
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
@@ -376,7 +403,9 @@ impl FuncCompiler<'_> {
                       i32_const(4); i32_load(0); i32_load(4);
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0);
+                });
+                self.emit_key_load(&key_ty, 0);
+                wasm!(self.func, {
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
@@ -386,7 +415,8 @@ impl FuncCompiler<'_> {
                       i32_const(4); i32_load(0); i32_load(0);
                 });
                 {
-                    let mut ct = vec![ValType::I32, ValType::I32];
+                    let key_vt = Self::key_valtype(&key_ty);
+                    let mut ct = vec![ValType::I32, key_vt];
                     if let Some(vt) = values::ty_to_valtype(&val_ty) { ct.push(vt); }
                     let ti = self.emitter.register_type(ct, vec![ValType::I32]);
                     wasm!(self.func, { call_indirect(ti, 0); });
@@ -399,8 +429,8 @@ impl FuncCompiler<'_> {
                         local_get(s + 2);
                         i32_const(0); i32_load(0); i32_const(4); i32_add;
                         local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                        i32_load(0); i32_store(0);
                 });
+                self.emit_elem_copy_sized(ks);
                 // Copy val
                 wasm!(self.func, {
                         local_get(s + 2); i32_const(ks as i32); i32_add;
@@ -424,18 +454,27 @@ impl FuncCompiler<'_> {
             "update" => {
                 // update(m, key, f) → Map: apply f to value at key
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
                 let s = self.match_i32_base + self.match_depth;
+                let s64 = self.match_i64_base + self.match_depth;
                 // Reuse set logic: find key, apply f to value, then set
+                // mem[0]=map, closure stored at mem[4] (or mem[8] for non-Int keys)
+                let closure_mem_offset = if matches!(key_ty, Ty::Int) { 4u32 } else { 8u32 };
                 wasm!(self.func, { i32_const(0); });
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { i32_store(0); });
+                // Store search key
+                if !matches!(key_ty, Ty::Int) {
+                    wasm!(self.func, { i32_const(4); });
+                }
                 self.emit_expr(&args[1]); // key
-                wasm!(self.func, { i32_store(0); i32_const(8); });
+                self.emit_search_key_store(&key_ty, 4, s64);
+                wasm!(self.func, { i32_const(closure_mem_offset as i32); });
                 self.emit_expr(&args[2]); // closure f
                 wasm!(self.func, {
-                    i32_store(0); // mem[8] = closure
+                    i32_store(0); // mem[closure_mem_offset] = closure
                     // Find key index
                     i32_const(0); local_set(s); // i
                     i32_const(-1); local_set(s + 1); // found_idx
@@ -443,9 +482,11 @@ impl FuncCompiler<'_> {
                       local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
                       i32_const(0); i32_load(0); i32_const(4); i32_add;
                       local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_load(0);
-                      i32_const(4); i32_load(0);
-                      call(self.emitter.rt.string.eq);
+                });
+                self.emit_key_load(&key_ty, 0);
+                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_key_eq(&key_ty);
+                wasm!(self.func, {
                       if_empty; local_get(s); local_set(s + 1); end;
                       local_get(s); i32_const(1); i32_add; local_set(s);
                       br(0);
@@ -463,12 +504,13 @@ impl FuncCompiler<'_> {
                       i32_const(0); local_set(s + 3);
                       block_empty; loop_empty;
                         local_get(s + 3); local_get(s); i32_ge_u; br_if(1);
+                        // Copy key
                         local_get(s + 2); i32_const(4); i32_add;
                         local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(0); i32_load(0); i32_const(4); i32_add;
                         local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
-                        i32_load(0); i32_store(0); // key
                 });
+                self.emit_elem_copy_sized(ks);
                 // Copy val
                 wasm!(self.func, {
                         local_get(s + 2); i32_const(4); i32_add;
@@ -487,7 +529,7 @@ impl FuncCompiler<'_> {
                       local_get(s + 2); i32_const(4); i32_add;
                       local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add; // dst val addr
-                      i32_const(8); i32_load(0); i32_load(4); // env
+                      i32_const(closure_mem_offset as i32); i32_load(0); i32_load(4); // env
                       // Load old val
                       local_get(s + 2); i32_const(4); i32_add;
                       local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
@@ -495,7 +537,7 @@ impl FuncCompiler<'_> {
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, {
-                      i32_const(8); i32_load(0); i32_load(0); // table_idx
+                      i32_const(closure_mem_offset as i32); i32_load(0); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32]; // env


### PR DESCRIPTION
## Summary
108 passed (stable), compile errors 12 → 11

### Fixes
- Map operations (get/set/contains/remove/keys/values/entries/merge/from_list) now work with Int and Bool keys, not just String
- Map closure operations (fold/each/any/all/filter/map/find/update) also type-aware for non-string keys
- list.map/filter/fold call_indirect return type derived from concrete source when lambda ret is TypeVar/Unknown
- list.map out_elem_ty fallback to lambda body type when call-site return type is unresolved

### Remaining compile errors (11)
- 4-5 caused by open record generics (`T: { key: Int, .. }`) — mono doesn't fully resolve lambda param types
- 2 "nothing on stack" — likely do-block or match codegen issues
- 1 "local index out of bounds" — scratch depth undercount
- 1 "values remaining on stack" — stack balance issue

## Test plan
- [x] almide test -- all 153 pass
- [x] almide test --target wasm -- 108 passed, 46 failed, 28 skipped