### PR TITLE
v0.9.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "clap",
  "lasso",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.9.9"
+version = "0.9.10"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,6 @@ cp target/release/almide ~/.local/bin/
 sudo cp target/release/almide /usr/local/bin/
 ```
 
-Verify the installation:
-
-```bash
-almide --version
-# almide 0.9.5
-```
-
 ### Hello World
 
 ```almd

--- a/src/codegen/emit_wasm/closures.rs
+++ b/src/codegen/emit_wasm/closures.rs
@@ -414,8 +414,9 @@ fn scan_closures_stmt(
             scan_closures_expr(cond, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
             scan_closures_expr(else_, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
         }
-        IrStmtKind::BindDestructure { value, .. } => {
+        IrStmtKind::BindDestructure { pattern, value, .. } => {
             scan_closures_expr(value, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
+            collect_pattern_var_ids(pattern, scope_vars);
         }
         IrStmtKind::IndexAssign { index, value, .. } => {
             scan_closures_expr(index, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
@@ -427,6 +428,23 @@ fn scan_closures_stmt(
         }
         IrStmtKind::FieldAssign { value, .. } => {
             scan_closures_expr(value, scope_vars, mutable_vars, var_table, lambdas, fn_refs);
+        }
+        _ => {}
+    }
+}
+
+/// Collect all VarIds bound by an IrPattern into a set.
+fn collect_pattern_var_ids(pattern: &crate::ir::IrPattern, out: &mut HashSet<u32>) {
+    use crate::ir::IrPattern;
+    match pattern {
+        IrPattern::Bind { var, .. } => { out.insert(var.0); }
+        IrPattern::Constructor { args, .. } => { for a in args { collect_pattern_var_ids(a, out); } }
+        IrPattern::Tuple { elements } => { for e in elements { collect_pattern_var_ids(e, out); } }
+        IrPattern::Some { inner, .. } | IrPattern::Ok { inner, .. } | IrPattern::Err { inner, .. } => {
+            collect_pattern_var_ids(inner, out);
+        }
+        IrPattern::RecordPattern { fields, .. } => {
+            for f in fields { if let Some(p) = &f.pattern { collect_pattern_var_ids(p, out); } }
         }
         _ => {}
     }


### PR DESCRIPTION
## Summary
- Fix FnMut closure capture: always clone `__cap_` and `__licm` variables (E0507/E0382)
- Fix tuple destructuring in closures with inferred parameter types
- Fix WASM closure capture missing `BindDestructure` pattern variables in scope
- Fix CloneInsertionPass missing Deref node traversal for Box'd pattern vars
- Generalize `list.sort_by` key type from i64 to Ord; support String key in WASM
- Fix stdlib doc drift; auto-generate CHEATSHEET stdlib section from TOML
- Add MSR modification benchmark

## Test plan
- [x] `almide test spec/` — 153 files passed (Rust)
- [x] `almide test spec/ --target wasm` — 153 files passed (WASM)
- [x] External packages: yaml (146), csv (22), toml (70), base64 (27), bindgen (32), lander (49) — all pass