### PR TITLE
Resolve all inference TypeVars before codegen

### DIFF
--- a/src/check/calls.rs
+++ b/src/check/calls.rs
@@ -8,6 +8,19 @@ use super::types::resolve_ty;
 use super::Checker;
 pub(crate) use super::builtin_calls::{builtin_module_for_type, types_mismatch};
 
+/// Substitute named TypeVars in a type with replacement types.
+fn subst_ty(ty: &Ty, subst: &HashMap<Sym, Ty>) -> Ty {
+    match ty {
+        Ty::TypeVar(name) => subst.get(name).cloned().unwrap_or_else(|| ty.clone()),
+        Ty::Applied(id, args) => Ty::Applied(id.clone(), args.iter().map(|a| subst_ty(a, subst)).collect()),
+        Ty::Named(name, args) => Ty::Named(*name, args.iter().map(|a| subst_ty(a, subst)).collect()),
+        Ty::Fn { params, ret } => Ty::Fn { params: params.iter().map(|p| subst_ty(p, subst)).collect(), ret: Box::new(subst_ty(ret, subst)) },
+        Ty::Tuple(elems) => Ty::Tuple(elems.iter().map(|e| subst_ty(e, subst)).collect()),
+        Ty::Record { fields } => Ty::Record { fields: fields.iter().map(|(n, t)| (*n, subst_ty(t, subst))).collect() },
+        _ => ty.clone(),
+    }
+}
+
 impl Checker {
     pub(crate) fn check_call_with_type_args(&mut self, callee: &mut ast::Expr, args: &mut [ast::Expr], type_args: Option<&[Ty]>) -> Ty {
         let arg_tys: Vec<Ty> = args.iter_mut().map(|a| self.infer_expr(a)).collect();
@@ -26,6 +39,27 @@ impl Checker {
                     self.check_constructor_args(name, &case, &arg_tys);
                     // Instantiate parent type's generics with fresh inference vars
                     let generic_args = self.instantiate_type_generics(type_name.as_str());
+                    // Unify constructor payload types with arg types to resolve generic vars.
+                    // e.g., Leaf(1) where Leaf(T) → unify T=?fresh with Int → ?fresh=Int
+                    if !generic_args.is_empty() {
+                        if let Some(ty_def) = self.env.types.get(&sym(type_name.as_str())).cloned() {
+                            let mut type_var_names = Vec::new();
+                            crate::types::TypeEnv::collect_typevars(&ty_def, &mut type_var_names);
+                            // Build substitution map: named TypeVar name → fresh inference var
+                            let subst: std::collections::HashMap<crate::intern::Sym, Ty> = type_var_names.iter()
+                                .zip(generic_args.iter())
+                                .map(|(tv, fresh)| (*tv, fresh.clone()))
+                                .collect();
+                            // Get expected payload types for this case
+                            if let crate::types::VariantPayload::Tuple(expected) = &case.payload {
+                                for (aty, ety) in arg_tys.iter().zip(expected.iter()) {
+                                    // Substitute named TypeVars with fresh inference vars, then unify
+                                    let substituted = subst_ty(ety, &subst);
+                                    self.unify_infer(aty, &substituted);
+                                }
+                            }
+                        }
+                    }
                     Ty::Named(type_name, generic_args)
                 } else { Ty::Named(sym(name), vec![]) }
             }

--- a/src/check/infer.rs
+++ b/src/check/infer.rs
@@ -598,9 +598,27 @@ impl Checker {
     fn infer_plus_op(&mut self, lc: &Ty, rc: &Ty, lt: Ty) -> Ty {
         let is_concat_ty = |t: &Ty| matches!(t, Ty::String | Ty::Applied(TypeConstructorId::List, _));
         let is_unknown_ty = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_));
+        // When one side is List and the other is TypeVar, unify the TypeVar with the List type
+        if is_unknown_ty(lc) && is_concat_ty(rc) {
+            self.unify_infer(&lt, rc);
+            let resolved_lt = resolve_ty(&lt, &self.uf);
+            // Now unify element types if both resolved to List
+            if let (Ty::Applied(TypeConstructorId::List, la), Ty::Applied(TypeConstructorId::List, ra)) = (&resolved_lt, rc) {
+                if let (Some(le), Some(re)) = (la.first(), ra.first()) {
+                    self.unify_infer(le, re);
+                }
+            }
+            return resolve_ty(&lt, &self.uf);
+        }
         if (is_concat_ty(lc) && (is_concat_ty(rc) || is_unknown_ty(rc)))
             || (is_concat_ty(rc) && is_unknown_ty(lc)) {
-            return lt; // concat: return same type
+            // Unify element types for list concatenation: List[?0] + List[Int] → ?0 = Int
+            if let (Ty::Applied(TypeConstructorId::List, la), Ty::Applied(TypeConstructorId::List, ra)) = (lc, rc) {
+                if let (Some(le), Some(re)) = (la.first(), ra.first()) {
+                    self.unify_infer(le, re);
+                }
+            }
+            return resolve_ty(&lt, &self.uf);
         }
         let is_numeric = |t: &Ty| matches!(t, Ty::Int | Ty::Float | Ty::Unknown | Ty::TypeVar(_));
         if !is_numeric(lc) || !is_numeric(rc) {

--- a/src/check/infer.rs
+++ b/src/check/infer.rs
@@ -147,7 +147,11 @@ impl Checker {
                             "Replace ++ with +", "operator ++"));
                         lt
                     }
-                    "==" | "!=" | "<" | ">" | "<=" | ">=" => Ty::Bool,
+                    "==" | "!=" | "<" | ">" | "<=" | ">=" => {
+                        // Unify left/right types so TypeVars in none/err/constructors get resolved
+                        self.unify_infer(&lt, &rt);
+                        Ty::Bool
+                    }
                     "and" | "or" => {
                         let lc = resolve_ty(&lt, &self.uf);
                         let rc = resolve_ty(&rt, &self.uf);

--- a/src/lower/mod.rs
+++ b/src/lower/mod.rs
@@ -328,7 +328,84 @@ pub fn lower_program(prog: &ast::Program, expr_types: &HashMap<crate::ast::ExprI
 
     compute_use_counts(&mut program); // After auto-derive so derived functions get correct use_counts
     demote_unused_mut(&mut program);
+
+    // Debug: report TypeVars remaining in IR (should be zero for correct codegen)
+    if std::env::var("ALMIDE_DEBUG_TYPEVARS").is_ok() {
+        report_remaining_typevars(&program);
+    }
+
     program
+}
+
+/// Report all TypeVar/Unknown types remaining in the IR after lowering.
+fn report_remaining_typevars(program: &IrProgram) {
+    use crate::types::Ty;
+    fn has_typevar(ty: &Ty) -> bool {
+        match ty {
+            Ty::TypeVar(name) => name.starts_with('?'), // Only inference vars, not generic params
+            Ty::Unknown => false,
+            Ty::Applied(_, args) => args.iter().any(has_typevar),
+            Ty::Tuple(elems) => elems.iter().any(has_typevar),
+            Ty::Fn { params, ret } => params.iter().any(has_typevar) || has_typevar(ret),
+            Ty::Named(_, args) => args.iter().any(has_typevar),
+            Ty::Record { fields } | Ty::OpenRecord { fields } => fields.iter().any(|(_, t)| has_typevar(t)),
+            _ => false,
+        }
+    }
+    fn report_expr(expr: &IrExpr, fn_name: &str, loc: &str) {
+        if has_typevar(&expr.ty) {
+            eprintln!("  [TypeVar] {} in {}: {:?} (expr: {:?})", loc, fn_name, expr.ty, std::mem::discriminant(&expr.kind));
+        }
+        // Recurse into children
+        match &expr.kind {
+            IrExprKind::Call { args, .. } => { for a in args { report_expr(a, fn_name, "call-arg"); } }
+            IrExprKind::Lambda { body, params, .. } => {
+                for (_, ty) in params { if has_typevar(ty) { eprintln!("  [TypeVar] lambda-param in {}: {:?}", fn_name, ty); } }
+                report_expr(body, fn_name, "lambda-body");
+            }
+            IrExprKind::BinOp { left, right, .. } => { report_expr(left, fn_name, "binop-left"); report_expr(right, fn_name, "binop-right"); }
+            IrExprKind::Match { subject, arms, .. } => {
+                report_expr(subject, fn_name, "match-subject");
+                for arm in arms { report_expr(&arm.body, fn_name, "match-arm"); }
+            }
+            IrExprKind::If { cond, then, else_, .. } => {
+                report_expr(cond, fn_name, "if-cond");
+                report_expr(then, fn_name, "if-then");
+                report_expr(else_, fn_name, "if-else");
+            }
+            IrExprKind::Block { stmts, expr, .. } => {
+                for s in stmts {
+                    if let IrStmtKind::Bind { ty, value, .. } = &s.kind {
+                        if has_typevar(ty) { eprintln!("  [TypeVar] bind-ty in {}: {:?}", fn_name, ty); }
+                        report_expr(value, fn_name, "bind-val");
+                    } else if let IrStmtKind::Expr { expr: e } = &s.kind {
+                        report_expr(e, fn_name, "stmt-expr");
+                    }
+                }
+                if let Some(e) = expr { report_expr(e, fn_name, "block-tail"); }
+            }
+            _ => {}
+        }
+    }
+    let mut count = 0;
+    for func in &program.functions {
+        let before = count;
+        report_expr(&func.body, &func.name, "body");
+        for p in &func.params { if has_typevar(&p.ty) { eprintln!("  [TypeVar] param in {}: {:?}", func.name, p.ty); count += 1; } }
+        if has_typevar(&func.ret_ty) { eprintln!("  [TypeVar] ret_ty in {}: {:?}", func.name, func.ret_ty); count += 1; }
+        if count > before { count += 1; }
+    }
+    // VarTable
+    for i in 0..program.var_table.len() {
+        let info = program.var_table.get(VarId(i as u32));
+        if has_typevar(&info.ty) {
+            eprintln!("  [TypeVar] var {} '{}': {:?}", i, info.name, info.ty);
+            count += 1;
+        }
+    }
+    if count > 0 {
+        eprintln!("[TypeVar report] {} TypeVar occurrences found in IR", count);
+    }
 }
 
 pub fn lower_module(

--- a/src/lower/mod.rs
+++ b/src/lower/mod.rs
@@ -329,16 +329,16 @@ pub fn lower_program(prog: &ast::Program, expr_types: &HashMap<crate::ast::ExprI
     compute_use_counts(&mut program); // After auto-derive so derived functions get correct use_counts
     demote_unused_mut(&mut program);
 
-    // Debug: report TypeVars remaining in IR (should be zero for correct codegen)
-    if std::env::var("ALMIDE_DEBUG_TYPEVARS").is_ok() {
-        report_remaining_typevars(&program);
-    }
+    // Verify no inference TypeVars remain in IR (ICE if any found)
+    verify_no_inference_typevars(&program);
 
     program
 }
 
-/// Report all TypeVar/Unknown types remaining in the IR after lowering.
-fn report_remaining_typevars(program: &IrProgram) {
+/// Verify no inference TypeVars (?N) remain in the IR.
+/// Any remaining TypeVar indicates a type checker bug — the codegen cannot
+/// reliably generate correct code without concrete types.
+fn verify_no_inference_typevars(program: &IrProgram) {
     use crate::types::Ty;
     fn has_typevar(ty: &Ty) -> bool {
         match ty {
@@ -352,59 +352,60 @@ fn report_remaining_typevars(program: &IrProgram) {
             _ => false,
         }
     }
-    fn report_expr(expr: &IrExpr, fn_name: &str, loc: &str) {
+    let verbose = std::env::var("ALMIDE_DEBUG_TYPEVARS").is_ok();
+    fn count_expr(expr: &IrExpr, fn_name: &str, loc: &str, verbose: bool) -> usize {
+        let mut c = 0;
         if has_typevar(&expr.ty) {
-            eprintln!("  [TypeVar] {} in {}: {:?} (expr: {:?})", loc, fn_name, expr.ty, std::mem::discriminant(&expr.kind));
+            c += 1;
+            if verbose { eprintln!("  [TypeVar] {} in {}: {:?}", loc, fn_name, expr.ty); }
         }
-        // Recurse into children
         match &expr.kind {
-            IrExprKind::Call { args, .. } => { for a in args { report_expr(a, fn_name, "call-arg"); } }
+            IrExprKind::Call { args, .. } => { for a in args { c += count_expr(a, fn_name, "call-arg", verbose); } }
             IrExprKind::Lambda { body, params, .. } => {
-                for (_, ty) in params { if has_typevar(ty) { eprintln!("  [TypeVar] lambda-param in {}: {:?}", fn_name, ty); } }
-                report_expr(body, fn_name, "lambda-body");
+                for (_, ty) in params { if has_typevar(ty) { c += 1; if verbose { eprintln!("  [TypeVar] lambda-param in {}: {:?}", fn_name, ty); } } }
+                c += count_expr(body, fn_name, "lambda-body", verbose);
             }
-            IrExprKind::BinOp { left, right, .. } => { report_expr(left, fn_name, "binop-left"); report_expr(right, fn_name, "binop-right"); }
+            IrExprKind::BinOp { left, right, .. } => { c += count_expr(left, fn_name, "binop-left", verbose); c += count_expr(right, fn_name, "binop-right", verbose); }
             IrExprKind::Match { subject, arms, .. } => {
-                report_expr(subject, fn_name, "match-subject");
-                for arm in arms { report_expr(&arm.body, fn_name, "match-arm"); }
+                c += count_expr(subject, fn_name, "match-subject", verbose);
+                for arm in arms { c += count_expr(&arm.body, fn_name, "match-arm", verbose); }
             }
             IrExprKind::If { cond, then, else_, .. } => {
-                report_expr(cond, fn_name, "if-cond");
-                report_expr(then, fn_name, "if-then");
-                report_expr(else_, fn_name, "if-else");
+                c += count_expr(cond, fn_name, "if-cond", verbose);
+                c += count_expr(then, fn_name, "if-then", verbose);
+                c += count_expr(else_, fn_name, "if-else", verbose);
             }
             IrExprKind::Block { stmts, expr, .. } => {
                 for s in stmts {
                     if let IrStmtKind::Bind { ty, value, .. } = &s.kind {
-                        if has_typevar(ty) { eprintln!("  [TypeVar] bind-ty in {}: {:?}", fn_name, ty); }
-                        report_expr(value, fn_name, "bind-val");
+                        if has_typevar(ty) { c += 1; if verbose { eprintln!("  [TypeVar] bind-ty in {}: {:?}", fn_name, ty); } }
+                        c += count_expr(value, fn_name, "bind-val", verbose);
                     } else if let IrStmtKind::Expr { expr: e } = &s.kind {
-                        report_expr(e, fn_name, "stmt-expr");
+                        c += count_expr(e, fn_name, "stmt-expr", verbose);
                     }
                 }
-                if let Some(e) = expr { report_expr(e, fn_name, "block-tail"); }
+                if let Some(e) = expr { c += count_expr(e, fn_name, "block-tail", verbose); }
             }
             _ => {}
         }
+        c
     }
     let mut count = 0;
     for func in &program.functions {
-        let before = count;
-        report_expr(&func.body, &func.name, "body");
-        for p in &func.params { if has_typevar(&p.ty) { eprintln!("  [TypeVar] param in {}: {:?}", func.name, p.ty); count += 1; } }
-        if has_typevar(&func.ret_ty) { eprintln!("  [TypeVar] ret_ty in {}: {:?}", func.name, func.ret_ty); count += 1; }
-        if count > before { count += 1; }
+        count += count_expr(&func.body, &func.name, "body", verbose);
+        for p in &func.params { if has_typevar(&p.ty) { count += 1; if verbose { eprintln!("  [TypeVar] param in {}: {:?}", func.name, p.ty); } } }
+        if has_typevar(&func.ret_ty) { count += 1; if verbose { eprintln!("  [TypeVar] ret_ty in {}: {:?}", func.name, func.ret_ty); } }
     }
-    // VarTable
     for i in 0..program.var_table.len() {
         let info = program.var_table.get(VarId(i as u32));
         if has_typevar(&info.ty) {
-            eprintln!("  [TypeVar] var {} '{}': {:?}", i, info.name, info.ty);
             count += 1;
+            if verbose { eprintln!("  [TypeVar] var {} '{}': {:?}", i, info.name, info.ty); }
         }
     }
     if count > 0 {
-        eprintln!("[TypeVar report] {} TypeVar occurrences found in IR", count);
+        eprintln!("[ICE] {} unresolved inference TypeVar(s) in IR after lowering. This is a type checker bug.", count);
+        eprintln!("[ICE] Codegen may produce incorrect code. Set ALMIDE_DEBUG_TYPEVARS=1 for details.");
     }
 }
 

--- a/src/mono/mod.rs
+++ b/src/mono/mod.rs
@@ -115,6 +115,38 @@ pub fn monomorphize(program: &mut IrProgram) {
     // types (e.g., `let x = mono_fn(...)` where x.ty was set before mono).
     propagate_concrete_types(program);
 
+    // Post-mono guard: ALL TypeVars (including generic params) should be resolved
+    verify_no_typevars_post_mono(program);
+}
+
+/// After monomorphization, no TypeVars of any kind should remain in the IR.
+/// Generic type params (A, B, T) should have been substituted by monomorphization.
+/// Inference vars (?0, ?1) should have been resolved by the type checker.
+fn verify_no_typevars_post_mono(program: &crate::ir::IrProgram) {
+    use crate::types::Ty;
+    fn has_any_typevar(ty: &Ty) -> bool {
+        match ty {
+            Ty::TypeVar(_) => true,
+            Ty::Applied(_, args) => args.iter().any(has_any_typevar),
+            Ty::Tuple(elems) => elems.iter().any(has_any_typevar),
+            Ty::Fn { params, ret } => params.iter().any(has_any_typevar) || has_any_typevar(ret),
+            Ty::Named(_, args) => args.iter().any(has_any_typevar),
+            Ty::Record { fields } | Ty::OpenRecord { fields } => fields.iter().any(|(_, t)| has_any_typevar(t)),
+            _ => false,
+        }
+    }
+    let mut count = 0;
+    for func in &program.functions {
+        if has_any_typevar(&func.ret_ty) { count += 1; }
+        for p in &func.params { if has_any_typevar(&p.ty) { count += 1; } }
+    }
+    for i in 0..program.var_table.len() {
+        let info = program.var_table.get(crate::ir::VarId(i as u32));
+        if has_any_typevar(&info.ty) { count += 1; }
+    }
+    if count > 0 {
+        eprintln!("[ICE] {} TypeVar(s) remain after monomorphization. Generic params should be fully substituted.", count);
+    }
 }
 
 /// Find functions that have structural bounds, protocol bounds, on generic type parameters,

--- a/tests/typevar_resolution_test.rs
+++ b/tests/typevar_resolution_test.rs
@@ -1,0 +1,124 @@
+/// Regression tests: verify that inference TypeVars (?N) are fully resolved
+/// before reaching codegen. These patterns previously caused WASM codegen
+/// to produce incorrect code due to unresolved TypeVars.
+
+use almide::lexer::Lexer;
+use almide::parser::Parser;
+use almide::check::Checker;
+use almide::types::Ty;
+
+/// Parse, check, and lower a program. Returns the IR VarTable for inspection.
+fn lower(input: &str) -> almide::ir::IrProgram {
+    let tokens = Lexer::tokenize(input);
+    let mut parser = Parser::new(tokens);
+    let mut prog = parser.parse().expect("parse failed");
+    let mut checker = Checker::new();
+    let _diags = checker.check_program(&mut prog);
+    almide::lower::lower_program(&prog, &checker.expr_types, &checker.env)
+}
+
+fn has_inference_typevar(ty: &Ty) -> bool {
+    match ty {
+        Ty::TypeVar(name) => name.starts_with('?'),
+        Ty::Applied(_, args) => args.iter().any(has_inference_typevar),
+        Ty::Tuple(elems) => elems.iter().any(has_inference_typevar),
+        Ty::Fn { params, ret } => params.iter().any(has_inference_typevar) || has_inference_typevar(ret),
+        Ty::Named(_, args) => args.iter().any(has_inference_typevar),
+        Ty::Record { fields } | Ty::OpenRecord { fields } => fields.iter().any(|(_, t)| has_inference_typevar(t)),
+        _ => false,
+    }
+}
+
+fn assert_no_inference_typevars(program: &almide::ir::IrProgram) {
+    for i in 0..program.var_table.len() {
+        let info = program.var_table.get(almide::ir::VarId(i as u32));
+        assert!(
+            !has_inference_typevar(&info.ty),
+            "var {} '{}' has unresolved TypeVar: {:?}",
+            i, info.name, info.ty
+        );
+    }
+    for func in &program.functions {
+        assert!(
+            !has_inference_typevar(&func.ret_ty),
+            "fn {} ret_ty has unresolved TypeVar: {:?}",
+            func.name, func.ret_ty
+        );
+    }
+}
+
+#[test]
+fn fold_with_list_accumulator() {
+    let program = lower(r#"
+        test "x" {
+          let xs = [10, 20]
+          let doubled = list.fold(xs, [], (acc, x) => acc + [x * 2])
+          let total = list.fold(doubled, 0, (acc, x) => acc + x)
+          assert_eq(total, 60)
+        }
+    "#);
+    assert_no_inference_typevars(&program);
+}
+
+#[test]
+fn none_compared_with_some() {
+    let program = lower(r#"
+        test "x" {
+          assert_eq(some(1) != none, true)
+        }
+    "#);
+    assert_no_inference_typevars(&program);
+}
+
+#[test]
+fn err_compared_with_ok() {
+    let program = lower(r#"
+        test "x" {
+          let a: Result[Int, String] = ok(1)
+          assert_eq(a != err("fail"), true)
+        }
+    "#);
+    assert_no_inference_typevars(&program);
+}
+
+#[test]
+fn generic_variant_constructor() {
+    let program = lower(r#"
+        type Wrapper[T] = | Wrapped(T) | Empty
+        fn unwrap_or[T](w: Wrapper[T], default: T) -> T = match w {
+          Wrapped(v) => v,
+          Empty => default,
+        }
+        test "x" {
+          let w = Wrapped(99)
+          assert_eq(unwrap_or(w, 0), 99)
+        }
+    "#);
+    assert_no_inference_typevars(&program);
+}
+
+#[test]
+fn recursive_generic_variant() {
+    let program = lower(r#"
+        type Tree[T] = | Leaf(T) | Node(Tree[T], Tree[T])
+        test "x" {
+          let t1 = Node(Leaf(1), Leaf(2))
+          let t2 = Node(Leaf(1), Leaf(2))
+          assert_eq(t1 == t2, true)
+        }
+    "#);
+    assert_no_inference_typevars(&program);
+}
+
+#[test]
+fn closure_with_record_field_access() {
+    let program = lower(r#"
+        type Row = { id: Int, name: String }
+        test "x" {
+          let p = Row { id: 1, name: "a" }
+          let get_id = (r) => r.id
+          assert_eq(get_id(p), 1)
+        }
+    "#);
+    assert_no_inference_typevars(&program);
+}


### PR DESCRIPTION
## Summary
Type checker was leaving inference TypeVars (?N) unresolved in the IR, causing WASM codegen to guess types via fragile fallback heuristics. This produced silent memory corruption in edge cases (chained fold, nested closures, generic variant constructors).

**Root cause fixes (type checker):**
- Unify element types in list concatenation (`List[?0] + List[Int]` → `?0 = Int`)
- Unify left/right types in comparison operators (`some(1) != none` → resolve Option type arg)
- Unify generic variant constructor args with payload types (`Leaf(1)` → `Tree[Int]`, not `Tree[?N]`)

**ICE guards (defense in depth):**
- Post-lowering: detect inference TypeVars remaining in IR
- Post-monomorphization: detect ALL TypeVars remaining
- Both always-on, verbose details via `ALMIDE_DEBUG_TYPEVARS=1`

**Regression tests:**
- 6 Rust unit tests covering: chained fold, none/err comparison, generic variant constructor, recursive generic variant, closure field access

## Test plan
- [x] All Rust tests pass (138 files)
- [x] All WASM tests pass (167 files, 0 failed)
- [x] TypeVar regression tests pass (6 tests)
- [x] ICE guard verified to fire when type checker fix disabled
- [x] Zero inference TypeVars across entire test suite