### PR TITLE
Monomorphization optimization (Phase 3.2 + 3.3)

### DIFF
--- a/src/mono/discovery.rs
+++ b/src/mono/discovery.rs
@@ -22,6 +22,7 @@ pub(super) fn collect_mono_bindings(
 }
 
 /// Discover all concrete instantiations of structurally-bounded functions.
+/// Scans all functions and top-level lets.
 pub(super) fn discover_instances(
     program: &IrProgram,
     bound_fns: &HashMap<String, Vec<BoundedParam>>,
@@ -36,6 +37,20 @@ pub(super) fn discover_instances(
         discover_in_expr(&tl.value, bound_fns, fns, &mut instances);
     }
 
+    instances
+}
+
+/// Discover instances only in the given frontier functions (newly added specializations).
+/// Uses all_fns for looking up original function signatures.
+pub(super) fn discover_instances_in_frontier(
+    frontier: &[IrFunction],
+    bound_fns: &HashMap<String, Vec<BoundedParam>>,
+    all_fns: &[IrFunction],
+) -> HashMap<MonoKey, HashMap<String, Ty>> {
+    let mut instances: HashMap<MonoKey, HashMap<String, Ty>> = HashMap::new();
+    for func in frontier {
+        discover_in_expr(&func.body, bound_fns, all_fns, &mut instances);
+    }
     instances
 }
 

--- a/src/mono/mod.rs
+++ b/src/mono/mod.rs
@@ -25,13 +25,17 @@ use crate::ir::*;
 use crate::types::Ty;
 
 use utils::{MonoKey, BoundedParam, has_typevar, ty_contains_typevar};
-use discovery::discover_instances;
+use discovery::{discover_instances, discover_instances_in_frontier};
 use specialization::{specialize_function, substitute_ty, update_var_table_types};
 use rewrite::rewrite_calls;
 use propagation::propagate_concrete_types;
 
 /// Run the monomorphization pass on an IR program.
 /// Specialize generic functions for concrete type arguments at each call site.
+///
+/// Uses frontier-based incremental discovery: after the first round scans all
+/// functions, subsequent rounds only scan newly created specializations.
+/// This reduces transitive discovery from O(N × total_functions) to O(N × new_functions).
 pub fn monomorphize(program: &mut IrProgram) {
     let bound_fns = find_structurally_bounded_fns(&program.functions, &program.type_decls);
     if bound_fns.is_empty() {
@@ -42,9 +46,19 @@ pub fn monomorphize(program: &mut IrProgram) {
     // Converges when no new instances are discovered. Warns if instance count
     // exceeds 1000 (possible infinite expansion).
     let mut all_instances: HashMap<MonoKey, HashMap<String, Ty>> = HashMap::new();
+    let mut frontier_start: Option<usize> = None; // None = first round (scan all)
+
     loop {
-        // Discover new instantiations (includes scanning previously generated specialized functions)
-        let instances = discover_instances(program, &bound_fns);
+        // Discovery: first round scans all functions + top_lets,
+        // subsequent rounds only scan the frontier (newly added specializations)
+        let instances = match frontier_start {
+            None => discover_instances(program, &bound_fns),
+            Some(start) => discover_instances_in_frontier(
+                &program.functions[start..],
+                &bound_fns,
+                &program.functions,
+            ),
+        };
 
         // Filter to only new instances
         let new: HashMap<MonoKey, HashMap<String, Ty>> = instances.into_iter()
@@ -58,12 +72,11 @@ pub fn monomorphize(program: &mut IrProgram) {
             break;
         }
 
-        // Clone and specialize new functions
+        // Specialize new functions
         let mut new_functions = Vec::new();
         for ((fn_name, suffix), bindings) in &new {
-                if let Some(orig) = program.functions.iter().find(|f| f.name == *fn_name) {
-                let specialized = specialize_function(orig, suffix, bindings);
-                new_functions.push(specialized);
+            if let Some(orig) = program.functions.iter().find(|f| f.name == *fn_name) {
+                new_functions.push(specialize_function(orig, suffix, bindings));
             }
         }
 
@@ -81,7 +94,8 @@ pub fn monomorphize(program: &mut IrProgram) {
         all_instances.extend(new);
         rewrite_calls(program, &bound_fns, &all_instances);
 
-        // Add specialized functions so next round can discover transitive calls in them
+        // Track frontier: next round only scans these new functions
+        frontier_start = Some(program.functions.len());
         program.functions.extend(new_functions);
     }
 

--- a/src/mono/specialization.rs
+++ b/src/mono/specialization.rs
@@ -3,35 +3,41 @@ use crate::ir::*;
 use crate::types::Ty;
 use super::utils::ty_to_name;
 
-/// Clone and specialize a function for concrete types.
+/// Specialize a function for concrete types.
+/// Builds the specialized function directly without cloning the entire original,
+/// avoiding redundant allocation of fields we immediately overwrite (generics, name).
 pub(super) fn specialize_function(
     orig: &IrFunction,
     suffix: &str,
     bindings: &HashMap<String, Ty>,
 ) -> IrFunction {
-    let mut func = orig.clone();
-    func.name = format!("{}__{}", orig.name, suffix);
-
-    // Remove structural bounds from generics (specialized function is concrete)
-    func.generics = None;
-
-    // Substitute type variables in parameter types
-    for param in &mut func.params {
-        // OpenRecord パラメータ (直接 or エイリアス) → 具体型に直接置換
-        let param_pos = orig.params.iter().position(|p| p.var == param.var).unwrap_or(0);
-        let open_key = format!("__open_{}", param_pos);
-        if bindings.contains_key(&open_key) {
-            if let Some(concrete) = bindings.get(&open_key) {
-                param.ty = concrete.clone();
-            }
+    // Build specialized params: substitute type variables
+    let params: Vec<IrParam> = orig.params.iter().enumerate().map(|(i, param)| {
+        let open_key = format!("__open_{}", i);
+        let new_ty = if let Some(concrete) = bindings.get(&open_key) {
+            concrete.clone()
         } else {
-            param.ty = substitute_ty(&param.ty, bindings);
-        }
-    }
-    func.ret_ty = substitute_ty(&func.ret_ty, bindings);
-    substitute_expr_types(&mut func.body, bindings);
+            substitute_ty(&param.ty, bindings)
+        };
+        IrParam { ty: new_ty, ..param.clone() }
+    }).collect();
 
-    func
+    // Build specialized body: clone + substitute in one step
+    let mut body = orig.body.clone();
+    substitute_expr_types(&mut body, bindings);
+
+    IrFunction {
+        name: format!("{}__{}", orig.name, suffix),
+        params,
+        ret_ty: substitute_ty(&orig.ret_ty, bindings),
+        body,
+        generics: None, // specialized function is concrete
+        is_effect: orig.is_effect,
+        is_async: orig.is_async,
+        is_test: orig.is_test,
+        extern_attrs: orig.extern_attrs.clone(),
+        visibility: orig.visibility.clone(),
+    }
 }
 
 /// Substitute TypeVars with concrete types.


### PR DESCRIPTION
## Summary
- **3.3 Incremental discovery**: Fixed-point loop now uses frontier-based scanning — after the first round scans all functions, subsequent rounds only scan newly created specializations. Reduces transitive discovery from O(N × total_functions) to O(N × new_functions).
- **3.2 Direct construction**: `specialize_function` builds the specialized function directly instead of clone-then-mutate. Avoids cloning `generics` (immediately discarded) and `name` (immediately overwritten).

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` — all 16 test suites pass
- [ ] CI: full test suite