### PR TITLE
Add ScratchAllocator for WASM scratch local management

### DIFF
--- a/src/codegen/emit_wasm/closures.rs
+++ b/src/codegen/emit_wasm/closures.rs
@@ -253,12 +253,15 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
 
         // Compile body
         let compiled_func = {
+            let mut scratch_alloc = super::scratch::ScratchAllocator::new();
+            scratch_alloc.set_bases(match_i32_base, match_i64_base, match_i32_base + scratch_depth as u32);
             let mut compiler = FuncCompiler {
                 emitter: &mut *emitter,
                 func: wasm_func,
                 var_map,
                 depth: 0,
                 loop_stack: Vec::new(),
+                scratch: scratch_alloc,
                 match_i64_base,
                 match_i32_base,
                 match_depth: 0,

--- a/src/codegen/emit_wasm/functions.rs
+++ b/src/codegen/emit_wasm/functions.rs
@@ -55,12 +55,15 @@ pub fn compile_function(
     let wasm_func = Function::new(local_decls);
 
     // Compile the body
+    let mut scratch_alloc = super::scratch::ScratchAllocator::new();
+    scratch_alloc.set_bases(match_i32_base, match_i64_base, match_i32_base + scan.scratch_depth as u32);
     let mut compiler = FuncCompiler {
         emitter,
         func: wasm_func,
         var_map,
         depth: 0,
         loop_stack: Vec::new(),
+        scratch: scratch_alloc,
         match_i64_base,
         match_i32_base,
         match_depth: 0,

--- a/src/codegen/emit_wasm/mod.rs
+++ b/src/codegen/emit_wasm/mod.rs
@@ -41,6 +41,7 @@ mod collections;
 mod control;
 pub mod statements;
 mod functions;
+pub mod scratch;
 
 use std::collections::HashMap;
 use wasm_encoder::{
@@ -313,7 +314,9 @@ pub struct FuncCompiler<'a> {
     pub var_map: HashMap<u32, u32>,
     pub depth: u32,
     pub loop_stack: Vec<LoopLabels>,
-    // Match/record scratch locals (one i64 + one i32 per nesting depth)
+    // Scratch local allocator (replaces match_i32_base/match_i64_base/match_depth)
+    pub scratch: scratch::ScratchAllocator,
+    // Legacy scratch (kept during migration — will be removed)
     pub match_i64_base: u32,
     pub match_i32_base: u32,
     pub match_depth: u32,
@@ -647,12 +650,15 @@ fn compile_init_globals(emitter: &mut WasmEmitter, program: &IrProgram) {
 
     let wasm_func = Function::new(local_decls);
     let compiled_func = {
+        let mut scratch_alloc = scratch::ScratchAllocator::new();
+        scratch_alloc.set_bases(match_i32_base, match_i64_base, match_i32_base + scan_depth as u32);
         let mut compiler = FuncCompiler {
             emitter: &mut *emitter,
             func: wasm_func,
             var_map: HashMap::new(),
             depth: 0,
             loop_stack: Vec::new(),
+            scratch: scratch_alloc,
             match_i64_base,
             match_i32_base,
             match_depth: 0,

--- a/src/codegen/emit_wasm/scratch.rs
+++ b/src/codegen/emit_wasm/scratch.rs
@@ -1,0 +1,135 @@
+//! ScratchAllocator: bump/reuse allocator for WASM temporary locals.
+//!
+//! Replaces the old match_i32_base/match_i64_base/match_depth system.
+//! Each type (i32, i64, f64) has independent slots. alloc() returns a WASM local index,
+//! free() marks it for reuse. High-water mark is tracked for local declaration.
+
+use wasm_encoder::ValType;
+
+/// Tracks allocation state for one WASM value type.
+struct TypedSlots {
+    /// true = in use
+    slots: Vec<bool>,
+    /// High-water mark: max simultaneous live slots
+    hwm: usize,
+    /// WASM local index where this type's slots start (set after all bind locals are allocated)
+    base: u32,
+}
+
+impl TypedSlots {
+    fn new() -> Self {
+        Self { slots: Vec::new(), hwm: 0, base: 0 }
+    }
+
+    fn alloc(&mut self) -> u32 {
+        // Find first free slot
+        if let Some(idx) = self.slots.iter().position(|&used| !used) {
+            self.slots[idx] = true;
+            self.update_hwm();
+            self.base + idx as u32
+        } else {
+            // All slots in use — add a new one
+            let idx = self.slots.len();
+            self.slots.push(true);
+            self.update_hwm();
+            self.base + idx as u32
+        }
+    }
+
+    fn free(&mut self, local_idx: u32) {
+        let slot = (local_idx - self.base) as usize;
+        debug_assert!(slot < self.slots.len(), "free: slot {} out of range (len={})", slot, self.slots.len());
+        debug_assert!(self.slots[slot], "free: slot {} already free (double-free)", slot);
+        self.slots[slot] = false;
+    }
+
+    fn update_hwm(&mut self) {
+        let live = self.slots.iter().filter(|&&u| u).count();
+        if live > self.hwm {
+            self.hwm = live;
+        }
+    }
+
+    fn live_count(&self) -> usize {
+        self.slots.iter().filter(|&&u| u).count()
+    }
+}
+
+/// Scratch local allocator for a single WASM function.
+///
+/// Usage:
+/// 1. Create with `new()`
+/// 2. Set bases with `set_bases(i32_base, i64_base, f64_base)` after bind locals are allocated
+/// 3. During emit: `alloc_i32()`, `free_i32(idx)`, etc.
+/// 4. After emit: `hwm_i32()`, `hwm_i64()`, `hwm_f64()` for local declarations
+pub struct ScratchAllocator {
+    i32: TypedSlots,
+    i64: TypedSlots,
+    f64: TypedSlots,
+}
+
+impl ScratchAllocator {
+    pub fn new() -> Self {
+        Self {
+            i32: TypedSlots::new(),
+            i64: TypedSlots::new(),
+            f64: TypedSlots::new(),
+        }
+    }
+
+    pub fn set_bases(&mut self, i32_base: u32, i64_base: u32, f64_base: u32) {
+        self.i32.base = i32_base;
+        self.i64.base = i64_base;
+        self.f64.base = f64_base;
+    }
+
+    // ── Alloc ──
+
+    pub fn alloc_i32(&mut self) -> u32 { self.i32.alloc() }
+    pub fn alloc_i64(&mut self) -> u32 { self.i64.alloc() }
+    pub fn alloc_f64(&mut self) -> u32 { self.f64.alloc() }
+
+    /// Allocate a scratch local for the given ValType.
+    pub fn alloc(&mut self, vt: ValType) -> u32 {
+        match vt {
+            ValType::I32 => self.alloc_i32(),
+            ValType::I64 => self.alloc_i64(),
+            ValType::F64 => self.alloc_f64(),
+            _ => self.alloc_i32(), // fallback
+        }
+    }
+
+    // ── Free ──
+
+    pub fn free_i32(&mut self, idx: u32) { self.i32.free(idx); }
+    pub fn free_i64(&mut self, idx: u32) { self.i64.free(idx); }
+    pub fn free_f64(&mut self, idx: u32) { self.f64.free(idx); }
+
+    /// Free a scratch local for the given ValType.
+    pub fn free(&mut self, idx: u32, vt: ValType) {
+        match vt {
+            ValType::I32 => self.free_i32(idx),
+            ValType::I64 => self.free_i64(idx),
+            ValType::F64 => self.free_f64(idx),
+            _ => self.free_i32(idx),
+        }
+    }
+
+    // ── HWM queries (for local declaration) ──
+
+    pub fn hwm_i32(&self) -> usize { self.i32.hwm }
+    pub fn hwm_i64(&self) -> usize { self.i64.hwm }
+    pub fn hwm_f64(&self) -> usize { self.f64.hwm }
+
+    /// Assert no scratch locals are still live (call at function end).
+    pub fn assert_all_freed(&self) {
+        let i32_live = self.i32.live_count();
+        let i64_live = self.i64.live_count();
+        let f64_live = self.f64.live_count();
+        debug_assert!(
+            i32_live == 0 && i64_live == 0 && f64_live == 0,
+            "Scratch leak: i32={} i64={} f64={} still live at function end",
+            i32_live, i64_live, f64_live,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
ScratchAllocator基盤を追加。FuncCompilerに組み込み、既存コードと共存。

### ScratchAllocator
- i32/i64/f64の3型独立のbump/reuse allocator
- `alloc_i32()` → WASM local index を返す
- `free_i32(idx)` → スロットを再利用可能に
- high-water mark追跡でlocal宣言数を自動算出
- debug_assertでleak/double-free検知

### 次のステップ
- 全stdlib関数をScratchAllocator経由に移行（mem[]全廃）
- legacy match_i32_base/match_depth 削除
- count_scratch_depth 廃止

## Test plan
- [x] almide test -- all 153 pass
- [x] almide test --target wasm -- 109 passed (no regression)