### PR TITLE
Fix shorthand record pattern binding in variant match (124→125 pass)

### DIFF
--- a/src/codegen/emit_wasm/control.rs
+++ b/src/codegen/emit_wasm/control.rs
@@ -622,13 +622,18 @@ impl FuncCompiler<'_> {
                     // Bind fields: load each field from subject + tag_offset + field_offset
                     let case_fields = self.emitter.record_fields.get(ctor_name).cloned().unwrap_or_default();
                     for pf in pat_fields {
-                        // Find the field in the case's fields
                         if let Some((foff, fty)) = values::field_offset(&case_fields, &pf.name) {
                             let total_offset = 4 + foff; // 4 = tag size
-                            if let Some(&local_idx) = self.find_var_by_field(&pf.name, &case_fields) {
+                            // Use VarId from Bind pattern (populated by lowering) to avoid name collisions
+                            let local_idx = if let Some(crate::ir::IrPattern::Bind { var, .. }) = &pf.pattern {
+                                self.var_map.get(&var.0).copied()
+                            } else {
+                                self.find_var_by_field(&pf.name, &case_fields).copied()
+                            };
+                            if let Some(idx) = local_idx {
                                 wasm!(self.func, { local_get(scratch); });
                                 self.emit_load_at(&fty, total_offset);
-                                wasm!(self.func, { local_set(local_idx); });
+                                wasm!(self.func, { local_set(idx); });
                             }
                         }
                     }

--- a/src/lower/statements.rs
+++ b/src/lower/statements.rs
@@ -112,18 +112,20 @@ pub(super) fn lower_pattern(ctx: &mut LowerCtx, pat: &ast::Pattern, ty: &Ty) -> 
             IrPattern::Constructor { name: name.clone(), args: ir_args }
         }
         ast::Pattern::RecordPattern { name, fields, rest } => {
-            let ir_fields = fields.iter().map(|f| {
+            let ir_fields: Vec<IrFieldPattern> = fields.iter().map(|f| {
                 let field_ty = resolve_record_field_ty(ctx, name, &f.name);
                 IrFieldPattern {
                     name: f.name.clone(),
                     pattern: f.pattern.as_ref().map(|p| lower_pattern(ctx, p, &field_ty)),
                 }
             }).collect();
-            // Bind unmatched fields as variables
-            for f in fields {
+            // Bind shorthand fields as variables and attach Bind pattern
+            let mut ir_fields = ir_fields;
+            for (i, f) in fields.iter().enumerate() {
                 if f.pattern.is_none() {
                     let field_ty = resolve_record_field_ty(ctx, name, &f.name);
-                    ctx.define_var(&f.name, field_ty, Mutability::Let, None);
+                    let var = ctx.define_var(&f.name, field_ty.clone(), Mutability::Let, None);
+                    ir_fields[i].pattern = Some(IrPattern::Bind { var, ty: field_ty });
                 }
             }
             IrPattern::RecordPattern { name: name.clone(), fields: ir_fields, rest: *rest }


### PR DESCRIPTION
## Summary
- **IR lowering**: Shorthand record patterns (`Match { scope, regex }`) now attach `Bind { var, ty }` to `IrFieldPattern.pattern` instead of leaving it `None`
- **Codegen**: `RecordPattern` field binding uses VarId from `pf.pattern.Bind` instead of name-based `find_var_by_field` lookup, avoiding name collisions across variant cases (e.g. `Match.scope` vs `BeginEnd.scope`)

## Root cause
When multiple variant cases share a field name (e.g. `scope`), `find_var_by_field` traversed `var_map` and returned the first match — which could be from a different case. Shorthand patterns (`{ scope }`) had `None` pattern, so codegen couldn't use VarId directly.

## Test plan
- [x] `almide test` — 153/153 (Rust)
- [x] `almide test --target wasm` — 125/182 (was 124)
- [x] `variant_record_test` — 13/13 pass (was failing on first test)
- [x] No regressions