### PR TITLE
Export public functions from WASM for Python FFI

### DIFF
--- a/runtime/rs/src/bytes.rs
+++ b/runtime/rs/src/bytes.rs
@@ -5,6 +5,7 @@ pub fn almide_rt_bytes_len(b: &Vec<u8>) -> i64 { b.len() as i64 }
 pub fn almide_rt_bytes_is_empty(b: &Vec<u8>) -> bool { b.is_empty() }
 pub fn almide_rt_bytes_get(b: &Vec<u8>, i: i64) -> Option<i64> { b.get(i as usize).map(|&x| x as i64) }
 pub fn almide_rt_bytes_get_or(b: &Vec<u8>, i: i64, default: i64) -> i64 { b.get(i as usize).map(|&x| x as i64).unwrap_or(default) }
+pub fn almide_rt_bytes_set(mut b: Vec<u8>, i: i64, val: i64) -> Vec<u8> { if (i as usize) < b.len() { b[i as usize] = val as u8; } b }
 pub fn almide_rt_bytes_slice(b: &Vec<u8>, start: i64, end: i64) -> Vec<u8> {
     let s = (start as usize).min(b.len());
     let e = (end as usize).min(b.len());

--- a/runtime/ts/bytes.ts
+++ b/runtime/ts/bytes.ts
@@ -3,6 +3,7 @@ const __almd_bytes = {
   len(b: Uint8Array): number { return b.length; },
   get(b: Uint8Array, i: number): number | null { return (i >= 0 && i < b.length) ? b[i] : null; },
   get_or(b: Uint8Array, i: number, d: number): number { return (i >= 0 && i < b.length) ? b[i] : d; },
+  set(b: Uint8Array, i: number, val: number): Uint8Array { const r = new Uint8Array(b); if (i >= 0 && i < r.length) r[i] = val & 0xFF; return r; },
   slice(b: Uint8Array, start: number, end: number): Uint8Array { return b.slice(Math.max(0, start), Math.min(b.length, end)); },
   from_list(xs: number[]): Uint8Array { return new Uint8Array(xs.map(x => x & 0xFF)); },
   to_list(b: Uint8Array): number[] { return Array.from(b); },

--- a/src/codegen/emit_wasm/calls_bytes.rs
+++ b/src/codegen/emit_wasm/calls_bytes.rs
@@ -85,6 +85,33 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(idx);
                 self.scratch.free_i32(buf);
             }
+            "set" => {
+                // bytes.set(b, i, val) → Bytes (mutate in place, return same pointer)
+                let buf = self.scratch.alloc_i32();
+                let idx = self.scratch.alloc_i32();
+                let val = self.scratch.alloc_i32();
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { local_set(buf); });
+                self.emit_expr(&args[1]);
+                wasm!(self.func, { i32_wrap_i64; local_set(idx); });
+                self.emit_expr(&args[2]);
+                wasm!(self.func, {
+                    i32_wrap_i64; local_set(val);
+                    // bounds check: idx < len
+                    local_get(idx); local_get(buf); i32_load(0); i32_lt_u;
+                    if_empty;
+                      // store byte: mem[buf + 4 + idx] = val
+                      local_get(buf); i32_const(4); i32_add; local_get(idx); i32_add;
+                      local_get(val);
+                      i32_store8(0);
+                    end;
+                    // return buf pointer
+                    local_get(buf);
+                });
+                self.scratch.free_i32(val);
+                self.scratch.free_i32(idx);
+                self.scratch.free_i32(buf);
+            }
             "new" => {
                 // bytes.new(len) → Bytes: alloc [len:i32][zeroed data]
                 let n = self.scratch.alloc_i32();

--- a/src/codegen/emit_wasm/mod.rs
+++ b/src/codegen/emit_wasm/mod.rs
@@ -193,6 +193,9 @@ pub struct WasmEmitter {
     pub func_table: Vec<u32>, // list of func_idx in table order
     pub func_to_table_idx: HashMap<u32, u32>, // func_idx → table index
 
+    // User-defined public functions to export (name list, populated during emit)
+    pub user_exports: Vec<String>,
+
     // Type info: record/variant name → field list (for field offset computation)
     pub record_fields: HashMap<String, Vec<(String, crate::types::Ty)>>,
     // Variant info: variant type name → list of (case_name, tag, fields)
@@ -300,6 +303,7 @@ impl WasmEmitter {
             effect_fns: HashSet::new(),
             mutable_captures: HashSet::new(),
             eq_funcs: HashMap::new(),
+            user_exports: Vec::new(),
         }
     }
 
@@ -689,6 +693,15 @@ pub fn emit(program: &IrProgram) -> Vec<u8> {
     // Phase 2.5: Dead Code Elimination
     let _dce_count = dce::eliminate_dead_code(&mut emitter);
 
+    // Collect public user functions for WASM export
+    for func in &program.functions {
+        if func.is_test { continue; }
+        if !matches!(func.visibility, crate::ir::IrVisibility::Public) { continue; }
+        if func.generics.as_ref().map_or(false, |g| !g.is_empty()) { continue; }
+        if func.name.as_str() == "main" { continue; }
+        emitter.user_exports.push(func.name.to_string());
+    }
+
     // Phase 3: Assemble
     assemble(&emitter)
 }
@@ -780,6 +793,16 @@ fn assemble(emitter: &WasmEmitter) -> Vec<u8> {
         exports.export("_start", wasm_encoder::ExportKind::Func, main_idx);
     } else if let Some(&runner_idx) = emitter.func_map.get("__test_runner") {
         exports.export("_start", wasm_encoder::ExportKind::Func, runner_idx);
+    }
+    // Export __alloc for FFI callers to allocate WASM linear memory
+    if let Some(&alloc_idx) = emitter.func_map.get("__alloc") {
+        exports.export("__alloc", wasm_encoder::ExportKind::Func, alloc_idx);
+    }
+    // Export public user functions (collected during emit)
+    for name in &emitter.user_exports {
+        if let Some(&idx) = emitter.func_map.get(name.as_str()) {
+            exports.export(name, wasm_encoder::ExportKind::Func, idx);
+        }
     }
     module.section(&exports);
 

--- a/src/generated/arg_transforms.rs
+++ b/src/generated/arg_transforms.rs
@@ -29,6 +29,7 @@ pub fn lookup(module: &str, func: &str) -> Option<StdlibCallInfo> {
             ("bytes", "len") => Some(StdlibCallInfo { args: &[ArgTransform::BorrowRef], effect: false, name: "almide_rt_bytes_len", required: 1 }),
             ("bytes", "new") => Some(StdlibCallInfo { args: &[ArgTransform::Direct], effect: false, name: "almide_rt_bytes_new", required: 1 }),
             ("bytes", "repeat") => Some(StdlibCallInfo { args: &[ArgTransform::BorrowRef, ArgTransform::Direct], effect: false, name: "almide_rt_bytes_repeat", required: 2 }),
+            ("bytes", "set") => Some(StdlibCallInfo { args: &[ArgTransform::Direct, ArgTransform::Direct, ArgTransform::Direct], effect: false, name: "almide_rt_bytes_set", required: 3 }),
             ("bytes", "slice") => Some(StdlibCallInfo { args: &[ArgTransform::BorrowRef, ArgTransform::Direct, ArgTransform::Direct], effect: false, name: "almide_rt_bytes_slice", required: 3 }),
             ("bytes", "to_list") => Some(StdlibCallInfo { args: &[ArgTransform::BorrowRef], effect: false, name: "almide_rt_bytes_to_list", required: 1 }),
             ("datetime", "add_days") => Some(StdlibCallInfo { args: &[ArgTransform::Direct, ArgTransform::Direct], effect: false, name: "almide_rt_datetime_add_days", required: 2 }),

--- a/src/generated/emit_rust_calls.rs
+++ b/src/generated/emit_rust_calls.rs
@@ -16,6 +16,7 @@ pub fn gen_generated_call(
             ("bytes", "len") => format!("almide_rt_bytes_len(&{})", args_str[0]),
             ("bytes", "new") => format!("almide_rt_bytes_new({})", args_str[0]),
             ("bytes", "repeat") => format!("almide_rt_bytes_repeat(&{}, {})", args_str[0], args_str[1]),
+            ("bytes", "set") => format!("almide_rt_bytes_set({}, {}, {})", args_str[0], args_str[1], args_str[2]),
             ("bytes", "slice") => format!("almide_rt_bytes_slice(&{}, {}, {})", args_str[0], args_str[1], args_str[2]),
             ("bytes", "to_list") => format!("almide_rt_bytes_to_list(&{})", args_str[0]),
             ("datetime", "add_days") => format!("{} + {} * 86400", args_str[0], args_str[1]),

--- a/src/generated/emit_ts_calls.rs
+++ b/src/generated/emit_ts_calls.rs
@@ -10,6 +10,7 @@ pub fn gen_generated_call(module: &str, func: &str, args_str: &[String]) -> Opti
             ("bytes", "len") => format!("__almd_bytes.len({})", args_str[0]),
             ("bytes", "new") => format!("__almd_bytes.new_bytes({})", args_str[0]),
             ("bytes", "repeat") => format!("__almd_bytes.repeat({}, {})", args_str[0], args_str[1]),
+            ("bytes", "set") => format!("__almd_bytes.set({}, {}, {})", args_str[0], args_str[1], args_str[2]),
             ("bytes", "slice") => format!("__almd_bytes.slice({}, {}, {})", args_str[0], args_str[1], args_str[2]),
             ("bytes", "to_list") => format!("__almd_bytes.to_list({})", args_str[0]),
             ("datetime", "add_days") => format!("{} + {} * 86400", args_str[0], args_str[1]),

--- a/src/generated/stdlib_sigs.rs
+++ b/src/generated/stdlib_sigs.rs
@@ -13,6 +13,7 @@ pub fn lookup_generated_sig(module: &str, func: &str) -> Option<FnSig> {
         ("bytes", "len") => FnSig { generics: vec![], params: vec![(s("b"), Ty::Bytes)], ret: Ty::Int, is_effect: false, structural_bounds: std::collections::HashMap::new(), protocol_bounds: std::collections::HashMap::new() },
         ("bytes", "new") => FnSig { generics: vec![], params: vec![(s("len"), Ty::Int)], ret: Ty::Bytes, is_effect: false, structural_bounds: std::collections::HashMap::new(), protocol_bounds: std::collections::HashMap::new() },
         ("bytes", "repeat") => FnSig { generics: vec![], params: vec![(s("b"), Ty::Bytes), (s("n"), Ty::Int)], ret: Ty::Bytes, is_effect: false, structural_bounds: std::collections::HashMap::new(), protocol_bounds: std::collections::HashMap::new() },
+        ("bytes", "set") => FnSig { generics: vec![], params: vec![(s("b"), Ty::Bytes), (s("i"), Ty::Int), (s("val"), Ty::Int)], ret: Ty::Bytes, is_effect: false, structural_bounds: std::collections::HashMap::new(), protocol_bounds: std::collections::HashMap::new() },
         ("bytes", "slice") => FnSig { generics: vec![], params: vec![(s("b"), Ty::Bytes), (s("start"), Ty::Int), (s("end"), Ty::Int)], ret: Ty::Bytes, is_effect: false, structural_bounds: std::collections::HashMap::new(), protocol_bounds: std::collections::HashMap::new() },
         ("bytes", "to_list") => FnSig { generics: vec![], params: vec![(s("b"), Ty::Bytes)], ret: Ty::list(Ty::Int), is_effect: false, structural_bounds: std::collections::HashMap::new(), protocol_bounds: std::collections::HashMap::new() },
         ("datetime", "add_days") => FnSig { generics: vec![], params: vec![(s("ts"), Ty::Int), (s("n"), Ty::Int)], ret: Ty::Int, is_effect: false, structural_bounds: std::collections::HashMap::new(), protocol_bounds: std::collections::HashMap::new() },
@@ -413,7 +414,7 @@ pub fn lookup_generated_sig(module: &str, func: &str) -> Option<FnSig> {
 
 pub fn generated_module_functions(module: &str) -> Vec<&'static str> {
     match module {
-        "bytes" => vec!["concat", "from_list", "get", "get_or", "is_empty", "len", "new", "repeat", "slice", "to_list"],
+        "bytes" => vec!["concat", "from_list", "get", "get_or", "is_empty", "len", "new", "repeat", "set", "slice", "to_list"],
         "datetime" => vec!["add_days", "add_hours", "add_minutes", "add_seconds", "day", "diff_seconds", "format", "from_parts", "from_unix", "hour", "is_after", "is_before", "minute", "month", "now", "parse_iso", "second", "to_iso", "to_unix", "weekday", "year"],
         "env" => vec!["args", "cwd", "get", "millis", "os", "set", "sleep_ms", "temp_dir", "unix_timestamp"],
         "error" => vec!["chain", "context", "message"],

--- a/stdlib/defs/bytes.toml
+++ b/stdlib/defs/bytes.toml
@@ -22,6 +22,14 @@ return = "Int"
 rust = "almide_rt_bytes_get_or(&{b}, {i}, {default})"
 ts = "__almd_bytes.get_or({b}, {i}, {default})"
 
+[set]
+description = "Set a byte value at an index (mutates in place for var bindings)."
+example = 'bytes.set(b, 0, 255)'
+params = [{ name = "b", type = "Bytes" }, { name = "i", type = "Int" }, { name = "val", type = "Int" }]
+return = "Bytes"
+rust = "almide_rt_bytes_set({b}, {i}, {val})"
+ts = "__almd_bytes.set({b}, {i}, {val})"
+
 [slice]
 description = "Extract a sub-range of bytes [start, end)."
 example = 'bytes.slice(b, 1, 3)'


### PR DESCRIPTION
## Summary
- Export all public, non-test, non-generic user functions from WASM output
- Export `__alloc` so FFI callers can allocate WASM linear memory
- Enables calling Almide functions from Python via `wasmtime-py`

## How it works
```
almide build quant.almd --target wasm -o quant.wasm
```
The `.wasm` binary now exports user functions alongside `_start` and `memory`. Python can call them directly:
```python
from wasmtime import Store, Module, Linker, Engine, WasiConfig
# ... load module ...
ptr_in = alloc(store, len(data) + 4)   # allocate in WASM memory
memory.write(store, data, ptr_in + 4)  # write bytes
ptr_out = pack_int6(store, ptr_in)     # call Almide function
result = memory.read(store, ptr_out + 4, ptr_out + 4 + n)  # read result
```

## Verified
- `pack_int6` / `unpack_int6` called from Python via wasmtime: roundtrip OK
- 1024-byte large test: roundtrip OK
- All 139 test files pass, zero regressions

## Test plan
- [x] WASM exports verified with `wasm-tools dump` (memory, _start, __alloc, pack_int6, unpack_int6)
- [x] Python integration test via wasmtime-py
- [x] `almide test` — 139/139 pass