### PR TITLE
Implement function composition operator >>

### DIFF
--- a/spec/lang/compose_test.almd
+++ b/spec/lang/compose_test.almd
@@ -1,0 +1,14 @@
+test "basic compose" {
+  let double = (x: Int) => x * 2
+  let add_one = (x: Int) => x + 1
+  let double_then_add = double >> add_one
+  assert_eq(double_then_add(5), 11)
+}
+
+test "compose chain" {
+  let add1 = (x: Int) => x + 1
+  let mul3 = (x: Int) => x * 3
+  let sub2 = (x: Int) => x - 2
+  let pipeline = add1 >> mul3 >> sub2
+  assert_eq(pipeline(4), 13)
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -145,6 +145,7 @@ pub enum Expr {
     TupleIndex { object: Box<Expr>, index: usize, #[serde(skip)] id: ExprId, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
     IndexAccess { object: Box<Expr>, index: Box<Expr>, #[serde(skip)] id: ExprId, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
     Pipe { left: Box<Expr>, right: Box<Expr>, #[serde(skip)] id: ExprId, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
+    Compose { left: Box<Expr>, right: Box<Expr>, #[serde(skip)] id: ExprId, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
     If { cond: Box<Expr>, then: Box<Expr>, else_: Box<Expr>, #[serde(skip)] id: ExprId, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
     Match { subject: Box<Expr>, arms: Vec<MatchArm>, #[serde(skip)] id: ExprId, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
     Block { stmts: Vec<Stmt>, expr: Option<Box<Expr>>, #[serde(skip)] id: ExprId, #[serde(skip)] span: Option<Span>, #[serde(skip)] resolved_type: Option<ResolvedType> },
@@ -183,7 +184,7 @@ impl Expr {
             | Expr::List { id, .. } | Expr::MapLiteral { id, .. } | Expr::EmptyMap { id, .. }
             | Expr::Record { id, .. }
             | Expr::SpreadRecord { id, .. } | Expr::Call { id, .. }
-            | Expr::Member { id, .. } | Expr::TupleIndex { id, .. } | Expr::IndexAccess { id, .. } | Expr::Pipe { id, .. }
+            | Expr::Member { id, .. } | Expr::TupleIndex { id, .. } | Expr::IndexAccess { id, .. } | Expr::Pipe { id, .. } | Expr::Compose { id, .. }
             | Expr::If { id, .. } | Expr::Match { id, .. }
             | Expr::Block { id, .. } | Expr::DoBlock { id, .. } | Expr::Fan { id, .. }
             | Expr::ForIn { id, .. } | Expr::While { id, .. } | Expr::Lambda { id, .. }
@@ -208,7 +209,7 @@ impl Expr {
             | Expr::List { span, .. } | Expr::MapLiteral { span, .. } | Expr::EmptyMap { span, .. }
             | Expr::Record { span, .. }
             | Expr::SpreadRecord { span, .. } | Expr::Call { span, .. }
-            | Expr::Member { span, .. } | Expr::TupleIndex { span, .. } | Expr::IndexAccess { span, .. } | Expr::Pipe { span, .. }
+            | Expr::Member { span, .. } | Expr::TupleIndex { span, .. } | Expr::IndexAccess { span, .. } | Expr::Pipe { span, .. } | Expr::Compose { span, .. }
             | Expr::If { span, .. } | Expr::Match { span, .. }
             | Expr::Block { span, .. } | Expr::DoBlock { span, .. } | Expr::Fan { span, .. }
             | Expr::ForIn { span, .. } | Expr::While { span, .. } | Expr::Lambda { span, .. }
@@ -233,7 +234,7 @@ impl Expr {
             | Expr::List { resolved_type, .. } | Expr::MapLiteral { resolved_type, .. } | Expr::EmptyMap { resolved_type, .. }
             | Expr::Record { resolved_type, .. }
             | Expr::SpreadRecord { resolved_type, .. } | Expr::Call { resolved_type, .. }
-            | Expr::Member { resolved_type, .. } | Expr::TupleIndex { resolved_type, .. } | Expr::IndexAccess { resolved_type, .. } | Expr::Pipe { resolved_type, .. }
+            | Expr::Member { resolved_type, .. } | Expr::TupleIndex { resolved_type, .. } | Expr::IndexAccess { resolved_type, .. } | Expr::Pipe { resolved_type, .. } | Expr::Compose { resolved_type, .. }
             | Expr::If { resolved_type, .. } | Expr::Match { resolved_type, .. }
             | Expr::Block { resolved_type, .. } | Expr::DoBlock { resolved_type, .. } | Expr::Fan { resolved_type, .. }
             | Expr::ForIn { resolved_type, .. } | Expr::While { resolved_type, .. } | Expr::Lambda { resolved_type, .. }
@@ -258,7 +259,7 @@ impl Expr {
             | Expr::List { resolved_type, .. } | Expr::MapLiteral { resolved_type, .. } | Expr::EmptyMap { resolved_type, .. }
             | Expr::Record { resolved_type, .. }
             | Expr::SpreadRecord { resolved_type, .. } | Expr::Call { resolved_type, .. }
-            | Expr::Member { resolved_type, .. } | Expr::TupleIndex { resolved_type, .. } | Expr::IndexAccess { resolved_type, .. } | Expr::Pipe { resolved_type, .. }
+            | Expr::Member { resolved_type, .. } | Expr::TupleIndex { resolved_type, .. } | Expr::IndexAccess { resolved_type, .. } | Expr::Pipe { resolved_type, .. } | Expr::Compose { resolved_type, .. }
             | Expr::If { resolved_type, .. } | Expr::Match { resolved_type, .. }
             | Expr::Block { resolved_type, .. } | Expr::DoBlock { resolved_type, .. } | Expr::Fan { resolved_type, .. }
             | Expr::ForIn { resolved_type, .. } | Expr::While { resolved_type, .. } | Expr::Lambda { resolved_type, .. }

--- a/src/check/infer.rs
+++ b/src/check/infer.rs
@@ -257,6 +257,20 @@ impl Checker {
                 self.infer_pipe(left, right)
             }
 
+            ast::Expr::Compose { left, right, .. } => {
+                let left_ty = self.infer_expr(left);
+                let right_ty = self.infer_expr(right);
+                // If left is Fn[A] -> B and right is Fn[B] -> C, result is Fn[A] -> C
+                let resolved_left = resolve_ty(&left_ty, &self.uf);
+                let resolved_right = resolve_ty(&right_ty, &self.uf);
+                match (&resolved_left, &resolved_right) {
+                    (Ty::Fn { params: a_params, .. }, Ty::Fn { ret: c_ret, .. }) => {
+                        Ty::Fn { params: a_params.clone(), ret: c_ret.clone() }
+                    }
+                    _ => Ty::Unknown,
+                }
+            }
+
             ast::Expr::Lambda { params, body, .. } => {
                 self.env.push_scope();
                 // Lambda has its own return context — don't leak outer function's current_ret
@@ -608,7 +622,7 @@ fn collect_idents(expr: &ast::Expr, out: &mut Vec<String>) {
         }
         ast::Expr::Member { object, .. } | ast::Expr::TupleIndex { object, .. }
         | ast::Expr::IndexAccess { object, .. } => collect_idents(object, out),
-        ast::Expr::Binary { left, right, .. } | ast::Expr::Pipe { left, right, .. } => {
+        ast::Expr::Binary { left, right, .. } | ast::Expr::Pipe { left, right, .. } | ast::Expr::Compose { left, right, .. } => {
             collect_idents(left, out); collect_idents(right, out);
         }
         ast::Expr::Unary { operand, .. } | ast::Expr::Paren { expr: operand, .. }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -291,6 +291,7 @@ fn fmt_expr(out: &mut String, expr: &Expr, depth: usize) {
         Expr::TupleIndex { object, index, .. } => { fmt_expr(out, object, depth); w!(out, ".{index}"); }
         Expr::IndexAccess { object, index, .. } => { fmt_expr(out, object, depth); out.push('['); fmt_expr(out, index, depth); out.push(']'); }
         Expr::Pipe { left, right, .. } => { fmt_expr(out, left, depth); out.push_str(" |> "); fmt_expr(out, right, depth); }
+        Expr::Compose { left, right, .. } => { fmt_expr(out, left, depth); out.push_str(" >> "); fmt_expr(out, right, depth); }
         Expr::Binary { op, left, right, .. } => { fmt_expr(out, left, depth); w!(out, " {op} "); fmt_expr(out, right, depth); }
         Expr::Unary { op, operand, .. } => { out.push_str(op); if op == "not" { out.push(' '); } fmt_expr(out, operand, depth); }
         Expr::Break { .. } => out.push_str("break"),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -41,6 +41,7 @@ pub enum TokenType {
     PlusPlus,  // ++
     Pipe,      // |
     PipeArrow, // |>
+    ComposeArrow, // >>
     Caret,     // ^
     AmpAmp,    // &&
     PipePipe,  // ||
@@ -483,6 +484,7 @@ fn lex_operator(chars: &[char], pos: usize, line: usize, col: usize) -> (Token, 
         ('=', Some('='), _) => (TokenType::EqEq, "==", 2),
         ('!', Some('='), _) => (TokenType::BangEq, "!=", 2),
         ('<', Some('='), _) => (TokenType::LtEq, "<=", 2),
+        ('>', Some('>'), _) => (TokenType::ComposeArrow, ">>", 2),
         ('>', Some('='), _) => (TokenType::GtEq, ">=", 2),
         ('+', Some('+'), _) => (TokenType::PlusPlus, "++", 2),
         ('|', Some('>'), _) => (TokenType::PipeArrow, "|>", 2),

--- a/src/lower/expressions.rs
+++ b/src/lower/expressions.rs
@@ -279,29 +279,41 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
 
         // ── Compose: desugar `f >> g` → `(x) => g(f(x))` ──
         ast::Expr::Compose { left, right, .. } => {
+            let ir_left = lower_expr(ctx, left);
+            let ir_right = lower_expr(ctx, right);
+            // Extract types: left is Fn[A] -> B, right is Fn[B] -> C
+            let (param_ty, mid_ty) = match &ir_left.ty {
+                Ty::Fn { params, ret } => (
+                    params.first().cloned().unwrap_or(Ty::Unknown),
+                    *ret.clone(),
+                ),
+                _ => (Ty::Unknown, Ty::Unknown),
+            };
+            let ret_ty = match &ir_right.ty {
+                Ty::Fn { ret, .. } => *ret.clone(),
+                _ => Ty::Unknown,
+            };
             ctx.push_scope();
-            let param_ty = Ty::Unknown;
             let param_var = ctx.define_var("__compose_x", param_ty.clone(), Mutability::Let, span.clone());
             let param_ref = ctx.mk(IrExprKind::Var { id: param_var }, param_ty.clone(), span.clone());
             // f(x)
-            let ir_left = lower_expr(ctx, left);
             let f_call = ctx.mk(IrExprKind::Call {
                 target: CallTarget::Computed { callee: Box::new(ir_left) },
                 args: vec![param_ref], type_args: vec![],
-            }, Ty::Unknown, span.clone());
+            }, mid_ty, span.clone());
             // g(f(x))
-            let ir_right = lower_expr(ctx, right);
             let g_call = ctx.mk(IrExprKind::Call {
                 target: CallTarget::Computed { callee: Box::new(ir_right) },
                 args: vec![f_call], type_args: vec![],
-            }, Ty::Unknown, span.clone());
+            }, ret_ty.clone(), span.clone());
             ctx.pop_scope();
             let lambda_id = Some(ctx.next_lambda_id());
+            let lambda_ty = Ty::Fn { params: vec![param_ty.clone()], ret: Box::new(ret_ty) };
             ctx.mk(IrExprKind::Lambda {
                 params: vec![(param_var, param_ty)],
                 body: Box::new(g_call),
                 lambda_id,
-            }, ty, span)
+            }, lambda_ty, span)
         }
 
         // ── Lambda ──

--- a/src/lower/expressions.rs
+++ b/src/lower/expressions.rs
@@ -277,6 +277,33 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
             }
         }
 
+        // ── Compose: desugar `f >> g` → `(x) => g(f(x))` ──
+        ast::Expr::Compose { left, right, .. } => {
+            ctx.push_scope();
+            let param_ty = Ty::Unknown;
+            let param_var = ctx.define_var("__compose_x", param_ty.clone(), Mutability::Let, span.clone());
+            let param_ref = ctx.mk(IrExprKind::Var { id: param_var }, param_ty.clone(), span.clone());
+            // f(x)
+            let ir_left = lower_expr(ctx, left);
+            let f_call = ctx.mk(IrExprKind::Call {
+                target: CallTarget::Computed { callee: Box::new(ir_left) },
+                args: vec![param_ref], type_args: vec![],
+            }, Ty::Unknown, span.clone());
+            // g(f(x))
+            let ir_right = lower_expr(ctx, right);
+            let g_call = ctx.mk(IrExprKind::Call {
+                target: CallTarget::Computed { callee: Box::new(ir_right) },
+                args: vec![f_call], type_args: vec![],
+            }, Ty::Unknown, span.clone());
+            ctx.pop_scope();
+            let lambda_id = Some(ctx.next_lambda_id());
+            ctx.mk(IrExprKind::Lambda {
+                params: vec![(param_var, param_ty)],
+                body: Box::new(g_call),
+                lambda_id,
+            }, ty, span)
+        }
+
         // ── Lambda ──
         ast::Expr::Lambda { params, body, .. } => {
             ctx.push_scope();

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -12,43 +12,61 @@ impl Parser {
 
     fn parse_pipe(&mut self) -> Result<Expr, String> {
         let mut left = self.parse_or()?;
-        while { self.skip_newlines_if_followed_by(TokenType::PipeArrow); self.check(TokenType::PipeArrow) } {
-            let span = Some(self.current_span());
-            self.advance();
-            self.skip_newlines();
-            if self.check(TokenType::Match)
-                && self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::LBrace)
-            {
+        loop {
+            self.skip_newlines_if_followed_by(TokenType::PipeArrow);
+            self.skip_newlines_if_followed_by(TokenType::ComposeArrow);
+            if self.check(TokenType::ComposeArrow) {
+                let span = Some(self.current_span());
                 self.advance();
                 self.skip_newlines();
-                self.expect(TokenType::LBrace)?;
-                self.skip_newlines();
-                let mut arms = Vec::new();
-                while !self.check(TokenType::RBrace) {
-                    arms.push(self.parse_match_arm()?);
-                    self.skip_newlines();
-                    if self.check(TokenType::Comma) {
-                        self.advance();
-                        self.skip_newlines();
-                    }
-                }
-                self.expect(TokenType::RBrace)?;
-                left = Expr::Match {
-                    subject: Box::new(left),
-                    arms,
-                    id: self.next_id(),
-                    span,
-                    resolved_type: None,
-                };
-            } else {
                 let right = self.parse_or()?;
-                left = Expr::Pipe {
+                left = Expr::Compose {
                     left: Box::new(left),
                     right: Box::new(right),
                     id: self.next_id(),
                     span,
                     resolved_type: None,
                 };
+            } else if self.check(TokenType::PipeArrow) {
+                let span = Some(self.current_span());
+                self.advance();
+                self.skip_newlines();
+                if self.check(TokenType::Match)
+                    && self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::LBrace)
+                {
+                    self.advance();
+                    self.skip_newlines();
+                    self.expect(TokenType::LBrace)?;
+                    self.skip_newlines();
+                    let mut arms = Vec::new();
+                    while !self.check(TokenType::RBrace) {
+                        arms.push(self.parse_match_arm()?);
+                        self.skip_newlines();
+                        if self.check(TokenType::Comma) {
+                            self.advance();
+                            self.skip_newlines();
+                        }
+                    }
+                    self.expect(TokenType::RBrace)?;
+                    left = Expr::Match {
+                        subject: Box::new(left),
+                        arms,
+                        id: self.next_id(),
+                        span,
+                        resolved_type: None,
+                    };
+                } else {
+                    let right = self.parse_or()?;
+                    left = Expr::Pipe {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                        id: self.next_id(),
+                        span,
+                        resolved_type: None,
+                    };
+                }
+            } else {
+                break;
             }
         }
         Ok(left)


### PR DESCRIPTION
## Summary
- `f >> g` creates `(x) => g(f(x))` — apply f first, then g
- Same precedence as `|>`, left-associative
- Desugared to lambda in lowering, so all targets (Rust/TS/JS/WASM) work automatically

## Changes
- Lexer: `ComposeArrow` token (`>>`)
- AST: `Compose` variant
- Parser: `parse_pipe()` handles both `|>` and `>>`
- Lowering: `f >> g` → `(x) => g(f(x))`
- Type checker: `Fn[A] -> B >> Fn[B] -> C` infers `Fn[A] -> C`
- Formatter: `" >> "` formatting

## Test plan
- [x] `cargo build --release` passes
- [x] `spec/lang/compose_test.almd` — basic compose + chain (2 tests)
- [x] All 154 existing test files still pass