### PR TITLE
Fix Unknown type resolution in WASM codegen (120→121 pass)

### DIFF
--- a/src/codegen/emit_wasm/calls_list.rs
+++ b/src/codegen/emit_wasm/calls_list.rs
@@ -851,7 +851,9 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(list); });
                 self.emit_expr(&args[1]);
-                if matches!(&args[1].ty, Ty::Int) {
+                // Index is always Int (i64) — wrap to i32 for memory addressing.
+                // Check both explicit type and Unknown (which may actually be Int from TupleIndex etc.)
+                if matches!(&args[1].ty, Ty::Int | Ty::Unknown | Ty::TypeVar(_)) {
                     wasm!(self.func, { i32_wrap_i64; });
                 }
                 wasm!(self.func, {

--- a/src/codegen/emit_wasm/collections.rs
+++ b/src/codegen/emit_wasm/collections.rs
@@ -305,15 +305,34 @@ impl FuncCompiler<'_> {
 
     /// Emit a tuple index access: load from tuple pointer + element offset.
     pub(super) fn emit_tuple_index(&mut self, object: &IrExpr, index: usize, result_ty: &Ty) {
-        // Compute offset by summing sizes of elements before `index`
-        let offset = if let Ty::Tuple(elem_types) = &object.ty {
-            elem_types.iter().take(index).map(|t| values::byte_size(t)).sum::<u32>()
+        // Resolve object type — try VarTable if object.ty is not Tuple
+        let obj_ty = if let Ty::Tuple(_) = &object.ty {
+            object.ty.clone()
+        } else if let crate::ir::IrExprKind::Var { id } = &object.kind {
+            let vt_ty = &self.var_table.get(*id).ty;
+            if let Ty::Tuple(_) = vt_ty { vt_ty.clone() } else { object.ty.clone() }
         } else {
-            0
+            object.ty.clone()
+        };
+
+        // Compute offset by summing sizes of elements before `index`
+        let (offset, elem_ty) = if let Ty::Tuple(elem_types) = &obj_ty {
+            let off = elem_types.iter().take(index).map(|t| values::byte_size(t)).sum::<u32>();
+            let ty = elem_types.get(index).cloned();
+            (off, ty)
+        } else {
+            (0, None)
+        };
+
+        // Use result_ty if concrete, otherwise fall back to tuple element type
+        let load_ty = if matches!(result_ty, Ty::Unknown | Ty::TypeVar(_)) {
+            elem_ty.as_ref().unwrap_or(result_ty)
+        } else {
+            result_ty
         };
 
         self.emit_expr(object);
-        self.emit_load_at(result_ty, offset);
+        self.emit_load_at(load_ty, offset);
     }
 
     /// Emit a field access: load from record/variant pointer + field offset.

--- a/src/codegen/emit_wasm/expressions.rs
+++ b/src/codegen/emit_wasm/expressions.rs
@@ -360,7 +360,15 @@ impl FuncCompiler<'_> {
 
             // ── Option/Result ──
             IrExprKind::OptionSome { expr: inner } => {
-                let inner_size = values::byte_size(&inner.ty);
+                // Resolve inner type: if Unknown, infer from outer Option type or inner expr
+                let inner_ty = if matches!(inner.ty, Ty::Unknown) {
+                    if let Ty::Applied(crate::types::constructor::TypeConstructorId::Option, args) = &expr.ty {
+                        let candidate = args.first().cloned().unwrap_or(Ty::Unknown);
+                        if !matches!(candidate, Ty::Unknown) { candidate }
+                        else { self.infer_type_from_expr(inner) }
+                    } else { self.infer_type_from_expr(inner) }
+                } else { inner.ty.clone() };
+                let inner_size = values::byte_size(&inner_ty);
                 let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_const(inner_size as i32);
@@ -369,7 +377,7 @@ impl FuncCompiler<'_> {
                     local_get(scratch);
                 });
                 self.emit_expr(inner);
-                self.emit_store_at(&inner.ty, 0);
+                self.emit_store_at(&inner_ty, 0);
                 wasm!(self.func, { local_get(scratch); });
                 self.scratch.free_i32(scratch);
             }
@@ -380,7 +388,11 @@ impl FuncCompiler<'_> {
             // ── Result ok/err ──
             IrExprKind::ResultOk { expr: inner } => {
                 // ok(x) = [tag:0, value]
-                let inner_size = values::byte_size(&inner.ty);
+                // Resolve inner type: if Unknown, try to infer from the outer Result type or expr
+                let inner_ty = if matches!(inner.ty, Ty::Unknown) {
+                    self.resolve_result_inner_ty(expr, true)
+                } else { inner.ty.clone() };
+                let inner_size = values::byte_size(&inner_ty);
                 let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_const((4 + inner_size) as i32);
@@ -391,17 +403,20 @@ impl FuncCompiler<'_> {
                     i32_const(0);
                     i32_store(0);
                 });
-                if values::ty_to_valtype(&inner.ty).is_some() {
+                if values::ty_to_valtype(&inner_ty).is_some() {
                     wasm!(self.func, { local_get(scratch); });
                     self.emit_expr(inner);
-                    self.emit_store_at(&inner.ty, 4);
+                    self.emit_store_at(&inner_ty, 4);
                 }
                 wasm!(self.func, { local_get(scratch); });
                 self.scratch.free_i32(scratch);
             }
             IrExprKind::ResultErr { expr: inner } => {
                 // err(e) = [tag:1, value]
-                let inner_size = values::byte_size(&inner.ty);
+                let inner_ty = if matches!(inner.ty, Ty::Unknown) {
+                    self.resolve_result_inner_ty(expr, false)
+                } else { inner.ty.clone() };
+                let inner_size = values::byte_size(&inner_ty);
                 let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_const((4 + inner_size) as i32);
@@ -412,10 +427,10 @@ impl FuncCompiler<'_> {
                     i32_const(1);
                     i32_store(0);
                 });
-                if values::ty_to_valtype(&inner.ty).is_some() {
+                if values::ty_to_valtype(&inner_ty).is_some() {
                     wasm!(self.func, { local_get(scratch); });
                     self.emit_expr(inner);
-                    self.emit_store_at(&inner.ty, 4);
+                    self.emit_store_at(&inner_ty, 4);
                 }
                 wasm!(self.func, { local_get(scratch); });
                 self.scratch.free_i32(scratch);
@@ -739,5 +754,69 @@ pub(super) fn substitute_type_params(ty: &Ty, generic_names: &[&str], type_args:
         }
         // Recursively substitute in all other type constructors
         _ => ty.map_children(&|child| substitute_type_params(child, generic_names, type_args)),
+    }
+}
+
+impl FuncCompiler<'_> {
+    /// Resolve the inner type of a ResultOk/ResultErr when inner.ty is Unknown.
+    /// Tries: 1) outer expr.ty Result[T,E] args, 2) inner expr IR kind inference.
+    pub(super) fn resolve_result_inner_ty(&self, expr: &IrExpr, is_ok: bool) -> Ty {
+        use crate::types::constructor::TypeConstructorId;
+        // Try from outer Result type
+        if let Ty::Applied(TypeConstructorId::Result, args) = &expr.ty {
+            let candidate = if is_ok {
+                args.first().cloned().unwrap_or(Ty::Unknown)
+            } else {
+                args.get(1).cloned().unwrap_or(Ty::Unknown)
+            };
+            if !matches!(candidate, Ty::Unknown) {
+                return candidate;
+            }
+        }
+        // Fall back to inferring from inner expr
+        let inner = match &expr.kind {
+            IrExprKind::ResultOk { expr: e } | IrExprKind::ResultErr { expr: e } => e,
+            _ => return Ty::Int,
+        };
+        self.infer_type_from_expr(inner)
+    }
+
+    /// Best-effort type inference from IR expression structure.
+    fn infer_type_from_expr(&self, expr: &IrExpr) -> Ty {
+        if !matches!(expr.ty, Ty::Unknown) {
+            return expr.ty.clone();
+        }
+        match &expr.kind {
+            IrExprKind::LitInt { .. } => Ty::Int,
+            IrExprKind::LitFloat { .. } => Ty::Float,
+            IrExprKind::LitBool { .. } => Ty::Bool,
+            IrExprKind::LitStr { .. } => Ty::String,
+            IrExprKind::BinOp { op, left, .. } => {
+                match op {
+                    BinOp::AddInt | BinOp::SubInt | BinOp::MulInt | BinOp::DivInt | BinOp::ModInt
+                    | BinOp::PowInt | BinOp::XorInt => Ty::Int,
+                    BinOp::AddFloat | BinOp::SubFloat | BinOp::MulFloat | BinOp::DivFloat
+                    | BinOp::ModFloat | BinOp::PowFloat => Ty::Float,
+                    BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte
+                    | BinOp::And | BinOp::Or => Ty::Bool,
+                    BinOp::ConcatStr => Ty::String,
+                    BinOp::ConcatList => {
+                        let lt = self.infer_type_from_expr(left);
+                        lt
+                    }
+                }
+            }
+            IrExprKind::UnOp { op, .. } => {
+                match op {
+                    UnOp::NegInt => Ty::Int,
+                    UnOp::NegFloat => Ty::Float,
+                    UnOp::Not => Ty::Bool,
+                }
+            }
+            IrExprKind::Var { id } => {
+                self.var_table.get(*id).ty.clone()
+            }
+            _ => Ty::Int, // conservative fallback
+        }
     }
 }

--- a/src/codegen/emit_wasm/statements.rs
+++ b/src/codegen/emit_wasm/statements.rs
@@ -1,6 +1,7 @@
 //! IrStmt → WASM instruction emission + local variable pre-scanning.
 
 use crate::ir::{IrExpr, IrExprKind, IrStmt, IrStmtKind, VarId};
+use crate::types::Ty;
 use wasm_encoder::ValType;
 
 use super::FuncCompiler;
@@ -198,6 +199,40 @@ impl FuncCompiler<'_> {
     }
 }
 
+/// Infer the type of a bind value from its IR expression structure.
+/// Used when value.ty and stmt ty are both Unknown.
+fn infer_bind_type(expr: &IrExpr) -> Ty {
+    match &expr.kind {
+        IrExprKind::LitInt { .. } => Ty::Int,
+        IrExprKind::LitFloat { .. } => Ty::Float,
+        IrExprKind::LitBool { .. } => Ty::Bool,
+        IrExprKind::LitStr { .. } => Ty::String,
+        // TupleIndex: infer from parent tuple type
+        IrExprKind::TupleIndex { object, index } => {
+            if let Ty::Tuple(elems) = &object.ty {
+                elems.get(*index).cloned().unwrap_or(Ty::Unknown)
+            } else {
+                Ty::Unknown
+            }
+        }
+        // BinOp: infer from operation kind
+        IrExprKind::BinOp { op, .. } => {
+            use crate::ir::BinOp;
+            match op {
+                BinOp::AddInt | BinOp::SubInt | BinOp::MulInt | BinOp::DivInt
+                | BinOp::ModInt | BinOp::PowInt | BinOp::XorInt => Ty::Int,
+                BinOp::AddFloat | BinOp::SubFloat | BinOp::MulFloat | BinOp::DivFloat
+                | BinOp::ModFloat | BinOp::PowFloat => Ty::Float,
+                BinOp::ConcatStr => Ty::String,
+                BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte
+                | BinOp::And | BinOp::Or => Ty::Bool,
+                BinOp::ConcatList => Ty::Unknown,
+            }
+        }
+        _ => Ty::Unknown,
+    }
+}
+
 /// Result of pre-scanning a function body for local variables.
 pub struct LocalScanResult {
     pub binds: Vec<(VarId, ValType)>,
@@ -307,8 +342,16 @@ fn scan_expr(expr: &IrExpr, locals: &mut Vec<(VarId, ValType)>, vt: &crate::ir::
 fn scan_stmt(stmt: &IrStmt, locals: &mut Vec<(VarId, ValType)>, vt: &crate::ir::VarTable) {
     match &stmt.kind {
         IrStmtKind::Bind { var, ty, value, .. } => {
-            let val_type = values::ty_to_valtype(&value.ty)
-                .or_else(|| values::ty_to_valtype(ty));
+            // Resolve bind type: prefer value.ty, then stmt ty.
+            // If both are Unknown, infer from value's IR structure.
+            let resolved_ty = if !matches!(&value.ty, Ty::Unknown | Ty::TypeVar(_)) {
+                value.ty.clone()
+            } else if !matches!(ty, Ty::Unknown | Ty::TypeVar(_)) {
+                ty.clone()
+            } else {
+                infer_bind_type(value)
+            };
+            let val_type = values::ty_to_valtype(&resolved_ty);
             if let Some(vt_wasm) = val_type {
                 locals.push((*var, vt_wasm));
             }


### PR DESCRIPTION
## Summary
- **ResultOk/ResultErr/OptionSome**: When inner expr type is Unknown, infer from outer Result/Option type args or from inner expr IR structure (BinOp kind, literals, TupleIndex)
- **TupleIndex**: When result_ty is Unknown, resolve from parent tuple's element types via VarTable
- **list.get index wrap**: Always emit `i32_wrap_i64` for index arg when type is Unknown (index is always Int)
- **Bind local type inference**: New `infer_bind_type` in scan_stmt resolves Unknown types from IR expression structure (TupleIndex, BinOp, literals)

## Root cause
Monomorphization/type inference leaves some closure-internal expressions with `Unknown` type. WASM codegen defaulted Unknown to i32, causing mismatches when the actual value is i64 (Int) or f64 (Float).

## Test plan
- [x] `almide test` — 153/153 (Rust, unchanged)
- [x] `almide test --target wasm` — 121/182 pass (was 120)
- [x] No regressions vs baseline (verified with diff)
- [x] almide-grep now compiles and passes tests