### PR TITLE
Remove newtype keyword, add type alias codegen

### DIFF
--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -13,8 +13,9 @@ import <module>
 type Name = { field: Type, ... }                     // record
 type Name = | Case1(Type) | Case2 | Case3{f: Type}  // variant (leading |)
 type Name[A, B] = { first: A, second: B }            // generic (use [] not <>)
-type Name = newtype Type                              // newtype (zero-cost wrapper)
+type Name = Type                                     // type alias (transparent)
 type Name = Case1(Type) | Case2(Type)                // inline variant (no leading |)
+type Handler = (String) -> String                    // function type alias
 ```
 
 ### deriving

--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -7,7 +7,7 @@ decl        = type_decl | fn_decl | protocol_decl | top_let | strict_decl | test
 protocol_decl = "protocol" IDENT "{" protocol_method* "}"
 protocol_method = "effect"? "fn" IDENT "(" params ")" "->" type
 type_decl   = "type" IDENT type_params? "=" type_body ("deriving" "From")?
-type_body   = record_body | variant_body | "newtype" type
+type_body   = record_body | variant_body | type
 record_body = "{" field ("," field)* "}"
 variant_body= "|"? variant ("|" variant)*
 variant     = IDENT | IDENT "(" type ("," type)* ")" | IDENT "{" field ("," field)* "}"

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -103,7 +103,7 @@ let     var     if      then    else    match   ok      err
 some    none    try     do      todo    unsafe  true    false
 not     and     or      strict  pub     effect  deriving test
 async   await   guard   break   continue while  local   mod
-newtype fan
+fan
 ```
 
 ### 1.6 Operators and Delimiters
@@ -362,16 +362,15 @@ fn show[T: Serializable](item: T) -> String = item.serialize()
 
 No dynamic dispatch — all protocol-bounded generics are monomorphized at compile time.
 
-### 5.6 newtype
+### 5.6 Type Alias
 
 ```
-type UserId = newtype Int
-type Email = newtype String
+type Score = Int
+type Handler = (String) -> String
 ```
 
-- `UserId` and `Int` are not implicitly convertible
-- Wrap: `UserId(42)` / Unwrap: `id.value`
-- Zero runtime cost
+- Transparent alias — `Score` and `Int` are interchangeable
+- Function type aliases use `(Params) -> Return` syntax
 
 ### 5.7 Type Application
 

--- a/docs/specs/type-system.md
+++ b/docs/specs/type-system.md
@@ -62,18 +62,7 @@ Three forms: unit (no payload), tuple-style (positional), record-style (named fi
 - Non-generic variants use `use Enum::*` for unqualified constructor access
 - `deriving From` generates `impl From<InnerType>` for single-field tuple cases
 
-### 3.3 Newtype
-
-```almide
-type UserId = newtype Int
-type Email = newtype String
-```
-
-- Wrap: `UserId(42)` / Unwrap: `id.value`
-- Zero runtime cost
-- Prevents mix-ups at the type level
-
-### 3.4 Type Alias
+### 3.3 Type Alias
 
 ```almide
 type Name = String

--- a/spec/lang/type_alias_test.almd
+++ b/spec/lang/type_alias_test.almd
@@ -1,34 +1,33 @@
 
-// newtype_test — newtype declarations
-// NOTE: newtype currently works as a type alias.
-// Constructor syntax (e.g., UserId(42)) is not yet implemented.
+// type_alias_test — type alias declarations
 type Score = Int
 
 type Label = String
 
-test "newtype as type alias for Int" {
+test "type alias for Int" {
   let s: Score = 100;
   assert_eq(s, 100)
 }
 
-test "newtype arithmetic" {
+test "type alias arithmetic" {
   let a: Score = 80;
   let b: Score = 20;
   assert_eq(a + b, 100)
 }
 
-test "newtype as type alias for String" {
+test "type alias for String" {
   let name: Label = "hello";
   assert_eq(name, "hello")
 }
 
-test "newtype string UFCS" {
+test "type alias string UFCS" {
   let name: Label = "Alice";
   assert_eq(name.len(), 5)
 }
 
-test "newtype in comparison" {
+test "type alias in comparison" {
   let a: Score = 50;
   let b: Score = 75;
   assert_eq(a < b, true)
 }
+

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -55,7 +55,6 @@ pub enum TypeExpr {
     OpenRecord { fields: Vec<FieldType> },
     Fn { params: Vec<TypeExpr>, ret: Box<TypeExpr> },
     Tuple { elements: Vec<TypeExpr> },
-    Newtype { inner: Box<TypeExpr> },
     Variant { cases: Vec<VariantCase> },
     Union { members: Vec<TypeExpr> },
 }

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -479,7 +479,6 @@ impl Checker {
             ast::TypeExpr::OpenRecord { fields } => Ty::OpenRecord { fields: fields.iter().map(|f| (sym(&f.name), self.resolve_type_expr(&f.ty))).collect() },
             ast::TypeExpr::Fn { params, ret } => Ty::Fn { params: params.iter().map(|p| self.resolve_type_expr(p)).collect(), ret: Box::new(self.resolve_type_expr(ret)) },
             ast::TypeExpr::Tuple { elements } => Ty::Tuple(elements.iter().map(|e| self.resolve_type_expr(e)).collect()),
-            ast::TypeExpr::Newtype { inner } => self.resolve_type_expr(inner),
             ast::TypeExpr::Union { members } => Ty::union(members.iter().map(|m| self.resolve_type_expr(m)).collect()),
             ast::TypeExpr::Variant { cases } => {
                 let cs = cases.iter().map(|c| match c {

--- a/src/codegen/walker/declarations.rs
+++ b/src/codegen/walker/declarations.rs
@@ -94,6 +94,10 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                 .unwrap_or(fallback)
         }
         IrTypeDeclKind::Alias { target } => {
+            // Fn type aliases are erased — the type checker expands them at use sites
+            if matches!(target, Ty::Fn { .. }) {
+                return String::new();
+            }
             let type_s = render_type(ctx, target);
             ctx.templates.render_with("type_alias", None, &[], &[("name", td.name.as_str()), ("type", type_s.as_str())])
                 .unwrap_or_else(|| format!("type {} = {};", td.name, render_type(ctx, target)))

--- a/src/codegen/walker/expressions.rs
+++ b/src/codegen/walker/expressions.rs
@@ -616,7 +616,7 @@ fn render_method_call_full(ctx: &RenderContext, object: &IrExpr, method: &str, a
         | "as_str" | "get" | "keys" | "values" | "abs" | "powi"
         | "is_empty" | "contains_key" | "entry" | "or_insert"
         | "expect" | "ok" | "err" | "and_then" | "map_err"
-        | "unwrap_or_else" | "ok_or" | "flatten" | "as_ref"
+        | "unwrap_or_else" | "ok_or" | "flatten" | "as_ref" | "as_deref"
     );
     // User-defined UFCS: plain method name (no dots) → func(object, args)
     if !method.contains('.') && !is_rust_intrinsic {

--- a/src/codegen/walker/mod.rs
+++ b/src/codegen/walker/mod.rs
@@ -38,11 +38,12 @@ pub struct RenderContext<'a> {
     pub target: Target,
     pub auto_unwrap: bool,
     pub ann: CodegenAnnotations,
+    pub type_aliases: std::collections::HashMap<crate::intern::Sym, crate::types::Ty>,
 }
 
 impl<'a> RenderContext<'a> {
     pub fn new(templates: &'a TemplateSet, var_table: &'a VarTable) -> Self {
-        Self { templates, var_table, indent: 0, target: Target::Rust, auto_unwrap: false, ann: CodegenAnnotations::default() }
+        Self { templates, var_table, indent: 0, target: Target::Rust, auto_unwrap: false, ann: CodegenAnnotations::default(), type_aliases: std::collections::HashMap::new() }
     }
 
     pub fn with_target(mut self, target: Target) -> Self {
@@ -91,6 +92,7 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
         target: ctx.target,
         auto_unwrap: func.is_effect && !func.is_test,
         ann: ctx.ann.clone(),
+        type_aliases: ctx.type_aliases.clone(),
     };
 
     // Extern fn: emit import/use via template
@@ -218,6 +220,13 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
 
 pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
     // Build constructor → enum name map
+    // Build type alias map for transparent expansion
+    let mut type_aliases = std::collections::HashMap::new();
+    for td in &program.type_decls {
+        if let IrTypeDeclKind::Alias { target } = &td.kind {
+            type_aliases.insert(td.name, target.clone());
+        }
+    }
     let mut ctx = RenderContext {
         templates: ctx.templates,
         var_table: ctx.var_table,
@@ -225,6 +234,7 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         target: ctx.target,
         auto_unwrap: ctx.auto_unwrap,
         ann: ctx.ann.clone(),
+        type_aliases,
     };
     for td in &program.type_decls {
         if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
@@ -313,6 +323,7 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
             target: ctx.target,
             auto_unwrap: false,
             ann: ctx.ann.clone(),
+            type_aliases: ctx.type_aliases.clone(),
         };
         // Module type decls
         for td in &module.type_decls {

--- a/src/codegen/walker/statements.rs
+++ b/src/codegen/walker/statements.rs
@@ -13,7 +13,28 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
         IrStmtKind::Bind { var, ty, value, mutability } => {
             let name_s = ctx.var_name(*var).to_string();
             // Erase Fn types in bindings (Rust can't write `impl Fn` in let position; TS gets `any`)
-            let ty = if matches!(ty, Ty::Fn { .. }) { &Ty::Unknown } else { ty };
+            // Also resolve aliases first — `type Handler = Fn(String) -> String` should erase too
+            let resolved_owned;
+            let ty = if matches!(ty, Ty::Fn { .. }) {
+                &Ty::Unknown
+            } else if let Ty::Named(name, args) = ty {
+                if args.is_empty() {
+                    if let Some(target) = ctx.type_aliases.get(name) {
+                        if matches!(target, Ty::Fn { .. }) {
+                            &Ty::Unknown
+                        } else {
+                            resolved_owned = target.clone();
+                            &resolved_owned
+                        }
+                    } else {
+                        ty
+                    }
+                } else {
+                    ty
+                }
+            } else {
+                ty
+            };
             // Erase named TypeVars (K, V, B) — not in scope for bindings
             let ty_owned;
             let ty = if ty_has_named_typevar(ty) {

--- a/src/codegen/walker/types.rs
+++ b/src/codegen/walker/types.rs
@@ -37,6 +37,12 @@ pub fn render_type(ctx: &RenderContext, ty: &Ty) -> String {
                 return ctx.templates.render_with("type_set", None, &[], &[("inner", &inner)])
                     .unwrap_or_else(|| format!("Set<{}>", inner));
             }
+            // Expand type aliases transparently
+            if args.is_empty() {
+                if let Some(target) = ctx.type_aliases.get(name) {
+                    return render_type(ctx, target);
+                }
+            }
             if args.is_empty() {
                 name.to_string()
             } else {

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -193,7 +193,6 @@ fn fmt_type(out: &mut String, ty: &TypeExpr, depth: usize) {
         TypeExpr::Tuple { elements } => {
             out.push('('); comma_sep(out, elements, |out, e| fmt_type(out, e, depth)); out.push(')');
         }
-        TypeExpr::Newtype { inner } => fmt_type(out, inner, depth),
         TypeExpr::Union { members } => {
             for (i, m) in members.iter().enumerate() {
                 if i > 0 { out.push_str(" | "); }

--- a/src/generated/textmate_patterns.txt
+++ b/src/generated/textmate_patterns.txt
@@ -7,7 +7,7 @@
 },
 {
   "name": "keyword.declaration.almide",
-  "match": "\\b(fn|type|protocol|impl|let|var|test|import|module|newtype)\\b"
+  "match": "\\b(fn|type|protocol|impl|let|var|test|import|module)\\b"
 },
 {
   "name": "keyword.control.flow.almide",

--- a/src/generated/token_table.rs
+++ b/src/generated/token_table.rs
@@ -31,7 +31,6 @@ pub fn build_keyword_map_generated() -> HashMap<&'static str, TokenType> {
         m.insert("match", TokenType::Match);
         m.insert("mod", TokenType::Mod);
         m.insert("module", TokenType::Module);
-        m.insert("newtype", TokenType::Newtype);
         m.insert("none", TokenType::None);
         m.insert("not", TokenType::Not);
         m.insert("ok", TokenType::Ok);
@@ -55,14 +54,14 @@ pub fn build_keyword_map_generated() -> HashMap<&'static str, TokenType> {
 }
 
 /// All keywords as a flat list (for validation, tree-sitter, TextMate generation)
-pub const ALL_KEYWORDS: &[&str] = &["and", "break", "continue", "effect", "else", "err", "false", "fan", "fn", "for", "guard", "if", "impl", "import", "in", "let", "local", "match", "mod", "module", "newtype", "none", "not", "ok", "or", "protocol", "pub", "some", "strict", "test", "then", "todo", "true", "type", "var", "while"];
+pub const ALL_KEYWORDS: &[&str] = &["and", "break", "continue", "effect", "else", "err", "false", "fan", "fn", "for", "guard", "if", "impl", "import", "in", "let", "local", "match", "mod", "module", "none", "not", "ok", "or", "protocol", "pub", "some", "strict", "test", "then", "todo", "true", "type", "var", "while"];
 
 /*
 ── Tree-sitter keyword list ──────────────────────────────────────────
     // control
     "if", "then", "else", "match", "for", "in", "while", "guard",
     // declaration
-    "fn", "type", "protocol", "impl", "let", "var", "test", "import", "module", "newtype",
+    "fn", "type", "protocol", "impl", "let", "var", "test", "import", "module",
     // flow
     "break", "continue", "fan",
     // modifier
@@ -76,7 +75,7 @@ pub const ALL_KEYWORDS: &[&str] = &["and", "break", "continue", "effect", "else"
     // scope: keyword.control.almide
     // pattern: \\b(if|then|else|match|for|in|while|guard)\\b
     // scope: keyword.declaration.almide
-    // pattern: \\b(fn|type|protocol|impl|let|var|test|import|module|newtype)\\b
+    // pattern: \\b(fn|type|protocol|impl|let|var|test|import|module)\\b
     // scope: keyword.control.flow.almide
     // pattern: \\b(break|continue|fan)\\b
     // scope: storage.modifier.almide

--- a/src/generated/tree_sitter_keywords.txt
+++ b/src/generated/tree_sitter_keywords.txt
@@ -21,7 +21,6 @@
     test_keyword: $ => 'test',
     import_keyword: $ => 'import',
     module_keyword: $ => 'module',
-    newtype_keyword: $ => 'newtype',
 
     // flow keywords
     break_keyword: $ => 'break',
@@ -74,7 +73,6 @@
     //   $.match_keyword,
     //   $.mod_keyword,
     //   $.module_keyword,
-    //   $.newtype_keyword,
     //   $.none_keyword,
     //   $.not_keyword,
     //   $.ok_keyword,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -23,7 +23,7 @@ pub enum TokenType {
     If, Then, Else, Match, Ok, Err, Some, None, Do, Todo,
     True, False, Not, And, Or,
     Strict, Pub, Effect, Test,
-    Guard, Break, Continue, While, Local, Mod, Newtype, Fan,
+    Guard, Break, Continue, While, Local, Mod, Fan,
     // Delimiters
     LParen, RParen, LBrace, RBrace, LBracket, RBracket,
     LAngle, RAngle,
@@ -469,7 +469,6 @@ fn keyword(s: &str) -> Option<TokenType> {
         "guard" => Some(TokenType::Guard), "break" => Some(TokenType::Break),
         "continue" => Some(TokenType::Continue), "while" => Some(TokenType::While),
         "local" => Some(TokenType::Local), "mod" => Some(TokenType::Mod),
-        "newtype" => Some(TokenType::Newtype),
         "fan" => Some(TokenType::Fan),
         _ => None,
     }

--- a/src/lower/types.rs
+++ b/src/lower/types.rs
@@ -102,7 +102,6 @@ pub(super) fn resolve_type_expr(te: &ast::TypeExpr) -> Ty {
             }).collect();
             Ty::Variant { name: sym(""), cases: cs }
         },
-        ast::TypeExpr::Newtype { inner } => resolve_type_expr(inner),
         ast::TypeExpr::Union { members } => Ty::union(members.iter().map(resolve_type_expr).collect()),
     }
 }

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -10,11 +10,6 @@ impl Parser {
         result
     }
     fn parse_type_expr_inner(&mut self) -> Result<TypeExpr, String> {
-        if self.check(TokenType::Newtype) {
-            self.advance();
-            let inner = self.parse_type_expr()?;
-            return Ok(TypeExpr::Newtype { inner: Box::new(inner) });
-        }
         if self.check(TokenType::Pipe) { return self.parse_variant_type(); }
         if self.check(TokenType::LBrace) { return self.parse_record_type(); }
         if self.check(TokenType::Fn) { return self.parse_fn_type(); }

--- a/tests/fuzz_test.rs
+++ b/tests/fuzz_test.rs
@@ -17,7 +17,7 @@ fn almide_like_source() -> impl Strategy<Value = String> {
         "type", "module", "import", "protocol", "impl", "do", "test",
         "ok", "err", "some", "none", "true", "false", "not", "and", "or",
         "effect", "pub", "strict", "guard", "break", "continue", "while",
-        "local", "mod", "newtype", "fan", "todo",
+        "local", "mod", "fan", "todo",
     ]);
     let ops = prop::sample::select(vec![
         "+", "-", "*", "/", "%", "**", "==", "!=", "<", ">", "<=", ">=",

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -118,7 +118,6 @@ fn lex_all_keywords() {
         ("strict", TokenType::Strict),
         ("local", TokenType::Local),
         ("mod", TokenType::Mod),
-        ("newtype", TokenType::Newtype),
     ];
     for (kw, expected) in keywords {
         let toks = token_types(kw);


### PR DESCRIPTION
## Summary
- Remove `newtype` keyword from lexer, parser, AST, formatter, and all generated files
- Add transparent type alias expansion in codegen (`type Score = Int` → `type Score = i64;` in Rust)
- Add `type_aliases` map to `RenderContext` for resolving aliases during type rendering
- Fn type aliases are erased in let bindings (Rust can't write `impl Fn` in let position)
- Update docs: CHEATSHEET, GRAMMAR, SPEC, type-system.md

## Test plan
- [x] `spec/lang/type_alias_test.almd` — Int/String alias, UFCS, arithmetic, comparison
- [x] All lang tests (78 files passed)
- [x] All stdlib tests (46 files passed)
- [x] All integration tests (14 files passed)
- [x] All exercises (24 files passed)
- [x] Rust compiler unit tests pass