### PR TITLE
v0.10.2: Closure Conversion pass — fix nested lambda captures in WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/spec/lang/closure_nested_capture_test.almd
+++ b/spec/lang/closure_nested_capture_test.almd
@@ -1,0 +1,57 @@
+// Nested closure capture tests — verifying that function parameters
+// captured through multiple lambda levels work correctly.
+
+fn make(n: Int) -> List[List[Int]] =
+  0..2 |> list.map((i) =>
+    0..n |> list.map((j) => i + j)
+  )
+
+test "nested capture of function param" {
+  let result = make(3)
+  assert_eq(list.len(result), 2)
+  let strs = result |> list.map((row) =>
+    row |> list.map((x) => int.to_string(x)) |> list.join(",")
+  )
+  assert_eq(list.join(strs, ";"), "0,1,2;1,2,3")
+}
+
+fn wave(w: Int) -> List[String] =
+  0..3 |> list.map((row) =>
+    0..w |> list.map((col) => {
+      let v = (row + col) % 4
+      if v == 0 then "A" else if v == 1 then "B" else if v == 2 then "C" else "D"
+    }) |> list.join("")
+  )
+
+test "nested capture: wave pattern" {
+  let rows = wave(4)
+  assert_eq(list.len(rows), 3)
+  assert_eq(list.join(rows, "|"), "ABCD|BCDA|CDAB")
+}
+
+fn grid(rows: Int, cols: Int) -> List[String] =
+  0..rows |> list.map((r) =>
+    0..cols |> list.map((c) => int.to_string(r * cols + c)) |> list.join(",")
+  )
+
+test "nested capture: two params" {
+  let g = grid(2, 3)
+  assert_eq(list.join(g, ";"), "0,1,2;3,4,5")
+}
+
+fn triple_nest(n: Int) -> List[List[List[Int]]] =
+  0..2 |> list.map((i) =>
+    0..2 |> list.map((j) =>
+      0..n |> list.map((k) => i + j + k)
+    )
+  )
+
+test "triple nested capture" {
+  let result = triple_nest(3)
+  let flat = result |> list.flat_map((rows) =>
+    rows |> list.map((row) =>
+      row |> list.map((x) => int.to_string(x)) |> list.join(",")
+    )
+  )
+  assert_eq(list.join(flat, "|"), "0,1,2|1,2,3|1,2,3|2,3,4")
+}

--- a/src/codegen/emit_wasm/calls_lambda.rs
+++ b/src/codegen/emit_wasm/calls_lambda.rs
@@ -143,4 +143,88 @@ impl FuncCompiler<'_> {
             self.scratch.free_i32(env_scratch);
         }
     }
+
+    /// Emit a ClosureCreate node (from closure conversion pass).
+    /// Allocates env, stores captures, creates [table_idx, env_ptr] pair.
+    pub(super) fn emit_closure_create(&mut self, func_name: &crate::intern::Sym, captures: &[(VarId, Ty)]) {
+        // Find the lifted function's index in the function table
+        let name_str = func_name.to_string();
+        let func_idx = self.emitter.func_map.get(&name_str).copied();
+        let table_idx = func_idx.and_then(|fi| self.emitter.func_to_table_idx.get(&fi).copied());
+
+        let table_idx = match table_idx {
+            Some(ti) => ti as i32,
+            None => {
+                eprintln!("WARNING: ClosureCreate: lifted function '{}' not in table", name_str);
+                wasm!(self.func, { unreachable; });
+                return;
+            }
+        };
+
+        let scratch = self.scratch.alloc_i32();
+
+        if captures.is_empty() {
+            // No captures: closure = [table_idx, 0]
+            wasm!(self.func, {
+                i32_const(8);
+                call(self.emitter.rt.alloc);
+                local_set(scratch);
+                local_get(scratch);
+                i32_const(table_idx);
+                i32_store(0);
+                local_get(scratch);
+                i32_const(0);
+                i32_store(4);
+                local_get(scratch);
+            });
+        } else {
+            // Allocate env
+            let env_size = (captures.len() as u32) * 8;
+            let env_scratch = self.scratch.alloc_i32();
+            wasm!(self.func, {
+                i32_const(env_size as i32);
+                call(self.emitter.rt.alloc);
+                local_set(env_scratch);
+            });
+
+            // Store each captured variable into env
+            for (ci, (vid, ty)) in captures.iter().enumerate() {
+                let offset = (ci as u32) * 8;
+                wasm!(self.func, { local_get(env_scratch); });
+                if let Some(&local_idx) = self.var_map.get(&vid.0) {
+                    wasm!(self.func, { local_get(local_idx); });
+                    self.emit_store_at(ty, offset);
+                } else {
+                    // This should not happen after closure conversion —
+                    // all captured vars should be in var_map (as locals or env-loaded params)
+                    eprintln!("WARNING: ClosureCreate capture var {} not in var_map", vid.0);
+                    match values::ty_to_valtype(ty) {
+                        Some(ValType::I64) => { wasm!(self.func, { i64_const(0); }); }
+                        Some(ValType::F64) => { wasm!(self.func, { f64_const(0.0); }); }
+                        _ => { wasm!(self.func, { i32_const(0); }); }
+                    }
+                    self.emit_store_at(ty, offset);
+                }
+            }
+
+            // Allocate closure pair [table_idx, env_ptr]
+            let closure_scratch = self.scratch.alloc_i32();
+            wasm!(self.func, {
+                i32_const(8);
+                call(self.emitter.rt.alloc);
+                local_set(closure_scratch);
+                local_get(closure_scratch);
+                i32_const(table_idx);
+                i32_store(0);
+                local_get(closure_scratch);
+                local_get(env_scratch);
+                i32_store(4);
+                local_get(closure_scratch);
+            });
+            self.scratch.free_i32(closure_scratch);
+            self.scratch.free_i32(env_scratch);
+        }
+
+        self.scratch.free_i32(scratch);
+    }
 }

--- a/src/codegen/emit_wasm/expressions.rs
+++ b/src/codegen/emit_wasm/expressions.rs
@@ -90,6 +90,40 @@ impl FuncCompiler<'_> {
                 self.emit_lambda_closure(params, body, *lambda_id);
             }
 
+            // ── ClosureCreate (from closure conversion pass) ──
+            IrExprKind::ClosureCreate { func_name, captures } => {
+                self.emit_closure_create(func_name, captures);
+            }
+
+            // ── EnvLoad (read captured var from env pointer) ──
+            IrExprKind::EnvLoad { env_var, index } => {
+                let offset = (*index) * 8;
+                if let Some(&local_idx) = self.var_map.get(&env_var.0) {
+                    wasm!(self.func, { local_get(local_idx); });
+                } else {
+                    // env_var should be local 0 in lifted functions (first param)
+                    wasm!(self.func, { local_get(0); });
+                }
+                // Load value from env at offset
+                match super::values::ty_to_valtype(&expr.ty) {
+                    Some(wasm_encoder::ValType::I64) => {
+                        self.func.instruction(&wasm_encoder::Instruction::I64Load(
+                            wasm_encoder::MemArg { offset: offset as u64, align: 3, memory_index: 0 }
+                        ));
+                    }
+                    Some(wasm_encoder::ValType::F64) => {
+                        self.func.instruction(&wasm_encoder::Instruction::F64Load(
+                            wasm_encoder::MemArg { offset: offset as u64, align: 3, memory_index: 0 }
+                        ));
+                    }
+                    _ => {
+                        self.func.instruction(&wasm_encoder::Instruction::I32Load(
+                            wasm_encoder::MemArg { offset: offset as u64, align: 2, memory_index: 0 }
+                        ));
+                    }
+                }
+            }
+
             // ── Binary operators ──
             IrExprKind::BinOp { op, left, right } => {
                 self.emit_binop(*op, left, right);

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -40,6 +40,7 @@ pub mod pass_stream_fusion;
 pub mod pass_tco;
 pub mod pass_licm;
 pub mod pass_peephole;
+pub mod pass_closure_conversion;
 pub mod template;
 pub mod target;
 pub mod walker;

--- a/src/codegen/pass_auto_parallel.rs
+++ b/src/codegen/pass_auto_parallel.rs
@@ -271,6 +271,7 @@ fn is_pure_expr(
 
         IrExprKind::EmptyMap => true,
         IrExprKind::Todo { .. } => false,
+        IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. } => true,
     }
 }
 

--- a/src/codegen/pass_closure_conversion.rs
+++ b/src/codegen/pass_closure_conversion.rs
@@ -1,0 +1,737 @@
+//! Closure Conversion pass: lifts all lambdas to top-level functions with explicit environments.
+//!
+//! After this pass, no `Lambda` nodes remain in the IR. Each lambda becomes:
+//! - A new `IrFunction` with an env pointer as its first parameter
+//! - A `ClosureCreate` node at the original lambda site
+//!
+//! Inside lifted functions, captured variables are accessed via `EnvLoad` nodes.
+//! This eliminates the need for WASM codegen to understand closures — it only sees
+//! plain functions and explicit environment allocation.
+//!
+//! Inspired by Elm/Haskell/Gleam closure conversion.
+
+use std::collections::HashSet;
+use crate::ir::*;
+use crate::types::Ty;
+use crate::intern::sym;
+use super::pass::{NanoPass, PassResult, Target};
+
+#[derive(Debug)]
+pub struct ClosureConversionPass;
+
+impl NanoPass for ClosureConversionPass {
+    fn name(&self) -> &str { "ClosureConversion" }
+
+    fn targets(&self) -> Option<Vec<Target>> {
+        Some(vec![Target::Wasm])
+    }
+
+    fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
+        let mut lifted = Vec::new();
+        let mut counter = 0u32;
+
+        // Convert lambdas in main program functions
+        for func in &mut program.functions {
+            func.body = convert_expr(
+                std::mem::take(&mut func.body),
+                &mut lifted, &mut counter, &mut program.var_table,
+            );
+        }
+        for tl in &mut program.top_lets {
+            tl.value = convert_expr(
+                std::mem::take(&mut tl.value),
+                &mut lifted, &mut counter, &mut program.var_table,
+            );
+        }
+
+        // Convert lambdas in module functions
+        for module in &mut program.modules {
+            for func in &mut module.functions {
+                func.body = convert_expr(
+                    std::mem::take(&mut func.body),
+                    &mut lifted, &mut counter, &mut module.var_table,
+                );
+            }
+            for tl in &mut module.top_lets {
+                tl.value = convert_expr(
+                    std::mem::take(&mut tl.value),
+                    &mut lifted, &mut counter, &mut module.var_table,
+                );
+            }
+        }
+
+        // Add all lifted functions to the main program
+        let changed = !lifted.is_empty();
+        program.functions.extend(lifted);
+
+        PassResult { program, changed }
+    }
+}
+
+/// Recursively convert all Lambda nodes in an expression (bottom-up).
+/// Inner lambdas are converted first, so their ClosureCreate captures are
+/// visible when processing outer lambdas.
+fn convert_expr(
+    expr: IrExpr,
+    lifted: &mut Vec<IrFunction>,
+    counter: &mut u32,
+    var_table: &mut VarTable,
+) -> IrExpr {
+    let span = expr.span;
+    let ty = expr.ty.clone();
+
+    let kind = match expr.kind {
+        IrExprKind::Lambda { params, body, lambda_id } => {
+            // 1. Recursively convert nested lambdas first (bottom-up)
+            let body = convert_expr(*body, lifted, counter, var_table);
+
+            // 2. Compute free variables of the lambda body
+            let param_ids: HashSet<VarId> = params.iter().map(|(v, _)| *v).collect();
+            let mut free = HashSet::new();
+            collect_free_vars(&body, &param_ids, &mut free);
+
+            // Sort captures for deterministic env layout
+            let mut captures: Vec<(VarId, Ty)> = free.into_iter()
+                .map(|vid| {
+                    let info = var_table.get(vid);
+                    (vid, info.ty.clone())
+                })
+                .collect();
+            captures.sort_by_key(|(vid, _)| vid.0);
+
+            // 3. Generate lifted function name
+            let id = lambda_id.unwrap_or_else(|| { let c = *counter; *counter = c + 1; c });
+            let func_name = sym(&format!("__closure_{}", id));
+
+            // 4. Create env parameter (i32 pointer in WASM)
+            // Use Ty::String as a proxy for i32 pointer type (maps to ValType::I32)
+            let env_ty = Ty::String;
+            let env_var = var_table.alloc(
+                sym("__env"), env_ty.clone(), Mutability::Let, None,
+            );
+
+            // 5. Create local bindings for each capture: let __cap_N = EnvLoad(N)
+            //    Then rewrite Var references to use the new local VarIds.
+            //    This ensures inner ClosureCreate nodes reference locals in var_map.
+            let mut prologue_stmts = Vec::new();
+            let mut cap_locals: Vec<(VarId, VarId, Ty)> = Vec::new(); // (original, new_local, ty)
+            for (idx, (vid, cap_ty)) in captures.iter().enumerate() {
+                let local_name = sym(&format!("__cap_{}", idx));
+                let local_var = var_table.alloc(local_name, cap_ty.clone(), Mutability::Let, None);
+                prologue_stmts.push(IrStmt {
+                    kind: IrStmtKind::Bind {
+                        var: local_var,
+                        mutability: Mutability::Let,
+                        ty: cap_ty.clone(),
+                        value: IrExpr {
+                            kind: IrExprKind::EnvLoad { env_var, index: idx as u32 },
+                            ty: cap_ty.clone(),
+                            span: None,
+                        },
+                    },
+                    span: None,
+                });
+                cap_locals.push((*vid, local_var, cap_ty.clone()));
+            }
+
+            // Rewrite body: replace original captured VarIds with new local VarIds
+            let rewritten_body = rewrite_var_ids(&body, &cap_locals);
+
+            // Wrap body with prologue
+            let final_body = if prologue_stmts.is_empty() {
+                rewritten_body
+            } else {
+                IrExpr {
+                    kind: IrExprKind::Block {
+                        stmts: prologue_stmts,
+                        expr: Some(Box::new(rewritten_body.clone())),
+                    },
+                    ty: rewritten_body.ty.clone(),
+                    span: rewritten_body.span,
+                }
+            };
+
+            // Build the ClosureCreate with original VarIds (they exist in the enclosing scope)
+            // The captures list uses the original VarIds because at the call site,
+            // these vars are in scope (as locals or as cap_locals from the enclosing lifted fn).
+
+            // 6. Build the lifted function
+            let mut func_params = vec![IrParam {
+                var: env_var,
+                ty: env_ty.clone(), // env pointer (i32 in WASM, maps via ty_to_valtype)
+                name: sym("__env"),
+                borrow: ParamBorrow::Own,
+                open_record: None,
+                default: None,
+            }];
+            for (vid, vty) in &params {
+                let info = var_table.get(*vid);
+                func_params.push(IrParam {
+                    var: *vid,
+                    ty: vty.clone(),
+                    name: info.name,
+                    borrow: ParamBorrow::Own,
+                    open_record: None,
+                    default: None,
+                });
+            }
+
+            let ret_ty = match &ty {
+                Ty::Fn { ret, .. } => *ret.clone(),
+                _ => body.ty.clone(),
+            };
+
+            lifted.push(IrFunction {
+                name: func_name,
+                params: func_params,
+                ret_ty,
+                body: final_body,
+                is_effect: false,
+                is_async: false,
+                is_test: false,
+                generics: None,
+                extern_attrs: vec![],
+                visibility: IrVisibility::Private,
+            });
+
+            // 7. Replace the Lambda with ClosureCreate
+            IrExprKind::ClosureCreate {
+                func_name,
+                captures,
+            }
+        }
+
+        // ── Recursive conversion for all other nodes ──
+
+        IrExprKind::Block { stmts, expr: tail } => IrExprKind::Block {
+            stmts: stmts.into_iter().map(|s| convert_stmt(s, lifted, counter, var_table)).collect(),
+            expr: tail.map(|e| Box::new(convert_expr(*e, lifted, counter, var_table))),
+        },
+        IrExprKind::Call { target, args, type_args } => IrExprKind::Call {
+            target: convert_target(target, lifted, counter, var_table),
+            args: args.into_iter().map(|a| convert_expr(a, lifted, counter, var_table)).collect(),
+            type_args,
+        },
+        IrExprKind::If { cond, then, else_ } => IrExprKind::If {
+            cond: Box::new(convert_expr(*cond, lifted, counter, var_table)),
+            then: Box::new(convert_expr(*then, lifted, counter, var_table)),
+            else_: Box::new(convert_expr(*else_, lifted, counter, var_table)),
+        },
+        IrExprKind::Match { subject, arms } => IrExprKind::Match {
+            subject: Box::new(convert_expr(*subject, lifted, counter, var_table)),
+            arms: arms.into_iter().map(|arm| IrMatchArm {
+                pattern: arm.pattern,
+                guard: arm.guard.map(|g| convert_expr(g, lifted, counter, var_table)),
+                body: convert_expr(arm.body, lifted, counter, var_table),
+            }).collect(),
+        },
+        IrExprKind::ForIn { var, var_tuple, iterable, body } => IrExprKind::ForIn {
+            var, var_tuple,
+            iterable: Box::new(convert_expr(*iterable, lifted, counter, var_table)),
+            body: body.into_iter().map(|s| convert_stmt(s, lifted, counter, var_table)).collect(),
+        },
+        IrExprKind::While { cond, body } => IrExprKind::While {
+            cond: Box::new(convert_expr(*cond, lifted, counter, var_table)),
+            body: body.into_iter().map(|s| convert_stmt(s, lifted, counter, var_table)).collect(),
+        },
+        IrExprKind::BinOp { op, left, right } => IrExprKind::BinOp {
+            op, left: Box::new(convert_expr(*left, lifted, counter, var_table)),
+            right: Box::new(convert_expr(*right, lifted, counter, var_table)),
+        },
+        IrExprKind::UnOp { op, operand } => IrExprKind::UnOp {
+            op, operand: Box::new(convert_expr(*operand, lifted, counter, var_table)),
+        },
+        IrExprKind::List { elements } => IrExprKind::List {
+            elements: elements.into_iter().map(|e| convert_expr(e, lifted, counter, var_table)).collect(),
+        },
+        IrExprKind::Tuple { elements } => IrExprKind::Tuple {
+            elements: elements.into_iter().map(|e| convert_expr(e, lifted, counter, var_table)).collect(),
+        },
+        IrExprKind::Fan { exprs } => IrExprKind::Fan {
+            exprs: exprs.into_iter().map(|e| convert_expr(e, lifted, counter, var_table)).collect(),
+        },
+        IrExprKind::Record { name, fields } => IrExprKind::Record {
+            name, fields: fields.into_iter().map(|(k, v)| (k, convert_expr(v, lifted, counter, var_table))).collect(),
+        },
+        IrExprKind::SpreadRecord { base, fields } => IrExprKind::SpreadRecord {
+            base: Box::new(convert_expr(*base, lifted, counter, var_table)),
+            fields: fields.into_iter().map(|(k, v)| (k, convert_expr(v, lifted, counter, var_table))).collect(),
+        },
+        IrExprKind::MapLiteral { entries } => IrExprKind::MapLiteral {
+            entries: entries.into_iter().map(|(k, v)| (convert_expr(k, lifted, counter, var_table), convert_expr(v, lifted, counter, var_table))).collect(),
+        },
+        IrExprKind::Range { start, end, inclusive } => IrExprKind::Range {
+            start: Box::new(convert_expr(*start, lifted, counter, var_table)),
+            end: Box::new(convert_expr(*end, lifted, counter, var_table)),
+            inclusive,
+        },
+        IrExprKind::Member { object, field } => IrExprKind::Member {
+            object: Box::new(convert_expr(*object, lifted, counter, var_table)), field,
+        },
+        IrExprKind::TupleIndex { object, index } => IrExprKind::TupleIndex {
+            object: Box::new(convert_expr(*object, lifted, counter, var_table)), index,
+        },
+        IrExprKind::IndexAccess { object, index } => IrExprKind::IndexAccess {
+            object: Box::new(convert_expr(*object, lifted, counter, var_table)),
+            index: Box::new(convert_expr(*index, lifted, counter, var_table)),
+        },
+        IrExprKind::MapAccess { object, key } => IrExprKind::MapAccess {
+            object: Box::new(convert_expr(*object, lifted, counter, var_table)),
+            key: Box::new(convert_expr(*key, lifted, counter, var_table)),
+        },
+        IrExprKind::StringInterp { parts } => IrExprKind::StringInterp {
+            parts: parts.into_iter().map(|p| match p {
+                IrStringPart::Expr { expr } => IrStringPart::Expr { expr: convert_expr(expr, lifted, counter, var_table) },
+                other => other,
+            }).collect(),
+        },
+        IrExprKind::ResultOk { expr } => IrExprKind::ResultOk { expr: Box::new(convert_expr(*expr, lifted, counter, var_table)) },
+        IrExprKind::ResultErr { expr } => IrExprKind::ResultErr { expr: Box::new(convert_expr(*expr, lifted, counter, var_table)) },
+        IrExprKind::OptionSome { expr } => IrExprKind::OptionSome { expr: Box::new(convert_expr(*expr, lifted, counter, var_table)) },
+        IrExprKind::Try { expr } => IrExprKind::Try { expr: Box::new(convert_expr(*expr, lifted, counter, var_table)) },
+        IrExprKind::Unwrap { expr } => IrExprKind::Unwrap { expr: Box::new(convert_expr(*expr, lifted, counter, var_table)) },
+        IrExprKind::ToOption { expr } => IrExprKind::ToOption { expr: Box::new(convert_expr(*expr, lifted, counter, var_table)) },
+        IrExprKind::UnwrapOr { expr, fallback } => IrExprKind::UnwrapOr {
+            expr: Box::new(convert_expr(*expr, lifted, counter, var_table)),
+            fallback: Box::new(convert_expr(*fallback, lifted, counter, var_table)),
+        },
+        IrExprKind::OptionalChain { expr, field } => IrExprKind::OptionalChain {
+            expr: Box::new(convert_expr(*expr, lifted, counter, var_table)), field,
+        },
+        IrExprKind::Clone { expr } => IrExprKind::Clone { expr: Box::new(convert_expr(*expr, lifted, counter, var_table)) },
+        IrExprKind::Deref { expr } => IrExprKind::Deref { expr: Box::new(convert_expr(*expr, lifted, counter, var_table)) },
+        IrExprKind::Borrow { expr, as_str, mutable } => IrExprKind::Borrow {
+            expr: Box::new(convert_expr(*expr, lifted, counter, var_table)), as_str, mutable,
+        },
+        IrExprKind::BoxNew { expr } => IrExprKind::BoxNew { expr: Box::new(convert_expr(*expr, lifted, counter, var_table)) },
+        IrExprKind::ToVec { expr } => IrExprKind::ToVec { expr: Box::new(convert_expr(*expr, lifted, counter, var_table)) },
+        IrExprKind::Await { expr } => IrExprKind::Await { expr: Box::new(convert_expr(*expr, lifted, counter, var_table)) },
+        IrExprKind::RustMacro { name, args } => IrExprKind::RustMacro {
+            name, args: args.into_iter().map(|a| convert_expr(a, lifted, counter, var_table)).collect(),
+        },
+
+        // Leaf nodes — no conversion needed
+        other => other,
+    };
+
+    IrExpr { kind, ty, span }
+}
+
+fn convert_stmt(
+    stmt: IrStmt,
+    lifted: &mut Vec<IrFunction>,
+    counter: &mut u32,
+    var_table: &mut VarTable,
+) -> IrStmt {
+    let kind = match stmt.kind {
+        IrStmtKind::Bind { var, mutability, ty, value } => IrStmtKind::Bind {
+            var, mutability, ty, value: convert_expr(value, lifted, counter, var_table),
+        },
+        IrStmtKind::BindDestructure { pattern, value } => IrStmtKind::BindDestructure {
+            pattern, value: convert_expr(value, lifted, counter, var_table),
+        },
+        IrStmtKind::Assign { var, value } => IrStmtKind::Assign {
+            var, value: convert_expr(value, lifted, counter, var_table),
+        },
+        IrStmtKind::IndexAssign { target, index, value } => IrStmtKind::IndexAssign {
+            target, index: convert_expr(index, lifted, counter, var_table),
+            value: convert_expr(value, lifted, counter, var_table),
+        },
+        IrStmtKind::MapInsert { target, key, value } => IrStmtKind::MapInsert {
+            target, key: convert_expr(key, lifted, counter, var_table),
+            value: convert_expr(value, lifted, counter, var_table),
+        },
+        IrStmtKind::FieldAssign { target, field, value } => IrStmtKind::FieldAssign {
+            target, field, value: convert_expr(value, lifted, counter, var_table),
+        },
+        IrStmtKind::Guard { cond, else_ } => IrStmtKind::Guard {
+            cond: convert_expr(cond, lifted, counter, var_table),
+            else_: convert_expr(else_, lifted, counter, var_table),
+        },
+        IrStmtKind::Expr { expr } => IrStmtKind::Expr {
+            expr: convert_expr(expr, lifted, counter, var_table),
+        },
+        other => other,
+    };
+    IrStmt { kind, span: stmt.span }
+}
+
+fn convert_target(
+    target: CallTarget,
+    lifted: &mut Vec<IrFunction>,
+    counter: &mut u32,
+    var_table: &mut VarTable,
+) -> CallTarget {
+    match target {
+        CallTarget::Method { object, method } => CallTarget::Method {
+            object: Box::new(convert_expr(*object, lifted, counter, var_table)), method,
+        },
+        CallTarget::Computed { callee } => CallTarget::Computed {
+            callee: Box::new(convert_expr(*callee, lifted, counter, var_table)),
+        },
+        other => other,
+    }
+}
+
+// ── Free variable analysis ──────────────────────────────────────
+
+fn collect_free_vars(expr: &IrExpr, bound: &HashSet<VarId>, free: &mut HashSet<VarId>) {
+    match &expr.kind {
+        IrExprKind::Var { id } => {
+            if !bound.contains(id) { free.insert(*id); }
+        }
+        // After bottom-up conversion, inner lambdas are already ClosureCreate.
+        // Their captures reference variables from the enclosing scope.
+        IrExprKind::ClosureCreate { captures, .. } => {
+            for (vid, _) in captures {
+                if !bound.contains(vid) { free.insert(*vid); }
+            }
+        }
+        IrExprKind::Lambda { params, body, .. } => {
+            // Should not happen after bottom-up conversion, but handle for safety
+            let mut inner_bound = bound.clone();
+            for (v, _) in params { inner_bound.insert(*v); }
+            collect_free_vars(body, &inner_bound, free);
+        }
+        IrExprKind::Block { stmts, expr: tail } => {
+            let mut local_bound = bound.clone();
+            for stmt in stmts {
+                collect_free_vars_stmt(stmt, &local_bound, free);
+                match &stmt.kind {
+                    IrStmtKind::Bind { var, .. } => { local_bound.insert(*var); }
+                    IrStmtKind::BindDestructure { pattern, .. } => {
+                        collect_pattern_bindings(pattern, &mut local_bound);
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(e) = tail { collect_free_vars(e, &local_bound, free); }
+        }
+        IrExprKind::Call { target, args, .. } => {
+            match target {
+                CallTarget::Method { object, .. } => collect_free_vars(object, bound, free),
+                CallTarget::Computed { callee } => collect_free_vars(callee, bound, free),
+                _ => {}
+            }
+            for a in args { collect_free_vars(a, bound, free); }
+        }
+        IrExprKind::BinOp { left, right, .. } => {
+            collect_free_vars(left, bound, free);
+            collect_free_vars(right, bound, free);
+        }
+        IrExprKind::UnOp { operand, .. } => collect_free_vars(operand, bound, free),
+        IrExprKind::If { cond, then, else_ } => {
+            collect_free_vars(cond, bound, free);
+            collect_free_vars(then, bound, free);
+            collect_free_vars(else_, bound, free);
+        }
+        IrExprKind::Match { subject, arms } => {
+            collect_free_vars(subject, bound, free);
+            for arm in arms {
+                let mut arm_bound = bound.clone();
+                collect_pattern_bindings(&arm.pattern, &mut arm_bound);
+                if let Some(g) = &arm.guard { collect_free_vars(g, &arm_bound, free); }
+                collect_free_vars(&arm.body, &arm_bound, free);
+            }
+        }
+        IrExprKind::ForIn { var, var_tuple, iterable, body } => {
+            collect_free_vars(iterable, bound, free);
+            let mut loop_bound = bound.clone();
+            loop_bound.insert(*var);
+            if let Some(vt) = var_tuple { for v in vt { loop_bound.insert(*v); } }
+            for s in body { collect_free_vars_stmt(s, &loop_bound, free); }
+        }
+        IrExprKind::While { cond, body } => {
+            collect_free_vars(cond, bound, free);
+            for s in body { collect_free_vars_stmt(s, bound, free); }
+        }
+        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
+        | IrExprKind::Fan { exprs: elements } => {
+            for e in elements { collect_free_vars(e, bound, free); }
+        }
+        IrExprKind::Record { fields, .. } => {
+            for (_, v) in fields { collect_free_vars(v, bound, free); }
+        }
+        IrExprKind::SpreadRecord { base, fields } => {
+            collect_free_vars(base, bound, free);
+            for (_, v) in fields { collect_free_vars(v, bound, free); }
+        }
+        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. }
+        | IrExprKind::OptionalChain { expr: object, .. } => {
+            collect_free_vars(object, bound, free);
+        }
+        IrExprKind::IndexAccess { object, index } | IrExprKind::MapAccess { object, key: index } => {
+            collect_free_vars(object, bound, free);
+            collect_free_vars(index, bound, free);
+        }
+        IrExprKind::OptionSome { expr: e } | IrExprKind::ResultOk { expr: e }
+        | IrExprKind::ResultErr { expr: e } | IrExprKind::Try { expr: e }
+        | IrExprKind::Unwrap { expr: e } | IrExprKind::ToOption { expr: e }
+        | IrExprKind::Clone { expr: e } | IrExprKind::Deref { expr: e }
+        | IrExprKind::Borrow { expr: e, .. } | IrExprKind::BoxNew { expr: e }
+        | IrExprKind::ToVec { expr: e } | IrExprKind::Await { expr: e } => {
+            collect_free_vars(e, bound, free);
+        }
+        IrExprKind::UnwrapOr { expr: e, fallback: f } => {
+            collect_free_vars(e, bound, free);
+            collect_free_vars(f, bound, free);
+        }
+        IrExprKind::StringInterp { parts } => {
+            for p in parts {
+                if let IrStringPart::Expr { expr: e } = p { collect_free_vars(e, bound, free); }
+            }
+        }
+        IrExprKind::Range { start, end, .. } => {
+            collect_free_vars(start, bound, free);
+            collect_free_vars(end, bound, free);
+        }
+        IrExprKind::MapLiteral { entries } => {
+            for (k, v) in entries {
+                collect_free_vars(k, bound, free);
+                collect_free_vars(v, bound, free);
+            }
+        }
+        IrExprKind::RustMacro { args, .. } => {
+            for a in args { collect_free_vars(a, bound, free); }
+        }
+        _ => {} // Leaf nodes: LitInt, LitStr, Unit, FnRef, etc.
+    }
+}
+
+fn collect_free_vars_stmt(stmt: &IrStmt, bound: &HashSet<VarId>, free: &mut HashSet<VarId>) {
+    match &stmt.kind {
+        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
+        | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => {
+            collect_free_vars(value, bound, free);
+        }
+        IrStmtKind::IndexAssign { index, value, .. } => {
+            collect_free_vars(index, bound, free);
+            collect_free_vars(value, bound, free);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            collect_free_vars(key, bound, free);
+            collect_free_vars(value, bound, free);
+        }
+        IrStmtKind::Guard { cond, else_ } => {
+            collect_free_vars(cond, bound, free);
+            collect_free_vars(else_, bound, free);
+        }
+        IrStmtKind::Expr { expr } => collect_free_vars(expr, bound, free),
+        IrStmtKind::ListSwap { a, b, .. } => {
+            collect_free_vars(a, bound, free);
+            collect_free_vars(b, bound, free);
+        }
+        _ => {}
+    }
+}
+
+fn collect_pattern_bindings(pattern: &IrPattern, bound: &mut HashSet<VarId>) {
+    match pattern {
+        IrPattern::Bind { var, .. } => { bound.insert(*var); }
+        IrPattern::Constructor { args, .. } => {
+            for p in args { collect_pattern_bindings(p, bound); }
+        }
+        IrPattern::RecordPattern { fields, .. } => {
+            for f in fields {
+                if let Some(p) = &f.pattern {
+                    collect_pattern_bindings(p, bound);
+                }
+            }
+        }
+        IrPattern::Tuple { elements } => {
+            for p in elements { collect_pattern_bindings(p, bound); }
+        }
+        IrPattern::Some { inner } | IrPattern::Ok { inner } | IrPattern::Err { inner } => {
+            collect_pattern_bindings(inner, bound);
+        }
+        _ => {}
+    }
+}
+
+// ── Variable ID rewriting ────────────────────────────────────────
+
+/// Rewrite Var references: replace original captured VarIds with new local VarIds.
+fn rewrite_var_ids(expr: &IrExpr, mappings: &[(VarId, VarId, Ty)]) -> IrExpr {
+    let kind = match &expr.kind {
+        IrExprKind::Var { id } => {
+            if let Some((_, new_id, _)) = mappings.iter().find(|(orig, _, _)| orig == id) {
+                IrExprKind::Var { id: *new_id }
+            } else {
+                expr.kind.clone()
+            }
+        }
+        // ClosureCreate captures: also rewrite VarIds
+        IrExprKind::ClosureCreate { func_name, captures } => {
+            let rewritten: Vec<(VarId, Ty)> = captures.iter().map(|(vid, ty)| {
+                if let Some((_, new_id, _)) = mappings.iter().find(|(orig, _, _)| orig == vid) {
+                    (*new_id, ty.clone())
+                } else {
+                    (*vid, ty.clone())
+                }
+            }).collect();
+            IrExprKind::ClosureCreate { func_name: *func_name, captures: rewritten }
+        }
+        IrExprKind::Block { stmts, expr: tail } => IrExprKind::Block {
+            stmts: stmts.iter().map(|s| rewrite_var_ids_stmt(s, mappings)).collect(),
+            expr: tail.as_ref().map(|e| Box::new(rewrite_var_ids(e, mappings))),
+        },
+        IrExprKind::Call { target, args, type_args } => IrExprKind::Call {
+            target: match target {
+                CallTarget::Method { object, method } => CallTarget::Method {
+                    object: Box::new(rewrite_var_ids(object, mappings)), method: *method,
+                },
+                CallTarget::Computed { callee } => CallTarget::Computed {
+                    callee: Box::new(rewrite_var_ids(callee, mappings)),
+                },
+                other => other.clone(),
+            },
+            args: args.iter().map(|a| rewrite_var_ids(a, mappings)).collect(),
+            type_args: type_args.clone(),
+        },
+        IrExprKind::If { cond, then, else_ } => IrExprKind::If {
+            cond: Box::new(rewrite_var_ids(cond, mappings)),
+            then: Box::new(rewrite_var_ids(then, mappings)),
+            else_: Box::new(rewrite_var_ids(else_, mappings)),
+        },
+        IrExprKind::Match { subject, arms } => IrExprKind::Match {
+            subject: Box::new(rewrite_var_ids(subject, mappings)),
+            arms: arms.iter().map(|arm| IrMatchArm {
+                pattern: arm.pattern.clone(),
+                guard: arm.guard.as_ref().map(|g| rewrite_var_ids(g, mappings)),
+                body: rewrite_var_ids(&arm.body, mappings),
+            }).collect(),
+        },
+        IrExprKind::BinOp { op, left, right } => IrExprKind::BinOp {
+            op: *op,
+            left: Box::new(rewrite_var_ids(left, mappings)),
+            right: Box::new(rewrite_var_ids(right, mappings)),
+        },
+        IrExprKind::UnOp { op, operand } => IrExprKind::UnOp {
+            op: *op, operand: Box::new(rewrite_var_ids(operand, mappings)),
+        },
+        IrExprKind::ForIn { var, var_tuple, iterable, body } => IrExprKind::ForIn {
+            var: *var, var_tuple: var_tuple.clone(),
+            iterable: Box::new(rewrite_var_ids(iterable, mappings)),
+            body: body.iter().map(|s| rewrite_var_ids_stmt(s, mappings)).collect(),
+        },
+        IrExprKind::While { cond, body } => IrExprKind::While {
+            cond: Box::new(rewrite_var_ids(cond, mappings)),
+            body: body.iter().map(|s| rewrite_var_ids_stmt(s, mappings)).collect(),
+        },
+        IrExprKind::List { elements } => IrExprKind::List {
+            elements: elements.iter().map(|e| rewrite_var_ids(e, mappings)).collect(),
+        },
+        IrExprKind::Tuple { elements } => IrExprKind::Tuple {
+            elements: elements.iter().map(|e| rewrite_var_ids(e, mappings)).collect(),
+        },
+        IrExprKind::Fan { exprs } => IrExprKind::Fan {
+            exprs: exprs.iter().map(|e| rewrite_var_ids(e, mappings)).collect(),
+        },
+        IrExprKind::Record { name, fields } => IrExprKind::Record {
+            name: *name, fields: fields.iter().map(|(k, v)| (*k, rewrite_var_ids(v, mappings))).collect(),
+        },
+        IrExprKind::SpreadRecord { base, fields } => IrExprKind::SpreadRecord {
+            base: Box::new(rewrite_var_ids(base, mappings)),
+            fields: fields.iter().map(|(k, v)| (*k, rewrite_var_ids(v, mappings))).collect(),
+        },
+        IrExprKind::MapLiteral { entries } => IrExprKind::MapLiteral {
+            entries: entries.iter().map(|(k, v)| (rewrite_var_ids(k, mappings), rewrite_var_ids(v, mappings))).collect(),
+        },
+        IrExprKind::Range { start, end, inclusive } => IrExprKind::Range {
+            start: Box::new(rewrite_var_ids(start, mappings)),
+            end: Box::new(rewrite_var_ids(end, mappings)),
+            inclusive: *inclusive,
+        },
+        IrExprKind::Member { object, field } => IrExprKind::Member {
+            object: Box::new(rewrite_var_ids(object, mappings)), field: *field,
+        },
+        IrExprKind::TupleIndex { object, index } => IrExprKind::TupleIndex {
+            object: Box::new(rewrite_var_ids(object, mappings)), index: *index,
+        },
+        IrExprKind::IndexAccess { object, index } => IrExprKind::IndexAccess {
+            object: Box::new(rewrite_var_ids(object, mappings)),
+            index: Box::new(rewrite_var_ids(index, mappings)),
+        },
+        IrExprKind::MapAccess { object, key } => IrExprKind::MapAccess {
+            object: Box::new(rewrite_var_ids(object, mappings)),
+            key: Box::new(rewrite_var_ids(key, mappings)),
+        },
+        IrExprKind::StringInterp { parts } => IrExprKind::StringInterp {
+            parts: parts.iter().map(|p| match p {
+                IrStringPart::Expr { expr } => IrStringPart::Expr { expr: rewrite_var_ids(expr, mappings) },
+                other => other.clone(),
+            }).collect(),
+        },
+        IrExprKind::ResultOk { expr } => IrExprKind::ResultOk { expr: Box::new(rewrite_var_ids(expr, mappings)) },
+        IrExprKind::ResultErr { expr } => IrExprKind::ResultErr { expr: Box::new(rewrite_var_ids(expr, mappings)) },
+        IrExprKind::OptionSome { expr } => IrExprKind::OptionSome { expr: Box::new(rewrite_var_ids(expr, mappings)) },
+        IrExprKind::Try { expr } => IrExprKind::Try { expr: Box::new(rewrite_var_ids(expr, mappings)) },
+        IrExprKind::Unwrap { expr } => IrExprKind::Unwrap { expr: Box::new(rewrite_var_ids(expr, mappings)) },
+        IrExprKind::ToOption { expr } => IrExprKind::ToOption { expr: Box::new(rewrite_var_ids(expr, mappings)) },
+        IrExprKind::UnwrapOr { expr, fallback } => IrExprKind::UnwrapOr {
+            expr: Box::new(rewrite_var_ids(expr, mappings)),
+            fallback: Box::new(rewrite_var_ids(fallback, mappings)),
+        },
+        IrExprKind::OptionalChain { expr, field } => IrExprKind::OptionalChain {
+            expr: Box::new(rewrite_var_ids(expr, mappings)), field: *field,
+        },
+        IrExprKind::Clone { expr } => IrExprKind::Clone { expr: Box::new(rewrite_var_ids(expr, mappings)) },
+        IrExprKind::Deref { expr } => IrExprKind::Deref { expr: Box::new(rewrite_var_ids(expr, mappings)) },
+        IrExprKind::Borrow { expr, as_str, mutable } => IrExprKind::Borrow {
+            expr: Box::new(rewrite_var_ids(expr, mappings)), as_str: *as_str, mutable: *mutable,
+        },
+        IrExprKind::BoxNew { expr } => IrExprKind::BoxNew { expr: Box::new(rewrite_var_ids(expr, mappings)) },
+        IrExprKind::ToVec { expr } => IrExprKind::ToVec { expr: Box::new(rewrite_var_ids(expr, mappings)) },
+        IrExprKind::Await { expr } => IrExprKind::Await { expr: Box::new(rewrite_var_ids(expr, mappings)) },
+        IrExprKind::RustMacro { name, args } => IrExprKind::RustMacro {
+            name: *name, args: args.iter().map(|a| rewrite_var_ids(a, mappings)).collect(),
+        },
+        // ClosureCreate inside a lifted body: captures might reference outer captures
+        IrExprKind::ClosureCreate { func_name, captures: inner_captures } => {
+            let rewritten: Vec<(VarId, Ty)> = inner_captures.iter().map(|(vid, ty)| {
+                // This captured var might itself be a capture from the enclosing scope
+                // We don't rewrite VarIds here — the EnvLoad already replaced the Var node
+                // in the inner lambda's body. The ClosureCreate stores values, which are
+                // resolved at the call site (where the var is in scope as a local or env load).
+                (*vid, ty.clone())
+            }).collect();
+            IrExprKind::ClosureCreate { func_name: *func_name, captures: rewritten }
+        },
+        // Leaf nodes
+        _ => expr.kind.clone(),
+    };
+    IrExpr { kind, ty: expr.ty.clone(), span: expr.span }
+}
+
+fn rewrite_var_ids_stmt(stmt: &IrStmt, mappings: &[(VarId, VarId, Ty)]) -> IrStmt {
+    let rw = |e: &IrExpr| rewrite_var_ids(e, mappings);
+    let kind = match &stmt.kind {
+        IrStmtKind::Bind { var, mutability, ty, value } => IrStmtKind::Bind {
+            var: *var, mutability: *mutability, ty: ty.clone(), value: rw(value),
+        },
+        IrStmtKind::BindDestructure { pattern, value } => IrStmtKind::BindDestructure {
+            pattern: pattern.clone(), value: rw(value),
+        },
+        IrStmtKind::Assign { var, value } => IrStmtKind::Assign {
+            var: *var, value: rw(value),
+        },
+        IrStmtKind::IndexAssign { target, index, value } => IrStmtKind::IndexAssign {
+            target: *target, index: rw(index), value: rw(value),
+        },
+        IrStmtKind::MapInsert { target, key, value } => IrStmtKind::MapInsert {
+            target: *target, key: rw(key), value: rw(value),
+        },
+        IrStmtKind::FieldAssign { target, field, value } => IrStmtKind::FieldAssign {
+            target: *target, field: *field, value: rw(value),
+        },
+        IrStmtKind::Guard { cond, else_ } => IrStmtKind::Guard {
+            cond: rw(cond), else_: rw(else_),
+        },
+        IrStmtKind::Expr { expr } => IrStmtKind::Expr { expr: rw(expr) },
+        IrStmtKind::ListSwap { target, a, b } => IrStmtKind::ListSwap {
+            target: *target, a: rw(a), b: rw(b),
+        },
+        other => other.clone(),
+    };
+    IrStmt { kind, span: stmt.span }
+}

--- a/src/codegen/target.rs
+++ b/src/codegen/target.rs
@@ -26,6 +26,7 @@ use super::pass_stream_fusion::StreamFusionPass;
 use super::pass_tco::TailCallOptPass;
 use super::pass_licm::LICMPass;
 use super::pass_peephole::PeepholePass;
+use super::pass_closure_conversion::ClosureConversionPass;
 use super::template::TemplateSet;
 
 /// Full configuration for a codegen target.
@@ -106,6 +107,8 @@ fn build_pipeline(target: Target) -> Pipeline {
             .add(ResultPropagationPass)
             // Peephole: swap/reverse/rotate/copy → specialized IR nodes
             .add(PeepholePass)
+            // Closure conversion: lift lambdas to top-level functions with explicit env
+            .add(ClosureConversionPass)
             .add(FanLoweringPass),
     }
 }

--- a/src/codegen/walker/expressions.rs
+++ b/src/codegen/walker/expressions.rs
@@ -575,8 +575,10 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                 .unwrap_or_else(|| format!("fan({})", rendered.join(", ")))
         }
 
-        // ── Fallback ──
-        // _ => format!("/* TODO: unhandled IR node */"),
+        // ── Closure conversion nodes (WASM-only, never reached by Rust walker) ──
+        IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. } => {
+            unreachable!("ClosureCreate/EnvLoad should only appear in WASM pipeline")
+        }
     }
 }
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -283,6 +283,18 @@ pub enum IrExprKind {
     /// Walker outputs this verbatim — no further processing.
     RenderedCall { code: String },
 
+    // ── Closure Conversion (inserted by ClosureConversionPass, WASM target) ──
+    /// Create a closure object: lifted function + captured environment.
+    ClosureCreate {
+        func_name: Sym,
+        captures: Vec<(VarId, Ty)>,
+    },
+    /// Load a captured variable from the closure environment pointer (first param of lifted fn).
+    EnvLoad {
+        env_var: VarId,
+        index: u32,
+    },
+
     // ── Misc ──
     Hole,
     Todo { message: String },

--- a/src/ir/substitute.rs
+++ b/src/ir/substitute.rs
@@ -241,7 +241,8 @@ pub fn substitute_var_in_expr(expr: &IrExpr, var: VarId, replacement: &IrExpr) -
         | IrExprKind::Unit | IrExprKind::EmptyMap | IrExprKind::OptionNone
         | IrExprKind::Break | IrExprKind::Continue
         | IrExprKind::Hole | IrExprKind::Todo { .. }
-        | IrExprKind::RenderedCall { .. } => expr.clone(),
+        | IrExprKind::RenderedCall { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::ClosureCreate { .. } => expr.clone(),
     }
 }
 

--- a/src/ir/use_count.rs
+++ b/src/ir/use_count.rs
@@ -31,7 +31,8 @@ fn count_uses_in_expr(expr: &IrExpr, table: &mut VarTable) {
         | IrExprKind::LitBool { .. } | IrExprKind::Unit | IrExprKind::OptionNone
         | IrExprKind::Hole | IrExprKind::Todo { .. }
         | IrExprKind::Break | IrExprKind::Continue
-        | IrExprKind::EmptyMap => {}
+        | IrExprKind::EmptyMap
+        | IrExprKind::EnvLoad { .. } | IrExprKind::ClosureCreate { .. } => {}
 
         IrExprKind::BinOp { left, right, .. } => {
             count_uses_in_expr(left, table);

--- a/src/ir/visit.rs
+++ b/src/ir/visit.rs
@@ -27,7 +27,8 @@ pub fn walk_expr<V: IrVisitor>(v: &mut V, expr: &IrExpr) {
         | IrExprKind::LitBool { .. } | IrExprKind::Unit | IrExprKind::Var { .. }
         | IrExprKind::FnRef { .. } | IrExprKind::EmptyMap | IrExprKind::OptionNone
         | IrExprKind::Break | IrExprKind::Continue | IrExprKind::Hole
-        | IrExprKind::Todo { .. } | IrExprKind::RenderedCall { .. } => {}
+        | IrExprKind::Todo { .. } | IrExprKind::RenderedCall { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::ClosureCreate { .. } => {}
 
         // ── Operators ──
         IrExprKind::BinOp { left, right, .. } => {


### PR DESCRIPTION
## Summary

- **Closure Conversion pass**: new nanopass that lifts all lambdas to top-level functions with explicit environment parameters. Runs for WASM target only, after PeepholePass, before FanLoweringPass.
- **Fixes nested capture bug**: function parameters captured through 2+ levels of lambda nesting previously read as 0 in WASM. The playground's default Shape renderer (wave pattern) was affected.
- WASM codegen no longer needs to understand closure scoping — it just sees plain functions and `ClosureCreate`/`EnvLoad` nodes.

## Architecture (Elm/Haskell-style)

```
// Before (IR)
fn make(n) = 0..2 |> map((i) => 0..n |> map((j) => i + j))

// After closure conversion (IR)
fn __closure_1(__env, j) = { let i = EnvLoad(0); let n = EnvLoad(1); i + j }
fn __closure_0(__env, i) = { let n = EnvLoad(0); 0..n |> map(ClosureCreate(__closure_1, [i, n])) }
fn make(n) = 0..2 |> map(ClosureCreate(__closure_0, [n]))
```

## New IR nodes

- `ClosureCreate { func_name, captures }` — replaces `Lambda` after the pass
- `EnvLoad { env_var, index }` — reads captured value from env pointer

## Test plan

- [x] `cargo test` — all passed
- [x] `almide test spec/` — 165 files passed (includes new closure_nested_capture_test)
- [x] `almide test spec/ --target wasm` — 162 passed, 3 skipped
- [x] `almide test research/benchmark/exercises/` — 24 files passed