### PR TITLE
Release 0.9.1

### DIFF
--- a/src/generated/textmate_patterns.txt
+++ b/src/generated/textmate_patterns.txt
@@ -3,23 +3,19 @@
 
 {
   "name": "keyword.control.almide",
-  "match": "\\b(if|then|else|match|for|in|while|do|guard)\\b"
+  "match": "\\b(if|then|else|match|for|in|while|guard)\\b"
 },
 {
   "name": "keyword.declaration.almide",
-  "match": "\\b(fn|type|trait|impl|let|var|test|import|module|newtype)\\b"
+  "match": "\\b(fn|type|protocol|impl|let|var|test|import|module|newtype)\\b"
 },
 {
   "name": "keyword.control.flow.almide",
-  "match": "\\b(try|await|break|continue)\\b"
+  "match": "\\b(break|continue|fan)\\b"
 },
 {
   "name": "storage.modifier.almide",
-  "match": "\\b(pub|local|mod|effect|async|strict|deriving)\\b"
-},
-{
-  "name": "keyword.other.almide",
-  "match": "\\b(unsafe)\\b"
+  "match": "\\b(pub|local|mod|effect|strict)\\b"
 },
 {
   "name": "constant.language.almide",

--- a/src/generated/token_table.rs
+++ b/src/generated/token_table.rs
@@ -14,7 +14,6 @@ pub fn build_keyword_map_generated() -> HashMap<&'static str, TokenType> {
         m.insert("and", TokenType::And);
         m.insert("break", TokenType::Break);
         m.insert("continue", TokenType::Continue);
-        m.insert("do", TokenType::Do);
         m.insert("effect", TokenType::Effect);
         m.insert("else", TokenType::Else);
         m.insert("err", TokenType::Err);
@@ -37,13 +36,13 @@ pub fn build_keyword_map_generated() -> HashMap<&'static str, TokenType> {
         m.insert("not", TokenType::Not);
         m.insert("ok", TokenType::Ok);
         m.insert("or", TokenType::Or);
+        m.insert("protocol", TokenType::Protocol);
         m.insert("pub", TokenType::Pub);
         m.insert("some", TokenType::Some);
         m.insert("strict", TokenType::Strict);
         m.insert("test", TokenType::Test);
         m.insert("then", TokenType::Then);
         m.insert("todo", TokenType::Todo);
-        m.insert("protocol", TokenType::Protocol);
         m.insert("true", TokenType::True);
         m.insert("type", TokenType::Type);
         m.insert("var", TokenType::Var);
@@ -56,16 +55,16 @@ pub fn build_keyword_map_generated() -> HashMap<&'static str, TokenType> {
 }
 
 /// All keywords as a flat list (for validation, tree-sitter, TextMate generation)
-pub const ALL_KEYWORDS: &[&str] = &["and", "break", "continue", "do", "effect", "else", "err", "false", "fan", "fn", "for", "guard", "if", "impl", "import", "in", "let", "local", "match", "mod", "module", "newtype", "none", "not", "ok", "or", "pub", "some", "strict", "test", "then", "todo", "protocol", "true", "type", "var", "while"];
+pub const ALL_KEYWORDS: &[&str] = &["and", "break", "continue", "effect", "else", "err", "false", "fan", "fn", "for", "guard", "if", "impl", "import", "in", "let", "local", "match", "mod", "module", "newtype", "none", "not", "ok", "or", "protocol", "pub", "some", "strict", "test", "then", "todo", "true", "type", "var", "while"];
 
 /*
 ── Tree-sitter keyword list ──────────────────────────────────────────
     // control
-    "if", "then", "else", "match", "for", "in", "while", "do", "guard", "fan",
+    "if", "then", "else", "match", "for", "in", "while", "guard",
     // declaration
     "fn", "type", "protocol", "impl", "let", "var", "test", "import", "module", "newtype",
     // flow
-    "break", "continue",
+    "break", "continue", "fan",
     // modifier
     "pub", "local", "mod", "effect", "strict",
     // value
@@ -75,11 +74,11 @@ pub const ALL_KEYWORDS: &[&str] = &["and", "break", "continue", "do", "effect", 
 
 ── TextMate grammar scopes ───────────────────────────────────────────
     // scope: keyword.control.almide
-    // pattern: \\b(if|then|else|match|for|in|while|do|guard|fan)\\b
+    // pattern: \\b(if|then|else|match|for|in|while|guard)\\b
     // scope: keyword.declaration.almide
-    // pattern: \\b(fn|type|trait|impl|let|var|test|import|module|newtype)\\b
+    // pattern: \\b(fn|type|protocol|impl|let|var|test|import|module|newtype)\\b
     // scope: keyword.control.flow.almide
-    // pattern: \\b(break|continue)\\b
+    // pattern: \\b(break|continue|fan)\\b
     // scope: storage.modifier.almide
     // pattern: \\b(pub|local|mod|effect|strict)\\b
     // scope: constant.language.almide

--- a/src/generated/tree_sitter_keywords.txt
+++ b/src/generated/tree_sitter_keywords.txt
@@ -9,13 +9,12 @@
     for_keyword: $ => 'for',
     in_keyword: $ => 'in',
     while_keyword: $ => 'while',
-    do_keyword: $ => 'do',
     guard_keyword: $ => 'guard',
 
     // declaration keywords
     fn_keyword: $ => 'fn',
     type_keyword: $ => 'type',
-    trait_keyword: $ => 'trait',
+    protocol_keyword: $ => 'protocol',
     impl_keyword: $ => 'impl',
     let_keyword: $ => 'let',
     var_keyword: $ => 'var',
@@ -25,22 +24,16 @@
     newtype_keyword: $ => 'newtype',
 
     // flow keywords
-    try_keyword: $ => 'try',
-    await_keyword: $ => 'await',
     break_keyword: $ => 'break',
     continue_keyword: $ => 'continue',
+    fan_keyword: $ => 'fan',
 
     // modifier keywords
     pub_keyword: $ => 'pub',
     local_keyword: $ => 'local',
     mod_keyword: $ => 'mod',
     effect_keyword: $ => 'effect',
-    async_keyword: $ => 'async',
     strict_keyword: $ => 'strict',
-    deriving_keyword: $ => 'deriving',
-
-    // other keywords
-    unsafe_keyword: $ => 'unsafe',
 
     // value keywords
     true_keyword: $ => 'true',
@@ -62,16 +55,13 @@
     // keyword() list for tree-sitter word rule:
     // keyword: $ => choice(
     //   $.and_keyword,
-    //   $.async_keyword,
-    //   $.await_keyword,
     //   $.break_keyword,
     //   $.continue_keyword,
-    //   $.deriving_keyword,
-    //   $.do_keyword,
     //   $.effect_keyword,
     //   $.else_keyword,
     //   $.err_keyword,
     //   $.false_keyword,
+    //   $.fan_keyword,
     //   $.fn_keyword,
     //   $.for_keyword,
     //   $.guard_keyword,
@@ -89,17 +79,15 @@
     //   $.not_keyword,
     //   $.ok_keyword,
     //   $.or_keyword,
+    //   $.protocol_keyword,
     //   $.pub_keyword,
     //   $.some_keyword,
     //   $.strict_keyword,
     //   $.test_keyword,
     //   $.then_keyword,
     //   $.todo_keyword,
-    //   $.trait_keyword,
     //   $.true_keyword,
-    //   $.try_keyword,
     //   $.type_keyword,
-    //   $.unsafe_keyword,
     //   $.var_keyword,
     //   $.while_keyword,
     // ),


### PR DESCRIPTION
## Summary
- Remove `do` block from compiler (AST, IR, parser, codegen, all passes)
- Introduce string interning (Sym) for type system and IR identifiers
- Add auto-parallelization nanopass and escape analysis
- LICM (Loop-Invariant Code Motion) optimization pass
- Effect fn Result wrapping for Rust/WASM codegen
- Parallelize test execution (2m30s → 16s)
- Fix grammar reserved words (remove async/await/trait/try/unsafe/deriving, add protocol/fan)
- Stdlib: result.collect, result.partition, result.collect_map
- Eliminate all compiler warnings

## Test plan
- All 159 .almd test files pass
- Cargo build succeeds with no errors