### PR TITLE
v0.10.1: Auto-install ImportTable in check_program

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -226,7 +226,7 @@ impl Checker {
 
     /// Build and install an ImportTable for the main program.
     /// Called by CLI pipelines before check_program.
-    pub fn install_import_table(&mut self, program: &ast::Program) {
+    fn install_import_table(&mut self, program: &ast::Program) {
         let self_name = self.env.self_module_name.map(|s| s.to_string());
         let (table, diags) = build_import_table(program, self_name.as_deref(), &self.env.user_modules);
         self.env.import_table = table;
@@ -234,6 +234,7 @@ impl Checker {
     }
 
     pub fn check_program(&mut self, program: &mut ast::Program) -> Vec<Diagnostic> {
+        self.install_import_table(program);
         self.register_decls(&program.decls, None);
         for decl in program.decls.iter_mut() { self.check_decl(decl); }
         self.solve_constraints();

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -139,7 +139,6 @@ fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool) {
     for (name, mod_prog, pkg_id, is_self) in &resolved.modules {
         checker.register_module(name, mod_prog, pkg_id.as_ref(), *is_self);
     }
-    checker.install_import_table(&program);
     let diagnostics = checker.check_program(&mut program);
     if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
         for d in &diagnostics {
@@ -219,7 +218,6 @@ fn cmd_build_npm(file: &str, out_dir: &str, _no_check: bool) {
     for (name, mod_prog, pkg_id, is_self) in &resolved.modules {
         checker.register_module(name, mod_prog, pkg_id.as_ref(), *is_self);
     }
-    checker.install_import_table(&program);
     let diagnostics = checker.check_program(&mut program);
     if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
         for d in &diagnostics {

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -25,7 +25,6 @@ pub fn cmd_check(file: &str, deny_warnings: bool) {
     for (name, mod_prog, pkg_id, is_self) in &resolved.modules {
         checker.register_module(name, mod_prog, pkg_id.as_ref(), *is_self);
     }
-    checker.install_import_table(&program);
     let diagnostics = checker.check_program(&mut program);
 
     // Lower to IR for unused variable analysis (only if no parse errors)
@@ -109,7 +108,6 @@ pub fn cmd_check_json(file: &str) {
     for (name, mod_prog, pkg_id, is_self) in &resolved.modules {
         checker.register_module(name, mod_prog, pkg_id.as_ref(), *is_self);
     }
-    checker.install_import_table(&program);
     let diagnostics = checker.check_program(&mut program);
 
     // Output each diagnostic as JSON (one per line)
@@ -163,7 +161,6 @@ pub fn cmd_check_effects(file: &str) {
     for (name, mod_prog, pkg_id, is_self) in &resolved.modules {
         checker.register_module(name, mod_prog, pkg_id.as_ref(), *is_self);
     }
-    checker.install_import_table(&program);
     let diagnostics = checker.check_program(&mut program);
 
     let errors: Vec<_> = diagnostics.iter()

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -223,7 +223,6 @@ pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
         for (name, mod_prog, pkg_id, is_self) in &resolved.modules {
             checker.register_module(name, mod_prog, pkg_id.as_ref(), *is_self);
         }
-        checker.install_import_table(&program);
         let diagnostics = checker.check_program(&mut program);
         if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
             eprintln!("SKIP {} (type errors)", test_file);
@@ -429,7 +428,6 @@ pub fn cmd_test_ts(file: &str, _run_filter: Option<&str>) {
         for (name, mod_prog, pkg_id, is_self) in &resolved.modules {
             checker.register_module(name, mod_prog, pkg_id.as_ref(), *is_self);
         }
-        checker.install_import_table(&program);
         let diagnostics = checker.check_program(&mut program);
         if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
             eprintln!("SKIP {} (type errors)", test_file);

--- a/src/cli/compile.rs
+++ b/src/cli/compile.rs
@@ -123,7 +123,6 @@ pub fn cmd_compile(module: Option<&str>, json: bool, dry_run: bool, output_dir: 
     for (name, mod_prog, pkg_id, is_self) in &resolved.modules {
         checker.register_module(name, mod_prog, pkg_id.as_ref(), *is_self);
     }
-    checker.install_import_table(&program);
     let diagnostics = checker.check_program(&mut program);
     let errors: Vec<_> = diagnostics.iter()
         .filter(|d| d.level == diagnostic::Level::Error)

--- a/src/cli/emit.rs
+++ b/src/cli/emit.rs
@@ -29,7 +29,6 @@ pub fn cmd_emit(file: &str, target: &str, emit_ast: bool, emit_ir: bool, no_chec
         for (name, mod_prog, pkg_id, is_self) in &resolved.modules {
             checker.register_module(name, mod_prog, pkg_id.as_ref(), *is_self);
         }
-        checker.install_import_table(&program);
         let diagnostics = checker.check_program(&mut program);
         let errors: Vec<_> = diagnostics.iter()
             .filter(|d| d.level == diagnostic::Level::Error)

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,7 +238,6 @@ pub(crate) fn try_compile_with_ir(file: &str, no_check: bool, codegen_opts: &cod
         for (name, mod_prog, pkg_id, is_self) in &resolved.modules {
             checker.register_module(name, mod_prog, pkg_id.as_ref(), *is_self);
         }
-        checker.install_import_table(&program);
         let diagnostics = checker.check_program(&mut program);
         // Combine parse errors + checker errors
         let mut all_errors: Vec<&diagnostic::Diagnostic> = parse_errors.iter().collect();

--- a/tests/checker_test.rs
+++ b/tests/checker_test.rs
@@ -9,7 +9,6 @@ fn check(input: &str) -> Vec<(Level, String)> {
     let mut prog = parser.parse().expect("parse failed");
     let diags = {
         let mut checker = Checker::new();
-        checker.install_import_table(&prog);
         checker.check_program(&mut prog)
     };
     diags.into_iter().map(|d| (d.level, d.message)).collect()
@@ -21,7 +20,6 @@ fn check_with_hints(input: &str) -> Vec<(Level, String, String)> {
     let mut prog = parser.parse().expect("parse failed");
     let diags = {
         let mut checker = Checker::new();
-        checker.install_import_table(&prog);
         checker.check_program(&mut prog)
     };
     diags.into_iter().map(|d| (d.level, d.message, d.hint)).collect()


### PR DESCRIPTION
## Summary

- **`check_program` now auto-installs ImportTable** — callers no longer need to call `install_import_table` separately. This was a broken API contract where every caller (CLI, playground, unit tests) had to remember the setup call, and forgetting it caused silent type resolution failures.
- `install_import_table` is now private to the checker module.

## Context

v0.10.0 introduced ImportTable but required all callers to call `install_import_table` before `check_program`. The playground and `cargo test` both missed this, causing `import json` etc. to silently fail (types resolved as Unknown).

## Test plan

- [x] `cargo test` — all passed
- [x] `almide test spec/` — 164 files passed
- [x] `almide test research/benchmark/exercises/` — 24 files passed
- [x] Playground deploys correctly without explicit `install_import_table`