### PR TITLE
v0.9.9

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,15 @@ Almide is a programming language (.almd files) compiled via a pure-Rust compiler
 - **Module system**: [docs/specs/module-system.md](./docs/specs/module-system.md) — import, サブモジュール, ダイヤモンド依存
 - **Package system**: [docs/specs/package-system.md](./docs/specs/package-system.md) — 依存管理, MVS, バージョン共存
 
-## Building & Usage
+## Building & Installing
+
+After modifying compiler source, always rebuild and install so the PATH binary is up to date:
+
+```bash
+make install   # cargo build --release + install to ~/.local/bin/almide
+```
+
+## Usage
 
 ```bash
 cargo build --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "clap",
  "lasso",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "clap",
  "lasso",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.9.8"
+version = "0.9.9"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/'
 INSTALL_DIR := $(HOME)/.local/almide
 BIN := target/release/almide
 
-.PHONY: build install test test-wasm test-ts check clean fmt release parity cross-target
+.PHONY: build install test test-wasm test-ts check clean fmt release parity cross-target cheatsheet
 
 ## Build
 
@@ -14,8 +14,11 @@ build:
 install: build
 	@mkdir -p $(INSTALL_DIR)
 	cp $(BIN) $(INSTALL_DIR)/almide
-	@echo "Installed almide $(VERSION) to $(INSTALL_DIR)/almide"
-	@$(INSTALL_DIR)/almide --version
+	@mkdir -p $(HOME)/.local/bin
+	rm -f $(HOME)/.local/bin/almide
+	cp $(BIN) $(HOME)/.local/bin/almide
+	@echo "Installed almide $(VERSION) to $(INSTALL_DIR)/almide and ~/.local/bin/almide"
+	@almide --version
 
 ## Test
 
@@ -41,6 +44,17 @@ parity:
 cross-target: build
 	bash tools/cross-target-check.sh spec/lang
 	bash tools/cross-target-check.sh spec/stdlib
+
+## Docs
+
+cheatsheet:
+	@bash tools/generate-stdlib-cheatsheet.sh > /tmp/stdlib-section.md
+	@echo "Generated stdlib section. Review and update docs/CHEATSHEET.md manually, or run:"
+	@echo "  make cheatsheet-update"
+
+cheatsheet-update:
+	@python3 tools/update-cheatsheet-stdlib.py
+	@echo "Updated docs/CHEATSHEET.md stdlib section from TOML definitions."
 
 ## Check
 

--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -285,51 +285,86 @@ The runtime calls `main(args)` where `args` includes the program name at index 0
 ## UFCS
 `f(x, y)` ≡ `x.f(y)` — compiler resolves automatically.
 
+<!-- AUTO-GENERATED from stdlib/defs/*.toml — do not edit manually. Run: make cheatsheet-update -->
 ## Standard library modules
 
 ### string (auto-imported)
-`string.trim(s)`, `string.trim_start(s)`, `string.trim_end(s)`, `string.split(s, sep)`, `string.join(list, sep)`, `string.len(s)`, `string.lines(s)`, `string.pad_left(s, n, ch)`, `string.pad_right(s, n, ch)`, `string.starts_with(s, prefix)`, `string.ends_with(s, suffix)`, `string.slice(s, start)`, `string.slice(s, start, end)`, `string.to_bytes(s)`, `string.from_bytes(bytes)`, `string.contains(s, sub)`, `string.to_upper(s)`, `string.to_lower(s)`, `string.to_int(s)` → `Result[Int, String]`, `string.replace(s, from, to)`, `string.char_at(s, i)` → `Option[String]`, `string.chars(s)` → `List[String]`, `string.index_of(s, needle)` → `Option[Int]`, `string.repeat(s, n)`, `string.count(s, sub)` → `Int`, `string.reverse(s)`, `string.is_empty(s)` → `Bool`, `string.is_digit(s)`, `string.is_alpha(s)`, `string.is_alphanumeric(s)`, `string.is_whitespace(s)`, `string.strip_prefix(s, prefix)` → `Option[String]`, `string.strip_suffix(s, suffix)` → `Option[String]`
+`string.trim(s)`, `string.split(s, sep)`, `string.join(list, sep)`, `string.len(s)`, `string.contains(s, sub)`, `string.starts_with(s, prefix)`, `string.ends_with(s, suffix)`, `string.slice(s, start, end)`, `string.pad_start(s, n, ch)`, `string.to_bytes(s)`, `string.capitalize(s)`, `string.to_upper(s)`, `string.to_lower(s)`, `string.replace(s, from, to)`, `string.get(s, i)` → `Option[String]`, `string.lines(s)`, `string.chars(s)`, `string.index_of(s, needle)` → `Option[Int]`, `string.repeat(s, n)`, `string.from_bytes(bytes)`, `string.is_digit(s)`, `string.is_alpha(s)`, `string.is_alphanumeric(s)`, `string.is_whitespace(s)`, `string.is_upper(s)`, `string.is_lower(s)`, `string.codepoint(s)` → `Option[Int]`, `string.from_codepoint(n)`, `string.pad_end(s, n, ch)`, `string.trim_start(s)`, `string.trim_end(s)`, `string.count(s, sub)`, `string.is_empty(s)`, `string.reverse(s)`, `string.strip_prefix(s, prefix)` → `Option[String]`, `string.strip_suffix(s, suffix)` → `Option[String]`, `string.replace_first(s, from, to)`, `string.last_index_of(s, needle)` → `Option[Int]`, `string.first(s)` → `Option[String]`, `string.last(s)` → `Option[String]`, `string.take(s, n)`, `string.take_end(s, n)`, `string.drop(s, n)`, `string.drop_end(s, n)`
 
 ### list (auto-imported)
-`list.len(xs)`, `list.get(xs, i)` → `Option[T]`, `list.get_or(xs, i, default)` → `T`, `list.first(xs)` → `Option[T]`, `list.last(xs)` → `Option[T]`, `list.sort(xs)`, `list.sort_by(xs, (x) => key)`, `list.reverse(xs)`, `list.contains(xs, x)`, `list.index_of(xs, x)` → `Option[Int]`, `list.any(xs, (x) => bool)`, `list.all(xs, (x) => bool)`, `list.each(xs, f)`, `list.map(xs, f)`, `list.flat_map(xs, f)`, `list.filter(xs, f)`, `list.filter_map(xs, (x) => Option[B])` → `List[B]`, `list.find(xs, f)`, `list.fold(xs, init, f)`, `list.enumerate(xs)` → `List[(Int, T)]`, `list.zip(a, b)` → `List[(T, U)]`, `list.flatten(xss)`, `list.take(xs, n)`, `list.drop(xs, n)`, `list.chunk(xs, n)` → `List[List[T]]`, `list.unique(xs)`, `list.repeat(val, n)`, `list.join(xs, sep)` → `String`, `list.sum(xs)` → `Int`, `list.product(xs)` → `Int`, `list.min(xs)` → `Option[T]`, `list.max(xs)` → `Option[T]`, `list.is_empty(xs)` → `Bool`, `list.push(xs, x)` (var), `list.pop(xs)` → `Option[T]` (var), `list.clear(xs)` (var)
+`list.len(xs)`, `list.get(xs, i)` → `Option[A]`, `list.get_or(xs, i, default)` → `A`, `list.set(xs, i, val)` → `List[A]`, `list.swap(xs, i, j)` → `List[A]`, `list.sort(xs)` → `List[A]`, `list.reverse(xs)` → `List[A]`, `list.contains(xs, x)`, `list.enumerate(xs)` → `List[(Int, A)]`, `list.zip(xs, ys)` → `List[(A, B)]`, `list.flatten(xss)` → `List[T]`, `list.take(xs, n)` → `List[A]`, `list.drop(xs, n)` → `List[A]`, `list.unique(xs)` → `List[A]`, `list.index_of(xs, x)` → `Option[Int]`, `list.last(xs)` → `Option[A]`, `list.chunk(xs, n)` → `List[List[A]]`, `list.sum(xs)`, `list.product(xs)`, `list.first(xs)` → `Option[A]`, `list.is_empty(xs)`, `list.min(xs)` → `Option[A]`, `list.max(xs)` → `Option[A]`, `list.join(xs, sep)`, `list.map(xs, f)` → `List[B]`, `list.filter(xs, f)` → `List[A]`, `list.find(xs, f)` → `Option[A]`, `list.any(xs, f)`, `list.all(xs, f)`, `list.each(xs, f)`, `list.sort_by(xs, f)` → `List[A]`, `list.flat_map(xs, f)` → `List[B]`, `list.filter_map(xs, f)` → `List[B]`, `list.take_while(xs, f)` → `List[A]`, `list.drop_while(xs, f)` → `List[A]`, `list.count(xs, f)`, `list.partition(xs, f)` → `(List[A], List[A])`, `list.reduce(xs, f)` → `Option[A]`, `list.group_by(xs, f)` → `Map[B, List[A]]`, `list.range(start, end)`, `list.slice(xs, start, end)` → `List[A]`, `list.insert(xs, i, val)` → `List[A]`, `list.remove_at(xs, i)` → `List[A]`, `list.find_index(xs, f)` → `Option[Int]`, `list.update(xs, i, f)` → `List[A]`, `list.repeat(val, n)` → `List[A]`, `list.scan(xs, init, f)` → `List[B]`, `list.intersperse(xs, sep)` → `List[A]`, `list.windows(xs, n)` → `List[List[A]]`, `list.dedup(xs)` → `List[A]`, `list.zip_with(xs, ys, f)` → `List[C]`, `list.fold(xs, init, f)` → `B`, `list.take_end(xs, n)` → `List[A]`, `list.drop_end(xs, n)` → `List[A]`, `list.unique_by(xs, f)` → `List[A]`, `list.shuffle(xs)` → `List[A]`, `list.window(xs, n)` → `List[List[A]]`, `list.push(xs, x)`, `list.pop(xs)` → `Option[A]`, `list.clear(xs)`
 
 ### map (auto-imported)
-`map.new()` → empty `Map[K, V]`, `map.get(m, key)` → `Option[V]`, `map.get_or(m, key, default)` → `V`, `map.set(m, key, value)` → `Map[K, V]`, `map.contains(m, key)` → `Bool`, `map.remove(m, key)` → `Map[K, V]`, `map.merge(a, b)` → `Map[K, V]`, `map.keys(m)` → `List[K]` (sorted), `map.values(m)` → `List[V]`, `map.len(m)` → `Int`, `map.entries(m)` → `List[(K, V)]`, `map.from_list(xs, (x) => (k, v))` → `Map[K, V]`, `map.is_empty(m)` → `Bool`, `map.insert(m, key, value)` (var), `map.delete(m, key)` (var), `map.clear(m)` (var)
+`map.new()` → `Map[K, V]`, `map.get(m, key)` → `Option[V]`, `map.get_or(m, key, default)` → `V`, `map.set(m, key, value)` → `Map[K, V]`, `map.contains(m, key)`, `map.remove(m, key)` → `Map[K, V]`, `map.keys(m)` → `List[K]`, `map.values(m)` → `List[V]`, `map.len(m)`, `map.entries(m)` → `List[(K, V)]`, `map.merge(a, b)` → `Map[K, V]`, `map.is_empty(m)`, `map.from_list(pairs)` → `Map[K, V]`, `map.map(m, f)` → `Map[K, B]`, `map.filter(m, f)` → `Map[K, V]`, `map.fold(m, init, f)` → `A`, `map.any(m, f)`, `map.all(m, f)`, `map.count(m, f)`, `map.each(m, f)`, `map.find(m, f)` → `Option[(K, V)]`, `map.update(m, key, f)` → `Map[K, V]`, `map.insert(m, key, value)`, `map.delete(m, key)`, `map.clear(m)`
 
-### int / float (auto-imported)
-`int.to_string(n)`, `int.to_hex(n)`, `int.parse(s)` → `Result[Int, String]`, `int.parse_hex(s)` → `Result[Int, String]`, `int.abs(n)`, `int.min(a, b)`, `int.max(a, b)`, `int.band(a, b)`, `int.bor(a, b)`, `int.bxor(a, b)`, `int.bshl(a, n)`, `int.bshr(a, n)`, `int.bnot(a)`, `int.wrap_add(a, b, bits)`, `int.wrap_mul(a, b, bits)`, `int.rotate_right(a, n, bits)`, `int.rotate_left(a, n, bits)`, `int.to_u32(a)`, `int.to_u8(a)`
-`float.to_string(n)`, `float.to_int(n)`, `float.from_int(n)`, `float.round(n)`, `float.floor(n)`, `float.ceil(n)`, `float.abs(n)`, `float.sqrt(n)`, `float.parse(s)` → `Result[Float, String]`
+### set (auto-imported)
+`set.new()` → `Set[A]`, `set.from_list(xs)` → `Set[A]`, `set.insert(s, value)` → `Set[A]`, `set.remove(s, value)` → `Set[A]`, `set.contains(s, value)`, `set.len(s)`, `set.is_empty(s)`, `set.to_list(s)` → `List[A]`, `set.union(a, b)` → `Set[A]`, `set.intersection(a, b)` → `Set[A]`, `set.difference(a, b)` → `Set[A]`, `set.symmetric_difference(a, b)` → `Set[A]`, `set.is_subset(a, b)`, `set.is_disjoint(a, b)`, `set.filter(s, f)` → `Set[A]`, `set.map(s, f)` → `Set[B]`, `set.fold(s, init, f)` → `B`, `set.each(s, f)`, `set.any(s, f)`, `set.all(s, f)`
+
+### int (auto-imported)
+`int.to_string(n)`, `int.to_hex(n)`, `int.parse(s)` → `Result[Int, String]`, `int.from_hex(s)` → `Result[Int, String]`, `int.abs(n)`, `int.min(a, b)`, `int.max(a, b)`, `int.band(a, b)`, `int.bor(a, b)`, `int.bxor(a, b)`, `int.bshl(a, n)`, `int.bshr(a, n)`, `int.bnot(a)`, `int.wrap_add(a, b, bits)`, `int.wrap_mul(a, b, bits)`, `int.rotate_right(a, n, bits)`, `int.rotate_left(a, n, bits)`, `int.to_u32(a)`, `int.to_u8(a)`, `int.clamp(n, lo, hi)`, `int.to_float(n)`
+
+### float (auto-imported)
+`float.to_string(n)`, `float.to_int(n)`, `float.round(n)`, `float.floor(n)`, `float.ceil(n)`, `float.abs(n)`, `float.sqrt(n)`, `float.parse(s)` → `Result[Float, String]`, `float.from_int(n)`, `float.min(a, b)`, `float.max(a, b)`, `float.to_fixed(n, decimals)`, `float.clamp(n, lo, hi)`, `float.sign(n)`, `float.is_nan(n)`, `float.is_infinite(n)`
+
+### value (auto-imported)
+`value.get(v, key)` → `Result[Value, String]`, `value.as_string(v)` → `Result[String, String]`, `value.as_int(v)` → `Result[Int, String]`, `value.as_float(v)` → `Result[Float, String]`, `value.as_bool(v)` → `Result[Bool, String]`, `value.as_array(v)` → `Result[List[Value], String]`, `value.str(s)` → `Value`, `value.int(n)` → `Value`, `value.float(f)` → `Value`, `value.bool(b)` → `Value`, `value.object(pairs)` → `Value`, `value.array(items)` → `Value`, `value.null()` → `Value`, `value.pick(v, keys)` → `Value`, `value.omit(v, keys)` → `Value`, `value.merge(a, b)` → `Value`, `value.to_camel_case(v)` → `Value`, `value.to_snake_case(v)` → `Value`, `value.stringify(v)`
+
+### result (auto-imported)
+`result.map(r, f)` → `Result[B, E]`, `result.map_err(r, f)` → `Result[A, F]`, `result.flat_map(r, f)` → `Result[B, E]`, `result.unwrap_or(r, default)` → `A`, `result.unwrap_or_else(r, f)` → `A`, `result.is_ok(r)`, `result.is_err(r)`, `result.to_option(r)` → `Option[A]`, `result.to_err_option(r)` → `Option[E]`, `result.collect(rs)` → `Result[List[T], List[E]]`, `result.partition(rs)` → `(List[T], List[E])`, `result.collect_map(xs, f)` → `Result[List[U], List[E]]`
+
+### option (auto-imported)
+`option.map(o, f)` → `Option[B]`, `option.flat_map(o, f)` → `Option[B]`, `option.flatten(o)` → `Option[A]`, `option.unwrap_or(o, default)` → `A`, `option.unwrap_or_else(o, f)` → `A`, `option.is_some(o)`, `option.is_none(o)`, `option.to_result(o, err)` → `Result[A, String]`, `option.filter(o, f)` → `Option[A]`, `option.zip(a, b)` → `Option[(A, B)]`, `option.or_else(o, f)` → `Option[A]`, `option.to_list(o)` → `List[A]`
 
 ### fs (requires `import fs`, effect fns)
-`fs.read_text(path)`, `fs.read_bytes(path)`, `fs.read_lines(path)`, `fs.write(path, content)`, `fs.write_bytes(path, bytes)`, `fs.append(path, content)`, `fs.mkdir_p(path)`, `fs.exists(path)` → `Bool`, `fs.is_dir(path)` → `Bool`, `fs.is_file(path)` → `Bool`, `fs.remove(path)`, `fs.list_dir(path)`, `fs.copy(src, dst)`, `fs.rename(src, dst)`
+`fs.read_text(path)` → `Result[String, String]`, `fs.read_bytes(path)` → `Result[List[Int], String]`, `fs.write(path, content)` → `Result[Unit, String]`, `fs.write_bytes(path, bytes)` → `Result[Unit, String]`, `fs.append(path, content)` → `Result[Unit, String]`, `fs.mkdir_p(path)` → `Result[Unit, String]`, `fs.exists(path)`, `fs.read_lines(path)` → `Result[List[String], String]`, `fs.remove(path)` → `Result[Unit, String]`, `fs.list_dir(path)` → `Result[List[String], String]`, `fs.is_dir(path)`, `fs.is_file(path)`, `fs.copy(src, dst)` → `Result[Unit, String]`, `fs.rename(src, dst)` → `Result[Unit, String]`, `fs.walk(dir)` → `Result[List[String], String]`, `fs.remove_all(path)` → `Result[Unit, String]`, `fs.file_size(path)` → `Result[Int, String]`, `fs.temp_dir()`, `fs.stat(path)` → `Result[{size: Int, is_dir: Bool, is_file: Bool, modified: Int}, String]`, `fs.glob(pattern)` → `Result[List[String], String]`, `fs.create_temp_file(prefix)` → `Result[String, String]`, `fs.create_temp_dir(prefix)` → `Result[String, String]`, `fs.is_symlink(path)`, `fs.modified_at(path)` → `Result[Int, String]`
+
+### env (requires `import env`, effect fns)
+`env.unix_timestamp()`, `env.args()`, `env.get(name)` → `Option[String]`, `env.set(name, value)`, `env.cwd()` → `Result[String, String]`, `env.millis()`, `env.sleep_ms(ms)`, `env.temp_dir()`, `env.os()`
+
+### process (requires `import process`, effect fns)
+`process.exec(cmd, args)` → `Result[String, String]`, `process.exit(code)`, `process.stdin_lines()` → `Result[List[String], String]`, `process.exec_in(dir, cmd, args)` → `Result[String, String]`, `process.exec_with_stdin(cmd, args, input)` → `Result[String, String]`, `process.exec_status(cmd, args)` → `Result[{code: Int, stdout: String, stderr: String}, String]`
+
+### io (requires `import io`, effect fns)
+`io.read_line()`, `io.print(s)`, `io.read_all()`, `io.write_bytes(data)`, `io.write(data)`
+
+### json (requires `import json`)
+`json.parse(text)` → `Result[Value, String]`, `json.stringify(v)`, `json.get(j, key)` → `Option[Value]`, `json.keys(j)`, `json.from_string(s)` → `Value`, `json.from_int(n)` → `Value`, `json.from_bool(b)` → `Value`, `json.null()` → `Value`, `json.array(items)` → `Value`, `json.from_float(n)` → `Value`, `json.stringify_pretty(j)`, `json.object(entries)` → `Value`, `json.get_string(j, key)` → `Option[String]`, `json.get_int(j, key)` → `Option[Int]`, `json.get_float(j, key)` → `Option[Float]`, `json.get_bool(j, key)` → `Option[Bool]`, `json.get_array(j, key)` → `Option[List[Value]]`, `json.as_string(j)` → `Option[String]`, `json.as_int(j)` → `Option[Int]`, `json.as_float(j)` → `Option[Float]`, `json.as_bool(j)` → `Option[Bool]`, `json.as_array(j)` → `Option[List[Value]]`, `json.root()` → `JsonPath`, `json.field(path, name)` → `JsonPath`, `json.index(path, i)` → `JsonPath`, `json.get_path(j, path)` → `Option[Value]`, `json.set_path(j, path, value)` → `Result[Value, String]`, `json.remove_path(j, path)` → `Value`
+
+### http (requires `import http`, effect fns)
+`http.serve(port, f)`, `http.response(status, body)` → `Response`, `http.json(status, body)` → `Response`, `http.with_headers(status, body, headers)` → `Response`, `http.redirect(url)` → `Response`, `http.status(resp, code)` → `Response`, `http.body(resp)`, `http.set_header(resp, key, value)` → `Response`, `http.get_header(resp, key)` → `Option[String]`, `http.req_method(req)`, `http.req_path(req)`, `http.req_body(req)`, `http.req_header(req, key)` → `Option[String]`, `http.query_params(req)` → `Map[String, String]`, `http.get(url)` → `Result[String, String]`, `http.post(url, body)` → `Result[String, String]`, `http.put(url, body)` → `Result[String, String]`, `http.patch(url, body)` → `Result[String, String]`, `http.delete(url)` → `Result[String, String]`, `http.request(method, url, body, headers)` → `Result[String, String]`
+
+### regex (requires `import regex`)
+`regex.is_match(pat, s)`, `regex.full_match(pat, s)`, `regex.find(pat, s)` → `Option[String]`, `regex.find_all(pat, s)`, `regex.replace(pat, s, rep)`, `regex.replace_first(pat, s, rep)`, `regex.split(pat, s)`, `regex.captures(pat, s)` → `Option[List[String]]`
+
+### bytes (requires `import bytes`)
+`bytes.len(b)`, `bytes.get(b, i)` → `Option[Int]`, `bytes.get_or(b, i, default)`, `bytes.set(b, i, val)` → `Bytes`, `bytes.slice(b, start, end)` → `Bytes`, `bytes.from_list(xs)` → `Bytes`, `bytes.to_list(b)`, `bytes.is_empty(b)`, `bytes.concat(a, b)` → `Bytes`, `bytes.repeat(b, n)` → `Bytes`, `bytes.new(len)` → `Bytes`, `bytes.push(b, val)`, `bytes.clear(b)`, `bytes.from_string(s)` → `Bytes`
+
+### datetime (requires `import datetime`, effect fns)
+`datetime.now()`, `datetime.from_parts(y, m, d, h, min, s)`, `datetime.parse_iso(s)` → `Result[Int, String]`, `datetime.from_unix(seconds)`, `datetime.format(ts, pattern)`, `datetime.to_iso(ts)`, `datetime.to_unix(ts)`, `datetime.year(ts)`, `datetime.month(ts)`, `datetime.day(ts)`, `datetime.hour(ts)`, `datetime.minute(ts)`, `datetime.second(ts)`, `datetime.weekday(ts)`, `datetime.add_days(ts, n)`, `datetime.add_hours(ts, n)`, `datetime.add_minutes(ts, n)`, `datetime.add_seconds(ts, n)`, `datetime.diff_seconds(a, b)`, `datetime.is_before(a, b)`, `datetime.is_after(a, b)`
+
+### log (requires `import log`, effect fns)
+`log.debug(msg)`, `log.info(msg)`, `log.warn(msg)`, `log.error(msg)`, `log.debug_with(msg, fields)`, `log.info_with(msg, fields)`, `log.warn_with(msg, fields)`, `log.error_with(msg, fields)`
+
+### math (requires `import math`)
+`math.min(a, b)`, `math.max(a, b)`, `math.abs(n)`, `math.pow(base, exp)`, `math.pi()`, `math.e()`, `math.sin(x)`, `math.cos(x)`, `math.tan(x)`, `math.log(x)`, `math.exp(x)`, `math.sqrt(x)`, `math.log10(x)`, `math.log2(x)`, `math.sign(n)`, `math.fmin(a, b)`, `math.fmax(a, b)`, `math.fpow(base, exp)`, `math.factorial(n)`, `math.choose(n, k)`, `math.log_gamma(x)`
+
+### matrix (requires `import matrix`)
+`matrix.zeros(rows, cols)` → `Matrix`, `matrix.ones(rows, cols)` → `Matrix`, `matrix.shape(m)` → `(Int, Int)`, `matrix.transpose(m)` → `Matrix`, `matrix.from_lists(rows)` → `Matrix`, `matrix.to_lists(m)` → `List[List[Float]]`, `matrix.get(m, row, col)`, `matrix.rows(m)`, `matrix.cols(m)`, `matrix.add(a, b)` → `Matrix`, `matrix.mul(a, b)` → `Matrix`, `matrix.scale(m, s)` → `Matrix`, `matrix.map(m, f)` → `Matrix`
+
+### random (requires `import random`, effect fns)
+`random.int(min, max)`, `random.float()`, `random.choice(xs)` → `Option[T]`, `random.shuffle(xs)` → `List[T]`
+
+### testing (requires `import testing`)
+`testing.assert_throws(f, expected)`, `testing.assert_contains(haystack, needle)`, `testing.assert_approx(a, b, tolerance)`, `testing.assert_gt(a, b)`, `testing.assert_lt(a, b)`, `testing.assert_some(opt)`, `testing.assert_ok(result)`
+
+### error (requires `import error`)
+`error.context(r, msg)` → `Result[T, String]`, `error.message(r)`, `error.chain(outer, cause)`
 
 ### path (requires `import path`)
 `path.join(base, child)`, `path.dirname(p)`, `path.basename(p)`, `path.extension(p)` → `Option[String]`, `path.is_absolute(p)` → `Bool`
 
-### env (requires `import env`, effect fns)
-`env.unix_timestamp()` → `Int`, `env.millis()` → `Int`, `env.args()` → `List[String]`, `env.get(name)` → `Option[String]`, `env.set(name, value)`, `env.cwd()` → `Result[String, String]`, `env.sleep_ms(ms)`
-
-### process (requires `import process`, effect fns)
-`process.exec(cmd, args)` → `Result[String, String]`, `process.exec_status(cmd, args)` → `Result[{code: Int, stdout: String, stderr: String}, String]`, `process.exit(code)`, `process.stdin_lines()` → `Result[List[String], String]`
-
-### io (requires `import io`, effect fns)
-`io.read_line()` → `String`, `io.print(s)` (no newline), `io.read_all()` → `String`
-
-### json (requires `import json`)
-`json.parse(text)` → `Result[Json, String]`, `json.stringify(j)`, `json.stringify_pretty(j)`, `json.get(j, key)` → `Option[Json]`, `json.get_string(j, key)` → `Option[String]`, `json.get_int(j, key)` → `Option[Int]`, `json.get_float(j, key)` → `Option[Float]`, `json.get_bool(j, key)` → `Option[Bool]`, `json.get_array(j, key)` → `Option[List[Json]]`, `json.keys(j)` → `List[String]`, `json.to_string(j)` → `Option[String]`, `json.to_int(j)` → `Option[Int]`, `json.as_string(j)` → `Option[String]`, `json.as_int(j)` → `Option[Int]`, `json.as_float(j)` → `Option[Float]`, `json.as_bool(j)` → `Option[Bool]`, `json.as_array(j)` → `Option[List[Json]]`, `json.object(entries)` → `Json`, `json.s(v)`, `json.i(v)`, `json.f(v)`, `json.b(v)`, `json.null()`, `json.array(items)`, `json.from_string(s)`, `json.from_int(n)`, `json.from_float(n)`, `json.from_bool(b)`, `json.from_map(m)`
-
-### math (requires `import math`)
-`math.min(a, b)`, `math.max(a, b)`, `math.abs(n)`, `math.pow(base, exp)`, `math.pi()`, `math.e()`, `math.sin(x)`, `math.cos(x)`, `math.tan(x)`, `math.log(x)`, `math.exp(x)`, `math.sqrt(x)`
-
-### random (requires `import random`, effect fns)
-`random.int(min, max)` (inclusive), `random.float()` (0.0..1.0), `random.choice(xs)` → `Option[T]`, `random.shuffle(xs)`
-
-### regex (requires `import regex`)
-`regex.match(pat, s)`, `regex.full_match(pat, s)`, `regex.find(pat, s)` → `Option[String]`, `regex.find_all(pat, s)`, `regex.replace(pat, s, rep)`, `regex.replace_first(pat, s, rep)`, `regex.split(pat, s)`, `regex.captures(pat, s)` → `Option[List[String]]`
-
 ### args (requires `import args`)
 `args.flag(name)` → `Bool`, `args.option(name)` → `Option[String]`, `args.option_or(name, fallback)` → `String`, `args.positional()` → `List[String]`
-
 ## Key rules
 - Newline = statement separator (no semicolons needed)
 - `[]` for generics, NOT `<>`

--- a/docs/CLAUDE_TEMPLATE.md
+++ b/docs/CLAUDE_TEMPLATE.md
@@ -108,7 +108,7 @@ let r = "hello".split(" ").reverse()  // chaining works too
 ```
 AUTO-IMPORTED (no import needed):
   string: len trim split join lines contains? starts_with? ends_with? replace
-          index_of slice to_upper to_lower to_int chars pad_left pad_right
+          index_of slice to_upper to_lower to_int chars pad_start pad_end
   list:   len get get_or first last map flat_map filter find fold enumerate
           zip sort sort_by reverse any? all? take drop unique join sum
   map:    new get set contains? remove keys values entries from_list merge len

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1076,7 +1076,7 @@ The `is_` prefix convention is used for predicates in the stdlib: `string.is_emp
 ### 18.1 Auto-Imported Modules
 
 **string** (41 functions):
-`trim`, `trim_start`, `trim_end`, `split`, `join`, `len`, `lines`, `pad_left`, `pad_right`, `starts_with`, `ends_with`, `slice`, `to_bytes`, `from_bytes`, `contains`, `to_upper`, `to_lower`, `to_int`, `replace`, `char_at`, `chars`, `index_of`, `repeat`, `count`, `reverse`, `is_empty`, `is_digit`, `is_alpha`, `is_alphanumeric`, `is_whitespace`, `strip_prefix`, `strip_suffix`, `capitalize`, `is_upper`, `is_lower`, `codepoint`, `from_codepoint`, `pad_end`, `replace_first`, `last_index_of`, `to_float`
+`trim`, `trim_start`, `trim_end`, `split`, `join`, `len`, `lines`, `pad_start`, `pad_end`, `starts_with`, `ends_with`, `slice`, `to_bytes`, `from_bytes`, `contains`, `to_upper`, `to_lower`, `to_int`, `replace`, `char_at`, `chars`, `index_of`, `repeat`, `count`, `reverse`, `is_empty`, `is_digit`, `is_alpha`, `is_alphanumeric`, `is_whitespace`, `strip_prefix`, `strip_suffix`, `capitalize`, `is_upper`, `is_lower`, `codepoint`, `from_codepoint`, `replace_first`, `last_index_of`, `to_float`
 
 **list** (54 functions):
 `len`, `get`, `get_or`, `first`, `last`, `sort`, `sort_by`, `reverse`, `contains`, `index_of`, `any`, `all`, `each`, `map`, `flat_map`, `filter`, `find`, `fold`, `enumerate`, `zip`, `flatten`, `take`, `drop`, `chunk`, `unique`, `join`, `sum`, `product`, `min`, `max`, `is_empty`, `push`, `pop`, `insert`, `remove`, `concat`, `slice`, `range`, `count`, `find_index`, `partition`, `scan`, `window`, `zip_with`, `unzip`, `group_by`, `frequencies`, `intersperse`, `reduce`, `take_while`, `drop_while`, `dedup`, `rotate`, `transpose`

--- a/docs/roadmap/done/stdlib-completeness.md
+++ b/docs/roadmap/done/stdlib-completeness.md
@@ -13,7 +13,7 @@ Fill gaps that make Almide less capable than Python/Go for everyday tasks.
 
 ### string module ✅
 
-- [x] `string.pad_right(s, n, ch)` → `String`
+- [x] `string.pad_end(s, n, ch)` → `String`
 - [x] `string.trim_start(s)` / `string.trim_end(s)` → `String`
 - [x] `string.count(s, sub)` → `Int`
 

--- a/research/benchmark/msr/modifications/outputs/haiku/m01-traffic-light-add-variant.almd
+++ b/research/benchmark/msr/modifications/outputs/haiku/m01-traffic-light-add-variant.almd
@@ -1,0 +1,23 @@
+type Light = | Red | Yellow | Green | FlashingRed
+
+fn next(l: Light) -> Light =
+  match l { Red => Green, Green => Yellow, Yellow => Red, FlashingRed => Red }
+
+fn duration(l: Light) -> Int =
+  match l { Red => 60, Yellow => 5, Green => 45, FlashingRed => 2 }
+
+fn describe(l: Light) -> String =
+  match l { Red => "stop", Yellow => "caution", Green => "go", FlashingRed => "caution" }
+
+test "next red" { assert_eq(next(Red), Green) }
+test "next green" { assert_eq(next(Green), Yellow) }
+test "next yellow" { assert_eq(next(Yellow), Red) }
+test "full cycle" { assert_eq(next(next(next(Red))), Red) }
+test "duration red" { assert_eq(duration(Red), 60) }
+test "duration yellow" { assert_eq(duration(Yellow), 5) }
+test "duration green" { assert_eq(duration(Green), 45) }
+test "describe" { assert_eq(describe(Red), "stop") }
+test "next flashing red" { assert_eq(next(FlashingRed), Red) }
+test "duration flashing red" { assert_eq(duration(FlashingRed), 2) }
+test "describe flashing red" { assert_eq(describe(FlashingRed), "caution") }
+test "cycle from flashing red" { assert_eq(next(next(FlashingRed)), Green) }

--- a/research/benchmark/msr/modifications/outputs/haiku/m02-todo-app-add-field.almd
+++ b/research/benchmark/msr/modifications/outputs/haiku/m02-todo-app-add-field.almd
@@ -1,0 +1,122 @@
+type Status = | Pending | Done | Cancelled
+
+type Todo = { id: Int, title: String, status: Status, priority: Int }
+
+fn create(id: Int, title: String, priority: Int) -> Todo =
+  Todo { id: id, title: title, status: Pending, priority: priority }
+
+fn complete(t: Todo) -> Todo = { ...t, status: Done }
+
+fn cancel(t: Todo) -> Todo = { ...t, status: Cancelled }
+
+fn is_done(t: Todo) -> Bool = match t.status { Done => true, _ => false }
+
+fn pending_count(todos: List[Todo]) -> Int =
+  todos |> list.filter((t) => match t.status { Pending => true, _ => false }) |> list.len
+
+fn titles(todos: List[Todo]) -> List[String] = list.map(todos, (t) => t.title)
+
+fn find_by_title(todos: List[Todo], title: String) -> Option[Todo] =
+  list.find(todos, (t) => t.title == title)
+
+fn status_label(s: Status) -> String =
+  match s { Pending => "pending", Done => "done", Cancelled => "cancelled" }
+
+fn summary(t: Todo) -> String = "[${status_label(t.status)}/p${int.to_string(t.priority)}] ${t.title}"
+
+fn high_priority(todos: List[Todo]) -> List[Todo] =
+  todos
+    |> list.filter((t) => t.priority >= 3)
+    |> list.sort_by((t) => t.priority)
+    |> list.reverse
+
+test "create todo" {
+  let t = create(1, "Buy milk", 1)
+  assert_eq(t.title, "Buy milk")
+  assert_eq(t.id, 1)
+}
+
+test "complete todo" {
+  let t = create(1, "Buy milk", 1) |> complete
+  assert_eq(is_done(t), true)
+}
+
+test "cancel todo" {
+  let t = create(1, "Buy milk", 1) |> cancel
+  assert_eq(status_label(t.status), "cancelled")
+}
+
+test "pending count" {
+  let todos = [create(1, "A", 1), create(2, "B", 1) |> complete, create(3, "C", 1)]
+  assert_eq(pending_count(todos), 2)
+}
+
+test "titles" {
+  let todos = [create(1, "A", 1), create(2, "B", 1), create(3, "C", 1)]
+  assert_eq(titles(todos), ["A", "B", "C"])
+}
+
+test "find by title found" {
+  let todos = [create(1, "Buy milk", 1), create(2, "Walk dog", 1)]
+  match find_by_title(todos, "Walk dog") {
+    some(t) => assert_eq(t.id, 2)
+    none => assert(false)
+  }
+}
+
+test "find by title not found" {
+  let todos = [create(1, "Buy milk", 1)]
+  assert_eq(find_by_title(todos, "nope"), none)
+}
+
+test "summary" {
+  assert_eq(summary(create(1, "Buy milk", 1)), "[pending/p1] Buy milk")
+  assert_eq(summary(create(1, "Done", 1) |> complete), "[done/p1] Done")
+}
+
+test "pipe chain: create filter map" {
+  let todos = [create(1, "A", 1), create(2, "B", 1) |> complete, create(3, "C", 1) |> cancel]
+  let pending_titles = todos
+    |> list.filter((t) => match t.status { Pending => true, _ => false })
+    |> list.map((t) => t.title)
+  assert_eq(pending_titles, ["A"])
+}
+
+test "multiple operations" {
+  var todos = [create(1, "A", 1), create(2, "B", 1), create(3, "C", 1)]
+  let updated = list.map(todos, (t) => if t.id == 2 then complete(t) else t)
+  assert_eq(pending_count(updated), 2)
+  assert(is_done(list.get_or(updated, 1, create(0, "", 1))))
+}
+
+test "create with priority" {
+  let t = create(1, "Buy milk", 3)
+  assert_eq(t.priority, 3)
+}
+
+test "high priority filter" {
+  let todos = [create(1, "A", 5), create(2, "B", 1), create(3, "C", 3)]
+  let hp = high_priority(todos)
+  assert_eq(list.len(hp), 2)
+  assert_eq(list.map(hp, (t) => t.title), ["A", "C"])
+}
+
+test "high priority empty" {
+  let todos = [create(1, "A", 1), create(2, "B", 2)]
+  assert_eq(high_priority(todos), [])
+}
+
+test "complete preserves priority" {
+  let t = create(1, "A", 5) |> complete
+  assert_eq(t.priority, 5)
+}
+
+test "cancel preserves priority" {
+  let t = create(1, "A", 3) |> cancel
+  assert_eq(t.priority, 3)
+}
+
+test "summary with priority" {
+  assert_eq(summary(create(1, "Buy milk", 3)), "[pending/p3] Buy milk")
+  assert_eq(summary(create(1, "Done", 2) |> complete), "[done/p2] Done")
+}

--- a/research/benchmark/msr/modifications/outputs/haiku/m03-expression-eval-add-variant.almd
+++ b/research/benchmark/msr/modifications/outputs/haiku/m03-expression-eval-add-variant.almd
@@ -1,0 +1,57 @@
+type Expr =
+  | Lit(Int)
+  | Add(Expr, Expr)
+  | Mul(Expr, Expr)
+  | Sub(Expr, Expr)
+  | Div(Expr, Expr)
+
+fn eval(e: Expr) -> Int =
+  match e {
+    Lit(n) => n
+    Add(l, r) => eval(l) + eval(r)
+    Mul(l, r) => eval(l) * eval(r)
+    Sub(l, r) => eval(l) - eval(r)
+    Div(l, r) => eval(l) / eval(r)
+  }
+
+fn to_string(e: Expr) -> String =
+  match e {
+    Lit(n) => int.to_string(n)
+    Add(l, r) => "(${to_string(l)} + ${to_string(r)})"
+    Mul(l, r) => "(${to_string(l)} * ${to_string(r)})"
+    Sub(l, r) => "(${to_string(l)} - ${to_string(r)})"
+    Div(l, r) => "(${to_string(l)} / ${to_string(r)})"
+  }
+
+test "literal" { assert_eq(eval(Lit(5)), 5) }
+test "add" { assert_eq(eval(Add(Lit(2), Lit(3))), 5) }
+test "mul" { assert_eq(eval(Mul(Lit(4), Lit(5))), 20) }
+test "sub" { assert_eq(eval(Sub(Lit(10), Lit(3))), 7) }
+test "nested add mul" { assert_eq(eval(Add(Lit(1), Mul(Lit(2), Lit(3)))), 7) }
+test "deep nesting" { assert_eq(eval(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))), 18) }
+test "to_string literal" { assert_eq(to_string(Lit(42)), "42") }
+test "to_string add" { assert_eq(to_string(Add(Lit(1), Lit(2))), "(1 + 2)") }
+test "to_string nested" { assert_eq(to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))), "((1 + 2) * 3)") }
+test "eval matches to_string" {
+  let e = Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))
+  assert_eq(eval(e), 15)
+}
+test "deeply nested eval" {
+  let e = Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))
+  assert_eq(eval(e), 8)
+}
+test "single negative via sub" {
+  assert_eq(eval(Sub(Lit(0), Lit(5))), -5)
+}
+
+test "eval div" { assert_eq(eval(Div(Lit(10), Lit(3))), 3) }
+test "eval div exact" { assert_eq(eval(Div(Lit(10), Lit(2))), 5) }
+test "to_string div" { assert_eq(to_string(Div(Lit(10), Lit(3))), "(10 / 3)") }
+test "nested with div" {
+  let e = Add(Lit(1), Div(Lit(10), Lit(3)))
+  assert_eq(eval(e), 4)
+}
+test "div in complex expr" {
+  let e = Mul(Div(Lit(20), Lit(4)), Sub(Lit(10), Lit(7)))
+  assert_eq(eval(e), 15)
+}

--- a/research/benchmark/msr/modifications/outputs/haiku/m04-expression-eval-return-type.almd
+++ b/research/benchmark/msr/modifications/outputs/haiku/m04-expression-eval-return-type.almd
@@ -1,0 +1,72 @@
+type Expr =
+  | Lit(Int)
+  | Add(Expr, Expr)
+  | Mul(Expr, Expr)
+  | Sub(Expr, Expr)
+  | Div(Expr, Expr)
+
+effect fn eval(e: Expr) -> Result[Int, String] =
+  match e {
+    Lit(n) => ok(n)
+    Add(l, r) => {
+      let left = eval(l)!
+      let right = eval(r)!
+      ok(left + right)
+    }
+    Mul(l, r) => {
+      let left = eval(l)!
+      let right = eval(r)!
+      ok(left * right)
+    }
+    Sub(l, r) => {
+      let left = eval(l)!
+      let right = eval(r)!
+      ok(left - right)
+    }
+    Div(l, r) => {
+      let left = eval(l)!
+      let right = eval(r)!
+      if right == 0 then err("division by zero") else ok(left / right)
+    }
+  }
+
+fn to_string(e: Expr) -> String =
+  match e {
+    Lit(n) => int.to_string(n)
+    Add(l, r) => "(${to_string(l)} + ${to_string(r)})"
+    Mul(l, r) => "(${to_string(l)} * ${to_string(r)})"
+    Sub(l, r) => "(${to_string(l)} - ${to_string(r)})"
+    Div(l, r) => "(${to_string(l)} / ${to_string(r)})"
+  }
+
+test "literal" { assert_eq(eval(Lit(5)), ok(5)) }
+test "add" { assert_eq(eval(Add(Lit(2), Lit(3))), ok(5)) }
+test "mul" { assert_eq(eval(Mul(Lit(4), Lit(5))), ok(20)) }
+test "sub" { assert_eq(eval(Sub(Lit(10), Lit(3))), ok(7)) }
+test "nested add mul" { assert_eq(eval(Add(Lit(1), Mul(Lit(2), Lit(3)))), ok(7)) }
+test "deep nesting" { assert_eq(eval(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))), ok(18)) }
+test "to_string literal" { assert_eq(to_string(Lit(42)), "42") }
+test "to_string add" { assert_eq(to_string(Add(Lit(1), Lit(2))), "(1 + 2)") }
+test "to_string nested" { assert_eq(to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))), "((1 + 2) * 3)") }
+test "eval matches to_string" {
+  let e = Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))
+  assert_eq(eval(e), ok(15))
+}
+test "deeply nested eval" {
+  let e = Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))
+  assert_eq(eval(e), ok(8))
+}
+test "single negative via sub" {
+  assert_eq(eval(Sub(Lit(0), Lit(5))), ok(-5))
+}
+test "eval div" { assert_eq(eval(Div(Lit(10), Lit(3))), ok(3)) }
+test "eval div by zero" { assert_eq(eval(Div(Lit(5), Lit(0))), err("division by zero")) }
+test "to_string div" { assert_eq(to_string(Div(Lit(10), Lit(3))), "(10 / 3)") }
+test "nested div" {
+  let e = Add(Lit(1), Div(Lit(10), Lit(2)))
+  assert_eq(eval(e), ok(6))
+}
+test "div by zero propagates" {
+  let e = Add(Lit(1), Div(Lit(5), Lit(0)))
+  assert_eq(eval(e), err("division by zero"))
+}

--- a/research/benchmark/msr/modifications/outputs/haiku/m05-todo-app-add-error-handling.almd
+++ b/research/benchmark/msr/modifications/outputs/haiku/m05-todo-app-add-error-handling.almd
@@ -1,0 +1,120 @@
+type Status = | Pending | Done | Cancelled
+
+type Todo = { id: Int, title: String, status: Status }
+
+fn create(id: Int, title: String) -> Todo =
+  Todo { id: id, title: title, status: Pending }
+
+fn complete(t: Todo) -> Result[Todo, String] =
+  match t.status {
+    Done => err("already done"),
+    Cancelled => err("cannot complete cancelled"),
+    Pending => ok({ ...t, status: Done }),
+  }
+
+fn cancel(t: Todo) -> Result[Todo, String] =
+  match t.status {
+    Cancelled => err("already cancelled"),
+    Done => err("cannot cancel done"),
+    Pending => ok({ ...t, status: Cancelled }),
+  }
+
+fn is_done(t: Todo) -> Bool = match t.status { Done => true, _ => false }
+
+fn pending_count(todos: List[Todo]) -> Int =
+  todos |> list.filter((t) => match t.status { Pending => true, _ => false }) |> list.len
+
+fn titles(todos: List[Todo]) -> List[String] = list.map(todos, (t) => t.title)
+
+fn find_by_title(todos: List[Todo], title: String) -> Option[Todo] =
+  list.find(todos, (t) => t.title == title)
+
+fn status_label(s: Status) -> String =
+  match s { Pending => "pending", Done => "done", Cancelled => "cancelled" }
+
+fn summary(t: Todo) -> String = "[${status_label(t.status)}] ${t.title}"
+
+test "create todo" {
+  let t = create(1, "Buy milk")
+  assert_eq(t.title, "Buy milk")
+  assert_eq(t.id, 1)
+}
+
+test "complete todo" {
+  assert_eq(complete(create(1, "Buy milk")), ok(Todo { id: 1, title: "Buy milk", status: Done }))
+}
+
+test "cancel todo" {
+  assert_eq(cancel(create(1, "Buy milk")), ok(Todo { id: 1, title: "Buy milk", status: Cancelled }))
+}
+
+test "pending count" {
+  let todos = [create(1, "A"), Todo { id: 2, title: "B", status: Done }, create(3, "C")]
+  assert_eq(pending_count(todos), 2)
+}
+
+test "titles" {
+  let todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+  assert_eq(titles(todos), ["A", "B", "C"])
+}
+
+test "find by title found" {
+  let todos = [create(1, "Buy milk"), create(2, "Walk dog")]
+  match find_by_title(todos, "Walk dog") {
+    some(t) => assert_eq(t.id, 2),
+    none => assert(false),
+  }
+}
+
+test "find by title not found" {
+  let todos = [create(1, "Buy milk")]
+  assert_eq(find_by_title(todos, "nope"), none)
+}
+
+test "summary" {
+  assert_eq(summary(create(1, "Buy milk")), "[pending] Buy milk")
+  assert_eq(summary(Todo { id: 1, title: "Done", status: Done }), "[done] Done")
+}
+
+test "pipe chain: create filter map" {
+  let todos = [create(1, "A"), Todo { id: 2, title: "B", status: Done }, Todo { id: 3, title: "C", status: Cancelled }]
+  let pending_titles = todos
+    |> list.filter((t) => match t.status { Pending => true, _ => false })
+    |> list.map((t) => t.title)
+  assert_eq(pending_titles, ["A"])
+}
+
+test "multiple operations" {
+  var todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+  let updated = list.map(todos, (t) => if t.id == 2 then Todo { id: t.id, title: t.title, status: Done } else t)
+  assert_eq(pending_count(updated), 2)
+  assert(is_done(list.get_or(updated, 1, create(0, ""))))
+}
+
+test "complete pending succeeds" {
+  assert_eq(complete(create(1, "A")), ok(Todo { id: 1, title: "A", status: Done }))
+}
+
+test "complete already done" {
+  let t = Todo { id: 1, title: "A", status: Done }
+  assert_eq(complete(t), err("already done"))
+}
+
+test "complete cancelled" {
+  let t = Todo { id: 1, title: "A", status: Cancelled }
+  assert_eq(complete(t), err("cannot complete cancelled"))
+}
+
+test "cancel pending succeeds" {
+  assert_eq(cancel(create(1, "A")), ok(Todo { id: 1, title: "A", status: Cancelled }))
+}
+
+test "cancel already cancelled" {
+  let t = Todo { id: 1, title: "A", status: Cancelled }
+  assert_eq(cancel(t), err("already cancelled"))
+}
+
+test "cancel done" {
+  let t = Todo { id: 1, title: "A", status: Done }
+  assert_eq(cancel(t), err("cannot cancel done"))
+}

--- a/research/benchmark/msr/modifications/outputs/haiku/m06-config-merger-add-function.almd
+++ b/research/benchmark/msr/modifications/outputs/haiku/m06-config-merger-add-function.almd
@@ -1,0 +1,279 @@
+import env
+import fs
+import string
+import list
+
+fn parse_config(content: String) -> Result[List[List[String]], String] = {
+  if string.len(content) == 0 then ok([])
+  else {
+    let lines = string.split(content, "\n");
+    let indexed = list.fold(lines, [], (acc, line) => {
+      let idx = list.len(acc) + 1;
+      acc + [[int.to_string(idx), line]]
+    });
+    list.fold(indexed, ok([]), (acc, entry) => {
+      match acc {
+        err(e) => err(e),
+        ok(pairs) => {
+          let line_num = match list.get(entry, 0) { some(v) => v, none => "0" };
+          let line = match list.get(entry, 1) { some(v) => v, none => "" };
+          let trimmed = string.trim(line);
+          if trimmed == "" then ok(pairs)
+          else if string.starts_with(trimmed, "#") then ok(pairs)
+          else if string.contains(trimmed, "=") then {
+            let parts = string.split(trimmed, "=");
+            let key = match list.get(parts, 0) { some(v) => v, none => "" };
+            if key == "" then err("line ${line_num}: empty key")
+            else {
+              let indexed_parts = list.fold(parts, [], (a, p) => a + [[int.to_string(list.len(a)), p]]);
+              let rest = list.filter(indexed_parts, (ip) => {
+                match list.get(ip, 0) { some(v) => v != "0", none => false }
+              });
+              let rest_vals = list.map(rest, (ip) => match list.get(ip, 1) { some(v) => v, none => "" });
+              let value = string.join(rest_vals, "=");
+              let existing_keys = list.map(pairs, (p) => match list.get(p, 0) { some(v) => v, none => "" });
+              if list.contains(existing_keys, key) then err("line ${line_num}: duplicate key: ${key}")
+              else ok(pairs + [[key, value]])
+            }
+          }
+          else err("line ${line_num}: missing '='")
+        }
+      }
+    })
+  }
+}
+
+fn merge_configs(base: List[List[String]], overlay: List[List[String]]) -> List[List[String]] = {
+  let overlay_keys = list.map(overlay, (p) => match list.get(p, 0) { some(v) => v, none => "" });
+  let overlay_for_find = overlay;
+  let merged_base = list.map(base, (pair) => {
+    let key = match list.get(pair, 0) { some(v) => v, none => "" };
+    if list.contains(overlay_keys, key) then {
+      match list.find(overlay_for_find, (op) => match list.get(op, 0) { some(v) => v == key, none => false }) {
+        some(found) => found,
+        none => pair
+      }
+    } else pair
+  });
+  let base_keys = list.map(base, (p) => match list.get(p, 0) { some(v) => v, none => "" });
+  let new_overlay = list.filter(overlay, (p) => {
+    let key = match list.get(p, 0) { some(v) => v, none => "" };
+    not list.contains(base_keys, key)
+  });
+  merged_base + new_overlay
+}
+
+fn serialize_config(pairs: List[List[String]]) -> String = {
+  let lines = list.map(pairs, (pair) => {
+    let key = match list.get(pair, 0) { some(v) => v, none => "" };
+    let value = match list.get(pair, 1) { some(v) => v, none => "" };
+    key + "=" + value
+  });
+  string.join(lines, "\n")
+}
+
+effect fn load_config(path: String) -> Result[List[List[String]], String] = {
+  let text = fs.read_text(path)!
+  match parse_config(text) {
+    ok(pairs) => ok(pairs),
+    err(e) => err("${path}: ${e}")
+  }
+}
+
+effect fn save_config(path: String, pairs: List[List[String]]) -> Result[Unit, String] = {
+  let content = serialize_config(pairs);
+  fs.write(path, content);
+  ok(())
+}
+
+effect fn merge_files(paths: List[String]) -> Result[List[List[String]], String] = {
+  var result = []
+  var i = 0
+  while i < list.len(paths) {
+    let path = match list.get(paths, i) { some(p) => p, none => "" }
+    let overlay = load_config(path)!
+    result = merge_configs(result, overlay)
+    i = i + 1
+  }
+  ok(result)
+}
+
+effect fn merge_and_save(paths: List[String], output: String) -> Result[Int, String] = {
+  match merge_files(paths) {
+    err(e) => err(e),
+    ok(pairs) => {
+      save_config(output, pairs)!;
+      ok(list.len(pairs))
+    }
+  }
+}
+
+fn lookup(pairs: List[List[String]], key: String) -> Option[String] = {
+  match list.find(pairs, (pair) => match list.get(pair, 0) { some(v) => v == key, none => false }) {
+    some(pair) => match list.get(pair, 1) { some(v) => some(v), none => none },
+    none => none
+  }
+}
+
+fn filter_by_prefix(pairs: List[List[String]], prefix: String) -> List[List[String]] = {
+  list.filter(pairs, (pair) => {
+    let key = match list.get(pair, 0) { some(v) => v, none => "" };
+    string.starts_with(key, prefix)
+  })
+}
+
+fn validate_keys(pairs: List[List[String]], required: List[String]) -> Result[Unit, String] = {
+  let pair_keys = list.map(pairs, (pair) => match list.get(pair, 0) { some(v) => v, none => "" });
+  match list.find(required, (key) => not list.contains(pair_keys, key)) {
+    some(missing_key) => err("missing required key: ${missing_key}"),
+    none => ok(())
+  }
+}
+
+effect fn load_and_validate(path: String, required: List[String]) -> Result[List[List[String]], String] = {
+  let pairs = load_config(path)!
+  validate_keys(pairs, required)!
+  ok(pairs)
+}
+
+test "parse basic config" {
+  let content = "host=localhost\nport=8080"
+  assert_eq(parse_config(content), ok([["host", "localhost"], ["port", "8080"]]))
+}
+
+test "parse with comments and blanks" {
+  let content = "# this is a comment\n\nhost=localhost\n# another comment\nport=8080"
+  assert_eq(parse_config(content), ok([["host", "localhost"], ["port", "8080"]]))
+}
+
+test "parse empty string" {
+  assert_eq(parse_config(""), ok([]))
+}
+
+test "parse only comments" {
+  assert_eq(parse_config("# comment\n# another"), ok([]))
+}
+
+test "parse missing equals" {
+  assert_eq(parse_config("host=ok\nbadline"), err("line 2: missing '='"))
+}
+
+test "parse empty key" {
+  assert_eq(parse_config("=value"), err("line 1: empty key"))
+}
+
+test "parse duplicate key" {
+  assert_eq(parse_config("host=a\nhost=b"), err("line 2: duplicate key: host"))
+}
+
+test "parse value with equals" {
+  let content = "formula=a=b+c"
+  assert_eq(parse_config(content), ok([["formula", "a=b+c"]]))
+}
+
+test "merge no overlap" {
+  let base = [["host", "localhost"]]
+  let overlay = [["port", "8080"]]
+  assert_eq(merge_configs(base, overlay), [["host", "localhost"], ["port", "8080"]])
+}
+
+test "merge with override" {
+  let base = [["host", "localhost"], ["port", "3000"]]
+  let overlay = [["port", "8080"]]
+  assert_eq(merge_configs(base, overlay), [["host", "localhost"], ["port", "8080"]])
+}
+
+test "merge empty base" {
+  let overlay = [["port", "8080"]]
+  assert_eq(merge_configs([], overlay), [["port", "8080"]])
+}
+
+test "merge empty overlay" {
+  let base = [["host", "localhost"]]
+  assert_eq(merge_configs(base, []), [["host", "localhost"]])
+}
+
+test "serialize config" {
+  let pairs = [["host", "localhost"], ["port", "8080"]]
+  assert_eq(serialize_config(pairs), "host=localhost\nport=8080")
+}
+
+test "serialize empty" {
+  assert_eq(serialize_config([]), "")
+}
+
+test "lookup found" {
+  let pairs = [["host", "localhost"], ["port", "8080"]]
+  assert_eq(lookup(pairs, "port"), some("8080"))
+}
+
+test "lookup not found" {
+  let pairs = [["host", "localhost"]]
+  assert_eq(lookup(pairs, "port"), none)
+}
+
+test "filter by prefix" {
+  let pairs = [["db_host", "localhost"], ["db_port", "5432"], ["app_port", "8080"]]
+  assert_eq(filter_by_prefix(pairs, "db_"), [["db_host", "localhost"], ["db_port", "5432"]])
+}
+
+test "filter by prefix no match" {
+  let pairs = [["app_port", "8080"]]
+  assert_eq(filter_by_prefix(pairs, "db_"), [])
+}
+
+test "load and parse config file" {
+  let td = env.temp_dir()
+  let f = td + "/almide_test_m06_base.conf"
+  fs.write(f, "host=localhost\nport=3000")
+  let result = load_config(f)
+  assert_eq(result, ok([["host", "localhost"], ["port", "3000"]]))
+}
+
+test "load config file not found" {
+  let td = env.temp_dir()
+  assert(match load_config(td + "/almide_test_m06_nonexistent.conf") { err(_e) => true, _ => false })
+}
+
+test "merge two files" {
+  let td = env.temp_dir()
+  let f1 = td + "/almide_test_m06_f1.conf"
+  let f2 = td + "/almide_test_m06_f2.conf"
+  fs.write(f1, "host=localhost\nport=3000")
+  fs.write(f2, "port=8080\ndebug=true")
+  let result = merge_files([f1, f2])
+  assert_eq(result, ok([["host", "localhost"], ["port", "8080"], ["debug", "true"]]))
+}
+
+test "validate keys all present" {
+  let pairs = [["host", "localhost"], ["port", "8080"]]
+  assert_eq(validate_keys(pairs, ["host", "port"]), ok(()))
+}
+
+test "validate keys missing" {
+  let pairs = [["host", "localhost"]]
+  assert_eq(validate_keys(pairs, ["host", "port"]), err("missing required key: port"))
+}
+
+test "validate keys empty required" {
+  assert_eq(validate_keys([["a", "b"]], []), ok(()))
+}
+
+test "validate keys first missing reported" {
+  let pairs = [["host", "localhost"]]
+  assert_eq(validate_keys(pairs, ["port", "debug"]), err("missing required key: port"))
+}
+
+test "load and validate success" {
+  let td = env.temp_dir()
+  let f = td + "/almide_test_m06_valid.conf"
+  fs.write(f, "host=localhost\nport=8080")
+  assert_eq(load_and_validate(f, ["host"]), ok([["host", "localhost"], ["port", "8080"]]))
+}
+
+test "load and validate missing key" {
+  let td = env.temp_dir()
+  let f = td + "/almide_test_m06_partial.conf"
+  fs.write(f, "host=localhost")
+  assert_eq(load_and_validate(f, ["host", "port"]), err("missing required key: port"))
+}

--- a/research/benchmark/msr/modifications/outputs/haiku/m07-grade-report-add-function.almd
+++ b/research/benchmark/msr/modifications/outputs/haiku/m07-grade-report-add-function.almd
@@ -1,0 +1,429 @@
+import string
+import list
+
+type StudentAvg = { name: String, avg: Int }
+
+fn str_to_int(s: String) -> Result[Int, String] = {
+  let bytes = string.to_bytes(s)
+  let len = list.len(bytes)
+  if len == 0 then err("invalid integer")
+  else {
+    let first = match list.get(bytes, 0) {
+      some(v) => v,
+      none => 0,
+    }
+    let is_negative = first == 45
+    let start_index = if is_negative then 1 else 0
+    if is_negative and len == 1 then err("invalid integer")
+    else {
+      let digit_bytes = if is_negative then {
+        let indices = list.fold(bytes, [], (acc, _b) => acc + [list.len(acc)])
+        list.fold(indices, [], (acc, i) => {
+          if i >= start_index then {
+            match list.get(bytes, i) {
+              some(v) => acc + [v],
+              none => acc,
+            }
+          } else acc
+        })
+      } else bytes
+      if list.len(digit_bytes) == 0 then err("invalid integer")
+      else {
+        let result = list.fold(digit_bytes, ok(0), (acc, b) => {
+          match acc {
+            ok(n) => {
+              if b >= 48 and b <= 57 then ok(n * 10 + (b - 48))
+              else err("invalid integer")
+            },
+            err(e) => err(e),
+          }
+        })
+        match result {
+          ok(n) => if is_negative then ok(0 - n) else ok(n),
+          err(e) => err(e),
+        }
+      }
+    }
+  }
+}
+
+fn parse_student(line: String) -> Result[List[String], String] = {
+  let parts = string.split(line, ":")
+  let num_parts = list.len(parts)
+  if num_parts < 2 then err("invalid format")
+  else {
+    let name = match list.get(parts, 0) { some(v) => v, none => "" }
+    if string.len(name) == 0 then err("empty name")
+    else {
+      let scores_str = match list.get(parts, 1) { some(v) => v, none => "" }
+      if string.len(scores_str) == 0 then err("no scores")
+      else {
+        let score_strs = string.split(scores_str, ",")
+        let validation = list.fold(score_strs, ok([]), (acc, s) => {
+          match acc {
+            err(e) => err(e),
+            ok(validated) => {
+              match str_to_int(s) {
+                err(_e) => err("invalid score: " + s),
+                ok(n) => {
+                  if n < 0 or n > 100 then err("score out of range: " + s)
+                  else ok(validated + [s])
+                },
+              }
+            },
+          }
+        })
+        match validation {
+          err(e) => err(e),
+          ok(scores) => ok([name] + scores),
+        }
+      }
+    }
+  }
+}
+
+fn parse_all(input: String) -> Result[List[List[String]], String] = {
+  if string.len(input) == 0 then err("empty input")
+  else {
+    let lines = string.split(input, "\n")
+    let indexed_lines = list.fold(lines, [], (acc, line) => {
+      let idx = list.len(acc) + 1
+      acc + [[int.to_string(idx), line]]
+    })
+    list.fold(indexed_lines, ok([]), (acc, entry) => {
+      match acc {
+        err(e) => err(e),
+        ok(students) => {
+          let line_num = match list.get(entry, 0) { some(v) => v, none => "0" }
+          let line = match list.get(entry, 1) { some(v) => v, none => "" }
+          match parse_student(line) {
+            err(e) => err("line " + line_num + ": " + e),
+            ok(student) => {
+              let name = match list.get(student, 0) { some(v) => v, none => "" }
+              let names = list.map(students, (s) => {
+                match list.get(s, 0) { some(v) => v, none => "" }
+              })
+              if list.contains(names, name) then err("duplicate name: " + name)
+              else ok(students + [student])
+            },
+          }
+        },
+      }
+    })
+  }
+}
+
+fn average(student: List[String]) -> Result[Int, String] = {
+  let len = list.len(student)
+  if len <= 1 then err("no scores")
+  else {
+    let indices = list.fold(student, [], (acc, _s) => acc + [list.len(acc)])
+    let score_indices = list.filter(indices, (i) => i >= 1)
+    let sum_result = list.fold(score_indices, ok(0), (acc, i) => {
+      match acc {
+        err(e) => err(e),
+        ok(total) => {
+          match list.get(student, i) {
+            none => err("missing score"),
+            some(s) => {
+              match str_to_int(s) {
+                err(e) => err(e),
+                ok(n) => ok(total + n),
+              }
+            },
+          }
+        },
+      }
+    })
+    let num_scores = len - 1
+    match sum_result {
+      err(e) => err(e),
+      ok(total) => ok(total / num_scores),
+    }
+  }
+}
+
+fn letter_grade(avg: Int) -> String = {
+  if avg >= 90 then "A"
+  else if avg >= 80 then "B"
+  else if avg >= 70 then "C"
+  else if avg >= 60 then "D"
+  else "F"
+}
+
+fn honor_roll(students: List[List[String]]) -> Result[List[String], String] = {
+  let result = list.fold(students, ok([]), (acc, student) => {
+    match acc {
+      err(e) => err(e),
+      ok(names) => {
+        match average(student) {
+          err(e) => err(e),
+          ok(avg) => {
+            if avg >= 85 then {
+              let name = match list.get(student, 0) { some(v) => v, none => "" }
+              ok(names + [name])
+            } else ok(names)
+          },
+        }
+      },
+    }
+  })
+  match result {
+    err(e) => err(e),
+    ok(names) => ok(list.sort(names)),
+  }
+}
+
+fn class_average(students: List[List[String]]) -> Result[Int, String] = {
+  let num_students = list.len(students)
+  if num_students == 0 then err("no students")
+  else {
+    let sum_result = list.fold(students, ok(0), (acc, student) => {
+      match acc {
+        err(e) => err(e),
+        ok(total) => {
+          match average(student) {
+            err(e) => err(e),
+            ok(avg) => ok(total + avg),
+          }
+        },
+      }
+    })
+    match sum_result {
+      err(e) => err(e),
+      ok(total) => ok(total / num_students),
+    }
+  }
+}
+
+fn format_student(student: List[String]) -> Result[String, String] = {
+  let name = match list.get(student, 0) { some(v) => v, none => "" }
+  match average(student) {
+    err(e) => err(e),
+    ok(avg) => {
+      let grade = letter_grade(avg)
+      ok(name + ": " + int.to_string(avg) + " (" + grade + ")")
+    },
+  }
+}
+
+fn generate_report(input: String) -> Result[String, String] = {
+  match parse_all(input) {
+    err(e) => err(e),
+    ok(students) => {
+      let formatted_result = list.fold(students, ok([]), (acc, student) => {
+        match acc {
+          err(e) => err(e),
+          ok(lines) => {
+            match format_student(student) {
+              err(e) => err(e),
+              ok(line) => ok(lines + [line]),
+            }
+          },
+        }
+      })
+      match formatted_result {
+        err(e) => err(e),
+        ok(lines) => {
+          match class_average(students) {
+            err(e) => err(e),
+            ok(cavg) => {
+              match honor_roll(students) {
+                err(e) => err(e),
+                ok(honors) => {
+                  let student_lines = string.join(lines, "\n")
+                  let class_line = "class average: " + int.to_string(cavg)
+                  let honor_line = "honor roll: " + string.join(honors, ", ")
+                  ok(student_lines + "\n" + class_line + "\n" + honor_line)
+                },
+              }
+            },
+          }
+        },
+      }
+    },
+  }
+}
+
+fn insert_sorted_student_avg(sorted: List[StudentAvg], pair: StudentAvg) -> List[StudentAvg] = {
+  match list.get(sorted, 0) {
+    none => [pair],
+    some(first) => {
+      let rest = list.drop(sorted, 1)
+      
+      if pair.avg > first.avg then
+        [pair] + sorted
+      else if pair.avg == first.avg and pair.name < first.name then
+        [pair] + sorted
+      else
+        [first] + insert_sorted_student_avg(rest, pair)
+    },
+  }
+}
+
+fn top_students(input: String, n: Int) -> Result[List[String], String] = {
+  match parse_all(input) {
+    err(e) => err(e),
+    ok(students) => {
+      let with_avgs_result = list.fold(students, ok([]), (acc, student) => {
+        match acc {
+          err(e) => err(e),
+          ok(pairs) => {
+            match average(student) {
+              err(e) => err(e),
+              ok(avg) => {
+                let name = match list.get(student, 0) { some(v) => v, none => "" }
+                ok(pairs + [{ name: name, avg: avg }])
+              },
+            }
+          },
+        }
+      })
+      
+      match with_avgs_result {
+        err(e) => err(e),
+        ok(pairs) => {
+          let sorted_pairs = list.fold(pairs, [], (sorted, pair) => {
+            insert_sorted_student_avg(sorted, pair)
+          })
+          
+          let top_n_pairs = list.take(sorted_pairs, n)
+          let names = list.map(top_n_pairs, (pair) => pair.name)
+          
+          ok(names)
+        },
+      }
+    },
+  }
+}
+
+test "parse single student" {
+  assert_eq(parse_student("Alice:85,92,78"), ok(["Alice", "85", "92", "78"]))
+}
+
+test "parse student with single score" {
+  assert_eq(parse_student("Bob:100"), ok(["Bob", "100"]))
+}
+
+test "parse student empty name" {
+  assert_eq(parse_student(":85,92"), err("empty name"))
+}
+
+test "parse student invalid score" {
+  assert_eq(parse_student("Alice:85,abc,78"), err("invalid score: abc"))
+}
+
+test "parse student score too high" {
+  assert_eq(parse_student("Alice:85,101,78"), err("score out of range: 101"))
+}
+
+test "parse student score negative" {
+  assert_eq(parse_student("Alice:85,-1,78"), err("score out of range: -1"))
+}
+
+test "parse student no scores" {
+  assert_eq(parse_student("Alice:"), err("no scores"))
+}
+
+test "parse student no colon" {
+  assert_eq(parse_student("Alice"), err("invalid format"))
+}
+
+test "parse all basic" {
+  let result = parse_all("Alice:85,92\nBob:70,80")
+  assert_eq(result, ok([["Alice", "85", "92"], ["Bob", "70", "80"]]))
+}
+
+test "parse all empty input" {
+  assert_eq(parse_all(""), err("empty input"))
+}
+
+test "parse all duplicate names" {
+  assert_eq(parse_all("Alice:85\nAlice:90"), err("duplicate name: Alice"))
+}
+
+test "parse all error with line number" {
+  assert_eq(parse_all("Alice:85\n:90"), err("line 2: empty name"))
+}
+
+test "average basic" {
+  assert_eq(average(["Alice", "80", "90", "100"]), ok(90))
+}
+
+test "average single score" {
+  assert_eq(average(["Bob", "75"]), ok(75))
+}
+
+test "average rounds down" {
+  assert_eq(average(["Carol", "80", "81"]), ok(80))
+}
+
+test "letter grade A" { assert_eq(letter_grade(95), "A") }
+test "letter grade B" { assert_eq(letter_grade(85), "B") }
+test "letter grade C" { assert_eq(letter_grade(75), "C") }
+test "letter grade D" { assert_eq(letter_grade(65), "D") }
+test "letter grade F" { assert_eq(letter_grade(55), "F") }
+test "letter grade boundary 90" { assert_eq(letter_grade(90), "A") }
+test "letter grade boundary 80" { assert_eq(letter_grade(80), "B") }
+
+test "honor roll basic" {
+  let students = [["Alice", "90", "95"], ["Bob", "70", "80"], ["Carol", "85", "90"]]
+  assert_eq(honor_roll(students), ok(["Alice", "Carol"]))
+}
+
+test "honor roll none qualify" {
+  let students = [["Alice", "70", "75"], ["Bob", "60", "65"]]
+  assert_eq(honor_roll(students), ok([]))
+}
+
+test "honor roll sorted" {
+  let students = [["Zara", "90", "95"], ["Alice", "85", "90"]]
+  assert_eq(honor_roll(students), ok(["Alice", "Zara"]))
+}
+
+test "class average basic" {
+  let students = [["Alice", "80", "90"], ["Bob", "70", "80"]]
+  assert_eq(class_average(students), ok(80))
+}
+
+test "format student" {
+  assert_eq(format_student(["Alice", "85", "92", "78"]), ok("Alice: 85 (B)"))
+}
+
+test "generate report" {
+  let input = "Alice:90,95,100\nBob:70,75,80"
+  let expected = "Alice: 95 (A)\nBob: 75 (C)\nclass average: 85\nhonor roll: Alice"
+  assert_eq(generate_report(input), ok(expected))
+}
+
+test "generate report error propagation" {
+  assert_eq(generate_report("Alice:90\n:bad"), err("line 2: empty name"))
+}
+
+test "generate report empty" {
+  assert_eq(generate_report(""), err("empty input"))
+}
+
+test "top students basic" {
+  let input = "Alice:90,95\nBob:70,80\nCarol:85,88"
+  assert_eq(top_students(input, 2), ok(["Alice", "Carol"]))
+}
+
+test "top students tie breaking" {
+  let input = "Bob:85,85\nAlice:85,85"
+  assert_eq(top_students(input, 2), ok(["Alice", "Bob"]))
+}
+
+test "top students n exceeds count" {
+  let input = "Alice:90,95"
+  assert_eq(top_students(input, 5), ok(["Alice"]))
+}
+
+test "top students error propagation" {
+  assert_eq(top_students("", 3), err("empty input"))
+}
+
+test "top students single" {
+  let input = "Alice:90,95\nBob:70,80\nCarol:85,88"
+  assert_eq(top_students(input, 1), ok(["Alice"]))
+}

--- a/research/benchmark/msr/modifications/outputs/haiku/m08-bob-behavioral-change.almd
+++ b/research/benchmark/msr/modifications/outputs/haiku/m08-bob-behavioral-change.almd
@@ -1,0 +1,46 @@
+fn respond(input: String) -> String = {
+  let trimmed = string.trim(input)
+  let is_silence = string.len(trimmed) == 0
+  let is_question = string.ends_with(trimmed, "?")
+  let has_letters = list.any(string.chars(trimmed), (c) => string.is_alpha(c))
+  let is_yelling = has_letters and string.to_upper(trimmed) == trimmed
+  let is_whispering = has_letters and string.to_lower(trimmed) == trimmed
+  if is_silence then "Fine. Be that way!"
+  else if is_yelling and is_question then "Calm down, I know what I'm doing!"
+  else if is_yelling then "Whoa, chill out!"
+  else if is_whispering and is_question then "Are you whispering? Speak up!"
+  else if is_whispering then "Could you speak up? I can't hear you."
+  else if is_question then "Sure."
+  else "Whatever."
+}
+
+test "stating something" { assert_eq(respond("Tom-ay-to, tom-ah-to."), "Whatever.") }
+test "shouting" { assert_eq(respond("WATCH OUT!"), "Whoa, chill out!") }
+test "shouting gibberish" { assert_eq(respond("FCECGC"), "Whoa, chill out!") }
+test "asking a question" { assert_eq(respond("Does this celi level have a caused caused caused effect?"), "Sure.") }
+test "asking a numeric question" { assert_eq(respond("You are, what, like 15?"), "Sure.") }
+test "asking gibberish" { assert_eq(respond("fffbbcbeab?"), "Are you whispering? Speak up!") }
+test "talking forcefully" { assert_eq(respond("Hi there!"), "Whatever.") }
+test "using acronyms in regular speech" { assert_eq(respond("It's OK if you don't want to go work for NASA."), "Whatever.") }
+test "forceful question" { assert_eq(respond("WHAT IS YOUR PROBLEM?"), "Calm down, I know what I'm doing!") }
+test "shouting numbers" { assert_eq(respond("1, 2, 3 GO!"), "Whoa, chill out!") }
+test "no letters" { assert_eq(respond("1, 2, 3"), "Whatever.") }
+test "question with no letters" { assert_eq(respond("4?"), "Sure.") }
+test "shouting with special characters" { assert_eq(respond("ZOMG THE %#@* ALARM IS GOING OFF!"), "Whoa, chill out!") }
+test "shouting with no exclamation mark" { assert_eq(respond("I HATE THE ALARM"), "Whoa, chill out!") }
+test "statement containing question mark" { assert_eq(respond("Ending with ? hmm"), "Whatever.") }
+test "non-letters with question" { assert_eq(respond(":) ?"), "Sure.") }
+test "prattling on" { assert_eq(respond("Wait! Hang on. Are you going to be OK?"), "Sure.") }
+test "silence" { assert_eq(respond(""), "Fine. Be that way!") }
+test "prolonged silence" { assert_eq(respond("          "), "Fine. Be that way!") }
+test "alternate silence" { assert_eq(respond("\t\t\t\t\t\t\t\t\t\t"), "Fine. Be that way!") }
+test "multiple line question" { assert_eq(respond("\nDoes this celi level have a caused caused caused effect?"), "Sure.") }
+test "starting with whitespace" { assert_eq(respond("         hmmmmm"), "Could you speak up? I can't hear you.") }
+test "ending with whitespace" { assert_eq(respond("Okay if like my  spacebar  quite a bit?   "), "Sure.") }
+test "other whitespace" { assert_eq(respond("\n\r \t"), "Fine. Be that way!") }
+test "non-question ending with whitespace" { assert_eq(respond("This is a statement ending with whitespace      "), "Whatever.") }
+test "whispering" { assert_eq(respond("hello there"), "Could you speak up? I can't hear you.") }
+test "whispering question" { assert_eq(respond("do you hear me?"), "Are you whispering? Speak up!") }
+test "whispering with numbers" { assert_eq(respond("hello 123"), "Could you speak up? I can't hear you.") }
+test "not whispering mixed case" { assert_eq(respond("Hello there"), "Whatever.") }
+test "whispering question with spaces" { assert_eq(respond("  can you hear me?  "), "Are you whispering? Speak up!") }

--- a/research/benchmark/msr/modifications/outputs/haiku/m09-expression-eval-compound.almd
+++ b/research/benchmark/msr/modifications/outputs/haiku/m09-expression-eval-compound.almd
@@ -1,0 +1,68 @@
+type Expr =
+  | Lit(Int)
+  | Add(Expr, Expr)
+  | Mul(Expr, Expr)
+  | Sub(Expr, Expr)
+  | Neg(Expr)
+  | Pow(Expr, Expr)
+
+fn eval(e: Expr) -> Int =
+  match e {
+    Lit(n) => n
+    Add(l, r) => eval(l) + eval(r)
+    Mul(l, r) => eval(l) * eval(r)
+    Sub(l, r) => eval(l) - eval(r)
+    Neg(e) => 0 - eval(e)
+    Pow(base, exp) => pow(eval(base), eval(exp))
+  }
+
+fn pow(base: Int, exp: Int) -> Int =
+  if exp == 0 then 1
+  else base * pow(base, exp - 1)
+
+fn to_string(e: Expr) -> String =
+  match e {
+    Lit(n) => int.to_string(n)
+    Add(l, r) => "(${to_string(l)} + ${to_string(r)})"
+    Mul(l, r) => "(${to_string(l)} * ${to_string(r)})"
+    Sub(l, r) => "(${to_string(l)} - ${to_string(r)})"
+    Neg(e) => "(-${to_string(e)})"
+    Pow(a, b) => "(${to_string(a)} ^ ${to_string(b)})"
+  }
+
+test "literal" { assert_eq(eval(Lit(5)), 5) }
+test "add" { assert_eq(eval(Add(Lit(2), Lit(3))), 5) }
+test "mul" { assert_eq(eval(Mul(Lit(4), Lit(5))), 20) }
+test "sub" { assert_eq(eval(Sub(Lit(10), Lit(3))), 7) }
+test "nested add mul" { assert_eq(eval(Add(Lit(1), Mul(Lit(2), Lit(3)))), 7) }
+test "deep nesting" { assert_eq(eval(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))), 18) }
+test "to_string literal" { assert_eq(to_string(Lit(42)), "42") }
+test "to_string add" { assert_eq(to_string(Add(Lit(1), Lit(2))), "(1 + 2)") }
+test "to_string nested" { assert_eq(to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))), "((1 + 2) * 3)") }
+test "eval matches to_string" {
+  let e = Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))
+  assert_eq(eval(e), 15)
+}
+test "deeply nested eval" {
+  let e = Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))
+  assert_eq(eval(e), 8)
+}
+test "single negative via sub" {
+  assert_eq(eval(Sub(Lit(0), Lit(5))), -5)
+}
+
+test "neg literal" { assert_eq(eval(Neg(Lit(5))), -5) }
+test "neg of neg" { assert_eq(eval(Neg(Neg(Lit(3)))), 3) }
+test "to_string neg" { assert_eq(to_string(Neg(Lit(5))), "(-5)") }
+test "pow basic" { assert_eq(eval(Pow(Lit(2), Lit(3))), 8) }
+test "pow zero" { assert_eq(eval(Pow(Lit(5), Lit(0))), 1) }
+test "pow one" { assert_eq(eval(Pow(Lit(7), Lit(1))), 7) }
+test "to_string pow" { assert_eq(to_string(Pow(Lit(2), Lit(3))), "(2 ^ 3)") }
+test "neg with pow" {
+  let e = Neg(Pow(Lit(2), Lit(3)))
+  assert_eq(eval(e), -8)
+}
+test "pow in expression" {
+  let e = Add(Pow(Lit(2), Lit(3)), Lit(2))
+  assert_eq(eval(e), 10)
+}

--- a/research/benchmark/msr/modifications/outputs/haiku/m10-traffic-light-compound.almd
+++ b/research/benchmark/msr/modifications/outputs/haiku/m10-traffic-light-compound.almd
@@ -1,0 +1,24 @@
+type Light = | Red | Yellow | Green | Broken
+
+fn next(l: Light) -> Light =
+  match l { Red => Green, Green => Yellow, Yellow => Red, Broken => Red }
+
+fn duration(l: Light) -> Result[Int, String] =
+  match l { Red => ok(60), Yellow => ok(5), Green => ok(45), Broken => err("broken light has no duration") }
+
+fn describe(l: Light) -> String =
+  match l { Red => "stop", Yellow => "caution", Green => "go", Broken => "out of order" }
+
+test "next red" { assert_eq(next(Red), Green) }
+test "next green" { assert_eq(next(Green), Yellow) }
+test "next yellow" { assert_eq(next(Yellow), Red) }
+test "full cycle" { assert_eq(next(next(next(Red))), Red) }
+test "duration red" { assert_eq(duration(Red), ok(60)) }
+test "duration yellow" { assert_eq(duration(Yellow), ok(5)) }
+test "duration green" { assert_eq(duration(Green), ok(45)) }
+test "describe" { assert_eq(describe(Red), "stop") }
+test "next broken" { assert_eq(next(Broken), Red) }
+test "describe broken" { assert_eq(describe(Broken), "out of order") }
+test "duration broken" { assert_eq(duration(Broken), err("broken light has no duration")) }
+test "cycle from broken" { assert_eq(next(next(Broken)), Green) }
+test "describe after broken" { assert_eq(describe(next(Broken)), "stop") }

--- a/research/benchmark/msr/modifications/prompts/m01-traffic-light-add-variant.almd
+++ b/research/benchmark/msr/modifications/prompts/m01-traffic-light-add-variant.almd
@@ -1,0 +1,36 @@
+// ========== V1 SOLUTION (working code — all tests pass) ==========
+
+type Light = | Red | Yellow | Green
+
+fn next(l: Light) -> Light =
+  match l { Red => Green, Green => Yellow, Yellow => Red }
+
+fn duration(l: Light) -> Int =
+  match l { Red => 60, Yellow => 5, Green => 45 }
+
+fn describe(l: Light) -> String =
+  match l { Red => "stop", Yellow => "caution", Green => "go" }
+
+test "next red" { assert_eq(next(Red), Green) }
+test "next green" { assert_eq(next(Green), Yellow) }
+test "next yellow" { assert_eq(next(Yellow), Red) }
+test "full cycle" { assert_eq(next(next(next(Red))), Red) }
+test "duration red" { assert_eq(duration(Red), 60) }
+test "duration yellow" { assert_eq(duration(Yellow), 5) }
+test "duration green" { assert_eq(duration(Green), 45) }
+test "describe" { assert_eq(describe(Red), "stop") }
+
+// ========== MODIFICATION INSTRUCTION ==========
+// Add a `FlashingRed` variant to the `Light` type.
+// FlashingRed is used at intersections late at night.
+// - `next(FlashingRed)` returns `Red`
+// - `duration(FlashingRed)` returns `2`
+// - `describe(FlashingRed)` returns `"caution"`
+// All existing tests must still pass unchanged.
+
+// ========== V2 TESTS (must also pass after modification) ==========
+
+test "next flashing red" { assert_eq(next(FlashingRed), Red) }
+test "duration flashing red" { assert_eq(duration(FlashingRed), 2) }
+test "describe flashing red" { assert_eq(describe(FlashingRed), "caution") }
+test "cycle from flashing red" { assert_eq(next(next(FlashingRed)), Green) }

--- a/research/benchmark/msr/modifications/prompts/m02-todo-app-add-field.almd
+++ b/research/benchmark/msr/modifications/prompts/m02-todo-app-add-field.almd
@@ -1,0 +1,135 @@
+// ========== V1 SOLUTION (working code — all tests pass) ==========
+
+type Status = | Pending | Done | Cancelled
+
+type Todo = { id: Int, title: String, status: Status }
+
+fn create(id: Int, title: String) -> Todo =
+  Todo { id: id, title: title, status: Pending }
+
+fn complete(t: Todo) -> Todo = { ...t, status: Done }
+
+fn cancel(t: Todo) -> Todo = { ...t, status: Cancelled }
+
+fn is_done(t: Todo) -> Bool = match t.status { Done => true, _ => false }
+
+fn pending_count(todos: List[Todo]) -> Int =
+  todos |> list.filter((t) => match t.status { Pending => true, _ => false }) |> list.len
+
+fn titles(todos: List[Todo]) -> List[String] = list.map(todos, (t) => t.title)
+
+fn find_by_title(todos: List[Todo], title: String) -> Option[Todo] =
+  list.find(todos, (t) => t.title == title)
+
+fn status_label(s: Status) -> String =
+  match s { Pending => "pending", Done => "done", Cancelled => "cancelled" }
+
+fn summary(t: Todo) -> String = "[${status_label(t.status)}] ${t.title}"
+
+test "create todo" {
+  let t = create(1, "Buy milk")
+  assert_eq(t.title, "Buy milk")
+  assert_eq(t.id, 1)
+}
+
+test "complete todo" {
+  let t = create(1, "Buy milk") |> complete
+  assert_eq(is_done(t), true)
+}
+
+test "cancel todo" {
+  let t = create(1, "Buy milk") |> cancel
+  assert_eq(status_label(t.status), "cancelled")
+}
+
+test "pending count" {
+  let todos = [create(1, "A"), create(2, "B") |> complete, create(3, "C")]
+  assert_eq(pending_count(todos), 2)
+}
+
+test "titles" {
+  let todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+  assert_eq(titles(todos), ["A", "B", "C"])
+}
+
+test "find by title found" {
+  let todos = [create(1, "Buy milk"), create(2, "Walk dog")]
+  match find_by_title(todos, "Walk dog") {
+    some(t) => assert_eq(t.id, 2)
+    none => assert(false)
+  }
+}
+
+test "find by title not found" {
+  let todos = [create(1, "Buy milk")]
+  assert_eq(find_by_title(todos, "nope"), none)
+}
+
+test "summary" {
+  assert_eq(summary(create(1, "Buy milk")), "[pending] Buy milk")
+  assert_eq(summary(create(1, "Done") |> complete), "[done] Done")
+}
+
+test "pipe chain: create filter map" {
+  let todos = [create(1, "A"), create(2, "B") |> complete, create(3, "C") |> cancel]
+  let pending_titles = todos
+    |> list.filter((t) => match t.status { Pending => true, _ => false })
+    |> list.map((t) => t.title)
+  assert_eq(pending_titles, ["A"])
+}
+
+test "multiple operations" {
+  var todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+  let updated = list.map(todos, (t) => if t.id == 2 then complete(t) else t)
+  assert_eq(pending_count(updated), 2)
+  assert(is_done(list.get_or(updated, 1, create(0, ""))))
+}
+
+// ========== MODIFICATION INSTRUCTION ==========
+// Add a `priority: Int` field to the `Todo` record type.
+// Update `create` to accept a third parameter `priority: Int`:
+//   `fn create(id: Int, title: String, priority: Int) -> Todo`
+// All existing functions (`complete`, `cancel`, `is_done`, etc.) must still work.
+// The `summary` function should now include priority: "[pending/p3] Buy milk"
+//   (format: "[${status}/p${priority}] ${title}")
+// Add a new function:
+//   `fn high_priority(todos: List[Todo]) -> List[Todo]`
+//   Returns todos with priority >= 3, sorted by priority descending.
+//
+// UPDATE EXISTING TESTS: All `create(id, title)` calls must become
+// `create(id, title, 1)` (default priority 1).
+// UPDATE `summary` test assertions to include priority in format.
+
+// ========== V2 TESTS (must also pass after modification) ==========
+
+test "create with priority" {
+  let t = create(1, "Buy milk", 3)
+  assert_eq(t.priority, 3)
+}
+
+test "high priority filter" {
+  let todos = [create(1, "A", 5), create(2, "B", 1), create(3, "C", 3)]
+  let hp = high_priority(todos)
+  assert_eq(list.len(hp), 2)
+  assert_eq(list.map(hp, (t) => t.title), ["A", "C"])
+}
+
+test "high priority empty" {
+  let todos = [create(1, "A", 1), create(2, "B", 2)]
+  assert_eq(high_priority(todos), [])
+}
+
+test "complete preserves priority" {
+  let t = create(1, "A", 5) |> complete
+  assert_eq(t.priority, 5)
+}
+
+test "cancel preserves priority" {
+  let t = create(1, "A", 3) |> cancel
+  assert_eq(t.priority, 3)
+}
+
+test "summary with priority" {
+  assert_eq(summary(create(1, "Buy milk", 3)), "[pending/p3] Buy milk")
+  assert_eq(summary(create(1, "Done", 2) |> complete), "[done/p2] Done")
+}

--- a/research/benchmark/msr/modifications/prompts/m03-expression-eval-add-variant.almd
+++ b/research/benchmark/msr/modifications/prompts/m03-expression-eval-add-variant.almd
@@ -1,0 +1,67 @@
+// ========== V1 SOLUTION (working code — all tests pass) ==========
+
+type Expr =
+  | Lit(Int)
+  | Add(Expr, Expr)
+  | Mul(Expr, Expr)
+  | Sub(Expr, Expr)
+
+fn eval(e: Expr) -> Int =
+  match e {
+    Lit(n) => n
+    Add(l, r) => eval(l) + eval(r)
+    Mul(l, r) => eval(l) * eval(r)
+    Sub(l, r) => eval(l) - eval(r)
+  }
+
+fn to_string(e: Expr) -> String =
+  match e {
+    Lit(n) => int.to_string(n)
+    Add(l, r) => "(${to_string(l)} + ${to_string(r)})"
+    Mul(l, r) => "(${to_string(l)} * ${to_string(r)})"
+    Sub(l, r) => "(${to_string(l)} - ${to_string(r)})"
+  }
+
+test "literal" { assert_eq(eval(Lit(5)), 5) }
+test "add" { assert_eq(eval(Add(Lit(2), Lit(3))), 5) }
+test "mul" { assert_eq(eval(Mul(Lit(4), Lit(5))), 20) }
+test "sub" { assert_eq(eval(Sub(Lit(10), Lit(3))), 7) }
+test "nested add mul" { assert_eq(eval(Add(Lit(1), Mul(Lit(2), Lit(3)))), 7) }
+test "deep nesting" { assert_eq(eval(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))), 18) }
+test "to_string literal" { assert_eq(to_string(Lit(42)), "42") }
+test "to_string add" { assert_eq(to_string(Add(Lit(1), Lit(2))), "(1 + 2)") }
+test "to_string nested" { assert_eq(to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))), "((1 + 2) * 3)") }
+test "eval matches to_string" {
+  let e = Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))
+  assert_eq(eval(e), 15)
+}
+test "deeply nested eval" {
+  let e = Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))
+  assert_eq(eval(e), 8)
+}
+test "single negative via sub" {
+  assert_eq(eval(Sub(Lit(0), Lit(5))), -5)
+}
+
+// ========== MODIFICATION INSTRUCTION ==========
+// Add a `Div(Expr, Expr)` variant to the `Expr` type for integer division.
+// Integer division truncates toward zero (standard integer division).
+// Division by zero is undefined — for simplicity, just use normal division
+// (it will not be tested with zero divisor in v1 or v2 tests).
+// Update both `eval` and `to_string` to handle `Div`.
+// `to_string(Div(a, b))` should produce `"(a / b)"`.
+// All existing tests must still pass unchanged.
+
+// ========== V2 TESTS (must also pass after modification) ==========
+
+test "eval div" { assert_eq(eval(Div(Lit(10), Lit(3))), 3) }
+test "eval div exact" { assert_eq(eval(Div(Lit(10), Lit(2))), 5) }
+test "to_string div" { assert_eq(to_string(Div(Lit(10), Lit(3))), "(10 / 3)") }
+test "nested with div" {
+  let e = Add(Lit(1), Div(Lit(10), Lit(3)))
+  assert_eq(eval(e), 4)
+}
+test "div in complex expr" {
+  let e = Mul(Div(Lit(20), Lit(4)), Sub(Lit(10), Lit(7)))
+  assert_eq(eval(e), 15)
+}

--- a/research/benchmark/msr/modifications/prompts/m04-expression-eval-return-type.almd
+++ b/research/benchmark/msr/modifications/prompts/m04-expression-eval-return-type.almd
@@ -1,0 +1,69 @@
+// ========== V1 SOLUTION (working code — all tests pass) ==========
+
+type Expr =
+  | Lit(Int)
+  | Add(Expr, Expr)
+  | Mul(Expr, Expr)
+  | Sub(Expr, Expr)
+
+fn eval(e: Expr) -> Int =
+  match e {
+    Lit(n) => n
+    Add(l, r) => eval(l) + eval(r)
+    Mul(l, r) => eval(l) * eval(r)
+    Sub(l, r) => eval(l) - eval(r)
+  }
+
+fn to_string(e: Expr) -> String =
+  match e {
+    Lit(n) => int.to_string(n)
+    Add(l, r) => "(${to_string(l)} + ${to_string(r)})"
+    Mul(l, r) => "(${to_string(l)} * ${to_string(r)})"
+    Sub(l, r) => "(${to_string(l)} - ${to_string(r)})"
+  }
+
+test "literal" { assert_eq(eval(Lit(5)), 5) }
+test "add" { assert_eq(eval(Add(Lit(2), Lit(3))), 5) }
+test "mul" { assert_eq(eval(Mul(Lit(4), Lit(5))), 20) }
+test "sub" { assert_eq(eval(Sub(Lit(10), Lit(3))), 7) }
+test "nested add mul" { assert_eq(eval(Add(Lit(1), Mul(Lit(2), Lit(3)))), 7) }
+test "deep nesting" { assert_eq(eval(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))), 18) }
+test "to_string literal" { assert_eq(to_string(Lit(42)), "42") }
+test "to_string add" { assert_eq(to_string(Add(Lit(1), Lit(2))), "(1 + 2)") }
+test "to_string nested" { assert_eq(to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))), "((1 + 2) * 3)") }
+test "eval matches to_string" {
+  let e = Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))
+  assert_eq(eval(e), 15)
+}
+test "deeply nested eval" {
+  let e = Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))
+  assert_eq(eval(e), 8)
+}
+test "single negative via sub" {
+  assert_eq(eval(Sub(Lit(0), Lit(5))), -5)
+}
+
+// ========== MODIFICATION INSTRUCTION ==========
+// Add a `Div(Expr, Expr)` variant to the `Expr` type.
+// Change `eval` from a pure function returning `Int` to an effect function:
+//   `effect fn eval(e: Expr) -> Result[Int, String]`
+// Division by zero returns `err("division by zero")`.
+// Errors propagate through nested expressions (use `!` operator).
+// Update `to_string` to handle `Div`: `to_string(Div(a, b))` produces `"(a / b)"`.
+//
+// UPDATE EXISTING TESTS: All `assert_eq(eval(...), N)` must become
+// `assert_eq(eval(...), ok(N))` because eval now returns Result.
+
+// ========== V2 TESTS (must also pass after modification) ==========
+
+test "eval div" { assert_eq(eval(Div(Lit(10), Lit(3))), ok(3)) }
+test "eval div by zero" { assert_eq(eval(Div(Lit(5), Lit(0))), err("division by zero")) }
+test "to_string div" { assert_eq(to_string(Div(Lit(10), Lit(3))), "(10 / 3)") }
+test "nested div" {
+  let e = Add(Lit(1), Div(Lit(10), Lit(2)))
+  assert_eq(eval(e), ok(6))
+}
+test "div by zero propagates" {
+  let e = Add(Lit(1), Div(Lit(5), Lit(0)))
+  assert_eq(eval(e), err("division by zero"))
+}

--- a/research/benchmark/msr/modifications/prompts/m05-todo-app-add-error-handling.almd
+++ b/research/benchmark/msr/modifications/prompts/m05-todo-app-add-error-handling.almd
@@ -1,0 +1,136 @@
+// ========== V1 SOLUTION (working code — all tests pass) ==========
+
+type Status = | Pending | Done | Cancelled
+
+type Todo = { id: Int, title: String, status: Status }
+
+fn create(id: Int, title: String) -> Todo =
+  Todo { id: id, title: title, status: Pending }
+
+fn complete(t: Todo) -> Todo = { ...t, status: Done }
+
+fn cancel(t: Todo) -> Todo = { ...t, status: Cancelled }
+
+fn is_done(t: Todo) -> Bool = match t.status { Done => true, _ => false }
+
+fn pending_count(todos: List[Todo]) -> Int =
+  todos |> list.filter((t) => match t.status { Pending => true, _ => false }) |> list.len
+
+fn titles(todos: List[Todo]) -> List[String] = list.map(todos, (t) => t.title)
+
+fn find_by_title(todos: List[Todo], title: String) -> Option[Todo] =
+  list.find(todos, (t) => t.title == title)
+
+fn status_label(s: Status) -> String =
+  match s { Pending => "pending", Done => "done", Cancelled => "cancelled" }
+
+fn summary(t: Todo) -> String = "[${status_label(t.status)}] ${t.title}"
+
+test "create todo" {
+  let t = create(1, "Buy milk")
+  assert_eq(t.title, "Buy milk")
+  assert_eq(t.id, 1)
+}
+
+test "complete todo" {
+  let t = create(1, "Buy milk") |> complete
+  assert_eq(is_done(t), true)
+}
+
+test "cancel todo" {
+  let t = create(1, "Buy milk") |> cancel
+  assert_eq(status_label(t.status), "cancelled")
+}
+
+test "pending count" {
+  let todos = [create(1, "A"), create(2, "B") |> complete, create(3, "C")]
+  assert_eq(pending_count(todos), 2)
+}
+
+test "titles" {
+  let todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+  assert_eq(titles(todos), ["A", "B", "C"])
+}
+
+test "find by title found" {
+  let todos = [create(1, "Buy milk"), create(2, "Walk dog")]
+  match find_by_title(todos, "Walk dog") {
+    some(t) => assert_eq(t.id, 2)
+    none => assert(false)
+  }
+}
+
+test "find by title not found" {
+  let todos = [create(1, "Buy milk")]
+  assert_eq(find_by_title(todos, "nope"), none)
+}
+
+test "summary" {
+  assert_eq(summary(create(1, "Buy milk")), "[pending] Buy milk")
+  assert_eq(summary(create(1, "Done") |> complete), "[done] Done")
+}
+
+test "pipe chain: create filter map" {
+  let todos = [create(1, "A"), create(2, "B") |> complete, create(3, "C") |> cancel]
+  let pending_titles = todos
+    |> list.filter((t) => match t.status { Pending => true, _ => false })
+    |> list.map((t) => t.title)
+  assert_eq(pending_titles, ["A"])
+}
+
+test "multiple operations" {
+  var todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+  let updated = list.map(todos, (t) => if t.id == 2 then complete(t) else t)
+  assert_eq(pending_count(updated), 2)
+  assert(is_done(list.get_or(updated, 1, create(0, ""))))
+}
+
+// ========== MODIFICATION INSTRUCTION ==========
+// Change `complete` and `cancel` to return `Result[Todo, String]` with validation:
+//   `fn complete(t: Todo) -> Result[Todo, String]`
+//   - Completing a `Done` todo returns `err("already done")`
+//   - Completing a `Cancelled` todo returns `err("cannot complete cancelled")`
+//   - Completing a `Pending` todo returns `ok({ ...t, status: Done })`
+//   `fn cancel(t: Todo) -> Result[Todo, String]`
+//   - Cancelling a `Cancelled` todo returns `err("already cancelled")`
+//   - Cancelling a `Done` todo returns `err("cannot cancel done")`
+//   - Cancelling a `Pending` todo returns `ok({ ...t, status: Cancelled })`
+//
+// UPDATE EXISTING TESTS:
+//   - "complete todo": `create(1, "Buy milk") |> complete` now returns Result.
+//     Change to: `assert_eq(complete(create(1, "Buy milk")), ok(Todo { id: 1, title: "Buy milk", status: Done }))`
+//   - "cancel todo": Change similarly.
+//   - "summary" test that uses `|> complete`: unwrap the Result with `!` or
+//     construct the Done todo directly.
+//   - "pipe chain" and "multiple operations": update `complete(t)` calls to
+//     handle Result (e.g., use match or construct directly).
+
+// ========== V2 TESTS (must also pass after modification) ==========
+
+test "complete pending succeeds" {
+  assert_eq(complete(create(1, "A")), ok(Todo { id: 1, title: "A", status: Done }))
+}
+
+test "complete already done" {
+  let t = Todo { id: 1, title: "A", status: Done }
+  assert_eq(complete(t), err("already done"))
+}
+
+test "complete cancelled" {
+  let t = Todo { id: 1, title: "A", status: Cancelled }
+  assert_eq(complete(t), err("cannot complete cancelled"))
+}
+
+test "cancel pending succeeds" {
+  assert_eq(cancel(create(1, "A")), ok(Todo { id: 1, title: "A", status: Cancelled }))
+}
+
+test "cancel already cancelled" {
+  let t = Todo { id: 1, title: "A", status: Cancelled }
+  assert_eq(cancel(t), err("already cancelled"))
+}
+
+test "cancel done" {
+  let t = Todo { id: 1, title: "A", status: Done }
+  assert_eq(cancel(t), err("cannot cancel done"))
+}

--- a/research/benchmark/msr/modifications/prompts/m06-config-merger-add-function.almd
+++ b/research/benchmark/msr/modifications/prompts/m06-config-merger-add-function.almd
@@ -1,0 +1,285 @@
+// ========== V1 SOLUTION (working code — all tests pass) ==========
+
+import env
+import fs
+import string
+import list
+
+fn parse_config(content: String) -> Result[List[List[String]], String] = {
+  if string.len(content) == 0 then ok([])
+  else {
+    let lines = string.split(content, "\n");
+    let indexed = list.fold(lines, [], (acc, line) => {
+      let idx = list.len(acc) + 1;
+      acc + [[int.to_string(idx), line]]
+    });
+    list.fold(indexed, ok([]), (acc, entry) => {
+      match acc {
+        err(e) => err(e),
+        ok(pairs) => {
+          let line_num = match list.get(entry, 0) { some(v) => v, none => "0" };
+          let line = match list.get(entry, 1) { some(v) => v, none => "" };
+          let trimmed = string.trim(line);
+          if trimmed == "" then ok(pairs)
+          else if string.starts_with(trimmed, "#") then ok(pairs)
+          else if string.contains(trimmed, "=") then {
+            let parts = string.split(trimmed, "=");
+            let key = match list.get(parts, 0) { some(v) => v, none => "" };
+            if key == "" then err("line ${line_num}: empty key")
+            else {
+              let indexed_parts = list.fold(parts, [], (a, p) => a + [[int.to_string(list.len(a)), p]]);
+              let rest = list.filter(indexed_parts, (ip) => {
+                match list.get(ip, 0) { some(v) => v != "0", none => false }
+              });
+              let rest_vals = list.map(rest, (ip) => match list.get(ip, 1) { some(v) => v, none => "" });
+              let value = string.join(rest_vals, "=");
+              let existing_keys = list.map(pairs, (p) => match list.get(p, 0) { some(v) => v, none => "" });
+              if list.contains(existing_keys, key) then err("line ${line_num}: duplicate key: ${key}")
+              else ok(pairs + [[key, value]])
+            }
+          }
+          else err("line ${line_num}: missing '='")
+        }
+      }
+    })
+  }
+}
+
+fn merge_configs(base: List[List[String]], overlay: List[List[String]]) -> List[List[String]] = {
+  let overlay_keys = list.map(overlay, (p) => match list.get(p, 0) { some(v) => v, none => "" });
+  let overlay_for_find = overlay;
+  let merged_base = list.map(base, (pair) => {
+    let key = match list.get(pair, 0) { some(v) => v, none => "" };
+    if list.contains(overlay_keys, key) then {
+      match list.find(overlay_for_find, (op) => match list.get(op, 0) { some(v) => v == key, none => false }) {
+        some(found) => found,
+        none => pair
+      }
+    } else pair
+  });
+  let base_keys = list.map(base, (p) => match list.get(p, 0) { some(v) => v, none => "" });
+  let new_overlay = list.filter(overlay, (p) => {
+    let key = match list.get(p, 0) { some(v) => v, none => "" };
+    not list.contains(base_keys, key)
+  });
+  merged_base + new_overlay
+}
+
+fn serialize_config(pairs: List[List[String]]) -> String = {
+  let lines = list.map(pairs, (pair) => {
+    let key = match list.get(pair, 0) { some(v) => v, none => "" };
+    let value = match list.get(pair, 1) { some(v) => v, none => "" };
+    key + "=" + value
+  });
+  string.join(lines, "\n")
+}
+
+effect fn load_config(path: String) -> Result[List[List[String]], String] = {
+  let text = fs.read_text(path)!
+  match parse_config(text) {
+    ok(pairs) => ok(pairs),
+    err(e) => err("${path}: ${e}")
+  }
+}
+
+effect fn save_config(path: String, pairs: List[List[String]]) -> Result[Unit, String] = {
+  let content = serialize_config(pairs);
+  fs.write(path, content);
+  ok(())
+}
+
+effect fn merge_files(paths: List[String]) -> Result[List[List[String]], String] = {
+  var result = []
+  var i = 0
+  while i < list.len(paths) {
+    let path = match list.get(paths, i) { some(p) => p, none => "" }
+    let overlay = load_config(path)!
+    result = merge_configs(result, overlay)
+    i = i + 1
+  }
+  ok(result)
+}
+
+effect fn merge_and_save(paths: List[String], output: String) -> Result[Int, String] = {
+  match merge_files(paths) {
+    err(e) => err(e),
+    ok(pairs) => {
+      save_config(output, pairs)!;
+      ok(list.len(pairs))
+    }
+  }
+}
+
+fn lookup(pairs: List[List[String]], key: String) -> Option[String] = {
+  match list.find(pairs, (pair) => match list.get(pair, 0) { some(v) => v == key, none => false }) {
+    some(pair) => match list.get(pair, 1) { some(v) => some(v), none => none },
+    none => none
+  }
+}
+
+fn filter_by_prefix(pairs: List[List[String]], prefix: String) -> List[List[String]] = {
+  list.filter(pairs, (pair) => {
+    let key = match list.get(pair, 0) { some(v) => v, none => "" };
+    string.starts_with(key, prefix)
+  })
+}
+
+test "parse basic config" {
+  let content = "host=localhost\nport=8080"
+  assert_eq(parse_config(content), ok([["host", "localhost"], ["port", "8080"]]))
+}
+
+test "parse with comments and blanks" {
+  let content = "# this is a comment\n\nhost=localhost\n# another comment\nport=8080"
+  assert_eq(parse_config(content), ok([["host", "localhost"], ["port", "8080"]]))
+}
+
+test "parse empty string" {
+  assert_eq(parse_config(""), ok([]))
+}
+
+test "parse only comments" {
+  assert_eq(parse_config("# comment\n# another"), ok([]))
+}
+
+test "parse missing equals" {
+  assert_eq(parse_config("host=ok\nbadline"), err("line 2: missing '='"))
+}
+
+test "parse empty key" {
+  assert_eq(parse_config("=value"), err("line 1: empty key"))
+}
+
+test "parse duplicate key" {
+  assert_eq(parse_config("host=a\nhost=b"), err("line 2: duplicate key: host"))
+}
+
+test "parse value with equals" {
+  let content = "formula=a=b+c"
+  assert_eq(parse_config(content), ok([["formula", "a=b+c"]]))
+}
+
+test "merge no overlap" {
+  let base = [["host", "localhost"]]
+  let overlay = [["port", "8080"]]
+  assert_eq(merge_configs(base, overlay), [["host", "localhost"], ["port", "8080"]])
+}
+
+test "merge with override" {
+  let base = [["host", "localhost"], ["port", "3000"]]
+  let overlay = [["port", "8080"]]
+  assert_eq(merge_configs(base, overlay), [["host", "localhost"], ["port", "8080"]])
+}
+
+test "merge empty base" {
+  let overlay = [["port", "8080"]]
+  assert_eq(merge_configs([], overlay), [["port", "8080"]])
+}
+
+test "merge empty overlay" {
+  let base = [["host", "localhost"]]
+  assert_eq(merge_configs(base, []), [["host", "localhost"]])
+}
+
+test "serialize config" {
+  let pairs = [["host", "localhost"], ["port", "8080"]]
+  assert_eq(serialize_config(pairs), "host=localhost\nport=8080")
+}
+
+test "serialize empty" {
+  assert_eq(serialize_config([]), "")
+}
+
+test "lookup found" {
+  let pairs = [["host", "localhost"], ["port", "8080"]]
+  assert_eq(lookup(pairs, "port"), some("8080"))
+}
+
+test "lookup not found" {
+  let pairs = [["host", "localhost"]]
+  assert_eq(lookup(pairs, "port"), none)
+}
+
+test "filter by prefix" {
+  let pairs = [["db_host", "localhost"], ["db_port", "5432"], ["app_port", "8080"]]
+  assert_eq(filter_by_prefix(pairs, "db_"), [["db_host", "localhost"], ["db_port", "5432"]])
+}
+
+test "filter by prefix no match" {
+  let pairs = [["app_port", "8080"]]
+  assert_eq(filter_by_prefix(pairs, "db_"), [])
+}
+
+test "load and parse config file" {
+  let td = env.temp_dir()
+  let f = td + "/almide_test_m06_base.conf"
+  fs.write(f, "host=localhost\nport=3000")
+  let result = load_config(f)
+  assert_eq(result, ok([["host", "localhost"], ["port", "3000"]]))
+}
+
+test "load config file not found" {
+  let td = env.temp_dir()
+  assert(match load_config(td + "/almide_test_m06_nonexistent.conf") { err(_e) => true, _ => false })
+}
+
+test "merge two files" {
+  let td = env.temp_dir()
+  let f1 = td + "/almide_test_m06_f1.conf"
+  let f2 = td + "/almide_test_m06_f2.conf"
+  fs.write(f1, "host=localhost\nport=3000")
+  fs.write(f2, "port=8080\ndebug=true")
+  let result = merge_files([f1, f2])
+  assert_eq(result, ok([["host", "localhost"], ["port", "8080"], ["debug", "true"]]))
+}
+
+// ========== MODIFICATION INSTRUCTION ==========
+// Add two new functions (do NOT modify any existing functions or tests):
+//
+// 1. `fn validate_keys(pairs: List[List[String]], required: List[String]) -> Result[Unit, String]`
+//    Checks that all keys in `required` are present in `pairs`.
+//    If a key is missing, return `err("missing required key: KEY")` for the first missing key.
+//    If all required keys are present, return `ok(())`.
+//
+// 2. `effect fn load_and_validate(path: String, required: List[String]) -> Result[List[List[String]], String]`
+//    Loads a config file and validates that all required keys are present.
+//    File read errors and parse errors propagate as usual.
+//    If validation fails, return the validation error.
+//    If everything succeeds, return the parsed pairs.
+//
+// All existing tests must still pass unchanged.
+
+// ========== V2 TESTS (must also pass after modification) ==========
+
+test "validate keys all present" {
+  let pairs = [["host", "localhost"], ["port", "8080"]]
+  assert_eq(validate_keys(pairs, ["host", "port"]), ok(()))
+}
+
+test "validate keys missing" {
+  let pairs = [["host", "localhost"]]
+  assert_eq(validate_keys(pairs, ["host", "port"]), err("missing required key: port"))
+}
+
+test "validate keys empty required" {
+  assert_eq(validate_keys([["a", "b"]], []), ok(()))
+}
+
+test "validate keys first missing reported" {
+  let pairs = [["host", "localhost"]]
+  assert_eq(validate_keys(pairs, ["port", "debug"]), err("missing required key: port"))
+}
+
+test "load and validate success" {
+  let td = env.temp_dir()
+  let f = td + "/almide_test_m06_valid.conf"
+  fs.write(f, "host=localhost\nport=8080")
+  assert_eq(load_and_validate(f, ["host"]), ok([["host", "localhost"], ["port", "8080"]]))
+}
+
+test "load and validate missing key" {
+  let td = env.temp_dir()
+  let f = td + "/almide_test_m06_partial.conf"
+  fs.write(f, "host=localhost")
+  assert_eq(load_and_validate(f, ["host", "port"]), err("missing required key: port"))
+}

--- a/research/benchmark/msr/modifications/prompts/m07-grade-report-add-function.almd
+++ b/research/benchmark/msr/modifications/prompts/m07-grade-report-add-function.almd
@@ -1,0 +1,389 @@
+// ========== V1 SOLUTION (working code — all tests pass) ==========
+
+import string
+import list
+
+fn str_to_int(s: String) -> Result[Int, String] = {
+  let bytes = string.to_bytes(s)
+  let len = list.len(bytes)
+  if len == 0 then err("invalid integer")
+  else {
+    let first = match list.get(bytes, 0) {
+      some(v) => v,
+      none => 0,
+    }
+    let is_negative = first == 45
+    let start_index = if is_negative then 1 else 0
+    if is_negative and len == 1 then err("invalid integer")
+    else {
+      let digit_bytes = if is_negative then {
+        let indices = list.fold(bytes, [], (acc, _b) => acc + [list.len(acc)])
+        list.fold(indices, [], (acc, i) => {
+          if i >= start_index then {
+            match list.get(bytes, i) {
+              some(v) => acc + [v],
+              none => acc,
+            }
+          } else acc
+        })
+      } else bytes
+      if list.len(digit_bytes) == 0 then err("invalid integer")
+      else {
+        let result = list.fold(digit_bytes, ok(0), (acc, b) => {
+          match acc {
+            ok(n) => {
+              if b >= 48 and b <= 57 then ok(n * 10 + (b - 48))
+              else err("invalid integer")
+            },
+            err(e) => err(e),
+          }
+        })
+        match result {
+          ok(n) => if is_negative then ok(0 - n) else ok(n),
+          err(e) => err(e),
+        }
+      }
+    }
+  }
+}
+
+fn parse_student(line: String) -> Result[List[String], String] = {
+  let parts = string.split(line, ":")
+  let num_parts = list.len(parts)
+  if num_parts < 2 then err("invalid format")
+  else {
+    let name = match list.get(parts, 0) { some(v) => v, none => "" }
+    if string.len(name) == 0 then err("empty name")
+    else {
+      let scores_str = match list.get(parts, 1) { some(v) => v, none => "" }
+      if string.len(scores_str) == 0 then err("no scores")
+      else {
+        let score_strs = string.split(scores_str, ",")
+        let validation = list.fold(score_strs, ok([]), (acc, s) => {
+          match acc {
+            err(e) => err(e),
+            ok(validated) => {
+              match str_to_int(s) {
+                err(_e) => err("invalid score: " + s),
+                ok(n) => {
+                  if n < 0 or n > 100 then err("score out of range: " + s)
+                  else ok(validated + [s])
+                },
+              }
+            },
+          }
+        })
+        match validation {
+          err(e) => err(e),
+          ok(scores) => ok([name] + scores),
+        }
+      }
+    }
+  }
+}
+
+fn parse_all(input: String) -> Result[List[List[String]], String] = {
+  if string.len(input) == 0 then err("empty input")
+  else {
+    let lines = string.split(input, "\n")
+    let indexed_lines = list.fold(lines, [], (acc, line) => {
+      let idx = list.len(acc) + 1
+      acc + [[int.to_string(idx), line]]
+    })
+    list.fold(indexed_lines, ok([]), (acc, entry) => {
+      match acc {
+        err(e) => err(e),
+        ok(students) => {
+          let line_num = match list.get(entry, 0) { some(v) => v, none => "0" }
+          let line = match list.get(entry, 1) { some(v) => v, none => "" }
+          match parse_student(line) {
+            err(e) => err("line " + line_num + ": " + e),
+            ok(student) => {
+              let name = match list.get(student, 0) { some(v) => v, none => "" }
+              let names = list.map(students, (s) => {
+                match list.get(s, 0) { some(v) => v, none => "" }
+              })
+              if list.contains(names, name) then err("duplicate name: " + name)
+              else ok(students + [student])
+            },
+          }
+        },
+      }
+    })
+  }
+}
+
+fn average(student: List[String]) -> Result[Int, String] = {
+  let len = list.len(student)
+  if len <= 1 then err("no scores")
+  else {
+    let indices = list.fold(student, [], (acc, _s) => acc + [list.len(acc)])
+    let score_indices = list.filter(indices, (i) => i >= 1)
+    let sum_result = list.fold(score_indices, ok(0), (acc, i) => {
+      match acc {
+        err(e) => err(e),
+        ok(total) => {
+          match list.get(student, i) {
+            none => err("missing score"),
+            some(s) => {
+              match str_to_int(s) {
+                err(e) => err(e),
+                ok(n) => ok(total + n),
+              }
+            },
+          }
+        },
+      }
+    })
+    let num_scores = len - 1
+    match sum_result {
+      err(e) => err(e),
+      ok(total) => ok(total / num_scores),
+    }
+  }
+}
+
+fn letter_grade(avg: Int) -> String = {
+  if avg >= 90 then "A"
+  else if avg >= 80 then "B"
+  else if avg >= 70 then "C"
+  else if avg >= 60 then "D"
+  else "F"
+}
+
+fn honor_roll(students: List[List[String]]) -> Result[List[String], String] = {
+  let result = list.fold(students, ok([]), (acc, student) => {
+    match acc {
+      err(e) => err(e),
+      ok(names) => {
+        match average(student) {
+          err(e) => err(e),
+          ok(avg) => {
+            if avg >= 85 then {
+              let name = match list.get(student, 0) { some(v) => v, none => "" }
+              ok(names + [name])
+            } else ok(names)
+          },
+        }
+      },
+    }
+  })
+  match result {
+    err(e) => err(e),
+    ok(names) => ok(list.sort(names)),
+  }
+}
+
+fn class_average(students: List[List[String]]) -> Result[Int, String] = {
+  let num_students = list.len(students)
+  if num_students == 0 then err("no students")
+  else {
+    let sum_result = list.fold(students, ok(0), (acc, student) => {
+      match acc {
+        err(e) => err(e),
+        ok(total) => {
+          match average(student) {
+            err(e) => err(e),
+            ok(avg) => ok(total + avg),
+          }
+        },
+      }
+    })
+    match sum_result {
+      err(e) => err(e),
+      ok(total) => ok(total / num_students),
+    }
+  }
+}
+
+fn format_student(student: List[String]) -> Result[String, String] = {
+  let name = match list.get(student, 0) { some(v) => v, none => "" }
+  match average(student) {
+    err(e) => err(e),
+    ok(avg) => {
+      let grade = letter_grade(avg)
+      ok(name + ": " + int.to_string(avg) + " (" + grade + ")")
+    },
+  }
+}
+
+fn generate_report(input: String) -> Result[String, String] = {
+  match parse_all(input) {
+    err(e) => err(e),
+    ok(students) => {
+      let formatted_result = list.fold(students, ok([]), (acc, student) => {
+        match acc {
+          err(e) => err(e),
+          ok(lines) => {
+            match format_student(student) {
+              err(e) => err(e),
+              ok(line) => ok(lines + [line]),
+            }
+          },
+        }
+      })
+      match formatted_result {
+        err(e) => err(e),
+        ok(lines) => {
+          match class_average(students) {
+            err(e) => err(e),
+            ok(cavg) => {
+              match honor_roll(students) {
+                err(e) => err(e),
+                ok(honors) => {
+                  let student_lines = string.join(lines, "\n")
+                  let class_line = "class average: " + int.to_string(cavg)
+                  let honor_line = "honor roll: " + string.join(honors, ", ")
+                  ok(student_lines + "\n" + class_line + "\n" + honor_line)
+                },
+              }
+            },
+          }
+        },
+      }
+    },
+  }
+}
+
+test "parse single student" {
+  assert_eq(parse_student("Alice:85,92,78"), ok(["Alice", "85", "92", "78"]))
+}
+
+test "parse student with single score" {
+  assert_eq(parse_student("Bob:100"), ok(["Bob", "100"]))
+}
+
+test "parse student empty name" {
+  assert_eq(parse_student(":85,92"), err("empty name"))
+}
+
+test "parse student invalid score" {
+  assert_eq(parse_student("Alice:85,abc,78"), err("invalid score: abc"))
+}
+
+test "parse student score too high" {
+  assert_eq(parse_student("Alice:85,101,78"), err("score out of range: 101"))
+}
+
+test "parse student score negative" {
+  assert_eq(parse_student("Alice:85,-1,78"), err("score out of range: -1"))
+}
+
+test "parse student no scores" {
+  assert_eq(parse_student("Alice:"), err("no scores"))
+}
+
+test "parse student no colon" {
+  assert_eq(parse_student("Alice"), err("invalid format"))
+}
+
+test "parse all basic" {
+  let result = parse_all("Alice:85,92\nBob:70,80")
+  assert_eq(result, ok([["Alice", "85", "92"], ["Bob", "70", "80"]]))
+}
+
+test "parse all empty input" {
+  assert_eq(parse_all(""), err("empty input"))
+}
+
+test "parse all duplicate names" {
+  assert_eq(parse_all("Alice:85\nAlice:90"), err("duplicate name: Alice"))
+}
+
+test "parse all error with line number" {
+  assert_eq(parse_all("Alice:85\n:90"), err("line 2: empty name"))
+}
+
+test "average basic" {
+  assert_eq(average(["Alice", "80", "90", "100"]), ok(90))
+}
+
+test "average single score" {
+  assert_eq(average(["Bob", "75"]), ok(75))
+}
+
+test "average rounds down" {
+  assert_eq(average(["Carol", "80", "81"]), ok(80))
+}
+
+test "letter grade A" { assert_eq(letter_grade(95), "A") }
+test "letter grade B" { assert_eq(letter_grade(85), "B") }
+test "letter grade C" { assert_eq(letter_grade(75), "C") }
+test "letter grade D" { assert_eq(letter_grade(65), "D") }
+test "letter grade F" { assert_eq(letter_grade(55), "F") }
+test "letter grade boundary 90" { assert_eq(letter_grade(90), "A") }
+test "letter grade boundary 80" { assert_eq(letter_grade(80), "B") }
+
+test "honor roll basic" {
+  let students = [["Alice", "90", "95"], ["Bob", "70", "80"], ["Carol", "85", "90"]]
+  assert_eq(honor_roll(students), ok(["Alice", "Carol"]))
+}
+
+test "honor roll none qualify" {
+  let students = [["Alice", "70", "75"], ["Bob", "60", "65"]]
+  assert_eq(honor_roll(students), ok([]))
+}
+
+test "honor roll sorted" {
+  let students = [["Zara", "90", "95"], ["Alice", "85", "90"]]
+  assert_eq(honor_roll(students), ok(["Alice", "Zara"]))
+}
+
+test "class average basic" {
+  let students = [["Alice", "80", "90"], ["Bob", "70", "80"]]
+  assert_eq(class_average(students), ok(80))
+}
+
+test "format student" {
+  assert_eq(format_student(["Alice", "85", "92", "78"]), ok("Alice: 85 (B)"))
+}
+
+test "generate report" {
+  let input = "Alice:90,95,100\nBob:70,75,80"
+  let expected = "Alice: 95 (A)\nBob: 75 (C)\nclass average: 85\nhonor roll: Alice"
+  assert_eq(generate_report(input), ok(expected))
+}
+
+test "generate report error propagation" {
+  assert_eq(generate_report("Alice:90\n:bad"), err("line 2: empty name"))
+}
+
+test "generate report empty" {
+  assert_eq(generate_report(""), err("empty input"))
+}
+
+// ========== MODIFICATION INSTRUCTION ==========
+// Add a new function:
+//   `fn top_students(input: String, n: Int) -> Result[List[String], String]`
+//   Returns the names of the top N students by average score (descending).
+//   Ties in average are broken alphabetically (ascending).
+//   If N exceeds the number of students, return all students sorted by score desc.
+//   Uses `parse_all` and `average` internally. Errors propagate.
+//
+// All existing functions and tests must remain unchanged.
+
+// ========== V2 TESTS (must also pass after modification) ==========
+
+test "top students basic" {
+  let input = "Alice:90,95\nBob:70,80\nCarol:85,88"
+  assert_eq(top_students(input, 2), ok(["Alice", "Carol"]))
+}
+
+test "top students tie breaking" {
+  let input = "Bob:85,85\nAlice:85,85"
+  assert_eq(top_students(input, 2), ok(["Alice", "Bob"]))
+}
+
+test "top students n exceeds count" {
+  let input = "Alice:90,95"
+  assert_eq(top_students(input, 5), ok(["Alice"]))
+}
+
+test "top students error propagation" {
+  assert_eq(top_students("", 3), err("empty input"))
+}
+
+test "top students single" {
+  let input = "Alice:90,95\nBob:70,80\nCarol:85,88"
+  assert_eq(top_students(input, 1), ok(["Alice"]))
+}

--- a/research/benchmark/msr/modifications/prompts/m08-bob-behavioral-change.almd
+++ b/research/benchmark/msr/modifications/prompts/m08-bob-behavioral-change.almd
@@ -1,0 +1,71 @@
+// ========== V1 SOLUTION (working code — all tests pass) ==========
+
+fn respond(input: String) -> String = {
+  let trimmed = string.trim(input)
+  let is_silence = string.len(trimmed) == 0
+  let is_question = string.ends_with(trimmed, "?")
+  let has_letters = list.any(string.chars(trimmed), (c) => string.is_alpha(c))
+  let is_yelling = has_letters and string.to_upper(trimmed) == trimmed
+  if is_silence then "Fine. Be that way!"
+  else if is_yelling and is_question then "Calm down, I know what I'm doing!"
+  else if is_yelling then "Whoa, chill out!"
+  else if is_question then "Sure."
+  else "Whatever."
+}
+
+test "stating something" { assert_eq(respond("Tom-ay-to, tom-ah-to."), "Whatever.") }
+test "shouting" { assert_eq(respond("WATCH OUT!"), "Whoa, chill out!") }
+test "shouting gibberish" { assert_eq(respond("FCECGC"), "Whoa, chill out!") }
+test "asking a question" { assert_eq(respond("Does this celi level have a caused caused caused effect?"), "Sure.") }
+test "asking a numeric question" { assert_eq(respond("You are, what, like 15?"), "Sure.") }
+test "asking gibberish" { assert_eq(respond("fffbbcbeab?"), "Sure.") }
+test "talking forcefully" { assert_eq(respond("Hi there!"), "Whatever.") }
+test "using acronyms in regular speech" { assert_eq(respond("It's OK if you don't want to go work for NASA."), "Whatever.") }
+test "forceful question" { assert_eq(respond("WHAT IS YOUR PROBLEM?"), "Calm down, I know what I'm doing!") }
+test "shouting numbers" { assert_eq(respond("1, 2, 3 GO!"), "Whoa, chill out!") }
+test "no letters" { assert_eq(respond("1, 2, 3"), "Whatever.") }
+test "question with no letters" { assert_eq(respond("4?"), "Sure.") }
+test "shouting with special characters" { assert_eq(respond("ZOMG THE %#@* ALARM IS GOING OFF!"), "Whoa, chill out!") }
+test "shouting with no exclamation mark" { assert_eq(respond("I HATE THE ALARM"), "Whoa, chill out!") }
+test "statement containing question mark" { assert_eq(respond("Ending with ? hmm"), "Whatever.") }
+test "non-letters with question" { assert_eq(respond(":) ?"), "Sure.") }
+test "prattling on" { assert_eq(respond("Wait! Hang on. Are you going to be OK?"), "Sure.") }
+test "silence" { assert_eq(respond(""), "Fine. Be that way!") }
+test "prolonged silence" { assert_eq(respond("          "), "Fine. Be that way!") }
+test "alternate silence" { assert_eq(respond("\t\t\t\t\t\t\t\t\t\t"), "Fine. Be that way!") }
+test "multiple line question" { assert_eq(respond("\nDoes this celi level have a caused caused caused effect?"), "Sure.") }
+test "starting with whitespace" { assert_eq(respond("         hmmmmm"), "Whatever.") }
+test "ending with whitespace" { assert_eq(respond("Okay if like my  spacebar  quite a bit?   "), "Sure.") }
+test "other whitespace" { assert_eq(respond("\n\r \t"), "Fine. Be that way!") }
+test "non-question ending with whitespace" { assert_eq(respond("This is a statement ending with whitespace      "), "Whatever.") }
+
+// ========== MODIFICATION INSTRUCTION ==========
+// Add "whispering" detection to Bob's response logic.
+// Whispering = input has letters AND all letters are lowercase (none uppercase).
+// Priority order (highest to lowest):
+//   1. Silence → "Fine. Be that way!"
+//   2. Yelling + question → "Calm down, I know what I'm doing!"
+//   3. Yelling → "Whoa, chill out!"
+//   4. Whispering + question → "Are you whispering? Speak up!"
+//   5. Whispering → "Could you speak up? I can't hear you."
+//   6. Question → "Sure."
+//   7. Default → "Whatever."
+//
+// UPDATE EXISTING TESTS:
+//   - "asking gibberish" test: `respond("fffbbcbeab?")` is now whispering+question.
+//     Change expected from `"Sure."` to `"Are you whispering? Speak up!"`
+//   - "starting with whitespace" test: `respond("         hmmmmm")` is now whispering.
+//     Change expected from `"Whatever."` to `"Could you speak up? I can't hear you."`
+//
+// Note: Tests with mixed case like "Tom-ay-to, tom-ah-to." (has uppercase T)
+// are NOT whispering and remain "Whatever.".
+// Tests like "Hi there!" have uppercase H, so NOT whispering.
+// Tests like "1, 2, 3" have no letters, so NOT whispering.
+
+// ========== V2 TESTS (must also pass after modification) ==========
+
+test "whispering" { assert_eq(respond("hello there"), "Could you speak up? I can't hear you.") }
+test "whispering question" { assert_eq(respond("do you hear me?"), "Are you whispering? Speak up!") }
+test "whispering with numbers" { assert_eq(respond("hello 123"), "Could you speak up? I can't hear you.") }
+test "not whispering mixed case" { assert_eq(respond("Hello there"), "Whatever.") }
+test "whispering question with spaces" { assert_eq(respond("  can you hear me?  "), "Are you whispering? Speak up!") }

--- a/research/benchmark/msr/modifications/prompts/m09-expression-eval-compound.almd
+++ b/research/benchmark/msr/modifications/prompts/m09-expression-eval-compound.almd
@@ -1,0 +1,80 @@
+// ========== V1 SOLUTION (working code — all tests pass) ==========
+
+type Expr =
+  | Lit(Int)
+  | Add(Expr, Expr)
+  | Mul(Expr, Expr)
+  | Sub(Expr, Expr)
+
+fn eval(e: Expr) -> Int =
+  match e {
+    Lit(n) => n
+    Add(l, r) => eval(l) + eval(r)
+    Mul(l, r) => eval(l) * eval(r)
+    Sub(l, r) => eval(l) - eval(r)
+  }
+
+fn to_string(e: Expr) -> String =
+  match e {
+    Lit(n) => int.to_string(n)
+    Add(l, r) => "(${to_string(l)} + ${to_string(r)})"
+    Mul(l, r) => "(${to_string(l)} * ${to_string(r)})"
+    Sub(l, r) => "(${to_string(l)} - ${to_string(r)})"
+  }
+
+test "literal" { assert_eq(eval(Lit(5)), 5) }
+test "add" { assert_eq(eval(Add(Lit(2), Lit(3))), 5) }
+test "mul" { assert_eq(eval(Mul(Lit(4), Lit(5))), 20) }
+test "sub" { assert_eq(eval(Sub(Lit(10), Lit(3))), 7) }
+test "nested add mul" { assert_eq(eval(Add(Lit(1), Mul(Lit(2), Lit(3)))), 7) }
+test "deep nesting" { assert_eq(eval(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))), 18) }
+test "to_string literal" { assert_eq(to_string(Lit(42)), "42") }
+test "to_string add" { assert_eq(to_string(Add(Lit(1), Lit(2))), "(1 + 2)") }
+test "to_string nested" { assert_eq(to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))), "((1 + 2) * 3)") }
+test "eval matches to_string" {
+  let e = Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))
+  assert_eq(eval(e), 15)
+}
+test "deeply nested eval" {
+  let e = Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))
+  assert_eq(eval(e), 8)
+}
+test "single negative via sub" {
+  assert_eq(eval(Sub(Lit(0), Lit(5))), -5)
+}
+
+// ========== MODIFICATION INSTRUCTION ==========
+// Make TWO changes to the Expr type simultaneously:
+//
+// 1. Add a `Neg(Expr)` variant for unary negation.
+//    `eval(Neg(e))` returns `0 - eval(e)`.
+//    `to_string(Neg(e))` returns `"(-${to_string(e)})"`.
+//
+// 2. Add a `Pow(Expr, Expr)` variant for exponentiation.
+//    `eval(Pow(base, exp))` computes base raised to the power of exp.
+//    Assume exp is always >= 0.
+//    `to_string(Pow(a, b))` returns `"(${to_string(a)} ^ ${to_string(b)})"`.
+//
+//    Hint: implement power via recursion or a loop:
+//    pow(base, 0) = 1, pow(base, n) = base * pow(base, n - 1)
+//
+// Both `eval` and `to_string` must handle the new variants.
+// All existing tests must still pass unchanged.
+
+// ========== V2 TESTS (must also pass after modification) ==========
+
+test "neg literal" { assert_eq(eval(Neg(Lit(5))), -5) }
+test "neg of neg" { assert_eq(eval(Neg(Neg(Lit(3)))), 3) }
+test "to_string neg" { assert_eq(to_string(Neg(Lit(5))), "(-5)") }
+test "pow basic" { assert_eq(eval(Pow(Lit(2), Lit(3))), 8) }
+test "pow zero" { assert_eq(eval(Pow(Lit(5), Lit(0))), 1) }
+test "pow one" { assert_eq(eval(Pow(Lit(7), Lit(1))), 7) }
+test "to_string pow" { assert_eq(to_string(Pow(Lit(2), Lit(3))), "(2 ^ 3)") }
+test "neg with pow" {
+  let e = Neg(Pow(Lit(2), Lit(3)))
+  assert_eq(eval(e), -8)
+}
+test "pow in expression" {
+  let e = Add(Pow(Lit(2), Lit(3)), Lit(2))
+  assert_eq(eval(e), 10)
+}

--- a/research/benchmark/msr/modifications/prompts/m10-traffic-light-compound.almd
+++ b/research/benchmark/msr/modifications/prompts/m10-traffic-light-compound.almd
@@ -1,0 +1,47 @@
+// ========== V1 SOLUTION (working code — all tests pass) ==========
+
+type Light = | Red | Yellow | Green
+
+fn next(l: Light) -> Light =
+  match l { Red => Green, Green => Yellow, Yellow => Red }
+
+fn duration(l: Light) -> Int =
+  match l { Red => 60, Yellow => 5, Green => 45 }
+
+fn describe(l: Light) -> String =
+  match l { Red => "stop", Yellow => "caution", Green => "go" }
+
+test "next red" { assert_eq(next(Red), Green) }
+test "next green" { assert_eq(next(Green), Yellow) }
+test "next yellow" { assert_eq(next(Yellow), Red) }
+test "full cycle" { assert_eq(next(next(next(Red))), Red) }
+test "duration red" { assert_eq(duration(Red), 60) }
+test "duration yellow" { assert_eq(duration(Yellow), 5) }
+test "duration green" { assert_eq(duration(Green), 45) }
+test "describe" { assert_eq(describe(Red), "stop") }
+
+// ========== MODIFICATION INSTRUCTION ==========
+// Make TWO changes simultaneously:
+//
+// 1. Add a `Broken` variant to the `Light` type.
+//    - `next(Broken)` returns `Red` (reset to red when repaired)
+//    - `describe(Broken)` returns `"out of order"`
+//
+// 2. Change `duration` to return `Result[Int, String]` instead of `Int`.
+//    - `duration(Red)` returns `ok(60)`
+//    - `duration(Yellow)` returns `ok(5)`
+//    - `duration(Green)` returns `ok(45)`
+//    - `duration(Broken)` returns `err("broken light has no duration")`
+//
+// UPDATE EXISTING TESTS:
+//   - "duration red": change `assert_eq(duration(Red), 60)` to `assert_eq(duration(Red), ok(60))`
+//   - "duration yellow": change `assert_eq(duration(Yellow), 5)` to `assert_eq(duration(Yellow), ok(5))`
+//   - "duration green": change `assert_eq(duration(Green), 45)` to `assert_eq(duration(Green), ok(45))`
+
+// ========== V2 TESTS (must also pass after modification) ==========
+
+test "next broken" { assert_eq(next(Broken), Red) }
+test "describe broken" { assert_eq(describe(Broken), "out of order") }
+test "duration broken" { assert_eq(duration(Broken), err("broken light has no duration")) }
+test "cycle from broken" { assert_eq(next(next(Broken)), Green) }
+test "describe after broken" { assert_eq(describe(next(Broken)), "stop") }

--- a/research/benchmark/msr/modifications/results/haiku_2026-03-30.json
+++ b/research/benchmark/msr/modifications/results/haiku_2026-03-30.json
@@ -1,0 +1,13 @@
+{
+  "date": "2026-03-30",
+  "language": "almide",
+  "type": "modification",
+  "model": "haiku",
+  "tasks": 10,
+  "passed": 10,
+  "failed": 0,
+  "check_failures": 0,
+  "test_failures": 0,
+  "msr": 1.0000,
+  "results": [{"name":"m01-traffic-light-add-variant","passed":true,"tests_passed":12,"v1_tests":8,"v2_tests":4},{"name":"m02-todo-app-add-field","passed":true,"tests_passed":16,"v1_tests":10,"v2_tests":6},{"name":"m03-expression-eval-add-variant","passed":true,"tests_passed":17,"v1_tests":12,"v2_tests":5},{"name":"m04-expression-eval-return-type","passed":true,"tests_passed":17,"v1_tests":12,"v2_tests":5},{"name":"m05-todo-app-add-error-handling","passed":true,"tests_passed":16,"v1_tests":10,"v2_tests":6},{"name":"m06-config-merger-add-function","passed":true,"tests_passed":27,"v1_tests":21,"v2_tests":6},{"name":"m07-grade-report-add-function","passed":true,"tests_passed":35,"v1_tests":30,"v2_tests":5},{"name":"m08-bob-behavioral-change","passed":true,"tests_passed":30,"v1_tests":25,"v2_tests":5},{"name":"m09-expression-eval-compound","passed":true,"tests_passed":21,"v1_tests":12,"v2_tests":9},{"name":"m10-traffic-light-compound","passed":true,"tests_passed":13,"v1_tests":8,"v2_tests":5}]
+}

--- a/research/benchmark/msr/modifications/verify/m01.almd
+++ b/research/benchmark/msr/modifications/verify/m01.almd
@@ -1,0 +1,26 @@
+type Light = | Red | Yellow | Green | FlashingRed
+
+fn next(l: Light) -> Light =
+  match l { Red => Green, Green => Yellow, Yellow => Red, FlashingRed => Red }
+
+fn duration(l: Light) -> Int =
+  match l { Red => 60, Yellow => 5, Green => 45, FlashingRed => 2 }
+
+fn describe(l: Light) -> String =
+  match l { Red => "stop", Yellow => "caution", Green => "go", FlashingRed => "caution" }
+
+// ALL v1 tests unchanged
+test "next red" { assert_eq(next(Red), Green) }
+test "next green" { assert_eq(next(Green), Yellow) }
+test "next yellow" { assert_eq(next(Yellow), Red) }
+test "full cycle" { assert_eq(next(next(next(Red))), Red) }
+test "duration red" { assert_eq(duration(Red), 60) }
+test "duration yellow" { assert_eq(duration(Yellow), 5) }
+test "duration green" { assert_eq(duration(Green), 45) }
+test "describe" { assert_eq(describe(Red), "stop") }
+
+// V2 tests
+test "next flashing red" { assert_eq(next(FlashingRed), Red) }
+test "duration flashing red" { assert_eq(duration(FlashingRed), 2) }
+test "describe flashing red" { assert_eq(describe(FlashingRed), "caution") }
+test "cycle from flashing red" { assert_eq(next(next(FlashingRed)), Green) }

--- a/research/benchmark/msr/modifications/verify/m02.almd
+++ b/research/benchmark/msr/modifications/verify/m02.almd
@@ -1,0 +1,123 @@
+type Status = | Pending | Done | Cancelled
+
+type Todo = { id: Int, title: String, status: Status, priority: Int }
+
+fn create(id: Int, title: String, priority: Int) -> Todo =
+  Todo { id: id, title: title, status: Pending, priority: priority }
+
+fn complete(t: Todo) -> Todo = { ...t, status: Done }
+
+fn cancel(t: Todo) -> Todo = { ...t, status: Cancelled }
+
+fn is_done(t: Todo) -> Bool = match t.status { Done => true, _ => false }
+
+fn pending_count(todos: List[Todo]) -> Int =
+  todos |> list.filter((t) => match t.status { Pending => true, _ => false }) |> list.len
+
+fn titles(todos: List[Todo]) -> List[String] = list.map(todos, (t) => t.title)
+
+fn find_by_title(todos: List[Todo], title: String) -> Option[Todo] =
+  list.find(todos, (t) => t.title == title)
+
+fn status_label(s: Status) -> String =
+  match s { Pending => "pending", Done => "done", Cancelled => "cancelled" }
+
+fn summary(t: Todo) -> String = "[${status_label(t.status)}/p${int.to_string(t.priority)}] ${t.title}"
+
+fn high_priority(todos: List[Todo]) -> List[Todo] =
+  todos
+    |> list.filter((t) => t.priority >= 3)
+    |> list.sort_by((t) => 0 - t.priority)
+
+// V1 tests — all create() calls updated to include priority 1
+test "create todo" {
+  let t = create(1, "Buy milk", 1)
+  assert_eq(t.title, "Buy milk")
+  assert_eq(t.id, 1)
+}
+
+test "complete todo" {
+  let t = create(1, "Buy milk", 1) |> complete
+  assert_eq(is_done(t), true)
+}
+
+test "cancel todo" {
+  let t = create(1, "Buy milk", 1) |> cancel
+  assert_eq(status_label(t.status), "cancelled")
+}
+
+test "pending count" {
+  let todos = [create(1, "A", 1), create(2, "B", 1) |> complete, create(3, "C", 1)]
+  assert_eq(pending_count(todos), 2)
+}
+
+test "titles" {
+  let todos = [create(1, "A", 1), create(2, "B", 1), create(3, "C", 1)]
+  assert_eq(titles(todos), ["A", "B", "C"])
+}
+
+test "find by title found" {
+  let todos = [create(1, "Buy milk", 1), create(2, "Walk dog", 1)]
+  match find_by_title(todos, "Walk dog") {
+    some(t) => assert_eq(t.id, 2)
+    none => assert(false)
+  }
+}
+
+test "find by title not found" {
+  let todos = [create(1, "Buy milk", 1)]
+  assert_eq(find_by_title(todos, "nope"), none)
+}
+
+test "summary" {
+  assert_eq(summary(create(1, "Buy milk", 1)), "[pending/p1] Buy milk")
+  assert_eq(summary(create(1, "Done", 1) |> complete), "[done/p1] Done")
+}
+
+test "pipe chain: create filter map" {
+  let todos = [create(1, "A", 1), create(2, "B", 1) |> complete, create(3, "C", 1) |> cancel]
+  let pending_titles = todos
+    |> list.filter((t) => match t.status { Pending => true, _ => false })
+    |> list.map((t) => t.title)
+  assert_eq(pending_titles, ["A"])
+}
+
+test "multiple operations" {
+  var todos = [create(1, "A", 1), create(2, "B", 1), create(3, "C", 1)]
+  let updated = list.map(todos, (t) => if t.id == 2 then complete(t) else t)
+  assert_eq(pending_count(updated), 2)
+  assert(is_done(list.get_or(updated, 1, create(0, "", 1))))
+}
+
+// V2 tests
+test "create with priority" {
+  let t = create(1, "Buy milk", 3)
+  assert_eq(t.priority, 3)
+}
+
+test "high priority filter" {
+  let todos = [create(1, "A", 5), create(2, "B", 1), create(3, "C", 3)]
+  let hp = high_priority(todos)
+  assert_eq(list.len(hp), 2)
+  assert_eq(list.map(hp, (t) => t.title), ["A", "C"])
+}
+
+test "high priority empty" {
+  let todos = [create(1, "A", 1), create(2, "B", 2)]
+  assert_eq(high_priority(todos), [])
+}
+
+test "complete preserves priority" {
+  let t = create(1, "A", 5) |> complete
+  assert_eq(t.priority, 5)
+}
+
+test "cancel preserves priority" {
+  let t = create(1, "A", 3) |> cancel
+  assert_eq(t.priority, 3)
+}
+
+test "summary with priority" {
+  assert_eq(summary(create(1, "Buy milk", 3)), "[pending/p3] Buy milk")
+  assert_eq(summary(create(1, "Done", 2) |> complete), "[done/p2] Done")
+}

--- a/research/benchmark/msr/modifications/verify/m03.almd
+++ b/research/benchmark/msr/modifications/verify/m03.almd
@@ -1,0 +1,59 @@
+type Expr =
+  | Lit(Int)
+  | Add(Expr, Expr)
+  | Mul(Expr, Expr)
+  | Sub(Expr, Expr)
+  | Div(Expr, Expr)
+
+fn eval(e: Expr) -> Int =
+  match e {
+    Lit(n) => n
+    Add(l, r) => eval(l) + eval(r)
+    Mul(l, r) => eval(l) * eval(r)
+    Sub(l, r) => eval(l) - eval(r)
+    Div(l, r) => eval(l) / eval(r)
+  }
+
+fn to_string(e: Expr) -> String =
+  match e {
+    Lit(n) => int.to_string(n)
+    Add(l, r) => "(${to_string(l)} + ${to_string(r)})"
+    Mul(l, r) => "(${to_string(l)} * ${to_string(r)})"
+    Sub(l, r) => "(${to_string(l)} - ${to_string(r)})"
+    Div(l, r) => "(${to_string(l)} / ${to_string(r)})"
+  }
+
+// ALL v1 tests unchanged
+test "literal" { assert_eq(eval(Lit(5)), 5) }
+test "add" { assert_eq(eval(Add(Lit(2), Lit(3))), 5) }
+test "mul" { assert_eq(eval(Mul(Lit(4), Lit(5))), 20) }
+test "sub" { assert_eq(eval(Sub(Lit(10), Lit(3))), 7) }
+test "nested add mul" { assert_eq(eval(Add(Lit(1), Mul(Lit(2), Lit(3)))), 7) }
+test "deep nesting" { assert_eq(eval(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))), 18) }
+test "to_string literal" { assert_eq(to_string(Lit(42)), "42") }
+test "to_string add" { assert_eq(to_string(Add(Lit(1), Lit(2))), "(1 + 2)") }
+test "to_string nested" { assert_eq(to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))), "((1 + 2) * 3)") }
+test "eval matches to_string" {
+  let e = Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))
+  assert_eq(eval(e), 15)
+}
+test "deeply nested eval" {
+  let e = Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))
+  assert_eq(eval(e), 8)
+}
+test "single negative via sub" {
+  assert_eq(eval(Sub(Lit(0), Lit(5))), -5)
+}
+
+// V2 tests
+test "eval div" { assert_eq(eval(Div(Lit(10), Lit(3))), 3) }
+test "eval div exact" { assert_eq(eval(Div(Lit(10), Lit(2))), 5) }
+test "to_string div" { assert_eq(to_string(Div(Lit(10), Lit(3))), "(10 / 3)") }
+test "nested with div" {
+  let e = Add(Lit(1), Div(Lit(10), Lit(3)))
+  assert_eq(eval(e), 4)
+}
+test "div in complex expr" {
+  let e = Mul(Div(Lit(20), Lit(4)), Sub(Lit(10), Lit(7)))
+  assert_eq(eval(e), 15)
+}

--- a/research/benchmark/msr/modifications/verify/m04.almd
+++ b/research/benchmark/msr/modifications/verify/m04.almd
@@ -1,0 +1,75 @@
+type Expr =
+  | Lit(Int)
+  | Add(Expr, Expr)
+  | Mul(Expr, Expr)
+  | Sub(Expr, Expr)
+  | Div(Expr, Expr)
+
+effect fn eval(e: Expr) -> Result[Int, String] =
+  match e {
+    Lit(n) => ok(n)
+    Add(l, r) => {
+      let lv = eval(l)!
+      let rv = eval(r)!
+      ok(lv + rv)
+    }
+    Mul(l, r) => {
+      let lv = eval(l)!
+      let rv = eval(r)!
+      ok(lv * rv)
+    }
+    Sub(l, r) => {
+      let lv = eval(l)!
+      let rv = eval(r)!
+      ok(lv - rv)
+    }
+    Div(l, r) => {
+      let lv = eval(l)!
+      let rv = eval(r)!
+      if rv == 0 then err("division by zero") else ok(lv / rv)
+    }
+  }
+
+fn to_string(e: Expr) -> String =
+  match e {
+    Lit(n) => int.to_string(n)
+    Add(l, r) => "(${to_string(l)} + ${to_string(r)})"
+    Mul(l, r) => "(${to_string(l)} * ${to_string(r)})"
+    Sub(l, r) => "(${to_string(l)} - ${to_string(r)})"
+    Div(l, r) => "(${to_string(l)} / ${to_string(r)})"
+  }
+
+// V1 tests updated: eval now returns Result
+test "literal" { assert_eq(eval(Lit(5)), ok(5)) }
+test "add" { assert_eq(eval(Add(Lit(2), Lit(3))), ok(5)) }
+test "mul" { assert_eq(eval(Mul(Lit(4), Lit(5))), ok(20)) }
+test "sub" { assert_eq(eval(Sub(Lit(10), Lit(3))), ok(7)) }
+test "nested add mul" { assert_eq(eval(Add(Lit(1), Mul(Lit(2), Lit(3)))), ok(7)) }
+test "deep nesting" { assert_eq(eval(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))), ok(18)) }
+test "to_string literal" { assert_eq(to_string(Lit(42)), "42") }
+test "to_string add" { assert_eq(to_string(Add(Lit(1), Lit(2))), "(1 + 2)") }
+test "to_string nested" { assert_eq(to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))), "((1 + 2) * 3)") }
+test "eval matches to_string" {
+  let e = Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))
+  assert_eq(eval(e), ok(15))
+}
+test "deeply nested eval" {
+  let e = Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))
+  assert_eq(eval(e), ok(8))
+}
+test "single negative via sub" {
+  assert_eq(eval(Sub(Lit(0), Lit(5))), ok(-5))
+}
+
+// V2 tests
+test "eval div" { assert_eq(eval(Div(Lit(10), Lit(3))), ok(3)) }
+test "eval div by zero" { assert_eq(eval(Div(Lit(5), Lit(0))), err("division by zero")) }
+test "to_string div" { assert_eq(to_string(Div(Lit(10), Lit(3))), "(10 / 3)") }
+test "nested div" {
+  let e = Add(Lit(1), Div(Lit(10), Lit(2)))
+  assert_eq(eval(e), ok(6))
+}
+test "div by zero propagates" {
+  let e = Add(Lit(1), Div(Lit(5), Lit(0)))
+  assert_eq(eval(e), err("division by zero"))
+}

--- a/research/benchmark/msr/modifications/verify/m05.almd
+++ b/research/benchmark/msr/modifications/verify/m05.almd
@@ -1,0 +1,126 @@
+type Status = | Pending | Done | Cancelled
+
+type Todo = { id: Int, title: String, status: Status }
+
+fn create(id: Int, title: String) -> Todo =
+  Todo { id: id, title: title, status: Pending }
+
+fn complete(t: Todo) -> Result[Todo, String] =
+  match t.status {
+    Done => err("already done"),
+    Cancelled => err("cannot complete cancelled"),
+    Pending => ok({ ...t, status: Done }),
+  }
+
+fn cancel(t: Todo) -> Result[Todo, String] =
+  match t.status {
+    Cancelled => err("already cancelled"),
+    Done => err("cannot cancel done"),
+    Pending => ok({ ...t, status: Cancelled }),
+  }
+
+fn is_done(t: Todo) -> Bool = match t.status { Done => true, _ => false }
+
+fn pending_count(todos: List[Todo]) -> Int =
+  todos |> list.filter((t) => match t.status { Pending => true, _ => false }) |> list.len
+
+fn titles(todos: List[Todo]) -> List[String] = list.map(todos, (t) => t.title)
+
+fn find_by_title(todos: List[Todo], title: String) -> Option[Todo] =
+  list.find(todos, (t) => t.title == title)
+
+fn status_label(s: Status) -> String =
+  match s { Pending => "pending", Done => "done", Cancelled => "cancelled" }
+
+fn summary(t: Todo) -> String = "[${status_label(t.status)}] ${t.title}"
+
+// V1 tests — updated for Result return type
+test "create todo" {
+  let t = create(1, "Buy milk")
+  assert_eq(t.title, "Buy milk")
+  assert_eq(t.id, 1)
+}
+
+test "complete todo" {
+  assert_eq(complete(create(1, "Buy milk")), ok(Todo { id: 1, title: "Buy milk", status: Done }))
+}
+
+test "cancel todo" {
+  assert_eq(cancel(create(1, "Buy milk")), ok(Todo { id: 1, title: "Buy milk", status: Cancelled }))
+}
+
+test "pending count" {
+  let todos = [create(1, "A"), Todo { id: 2, title: "B", status: Done }, create(3, "C")]
+  assert_eq(pending_count(todos), 2)
+}
+
+test "titles" {
+  let todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+  assert_eq(titles(todos), ["A", "B", "C"])
+}
+
+test "find by title found" {
+  let todos = [create(1, "Buy milk"), create(2, "Walk dog")]
+  match find_by_title(todos, "Walk dog") {
+    some(t) => assert_eq(t.id, 2)
+    none => assert(false)
+  }
+}
+
+test "find by title not found" {
+  let todos = [create(1, "Buy milk")]
+  assert_eq(find_by_title(todos, "nope"), none)
+}
+
+test "summary" {
+  assert_eq(summary(create(1, "Buy milk")), "[pending] Buy milk")
+  assert_eq(summary(Todo { id: 1, title: "Done", status: Done }), "[done] Done")
+}
+
+test "pipe chain: create filter map" {
+  let todos = [create(1, "A"), Todo { id: 2, title: "B", status: Done }, Todo { id: 3, title: "C", status: Cancelled }]
+  let pending_titles = todos
+    |> list.filter((t) => match t.status { Pending => true, _ => false })
+    |> list.map((t) => t.title)
+  assert_eq(pending_titles, ["A"])
+}
+
+test "multiple operations" {
+  var todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+  let updated = list.map(todos, (t) => {
+    if t.id == 2 then {
+      match complete(t) { ok(done) => done, err(_) => t }
+    } else t
+  })
+  assert_eq(pending_count(updated), 2)
+  assert(is_done(list.get_or(updated, 1, create(0, ""))))
+}
+
+// V2 tests
+test "complete pending succeeds" {
+  assert_eq(complete(create(1, "A")), ok(Todo { id: 1, title: "A", status: Done }))
+}
+
+test "complete already done" {
+  let t = Todo { id: 1, title: "A", status: Done }
+  assert_eq(complete(t), err("already done"))
+}
+
+test "complete cancelled" {
+  let t = Todo { id: 1, title: "A", status: Cancelled }
+  assert_eq(complete(t), err("cannot complete cancelled"))
+}
+
+test "cancel pending succeeds" {
+  assert_eq(cancel(create(1, "A")), ok(Todo { id: 1, title: "A", status: Cancelled }))
+}
+
+test "cancel already cancelled" {
+  let t = Todo { id: 1, title: "A", status: Cancelled }
+  assert_eq(cancel(t), err("already cancelled"))
+}
+
+test "cancel done" {
+  let t = Todo { id: 1, title: "A", status: Done }
+  assert_eq(cancel(t), err("cannot cancel done"))
+}

--- a/research/benchmark/msr/modifications/verify/m06.almd
+++ b/research/benchmark/msr/modifications/verify/m06.almd
@@ -1,0 +1,286 @@
+import env
+import fs
+import string
+import list
+
+fn parse_config(content: String) -> Result[List[List[String]], String] = {
+  if string.len(content) == 0 then ok([])
+  else {
+    let lines = string.split(content, "\n");
+    let indexed = list.fold(lines, [], (acc, line) => {
+      let idx = list.len(acc) + 1;
+      acc + [[int.to_string(idx), line]]
+    });
+    list.fold(indexed, ok([]), (acc, entry) => {
+      match acc {
+        err(e) => err(e),
+        ok(pairs) => {
+          let line_num = match list.get(entry, 0) { some(v) => v, none => "0" };
+          let line = match list.get(entry, 1) { some(v) => v, none => "" };
+          let trimmed = string.trim(line);
+          if trimmed == "" then ok(pairs)
+          else if string.starts_with(trimmed, "#") then ok(pairs)
+          else if string.contains(trimmed, "=") then {
+            let parts = string.split(trimmed, "=");
+            let key = match list.get(parts, 0) { some(v) => v, none => "" };
+            if key == "" then err("line ${line_num}: empty key")
+            else {
+              let indexed_parts = list.fold(parts, [], (a, p) => a + [[int.to_string(list.len(a)), p]]);
+              let rest = list.filter(indexed_parts, (ip) => {
+                match list.get(ip, 0) { some(v) => v != "0", none => false }
+              });
+              let rest_vals = list.map(rest, (ip) => match list.get(ip, 1) { some(v) => v, none => "" });
+              let value = string.join(rest_vals, "=");
+              let existing_keys = list.map(pairs, (p) => match list.get(p, 0) { some(v) => v, none => "" });
+              if list.contains(existing_keys, key) then err("line ${line_num}: duplicate key: ${key}")
+              else ok(pairs + [[key, value]])
+            }
+          }
+          else err("line ${line_num}: missing '='")
+        }
+      }
+    })
+  }
+}
+
+fn merge_configs(base: List[List[String]], overlay: List[List[String]]) -> List[List[String]] = {
+  let overlay_keys = list.map(overlay, (p) => match list.get(p, 0) { some(v) => v, none => "" });
+  let overlay_for_find = overlay;
+  let merged_base = list.map(base, (pair) => {
+    let key = match list.get(pair, 0) { some(v) => v, none => "" };
+    if list.contains(overlay_keys, key) then {
+      match list.find(overlay_for_find, (op) => match list.get(op, 0) { some(v) => v == key, none => false }) {
+        some(found) => found,
+        none => pair
+      }
+    } else pair
+  });
+  let base_keys = list.map(base, (p) => match list.get(p, 0) { some(v) => v, none => "" });
+  let new_overlay = list.filter(overlay, (p) => {
+    let key = match list.get(p, 0) { some(v) => v, none => "" };
+    not list.contains(base_keys, key)
+  });
+  merged_base + new_overlay
+}
+
+fn serialize_config(pairs: List[List[String]]) -> String = {
+  let lines = list.map(pairs, (pair) => {
+    let key = match list.get(pair, 0) { some(v) => v, none => "" };
+    let value = match list.get(pair, 1) { some(v) => v, none => "" };
+    key + "=" + value
+  });
+  string.join(lines, "\n")
+}
+
+effect fn load_config(path: String) -> Result[List[List[String]], String] = {
+  let text = fs.read_text(path)!
+  match parse_config(text) {
+    ok(pairs) => ok(pairs),
+    err(e) => err("${path}: ${e}")
+  }
+}
+
+effect fn save_config(path: String, pairs: List[List[String]]) -> Result[Unit, String] = {
+  let content = serialize_config(pairs);
+  fs.write(path, content);
+  ok(())
+}
+
+effect fn merge_files(paths: List[String]) -> Result[List[List[String]], String] = {
+  var result = []
+  var i = 0
+  while i < list.len(paths) {
+    let path = match list.get(paths, i) { some(p) => p, none => "" }
+    let overlay = load_config(path)!
+    result = merge_configs(result, overlay)
+    i = i + 1
+  }
+  ok(result)
+}
+
+effect fn merge_and_save(paths: List[String], output: String) -> Result[Int, String] = {
+  match merge_files(paths) {
+    err(e) => err(e),
+    ok(pairs) => {
+      save_config(output, pairs)!;
+      ok(list.len(pairs))
+    }
+  }
+}
+
+fn lookup(pairs: List[List[String]], key: String) -> Option[String] = {
+  match list.find(pairs, (pair) => match list.get(pair, 0) { some(v) => v == key, none => false }) {
+    some(pair) => match list.get(pair, 1) { some(v) => some(v), none => none },
+    none => none
+  }
+}
+
+fn filter_by_prefix(pairs: List[List[String]], prefix: String) -> List[List[String]] = {
+  list.filter(pairs, (pair) => {
+    let key = match list.get(pair, 0) { some(v) => v, none => "" };
+    string.starts_with(key, prefix)
+  })
+}
+
+fn validate_keys(pairs: List[List[String]], required: List[String]) -> Result[Unit, String] = {
+  list.fold(required, ok(()), (acc, key) => {
+    match acc {
+      err(e) => err(e),
+      ok(_) => {
+        let keys = list.map(pairs, (p) => match list.get(p, 0) { some(v) => v, none => "" })
+        if list.contains(keys, key) then ok(())
+        else err("missing required key: " + key)
+      }
+    }
+  })
+}
+
+effect fn load_and_validate(path: String, required: List[String]) -> Result[List[List[String]], String] = {
+  let pairs = load_config(path)!
+  match validate_keys(pairs, required) {
+    err(e) => err(e),
+    ok(_) => ok(pairs)
+  }
+}
+
+test "parse basic config" {
+  let content = "host=localhost\nport=8080"
+  assert_eq(parse_config(content), ok([["host", "localhost"], ["port", "8080"]]))
+}
+
+test "parse with comments and blanks" {
+  let content = "# this is a comment\n\nhost=localhost\n# another comment\nport=8080"
+  assert_eq(parse_config(content), ok([["host", "localhost"], ["port", "8080"]]))
+}
+
+test "parse empty string" {
+  assert_eq(parse_config(""), ok([]))
+}
+
+test "parse only comments" {
+  assert_eq(parse_config("# comment\n# another"), ok([]))
+}
+
+test "parse missing equals" {
+  assert_eq(parse_config("host=ok\nbadline"), err("line 2: missing '='"))
+}
+
+test "parse empty key" {
+  assert_eq(parse_config("=value"), err("line 1: empty key"))
+}
+
+test "parse duplicate key" {
+  assert_eq(parse_config("host=a\nhost=b"), err("line 2: duplicate key: host"))
+}
+
+test "parse value with equals" {
+  let content = "formula=a=b+c"
+  assert_eq(parse_config(content), ok([["formula", "a=b+c"]]))
+}
+
+test "merge no overlap" {
+  let base = [["host", "localhost"]]
+  let overlay = [["port", "8080"]]
+  assert_eq(merge_configs(base, overlay), [["host", "localhost"], ["port", "8080"]])
+}
+
+test "merge with override" {
+  let base = [["host", "localhost"], ["port", "3000"]]
+  let overlay = [["port", "8080"]]
+  assert_eq(merge_configs(base, overlay), [["host", "localhost"], ["port", "8080"]])
+}
+
+test "merge empty base" {
+  let overlay = [["port", "8080"]]
+  assert_eq(merge_configs([], overlay), [["port", "8080"]])
+}
+
+test "merge empty overlay" {
+  let base = [["host", "localhost"]]
+  assert_eq(merge_configs(base, []), [["host", "localhost"]])
+}
+
+test "serialize config" {
+  let pairs = [["host", "localhost"], ["port", "8080"]]
+  assert_eq(serialize_config(pairs), "host=localhost\nport=8080")
+}
+
+test "serialize empty" {
+  assert_eq(serialize_config([]), "")
+}
+
+test "lookup found" {
+  let pairs = [["host", "localhost"], ["port", "8080"]]
+  assert_eq(lookup(pairs, "port"), some("8080"))
+}
+
+test "lookup not found" {
+  let pairs = [["host", "localhost"]]
+  assert_eq(lookup(pairs, "port"), none)
+}
+
+test "filter by prefix" {
+  let pairs = [["db_host", "localhost"], ["db_port", "5432"], ["app_port", "8080"]]
+  assert_eq(filter_by_prefix(pairs, "db_"), [["db_host", "localhost"], ["db_port", "5432"]])
+}
+
+test "filter by prefix no match" {
+  let pairs = [["app_port", "8080"]]
+  assert_eq(filter_by_prefix(pairs, "db_"), [])
+}
+
+test "load and parse config file" {
+  let td = env.temp_dir()
+  let f = td + "/almide_test_m06_base.conf"
+  fs.write(f, "host=localhost\nport=3000")
+  let result = load_config(f)
+  assert_eq(result, ok([["host", "localhost"], ["port", "3000"]]))
+}
+
+test "load config file not found" {
+  let td = env.temp_dir()
+  assert(match load_config(td + "/almide_test_m06_nonexistent.conf") { err(_e) => true, _ => false })
+}
+
+test "merge two files" {
+  let td = env.temp_dir()
+  let f1 = td + "/almide_test_m06_f1.conf"
+  let f2 = td + "/almide_test_m06_f2.conf"
+  fs.write(f1, "host=localhost\nport=3000")
+  fs.write(f2, "port=8080\ndebug=true")
+  let result = merge_files([f1, f2])
+  assert_eq(result, ok([["host", "localhost"], ["port", "8080"], ["debug", "true"]]))
+}
+
+test "validate keys all present" {
+  let pairs = [["host", "localhost"], ["port", "8080"]]
+  assert_eq(validate_keys(pairs, ["host", "port"]), ok(()))
+}
+
+test "validate keys missing" {
+  let pairs = [["host", "localhost"]]
+  assert_eq(validate_keys(pairs, ["host", "port"]), err("missing required key: port"))
+}
+
+test "validate keys empty required" {
+  assert_eq(validate_keys([["a", "b"]], []), ok(()))
+}
+
+test "validate keys first missing reported" {
+  let pairs = [["host", "localhost"]]
+  assert_eq(validate_keys(pairs, ["port", "debug"]), err("missing required key: port"))
+}
+
+test "load and validate success" {
+  let td = env.temp_dir()
+  let f = td + "/almide_test_m06_valid.conf"
+  fs.write(f, "host=localhost\nport=8080")
+  assert_eq(load_and_validate(f, ["host"]), ok([["host", "localhost"], ["port", "8080"]]))
+}
+
+test "load and validate missing key" {
+  let td = env.temp_dir()
+  let f = td + "/almide_test_m06_partial.conf"
+  fs.write(f, "host=localhost")
+  assert_eq(load_and_validate(f, ["host", "port"]), err("missing required key: port"))
+}

--- a/research/benchmark/msr/modifications/verify/m07.almd
+++ b/research/benchmark/msr/modifications/verify/m07.almd
@@ -1,0 +1,418 @@
+// ========== V1 SOLUTION (working code — all tests pass) ==========
+
+fn str_to_int(s: String) -> Result[Int, String] = {
+  let bytes = string.to_bytes(s)
+  let len = list.len(bytes)
+  if len == 0 then err("invalid integer")
+  else {
+    let first = match list.get(bytes, 0) {
+      some(v) => v,
+      none => 0,
+    }
+    let is_negative = first == 45
+    let start_index = if is_negative then 1 else 0
+    if is_negative and len == 1 then err("invalid integer")
+    else {
+      let digit_bytes = if is_negative then {
+        let indices = list.fold(bytes, [], (acc, _b) => acc + [list.len(acc)])
+        list.fold(indices, [], (acc, i) => {
+          if i >= start_index then {
+            match list.get(bytes, i) {
+              some(v) => acc + [v],
+              none => acc,
+            }
+          } else acc
+        })
+      } else bytes
+      if list.len(digit_bytes) == 0 then err("invalid integer")
+      else {
+        let result = list.fold(digit_bytes, ok(0), (acc, b) => {
+          match acc {
+            ok(n) => {
+              if b >= 48 and b <= 57 then ok(n * 10 + (b - 48))
+              else err("invalid integer")
+            },
+            err(e) => err(e),
+          }
+        })
+        match result {
+          ok(n) => if is_negative then ok(0 - n) else ok(n),
+          err(e) => err(e),
+        }
+      }
+    }
+  }
+}
+
+fn parse_student(line: String) -> Result[List[String], String] = {
+  let parts = string.split(line, ":")
+  let num_parts = list.len(parts)
+  if num_parts < 2 then err("invalid format")
+  else {
+    let name = match list.get(parts, 0) { some(v) => v, none => "" }
+    if string.len(name) == 0 then err("empty name")
+    else {
+      let scores_str = match list.get(parts, 1) { some(v) => v, none => "" }
+      if string.len(scores_str) == 0 then err("no scores")
+      else {
+        let score_strs = string.split(scores_str, ",")
+        let validation = list.fold(score_strs, ok([]), (acc, s) => {
+          match acc {
+            err(e) => err(e),
+            ok(validated) => {
+              match str_to_int(s) {
+                err(_e) => err("invalid score: " + s),
+                ok(n) => {
+                  if n < 0 or n > 100 then err("score out of range: " + s)
+                  else ok(validated + [s])
+                },
+              }
+            },
+          }
+        })
+        match validation {
+          err(e) => err(e),
+          ok(scores) => ok([name] + scores),
+        }
+      }
+    }
+  }
+}
+
+fn parse_all(input: String) -> Result[List[List[String]], String] = {
+  if string.len(input) == 0 then err("empty input")
+  else {
+    let lines = string.split(input, "\n")
+    let indexed_lines = list.fold(lines, [], (acc, line) => {
+      let idx = list.len(acc) + 1
+      acc + [[int.to_string(idx), line]]
+    })
+    list.fold(indexed_lines, ok([]), (acc, entry) => {
+      match acc {
+        err(e) => err(e),
+        ok(students) => {
+          let line_num = match list.get(entry, 0) { some(v) => v, none => "0" }
+          let line = match list.get(entry, 1) { some(v) => v, none => "" }
+          match parse_student(line) {
+            err(e) => err("line " + line_num + ": " + e),
+            ok(student) => {
+              let name = match list.get(student, 0) { some(v) => v, none => "" }
+              let names = list.map(students, (s) => {
+                match list.get(s, 0) { some(v) => v, none => "" }
+              })
+              if list.contains(names, name) then err("duplicate name: " + name)
+              else ok(students + [student])
+            },
+          }
+        },
+      }
+    })
+  }
+}
+
+fn average(student: List[String]) -> Result[Int, String] = {
+  let len = list.len(student)
+  if len <= 1 then err("no scores")
+  else {
+    let indices = list.fold(student, [], (acc, _s) => acc + [list.len(acc)])
+    let score_indices = list.filter(indices, (i) => i >= 1)
+    let sum_result = list.fold(score_indices, ok(0), (acc, i) => {
+      match acc {
+        err(e) => err(e),
+        ok(total) => {
+          match list.get(student, i) {
+            none => err("missing score"),
+            some(s) => {
+              match str_to_int(s) {
+                err(e) => err(e),
+                ok(n) => ok(total + n),
+              }
+            },
+          }
+        },
+      }
+    })
+    let num_scores = len - 1
+    match sum_result {
+      err(e) => err(e),
+      ok(total) => ok(total / num_scores),
+    }
+  }
+}
+
+fn letter_grade(avg: Int) -> String = {
+  if avg >= 90 then "A"
+  else if avg >= 80 then "B"
+  else if avg >= 70 then "C"
+  else if avg >= 60 then "D"
+  else "F"
+}
+
+fn honor_roll(students: List[List[String]]) -> Result[List[String], String] = {
+  let result = list.fold(students, ok([]), (acc, student) => {
+    match acc {
+      err(e) => err(e),
+      ok(names) => {
+        match average(student) {
+          err(e) => err(e),
+          ok(avg) => {
+            if avg >= 85 then {
+              let name = match list.get(student, 0) { some(v) => v, none => "" }
+              ok(names + [name])
+            } else ok(names)
+          },
+        }
+      },
+    }
+  })
+  match result {
+    err(e) => err(e),
+    ok(names) => ok(list.sort(names)),
+  }
+}
+
+fn class_average(students: List[List[String]]) -> Result[Int, String] = {
+  let num_students = list.len(students)
+  if num_students == 0 then err("no students")
+  else {
+    let sum_result = list.fold(students, ok(0), (acc, student) => {
+      match acc {
+        err(e) => err(e),
+        ok(total) => {
+          match average(student) {
+            err(e) => err(e),
+            ok(avg) => ok(total + avg),
+          }
+        },
+      }
+    })
+    match sum_result {
+      err(e) => err(e),
+      ok(total) => ok(total / num_students),
+    }
+  }
+}
+
+fn format_student(student: List[String]) -> Result[String, String] = {
+  let name = match list.get(student, 0) { some(v) => v, none => "" }
+  match average(student) {
+    err(e) => err(e),
+    ok(avg) => {
+      let grade = letter_grade(avg)
+      ok(name + ": " + int.to_string(avg) + " (" + grade + ")")
+    },
+  }
+}
+
+fn generate_report(input: String) -> Result[String, String] = {
+  match parse_all(input) {
+    err(e) => err(e),
+    ok(students) => {
+      let formatted_result = list.fold(students, ok([]), (acc, student) => {
+        match acc {
+          err(e) => err(e),
+          ok(lines) => {
+            match format_student(student) {
+              err(e) => err(e),
+              ok(line) => ok(lines + [line]),
+            }
+          },
+        }
+      })
+      match formatted_result {
+        err(e) => err(e),
+        ok(lines) => {
+          match class_average(students) {
+            err(e) => err(e),
+            ok(cavg) => {
+              match honor_roll(students) {
+                err(e) => err(e),
+                ok(honors) => {
+                  let student_lines = string.join(lines, "\n")
+                  let class_line = "class average: " + int.to_string(cavg)
+                  let honor_line = "honor roll: " + string.join(honors, ", ")
+                  ok(student_lines + "\n" + class_line + "\n" + honor_line)
+                },
+              }
+            },
+          }
+        },
+      }
+    },
+  }
+}
+
+fn pad3(n: Int) -> String = {
+  let s = int.to_string(n)
+  if n < 10 then "00" + s
+  else if n < 100 then "0" + s
+  else s
+}
+
+fn top_students(input: String, n: Int) -> Result[List[String], String] = {
+  match parse_all(input) {
+    err(e) => err(e),
+    ok(students) => {
+      let pairs_result = list.fold(students, ok([]), (acc, student) => {
+        match acc {
+          err(e) => err(e),
+          ok(pairs) => {
+            match average(student) {
+              err(e) => err(e),
+              ok(avg) => {
+                let name = match list.get(student, 0) { some(v) => v, none => "" }
+                // Higher avg => smaller inverted key => sorts first
+                // Name appended for alphabetical tie-breaking
+                let sort_key = pad3(100 - avg) + ":" + name
+                ok(pairs + [[sort_key, name]])
+              }
+            }
+          }
+        }
+      })
+      match pairs_result {
+        err(e) => err(e),
+        ok(pairs) => {
+          let sorted = list.sort(pairs)
+          let taken = list.take(sorted, n)
+          ok(list.map(taken, (p) => match list.get(p, 1) { some(v) => v, none => "" }))
+        }
+      }
+    }
+  }
+}
+
+// ========== V1 TESTS ==========
+
+test "parse single student" {
+  assert_eq(parse_student("Alice:85,92,78"), ok(["Alice", "85", "92", "78"]))
+}
+
+test "parse student with single score" {
+  assert_eq(parse_student("Bob:100"), ok(["Bob", "100"]))
+}
+
+test "parse student empty name" {
+  assert_eq(parse_student(":85,92"), err("empty name"))
+}
+
+test "parse student invalid score" {
+  assert_eq(parse_student("Alice:85,abc,78"), err("invalid score: abc"))
+}
+
+test "parse student score too high" {
+  assert_eq(parse_student("Alice:85,101,78"), err("score out of range: 101"))
+}
+
+test "parse student score negative" {
+  assert_eq(parse_student("Alice:85,-1,78"), err("score out of range: -1"))
+}
+
+test "parse student no scores" {
+  assert_eq(parse_student("Alice:"), err("no scores"))
+}
+
+test "parse student no colon" {
+  assert_eq(parse_student("Alice"), err("invalid format"))
+}
+
+test "parse all basic" {
+  let result = parse_all("Alice:85,92\nBob:70,80")
+  assert_eq(result, ok([["Alice", "85", "92"], ["Bob", "70", "80"]]))
+}
+
+test "parse all empty input" {
+  assert_eq(parse_all(""), err("empty input"))
+}
+
+test "parse all duplicate names" {
+  assert_eq(parse_all("Alice:85\nAlice:90"), err("duplicate name: Alice"))
+}
+
+test "parse all error with line number" {
+  assert_eq(parse_all("Alice:85\n:90"), err("line 2: empty name"))
+}
+
+test "average basic" {
+  assert_eq(average(["Alice", "80", "90", "100"]), ok(90))
+}
+
+test "average single score" {
+  assert_eq(average(["Bob", "75"]), ok(75))
+}
+
+test "average rounds down" {
+  assert_eq(average(["Carol", "80", "81"]), ok(80))
+}
+
+test "letter grade A" { assert_eq(letter_grade(95), "A") }
+test "letter grade B" { assert_eq(letter_grade(85), "B") }
+test "letter grade C" { assert_eq(letter_grade(75), "C") }
+test "letter grade D" { assert_eq(letter_grade(65), "D") }
+test "letter grade F" { assert_eq(letter_grade(55), "F") }
+test "letter grade boundary 90" { assert_eq(letter_grade(90), "A") }
+test "letter grade boundary 80" { assert_eq(letter_grade(80), "B") }
+
+test "honor roll basic" {
+  let students = [["Alice", "90", "95"], ["Bob", "70", "80"], ["Carol", "85", "90"]]
+  assert_eq(honor_roll(students), ok(["Alice", "Carol"]))
+}
+
+test "honor roll none qualify" {
+  let students = [["Alice", "70", "75"], ["Bob", "60", "65"]]
+  assert_eq(honor_roll(students), ok([]))
+}
+
+test "honor roll sorted" {
+  let students = [["Zara", "90", "95"], ["Alice", "85", "90"]]
+  assert_eq(honor_roll(students), ok(["Alice", "Zara"]))
+}
+
+test "class average basic" {
+  let students = [["Alice", "80", "90"], ["Bob", "70", "80"]]
+  assert_eq(class_average(students), ok(80))
+}
+
+test "format student" {
+  assert_eq(format_student(["Alice", "85", "92", "78"]), ok("Alice: 85 (B)"))
+}
+
+test "generate report" {
+  let input = "Alice:90,95,100\nBob:70,75,80"
+  let expected = "Alice: 95 (A)\nBob: 75 (C)\nclass average: 85\nhonor roll: Alice"
+  assert_eq(generate_report(input), ok(expected))
+}
+
+test "generate report error propagation" {
+  assert_eq(generate_report("Alice:90\n:bad"), err("line 2: empty name"))
+}
+
+test "generate report empty" {
+  assert_eq(generate_report(""), err("empty input"))
+}
+
+// ========== V2 TESTS ==========
+
+test "top students basic" {
+  let input = "Alice:90,95\nBob:70,80\nCarol:85,88"
+  assert_eq(top_students(input, 2), ok(["Alice", "Carol"]))
+}
+
+test "top students tie breaking" {
+  let input = "Bob:85,85\nAlice:85,85"
+  assert_eq(top_students(input, 2), ok(["Alice", "Bob"]))
+}
+
+test "top students n exceeds count" {
+  let input = "Alice:90,95"
+  assert_eq(top_students(input, 5), ok(["Alice"]))
+}
+
+test "top students error propagation" {
+  assert_eq(top_students("", 3), err("empty input"))
+}
+
+test "top students single" {
+  let input = "Alice:90,95\nBob:70,80\nCarol:85,88"
+  assert_eq(top_students(input, 1), ok(["Alice"]))
+}

--- a/research/benchmark/msr/modifications/verify/m08.almd
+++ b/research/benchmark/msr/modifications/verify/m08.almd
@@ -1,0 +1,49 @@
+fn respond(input: String) -> String = {
+  let trimmed = string.trim(input)
+  let is_silence = string.len(trimmed) == 0
+  let is_question = string.ends_with(trimmed, "?")
+  let has_letters = list.any(string.chars(trimmed), (c) => string.is_alpha(c))
+  let is_yelling = has_letters and string.to_upper(trimmed) == trimmed
+  let is_whispering = has_letters and string.to_lower(trimmed) == trimmed
+  if is_silence then "Fine. Be that way!"
+  else if is_yelling and is_question then "Calm down, I know what I'm doing!"
+  else if is_yelling then "Whoa, chill out!"
+  else if is_whispering and is_question then "Are you whispering? Speak up!"
+  else if is_whispering then "Could you speak up? I can't hear you."
+  else if is_question then "Sure."
+  else "Whatever."
+}
+
+// V1 tests — two tests updated for whispering behavior
+test "stating something" { assert_eq(respond("Tom-ay-to, tom-ah-to."), "Whatever.") }
+test "shouting" { assert_eq(respond("WATCH OUT!"), "Whoa, chill out!") }
+test "shouting gibberish" { assert_eq(respond("FCECGC"), "Whoa, chill out!") }
+test "asking a question" { assert_eq(respond("Does this celi level have a caused caused caused effect?"), "Sure.") }
+test "asking a numeric question" { assert_eq(respond("You are, what, like 15?"), "Sure.") }
+test "asking gibberish" { assert_eq(respond("fffbbcbeab?"), "Are you whispering? Speak up!") }
+test "talking forcefully" { assert_eq(respond("Hi there!"), "Whatever.") }
+test "using acronyms in regular speech" { assert_eq(respond("It's OK if you don't want to go work for NASA."), "Whatever.") }
+test "forceful question" { assert_eq(respond("WHAT IS YOUR PROBLEM?"), "Calm down, I know what I'm doing!") }
+test "shouting numbers" { assert_eq(respond("1, 2, 3 GO!"), "Whoa, chill out!") }
+test "no letters" { assert_eq(respond("1, 2, 3"), "Whatever.") }
+test "question with no letters" { assert_eq(respond("4?"), "Sure.") }
+test "shouting with special characters" { assert_eq(respond("ZOMG THE %#@* ALARM IS GOING OFF!"), "Whoa, chill out!") }
+test "shouting with no exclamation mark" { assert_eq(respond("I HATE THE ALARM"), "Whoa, chill out!") }
+test "statement containing question mark" { assert_eq(respond("Ending with ? hmm"), "Whatever.") }
+test "non-letters with question" { assert_eq(respond(":) ?"), "Sure.") }
+test "prattling on" { assert_eq(respond("Wait! Hang on. Are you going to be OK?"), "Sure.") }
+test "silence" { assert_eq(respond(""), "Fine. Be that way!") }
+test "prolonged silence" { assert_eq(respond("          "), "Fine. Be that way!") }
+test "alternate silence" { assert_eq(respond("\t\t\t\t\t\t\t\t\t\t"), "Fine. Be that way!") }
+test "multiple line question" { assert_eq(respond("\nDoes this celi level have a caused caused caused effect?"), "Sure.") }
+test "starting with whitespace" { assert_eq(respond("         hmmmmm"), "Could you speak up? I can't hear you.") }
+test "ending with whitespace" { assert_eq(respond("Okay if like my  spacebar  quite a bit?   "), "Sure.") }
+test "other whitespace" { assert_eq(respond("\n\r \t"), "Fine. Be that way!") }
+test "non-question ending with whitespace" { assert_eq(respond("This is a statement ending with whitespace      "), "Whatever.") }
+
+// V2 tests
+test "whispering" { assert_eq(respond("hello there"), "Could you speak up? I can't hear you.") }
+test "whispering question" { assert_eq(respond("do you hear me?"), "Are you whispering? Speak up!") }
+test "whispering with numbers" { assert_eq(respond("hello 123"), "Could you speak up? I can't hear you.") }
+test "not whispering mixed case" { assert_eq(respond("Hello there"), "Whatever.") }
+test "whispering question with spaces" { assert_eq(respond("  can you hear me?  "), "Are you whispering? Speak up!") }

--- a/research/benchmark/msr/modifications/verify/m09.almd
+++ b/research/benchmark/msr/modifications/verify/m09.almd
@@ -1,0 +1,70 @@
+type Expr =
+  | Lit(Int)
+  | Add(Expr, Expr)
+  | Mul(Expr, Expr)
+  | Sub(Expr, Expr)
+  | Neg(Expr)
+  | Pow(Expr, Expr)
+
+fn power(base: Int, exp: Int) -> Int =
+  if exp <= 0 then 1
+  else base * power(base, exp - 1)
+
+fn eval(e: Expr) -> Int =
+  match e {
+    Lit(n) => n
+    Add(l, r) => eval(l) + eval(r)
+    Mul(l, r) => eval(l) * eval(r)
+    Sub(l, r) => eval(l) - eval(r)
+    Neg(inner) => 0 - eval(inner)
+    Pow(b, exp) => power(eval(b), eval(exp))
+  }
+
+fn to_string(e: Expr) -> String =
+  match e {
+    Lit(n) => int.to_string(n)
+    Add(l, r) => "(${to_string(l)} + ${to_string(r)})"
+    Mul(l, r) => "(${to_string(l)} * ${to_string(r)})"
+    Sub(l, r) => "(${to_string(l)} - ${to_string(r)})"
+    Neg(inner) => "(-${to_string(inner)})"
+    Pow(b, exp) => "(${to_string(b)} ^ ${to_string(exp)})"
+  }
+
+// ALL v1 tests unchanged
+test "literal" { assert_eq(eval(Lit(5)), 5) }
+test "add" { assert_eq(eval(Add(Lit(2), Lit(3))), 5) }
+test "mul" { assert_eq(eval(Mul(Lit(4), Lit(5))), 20) }
+test "sub" { assert_eq(eval(Sub(Lit(10), Lit(3))), 7) }
+test "nested add mul" { assert_eq(eval(Add(Lit(1), Mul(Lit(2), Lit(3)))), 7) }
+test "deep nesting" { assert_eq(eval(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))), 18) }
+test "to_string literal" { assert_eq(to_string(Lit(42)), "42") }
+test "to_string add" { assert_eq(to_string(Add(Lit(1), Lit(2))), "(1 + 2)") }
+test "to_string nested" { assert_eq(to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))), "((1 + 2) * 3)") }
+test "eval matches to_string" {
+  let e = Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))
+  assert_eq(eval(e), 15)
+}
+test "deeply nested eval" {
+  let e = Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))
+  assert_eq(eval(e), 8)
+}
+test "single negative via sub" {
+  assert_eq(eval(Sub(Lit(0), Lit(5))), -5)
+}
+
+// V2 tests
+test "neg literal" { assert_eq(eval(Neg(Lit(5))), -5) }
+test "neg of neg" { assert_eq(eval(Neg(Neg(Lit(3)))), 3) }
+test "to_string neg" { assert_eq(to_string(Neg(Lit(5))), "(-5)") }
+test "pow basic" { assert_eq(eval(Pow(Lit(2), Lit(3))), 8) }
+test "pow zero" { assert_eq(eval(Pow(Lit(5), Lit(0))), 1) }
+test "pow one" { assert_eq(eval(Pow(Lit(7), Lit(1))), 7) }
+test "to_string pow" { assert_eq(to_string(Pow(Lit(2), Lit(3))), "(2 ^ 3)") }
+test "neg with pow" {
+  let e = Neg(Pow(Lit(2), Lit(3)))
+  assert_eq(eval(e), -8)
+}
+test "pow in expression" {
+  let e = Add(Pow(Lit(2), Lit(3)), Lit(2))
+  assert_eq(eval(e), 10)
+}

--- a/research/benchmark/msr/modifications/verify/m10.almd
+++ b/research/benchmark/msr/modifications/verify/m10.almd
@@ -1,0 +1,27 @@
+type Light = | Red | Yellow | Green | Broken
+
+fn next(l: Light) -> Light =
+  match l { Red => Green, Green => Yellow, Yellow => Red, Broken => Red }
+
+fn duration(l: Light) -> Result[Int, String] =
+  match l { Red => ok(60), Yellow => ok(5), Green => ok(45), Broken => err("broken light has no duration") }
+
+fn describe(l: Light) -> String =
+  match l { Red => "stop", Yellow => "caution", Green => "go", Broken => "out of order" }
+
+// V1 tests — duration tests updated to use ok()
+test "next red" { assert_eq(next(Red), Green) }
+test "next green" { assert_eq(next(Green), Yellow) }
+test "next yellow" { assert_eq(next(Yellow), Red) }
+test "full cycle" { assert_eq(next(next(next(Red))), Red) }
+test "duration red" { assert_eq(duration(Red), ok(60)) }
+test "duration yellow" { assert_eq(duration(Yellow), ok(5)) }
+test "duration green" { assert_eq(duration(Green), ok(45)) }
+test "describe" { assert_eq(describe(Red), "stop") }
+
+// V2 tests
+test "next broken" { assert_eq(next(Broken), Red) }
+test "describe broken" { assert_eq(describe(Broken), "out of order") }
+test "duration broken" { assert_eq(duration(Broken), err("broken light has no duration")) }
+test "cycle from broken" { assert_eq(next(next(Broken)), Green) }
+test "describe after broken" { assert_eq(describe(next(Broken)), "stop") }

--- a/research/benchmark/msr/python/modifications/outputs/haiku/m01-traffic-light-add-variant.py
+++ b/research/benchmark/msr/python/modifications/outputs/haiku/m01-traffic-light-add-variant.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+from enum import Enum, auto
+
+
+class Light(Enum):
+    Red = auto()
+    Yellow = auto()
+    Green = auto()
+    FlashingRed = auto()
+
+
+def next_light(l: Light) -> Light:
+    if l == Light.Red: return Light.Green
+    elif l == Light.Green: return Light.Yellow
+    elif l == Light.Yellow: return Light.Red
+    elif l == Light.FlashingRed: return Light.Red
+
+
+def duration(l: Light) -> int:
+    if l == Light.Red: return 60
+    elif l == Light.Yellow: return 5
+    elif l == Light.Green: return 45
+    elif l == Light.FlashingRed: return 2
+
+
+def describe(l: Light) -> str:
+    if l == Light.Red: return "stop"
+    elif l == Light.Yellow: return "caution"
+    elif l == Light.Green: return "go"
+    elif l == Light.FlashingRed: return "caution"
+
+
+# Tests
+assert next_light(Light.Red) == Light.Green, "next red"
+assert next_light(Light.Green) == Light.Yellow, "next green"
+assert next_light(Light.Yellow) == Light.Red, "next yellow"
+assert next_light(next_light(next_light(Light.Red))) == Light.Red, "full cycle"
+assert duration(Light.Red) == 60, "duration red"
+assert duration(Light.Yellow) == 5, "duration yellow"
+assert duration(Light.Green) == 45, "duration green"
+assert describe(Light.Red) == "stop", "describe"
+
+# ========== MODIFICATION INSTRUCTION ==========
+# Add a `FlashingRed` member to the `Light` enum.
+# FlashingRed is used at intersections late at night.
+# - `next_light(Light.FlashingRed)` returns `Light.Red`
+# - `duration(Light.FlashingRed)` returns `2`
+# - `describe(Light.FlashingRed)` returns `"caution"`
+# All existing tests must still pass unchanged.
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+assert next_light(Light.FlashingRed) == Light.Red, "next flashing red"
+assert duration(Light.FlashingRed) == 2, "duration flashing red"
+assert describe(Light.FlashingRed) == "caution", "describe flashing red"
+assert next_light(next_light(Light.FlashingRed)) == Light.Green, "cycle from flashing red"

--- a/research/benchmark/msr/python/modifications/outputs/haiku/m02-todo-app-add-field.py
+++ b/research/benchmark/msr/python/modifications/outputs/haiku/m02-todo-app-add-field.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+from enum import Enum, auto
+from dataclasses import dataclass
+
+
+class Status(Enum):
+    Pending = auto()
+    Done = auto()
+    Cancelled = auto()
+
+
+@dataclass
+class Todo:
+    id: int
+    title: str
+    status: Status
+    priority: int
+
+
+def create(id: int, title: str, priority: int) -> Todo:
+    return Todo(id=id, title=title, status=Status.Pending, priority=priority)
+
+
+def complete(t: Todo) -> Todo:
+    return Todo(id=t.id, title=t.title, status=Status.Done, priority=t.priority)
+
+
+def cancel(t: Todo) -> Todo:
+    return Todo(id=t.id, title=t.title, status=Status.Cancelled, priority=t.priority)
+
+
+def is_done(t: Todo) -> bool:
+    return t.status == Status.Done
+
+
+def pending_count(todos: list[Todo]) -> int:
+    return len([t for t in todos if t.status == Status.Pending])
+
+
+def titles(todos: list[Todo]) -> list[str]:
+    return [t.title for t in todos]
+
+
+def find_by_title(todos: list[Todo], title: str) -> object:
+    return next((t for t in todos if t.title == title), None)
+
+
+def status_label(s: Status) -> str:
+    if s == Status.Pending: return "pending"
+    elif s == Status.Done: return "done"
+    elif s == Status.Cancelled: return "cancelled"
+
+
+def summary(t: Todo) -> str:
+    label = status_label(t.status)
+    return f"[{label}/p{t.priority}] {t.title}"
+
+
+def high_priority(todos: list[Todo]) -> list[Todo]:
+    hp = [t for t in todos if t.priority >= 3]
+    return sorted(hp, key=lambda t: t.priority, reverse=True)
+
+
+# Tests
+t = create(1, "Buy milk", 1)
+assert t.title == "Buy milk", "create todo title"
+assert t.id == 1, "create todo id"
+
+t = complete(create(1, "Buy milk", 1))
+assert is_done(t) == True, "complete todo"
+
+t = cancel(create(1, "Buy milk", 1))
+assert status_label(t.status) == "cancelled", "cancel todo"
+
+todos = [create(1, "A", 1), complete(create(2, "B", 1)), create(3, "C", 1)]
+assert pending_count(todos) == 2, "pending count"
+
+todos = [create(1, "A", 1), create(2, "B", 1), create(3, "C", 1)]
+assert titles(todos) == ["A", "B", "C"], "titles"
+
+todos = [create(1, "Buy milk", 1), create(2, "Walk dog", 1)]
+t = find_by_title(todos, "Walk dog")
+assert t is not None and t.id == 2, "find by title found"
+
+todos = [create(1, "Buy milk", 1)]
+assert find_by_title(todos, "nope") is None, "find by title not found"
+
+assert summary(create(1, "Buy milk", 1)) == "[pending/p1] Buy milk", "summary pending"
+assert summary(complete(create(1, "Done", 1))) == "[done/p1] Done", "summary done"
+
+todos = [create(1, "A", 1), complete(create(2, "B", 1)), cancel(create(3, "C", 1))]
+pending_titles = [t.title for t in todos if t.status == Status.Pending]
+assert pending_titles == ["A"], "pipe chain"
+
+todos = [create(1, "A", 1), create(2, "B", 1), create(3, "C", 1)]
+updated = [complete(t) if t.id == 2 else t for t in todos]
+assert pending_count(updated) == 2, "multiple operations pending"
+assert is_done(updated[1]), "multiple operations done"
+
+# ========== V2 TESTS ==========
+
+t = create(1, "Buy milk", 3)
+assert t.priority == 3, "create with priority"
+
+hp = high_priority([create(1, "A", 5), create(2, "B", 1), create(3, "C", 3)])
+assert len(hp) == 2, "high priority count"
+assert [t.title for t in hp] == ["A", "C"], "high priority order"
+
+assert high_priority([create(1, "A", 1), create(2, "B", 2)]) == [], "high priority empty"
+
+t = complete(create(1, "A", 5))
+assert t.priority == 5, "complete preserves priority"
+
+t = cancel(create(1, "A", 3))
+assert t.priority == 3, "cancel preserves priority"
+
+assert summary(create(1, "Buy milk", 3)) == "[pending/p3] Buy milk", "summary with priority"
+assert summary(complete(create(1, "Done", 2))) == "[done/p2] Done", "summary done with priority"

--- a/research/benchmark/msr/python/modifications/outputs/haiku/m03-expression-eval-add-variant.py
+++ b/research/benchmark/msr/python/modifications/outputs/haiku/m03-expression-eval-add-variant.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
+
+@dataclass
+class Lit:
+    value: int
+
+@dataclass
+class Add:
+    left: 'Expr'
+    right: 'Expr'
+
+@dataclass
+class Mul:
+    left: 'Expr'
+    right: 'Expr'
+
+@dataclass
+class Sub:
+    left: 'Expr'
+    right: 'Expr'
+
+@dataclass
+class Div:
+    left: 'Expr'
+    right: 'Expr'
+
+# Expr is one of: Lit, Add, Mul, Sub, Div
+
+Expr = Lit | Add | Mul | Sub | Div
+
+
+def eval_expr(e: Expr) -> int:
+    if isinstance(e, Lit): return e.value
+    elif isinstance(e, Add): return eval_expr(e.left) + eval_expr(e.right)
+    elif isinstance(e, Mul): return eval_expr(e.left) * eval_expr(e.right)
+    elif isinstance(e, Sub): return eval_expr(e.left) - eval_expr(e.right)
+    elif isinstance(e, Div): return eval_expr(e.left) // eval_expr(e.right)
+
+
+def to_string(e: Expr) -> str:
+    if isinstance(e, Lit): return str(e.value)
+    elif isinstance(e, Add): return f"({to_string(e.left)} + {to_string(e.right)})"
+    elif isinstance(e, Mul): return f"({to_string(e.left)} * {to_string(e.right)})"
+    elif isinstance(e, Sub): return f"({to_string(e.left)} - {to_string(e.right)})"
+    elif isinstance(e, Div): return f"({to_string(e.left)} / {to_string(e.right)})"
+
+
+# Tests
+assert eval_expr(Lit(5)) == 5, "literal"
+assert eval_expr(Add(Lit(2), Lit(3))) == 5, "add"
+assert eval_expr(Mul(Lit(4), Lit(5))) == 20, "mul"
+assert eval_expr(Sub(Lit(10), Lit(3))) == 7, "sub"
+assert eval_expr(Add(Lit(1), Mul(Lit(2), Lit(3)))) == 7, "nested add mul"
+assert eval_expr(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))) == 18, "deep nesting"
+assert to_string(Lit(42)) == "42", "to_string literal"
+assert to_string(Add(Lit(1), Lit(2))) == "(1 + 2)", "to_string add"
+assert to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))) == "((1 + 2) * 3)", "to_string nested"
+assert eval_expr(Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))) == 15, "eval matches"
+assert eval_expr(Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))) == 8, "deeply nested"
+assert eval_expr(Sub(Lit(0), Lit(5))) == -5, "single negative via sub"
+
+# V2 Tests
+assert eval_expr(Div(Lit(10), Lit(3))) == 3, "eval div"
+assert eval_expr(Div(Lit(10), Lit(2))) == 5, "eval div exact"
+assert to_string(Div(Lit(10), Lit(3))) == "(10 / 3)", "to_string div"
+assert eval_expr(Add(Lit(1), Div(Lit(10), Lit(3)))) == 4, "nested with div"
+assert eval_expr(Mul(Div(Lit(20), Lit(4)), Sub(Lit(10), Lit(7)))) == 15, "div in complex expr"

--- a/research/benchmark/msr/python/modifications/outputs/haiku/m05-todo-app-add-error-handling.py
+++ b/research/benchmark/msr/python/modifications/outputs/haiku/m05-todo-app-add-error-handling.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from enum import Enum, auto
+from dataclasses import dataclass
+
+
+class Status(Enum):
+    Pending = auto()
+    Done = auto()
+    Cancelled = auto()
+
+
+@dataclass
+class Todo:
+    id: int
+    title: str
+    status: Status
+
+
+def create(id: int, title: str) -> Todo:
+    return Todo(id=id, title=title, status=Status.Pending)
+
+
+def complete(t: Todo) -> Todo:
+    if t.status == Status.Done:
+        raise ValueError("already done")
+    elif t.status == Status.Cancelled:
+        raise ValueError("cannot complete cancelled")
+    return Todo(id=t.id, title=t.title, status=Status.Done)
+
+
+def cancel(t: Todo) -> Todo:
+    if t.status == Status.Cancelled:
+        raise ValueError("already cancelled")
+    elif t.status == Status.Done:
+        raise ValueError("cannot cancel done")
+    return Todo(id=t.id, title=t.title, status=Status.Cancelled)
+
+
+def is_done(t: Todo) -> bool:
+    return t.status == Status.Done
+
+
+def pending_count(todos: list[Todo]) -> int:
+    return len([t for t in todos if t.status == Status.Pending])
+
+
+def titles(todos: list[Todo]) -> list[str]:
+    return [t.title for t in todos]
+
+
+def find_by_title(todos: list[Todo], title: str) -> object:
+    return next((t for t in todos if t.title == title), None)
+
+
+def status_label(s: Status) -> str:
+    if s == Status.Pending: return "pending"
+    elif s == Status.Done: return "done"
+    elif s == Status.Cancelled: return "cancelled"
+
+
+def summary(t: Todo) -> str:
+    return f"[{status_label(t.status)}] {t.title}"
+
+
+# Tests
+t = create(1, "Buy milk")
+assert t.title == "Buy milk", "create todo title"
+assert t.id == 1, "create todo id"
+
+t = complete(create(1, "Buy milk"))
+assert is_done(t) == True, "complete todo"
+
+t = cancel(create(1, "Buy milk"))
+assert status_label(t.status) == "cancelled", "cancel todo"
+
+todos = [create(1, "A"), complete(create(2, "B")), create(3, "C")]
+assert pending_count(todos) == 2, "pending count"
+
+todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+assert titles(todos) == ["A", "B", "C"], "titles"
+
+todos = [create(1, "Buy milk"), create(2, "Walk dog")]
+t = find_by_title(todos, "Walk dog")
+assert t is not None and t.id == 2, "find by title found"
+
+todos = [create(1, "Buy milk")]
+assert find_by_title(todos, "nope") is None, "find by title not found"
+
+assert summary(create(1, "Buy milk")) == "[pending] Buy milk", "summary pending"
+assert summary(complete(create(1, "Done"))) == "[done] Done", "summary done"
+
+todos = [create(1, "A"), complete(create(2, "B")), cancel(create(3, "C"))]
+pending_titles = [t.title for t in todos if t.status == Status.Pending]
+assert pending_titles == ["A"], "pipe chain"
+
+todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+updated = [complete(t) if t.id == 2 else t for t in todos]
+assert pending_count(updated) == 2, "multiple operations pending"
+assert is_done(updated[1]), "multiple operations done"
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+assert complete(create(1, "A")) == Todo(id=1, title="A", status=Status.Done), "complete pending succeeds"
+
+try:
+    complete(Todo(id=1, title="A", status=Status.Done))
+    assert False, "complete already done should raise"
+except ValueError as e:
+    assert str(e) == "already done", "complete already done message"
+
+try:
+    complete(Todo(id=1, title="A", status=Status.Cancelled))
+    assert False, "complete cancelled should raise"
+except ValueError as e:
+    assert str(e) == "cannot complete cancelled", "complete cancelled message"
+
+assert cancel(create(1, "A")) == Todo(id=1, title="A", status=Status.Cancelled), "cancel pending succeeds"
+
+try:
+    cancel(Todo(id=1, title="A", status=Status.Cancelled))
+    assert False, "cancel already cancelled should raise"
+except ValueError as e:
+    assert str(e) == "already cancelled", "cancel already cancelled message"
+
+try:
+    cancel(Todo(id=1, title="A", status=Status.Done))
+    assert False, "cancel done should raise"
+except ValueError as e:
+    assert str(e) == "cannot cancel done", "cancel done message"

--- a/research/benchmark/msr/python/modifications/outputs/haiku/m06-config-merger-add-function.py
+++ b/research/benchmark/msr/python/modifications/outputs/haiku/m06-config-merger-add-function.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+import os
+import tempfile
+
+
+def parse_config(content: str) -> list[list[str]]:
+    """Parse a config string into key-value pairs.
+    Skip blank lines and lines starting with #.
+    Raises ValueError: "line N: missing '='", "line N: empty key", "line N: duplicate key: KEY"
+    """
+    if content == "":
+        return []
+    pairs: list[list[str]] = []
+    seen_keys: set[str] = set()
+    for i, line in enumerate(content.split("\n"), start=1):
+        trimmed = line.strip()
+        if trimmed == "" or trimmed.startswith("#"):
+            continue
+        if "=" not in trimmed:
+            raise ValueError(f"line {i}: missing '='")
+        key, value = trimmed.split("=", 1)
+        if key == "":
+            raise ValueError(f"line {i}: empty key")
+        if key in seen_keys:
+            raise ValueError(f"line {i}: duplicate key: {key}")
+        seen_keys.add(key)
+        pairs.append([key, value])
+    return pairs
+
+
+def merge_configs(base: list[list[str]], overlay: list[list[str]]) -> list[list[str]]:
+    """Merge two parsed configs: entries in overlay override base for matching keys.
+    Non-matching keys from both are preserved. Order: base keys first, then new overlay keys.
+    """
+    overlay_map = {pair[0]: pair[1] for pair in overlay}
+    base_keys = set()
+    merged = []
+    for pair in base:
+        key = pair[0]
+        base_keys.add(key)
+        if key in overlay_map:
+            merged.append([key, overlay_map[key]])
+        else:
+            merged.append(list(pair))
+    for pair in overlay:
+        if pair[0] not in base_keys:
+            merged.append(list(pair))
+    return merged
+
+
+def serialize_config(pairs: list[list[str]]) -> str:
+    """Serialize config pairs back to string format (key=value lines)."""
+    return "\n".join(f"{pair[0]}={pair[1]}" for pair in pairs)
+
+
+def load_config(path: str) -> list[list[str]]:
+    """Read and parse a config file.
+    Raises on file read errors or parse errors (prefixed with filename).
+    """
+    with open(path) as f:
+        content = f.read()
+    try:
+        return parse_config(content)
+    except ValueError as e:
+        raise ValueError(f"{path}: {e}") from e
+
+
+def save_config(path: str, pairs: list[list[str]]) -> None:
+    """Write config pairs to a file."""
+    with open(path, "w") as f:
+        f.write(serialize_config(pairs))
+
+
+def merge_files(paths: list[str]) -> list[list[str]]:
+    """Load multiple config files and merge them in order (left to right).
+    First file is base, each subsequent file overlays on top.
+    """
+    result: list[list[str]] = []
+    for path in paths:
+        overlay = load_config(path)
+        result = merge_configs(result, overlay)
+    return result
+
+
+def merge_and_save(paths: list[str], output: str) -> int:
+    """Full pipeline: load configs from paths, merge, save to output path.
+    Returns number of keys in final config.
+    """
+    pairs = merge_files(paths)
+    save_config(output, pairs)
+    return len(pairs)
+
+
+def lookup(pairs: list[list[str]], key: str) -> str | None:
+    """Lookup a key in config pairs, returns None if not found."""
+    for pair in pairs:
+        if pair[0] == key:
+            return pair[1]
+    return None
+
+
+def filter_by_prefix(pairs: list[list[str]], prefix: str) -> list[list[str]]:
+    """Filter config pairs by key prefix."""
+    return [pair for pair in pairs if pair[0].startswith(prefix)]
+
+
+def validate_keys(pairs: list[list[str]], required: list[str]) -> None:
+    """Validate that all required keys are present in pairs.
+    Raises ValueError("missing required key: KEY") for the first missing key.
+    Returns None if all required keys are present.
+    """
+    pairs_keys = {pair[0] for pair in pairs}
+    for key in required:
+        if key not in pairs_keys:
+            raise ValueError(f"missing required key: {key}")
+
+
+def load_and_validate(path: str, required: list[str]) -> list[list[str]]:
+    """Load a config file and validate that all required keys are present.
+    File read errors and parse errors propagate as usual.
+    If validation fails, raise the validation error.
+    If everything succeeds, return the parsed pairs.
+    """
+    pairs = load_config(path)
+    validate_keys(pairs, required)
+    return pairs
+
+
+# Tests
+assert parse_config("host=localhost\nport=8080") == [["host", "localhost"], ["port", "8080"]], "parse basic config"
+
+assert parse_config("# this is a comment\n\nhost=localhost\n# another comment\nport=8080") == [["host", "localhost"], ["port", "8080"]], "parse with comments and blanks"
+
+assert parse_config("") == [], "parse empty string"
+
+assert parse_config("# comment\n# another") == [], "parse only comments"
+
+try:
+    parse_config("host=ok\nbadline")
+    assert False, "parse missing equals should raise"
+except ValueError as e:
+    assert str(e) == "line 2: missing '='", "parse missing equals"
+
+try:
+    parse_config("=value")
+    assert False, "parse empty key should raise"
+except ValueError as e:
+    assert str(e) == "line 1: empty key", "parse empty key"
+
+try:
+    parse_config("host=a\nhost=b")
+    assert False, "parse duplicate key should raise"
+except ValueError as e:
+    assert str(e) == "line 2: duplicate key: host", "parse duplicate key"
+
+assert parse_config("formula=a=b+c") == [["formula", "a=b+c"]], "parse value with equals"
+
+assert merge_configs([["host", "localhost"]], [["port", "8080"]]) == [["host", "localhost"], ["port", "8080"]], "merge no overlap"
+
+assert merge_configs([["host", "localhost"], ["port", "3000"]], [["port", "8080"]]) == [["host", "localhost"], ["port", "8080"]], "merge with override"
+
+assert merge_configs([], [["port", "8080"]]) == [["port", "8080"]], "merge empty base"
+
+assert merge_configs([["host", "localhost"]], []) == [["host", "localhost"]], "merge empty overlay"
+
+assert serialize_config([["host", "localhost"], ["port", "8080"]]) == "host=localhost\nport=8080", "serialize config"
+
+assert serialize_config([]) == "", "serialize empty"
+
+assert lookup([["host", "localhost"], ["port", "8080"]], "port") == "8080", "lookup found"
+
+assert lookup([["host", "localhost"]], "port") is None, "lookup not found"
+
+assert filter_by_prefix([["db_host", "localhost"], ["db_port", "5432"], ["app_port", "8080"]], "db_") == [["db_host", "localhost"], ["db_port", "5432"]], "filter by prefix"
+
+assert filter_by_prefix([["app_port", "8080"]], "db_") == [], "filter by prefix no match"
+
+# File I/O tests
+td = tempfile.gettempdir()
+
+f = os.path.join(td, "almide_test_base.conf")
+with open(f, "w") as fh:
+    fh.write("host=localhost\nport=3000")
+assert load_config(f) == [["host", "localhost"], ["port", "3000"]], "load and parse config file"
+
+try:
+    load_config(os.path.join(td, "almide_test_nonexistent_file.conf"))
+    assert False, "load nonexistent should raise"
+except Exception:
+    pass  # expected
+
+f_bad = os.path.join(td, "almide_test_bad.conf")
+with open(f_bad, "w") as fh:
+    fh.write("good=ok\nbadline")
+try:
+    load_config(f_bad)
+    assert False, "load config with parse error should raise"
+except ValueError as e:
+    assert str(e) == f_bad + ": line 2: missing '='", "load config with parse error"
+
+f_out = os.path.join(td, "almide_test_output.conf")
+save_config(f_out, [["host", "localhost"], ["port", "8080"]])
+with open(f_out) as fh:
+    assert fh.read() == "host=localhost\nport=8080", "save config file"
+
+f1 = os.path.join(td, "almide_test_m1.conf")
+f2 = os.path.join(td, "almide_test_m2.conf")
+with open(f1, "w") as fh:
+    fh.write("host=localhost\nport=3000")
+with open(f2, "w") as fh:
+    fh.write("port=8080\ndebug=true")
+assert merge_files([f1, f2]) == [["host", "localhost"], ["port", "8080"], ["debug", "true"]], "merge two files"
+
+f1 = os.path.join(td, "almide_test_t1.conf")
+f2 = os.path.join(td, "almide_test_t2.conf")
+f3 = os.path.join(td, "almide_test_t3.conf")
+with open(f1, "w") as fh:
+    fh.write("host=a\nport=1")
+with open(f2, "w") as fh:
+    fh.write("port=2\nmode=dev")
+with open(f3, "w") as fh:
+    fh.write("mode=prod\nlog=true")
+assert merge_files([f1, f2, f3]) == [["host", "a"], ["port", "2"], ["mode", "prod"], ["log", "true"]], "merge three files"
+
+f1 = os.path.join(td, "almide_test_e1.conf")
+f2 = os.path.join(td, "almide_test_e2.conf")
+with open(f1, "w") as fh:
+    fh.write("ok=yes")
+with open(f2, "w") as fh:
+    fh.write("badline")
+try:
+    merge_files([f1, f2])
+    assert False, "merge files error should propagate"
+except ValueError as e:
+    assert str(e) == f2 + ": line 1: missing '='", "merge files error propagation"
+
+f1 = os.path.join(td, "almide_test_p1.conf")
+f2 = os.path.join(td, "almide_test_p2.conf")
+out = os.path.join(td, "almide_test_merged.conf")
+with open(f1, "w") as fh:
+    fh.write("host=localhost\nport=3000")
+with open(f2, "w") as fh:
+    fh.write("port=8080\ndebug=true")
+assert merge_and_save([f1, f2], out) == 3, "merge and save full pipeline"
+with open(out) as fh:
+    assert fh.read() == "host=localhost\nport=8080\ndebug=true", "merge and save content"
+
+f1 = os.path.join(td, "almide_test_ep1.conf")
+out = os.path.join(td, "almide_test_should_not_exist.conf")
+with open(f1, "w") as fh:
+    fh.write("ok=yes")
+if os.path.exists(out):
+    os.remove(out)
+try:
+    merge_and_save([f1, os.path.join(td, "almide_test_nonexistent_file.conf")], out)
+    assert False, "merge and save error should propagate"
+except Exception:
+    pass
+assert not os.path.exists(out), "merge and save error should not create output"
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+assert validate_keys([["host", "localhost"], ["port", "8080"]], ["host", "port"]) is None, "validate keys all present"
+
+assert validate_keys([["a", "b"]], []) is None, "validate keys empty required"
+
+try:
+    validate_keys([["host", "localhost"]], ["host", "port"])
+    assert False, "validate keys missing should raise"
+except ValueError as e:
+    assert str(e) == "missing required key: port", "validate keys missing"
+
+try:
+    validate_keys([["host", "localhost"]], ["port", "debug"])
+    assert False, "validate keys first missing should raise"
+except ValueError as e:
+    assert str(e) == "missing required key: port", "validate keys first missing reported"
+
+td = tempfile.gettempdir()
+
+f = os.path.join(td, "almide_test_m06_valid.conf")
+with open(f, "w") as fh:
+    fh.write("host=localhost\nport=8080")
+assert load_and_validate(f, ["host"]) == [["host", "localhost"], ["port", "8080"]], "load and validate success"
+
+f = os.path.join(td, "almide_test_m06_partial.conf")
+with open(f, "w") as fh:
+    fh.write("host=localhost")
+try:
+    load_and_validate(f, ["host", "port"])
+    assert False, "load and validate missing key should raise"
+except ValueError as e:
+    assert str(e) == "missing required key: port", "load and validate missing key"

--- a/research/benchmark/msr/python/modifications/outputs/haiku/m07-grade-report-add-function.py
+++ b/research/benchmark/msr/python/modifications/outputs/haiku/m07-grade-report-add-function.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+# Student grade report processor
+# Input format: "name:score1,score2,score3" (one student per line)
+# Scores are integers 0-100
+
+
+def parse_student(line: str) -> list[str]:
+    """Parse a single student line like "Alice:85,92,78".
+    Returns [name, score1, score2, ...] as strings.
+    Raises ValueError: "empty name", "invalid score: X", "score out of range: X",
+                       "no scores", "invalid format"
+    """
+    if ":" not in line:
+        raise ValueError("invalid format")
+    parts = line.split(":", 1)
+    name = parts[0]
+    if name == "":
+        raise ValueError("empty name")
+    scores_str = parts[1]
+    if scores_str == "":
+        raise ValueError("no scores")
+    score_strs = scores_str.split(",")
+    for s in score_strs:
+        try:
+            n = int(s)
+        except ValueError:
+            raise ValueError(f"invalid score: {s}")
+        if n < 0 or n > 100:
+            raise ValueError(f"score out of range: {s}")
+    return [name] + score_strs
+
+
+def parse_all(input: str) -> list[list[str]]:
+    """Parse multiple students from newline-separated input.
+    Raises ValueError: "empty input", line errors prefixed with "line N: ",
+                       "duplicate name: NAME"
+    """
+    if input == "":
+        raise ValueError("empty input")
+    lines = input.split("\n")
+    students: list[list[str]] = []
+    seen_names: set[str] = set()
+    for i, line in enumerate(lines, 1):
+        try:
+            student = parse_student(line)
+        except ValueError as e:
+            raise ValueError(f"line {i}: {e}")
+        name = student[0]
+        if name in seen_names:
+            raise ValueError(f"duplicate name: {name}")
+        seen_names.add(name)
+        students.append(student)
+    return students
+
+
+def average(student: list[str]) -> int:
+    """Calculate average score for a student record [name, score1, score2, ...].
+    Returns integer (floor division). Raises ValueError if no scores.
+    """
+    scores = student[1:]
+    if len(scores) == 0:
+        raise ValueError("no scores")
+    total = sum(int(s) for s in scores)
+    return total // len(scores)
+
+
+def letter_grade(avg: int) -> str:
+    """Convert numeric average to letter grade.
+    90-100: "A", 80-89: "B", 70-79: "C", 60-69: "D", below 60: "F"
+    """
+    if avg >= 90:
+        return "A"
+    elif avg >= 80:
+        return "B"
+    elif avg >= 70:
+        return "C"
+    elif avg >= 60:
+        return "D"
+    else:
+        return "F"
+
+
+def honor_roll(students: list[list[str]]) -> list[str]:
+    """Find students on honor roll (average >= 85).
+    Returns list of names, sorted alphabetically.
+    """
+    names = [s[0] for s in students if average(s) >= 85]
+    return sorted(names)
+
+
+def class_average(students: list[list[str]]) -> int:
+    """Calculate class average across all students."""
+    total = sum(average(s) for s in students)
+    return total // len(students)
+
+
+def format_student(student: list[str]) -> str:
+    """Format a single student summary: "name: avg (grade)"."""
+    avg = average(student)
+    grade = letter_grade(avg)
+    return f"{student[0]}: {avg} ({grade})"
+
+
+def generate_report(input: str) -> str:
+    """Generate full report as multi-line string.
+    Raises ValueError on parse errors.
+    """
+    students = parse_all(input)
+    lines = [format_student(s) for s in students]
+    cavg = class_average(students)
+    honors = honor_roll(students)
+    return "\n".join(lines) + f"\nclass average: {cavg}\nhonor roll: {', '.join(honors)}"
+
+
+def top_students(input: str, n: int) -> list[str]:
+    """Return the names of the top N students by average score (descending).
+    Ties in average are broken alphabetically (ascending).
+    If N exceeds the number of students, return all students sorted by score desc.
+    Uses `parse_all` and `average` internally.
+    Raises ValueError on parse errors (propagated from parse_all).
+    """
+    students = parse_all(input)
+    student_avgs = [(s[0], average(s)) for s in students]
+    sorted_students = sorted(student_avgs, key=lambda x: (-x[1], x[0]))
+    top_n = sorted_students[:n]
+    return [name for name, avg in top_n]
+
+
+# Tests
+assert parse_student("Alice:85,92,78") == ["Alice", "85", "92", "78"], "parse single student"
+assert parse_student("Bob:100") == ["Bob", "100"], "parse student with single score"
+
+try:
+    parse_student(":85,92")
+    assert False
+except ValueError as e:
+    assert str(e) == "empty name", "parse student empty name"
+
+try:
+    parse_student("Alice:85,abc,78")
+    assert False
+except ValueError as e:
+    assert str(e) == "invalid score: abc", "parse student invalid score"
+
+try:
+    parse_student("Alice:85,101,78")
+    assert False
+except ValueError as e:
+    assert str(e) == "score out of range: 101", "parse student score too high"
+
+try:
+    parse_student("Alice:85,-1,78")
+    assert False
+except ValueError as e:
+    assert str(e) == "score out of range: -1", "parse student score negative"
+
+try:
+    parse_student("Alice:")
+    assert False
+except ValueError as e:
+    assert str(e) == "no scores", "parse student no scores"
+
+try:
+    parse_student("Alice")
+    assert False
+except ValueError as e:
+    assert str(e) == "invalid format", "parse student no colon"
+
+assert parse_all("Alice:85,92\nBob:70,80") == [["Alice", "85", "92"], ["Bob", "70", "80"]], "parse all basic"
+
+try:
+    parse_all("")
+    assert False
+except ValueError as e:
+    assert str(e) == "empty input", "parse all empty input"
+
+try:
+    parse_all("Alice:85\nAlice:90")
+    assert False
+except ValueError as e:
+    assert str(e) == "duplicate name: Alice", "parse all duplicate names"
+
+try:
+    parse_all("Alice:85\n:90")
+    assert False
+except ValueError as e:
+    assert str(e) == "line 2: empty name", "parse all error with line number"
+
+assert average(["Alice", "80", "90", "100"]) == 90, "average basic"
+assert average(["Bob", "75"]) == 75, "average single score"
+assert average(["Carol", "80", "81"]) == 80, "average rounds down"
+
+assert letter_grade(95) == "A", "letter grade A"
+assert letter_grade(85) == "B", "letter grade B"
+assert letter_grade(75) == "C", "letter grade C"
+assert letter_grade(65) == "D", "letter grade D"
+assert letter_grade(55) == "F", "letter grade F"
+assert letter_grade(90) == "A", "letter grade boundary 90"
+assert letter_grade(80) == "B", "letter grade boundary 80"
+
+assert honor_roll([["Alice", "90", "95"], ["Bob", "70", "80"], ["Carol", "85", "90"]]) == ["Alice", "Carol"], "honor roll basic"
+assert honor_roll([["Alice", "70", "75"], ["Bob", "60", "65"]]) == [], "honor roll none qualify"
+assert honor_roll([["Zara", "90", "95"], ["Alice", "85", "90"]]) == ["Alice", "Zara"], "honor roll sorted"
+
+assert class_average([["Alice", "80", "90"], ["Bob", "70", "80"]]) == 80, "class average basic"
+
+assert format_student(["Alice", "85", "92", "78"]) == "Alice: 85 (B)", "format student"
+
+assert generate_report("Alice:90,95,100\nBob:70,75,80") == "Alice: 95 (A)\nBob: 75 (C)\nclass average: 85\nhonor roll: Alice", "generate report"
+
+try:
+    generate_report("Alice:90\n:bad")
+    assert False
+except ValueError as e:
+    assert str(e) == "line 2: empty name", "generate report error propagation"
+
+try:
+    generate_report("")
+    assert False
+except ValueError as e:
+    assert str(e) == "empty input", "generate report empty"
+
+assert top_students("Alice:90,95\nBob:70,80\nCarol:85,88", 2) == ["Alice", "Carol"], "top students basic"
+assert top_students("Bob:85,85\nAlice:85,85", 2) == ["Alice", "Bob"], "top students tie breaking"
+assert top_students("Alice:90,95", 5) == ["Alice"], "top students n exceeds count"
+try:
+    top_students("", 3)
+    assert False, "top students empty should raise"
+except ValueError as e:
+    assert str(e) == "empty input", "top students error propagation"
+assert top_students("Alice:90,95\nBob:70,80\nCarol:85,88", 1) == ["Alice"], "top students single"

--- a/research/benchmark/msr/python/modifications/outputs/haiku/m08-bob-behavioral-change.py
+++ b/research/benchmark/msr/python/modifications/outputs/haiku/m08-bob-behavioral-change.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+
+def respond(input: str) -> str:
+    trimmed = input.strip()
+    is_silence = len(trimmed) == 0
+    is_question = trimmed.endswith("?")
+    has_letters = any(c.isalpha() for c in trimmed)
+    is_yelling = has_letters and trimmed == trimmed.upper()
+    is_whispering = has_letters and trimmed == trimmed.lower()
+    
+    if is_silence:
+        return "Fine. Be that way!"
+    elif is_yelling and is_question:
+        return "Calm down, I know what I'm doing!"
+    elif is_yelling:
+        return "Whoa, chill out!"
+    elif is_whispering and is_question:
+        return "Are you whispering? Speak up!"
+    elif is_whispering:
+        return "Could you speak up? I can't hear you."
+    elif is_question:
+        return "Sure."
+    else:
+        return "Whatever."
+
+
+# Tests
+assert respond("Tom-ay-to, tom-ah-to.") == "Whatever.", "stating something"
+assert respond("WATCH OUT!") == "Whoa, chill out!", "shouting"
+assert respond("FCECGC") == "Whoa, chill out!", "shouting gibberish"
+assert respond("Does this celi level have a caused caused caused effect?") == "Sure.", "asking a question"
+assert respond("You are, what, like 15?") == "Sure.", "asking a numeric question"
+assert respond("fffbbcbeab?") == "Are you whispering? Speak up!", "asking gibberish"
+assert respond("Hi there!") == "Whatever.", "talking forcefully"
+assert respond("It's OK if you don't want to go work for NASA.") == "Whatever.", "using acronyms"
+assert respond("WHAT IS YOUR PROBLEM?") == "Calm down, I know what I'm doing!", "forceful question"
+assert respond("1, 2, 3 GO!") == "Whoa, chill out!", "shouting numbers"
+assert respond("1, 2, 3") == "Whatever.", "no letters"
+assert respond("4?") == "Sure.", "question with no letters"
+assert respond("ZOMG THE %#@* ALARM IS GOING OFF!") == "Whoa, chill out!", "shouting with special chars"
+assert respond("I HATE THE ALARM") == "Whoa, chill out!", "shouting no exclamation"
+assert respond("Ending with ? hmm") == "Whatever.", "statement containing question mark"
+assert respond(":) ?") == "Sure.", "non-letters with question"
+assert respond("Wait! Hang on. Are you going to be OK?") == "Sure.", "prattling on"
+assert respond("") == "Fine. Be that way!", "silence"
+assert respond("          ") == "Fine. Be that way!", "prolonged silence"
+assert respond("\t\t\t\t\t\t\t\t\t\t") == "Fine. Be that way!", "alternate silence"
+assert respond("\nDoes this celi level have a caused caused caused effect?") == "Sure.", "multiple line question"
+assert respond("         hmmmmm") == "Could you speak up? I can't hear you.", "starting with whitespace"
+assert respond("Okay if like my  spacebar  quite a bit?   ") == "Sure.", "ending with whitespace"
+assert respond("\n\r \t") == "Fine. Be that way!", "other whitespace"
+assert respond("This is a statement ending with whitespace      ") == "Whatever.", "non-question ending with ws"
+
+# V2 Tests
+assert respond("hello there") == "Could you speak up? I can't hear you.", "whispering"
+assert respond("do you hear me?") == "Are you whispering? Speak up!", "whispering question"
+assert respond("hello 123") == "Could you speak up? I can't hear you.", "whispering with numbers"
+assert respond("Hello there") == "Whatever.", "not whispering mixed case"
+assert respond("  can you hear me?  ") == "Are you whispering? Speak up!", "whispering question with spaces"

--- a/research/benchmark/msr/python/modifications/outputs/haiku/m09-expression-eval-compound.py
+++ b/research/benchmark/msr/python/modifications/outputs/haiku/m09-expression-eval-compound.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Union
+
+
+@dataclass
+class Lit:
+    value: int
+
+@dataclass
+class Add:
+    left: 'Expr'
+    right: 'Expr'
+
+@dataclass
+class Mul:
+    left: 'Expr'
+    right: 'Expr'
+
+@dataclass
+class Sub:
+    left: 'Expr'
+    right: 'Expr'
+
+@dataclass
+class Neg:
+    operand: 'Expr'
+
+@dataclass
+class Pow:
+    base: 'Expr'
+    exp: 'Expr'
+
+Expr = Union[Lit, Add, Mul, Sub, Neg, Pow]
+
+
+def eval_expr(e: Expr) -> int:
+    if isinstance(e, Lit): return e.value
+    elif isinstance(e, Add): return eval_expr(e.left) + eval_expr(e.right)
+    elif isinstance(e, Mul): return eval_expr(e.left) * eval_expr(e.right)
+    elif isinstance(e, Sub): return eval_expr(e.left) - eval_expr(e.right)
+    elif isinstance(e, Neg): return -eval_expr(e.operand)
+    elif isinstance(e, Pow): return eval_expr(e.base) ** eval_expr(e.exp)
+
+
+def to_string(e: Expr) -> str:
+    if isinstance(e, Lit): return str(e.value)
+    elif isinstance(e, Add): return f"({to_string(e.left)} + {to_string(e.right)})"
+    elif isinstance(e, Mul): return f"({to_string(e.left)} * {to_string(e.right)})"
+    elif isinstance(e, Sub): return f"({to_string(e.left)} - {to_string(e.right)})"
+    elif isinstance(e, Neg): return f"(-{to_string(e.operand)})"
+    elif isinstance(e, Pow): return f"({to_string(e.base)} ^ {to_string(e.exp)})"
+
+
+# Tests
+assert eval_expr(Lit(5)) == 5, "literal"
+assert eval_expr(Add(Lit(2), Lit(3))) == 5, "add"
+assert eval_expr(Mul(Lit(4), Lit(5))) == 20, "mul"
+assert eval_expr(Sub(Lit(10), Lit(3))) == 7, "sub"
+assert eval_expr(Add(Lit(1), Mul(Lit(2), Lit(3)))) == 7, "nested add mul"
+assert eval_expr(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))) == 18, "deep nesting"
+assert to_string(Lit(42)) == "42", "to_string literal"
+assert to_string(Add(Lit(1), Lit(2))) == "(1 + 2)", "to_string add"
+assert to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))) == "((1 + 2) * 3)", "to_string nested"
+assert eval_expr(Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))) == 15, "eval matches"
+assert eval_expr(Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))) == 8, "deeply nested"
+assert eval_expr(Sub(Lit(0), Lit(5))) == -5, "single negative via sub"
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+assert eval_expr(Neg(Lit(5))) == -5, "neg literal"
+assert eval_expr(Neg(Neg(Lit(3)))) == 3, "neg of neg"
+assert to_string(Neg(Lit(5))) == "(-5)", "to_string neg"
+assert eval_expr(Pow(Lit(2), Lit(3))) == 8, "pow basic"
+assert eval_expr(Pow(Lit(5), Lit(0))) == 1, "pow zero"
+assert eval_expr(Pow(Lit(7), Lit(1))) == 7, "pow one"
+assert to_string(Pow(Lit(2), Lit(3))) == "(2 ^ 3)", "to_string pow"
+assert eval_expr(Neg(Pow(Lit(2), Lit(3)))) == -8, "neg with pow"
+assert eval_expr(Add(Pow(Lit(2), Lit(3)), Lit(2))) == 10, "pow in expression"

--- a/research/benchmark/msr/python/modifications/outputs/haiku/m10-traffic-light-compound.py
+++ b/research/benchmark/msr/python/modifications/outputs/haiku/m10-traffic-light-compound.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+from enum import Enum, auto
+
+
+class Light(Enum):
+    Red = auto()
+    Yellow = auto()
+    Green = auto()
+    Broken = auto()
+
+
+def next_light(l: Light) -> Light:
+    if l == Light.Red: return Light.Green
+    elif l == Light.Green: return Light.Yellow
+    elif l == Light.Yellow: return Light.Red
+    elif l == Light.Broken: return Light.Red
+
+
+def duration(l: Light) -> int | None:
+    if l == Light.Red: return 60
+    elif l == Light.Yellow: return 5
+    elif l == Light.Green: return 45
+    elif l == Light.Broken: return None
+
+
+def describe(l: Light) -> str:
+    if l == Light.Red: return "stop"
+    elif l == Light.Yellow: return "caution"
+    elif l == Light.Green: return "go"
+    elif l == Light.Broken: return "out of order"
+
+
+# Tests
+assert next_light(Light.Red) == Light.Green, "next red"
+assert next_light(Light.Green) == Light.Yellow, "next green"
+assert next_light(Light.Yellow) == Light.Red, "next yellow"
+assert next_light(next_light(next_light(Light.Red))) == Light.Red, "full cycle"
+assert duration(Light.Red) == 60, "duration red"
+assert duration(Light.Yellow) == 5, "duration yellow"
+assert duration(Light.Green) == 45, "duration green"
+assert describe(Light.Red) == "stop", "describe"
+
+# V2 Tests
+assert next_light(Light.Broken) == Light.Red, "next broken"
+assert describe(Light.Broken) == "out of order", "describe broken"
+assert duration(Light.Broken) is None, "duration broken"
+assert next_light(next_light(Light.Broken)) == Light.Green, "cycle from broken"
+assert describe(next_light(Light.Broken)) == "stop", "describe after broken"

--- a/research/benchmark/msr/python/modifications/prompts/m01-traffic-light-add-variant.py
+++ b/research/benchmark/msr/python/modifications/prompts/m01-traffic-light-add-variant.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+from enum import Enum, auto
+
+
+class Light(Enum):
+    Red = auto()
+    Yellow = auto()
+    Green = auto()
+
+
+def next_light(l: Light) -> Light:
+    if l == Light.Red: return Light.Green
+    elif l == Light.Green: return Light.Yellow
+    elif l == Light.Yellow: return Light.Red
+
+
+def duration(l: Light) -> int:
+    if l == Light.Red: return 60
+    elif l == Light.Yellow: return 5
+    elif l == Light.Green: return 45
+
+
+def describe(l: Light) -> str:
+    if l == Light.Red: return "stop"
+    elif l == Light.Yellow: return "caution"
+    elif l == Light.Green: return "go"
+
+
+# Tests
+assert next_light(Light.Red) == Light.Green, "next red"
+assert next_light(Light.Green) == Light.Yellow, "next green"
+assert next_light(Light.Yellow) == Light.Red, "next yellow"
+assert next_light(next_light(next_light(Light.Red))) == Light.Red, "full cycle"
+assert duration(Light.Red) == 60, "duration red"
+assert duration(Light.Yellow) == 5, "duration yellow"
+assert duration(Light.Green) == 45, "duration green"
+assert describe(Light.Red) == "stop", "describe"
+
+# ========== MODIFICATION INSTRUCTION ==========
+# Add a `FlashingRed` member to the `Light` enum.
+# FlashingRed is used at intersections late at night.
+# - `next_light(Light.FlashingRed)` returns `Light.Red`
+# - `duration(Light.FlashingRed)` returns `2`
+# - `describe(Light.FlashingRed)` returns `"caution"`
+# All existing tests must still pass unchanged.
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+assert next_light(Light.FlashingRed) == Light.Red, "next flashing red"
+assert duration(Light.FlashingRed) == 2, "duration flashing red"
+assert describe(Light.FlashingRed) == "caution", "describe flashing red"
+assert next_light(next_light(Light.FlashingRed)) == Light.Green, "cycle from flashing red"

--- a/research/benchmark/msr/python/modifications/prompts/m02-todo-app-add-field.py
+++ b/research/benchmark/msr/python/modifications/prompts/m02-todo-app-add-field.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+from enum import Enum, auto
+from dataclasses import dataclass
+
+
+class Status(Enum):
+    Pending = auto()
+    Done = auto()
+    Cancelled = auto()
+
+
+@dataclass
+class Todo:
+    id: int
+    title: str
+    status: Status
+
+
+def create(id: int, title: str) -> Todo:
+    return Todo(id=id, title=title, status=Status.Pending)
+
+
+def complete(t: Todo) -> Todo:
+    return Todo(id=t.id, title=t.title, status=Status.Done)
+
+
+def cancel(t: Todo) -> Todo:
+    return Todo(id=t.id, title=t.title, status=Status.Cancelled)
+
+
+def is_done(t: Todo) -> bool:
+    return t.status == Status.Done
+
+
+def pending_count(todos: list[Todo]) -> int:
+    return len([t for t in todos if t.status == Status.Pending])
+
+
+def titles(todos: list[Todo]) -> list[str]:
+    return [t.title for t in todos]
+
+
+def find_by_title(todos: list[Todo], title: str) -> object:
+    return next((t for t in todos if t.title == title), None)
+
+
+def status_label(s: Status) -> str:
+    if s == Status.Pending: return "pending"
+    elif s == Status.Done: return "done"
+    elif s == Status.Cancelled: return "cancelled"
+
+
+def summary(t: Todo) -> str:
+    return f"[{status_label(t.status)}] {t.title}"
+
+
+# Tests
+t = create(1, "Buy milk")
+assert t.title == "Buy milk", "create todo title"
+assert t.id == 1, "create todo id"
+
+t = complete(create(1, "Buy milk"))
+assert is_done(t) == True, "complete todo"
+
+t = cancel(create(1, "Buy milk"))
+assert status_label(t.status) == "cancelled", "cancel todo"
+
+todos = [create(1, "A"), complete(create(2, "B")), create(3, "C")]
+assert pending_count(todos) == 2, "pending count"
+
+todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+assert titles(todos) == ["A", "B", "C"], "titles"
+
+todos = [create(1, "Buy milk"), create(2, "Walk dog")]
+t = find_by_title(todos, "Walk dog")
+assert t is not None and t.id == 2, "find by title found"
+
+todos = [create(1, "Buy milk")]
+assert find_by_title(todos, "nope") is None, "find by title not found"
+
+assert summary(create(1, "Buy milk")) == "[pending] Buy milk", "summary pending"
+assert summary(complete(create(1, "Done"))) == "[done] Done", "summary done"
+
+todos = [create(1, "A"), complete(create(2, "B")), cancel(create(3, "C"))]
+pending_titles = [t.title for t in todos if t.status == Status.Pending]
+assert pending_titles == ["A"], "pipe chain"
+
+todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+updated = [complete(t) if t.id == 2 else t for t in todos]
+assert pending_count(updated) == 2, "multiple operations pending"
+assert is_done(updated[1]), "multiple operations done"
+
+# ========== MODIFICATION INSTRUCTION ==========
+# Add a `priority: int` field to the `Todo` dataclass.
+# Update `create` to accept a third parameter `priority: int`:
+#   `def create(id: int, title: str, priority: int) -> Todo`
+# All existing functions (`complete`, `cancel`, `is_done`, etc.) must still work.
+# The `summary` function should now include priority: "[pending/p3] Buy milk"
+#   (format: f"[{status}/p{priority}] {title}")
+# Add a new function:
+#   `def high_priority(todos: list[Todo]) -> list[Todo]`
+#   Returns todos with priority >= 3, sorted by priority descending.
+#
+# UPDATE EXISTING TESTS: All `create(id, title)` calls must become
+# `create(id, title, 1)` (default priority 1).
+# UPDATE `summary` test assertions to include priority in format.
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+t = create(1, "Buy milk", 3)
+assert t.priority == 3, "create with priority"
+
+hp = high_priority([create(1, "A", 5), create(2, "B", 1), create(3, "C", 3)])
+assert len(hp) == 2, "high priority count"
+assert [t.title for t in hp] == ["A", "C"], "high priority order"
+
+assert high_priority([create(1, "A", 1), create(2, "B", 2)]) == [], "high priority empty"
+
+t = complete(create(1, "A", 5))
+assert t.priority == 5, "complete preserves priority"
+
+t = cancel(create(1, "A", 3))
+assert t.priority == 3, "cancel preserves priority"
+
+assert summary(create(1, "Buy milk", 3)) == "[pending/p3] Buy milk", "summary with priority"
+assert summary(complete(create(1, "Done", 2))) == "[done/p2] Done", "summary done with priority"

--- a/research/benchmark/msr/python/modifications/prompts/m03-expression-eval-add-variant.py
+++ b/research/benchmark/msr/python/modifications/prompts/m03-expression-eval-add-variant.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Lit:
+    value: int
+
+@dataclass
+class Add:
+    left: 'Expr'
+    right: 'Expr'
+
+@dataclass
+class Mul:
+    left: 'Expr'
+    right: 'Expr'
+
+@dataclass
+class Sub:
+    left: 'Expr'
+    right: 'Expr'
+
+# Expr is one of: Lit, Add, Mul, Sub
+
+
+def eval_expr(e: Expr) -> int:
+    if isinstance(e, Lit): return e.value
+    elif isinstance(e, Add): return eval_expr(e.left) + eval_expr(e.right)
+    elif isinstance(e, Mul): return eval_expr(e.left) * eval_expr(e.right)
+    elif isinstance(e, Sub): return eval_expr(e.left) - eval_expr(e.right)
+
+
+def to_string(e: Expr) -> str:
+    if isinstance(e, Lit): return str(e.value)
+    elif isinstance(e, Add): return f"({to_string(e.left)} + {to_string(e.right)})"
+    elif isinstance(e, Mul): return f"({to_string(e.left)} * {to_string(e.right)})"
+    elif isinstance(e, Sub): return f"({to_string(e.left)} - {to_string(e.right)})"
+
+
+# Tests
+assert eval_expr(Lit(5)) == 5, "literal"
+assert eval_expr(Add(Lit(2), Lit(3))) == 5, "add"
+assert eval_expr(Mul(Lit(4), Lit(5))) == 20, "mul"
+assert eval_expr(Sub(Lit(10), Lit(3))) == 7, "sub"
+assert eval_expr(Add(Lit(1), Mul(Lit(2), Lit(3)))) == 7, "nested add mul"
+assert eval_expr(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))) == 18, "deep nesting"
+assert to_string(Lit(42)) == "42", "to_string literal"
+assert to_string(Add(Lit(1), Lit(2))) == "(1 + 2)", "to_string add"
+assert to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))) == "((1 + 2) * 3)", "to_string nested"
+assert eval_expr(Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))) == 15, "eval matches"
+assert eval_expr(Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))) == 8, "deeply nested"
+assert eval_expr(Sub(Lit(0), Lit(5))) == -5, "single negative via sub"
+
+# ========== MODIFICATION INSTRUCTION ==========
+# Add a `Div` dataclass to represent integer division.
+# Integer division truncates toward zero (standard Python // behavior).
+# Division by zero will not be tested.
+# Update both `eval_expr` and `to_string` to handle `Div`.
+# `to_string(Div(a, b))` should produce `"(a / b)"`.
+# Update the `Expr` type alias to include `Div`.
+# All existing tests must still pass unchanged.
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+assert eval_expr(Div(Lit(10), Lit(3))) == 3, "eval div"
+assert eval_expr(Div(Lit(10), Lit(2))) == 5, "eval div exact"
+assert to_string(Div(Lit(10), Lit(3))) == "(10 / 3)", "to_string div"
+assert eval_expr(Add(Lit(1), Div(Lit(10), Lit(3)))) == 4, "nested with div"
+assert eval_expr(Mul(Div(Lit(20), Lit(4)), Sub(Lit(10), Lit(7)))) == 15, "div in complex expr"

--- a/research/benchmark/msr/python/modifications/prompts/m05-todo-app-add-error-handling.py
+++ b/research/benchmark/msr/python/modifications/prompts/m05-todo-app-add-error-handling.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+from enum import Enum, auto
+from dataclasses import dataclass
+
+
+class Status(Enum):
+    Pending = auto()
+    Done = auto()
+    Cancelled = auto()
+
+
+@dataclass
+class Todo:
+    id: int
+    title: str
+    status: Status
+
+
+def create(id: int, title: str) -> Todo:
+    return Todo(id=id, title=title, status=Status.Pending)
+
+
+def complete(t: Todo) -> Todo:
+    return Todo(id=t.id, title=t.title, status=Status.Done)
+
+
+def cancel(t: Todo) -> Todo:
+    return Todo(id=t.id, title=t.title, status=Status.Cancelled)
+
+
+def is_done(t: Todo) -> bool:
+    return t.status == Status.Done
+
+
+def pending_count(todos: list[Todo]) -> int:
+    return len([t for t in todos if t.status == Status.Pending])
+
+
+def titles(todos: list[Todo]) -> list[str]:
+    return [t.title for t in todos]
+
+
+def find_by_title(todos: list[Todo], title: str) -> object:
+    return next((t for t in todos if t.title == title), None)
+
+
+def status_label(s: Status) -> str:
+    if s == Status.Pending: return "pending"
+    elif s == Status.Done: return "done"
+    elif s == Status.Cancelled: return "cancelled"
+
+
+def summary(t: Todo) -> str:
+    return f"[{status_label(t.status)}] {t.title}"
+
+
+# Tests
+t = create(1, "Buy milk")
+assert t.title == "Buy milk", "create todo title"
+assert t.id == 1, "create todo id"
+
+t = complete(create(1, "Buy milk"))
+assert is_done(t) == True, "complete todo"
+
+t = cancel(create(1, "Buy milk"))
+assert status_label(t.status) == "cancelled", "cancel todo"
+
+todos = [create(1, "A"), complete(create(2, "B")), create(3, "C")]
+assert pending_count(todos) == 2, "pending count"
+
+todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+assert titles(todos) == ["A", "B", "C"], "titles"
+
+todos = [create(1, "Buy milk"), create(2, "Walk dog")]
+t = find_by_title(todos, "Walk dog")
+assert t is not None and t.id == 2, "find by title found"
+
+todos = [create(1, "Buy milk")]
+assert find_by_title(todos, "nope") is None, "find by title not found"
+
+assert summary(create(1, "Buy milk")) == "[pending] Buy milk", "summary pending"
+assert summary(complete(create(1, "Done"))) == "[done] Done", "summary done"
+
+todos = [create(1, "A"), complete(create(2, "B")), cancel(create(3, "C"))]
+pending_titles = [t.title for t in todos if t.status == Status.Pending]
+assert pending_titles == ["A"], "pipe chain"
+
+todos = [create(1, "A"), create(2, "B"), create(3, "C")]
+updated = [complete(t) if t.id == 2 else t for t in todos]
+assert pending_count(updated) == 2, "multiple operations pending"
+assert is_done(updated[1]), "multiple operations done"
+
+# ========== MODIFICATION INSTRUCTION ==========
+# Change `complete` and `cancel` to raise `ValueError` on invalid state transitions:
+#   `complete(t)`:
+#   - If t.status is Done, raise `ValueError("already done")`
+#   - If t.status is Cancelled, raise `ValueError("cannot complete cancelled")`
+#   - If t.status is Pending, return the completed Todo as before
+#   `cancel(t)`:
+#   - If t.status is Cancelled, raise `ValueError("already cancelled")`
+#   - If t.status is Done, raise `ValueError("cannot cancel done")`
+#   - If t.status is Pending, return the cancelled Todo as before
+#
+# UPDATE EXISTING TESTS:
+#   - "complete todo" test: now call complete(create(1, "Buy milk")) and check result
+#   - "cancel todo" test: similar update
+#   - "pipe chain" and "multiple operations": update complete() calls to handle
+#     the fact that complete() may raise (use try/except or construct Todo directly)
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+assert complete(create(1, "A")) == Todo(id=1, title="A", status=Status.Done), "complete pending succeeds"
+
+try:
+    complete(Todo(id=1, title="A", status=Status.Done))
+    assert False, "complete already done should raise"
+except ValueError as e:
+    assert str(e) == "already done", "complete already done message"
+
+try:
+    complete(Todo(id=1, title="A", status=Status.Cancelled))
+    assert False, "complete cancelled should raise"
+except ValueError as e:
+    assert str(e) == "cannot complete cancelled", "complete cancelled message"
+
+assert cancel(create(1, "A")) == Todo(id=1, title="A", status=Status.Cancelled), "cancel pending succeeds"
+
+try:
+    cancel(Todo(id=1, title="A", status=Status.Cancelled))
+    assert False, "cancel already cancelled should raise"
+except ValueError as e:
+    assert str(e) == "already cancelled", "cancel already cancelled message"
+
+try:
+    cancel(Todo(id=1, title="A", status=Status.Done))
+    assert False, "cancel done should raise"
+except ValueError as e:
+    assert str(e) == "cannot cancel done", "cancel done message"

--- a/research/benchmark/msr/python/modifications/prompts/m06-config-merger-add-function.py
+++ b/research/benchmark/msr/python/modifications/prompts/m06-config-merger-add-function.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+import os
+import tempfile
+
+
+def parse_config(content: str) -> list[list[str]]:
+    """Parse a config string into key-value pairs.
+    Skip blank lines and lines starting with #.
+    Raises ValueError: "line N: missing '='", "line N: empty key", "line N: duplicate key: KEY"
+    """
+    if content == "":
+        return []
+    pairs: list[list[str]] = []
+    seen_keys: set[str] = set()
+    for i, line in enumerate(content.split("\n"), start=1):
+        trimmed = line.strip()
+        if trimmed == "" or trimmed.startswith("#"):
+            continue
+        if "=" not in trimmed:
+            raise ValueError(f"line {i}: missing '='")
+        key, value = trimmed.split("=", 1)
+        if key == "":
+            raise ValueError(f"line {i}: empty key")
+        if key in seen_keys:
+            raise ValueError(f"line {i}: duplicate key: {key}")
+        seen_keys.add(key)
+        pairs.append([key, value])
+    return pairs
+
+
+def merge_configs(base: list[list[str]], overlay: list[list[str]]) -> list[list[str]]:
+    """Merge two parsed configs: entries in overlay override base for matching keys.
+    Non-matching keys from both are preserved. Order: base keys first, then new overlay keys.
+    """
+    overlay_map = {pair[0]: pair[1] for pair in overlay}
+    base_keys = set()
+    merged = []
+    for pair in base:
+        key = pair[0]
+        base_keys.add(key)
+        if key in overlay_map:
+            merged.append([key, overlay_map[key]])
+        else:
+            merged.append(list(pair))
+    for pair in overlay:
+        if pair[0] not in base_keys:
+            merged.append(list(pair))
+    return merged
+
+
+def serialize_config(pairs: list[list[str]]) -> str:
+    """Serialize config pairs back to string format (key=value lines)."""
+    return "\n".join(f"{pair[0]}={pair[1]}" for pair in pairs)
+
+
+def load_config(path: str) -> list[list[str]]:
+    """Read and parse a config file.
+    Raises on file read errors or parse errors (prefixed with filename).
+    """
+    with open(path) as f:
+        content = f.read()
+    try:
+        return parse_config(content)
+    except ValueError as e:
+        raise ValueError(f"{path}: {e}") from e
+
+
+def save_config(path: str, pairs: list[list[str]]) -> None:
+    """Write config pairs to a file."""
+    with open(path, "w") as f:
+        f.write(serialize_config(pairs))
+
+
+def merge_files(paths: list[str]) -> list[list[str]]:
+    """Load multiple config files and merge them in order (left to right).
+    First file is base, each subsequent file overlays on top.
+    """
+    result: list[list[str]] = []
+    for path in paths:
+        overlay = load_config(path)
+        result = merge_configs(result, overlay)
+    return result
+
+
+def merge_and_save(paths: list[str], output: str) -> int:
+    """Full pipeline: load configs from paths, merge, save to output path.
+    Returns number of keys in final config.
+    """
+    pairs = merge_files(paths)
+    save_config(output, pairs)
+    return len(pairs)
+
+
+def lookup(pairs: list[list[str]], key: str) -> str | None:
+    """Lookup a key in config pairs, returns None if not found."""
+    for pair in pairs:
+        if pair[0] == key:
+            return pair[1]
+    return None
+
+
+def filter_by_prefix(pairs: list[list[str]], prefix: str) -> list[list[str]]:
+    """Filter config pairs by key prefix."""
+    return [pair for pair in pairs if pair[0].startswith(prefix)]
+
+
+# Tests
+assert parse_config("host=localhost\nport=8080") == [["host", "localhost"], ["port", "8080"]], "parse basic config"
+
+assert parse_config("# this is a comment\n\nhost=localhost\n# another comment\nport=8080") == [["host", "localhost"], ["port", "8080"]], "parse with comments and blanks"
+
+assert parse_config("") == [], "parse empty string"
+
+assert parse_config("# comment\n# another") == [], "parse only comments"
+
+try:
+    parse_config("host=ok\nbadline")
+    assert False, "parse missing equals should raise"
+except ValueError as e:
+    assert str(e) == "line 2: missing '='", "parse missing equals"
+
+try:
+    parse_config("=value")
+    assert False, "parse empty key should raise"
+except ValueError as e:
+    assert str(e) == "line 1: empty key", "parse empty key"
+
+try:
+    parse_config("host=a\nhost=b")
+    assert False, "parse duplicate key should raise"
+except ValueError as e:
+    assert str(e) == "line 2: duplicate key: host", "parse duplicate key"
+
+assert parse_config("formula=a=b+c") == [["formula", "a=b+c"]], "parse value with equals"
+
+assert merge_configs([["host", "localhost"]], [["port", "8080"]]) == [["host", "localhost"], ["port", "8080"]], "merge no overlap"
+
+assert merge_configs([["host", "localhost"], ["port", "3000"]], [["port", "8080"]]) == [["host", "localhost"], ["port", "8080"]], "merge with override"
+
+assert merge_configs([], [["port", "8080"]]) == [["port", "8080"]], "merge empty base"
+
+assert merge_configs([["host", "localhost"]], []) == [["host", "localhost"]], "merge empty overlay"
+
+assert serialize_config([["host", "localhost"], ["port", "8080"]]) == "host=localhost\nport=8080", "serialize config"
+
+assert serialize_config([]) == "", "serialize empty"
+
+assert lookup([["host", "localhost"], ["port", "8080"]], "port") == "8080", "lookup found"
+
+assert lookup([["host", "localhost"]], "port") is None, "lookup not found"
+
+assert filter_by_prefix([["db_host", "localhost"], ["db_port", "5432"], ["app_port", "8080"]], "db_") == [["db_host", "localhost"], ["db_port", "5432"]], "filter by prefix"
+
+assert filter_by_prefix([["app_port", "8080"]], "db_") == [], "filter by prefix no match"
+
+# File I/O tests
+td = tempfile.gettempdir()
+
+f = os.path.join(td, "almide_test_base.conf")
+with open(f, "w") as fh:
+    fh.write("host=localhost\nport=3000")
+assert load_config(f) == [["host", "localhost"], ["port", "3000"]], "load and parse config file"
+
+try:
+    load_config(os.path.join(td, "almide_test_nonexistent_file.conf"))
+    assert False, "load nonexistent should raise"
+except Exception:
+    pass  # expected
+
+f_bad = os.path.join(td, "almide_test_bad.conf")
+with open(f_bad, "w") as fh:
+    fh.write("good=ok\nbadline")
+try:
+    load_config(f_bad)
+    assert False, "load config with parse error should raise"
+except ValueError as e:
+    assert str(e) == f_bad + ": line 2: missing '='", "load config with parse error"
+
+f_out = os.path.join(td, "almide_test_output.conf")
+save_config(f_out, [["host", "localhost"], ["port", "8080"]])
+with open(f_out) as fh:
+    assert fh.read() == "host=localhost\nport=8080", "save config file"
+
+f1 = os.path.join(td, "almide_test_m1.conf")
+f2 = os.path.join(td, "almide_test_m2.conf")
+with open(f1, "w") as fh:
+    fh.write("host=localhost\nport=3000")
+with open(f2, "w") as fh:
+    fh.write("port=8080\ndebug=true")
+assert merge_files([f1, f2]) == [["host", "localhost"], ["port", "8080"], ["debug", "true"]], "merge two files"
+
+f1 = os.path.join(td, "almide_test_t1.conf")
+f2 = os.path.join(td, "almide_test_t2.conf")
+f3 = os.path.join(td, "almide_test_t3.conf")
+with open(f1, "w") as fh:
+    fh.write("host=a\nport=1")
+with open(f2, "w") as fh:
+    fh.write("port=2\nmode=dev")
+with open(f3, "w") as fh:
+    fh.write("mode=prod\nlog=true")
+assert merge_files([f1, f2, f3]) == [["host", "a"], ["port", "2"], ["mode", "prod"], ["log", "true"]], "merge three files"
+
+f1 = os.path.join(td, "almide_test_e1.conf")
+f2 = os.path.join(td, "almide_test_e2.conf")
+with open(f1, "w") as fh:
+    fh.write("ok=yes")
+with open(f2, "w") as fh:
+    fh.write("badline")
+try:
+    merge_files([f1, f2])
+    assert False, "merge files error should propagate"
+except ValueError as e:
+    assert str(e) == f2 + ": line 1: missing '='", "merge files error propagation"
+
+f1 = os.path.join(td, "almide_test_p1.conf")
+f2 = os.path.join(td, "almide_test_p2.conf")
+out = os.path.join(td, "almide_test_merged.conf")
+with open(f1, "w") as fh:
+    fh.write("host=localhost\nport=3000")
+with open(f2, "w") as fh:
+    fh.write("port=8080\ndebug=true")
+assert merge_and_save([f1, f2], out) == 3, "merge and save full pipeline"
+with open(out) as fh:
+    assert fh.read() == "host=localhost\nport=8080\ndebug=true", "merge and save content"
+
+f1 = os.path.join(td, "almide_test_ep1.conf")
+out = os.path.join(td, "almide_test_should_not_exist.conf")
+with open(f1, "w") as fh:
+    fh.write("ok=yes")
+if os.path.exists(out):
+    os.remove(out)
+try:
+    merge_and_save([f1, os.path.join(td, "almide_test_nonexistent_file.conf")], out)
+    assert False, "merge and save error should propagate"
+except Exception:
+    pass
+assert not os.path.exists(out), "merge and save error should not create output"
+
+# ========== MODIFICATION INSTRUCTION ==========
+# Add two new functions (do NOT modify any existing functions or tests):
+#
+# 1. `validate_keys(pairs: list[list[str]], required: list[str]) -> None`
+#    Checks that all keys in `required` are present in `pairs`.
+#    If a key is missing, raise `ValueError("missing required key: KEY")` for the first missing key.
+#    If all required keys are present, return None.
+#
+# 2. `load_and_validate(path: str, required: list[str]) -> list[list[str]]`
+#    Loads a config file and validates that all required keys are present.
+#    File read errors and parse errors propagate as usual.
+#    If validation fails, raise the validation error.
+#    If everything succeeds, return the parsed pairs.
+#
+# All existing tests must still pass unchanged.
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+assert validate_keys([["host", "localhost"], ["port", "8080"]], ["host", "port"]) is None, "validate keys all present"
+
+assert validate_keys([["a", "b"]], []) is None, "validate keys empty required"
+
+try:
+    validate_keys([["host", "localhost"]], ["host", "port"])
+    assert False, "validate keys missing should raise"
+except ValueError as e:
+    assert str(e) == "missing required key: port", "validate keys missing"
+
+try:
+    validate_keys([["host", "localhost"]], ["port", "debug"])
+    assert False, "validate keys first missing should raise"
+except ValueError as e:
+    assert str(e) == "missing required key: port", "validate keys first missing reported"
+
+td = tempfile.gettempdir()
+
+f = os.path.join(td, "almide_test_m06_valid.conf")
+with open(f, "w") as fh:
+    fh.write("host=localhost\nport=8080")
+assert load_and_validate(f, ["host"]) == [["host", "localhost"], ["port", "8080"]], "load and validate success"
+
+f = os.path.join(td, "almide_test_m06_partial.conf")
+with open(f, "w") as fh:
+    fh.write("host=localhost")
+try:
+    load_and_validate(f, ["host", "port"])
+    assert False, "load and validate missing key should raise"
+except ValueError as e:
+    assert str(e) == "missing required key: port", "load and validate missing key"

--- a/research/benchmark/msr/python/modifications/prompts/m07-grade-report-add-function.py
+++ b/research/benchmark/msr/python/modifications/prompts/m07-grade-report-add-function.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+# Student grade report processor
+# Input format: "name:score1,score2,score3" (one student per line)
+# Scores are integers 0-100
+
+
+def parse_student(line: str) -> list[str]:
+    """Parse a single student line like "Alice:85,92,78".
+    Returns [name, score1, score2, ...] as strings.
+    Raises ValueError: "empty name", "invalid score: X", "score out of range: X",
+                       "no scores", "invalid format"
+    """
+    if ":" not in line:
+        raise ValueError("invalid format")
+    parts = line.split(":", 1)
+    name = parts[0]
+    if name == "":
+        raise ValueError("empty name")
+    scores_str = parts[1]
+    if scores_str == "":
+        raise ValueError("no scores")
+    score_strs = scores_str.split(",")
+    for s in score_strs:
+        try:
+            n = int(s)
+        except ValueError:
+            raise ValueError(f"invalid score: {s}")
+        if n < 0 or n > 100:
+            raise ValueError(f"score out of range: {s}")
+    return [name] + score_strs
+
+
+def parse_all(input: str) -> list[list[str]]:
+    """Parse multiple students from newline-separated input.
+    Raises ValueError: "empty input", line errors prefixed with "line N: ",
+                       "duplicate name: NAME"
+    """
+    if input == "":
+        raise ValueError("empty input")
+    lines = input.split("\n")
+    students: list[list[str]] = []
+    seen_names: set[str] = set()
+    for i, line in enumerate(lines, 1):
+        try:
+            student = parse_student(line)
+        except ValueError as e:
+            raise ValueError(f"line {i}: {e}")
+        name = student[0]
+        if name in seen_names:
+            raise ValueError(f"duplicate name: {name}")
+        seen_names.add(name)
+        students.append(student)
+    return students
+
+
+def average(student: list[str]) -> int:
+    """Calculate average score for a student record [name, score1, score2, ...].
+    Returns integer (floor division). Raises ValueError if no scores.
+    """
+    scores = student[1:]
+    if len(scores) == 0:
+        raise ValueError("no scores")
+    total = sum(int(s) for s in scores)
+    return total // len(scores)
+
+
+def letter_grade(avg: int) -> str:
+    """Convert numeric average to letter grade.
+    90-100: "A", 80-89: "B", 70-79: "C", 60-69: "D", below 60: "F"
+    """
+    if avg >= 90:
+        return "A"
+    elif avg >= 80:
+        return "B"
+    elif avg >= 70:
+        return "C"
+    elif avg >= 60:
+        return "D"
+    else:
+        return "F"
+
+
+def honor_roll(students: list[list[str]]) -> list[str]:
+    """Find students on honor roll (average >= 85).
+    Returns list of names, sorted alphabetically.
+    """
+    names = [s[0] for s in students if average(s) >= 85]
+    return sorted(names)
+
+
+def class_average(students: list[list[str]]) -> int:
+    """Calculate class average across all students."""
+    total = sum(average(s) for s in students)
+    return total // len(students)
+
+
+def format_student(student: list[str]) -> str:
+    """Format a single student summary: "name: avg (grade)"."""
+    avg = average(student)
+    grade = letter_grade(avg)
+    return f"{student[0]}: {avg} ({grade})"
+
+
+def generate_report(input: str) -> str:
+    """Generate full report as multi-line string.
+    Raises ValueError on parse errors.
+    """
+    students = parse_all(input)
+    lines = [format_student(s) for s in students]
+    cavg = class_average(students)
+    honors = honor_roll(students)
+    return "\n".join(lines) + f"\nclass average: {cavg}\nhonor roll: {', '.join(honors)}"
+
+
+# Tests
+assert parse_student("Alice:85,92,78") == ["Alice", "85", "92", "78"], "parse single student"
+assert parse_student("Bob:100") == ["Bob", "100"], "parse student with single score"
+
+try:
+    parse_student(":85,92")
+    assert False
+except ValueError as e:
+    assert str(e) == "empty name", "parse student empty name"
+
+try:
+    parse_student("Alice:85,abc,78")
+    assert False
+except ValueError as e:
+    assert str(e) == "invalid score: abc", "parse student invalid score"
+
+try:
+    parse_student("Alice:85,101,78")
+    assert False
+except ValueError as e:
+    assert str(e) == "score out of range: 101", "parse student score too high"
+
+try:
+    parse_student("Alice:85,-1,78")
+    assert False
+except ValueError as e:
+    assert str(e) == "score out of range: -1", "parse student score negative"
+
+try:
+    parse_student("Alice:")
+    assert False
+except ValueError as e:
+    assert str(e) == "no scores", "parse student no scores"
+
+try:
+    parse_student("Alice")
+    assert False
+except ValueError as e:
+    assert str(e) == "invalid format", "parse student no colon"
+
+assert parse_all("Alice:85,92\nBob:70,80") == [["Alice", "85", "92"], ["Bob", "70", "80"]], "parse all basic"
+
+try:
+    parse_all("")
+    assert False
+except ValueError as e:
+    assert str(e) == "empty input", "parse all empty input"
+
+try:
+    parse_all("Alice:85\nAlice:90")
+    assert False
+except ValueError as e:
+    assert str(e) == "duplicate name: Alice", "parse all duplicate names"
+
+try:
+    parse_all("Alice:85\n:90")
+    assert False
+except ValueError as e:
+    assert str(e) == "line 2: empty name", "parse all error with line number"
+
+assert average(["Alice", "80", "90", "100"]) == 90, "average basic"
+assert average(["Bob", "75"]) == 75, "average single score"
+assert average(["Carol", "80", "81"]) == 80, "average rounds down"
+
+assert letter_grade(95) == "A", "letter grade A"
+assert letter_grade(85) == "B", "letter grade B"
+assert letter_grade(75) == "C", "letter grade C"
+assert letter_grade(65) == "D", "letter grade D"
+assert letter_grade(55) == "F", "letter grade F"
+assert letter_grade(90) == "A", "letter grade boundary 90"
+assert letter_grade(80) == "B", "letter grade boundary 80"
+
+assert honor_roll([["Alice", "90", "95"], ["Bob", "70", "80"], ["Carol", "85", "90"]]) == ["Alice", "Carol"], "honor roll basic"
+assert honor_roll([["Alice", "70", "75"], ["Bob", "60", "65"]]) == [], "honor roll none qualify"
+assert honor_roll([["Zara", "90", "95"], ["Alice", "85", "90"]]) == ["Alice", "Zara"], "honor roll sorted"
+
+assert class_average([["Alice", "80", "90"], ["Bob", "70", "80"]]) == 80, "class average basic"
+
+assert format_student(["Alice", "85", "92", "78"]) == "Alice: 85 (B)", "format student"
+
+assert generate_report("Alice:90,95,100\nBob:70,75,80") == "Alice: 95 (A)\nBob: 75 (C)\nclass average: 85\nhonor roll: Alice", "generate report"
+
+try:
+    generate_report("Alice:90\n:bad")
+    assert False
+except ValueError as e:
+    assert str(e) == "line 2: empty name", "generate report error propagation"
+
+try:
+    generate_report("")
+    assert False
+except ValueError as e:
+    assert str(e) == "empty input", "generate report empty"
+
+
+# ========== MODIFICATION INSTRUCTION ==========
+# Add a new function:
+#   `top_students(input: str, n: int) -> list[str]`
+#   Returns the names of the top N students by average score (descending).
+#   Ties in average are broken alphabetically (ascending).
+#   If N exceeds the number of students, return all students sorted by score desc.
+#   Uses `parse_all` and `average` internally.
+#   Raises ValueError on parse errors (propagated from parse_all).
+#
+# All existing functions and tests must remain unchanged.
+
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+assert top_students("Alice:90,95\nBob:70,80\nCarol:85,88", 2) == ["Alice", "Carol"], "top students basic"
+assert top_students("Bob:85,85\nAlice:85,85", 2) == ["Alice", "Bob"], "top students tie breaking"
+assert top_students("Alice:90,95", 5) == ["Alice"], "top students n exceeds count"
+try:
+    top_students("", 3)
+    assert False, "top students empty should raise"
+except ValueError as e:
+    assert str(e) == "empty input", "top students error propagation"
+assert top_students("Alice:90,95\nBob:70,80\nCarol:85,88", 1) == ["Alice"], "top students single"

--- a/research/benchmark/msr/python/modifications/prompts/m08-bob-behavioral-change.py
+++ b/research/benchmark/msr/python/modifications/prompts/m08-bob-behavioral-change.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+
+def respond(input: str) -> str:
+    trimmed = input.strip()
+    is_silence = len(trimmed) == 0
+    is_question = trimmed.endswith("?")
+    has_letters = any(c.isalpha() for c in trimmed)
+    is_yelling = has_letters and trimmed == trimmed.upper()
+    if is_silence:
+        return "Fine. Be that way!"
+    elif is_yelling and is_question:
+        return "Calm down, I know what I'm doing!"
+    elif is_yelling:
+        return "Whoa, chill out!"
+    elif is_question:
+        return "Sure."
+    else:
+        return "Whatever."
+
+
+# Tests
+assert respond("Tom-ay-to, tom-ah-to.") == "Whatever.", "stating something"
+assert respond("WATCH OUT!") == "Whoa, chill out!", "shouting"
+assert respond("FCECGC") == "Whoa, chill out!", "shouting gibberish"
+assert respond("Does this celi level have a caused caused caused effect?") == "Sure.", "asking a question"
+assert respond("You are, what, like 15?") == "Sure.", "asking a numeric question"
+assert respond("fffbbcbeab?") == "Sure.", "asking gibberish"
+assert respond("Hi there!") == "Whatever.", "talking forcefully"
+assert respond("It's OK if you don't want to go work for NASA.") == "Whatever.", "using acronyms"
+assert respond("WHAT IS YOUR PROBLEM?") == "Calm down, I know what I'm doing!", "forceful question"
+assert respond("1, 2, 3 GO!") == "Whoa, chill out!", "shouting numbers"
+assert respond("1, 2, 3") == "Whatever.", "no letters"
+assert respond("4?") == "Sure.", "question with no letters"
+assert respond("ZOMG THE %#@* ALARM IS GOING OFF!") == "Whoa, chill out!", "shouting with special chars"
+assert respond("I HATE THE ALARM") == "Whoa, chill out!", "shouting no exclamation"
+assert respond("Ending with ? hmm") == "Whatever.", "statement containing question mark"
+assert respond(":) ?") == "Sure.", "non-letters with question"
+assert respond("Wait! Hang on. Are you going to be OK?") == "Sure.", "prattling on"
+assert respond("") == "Fine. Be that way!", "silence"
+assert respond("          ") == "Fine. Be that way!", "prolonged silence"
+assert respond("\t\t\t\t\t\t\t\t\t\t") == "Fine. Be that way!", "alternate silence"
+assert respond("\nDoes this celi level have a caused caused caused effect?") == "Sure.", "multiple line question"
+assert respond("         hmmmmm") == "Whatever.", "starting with whitespace"
+assert respond("Okay if like my  spacebar  quite a bit?   ") == "Sure.", "ending with whitespace"
+assert respond("\n\r \t") == "Fine. Be that way!", "other whitespace"
+assert respond("This is a statement ending with whitespace      ") == "Whatever.", "non-question ending with ws"
+
+# ========== MODIFICATION INSTRUCTION ==========
+# Add "whispering" detection to Bob's response logic.
+# Whispering = input has letters AND all letters are lowercase (none uppercase).
+# Priority order (highest to lowest):
+#   1. Silence -> "Fine. Be that way!"
+#   2. Yelling + question -> "Calm down, I know what I'm doing!"
+#   3. Yelling -> "Whoa, chill out!"
+#   4. Whispering + question -> "Are you whispering? Speak up!"
+#   5. Whispering -> "Could you speak up? I can't hear you."
+#   6. Question -> "Sure."
+#   7. Default -> "Whatever."
+#
+# UPDATE EXISTING TESTS:
+#   - "asking gibberish" test: respond("fffbbcbeab?") is now whispering+question.
+#     Change expected from "Sure." to "Are you whispering? Speak up!"
+#   - "starting with whitespace" test: respond("         hmmmmm") is now whispering.
+#     Change expected from "Whatever." to "Could you speak up? I can't hear you."
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+assert respond("hello there") == "Could you speak up? I can't hear you.", "whispering"
+assert respond("do you hear me?") == "Are you whispering? Speak up!", "whispering question"
+assert respond("hello 123") == "Could you speak up? I can't hear you.", "whispering with numbers"
+assert respond("Hello there") == "Whatever.", "not whispering mixed case"
+assert respond("  can you hear me?  ") == "Are you whispering? Speak up!", "whispering question with spaces"

--- a/research/benchmark/msr/python/modifications/prompts/m09-expression-eval-compound.py
+++ b/research/benchmark/msr/python/modifications/prompts/m09-expression-eval-compound.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Lit:
+    value: int
+
+@dataclass
+class Add:
+    left: 'Expr'
+    right: 'Expr'
+
+@dataclass
+class Mul:
+    left: 'Expr'
+    right: 'Expr'
+
+@dataclass
+class Sub:
+    left: 'Expr'
+    right: 'Expr'
+
+# Expr is one of: Lit, Add, Mul, Sub
+
+
+def eval_expr(e: Expr) -> int:
+    if isinstance(e, Lit): return e.value
+    elif isinstance(e, Add): return eval_expr(e.left) + eval_expr(e.right)
+    elif isinstance(e, Mul): return eval_expr(e.left) * eval_expr(e.right)
+    elif isinstance(e, Sub): return eval_expr(e.left) - eval_expr(e.right)
+
+
+def to_string(e: Expr) -> str:
+    if isinstance(e, Lit): return str(e.value)
+    elif isinstance(e, Add): return f"({to_string(e.left)} + {to_string(e.right)})"
+    elif isinstance(e, Mul): return f"({to_string(e.left)} * {to_string(e.right)})"
+    elif isinstance(e, Sub): return f"({to_string(e.left)} - {to_string(e.right)})"
+
+
+# Tests
+assert eval_expr(Lit(5)) == 5, "literal"
+assert eval_expr(Add(Lit(2), Lit(3))) == 5, "add"
+assert eval_expr(Mul(Lit(4), Lit(5))) == 20, "mul"
+assert eval_expr(Sub(Lit(10), Lit(3))) == 7, "sub"
+assert eval_expr(Add(Lit(1), Mul(Lit(2), Lit(3)))) == 7, "nested add mul"
+assert eval_expr(Mul(Add(Lit(1), Lit(2)), Sub(Lit(10), Lit(4)))) == 18, "deep nesting"
+assert to_string(Lit(42)) == "42", "to_string literal"
+assert to_string(Add(Lit(1), Lit(2))) == "(1 + 2)", "to_string add"
+assert to_string(Mul(Add(Lit(1), Lit(2)), Lit(3))) == "((1 + 2) * 3)", "to_string nested"
+assert eval_expr(Add(Mul(Lit(2), Lit(3)), Sub(Lit(10), Lit(1)))) == 15, "eval matches"
+assert eval_expr(Sub(Mul(Add(Lit(1), Lit(2)), Lit(5)), Add(Lit(3), Lit(4)))) == 8, "deeply nested"
+assert eval_expr(Sub(Lit(0), Lit(5))) == -5, "single negative via sub"
+
+# ========== MODIFICATION INSTRUCTION ==========
+# Make TWO changes to the Expr types simultaneously:
+#
+# 1. Add a `Neg` dataclass for unary negation.
+#    `eval_expr(Neg(e))` returns `-eval_expr(e)` (or `0 - eval_expr(e)`).
+#    `to_string(Neg(e))` returns `f"(-{to_string(e)})"`.
+#
+# 2. Add a `Pow` dataclass for exponentiation.
+#    `eval_expr(Pow(base, exp))` computes base raised to the power of exp.
+#    Assume exp is always >= 0.
+#    `to_string(Pow(a, b))` returns `f"({to_string(a)} ^ {to_string(b)})"`.
+#
+# Update the `Expr` type alias, `eval_expr`, and `to_string` to handle both.
+# All existing tests must still pass unchanged.
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+assert eval_expr(Neg(Lit(5))) == -5, "neg literal"
+assert eval_expr(Neg(Neg(Lit(3)))) == 3, "neg of neg"
+assert to_string(Neg(Lit(5))) == "(-5)", "to_string neg"
+assert eval_expr(Pow(Lit(2), Lit(3))) == 8, "pow basic"
+assert eval_expr(Pow(Lit(5), Lit(0))) == 1, "pow zero"
+assert eval_expr(Pow(Lit(7), Lit(1))) == 7, "pow one"
+assert to_string(Pow(Lit(2), Lit(3))) == "(2 ^ 3)", "to_string pow"
+assert eval_expr(Neg(Pow(Lit(2), Lit(3)))) == -8, "neg with pow"
+assert eval_expr(Add(Pow(Lit(2), Lit(3)), Lit(2))) == 10, "pow in expression"

--- a/research/benchmark/msr/python/modifications/prompts/m10-traffic-light-compound.py
+++ b/research/benchmark/msr/python/modifications/prompts/m10-traffic-light-compound.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+# ========== V1 SOLUTION (working code — all tests pass) ==========
+
+from enum import Enum, auto
+
+
+class Light(Enum):
+    Red = auto()
+    Yellow = auto()
+    Green = auto()
+
+
+def next_light(l: Light) -> Light:
+    if l == Light.Red: return Light.Green
+    elif l == Light.Green: return Light.Yellow
+    elif l == Light.Yellow: return Light.Red
+
+
+def duration(l: Light) -> int:
+    if l == Light.Red: return 60
+    elif l == Light.Yellow: return 5
+    elif l == Light.Green: return 45
+
+
+def describe(l: Light) -> str:
+    if l == Light.Red: return "stop"
+    elif l == Light.Yellow: return "caution"
+    elif l == Light.Green: return "go"
+
+
+# Tests
+assert next_light(Light.Red) == Light.Green, "next red"
+assert next_light(Light.Green) == Light.Yellow, "next green"
+assert next_light(Light.Yellow) == Light.Red, "next yellow"
+assert next_light(next_light(next_light(Light.Red))) == Light.Red, "full cycle"
+assert duration(Light.Red) == 60, "duration red"
+assert duration(Light.Yellow) == 5, "duration yellow"
+assert duration(Light.Green) == 45, "duration green"
+assert describe(Light.Red) == "stop", "describe"
+
+# ========== MODIFICATION INSTRUCTION ==========
+# Make TWO changes simultaneously:
+#
+# 1. Add a `Broken` member to the `Light` enum.
+#    - `next_light(Light.Broken)` returns `Light.Red` (reset when repaired)
+#    - `describe(Light.Broken)` returns `"out of order"`
+#
+# 2. Change `duration` to return `int | None` instead of `int`.
+#    - `duration(Light.Red)` returns `60`
+#    - `duration(Light.Yellow)` returns `5`
+#    - `duration(Light.Green)` returns `45`
+#    - `duration(Light.Broken)` returns `None`
+#
+# UPDATE EXISTING TESTS: duration tests remain the same (60, 5, 45 are still valid
+# since int is a valid `int | None`). No changes needed to existing duration tests.
+
+# ========== V2 TESTS (must also pass after modification) ==========
+
+assert next_light(Light.Broken) == Light.Red, "next broken"
+assert describe(Light.Broken) == "out of order", "describe broken"
+assert duration(Light.Broken) is None, "duration broken"
+assert next_light(next_light(Light.Broken)) == Light.Green, "cycle from broken"
+assert describe(next_light(Light.Broken)) == "stop", "describe after broken"

--- a/research/benchmark/msr/python/modifications/results/haiku_2026-03-30.json
+++ b/research/benchmark/msr/python/modifications/results/haiku_2026-03-30.json
@@ -1,0 +1,11 @@
+{
+  "date": "2026-03-30",
+  "language": "python",
+  "type": "modification",
+  "model": "haiku",
+  "tasks": 9,
+  "passed": 8,
+  "failed": 1,
+  "msr": .8888,
+  "results": [{"name":"m01-traffic-light-add-variant","passed":true},{"name":"m02-todo-app-add-field","passed":true},{"name":"m03-expression-eval-add-variant","passed":false,"error":"TypeError: unsupported operand type(s) for |: 'type' and 'type'"},{"name":"m05-todo-app-add-error-handling","passed":true},{"name":"m06-config-merger-add-function","passed":true},{"name":"m07-grade-report-add-function","passed":true},{"name":"m08-bob-behavioral-change","passed":true},{"name":"m09-expression-eval-compound","passed":true},{"name":"m10-traffic-light-compound","passed":true}]
+}

--- a/research/benchmark/msr/python/modifications/run.sh
+++ b/research/benchmark/msr/python/modifications/run.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# python/modifications/run.sh — Run Python Modification Survival Rate benchmark
+#
+# Usage:
+#   ./msr/python/modifications/run.sh                              # default: haiku
+#   ./msr/python/modifications/run.sh --model sonnet               # use sonnet
+#   ./msr/python/modifications/run.sh --exercise m01               # single task
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+MODEL="haiku"
+EXERCISE=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --model) MODEL="$2"; shift 2 ;;
+    --exercise) EXERCISE="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+PROMPT_DIR="research/benchmark/msr/python/modifications/prompts"
+OUTPUT_DIR="research/benchmark/msr/python/modifications/outputs/$MODEL"
+
+mkdir -p "$OUTPUT_DIR"
+
+SYSTEM_PROMPT="You are modifying Python code. Output ONLY the complete modified .py file. No markdown, no explanation, no code fences. When adding an enum member, update ALL match/case statements. When changing a return type or error handling, update ALL callers and test assertions."
+
+# Collect exercises
+if [ -n "$EXERCISE" ]; then
+  PROMPTS_LIST=$(ls "$PROMPT_DIR"/${EXERCISE}*.py 2>/dev/null || true)
+  if [ -z "$PROMPTS_LIST" ]; then
+    echo "Exercise not found matching: $EXERCISE"
+    exit 1
+  fi
+else
+  PROMPTS_LIST=$(ls "$PROMPT_DIR"/*.py 2>/dev/null)
+fi
+
+PASS=0
+FAIL=0
+TOTAL=0
+RESULTS=""
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║  Python MSR Modification Benchmark — $MODEL"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+for prompt_file in $PROMPTS_LIST; do
+  name=$(basename "$prompt_file" .py)
+  output_file="$OUTPUT_DIR/${name}.py"
+  TOTAL=$((TOTAL + 1))
+
+  echo -n "⏳ $name ... "
+
+  # Read the entire prompt file and send it to the LLM
+  # This avoids bash variable expansion issues with \t \n etc.
+  PROMPT="$(cat "$prompt_file")
+
+Modify the code above according to the MODIFICATION INSTRUCTION section.
+Output ONLY the complete modified .py file containing:
+- All original imports and code (updated as specified)
+- All original tests (updated as specified in the instruction)
+- All new V2 tests
+Do not omit any tests."
+
+  claude --model "$MODEL" --print --system-prompt "$SYSTEM_PROMPT" "$PROMPT" > "$output_file" 2>/dev/null || true
+
+  # Strip markdown code fences if present
+  sed -i.bak '/^```/d' "$output_file" 2>/dev/null && rm -f "${output_file}.bak" || true
+  sed -i.bak '/^python$/d' "$output_file" 2>/dev/null && rm -f "${output_file}.bak" || true
+
+  # Run with Python
+  TEST_OUTPUT=$(python3 "$output_file" 2>&1 || true)
+  if [ -z "$TEST_OUTPUT" ]; then
+    echo "✅"
+    PASS=$((PASS + 1))
+    RESULTS="$RESULTS{\"name\":\"$name\",\"passed\":true},"
+  else
+    # Extract error info
+    ERROR_LINE=$(echo "$TEST_OUTPUT" | tail -1 | head -c 200)
+    echo "❌ $ERROR_LINE"
+    FAIL=$((FAIL + 1))
+    RESULTS="$RESULTS{\"name\":\"$name\",\"passed\":false,\"error\":\"$(echo "$ERROR_LINE" | sed 's/"/\\"/g')\"},"
+  fi
+done
+
+echo ""
+echo "════════════════════════════════════════════════════════════"
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "No modification tasks found."
+  exit 1
+fi
+
+MSR=$((PASS * 100 / TOTAL))
+
+echo "  Model:          $MODEL"
+echo "  Language:       Python"
+echo "  Tasks:          $TOTAL"
+echo "  Passed:         $PASS / $TOTAL"
+echo ""
+echo "  ┌──────────────────────────────┐"
+echo "  │  Modification MSR: ${MSR}%      │"
+echo "  └──────────────────────────────┘"
+
+RESULTS_DIR="research/benchmark/msr/python/modifications/results"
+mkdir -p "$RESULTS_DIR"
+DATE=$(date +%Y-%m-%d)
+RESULTS="${RESULTS%,}"
+
+cat > "$RESULTS_DIR/${MODEL}_${DATE}.json" <<ENDJSON
+{
+  "date": "$DATE",
+  "language": "python",
+  "type": "modification",
+  "model": "$MODEL",
+  "tasks": $TOTAL,
+  "passed": $PASS,
+  "failed": $FAIL,
+  "msr": $(echo "scale=4; $PASS / $TOTAL" | bc),
+  "results": [$RESULTS]
+}
+ENDJSON
+
+echo ""
+echo "Results saved: $RESULTS_DIR/${MODEL}_${DATE}.json"
+echo "Solutions:     $OUTPUT_DIR/"

--- a/research/benchmark/msr/scripts/run-modifications.sh
+++ b/research/benchmark/msr/scripts/run-modifications.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# msr/scripts/run-modifications.sh — Run Modification Survival Rate benchmark
+#
+# Usage:
+#   ./msr/scripts/run-modifications.sh                              # default: haiku, all tasks
+#   ./msr/scripts/run-modifications.sh --model sonnet               # use sonnet
+#   ./msr/scripts/run-modifications.sh --exercise m01-traffic-light-add-variant  # single task
+#   ./msr/scripts/run-modifications.sh --model sonnet --exercise m03
+#
+# Each modification task provides:
+#   - A working v1 solution
+#   - A natural language modification instruction
+#   - V2 tests that must pass alongside surviving v1 tests
+#
+# Prerequisites:
+#   - claude CLI installed and authenticated
+#   - almide CLI available
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+MODEL="haiku"
+EXERCISE=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --model) MODEL="$2"; shift 2 ;;
+    --exercise) EXERCISE="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+PROMPT_DIR="research/benchmark/msr/modifications/prompts"
+OUTPUT_DIR="research/benchmark/msr/modifications/outputs/$MODEL"
+CHEATSHEET="docs/CHEATSHEET.md"
+
+mkdir -p "$OUTPUT_DIR"
+
+# System prompt with language reference
+SYSTEM_PROMPT="You are modifying Almide code (.almd files). Here is the language reference:
+
+$(cat "$CHEATSHEET")
+
+IMPORTANT RULES:
+- Output ONLY the complete modified .almd file. No markdown, no explanation, no code fences.
+- Include ALL original tests (updated as specified in the instruction) AND the new v2 tests.
+- Lambda syntax: (x) => expr, NOT fn(x) => expr
+- if requires then: if cond then a else b
+- String concat uses +
+- Use match for pattern matching, not if chains on variants
+- effect fn returns Result, auto-unwraps with !
+- When adding a variant to a type, update ALL match expressions on that type.
+- When changing a return type, update ALL callers and test assertions.
+"
+
+# Extract sections from a prompt file (macOS compatible — no head -n -1)
+extract_v1() {
+  local content
+  content=$(sed -n '/^\/\/ ========== V1 SOLUTION/,/^\/\/ ========== MODIFICATION INSTRUCTION/p' "$1")
+  echo "$content" | tail -n +2 | sed '$d'
+}
+
+extract_instruction() {
+  local content
+  content=$(sed -n '/^\/\/ ========== MODIFICATION INSTRUCTION/,/^\/\/ ========== V2 TESTS/p' "$1")
+  echo "$content" | tail -n +2 | sed '$d' | sed 's/^\/\/ //'
+}
+
+extract_v2_tests() {
+  sed -n '/^\/\/ ========== V2 TESTS/,$p' "$1" | tail -n +2
+}
+
+# Collect exercises to run
+if [ -n "$EXERCISE" ]; then
+  # Support partial match: --exercise m01 matches m01-traffic-light-add-variant.almd
+  PROMPTS_LIST=$(ls "$PROMPT_DIR"/${EXERCISE}*.almd 2>/dev/null || true)
+  if [ -z "$PROMPTS_LIST" ]; then
+    echo "Exercise not found matching: $EXERCISE"
+    exit 1
+  fi
+else
+  PROMPTS_LIST=$(ls "$PROMPT_DIR"/*.almd 2>/dev/null)
+fi
+
+PASS=0
+FAIL=0
+CHECK_FAIL=0
+TEST_FAIL=0
+TOTAL=0
+RESULTS=""
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║  MSR Modification Benchmark — $MODEL"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+for prompt_file in $PROMPTS_LIST; do
+  name=$(basename "$prompt_file" .almd)
+  output_file="$OUTPUT_DIR/${name}.almd"
+  TOTAL=$((TOTAL + 1))
+
+  echo -n "⏳ $name ... "
+
+  # Extract sections
+  # Count v1 and v2 tests directly from file (avoids bash variable expansion issues)
+  V1_TEST_COUNT=$(sed -n '/^\/\/ ========== V1 SOLUTION/,/^\/\/ ========== MODIFICATION INSTRUCTION/p' "$prompt_file" | grep -c '^test ' || true)
+  V2_TEST_COUNT=$(sed -n '/^\/\/ ========== V2 TESTS/,$p' "$prompt_file" | grep -c '^test ' || true)
+
+  # Send entire prompt file to LLM (avoids bash expansion of \t \n etc.)
+  PROMPT="$(cat "$prompt_file")
+
+Modify the code above according to the MODIFICATION INSTRUCTION section.
+Output ONLY the complete modified .almd file containing:
+- All type declarations (updated as specified)
+- All functions (updated as specified)
+- All original tests (updated as specified in the instruction)
+- All new V2 tests
+Do not omit any tests."
+
+  # Call LLM
+  claude --model "$MODEL" --print --system-prompt "$SYSTEM_PROMPT" "$PROMPT" > "$output_file" 2>/dev/null || true
+
+  # Strip markdown code fences if present
+  sed -i.bak '/^```/d' "$output_file" 2>/dev/null && rm -f "${output_file}.bak" || true
+  # Strip language identifier lines (e.g., "almide" after opening fence)
+  sed -i.bak '/^almide$/d' "$output_file" 2>/dev/null && rm -f "${output_file}.bak" || true
+
+  # Count tests in output
+  OUTPUT_TEST_COUNT=$(grep -c '^test ' "$output_file" 2>/dev/null || true)
+
+  # Verify: type check
+  if ! almide check "$output_file" > /dev/null 2>&1; then
+    echo "❌ type check failed ($OUTPUT_TEST_COUNT tests found, v1:$V1_TEST_COUNT v2:$V2_TEST_COUNT expected)"
+    FAIL=$((FAIL + 1))
+    CHECK_FAIL=$((CHECK_FAIL + 1))
+    RESULTS="$RESULTS{\"name\":\"$name\",\"passed\":false,\"error\":\"type_check\",\"v1_tests\":$V1_TEST_COUNT,\"v2_tests\":$V2_TEST_COUNT,\"output_tests\":$OUTPUT_TEST_COUNT},"
+    continue
+  fi
+
+  # Verify: run tests
+  TEST_OUTPUT=$(almide test "$output_file" 2>&1 || true)
+  if echo "$TEST_OUTPUT" | grep -q "passed.*0 failed"; then
+    # Extract pass count
+    PASSED=$(echo "$TEST_OUTPUT" | grep -o '[0-9]* passed' | head -1 | grep -o '[0-9]*')
+    echo "✅ ($PASSED tests passed, v1:$V1_TEST_COUNT v2:$V2_TEST_COUNT)"
+    PASS=$((PASS + 1))
+    RESULTS="$RESULTS{\"name\":\"$name\",\"passed\":true,\"tests_passed\":$PASSED,\"v1_tests\":$V1_TEST_COUNT,\"v2_tests\":$V2_TEST_COUNT},"
+  else
+    # Try to extract pass/fail counts
+    PASSED=$(echo "$TEST_OUTPUT" | grep -o '[0-9]* passed' | head -1 | grep -o '[0-9]*' || echo "0")
+    FAILED_COUNT=$(echo "$TEST_OUTPUT" | grep -o '[0-9]* failed' | head -1 | grep -o '[0-9]*' || echo "?")
+    echo "❌ test failed ($PASSED passed, $FAILED_COUNT failed, v1:$V1_TEST_COUNT v2:$V2_TEST_COUNT)"
+    FAIL=$((FAIL + 1))
+    TEST_FAIL=$((TEST_FAIL + 1))
+    RESULTS="$RESULTS{\"name\":\"$name\",\"passed\":false,\"error\":\"test_fail\",\"tests_passed\":$PASSED,\"tests_failed\":$FAILED_COUNT,\"v1_tests\":$V1_TEST_COUNT,\"v2_tests\":$V2_TEST_COUNT},"
+  fi
+done
+
+echo ""
+echo "════════════════════════════════════════════════════════════"
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "No modification tasks found."
+  exit 1
+fi
+
+MSR=$((PASS * 100 / TOTAL))
+
+echo "  Model:          $MODEL"
+echo "  Tasks:          $TOTAL"
+echo "  Passed:         $PASS / $TOTAL"
+echo "  Check failures: $CHECK_FAIL"
+echo "  Test failures:  $TEST_FAIL"
+echo ""
+echo "  ┌──────────────────────────────┐"
+echo "  │  Modification MSR: ${MSR}%      │"
+echo "  └──────────────────────────────┘"
+
+# Save JSON result
+RESULTS_DIR="research/benchmark/msr/modifications/results"
+mkdir -p "$RESULTS_DIR"
+DATE=$(date +%Y-%m-%d)
+RESULTS="${RESULTS%,}"
+
+cat > "$RESULTS_DIR/${MODEL}_${DATE}.json" <<ENDJSON
+{
+  "date": "$DATE",
+  "language": "almide",
+  "type": "modification",
+  "model": "$MODEL",
+  "tasks": $TOTAL,
+  "passed": $PASS,
+  "failed": $FAIL,
+  "check_failures": $CHECK_FAIL,
+  "test_failures": $TEST_FAIL,
+  "msr": $(echo "scale=4; $PASS / $TOTAL" | bc),
+  "results": [$RESULTS]
+}
+ENDJSON
+
+echo ""
+echo "Results saved: $RESULTS_DIR/${MODEL}_${DATE}.json"
+echo "Solutions:     $OUTPUT_DIR/"

--- a/runtime/rs/src/list.rs
+++ b/runtime/rs/src/list.rs
@@ -57,7 +57,7 @@ pub fn almide_rt_list_repeat<T: Clone>(x: T, n: i64) -> Vec<T> { vec![x; n as us
 pub fn almide_rt_list_range(start: i64, end: i64) -> Vec<i64> { (start..end).collect() }
 pub fn almide_rt_list_reduce<A: Clone>(xs: Vec<A>, mut f: impl FnMut(A, A) -> A) -> Option<A> { xs.into_iter().reduce(f) }
 pub fn almide_rt_list_scan<A: Clone, B: Clone>(xs: Vec<A>, init: B, mut f: impl FnMut(B, A) -> B) -> Vec<B> { let mut r = Vec::new(); let mut a = init; for x in xs { a = f(a, x); r.push(a.clone()); } r }
-pub fn almide_rt_list_sort_by<A: Clone>(mut xs: Vec<A>, mut f: impl FnMut(A) -> i64) -> Vec<A> { xs.sort_by_key(|x| f(x.clone())); xs }
+pub fn almide_rt_list_sort_by<A: Clone, B: Ord>(mut xs: Vec<A>, mut f: impl FnMut(A) -> B) -> Vec<A> { xs.sort_by_key(|x| f(x.clone())); xs }
 pub fn almide_rt_list_fold_effect<A, B>(xs: Vec<A>, init: B, mut f: impl FnMut(B, A) -> Result<B, String>) -> Result<B, String> { let mut a = init; for x in xs { a = f(a, x)?; } Ok(a) }
 pub fn almide_rt_list_map_effect<A, B>(xs: Vec<A>, mut f: impl FnMut(A) -> Result<B, String>) -> Result<Vec<B>, String> { xs.into_iter().map(f).collect() }
 

--- a/spec/lang/box_deref_clone_test.almd
+++ b/spec/lang/box_deref_clone_test.almd
@@ -1,0 +1,52 @@
+// Regression: CloneInsertionPass must recurse into Deref nodes.
+// Without this, multi-use of Box'd pattern vars produces use-after-move in Rust.
+
+type Expr =
+  | Lit(Int)
+  | Add(Expr, Expr)
+
+// --- fn: multi-use of boxed var ---
+
+fn eval(e: Expr) -> Int =
+  match e {
+    Lit(n) => n
+    Add(l, r) => eval(l) + eval(l) + eval(r)
+  }
+
+test "fn: boxed var used twice" {
+  assert_eq(eval(Add(Lit(1), Lit(2))), 4)
+}
+
+test "fn: nested recursive" {
+  // eval(l) + eval(l) + eval(r) where l=Add(1,2)→4, r=Lit(3)→3 ⇒ 4+4+3=11
+  assert_eq(eval(Add(Add(Lit(1), Lit(2)), Lit(3))), 11)
+}
+
+// --- effect fn: multi-use of boxed var ---
+
+effect fn eval_e(e: Expr) -> Result[Int, String] =
+  match e {
+    Lit(n) => ok(n)
+    Add(l, r) => {
+      let lv = eval_e(l)!
+      let lv2 = eval_e(l)!
+      let rv = eval_e(r)!
+      ok(lv + lv2 + rv)
+    }
+  }
+
+test "effect fn: boxed var used twice" {
+  assert_eq(eval_e(Add(Lit(1), Lit(2))), ok(4))
+}
+
+// --- single use (no clone needed, deref only) ---
+
+fn eval_once(e: Expr) -> Int =
+  match e {
+    Lit(n) => n
+    Add(l, r) => eval_once(l) + eval_once(r)
+  }
+
+test "single use: no clone needed" {
+  assert_eq(eval_once(Add(Lit(10), Lit(20))), 30)
+}

--- a/spec/lang/string_test.almd
+++ b/spec/lang/string_test.almd
@@ -147,12 +147,12 @@ test "string slice" {
   assert_eq(string.slice("abcdef", 2, 4), "cd")
 }
 
-test "string pad_left" {
+test "string pad_start" {
   assert_eq(string.pad_start("42", 5, "0"), "00042");
   assert_eq(string.pad_start("hello", 3, " "), "hello")
 }
 
-test "string pad_right" {
+test "string pad_end" {
   assert_eq(string.pad_end("hi", 5, "."), "hi...");
   assert_eq(string.pad_end("hello", 3, " "), "hello")
 }

--- a/spec/stdlib/stdlib-test.almd
+++ b/spec/stdlib/stdlib-test.almd
@@ -532,6 +532,12 @@ test "list.sort_by string length" {
   assert_eq(result, ["a", "bb", "ccc"])
 }
 
+test "list.sort_by string key" {
+  let xs = [["b", "2"], ["a", "1"], ["c", "3"]]
+  let sorted = list.sort_by(xs, (x) => match list.get(x, 0) { some(v) => v, none => "" })
+  assert_eq(list.map(sorted, (x) => match list.get(x, 0) { some(v) => v, none => "" }), ["a", "b", "c"])
+}
+
 // ============================================================
 // list.unique
 // ============================================================

--- a/spec/stdlib/string_test.almd
+++ b/spec/stdlib/string_test.almd
@@ -111,7 +111,7 @@ test "string.slice empty result" {
   assert_eq(string.slice("hello", 5), "")
 }
 
-// ── pad_left / pad_right ──
+// ── pad_start / pad_end ──
 test "string.pad_start shorter string" {
   assert_eq(string.pad_start("42", 5, "0"), "00042")
 }

--- a/src/check/infer.rs
+++ b/src/check/infer.rs
@@ -732,7 +732,13 @@ impl Checker {
                 }
             }
             ast::Pattern::Tuple { elements } => {
-                if let Ty::Tuple(tys) = ty { for (i, e) in elements.iter().enumerate() { self.bind_pattern(e, tys.get(i).unwrap_or(&Ty::Unknown)); } }
+                let resolved = resolve_ty(ty, &self.uf);
+                if let Ty::Tuple(tys) = &resolved {
+                    for (i, e) in elements.iter().enumerate() { self.bind_pattern(e, tys.get(i).unwrap_or(&Ty::Unknown)); }
+                } else {
+                    // Type not yet resolved — bind each element as Unknown so variables are in scope
+                    for e in elements { self.bind_pattern(e, &Ty::Unknown); }
+                }
             }
             ast::Pattern::Some { inner } => { let it = match ty { Ty::Applied(TypeConstructorId::Option, args) if args.len() == 1 => args[0].clone(), _ => Ty::Unknown }; self.bind_pattern(inner, &it); }
             ast::Pattern::Ok { inner } => { let it = match ty { Ty::Applied(TypeConstructorId::Result, args) if args.len() == 2 => args[0].clone(), _ => Ty::Unknown }; self.bind_pattern(inner, &it); }

--- a/src/codegen/emit_wasm/calls_list_closure.rs
+++ b/src/codegen/emit_wasm/calls_list_closure.rs
@@ -861,6 +861,12 @@ impl FuncCompiler<'_> {
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
                 let elem_vt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32);
+                // Infer key type from closure return type (Int or String)
+                let key_ty = if let Ty::Fn { ret, .. } = &args[1].ty {
+                    (**ret).clone()
+                } else { Ty::Int };
+                let key_is_str = matches!(&key_ty, Ty::String);
+                let ks: i32 = if key_is_str { 4 } else { 8 }; // key byte size
                 let xs = self.scratch.alloc_i32();
                 let closure = self.scratch.alloc_i32();
                 let len = self.scratch.alloc_i32();
@@ -868,7 +874,7 @@ impl FuncCompiler<'_> {
                 let keys = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 let j = self.scratch.alloc_i32();
-                let tmp_key = self.scratch.alloc_i64();
+                let tmp_key = if key_is_str { self.scratch.alloc_i32() } else { self.scratch.alloc_i64() };
                 let tmp_elem = self.scratch.alloc(elem_vt);
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(xs); });
@@ -895,9 +901,9 @@ impl FuncCompiler<'_> {
                       br(0);
                     end; end;
                 });
-                // Alloc keys array: len * 8 (i64 keys)
+                // Alloc keys array: len * ks
                 wasm!(self.func, {
-                    local_get(len); i32_const(8); i32_mul;
+                    local_get(len); i32_const(ks); i32_mul;
                     call(self.emitter.rt.alloc); local_set(keys);
                     // Compute keys for all elements
                     i32_const(0); local_set(i);
@@ -911,12 +917,23 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                       local_get(closure); i32_load(0); // table_idx
                 });
-                self.emit_closure_call(&elem_ty, &Ty::Int); // key fn returns Int (i64)
+                self.emit_closure_call(&elem_ty, &key_ty);
+                if key_is_str {
+                    wasm!(self.func, {
+                          local_set(tmp_key);
+                          local_get(keys);
+                          local_get(i); i32_const(ks); i32_mul; i32_add;
+                          local_get(tmp_key); i32_store(0);
+                    });
+                } else {
+                    wasm!(self.func, {
+                          local_set(tmp_key);
+                          local_get(keys);
+                          local_get(i); i32_const(ks); i32_mul; i32_add;
+                          local_get(tmp_key); i64_store(0);
+                    });
+                }
                 wasm!(self.func, {
-                      local_set(tmp_key);
-                      local_get(keys);
-                      local_get(i); i32_const(8); i32_mul; i32_add;
-                      local_get(tmp_key); i64_store(0);
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
@@ -933,25 +950,57 @@ impl FuncCompiler<'_> {
                         local_get(j); i32_le_u; br_if(1);
                         // Compare keys[j] > keys[j+1]
                         local_get(keys);
-                        local_get(j); i32_const(8); i32_mul; i32_add;
+                        local_get(j); i32_const(ks); i32_mul; i32_add;
+                });
+                if key_is_str {
+                    wasm!(self.func, {
+                        i32_load(0);
+                        local_get(keys);
+                        local_get(j); i32_const(1); i32_add; i32_const(ks); i32_mul; i32_add;
+                        i32_load(0);
+                        call(self.emitter.rt.string.cmp); i32_const(0); i32_gt_s;
+                    });
+                } else {
+                    wasm!(self.func, {
                         i64_load(0);
                         local_get(keys);
-                        local_get(j); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
+                        local_get(j); i32_const(1); i32_add; i32_const(ks); i32_mul; i32_add;
                         i64_load(0);
                         i64_gt_s;
+                    });
+                }
+                wasm!(self.func, {
                         if_empty;
                           // Swap keys[j] and keys[j+1]
                           local_get(keys);
-                          local_get(j); i32_const(8); i32_mul; i32_add;
-                          i64_load(0); local_set(tmp_key); // temp_key
+                          local_get(j); i32_const(ks); i32_mul; i32_add;
+                });
+                if key_is_str {
+                    wasm!(self.func, {
+                          i32_load(0); local_set(tmp_key);
                           local_get(keys);
-                          local_get(j); i32_const(8); i32_mul; i32_add;
+                          local_get(j); i32_const(ks); i32_mul; i32_add;
                           local_get(keys);
-                          local_get(j); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
+                          local_get(j); i32_const(1); i32_add; i32_const(ks); i32_mul; i32_add;
+                          i32_load(0); i32_store(0);
+                          local_get(keys);
+                          local_get(j); i32_const(1); i32_add; i32_const(ks); i32_mul; i32_add;
+                          local_get(tmp_key); i32_store(0);
+                    });
+                } else {
+                    wasm!(self.func, {
+                          i64_load(0); local_set(tmp_key);
+                          local_get(keys);
+                          local_get(j); i32_const(ks); i32_mul; i32_add;
+                          local_get(keys);
+                          local_get(j); i32_const(1); i32_add; i32_const(ks); i32_mul; i32_add;
                           i64_load(0); i64_store(0);
                           local_get(keys);
-                          local_get(j); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
+                          local_get(j); i32_const(1); i32_add; i32_const(ks); i32_mul; i32_add;
                           local_get(tmp_key); i64_store(0);
+                    });
+                }
+                wasm!(self.func, {
                           // Swap dst[j] and dst[j+1] using typed scratch local
                           // tmp_elem = dst[j]
                           local_get(dst); i32_const(4); i32_add;
@@ -985,7 +1034,7 @@ impl FuncCompiler<'_> {
                     local_get(dst);
                 });
                 self.scratch.free(tmp_elem, elem_vt);
-                self.scratch.free_i64(tmp_key);
+                if key_is_str { self.scratch.free_i32(tmp_key); } else { self.scratch.free_i64(tmp_key); }
                 self.scratch.free_i32(j);
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(keys);

--- a/src/codegen/pass_clone.rs
+++ b/src/codegen/pass_clone.rs
@@ -168,6 +168,7 @@ fn insert_clones(expr: IrExpr, clone_ids: &HashSet<VarId>) -> IrExpr {
         IrExprKind::ResultErr { expr } => IrExprKind::ResultErr { expr: Box::new(insert_clones(*expr, clone_ids)) },
         IrExprKind::Try { expr } => IrExprKind::Try { expr: Box::new(insert_clones(*expr, clone_ids)) },
         IrExprKind::Unwrap { expr } => IrExprKind::Unwrap { expr: Box::new(insert_clones(*expr, clone_ids)) },
+        IrExprKind::Deref { expr } => IrExprKind::Deref { expr: Box::new(insert_clones(*expr, clone_ids)) },
         IrExprKind::UnwrapOr { expr, fallback } => IrExprKind::UnwrapOr {
             expr: Box::new(insert_clones(*expr, clone_ids)),
             fallback: Box::new(insert_clones(*fallback, clone_ids)),

--- a/src/codegen/pass_clone.rs
+++ b/src/codegen/pass_clone.rs
@@ -56,7 +56,10 @@ fn collect_clone_ids(vt: &VarTable, always_clone: &HashSet<VarId>) -> HashSet<Va
         if !needs_clone(&info.ty) { continue; }
         // Top-level lets (LazyLock statics): always clone — can't move out of LazyLock
         // Fn/TypeVar: always clone (closure mutability, generic type erasure)
-        if always_clone.contains(&id) || matches!(&info.ty, Ty::Fn { .. } | Ty::TypeVar(_)) {
+        // Capture clones (__cap_N): always clone — used inside FnMut closures called multiple times
+        let name = crate::intern::resolve(info.name);
+        if always_clone.contains(&id) || matches!(&info.ty, Ty::Fn { .. } | Ty::TypeVar(_))
+            || name.starts_with("__cap_") || name.starts_with("__licm") {
             ids.insert(id);
             continue;
         }

--- a/stdlib/defs/list.toml
+++ b/stdlib/defs/list.toml
@@ -313,7 +313,7 @@ ts = "__almd_list.flat_map({xs}, {f.args} => {f.body})"
 
 [filter_map]
 description = "Map and filter in one pass: keep only some values."
-example = '["1", "x", "3"].filter_map(fn(s) => string.to_int(s)) // => [1, 3]'
+example = '["1", "x", "3"].filter_map(fn(s) => int.parse(s)) // => [1, 3]'
 type_params = ["A", "B"]
 params = [
     { name = "xs", type = "List[A]" },

--- a/stdlib/defs/string.toml
+++ b/stdlib/defs/string.toml
@@ -66,7 +66,7 @@ ts_min = "__almd_string.slice({s}, {start})"
 
 [pad_start]
 description = "Pad a string on the left to reach a target length."
-example = 'string.pad_left("42", 5, "0") // => "00042"'
+example = 'string.pad_start("42", 5, "0") // => "00042"'
 params = [{ name = "s", type = "String" }, { name = "n", type = "Int" }, { name = "ch", type = "String" }]
 return = "String"
 rust = "almide_rt_string_pad_left(&*{s}, {n}, &*{ch})"
@@ -226,7 +226,7 @@ ts = "String.fromCodePoint({n})"
 
 [pad_end]
 description = "Pad a string on the right to reach a target length."
-example = 'string.pad_right("hi", 5, ".") // => "hi..."'
+example = 'string.pad_end("hi", 5, ".") // => "hi..."'
 params = [{ name = "s", type = "String" }, { name = "n", type = "Int" }, { name = "ch", type = "String" }]
 return = "String"
 rust = "almide_rt_string_pad_right(&*{s}, {n}, &*{ch})"

--- a/tools/generate-stdlib-cheatsheet.sh
+++ b/tools/generate-stdlib-cheatsheet.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# generate-stdlib-cheatsheet.sh — Generate stdlib reference from TOML definitions
+#
+# Usage: bash tools/generate-stdlib-cheatsheet.sh
+#
+# Outputs the "Standard library modules" section for CHEATSHEET.md.
+# Pipe to a file or use to replace the section in CHEATSHEET.md.
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+DEFS_DIR="stdlib/defs"
+
+# Auto-imported modules (no import needed)
+AUTO_IMPORT="string list map set int float value result option"
+# Modules requiring explicit import
+EXPLICIT_IMPORT="fs path env process io json http regex bytes datetime log math matrix random testing error"
+
+# Generate one module's function list from its TOML
+generate_module() {
+  local module="$1"
+  local toml="$DEFS_DIR/${module}.toml"
+
+  if [ ! -f "$toml" ]; then
+    return
+  fi
+
+  # Parse TOML: extract function names, params, return types, and effect status
+  python3 -c "
+import sys
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
+with open('$toml', 'rb') as f:
+    defs = tomllib.load(f)
+
+parts = []
+for fn_name, fn_def in defs.items():
+    if not isinstance(fn_def, dict) or 'params' not in fn_def:
+        continue
+    params = fn_def['params']
+    ret = fn_def.get('return', '')
+    effect = fn_def.get('effect', False)
+
+    # Build param string
+    param_strs = []
+    for p in params:
+        param_strs.append(p['name'])
+    param_str = ', '.join(param_strs)
+
+    # Build signature
+    sig = f\"\`${module}.{fn_name}({param_str})\`\"
+
+    # Add return type annotation for non-obvious types
+    simple_returns = {'String', 'Int', 'Float', 'Bool', 'Unit', 'List[String]', 'List[Int]', ''}
+    if ret and ret not in simple_returns:
+        sig += f' → \`{ret}\`'
+
+    parts.append(sig)
+
+print(', '.join(parts))
+"
+}
+
+echo "## Standard library modules"
+echo ""
+
+# Auto-imported modules
+for module in $AUTO_IMPORT; do
+  toml="$DEFS_DIR/${module}.toml"
+  [ ! -f "$toml" ] && continue
+
+  funcs=$(generate_module "$module")
+  [ -z "$funcs" ] && continue
+
+  echo "### $module (auto-imported)"
+  echo "$funcs"
+  echo ""
+done
+
+# Explicit import modules
+for module in $EXPLICIT_IMPORT; do
+  toml="$DEFS_DIR/${module}.toml"
+  [ ! -f "$toml" ] && continue
+
+  funcs=$(generate_module "$module")
+  [ -z "$funcs" ] && continue
+
+  # Check if module has effect functions
+  has_effect=$(python3 -c "
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+with open('$toml', 'rb') as f:
+    defs = tomllib.load(f)
+for fn_def in defs.values():
+    if isinstance(fn_def, dict) and fn_def.get('effect', False):
+        print('effect'); break
+" 2>/dev/null || true)
+
+  suffix="requires \`import $module\`"
+  if [ -n "$has_effect" ]; then
+    suffix="$suffix, effect fns"
+  fi
+
+  echo "### $module ($suffix)"
+  echo "$funcs"
+  echo ""
+done

--- a/tools/update-cheatsheet-stdlib.py
+++ b/tools/update-cheatsheet-stdlib.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Replace the stdlib section in CHEATSHEET.md with auto-generated content from TOML definitions."""
+
+import subprocess
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CHEATSHEET = ROOT / "docs" / "CHEATSHEET.md"
+GENERATOR = ROOT / "tools" / "generate-stdlib-cheatsheet.sh"
+
+# Generate new stdlib section
+result = subprocess.run(["bash", str(GENERATOR)], capture_output=True, text=True, cwd=ROOT)
+if result.returncode != 0:
+    print(f"Error running generator: {result.stderr}")
+    exit(1)
+
+new_section = result.stdout.rstrip()
+
+# Append manual sections (path, args — no TOML definitions)
+manual = """
+### path (requires `import path`)
+`path.join(base, child)`, `path.dirname(p)`, `path.basename(p)`, `path.extension(p)` → `Option[String]`, `path.is_absolute(p)` → `Bool`
+
+### args (requires `import args`)
+`args.flag(name)` → `Bool`, `args.option(name)` → `Option[String]`, `args.option_or(name, fallback)` → `String`, `args.positional()` → `List[String]`"""
+
+new_section = new_section + "\n" + manual
+
+# Read current cheatsheet
+content = CHEATSHEET.read_text()
+
+# Find and replace the stdlib section
+# Starts with "<!-- AUTO-GENERATED" or "## Standard library modules"
+# Ends just before "## Key rules"
+pattern = r"(<!-- AUTO-GENERATED[^\n]*\n)?## Standard library modules\n.*?(?=\n## Key rules)"
+replacement = f"<!-- AUTO-GENERATED from stdlib/defs/*.toml — do not edit manually. Run: make cheatsheet-update -->\n{new_section}"
+
+new_content, count = re.subn(pattern, replacement, content, flags=re.DOTALL)
+
+if count == 0:
+    print("ERROR: Could not find stdlib section in CHEATSHEET.md")
+    exit(1)
+
+CHEATSHEET.write_text(new_content)
+print(f"Replaced stdlib section ({count} substitution)")


### PR DESCRIPTION
## Summary

- Fix CloneInsertionPass missing Deref node traversal for Box'd pattern vars
- Fix tuple destructuring in closures with inferred parameter types
- Always clone __cap_ and __licm variables in FnMut closures and loops
- Generalize list.sort_by key type from i64 to Ord (String keys now work)
- Fix stdlib doc drift: pad_left→pad_start, remove phantom string.to_int
- Auto-generate CHEATSHEET stdlib section from TOML definitions (`make cheatsheet-update`)
- Add MSR modification benchmark: 10 tasks × Almide + Python, runners, verification solutions
- Almide MSR: 10/10 (100%), Python MSR: 8/9 (88%) on Haiku

## Test plan

- [x] `almide test` all specs pass
- [x] `make install` installs to both ~/.local/almide and ~/.local/bin
- [x] `make cheatsheet-update` regenerates stdlib section correctly
- [x] MSR modification benchmark: `bash research/benchmark/msr/scripts/run-modifications.sh --model haiku`
- [x] Python MSR benchmark: `bash research/benchmark/msr/python/modifications/run.sh --model haiku`