### PR TITLE
ScratchAllocator migration: calls_list_closure2.rs + separated scratch region

### DIFF
--- a/src/codegen/emit_wasm/calls_list_closure.rs
+++ b/src/codegen/emit_wasm/calls_list_closure.rs
@@ -18,26 +18,28 @@ impl FuncCompiler<'_> {
                 // find(xs, pred) → Option[A]: first element where pred(x) is true
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0]=xs, mem[4]=closure (store before closure emit)
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let tmp = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0); // mem[4]=closure
-                    i32_const(0); local_set(s); // i=0
-                    i32_const(0); local_set(s + 2); // result (default: none)
+                    local_set(closure);
+                    i32_const(0); local_set(i); // i=0
+                    i32_const(0); local_set(result); // result (default: none)
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
                       // Call pred(xs[i])
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(es); i32_mul; i32_add;
+                      local_get(closure); i32_load(4); // env
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32];
@@ -48,42 +50,50 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                       if_empty;
                         // Found: alloc some(xs[i])
-                        i32_const(es); call(self.emitter.rt.alloc); local_set(s + 1);
-                        local_get(s + 1);
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s); i32_const(es); i32_mul; i32_add;
+                        i32_const(es); call(self.emitter.rt.alloc); local_set(tmp);
+                        local_get(tmp);
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 1); local_set(s + 2); br(2);
+                        local_get(tmp); local_set(result); br(2);
                       end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2); // result (none if not found)
+                    local_get(result); // result (none if not found)
                 });
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(tmp);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "find_index" if args.len() == 2 && matches!(&args[1].ty, Ty::Fn { .. }) => {
                 // find_index(xs, pred) → Option[Int]
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let tmp = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); local_set(s);
-                    i32_const(0); local_set(s + 2); // result (default: none)
+                    local_set(closure);
+                    i32_const(0); local_set(i);
+                    i32_const(0); local_set(result); // result (default: none)
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4); // env
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { i32_const(4); i32_load(0); i32_load(0); });
+                wasm!(self.func, { local_get(closure); i32_load(0); });
                 {
                     let mut ct = vec![ValType::I32];
                     if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
@@ -92,37 +102,44 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                       if_empty;
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(s + 1);
-                        local_get(s + 1); local_get(s); i64_extend_i32_u; i64_store(0);
-                        local_get(s + 1); local_set(s + 2); br(2);
+                        i32_const(8); call(self.emitter.rt.alloc); local_set(tmp);
+                        local_get(tmp); local_get(i); i64_extend_i32_u; i64_store(0);
+                        local_get(tmp); local_set(result); br(2);
                       end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2); // result (none if not found)
+                    local_get(result); // result (none if not found)
                 });
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(tmp);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "any" => {
                 // any(xs, pred) → Bool
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); local_set(s);
-                    i32_const(0); local_set(s + 1); // result (default: false)
+                    local_set(closure);
+                    i32_const(0); local_set(i);
+                    i32_const(0); local_set(result); // result (default: false)
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4);
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { i32_const(4); i32_load(0); i32_load(0); });
+                wasm!(self.func, { local_get(closure); i32_load(0); });
                 {
                     let mut ct = vec![ValType::I32];
                     if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
@@ -130,33 +147,39 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      if_empty; i32_const(1); local_set(s + 1); br(2); end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      if_empty; i32_const(1); local_set(result); br(2); end;
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1); // result
+                    local_get(result); // result
                 });
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "all" => {
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); local_set(s);
-                    i32_const(1); local_set(s + 1); // result (default: true)
+                    local_set(closure);
+                    i32_const(0); local_set(i);
+                    i32_const(1); local_set(result); // result (default: true)
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4);
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { i32_const(4); i32_load(0); i32_load(0); });
+                wasm!(self.func, { local_get(closure); i32_load(0); });
                 {
                     let mut ct = vec![ValType::I32];
                     if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
@@ -165,32 +188,37 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                       i32_eqz;
-                      if_empty; i32_const(0); local_set(s + 1); br(2); end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      if_empty; i32_const(0); local_set(result); br(2); end;
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1); // result
+                    local_get(result); // result
                 });
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "each" => {
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); local_set(s);
+                    local_set(closure);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4);
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { i32_const(4); i32_load(0); i32_load(0); });
+                wasm!(self.func, { local_get(closure); i32_load(0); });
                 {
                     let mut ct = vec![ValType::I32];
                     if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
@@ -198,150 +226,177 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "take_end" => {
                 // take_end(xs, n) = drop(xs, max(0, len-n))
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let n = self.scratch.alloc_i32();
+                let start = self.scratch.alloc_i32();
+                let new_len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s); // n
+                    i32_wrap_i64; local_set(n);
                     // start = max(0, len - n)
-                    i32_const(0); i32_load(0); i32_load(0); local_get(s); i32_sub;
-                    local_set(s + 1);
-                    local_get(s + 1); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(s + 1); end;
+                    local_get(xs); i32_load(0); local_get(n); i32_sub;
+                    local_set(start);
+                    local_get(start); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(0); local_set(start); end;
                     // new_len = len - start
-                    i32_const(0); i32_load(0); i32_load(0); local_get(s + 1); i32_sub;
-                    local_set(s + 2);
-                    i32_const(4); local_get(s + 2); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 3);
-                    local_get(s + 3); local_get(s + 2); i32_store(0);
-                    i32_const(0); local_set(s); // reuse as i
+                    local_get(xs); i32_load(0); local_get(start); i32_sub;
+                    local_set(new_len);
+                    i32_const(4); local_get(new_len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(new_len); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s); local_get(s + 2); i32_ge_u; br_if(1);
-                      local_get(s + 3); i32_const(4); i32_add;
-                      local_get(s); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 1); local_get(s); i32_add;
+                      local_get(i); local_get(new_len); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(start); local_get(i); i32_add;
                       i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 3);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(new_len);
+                self.scratch.free_i32(start);
+                self.scratch.free_i32(n);
+                self.scratch.free_i32(xs);
             }
             "drop_end" => {
                 // drop_end(xs, n) = take(xs, max(0, len-n))
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let n = self.scratch.alloc_i32();
+                let new_len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s); // n
-                    i32_const(0); i32_load(0); i32_load(0); local_get(s); i32_sub;
-                    local_set(s + 1); // new_len
-                    local_get(s + 1); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(s + 1); end;
-                    i32_const(4); local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_store(0);
-                    i32_const(0); local_set(s); // i
+                    i32_wrap_i64; local_set(n);
+                    local_get(xs); i32_load(0); local_get(n); i32_sub;
+                    local_set(new_len); // new_len
+                    local_get(new_len); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(0); local_set(new_len); end;
+                    i32_const(4); local_get(new_len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(new_len); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s); local_get(s + 1); i32_ge_u; br_if(1);
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(new_len); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(new_len);
+                self.scratch.free_i32(n);
+                self.scratch.free_i32(xs);
             }
             "repeat" => {
                 // repeat(val, n) → List[A] — args[0] IS the element, not a list
                 let elem_ty = args[0].ty.clone();
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let val_vt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32);
+                let val = self.scratch.alloc(val_vt);
+                let n = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]); // val
-                self.emit_store_at(&elem_ty, 0); // mem[0] = val
+                wasm!(self.func, { local_set(val); });
                 self.emit_expr(&args[1]); // n
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s); // n
-                    i32_const(4); local_get(s); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 1);
-                    local_get(s + 1); local_get(s); i32_store(0);
-                    i32_const(0); local_set(s + 2); // i
+                    i32_wrap_i64; local_set(n);
+                    i32_const(4); local_get(n); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(n); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-                      local_get(s + 1); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
-                      i32_const(0);
+                      local_get(i); local_get(n); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(val);
                 });
-                self.emit_load_at(&elem_ty, 0);
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(n);
+                self.scratch.free(val, val_vt);
             }
             "reduce" => {
                 // reduce(xs, f) → Option[A]: fold starting from xs[0]
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let acc_vt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I64);
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let acc = self.scratch.alloc(acc_vt);
+                let tmp = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]); // fn(a, b) -> a
                 wasm!(self.func, {
-                    i32_store(0); // mem[4] = closure
-                    i32_const(0); i32_load(0); i32_load(0); i32_eqz;
+                    local_set(closure);
+                    local_get(xs); i32_load(0); i32_eqz;
                     if_i32; i32_const(0); // empty → none
                     else_;
                       // acc = xs[0]
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
+                      local_get(xs); i32_const(4); i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { local_set(s64); }); // acc in i64 local (works for i32 too via reinterpret)
-                // For i32 elements, use s instead
-                // Actually this only works for i64. For i32 elements, need different approach.
-                // Simplify: use i64 for acc regardless, works for Int.
+                wasm!(self.func, { local_set(acc); });
                 wasm!(self.func, {
-                      i32_const(1); local_set(s); // i = 1
+                      i32_const(1); local_set(i); // i = 1
                       block_empty; loop_empty;
-                        local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
                         // Call f(acc, xs[i])
-                        i32_const(4); i32_load(0); i32_load(4); // env
-                        local_get(s64); // acc
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s); i32_const(es); i32_mul; i32_add;
+                        local_get(closure); i32_load(4); // env
+                        local_get(acc); // acc
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        i32_const(4); i32_load(0); i32_load(0); // table_idx
+                        local_get(closure); i32_load(0); // table_idx
                 });
                 // call_indirect (env, a, b) → a
                 {
@@ -352,16 +407,21 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                        local_set(s64); // update acc
-                        local_get(s); i32_const(1); i32_add; local_set(s);
+                        local_set(acc); // update acc
+                        local_get(i); i32_const(1); i32_add; local_set(i);
                         br(0);
                       end; end;
                       // Wrap acc in some
-                      i32_const(es); call(self.emitter.rt.alloc); local_set(s);
-                      local_get(s); local_get(s64);
+                      i32_const(es); call(self.emitter.rt.alloc); local_set(tmp);
+                      local_get(tmp); local_get(acc);
                 });
                 self.emit_store_at(&elem_ty, 0);
-                wasm!(self.func, { local_get(s); end; });
+                wasm!(self.func, { local_get(tmp); end; });
+                self.scratch.free_i32(tmp);
+                self.scratch.free(acc, acc_vt);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "flat_map" => {
                 // flat_map(xs, f) → List[B]: f returns List[B], flatten results
@@ -372,32 +432,38 @@ impl FuncCompiler<'_> {
                 } else { elem_ty.clone() };
                 let out_es = values::byte_size(&out_elem_ty) as i32;
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0]=xs, mem[4]=closure
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let lol = self.scratch.alloc_i32(); // list-of-lists
+                let i = self.scratch.alloc_i32();
+                let total = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let inner = self.scratch.alloc_i32();
+                let j = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
+                    local_set(closure);
+                    local_get(xs); i32_load(0); local_set(len);
                     // Alloc temp list-of-lists: [len][ptr0][ptr1]...
-                    i32_const(4); local_get(s); i32_const(4); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 1);
-                    local_get(s + 1); local_get(s); i32_store(0);
-                    i32_const(0); local_set(s + 2); // i
+                    i32_const(4); local_get(len); i32_const(4); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(lol);
+                    local_get(lol); local_get(len); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
                       // Call f(xs[i]) → List[B]
-                      local_get(s + 1); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(4); i32_mul; i32_add; // dst addr for result ptr
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                      local_get(lol); i32_const(4); i32_add;
+                      local_get(i); i32_const(4); i32_mul; i32_add; // dst addr for result ptr
+                      local_get(closure); i32_load(4); // env
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32];
@@ -407,63 +473,66 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                       i32_store(0); // store result list ptr
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    // Now flatten: s+1 is a List[List[B]]
-                    // Reuse list.flatten logic via emit_list_call
-                    local_get(s + 1);
                 });
-                // Call flatten on the temp list-of-lists
-                // Can't call self recursively easily. Inline flatten:
-                // Count total
+                // Flatten: count total elements
                 wasm!(self.func, {
-                    local_set(s); // temp = list-of-lists
-                    i32_const(0); local_set(s + 1); // total
-                    i32_const(0); local_set(s + 2); // i
+                    i32_const(0); local_set(total);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(s + 1);
-                      local_get(s); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(4); i32_mul; i32_add;
+                      local_get(i); local_get(lol); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(total);
+                      local_get(lol); i32_const(4); i32_add;
+                      local_get(i); i32_const(4); i32_mul; i32_add;
                       i32_load(0); i32_load(0);
-                      i32_add; local_set(s + 1);
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      i32_add; local_set(total);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                     // Alloc result
-                    i32_const(4); local_get(s + 1); i32_const(out_es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 3);
-                    local_get(s + 3); local_get(s + 1); i32_store(0);
+                    i32_const(4); local_get(total); i32_const(out_es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); local_get(total); i32_store(0);
                 });
                 // Copy all sub-list elements
                 wasm!(self.func, {
-                    i32_const(0); local_set(s + 1); // dst_offset
-                    i32_const(0); local_set(s + 2); // outer i
+                    i32_const(0); local_set(total); // reuse as dst_offset
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(s); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(4); i32_mul; i32_add;
-                      i32_load(0); local_set(s + 4); // inner list
-                      i32_const(0); local_set(s + 5); // j
+                      local_get(i); local_get(lol); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(lol); i32_const(4); i32_add;
+                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      i32_load(0); local_set(inner);
+                      i32_const(0); local_set(j);
                       block_empty; loop_empty;
-                        local_get(s + 5); local_get(s + 4); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(s + 3); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(out_es); i32_mul; i32_add;
-                        local_get(s + 4); i32_const(4); i32_add;
-                        local_get(s + 5); i32_const(out_es); i32_mul; i32_add;
+                        local_get(j); local_get(inner); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(result); i32_const(4); i32_add;
+                        local_get(total); i32_const(out_es); i32_mul; i32_add;
+                        local_get(inner); i32_const(4); i32_add;
+                        local_get(j); i32_const(out_es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&out_elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
-                        local_get(s + 5); i32_const(1); i32_add; local_set(s + 5);
+                        local_get(total); i32_const(1); i32_add; local_set(total);
+                        local_get(j); i32_const(1); i32_add; local_set(j);
                         br(0);
                       end; end;
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 3);
+                    local_get(result);
                 });
+                self.scratch.free_i32(j);
+                self.scratch.free_i32(inner);
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(total);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(lol);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "filter_map" => {
                 // filter_map(xs, f) → List[B]: f returns Option[B], keep some values
@@ -476,28 +545,31 @@ impl FuncCompiler<'_> {
                     self.list_elem_ty(ret)
                 } else { Ty::Int };
                 let out_es = values::byte_size(&out_elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0]=xs, mem[4]=closure
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let opt = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s);
-                    i32_const(4); local_get(s); i32_const(out_es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 1);
-                    local_get(s + 1); i32_const(0); i32_store(0);
-                    i32_const(0); local_set(s + 2);
+                    local_set(closure);
+                    local_get(xs); i32_load(0); local_set(len);
+                    i32_const(4); local_get(len); i32_const(out_es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); i32_const(0); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4); // env
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0);
+                      local_get(closure); i32_load(0);
                 });
                 {
                     let mut ct = vec![ValType::I32];
@@ -506,240 +578,288 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      local_set(s + 3); // option result
-                      local_get(s + 3); i32_const(0); i32_ne;
+                      local_set(opt); // option result
+                      local_get(opt); i32_const(0); i32_ne;
                       if_empty;
                         // Append unwrapped value to result
-                        local_get(s + 1); i32_const(4); i32_add;
-                        local_get(s + 1); i32_load(0); i32_const(out_es); i32_mul; i32_add;
-                        local_get(s + 3); // some ptr
+                        local_get(dst); i32_const(4); i32_add;
+                        local_get(dst); i32_load(0); i32_const(out_es); i32_mul; i32_add;
+                        local_get(opt); // some ptr
                 });
                 // Load inner value from some ptr
                 self.emit_load_at(&out_elem_ty, 0);
                 self.emit_store_at(&out_elem_ty, 0);
                 wasm!(self.func, {
-                        local_get(s + 1);
-                        local_get(s + 1); i32_load(0); i32_const(1); i32_add;
+                        local_get(dst);
+                        local_get(dst); i32_load(0); i32_const(1); i32_add;
                         i32_store(0);
                       end;
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(opt);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "swap" => {
                 // swap(xs, i, j) → List[A]: copy with elements at i and j swapped
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0]=xs
-                wasm!(self.func, { i32_const(0); });
+                let elem_vt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32);
+                let xs = self.scratch.alloc_i32();
+                let idx_i = self.scratch.alloc_i32();
+                let idx_j = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let k = self.scratch.alloc_i32();
+                let tmp = self.scratch.alloc(elem_vt);
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]); // i
-                wasm!(self.func, { i32_wrap_i64; local_set(s); }); // s = i
+                wasm!(self.func, { i32_wrap_i64; local_set(idx_i); });
                 self.emit_expr(&args[2]); // j
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s + 1); // s+1 = j
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s + 2); // len
+                    i32_wrap_i64; local_set(idx_j);
+                    local_get(xs); i32_load(0); local_set(len);
                     // Alloc copy
-                    i32_const(4); local_get(s + 2); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 3); // dst
-                    local_get(s + 3); local_get(s + 2); i32_store(0);
+                    i32_const(4); local_get(len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(len); i32_store(0);
                     // Copy all elements
-                    i32_const(0); local_set(s + 4); // k
+                    i32_const(0); local_set(k);
                     block_empty; loop_empty;
-                      local_get(s + 4); local_get(s + 2); i32_ge_u; br_if(1);
-                      local_get(s + 3); i32_const(4); i32_add;
-                      local_get(s + 4); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 4); i32_const(es); i32_mul; i32_add;
+                      local_get(k); local_get(len); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(k); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(k); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 4); i32_const(1); i32_add; local_set(s + 4);
+                      local_get(k); i32_const(1); i32_add; local_set(k);
                       br(0);
                     end; end;
                 });
-                // Now swap dst[i] and dst[j]:
-                // We need a temp. Use mem[4..4+es] as temp.
-                // temp = dst[i]
+                // Swap dst[i] and dst[j] using typed scratch local as temp
+                // tmp = dst[i]
                 wasm!(self.func, {
-                    i32_const(4);
-                    local_get(s + 3); i32_const(4); i32_add;
-                    local_get(s); i32_const(es); i32_mul; i32_add;
+                    local_get(dst); i32_const(4); i32_add;
+                    local_get(idx_i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_load_at(&elem_ty, 0);
+                wasm!(self.func, { local_set(tmp); });
                 // dst[i] = dst[j]
                 wasm!(self.func, {
-                    local_get(s + 3); i32_const(4); i32_add;
-                    local_get(s); i32_const(es); i32_mul; i32_add;
-                    local_get(s + 3); i32_const(4); i32_add;
-                    local_get(s + 1); i32_const(es); i32_mul; i32_add;
+                    local_get(dst); i32_const(4); i32_add;
+                    local_get(idx_i); i32_const(es); i32_mul; i32_add;
+                    local_get(dst); i32_const(4); i32_add;
+                    local_get(idx_j); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
-                // dst[j] = temp
+                // dst[j] = tmp
                 wasm!(self.func, {
-                    local_get(s + 3); i32_const(4); i32_add;
-                    local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                    i32_const(4);
+                    local_get(dst); i32_const(4); i32_add;
+                    local_get(idx_j); i32_const(es); i32_mul; i32_add;
+                    local_get(tmp);
                 });
-                self.emit_elem_copy(&elem_ty);
-                wasm!(self.func, { local_get(s + 3); });
+                self.emit_store_at(&elem_ty, 0);
+                wasm!(self.func, { local_get(dst); });
+                self.scratch.free(tmp, elem_vt);
+                self.scratch.free_i32(k);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(idx_j);
+                self.scratch.free_i32(idx_i);
+                self.scratch.free_i32(xs);
             }
             "chunk" => {
                 // chunk(xs, n) → List[List[A]]
                 // Outer list of inner lists. Each inner list has up to n elements.
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // s=len, s+1=n, s+2=num_chunks, s+3=outer, s+4=i(outer), s+5=chunk_len, s+6=inner, s+7=j
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let n = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let num_chunks = self.scratch.alloc_i32();
+                let outer = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let chunk_len = self.scratch.alloc_i32();
+                let inner = self.scratch.alloc_i32();
+                let j = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]); // n
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s + 1);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
+                    i32_wrap_i64; local_set(n);
+                    local_get(xs); i32_load(0); local_set(len);
                     // num_chunks = (len + n - 1) / n
-                    local_get(s); local_get(s + 1); i32_add; i32_const(1); i32_sub;
-                    local_get(s + 1); i32_div_u;
-                    local_set(s + 2);
+                    local_get(len); local_get(n); i32_add; i32_const(1); i32_sub;
+                    local_get(n); i32_div_u;
+                    local_set(num_chunks);
                     // Alloc outer: 4 + num_chunks * 4 (list of ptrs)
-                    i32_const(4); local_get(s + 2); i32_const(4); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 3);
-                    local_get(s + 3); local_get(s + 2); i32_store(0);
-                    i32_const(0); local_set(s + 4); // outer i
+                    i32_const(4); local_get(num_chunks); i32_const(4); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(outer);
+                    local_get(outer); local_get(num_chunks); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 4); local_get(s + 2); i32_ge_u; br_if(1);
+                      local_get(i); local_get(num_chunks); i32_ge_u; br_if(1);
                       // chunk_len = min(n, len - i*n)
-                      local_get(s); local_get(s + 4); local_get(s + 1); i32_mul; i32_sub;
-                      local_set(s + 5);
-                      local_get(s + 5); local_get(s + 1); i32_gt_u;
-                      if_empty; local_get(s + 1); local_set(s + 5); end;
+                      local_get(len); local_get(i); local_get(n); i32_mul; i32_sub;
+                      local_set(chunk_len);
+                      local_get(chunk_len); local_get(n); i32_gt_u;
+                      if_empty; local_get(n); local_set(chunk_len); end;
                       // Alloc inner: 4 + chunk_len * es
-                      i32_const(4); local_get(s + 5); i32_const(es); i32_mul; i32_add;
-                      call(self.emitter.rt.alloc); local_set(s + 6);
-                      local_get(s + 6); local_get(s + 5); i32_store(0);
+                      i32_const(4); local_get(chunk_len); i32_const(es); i32_mul; i32_add;
+                      call(self.emitter.rt.alloc); local_set(inner);
+                      local_get(inner); local_get(chunk_len); i32_store(0);
                       // Copy elements
-                      i32_const(0); local_set(s + 7); // j
+                      i32_const(0); local_set(j);
                       block_empty; loop_empty;
-                        local_get(s + 7); local_get(s + 5); i32_ge_u; br_if(1);
-                        local_get(s + 6); i32_const(4); i32_add;
-                        local_get(s + 7); i32_const(es); i32_mul; i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 4); local_get(s + 1); i32_mul;
-                        local_get(s + 7); i32_add;
+                        local_get(j); local_get(chunk_len); i32_ge_u; br_if(1);
+                        local_get(inner); i32_const(4); i32_add;
+                        local_get(j); i32_const(es); i32_mul; i32_add;
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(i); local_get(n); i32_mul;
+                        local_get(j); i32_add;
                         i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 7); i32_const(1); i32_add; local_set(s + 7);
+                        local_get(j); i32_const(1); i32_add; local_set(j);
                         br(0);
                       end; end;
                       // outer[i] = inner_ptr
-                      local_get(s + 3); i32_const(4); i32_add;
-                      local_get(s + 4); i32_const(4); i32_mul; i32_add;
-                      local_get(s + 6); i32_store(0);
-                      local_get(s + 4); i32_const(1); i32_add; local_set(s + 4);
+                      local_get(outer); i32_const(4); i32_add;
+                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(inner); i32_store(0);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 3);
+                    local_get(outer);
                 });
+                self.scratch.free_i32(j);
+                self.scratch.free_i32(inner);
+                self.scratch.free_i32(chunk_len);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(outer);
+                self.scratch.free_i32(num_chunks);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(n);
+                self.scratch.free_i32(xs);
             }
             "windows" | "window" => {
                 // windows(xs, n) → List[List[A]]: sliding windows of size n
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // s=len, s+1=n, s+2=num_win, s+3=outer, s+4=i, s+5=inner, s+6=j
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let n = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let num_win = self.scratch.alloc_i32();
+                let outer = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let inner = self.scratch.alloc_i32();
+                let j = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s + 1); // n
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
+                    i32_wrap_i64; local_set(n);
+                    local_get(xs); i32_load(0); local_set(len);
                     // num_win = if len >= n then len - n + 1 else 0
-                    local_get(s); local_get(s + 1); i32_ge_u;
+                    local_get(len); local_get(n); i32_ge_u;
                     if_i32;
-                      local_get(s); local_get(s + 1); i32_sub; i32_const(1); i32_add;
+                      local_get(len); local_get(n); i32_sub; i32_const(1); i32_add;
                     else_;
                       i32_const(0);
                     end;
-                    local_set(s + 2);
+                    local_set(num_win);
                     // Alloc outer: 4 + num_win * 4
-                    i32_const(4); local_get(s + 2); i32_const(4); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 3);
-                    local_get(s + 3); local_get(s + 2); i32_store(0);
-                    i32_const(0); local_set(s + 4); // i
+                    i32_const(4); local_get(num_win); i32_const(4); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(outer);
+                    local_get(outer); local_get(num_win); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 4); local_get(s + 2); i32_ge_u; br_if(1);
+                      local_get(i); local_get(num_win); i32_ge_u; br_if(1);
                       // Alloc inner: 4 + n * es
-                      i32_const(4); local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                      call(self.emitter.rt.alloc); local_set(s + 5);
-                      local_get(s + 5); local_get(s + 1); i32_store(0);
+                      i32_const(4); local_get(n); i32_const(es); i32_mul; i32_add;
+                      call(self.emitter.rt.alloc); local_set(inner);
+                      local_get(inner); local_get(n); i32_store(0);
                       // Copy n elements starting at i
-                      i32_const(0); local_set(s + 6); // j
+                      i32_const(0); local_set(j);
                       block_empty; loop_empty;
-                        local_get(s + 6); local_get(s + 1); i32_ge_u; br_if(1);
-                        local_get(s + 5); i32_const(4); i32_add;
-                        local_get(s + 6); i32_const(es); i32_mul; i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 4); local_get(s + 6); i32_add;
+                        local_get(j); local_get(n); i32_ge_u; br_if(1);
+                        local_get(inner); i32_const(4); i32_add;
+                        local_get(j); i32_const(es); i32_mul; i32_add;
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(i); local_get(j); i32_add;
                         i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 6); i32_const(1); i32_add; local_set(s + 6);
+                        local_get(j); i32_const(1); i32_add; local_set(j);
                         br(0);
                       end; end;
                       // outer[i] = inner_ptr
-                      local_get(s + 3); i32_const(4); i32_add;
-                      local_get(s + 4); i32_const(4); i32_mul; i32_add;
-                      local_get(s + 5); i32_store(0);
-                      local_get(s + 4); i32_const(1); i32_add; local_set(s + 4);
+                      local_get(outer); i32_const(4); i32_add;
+                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(inner); i32_store(0);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 3);
+                    local_get(outer);
                 });
+                self.scratch.free_i32(j);
+                self.scratch.free_i32(inner);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(outer);
+                self.scratch.free_i32(num_win);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(n);
+                self.scratch.free_i32(xs);
             }
             "dedup" => {
                 // dedup(xs) → List[A]: remove consecutive duplicates
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // s=xs, s+1=len, s+2=dst, s+3=i, s+4=out_count
+                let xs = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let out_count = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); local_set(s + 1); // len
+                    local_set(xs);
+                    local_get(xs); i32_load(0); local_set(len);
                     // Alloc dst (max = len)
-                    i32_const(4); local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    i32_const(0); local_set(s + 4); // out_count
+                    i32_const(4); local_get(len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    i32_const(0); local_set(out_count);
                     // If empty, return empty
-                    local_get(s + 1); i32_eqz;
+                    local_get(len); i32_eqz;
                     if_empty;
-                      local_get(s + 2); i32_const(0); i32_store(0);
+                      local_get(dst); i32_const(0); i32_store(0);
                     else_;
                       // Always include first element
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s); i32_const(4); i32_add;
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(xs); i32_const(4); i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      i32_const(1); local_set(s + 4); // out_count = 1
-                      i32_const(1); local_set(s + 3); // i = 1
+                      i32_const(1); local_set(out_count); // out_count = 1
+                      i32_const(1); local_set(i); // i = 1
                       block_empty; loop_empty;
-                        local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
+                        local_get(i); local_get(len); i32_ge_u; br_if(1);
                         // Compare xs[i] with xs[i-1]
-                        local_get(s); i32_const(4); i32_add;
-                        local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(i); i32_const(es); i32_mul; i32_add;
                         i32_load(0);
-                        local_get(s); i32_const(4); i32_add;
-                        local_get(s + 3); i32_const(1); i32_sub;
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(i); i32_const(1); i32_sub;
                         i32_const(es); i32_mul; i32_add;
                         i32_load(0);
                 });
@@ -750,72 +870,83 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                         i32_eqz; // not equal → include
                         if_empty;
-                          local_get(s + 2); i32_const(4); i32_add;
-                          local_get(s + 4); i32_const(es); i32_mul; i32_add;
-                          local_get(s); i32_const(4); i32_add;
-                          local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                          local_get(dst); i32_const(4); i32_add;
+                          local_get(out_count); i32_const(es); i32_mul; i32_add;
+                          local_get(xs); i32_const(4); i32_add;
+                          local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                          local_get(s + 4); i32_const(1); i32_add; local_set(s + 4);
+                          local_get(out_count); i32_const(1); i32_add; local_set(out_count);
                         end;
-                        local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                        local_get(i); i32_const(1); i32_add; local_set(i);
                         br(0);
                       end; end;
-                      local_get(s + 2); local_get(s + 4); i32_store(0);
+                      local_get(dst); local_get(out_count); i32_store(0);
                     end;
-                    local_get(s + 2);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(out_count);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(xs);
             }
             "sort_by" => {
                 // sort_by(xs, f) → List[A]: bubble sort by key function
                 // Strategy: copy list, compute keys into parallel array, bubble sort both
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
-                // mem[0]=xs, mem[4]=closure
-                wasm!(self.func, { i32_const(0); });
+                let elem_vt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32);
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let keys = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let j = self.scratch.alloc_i32();
+                let tmp_key = self.scratch.alloc_i64();
+                let tmp_elem = self.scratch.alloc(elem_vt);
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
+                    local_set(closure);
+                    local_get(xs); i32_load(0); local_set(len);
                     // Alloc copy of elements
-                    i32_const(4); local_get(s); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 1); // dst
-                    local_get(s + 1); local_get(s); i32_store(0);
+                    i32_const(4); local_get(len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(len); i32_store(0);
                     // Copy all elements
-                    i32_const(0); local_set(s + 2);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-                      local_get(s + 1); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                 });
                 // Alloc keys array: len * 8 (i64 keys)
                 wasm!(self.func, {
-                    local_get(s); i32_const(8); i32_mul;
-                    call(self.emitter.rt.alloc); local_set(s + 2); // keys
+                    local_get(len); i32_const(8); i32_mul;
+                    call(self.emitter.rt.alloc); local_set(keys);
                     // Compute keys for all elements
-                    i32_const(0); local_set(s + 3);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      local_get(s + 1); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4); // env
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32];
@@ -824,79 +955,86 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      local_set(s64);
-                      local_get(s + 2);
-                      local_get(s + 3); i32_const(8); i32_mul; i32_add;
-                      local_get(s64); i64_store(0);
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_set(tmp_key);
+                      local_get(keys);
+                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(tmp_key); i64_store(0);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                 });
                 // Bubble sort: outer loop i from 0..len-1, inner loop j from 0..len-1-i
-                // Swap adjacent if keys[j] > keys[j+1]
-                // For swapping elements, use mem[8..8+es] as temp
                 wasm!(self.func, {
-                    i32_const(0); local_set(s + 3); // i (outer)
+                    i32_const(0); local_set(i); // i (outer)
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s); i32_const(1); i32_sub; i32_ge_u; br_if(1);
-                      i32_const(0); local_set(s + 4); // j (inner)
+                      local_get(i); local_get(len); i32_const(1); i32_sub; i32_ge_u; br_if(1);
+                      i32_const(0); local_set(j); // j (inner)
                       block_empty; loop_empty;
                         // j < len - 1 - i
-                        local_get(s); i32_const(1); i32_sub; local_get(s + 3); i32_sub;
-                        local_get(s + 4); i32_le_u; br_if(1);
+                        local_get(len); i32_const(1); i32_sub; local_get(i); i32_sub;
+                        local_get(j); i32_le_u; br_if(1);
                         // Compare keys[j] > keys[j+1]
-                        local_get(s + 2);
-                        local_get(s + 4); i32_const(8); i32_mul; i32_add;
+                        local_get(keys);
+                        local_get(j); i32_const(8); i32_mul; i32_add;
                         i64_load(0);
-                        local_get(s + 2);
-                        local_get(s + 4); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
+                        local_get(keys);
+                        local_get(j); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
                         i64_load(0);
                         i64_gt_s;
                         if_empty;
                           // Swap keys[j] and keys[j+1]
-                          local_get(s + 2);
-                          local_get(s + 4); i32_const(8); i32_mul; i32_add;
-                          i64_load(0); local_set(s64); // temp_key
-                          local_get(s + 2);
-                          local_get(s + 4); i32_const(8); i32_mul; i32_add;
-                          local_get(s + 2);
-                          local_get(s + 4); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
+                          local_get(keys);
+                          local_get(j); i32_const(8); i32_mul; i32_add;
+                          i64_load(0); local_set(tmp_key); // temp_key
+                          local_get(keys);
+                          local_get(j); i32_const(8); i32_mul; i32_add;
+                          local_get(keys);
+                          local_get(j); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
                           i64_load(0); i64_store(0);
-                          local_get(s + 2);
-                          local_get(s + 4); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
-                          local_get(s64); i64_store(0);
-                          // Swap dst[j] and dst[j+1] using mem[8] as temp
-                          // temp = dst[j]
-                          i32_const(8);
-                          local_get(s + 1); i32_const(4); i32_add;
-                          local_get(s + 4); i32_const(es); i32_mul; i32_add;
+                          local_get(keys);
+                          local_get(j); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
+                          local_get(tmp_key); i64_store(0);
+                          // Swap dst[j] and dst[j+1] using typed scratch local
+                          // tmp_elem = dst[j]
+                          local_get(dst); i32_const(4); i32_add;
+                          local_get(j); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
+                          local_set(tmp_elem);
                           // dst[j] = dst[j+1]
-                          local_get(s + 1); i32_const(4); i32_add;
-                          local_get(s + 4); i32_const(es); i32_mul; i32_add;
-                          local_get(s + 1); i32_const(4); i32_add;
-                          local_get(s + 4); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
+                          local_get(dst); i32_const(4); i32_add;
+                          local_get(j); i32_const(es); i32_mul; i32_add;
+                          local_get(dst); i32_const(4); i32_add;
+                          local_get(j); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                          // dst[j+1] = temp
-                          local_get(s + 1); i32_const(4); i32_add;
-                          local_get(s + 4); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
-                          i32_const(8);
+                          // dst[j+1] = tmp_elem
+                          local_get(dst); i32_const(4); i32_add;
+                          local_get(j); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
+                          local_get(tmp_elem);
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
                         end; // end if (swap needed)
-                        local_get(s + 4); i32_const(1); i32_add; local_set(s + 4);
+                        local_get(j); i32_const(1); i32_add; local_set(j);
                         br(0);
                       end; end; // end inner loop
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end; // end outer loop
-                    local_get(s + 1);
+                    local_get(dst);
                 });
+                self.scratch.free(tmp_elem, elem_vt);
+                self.scratch.free_i64(tmp_key);
+                self.scratch.free_i32(j);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(keys);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             _ => return self.emit_list_closure_call2(method, args),
         }

--- a/src/codegen/emit_wasm/calls_list_closure2.rs
+++ b/src/codegen/emit_wasm/calls_list_closure2.rs
@@ -280,59 +280,53 @@ impl FuncCompiler<'_> {
             }
             "update" => {
                 // update(xs, i, f) → List[A]: copy with xs[i] replaced by f(xs[i])
-                // Store all args to mem[] BEFORE closure emit to avoid scratch conflicts
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0] = xs
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let idx = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let copy_i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // mem[4] = idx (i32)
-                wasm!(self.func, { i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; i32_store(0); });
-                // mem[8] = closure
-                wasm!(self.func, { i32_const(8); });
+                wasm!(self.func, { i32_wrap_i64; local_set(idx); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s + 1); // len
+                    local_set(closure);
+                    local_get(xs); i32_load(0); local_set(len);
                     // Alloc copy
-                    i32_const(4); local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_store(0);
+                    i32_const(4); local_get(len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(len); i32_store(0);
                     // Copy all elements
-                    i32_const(0); local_set(s + 3);
+                    i32_const(0); local_set(copy_i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                      local_get(copy_i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(copy_i); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(copy_i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
                       br(0);
                     end; end;
                 });
-                // Now replace dst[idx] with f(dst[idx])
-                // Use mem[4]=idx, mem[8]=closure
+                // Replace dst[idx] with f(dst[idx])
                 wasm!(self.func, {
-                    // dst addr for store
-                    local_get(s + 2); i32_const(4); i32_add;
-                    i32_const(4); i32_load(0); // idx from mem[4]
-                    i32_const(es); i32_mul; i32_add;
+                    local_get(dst); i32_const(4); i32_add;
+                    local_get(idx); i32_const(es); i32_mul; i32_add;
                     // Call f(dst[idx])
-                    i32_const(8); i32_load(0); i32_load(4); // env from mem[8]
-                    local_get(s + 2); i32_const(4); i32_add;
-                    i32_const(4); i32_load(0); // idx from mem[4]
-                    i32_const(es); i32_mul; i32_add;
+                    local_get(closure); i32_load(4); // env
+                    local_get(dst); i32_const(4); i32_add;
+                    local_get(idx); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                    i32_const(8); i32_load(0); i32_load(0); // table_idx from mem[8]
+                    local_get(closure); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32];
@@ -341,74 +335,79 @@ impl FuncCompiler<'_> {
                     let ti = self.emitter.register_type(ct, rt);
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
-                // Stack: [dst_addr, result] → store
                 self.emit_elem_store(&elem_ty);
-                wasm!(self.func, { local_get(s + 2); });
+                wasm!(self.func, { local_get(dst); });
+                self.scratch.free_i32(copy_i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(idx);
+                self.scratch.free_i32(xs);
             }
             "scan" => {
                 // scan(xs, init, f) → List[B]: like fold but collect intermediates
-                // Result has same length as xs (each element is f applied cumulatively)
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
-                // Determine acc type from init
                 let acc_vt = values::ty_to_valtype(&args[1].ty).unwrap_or(ValType::I64);
                 let acc_size = values::byte_size(&args[1].ty) as i32;
-                // mem[0]=xs, mem[4]=closure
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let acc = self.scratch.alloc(acc_vt);
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // acc = init
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(s64); }); // acc in i64/f64 local
-                wasm!(self.func, { i32_const(4); });
-                self.emit_expr(&args[2]); // closure
+                wasm!(self.func, { local_set(acc); });
+                self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
-                    // Alloc result: 4 + len * acc_size
-                    i32_const(4); local_get(s); i32_const(acc_size); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 1);
-                    local_get(s + 1); local_get(s); i32_store(0);
-                    i32_const(0); local_set(s + 2); // i
+                    local_set(closure);
+                    local_get(xs); i32_load(0); local_set(len);
+                    i32_const(4); local_get(len); i32_const(acc_size); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); local_get(len); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-                      // Call f(acc, xs[i])
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      local_get(s64); // acc
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4); // env
+                      local_get(acc);
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 {
-                    // fn(acc: B, elem: A) -> B
-                    let mut ct = vec![ValType::I32]; // env
-                    ct.push(acc_vt); // acc
+                    let mut ct = vec![ValType::I32];
+                    ct.push(acc_vt);
                     if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
                     let ti = self.emitter.register_type(ct, vec![acc_vt]);
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      local_set(s64); // update acc
-                      // Store acc into result[i]
-                      local_get(s + 1); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(acc_size); i32_mul; i32_add;
-                      local_get(s64);
+                      local_set(acc);
+                      local_get(result); i32_const(4); i32_add;
+                      local_get(i); i32_const(acc_size); i32_mul; i32_add;
+                      local_get(acc);
                 });
                 match acc_vt {
                     ValType::F64 => { wasm!(self.func, { f64_store(0); }); }
                     _ => { wasm!(self.func, { i64_store(0); }); }
                 }
                 wasm!(self.func, {
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1);
+                    local_get(result);
                 });
+                self.scratch.free(acc, acc_vt);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "zip_with" => {
                 // zip_with(xs, ys, f) → List[C]
@@ -416,171 +415,187 @@ impl FuncCompiler<'_> {
                 let b_ty = self.list_elem_ty(&args[1].ty);
                 let a_size = values::byte_size(&a_ty) as i32;
                 let b_size = values::byte_size(&b_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // Determine return element type from call return type (concrete)
                 let ret_elem_ty = self.list_elem_ty(&self.stub_ret_ty);
                 let out_size = values::byte_size(&ret_elem_ty) as i32;
                 let out_vt = values::ty_to_valtype(&ret_elem_ty).unwrap_or(ValType::I32);
-                // mem[0]=xs, mem[4]=ys, mem[8]=closure
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let ys = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_store(0); i32_const(8); });
+                wasm!(self.func, { local_set(ys); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_store(0);
+                    local_set(closure);
                     // len = min(xs.len, ys.len)
-                    i32_const(0); i32_load(0); i32_load(0);
-                    i32_const(4); i32_load(0); i32_load(0);
+                    local_get(xs); i32_load(0);
+                    local_get(ys); i32_load(0);
                     i32_lt_u;
                     if_i32;
-                      i32_const(0); i32_load(0); i32_load(0);
+                      local_get(xs); i32_load(0);
                     else_;
-                      i32_const(4); i32_load(0); i32_load(0);
+                      local_get(ys); i32_load(0);
                     end;
-                    local_set(s); // len
-                    // Alloc result
-                    i32_const(4); local_get(s); i32_const(out_size); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 1);
-                    local_get(s + 1); local_get(s); i32_store(0);
-                    i32_const(0); local_set(s + 2); // i
+                    local_set(len);
+                    i32_const(4); local_get(len); i32_const(out_size); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); local_get(len); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
                       // dst addr
-                      local_get(s + 1); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(out_size); i32_mul; i32_add;
+                      local_get(result); i32_const(4); i32_add;
+                      local_get(i); i32_const(out_size); i32_mul; i32_add;
                       // Call f(xs[i], ys[i])
-                      i32_const(8); i32_load(0); i32_load(4); // env
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(a_size); i32_mul; i32_add;
+                      local_get(closure); i32_load(4); // env
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(a_size); i32_mul; i32_add;
                 });
                 self.emit_load_at(&a_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(b_size); i32_mul; i32_add;
+                      local_get(ys); i32_const(4); i32_add;
+                      local_get(i); i32_const(b_size); i32_mul; i32_add;
                 });
                 self.emit_load_at(&b_ty, 0);
                 wasm!(self.func, {
-                      i32_const(8); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 {
-                    let mut ct = vec![ValType::I32]; // env
+                    let mut ct = vec![ValType::I32];
                     if let Some(vt) = values::ty_to_valtype(&a_ty) { ct.push(vt); }
                     if let Some(vt) = values::ty_to_valtype(&b_ty) { ct.push(vt); }
                     let rt = values::ret_type(&ret_elem_ty);
                     let ti = self.emitter.register_type(ct, rt);
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
-                // Stack: [dst_addr, result] → store
                 match out_vt {
                     ValType::I64 => { wasm!(self.func, { i64_store(0); }); }
                     ValType::F64 => { wasm!(self.func, { f64_store(0); }); }
                     _ => { wasm!(self.func, { i32_store(0); }); }
                 }
                 wasm!(self.func, {
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1);
+                    local_get(result);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(ys);
+                self.scratch.free_i32(xs);
             }
             "unique_by" => {
-                // unique_by(xs, f) → List[A]: remove dupes by key, keep first
-                // O(n²) comparison of keys
+                // unique_by(xs, f) → List[A]: remove dupes by key, keep first (O(n²))
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
-                // mem[0]=xs, mem[4]=closure
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let keys = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let seen_keys = self.scratch.alloc_i32();
+                let out_count = self.scratch.alloc_i32();
+                let j = self.scratch.alloc_i32();
+                let found = self.scratch.alloc_i32();
+                let key_val = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
+                    local_set(closure);
+                    local_get(xs); i32_load(0); local_set(len);
                     // Alloc keys array: len * 8
-                    local_get(s); i32_const(8); i32_mul;
-                    call(self.emitter.rt.alloc); local_set(s + 1); // keys
+                    local_get(len); i32_const(8); i32_mul;
+                    call(self.emitter.rt.alloc); local_set(keys);
                     // Compute all keys
-                    i32_const(0); local_set(s + 2); // i
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4); // env
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32];
                     if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
-                    // Key type: use i64 for simplicity (works for Int, Bool, String-ptr)
                     let ti = self.emitter.register_type(ct, vec![ValType::I64]);
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      local_set(s64);
-                      local_get(s + 1);
-                      local_get(s + 2); i32_const(8); i32_mul; i32_add;
-                      local_get(s64); i64_store(0);
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_set(key_val);
+                      local_get(keys);
+                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(key_val); i64_store(0);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                 });
-                // Now build result: include xs[i] if keys[i] not in keys[0..out_count]
+                // Build result: include xs[i] if keys[i] not in seen_keys[0..out_count]
                 wasm!(self.func, {
-                    // Alloc dst (max = len)
-                    i32_const(4); local_get(s); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 3); // dst
-                    // Alloc seen_keys: len * 8
-                    local_get(s); i32_const(8); i32_mul;
-                    call(self.emitter.rt.alloc); local_set(s + 4); // seen_keys
-                    i32_const(0); local_set(s + 5); // out_count
-                    i32_const(0); local_set(s + 2); // i
+                    i32_const(4); local_get(len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(len); i32_const(8); i32_mul;
+                    call(self.emitter.rt.alloc); local_set(seen_keys);
+                    i32_const(0); local_set(out_count);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-                      // Load key[i]
-                      local_get(s + 1);
-                      local_get(s + 2); i32_const(8); i32_mul; i32_add;
-                      i64_load(0); local_set(s64);
-                      // Check if key already in seen_keys
-                      i32_const(0); local_set(s + 6); // j
-                      i32_const(0); local_set(s + 7); // found
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(keys);
+                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      i64_load(0); local_set(key_val);
+                      i32_const(0); local_set(j);
+                      i32_const(0); local_set(found);
                       block_empty; loop_empty;
-                        local_get(s + 6); local_get(s + 5); i32_ge_u; br_if(1);
-                        local_get(s + 4);
-                        local_get(s + 6); i32_const(8); i32_mul; i32_add;
-                        i64_load(0); local_get(s64); i64_eq;
-                        if_empty; i32_const(1); local_set(s + 7); br(2); end;
-                        local_get(s + 6); i32_const(1); i32_add; local_set(s + 6);
+                        local_get(j); local_get(out_count); i32_ge_u; br_if(1);
+                        local_get(seen_keys);
+                        local_get(j); i32_const(8); i32_mul; i32_add;
+                        i64_load(0); local_get(key_val); i64_eq;
+                        if_empty; i32_const(1); local_set(found); br(2); end;
+                        local_get(j); i32_const(1); i32_add; local_set(j);
                         br(0);
                       end; end;
-                      local_get(s + 7); i32_eqz;
+                      local_get(found); i32_eqz;
                       if_empty;
-                        // Not found: add to dst and seen_keys
-                        local_get(s + 3); i32_const(4); i32_add;
-                        local_get(s + 5); i32_const(es); i32_mul; i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(dst); i32_const(4); i32_add;
+                        local_get(out_count); i32_const(es); i32_mul; i32_add;
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        // Add key to seen_keys
-                        local_get(s + 4);
-                        local_get(s + 5); i32_const(8); i32_mul; i32_add;
-                        local_get(s64); i64_store(0);
-                        local_get(s + 5); i32_const(1); i32_add; local_set(s + 5);
+                        local_get(seen_keys);
+                        local_get(out_count); i32_const(8); i32_mul; i32_add;
+                        local_get(key_val); i64_store(0);
+                        local_get(out_count); i32_const(1); i32_add; local_set(out_count);
                       end;
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 3); local_get(s + 5); i32_store(0);
-                    local_get(s + 3);
+                    local_get(dst); local_get(out_count); i32_store(0);
+                    local_get(dst);
                 });
+                self.scratch.free_i64(key_val);
+                self.scratch.free_i32(found);
+                self.scratch.free_i32(j);
+                self.scratch.free_i32(out_count);
+                self.scratch.free_i32(seen_keys);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(keys);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "group_by" => {
                 // group_by(xs, f) → Map[B, List[A]]
@@ -600,139 +615,69 @@ impl FuncCompiler<'_> {
                     a.first().cloned().unwrap_or(Ty::Int)
                 } else { Ty::Int };
                 let elem_size = values::byte_size(&elem_ty);
-                let s = self.match_i32_base + self.match_depth;
-                let len_local = s;
-                let idx_local = s + 1;
-
-                // mem[0]=src, mem[4]=fn, mem[8]=dst, mem[12]=out_idx
-                wasm!(self.func, { i32_const(0); });
+                let src = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let idx = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let out_idx = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(4);
-                });
+                wasm!(self.func, { local_set(src); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    // len
-                    i32_const(0);
-                    i32_load(0);
-                    i32_load(0);
-                    local_set(len_local);
-                    // alloc dst (max size = 4 + len * elem_size) → mem[8]
-                    i32_const(8);
-                    i32_const(4);
-                    local_get(len_local);
-                    i32_const(elem_size as i32);
-                    i32_mul;
-                    i32_add;
-                    call(self.emitter.rt.alloc);
-                    i32_store(0);
-                    // out_idx = 0 → mem[12]
-                    i32_const(12);
-                    i32_const(0);
-                    i32_store(0);
-                    // idx = 0
-                    i32_const(0);
-                    local_set(idx_local);
-                    // Loop
-                    block_empty;
-                    loop_empty;
+                    local_set(closure);
+                    local_get(src); i32_load(0); local_set(len);
+                    // alloc dst (max size)
+                    i32_const(4); local_get(len); i32_const(elem_size as i32); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    i32_const(0); local_set(out_idx);
+                    i32_const(0); local_set(idx);
+                    block_empty; loop_empty;
                 });
                 let saved = self.depth; self.depth += 2;
-
                 wasm!(self.func, {
-                    local_get(idx_local);
-                    local_get(len_local);
-                    i32_ge_u;
-                    br_if(1);
-                    // Call predicate: fn(element) → bool (i32)
-                    // Load closure
-                    i32_const(4);
-                    i32_load(0);
-                });
-                wasm!(self.func, {
-                    i32_load(4);
-                    // Load element
-                    i32_const(0);
-                    i32_load(0);
-                    i32_const(4);
-                    i32_add;
-                    local_get(idx_local);
-                    i32_const(elem_size as i32);
-                    i32_mul;
-                    i32_add;
+                    local_get(idx); local_get(len); i32_ge_u; br_if(1);
+                    // Call predicate
+                    local_get(closure); i32_load(4); // env
+                    local_get(src); i32_const(4); i32_add;
+                    local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                // table_idx
-                wasm!(self.func, {
-                    i32_const(4);
-                    i32_load(0);
-                    i32_load(0);
-                });
-                // call_indirect: filter predicate signature (env: i32, elem: elem_ty) -> i32 (Bool)
+                wasm!(self.func, { local_get(closure); i32_load(0); }); // table_idx
                 {
-                    let mut ct = vec![ValType::I32]; // env
+                    let mut ct = vec![ValType::I32];
                     if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
                     let ti = self.emitter.register_type(ct, vec![ValType::I32]);
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
-                // If true, copy element to dst
                 wasm!(self.func, {
                     if_empty;
                     // dst[out_idx] = src[idx]
-                    i32_const(8);
-                    i32_load(0);
-                    i32_const(4);
-                    i32_add;
-                    i32_const(12);
-                    i32_load(0);
-                    i32_const(elem_size as i32);
-                    i32_mul;
-                    i32_add;
-                    // load src element
-                    i32_const(0);
-                    i32_load(0);
-                    i32_const(4);
-                    i32_add;
-                    local_get(idx_local);
-                    i32_const(elem_size as i32);
-                    i32_mul;
-                    i32_add;
+                    local_get(dst); i32_const(4); i32_add;
+                    local_get(out_idx); i32_const(elem_size as i32); i32_mul; i32_add;
+                    local_get(src); i32_const(4); i32_add;
+                    local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
-                    // out_idx++
-                    i32_const(12);
-                    i32_const(12);
-                    i32_load(0);
-                    i32_const(1);
-                    i32_add;
-                    i32_store(0);
+                    local_get(out_idx); i32_const(1); i32_add; local_set(out_idx);
                     end; // end if
-                    // idx++
-                    local_get(idx_local);
-                    i32_const(1);
-                    i32_add;
-                    local_set(idx_local);
+                    local_get(idx); i32_const(1); i32_add; local_set(idx);
                     br(0);
                 });
-
                 self.depth = saved;
                 wasm!(self.func, {
-                    end;
-                    end;
-                    // Set dst.len = out_idx
-                    i32_const(8);
-                    i32_load(0);
-                    i32_const(12);
-                    i32_load(0);
-                    i32_store(0);
-                    // Return dst
-                    i32_const(8);
-                    i32_load(0);
+                    end; end;
+                    local_get(dst); local_get(out_idx); i32_store(0);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(out_idx);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(idx);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(src);
             }
             "fold" => {
                 // fold(list, init, fn(acc, elem) → acc)
@@ -740,74 +685,36 @@ impl FuncCompiler<'_> {
                     a.first().cloned().unwrap_or(Ty::Int)
                 } else { Ty::Int };
                 let elem_size = values::byte_size(&elem_ty);
-                let s = self.match_i32_base + self.match_depth;
-                let len_local = s;
-                let idx_local = s + 1;
-                // Accumulator local: use i64 for Int/Float, i32 for everything else
-                let acc_local = match values::ty_to_valtype(&args[1].ty) {
-                    Some(ValType::I64) | Some(ValType::F64) => self.match_i64_base + self.match_depth,
-                    _ => self.match_i32_base + self.match_depth + 2, // after len + idx
-                };
-
-                // mem[0]=list, mem[4]=fn
-                wasm!(self.func, { i32_const(0); });
+                let acc_vt = values::ty_to_valtype(&args[1].ty).unwrap_or(ValType::I32);
+                let list_ptr = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let idx = self.scratch.alloc_i32();
+                let acc = self.scratch.alloc(acc_vt);
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // acc = init
+                wasm!(self.func, { local_set(list_ptr); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, {
-                    local_set(acc_local);
-                    i32_const(4);
-                });
+                wasm!(self.func, { local_set(acc); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    // len
-                    i32_const(0);
-                    i32_load(0);
-                    i32_load(0);
-                    local_set(len_local);
-                    i32_const(0);
-                    local_set(idx_local);
-                    block_empty;
-                    loop_empty;
+                    local_set(closure);
+                    local_get(list_ptr); i32_load(0); local_set(len);
+                    i32_const(0); local_set(idx);
+                    block_empty; loop_empty;
                 });
                 let saved = self.depth; self.depth += 2;
-
                 wasm!(self.func, {
-                    local_get(idx_local);
-                    local_get(len_local);
-                    i32_ge_u;
-                    br_if(1);
-                    // acc = fn(acc, elem)
-                    i32_const(4);
-                    i32_load(0);
-                });
-                wasm!(self.func, {
-                    i32_load(4);
-                    local_get(acc_local);
-                    // load elem
-                    i32_const(0);
-                    i32_load(0);
-                    i32_const(4);
-                    i32_add;
-                    local_get(idx_local);
-                    i32_const(elem_size as i32);
-                    i32_mul;
-                    i32_add;
+                    local_get(idx); local_get(len); i32_ge_u; br_if(1);
+                    local_get(closure); i32_load(4); // env
+                    local_get(acc);
+                    local_get(list_ptr); i32_const(4); i32_add;
+                    local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                // table_idx
-                wasm!(self.func, {
-                    i32_const(4);
-                    i32_load(0);
-                    i32_load(0);
-                });
-                // Build call_indirect type from concrete types (not lambda Fn type which may have Unknown params)
-                // fold signature: (env: i32, acc: acc_ty, elem: elem_ty) -> acc_ty
+                wasm!(self.func, { local_get(closure); i32_load(0); }); // table_idx
                 {
                     let acc_ty = &args[1].ty;
-                    let mut ct = vec![ValType::I32]; // env
+                    let mut ct = vec![ValType::I32];
                     if let Some(vt) = values::ty_to_valtype(acc_ty) { ct.push(vt); }
                     if let Some(vt) = values::ty_to_valtype(&elem_ty) { ct.push(vt); }
                     let rt = values::ret_type(acc_ty);
@@ -815,20 +722,17 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                    local_set(acc_local);
-                    local_get(idx_local);
-                    i32_const(1);
-                    i32_add;
-                    local_set(idx_local);
+                    local_set(acc);
+                    local_get(idx); i32_const(1); i32_add; local_set(idx);
                     br(0);
                 });
-
                 self.depth = saved;
-                wasm!(self.func, {
-                    end;
-                    end;
-                    local_get(acc_local);
-                });
+                wasm!(self.func, { end; end; local_get(acc); });
+                self.scratch.free(acc, acc_vt);
+                self.scratch.free_i32(idx);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(list_ptr);
             }
             "map" => {
                 let ret_ty = self.stub_ret_ty.clone();
@@ -872,108 +776,60 @@ impl FuncCompiler<'_> {
         let in_size = values::byte_size(&in_elem_ty);
         let out_size = values::byte_size(&out_elem_ty);
 
-        let s = self.match_i32_base + self.match_depth;
-        let len_local = s;
-        let idx_local = s + 1;
-        let src_local = s + 2;
-        let closure_local = s + 3;
+        let len_local = self.scratch.alloc_i32();
+        let idx_local = self.scratch.alloc_i32();
+        let src_local = self.scratch.alloc_i32();
+        let closure_local = self.scratch.alloc_i32();
+        let dst_local = self.scratch.alloc_i32();
 
-        // Store src_ptr and closure in scratch locals (not mem[]) to survive nested calls
         self.emit_expr(list_arg);
         wasm!(self.func, { local_set(src_local); });
         self.emit_expr(fn_arg);
         wasm!(self.func, {
             local_set(closure_local);
-            local_get(src_local);
-            i32_load(0);
-            local_set(len_local);
-            // Alloc dst
-            i32_const(4);
-            local_get(len_local);
-            i32_const(out_size as i32);
-            i32_mul;
-            i32_add;
-            call(self.emitter.rt.alloc);
-            local_set(s + 4); // dst_local
-        });
-        let dst_local = s + 4;
-        wasm!(self.func, {
-            // Set dst.len
-            local_get(dst_local);
-            local_get(len_local);
-            i32_store(0);
-            // idx = 0
-            i32_const(0);
-            local_set(idx_local);
-            // Loop
-            block_empty;
-            loop_empty;
+            local_get(src_local); i32_load(0); local_set(len_local);
+            i32_const(4); local_get(len_local); i32_const(out_size as i32); i32_mul; i32_add;
+            call(self.emitter.rt.alloc); local_set(dst_local);
+            local_get(dst_local); local_get(len_local); i32_store(0);
+            i32_const(0); local_set(idx_local);
+            block_empty; loop_empty;
         });
         let saved = self.depth;
         self.depth += 2;
 
         wasm!(self.func, {
-            local_get(idx_local);
-            local_get(len_local);
-            i32_ge_u;
-            br_if(1);
+            local_get(idx_local); local_get(len_local); i32_ge_u; br_if(1);
             // dst addr
-            local_get(dst_local);
-            i32_const(4);
-            i32_add;
-            local_get(idx_local);
-            i32_const(out_size as i32);
-            i32_mul;
-            i32_add;
-            // env_ptr from closure
-            local_get(closure_local);
-            i32_load(4);
+            local_get(dst_local); i32_const(4); i32_add;
+            local_get(idx_local); i32_const(out_size as i32); i32_mul; i32_add;
+            // env_ptr
+            local_get(closure_local); i32_load(4);
             // src element
-            local_get(src_local);
-            i32_const(4);
-            i32_add;
-            local_get(idx_local);
-            i32_const(in_size as i32);
-            i32_mul;
-            i32_add;
+            local_get(src_local); i32_const(4); i32_add;
+            local_get(idx_local); i32_const(in_size as i32); i32_mul; i32_add;
         });
         self.emit_load_at(&in_elem_ty, 0);
-        // table_idx from closure
-        wasm!(self.func, {
-            local_get(closure_local);
-            i32_load(0);
-        });
-        // Stack: [dst_elem_addr, env_ptr, element, table_idx]
-
-        // call_indirect: map signature (env: i32, elem: in_elem_ty) -> out_elem_ty
-        // Always use concrete types from list/return type, not lambda Fn type (which may have Unknown params)
+        wasm!(self.func, { local_get(closure_local); i32_load(0); }); // table_idx
         {
-            let mut ct = vec![ValType::I32]; // env
+            let mut ct = vec![ValType::I32];
             if let Some(vt) = values::ty_to_valtype(&in_elem_ty) { ct.push(vt); }
             let rt = values::ret_type(&out_elem_ty);
             let ti = self.emitter.register_type(ct, rt);
             wasm!(self.func, { call_indirect(ti, 0); });
         }
-        // Stack: [dst_elem_addr, result]
-
-        // ── Store result at dst addr ──
         self.emit_store_at(&out_elem_ty, 0);
-        // Stack: []
 
-        // idx++
         wasm!(self.func, {
-            local_get(idx_local);
-            i32_const(1);
-            i32_add;
-            local_set(idx_local);
+            local_get(idx_local); i32_const(1); i32_add; local_set(idx_local);
             br(0);
         });
-
         self.depth = saved;
-        wasm!(self.func, {
-            end;
-            end;
-            local_get(dst_local);
-        });
+        wasm!(self.func, { end; end; local_get(dst_local); });
+
+        self.scratch.free_i32(dst_local);
+        self.scratch.free_i32(closure_local);
+        self.scratch.free_i32(src_local);
+        self.scratch.free_i32(idx_local);
+        self.scratch.free_i32(len_local);
     }
 }

--- a/src/codegen/emit_wasm/calls_list_closure2.rs
+++ b/src/codegen/emit_wasm/calls_list_closure2.rs
@@ -17,27 +17,28 @@ impl FuncCompiler<'_> {
                 // take_while(xs, pred) → List[A]: take while pred returns true
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0]=xs, mem[4]=closure
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let count = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let copy_i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
-                    // First pass: find how many elements to take
-                    i32_const(0); local_set(s + 1); // count
+                    local_set(closure);
+                    local_get(xs); i32_load(0); local_set(len);
+                    i32_const(0); local_set(count);
                     block_empty; loop_empty;
-                      local_get(s + 1); local_get(s); i32_ge_u; br_if(1);
-                      // Call pred(xs[count])
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 1); i32_const(es); i32_mul; i32_add;
+                      local_get(count); local_get(len); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4); // env
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(count); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32];
@@ -46,56 +47,64 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      i32_eqz; br_if(1); // pred false → break out of block+loop
-                      local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                      i32_eqz; br_if(1);
+                      local_get(count); i32_const(1); i32_add; local_set(count);
                       br(0);
                     end; end;
-                    // s+1 = count of elements to take
                     // Alloc result
-                    i32_const(4); local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_store(0);
+                    i32_const(4); local_get(count); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(count); i32_store(0);
                     // Copy loop
-                    i32_const(0); local_set(s + 3); // i
+                    i32_const(0); local_set(copy_i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                      local_get(copy_i); local_get(count); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(copy_i); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(copy_i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(copy_i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(count);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "drop_while" => {
                 // drop_while(xs, pred) → List[A]: drop while pred returns true
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0]=xs, mem[4]=closure
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let start = self.scratch.alloc_i32();
+                let new_len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let copy_i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
-                    // Find start index (first element where pred is false)
-                    i32_const(0); local_set(s + 1); // start
+                    local_set(closure);
+                    local_get(xs); i32_load(0); local_set(len);
+                    i32_const(0); local_set(start);
                     block_empty; loop_empty;
-                      local_get(s + 1); local_get(s); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 1); i32_const(es); i32_mul; i32_add;
+                      local_get(start); local_get(len); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4); // env
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(start); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32];
@@ -104,56 +113,65 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      i32_eqz; br_if(1); // pred false → break
-                      local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                      i32_eqz; br_if(1);
+                      local_get(start); i32_const(1); i32_add; local_set(start);
                       br(0);
                     end; end;
                     // new_len = len - start
-                    local_get(s); local_get(s + 1); i32_sub; local_set(s + 2);
+                    local_get(len); local_get(start); i32_sub; local_set(new_len);
                     // Alloc result
-                    i32_const(4); local_get(s + 2); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 3);
-                    local_get(s + 3); local_get(s + 2); i32_store(0);
+                    i32_const(4); local_get(new_len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(new_len); i32_store(0);
                     // Copy loop
-                    i32_const(0); local_set(s + 4); // i
+                    i32_const(0); local_set(copy_i);
                     block_empty; loop_empty;
-                      local_get(s + 4); local_get(s + 2); i32_ge_u; br_if(1);
-                      local_get(s + 3); i32_const(4); i32_add;
-                      local_get(s + 4); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 1); local_get(s + 4); i32_add;
+                      local_get(copy_i); local_get(new_len); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(copy_i); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(start); local_get(copy_i); i32_add;
                       i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 4); i32_const(1); i32_add; local_set(s + 4);
+                      local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
                       br(0);
                     end; end;
-                    local_get(s + 3);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(copy_i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(new_len);
+                self.scratch.free_i32(start);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "count" => {
                 // count(xs, pred) → Int
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let cnt = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); local_set(s); // i
-                    i32_const(0); local_set(s + 1); // count
+                    local_set(closure);
+                    i32_const(0); local_set(i);
+                    i32_const(0); local_set(cnt);
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4); // env
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32];
@@ -163,46 +181,53 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                       if_empty;
-                        local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                        local_get(cnt); i32_const(1); i32_add; local_set(cnt);
                       end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1); i64_extend_i32_u;
+                    local_get(cnt); i64_extend_i32_u;
                 });
+                self.scratch.free_i32(cnt);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "partition" => {
                 // partition(xs, pred) → (List[A], List[A])
-                // Returns a tuple: (matching, non-matching)
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0]=xs, mem[4]=closure
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let true_list = self.scratch.alloc_i32();
+                let false_list = self.scratch.alloc_i32();
+                let true_cnt = self.scratch.alloc_i32();
+                let false_cnt = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let tuple_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
-                    // Alloc two lists (max size each = len)
-                    i32_const(4); local_get(s); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 1); // true_list
-                    i32_const(4); local_get(s); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2); // false_list
-                    i32_const(0); local_set(s + 3); // true_count
-                    i32_const(0); local_set(s + 4); // false_count
-                    i32_const(0); local_set(s + 5); // i
+                    local_set(closure);
+                    local_get(xs); i32_load(0); local_set(len);
+                    i32_const(4); local_get(len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(true_list);
+                    i32_const(4); local_get(len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(false_list);
+                    i32_const(0); local_set(true_cnt);
+                    i32_const(0); local_set(false_cnt);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 5); local_get(s); i32_ge_u; br_if(1);
-                      // Call pred(xs[i])
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 5); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4); // env
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32];
@@ -212,41 +237,46 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                       if_i32;
-                        // Copy to true_list
-                        local_get(s + 1); i32_const(4); i32_add;
-                        local_get(s + 3); i32_const(es); i32_mul; i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 5); i32_const(es); i32_mul; i32_add;
+                        local_get(true_list); i32_const(4); i32_add;
+                        local_get(true_cnt); i32_const(es); i32_mul; i32_add;
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
-                        i32_const(0); // push 0 as dummy for consistent stack
+                        local_get(true_cnt); i32_const(1); i32_add; local_set(true_cnt);
+                        i32_const(0);
                       else_;
-                        // Copy to false_list
-                        local_get(s + 2); i32_const(4); i32_add;
-                        local_get(s + 4); i32_const(es); i32_mul; i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 5); i32_const(es); i32_mul; i32_add;
+                        local_get(false_list); i32_const(4); i32_add;
+                        local_get(false_cnt); i32_const(es); i32_mul; i32_add;
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 4); i32_const(1); i32_add; local_set(s + 4);
-                        i32_const(0); // push 0 as dummy for consistent stack
+                        local_get(false_cnt); i32_const(1); i32_add; local_set(false_cnt);
+                        i32_const(0);
                       end;
-                      drop; // drop dummy
-                      local_get(s + 5); i32_const(1); i32_add; local_set(s + 5);
+                      drop;
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    // Set lengths
-                    local_get(s + 1); local_get(s + 3); i32_store(0);
-                    local_get(s + 2); local_get(s + 4); i32_store(0);
-                    // Alloc tuple (true_list_ptr, false_list_ptr)
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(s + 5);
-                    local_get(s + 5); local_get(s + 1); i32_store(0);
-                    local_get(s + 5); local_get(s + 2); i32_store(4);
-                    local_get(s + 5);
+                    local_get(true_list); local_get(true_cnt); i32_store(0);
+                    local_get(false_list); local_get(false_cnt); i32_store(0);
+                    i32_const(8); call(self.emitter.rt.alloc); local_set(tuple_ptr);
+                    local_get(tuple_ptr); local_get(true_list); i32_store(0);
+                    local_get(tuple_ptr); local_get(false_list); i32_store(4);
+                    local_get(tuple_ptr);
                 });
+                self.scratch.free_i32(tuple_ptr);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(false_cnt);
+                self.scratch.free_i32(true_cnt);
+                self.scratch.free_i32(false_list);
+                self.scratch.free_i32(true_list);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(xs);
             }
             "update" => {
                 // update(xs, i, f) → List[A]: copy with xs[i] replaced by f(xs[i])

--- a/src/codegen/emit_wasm/closures.rs
+++ b/src/codegen/emit_wasm/closures.rs
@@ -199,7 +199,7 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
             local_idx += 1;
         }
 
-        // Scratch locals
+        // Legacy scratch locals
         let scratch_depth = scan.scratch_depth.max(1);
         let match_i64_base = local_idx;
         for _ in 0..scratch_depth {
@@ -211,6 +211,15 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
             local_decls.push((1, ValType::I32));
             local_idx += 1;
         }
+
+        // ScratchAllocator locals (separate region)
+        let scratch_i32_base = local_idx;
+        let scratch_extra = 12usize;
+        for _ in 0..scratch_extra { local_decls.push((1, ValType::I32)); local_idx += 1; }
+        let scratch_i64_base = local_idx;
+        for _ in 0..scratch_extra { local_decls.push((1, ValType::I64)); local_idx += 1; }
+        let scratch_f64_base = local_idx;
+        for _ in 0..2 { local_decls.push((1, ValType::F64)); local_idx += 1; }
 
         let mut wasm_func = wasm_encoder::Function::new(local_decls);
 
@@ -254,7 +263,7 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
         // Compile body
         let compiled_func = {
             let mut scratch_alloc = super::scratch::ScratchAllocator::new();
-            scratch_alloc.set_bases(match_i32_base, match_i64_base, match_i32_base + scratch_depth as u32);
+            scratch_alloc.set_bases(scratch_i32_base, scratch_i64_base, scratch_f64_base);
             let mut compiler = FuncCompiler {
                 emitter: &mut *emitter,
                 func: wasm_func,

--- a/src/codegen/emit_wasm/functions.rs
+++ b/src/codegen/emit_wasm/functions.rs
@@ -39,7 +39,7 @@ pub fn compile_function(
         }
     }
 
-    // Match scratch locals: one i64 + one i32 per nesting depth level
+    // Legacy scratch locals (for unmigrated code)
     let match_i64_base = param_count + local_decls.len() as u32;
     for _ in 0..scan.scratch_depth {
         local_decls.push((1, ValType::I64));
@@ -49,14 +49,27 @@ pub fn compile_function(
         local_decls.push((1, ValType::I32));
     }
 
-    let init_globals_idx: Option<u32> = None; // disabled, using inline init instead
+    // ScratchAllocator locals (separate region, after legacy)
+    let scratch_i32_base = param_count + local_decls.len() as u32;
+    let scratch_extra = 12; // enough for the largest stdlib function (unique_by = 10+)
+    for _ in 0..scratch_extra {
+        local_decls.push((1, ValType::I32));
+    }
+    let scratch_i64_base = param_count + local_decls.len() as u32;
+    for _ in 0..scratch_extra {
+        local_decls.push((1, ValType::I64));
+    }
+    let scratch_f64_base = param_count + local_decls.len() as u32;
+    for _ in 0..2 { // f64 scratch (for float operations)
+        local_decls.push((1, ValType::F64));
+    }
 
-    // Create WASM function with declared locals
+    let init_globals_idx: Option<u32> = None;
+
     let wasm_func = Function::new(local_decls);
 
-    // Compile the body
     let mut scratch_alloc = super::scratch::ScratchAllocator::new();
-    scratch_alloc.set_bases(match_i32_base, match_i64_base, match_i32_base + scan.scratch_depth as u32);
+    scratch_alloc.set_bases(scratch_i32_base, scratch_i64_base, scratch_f64_base);
     let mut compiler = FuncCompiler {
         emitter,
         func: wasm_func,

--- a/src/codegen/emit_wasm/mod.rs
+++ b/src/codegen/emit_wasm/mod.rs
@@ -314,9 +314,9 @@ pub struct FuncCompiler<'a> {
     pub var_map: HashMap<u32, u32>,
     pub depth: u32,
     pub loop_stack: Vec<LoopLabels>,
-    // Scratch local allocator (replaces match_i32_base/match_i64_base/match_depth)
+    // Scratch local allocator
     pub scratch: scratch::ScratchAllocator,
-    // Legacy scratch (kept during migration — will be removed)
+    // Legacy compatibility — delegates to scratch allocator internally
     pub match_i64_base: u32,
     pub match_i32_base: u32,
     pub match_depth: u32,
@@ -647,11 +647,18 @@ fn compile_init_globals(emitter: &mut WasmEmitter, program: &IrProgram) {
     for _ in 0..scan_depth {
         local_decls.push((1, ValType::I32));
     }
+    // ScratchAllocator region (separate from legacy)
+    let scratch_i32_base = local_decls.len() as u32;
+    for _ in 0..12 { local_decls.push((1, ValType::I32)); }
+    let scratch_i64_base = local_decls.len() as u32;
+    for _ in 0..12 { local_decls.push((1, ValType::I64)); }
+    let scratch_f64_base = local_decls.len() as u32;
+    for _ in 0..2 { local_decls.push((1, ValType::F64)); }
 
     let wasm_func = Function::new(local_decls);
     let compiled_func = {
         let mut scratch_alloc = scratch::ScratchAllocator::new();
-        scratch_alloc.set_bases(match_i32_base, match_i64_base, match_i32_base + scan_depth as u32);
+        scratch_alloc.set_bases(scratch_i32_base, scratch_i64_base, scratch_f64_base);
         let mut compiler = FuncCompiler {
             emitter: &mut *emitter,
             func: wasm_func,

--- a/src/codegen/emit_wasm/statements.rs
+++ b/src/codegen/emit_wasm/statements.rs
@@ -261,9 +261,10 @@ fn count_scratch_depth(expr: &IrExpr) -> usize {
         }
         IrExprKind::UnOp { operand, .. } => count_scratch_depth(operand),
         IrExprKind::Call { args, target, .. } => {
-            // Calls may use scratch: option/result ops (3), list ops (4), variant constructors (1), computed calls (1)
+            // ScratchAllocator: stdlib functions alloc up to 10 i32 scratch locals
+            // (unique_by uses 10). This must be enough to cover the worst case.
             let inner = args.iter().map(|a| count_scratch_depth(a)).max().unwrap_or(0);
-            4 + inner
+            10 + inner
         }
         // SpreadRecord needs 2 i32 scratch (result + base ptrs) + 1 i64 scratch (copy counter)
         IrExprKind::SpreadRecord { base, fields, .. } => {


### PR DESCRIPTION
## Summary
calls_list_closure2.rsの全関数(take_while, drop_while, count, partition, update, scan, zip_with, unique_by, filter, fold, emit_list_map)をScratchAllocator経由に移行。mem[]スクラッチを全廃。

### アーキテクチャ変更
- ScratchAllocatorのlocal領域をlegacy(match_i32_base)の**後ろ**に分離配置
- legacy方式と衝突しない → 残りファイルの段階的移行が可能

### 改善
- mem[0]/mem[4]/mem[8]パターン全廃 → closure内部からの書き込みで壊れない
- 11テストが新たにパス（list系テストのnested call問題解消）

## Test plan
- [x] almide test -- all 153 pass
- [x] almide test --target wasm -- 105 passed