### PR TITLE
Unify codegen entry point (Phase 4.3)

### DIFF
--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -154,12 +154,11 @@ fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool) {
     // Monomorphize
     almide::mono::monomorphize(&mut ir_program);
 
-    // Run nanopass pipeline (TCO, effect inference, stream fusion, result propagation, fan lowering)
-    let config = almide::codegen::target::configure(almide::codegen::pass::Target::Wasm);
-    config.pipeline.run(&mut ir_program, almide::codegen::pass::Target::Wasm);
-
-    // Emit WASM binary
-    let bytes = almide::codegen::emit_wasm_binary(&ir_program);
+    // Codegen (nanopass pipeline + WASM binary emit)
+    let bytes = match almide::codegen::codegen(&mut ir_program, almide::codegen::pass::Target::Wasm) {
+        almide::codegen::CodegenOutput::Binary(b) => b,
+        almide::codegen::CodegenOutput::Source(_) => unreachable!(),
+    };
 
     if let Err(e) = std::fs::write(output, &bytes) {
         eprintln!("Failed to write {}: {}", output, e);
@@ -227,7 +226,10 @@ fn cmd_build_npm(file: &str, out_dir: &str, _no_check: bool) {
 
     // Generate JS via v3 codegen
     almide::mono::monomorphize(&mut ir_program);
-    let js_code = almide::codegen::emit(&mut ir_program, almide::codegen::pass::Target::TypeScript);
+    let js_code = match almide::codegen::codegen(&mut ir_program, almide::codegen::pass::Target::TypeScript) {
+        almide::codegen::CodegenOutput::Source(s) => s,
+        almide::codegen::CodegenOutput::Binary(_) => unreachable!(),
+    };
 
     let package_json = format!(
         r#"{{"name":"{}","version":"{}","main":"index.js","type":"module"}}"#,

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -187,11 +187,11 @@ pub fn cmd_test_wasm(file: &str, run_filter: Option<&str>) {
         let mut ir_program = almide::lower::lower_program(&program, &checker.expr_types, &checker.env);
         almide::optimize::optimize_program(&mut ir_program);
         almide::mono::monomorphize(&mut ir_program);
-        let config = almide::codegen::target::configure(almide::codegen::pass::Target::Wasm);
-        config.pipeline.run(&mut ir_program, almide::codegen::pass::Target::Wasm);
-
         let bytes = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            almide::codegen::emit_wasm_binary(&ir_program)
+            match almide::codegen::codegen(&mut ir_program, almide::codegen::pass::Target::Wasm) {
+                almide::codegen::CodegenOutput::Binary(b) => b,
+                almide::codegen::CodegenOutput::Source(_) => unreachable!(),
+            }
         }));
         let bytes = match bytes {
             Ok(b) => b,

--- a/src/cli/emit.rs
+++ b/src/cli/emit.rs
@@ -113,22 +113,16 @@ pub fn cmd_emit(file: &str, target: &str, emit_ast: bool, emit_ir: bool, no_chec
             .unwrap_or_else(|e| { eprintln!("JSON serialize error: {}", e); std::process::exit(1); });
         println!("{}", json);
     } else {
-        let code = match target {
-            // v3 codegen (default)
-            "rust" | "rs" => {
-                let ir = ir_program.as_mut().expect("IR required for codegen");
-                codegen::emit(ir, codegen::pass::Target::Rust)
-            }
-            "ts" | "typescript" => {
-                let ir = ir_program.as_mut().expect("IR required for codegen");
-                codegen::emit(ir, codegen::pass::Target::TypeScript)
-            }
-            "js" | "javascript" => {
-                let ir = ir_program.as_mut().expect("IR required for codegen");
-                codegen::emit(ir, codegen::pass::Target::JavaScript)
-            }
+        let t = match target {
+            "rust" | "rs" => codegen::pass::Target::Rust,
+            "ts" | "typescript" => codegen::pass::Target::TypeScript,
+            "js" | "javascript" => codegen::pass::Target::JavaScript,
             other => { eprintln!("Unknown target: {}. Use rust, ts, js.", other); std::process::exit(1); }
         };
-        print!("{}", code);
+        let ir = ir_program.as_mut().expect("IR required for codegen");
+        match codegen::codegen(ir, t) {
+            codegen::CodegenOutput::Source(code) => print!("{}", code),
+            codegen::CodegenOutput::Binary(_) => unreachable!(),
+        }
     }
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -7,10 +7,12 @@
 //!     ↓
 //! Layer 2: Semantic Rewrite (target-specific Nanopass pipeline)
 //!     ↓
-//! Layer 3: Template Renderer (TOML-driven syntax output)
-//!     ↓
-//! Target source code (Rust / TypeScript / Go / Python)
+//! Layer 3: Emit (target-specific output)
+//!     Rust/TS/JS → Template Renderer (TOML-driven syntax) → source code
+//!     WASM       → Direct binary emit → .wasm bytes
 //! ```
+//!
+//! Single entry point: `codegen(program, target) → CodegenOutput`
 //!
 //! Design references:
 //! - MLIR progressive lowering (dialect conversion)
@@ -42,6 +44,12 @@ pub mod emit_wasm;
 use crate::ir::IrProgram;
 use pass::Target;
 
+/// Codegen output: source code for text targets, binary for WASM.
+pub enum CodegenOutput {
+    Source(String),
+    Binary(Vec<u8>),
+}
+
 /// Strip `mod tests { ... }` blocks from runtime source (avoid conflicts with user tests)
 fn strip_test_blocks(src: &str) -> String {
     let mut out = String::new();
@@ -69,15 +77,27 @@ fn strip_test_blocks(src: &str) -> String {
     out
 }
 
-/// Full codegen v3 pipeline: IR → Nanopass → Annotations → Walker → source code.
-pub fn emit(program: &mut IrProgram, target: Target) -> String {
+/// Unified codegen entry point: IR → Nanopass pipeline → target output.
+///
+/// Handles all targets through a single path:
+/// - Rust/TS/JS: Nanopass → Walker (template renderer) → source code
+/// - WASM: Nanopass → direct binary emit → .wasm bytes
+pub fn codegen(program: &mut IrProgram, target: Target) -> CodegenOutput {
     let config = target::configure(target);
 
     // Layer 2: Run Nanopass pipeline (semantic rewrites — modifies IR)
-    // BoxDerefPass runs first for Rust target, populating program.codegen_annotations
     config.pipeline.run(program, target);
 
-    // Layer 3: Template-driven rendering (walker reads annotations, never checks types)
+    // Layer 3: Target-specific emit
+    match target {
+        Target::Wasm => CodegenOutput::Binary(emit_wasm::emit(program)),
+        _ => CodegenOutput::Source(emit_source(program, target, &config)),
+    }
+}
+
+/// Emit source code for text targets (Rust, TypeScript, JavaScript).
+fn emit_source(program: &mut IrProgram, target: Target, config: &target::TargetConfig) -> String {
+    // Template-driven rendering (walker reads annotations, never checks types)
     let ann = std::mem::take(&mut program.codegen_annotations);
     let ctx = walker::RenderContext::new(&config.templates, &program.var_table)
         .with_target(target)
@@ -90,7 +110,6 @@ pub fn emit(program: &mut IrProgram, target: Target) -> String {
         Target::Rust => {
             output.push_str("#![allow(unused_parens, unused_variables, dead_code, unused_imports, unused_mut, unused_must_use)]\n\n");
             output.push_str("use std::collections::HashMap;\nuse std::collections::HashSet;\n");
-            // Core traits and macros (same as lower_rust.rs)
             output.push_str("trait AlmideConcat<Rhs> { type Output; fn concat(self, rhs: Rhs) -> Self::Output; }\n");
             output.push_str("impl AlmideConcat<String> for String { type Output = String; #[inline(always)] fn concat(self, rhs: String) -> String { format!(\"{}{}\", self, rhs) } }\n");
             output.push_str("impl AlmideConcat<&str> for String { type Output = String; #[inline(always)] fn concat(self, rhs: &str) -> String { format!(\"{}{}\", self, rhs) } }\n");
@@ -99,7 +118,6 @@ pub fn emit(program: &mut IrProgram, target: Target) -> String {
             output.push_str("impl<T: Clone> AlmideConcat<Vec<T>> for Vec<T> { type Output = Vec<T>; #[inline(always)] fn concat(self, rhs: Vec<T>) -> Vec<T> { let mut r = self; r.extend(rhs); r } }\n");
             output.push_str("macro_rules! almide_eq { ($a:expr, $b:expr) => { ($a) == ($b) }; }\n");
             output.push_str("macro_rules! almide_ne { ($a:expr, $b:expr) => { ($a) != ($b) }; }\n");
-            // Embed the full Rust runtime (stdlib functions), strip test blocks
             for (_name, source) in crate::generated::rust_runtime::RUST_RUNTIME_MODULES {
                 output.push_str(&strip_test_blocks(source));
                 output.push('\n');
@@ -107,12 +125,10 @@ pub fn emit(program: &mut IrProgram, target: Target) -> String {
             output.push('\n');
         }
         Target::TypeScript => {
-            // Embed the full TS runtime (Deno mode)
             output.push_str(&crate::emit_ts_runtime::full_runtime(false));
             output.push('\n');
         }
         Target::JavaScript => {
-            // Embed the JS runtime (no type annotations)
             output.push_str(&crate::emit_ts_runtime::full_runtime(true));
             output.push('\n');
         }
@@ -120,9 +136,4 @@ pub fn emit(program: &mut IrProgram, target: Target) -> String {
     }
     output.push_str(&user_code);
     output
-}
-
-/// Emit WASM binary directly from IR (no rustc intermediary).
-pub fn emit_wasm_binary(program: &IrProgram) -> Vec<u8> {
-    emit_wasm::emit(program)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,7 +307,10 @@ fn try_compile_with_ir(file: &str, no_check: bool) -> Result<(String, Option<alm
 
     // Codegen v3: three-layer pipeline (Nanopass + Templates)
     let ir = ir_program.as_mut().expect("IR required for codegen");
-    let code = codegen::emit(ir, codegen::pass::Target::Rust);
+    let code = match codegen::codegen(ir, codegen::pass::Target::Rust) {
+        codegen::CodegenOutput::Source(s) => s,
+        codegen::CodegenOutput::Binary(_) => unreachable!(),
+    };
     Ok((code, ir_program))
 }
 

--- a/tests/codegen_v3_real.rs
+++ b/tests/codegen_v3_real.rs
@@ -99,14 +99,17 @@ fn test_real_ir_diff_summary() {
     eprintln!("List type — Rust Vec: {}, TS []: {}", rust_has_vec, ts_has_array);
 }
 
-/// End-to-end: codegen::emit() — full pipeline in one call
+/// End-to-end: codegen::codegen() — full pipeline in one call
 #[test]
 fn test_emit_end_to_end_rust() {
     let mut program: IrProgram = serde_json::from_str(IR_JSON)
         .expect("failed to parse IR JSON");
 
-    let output = codegen::emit(&mut program, Target::Rust);
-    eprintln!("=== codegen::emit Rust ===\n{}", output);
+    let output = match codegen::codegen(&mut program, Target::Rust) {
+        codegen::CodegenOutput::Source(s) => s,
+        codegen::CodegenOutput::Binary(_) => unreachable!(),
+    };
+    eprintln!("=== codegen::codegen Rust ===\n{}", output);
 
     assert!(output.contains("pub fn find_price"), "should have pub fn");
     assert!(output.contains("almide_rt_list_find"), "should have stdlib call");
@@ -119,8 +122,11 @@ fn test_emit_end_to_end_ts() {
     let mut program: IrProgram = serde_json::from_str(IR_JSON)
         .expect("failed to parse IR JSON");
 
-    let output = codegen::emit(&mut program, Target::TypeScript);
-    eprintln!("=== codegen::emit TS ===\n{}", output);
+    let output = match codegen::codegen(&mut program, Target::TypeScript) {
+        codegen::CodegenOutput::Source(s) => s,
+        codegen::CodegenOutput::Binary(_) => unreachable!(),
+    };
+    eprintln!("=== codegen::codegen TS ===\n{}", output);
 
     assert!(output.contains("function find_price"), "should have function");
     assert!(output.contains("__almd_list.fold"), "should have stdlib call (fold)");


### PR DESCRIPTION
## Summary
- `emit()` + `emit_wasm_binary()` → single `codegen()` function returning `CodegenOutput` enum (`Source(String)` / `Binary(Vec<u8>)`)
- WASM pipeline execution moved from CLI into `codegen()` — all targets now go through the same path
- Removed duplicated `target::configure()` + `pipeline.run()` from `cli/commands.rs` and `cli/build.rs`

## Test plan
- [x] `cargo build` passes (warnings only, no errors)
- [x] `cargo test` — all Rust tests pass
- [ ] CI: full test suite (Build, Test, Emit & Format)