### PR TITLE
Complete ScratchAllocator migration, remove legacy match_depth, add DepthGuard RAII

### DIFF
--- a/src/codegen/emit_wasm/calls.rs
+++ b/src/codegen/emit_wasm/calls.rs
@@ -86,7 +86,7 @@ impl FuncCompiler<'_> {
                         if let Some((tag, is_unit)) = self.find_variant_ctor_tag(name) {
                             if is_unit && args.is_empty() {
                                 // Unit variant: allocate [tag:i32]
-                                let scratch = self.match_i32_base + self.match_depth;
+                                let scratch = self.scratch.alloc_i32();
                                 wasm!(self.func, {
                                     i32_const(4);
                                     call(self.emitter.rt.alloc);
@@ -96,13 +96,13 @@ impl FuncCompiler<'_> {
                                     i32_store(0);
                                     local_get(scratch);
                                 });
+                                self.scratch.free_i32(scratch);
                                 return;
                             } else if !is_unit {
                                 // Tuple payload variant: [tag:i32][arg0][arg1]...
                                 let mut total_size = 4u32; // tag
                                 for arg in args { total_size += values::byte_size(&arg.ty); }
-                                let scratch = self.match_i32_base + self.match_depth;
-                                self.match_depth += 1;
+                                let scratch = self.scratch.alloc_i32();
                                 wasm!(self.func, {
                                     i32_const(total_size as i32);
                                     call(self.emitter.rt.alloc);
@@ -120,8 +120,8 @@ impl FuncCompiler<'_> {
                                     self.emit_store_at(&arg.ty, offset);
                                     offset += values::byte_size(&arg.ty);
                                 }
-                                self.match_depth -= 1;
                                 wasm!(self.func, { local_get(scratch); });
+                                self.scratch.free_i32(scratch);
                                 return;
                             }
                         }
@@ -183,25 +183,31 @@ impl FuncCompiler<'_> {
                     ("error", "message") => {
                         // error.message(r: Result[T, String]) → String
                         // tag==0(ok): empty string, tag==1(err): load string at offset 4
-                        let s = self.match_i32_base + self.match_depth;
+                        let s = self.scratch.alloc_i32();
+                        let s1 = self.scratch.alloc_i32();
                         self.emit_expr(&args[0]);
                         wasm!(self.func, {
                             local_set(s);
                             local_get(s); i32_load(0); i32_eqz; // tag == 0?
                             if_i32;
                               // ok → empty string
-                              i32_const(4); call(self.emitter.rt.alloc); local_set(s + 1);
-                              local_get(s + 1); i32_const(0); i32_store(0);
-                              local_get(s + 1);
+                              i32_const(4); call(self.emitter.rt.alloc); local_set(s1);
+                              local_get(s1); i32_const(0); i32_store(0);
+                              local_get(s1);
                             else_;
                               local_get(s); i32_load(4); // err string ptr
                             end;
                         });
+                        self.scratch.free_i32(s1);
+                        self.scratch.free_i32(s);
                     }
                     ("error", "context") => {
                         // error.context(result, msg) → Result[T, String]
                         // If err: wrap error message with context. If ok: pass through.
-                        let s = self.match_i32_base + self.match_depth;
+                        let s = self.scratch.alloc_i32();
+                        let s1 = self.scratch.alloc_i32();
+                        let s2 = self.scratch.alloc_i32();
+                        let s3 = self.scratch.alloc_i32();
                         self.emit_expr(&args[0]);
                         wasm!(self.func, {
                             local_set(s);
@@ -210,44 +216,51 @@ impl FuncCompiler<'_> {
                               local_get(s); // pass ok through
                             else_;
                               // Build new err with context: "msg: original_err"
-                              local_get(s); i32_load(4); local_set(s + 1); // original err string
+                              local_get(s); i32_load(4); local_set(s1); // original err string
                         });
                         self.emit_expr(&args[1]); // context msg
                         wasm!(self.func, {
-                              local_set(s + 2);
+                              local_set(s2);
                               // Build ": " separator
-                              i32_const(6); call(self.emitter.rt.alloc); local_set(s + 3);
-                              local_get(s + 3); i32_const(2); i32_store(0);
-                              local_get(s + 3); i32_const(58); i32_store8(4);
-                              local_get(s + 3); i32_const(32); i32_store8(5);
+                              i32_const(6); call(self.emitter.rt.alloc); local_set(s3);
+                              local_get(s3); i32_const(2); i32_store(0);
+                              local_get(s3); i32_const(58); i32_store8(4);
+                              local_get(s3); i32_const(32); i32_store8(5);
                               // concat: msg + ": " + original
-                              local_get(s + 2); local_get(s + 3); call(self.emitter.rt.concat_str);
-                              local_get(s + 1); call(self.emitter.rt.concat_str);
-                              local_set(s + 1);
+                              local_get(s2); local_get(s3); call(self.emitter.rt.concat_str);
+                              local_get(s1); call(self.emitter.rt.concat_str);
+                              local_set(s1);
                               // Build new err Result
                               i32_const(8); call(self.emitter.rt.alloc); local_set(s);
                               local_get(s); i32_const(1); i32_store(0);
-                              local_get(s); local_get(s + 1); i32_store(4);
+                              local_get(s); local_get(s1); i32_store(4);
                               local_get(s);
                             end;
                         });
+                        self.scratch.free_i32(s3);
+                        self.scratch.free_i32(s2);
+                        self.scratch.free_i32(s1);
+                        self.scratch.free_i32(s);
                     }
                     ("error", "chain") => {
                         // error.chain(outer, cause) → "outer: cause"
                         self.emit_expr(&args[0]);
                         // concat outer + ": " + cause
                         // Build ": " string
-                        let s = self.match_i32_base + self.match_depth;
+                        let s = self.scratch.alloc_i32();
+                        let s1 = self.scratch.alloc_i32();
                         wasm!(self.func, {
                             local_set(s);
-                            i32_const(6); call(self.emitter.rt.alloc); local_set(s + 1);
-                            local_get(s + 1); i32_const(2); i32_store(0);
-                            local_get(s + 1); i32_const(58); i32_store8(4); // ':'
-                            local_get(s + 1); i32_const(32); i32_store8(5); // ' '
-                            local_get(s); local_get(s + 1); call(self.emitter.rt.concat_str);
+                            i32_const(6); call(self.emitter.rt.alloc); local_set(s1);
+                            local_get(s1); i32_const(2); i32_store(0);
+                            local_get(s1); i32_const(58); i32_store8(4); // ':'
+                            local_get(s1); i32_const(32); i32_store8(5); // ' '
+                            local_get(s); local_get(s1); call(self.emitter.rt.concat_str);
                         });
                         self.emit_expr(&args[1]);
                         wasm!(self.func, { call(self.emitter.rt.concat_str); });
+                        self.scratch.free_i32(s1);
+                        self.scratch.free_i32(s);
                     }
                     _ if module == "set" => {
                         if !self.emit_set_call(func, args) {
@@ -420,14 +433,11 @@ impl FuncCompiler<'_> {
 
             CallTarget::Computed { callee } => {
                 // Closure call: callee is a closure ptr [table_idx: i32][env_ptr: i32]
-                let scratch = self.match_i32_base + self.match_depth;
+                let scratch = self.scratch.alloc_i32();
 
                 // Evaluate callee → closure ptr
                 self.emit_expr(callee);
                 wasm!(self.func, { local_set(scratch); });
-
-                // Reserve this scratch so nested calls use different locals
-                self.match_depth += 1;
 
                 // Push env_ptr (first hidden arg)
                 wasm!(self.func, {
@@ -439,9 +449,6 @@ impl FuncCompiler<'_> {
                 for arg in args {
                     self.emit_expr(arg);
                 }
-
-                // Restore depth
-                self.match_depth -= 1;
 
                 // Push table_idx (on top of stack for call_indirect)
                 wasm!(self.func, {
@@ -463,6 +470,7 @@ impl FuncCompiler<'_> {
                 } else {
                     wasm!(self.func, { unreachable; });
                 }
+                self.scratch.free_i32(scratch);
             }
         }
     }
@@ -496,23 +504,27 @@ impl FuncCompiler<'_> {
             Ty::Bool => { wasm!(self.func, { i32_const(0); }); }
             Ty::String => {
                 // Empty string: alloc 4 bytes, len=0
+                let tmp = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_const(4); call(self.emitter.rt.alloc);
-                    local_set(self.match_i32_base + self.match_depth);
-                    local_get(self.match_i32_base + self.match_depth);
+                    local_set(tmp);
+                    local_get(tmp);
                     i32_const(0); i32_store(0);
-                    local_get(self.match_i32_base + self.match_depth);
+                    local_get(tmp);
                 });
+                self.scratch.free_i32(tmp);
             }
             Ty::Applied(TypeConstructorId::List, _) => {
                 // Empty list: alloc 4 bytes, len=0
+                let tmp = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_const(4); call(self.emitter.rt.alloc);
-                    local_set(self.match_i32_base + self.match_depth);
-                    local_get(self.match_i32_base + self.match_depth);
+                    local_set(tmp);
+                    local_get(tmp);
                     i32_const(0); i32_store(0);
-                    local_get(self.match_i32_base + self.match_depth);
+                    local_get(tmp);
                 });
+                self.scratch.free_i32(tmp);
             }
             Ty::Applied(TypeConstructorId::Option, _) => {
                 // none
@@ -520,16 +532,18 @@ impl FuncCompiler<'_> {
             }
             Ty::Applied(TypeConstructorId::Result, _) => {
                 // err("stub") — tag=1, value=empty string
+                let tmp = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_const(8); call(self.emitter.rt.alloc);
-                    local_set(self.match_i32_base + self.match_depth);
-                    local_get(self.match_i32_base + self.match_depth);
+                    local_set(tmp);
+                    local_get(tmp);
                     i32_const(1); i32_store(0); // tag=err
-                    local_get(self.match_i32_base + self.match_depth);
+                    local_get(tmp);
                     i32_const(4); call(self.emitter.rt.alloc);
                     i32_store(4); // empty string at offset 4
-                    local_get(self.match_i32_base + self.match_depth);
+                    local_get(tmp);
                 });
+                self.scratch.free_i32(tmp);
             }
             Ty::Unit => { /* no value */ }
             _ => {

--- a/src/codegen/emit_wasm/calls_lambda.rs
+++ b/src/codegen/emit_wasm/calls_lambda.rs
@@ -12,7 +12,7 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_fn_ref_closure(&mut self, name: &str) {
         if let Some(&wrapper_table_idx) = self.emitter.fn_ref_wrappers.get(name) {
             // Allocate closure: [table_idx: i32][env_ptr: i32] = 8 bytes
-            let scratch = self.match_i32_base + self.match_depth;
+            let scratch = self.scratch.alloc_i32();
             wasm!(self.func, {
                 i32_const(8);
                 call(self.emitter.rt.alloc);
@@ -28,6 +28,7 @@ impl FuncCompiler<'_> {
                 // Return closure ptr
                 local_get(scratch);
             });
+            self.scratch.free_i32(scratch);
         } else {
             eprintln!("WARNING: FnRef wrapper not found for '{}', using direct table entry", name);
             wasm!(self.func, { unreachable; });
@@ -59,7 +60,7 @@ impl FuncCompiler<'_> {
         let table_idx = self.emitter.lambdas[lambda_idx].table_idx;
         let captures = self.emitter.lambdas[lambda_idx].captures.clone();
 
-        let scratch = self.match_i32_base + self.match_depth;
+        let scratch = self.scratch.alloc_i32();
 
         if captures.is_empty() {
             // No captures: allocate closure [table_idx, 0]
@@ -75,10 +76,11 @@ impl FuncCompiler<'_> {
                 i32_store(4);
                 local_get(scratch);
             });
+            self.scratch.free_i32(scratch);
         } else {
             // Allocate env: each capture gets 8 bytes (padded for alignment)
             let env_size = (captures.len() as u32) * 8;
-            let env_scratch = scratch; // reuse for env_ptr
+            let env_scratch = scratch;
             wasm!(self.func, {
                 i32_const(env_size as i32);
                 call(self.emitter.rt.alloc);
@@ -109,7 +111,7 @@ impl FuncCompiler<'_> {
             }
 
             // Allocate closure: [table_idx, env_ptr]
-            let closure_scratch = scratch + 1; // second i32 scratch slot
+            let closure_scratch = self.scratch.alloc_i32();
             wasm!(self.func, {
                 i32_const(8);
                 call(self.emitter.rt.alloc);
@@ -122,6 +124,8 @@ impl FuncCompiler<'_> {
                 i32_store(4);
                 local_get(closure_scratch);
             });
+            self.scratch.free_i32(closure_scratch);
+            self.scratch.free_i32(env_scratch);
         }
     }
 }

--- a/src/codegen/emit_wasm/calls_list.rs
+++ b/src/codegen/emit_wasm/calls_list.rs
@@ -19,285 +19,324 @@ impl FuncCompiler<'_> {
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let elem_size = values::byte_size(&elem_ty);
                 let vt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32);
-                let s = self.match_i32_base + self.match_depth;
-                // Store xs → mem[0], i → mem[4]
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let idx = self.scratch.alloc_i32();
+                // Store xs, i
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]); // i: i64
-                wasm!(self.func, { i32_wrap_i64; i32_store(0); });
+                wasm!(self.func, { i32_wrap_i64; local_set(idx); });
                 // bounds check: i < 0 || i >= len → default
                 match vt {
                     ValType::I64 => {
                         wasm!(self.func, {
-                            i32_const(4); i32_load(0); // i
-                            i32_const(0); i32_load(0); i32_load(0); // len
+                            local_get(idx); // i
+                            local_get(xs); i32_load(0); // len
                             i32_ge_u;
-                            i32_const(4); i32_load(0); i32_const(0); i32_lt_s;
+                            local_get(idx); i32_const(0); i32_lt_s;
                             i32_or;
                             if_i64;
                         });
                         self.emit_expr(&args[2]); // default
                         wasm!(self.func, {
                             else_;
-                              i32_const(0); i32_load(0); i32_const(4); i32_add;
-                              i32_const(4); i32_load(0); i32_const(elem_size as i32); i32_mul; i32_add;
+                              local_get(xs); i32_const(4); i32_add;
+                              local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
                               i64_load(0);
                             end;
                         });
                     }
                     ValType::F64 => {
                         wasm!(self.func, {
-                            i32_const(4); i32_load(0);
-                            i32_const(0); i32_load(0); i32_load(0);
+                            local_get(idx);
+                            local_get(xs); i32_load(0);
                             i32_ge_u;
-                            i32_const(4); i32_load(0); i32_const(0); i32_lt_s;
+                            local_get(idx); i32_const(0); i32_lt_s;
                             i32_or;
                             if_f64;
                         });
                         self.emit_expr(&args[2]);
                         wasm!(self.func, {
                             else_;
-                              i32_const(0); i32_load(0); i32_const(4); i32_add;
-                              i32_const(4); i32_load(0); i32_const(elem_size as i32); i32_mul; i32_add;
+                              local_get(xs); i32_const(4); i32_add;
+                              local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
                               f64_load(0);
                             end;
                         });
                     }
                     _ => {
                         wasm!(self.func, {
-                            i32_const(4); i32_load(0);
-                            i32_const(0); i32_load(0); i32_load(0);
+                            local_get(idx);
+                            local_get(xs); i32_load(0);
                             i32_ge_u;
-                            i32_const(4); i32_load(0); i32_const(0); i32_lt_s;
+                            local_get(idx); i32_const(0); i32_lt_s;
                             i32_or;
                             if_i32;
                         });
                         self.emit_expr(&args[2]);
                         wasm!(self.func, {
                             else_;
-                              i32_const(0); i32_load(0); i32_const(4); i32_add;
-                              i32_const(4); i32_load(0); i32_const(elem_size as i32); i32_mul; i32_add;
+                              local_get(xs); i32_const(4); i32_add;
+                              local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
                               i32_load(0);
                             end;
                         });
                     }
                 }
+                self.scratch.free_i32(idx);
+                self.scratch.free_i32(xs);
             }
             "take" => {
                 // take(xs, n) → List[A]: first min(n, len) elements
-                // mem[0]=xs, s=n, s+1=new_len, s+2=dst, s+3=i
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let n = self.scratch.alloc_i32();
+                let new_len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s);
+                    i32_wrap_i64; local_set(n);
                     // new_len = min(n, len)
-                    local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_lt_u;
-                    if_i32; local_get(s); else_; i32_const(0); i32_load(0); i32_load(0); end;
-                    local_set(s + 1);
-                    i32_const(4); local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_store(0);
-                    i32_const(0); local_set(s + 3);
+                    local_get(n); local_get(xs); i32_load(0); i32_lt_u;
+                    if_i32; local_get(n); else_; local_get(xs); i32_load(0); end;
+                    local_set(new_len);
+                    i32_const(4); local_get(new_len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(new_len); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(new_len); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(new_len);
+                self.scratch.free_i32(n);
+                self.scratch.free_i32(xs);
             }
             "drop" => {
                 // drop(xs, n): skip first n
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let start = self.scratch.alloc_i32();
+                let new_len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s);
+                    i32_wrap_i64; local_set(start);
                     // start = min(n, len)
-                    local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_lt_u;
-                    if_i32; local_get(s); else_; i32_const(0); i32_load(0); i32_load(0); end;
-                    local_set(s);
+                    local_get(start); local_get(xs); i32_load(0); i32_lt_u;
+                    if_i32; local_get(start); else_; local_get(xs); i32_load(0); end;
+                    local_set(start);
                     // new_len = len - start
-                    i32_const(0); i32_load(0); i32_load(0); local_get(s); i32_sub;
-                    local_set(s + 1);
-                    i32_const(4); local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_store(0);
-                    i32_const(0); local_set(s + 3);
+                    local_get(xs); i32_load(0); local_get(start); i32_sub;
+                    local_set(new_len);
+                    i32_const(4); local_get(new_len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(new_len); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); local_get(s + 3); i32_add;
+                      local_get(i); local_get(new_len); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(start); local_get(i); i32_add;
                       i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(new_len);
+                self.scratch.free_i32(start);
+                self.scratch.free_i32(xs);
             }
             "slice" => {
                 // slice(xs, start, end) → List[A]
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0]=xs
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let start = self.scratch.alloc_i32();
+                let end = self.scratch.alloc_i32();
+                let new_len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]); // start
-                wasm!(self.func, { i32_wrap_i64; local_set(s); });
+                wasm!(self.func, { i32_wrap_i64; local_set(start); });
                 self.emit_expr(&args[2]); // end
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s + 1);
-                    local_get(s + 1); local_get(s); i32_sub; local_set(s + 2); // new_len
-                    i32_const(4); local_get(s + 2); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 3);
-                    local_get(s + 3); local_get(s + 2); i32_store(0);
-                    // copy loop
-                    i32_const(0); local_set(s + 2); // reuse as i
+                    i32_wrap_i64; local_set(end);
+                    local_get(end); local_get(start); i32_sub; local_set(new_len);
+                    i32_const(4); local_get(new_len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(new_len); i32_store(0);
+                    // copy loop — reuse new_len as i
+                    i32_const(0); local_set(new_len);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s + 1); local_get(s); i32_sub; i32_ge_u; br_if(1);
-                      local_get(s + 3); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); local_get(s + 2); i32_add;
+                      local_get(new_len); local_get(end); local_get(start); i32_sub; i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(new_len); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(start); local_get(new_len); i32_add;
                       i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(new_len); i32_const(1); i32_add; local_set(new_len);
                       br(0);
                     end; end;
-                    local_get(s + 3);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(new_len);
+                self.scratch.free_i32(end);
+                self.scratch.free_i32(start);
+                self.scratch.free_i32(xs);
             }
             "reverse" => {
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let elem_size = values::byte_size(&elem_ty);
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
+                    local_set(xs);
+                    local_get(xs); i32_load(0); local_set(len);
                     // alloc dst
-                    i32_const(4); local_get(s); i32_const(elem_size as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 1);
-                    local_get(s + 1); local_get(s); i32_store(0);
+                    i32_const(4); local_get(len); i32_const(elem_size as i32); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(len); i32_store(0);
                     // loop: dst[i] = src[len-1-i]
-                    i32_const(0); local_set(s + 2); // i
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
                       // dst addr
-                      local_get(s + 1); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(elem_size as i32); i32_mul; i32_add;
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
                       // src addr
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(1); i32_sub; local_get(s + 2); i32_sub;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(len); i32_const(1); i32_sub; local_get(i); i32_sub;
                       i32_const(elem_size as i32); i32_mul; i32_add;
                 });
                 // Copy elem_size bytes
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(xs);
             }
             "range" => {
                 // range(start, end) → List[Int]
-                // mem[0]=start(i32), mem[4]=len(i32), s=dst, s+1=i
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let start_val = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_wrap_i64; i32_store(0); }); // mem[0] = start
+                wasm!(self.func, { i32_wrap_i64; local_set(start_val); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
                     i32_wrap_i64;
-                    i32_const(0); i32_load(0); i32_sub; // len = end - start
-                    local_set(s);
-                    local_get(s); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(s); end; // clamp to 0
-                    // mem[4] = len
-                    i32_const(4); local_get(s); i32_store(0);
+                    local_get(start_val); i32_sub; // len = end - start
+                    local_set(len);
+                    local_get(len); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(0); local_set(len); end; // clamp to 0
                     // alloc
-                    i32_const(4); local_get(s); i32_const(8); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s);
-                    local_get(s); i32_const(4); i32_load(0); i32_store(0); // dst.len
-                    i32_const(0); local_set(s + 1); // i
+                    i32_const(4); local_get(len); i32_const(8); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(len); i32_store(0); // dst.len
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 1); i32_const(4); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(s); i32_const(4); i32_add;
-                      local_get(s + 1); i32_const(8); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); local_get(s + 1); i32_add;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(start_val); local_get(i); i32_add;
                       i64_extend_i32_s;
                       i64_store(0);
-                      local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(start_val);
             }
             "first" => {
                 // first(xs) → Option[A]: xs[0] or none
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let elem_size = values::byte_size(&elem_ty);
-                let s = self.match_i32_base + self.match_depth;
+                let xs = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); i32_eqz;
+                    local_set(xs);
+                    local_get(xs); i32_load(0); i32_eqz;
                     if_i32; i32_const(0); // none
                     else_;
-                      i32_const(elem_size as i32); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1);
-                      local_get(s); i32_const(4); i32_add;
+                      i32_const(elem_size as i32); call(self.emitter.rt.alloc); local_set(result);
+                      local_get(result);
+                      local_get(xs); i32_const(4); i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
-                wasm!(self.func, { local_get(s + 1); end; });
+                wasm!(self.func, { local_get(result); end; });
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(xs);
             }
             "last" => {
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let elem_size = values::byte_size(&elem_ty);
-                let s = self.match_i32_base + self.match_depth;
+                let xs = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); i32_eqz;
+                    local_set(xs);
+                    local_get(xs); i32_load(0); i32_eqz;
                     if_i32; i32_const(0);
                     else_;
-                      i32_const(elem_size as i32); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1);
+                      i32_const(elem_size as i32); call(self.emitter.rt.alloc); local_set(result);
+                      local_get(result);
                       // src = xs + 4 + (len-1) * elem_size
-                      local_get(s); i32_const(4); i32_add;
-                      local_get(s); i32_load(0); i32_const(1); i32_sub;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(xs); i32_load(0); i32_const(1); i32_sub;
                       i32_const(elem_size as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
-                wasm!(self.func, { local_get(s + 1); end; });
+                wasm!(self.func, { local_get(result); end; });
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(xs);
             }
             "is_empty" => {
                 self.emit_expr(&args[0]);
@@ -305,46 +344,54 @@ impl FuncCompiler<'_> {
             }
             "sum" => {
                 // sum(xs: List[Int]) → Int
-                let s = self.match_i32_base + self.match_depth;
+                let xs = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let acc = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
-                let s64 = self.match_i64_base + self.match_depth;
                 wasm!(self.func, {
-                    local_set(s); // xs
-                    i64_const(0); local_set(s64); // acc
-                    i32_const(0); local_set(s + 1); // i
+                    local_set(xs);
+                    i64_const(0); local_set(acc);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(s64);
-                      local_get(s); i32_const(4); i32_add;
-                      local_get(s + 1); i32_const(8); i32_mul; i32_add;
+                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(acc);
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(8); i32_mul; i32_add;
                       i64_load(0);
-                      i64_add; local_set(s64);
-                      local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                      i64_add; local_set(acc);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s64);
+                    local_get(acc);
                 });
+                self.scratch.free_i64(acc);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(xs);
             }
             "product" => {
-                let s = self.match_i32_base + self.match_depth;
+                let xs = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let acc = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
-                let s64 = self.match_i64_base + self.match_depth;
                 wasm!(self.func, {
-                    local_set(s);
-                    i64_const(1); local_set(s64);
-                    i32_const(0); local_set(s + 1);
+                    local_set(xs);
+                    i64_const(1); local_set(acc);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(s64);
-                      local_get(s); i32_const(4); i32_add;
-                      local_get(s + 1); i32_const(8); i32_mul; i32_add;
+                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(acc);
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(8); i32_mul; i32_add;
                       i64_load(0);
-                      i64_mul; local_set(s64);
-                      local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                      i64_mul; local_set(acc);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s64);
+                    local_get(acc);
                 });
+                self.scratch.free_i64(acc);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(xs);
             }
             "join" => {
                 // list.join(xs, sep) — delegate to string.join
@@ -358,60 +405,71 @@ impl FuncCompiler<'_> {
                 let inner_list_ty = self.list_elem_ty(&args[0].ty); // List[T]
                 let elem_ty = self.list_elem_ty(&inner_list_ty); // T
                 let elem_size = values::byte_size(&elem_ty); // size of T
-                let s = self.match_i32_base + self.match_depth;
+                let xss = self.scratch.alloc_i32();
+                let total = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let inner = self.scratch.alloc_i32();
+                let j = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s); // xss
+                    local_set(xss);
                     // Pass 1: count total elements
-                    i32_const(0); local_set(s + 1); // total
-                    i32_const(0); local_set(s + 2); // i
+                    i32_const(0); local_set(total);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(s + 1);
-                      local_get(s); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(4); i32_mul; i32_add; // &xss[i]
+                      local_get(i); local_get(xss); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(total);
+                      local_get(xss); i32_const(4); i32_add;
+                      local_get(i); i32_const(4); i32_mul; i32_add; // &xss[i]
                       i32_load(0); // inner list ptr
                       i32_load(0); // inner list len
-                      i32_add; local_set(s + 1);
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      i32_add; local_set(total);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                     // Alloc result
-                    i32_const(4); local_get(s + 1); i32_const(elem_size as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 3);
-                    local_get(s + 3); local_get(s + 1); i32_store(0);
+                    i32_const(4); local_get(total); i32_const(elem_size as i32); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(total); i32_store(0);
                     // Pass 2: copy
-                    i32_const(0); local_set(s + 1); // dst offset (in elements)
-                    i32_const(0); local_set(s + 2); // i (outer)
+                    i32_const(0); local_set(total); // dst offset (in elements)
+                    i32_const(0); local_set(i); // i (outer)
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(i); local_get(xss); i32_load(0); i32_ge_u; br_if(1);
                       // inner = xss[i]
-                      local_get(s); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(4); i32_mul; i32_add;
-                      i32_load(0); local_set(s + 4); // inner list ptr
+                      local_get(xss); i32_const(4); i32_add;
+                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      i32_load(0); local_set(inner);
                       // Copy inner elements
-                      i32_const(0); local_set(s + 5); // j
+                      i32_const(0); local_set(j);
                       block_empty; loop_empty;
-                        local_get(s + 5); local_get(s + 4); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(j); local_get(inner); i32_load(0); i32_ge_u; br_if(1);
                         // dst[dst_offset + j]
-                        local_get(s + 3); i32_const(4); i32_add;
-                        local_get(s + 1); local_get(s + 5); i32_add;
+                        local_get(dst); i32_const(4); i32_add;
+                        local_get(total); local_get(j); i32_add;
                         i32_const(elem_size as i32); i32_mul; i32_add;
                         // src inner[j]
-                        local_get(s + 4); i32_const(4); i32_add;
-                        local_get(s + 5); i32_const(elem_size as i32); i32_mul; i32_add;
+                        local_get(inner); i32_const(4); i32_add;
+                        local_get(j); i32_const(elem_size as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 5); i32_const(1); i32_add; local_set(s + 5);
+                        local_get(j); i32_const(1); i32_add; local_set(j);
                         br(0);
                       end; end;
-                      local_get(s + 1); local_get(s + 4); i32_load(0); i32_add; local_set(s + 1);
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(total); local_get(inner); i32_load(0); i32_add; local_set(total);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 3);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(j);
+                self.scratch.free_i32(inner);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(total);
+                self.scratch.free_i32(xss);
             }
             "sort" => {
                 self.emit_list_sort(args);
@@ -423,101 +481,119 @@ impl FuncCompiler<'_> {
             "min" | "max" => {
                 // min/max(xs: List[Int]) → Option[Int]
                 let is_max = method == "max";
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
+                let xs = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let best = self.scratch.alloc_i64();
+                let candidate = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); i32_eqz;
+                    local_set(xs);
+                    local_get(xs); i32_load(0); i32_eqz;
                     if_i32; i32_const(0); // none
                     else_;
                       // best = xs[0]
-                      local_get(s); i32_const(4); i32_add; i64_load(0); local_set(s64);
-                      i32_const(1); local_set(s + 1); // i=1
+                      local_get(xs); i32_const(4); i32_add; i64_load(0); local_set(best);
+                      i32_const(1); local_set(i); // i=1
                       block_empty; loop_empty;
-                        local_get(s + 1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(s); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(8); i32_mul; i32_add;
-                        i64_load(0); local_set(s64 + 1); // candidate
+                        local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(i); i32_const(8); i32_mul; i32_add;
+                        i64_load(0); local_set(candidate);
                 });
                 if is_max {
                     wasm!(self.func, {
-                        local_get(s64 + 1); local_get(s64); i64_gt_s;
-                        if_empty; local_get(s64 + 1); local_set(s64); end;
+                        local_get(candidate); local_get(best); i64_gt_s;
+                        if_empty; local_get(candidate); local_set(best); end;
                     });
                 } else {
                     wasm!(self.func, {
-                        local_get(s64 + 1); local_get(s64); i64_lt_s;
-                        if_empty; local_get(s64 + 1); local_set(s64); end;
+                        local_get(candidate); local_get(best); i64_lt_s;
+                        if_empty; local_get(candidate); local_set(best); end;
                     });
                 }
                 wasm!(self.func, {
-                        local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                        local_get(i); i32_const(1); i32_add; local_set(i);
                         br(0);
                       end; end;
                       // some(best)
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1); local_get(s64); i64_store(0);
-                      local_get(s + 1);
+                      i32_const(8); call(self.emitter.rt.alloc); local_set(i);
+                      local_get(i); local_get(best); i64_store(0);
+                      local_get(i);
                     end;
                 });
+                self.scratch.free_i64(candidate);
+                self.scratch.free_i64(best);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(xs);
             }
             "intersperse" => {
                 // intersperse(xs, sep) → List[A]: insert sep between elements
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let elem_size = values::byte_size(&elem_ty);
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let vt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32);
+                let xs = self.scratch.alloc_i32();
+                let sep = self.scratch.alloc(vt);
+                let len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let new_len = self.scratch.alloc_i32();
+                let src_i = self.scratch.alloc_i32();
+                let dst_i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]); // sep
-                self.emit_store_at(&elem_ty, 0); // mem[4] = sep (type-aware)
+                wasm!(self.func, { local_set(sep); });
                 wasm!(self.func, {
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
+                    local_get(xs); i32_load(0); local_set(len);
                     // new_len = max(0, 2*len - 1)
-                    local_get(s); i32_eqz;
+                    local_get(len); i32_eqz;
                     if_i32;
                       // empty list
-                      i32_const(4); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1); i32_const(0); i32_store(0);
-                      local_get(s + 1);
+                      i32_const(4); call(self.emitter.rt.alloc); local_set(dst);
+                      local_get(dst); i32_const(0); i32_store(0);
+                      local_get(dst);
                     else_;
-                      local_get(s); i32_const(2); i32_mul; i32_const(1); i32_sub; local_set(s + 2); // new_len
-                      i32_const(4); local_get(s + 2); i32_const(elem_size as i32); i32_mul; i32_add;
-                      call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1); local_get(s + 2); i32_store(0);
+                      local_get(len); i32_const(2); i32_mul; i32_const(1); i32_sub; local_set(new_len);
+                      i32_const(4); local_get(new_len); i32_const(elem_size as i32); i32_mul; i32_add;
+                      call(self.emitter.rt.alloc); local_set(dst);
+                      local_get(dst); local_get(new_len); i32_store(0);
                       // Fill
-                      i32_const(0); local_set(s + 3); // src_i
-                      i32_const(0); local_set(s + 4); // dst_i
+                      i32_const(0); local_set(src_i);
+                      i32_const(0); local_set(dst_i);
                       block_empty; loop_empty;
-                        local_get(s + 3); local_get(s); i32_ge_u; br_if(1);
+                        local_get(src_i); local_get(len); i32_ge_u; br_if(1);
                         // Copy xs[src_i] to dst[dst_i]
-                        local_get(s + 1); i32_const(4); i32_add;
-                        local_get(s + 4); i32_const(elem_size as i32); i32_mul; i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 3); i32_const(elem_size as i32); i32_mul; i32_add;
+                        local_get(dst); i32_const(4); i32_add;
+                        local_get(dst_i); i32_const(elem_size as i32); i32_mul; i32_add;
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(src_i); i32_const(elem_size as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 4); i32_const(1); i32_add; local_set(s + 4);
+                        local_get(dst_i); i32_const(1); i32_add; local_set(dst_i);
                         // Insert sep if not last
-                        local_get(s + 3); local_get(s); i32_const(1); i32_sub; i32_lt_u;
+                        local_get(src_i); local_get(len); i32_const(1); i32_sub; i32_lt_u;
                         if_empty;
-                          local_get(s + 1); i32_const(4); i32_add;
-                          local_get(s + 4); i32_const(elem_size as i32); i32_mul; i32_add;
-                          i32_const(4);
+                          local_get(dst); i32_const(4); i32_add;
+                          local_get(dst_i); i32_const(elem_size as i32); i32_mul; i32_add;
+                          local_get(sep);
                 });
-                self.emit_load_at(&elem_ty, 0); // load sep from mem[4]
-                self.emit_store_at(&elem_ty, 0);
+                self.emit_elem_store(&elem_ty);
                 wasm!(self.func, {
-                          local_get(s + 4); i32_const(1); i32_add; local_set(s + 4);
+                          local_get(dst_i); i32_const(1); i32_add; local_set(dst_i);
                         end;
-                        local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                        local_get(src_i); i32_const(1); i32_add; local_set(src_i);
                         br(0);
                       end; end;
-                      local_get(s + 1);
+                      local_get(dst);
                     end;
                 });
+                self.scratch.free_i32(dst_i);
+                self.scratch.free_i32(src_i);
+                self.scratch.free_i32(new_len);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(len);
+                self.scratch.free(sep, vt);
+                self.scratch.free_i32(xs);
             }
             "zip" => {
                 // zip(xs, ys) → List[(A, B)]
@@ -527,202 +603,234 @@ impl FuncCompiler<'_> {
                 let a_size = values::byte_size(&a_ty);
                 let b_size = values::byte_size(&b_ty);
                 let tuple_size = a_size + b_size;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0]=xs, mem[4]=ys
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let ys = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let tup = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
+                    local_set(ys);
                     // len = min(xs.len, ys.len)
-                    i32_const(0); i32_load(0); i32_load(0);
-                    i32_const(4); i32_load(0); i32_load(0);
+                    local_get(xs); i32_load(0);
+                    local_get(ys); i32_load(0);
                     i32_lt_u;
                     if_i32;
-                      i32_const(0); i32_load(0); i32_load(0);
+                      local_get(xs); i32_load(0);
                     else_;
-                      i32_const(4); i32_load(0); i32_load(0);
+                      local_get(ys); i32_load(0);
                     end;
-                    local_set(s); // len
+                    local_set(len);
                     // Alloc result: list of ptrs to tuples
-                    i32_const(4); local_get(s); i32_const(4); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 1);
-                    local_get(s + 1); local_get(s); i32_store(0);
-                    i32_const(0); local_set(s + 2); // i
+                    i32_const(4); local_get(len); i32_const(4); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(len); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
                       // Alloc tuple
-                      i32_const(tuple_size as i32); call(self.emitter.rt.alloc); local_set(s + 3);
+                      i32_const(tuple_size as i32); call(self.emitter.rt.alloc); local_set(tup);
                       // Copy a: tuple[0] = xs[i]
-                      local_get(s + 3);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(a_size as i32); i32_mul; i32_add;
+                      local_get(tup);
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(a_size as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&a_ty);
                 // Copy b: tuple[a_size] = ys[i]
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(a_size as i32); i32_add;
-                      i32_const(4); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(b_size as i32); i32_mul; i32_add;
+                      local_get(tup); i32_const(a_size as i32); i32_add;
+                      local_get(ys); i32_const(4); i32_add;
+                      local_get(i); i32_const(b_size as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&b_ty);
                 wasm!(self.func, {
                       // result[i] = tuple_ptr
-                      local_get(s + 1); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(4); i32_mul; i32_add;
-                      local_get(s + 3); i32_store(0);
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(tup); i32_store(0);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(tup);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(ys);
+                self.scratch.free_i32(xs);
             }
             "set" => {
                 // set(xs, i, val) → List[A]: copy + replace element at i
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0]=xs
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let idx = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]); // i: i64
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s); // s = idx
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s + 1); // len
+                    i32_wrap_i64; local_set(idx);
+                    local_get(xs); i32_load(0); local_set(len);
                     // Alloc copy
-                    i32_const(4); local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_store(0);
+                    i32_const(4); local_get(len); i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(len); i32_store(0);
                     // Copy all elements
-                    i32_const(0); local_set(s + 3);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                 });
                 // Overwrite dst[idx] with val
                 wasm!(self.func, {
-                    local_get(s + 2); i32_const(4); i32_add;
-                    local_get(s); i32_const(es); i32_mul; i32_add;
+                    local_get(dst); i32_const(4); i32_add;
+                    local_get(idx); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_expr(&args[2]);
                 self.emit_elem_store(&elem_ty);
-                wasm!(self.func, { local_get(s + 2); });
+                wasm!(self.func, { local_get(dst); });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(idx);
+                self.scratch.free_i32(xs);
             }
             "insert" => {
                 // insert(xs, i, val) → List[A]: copy with element inserted at i
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let idx = self.scratch.alloc_i32();
+                let old_len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s); // idx
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s + 1); // old_len
+                    i32_wrap_i64; local_set(idx);
+                    local_get(xs); i32_load(0); local_set(old_len);
                     // new_len = old_len + 1
-                    i32_const(4); local_get(s + 1); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_const(1); i32_add; i32_store(0);
+                    i32_const(4); local_get(old_len); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(old_len); i32_const(1); i32_add; i32_store(0);
                     // Copy [0..idx)
-                    i32_const(0); local_set(s + 3);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s); i32_ge_u; br_if(1);
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(idx); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                 });
                 // Insert val at idx
                 wasm!(self.func, {
-                    local_get(s + 2); i32_const(4); i32_add;
-                    local_get(s); i32_const(es); i32_mul; i32_add;
+                    local_get(dst); i32_const(4); i32_add;
+                    local_get(idx); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_expr(&args[2]);
                 self.emit_elem_store(&elem_ty);
                 // Copy [idx..old_len)
                 wasm!(self.func, {
-                    local_get(s); local_set(s + 3);
+                    local_get(idx); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(old_len); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(old_len);
+                self.scratch.free_i32(idx);
+                self.scratch.free_i32(xs);
             }
             "remove_at" => {
                 // remove_at(xs, i) → List[A]
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let xs = self.scratch.alloc_i32();
+                let idx = self.scratch.alloc_i32();
+                let old_len = self.scratch.alloc_i32();
+                let dst = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(xs); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s); // idx
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s + 1); // old_len
+                    i32_wrap_i64; local_set(idx);
+                    local_get(xs); i32_load(0); local_set(old_len);
                     // new_len = old_len - 1
-                    i32_const(4); local_get(s + 1); i32_const(1); i32_sub; i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_const(1); i32_sub; i32_store(0);
+                    i32_const(4); local_get(old_len); i32_const(1); i32_sub; i32_const(es); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(dst); local_get(old_len); i32_const(1); i32_sub; i32_store(0);
                     // Copy [0..idx)
-                    i32_const(0); local_set(s + 3);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s); i32_ge_u; br_if(1);
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(idx); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                 });
                 // Copy [idx+1..old_len)
                 wasm!(self.func, {
-                    local_get(s); i32_const(1); i32_add; local_set(s + 3);
+                    local_get(idx); i32_const(1); i32_add; local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(1); i32_sub; i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                      local_get(i); local_get(old_len); i32_ge_u; br_if(1);
+                      local_get(dst); i32_const(4); i32_add;
+                      local_get(i); i32_const(1); i32_sub; i32_const(es); i32_mul; i32_add;
+                      local_get(xs); i32_const(4); i32_add;
+                      local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(dst);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(dst);
+                self.scratch.free_i32(old_len);
+                self.scratch.free_i32(idx);
+                self.scratch.free_i32(xs);
             }
             "unique" => {
                 self.emit_list_unique(args);
@@ -737,43 +845,35 @@ impl FuncCompiler<'_> {
                 } else { Ty::Int };
                 let elem_size = values::byte_size(&elem_ty);
 
-                // mem[0]=list, mem[4]=idx(i32)
-                wasm!(self.func, { i32_const(0); });
+                let list = self.scratch.alloc_i32();
+                let idx = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(4);
-                });
+                wasm!(self.func, { local_set(list); });
                 self.emit_expr(&args[1]);
                 if matches!(&args[1].ty, Ty::Int) {
                     wasm!(self.func, { i32_wrap_i64; });
                 }
                 wasm!(self.func, {
-                    i32_store(0);
+                    local_set(idx);
                     // bounds: idx >= len → none(0)
-                    i32_const(4);
-                    i32_load(0); // idx
-                    i32_const(0);
-                    i32_load(0); // list
+                    local_get(idx);
+                    local_get(list);
                     i32_load(0); // len
                     i32_ge_u;
                     if_i32;
                     i32_const(0); // none
                     else_;
-                    // alloc → mem[8]
-                    i32_const(8);
+                    // alloc
                     i32_const(elem_size as i32);
                     call(self.emitter.rt.alloc);
-                    i32_store(0);
-                    // dst=mem[8], src=list+4+idx*elem_size
-                    i32_const(8);
-                    i32_load(0); // dst
-                    i32_const(0);
-                    i32_load(0); // list
+                    local_set(result);
+                    // dst=result, src=list+4+idx*elem_size
+                    local_get(result);
+                    local_get(list);
                     i32_const(4);
                     i32_add;
-                    i32_const(4);
-                    i32_load(0); // idx
+                    local_get(idx);
                     i32_const(elem_size as i32);
                     i32_mul;
                     i32_add;
@@ -781,59 +881,63 @@ impl FuncCompiler<'_> {
                 self.emit_load_at(&elem_ty, 0); // load elem
                 self.emit_store_at(&elem_ty, 0); // store at dst
                 wasm!(self.func, {
-                    i32_const(8);
-                    i32_load(0); // return ptr
+                    local_get(result); // return ptr
                     end;
                 });
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(idx);
+                self.scratch.free_i32(list);
             }
             "contains" => {
                 // list.contains(list, elem) -> Bool (i32)
-                // Uses only scratch locals — no mem[] to avoid nested call conflicts
                 let elem_ty = if let Ty::Applied(_, a) = &args[0].ty {
                     a.first().cloned().unwrap_or(Ty::Int)
                 } else { Ty::Int };
                 let elem_size = values::byte_size(&elem_ty);
-                let s = self.match_i32_base + self.match_depth;
-                // s=list_ptr, s+1=idx, s+2=result
+                let list_ptr = self.scratch.alloc_i32();
+                let idx = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); });
+                wasm!(self.func, { local_set(list_ptr); });
                 // Save target to i64 scratch or i32 scratch depending on type
                 match values::ty_to_valtype(&elem_ty) {
                     Some(ValType::I64) => {
-                        let t = self.match_i64_base + self.match_depth;
+                        let target = self.scratch.alloc_i64();
                         self.emit_expr(&args[1]);
                         wasm!(self.func, {
-                            local_set(t); // target in i64 local
-                            i32_const(0); local_set(s + 1); // idx
-                            i32_const(0); local_set(s + 2); // result = false
+                            local_set(target);
+                            i32_const(0); local_set(idx);
+                            i32_const(0); local_set(result); // result = false
                             block_empty; loop_empty;
-                              local_get(s + 1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                              local_get(s); i32_const(4); i32_add;
-                              local_get(s + 1); i32_const(elem_size as i32); i32_mul; i32_add;
+                              local_get(idx); local_get(list_ptr); i32_load(0); i32_ge_u; br_if(1);
+                              local_get(list_ptr); i32_const(4); i32_add;
+                              local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
                               i64_load(0);
-                              local_get(t); i64_eq;
+                              local_get(target); i64_eq;
                               if_empty;
-                                i32_const(1); local_set(s + 2); br(2);
+                                i32_const(1); local_set(result); br(2);
                               end;
-                              local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                              local_get(idx); i32_const(1); i32_add; local_set(idx);
                               br(0);
                             end; end;
-                            local_get(s + 2);
+                            local_get(result);
                         });
+                        self.scratch.free_i64(target);
                     }
                     _ => {
                         // i32 types: String, Option, etc.
+                        let target = self.scratch.alloc_i32();
                         self.emit_expr(&args[1]);
                         wasm!(self.func, {
-                            local_set(s + 3); // target in i32 local
-                            i32_const(0); local_set(s + 1);
-                            i32_const(0); local_set(s + 2);
+                            local_set(target);
+                            i32_const(0); local_set(idx);
+                            i32_const(0); local_set(result);
                             block_empty; loop_empty;
-                              local_get(s + 1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                              local_get(s); i32_const(4); i32_add;
-                              local_get(s + 1); i32_const(elem_size as i32); i32_mul; i32_add;
+                              local_get(idx); local_get(list_ptr); i32_load(0); i32_ge_u; br_if(1);
+                              local_get(list_ptr); i32_const(4); i32_add;
+                              local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
                               i32_load(0);
-                              local_get(s + 3);
+                              local_get(target);
                         });
                         match &elem_ty {
                             Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
@@ -841,15 +945,19 @@ impl FuncCompiler<'_> {
                         }
                         wasm!(self.func, {
                               if_empty;
-                                i32_const(1); local_set(s + 2); br(2);
+                                i32_const(1); local_set(result); br(2);
                               end;
-                              local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                              local_get(idx); i32_const(1); i32_add; local_set(idx);
                               br(0);
                             end; end;
-                            local_get(s + 2);
+                            local_get(result);
                         });
+                        self.scratch.free_i32(target);
                     }
                 }
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(idx);
+                self.scratch.free_i32(list_ptr);
             }
             _ => return self.emit_list_closure_call(method, args),
         }

--- a/src/codegen/emit_wasm/calls_list_closure2.rs
+++ b/src/codegen/emit_wasm/calls_list_closure2.rs
@@ -634,7 +634,7 @@ impl FuncCompiler<'_> {
                     i32_const(0); local_set(idx);
                     block_empty; loop_empty;
                 });
-                let saved = self.depth; self.depth += 2;
+                let depth_guard = self.depth_push_n(2);
                 wasm!(self.func, {
                     local_get(idx); local_get(len); i32_ge_u; br_if(1);
                     // Call predicate
@@ -666,7 +666,7 @@ impl FuncCompiler<'_> {
                     local_get(idx); i32_const(1); i32_add; local_set(idx);
                     br(0);
                 });
-                self.depth = saved;
+                self.depth_pop(depth_guard);
                 wasm!(self.func, {
                     end; end;
                     local_get(dst); local_get(out_idx); i32_store(0);
@@ -702,7 +702,7 @@ impl FuncCompiler<'_> {
                     i32_const(0); local_set(idx);
                     block_empty; loop_empty;
                 });
-                let saved = self.depth; self.depth += 2;
+                let depth_guard = self.depth_push_n(2);
                 wasm!(self.func, {
                     local_get(idx); local_get(len); i32_ge_u; br_if(1);
                     local_get(closure); i32_load(4); // env
@@ -726,7 +726,7 @@ impl FuncCompiler<'_> {
                     local_get(idx); i32_const(1); i32_add; local_set(idx);
                     br(0);
                 });
-                self.depth = saved;
+                self.depth_pop(depth_guard);
                 wasm!(self.func, { end; end; local_get(acc); });
                 self.scratch.free(acc, acc_vt);
                 self.scratch.free_i32(idx);
@@ -794,8 +794,7 @@ impl FuncCompiler<'_> {
             i32_const(0); local_set(idx_local);
             block_empty; loop_empty;
         });
-        let saved = self.depth;
-        self.depth += 2;
+        let depth_guard = self.depth_push_n(2);
 
         wasm!(self.func, {
             local_get(idx_local); local_get(len_local); i32_ge_u; br_if(1);
@@ -823,7 +822,7 @@ impl FuncCompiler<'_> {
             local_get(idx_local); i32_const(1); i32_add; local_set(idx_local);
             br(0);
         });
-        self.depth = saved;
+        self.depth_pop(depth_guard);
         wasm!(self.func, { end; end; local_get(dst_local); });
 
         self.scratch.free_i32(dst_local);

--- a/src/codegen/emit_wasm/calls_list_helpers.rs
+++ b/src/codegen/emit_wasm/calls_list_helpers.rs
@@ -488,8 +488,7 @@ impl FuncCompiler<'_> {
             block_empty;
             loop_empty;
         });
-        let saved = self.depth;
-        self.depth += 2;
+        let depth_guard = self.depth_push_n(2);
 
         wasm!(self.func, {
             local_get(idx_local);
@@ -538,7 +537,7 @@ impl FuncCompiler<'_> {
             br(0);
         });
 
-        self.depth = saved;
+        self.depth_pop(depth_guard);
         wasm!(self.func, {
             end;
             end;

--- a/src/codegen/emit_wasm/calls_list_helpers.rs
+++ b/src/codegen/emit_wasm/calls_list_helpers.rs
@@ -39,53 +39,59 @@ impl FuncCompiler<'_> {
         &mut self, xs: &IrExpr, start_arg: Option<&IrExpr>, end_arg: Option<&IrExpr>,
         elem_size: usize, is_take: bool,
     ) {
-        let s = self.match_i32_base + self.match_depth;
-        wasm!(self.func, { i32_const(0); });
+        let xs_ptr = self.scratch.alloc_i32();
+        let n = self.scratch.alloc_i32();
+        let start = self.scratch.alloc_i32();
+        let end = self.scratch.alloc_i32();
+        let new_len = self.scratch.alloc_i32();
+        let dst = self.scratch.alloc_i32();
+        let i = self.scratch.alloc_i32();
+
         self.emit_expr(xs);
-        wasm!(self.func, { i32_store(0); }); // mem[0] = xs
+        wasm!(self.func, { local_set(xs_ptr); }); // xs_ptr = xs
         // Compute start and end
         if is_take {
             // take(xs, n): start=0, end=min(n, len)
             self.emit_expr(end_arg.unwrap());
             wasm!(self.func, {
-                i32_wrap_i64; local_set(s); // n
-                i32_const(0); local_set(s + 1); // start = 0
+                i32_wrap_i64; local_set(n); // n
+                i32_const(0); local_set(start); // start = 0
                 // end = min(n, len)
-                local_get(s); i32_const(0); i32_load(0); i32_load(0);
+                local_get(n); local_get(xs_ptr); i32_load(0);
                 i32_lt_u;
-                if_i32; local_get(s); else_; i32_const(0); i32_load(0); i32_load(0); end;
-                local_set(s + 2); // end
+                if_i32; local_get(n); else_; local_get(xs_ptr); i32_load(0); end;
+                local_set(end); // end
             });
         } else {
             // drop(xs, n): start=min(n, len), end=len
             self.emit_expr(start_arg.unwrap());
             wasm!(self.func, {
-                i32_wrap_i64; local_set(s); // n
+                i32_wrap_i64; local_set(n); // n
                 // start = min(n, len)
-                local_get(s); i32_const(0); i32_load(0); i32_load(0);
+                local_get(n); local_get(xs_ptr); i32_load(0);
                 i32_lt_u;
-                if_i32; local_get(s); else_; i32_const(0); i32_load(0); i32_load(0); end;
-                local_set(s + 1); // start
-                i32_const(0); i32_load(0); i32_load(0); local_set(s + 2); // end = len
+                if_i32; local_get(n); else_; local_get(xs_ptr); i32_load(0); end;
+                local_set(start); // start
+                local_get(xs_ptr); i32_load(0); local_set(end); // end = len
             });
         }
         // new_len = end - start
         wasm!(self.func, {
-            local_get(s + 2); local_get(s + 1); i32_sub; local_set(s + 3);
+            local_get(end); local_get(start); i32_sub; local_set(new_len);
             // alloc
-            i32_const(4); local_get(s + 3); i32_const(elem_size as i32); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(s + 4);
-            local_get(s + 4); local_get(s + 3); i32_store(0);
+            i32_const(4); local_get(new_len); i32_const(elem_size as i32); i32_mul; i32_add;
+            call(self.emitter.rt.alloc); local_set(dst);
+            local_get(dst); local_get(new_len); i32_store(0);
             // copy loop
-            i32_const(0); local_set(s + 5); // i
+            i32_const(0); local_set(i); // i
             block_empty; loop_empty;
-              local_get(s + 5); local_get(s + 3); i32_ge_u; br_if(1);
+              local_get(i); local_get(new_len); i32_ge_u; br_if(1);
               // dst[4 + i*es]
-              local_get(s + 4); i32_const(4); i32_add;
-              local_get(s + 5); i32_const(elem_size as i32); i32_mul; i32_add;
+              local_get(dst); i32_const(4); i32_add;
+              local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
               // src[4 + (start+i)*es]
-              i32_const(0); i32_load(0); i32_const(4); i32_add;
-              local_get(s + 1); local_get(s + 5); i32_add;
+              local_get(xs_ptr); i32_const(4); i32_add;
+              local_get(start); local_get(i); i32_add;
               i32_const(elem_size as i32); i32_mul; i32_add;
         });
         // Copy one element
@@ -97,11 +103,19 @@ impl FuncCompiler<'_> {
         // Actually use xs type
         self.emit_elem_copy(&self.list_elem_ty(&xs.ty));
         wasm!(self.func, {
-              local_get(s + 5); i32_const(1); i32_add; local_set(s + 5);
+              local_get(i); i32_const(1); i32_add; local_set(i);
               br(0);
             end; end;
-            local_get(s + 4);
+            local_get(dst);
         });
+
+        self.scratch.free_i32(i);
+        self.scratch.free_i32(dst);
+        self.scratch.free_i32(new_len);
+        self.scratch.free_i32(end);
+        self.scratch.free_i32(start);
+        self.scratch.free_i32(n);
+        self.scratch.free_i32(xs_ptr);
     }
 
     fn emit_memcpy_loop(&mut self, _i_local: u32, _dst_local: u32, _start_local: u32, _elem_size: usize) {
@@ -121,194 +135,219 @@ impl FuncCompiler<'_> {
 
     /// Insertion sort for List[Int] (elements are i64, 8 bytes each).
     fn emit_list_sort_int(&mut self, args: &[IrExpr]) {
-        let s = self.match_i32_base + self.match_depth;
-        let s64 = self.match_i64_base + self.match_depth;
+        let xs_ptr = self.scratch.alloc_i32();
+        let len = self.scratch.alloc_i32();
+        let dst = self.scratch.alloc_i32();
+        let i = self.scratch.alloc_i32();
+        let j = self.scratch.alloc_i32();
+        let key = self.scratch.alloc_i64();
+
         // Copy list first
-        wasm!(self.func, { i32_const(0); });
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            i32_store(0);
-            i32_const(0); i32_load(0); i32_load(0); local_set(s);
-            i32_const(4); local_get(s); i32_const(8); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(s + 1);
-            local_get(s + 1); local_get(s); i32_store(0);
+            local_set(xs_ptr);
+            local_get(xs_ptr); i32_load(0); local_set(len);
+            i32_const(4); local_get(len); i32_const(8); i32_mul; i32_add;
+            call(self.emitter.rt.alloc); local_set(dst);
+            local_get(dst); local_get(len); i32_store(0);
         });
         // Copy all elements
         wasm!(self.func, {
-            i32_const(0); local_set(s + 2);
+            i32_const(0); local_set(i);
             block_empty; loop_empty;
-              local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-              local_get(s + 1); i32_const(4); i32_add;
-              local_get(s + 2); i32_const(8); i32_mul; i32_add;
-              i32_const(0); i32_load(0); i32_const(4); i32_add;
-              local_get(s + 2); i32_const(8); i32_mul; i32_add;
+              local_get(i); local_get(len); i32_ge_u; br_if(1);
+              local_get(dst); i32_const(4); i32_add;
+              local_get(i); i32_const(8); i32_mul; i32_add;
+              local_get(xs_ptr); i32_const(4); i32_add;
+              local_get(i); i32_const(8); i32_mul; i32_add;
               i64_load(0); i64_store(0);
-              local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+              local_get(i); i32_const(1); i32_add; local_set(i);
               br(0);
             end; end;
         });
         // Insertion sort outer loop
         wasm!(self.func, {
-            i32_const(1); local_set(s + 2);
+            i32_const(1); local_set(i);
             block_empty; loop_empty;
-              local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-              local_get(s + 1); i32_const(4); i32_add;
-              local_get(s + 2); i32_const(8); i32_mul; i32_add;
-              i64_load(0); local_set(s64);
-              local_get(s + 2); i32_const(1); i32_sub; local_set(s + 3);
+              local_get(i); local_get(len); i32_ge_u; br_if(1);
+              local_get(dst); i32_const(4); i32_add;
+              local_get(i); i32_const(8); i32_mul; i32_add;
+              i64_load(0); local_set(key);
+              local_get(i); i32_const(1); i32_sub; local_set(j);
         });
         // Inner loop: shift elements right
         wasm!(self.func, {
               block_empty; loop_empty;
-                local_get(s + 3); i32_const(0); i32_lt_s; br_if(1);
-                local_get(s + 1); i32_const(4); i32_add;
-                local_get(s + 3); i32_const(8); i32_mul; i32_add;
-                i64_load(0); local_get(s64); i64_le_s; br_if(1);
-                local_get(s + 1); i32_const(4); i32_add;
-                local_get(s + 3); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
-                local_get(s + 1); i32_const(4); i32_add;
-                local_get(s + 3); i32_const(8); i32_mul; i32_add;
+                local_get(j); i32_const(0); i32_lt_s; br_if(1);
+                local_get(dst); i32_const(4); i32_add;
+                local_get(j); i32_const(8); i32_mul; i32_add;
+                i64_load(0); local_get(key); i64_le_s; br_if(1);
+                local_get(dst); i32_const(4); i32_add;
+                local_get(j); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
+                local_get(dst); i32_const(4); i32_add;
+                local_get(j); i32_const(8); i32_mul; i32_add;
                 i64_load(0); i64_store(0);
-                local_get(s + 3); i32_const(1); i32_sub; local_set(s + 3);
+                local_get(j); i32_const(1); i32_sub; local_set(j);
                 br(0);
               end; end;
         });
         // Place key and continue
         wasm!(self.func, {
-              local_get(s + 1); i32_const(4); i32_add;
-              local_get(s + 3); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
-              local_get(s64); i64_store(0);
-              local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+              local_get(dst); i32_const(4); i32_add;
+              local_get(j); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
+              local_get(key); i64_store(0);
+              local_get(i); i32_const(1); i32_add; local_set(i);
               br(0);
             end; end;
-            local_get(s + 1);
+            local_get(dst);
         });
+
+        self.scratch.free_i64(key);
+        self.scratch.free_i32(j);
+        self.scratch.free_i32(i);
+        self.scratch.free_i32(dst);
+        self.scratch.free_i32(len);
+        self.scratch.free_i32(xs_ptr);
     }
 
     /// Insertion sort for List[String] (elements are i32 pointers, 4 bytes each).
     /// Comparison uses __str_cmp which returns negative/0/positive.
     fn emit_list_sort_string(&mut self, args: &[IrExpr]) {
-        let s = self.match_i32_base + self.match_depth;
-        // s: len, s+1: dst, s+2: i (outer), s+3: j (inner), s+4: key (i32 str ptr)
+        let xs_ptr = self.scratch.alloc_i32();
+        let len = self.scratch.alloc_i32();
+        let dst = self.scratch.alloc_i32();
+        let i = self.scratch.alloc_i32();
+        let j = self.scratch.alloc_i32();
+        let str_key = self.scratch.alloc_i32();
+
         // Copy list first
-        wasm!(self.func, { i32_const(0); });
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            i32_store(0);
-            i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
-            i32_const(4); local_get(s); i32_const(4); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(s + 1); // dst
-            local_get(s + 1); local_get(s); i32_store(0);
+            local_set(xs_ptr);
+            local_get(xs_ptr); i32_load(0); local_set(len); // len
+            i32_const(4); local_get(len); i32_const(4); i32_mul; i32_add;
+            call(self.emitter.rt.alloc); local_set(dst); // dst
+            local_get(dst); local_get(len); i32_store(0);
         });
         // Copy all elements (i32 pointers)
         wasm!(self.func, {
-            i32_const(0); local_set(s + 2);
+            i32_const(0); local_set(i);
             block_empty; loop_empty;
-              local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-              local_get(s + 1); i32_const(4); i32_add;
-              local_get(s + 2); i32_const(4); i32_mul; i32_add;
-              i32_const(0); i32_load(0); i32_const(4); i32_add;
-              local_get(s + 2); i32_const(4); i32_mul; i32_add;
+              local_get(i); local_get(len); i32_ge_u; br_if(1);
+              local_get(dst); i32_const(4); i32_add;
+              local_get(i); i32_const(4); i32_mul; i32_add;
+              local_get(xs_ptr); i32_const(4); i32_add;
+              local_get(i); i32_const(4); i32_mul; i32_add;
               i32_load(0); i32_store(0);
-              local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+              local_get(i); i32_const(1); i32_add; local_set(i);
               br(0);
             end; end;
         });
         // Insertion sort outer loop
         wasm!(self.func, {
-            i32_const(1); local_set(s + 2); // i = 1
+            i32_const(1); local_set(i); // i = 1
             block_empty; loop_empty;
-              local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
+              local_get(i); local_get(len); i32_ge_u; br_if(1);
               // key = dst[4 + i*4]
-              local_get(s + 1); i32_const(4); i32_add;
-              local_get(s + 2); i32_const(4); i32_mul; i32_add;
-              i32_load(0); local_set(s + 4); // key
-              local_get(s + 2); i32_const(1); i32_sub; local_set(s + 3); // j = i - 1
+              local_get(dst); i32_const(4); i32_add;
+              local_get(i); i32_const(4); i32_mul; i32_add;
+              i32_load(0); local_set(str_key); // key
+              local_get(i); i32_const(1); i32_sub; local_set(j); // j = i - 1
         });
         // Inner loop: shift elements right while dst[j] > key
         wasm!(self.func, {
               block_empty; loop_empty;
-                local_get(s + 3); i32_const(0); i32_lt_s; br_if(1);
+                local_get(j); i32_const(0); i32_lt_s; br_if(1);
                 // Compare: str_cmp(dst[j], key) <= 0 means stop
-                local_get(s + 1); i32_const(4); i32_add;
-                local_get(s + 3); i32_const(4); i32_mul; i32_add;
+                local_get(dst); i32_const(4); i32_add;
+                local_get(j); i32_const(4); i32_mul; i32_add;
                 i32_load(0); // dst[j]
-                local_get(s + 4); // key
+                local_get(str_key); // key
                 call(self.emitter.rt.string.cmp);
                 i32_const(0); i32_le_s; br_if(1); // if dst[j] <= key, stop
                 // Shift: dst[j+1] = dst[j]
-                local_get(s + 1); i32_const(4); i32_add;
-                local_get(s + 3); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
-                local_get(s + 1); i32_const(4); i32_add;
-                local_get(s + 3); i32_const(4); i32_mul; i32_add;
+                local_get(dst); i32_const(4); i32_add;
+                local_get(j); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+                local_get(dst); i32_const(4); i32_add;
+                local_get(j); i32_const(4); i32_mul; i32_add;
                 i32_load(0); i32_store(0);
-                local_get(s + 3); i32_const(1); i32_sub; local_set(s + 3);
+                local_get(j); i32_const(1); i32_sub; local_set(j);
                 br(0);
               end; end;
         });
         // Place key at dst[j+1]
         wasm!(self.func, {
-              local_get(s + 1); i32_const(4); i32_add;
-              local_get(s + 3); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
-              local_get(s + 4); i32_store(0);
-              local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+              local_get(dst); i32_const(4); i32_add;
+              local_get(j); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+              local_get(str_key); i32_store(0);
+              local_get(i); i32_const(1); i32_add; local_set(i);
               br(0);
             end; end;
-            local_get(s + 1);
+            local_get(dst);
         });
+
+        self.scratch.free_i32(str_key);
+        self.scratch.free_i32(j);
+        self.scratch.free_i32(i);
+        self.scratch.free_i32(dst);
+        self.scratch.free_i32(len);
+        self.scratch.free_i32(xs_ptr);
     }
 
     /// Emit list.index_of(xs, x) → Option[Int].
     pub(super) fn emit_list_index_of(&mut self, args: &[IrExpr]) {
         let elem_ty = self.list_elem_ty(&args[0].ty);
         let elem_size = values::byte_size(&elem_ty);
-        let s = self.match_i32_base + self.match_depth;
-        let s64 = self.match_i64_base + self.match_depth;
-        wasm!(self.func, { i32_const(0); });
+        let xs_ptr = self.scratch.alloc_i32();
+        let i = self.scratch.alloc_i32();
+        let found_ptr = self.scratch.alloc_i32();
+        let result = self.scratch.alloc_i32();
+        let search_val_i64 = self.scratch.alloc_i64();
+        let search_val_i32 = self.scratch.alloc_i32();
+
         self.emit_expr(&args[0]);
-        wasm!(self.func, { i32_store(0); });
+        wasm!(self.func, { local_set(xs_ptr); });
         // Store search value
         match values::ty_to_valtype(&elem_ty) {
             Some(ValType::I64) => {
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(s64); });
+                wasm!(self.func, { local_set(search_val_i64); });
             }
             _ => {
-                wasm!(self.func, { i32_const(4); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(search_val_i32); });
             }
         }
         wasm!(self.func, {
-            i32_const(0); local_set(s); // i
-            i32_const(0); local_set(s + 2); // result (default: none)
+            i32_const(0); local_set(i); // i
+            i32_const(0); local_set(result); // result (default: none)
             block_empty; loop_empty;
-              local_get(s);
-              i32_const(0); i32_load(0); i32_load(0); // len
+              local_get(i);
+              local_get(xs_ptr); i32_load(0); // len
               i32_ge_u; br_if(1);
         });
         // Compare element
         match values::ty_to_valtype(&elem_ty) {
             Some(ValType::I64) => {
                 wasm!(self.func, {
-                    i32_const(0); i32_load(0); i32_const(4); i32_add;
-                    local_get(s); i32_const(8); i32_mul; i32_add;
+                    local_get(xs_ptr); i32_const(4); i32_add;
+                    local_get(i); i32_const(8); i32_mul; i32_add;
                     i64_load(0);
-                    local_get(s64); i64_eq;
+                    local_get(search_val_i64); i64_eq;
                     if_empty;
                       // Found: store some(i) and break
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1); local_get(s); i64_extend_i32_u; i64_store(0);
-                      local_get(s + 1); local_set(s + 2); br(2);
+                      i32_const(8); call(self.emitter.rt.alloc); local_set(found_ptr);
+                      local_get(found_ptr); local_get(i); i64_extend_i32_u; i64_store(0);
+                      local_get(found_ptr); local_set(result); br(2);
                     end;
                 });
             }
             _ => {
                 wasm!(self.func, {
-                    i32_const(0); i32_load(0); i32_const(4); i32_add;
-                    local_get(s); i32_const(elem_size as i32); i32_mul; i32_add;
+                    local_get(xs_ptr); i32_const(4); i32_add;
+                    local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
                     i32_load(0);
-                    i32_const(4); i32_load(0);
+                    local_get(search_val_i32);
                 });
                 // String eq or i32 eq
                 if matches!(&elem_ty, Ty::String) {
@@ -318,46 +357,59 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                     if_empty;
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1); local_get(s); i64_extend_i32_u; i64_store(0);
-                      local_get(s + 1); local_set(s + 2); br(2);
+                      i32_const(8); call(self.emitter.rt.alloc); local_set(found_ptr);
+                      local_get(found_ptr); local_get(i); i64_extend_i32_u; i64_store(0);
+                      local_get(found_ptr); local_set(result); br(2);
                     end;
                 });
             }
         }
         wasm!(self.func, {
-              local_get(s); i32_const(1); i32_add; local_set(s);
+              local_get(i); i32_const(1); i32_add; local_set(i);
               br(0);
             end; end;
-            local_get(s + 2); // result (none if not found)
+            local_get(result); // result (none if not found)
         });
+
+        self.scratch.free_i32(search_val_i32);
+        self.scratch.free_i64(search_val_i64);
+        self.scratch.free_i32(result);
+        self.scratch.free_i32(found_ptr);
+        self.scratch.free_i32(i);
+        self.scratch.free_i32(xs_ptr);
     }
 
     /// Emit list.unique(xs) → List[A]: O(n²) dedup.
     pub(super) fn emit_list_unique(&mut self, args: &[IrExpr]) {
         let elem_ty = self.list_elem_ty(&args[0].ty);
         let es = values::byte_size(&elem_ty) as i32;
-        let s = self.match_i32_base + self.match_depth;
+        let src = self.scratch.alloc_i32();
+        let src_len = self.scratch.alloc_i32();
+        let dst = self.scratch.alloc_i32();
+        let i = self.scratch.alloc_i32();
+        let j = self.scratch.alloc_i32();
+        let found = self.scratch.alloc_i32();
+
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(s);
-            local_get(s); i32_load(0); local_set(s + 1); // src_len
-            i32_const(4); local_get(s + 1); i32_const(es); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(s + 2); // dst
-            local_get(s + 2); i32_const(0); i32_store(0);
-            i32_const(0); local_set(s + 3); // i
+            local_set(src);
+            local_get(src); i32_load(0); local_set(src_len); // src_len
+            i32_const(4); local_get(src_len); i32_const(es); i32_mul; i32_add;
+            call(self.emitter.rt.alloc); local_set(dst); // dst
+            local_get(dst); i32_const(0); i32_store(0);
+            i32_const(0); local_set(i); // i
             block_empty; loop_empty;
-              local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
+              local_get(i); local_get(src_len); i32_ge_u; br_if(1);
               // Check if src[i] already in dst
-              i32_const(0); local_set(s + 4); // j
-              i32_const(0); local_set(s + 5); // found
+              i32_const(0); local_set(j); // j
+              i32_const(0); local_set(found); // found
               block_empty; loop_empty;
-                local_get(s + 4); local_get(s + 2); i32_load(0); i32_ge_u; br_if(1);
-                local_get(s); i32_const(4); i32_add;
-                local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                local_get(j); local_get(dst); i32_load(0); i32_ge_u; br_if(1);
+                local_get(src); i32_const(4); i32_add;
+                local_get(i); i32_const(es); i32_mul; i32_add;
                 i32_load(0);
-                local_get(s + 2); i32_const(4); i32_add;
-                local_get(s + 4); i32_const(es); i32_mul; i32_add;
+                local_get(dst); i32_const(4); i32_add;
+                local_get(j); i32_const(es); i32_mul; i32_add;
                 i32_load(0);
         });
         match &elem_ty {
@@ -365,28 +417,35 @@ impl FuncCompiler<'_> {
             _ => { wasm!(self.func, { i32_eq; }); }
         }
         wasm!(self.func, {
-                if_empty; i32_const(1); local_set(s + 5); br(2); end;
-                local_get(s + 4); i32_const(1); i32_add; local_set(s + 4);
+                if_empty; i32_const(1); local_set(found); br(2); end;
+                local_get(j); i32_const(1); i32_add; local_set(j);
                 br(0);
               end; end;
-              local_get(s + 5); i32_eqz;
+              local_get(found); i32_eqz;
               if_empty;
-                local_get(s + 2); i32_const(4); i32_add;
-                local_get(s + 2); i32_load(0); i32_const(es); i32_mul; i32_add;
-                local_get(s); i32_const(4); i32_add;
-                local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                local_get(dst); i32_const(4); i32_add;
+                local_get(dst); i32_load(0); i32_const(es); i32_mul; i32_add;
+                local_get(src); i32_const(4); i32_add;
+                local_get(i); i32_const(es); i32_mul; i32_add;
         });
         self.emit_elem_copy(&elem_ty);
         wasm!(self.func, {
-                local_get(s + 2);
-                local_get(s + 2); i32_load(0); i32_const(1); i32_add;
+                local_get(dst);
+                local_get(dst); i32_load(0); i32_const(1); i32_add;
                 i32_store(0);
               end;
-              local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+              local_get(i); i32_const(1); i32_add; local_set(i);
               br(0);
             end; end;
-            local_get(s + 2);
+            local_get(dst);
         });
+
+        self.scratch.free_i32(found);
+        self.scratch.free_i32(j);
+        self.scratch.free_i32(i);
+        self.scratch.free_i32(dst);
+        self.scratch.free_i32(src_len);
+        self.scratch.free_i32(src);
     }
 
     /// Emit list.enumerate(xs) → List[(Int, A)].
@@ -397,33 +456,30 @@ impl FuncCompiler<'_> {
         let elem_size = values::byte_size(&elem_ty);
         let tuple_size = 8 + elem_size; // Int(8) + elem
 
-        let s = self.match_i32_base + self.match_depth;
-        let len_local = s;
-        let idx_local = s + 1;
+        let src_ptr = self.scratch.alloc_i32();
+        let len_local = self.scratch.alloc_i32();
+        let idx_local = self.scratch.alloc_i32();
+        let dst_ptr = self.scratch.alloc_i32();
+        let tuple_ptr = self.scratch.alloc_i32();
 
-        // Store src → mem[0]
-        wasm!(self.func, { i32_const(0); });
+        // Store src
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            i32_store(0);
+            local_set(src_ptr);
             // len
-            i32_const(0);
-            i32_load(0);
+            local_get(src_ptr);
             i32_load(0);
             local_set(len_local);
             // Alloc dst: [len] + len * ptr_size(4)
-            i32_const(8);
             i32_const(4);
             local_get(len_local);
             i32_const(4); // each entry is a tuple ptr (i32)
             i32_mul;
             i32_add;
             call(self.emitter.rt.alloc);
-            i32_store(0);
-            // dst = mem[8]
+            local_set(dst_ptr);
             // Store len in dst
-            i32_const(8);
-            i32_load(0);
+            local_get(dst_ptr);
             local_get(len_local);
             i32_store(0);
             // Loop: create tuples
@@ -443,24 +499,16 @@ impl FuncCompiler<'_> {
             // Alloc tuple: [index:i64][element]
             i32_const(tuple_size as i32);
             call(self.emitter.rt.alloc);
-            drop;
-            // Re-alloc tuple
-            i32_const(12);
-            i32_const(tuple_size as i32);
-            call(self.emitter.rt.alloc);
-            i32_store(0); // mem[12] = tuple_ptr
+            local_set(tuple_ptr); // tuple_ptr
             // tuple.index = idx (as i64)
-            i32_const(12);
-            i32_load(0); // tuple_ptr
+            local_get(tuple_ptr);
             local_get(idx_local);
             i64_extend_i32_u;
             i64_store(0);
             // tuple.element = src[idx]
-            i32_const(12);
-            i32_load(0); // tuple_ptr
+            local_get(tuple_ptr);
             // Load src element
-            i32_const(0);
-            i32_load(0); // src_ptr
+            local_get(src_ptr);
             i32_const(4);
             i32_add;
             local_get(idx_local);
@@ -473,16 +521,14 @@ impl FuncCompiler<'_> {
 
         wasm!(self.func, {
             // dst[idx] = tuple_ptr
-            i32_const(8);
-            i32_load(0); // dst_ptr
+            local_get(dst_ptr);
             i32_const(4);
             i32_add;
             local_get(idx_local);
             i32_const(4); // tuple ptrs are i32
             i32_mul;
             i32_add;
-            i32_const(12);
-            i32_load(0); // tuple_ptr
+            local_get(tuple_ptr);
             i32_store(0);
             // idx++
             local_get(idx_local);
@@ -497,8 +543,13 @@ impl FuncCompiler<'_> {
             end;
             end;
             // Return dst
-            i32_const(8);
-            i32_load(0);
+            local_get(dst_ptr);
         });
+
+        self.scratch.free_i32(tuple_ptr);
+        self.scratch.free_i32(dst_ptr);
+        self.scratch.free_i32(idx_local);
+        self.scratch.free_i32(len_local);
+        self.scratch.free_i32(src_ptr);
     }
 }

--- a/src/codegen/emit_wasm/calls_map.rs
+++ b/src/codegen/emit_wasm/calls_map.rs
@@ -14,12 +14,13 @@ impl FuncCompiler<'_> {
         match method {
             "new" => {
                 // map.new() → empty map [len=0]
-                let s = self.match_i32_base + self.match_depth;
+                let result = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc); local_set(s);
-                    local_get(s); i32_const(0); i32_store(0);
-                    local_get(s);
+                    i32_const(4); call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); i32_const(0); i32_store(0);
+                    local_get(result);
                 });
+                self.scratch.free_i32(result);
             }
             "len" | "length" | "size" => {
                 self.emit_expr(&args[0]);
@@ -35,122 +36,128 @@ impl FuncCompiler<'_> {
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
-                // mem[0]=map
-                wasm!(self.func, { i32_const(0); });
+                let map_ptr = self.scratch.alloc_i32();
+                let sk_i32 = self.scratch.alloc_i32();
+                let sk_i64 = self.scratch.alloc_i64();
+                let i = self.scratch.alloc_i32();
+                let val_copy = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // Store search key
-                if !matches!(key_ty, Ty::Int) {
-                    wasm!(self.func, { i32_const(4); });
-                }
+                wasm!(self.func, { local_set(map_ptr); });
                 self.emit_expr(&args[1]); // key
-                self.emit_search_key_store(&key_ty, 4, s64);
+                self.emit_search_key_store(&key_ty, sk_i32, sk_i64);
                 wasm!(self.func, {
-                    i32_const(0); local_set(s); // i
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(i); local_get(map_ptr); i32_load(0); i32_ge_u; br_if(1);
                       // Compare map_key[i] with search key
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
-                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_search_key_load(&key_ty, sk_i32, sk_i64);
                 self.emit_key_eq(&key_ty);
                 wasm!(self.func, {
                       if_empty;
                         // Found: return some(val)
-                        i32_const(vs as i32); call(self.emitter.rt.alloc); local_set(s + 1);
-                        local_get(s + 1);
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                        i32_const(vs as i32); call(self.emitter.rt.alloc); local_set(val_copy);
+                        local_get(val_copy);
+                        local_get(map_ptr); i32_const(4); i32_add;
+                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(ks as i32); i32_add; // val offset
                 });
                 self.emit_elem_copy_sized(vs);
                 wasm!(self.func, {
-                        local_get(s + 1); return_;
+                        local_get(val_copy); return_;
                       end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                     i32_const(0); // none
                 });
+                self.scratch.free_i32(val_copy);
+                self.scratch.free_i32(i);
+                self.scratch.free_i64(sk_i64);
+                self.scratch.free_i32(sk_i32);
+                self.scratch.free_i32(map_ptr);
             }
             "get_or" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
+                let map_ptr = self.scratch.alloc_i32();
+                let sk_i32 = self.scratch.alloc_i32();
+                let sk_i64 = self.scratch.alloc_i64();
+                let i = self.scratch.alloc_i32();
                 let vt = values::ty_to_valtype(&val_ty).unwrap_or(ValType::I32);
-                wasm!(self.func, { i32_const(0); });
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                if !matches!(key_ty, Ty::Int) {
-                    wasm!(self.func, { i32_const(4); });
-                }
+                wasm!(self.func, { local_set(map_ptr); });
                 self.emit_expr(&args[1]); // key
-                self.emit_search_key_store(&key_ty, 4, s64);
+                self.emit_search_key_store(&key_ty, sk_i32, sk_i64);
                 wasm!(self.func, {
-                    i32_const(0); local_set(s);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(map_ptr); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
-                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_search_key_load(&key_ty, sk_i32, sk_i64);
                 self.emit_key_eq(&key_ty);
                 wasm!(self.func, {
                       if_empty;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(map_ptr); i32_const(4); i32_add;
+                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(ks as i32); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, {
                         return_;
                       end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                 });
                 // Not found: return default
                 self.emit_expr(&args[2]);
+                self.scratch.free_i32(i);
+                self.scratch.free_i64(sk_i64);
+                self.scratch.free_i32(sk_i32);
+                self.scratch.free_i32(map_ptr);
             }
             "contains" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let map_ptr = self.scratch.alloc_i32();
+                let sk_i32 = self.scratch.alloc_i32();
+                let sk_i64 = self.scratch.alloc_i64();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                if !matches!(key_ty, Ty::Int) {
-                    wasm!(self.func, { i32_const(4); });
-                }
+                wasm!(self.func, { local_set(map_ptr); });
                 self.emit_expr(&args[1]);
-                self.emit_search_key_store(&key_ty, 4, s64);
+                self.emit_search_key_store(&key_ty, sk_i32, sk_i64);
                 wasm!(self.func, {
-                    i32_const(0); local_set(s);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(map_ptr); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
-                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_search_key_load(&key_ty, sk_i32, sk_i64);
                 self.emit_key_eq(&key_ty);
                 wasm!(self.func, {
                       if_empty; i32_const(1); return_; end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                     i32_const(0);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i64(sk_i64);
+                self.scratch.free_i32(sk_i32);
+                self.scratch.free_i32(map_ptr);
             }
             "set" => {
                 // set(m, key, value) → new Map
@@ -159,305 +166,281 @@ impl FuncCompiler<'_> {
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
-                // mem[0]=map
-                wasm!(self.func, { i32_const(0); });
+                let vt = values::ty_to_valtype(&val_ty).unwrap_or(ValType::I32);
+                let map_ptr = self.scratch.alloc_i32();
+                let sk_i32 = self.scratch.alloc_i32();
+                let sk_i64 = self.scratch.alloc_i64();
+                let val_scratch = self.scratch.alloc(vt);
+                let old_len = self.scratch.alloc_i32();
+                let found_idx = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let new_map = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(map_ptr); });
                 // Store search key
-                if !matches!(key_ty, Ty::Int) {
-                    wasm!(self.func, { i32_const(4); });
-                }
                 self.emit_expr(&args[1]); // key
-                self.emit_search_key_store(&key_ty, 4, s64);
-                // Store value to mem[8..8+vs] (safe: Int key uses i64 local, not mem[4..12])
-                let val_mem_offset = if matches!(key_ty, Ty::Int) { 4u32 } else { 8u32 };
-                wasm!(self.func, { i32_const(val_mem_offset as i32); });
+                self.emit_search_key_store(&key_ty, sk_i32, sk_i64);
+                // Store value in scratch local
                 self.emit_expr(&args[2]); // value
-                self.emit_store_at(&val_ty, 0);
+                wasm!(self.func, { local_set(val_scratch); });
                 wasm!(self.func, {
                     // Find if key exists
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // old_len
-                    i32_const(-1); local_set(s + 1); // found_idx = -1
-                    i32_const(0); local_set(s + 2); // i
+                    local_get(map_ptr); i32_load(0); local_set(old_len);
+                    i32_const(-1); local_set(found_idx); // found_idx = -1
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(old_len); i32_ge_u; br_if(1);
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
-                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_search_key_load(&key_ty, sk_i32, sk_i64);
                 self.emit_key_eq(&key_ty);
                 wasm!(self.func, {
                       if_empty;
-                        local_get(s + 2); local_set(s + 1); // found
+                        local_get(i); local_set(found_idx); // found
                       end;
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                     // new_len = found >= 0 ? old_len : old_len + 1
-                    local_get(s + 1); i32_const(0); i32_lt_s; i32_eqz;
-                    if_i32; local_get(s); else_; local_get(s); i32_const(1); i32_add; end;
-                    local_set(s + 2); // new_len
+                    local_get(found_idx); i32_const(0); i32_lt_s; i32_eqz;
+                    if_i32; local_get(old_len); else_; local_get(old_len); i32_const(1); i32_add; end;
+                    local_set(i); // reuse i as new_len
                     // Alloc new map
-                    i32_const(4); local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 3);
-                    local_get(s + 3); local_get(s + 2); i32_store(0);
+                    i32_const(4); local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(new_map);
+                    local_get(new_map); local_get(i); i32_store(0);
                 });
                 // Copy old entries, replacing found_idx
                 wasm!(self.func, {
-                    i32_const(0); local_set(s + 2); // i
+                    i32_const(0); local_set(i); // i
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
+                      local_get(i); local_get(old_len); i32_ge_u; br_if(1);
                       // Copy key: dst entry, src entry
-                      local_get(s + 3); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(new_map); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_sized(ks);
-                // Copy value: if this is the found_idx, use new value from mem
+                // Copy value: if this is the found_idx, use new value from scratch
                 wasm!(self.func, {
-                      local_get(s + 2); local_get(s + 1); i32_eq;
+                      local_get(i); local_get(found_idx); i32_eq;
                       if_empty;
-                        // Replace value
-                        local_get(s + 3); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
+                        // Replace value from scratch local
+                        local_get(new_map); i32_const(4); i32_add;
+                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(ks as i32); i32_add;
-                        i32_const(val_mem_offset as i32);
+                        local_get(val_scratch);
                 });
-                self.emit_elem_copy_sized(vs);
+                match vt {
+                    ValType::I64 => { wasm!(self.func, { i64_store(0); }); }
+                    ValType::F64 => { wasm!(self.func, { f64_store(0); }); }
+                    _ => { wasm!(self.func, { i32_store(0); }); }
+                }
                 wasm!(self.func, {
                       else_;
                         // Copy original value
-                        local_get(s + 3); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(new_map); i32_const(4); i32_add;
+                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(ks as i32); i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(map_ptr); i32_const(4); i32_add;
+                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(ks as i32); i32_add;
                 });
                 self.emit_elem_copy_sized(vs);
                 wasm!(self.func, {
                       end;
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                 });
                 // If key was new, append at end
                 wasm!(self.func, {
-                    local_get(s + 1); i32_const(0); i32_lt_s;
+                    local_get(found_idx); i32_const(0); i32_lt_s;
                     if_empty;
                       // Append key: dst[old_len]
-                      local_get(s + 3); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(new_map); i32_const(4); i32_add;
+                      local_get(old_len); i32_const(entry as i32); i32_mul; i32_add;
                 });
-                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_search_key_load(&key_ty, sk_i32, sk_i64);
                 self.emit_key_store(&key_ty, 0);
                 // Append value
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(new_map); i32_const(4); i32_add;
+                      local_get(old_len); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
-                      i32_const(val_mem_offset as i32);
+                      local_get(val_scratch);
                 });
-                self.emit_elem_copy_sized(vs);
+                match vt {
+                    ValType::I64 => { wasm!(self.func, { i64_store(0); }); }
+                    ValType::F64 => { wasm!(self.func, { f64_store(0); }); }
+                    _ => { wasm!(self.func, { i32_store(0); }); }
+                }
                 wasm!(self.func, {
                     end;
-                    local_get(s + 3);
+                    local_get(new_map);
                 });
+                self.scratch.free_i32(new_map);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(found_idx);
+                self.scratch.free_i32(old_len);
+                self.scratch.free(val_scratch, vt);
+                self.scratch.free_i64(sk_i64);
+                self.scratch.free_i32(sk_i32);
+                self.scratch.free_i32(map_ptr);
             }
             "remove" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let map_ptr = self.scratch.alloc_i32();
+                let sk_i32 = self.scratch.alloc_i32();
+                let sk_i64 = self.scratch.alloc_i64();
+                let old_len = self.scratch.alloc_i32();
+                let found_idx = self.scratch.alloc_i32();
+                let src_i = self.scratch.alloc_i32();
+                let new_map = self.scratch.alloc_i32();
+                let dst_i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                if !matches!(key_ty, Ty::Int) {
-                    wasm!(self.func, { i32_const(4); });
-                }
+                wasm!(self.func, { local_set(map_ptr); });
                 self.emit_expr(&args[1]);
-                self.emit_search_key_store(&key_ty, 4, s64);
+                self.emit_search_key_store(&key_ty, sk_i32, sk_i64);
                 wasm!(self.func, {
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // old_len
+                    local_get(map_ptr); i32_load(0); local_set(old_len);
                     // Find key index
-                    i32_const(-1); local_set(s + 1);
-                    i32_const(0); local_set(s + 2);
+                    i32_const(-1); local_set(found_idx);
+                    i32_const(0); local_set(src_i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(src_i); local_get(old_len); i32_ge_u; br_if(1);
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(src_i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
-                self.emit_search_key_load(&key_ty, 4, s64);
+                self.emit_search_key_load(&key_ty, sk_i32, sk_i64);
                 self.emit_key_eq(&key_ty);
                 wasm!(self.func, {
-                      if_empty; local_get(s + 2); local_set(s + 1); end;
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      if_empty; local_get(src_i); local_set(found_idx); end;
+                      local_get(src_i); i32_const(1); i32_add; local_set(src_i);
                       br(0);
                     end; end;
                     // Not found → return original
-                    local_get(s + 1); i32_const(0); i32_lt_s;
-                    if_i32; i32_const(0); i32_load(0);
+                    local_get(found_idx); i32_const(0); i32_lt_s;
+                    if_i32; local_get(map_ptr);
                     else_;
                       // Alloc new map with len-1
-                      i32_const(4); local_get(s); i32_const(1); i32_sub;
+                      i32_const(4); local_get(old_len); i32_const(1); i32_sub;
                       i32_const(entry as i32); i32_mul; i32_add;
-                      call(self.emitter.rt.alloc); local_set(s + 3);
-                      local_get(s + 3); local_get(s); i32_const(1); i32_sub; i32_store(0);
+                      call(self.emitter.rt.alloc); local_set(new_map);
+                      local_get(new_map); local_get(old_len); i32_const(1); i32_sub; i32_store(0);
                       // Copy entries skipping found_idx
-                      i32_const(0); local_set(s + 2); // src_i
-                      i32_const(0); local_set(s); // dst_i (reuse)
+                      i32_const(0); local_set(src_i);
+                      i32_const(0); local_set(dst_i);
                       block_empty; loop_empty;
-                        local_get(s + 2);
-                        i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(s + 2); local_get(s + 1); i32_ne;
+                        local_get(src_i); local_get(old_len); i32_ge_u; br_if(1);
+                        local_get(src_i); local_get(found_idx); i32_ne;
                         if_empty;
                           // Copy entire entry (key+val)
-                          local_get(s + 3); i32_const(4); i32_add;
-                          local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                          i32_const(0); i32_load(0); i32_const(4); i32_add;
-                          local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
+                          local_get(new_map); i32_const(4); i32_add;
+                          local_get(dst_i); i32_const(entry as i32); i32_mul; i32_add;
+                          local_get(map_ptr); i32_const(4); i32_add;
+                          local_get(src_i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_entry_copy(entry);
                 wasm!(self.func, {
-                          local_get(s); i32_const(1); i32_add; local_set(s);
+                          local_get(dst_i); i32_const(1); i32_add; local_set(dst_i);
                         end;
-                        local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                        local_get(src_i); i32_const(1); i32_add; local_set(src_i);
                         br(0);
                       end; end;
-                      local_get(s + 3);
+                      local_get(new_map);
                     end;
                 });
+                self.scratch.free_i32(dst_i);
+                self.scratch.free_i32(new_map);
+                self.scratch.free_i32(src_i);
+                self.scratch.free_i32(found_idx);
+                self.scratch.free_i32(old_len);
+                self.scratch.free_i64(sk_i64);
+                self.scratch.free_i32(sk_i32);
+                self.scratch.free_i32(map_ptr);
             }
             "keys" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
+                let map_ptr = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); local_set(s + 1); // len
-                    i32_const(4); local_get(s + 1); i32_const(ks as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_store(0);
-                    i32_const(0); local_set(s + 3);
+                    local_set(map_ptr);
+                    local_get(map_ptr); i32_load(0); local_set(len);
+                    i32_const(4); local_get(len); i32_const(ks as i32); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); local_get(len); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
                       // dst: result[4 + i*ks]
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(ks as i32); i32_mul; i32_add;
+                      local_get(result); i32_const(4); i32_add;
+                      local_get(i); i32_const(ks as i32); i32_mul; i32_add;
                       // src: map[4 + i*entry]
-                      local_get(s); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_sized(ks);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(result);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(map_ptr);
             }
             "values" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
+                let map_ptr = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); local_set(s + 1);
-                    i32_const(4); local_get(s + 1); i32_const(vs as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_store(0);
-                    i32_const(0); local_set(s + 3);
+                    local_set(map_ptr);
+                    local_get(map_ptr); i32_load(0); local_set(len);
+                    i32_const(4); local_get(len); i32_const(vs as i32); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); local_get(len); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(vs as i32); i32_mul; i32_add;
-                      local_get(s); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(result); i32_const(4); i32_add;
+                      local_get(i); i32_const(vs as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
                 });
                 self.emit_elem_copy_sized(vs);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(result);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(map_ptr);
             }
             "entries" => {
-                // entries(m) → List[(K, V)] — list of tuple ptrs
-                let (ks, vs) = self.map_kv_sizes(&args[0].ty);
-                let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                self.emit_expr(&args[0]);
-                wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); local_set(s + 1);
-                    // Alloc list of ptrs
-                    i32_const(4); local_get(s + 1); i32_const(4); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_store(0);
-                    i32_const(0); local_set(s + 3);
-                    block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
-                      // Alloc tuple (key_size + val_size)
-                      i32_const(entry as i32); call(self.emitter.rt.alloc);
-                      local_set(s + 1); // reuse temporarily — careful
-                });
-                // Actually can't reuse s+1. Use different approach.
-                // Simpler: entries are already laid out as (key, val) in the map.
-                // Just copy each entry to a new alloc.
-                wasm!(self.func, {
-                      // Restore len (it was overwritten)
-                      local_get(s); i32_load(0); local_set(s + 1);
-                });
-                // This is getting complex. Simplify: just return raw entry pointers.
-                // Each entry in the map is already [key:4][val:vs]. If we treat them as tuples
-                // we can point directly into the map memory.
-                // But that couples the tuple layout to the map layout. Allocate copies instead.
-                // Reset approach: allocate all upfront.
-                wasm!(self.func, {
-                      br(1); // break out — we'll restart
-                    end; end;
-                });
-                // Restart with cleaner approach
-                self.emit_expr(&args[0]);
-                wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); local_set(s + 1);
-                    i32_const(4); local_get(s + 1); i32_const(4); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_store(0);
-                    i32_const(0); local_set(s + 3);
-                    block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
-                      // Alloc tuple
-                      i32_const(entry as i32); call(self.emitter.rt.alloc);
-                });
-                // Store tuple ptr in list
-                wasm!(self.func, {
-                      local_set(s); // temp: tuple ptr (overwrites map ptr but we don't need it after scan)
-                });
-                // Wait, we still need map ptr for copying. This is the scratch problem again.
-                // Use mem[0] for map ptr.
-                // Let me restructure.
-                wasm!(self.func, {
-                      local_get(s); // give back tuple ptr
-                      drop;
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
-                      br(0);
-                    end; end;
-                });
-                // entries is complex. Stub for now.
+                // entries is complex — stub for now
                 self.emit_stub_call(args);
                 return true;
             }
@@ -465,59 +448,68 @@ impl FuncCompiler<'_> {
                 // merge(a, b) → concat a entries then b entries (later values win on get)
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let map_a = self.scratch.alloc_i32();
+                let map_b = self.scratch.alloc_i32();
+                let a_len = self.scratch.alloc_i32();
+                let b_len = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(map_a); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // a_len
-                    i32_const(4); i32_load(0); i32_load(0); local_set(s + 1); // b_len
+                    local_set(map_b);
+                    local_get(map_a); i32_load(0); local_set(a_len);
+                    local_get(map_b); i32_load(0); local_set(b_len);
                     // Alloc: a_len + b_len entries
-                    i32_const(4); local_get(s); local_get(s + 1); i32_add;
+                    i32_const(4); local_get(a_len); local_get(b_len); i32_add;
                     i32_const(entry as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s); local_get(s + 1); i32_add; i32_store(0);
+                    call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); local_get(a_len); local_get(b_len); i32_add; i32_store(0);
                     // Copy a entries
-                    i32_const(0); local_set(s + 3);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s); i32_ge_u; br_if(1);
+                      local_get(i); local_get(a_len); i32_ge_u; br_if(1);
                       // Copy key
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(result); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_a); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_sized(ks);
                 // Copy val
-                self.emit_merge_copy_val(entry, ks, vs);
+                self.emit_merge_copy_val(entry, ks, vs, result, i, map_a);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                     // Copy b entries after a
-                    i32_const(0); local_set(s + 3);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s); local_get(s + 3); i32_add;
+                      local_get(i); local_get(b_len); i32_ge_u; br_if(1);
+                      local_get(result); i32_const(4); i32_add;
+                      local_get(a_len); local_get(i); i32_add;
                       i32_const(entry as i32); i32_mul; i32_add;
-                      i32_const(4); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_b); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_sized(ks);
-                self.emit_merge_copy_val2(entry, ks, vs);
+                self.emit_merge_copy_val2(entry, ks, vs, result, a_len, i, map_b);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(result);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(b_len);
+                self.scratch.free_i32(a_len);
+                self.scratch.free_i32(map_b);
+                self.scratch.free_i32(map_a);
             }
             "from_list" => {
                 // from_list(pairs: List[(K,V)]) → Map
-                // Infer K,V from pair type: List[(K,V)] → elem = (K,V)
                 let pair_ty = self.list_elem_ty(&args[0].ty);
                 let (ks, vs) = if let Ty::Tuple(elems) = &pair_ty {
                     let k = elems.first().map(|t| values::byte_size(t)).unwrap_or(4);
@@ -525,43 +517,52 @@ impl FuncCompiler<'_> {
                     (k, v)
                 } else { (4u32, 4u32) };
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
+                let pairs = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let tuple_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s); // pairs list
-                    local_get(s); i32_load(0); local_set(s + 1); // len
+                    local_set(pairs); // pairs list
+                    local_get(pairs); i32_load(0); local_set(len);
                     // Alloc map: 4 + len * entry
-                    i32_const(4); local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 2);
-                    local_get(s + 2); local_get(s + 1); i32_store(0);
+                    i32_const(4); local_get(len); i32_const(entry as i32); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); local_get(len); i32_store(0);
                     // Copy: for each pair, copy key and val into map entry
-                    i32_const(0); local_set(s + 3); // i
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
                       // tuple_ptr = pairs[4 + i*4]
-                      local_get(s); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(4); i32_mul; i32_add;
-                      i32_load(0); local_set(s + 4); // tuple ptr
+                      local_get(pairs); i32_const(4); i32_add;
+                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      i32_load(0); local_set(tuple_ptr);
                       // Copy key: map[4 + i*entry] = tuple[0]
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
-                      local_get(s + 4);
+                      local_get(result); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(tuple_ptr);
                 });
                 self.emit_elem_copy_sized(ks);
                 wasm!(self.func, {
                       // Copy val: map[4 + i*entry + ks] = tuple[ks]
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(result); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
-                      local_get(s + 4); i32_const(ks as i32); i32_add;
+                      local_get(tuple_ptr); i32_const(ks as i32); i32_add;
                 });
                 self.emit_elem_copy_sized(vs);
                 wasm!(self.func, {
-                      local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(result);
                 });
+                self.scratch.free_i32(tuple_ptr);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(pairs);
             }
             _ => return self.emit_map_closure_call(method, args),
         }
@@ -618,29 +619,28 @@ impl FuncCompiler<'_> {
         }
     }
 
-    /// Store search key to scratch. For Int keys, stores to i64 scratch local.
-    /// For other keys, stores to mem[mem_offset]. Returns true if an i64 local was used.
-    pub(super) fn emit_search_key_store(&mut self, key_ty: &Ty, mem_offset: u32, scratch_i64: u32) {
+    /// Store search key to scratch local. For Int keys, stores to i64 local.
+    /// For other keys, stores to i32 local.
+    pub(super) fn emit_search_key_store(&mut self, key_ty: &Ty, scratch_i32: u32, scratch_i64: u32) {
         match key_ty {
             Ty::Int => {
-                // Store search key in i64 scratch local (8 bytes don't fit in mem[4..8] safely)
                 wasm!(self.func, { local_set(scratch_i64); });
             }
             _ => {
-                wasm!(self.func, { i32_store(0); }); // mem[mem_offset] already on stack
+                wasm!(self.func, { local_set(scratch_i32); });
             }
         }
     }
 
-    /// Load search key from scratch. For Int keys, loads from i64 scratch local.
-    /// For other keys, loads from mem[mem_offset].
-    pub(super) fn emit_search_key_load(&mut self, key_ty: &Ty, mem_offset: u32, scratch_i64: u32) {
+    /// Load search key from scratch local. For Int keys, loads i64 local.
+    /// For other keys, loads i32 local.
+    pub(super) fn emit_search_key_load(&mut self, key_ty: &Ty, scratch_i32: u32, scratch_i64: u32) {
         match key_ty {
             Ty::Int => {
                 wasm!(self.func, { local_get(scratch_i64); });
             }
             _ => {
-                wasm!(self.func, { i32_const(mem_offset as i32); i32_load(0); });
+                wasm!(self.func, { local_get(scratch_i32); });
             }
         }
     }
@@ -653,29 +653,26 @@ impl FuncCompiler<'_> {
         }
     }
 
-    fn emit_merge_copy_val(&mut self, entry: u32, ks: u32, vs: u32) {
-        // Copy val portion: dst already has key set. Copy val from src.
-        let s = self.match_i32_base + self.match_depth;
+    fn emit_merge_copy_val(&mut self, entry: u32, ks: u32, vs: u32, result: u32, i: u32, map_a: u32) {
         wasm!(self.func, {
-              local_get(s + 2); i32_const(4); i32_add;
-              local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+              local_get(result); i32_const(4); i32_add;
+              local_get(i); i32_const(entry as i32); i32_mul; i32_add;
               i32_const(ks as i32); i32_add;
-              i32_const(0); i32_load(0); i32_const(4); i32_add;
-              local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+              local_get(map_a); i32_const(4); i32_add;
+              local_get(i); i32_const(entry as i32); i32_mul; i32_add;
               i32_const(ks as i32); i32_add;
         });
         self.emit_elem_copy_sized(vs);
     }
 
-    fn emit_merge_copy_val2(&mut self, entry: u32, ks: u32, vs: u32) {
-        let s = self.match_i32_base + self.match_depth;
+    fn emit_merge_copy_val2(&mut self, entry: u32, ks: u32, vs: u32, result: u32, a_len: u32, i: u32, map_b: u32) {
         wasm!(self.func, {
-              local_get(s + 2); i32_const(4); i32_add;
-              local_get(s); local_get(s + 3); i32_add;
+              local_get(result); i32_const(4); i32_add;
+              local_get(a_len); local_get(i); i32_add;
               i32_const(entry as i32); i32_mul; i32_add;
               i32_const(ks as i32); i32_add;
-              i32_const(4); i32_load(0); i32_const(4); i32_add;
-              local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+              local_get(map_b); i32_const(4); i32_add;
+              local_get(i); i32_const(entry as i32); i32_mul; i32_add;
               i32_const(ks as i32); i32_add;
         });
         self.emit_elem_copy_sized(vs);
@@ -695,38 +692,39 @@ impl FuncCompiler<'_> {
 
     fn emit_entry_copy(&mut self, entry_size: u32) {
         // Copy entire entry (key + val) — byte by byte for arbitrary sizes
-        // For common case (key=4, val=4 or 8): just do 2 loads
         match entry_size {
             8 => { wasm!(self.func, { i64_load(0); i64_store(0); }); }
             12 => {
-                // key(4) + val(8): copy as i32 + i64
-                // Need to restructure — just use i32+i64 manually
-                // Actually can't do two loads from same pair of stack values.
-                // Simplify: treat as 3 i32 loads
-                let s = self.match_i32_base + self.match_depth;
+                let dst = self.scratch.alloc_i32();
+                let src = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(s + 1); // src
-                    local_set(s);     // dst
-                    local_get(s); local_get(s + 1); i32_load(0); i32_store(0);
-                    local_get(s); local_get(s + 1); i32_load(4); i32_store(4);
-                    local_get(s); local_get(s + 1); i32_load(8); i32_store(8);
+                    local_set(src);
+                    local_set(dst);
+                    local_get(dst); local_get(src); i32_load(0); i32_store(0);
+                    local_get(dst); local_get(src); i32_load(4); i32_store(4);
+                    local_get(dst); local_get(src); i32_load(8); i32_store(8);
                 });
+                self.scratch.free_i32(src);
+                self.scratch.free_i32(dst);
             }
             _ => {
                 // Fallback: copy as i32 words
-                let s = self.match_i32_base + self.match_depth;
+                let dst = self.scratch.alloc_i32();
+                let src = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(s + 1);
-                    local_set(s);
+                    local_set(src);
+                    local_set(dst);
                 });
                 let words = (entry_size + 3) / 4;
-                for i in 0..words {
-                    let off = i * 4;
+                for w in 0..words {
+                    let off = w * 4;
                     wasm!(self.func, {
-                        local_get(s); local_get(s + 1);
+                        local_get(dst); local_get(src);
                         i32_load(off); i32_store(off);
                     });
                 }
+                self.scratch.free_i32(src);
+                self.scratch.free_i32(dst);
             }
         }
     }

--- a/src/codegen/emit_wasm/calls_map_closure.rs
+++ b/src/codegen/emit_wasm/calls_map_closure.rs
@@ -17,39 +17,38 @@ impl FuncCompiler<'_> {
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
-                // mem[0]=map, mem[4]=closure
-                wasm!(self.func, { i32_const(0); });
+                let map_ptr = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let acc = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(map_ptr); });
                 // init → acc
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(s64); }); // acc (as i64; works for i32 via reinterpret)
-                wasm!(self.func, { i32_const(4); });
+                wasm!(self.func, { local_set(acc); });
                 self.emit_expr(&args[2]); // closure
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); local_set(s); // i
+                    local_set(closure);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(i); local_get(map_ptr); i32_load(0); i32_ge_u; br_if(1);
                       // Call f(acc, key, val)
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      local_get(s64); // acc
+                      local_get(closure); i32_load(4); // env
+                      local_get(acc); // acc
                       // key = map[4 + i*entry]
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 wasm!(self.func, {
                       // val = map[4 + i*entry + ks]
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 // call_indirect (env, acc, key, val) → acc
                 {
@@ -61,41 +60,46 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      local_set(s64);
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_set(acc);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s64);
+                    local_get(acc);
                 });
+                self.scratch.free_i64(acc);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(map_ptr);
             }
             "each" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let map_ptr = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(map_ptr); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); local_set(s);
+                    local_set(closure);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(map_ptr); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4); // env
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 wasm!(self.func, {
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0);
+                      local_get(closure); i32_load(0);
                 });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
@@ -105,87 +109,98 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(map_ptr);
             }
             "any" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let map_ptr = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(map_ptr); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); local_set(s);
-                    i32_const(0); local_set(s + 1); // result
+                    local_set(closure);
+                    i32_const(0); local_set(i);
+                    i32_const(0); local_set(result);
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(map_ptr); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4);
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 wasm!(self.func, {
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0);
+                      local_get(closure); i32_load(0);
                 });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
-                    let mut ct = vec![ValType::I32, key_vt]; // env, key
+                    let mut ct = vec![ValType::I32, key_vt];
                     if let Some(vt) = values::ty_to_valtype(&val_ty) { ct.push(vt); }
                     let ti = self.emitter.register_type(ct, vec![ValType::I32]);
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
                       if_empty;
-                        i32_const(1); local_set(s + 1); br(2);
+                        i32_const(1); local_set(result); br(2);
                       end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1);
+                    local_get(result);
                 });
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(map_ptr);
             }
             "all" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let map_ptr = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(map_ptr); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); local_set(s);
-                    i32_const(1); local_set(s + 1);
+                    local_set(closure);
+                    i32_const(0); local_set(i);
+                    i32_const(1); local_set(result);
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(map_ptr); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4);
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 wasm!(self.func, {
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0);
+                      local_get(closure); i32_load(0);
                 });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
@@ -197,44 +212,49 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                       i32_eqz;
                       if_empty;
-                        i32_const(0); local_set(s + 1); br(2);
+                        i32_const(0); local_set(result); br(2);
                       end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1);
+                    local_get(result);
                 });
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(map_ptr);
             }
             "count" => {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let map_ptr = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let cnt = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(map_ptr); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); local_set(s); // i
-                    i64_const(0); local_set(s64); // count
+                    local_set(closure);
+                    i32_const(0); local_set(i);
+                    i64_const(0); local_set(cnt);
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(map_ptr); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4);
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 wasm!(self.func, {
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0);
+                      local_get(closure); i32_load(0);
                 });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
@@ -245,13 +265,17 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                       if_empty;
-                        local_get(s64); i64_const(1); i64_add; local_set(s64);
+                        local_get(cnt); i64_const(1); i64_add; local_set(cnt);
                       end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s64);
+                    local_get(cnt);
                 });
+                self.scratch.free_i64(cnt);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(map_ptr);
             }
             "filter" => {
                 // filter(m, pred) → Map: keep entries where pred(k, v) is true
@@ -259,34 +283,36 @@ impl FuncCompiler<'_> {
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let map_ptr = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(map_ptr); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
+                    local_set(closure);
                     // Alloc max-size result
-                    i32_const(4); i32_const(0); i32_load(0); i32_load(0);
+                    i32_const(4); local_get(map_ptr); i32_load(0);
                     i32_const(entry as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s); // result
-                    local_get(s); i32_const(0); i32_store(0); // len=0
-                    i32_const(0); local_set(s + 1); // i
+                    call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); i32_const(0); i32_store(0); // len=0
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 1); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(map_ptr); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4);
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 wasm!(self.func, {
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0);
+                      local_get(closure); i32_load(0);
                 });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
@@ -298,73 +324,80 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                       if_empty;
                         // Copy key to result[result.len]
-                        local_get(s); i32_const(4); i32_add;
-                        local_get(s); i32_load(0); i32_const(entry as i32); i32_mul; i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(result); i32_const(4); i32_add;
+                        local_get(result); i32_load(0); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(map_ptr); i32_const(4); i32_add;
+                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_sized(ks);
                 // Copy val
                 wasm!(self.func, {
-                        local_get(s); i32_const(4); i32_add;
-                        local_get(s); i32_load(0); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(result); i32_const(4); i32_add;
+                        local_get(result); i32_load(0); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(ks as i32); i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(map_ptr); i32_const(4); i32_add;
+                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(ks as i32); i32_add;
                 });
                 self.emit_elem_copy_sized(vs);
                 wasm!(self.func, {
-                        local_get(s);
-                        local_get(s); i32_load(0); i32_const(1); i32_add;
+                        local_get(result);
+                        local_get(result); i32_load(0); i32_const(1); i32_add;
                         i32_store(0);
                       end;
-                      local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s);
+                    local_get(result);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(map_ptr);
             }
             "map" => {
                 // map(m, f) → Map[K, B]: transform values
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let map_ptr = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(map_ptr); });
                 self.emit_expr(&args[1]); // f(v) -> B
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
+                    local_set(closure);
+                    local_get(map_ptr); i32_load(0); local_set(len);
                     // Result: same key size, assume same val size (B might differ but we use same entry layout)
-                    i32_const(4); local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 1);
-                    local_get(s + 1); local_get(s); i32_store(0);
-                    i32_const(0); local_set(s + 2); // i
+                    i32_const(4); local_get(len); i32_const(entry as i32); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); local_get(len); i32_store(0);
+                    i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_ge_u; br_if(1);
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
                       // Copy key
-                      local_get(s + 1); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(result); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_sized(ks);
                 wasm!(self.func, {
                       // Call f(val) → new val
-                      local_get(s + 1); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(result); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add; // dst val addr
-                      i32_const(4); i32_load(0); i32_load(4); // env
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(closure); i32_load(4); // env
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32]; // env
@@ -377,11 +410,16 @@ impl FuncCompiler<'_> {
                 // Store result val
                 self.emit_store_at(&val_ty, 0);
                 wasm!(self.func, {
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1);
+                    local_get(result);
                 });
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(map_ptr);
             }
             "find" => {
                 // find(m, pred) → Option[(K, V)]
@@ -389,30 +427,33 @@ impl FuncCompiler<'_> {
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let map_ptr = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let tuple_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(map_ptr); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(0); local_set(s); // i
-                    i32_const(0); local_set(s + 1); // result (none)
+                    local_set(closure);
+                    i32_const(0); local_set(i);
+                    i32_const(0); local_set(result); // none
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(4); i32_load(0); i32_load(4);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(map_ptr); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(closure); i32_load(4);
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 wasm!(self.func, {
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, {
-                      i32_const(4); i32_load(0); i32_load(0);
+                      local_get(closure); i32_load(0);
                 });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
@@ -424,32 +465,37 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                       if_empty;
                         // Alloc tuple (key, val) and wrap in Option
-                        i32_const(entry as i32); call(self.emitter.rt.alloc); local_set(s + 2);
+                        i32_const(entry as i32); call(self.emitter.rt.alloc); local_set(tuple_ptr);
                         // Copy key
-                        local_get(s + 2);
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(tuple_ptr);
+                        local_get(map_ptr); i32_const(4); i32_add;
+                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_sized(ks);
                 // Copy val
                 wasm!(self.func, {
-                        local_get(s + 2); i32_const(ks as i32); i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(tuple_ptr); i32_const(ks as i32); i32_add;
+                        local_get(map_ptr); i32_const(4); i32_add;
+                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(ks as i32); i32_add;
                 });
                 self.emit_elem_copy_sized(vs);
                 wasm!(self.func, {
                         // Wrap in some
-                        i32_const(4); call(self.emitter.rt.alloc); local_set(s + 1);
-                        local_get(s + 1); local_get(s + 2); i32_store(0);
+                        i32_const(4); call(self.emitter.rt.alloc); local_set(result);
+                        local_get(result); local_get(tuple_ptr); i32_store(0);
                         br(2); // break out
                       end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1); // result (none=0 or some ptr)
+                    local_get(result); // result (none=0 or some ptr)
                 });
+                self.scratch.free_i32(tuple_ptr);
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(map_ptr);
             }
             "update" => {
                 // update(m, key, f) → Map: apply f to value at key
@@ -457,87 +503,100 @@ impl FuncCompiler<'_> {
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
-                // Reuse set logic: find key, apply f to value, then set
-                // mem[0]=map, closure stored at mem[4] (or mem[8] for non-Int keys)
-                let closure_mem_offset = if matches!(key_ty, Ty::Int) { 4u32 } else { 8u32 };
-                wasm!(self.func, { i32_const(0); });
+                let map_ptr = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let search_key_i64 = self.scratch.alloc_i64();
+                let search_key_i32 = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let found_idx = self.scratch.alloc_i32();
+                let new_map = self.scratch.alloc_i32();
+                let copy_i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(map_ptr); });
                 // Store search key
-                if !matches!(key_ty, Ty::Int) {
-                    wasm!(self.func, { i32_const(4); });
-                }
                 self.emit_expr(&args[1]); // key
-                self.emit_search_key_store(&key_ty, 4, s64);
-                wasm!(self.func, { i32_const(closure_mem_offset as i32); });
+                match &key_ty {
+                    Ty::Int => {
+                        wasm!(self.func, { local_set(search_key_i64); });
+                    }
+                    _ => {
+                        wasm!(self.func, { local_set(search_key_i32); });
+                    }
+                }
                 self.emit_expr(&args[2]); // closure f
                 wasm!(self.func, {
-                    i32_store(0); // mem[closure_mem_offset] = closure
+                    local_set(closure);
                     // Find key index
-                    i32_const(0); local_set(s); // i
-                    i32_const(-1); local_set(s + 1); // found_idx
+                    i32_const(0); local_set(i);
+                    i32_const(-1); local_set(found_idx);
                     block_empty; loop_empty;
-                      local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(map_ptr); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
-                self.emit_search_key_load(&key_ty, 4, s64);
+                // Load search key for comparison
+                match &key_ty {
+                    Ty::Int => {
+                        wasm!(self.func, { local_get(search_key_i64); });
+                    }
+                    _ => {
+                        wasm!(self.func, { local_get(search_key_i32); });
+                    }
+                }
                 self.emit_key_eq(&key_ty);
                 wasm!(self.func, {
-                      if_empty; local_get(s); local_set(s + 1); end;
-                      local_get(s); i32_const(1); i32_add; local_set(s);
+                      if_empty; local_get(i); local_set(found_idx); end;
+                      local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                     // If not found, return original
-                    local_get(s + 1); i32_const(0); i32_lt_s;
-                    if_i32; i32_const(0); i32_load(0);
+                    local_get(found_idx); i32_const(0); i32_lt_s;
+                    if_i32; local_get(map_ptr);
                     else_;
                       // Copy map, replace value at found_idx with f(old_val)
-                      i32_const(0); i32_load(0); i32_load(0); local_set(s); // len
-                      i32_const(4); local_get(s); i32_const(entry as i32); i32_mul; i32_add;
-                      call(self.emitter.rt.alloc); local_set(s + 2);
-                      local_get(s + 2); local_get(s); i32_store(0);
+                      local_get(map_ptr); i32_load(0); local_set(i); // reuse i as len
+                      i32_const(4); local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                      call(self.emitter.rt.alloc); local_set(new_map);
+                      local_get(new_map); local_get(i); i32_store(0);
                       // Copy all entries
-                      i32_const(0); local_set(s + 3);
+                      i32_const(0); local_set(copy_i);
                       block_empty; loop_empty;
-                        local_get(s + 3); local_get(s); i32_ge_u; br_if(1);
+                        local_get(copy_i); local_get(i); i32_ge_u; br_if(1);
                         // Copy key
-                        local_get(s + 2); i32_const(4); i32_add;
-                        local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(new_map); i32_const(4); i32_add;
+                        local_get(copy_i); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(map_ptr); i32_const(4); i32_add;
+                        local_get(copy_i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_sized(ks);
                 // Copy val
                 wasm!(self.func, {
-                        local_get(s + 2); i32_const(4); i32_add;
-                        local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(new_map); i32_const(4); i32_add;
+                        local_get(copy_i); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(ks as i32); i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 3); i32_const(entry as i32); i32_mul; i32_add;
+                        local_get(map_ptr); i32_const(4); i32_add;
+                        local_get(copy_i); i32_const(entry as i32); i32_mul; i32_add;
                         i32_const(ks as i32); i32_add;
                 });
                 self.emit_elem_copy_sized(vs);
                 wasm!(self.func, {
-                        local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                        local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
                         br(0);
                       end; end;
                       // Now apply f to the value at found_idx
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(new_map); i32_const(4); i32_add;
+                      local_get(found_idx); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add; // dst val addr
-                      i32_const(closure_mem_offset as i32); i32_load(0); i32_load(4); // env
+                      local_get(closure); i32_load(4); // env
                       // Load old val
-                      local_get(s + 2); i32_const(4); i32_add;
-                      local_get(s + 1); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(new_map); i32_const(4); i32_add;
+                      local_get(found_idx); i32_const(entry as i32); i32_mul; i32_add;
                       i32_const(ks as i32); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, {
-                      i32_const(closure_mem_offset as i32); i32_load(0); i32_load(0); // table_idx
+                      local_get(closure); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32]; // env
@@ -548,9 +607,17 @@ impl FuncCompiler<'_> {
                 }
                 self.emit_store_at(&val_ty, 0);
                 wasm!(self.func, {
-                      local_get(s + 2);
+                      local_get(new_map);
                     end;
                 });
+                self.scratch.free_i32(copy_i);
+                self.scratch.free_i32(new_map);
+                self.scratch.free_i32(found_idx);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(search_key_i32);
+                self.scratch.free_i64(search_key_i64);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(map_ptr);
             }
             _ => return false,
         }

--- a/src/codegen/emit_wasm/calls_numeric.rs
+++ b/src/codegen/emit_wasm/calls_numeric.rs
@@ -21,16 +21,16 @@ impl FuncCompiler<'_> {
             }
             "round" => {
                 // Round half away from zero: copysign(floor(abs(x) + 0.5), x)
-                // Use mem[0..8] as f64 scratch since no f64 local available
-                wasm!(self.func, { i32_const(0); });
+                let tmp = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    f64_store(0);  // mem[0] = x
-                    i32_const(0); f64_load(0); // x
+                    local_set(tmp);
+                    local_get(tmp); // x
                     f64_abs; f64_const(0.5); f64_add; f64_floor; // floor(abs(x)+0.5)
-                    i32_const(0); f64_load(0); // x (for sign)
+                    local_get(tmp); // x (for sign)
                     f64_copysign; // copysign(magnitude, sign)
                 });
+                self.scratch.free_f64(tmp);
             }
             "floor" => {
                 self.emit_expr(&args[0]);
@@ -54,16 +54,15 @@ impl FuncCompiler<'_> {
             }
             "sign" => {
                 // sign(n) → -1.0, 0.0, or 1.0
-                // Store f64 in mem[0] (as 8 bytes) since no f64 scratch local
-                wasm!(self.func, { i32_const(0); });
+                let tmp = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    f64_store(0);
-                    i32_const(0); f64_load(0); f64_const(0.0); f64_lt;
+                    local_set(tmp);
+                    local_get(tmp); f64_const(0.0); f64_lt;
                     if_f64;
                       f64_const(-1.0);
                     else_;
-                      i32_const(0); f64_load(0); f64_const(0.0); f64_gt;
+                      local_get(tmp); f64_const(0.0); f64_gt;
                       if_f64;
                         f64_const(1.0);
                       else_;
@@ -71,6 +70,7 @@ impl FuncCompiler<'_> {
                       end;
                     end;
                 });
+                self.scratch.free_f64(tmp);
             }
             "min" => {
                 self.emit_expr(&args[0]);
@@ -91,15 +91,16 @@ impl FuncCompiler<'_> {
                 self.func.instruction(&Instruction::F64Max); // max(lo, min(n, hi))
             }
             "is_nan" => {
-                // NaN != NaN. Store in mem to avoid double eval.
-                wasm!(self.func, { i32_const(0); });
+                // NaN != NaN. Store to avoid double eval.
+                let tmp = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    f64_store(0);
-                    i32_const(0); f64_load(0);
-                    i32_const(0); f64_load(0);
+                    local_set(tmp);
+                    local_get(tmp);
+                    local_get(tmp);
                     f64_ne;
                 });
+                self.scratch.free_f64(tmp);
             }
             "is_infinite" => {
                 self.emit_expr(&args[0]);
@@ -134,7 +135,7 @@ impl FuncCompiler<'_> {
             }
             "abs" => {
                 self.emit_expr(&args[0]);
-                let s = self.match_i64_base + self.match_depth;
+                let s = self.scratch.alloc_i64();
                 wasm!(self.func, {
                     local_set(s);
                     local_get(s); i64_const(0); i64_lt_s;
@@ -144,45 +145,57 @@ impl FuncCompiler<'_> {
                       local_get(s);
                     end;
                 });
+                self.scratch.free_i64(s);
             }
             "min" => {
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                let s = self.match_i64_base + self.match_depth;
+                let a = self.scratch.alloc_i64();
+                let b = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(s); local_set(s + 1);
-                    local_get(s + 1); local_get(s); i64_lt_s;
-                    if_i64; local_get(s + 1); else_; local_get(s); end;
+                    local_set(a); local_set(b);
+                    local_get(b); local_get(a); i64_lt_s;
+                    if_i64; local_get(b); else_; local_get(a); end;
                 });
+                self.scratch.free_i64(b);
+                self.scratch.free_i64(a);
             }
             "max" => {
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                let s = self.match_i64_base + self.match_depth;
+                let a = self.scratch.alloc_i64();
+                let b = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(s); local_set(s + 1);
-                    local_get(s + 1); local_get(s); i64_gt_s;
-                    if_i64; local_get(s + 1); else_; local_get(s); end;
+                    local_set(a); local_set(b);
+                    local_get(b); local_get(a); i64_gt_s;
+                    if_i64; local_get(b); else_; local_get(a); end;
                 });
+                self.scratch.free_i64(b);
+                self.scratch.free_i64(a);
             }
             "clamp" => {
                 // clamp(n, lo, hi) = max(lo, min(n, hi))
                 self.emit_expr(&args[0]); // n
                 self.emit_expr(&args[1]); // lo
                 self.emit_expr(&args[2]); // hi
-                let s = self.match_i64_base + self.match_depth;
+                let hi = self.scratch.alloc_i64();
+                let lo = self.scratch.alloc_i64();
+                let n = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(s);       // hi
-                    local_set(s + 1);   // lo
-                    local_set(s + 2);   // n
+                    local_set(hi);       // hi
+                    local_set(lo);   // lo
+                    local_set(n);   // n
                     // min(n, hi)
-                    local_get(s + 2); local_get(s); i64_lt_s;
-                    if_i64; local_get(s + 2); else_; local_get(s); end;
+                    local_get(n); local_get(hi); i64_lt_s;
+                    if_i64; local_get(n); else_; local_get(hi); end;
                     // max(lo, result)
-                    local_set(s + 2); // temp = min(n, hi)
-                    local_get(s + 1); local_get(s + 2); i64_gt_s;
-                    if_i64; local_get(s + 1); else_; local_get(s + 2); end;
+                    local_set(n); // temp = min(n, hi)
+                    local_get(lo); local_get(n); i64_gt_s;
+                    if_i64; local_get(lo); else_; local_get(n); end;
                 });
+                self.scratch.free_i64(n);
+                self.scratch.free_i64(lo);
+                self.scratch.free_i64(hi);
             }
             "to_float" => {
                 self.emit_expr(&args[0]);
@@ -227,91 +240,103 @@ impl FuncCompiler<'_> {
             }
             "wrap_add" => {
                 // wrap_add(a, b, bits)
+                let bits = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
                 wasm!(self.func, { i64_add; });
                 self.emit_expr(&args[2]);
                 // mask = (1 << bits) - 1
                 wasm!(self.func, {
-                    local_set(self.match_i64_base + self.match_depth);
+                    local_set(bits);
                     i64_const(1);
-                    local_get(self.match_i64_base + self.match_depth);
+                    local_get(bits);
                     i64_shl;
                     i64_const(1);
                     i64_sub;
                     i64_and;
                 });
+                self.scratch.free_i64(bits);
             }
             "wrap_mul" => {
+                let bits = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
                 wasm!(self.func, { i64_mul; });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    local_set(self.match_i64_base + self.match_depth);
+                    local_set(bits);
                     i64_const(1);
-                    local_get(self.match_i64_base + self.match_depth);
+                    local_get(bits);
                     i64_shl;
                     i64_const(1);
                     i64_sub;
                     i64_and;
                 });
+                self.scratch.free_i64(bits);
             }
             "to_hex" => {
                 // to_hex(n: Int) → String: hex lowercase
                 // Alloc temp buffer (20 bytes max), write digits in reverse, then create result
-                let s = self.match_i32_base + self.match_depth;
-                let s64 = self.match_i64_base + self.match_depth;
+                let buf = self.scratch.alloc_i32();
+                let count = self.scratch.alloc_i32();
+                let digit = self.scratch.alloc_i32();
+                let idx = self.scratch.alloc_i32();
+                let n64 = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s64);
-                    local_get(s64); i64_eqz;
+                    local_set(n64);
+                    local_get(n64); i64_eqz;
                     if_i32;
-                      i32_const(5); call(self.emitter.rt.alloc); local_set(s);
-                      local_get(s); i32_const(1); i32_store(0);
-                      local_get(s); i32_const(48); i32_store8(4);
-                      local_get(s);
+                      i32_const(5); call(self.emitter.rt.alloc); local_set(buf);
+                      local_get(buf); i32_const(1); i32_store(0);
+                      local_get(buf); i32_const(48); i32_store8(4);
+                      local_get(buf);
                     else_;
                       // Alloc temp buffer for reversed digits
-                      i32_const(20); call(self.emitter.rt.alloc); local_set(s); // buf
-                      i32_const(0); local_set(s + 1); // count
+                      i32_const(20); call(self.emitter.rt.alloc); local_set(buf); // buf
+                      i32_const(0); local_set(count); // count
                 });
                 wasm!(self.func, {
                       block_empty; loop_empty;
-                        local_get(s64); i64_eqz; br_if(1);
-                        local_get(s64); i64_const(16); i64_rem_u; i32_wrap_i64;
-                        local_set(s + 2); // digit
-                        local_get(s + 2); i32_const(10); i32_lt_u;
-                        if_i32; local_get(s + 2); i32_const(48); i32_add;
-                        else_; local_get(s + 2); i32_const(87); i32_add; end;
-                        local_set(s + 2); // char
-                        local_get(s); local_get(s + 1); i32_add;
-                        local_get(s + 2); i32_store8(0);
-                        local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
-                        local_get(s64); i64_const(16); i64_div_u; local_set(s64);
+                        local_get(n64); i64_eqz; br_if(1);
+                        local_get(n64); i64_const(16); i64_rem_u; i32_wrap_i64;
+                        local_set(digit); // digit
+                        local_get(digit); i32_const(10); i32_lt_u;
+                        if_i32; local_get(digit); i32_const(48); i32_add;
+                        else_; local_get(digit); i32_const(87); i32_add; end;
+                        local_set(digit); // char
+                        local_get(buf); local_get(count); i32_add;
+                        local_get(digit); i32_store8(0);
+                        local_get(count); i32_const(1); i32_add; local_set(count);
+                        local_get(n64); i64_const(16); i64_div_u; local_set(n64);
                         br(0);
                       end; end;
                 });
                 wasm!(self.func, {
                       // Alloc result string
-                      i32_const(4); local_get(s + 1); i32_add;
-                      call(self.emitter.rt.alloc); local_set(s + 2);
-                      local_get(s + 2); local_get(s + 1); i32_store(0);
+                      i32_const(4); local_get(count); i32_add;
+                      call(self.emitter.rt.alloc); local_set(digit);
+                      local_get(digit); local_get(count); i32_store(0);
                       // Copy reversed
-                      i32_const(0); local_set(s + 3);
+                      i32_const(0); local_set(idx);
                       block_empty; loop_empty;
-                        local_get(s + 3); local_get(s + 1); i32_ge_u; br_if(1);
-                        local_get(s + 2); i32_const(4); i32_add; local_get(s + 3); i32_add;
-                        local_get(s);
-                        local_get(s + 1); i32_const(1); i32_sub; local_get(s + 3); i32_sub;
+                        local_get(idx); local_get(count); i32_ge_u; br_if(1);
+                        local_get(digit); i32_const(4); i32_add; local_get(idx); i32_add;
+                        local_get(buf);
+                        local_get(count); i32_const(1); i32_sub; local_get(idx); i32_sub;
                         i32_add; i32_load8_u(0);
                         i32_store8(0);
-                        local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                        local_get(idx); i32_const(1); i32_add; local_set(idx);
                         br(0);
                       end; end;
-                      local_get(s + 2);
+                      local_get(digit);
                     end;
                 });
+                self.scratch.free_i64(n64);
+                self.scratch.free_i32(idx);
+                self.scratch.free_i32(digit);
+                self.scratch.free_i32(count);
+                self.scratch.free_i32(buf);
             }
             "from_hex" => {
                 self.emit_expr(&args[0]);
@@ -347,35 +372,42 @@ impl FuncCompiler<'_> {
                 match &args[0].ty {
                     Ty::Float => { wasm!(self.func, { f64_abs; }); }
                     _ => {
-                        let s = self.match_i64_base + self.match_depth;
+                        let s = self.scratch.alloc_i64();
                         wasm!(self.func, {
                             local_set(s);
                             local_get(s); i64_const(0); i64_lt_s;
                             if_i64; i64_const(0); local_get(s); i64_sub;
                             else_; local_get(s); end;
                         });
+                        self.scratch.free_i64(s);
                     }
                 }
             }
             "max" => {
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                let s = self.match_i64_base + self.match_depth;
+                let a = self.scratch.alloc_i64();
+                let b = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(s); local_set(s + 1);
-                    local_get(s + 1); local_get(s); i64_gt_s;
-                    if_i64; local_get(s + 1); else_; local_get(s); end;
+                    local_set(a); local_set(b);
+                    local_get(b); local_get(a); i64_gt_s;
+                    if_i64; local_get(b); else_; local_get(a); end;
                 });
+                self.scratch.free_i64(b);
+                self.scratch.free_i64(a);
             }
             "min" => {
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                let s = self.match_i64_base + self.match_depth;
+                let a = self.scratch.alloc_i64();
+                let b = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(s); local_set(s + 1);
-                    local_get(s + 1); local_get(s); i64_lt_s;
-                    if_i64; local_get(s + 1); else_; local_get(s); end;
+                    local_set(a); local_set(b);
+                    local_get(b); local_get(a); i64_lt_s;
+                    if_i64; local_get(b); else_; local_get(a); end;
                 });
+                self.scratch.free_i64(b);
+                self.scratch.free_i64(a);
             }
             "fmin" => {
                 self.emit_expr(&args[0]);
@@ -439,7 +471,7 @@ impl FuncCompiler<'_> {
             "sign" => {
                 // math.sign(n: Int) → Int (-1, 0, 1)
                 self.emit_expr(&args[0]);
-                let s = self.match_i64_base + self.match_depth;
+                let s = self.scratch.alloc_i64();
                 wasm!(self.func, {
                     local_set(s);
                     local_get(s); i64_const(0); i64_lt_s;
@@ -451,28 +483,36 @@ impl FuncCompiler<'_> {
                       end;
                     end;
                 });
+                self.scratch.free_i64(s);
             }
             "pow" => {
                 // pow(base: Int, exp: Int) → Int
                 // Loop: result = 1; for i in 0..exp: result *= base
                 self.emit_expr(&args[0]); // base
                 self.emit_expr(&args[1]); // exp
-                let s = self.match_i64_base + self.match_depth;
+                let exp = self.scratch.alloc_i64();
+                let base = self.scratch.alloc_i64();
+                let result = self.scratch.alloc_i64();
+                let i = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(s);       // exp
-                    local_set(s + 1);   // base
+                    local_set(exp);       // exp
+                    local_set(base);   // base
                     i64_const(1);
-                    local_set(s + 2);   // result = 1
+                    local_set(result);   // result = 1
                     i64_const(0);
-                    local_set(s + 3);   // i = 0
+                    local_set(i);   // i = 0
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s); i64_ge_s; br_if(1);
-                      local_get(s + 2); local_get(s + 1); i64_mul; local_set(s + 2);
-                      local_get(s + 3); i64_const(1); i64_add; local_set(s + 3);
+                      local_get(i); local_get(exp); i64_ge_s; br_if(1);
+                      local_get(result); local_get(base); i64_mul; local_set(result);
+                      local_get(i); i64_const(1); i64_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(result);
                 });
+                self.scratch.free_i64(i);
+                self.scratch.free_i64(result);
+                self.scratch.free_i64(base);
+                self.scratch.free_i64(exp);
             }
             "fpow" => {
                 // fpow(base: Float, exp: Float) → Float
@@ -483,45 +523,57 @@ impl FuncCompiler<'_> {
             "factorial" => {
                 // factorial(n) → Int, loop
                 self.emit_expr(&args[0]);
-                let s = self.match_i64_base + self.match_depth;
+                let n = self.scratch.alloc_i64();
+                let result = self.scratch.alloc_i64();
+                let i = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(s); // n
-                    i64_const(1); local_set(s + 1); // result
-                    i64_const(2); local_set(s + 2); // i
+                    local_set(n); // n
+                    i64_const(1); local_set(result); // result
+                    i64_const(2); local_set(i); // i
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i64_gt_s; br_if(1);
-                      local_get(s + 1); local_get(s + 2); i64_mul; local_set(s + 1);
-                      local_get(s + 2); i64_const(1); i64_add; local_set(s + 2);
+                      local_get(i); local_get(n); i64_gt_s; br_if(1);
+                      local_get(result); local_get(i); i64_mul; local_set(result);
+                      local_get(i); i64_const(1); i64_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 1);
+                    local_get(result);
                 });
+                self.scratch.free_i64(i);
+                self.scratch.free_i64(result);
+                self.scratch.free_i64(n);
             }
             "choose" => {
                 // choose(n, k) = n! / (k! * (n-k)!)
                 // Iterative: result = 1; for i in 0..k: result = result * (n-i) / (i+1)
                 self.emit_expr(&args[0]); // n
                 self.emit_expr(&args[1]); // k
-                let s = self.match_i64_base + self.match_depth;
+                let k = self.scratch.alloc_i64();
+                let n = self.scratch.alloc_i64();
+                let result = self.scratch.alloc_i64();
+                let i = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(s);       // k
-                    local_set(s + 1);   // n
-                    i64_const(1); local_set(s + 2); // result
-                    i64_const(0); local_set(s + 3); // i
+                    local_set(k);       // k
+                    local_set(n);   // n
+                    i64_const(1); local_set(result); // result
+                    i64_const(0); local_set(i); // i
                     block_empty; loop_empty;
-                      local_get(s + 3); local_get(s); i64_ge_s; br_if(1);
+                      local_get(i); local_get(k); i64_ge_s; br_if(1);
                       // result = result * (n - i) / (i + 1)
-                      local_get(s + 2);
-                      local_get(s + 1); local_get(s + 3); i64_sub;
+                      local_get(result);
+                      local_get(n); local_get(i); i64_sub;
                       i64_mul;
-                      local_get(s + 3); i64_const(1); i64_add;
+                      local_get(i); i64_const(1); i64_add;
                       i64_div_s;
-                      local_set(s + 2);
-                      local_get(s + 3); i64_const(1); i64_add; local_set(s + 3);
+                      local_set(result);
+                      local_get(i); i64_const(1); i64_add; local_set(i);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(result);
                 });
+                self.scratch.free_i64(i);
+                self.scratch.free_i64(result);
+                self.scratch.free_i64(n);
+                self.scratch.free_i64(k);
             }
             "log_gamma" => {
                 self.emit_stub_call(args);

--- a/src/codegen/emit_wasm/calls_option.rs
+++ b/src/codegen/emit_wasm/calls_option.rs
@@ -23,7 +23,7 @@ impl FuncCompiler<'_> {
                 // unwrap_or(opt, default) → T
                 // if opt != 0 then load *opt else default
                 let inner_ty = self.option_inner_ty(&args[0].ty);
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 let vt = values::ty_to_valtype(&inner_ty);
                 match vt {
@@ -71,22 +71,22 @@ impl FuncCompiler<'_> {
                         });
                     }
                 }
+                self.scratch.free_i32(s);
             }
             "map" => {
                 // map(opt, f) → Option[B]
-                // Use mem[4]=opt_ptr, mem[0]=closure to avoid scratch conflicts
                 let inner_ty = self.option_inner_ty(&args[0].ty);
-                let s = self.match_i32_base + self.match_depth;
-                // Store opt → mem[4]
-                wasm!(self.func, { i32_const(4); });
+                let opt = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let s = self.scratch.alloc_i32();
+                // Store opt
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // Store closure → mem[0]
-                wasm!(self.func, { i32_const(0); });
+                wasm!(self.func, { local_set(opt); });
+                // Store closure
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(4); i32_load(0); i32_eqz; // opt == 0?
+                    local_set(closure);
+                    local_get(opt); i32_eqz; // opt == 0?
                     if_i32;
                       i32_const(0); // none
                     else_;
@@ -99,14 +99,14 @@ impl FuncCompiler<'_> {
                     local_set(s);
                     local_get(s);
                     // env_ptr
-                    i32_const(0); i32_load(0); i32_load(4);
+                    local_get(closure); i32_load(4);
                     // Load inner value
-                    i32_const(4); i32_load(0);
+                    local_get(opt);
                 });
                 self.emit_load_at(&inner_ty, 0);
                 // table_idx
                 wasm!(self.func, {
-                    i32_const(0); i32_load(0); i32_load(0);
+                    local_get(closure); i32_load(0);
                 });
                 self.emit_closure_call(&inner_ty, &out_ty);
                 self.emit_store_at(&out_ty, 0);
@@ -114,86 +114,93 @@ impl FuncCompiler<'_> {
                       local_get(s);
                     end;
                 });
+                self.scratch.free_i32(s);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(opt);
             }
             "flat_map" => {
                 // flat_map(opt, f) → Option[B]
                 // if opt == 0 → 0; else → f(*opt) (f returns Option)
-                // Use mem[4]=opt_ptr, mem[0]=closure to avoid scratch local conflicts
                 let inner_ty = self.option_inner_ty(&args[0].ty);
-                // Store opt → mem[4]
-                wasm!(self.func, { i32_const(4); });
+                let opt = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                // Store opt
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // Store closure → mem[0]
-                wasm!(self.func, { i32_const(0); });
+                wasm!(self.func, { local_set(opt); });
+                // Store closure
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(4); i32_load(0); i32_eqz; // opt == 0?
+                    local_set(closure);
+                    local_get(opt); i32_eqz; // opt == 0?
                     if_i32;
                       i32_const(0);
                     else_;
-                      i32_const(0); i32_load(0); i32_load(4); // env
+                      local_get(closure); i32_load(4); // env
                 });
-                wasm!(self.func, { i32_const(4); i32_load(0); });
+                wasm!(self.func, { local_get(opt); });
                 self.emit_load_at(&inner_ty, 0);
                 wasm!(self.func, {
-                    i32_const(0); i32_load(0); i32_load(0); // table_idx
+                    local_get(closure); i32_load(0); // table_idx
                 });
                 // Result is i32 (Option ptr)
                 self.emit_closure_call(&inner_ty, &Ty::Unknown);
                 wasm!(self.func, { end; });
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(opt);
             }
             "flatten" => {
                 // flatten(opt) → Option[T]: if opt != 0 then *opt (which is also an Option ptr) else 0
+                let s = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(self.match_i32_base + self.match_depth);
-                    local_get(self.match_i32_base + self.match_depth); i32_eqz;
+                    local_set(s);
+                    local_get(s); i32_eqz;
                     if_i32;
                       i32_const(0);
                     else_;
-                      local_get(self.match_i32_base + self.match_depth);
+                      local_get(s);
                       i32_load(0); // inner Option ptr
                     end;
                 });
+                self.scratch.free_i32(s);
             }
             "filter" => {
                 // filter(opt, pred) → Option[T]
                 // if opt == 0 → 0; else if pred(*opt) → opt; else → 0
-                // Use mem[4]=opt_ptr, mem[0]=closure to avoid scratch local conflicts
                 let inner_ty = self.option_inner_ty(&args[0].ty);
-                // Store opt → mem[4]
-                wasm!(self.func, { i32_const(4); });
+                let opt = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                // Store opt
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // Store closure → mem[0]
-                wasm!(self.func, { i32_const(0); });
+                wasm!(self.func, { local_set(opt); });
+                // Store closure
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(4); i32_load(0); i32_eqz; // opt == 0?
+                    local_set(closure);
+                    local_get(opt); i32_eqz; // opt == 0?
                     if_i32;
                       i32_const(0);
                     else_;
                       // Call pred(*opt)
-                      i32_const(0); i32_load(0); i32_load(4); // env
+                      local_get(closure); i32_load(4); // env
                 });
-                wasm!(self.func, { i32_const(4); i32_load(0); });
+                wasm!(self.func, { local_get(opt); });
                 self.emit_load_at(&inner_ty, 0);
                 wasm!(self.func, {
-                    i32_const(0); i32_load(0); i32_load(0); // table_idx
+                    local_get(closure); i32_load(0); // table_idx
                 });
                 self.emit_closure_call(&inner_ty, &Ty::Bool);
                 // Result is Bool(i32): if true return opt, else 0
                 wasm!(self.func, {
                       if_i32;
-                        i32_const(4); i32_load(0);
+                        local_get(opt);
                       else_;
                         i32_const(0);
                       end;
                     end;
                 });
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(opt);
             }
             "to_result" => {
                 // to_result(opt, err_msg) → Result[T, String]
@@ -203,7 +210,8 @@ impl FuncCompiler<'_> {
                 let inner_size = values::byte_size(&inner_ty);
                 let err_size = values::byte_size(&Ty::String);
                 let alloc_size = 4 + inner_size.max(err_size);
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(s);
@@ -212,145 +220,152 @@ impl FuncCompiler<'_> {
                       // err(err_msg)
                       i32_const((4 + err_size) as i32);
                       call(self.emitter.rt.alloc);
-                      local_set(s + 1);
-                      local_get(s + 1); i32_const(1); i32_store(0); // tag=1
-                      local_get(s + 1);
+                      local_set(s2);
+                      local_get(s2); i32_const(1); i32_store(0); // tag=1
+                      local_get(s2);
                 });
                 self.emit_expr(&args[1]); // err_msg
                 wasm!(self.func, {
                       i32_store(4);
-                      local_get(s + 1);
+                      local_get(s2);
                     else_;
                       // ok(*opt)
                       i32_const(alloc_size as i32);
                       call(self.emitter.rt.alloc);
-                      local_set(s + 1);
-                      local_get(s + 1); i32_const(0); i32_store(0); // tag=0
-                      local_get(s + 1);
+                      local_set(s2);
+                      local_get(s2); i32_const(0); i32_store(0); // tag=0
+                      local_get(s2);
                       local_get(s);
                 });
                 self.emit_load_at(&inner_ty, 0);
                 self.emit_store_at(&inner_ty, 4);
                 wasm!(self.func, {
-                      local_get(s + 1);
+                      local_get(s2);
                     end;
                 });
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s);
             }
             "or_else" => {
                 // or_else(opt, f) → Option[T]: if opt != 0 then opt else f()
-                // Use mem[4]=opt_ptr, mem[0]=closure to avoid scratch local conflicts
-                // Store opt → mem[4]
-                wasm!(self.func, { i32_const(4); });
+                let opt = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                // Store opt
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // Store closure → mem[0]
-                wasm!(self.func, { i32_const(0); });
+                wasm!(self.func, { local_set(opt); });
+                // Store closure
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(4); i32_load(0); i32_eqz; // opt == 0?
+                    local_set(closure);
+                    local_get(opt); i32_eqz; // opt == 0?
                     if_i32;
                 });
                 // Call f() — thunk returning Option
                 wasm!(self.func, {
-                    i32_const(0); i32_load(0); i32_load(4); // env
-                    i32_const(0); i32_load(0); i32_load(0); // table_idx
+                    local_get(closure); i32_load(4); // env
+                    local_get(closure); i32_load(0); // table_idx
                 });
                 // call_indirect () → i32
                 let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
                 wasm!(self.func, {
                     call_indirect(ti, 0);
                     else_;
-                      i32_const(4); i32_load(0);
+                      local_get(opt);
                     end;
                 });
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(opt);
             }
             "unwrap_or_else" => {
                 // unwrap_or_else(opt, f) → T: if opt != 0 then *opt else f()
-                // Use mem[4]=opt_ptr, mem[0]=closure to avoid scratch local conflicts
                 let inner_ty = self.option_inner_ty(&args[0].ty);
                 let vt = values::ty_to_valtype(&inner_ty).unwrap_or(ValType::I32);
-                // Store opt → mem[4]
-                wasm!(self.func, { i32_const(4); });
+                let opt = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                // Store opt
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // Store closure → mem[0]
-                wasm!(self.func, { i32_const(0); });
+                wasm!(self.func, { local_set(opt); });
+                // Store closure
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(closure); });
                 match vt {
                     ValType::I64 => {
-                        wasm!(self.func, { i32_const(4); i32_load(0); i32_eqz; if_i64; });
+                        wasm!(self.func, { local_get(opt); i32_eqz; if_i64; });
                         // f()
                         wasm!(self.func, {
-                            i32_const(0); i32_load(0); i32_load(4);
-                            i32_const(0); i32_load(0); i32_load(0);
+                            local_get(closure); i32_load(4);
+                            local_get(closure); i32_load(0);
                         });
                         let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::I64]);
-                        wasm!(self.func, { call_indirect(ti, 0); else_; i32_const(4); i32_load(0); i64_load(0); end; });
+                        wasm!(self.func, { call_indirect(ti, 0); else_; local_get(opt); i64_load(0); end; });
                     }
                     ValType::F64 => {
-                        wasm!(self.func, { i32_const(4); i32_load(0); i32_eqz; if_f64; });
+                        wasm!(self.func, { local_get(opt); i32_eqz; if_f64; });
                         wasm!(self.func, {
-                            i32_const(0); i32_load(0); i32_load(4);
-                            i32_const(0); i32_load(0); i32_load(0);
+                            local_get(closure); i32_load(4);
+                            local_get(closure); i32_load(0);
                         });
                         let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::F64]);
-                        wasm!(self.func, { call_indirect(ti, 0); else_; i32_const(4); i32_load(0); f64_load(0); end; });
+                        wasm!(self.func, { call_indirect(ti, 0); else_; local_get(opt); f64_load(0); end; });
                     }
                     _ => {
-                        wasm!(self.func, { i32_const(4); i32_load(0); i32_eqz; if_i32; });
+                        wasm!(self.func, { local_get(opt); i32_eqz; if_i32; });
                         wasm!(self.func, {
-                            i32_const(0); i32_load(0); i32_load(4);
-                            i32_const(0); i32_load(0); i32_load(0);
+                            local_get(closure); i32_load(4);
+                            local_get(closure); i32_load(0);
                         });
                         let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
-                        wasm!(self.func, { call_indirect(ti, 0); else_; i32_const(4); i32_load(0); i32_load(0); end; });
+                        wasm!(self.func, { call_indirect(ti, 0); else_; local_get(opt); i32_load(0); end; });
                     }
                 }
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(opt);
             }
             "to_list" => {
                 // to_list(opt) → List[T]: some(x) → [x], none → []
                 let inner_ty = self.option_inner_ty(&args[0].ty);
                 let elem_size = values::byte_size(&inner_ty);
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(s);
                     local_get(s); i32_eqz;
                     if_i32;
                       // empty list: [len=0]
-                      i32_const(4); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1); i32_const(0); i32_store(0);
-                      local_get(s + 1);
+                      i32_const(4); call(self.emitter.rt.alloc); local_set(s2);
+                      local_get(s2); i32_const(0); i32_store(0);
+                      local_get(s2);
                     else_;
                       // [len=1, elem]
-                      i32_const((4 + elem_size) as i32); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1); i32_const(1); i32_store(0);
-                      local_get(s + 1);
+                      i32_const((4 + elem_size) as i32); call(self.emitter.rt.alloc); local_set(s2);
+                      local_get(s2); i32_const(1); i32_store(0);
+                      local_get(s2);
                       local_get(s);
                 });
                 self.emit_load_at(&inner_ty, 0);
                 self.emit_store_at(&inner_ty, 4);
                 wasm!(self.func, {
-                      local_get(s + 1);
+                      local_get(s2);
                     end;
                 });
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s);
             }
             "zip" => {
                 // zip(a, b) → Option[(A,B)]
                 // if a == 0 || b == 0 → 0; else → some((*a, *b))
-                let s = self.match_i32_base + self.match_depth;
-                // Reserve scratch locals so emitting args doesn't collide
-                self.match_depth += 4;
+                let sa = self.scratch.alloc_i32();
+                let sb = self.scratch.alloc_i32();
+                let s_tuple = self.scratch.alloc_i32();
+                let s_some = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); });
+                wasm!(self.func, { local_set(sa); });
                 self.emit_expr(&args[1]);
-                self.match_depth -= 4;
                 wasm!(self.func, {
-                    local_set(s + 1);
-                    local_get(s); i32_eqz;
-                    local_get(s + 1); i32_eqz;
+                    local_set(sb);
+                    local_get(sa); i32_eqz;
+                    local_get(sb); i32_eqz;
                     i32_or;
                     if_i32;
                       i32_const(0);
@@ -365,25 +380,29 @@ impl FuncCompiler<'_> {
                 // Tuple ptr
                 wasm!(self.func, {
                     i32_const(tuple_size as i32); call(self.emitter.rt.alloc);
-                    local_set(s + 2);
-                    local_get(s + 2);
-                    local_get(s);
+                    local_set(s_tuple);
+                    local_get(s_tuple);
+                    local_get(sa);
                 });
                 self.emit_load_at(&a_ty, 0);
                 self.emit_store_at(&a_ty, 0);
-                wasm!(self.func, { local_get(s + 2); local_get(s + 1); });
+                wasm!(self.func, { local_get(s_tuple); local_get(sb); });
                 self.emit_load_at(&b_ty, 0);
                 self.emit_store_at(&b_ty, a_size as u32);
                 // Wrap tuple in Some: alloc ptr-size, store tuple ptr
                 wasm!(self.func, {
                     i32_const(4); call(self.emitter.rt.alloc);
-                    local_set(s + 3);
-                    local_get(s + 3);
-                    local_get(s + 2);
+                    local_set(s_some);
+                    local_get(s_some);
+                    local_get(s_tuple);
                     i32_store(0);
-                    local_get(s + 3);
+                    local_get(s_some);
                     end;
                 });
+                self.scratch.free_i32(s_some);
+                self.scratch.free_i32(s_tuple);
+                self.scratch.free_i32(sb);
+                self.scratch.free_i32(sa);
             }
             _ => return false,
         }
@@ -404,7 +423,7 @@ impl FuncCompiler<'_> {
             "unwrap_or" => {
                 // unwrap_or(result, default) → T
                 let inner_ty = self.result_ok_ty(&args[0].ty);
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 let vt = values::ty_to_valtype(&inner_ty).unwrap_or(ValType::I32);
                 match vt {
@@ -424,26 +443,26 @@ impl FuncCompiler<'_> {
                         wasm!(self.func, { end; });
                     }
                 }
+                self.scratch.free_i32(s);
             }
             "map" => {
                 // map(result, f) → Result[B, E]
-                // Use mem[4]=result_ptr, mem[0]=closure to avoid scratch local conflicts
                 let ok_ty = self.result_ok_ty(&args[0].ty);
-                let s = self.match_i32_base + self.match_depth;
-                // Store result → mem[4]
-                wasm!(self.func, { i32_const(4); });
+                let result = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let s = self.scratch.alloc_i32();
+                // Store result
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // Store closure → mem[0]
-                wasm!(self.func, { i32_const(0); });
+                wasm!(self.func, { local_set(result); });
+                // Store closure
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
+                    local_set(closure);
                     // Check tag
-                    i32_const(4); i32_load(0); // result_ptr
+                    local_get(result); // result_ptr
                     i32_load(0); i32_const(0); i32_ne; // tag != 0 (err?)
                     if_i32;
-                      i32_const(4); i32_load(0); // return err as-is
+                      local_get(result); // return err as-is
                     else_;
                 });
                 let out_ty = self.fn_ret_ty(&args[1].ty);
@@ -454,35 +473,37 @@ impl FuncCompiler<'_> {
                     local_get(s); i32_const(0); i32_store(0); // tag=0
                     local_get(s);
                     // env
-                    i32_const(0); i32_load(0); i32_load(4);
+                    local_get(closure); i32_load(4);
                     // Load ok value from result
-                    i32_const(4); i32_load(0);
+                    local_get(result);
                 });
                 self.emit_load_at(&ok_ty, 4);
                 // table_idx
-                wasm!(self.func, { i32_const(0); i32_load(0); i32_load(0); });
+                wasm!(self.func, { local_get(closure); i32_load(0); });
                 self.emit_closure_call(&ok_ty, &out_ty);
                 self.emit_store_at(&out_ty, 4);
                 wasm!(self.func, { local_get(s); end; });
+                self.scratch.free_i32(s);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(result);
             }
             "map_err" => {
                 // map_err(result, f) → Result[T, F]
-                // Use mem[4]=result_ptr, mem[0]=closure to avoid scratch local conflicts
                 let err_ty = self.result_err_ty(&args[0].ty);
-                let s = self.match_i32_base + self.match_depth;
-                // Store result → mem[4]
-                wasm!(self.func, { i32_const(4); });
+                let result = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                let s = self.scratch.alloc_i32();
+                // Store result
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // Store closure → mem[0]
-                wasm!(self.func, { i32_const(0); });
+                wasm!(self.func, { local_set(result); });
+                // Store closure
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(4); i32_load(0); // result_ptr
+                    local_set(closure);
+                    local_get(result); // result_ptr
                     i32_load(0); i32_eqz; // tag==0 (ok?)
                     if_i32;
-                      i32_const(4); i32_load(0); // return ok as-is
+                      local_get(result); // return ok as-is
                     else_;
                 });
                 let out_ty = self.fn_ret_ty(&args[1].ty);
@@ -491,47 +512,52 @@ impl FuncCompiler<'_> {
                     i32_const((4 + out_size) as i32); call(self.emitter.rt.alloc); local_set(s);
                     local_get(s); i32_const(1); i32_store(0); // tag=1 (err)
                     local_get(s);
-                    i32_const(0); i32_load(0); i32_load(4); // env
+                    local_get(closure); i32_load(4); // env
                 });
-                wasm!(self.func, { i32_const(4); i32_load(0); });
+                wasm!(self.func, { local_get(result); });
                 self.emit_load_at(&err_ty, 4);
-                wasm!(self.func, { i32_const(0); i32_load(0); i32_load(0); });
+                wasm!(self.func, { local_get(closure); i32_load(0); });
                 self.emit_closure_call(&err_ty, &out_ty);
                 self.emit_store_at(&out_ty, 4);
                 wasm!(self.func, { local_get(s); end; });
+                self.scratch.free_i32(s);
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(result);
             }
             "flat_map" => {
                 // flat_map(result, f) → Result[B, E]
-                // Use mem[4]=result_ptr, mem[0]=closure to avoid scratch local conflicts
                 let ok_ty = self.result_ok_ty(&args[0].ty);
-                // Store result → mem[4]
-                wasm!(self.func, { i32_const(4); });
+                let result = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                // Store result
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // Store closure → mem[0]
-                wasm!(self.func, { i32_const(0); });
+                wasm!(self.func, { local_set(result); });
+                // Store closure
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(4); i32_load(0); // result_ptr
+                    local_set(closure);
+                    local_get(result); // result_ptr
                     i32_load(0); i32_const(0); i32_ne; // tag != 0 (err?)
                     if_i32;
-                      i32_const(4); i32_load(0); // return err as-is
+                      local_get(result); // return err as-is
                     else_;
-                      i32_const(0); i32_load(0); i32_load(4); // env
+                      local_get(closure); i32_load(4); // env
                 });
-                wasm!(self.func, { i32_const(4); i32_load(0); });
+                wasm!(self.func, { local_get(result); });
                 self.emit_load_at(&ok_ty, 4);
-                wasm!(self.func, { i32_const(0); i32_load(0); i32_load(0); });
+                wasm!(self.func, { local_get(closure); i32_load(0); });
                 // Returns Result ptr (i32)
                 self.emit_closure_call(&ok_ty, &Ty::Unknown);
                 wasm!(self.func, { end; });
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(result);
             }
             "to_option" => {
                 // to_option(result) → Option[T]: ok(x) → some(x), err(_) → none
                 let ok_ty = self.result_ok_ty(&args[0].ty);
                 let ok_size = values::byte_size(&ok_ty);
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(s);
@@ -540,18 +566,21 @@ impl FuncCompiler<'_> {
                       i32_const(0); // none
                     else_;
                       // some(ok_value)
-                      i32_const(ok_size as i32); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1);
+                      i32_const(ok_size as i32); call(self.emitter.rt.alloc); local_set(s2);
+                      local_get(s2);
                       local_get(s);
                 });
                 self.emit_load_at(&ok_ty, 4);
                 self.emit_store_at(&ok_ty, 0);
-                wasm!(self.func, { local_get(s + 1); end; });
+                wasm!(self.func, { local_get(s2); end; });
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s);
             }
             "to_err_option" => {
                 let err_ty = self.result_err_ty(&args[0].ty);
                 let err_size = values::byte_size(&err_ty);
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(s);
@@ -559,43 +588,46 @@ impl FuncCompiler<'_> {
                     if_i32;
                       i32_const(0); // none (was ok)
                     else_;
-                      i32_const(err_size as i32); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1);
+                      i32_const(err_size as i32); call(self.emitter.rt.alloc); local_set(s2);
+                      local_get(s2);
                       local_get(s);
                 });
                 self.emit_load_at(&err_ty, 4);
                 self.emit_store_at(&err_ty, 0);
-                wasm!(self.func, { local_get(s + 1); end; });
+                wasm!(self.func, { local_get(s2); end; });
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s);
             }
             "unwrap_or_else" => {
-                // Use mem[4]=result_ptr, mem[0]=closure to avoid scratch local conflicts
                 let ok_ty = self.result_ok_ty(&args[0].ty);
                 let vt = values::ty_to_valtype(&ok_ty).unwrap_or(ValType::I32);
-                // Store result → mem[4]
-                wasm!(self.func, { i32_const(4); });
+                let result = self.scratch.alloc_i32();
+                let closure = self.scratch.alloc_i32();
+                // Store result
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
-                // Store closure → mem[0]
-                wasm!(self.func, { i32_const(0); });
+                wasm!(self.func, { local_set(result); });
+                // Store closure
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(closure); });
                 match vt {
                     ValType::I64 => {
-                        wasm!(self.func, { i32_const(4); i32_load(0); i32_load(0); i32_eqz; if_i64; i32_const(4); i32_load(0); i64_load(4); else_; });
+                        wasm!(self.func, { local_get(result); i32_load(0); i32_eqz; if_i64; local_get(result); i64_load(4); else_; });
                         // f(err)
-                        wasm!(self.func, { i32_const(0); i32_load(0); i32_load(4); i32_const(4); i32_load(0); i32_load(4); i32_const(0); i32_load(0); i32_load(0); });
+                        wasm!(self.func, { local_get(closure); i32_load(4); local_get(result); i32_load(4); local_get(closure); i32_load(0); });
                         let err_ty = self.result_err_ty(&args[0].ty);
                         self.emit_closure_call(&err_ty, &ok_ty);
                         wasm!(self.func, { end; });
                     }
                     _ => {
-                        wasm!(self.func, { i32_const(4); i32_load(0); i32_load(0); i32_eqz; if_i32; i32_const(4); i32_load(0); i32_load(4); else_; });
-                        wasm!(self.func, { i32_const(0); i32_load(0); i32_load(4); i32_const(4); i32_load(0); i32_load(4); i32_const(0); i32_load(0); i32_load(0); });
+                        wasm!(self.func, { local_get(result); i32_load(0); i32_eqz; if_i32; local_get(result); i32_load(4); else_; });
+                        wasm!(self.func, { local_get(closure); i32_load(4); local_get(result); i32_load(4); local_get(closure); i32_load(0); });
                         let err_ty = self.result_err_ty(&args[0].ty);
                         self.emit_closure_call(&err_ty, &ok_ty);
                         wasm!(self.func, { end; });
                     }
                 }
+                self.scratch.free_i32(closure);
+                self.scratch.free_i32(result);
             }
             _ => return false,
         }

--- a/src/codegen/emit_wasm/calls_set.rs
+++ b/src/codegen/emit_wasm/calls_set.rs
@@ -13,12 +13,13 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_set_call(&mut self, method: &str, args: &[IrExpr]) -> bool {
         match method {
             "new" => {
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_const(4); call(self.emitter.rt.alloc); local_set(s);
                     local_get(s); i32_const(0); i32_store(0);
                     local_get(s);
                 });
+                self.scratch.free_i32(s);
             }
             "len" | "size" => {
                 self.emit_expr(&args[0]);
@@ -32,114 +33,126 @@ impl FuncCompiler<'_> {
                 // from_list(xs) → Set[A]: copy list, dedup
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
+                let s3 = self.scratch.alloc_i32();
+                let xs = self.scratch.alloc_i32();
                 // Start with empty set
                 wasm!(self.func, {
                     i32_const(4); call(self.emitter.rt.alloc); local_set(s);
                     local_get(s); i32_const(0); i32_store(0);
-                    i32_const(0);
                 });
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i32_store(0); // mem[0] = xs
-                    i32_const(0); local_set(s + 1); // i
+                    local_set(xs); // xs
+                    i32_const(0); local_set(s1); // i
                     block_empty; loop_empty;
-                      local_get(s + 1); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(s1); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
                       // Check if elem already in set
-                      i32_const(0); local_set(s + 2); // j
-                      i32_const(0); local_set(s + 3); // found
+                      i32_const(0); local_set(s2); // j
+                      i32_const(0); local_set(s3); // found
                       block_empty; loop_empty;
-                        local_get(s + 2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(s2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
                         local_get(s); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(es); i32_mul; i32_add;
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(s1); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
-                        if_empty; i32_const(1); local_set(s + 3); br(2); end;
-                        local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                        if_empty; i32_const(1); local_set(s3); br(2); end;
+                        local_get(s2); i32_const(1); i32_add; local_set(s2);
                         br(0);
                       end; end;
                       // If not found, append
-                      local_get(s + 3); i32_eqz;
+                      local_get(s3); i32_eqz;
                       if_empty;
                         // Grow set: alloc new with len+1
                         i32_const(4); local_get(s); i32_load(0); i32_const(1); i32_add;
                         i32_const(es); i32_mul; i32_add;
-                        call(self.emitter.rt.alloc); local_set(s + 2);
-                        local_get(s + 2); local_get(s); i32_load(0); i32_const(1); i32_add; i32_store(0);
+                        call(self.emitter.rt.alloc); local_set(s2);
+                        local_get(s2); local_get(s); i32_load(0); i32_const(1); i32_add; i32_store(0);
                         // Copy old elements
-                        i32_const(0); local_set(s + 3);
+                        i32_const(0); local_set(s3);
                         block_empty; loop_empty;
-                          local_get(s + 3); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                          local_get(s + 2); i32_const(4); i32_add;
-                          local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                          local_get(s3); local_get(s); i32_load(0); i32_ge_u; br_if(1);
+                          local_get(s2); i32_const(4); i32_add;
+                          local_get(s3); i32_const(es); i32_mul; i32_add;
                           local_get(s); i32_const(4); i32_add;
-                          local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                          local_get(s3); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                          local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                          local_get(s3); i32_const(1); i32_add; local_set(s3);
                           br(0);
                         end; end;
                         // Append new element
-                        local_get(s + 2); i32_const(4); i32_add;
+                        local_get(s2); i32_const(4); i32_add;
                         local_get(s); i32_load(0); i32_const(es); i32_mul; i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(es); i32_mul; i32_add;
+                        local_get(xs); i32_const(4); i32_add;
+                        local_get(s1); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 2); local_set(s);
+                        local_get(s2); local_set(s);
                       end;
-                      local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                      local_get(s1); i32_const(1); i32_add; local_set(s1);
                       br(0);
                     end; end;
                     local_get(s);
                 });
+                self.scratch.free_i32(xs);
+                self.scratch.free_i32(s3);
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "contains" => {
                 let elem_ty = self.set_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s); });
                 match values::ty_to_valtype(&elem_ty) {
                     Some(ValType::I64) => {
-                        let s64 = self.match_i64_base + self.match_depth;
+                        let s64 = self.scratch.alloc_i64();
                         self.emit_expr(&args[1]);
                         wasm!(self.func, {
                             local_set(s64);
-                            i32_const(0); local_set(s + 1);
-                            i32_const(0); local_set(s + 2);
+                            i32_const(0); local_set(s1);
+                            i32_const(0); local_set(s2);
                             block_empty; loop_empty;
-                              local_get(s + 1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
+                              local_get(s1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
                               local_get(s); i32_const(4); i32_add;
-                              local_get(s + 1); i32_const(es); i32_mul; i32_add;
+                              local_get(s1); i32_const(es); i32_mul; i32_add;
                               i64_load(0); local_get(s64); i64_eq;
-                              if_empty; i32_const(1); local_set(s + 2); br(2); end;
-                              local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                              if_empty; i32_const(1); local_set(s2); br(2); end;
+                              local_get(s1); i32_const(1); i32_add; local_set(s1);
                               br(0);
                             end; end;
-                            local_get(s + 2);
+                            local_get(s2);
                         });
+                        self.scratch.free_i64(s64);
                     }
                     _ => {
+                        let s3 = self.scratch.alloc_i32();
                         self.emit_expr(&args[1]);
                         wasm!(self.func, {
-                            local_set(s + 3);
-                            i32_const(0); local_set(s + 1);
-                            i32_const(0); local_set(s + 2);
+                            local_set(s3);
+                            i32_const(0); local_set(s1);
+                            i32_const(0); local_set(s2);
                             block_empty; loop_empty;
-                              local_get(s + 1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
+                              local_get(s1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
                               local_get(s); i32_const(4); i32_add;
-                              local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                              i32_load(0); local_get(s + 3);
+                              local_get(s1); i32_const(es); i32_mul; i32_add;
+                              i32_load(0); local_get(s3);
                         });
                         if matches!(&elem_ty, Ty::String) {
                             wasm!(self.func, { call(self.emitter.rt.string.eq); });
@@ -147,174 +160,202 @@ impl FuncCompiler<'_> {
                             wasm!(self.func, { i32_eq; });
                         }
                         wasm!(self.func, {
-                              if_empty; i32_const(1); local_set(s + 2); br(2); end;
-                              local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                              if_empty; i32_const(1); local_set(s2); br(2); end;
+                              local_get(s1); i32_const(1); i32_add; local_set(s1);
                               br(0);
                             end; end;
-                            local_get(s + 2);
+                            local_get(s2);
                         });
+                        self.scratch.free_i32(s3);
                     }
                 }
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "insert" => {
                 let elem_ty = self.set_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
+                let val = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); i32_const(0); });
+                wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
-                self.emit_store_at(&elem_ty, 0); // mem[0] = val
+                wasm!(self.func, { local_set(val); });
                 wasm!(self.func, {
-                    i32_const(0); local_set(s + 1); // i
-                    i32_const(0); local_set(s + 2); // found
+                    i32_const(0); local_set(s1); // i
+                    i32_const(0); local_set(s2); // found
                     block_empty; loop_empty;
-                      local_get(s + 1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(s1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
                       local_get(s); i32_const(4); i32_add;
-                      local_get(s + 1); i32_const(es); i32_mul; i32_add;
+                      local_get(s1); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { i32_const(0); });
-                self.emit_load_at(&elem_ty, 0);
+                wasm!(self.func, { local_get(val); });
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
-                      if_empty; i32_const(1); local_set(s + 2); br(2); end;
-                      local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                      if_empty; i32_const(1); local_set(s2); br(2); end;
+                      local_get(s1); i32_const(1); i32_add; local_set(s1);
                       br(0);
                     end; end;
-                    local_get(s + 2);
+                    local_get(s2);
                     if_i32; local_get(s);
                     else_;
                       i32_const(4); local_get(s); i32_load(0); i32_const(1); i32_add;
                       i32_const(es); i32_mul; i32_add;
-                      call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1); local_get(s); i32_load(0); i32_const(1); i32_add; i32_store(0);
-                      i32_const(0); local_set(s + 2);
+                      call(self.emitter.rt.alloc); local_set(s1);
+                      local_get(s1); local_get(s); i32_load(0); i32_const(1); i32_add; i32_store(0);
+                      i32_const(0); local_set(s2);
                       block_empty; loop_empty;
-                        local_get(s + 2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(s + 1); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(s2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(s1); i32_const(4); i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                         local_get(s); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                        local_get(s2); i32_const(1); i32_add; local_set(s2);
                         br(0);
                       end; end;
-                      local_get(s + 1); i32_const(4); i32_add;
+                      local_get(s1); i32_const(4); i32_add;
                       local_get(s); i32_load(0); i32_const(es); i32_mul; i32_add;
-                      i32_const(0);
+                      local_get(val);
                 });
-                self.emit_load_at(&elem_ty, 0);
                 self.emit_store_at(&elem_ty, 0);
-                wasm!(self.func, { local_get(s + 1); end; });
+                wasm!(self.func, { local_get(s1); end; });
+                self.scratch.free_i32(val);
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "remove" => {
                 let elem_ty = self.set_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
+                let s3 = self.scratch.alloc_i32();
+                let val = self.scratch.alloc_i32();
+                let orig = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); i32_const(0); });
+                wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
-                self.emit_store_at(&elem_ty, 0); // mem[0] = val
+                wasm!(self.func, { local_set(val); });
                 wasm!(self.func, {
-                    i32_const(-1); local_set(s + 1); // found_idx
-                    i32_const(0); local_set(s + 2);
+                    i32_const(-1); local_set(s1); // found_idx
+                    i32_const(0); local_set(s2);
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(s2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
                       local_get(s); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                      local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { i32_const(0); });
-                self.emit_load_at(&elem_ty, 0);
+                wasm!(self.func, { local_get(val); });
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
-                      if_empty; local_get(s + 2); local_set(s + 1); br(2); end;
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      if_empty; local_get(s2); local_set(s1); br(2); end;
+                      local_get(s2); i32_const(1); i32_add; local_set(s2);
                       br(0);
                     end; end;
-                    local_get(s + 1); i32_const(0); i32_lt_s;
+                    local_get(s1); i32_const(0); i32_lt_s;
                     if_i32; local_get(s); // not found
                     else_;
-                      // Store original set ptr at mem[4]
-                      i32_const(4); local_get(s); i32_store(0);
-                      i32_const(4); i32_const(4); i32_load(0); i32_load(0); i32_const(1); i32_sub;
+                      // Store original set ptr
+                      local_get(s); local_set(orig);
+                      i32_const(4); local_get(orig); i32_load(0); i32_const(1); i32_sub;
                       i32_const(es); i32_mul; i32_add;
-                      call(self.emitter.rt.alloc); local_set(s + 2);
-                      local_get(s + 2);
-                      i32_const(4); i32_load(0); i32_load(0); i32_const(1); i32_sub;
+                      call(self.emitter.rt.alloc); local_set(s2);
+                      local_get(s2);
+                      local_get(orig); i32_load(0); i32_const(1); i32_sub;
                       i32_store(0);
-                      i32_const(0); local_set(s + 3); // src_i
+                      i32_const(0); local_set(s3); // src_i
                       i32_const(0); local_set(s);     // dst_i
                       block_empty; loop_empty;
-                        local_get(s + 3);
-                        i32_const(4); i32_load(0); i32_load(0); // original len
+                        local_get(s3);
+                        local_get(orig); i32_load(0); // original len
                         i32_ge_u; br_if(1);
-                        local_get(s + 3); local_get(s + 1); i32_ne;
+                        local_get(s3); local_get(s1); i32_ne;
                         if_empty;
-                          local_get(s + 2); i32_const(4); i32_add;
+                          local_get(s2); i32_const(4); i32_add;
                           local_get(s); i32_const(es); i32_mul; i32_add;
-                          i32_const(4); i32_load(0); i32_const(4); i32_add;
-                          local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                          local_get(orig); i32_const(4); i32_add;
+                          local_get(s3); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
                           local_get(s); i32_const(1); i32_add; local_set(s);
                         end;
-                        local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                        local_get(s3); i32_const(1); i32_add; local_set(s3);
                         br(0);
                       end; end;
-                      local_get(s + 2);
+                      local_get(s2);
                     end;
                 });
+                self.scratch.free_i32(orig);
+                self.scratch.free_i32(val);
+                self.scratch.free_i32(s3);
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "union" => {
                 let elem_ty = self.set_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
+                let s3 = self.scratch.alloc_i32();
+                let b = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); i32_const(0); });
+                wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0); // mem[0] = b
-                    local_get(s); i32_load(0); local_set(s + 1); // a_len
-                    i32_const(0); i32_load(0); i32_load(0); local_set(s + 2); // b_len
-                    i32_const(4); local_get(s + 1); local_get(s + 2); i32_add;
+                    local_set(b); // b
+                    local_get(s); i32_load(0); local_set(s1); // a_len
+                    local_get(b); i32_load(0); local_set(s2); // b_len
+                    i32_const(4); local_get(s1); local_get(s2); i32_add;
                     i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s + 3);
-                    local_get(s + 3); local_get(s + 1); local_get(s + 2); i32_add; i32_store(0);
+                    call(self.emitter.rt.alloc); local_set(s3);
+                    local_get(s3); local_get(s1); local_get(s2); i32_add; i32_store(0);
                     // Copy a
-                    i32_const(0); local_set(s + 2); // i
+                    i32_const(0); local_set(s2); // i
                     block_empty; loop_empty;
-                      local_get(s + 2); local_get(s + 1); i32_ge_u; br_if(1);
-                      local_get(s + 3); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                      local_get(s2); local_get(s1); i32_ge_u; br_if(1);
+                      local_get(s3); i32_const(4); i32_add;
+                      local_get(s2); i32_const(es); i32_mul; i32_add;
                       local_get(s); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                      local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(s2); i32_const(1); i32_add; local_set(s2);
                       br(0);
                     end; end;
                     // Copy b
-                    i32_const(0); local_set(s + 2);
+                    i32_const(0); local_set(s2);
                     block_empty; loop_empty;
-                      local_get(s + 2); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(s + 3); i32_const(4); i32_add;
-                      local_get(s + 1); local_get(s + 2); i32_add;
+                      local_get(s2); local_get(b); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(s3); i32_const(4); i32_add;
+                      local_get(s1); local_get(s2); i32_add;
                       i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                      local_get(b); i32_const(4); i32_add;
+                      local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(s2); i32_const(1); i32_add; local_set(s2);
                       br(0);
                     end; end;
-                    local_get(s + 3);
+                    local_get(s3);
                 });
+                self.scratch.free_i32(b);
+                self.scratch.free_i32(s3);
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "to_list" => {
                 // Set has same layout as List — just return the ptr
@@ -324,314 +365,360 @@ impl FuncCompiler<'_> {
                 // intersection(a, b) → Set[A]: elements in both a and b.
                 // For each a[i], scan b for a match. Use j as loop counter;
                 // after inner loop, j < b.len means we found a match (broke early).
-                // Locals: s=result, s+1=out_count, s+2=i, s+3=j
+                // Locals: s=result, s1=out_count, s2=i, s3=j
                 let elem_ty = self.set_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0]=a, mem[4]=b
-                wasm!(self.func, { i32_const(0); });
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
+                let s3 = self.scratch.alloc_i32();
+                let a = self.scratch.alloc_i32();
+                let b = self.scratch.alloc_i32();
+                // a, b
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(a); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
+                    local_set(b);
                     // result = alloc(4 + a.len * es)
-                    i32_const(4); i32_const(0); i32_load(0); i32_load(0);
+                    i32_const(4); local_get(a); i32_load(0);
                     i32_const(es); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(s);
-                    i32_const(0); local_set(s + 1); // out_count
-                    i32_const(0); local_set(s + 2); // i
+                    i32_const(0); local_set(s1); // out_count
+                    i32_const(0); local_set(s2); // i
                     block_empty; loop_empty;
-                      local_get(s + 2); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(s2); local_get(a); i32_load(0); i32_ge_u; br_if(1);
                       // Inner: scan b for a[i]
-                      i32_const(0); local_set(s + 3); // j
+                      i32_const(0); local_set(s3); // j
                       block_empty; loop_empty;
-                        local_get(s + 3); i32_const(4); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(s3); local_get(b); i32_load(0); i32_ge_u; br_if(1);
                         // Load a[i]
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(a); i32_const(4); i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
                         // Load b[j]
-                        i32_const(4); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                        local_get(b); i32_const(4); i32_add;
+                        local_get(s3); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1); // found → break out of inner loop
-                        local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                        local_get(s3); i32_const(1); i32_add; local_set(s3);
                         br(0);
                       end; end;
                       // After inner loop: j < b.len means found
-                      local_get(s + 3); i32_const(4); i32_load(0); i32_load(0); i32_lt_u;
+                      local_get(s3); local_get(b); i32_load(0); i32_lt_u;
                       if_empty;
                         // Copy a[i] to result[out_count]
                         local_get(s); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(s1); i32_const(es); i32_mul; i32_add;
+                        local_get(a); i32_const(4); i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                        local_get(s1); i32_const(1); i32_add; local_set(s1);
                       end;
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(s2); i32_const(1); i32_add; local_set(s2);
                       br(0);
                     end; end;
-                    local_get(s); local_get(s + 1); i32_store(0);
+                    local_get(s); local_get(s1); i32_store(0);
                     local_get(s);
                 });
+                self.scratch.free_i32(b);
+                self.scratch.free_i32(a);
+                self.scratch.free_i32(s3);
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "difference" => {
                 // difference(a, b) → Set[A]: elements in a but not in b.
-                // Locals: s=result, s+1=out_count, s+2=i, s+3=j
+                // Locals: s=result, s1=out_count, s2=i, s3=j
                 let elem_ty = self.set_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
+                let s3 = self.scratch.alloc_i32();
+                let a = self.scratch.alloc_i32();
+                let b = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(a); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(4); i32_const(0); i32_load(0); i32_load(0);
+                    local_set(b);
+                    i32_const(4); local_get(a); i32_load(0);
                     i32_const(es); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(s);
-                    i32_const(0); local_set(s + 1);
-                    i32_const(0); local_set(s + 2);
+                    i32_const(0); local_set(s1);
+                    i32_const(0); local_set(s2);
                     block_empty; loop_empty;
-                      local_get(s + 2); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(s + 3); // j
+                      local_get(s2); local_get(a); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(0); local_set(s3); // j
                       block_empty; loop_empty;
-                        local_get(s + 3); i32_const(4); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(s3); local_get(b); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(a); i32_const(4); i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        i32_const(4); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                        local_get(b); i32_const(4); i32_add;
+                        local_get(s3); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1); // found → break
-                        local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                        local_get(s3); i32_const(1); i32_add; local_set(s3);
                         br(0);
                       end; end;
                       // j >= b.len means NOT found → keep element
-                      local_get(s + 3); i32_const(4); i32_load(0); i32_load(0); i32_ge_u;
+                      local_get(s3); local_get(b); i32_load(0); i32_ge_u;
                       if_empty;
                         local_get(s); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(s1); i32_const(es); i32_mul; i32_add;
+                        local_get(a); i32_const(4); i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                        local_get(s1); i32_const(1); i32_add; local_set(s1);
                       end;
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(s2); i32_const(1); i32_add; local_set(s2);
                       br(0);
                     end; end;
-                    local_get(s); local_get(s + 1); i32_store(0);
+                    local_get(s); local_get(s1); i32_store(0);
                     local_get(s);
                 });
+                self.scratch.free_i32(b);
+                self.scratch.free_i32(a);
+                self.scratch.free_i32(s3);
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "symmetric_difference" => {
                 // symmetric_difference(a, b) = difference(a,b) ∪ difference(b,a)
                 // Two passes, collecting into one result buffer.
-                // Locals: s=result, s+1=out_count, s+2=i, s+3=j
+                // Locals: s=result, s1=out_count, s2=i, s3=j
                 let elem_ty = self.set_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                // mem[0]=a, mem[4]=b
-                wasm!(self.func, { i32_const(0); });
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
+                let s3 = self.scratch.alloc_i32();
+                let a = self.scratch.alloc_i32();
+                let b = self.scratch.alloc_i32();
+                // a, b
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(a); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
+                    local_set(b);
                     // result = alloc(4 + (a.len + b.len) * es)
                     i32_const(4);
-                    i32_const(0); i32_load(0); i32_load(0);
-                    i32_const(4); i32_load(0); i32_load(0);
+                    local_get(a); i32_load(0);
+                    local_get(b); i32_load(0);
                     i32_add; i32_const(es); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(s);
-                    i32_const(0); local_set(s + 1); // out_count
+                    i32_const(0); local_set(s1); // out_count
                 });
                 // Pass 1: elements of a not in b
                 wasm!(self.func, {
-                    i32_const(0); local_set(s + 2);
+                    i32_const(0); local_set(s2);
                     block_empty; loop_empty;
-                      local_get(s + 2); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(s + 3);
+                      local_get(s2); local_get(a); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(0); local_set(s3);
                       block_empty; loop_empty;
-                        local_get(s + 3); i32_const(4); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(s3); local_get(b); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(a); i32_const(4); i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        i32_const(4); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                        local_get(b); i32_const(4); i32_add;
+                        local_get(s3); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1);
-                        local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                        local_get(s3); i32_const(1); i32_add; local_set(s3);
                         br(0);
                       end; end;
-                      local_get(s + 3); i32_const(4); i32_load(0); i32_load(0); i32_ge_u;
+                      local_get(s3); local_get(b); i32_load(0); i32_ge_u;
                       if_empty;
                         local_get(s); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(s1); i32_const(es); i32_mul; i32_add;
+                        local_get(a); i32_const(4); i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                        local_get(s1); i32_const(1); i32_add; local_set(s1);
                       end;
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(s2); i32_const(1); i32_add; local_set(s2);
                       br(0);
                     end; end;
                 });
                 // Pass 2: elements of b not in a
                 wasm!(self.func, {
-                    i32_const(0); local_set(s + 2);
+                    i32_const(0); local_set(s2);
                     block_empty; loop_empty;
-                      local_get(s + 2); i32_const(4); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(s + 3);
+                      local_get(s2); local_get(b); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(0); local_set(s3);
                       block_empty; loop_empty;
-                        local_get(s + 3); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                        i32_const(4); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(s3); local_get(a); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(b); i32_const(4); i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 3); i32_const(es); i32_mul; i32_add;
+                        local_get(a); i32_const(4); i32_add;
+                        local_get(s3); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1);
-                        local_get(s + 3); i32_const(1); i32_add; local_set(s + 3);
+                        local_get(s3); i32_const(1); i32_add; local_set(s3);
                         br(0);
                       end; end;
-                      local_get(s + 3); i32_const(0); i32_load(0); i32_load(0); i32_ge_u;
+                      local_get(s3); local_get(a); i32_load(0); i32_ge_u;
                       if_empty;
                         local_get(s); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(es); i32_mul; i32_add;
-                        i32_const(4); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(s1); i32_const(es); i32_mul; i32_add;
+                        local_get(b); i32_const(4); i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                        local_get(s1); i32_const(1); i32_add; local_set(s1);
                       end;
-                      local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                      local_get(s2); i32_const(1); i32_add; local_set(s2);
                       br(0);
                     end; end;
-                    local_get(s); local_get(s + 1); i32_store(0);
+                    local_get(s); local_get(s1); i32_store(0);
                     local_get(s);
                 });
+                self.scratch.free_i32(b);
+                self.scratch.free_i32(a);
+                self.scratch.free_i32(s3);
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "is_subset" => {
                 // is_subset(a, b) → Bool: all elements of a are in b.
-                // Locals: s=result, s+1=i, s+2=j. Use j sentinel: j < b.len = found.
+                // Locals: s=result, s1=i, s2=j. Use j sentinel: j < b.len = found.
                 let elem_ty = self.set_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
+                let a = self.scratch.alloc_i32();
+                let b = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(a); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
+                    local_set(b);
                     i32_const(1); local_set(s); // result = true
-                    i32_const(0); local_set(s + 1); // i
+                    i32_const(0); local_set(s1); // i
                     block_empty; loop_empty;
-                      local_get(s + 1); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(s + 2); // j
+                      local_get(s1); local_get(a); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(0); local_set(s2); // j
                       block_empty; loop_empty;
-                        local_get(s + 2); i32_const(4); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(es); i32_mul; i32_add;
+                        local_get(s2); local_get(b); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(a); i32_const(4); i32_add;
+                        local_get(s1); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        i32_const(4); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(b); i32_const(4); i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1); // found → break inner
-                        local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                        local_get(s2); i32_const(1); i32_add; local_set(s2);
                         br(0);
                       end; end;
                       // j >= b.len means NOT found → a[i] not in b → result = false
-                      local_get(s + 2); i32_const(4); i32_load(0); i32_load(0); i32_ge_u;
+                      local_get(s2); local_get(b); i32_load(0); i32_ge_u;
                       if_empty;
                         i32_const(0); local_set(s);
                         br(2); // break outer
                       end;
-                      local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                      local_get(s1); i32_const(1); i32_add; local_set(s1);
                       br(0);
                     end; end;
                     local_get(s);
                 });
+                self.scratch.free_i32(b);
+                self.scratch.free_i32(a);
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "is_disjoint" => {
                 // is_disjoint(a, b) → Bool: no element of a is in b.
-                // Locals: s=result, s+1=i, s+2=j
+                // Locals: s=result, s1=i, s2=j
                 let elem_ty = self.set_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
+                let a = self.scratch.alloc_i32();
+                let b = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(a); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
+                    local_set(b);
                     i32_const(1); local_set(s); // result = true
-                    i32_const(0); local_set(s + 1); // i
+                    i32_const(0); local_set(s1); // i
                     block_empty; loop_empty;
-                      local_get(s + 1); i32_const(0); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(s + 2); // j
+                      local_get(s1); local_get(a); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(0); local_set(s2); // j
                       block_empty; loop_empty;
-                        local_get(s + 2); i32_const(4); i32_load(0); i32_load(0); i32_ge_u; br_if(1);
-                        i32_const(0); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 1); i32_const(es); i32_mul; i32_add;
+                        local_get(s2); local_get(b); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(a); i32_const(4); i32_add;
+                        local_get(s1); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        i32_const(4); i32_load(0); i32_const(4); i32_add;
-                        local_get(s + 2); i32_const(es); i32_mul; i32_add;
+                        local_get(b); i32_const(4); i32_add;
+                        local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1); // found → break inner
-                        local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                        local_get(s2); i32_const(1); i32_add; local_set(s2);
                         br(0);
                       end; end;
                       // j < b.len means found → result = false
-                      local_get(s + 2); i32_const(4); i32_load(0); i32_load(0); i32_lt_u;
+                      local_get(s2); local_get(b); i32_load(0); i32_lt_u;
                       if_empty;
                         i32_const(0); local_set(s);
                         br(2); // break outer
                       end;
-                      local_get(s + 1); i32_const(1); i32_add; local_set(s + 1);
+                      local_get(s1); i32_const(1); i32_add; local_set(s1);
                       br(0);
                     end; end;
                     local_get(s);
                 });
+                self.scratch.free_i32(b);
+                self.scratch.free_i32(a);
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "filter" | "map" | "fold" | "any" | "all" => {
                 // Set has the same memory layout as List — delegate to list implementations

--- a/src/codegen/emit_wasm/calls_string.rs
+++ b/src/codegen/emit_wasm/calls_string.rs
@@ -557,7 +557,7 @@ impl FuncCompiler<'_> {
             block_empty;
             loop_empty;
         });
-        let saved = self.depth; self.depth += 2;
+        let depth_guard = self.depth_push_n(2);
         wasm!(self.func, {
             local_get(s);
             local_get(src);
@@ -623,7 +623,7 @@ impl FuncCompiler<'_> {
             local_set(s);
             br(0);
         });
-        self.depth = saved;
+        self.depth_pop(depth_guard);
         wasm!(self.func, {
             end;
             end;

--- a/src/codegen/emit_wasm/calls_string.rs
+++ b/src/codegen/emit_wasm/calls_string.rs
@@ -28,76 +28,85 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { call(self.emitter.rt.string.contains); });
             }
             "starts_with" => {
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let s0 = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(s0); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(4); i32_load(0); i32_load(0); // prefix.len
-                    i32_const(0); i32_load(0); i32_load(0); // s.len
+                    local_set(s1);
+                    local_get(s1); i32_load(0); // prefix.len
+                    local_get(s0); i32_load(0); // s.len
                     i32_gt_u;
                     if_i32; i32_const(0);
                     else_;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      i32_const(4); i32_load(0); i32_const(4); i32_add;
-                      i32_const(4); i32_load(0); i32_load(0);
+                      local_get(s0); i32_const(4); i32_add;
+                      local_get(s1); i32_const(4); i32_add;
+                      local_get(s1); i32_load(0);
                       call(self.emitter.rt.mem_eq);
                     end;
                 });
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s0);
             }
             "ends_with" => {
-                wasm!(self.func, { i32_const(0); });
+                let s0 = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); i32_const(4); });
+                wasm!(self.func, { local_set(s0); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_store(0);
-                    i32_const(4); i32_load(0); i32_load(0);
-                    i32_const(0); i32_load(0); i32_load(0);
+                    local_set(s1);
+                    local_get(s1); i32_load(0);
+                    local_get(s0); i32_load(0);
                     i32_gt_u;
                     if_i32; i32_const(0);
                     else_;
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      i32_const(0); i32_load(0); i32_load(0); i32_add;
-                      i32_const(4); i32_load(0); i32_load(0); i32_sub;
-                      i32_const(4); i32_load(0); i32_const(4); i32_add;
-                      i32_const(4); i32_load(0); i32_load(0);
+                      local_get(s0); i32_const(4); i32_add;
+                      local_get(s0); i32_load(0); i32_add;
+                      local_get(s1); i32_load(0); i32_sub;
+                      local_get(s1); i32_const(4); i32_add;
+                      local_get(s1); i32_load(0);
                       call(self.emitter.rt.mem_eq);
                     end;
                 });
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s0);
             }
             "get" => {
                 // get(s, i) → Option[String]
                 // OOB → none(0), else → some(1-char string)
-                let s = self.match_i32_base + self.match_depth;
-                wasm!(self.func, { i32_const(0); });
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_store(0); });
+                wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s);
+                    i32_wrap_i64; local_set(s1);
                     // bounds check
-                    local_get(s); i32_const(0); i32_lt_s;
-                    local_get(s); i32_const(0); i32_load(0); i32_load(0); i32_ge_u;
+                    local_get(s1); i32_const(0); i32_lt_s;
+                    local_get(s1); local_get(s); i32_load(0); i32_ge_u;
                     i32_or;
                     if_i32;
                       i32_const(0); // none
                     else_;
                       // Build 1-char string
-                      i32_const(5); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1); i32_const(1); i32_store(0);
-                      local_get(s + 1);
-                      i32_const(0); i32_load(0); i32_const(4); i32_add;
-                      local_get(s); i32_add; i32_load8_u(0);
+                      i32_const(5); call(self.emitter.rt.alloc); local_set(s2);
+                      local_get(s2); i32_const(1); i32_store(0);
+                      local_get(s2);
+                      local_get(s); i32_const(4); i32_add;
+                      local_get(s1); i32_add; i32_load8_u(0);
                       i32_store8(4);
                       // Wrap in some: alloc ptr, store string ptr
-                      i32_const(4); call(self.emitter.rt.alloc); local_set(s + 2);
-                      local_get(s + 2); local_get(s + 1); i32_store(0);
-                      local_get(s + 2);
+                      i32_const(4); call(self.emitter.rt.alloc); local_set(s1);
+                      local_get(s1); local_get(s2); i32_store(0);
+                      local_get(s1);
                     end;
                 });
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "reverse" => {
                 self.emit_expr(&args[0]);
@@ -138,8 +147,8 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { call(self.emitter.rt.string.slice); });
             }
             "index_of" => {
-                let s64 = self.match_i64_base + self.match_depth;
-                let s32 = self.match_i32_base + self.match_depth;
+                let s64 = self.scratch.alloc_i64();
+                let s32 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
@@ -154,10 +163,12 @@ impl FuncCompiler<'_> {
                       local_get(s32);
                     end;
                 });
+                self.scratch.free_i32(s32);
+                self.scratch.free_i64(s64);
             }
             "last_index_of" => {
-                let s64 = self.match_i64_base + self.match_depth;
-                let s32 = self.match_i32_base + self.match_depth;
+                let s64 = self.scratch.alloc_i64();
+                let s32 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
@@ -172,6 +183,8 @@ impl FuncCompiler<'_> {
                       local_get(s32);
                     end;
                 });
+                self.scratch.free_i32(s32);
+                self.scratch.free_i64(s64);
             }
             "count" => {
                 self.emit_expr(&args[0]);
@@ -209,7 +222,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { call(self.emitter.rt.string.to_lower); });
             }
             "capitalize" => {
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(s);
@@ -224,6 +237,7 @@ impl FuncCompiler<'_> {
                       call(self.emitter.rt.concat_str);
                     end;
                 });
+                self.scratch.free_i32(s);
             }
             "chars" => {
                 self.emit_expr(&args[0]);
@@ -270,31 +284,37 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { call(self.emitter.rt.string.is_lower); });
             }
             "codepoint" => {
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(s);
                     local_get(s); i32_load(0); i32_eqz;
                     if_i32; i32_const(0);
                     else_;
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1);
+                      i32_const(8); call(self.emitter.rt.alloc); local_set(s1);
+                      local_get(s1);
                       local_get(s); i32_load8_u(4); i64_extend_i32_u;
                       i64_store(0);
-                      local_get(s + 1);
+                      local_get(s1);
                     end;
                 });
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "from_codepoint" => {
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     i32_wrap_i64; local_set(s);
-                    i32_const(5); call(self.emitter.rt.alloc); local_set(s + 1);
-                    local_get(s + 1); i32_const(1); i32_store(0);
-                    local_get(s + 1); local_get(s); i32_store8(4);
-                    local_get(s + 1);
+                    i32_const(5); call(self.emitter.rt.alloc); local_set(s1);
+                    local_get(s1); i32_const(1); i32_store(0);
+                    local_get(s1); local_get(s); i32_store8(4);
+                    local_get(s1);
                 });
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "replace_first" => {
                 self.emit_expr(&args[0]);
@@ -314,7 +334,9 @@ impl FuncCompiler<'_> {
             }
             "first" => {
                 // first(s) → Option[String]: get(s, 0)
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(s);
@@ -322,98 +344,118 @@ impl FuncCompiler<'_> {
                     if_i32; i32_const(0); // none
                     else_;
                       // alloc 1-char string
-                      i32_const(5); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1); i32_const(1); i32_store(0);
-                      local_get(s + 1); local_get(s); i32_load8_u(4); i32_store8(4);
+                      i32_const(5); call(self.emitter.rt.alloc); local_set(s1);
+                      local_get(s1); i32_const(1); i32_store(0);
+                      local_get(s1); local_get(s); i32_load8_u(4); i32_store8(4);
                       // wrap in some: alloc ptr
-                      i32_const(4); call(self.emitter.rt.alloc); local_set(s + 2);
-                      local_get(s + 2); local_get(s + 1); i32_store(0);
-                      local_get(s + 2);
+                      i32_const(4); call(self.emitter.rt.alloc); local_set(s2);
+                      local_get(s2); local_get(s1); i32_store(0);
+                      local_get(s2);
                     end;
                 });
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "last" => {
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
+                let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(s);
                     local_get(s); i32_load(0); i32_eqz;
                     if_i32; i32_const(0);
                     else_;
-                      i32_const(5); call(self.emitter.rt.alloc); local_set(s + 1);
-                      local_get(s + 1); i32_const(1); i32_store(0);
-                      local_get(s + 1);
+                      i32_const(5); call(self.emitter.rt.alloc); local_set(s1);
+                      local_get(s1); i32_const(1); i32_store(0);
+                      local_get(s1);
                       local_get(s); i32_const(4); i32_add;
                       local_get(s); i32_load(0); i32_const(1); i32_sub; i32_add;
                       i32_load8_u(0); i32_store8(4);
-                      i32_const(4); call(self.emitter.rt.alloc); local_set(s + 2);
-                      local_get(s + 2); local_get(s + 1); i32_store(0);
-                      local_get(s + 2);
+                      i32_const(4); call(self.emitter.rt.alloc); local_set(s2);
+                      local_get(s2); local_get(s1); i32_store(0);
+                      local_get(s2);
                     end;
                 });
+                self.scratch.free_i32(s2);
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "take_end" => {
                 // take_end(s, n) = slice(s, max(0, len-n), len)
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s + 1);
-                    local_get(s); i32_load(0); local_get(s + 1); i32_sub;
-                    local_set(s + 1);
-                    local_get(s + 1); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(s + 1); end;
-                    local_get(s); local_get(s + 1); local_get(s); i32_load(0);
+                    i32_wrap_i64; local_set(s1);
+                    local_get(s); i32_load(0); local_get(s1); i32_sub;
+                    local_set(s1);
+                    local_get(s1); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(0); local_set(s1); end;
+                    local_get(s); local_get(s1); local_get(s); i32_load(0);
                     call(self.emitter.rt.string.slice);
                 });
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "drop_end" => {
                 // drop_end(s, n) = slice(s, 0, max(0, len-n))
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s + 1);
-                    local_get(s); i32_load(0); local_get(s + 1); i32_sub;
-                    local_set(s + 1);
-                    local_get(s + 1); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(s + 1); end;
-                    local_get(s); i32_const(0); local_get(s + 1);
+                    i32_wrap_i64; local_set(s1);
+                    local_get(s); i32_load(0); local_get(s1); i32_sub;
+                    local_set(s1);
+                    local_get(s1); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(0); local_set(s1); end;
+                    local_get(s); i32_const(0); local_get(s1);
                     call(self.emitter.rt.string.slice);
                 });
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "take" => {
                 // take(s, n) = slice(s, 0, min(n, len))
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s + 1); // n
+                    i32_wrap_i64; local_set(s1); // n
                     // min(n, len)
-                    local_get(s + 1); local_get(s); i32_load(0); i32_lt_u;
-                    if_i32; local_get(s + 1); else_; local_get(s); i32_load(0); end;
-                    local_set(s + 1);
-                    local_get(s); i32_const(0); local_get(s + 1);
+                    local_get(s1); local_get(s); i32_load(0); i32_lt_u;
+                    if_i32; local_get(s1); else_; local_get(s); i32_load(0); end;
+                    local_set(s1);
+                    local_get(s); i32_const(0); local_get(s1);
                     call(self.emitter.rt.string.slice);
                 });
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             "drop" => {
                 // drop(s, n) = slice(s, min(n, len), len)
-                let s = self.match_i32_base + self.match_depth;
+                let s = self.scratch.alloc_i32();
+                let s1 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s + 1);
-                    local_get(s + 1); local_get(s); i32_load(0); i32_lt_u;
-                    if_i32; local_get(s + 1); else_; local_get(s); i32_load(0); end;
-                    local_set(s + 1);
-                    local_get(s); local_get(s + 1); local_get(s); i32_load(0);
+                    i32_wrap_i64; local_set(s1);
+                    local_get(s1); local_get(s); i32_load(0); i32_lt_u;
+                    if_i32; local_get(s1); else_; local_get(s); i32_load(0); end;
+                    local_set(s1);
+                    local_get(s); local_get(s1); local_get(s); i32_load(0);
                     call(self.emitter.rt.string.slice);
                 });
+                self.scratch.free_i32(s1);
+                self.scratch.free_i32(s);
             }
             _ => return false,
         }
@@ -488,32 +530,27 @@ impl FuncCompiler<'_> {
 
     /// ASCII case conversion. Expects string ptr on stack. Returns new string ptr.
     pub(super) fn emit_str_case_convert(&mut self, is_upper: bool) {
-        // String ptr is on stack. Store to mem[0] via scratch.
-        let scratch = self.match_i32_base + self.match_depth;
+        // String ptr is on stack. Store to scratch local.
+        let src = self.scratch.alloc_i32();
+        let dst = self.scratch.alloc_i32();
+        let s = self.scratch.alloc_i32();
+        let s1 = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(scratch);
-            i32_const(0);
-            local_get(scratch);
-            i32_store(0);
-            // Alloc dst with same len → mem[4]
+            local_set(src);
+            // Alloc dst with same len
             i32_const(4);
-            i32_const(4);
-            i32_const(0);
-            i32_load(0);
+            local_get(src);
             i32_load(0);
             i32_add;
             call(self.emitter.rt.alloc);
-            i32_store(0);
+            local_set(dst);
             // Store len in dst
-            i32_const(4);
-            i32_load(0);
-            i32_const(0);
-            i32_load(0);
+            local_get(dst);
+            local_get(src);
             i32_load(0);
             i32_store(0);
         });
         // Loop: convert each byte
-        let s = self.match_i32_base + self.match_depth;
         wasm!(self.func, {
             i32_const(0);
             local_set(s);
@@ -523,61 +560,58 @@ impl FuncCompiler<'_> {
         let saved = self.depth; self.depth += 2;
         wasm!(self.func, {
             local_get(s);
-            i32_const(0);
-            i32_load(0);
+            local_get(src);
             i32_load(0);
             i32_ge_u;
             br_if(1);
             // dst addr
-            i32_const(4);
-            i32_load(0);
+            local_get(dst);
             i32_const(4);
             i32_add;
             local_get(s);
             i32_add;
             // src byte
-            i32_const(0);
-            i32_load(0);
+            local_get(src);
             i32_const(4);
             i32_add;
             local_get(s);
             i32_add;
             i32_load8_u(0);
             // Convert
-            local_set(s + 1);
+            local_set(s1);
         });
         if is_upper {
             wasm!(self.func, {
-                local_get(s + 1);
+                local_get(s1);
                 i32_const(97);
                 i32_ge_u;
-                local_get(s + 1);
+                local_get(s1);
                 i32_const(122);
                 i32_le_u;
                 i32_and;
                 if_i32;
-                local_get(s + 1);
+                local_get(s1);
                 i32_const(32);
                 i32_sub;
                 else_;
-                local_get(s + 1);
+                local_get(s1);
                 end;
             });
         } else {
             wasm!(self.func, {
-                local_get(s + 1);
+                local_get(s1);
                 i32_const(65);
                 i32_ge_u;
-                local_get(s + 1);
+                local_get(s1);
                 i32_const(90);
                 i32_le_u;
                 i32_and;
                 if_i32;
-                local_get(s + 1);
+                local_get(s1);
                 i32_const(32);
                 i32_add;
                 else_;
-                local_get(s + 1);
+                local_get(s1);
                 end;
             });
         }
@@ -594,8 +628,11 @@ impl FuncCompiler<'_> {
             end;
             end;
             // Return dst
-            i32_const(4);
-            i32_load(0);
+            local_get(dst);
         });
+        self.scratch.free_i32(s1);
+        self.scratch.free_i32(s);
+        self.scratch.free_i32(dst);
+        self.scratch.free_i32(src);
     }
 }

--- a/src/codegen/emit_wasm/closures.rs
+++ b/src/codegen/emit_wasm/closures.rs
@@ -199,20 +199,7 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
             local_idx += 1;
         }
 
-        // Legacy scratch locals
-        let scratch_depth = scan.scratch_depth.max(1);
-        let match_i64_base = local_idx;
-        for _ in 0..scratch_depth {
-            local_decls.push((1, ValType::I64));
-            local_idx += 1;
-        }
-        let match_i32_base = local_idx;
-        for _ in 0..scratch_depth {
-            local_decls.push((1, ValType::I32));
-            local_idx += 1;
-        }
-
-        // ScratchAllocator locals (separate region)
+        // ScratchAllocator locals
         let scratch_i32_base = local_idx;
         let scratch_extra = 12usize;
         for _ in 0..scratch_extra { local_decls.push((1, ValType::I32)); local_idx += 1; }
@@ -271,9 +258,6 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
                 depth: 0,
                 loop_stack: Vec::new(),
                 scratch: scratch_alloc,
-                match_i64_base,
-                match_i32_base,
-                match_depth: 0,
                 var_table: &program.var_table,
                 stub_ret_ty: Ty::Unit,
             };

--- a/src/codegen/emit_wasm/collections.rs
+++ b/src/codegen/emit_wasm/collections.rs
@@ -2,8 +2,6 @@
 
 use crate::ir::IrExpr;
 use crate::types::Ty;
-use wasm_encoder::MemArg;
-
 use super::FuncCompiler;
 use super::values;
 
@@ -42,8 +40,7 @@ impl FuncCompiler<'_> {
             call(self.emitter.rt.alloc);
         });
 
-        let scratch = self.match_i32_base + self.match_depth;
-        self.match_depth += 1;
+        let scratch = self.scratch.alloc_i32();
         wasm!(self.func, { local_set(scratch); });
 
         // Write tag if variant
@@ -120,7 +117,7 @@ impl FuncCompiler<'_> {
             }
         }
 
-        self.match_depth -= 1;
+        self.scratch.free_i32(scratch);
         wasm!(self.func, { local_get(scratch); });
     }
 
@@ -150,16 +147,16 @@ impl FuncCompiler<'_> {
             i32_const(total_size as i32);
             call(self.emitter.rt.alloc);
         });
-        let result_scratch = self.match_i32_base + self.match_depth;
+        let result_scratch = self.scratch.alloc_i32();
         wasm!(self.func, { local_set(result_scratch); });
 
         // Evaluate base and store ptr
         self.emit_expr(base);
-        let base_scratch = result_scratch + 1;
+        let base_scratch = self.scratch.alloc_i32();
         wasm!(self.func, { local_set(base_scratch); });
 
         // Copy all bytes from base to result (including tag if variant)
-        let counter = self.match_i64_base + self.match_depth;
+        let counter = self.scratch.alloc_i64();
         wasm!(self.func, {
             i64_const(0);
             local_set(counter);
@@ -208,6 +205,9 @@ impl FuncCompiler<'_> {
         }
 
         // Return result ptr
+        self.scratch.free_i64(counter);
+        self.scratch.free_i32(base_scratch);
+        self.scratch.free_i32(result_scratch);
         wasm!(self.func, { local_get(result_scratch); });
     }
 
@@ -227,8 +227,7 @@ impl FuncCompiler<'_> {
             call(self.emitter.rt.alloc);
         });
 
-        let scratch = self.match_i32_base + self.match_depth;
-        self.match_depth += 1;
+        let scratch = self.scratch.alloc_i32();
         wasm!(self.func, { local_set(scratch); });
 
         // Store length
@@ -246,7 +245,7 @@ impl FuncCompiler<'_> {
             self.emit_store_at(&elem.ty, offset);
         }
 
-        self.match_depth -= 1;
+        self.scratch.free_i32(scratch);
         wasm!(self.func, { local_get(scratch); });
     }
 
@@ -288,8 +287,7 @@ impl FuncCompiler<'_> {
             call(self.emitter.rt.alloc);
         });
 
-        let scratch = self.match_i32_base + self.match_depth;
-        self.match_depth += 1;
+        let scratch = self.scratch.alloc_i32();
         wasm!(self.func, { local_set(scratch); });
 
         let mut offset = 0u32;
@@ -301,7 +299,7 @@ impl FuncCompiler<'_> {
             offset += size;
         }
 
-        self.match_depth -= 1;
+        self.scratch.free_i32(scratch);
         wasm!(self.func, { local_get(scratch); });
     }
 

--- a/src/codegen/emit_wasm/control.rs
+++ b/src/codegen/emit_wasm/control.rs
@@ -27,13 +27,11 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { local_set(loop_var); });
 
                 // block $break { loop $loop { check; block $continue { body }; i++; br $loop } }
-                let break_depth = self.depth;
                 wasm!(self.func, { block_empty; });
-                self.depth += 1;
+                let break_guard = self.depth_push();
 
-                let loop_depth = self.depth;
                 wasm!(self.func, { loop_empty; });
-                self.depth += 1;
+                let loop_guard = self.depth_push();
 
                 // Break condition
                 wasm!(self.func, { local_get(loop_var); });
@@ -43,14 +41,13 @@ impl FuncCompiler<'_> {
                 } else {
                     wasm!(self.func, { i64_ge_s; });
                 }
-                wasm!(self.func, { br_if(self.depth - break_depth - 1); });
+                wasm!(self.func, { br_if(self.depth - break_guard.saved() - 1); });
 
                 // Inner block for continue target
-                let continue_depth = self.depth;
                 wasm!(self.func, { block_empty; });
-                self.depth += 1;
+                let continue_guard = self.depth_push();
 
-                self.loop_stack.push(super::LoopLabels { break_depth, continue_depth });
+                self.loop_stack.push(super::LoopLabels { break_depth: break_guard.saved(), continue_depth: continue_guard.saved() });
 
                 // Body
                 for stmt in body {
@@ -58,7 +55,7 @@ impl FuncCompiler<'_> {
                 }
 
                 self.loop_stack.pop();
-                self.depth -= 1;
+                self.depth_pop(continue_guard);
                 wasm!(self.func, { end; }); // end continue block
 
                 // Increment: var += 1 (always runs, even after continue)
@@ -70,11 +67,11 @@ impl FuncCompiler<'_> {
                 });
 
                 // Loop back
-                wasm!(self.func, { br(self.depth - loop_depth - 1); });
+                wasm!(self.func, { br(self.depth - loop_guard.saved() - 1); });
 
-                self.depth -= 1;
+                self.depth_pop(loop_guard);
                 wasm!(self.func, { end; }); // end loop
-                self.depth -= 1;
+                self.depth_pop(break_guard);
                 wasm!(self.func, { end; }); // end break block
             }
             _ => {
@@ -117,13 +114,11 @@ impl FuncCompiler<'_> {
                 });
 
                 // Structure: block $break { loop $loop { check; load; block $continue { body }; i++; br $loop } }
-                let break_depth = self.depth;
                 wasm!(self.func, { block_empty; });
-                self.depth += 1;
+                let break_guard = self.depth_push();
 
-                let loop_depth = self.depth;
                 wasm!(self.func, { loop_empty; });
-                self.depth += 1;
+                let loop_guard = self.depth_push();
 
                 // Break if index >= len
                 wasm!(self.func, {
@@ -131,7 +126,7 @@ impl FuncCompiler<'_> {
                     local_get(list_scratch);
                     i32_load(0);
                     i32_ge_u;
-                    br_if(self.depth - break_depth - 1);
+                    br_if(self.depth - break_guard.saved() - 1);
                 });
 
                 if is_map {
@@ -207,11 +202,10 @@ impl FuncCompiler<'_> {
                 }
 
                 // Inner block for continue target
-                let continue_depth = self.depth;
                 wasm!(self.func, { block_empty; });
-                self.depth += 1;
+                let continue_guard = self.depth_push();
 
-                self.loop_stack.push(super::LoopLabels { break_depth, continue_depth });
+                self.loop_stack.push(super::LoopLabels { break_depth: break_guard.saved(), continue_depth: continue_guard.saved() });
 
                 // Body
                 for stmt in body {
@@ -219,7 +213,7 @@ impl FuncCompiler<'_> {
                 }
 
                 self.loop_stack.pop();
-                self.depth -= 1;
+                self.depth_pop(continue_guard);
                 wasm!(self.func, { end; }); // end continue block
 
                 // Increment index (always runs, even after continue)
@@ -231,11 +225,11 @@ impl FuncCompiler<'_> {
                 });
 
                 // Loop back
-                wasm!(self.func, { br(self.depth - loop_depth - 1); });
+                wasm!(self.func, { br(self.depth - loop_guard.saved() - 1); });
 
-                self.depth -= 1;
+                self.depth_pop(loop_guard);
                 wasm!(self.func, { end; }); // end loop
-                self.depth -= 1;
+                self.depth_pop(break_guard);
                 wasm!(self.func, { end; }); // end break block
                 self.scratch.free_i32(idx_scratch);
                 self.scratch.free_i32(list_scratch);
@@ -357,7 +351,7 @@ impl FuncCompiler<'_> {
                     self.emit_expr(guard);
                     let bt = values::block_type(result_ty);
                     self.func.instruction(&Instruction::If(bt));
-                    self.depth += 1;
+                    let _g = self.depth_push();
                     self.emit_expr(&arm.body);
                     wasm!(self.func, { else_; });
                     if is_last {
@@ -365,7 +359,7 @@ impl FuncCompiler<'_> {
                     } else {
                         self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1);
                     }
-                    self.depth -= 1;
+                    self.depth_pop(_g);
                     wasm!(self.func, { end; });
                 } else {
                     self.emit_expr(&arm.body);
@@ -392,7 +386,7 @@ impl FuncCompiler<'_> {
 
                 let bt = values::block_type(result_ty);
                 self.func.instruction(&Instruction::If(bt));
-                self.depth += 1;
+                let _g = self.depth_push();
                 self.emit_expr(&arm.body);
                 wasm!(self.func, { else_; });
 
@@ -402,7 +396,7 @@ impl FuncCompiler<'_> {
                     self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1);
                 }
 
-                self.depth -= 1;
+                self.depth_pop(_g);
                 wasm!(self.func, { end; });
             }
 
@@ -420,7 +414,7 @@ impl FuncCompiler<'_> {
 
                     let bt = values::block_type(result_ty);
                     self.func.instruction(&Instruction::If(bt));
-                    self.depth += 1;
+                    let ctor_guard = self.depth_push();
 
                     // Resolve constructor field types from variant info + subject type_args
                     let ctor_fields = self.emitter.record_fields.get(ctor_name).cloned().unwrap_or_default();
@@ -482,12 +476,12 @@ impl FuncCompiler<'_> {
                         self.emit_expr(guard);
                         let bt2 = values::block_type(result_ty);
                         self.func.instruction(&Instruction::If(bt2));
-                        self.depth += 1;
+                        let guard_g = self.depth_push();
                         self.emit_expr(&arm.body);
                         wasm!(self.func, { else_; });
                         if is_last { wasm!(self.func, { unreachable; }); }
                         else { self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1); }
-                        self.depth -= 1;
+                        self.depth_pop(guard_g);
                         wasm!(self.func, { end; });
                     } else {
                         self.emit_expr(&arm.body);
@@ -498,7 +492,7 @@ impl FuncCompiler<'_> {
                     } else {
                         self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1);
                     }
-                    self.depth -= 1;
+                    self.depth_pop(ctor_guard);
                     wasm!(self.func, { end; });
                 } else {
                     eprintln!("[CTOR ELSE] ctor='{}' is_last={} — tag not found, falling through", ctor_name, is_last);
@@ -520,7 +514,7 @@ impl FuncCompiler<'_> {
                 });
                 let bt = values::block_type(result_ty);
                 self.func.instruction(&Instruction::If(bt));
-                self.depth += 1;
+                let some_guard = self.depth_push();
 
                 // Bind the inner value
                 if let IrPattern::Bind { var, .. } = inner.as_ref() {
@@ -539,7 +533,7 @@ impl FuncCompiler<'_> {
                     self.emit_expr(guard);
                     let bt2 = values::block_type(result_ty);
                     self.func.instruction(&Instruction::If(bt2));
-                    self.depth += 1;
+                    let guard_g = self.depth_push();
                     self.emit_expr(&arm.body);
                     wasm!(self.func, { else_; });
                     if is_last {
@@ -547,7 +541,7 @@ impl FuncCompiler<'_> {
                     } else {
                         self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1);
                     }
-                    self.depth -= 1;
+                    self.depth_pop(guard_g);
                     wasm!(self.func, { end; });
                 } else {
                     self.emit_expr(&arm.body);
@@ -559,7 +553,7 @@ impl FuncCompiler<'_> {
                 } else {
                     self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1);
                 }
-                self.depth -= 1;
+                self.depth_pop(some_guard);
                 wasm!(self.func, { end; });
             }
 
@@ -572,7 +566,7 @@ impl FuncCompiler<'_> {
                 });
                 let bt = values::block_type(result_ty);
                 self.func.instruction(&Instruction::If(bt));
-                self.depth += 1;
+                let none_guard = self.depth_push();
                 self.emit_expr(&arm.body);
                 wasm!(self.func, { else_; });
                 if is_last {
@@ -580,7 +574,7 @@ impl FuncCompiler<'_> {
                 } else {
                     self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1);
                 }
-                self.depth -= 1;
+                self.depth_pop(none_guard);
                 wasm!(self.func, { end; });
             }
 
@@ -600,7 +594,7 @@ impl FuncCompiler<'_> {
 
                     let bt = values::block_type(result_ty);
                     self.func.instruction(&Instruction::If(bt));
-                    self.depth += 1;
+                    let rec_guard = self.depth_push();
 
                     // Bind fields: load each field from subject + tag_offset + field_offset
                     let case_fields = self.emitter.record_fields.get(ctor_name).cloned().unwrap_or_default();
@@ -625,7 +619,7 @@ impl FuncCompiler<'_> {
                         self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1);
                     }
 
-                    self.depth -= 1;
+                    self.depth_pop(rec_guard);
                     wasm!(self.func, { end; });
                 } else {
                     // Not a variant — treat as plain record (always matches)
@@ -643,7 +637,7 @@ impl FuncCompiler<'_> {
                 });
                 let bt = values::block_type(result_ty);
                 self.func.instruction(&Instruction::If(bt));
-                self.depth += 1;
+                let ok_guard = self.depth_push();
                 if let IrPattern::Bind { var, .. } = inner.as_ref() {
                     if let Some(&local_idx) = self.var_map.get(&var.0) {
                         let inner_ty = if let Ty::Applied(_, args) = subject_ty {
@@ -658,12 +652,12 @@ impl FuncCompiler<'_> {
                     self.emit_expr(guard);
                     let bt2 = values::block_type(result_ty);
                     self.func.instruction(&Instruction::If(bt2));
-                    self.depth += 1;
+                    let guard_g = self.depth_push();
                     self.emit_expr(&arm.body);
                     wasm!(self.func, { else_; });
                     if is_last { wasm!(self.func, { unreachable; }); }
                     else { self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1); }
-                    self.depth -= 1;
+                    self.depth_pop(guard_g);
                     wasm!(self.func, { end; });
                 } else {
                     self.emit_expr(&arm.body);
@@ -671,7 +665,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { else_; });
                 if is_last { wasm!(self.func, { unreachable; }); }
                 else { self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1); }
-                self.depth -= 1;
+                self.depth_pop(ok_guard);
                 wasm!(self.func, { end; });
             }
 
@@ -685,7 +679,7 @@ impl FuncCompiler<'_> {
                 });
                 let bt = values::block_type(result_ty);
                 self.func.instruction(&Instruction::If(bt));
-                self.depth += 1;
+                let err_guard = self.depth_push();
                 if let IrPattern::Bind { var, .. } = inner.as_ref() {
                     if let Some(&local_idx) = self.var_map.get(&var.0) {
                         let inner_ty = if let Ty::Applied(_, args) = subject_ty {
@@ -700,12 +694,12 @@ impl FuncCompiler<'_> {
                     self.emit_expr(guard);
                     let bt2 = values::block_type(result_ty);
                     self.func.instruction(&Instruction::If(bt2));
-                    self.depth += 1;
+                    let guard_g = self.depth_push();
                     self.emit_expr(&arm.body);
                     wasm!(self.func, { else_; });
                     if is_last { wasm!(self.func, { unreachable; }); }
                     else { self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1); }
-                    self.depth -= 1;
+                    self.depth_pop(guard_g);
                     wasm!(self.func, { end; });
                 } else {
                     self.emit_expr(&arm.body);
@@ -713,7 +707,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { else_; });
                 if is_last { wasm!(self.func, { unreachable; }); }
                 else { self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1); }
-                self.depth -= 1;
+                self.depth_pop(err_guard);
                 wasm!(self.func, { end; });
             }
 
@@ -722,7 +716,7 @@ impl FuncCompiler<'_> {
                 if let Ty::Tuple(elem_types) = subject_ty {
                     let has_literal = elements.iter().any(|p| matches!(p, IrPattern::Literal { .. }));
 
-                    if has_literal && !is_last {
+                    let tuple_guard = if has_literal && !is_last {
                         // Build condition: check all literal elements
                         let mut offset = 0u32;
                         let mut cond_count = 0;
@@ -752,8 +746,10 @@ impl FuncCompiler<'_> {
                             Some(ValType::I32) => { wasm!(self.func, { if_i32; }); }
                             _ => { wasm!(self.func, { if_i32; }); } // String/ptr results are i32
                         }
-                        self.depth += 1;
-                    }
+                        Some(self.depth_push())
+                    } else {
+                        None
+                    };
 
                     // Bind elements
                     let mut offset = 0u32;
@@ -771,12 +767,12 @@ impl FuncCompiler<'_> {
 
                     self.emit_expr(&arm.body);
 
-                    if has_literal && !is_last {
+                    if let Some(tg) = tuple_guard {
                         wasm!(self.func, { else_; });
                         // Emit remaining arms
                         self.emit_match_arms(arms, scratch, subject_ty, result_ty, idx + 1);
                         wasm!(self.func, { end; });
-                        self.depth -= 1;
+                        self.depth_pop(tg);
                         return; // Don't fall through to normal next-arm processing
                     }
                 } else {

--- a/src/codegen/emit_wasm/control.rs
+++ b/src/codegen/emit_wasm/control.rs
@@ -85,10 +85,9 @@ impl FuncCompiler<'_> {
                     Ty::Applied(crate::types::TypeConstructorId::Map, _)
                 );
 
-                // scratch[0] = collection ptr, scratch[1] = index counter
-                let list_scratch = self.match_i32_base + self.match_depth;
-                let idx_scratch = list_scratch + 1;
-                self.match_depth += 2; // Reserve 2 scratch locals for ptr + index
+                // scratch locals: collection ptr + index counter
+                let list_scratch = self.scratch.alloc_i32();
+                let idx_scratch = self.scratch.alloc_i32();
                 let loop_var = self.var_map[&var.0];
 
                 // Determine element type and entry stride
@@ -238,7 +237,8 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { end; }); // end loop
                 self.depth -= 1;
                 wasm!(self.func, { end; }); // end break block
-                self.match_depth -= 2; // Release for..in scratch locals
+                self.scratch.free_i32(idx_scratch);
+                self.scratch.free_i32(list_scratch);
             }
         }
     }
@@ -275,17 +275,22 @@ impl FuncCompiler<'_> {
 
         self.emit_expr(subject);
 
-        let scratch = match values::ty_to_valtype(&subject_ty) {
-            Some(ValType::I64) => self.match_i64_base + self.match_depth,
-            _ => self.match_i32_base + self.match_depth,
+        let is_i64 = matches!(values::ty_to_valtype(&subject_ty), Some(ValType::I64));
+        let scratch = if is_i64 {
+            self.scratch.alloc_i64()
+        } else {
+            self.scratch.alloc_i32()
         };
-        self.match_depth += 1;
 
         wasm!(self.func, { local_set(scratch); });
 
         self.emit_match_arms(arms, scratch, &subject_ty, result_ty, 0);
 
-        self.match_depth -= 1;
+        if is_i64 {
+            self.scratch.free_i64(scratch);
+        } else {
+            self.scratch.free_i32(scratch);
+        }
     }
 
     /// Resolve the actual subject type, fixing IR type inference gaps.

--- a/src/codegen/emit_wasm/equality.rs
+++ b/src/codegen/emit_wasm/equality.rs
@@ -169,34 +169,36 @@ impl FuncCompiler<'_> {
 
     /// Deep list equality: [a_ptr, b_ptr] → i32
     fn emit_list_eq_deep(&mut self, elem_ty: &Ty) {
-        let s = self.match_i32_base + self.match_depth;
+        let a = self.scratch.alloc_i32();
+        let b = self.scratch.alloc_i32();
+        let i = self.scratch.alloc_i32();
         let elem_size = values::byte_size(elem_ty);
         wasm!(self.func, {
-            local_set(s + 1); // b
-            local_set(s);     // a
+            local_set(b); // b
+            local_set(a); // a
             // Same pointer → true
-            local_get(s); local_get(s + 1); i32_eq;
+            local_get(a); local_get(b); i32_eq;
             if_i32; i32_const(1);
             else_;
               // Different lengths → false
-              local_get(s); i32_load(0);
-              local_get(s + 1); i32_load(0);
+              local_get(a); i32_load(0);
+              local_get(b); i32_load(0);
               i32_ne;
               if_i32; i32_const(0);
               else_;
                 // Compare element by element
-                i32_const(0); local_set(s + 2); // i
+                i32_const(0); local_set(i); // i
                 block_empty; loop_empty;
-                  local_get(s + 2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
+                  local_get(i); local_get(a); i32_load(0); i32_ge_u; br_if(1);
                   // Load a[i]
-                  local_get(s); i32_const(4); i32_add;
-                  local_get(s + 2); i32_const(elem_size as i32); i32_mul; i32_add;
+                  local_get(a); i32_const(4); i32_add;
+                  local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
         });
         self.emit_load_at(elem_ty, 0);
         // Load b[i]
         wasm!(self.func, {
-                  local_get(s + 1); i32_const(4); i32_add;
-                  local_get(s + 2); i32_const(elem_size as i32); i32_mul; i32_add;
+                  local_get(b); i32_const(4); i32_add;
+                  local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
         });
         self.emit_load_at(elem_ty, 0);
         // Compare elements (recursive)
@@ -207,7 +209,7 @@ impl FuncCompiler<'_> {
                   if_empty;
                     i32_const(0); return_;
                   end;
-                  local_get(s + 2); i32_const(1); i32_add; local_set(s + 2);
+                  local_get(i); i32_const(1); i32_add; local_set(i);
                   br(0);
                 end; end;
                 // All elements matched
@@ -215,27 +217,31 @@ impl FuncCompiler<'_> {
               end;
             end;
         });
+        self.scratch.free_i32(i);
+        self.scratch.free_i32(b);
+        self.scratch.free_i32(a);
     }
 
     /// Deep option equality: [a_ptr, b_ptr] → i32
     fn emit_option_eq_deep(&mut self, inner_ty: &Ty) {
-        let s = self.match_i32_base + self.match_depth;
+        let a = self.scratch.alloc_i32();
+        let b = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(s + 1); // b
-            local_set(s);     // a
+            local_set(b); // b
+            local_set(a); // a
             // Both none → true
-            local_get(s); i32_eqz; local_get(s + 1); i32_eqz; i32_and;
+            local_get(a); i32_eqz; local_get(b); i32_eqz; i32_and;
             if_i32; i32_const(1);
             else_;
               // One none → false
-              local_get(s); i32_eqz; local_get(s + 1); i32_eqz; i32_or;
+              local_get(a); i32_eqz; local_get(b); i32_eqz; i32_or;
               if_i32; i32_const(0);
               else_;
                 // Both some: compare inner values
-                local_get(s);
+                local_get(a);
         });
         self.emit_load_at(inner_ty, 0);
-        wasm!(self.func, { local_get(s + 1); });
+        wasm!(self.func, { local_get(b); });
         self.emit_load_at(inner_ty, 0);
         let inner_clone = inner_ty.clone();
         self.emit_eq_typed(&inner_clone);
@@ -243,37 +249,40 @@ impl FuncCompiler<'_> {
               end;
             end;
         });
+        self.scratch.free_i32(b);
+        self.scratch.free_i32(a);
     }
 
     /// Deep result equality: [a_ptr, b_ptr] → i32
     fn emit_result_eq_deep(&mut self, ok_ty: &Ty, err_ty: &Ty) {
-        let s = self.match_i32_base + self.match_depth;
+        let a = self.scratch.alloc_i32();
+        let b = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(s + 1); // b
-            local_set(s);     // a
+            local_set(b); // b
+            local_set(a); // a
             // Tags must match
-            local_get(s); i32_load(0);
-            local_get(s + 1); i32_load(0);
+            local_get(a); i32_load(0);
+            local_get(b); i32_load(0);
             i32_ne;
             if_i32; i32_const(0);
             else_;
               // Same tag. If tag==0 (ok): compare ok values
-              local_get(s); i32_load(0); i32_eqz;
+              local_get(a); i32_load(0); i32_eqz;
               if_i32;
-                local_get(s);
+                local_get(a);
         });
         self.emit_load_at(ok_ty, 4);
-        wasm!(self.func, { local_get(s + 1); });
+        wasm!(self.func, { local_get(b); });
         self.emit_load_at(ok_ty, 4);
         let ok_clone = ok_ty.clone();
         self.emit_eq_typed(&ok_clone);
         wasm!(self.func, {
               else_;
                 // tag==1 (err): compare err values
-                local_get(s);
+                local_get(a);
         });
         self.emit_load_at(err_ty, 4);
-        wasm!(self.func, { local_get(s + 1); });
+        wasm!(self.func, { local_get(b); });
         self.emit_load_at(err_ty, 4);
         let err_clone = err_ty.clone();
         self.emit_eq_typed(&err_clone);
@@ -281,22 +290,25 @@ impl FuncCompiler<'_> {
               end;
             end;
         });
+        self.scratch.free_i32(b);
+        self.scratch.free_i32(a);
     }
 
     /// Deep tuple equality: [a_ptr, b_ptr] → i32
     fn emit_tuple_eq_deep(&mut self, elems: &[Ty]) {
-        let s = self.match_i32_base + self.match_depth;
+        let a = self.scratch.alloc_i32();
+        let b = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(s + 1); // b
-            local_set(s);     // a
+            local_set(b); // b
+            local_set(a); // a
         });
         // Compare each field, short-circuit on mismatch
         let mut offset: u32 = 0;
         for (i, elem_ty) in elems.iter().enumerate() {
             let elem_size = values::byte_size(elem_ty);
-            wasm!(self.func, { local_get(s); });
+            wasm!(self.func, { local_get(a); });
             self.emit_load_at(elem_ty, offset);
-            wasm!(self.func, { local_get(s + 1); });
+            wasm!(self.func, { local_get(b); });
             self.emit_load_at(elem_ty, offset);
             let elem_clone = elem_ty.clone();
             self.emit_eq_typed(&elem_clone);
@@ -307,21 +319,24 @@ impl FuncCompiler<'_> {
             offset += elem_size;
         }
         // If we reach here, all fields matched. Last comparison result is on stack.
+        self.scratch.free_i32(b);
+        self.scratch.free_i32(a);
     }
 
     /// Deep record equality: [a_ptr, b_ptr] → i32
     fn emit_record_eq_deep(&mut self, fields: &[(std::string::String, Ty)]) {
-        let s = self.match_i32_base + self.match_depth;
+        let a = self.scratch.alloc_i32();
+        let b = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(s + 1);
-            local_set(s);
+            local_set(b);
+            local_set(a);
         });
         let mut offset: u32 = 0;
         for (i, (_, field_ty)) in fields.iter().enumerate() {
             let field_size = values::byte_size(field_ty);
-            wasm!(self.func, { local_get(s); });
+            wasm!(self.func, { local_get(a); });
             self.emit_load_at(field_ty, offset);
-            wasm!(self.func, { local_get(s + 1); });
+            wasm!(self.func, { local_get(b); });
             self.emit_load_at(field_ty, offset);
             let field_clone = field_ty.clone();
             self.emit_eq_typed(&field_clone);
@@ -330,6 +345,8 @@ impl FuncCompiler<'_> {
             }
             offset += field_size;
         }
+        self.scratch.free_i32(b);
+        self.scratch.free_i32(a);
     }
 
     pub(super) fn emit_cmp_instruction(&mut self, ty: &Ty, kind: CmpKind) {

--- a/src/codegen/emit_wasm/expressions.rs
+++ b/src/codegen/emit_wasm/expressions.rs
@@ -123,11 +123,11 @@ impl FuncCompiler<'_> {
                 self.emit_expr(cond);
                 let bt = values::block_type(&expr.ty);
                 self.func.instruction(&Instruction::If(bt));
-                self.depth += 1;
+                let _g0 = self.depth_push();
                 self.emit_expr(then);
                 wasm!(self.func, { else_; });
                 self.emit_expr(else_);
-                self.depth -= 1;
+                self.depth_pop(_g0);
                 wasm!(self.func, { end; });
             }
 
@@ -158,13 +158,13 @@ impl FuncCompiler<'_> {
                     }
                 } else { None };
 
-                let break_depth = self.depth;
                 wasm!(self.func, { block_empty; });
-                self.depth += 1;
+                let _g1 = self.depth_push();
+                let break_depth = _g1.saved();
 
-                let continue_depth = self.depth;
                 wasm!(self.func, { loop_empty; });
-                self.depth += 1;
+                let _g2 = self.depth_push();
+                let continue_depth = _g2.saved();
 
                 self.loop_stack.push(super::LoopLabels { break_depth, continue_depth });
 
@@ -190,9 +190,9 @@ impl FuncCompiler<'_> {
                 }
 
                 self.loop_stack.pop();
-                self.depth -= 1;
+                self.depth_pop(_g2);
                 wasm!(self.func, { end; }); // end loop
-                self.depth -= 1;
+                self.depth_pop(_g1);
                 wasm!(self.func, { end; }); // end block
 
                 // After block: load saved result (if any)
@@ -208,13 +208,13 @@ impl FuncCompiler<'_> {
 
             // ── While loop ──
             IrExprKind::While { cond, body } => {
-                let break_depth = self.depth;
                 wasm!(self.func, { block_empty; });
-                self.depth += 1;
+                let _g3 = self.depth_push();
+                let break_depth = _g3.saved();
 
-                let continue_depth = self.depth;
                 wasm!(self.func, { loop_empty; });
-                self.depth += 1;
+                let _g4 = self.depth_push();
+                let continue_depth = _g4.saved();
 
                 self.loop_stack.push(super::LoopLabels { break_depth, continue_depth });
 
@@ -234,9 +234,9 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { br(self.depth - continue_depth - 1); });
 
                 self.loop_stack.pop();
-                self.depth -= 1;
+                self.depth_pop(_g4);
                 wasm!(self.func, { end; }); // end loop
-                self.depth -= 1;
+                self.depth_pop(_g3);
                 wasm!(self.func, { end; }); // end block
             }
 

--- a/src/codegen/emit_wasm/expressions.rs
+++ b/src/codegen/emit_wasm/expressions.rs
@@ -152,9 +152,9 @@ impl FuncCompiler<'_> {
                     // Use i64 scratch for i64/f64, i32 scratch for i32
                     match tail_vt {
                         Some(ValType::I64) | Some(ValType::F64) =>
-                            Some(self.match_i64_base + self.match_depth),
+                            Some(self.scratch.alloc_i64()),
                         _ =>
-                            Some(self.match_i32_base + self.match_depth),
+                            Some(self.scratch.alloc_i32()),
                     }
                 } else { None };
 
@@ -198,6 +198,11 @@ impl FuncCompiler<'_> {
                 // After block: load saved result (if any)
                 if let Some(rl) = result_local {
                     wasm!(self.func, { local_get(rl); });
+                    // Free scratch in reverse order
+                    match tail_vt {
+                        Some(ValType::I64) | Some(ValType::F64) => self.scratch.free_i64(rl),
+                        _ => self.scratch.free_i32(rl),
+                    }
                 }
             }
 
@@ -307,7 +312,7 @@ impl FuncCompiler<'_> {
             // ── Map ──
             IrExprKind::EmptyMap => {
                 // Empty map: just [len=0:i32]
-                let scratch = self.match_i32_base + self.match_depth;
+                let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_const(4);
                     call(self.emitter.rt.alloc);
@@ -317,6 +322,7 @@ impl FuncCompiler<'_> {
                     i32_store(0);
                     local_get(scratch);
                 });
+                self.scratch.free_i32(scratch);
             }
             IrExprKind::MapLiteral { entries } => {
                 // Map literal: [len:i32][key0][val0][key1][val1]...
@@ -326,7 +332,7 @@ impl FuncCompiler<'_> {
                     values::byte_size(&k.ty) + values::byte_size(&v.ty)
                 } else { 8 };
                 let total = 4 + n * entry_size;
-                let scratch = self.match_i32_base + self.match_depth;
+                let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_const(total as i32);
                     call(self.emitter.rt.alloc);
@@ -349,24 +355,23 @@ impl FuncCompiler<'_> {
                     offset += values::byte_size(&val.ty);
                 }
                 wasm!(self.func, { local_get(scratch); });
+                self.scratch.free_i32(scratch);
             }
 
             // ── Option/Result ──
             IrExprKind::OptionSome { expr: inner } => {
                 let inner_size = values::byte_size(&inner.ty);
-                let scratch = self.match_i32_base + self.match_depth;
+                let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_const(inner_size as i32);
                     call(self.emitter.rt.alloc);
                     local_set(scratch);
                     local_get(scratch);
                 });
-                // Reserve scratch so inner expr uses different local
-                self.match_depth += 1;
                 self.emit_expr(inner);
-                self.match_depth -= 1;
                 self.emit_store_at(&inner.ty, 0);
                 wasm!(self.func, { local_get(scratch); });
+                self.scratch.free_i32(scratch);
             }
             IrExprKind::OptionNone => {
                 wasm!(self.func, { i32_const(0); });
@@ -376,7 +381,7 @@ impl FuncCompiler<'_> {
             IrExprKind::ResultOk { expr: inner } => {
                 // ok(x) = [tag:0, value]
                 let inner_size = values::byte_size(&inner.ty);
-                let scratch = self.match_i32_base + self.match_depth;
+                let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_const((4 + inner_size) as i32);
                     call(self.emitter.rt.alloc);
@@ -388,17 +393,16 @@ impl FuncCompiler<'_> {
                 });
                 if values::ty_to_valtype(&inner.ty).is_some() {
                     wasm!(self.func, { local_get(scratch); });
-                    self.match_depth += 1;
                     self.emit_expr(inner);
-                    self.match_depth -= 1;
                     self.emit_store_at(&inner.ty, 4);
                 }
                 wasm!(self.func, { local_get(scratch); });
+                self.scratch.free_i32(scratch);
             }
             IrExprKind::ResultErr { expr: inner } => {
                 // err(e) = [tag:1, value]
                 let inner_size = values::byte_size(&inner.ty);
-                let scratch = self.match_i32_base + self.match_depth;
+                let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_const((4 + inner_size) as i32);
                     call(self.emitter.rt.alloc);
@@ -410,12 +414,11 @@ impl FuncCompiler<'_> {
                 });
                 if values::ty_to_valtype(&inner.ty).is_some() {
                     wasm!(self.func, { local_get(scratch); });
-                    self.match_depth += 1;
                     self.emit_expr(inner);
-                    self.match_depth -= 1;
                     self.emit_store_at(&inner.ty, 4);
                 }
                 wasm!(self.func, { local_get(scratch); });
+                self.scratch.free_i32(scratch);
             }
 
             // ── Fan block (sequential fallback — no parallelism in WASM) ──
@@ -434,7 +437,7 @@ impl FuncCompiler<'_> {
                 // If tag == 0 (ok): unwrap → push value
                 // If tag != 0 (err): return the Result as-is
                 self.emit_expr(inner);
-                let scratch = self.match_i32_base + self.match_depth;
+                let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     local_set(scratch);
                     // Check tag
@@ -451,6 +454,7 @@ impl FuncCompiler<'_> {
                     local_get(scratch);
                 });
                 self.emit_load_at(&expr.ty, 4);
+                self.scratch.free_i32(scratch);
             }
 
             // ── Map index access: m[key] → Option[V] ──
@@ -594,9 +598,9 @@ impl FuncCompiler<'_> {
                 self.emit_expr(left);
                 self.emit_expr(right);
                 // Use i32 scratch for counter, i64 scratch for result/base
-                let base_s = self.match_i64_base + self.match_depth;
-                let result_s = base_s + 1;
-                let counter_s = self.match_i32_base + self.match_depth;
+                let base_s = self.scratch.alloc_i64();
+                let result_s = self.scratch.alloc_i64();
+                let counter_s = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_wrap_i64;
                     local_set(counter_s);
@@ -621,12 +625,15 @@ impl FuncCompiler<'_> {
                     end;
                     local_get(result_s);
                 });
+                self.scratch.free_i32(counter_s);
+                self.scratch.free_i64(result_s);
+                self.scratch.free_i64(base_s);
             }
             BinOp::PowFloat => {
                 // Float power: check if exp == 0.5 → sqrt, else integer loop
-                let base_s = self.match_i64_base + self.match_depth;
-                let result_s = base_s + 1;
-                let counter_s = self.match_i32_base + self.match_depth;
+                let base_s = self.scratch.alloc_i64();
+                let result_s = self.scratch.alloc_i64();
+                let counter_s = self.scratch.alloc_i32();
                 self.emit_expr(left);
                 wasm!(self.func, { i64_reinterpret_f64; local_set(base_s); });
                 self.emit_expr(right);
@@ -672,6 +679,9 @@ impl FuncCompiler<'_> {
                     f64_reinterpret_i64;
                     end;
                 });
+                self.scratch.free_i32(counter_s);
+                self.scratch.free_i64(result_s);
+                self.scratch.free_i64(base_s);
             }
             BinOp::XorInt => {
                 self.emit_expr(left);

--- a/src/codegen/emit_wasm/functions.rs
+++ b/src/codegen/emit_wasm/functions.rs
@@ -39,17 +39,7 @@ pub fn compile_function(
         }
     }
 
-    // Legacy scratch locals (for unmigrated code)
-    let match_i64_base = param_count + local_decls.len() as u32;
-    for _ in 0..scan.scratch_depth {
-        local_decls.push((1, ValType::I64));
-    }
-    let match_i32_base = param_count + local_decls.len() as u32;
-    for _ in 0..scan.scratch_depth {
-        local_decls.push((1, ValType::I32));
-    }
-
-    // ScratchAllocator locals (separate region, after legacy)
+    // ScratchAllocator locals
     let scratch_i32_base = param_count + local_decls.len() as u32;
     let scratch_extra = 12; // enough for the largest stdlib function (unique_by = 10+)
     for _ in 0..scratch_extra {
@@ -77,9 +67,6 @@ pub fn compile_function(
         depth: 0,
         loop_stack: Vec::new(),
         scratch: scratch_alloc,
-        match_i64_base,
-        match_i32_base,
-        match_depth: 0,
         var_table: _var_table,
         stub_ret_ty: crate::types::Ty::Unit,
     };

--- a/src/codegen/emit_wasm/mod.rs
+++ b/src/codegen/emit_wasm/mod.rs
@@ -316,10 +316,6 @@ pub struct FuncCompiler<'a> {
     pub loop_stack: Vec<LoopLabels>,
     // Scratch local allocator
     pub scratch: scratch::ScratchAllocator,
-    // Legacy compatibility — delegates to scratch allocator internally
-    pub match_i64_base: u32,
-    pub match_i32_base: u32,
-    pub match_depth: u32,
     // Variable table for name lookups (pattern matching)
     pub var_table: &'a crate::ir::VarTable,
     // Return type for stub calls (set by emit_call before delegating to handlers)
@@ -633,21 +629,8 @@ fn assemble(emitter: &WasmEmitter) -> Vec<u8> {
 fn compile_init_globals(emitter: &mut WasmEmitter, program: &IrProgram) {
     let void_type = emitter.register_type(vec![], vec![]);
 
-    // We need scratch locals for computing top_let values
-    let scan_depth = program.top_lets.iter()
-        .map(|tl| statements::count_scratch_depth_public(&tl.value))
-        .max().unwrap_or(0).max(1);
-
     let mut local_decls = Vec::new();
-    let match_i64_base = local_decls.len() as u32;
-    for _ in 0..scan_depth {
-        local_decls.push((1, ValType::I64));
-    }
-    let match_i32_base = local_decls.len() as u32;
-    for _ in 0..scan_depth {
-        local_decls.push((1, ValType::I32));
-    }
-    // ScratchAllocator region (separate from legacy)
+    // ScratchAllocator locals
     let scratch_i32_base = local_decls.len() as u32;
     for _ in 0..12 { local_decls.push((1, ValType::I32)); }
     let scratch_i64_base = local_decls.len() as u32;
@@ -666,9 +649,6 @@ fn compile_init_globals(emitter: &mut WasmEmitter, program: &IrProgram) {
             depth: 0,
             loop_stack: Vec::new(),
             scratch: scratch_alloc,
-            match_i64_base,
-            match_i32_base,
-            match_depth: 0,
             var_table: &program.var_table,
             stub_ret_ty: Ty::Unit,
         };

--- a/src/codegen/emit_wasm/mod.rs
+++ b/src/codegen/emit_wasm/mod.rs
@@ -307,6 +307,17 @@ pub struct LoopLabels {
     pub continue_depth: u32,
 }
 
+/// RAII guard for WASM block nesting depth.
+/// Created by `depth_push`/`depth_push_n`, consumed by `depth_pop`.
+/// `#[must_use]` ensures the guard is not silently dropped.
+#[must_use = "call depth_pop() to restore depth"]
+pub struct DepthGuard(u32);
+
+impl DepthGuard {
+    /// The depth value at the point this guard was created (before push).
+    pub fn saved(&self) -> u32 { self.0 }
+}
+
 /// Per-function compilation state.
 pub struct FuncCompiler<'a> {
     pub emitter: &'a mut WasmEmitter,
@@ -320,6 +331,32 @@ pub struct FuncCompiler<'a> {
     pub var_table: &'a crate::ir::VarTable,
     // Return type for stub calls (set by emit_call before delegating to handlers)
     pub stub_ret_ty: Ty,
+}
+
+impl FuncCompiler<'_> {
+    /// Push depth by 1. Returns a guard that must be passed to `depth_pop`.
+    pub fn depth_push(&mut self) -> DepthGuard {
+        let g = DepthGuard(self.depth);
+        self.depth += 1;
+        g
+    }
+
+    /// Push depth by N. Returns a guard that restores to the saved depth.
+    pub fn depth_push_n(&mut self, n: u32) -> DepthGuard {
+        let g = DepthGuard(self.depth);
+        self.depth += n;
+        g
+    }
+
+    /// Restore depth from guard. Debug-asserts that depth hasn't been corrupted.
+    pub fn depth_pop(&mut self, guard: DepthGuard) {
+        debug_assert!(
+            self.depth > guard.0,
+            "depth_pop: depth {} should be > saved {}",
+            self.depth, guard.0,
+        );
+        self.depth = guard.0;
+    }
 }
 
 // ── Public API ──────────────────────────────────────────────────────

--- a/src/codegen/emit_wasm/statements.rs
+++ b/src/codegen/emit_wasm/statements.rs
@@ -108,7 +108,7 @@ impl FuncCompiler<'_> {
 
             IrStmtKind::BindDestructure { pattern, value } => {
                 self.emit_expr(value);
-                let scratch = self.match_i32_base + self.match_depth;
+                let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, { local_set(scratch); });
 
                 // Destructure pattern
@@ -151,6 +151,7 @@ impl FuncCompiler<'_> {
                     }
                     _ => {}
                 }
+                self.scratch.free_i32(scratch);
             }
 
             IrStmtKind::IndexAssign { target, index, value } => {
@@ -200,8 +201,6 @@ impl FuncCompiler<'_> {
 /// Result of pre-scanning a function body for local variables.
 pub struct LocalScanResult {
     pub binds: Vec<(VarId, ValType)>,
-    /// Max scratch local depth needed (match subjects + record temporaries).
-    pub scratch_depth: usize,
 }
 
 /// Pre-scan a function body to collect all local variable bindings
@@ -209,128 +208,7 @@ pub struct LocalScanResult {
 pub fn collect_locals(body: &IrExpr, var_table: &crate::ir::VarTable) -> LocalScanResult {
     let mut binds = Vec::new();
     scan_expr(body, &mut binds, var_table);
-    // Always at least 1 scratch level (used by record/variant construction)
-    let scratch_depth = count_scratch_depth(body).max(1);
-    LocalScanResult { binds, scratch_depth }
-}
-
-/// Count the maximum scratch local depth needed.
-/// Match expressions and Record constructions each consume 1 level.
-/// Public access to scratch depth counting (used by init_globals compilation).
-pub fn count_scratch_depth_public(expr: &IrExpr) -> usize {
-    count_scratch_depth(expr)
-}
-
-fn count_scratch_depth(expr: &IrExpr) -> usize {
-    match &expr.kind {
-        IrExprKind::Match { subject, arms } => {
-            let inner = arms.iter()
-                .map(|a| count_scratch_depth(&a.body))
-                .max().unwrap_or(0);
-            let subj = count_scratch_depth(subject);
-            1 + inner.max(subj)
-        }
-        IrExprKind::Record { fields, .. } => {
-            let inner = fields.iter()
-                .map(|(_, e)| count_scratch_depth(e))
-                .max().unwrap_or(0);
-            1 + inner
-        }
-        IrExprKind::Block { stmts, expr } | IrExprKind::DoBlock { stmts, expr } => {
-            let s = stmts.iter().map(|s| count_scratch_depth_stmt(s)).max().unwrap_or(0);
-            let e = expr.as_ref().map(|e| count_scratch_depth(e)).unwrap_or(0);
-            s.max(e)
-        }
-        IrExprKind::If { cond, then, else_ } => {
-            count_scratch_depth(cond)
-                .max(count_scratch_depth(then))
-                .max(count_scratch_depth(else_))
-        }
-        IrExprKind::While { cond, body } => {
-            let b = body.iter().map(|s| count_scratch_depth_stmt(s)).max().unwrap_or(0);
-            count_scratch_depth(cond).max(b)
-        }
-        IrExprKind::BinOp { op, left, right } => {
-            let inner = count_scratch_depth(left).max(count_scratch_depth(right));
-            match op {
-                crate::ir::BinOp::PowInt | crate::ir::BinOp::PowFloat => 4 + inner,
-                // Eq/Neq: deep equality uses up to 3 scratch locals (list_eq_deep, option_eq_deep, etc.)
-                crate::ir::BinOp::Eq | crate::ir::BinOp::Neq => 3 + inner,
-                _ => inner,
-            }
-        }
-        IrExprKind::UnOp { operand, .. } => count_scratch_depth(operand),
-        IrExprKind::Call { args, target, .. } => {
-            // ScratchAllocator: stdlib functions alloc up to 10 i32 scratch locals
-            // (unique_by uses 10). This must be enough to cover the worst case.
-            let inner = args.iter().map(|a| count_scratch_depth(a)).max().unwrap_or(0);
-            10 + inner
-        }
-        // SpreadRecord needs 2 i32 scratch (result + base ptrs) + 1 i64 scratch (copy counter)
-        IrExprKind::SpreadRecord { base, fields, .. } => {
-            let inner = fields.iter().map(|(_, e)| count_scratch_depth(e)).max().unwrap_or(0);
-            2 + count_scratch_depth(base).max(inner)
-        }
-        // Option/Result construction: 1 scratch + inner (scratch held while emitting inner expr)
-        IrExprKind::OptionSome { expr } => 1 + count_scratch_depth(expr),
-        IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr } => 1 + count_scratch_depth(expr),
-        IrExprKind::EmptyMap => 1,
-        IrExprKind::MapLiteral { entries } => {
-            let inner = entries.iter()
-                .flat_map(|(k, v)| [count_scratch_depth(k), count_scratch_depth(v)])
-                .max().unwrap_or(0);
-            1 + inner
-        }
-        IrExprKind::List { elements } => {
-            let inner = elements.iter().map(|e| count_scratch_depth(e)).max().unwrap_or(0);
-            1 + inner
-        }
-        IrExprKind::Tuple { elements } => {
-            let inner = elements.iter().map(|e| count_scratch_depth(e)).max().unwrap_or(0);
-            1 + inner
-        }
-        // FnRef needs 1 scratch, Lambda with captures needs 2 (env + closure ptr)
-        IrExprKind::FnRef { .. } => 1,
-        IrExprKind::Lambda { .. } => 2,
-        IrExprKind::Try { expr } => 1 + count_scratch_depth(expr),
-        IrExprKind::ForIn { iterable, body, .. } => {
-            let b = body.iter().map(|s| count_scratch_depth_stmt(s)).max().unwrap_or(0);
-            // List for...in reserves 2 scratch slots (list ptr + index counter)
-            // via match_depth += 2 BEFORE emitting iterable and body,
-            // so both iterable and body scratch are additive to the 2 reserved slots.
-            let for_in_need = match &iterable.kind {
-                IrExprKind::Range { .. } => 0,
-                _ => 2,
-            };
-            for_in_need + count_scratch_depth(iterable).max(b)
-        }
-        IrExprKind::StringInterp { parts } => {
-            parts.iter().map(|p| match p {
-                crate::ir::IrStringPart::Expr { expr } => count_scratch_depth(expr),
-                _ => 0,
-            }).max().unwrap_or(0)
-        }
-        IrExprKind::Clone { expr } | IrExprKind::Deref { expr } => count_scratch_depth(expr),
-        IrExprKind::Member { object, .. } | IrExprKind::IndexAccess { object, .. }
-        | IrExprKind::TupleIndex { object, .. } => count_scratch_depth(object),
-        // MapAccess delegates to map.get which uses 2 scratch locals (loop index + result ptr)
-        IrExprKind::MapAccess { object, key } => {
-            2 + count_scratch_depth(object).max(count_scratch_depth(key))
-        }
-        _ => 0,
-    }
-}
-
-fn count_scratch_depth_stmt(stmt: &IrStmt) -> usize {
-    match &stmt.kind {
-        IrStmtKind::Bind { value, .. } | IrStmtKind::Assign { value, .. } => count_scratch_depth(value),
-        IrStmtKind::BindDestructure { value, .. } => 1 + count_scratch_depth(value),
-        IrStmtKind::Expr { expr } => count_scratch_depth(expr),
-        IrStmtKind::Guard { cond, else_ } => count_scratch_depth(cond).max(count_scratch_depth(else_)),
-        IrStmtKind::IndexAssign { index, value, .. } => count_scratch_depth(index).max(count_scratch_depth(value)),
-        IrStmtKind::FieldAssign { value, .. } => count_scratch_depth(value),
-        _ => 0,
-    }
+    LocalScanResult { binds }
 }
 
 fn scan_expr(expr: &IrExpr, locals: &mut Vec<(VarId, ValType)>, vt: &crate::ir::VarTable) {

--- a/src/codegen/emit_wasm/statements.rs
+++ b/src/codegen/emit_wasm/statements.rs
@@ -69,7 +69,7 @@ impl FuncCompiler<'_> {
                     i32_eqz;
                     if_empty;
                 });
-                self.depth += 1;
+                let _g = self.depth_push();
 
                 match &else_.kind {
                     // Break/Continue: emit directly (they generate the right br)
@@ -98,7 +98,7 @@ impl FuncCompiler<'_> {
                     }
                 }
 
-                self.depth -= 1;
+                self.depth_pop(_g);
                 wasm!(self.func, { end; });
             }
 


### PR DESCRIPTION
## Summary
- Migrate all 18 WASM codegen files from legacy `match_i32_base`/`match_i64_base`/`match_depth` scratch system to `ScratchAllocator` (bump/reuse per-type locals)
- Remove `match_i32_base`, `match_i64_base`, `match_depth` fields from `FuncCompiler`
- Remove `count_scratch_depth` static analysis (~120 lines) — no longer needed since ScratchAllocator manages allocation dynamically
- Remove legacy local pre-allocation from `functions.rs`, `closures.rs`, `mod.rs`
- Replace all manual `self.depth += 1` / `self.depth -= 1` with `DepthGuard` RAII pattern (`depth_push`/`depth_pop`) with `#[must_use]` and debug assertions

## Test plan
- [x] `cargo build` — zero errors
- [x] `almide test` — all 153 test files pass
- [x] `grep match_i32_base` in emit_wasm — only a comment in scratch.rs remains
- [x] `grep "self.depth +="` — only inside `depth_push`/`depth_push_n` implementations