### PR TITLE
Fix WASM compile errors, implement map.entries (105→115 pass)

### DIFF
--- a/src/codegen/emit_wasm/calls_map.rs
+++ b/src/codegen/emit_wasm/calls_map.rs
@@ -440,9 +440,56 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(map_ptr);
             }
             "entries" => {
-                // entries is complex — stub for now
-                self.emit_stub_call(args);
-                return true;
+                // entries(m) → List[(K, V)] — list of heap-allocated tuple pointers
+                let (ks, vs) = self.map_kv_sizes(&args[0].ty);
+                let entry = ks + vs;
+                let map_ptr = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let tuple_ptr = self.scratch.alloc_i32();
+                self.emit_expr(&args[0]);
+                wasm!(self.func, {
+                    local_set(map_ptr);
+                    local_get(map_ptr); i32_load(0); local_set(len);
+                    // Alloc list of ptrs: [len:4][ptr0:4][ptr1:4]...
+                    i32_const(4); local_get(len); i32_const(4); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); local_get(len); i32_store(0);
+                    i32_const(0); local_set(i);
+                    block_empty; loop_empty;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      // Alloc tuple: [key:ks][val:vs]
+                      i32_const(entry as i32); call(self.emitter.rt.alloc); local_set(tuple_ptr);
+                      // Copy key
+                      local_get(tuple_ptr);
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                });
+                self.emit_elem_copy_sized(ks);
+                // Copy val
+                wasm!(self.func, {
+                      local_get(tuple_ptr); i32_const(ks as i32); i32_add;
+                      local_get(map_ptr); i32_const(4); i32_add;
+                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                      i32_const(ks as i32); i32_add;
+                });
+                self.emit_elem_copy_sized(vs);
+                wasm!(self.func, {
+                      // Store tuple ptr in result list
+                      local_get(result); i32_const(4); i32_add;
+                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(tuple_ptr); i32_store(0);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      br(0);
+                    end; end;
+                    local_get(result);
+                });
+                self.scratch.free_i32(tuple_ptr);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(map_ptr);
             }
             "merge" => {
                 // merge(a, b) → concat a entries then b entries (later values win on get)

--- a/src/codegen/emit_wasm/calls_set.rs
+++ b/src/codegen/emit_wasm/calls_set.rs
@@ -176,10 +176,11 @@ impl FuncCompiler<'_> {
             "insert" => {
                 let elem_ty = self.set_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
+                let vt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32);
                 let s = self.scratch.alloc_i32();
                 let s1 = self.scratch.alloc_i32();
                 let s2 = self.scratch.alloc_i32();
-                let val = self.scratch.alloc_i32();
+                let val = self.scratch.alloc(vt);
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
@@ -226,7 +227,7 @@ impl FuncCompiler<'_> {
                 });
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, { local_get(s1); end; });
-                self.scratch.free_i32(val);
+                self.scratch.free(val, vt);
                 self.scratch.free_i32(s2);
                 self.scratch.free_i32(s1);
                 self.scratch.free_i32(s);
@@ -234,11 +235,12 @@ impl FuncCompiler<'_> {
             "remove" => {
                 let elem_ty = self.set_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
+                let vt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32);
                 let s = self.scratch.alloc_i32();
                 let s1 = self.scratch.alloc_i32();
                 let s2 = self.scratch.alloc_i32();
                 let s3 = self.scratch.alloc_i32();
-                let val = self.scratch.alloc_i32();
+                let val = self.scratch.alloc(vt);
                 let orig = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s); });
@@ -295,7 +297,7 @@ impl FuncCompiler<'_> {
                     end;
                 });
                 self.scratch.free_i32(orig);
-                self.scratch.free_i32(val);
+                self.scratch.free(val, vt);
                 self.scratch.free_i32(s3);
                 self.scratch.free_i32(s2);
                 self.scratch.free_i32(s1);

--- a/src/codegen/emit_wasm/closures.rs
+++ b/src/codegen/emit_wasm/closures.rs
@@ -200,13 +200,15 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
         }
 
         // ScratchAllocator locals
+        let scratch_i32_cap = 32usize;
+        let scratch_i64_cap = 16usize;
+        let scratch_f64_cap = 4usize;
         let scratch_i32_base = local_idx;
-        let scratch_extra = 12usize;
-        for _ in 0..scratch_extra { local_decls.push((1, ValType::I32)); local_idx += 1; }
+        for _ in 0..scratch_i32_cap { local_decls.push((1, ValType::I32)); local_idx += 1; }
         let scratch_i64_base = local_idx;
-        for _ in 0..scratch_extra { local_decls.push((1, ValType::I64)); local_idx += 1; }
+        for _ in 0..scratch_i64_cap { local_decls.push((1, ValType::I64)); local_idx += 1; }
         let scratch_f64_base = local_idx;
-        for _ in 0..2 { local_decls.push((1, ValType::F64)); local_idx += 1; }
+        for _ in 0..scratch_f64_cap { local_decls.push((1, ValType::F64)); local_idx += 1; }
 
         let mut wasm_func = wasm_encoder::Function::new(local_decls);
 
@@ -250,7 +252,7 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
         // Compile body
         let compiled_func = {
             let mut scratch_alloc = super::scratch::ScratchAllocator::new();
-            scratch_alloc.set_bases(scratch_i32_base, scratch_i64_base, scratch_f64_base);
+            scratch_alloc.set_bases_with_capacity(scratch_i32_base, scratch_i32_cap, scratch_i64_base, scratch_i64_cap, scratch_f64_base, scratch_f64_cap);
             let mut compiler = FuncCompiler {
                 emitter: &mut *emitter,
                 func: wasm_func,

--- a/src/codegen/emit_wasm/functions.rs
+++ b/src/codegen/emit_wasm/functions.rs
@@ -39,27 +39,24 @@ pub fn compile_function(
         }
     }
 
-    // ScratchAllocator locals
+    // ScratchAllocator locals — must be large enough for deepest nested call chain
+    // (e.g. sum(map(filter([...], λ), λ)) needs ~14 simultaneous i32 scratch)
+    let scratch_i32_cap = 32usize;
+    let scratch_i64_cap = 16usize;
+    let scratch_f64_cap = 4usize;
     let scratch_i32_base = param_count + local_decls.len() as u32;
-    let scratch_extra = 12; // enough for the largest stdlib function (unique_by = 10+)
-    for _ in 0..scratch_extra {
-        local_decls.push((1, ValType::I32));
-    }
+    for _ in 0..scratch_i32_cap { local_decls.push((1, ValType::I32)); }
     let scratch_i64_base = param_count + local_decls.len() as u32;
-    for _ in 0..scratch_extra {
-        local_decls.push((1, ValType::I64));
-    }
+    for _ in 0..scratch_i64_cap { local_decls.push((1, ValType::I64)); }
     let scratch_f64_base = param_count + local_decls.len() as u32;
-    for _ in 0..2 { // f64 scratch (for float operations)
-        local_decls.push((1, ValType::F64));
-    }
+    for _ in 0..scratch_f64_cap { local_decls.push((1, ValType::F64)); }
 
     let init_globals_idx: Option<u32> = None;
 
     let wasm_func = Function::new(local_decls);
 
     let mut scratch_alloc = super::scratch::ScratchAllocator::new();
-    scratch_alloc.set_bases(scratch_i32_base, scratch_i64_base, scratch_f64_base);
+    scratch_alloc.set_bases_with_capacity(scratch_i32_base, scratch_i32_cap, scratch_i64_base, scratch_i64_cap, scratch_f64_base, scratch_f64_cap);
     let mut compiler = FuncCompiler {
         emitter,
         func: wasm_func,

--- a/src/codegen/emit_wasm/mod.rs
+++ b/src/codegen/emit_wasm/mod.rs
@@ -668,17 +668,20 @@ fn compile_init_globals(emitter: &mut WasmEmitter, program: &IrProgram) {
 
     let mut local_decls = Vec::new();
     // ScratchAllocator locals
+    let scratch_i32_cap = 32usize;
+    let scratch_i64_cap = 16usize;
+    let scratch_f64_cap = 4usize;
     let scratch_i32_base = local_decls.len() as u32;
-    for _ in 0..12 { local_decls.push((1, ValType::I32)); }
+    for _ in 0..scratch_i32_cap { local_decls.push((1, ValType::I32)); }
     let scratch_i64_base = local_decls.len() as u32;
-    for _ in 0..12 { local_decls.push((1, ValType::I64)); }
+    for _ in 0..scratch_i64_cap { local_decls.push((1, ValType::I64)); }
     let scratch_f64_base = local_decls.len() as u32;
-    for _ in 0..2 { local_decls.push((1, ValType::F64)); }
+    for _ in 0..scratch_f64_cap { local_decls.push((1, ValType::F64)); }
 
     let wasm_func = Function::new(local_decls);
     let compiled_func = {
         let mut scratch_alloc = scratch::ScratchAllocator::new();
-        scratch_alloc.set_bases(scratch_i32_base, scratch_i64_base, scratch_f64_base);
+        scratch_alloc.set_bases_with_capacity(scratch_i32_base, scratch_i32_cap, scratch_i64_base, scratch_i64_cap, scratch_f64_base, scratch_f64_cap);
         let mut compiler = FuncCompiler {
             emitter: &mut *emitter,
             func: wasm_func,

--- a/src/codegen/emit_wasm/scratch.rs
+++ b/src/codegen/emit_wasm/scratch.rs
@@ -14,11 +14,13 @@ struct TypedSlots {
     hwm: usize,
     /// WASM local index where this type's slots start (set after all bind locals are allocated)
     base: u32,
+    /// Max pre-allocated slots (overflow beyond this corrupts adjacent type regions)
+    capacity: usize,
 }
 
 impl TypedSlots {
     fn new() -> Self {
-        Self { slots: Vec::new(), hwm: 0, base: 0 }
+        Self { slots: Vec::new(), hwm: 0, base: 0, capacity: 0 }
     }
 
     fn alloc(&mut self) -> u32 {
@@ -30,6 +32,11 @@ impl TypedSlots {
         } else {
             // All slots in use — add a new one
             let idx = self.slots.len();
+            assert!(
+                idx < self.capacity,
+                "ScratchAllocator overflow: need {} slots but only {} pre-allocated (base={})",
+                idx + 1, self.capacity, self.base,
+            );
             self.slots.push(true);
             self.update_hwm();
             self.base + idx as u32
@@ -75,6 +82,15 @@ impl ScratchAllocator {
             i64: TypedSlots::new(),
             f64: TypedSlots::new(),
         }
+    }
+
+    pub fn set_bases_with_capacity(&mut self, i32_base: u32, i32_cap: usize, i64_base: u32, i64_cap: usize, f64_base: u32, f64_cap: usize) {
+        self.i32.base = i32_base;
+        self.i32.capacity = i32_cap;
+        self.i64.base = i64_base;
+        self.i64.capacity = i64_cap;
+        self.f64.base = f64_base;
+        self.f64.capacity = f64_cap;
     }
 
     pub fn set_bases(&mut self, i32_base: u32, i64_base: u32, f64_base: u32) {


### PR DESCRIPTION
## Summary
- Fix `set.insert`/`set.remove` using i32 scratch for Int (i64) element values → typed scratch via `alloc(vt)`
- Fix scratch pre-allocation overflow: 12 slots was insufficient for nested pipe chains (e.g. `[...] |> filter |> map |> sum` needs 14+ simultaneous i32 scratch). Increased to 32/16/4 with bounds-checking assert
- Implement `map.entries` for WASM (was stub) — allocates tuple pointers per entry

## Impact
- WASM tests: **105 → 115 passed** (+10)
- `pipe_chain_test` (+20 individual tests), `stdlib-test` (+88), `map_higher_order_test` (+39) now pass
- Rust tests: all 153 pass (unchanged)

## Test plan
- [x] `cargo build` — zero errors
- [x] `almide test` — 153/153 pass (Rust)
- [x] `almide test --target wasm` — 115/182 pass (was 105)