### PR TITLE
Monomorphization convergence detection (Phase 3.4)

### DIFF
--- a/src/mono/mod.rs
+++ b/src/mono/mod.rs
@@ -39,9 +39,10 @@ pub fn monomorphize(program: &mut IrProgram) {
     }
 
     // Fixed-point loop: transitive monomorphization (A → B → C chains)
+    // Converges when no new instances are discovered. Warns if instance count
+    // exceeds 1000 (possible infinite expansion).
     let mut all_instances: HashMap<MonoKey, HashMap<String, Ty>> = HashMap::new();
-    let max_iterations = 10;
-    for _ in 0..max_iterations {
+    loop {
         // Discover new instantiations (includes scanning previously generated specialized functions)
         let instances = discover_instances(program, &bound_fns);
 
@@ -50,6 +51,10 @@ pub fn monomorphize(program: &mut IrProgram) {
             .filter(|(k, _)| !all_instances.contains_key(k))
             .collect();
         if new.is_empty() {
+            break; // convergence: no new instances
+        }
+        if all_instances.len() + new.len() > 1000 {
+            eprintln!("[WARN] monomorphization: {}+ instances, possible infinite expansion", all_instances.len() + new.len());
             break;
         }
 


### PR DESCRIPTION
## Summary
- Replace `max_iterations = 10` fixed loop with convergence-based `loop` + `break`
- Add explosion guard: warn if 1000+ instances (possible infinite expansion)
- No behavior change for normal programs — loop already converged within 1-3 rounds

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test` — all 199 tests pass
- [x] WASM integration tests pass (exercises monomorphization)