### PR TITLE
v0.10.3: Unify Result/Option/effect semantics, Never type, parser fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/buildscript/stdlib_codegen.rs
+++ b/buildscript/stdlib_codegen.rs
@@ -125,6 +125,7 @@ fn parse_type(s: &str, type_params: &[String]) -> String {
         "Unit" => "Ty::Unit".to_string(),
         "Bytes" => "Ty::Bytes".to_string(),
         "Matrix" => "Ty::Matrix".to_string(),
+        "Never" => "Ty::Never".to_string(),
         "Unknown" => "Ty::Unknown".to_string(),
         other if other.starts_with("List[") => {
             let inner = &other[5..other.len() - 1];

--- a/docs/roadmap/active/canonical-ast.md
+++ b/docs/roadmap/active/canonical-ast.md
@@ -1,0 +1,41 @@
+<!-- description: Introduce Canonical AST phase to separate name resolution from type checking -->
+# Canonical AST
+
+Source AST → Canonical AST → Type Check の 2 段階に分離する。
+
+## 問題
+
+現在 Almide は AST のまま型チェックに入るため、import 解決とチェッカーが絡み合っている。ImportTable リファクタリングが必要になった根本原因。
+
+- チェッカーが import 解決、モジュール登録、エイリアス管理を兼務
+- lowering 時にモジュールエイリアスが消失するバグが発生（`import self as lander` 等）
+- サブモジュールの暗黙エイリアス（Go 方式）の導入で複雑度が爆発
+
+## 参考
+
+- **Elm**: `AST/Source.hs` → `Canonicalize/Module.hs` → `AST/Canonical.hs`
+  - Canonical AST で変数が `VarLocal` / `VarTopLevel` / `VarKernel` / `VarForeign` にタグ付け
+  - 全名前が完全修飾済み。型チェッカーは名前解決を一切しない
+- **Roc**: `can/module.rs` — `exposed_imports`, `exposed_symbols`, `referenced_values` を Canonical 化で確定
+
+## ゴール
+
+```
+Source AST (parser 出力)
+    │
+    ▼
+Canonicalize (名前解決 + import 解決 + UFCS 解決)
+    │
+    ▼
+Canonical AST (全名前が module.func 形式に確定)
+    │
+    ▼
+Type Checker (純粋に型だけを扱う)
+    │
+    ▼
+Typed Canonical AST → Lowering → IR
+```
+
+- チェッカーから import/module 解決を完全に分離
+- Canonical AST の各ノードにモジュール情報を持たせる
+- lowering はエイリアス解決を一切しない（Canonical で完了済み）

--- a/docs/roadmap/active/contracts-runtime-validation.md
+++ b/docs/roadmap/active/contracts-runtime-validation.md
@@ -1,0 +1,23 @@
+<!-- description: Runtime contracts for value constraints -->
+# Contracts — Runtime Validation
+
+値の制約をランタイムで検証する仕組み。
+
+## 参考
+
+- **Nickel**: `label.rs` + `contract_eq.rs` — blame tracking 付き契約システム
+  - Polarity (正/負) で契約違反の責任を追跡
+  - `ty_path::Path` で制約違反の正確な位置を報告
+  - RFC005: マージ時に契約がクロス適用される
+
+## 設計案
+
+```almide
+type Score = Int | Range(0, 100)
+
+fn validate(s: Score) -> Result[Unit, String] = ...
+```
+
+- 契約違反時に正確なエラー（どの制約が、どの値で違反したか）
+- 契約の合成（複数の制約を AND/OR で組み合わせ）
+- 範囲制約、型制約、カスタム述語

--- a/docs/roadmap/active/dead-code-elimination.md
+++ b/docs/roadmap/active/dead-code-elimination.md
@@ -1,0 +1,24 @@
+<!-- description: Dependency-graph-based dead code elimination for smaller WASM binaries -->
+# Dead Code Elimination
+
+エクスポートされた関数から依存グラフを辿り、到達不能な定義を削除する。WASM バイナリサイズの削減に直結。
+
+## 参考
+
+- **Elm**: `Optimize/Names.hs` — `Tracker` モナドで使用されるグローバル・フィールドアクセスを追跡
+  - エクスポートから到達可能な定義だけを残す
+  - フィールドアクセス頻度でレコードフィールドの最適化判断
+  - コンストラクタの最適化: `Enum`（整数化）、`Unbox`（ラッパー除去）
+- **Elm**: `Optimize/DecisionTree.hs` — match 式の冗長ブランチ除去
+
+## 現状
+
+Almide の Rust codegen は `#[allow(dead_code)]` で未使用コードを許容。WASM codegen は全関数を出力。
+stdlib ランタイム（Rust）は使用モジュールだけ include する仕組みがあるが、関数レベルの除去はない。
+
+## ゴール
+
+- IR レベルで依存グラフを構築（main/test から辿る）
+- 到達不能な関数・型定義を IR から除去
+- WASM バイナリサイズの削減（現状 playground の Shape renderer: 5KB → 目標 3KB 以下）
+- コンストラクタの最適化（引数なしバリアント → 整数、単一フィールド → unbox）

--- a/docs/roadmap/active/error-message-suggestions.md
+++ b/docs/roadmap/active/error-message-suggestions.md
@@ -1,0 +1,20 @@
+<!-- description: Fuzzy matching suggestions in error messages (did you mean?) -->
+# Error Message Suggestions
+
+未定義の変数・関数に対して Levenshtein 距離ベースの候補を提示する。
+
+## 参考
+
+- **Gleam**: `error.rs` の `did_you_mean()` — 距離 < name.len()/3 で候補表示
+- **Elm**: `Reporting/Suggest.hs` — restricted Damerau-Levenshtein + case-insensitive matching
+
+## ゴール
+
+```
+error[E003]: undefined variable 'prntln'
+  hint: Did you mean `println`?
+```
+
+- スコープ内の変数名・関数名・モジュール名を候補として検索
+- 大文字小文字を無視したマッチング
+- LLM のタイポを自動修正可能にする

--- a/docs/roadmap/active/nanopass-debug-dump.md
+++ b/docs/roadmap/active/nanopass-debug-dump.md
@@ -1,0 +1,37 @@
+<!-- description: Environment-variable-controlled IR dump for each nanopass stage -->
+# Nanopass Debug Dump
+
+環境変数で各 nanopass の中間 IR をダンプし、コンパイラのデバッグと最適化の検証を容易にする。
+
+## 参考
+
+- **Roc**: `load_internal/file.rs` — デバッグフラグで各パス後の IR を出力
+  ```rust
+  ROC_PRINT_IR_AFTER_SPECIALIZATION
+  ROC_PRINT_IR_AFTER_DROP_SPECIALIZATION
+  ROC_PRINT_IR_AFTER_REFCOUNT
+  ROC_PRINT_IR_AFTER_RESET_REUSE
+  ROC_PRINT_IR_AFTER_TRMC
+  ROC_CHECK_MONO_IR  // IR の整合性チェック
+  ```
+- **Roc**: `assert_sizeof_all!` マクロで構造体サイズの退行を検出
+
+## 設計案
+
+```bash
+# 特定パスの後の IR をダンプ
+ALMIDE_DUMP_IR=capture_clone,clone_insertion almide build app.almd --target wasm
+
+# 全パスをダンプ
+ALMIDE_DUMP_IR=all almide build app.almd
+
+# IR の整合性チェック（TypeVar が残っていないか等）
+ALMIDE_CHECK_IR=1 almide build app.almd
+```
+
+## ゴール
+
+- 各 nanopass の before/after で IR をファイルまたは stderr に出力
+- パス名でフィルタリング可能
+- IR の整合性チェック（TypeVar 残存、未解決参照、型不一致の検出）
+- コンパイラ開発者が最適化パスの効果を視覚的に確認できる

--- a/docs/roadmap/active/pattern-exhaustiveness-check.md
+++ b/docs/roadmap/active/pattern-exhaustiveness-check.md
@@ -1,0 +1,20 @@
+<!-- description: Static exhaustiveness checking for match expressions -->
+# Pattern Exhaustiveness Check
+
+match 式でバリアントの漏れをコンパイル時に検出する。
+
+## 参考
+
+- **Elm**: `Nitpick/PatternMatches.hs` — Maranget のアルゴリズムで decision tree を構築
+- **Gleam**: `exhaustiveness.rs` (155KB) — Jules Jacobs のアルゴリズム
+
+## 現状
+
+WASM codegen では網羅性チェックなし。到達しない場合は `unreachable` trap。
+Rust ターゲットでは Rust コンパイラが検出するため間接的にカバー。
+
+## ゴール
+
+- 型チェッカーで match の網羅性を検証
+- 不足しているパターンをエラーメッセージで列挙
+- 到達不能パターンを warning で報告

--- a/docs/roadmap/active/typed-ast-cache.md
+++ b/docs/roadmap/active/typed-ast-cache.md
@@ -1,0 +1,32 @@
+<!-- description: Cache type annotations on AST nodes to eliminate re-inference in lowering -->
+# Typed AST Cache
+
+型情報を AST ノードに直接キャッシュし、lowering での型引き直しを不要にする。
+
+## 問題
+
+現在の lowering は `expr_types` (HashMap) と `checker.env` を受け取って IR を生成する。型チェック結果が AST に紐づいていないため：
+
+- lowering 時に型を HashMap から引き直す必要がある
+- TypeVar が未解決のまま IR に残る ICE の原因になる
+- expr_types のキーが位置ベースで、同一位置の式が複数あると壊れる
+
+## 参考
+
+- **Elm**: `AST/Canonical.hs` — `Can.Annotation` を変数に直接キャッシュ。後段は O(1) で型を取得
+- **Gleam**: `TypedModule` に全型情報を格納。immutable で再利用可能
+- **Roc**: `AbilityMemberData<Phase>` — フェーズ型パラメータで Pending → Resolved を型安全に遷移
+
+## ゴール
+
+```rust
+// Before: 型を外部 HashMap から引く
+let ty = expr_types.get(&expr.span).unwrap_or(&Ty::Unknown);
+
+// After: AST ノードに型が貼り付いている
+let ty = &expr.ty;  // Canonical AST のフィールド
+```
+
+- 各 AST ノードに `ty: Ty` フィールドを追加（Canonical 化後に設定）
+- lowering は `expr_types` HashMap を参照しない
+- TypeVar の ICE が構造的に不可能になる

--- a/docs/roadmap/on-hold/api-diff-auto-versioning.md
+++ b/docs/roadmap/on-hold/api-diff-auto-versioning.md
@@ -1,0 +1,20 @@
+<!-- description: Automatic semver bump detection via public API diffing -->
+# API Diff & Automatic Versioning
+
+パッケージの公開 API を比較して MAJOR/MINOR/PATCH を自動判定する。
+
+## 参考
+
+- **Elm**: `Deps/Diff.hs` — 型シグネチャの構造比較
+  - 型変数のリネーミングを考慮した等価判定
+  - モジュール追加 = MINOR、型変更 = MAJOR、関数追加 = MINOR
+  - `elm diff` コマンドで CLI から実行可能
+
+## ゴール
+
+```bash
+almide diff v0.1.0..v0.2.0
+# Added: yaml.parse_all (MINOR)
+# Changed: yaml.stringify return type String → Result[String, String] (MAJOR)
+# Suggested version: v1.0.0
+```

--- a/docs/roadmap/on-hold/gradual-typing.md
+++ b/docs/roadmap/on-hold/gradual-typing.md
@@ -1,0 +1,19 @@
+<!-- description: Gradual typing with automatic runtime checks at typed/untyped boundaries -->
+# Gradual Typing
+
+typed と untyped コードの境界に自動でランタイムチェックを挿入する。ライブラリは strict、設定/スクリプトは flexible に書ける。
+
+## 参考
+
+- **Nickel**: `typecheck/mod.rs` — Walk モード（動的）と Enforce モード（静的）の 2 モード
+  - 型注釈がある関数の内部だけ静的型チェック
+  - 境界で自動的にブリッジ契約を挿入
+  - 型変数は明示的 `forall` が必要（自動汎化なし）
+  - RATIONALE.md: 設定データは untyped（すぐテストされる）、ライブラリは typed（無限の入力パターン）
+
+## 設計の方向性
+
+- 型注釈のない関数は動的チェック（現状の Almide は全て型推論）
+- パッケージの public API は型注釈を強制
+- 外部パッケージからの呼び出し境界で自動チェック挿入
+- `strict` モードフラグで全関数に型注釈を要求（CI 向け）

--- a/docs/roadmap/on-hold/lsp-code-actions.md
+++ b/docs/roadmap/on-hold/lsp-code-actions.md
@@ -1,0 +1,20 @@
+<!-- description: LSP code actions for auto-fix, refactoring, and import management -->
+# LSP Code Actions
+
+エディタ上で自動修正・リファクタリングを提供する。
+
+## 参考
+
+- **Gleam**: `code_action.rs` (384KB) — 40+ のコードアクション
+  - import 追加/削除
+  - unused 変数削除
+  - パターン抽出
+  - 型注釈追加
+- **Nickel**: `analysis.rs` (45KB) — 型とコントラクト情報を使った補完
+
+## ゴール
+
+- import 自動追加（`almide fmt` のエディタ統合版）
+- 未使用変数の削除提案
+- match パターンの自動補完（全バリアント列挙）
+- 関数シグネチャの型注釈追加

--- a/docs/roadmap/on-hold/phase-typed-ast.md
+++ b/docs/roadmap/on-hold/phase-typed-ast.md
@@ -1,0 +1,46 @@
+<!-- description: Phase type parameters for type-safe compiler pipeline transitions -->
+# Phase-Typed AST
+
+コンパイラのフェーズ遷移を型パラメータで表現し、各フェーズで利用可能な情報を型レベルで保証する。
+
+## 参考
+
+- **Roc**: `can/abilities.rs` — `ResolvePhase` トレイトで Pending → Resolved を型安全に遷移
+  ```rust
+  pub trait ResolvePhase {
+      type MemberType;
+  }
+  pub struct Pending;
+  pub struct Resolved;
+
+  pub struct AbilityMemberData<Phase: ResolvePhase> {
+      pub parent_ability: Symbol,
+      pub typ: Phase::MemberType,
+  }
+  ```
+  Pending フェーズでは型が未確定、Resolved フェーズでは確定済み。間違ったフェーズのデータにアクセスするとコンパイルエラー。
+
+## 設計の方向性
+
+Canonical AST の導入と組み合わせて：
+
+```rust
+struct Expr<Phase> {
+    kind: ExprKind,
+    ty: Phase::Type,      // Parsed: (), Checked: Ty
+    module: Phase::Module, // Parsed: String, Canonical: ModuleId
+}
+
+struct Parsed;   // ty = (), module = raw string
+struct Canon;    // ty = (), module = ModuleId (resolved)
+struct Typed;    // ty = Ty, module = ModuleId
+
+impl Phase for Parsed { type Type = (); type Module = String; }
+impl Phase for Canon  { type Type = (); type Module = ModuleId; }
+impl Phase for Typed  { type Type = Ty; type Module = ModuleId; }
+```
+
+- パーサーは `Expr<Parsed>` を返す
+- Canonicalize は `Expr<Canon>` を返す
+- 型チェッカーは `Expr<Typed>` を返す
+- lowering は `Expr<Typed>` だけを受け取る（型なし AST を渡すとコンパイルエラー）

--- a/docs/roadmap/on-hold/platform-app-separation.md
+++ b/docs/roadmap/on-hold/platform-app-separation.md
@@ -1,0 +1,16 @@
+<!-- description: Platform/application separation for dual-target compilation -->
+# Platform/Application Separation
+
+プラットフォーム（ランタイム層）とアプリケーションを分離し、WASM + native のデュアルターゲットを効率化する。
+
+## 参考
+
+- **Roc**: `parse/header.rs` — `PlatformHeader` で requires/provides/exposes を宣言
+  - プラットフォームは一度コンパイルすれば複数アプリで再利用
+  - アプリはプラットフォームの型にだけ依存
+
+## ゴール
+
+- プラットフォームが WASM/native 両方のバイナリを提供
+- アプリはターゲットを意識せず書ける
+- プラットフォームの切り替えでデプロイ先を変更

--- a/docs/roadmap/on-hold/snapshot-testing.md
+++ b/docs/roadmap/on-hold/snapshot-testing.md
@@ -1,0 +1,18 @@
+<!-- description: Built-in snapshot testing for output regression detection -->
+# Snapshot Testing
+
+出力のスナップショットをファイルに保存し、回帰を自動検出する。
+
+## 参考
+
+- **MoonBit**: `inspect(x, content="expected")` — Show ベース + JSON スナップショット
+- **Gleam**: `type_/tests/snapshots/` — テスト結果のスナップショット保存
+
+## ゴール
+
+```almide
+test "format output" {
+  let result = format_table(data)
+  snapshot(result)  // 初回: ファイルに保存。2回目以降: 比較
+}
+```

--- a/docs/roadmap/on-hold/trait-based-io.md
+++ b/docs/roadmap/on-hold/trait-based-io.md
@@ -1,0 +1,32 @@
+<!-- description: Abstract filesystem and I/O behind traits for testability -->
+# Trait-Based I/O Abstraction
+
+ファイルシステム・HTTP 等の I/O をトレイトで抽象化し、テストでインメモリ実装に差し替え可能にする。
+
+## 参考
+
+- **Gleam**: `FileSystemReader`, `FileSystemWriter`, `HttpClient` トレイト
+  - テストで `InMemoryFileSystem` を使用（OS I/O なし）
+  - `LanguageServerTestIO` が全 I/O をラップ
+  - LSP テストもインメモリで高速実行
+
+## 現状
+
+Almide コンパイラは `std::fs::read_to_string` 等を直接呼び出し。テストでファイルシステムのモックができない。
+
+## ゴール
+
+```rust
+trait FileSystem {
+    fn read(&self, path: &Path) -> Result<String, Error>;
+    fn write(&self, path: &Path, content: &str) -> Result<(), Error>;
+    fn exists(&self, path: &Path) -> bool;
+}
+
+struct RealFileSystem;      // 本番用
+struct InMemoryFileSystem;  // テスト用
+```
+
+- resolve.rs, project.rs, project_fetch.rs のファイルアクセスをトレイト経由に
+- コンパイラのユニットテストがファイルシステムに依存しない
+- WASM playground のコンパイラもインメモリ FS で動作（仮想ファイルシステム）

--- a/docs/roadmap/on-hold/wasm-component-model.md
+++ b/docs/roadmap/on-hold/wasm-component-model.md
@@ -1,0 +1,14 @@
+<!-- description: WebAssembly Component Model support with WIT bindings -->
+# WASM Component Model
+
+WebAssembly Component Model と WIT (WebAssembly Interface Types) をサポートし、言語間の相互運用を実現する。
+
+## 参考
+
+- **MoonBit**: `wit-bindgen` でバインディング自動生成、`--derive-error` フラグ
+
+## ゴール
+
+- WIT ファイルからバインディング自動生成
+- コンポーネント境界での型安全な呼び出し
+- 既存の WASI 対応との統合

--- a/docs/specs/result-option-effect.md
+++ b/docs/specs/result-option-effect.md
@@ -1,0 +1,182 @@
+# Result, Option, Effect — 完全仕様 (DRAFT)
+
+> 1.0.0 に向けた仕様確定ドラフト。全演算子・全関数形態で辻褄が合うことを保証する。
+
+## 1. 型
+
+### Result[T, E]
+```
+ok(v)   : Result[T, E]   // 成功値
+err(e)  : Result[T, E]   // エラー値
+```
+
+### Option[T]
+```
+some(v) : Option[T]       // 値あり
+none    : Option[T]       // 値なし
+```
+
+### Never (bottom type)
+```
+process.exit(n) : Never   // 戻らない関数の戻り値型
+```
+Never はどの型にも代入可能。guard else, if then, match arm で使える。
+
+## 2. 演算子
+
+### `expr!` — unwrap with propagation
+
+| 入力型 | 出力型 | Rust 生成 | 制限 |
+|---|---|---|---|
+| `Result[T, E]` | `T` | `(expr)?` | effect fn 内のみ |
+| `Option[T]` | `T` | `(expr).ok_or("none".to_string())?` | effect fn 内のみ |
+| test 内 | `T` | `(expr).unwrap()` | テスト専用 |
+
+effect fn の外で `!` を使うとコンパイルエラー。
+
+### `expr?` — Result → Option 変換
+
+| 入力型 | 出力型 | Rust 生成 |
+|---|---|---|
+| `Result[T, E]` | `Option[T]` | `(expr).ok()` |
+| `Option[T]` | `Option[T]` | identity（変換なし） |
+
+### `expr ?? fallback` — unwrap with fallback
+
+| 入力型 | 出力型 | Rust 生成 |
+|---|---|---|
+| `Result[T, E]` | `T` | `match expr { Ok(v) => v, Err(_) => fallback }` |
+| `Option[T]` | `T` | `match expr { Some(v) => v, None => fallback }` |
+
+**型判定ルール**: `inner.ty` が `Option[T]` なら Option テンプレート、それ以外は Result テンプレート。
+
+**⚠ 既知の問題**: 型が `Unknown` のとき Result 扱いになる。型推論が失敗すると壊れる。
+
+## 3. effect fn
+
+### 宣言
+
+```almide
+effect fn read_file(path: String) -> String = fs.read_text(path)!
+```
+
+ユーザーは `-> T` を書く。コンパイラが暗黙に `Result<T, String>` に変換する。
+
+### Rust 生成ルール
+
+| Almide | Rust |
+|---|---|
+| `effect fn f() -> T` | `fn f() -> Result<T, String>` |
+| `effect fn f() -> Result[T, E]` | `fn f() -> Result<T, E>`（二重包装しない） |
+| `fn f() -> T` | `fn f() -> T`（変換なし） |
+
+### 変換の詳細 (pass_result_propagation)
+
+1. 戻り値型を `T` → `Result<T, String>` に変換
+2. body の tail expression を `Ok(...)` で包む
+3. if/match の全分岐を再帰的に包む
+4. 既に `ResultOk` / `ResultErr` の場合は包まない（二重包装防止）
+
+## 4. fn main
+
+| Almide | Rust | 備考 |
+|---|---|---|
+| `fn main() -> Unit` | `fn main()` | 純粋。副作用なし |
+| `effect fn main() -> Unit` | `fn main() -> Result<(), String>` | Rust の Termination trait で動作 |
+| `effect fn main(args: List[String]) -> Unit` | 未定義 | args の受け渡し方法を決める必要あり |
+
+### 現状
+
+- `effect fn main()` は `Result<(), String>` を返す Rust main として生成される
+- Rust の Termination trait がこれを受け付けるので動作する
+- エラー時は `Err(msg)` で終了し、Rust ランタイムがメッセージを stderr に出力
+
+## 5. test ブロック
+
+```almide
+test "name" {
+  assert_eq(f(), expected)
+}
+```
+
+| 属性 | 値 |
+|---|---|
+| `is_effect` | `true`（effect fn の呼び出し可） |
+| `is_test` | `true` |
+| Result 包装 | なし（`-> ()` のまま） |
+| `!` の挙動 | `.unwrap()`（`?` ではなく） |
+
+test 内では `!` が `.unwrap()` に展開される。失敗時は panic でテスト失敗。
+
+## 6. guard else
+
+```almide
+guard condition else { diverge_expr }
+```
+
+### 生成ルール
+
+| コンテキスト | else が Unit/Break/Continue | else がそれ以外 |
+|---|---|---|
+| ループ内 | `if !(cond) { break }` or `continue` | `if !(cond) { return else_expr }` |
+| 関数内 | N/A | `if !(cond) { return else_expr }` |
+
+### else ブロックの型制約
+
+`else_expr` の型は以下のいずれか:
+1. 関数の戻り値型と一致（effect fn なら `Result<T, String>`）
+2. `Never` 型（`process.exit()`, `panic()` 等）
+3. `Unit`（ループ制御: break/continue に変換）
+
+### ⚠ 現状の問題
+
+- `process.exit()` の戻り値型が `-> !` (never) になったことで guard else での使用は修正済み
+- ただし Almide の型システムに Never 型が存在しないため、型チェッカーレベルでの保証はない
+
+## 7. テストで確認済みの動作
+
+```
+✅ effect fn から test 内で直接呼べる（test は is_effect=true）
+✅ test 内で effect fn の結果に ! 不要（auto-unwrap ではなく test 特殊扱い）
+✅ ? で Result → Option 変換
+✅ ?? で Result ok/err の分岐
+✅ ?? で Option some/none の分岐
+✅ ?? で json.get() (Option) のフォールバック
+✅ guard else { err("msg")! } で早期リターン
+✅ effect fn が暗黙に Result 包装
+```
+
+## 8. 現状と仕様のギャップ
+
+| # | 仕様 | 現状 | ステータス |
+|---|---|---|---|
+| 1 | `??` は Option/Result を正しく判別 | `Ty::Unknown` → Result 扱い | ⚠ 型推論が壊れると誤生成 |
+| 2 | Never 型がある | 型システムに存在しない | ❌ 未実装 |
+| 3 | effect fn の戻り値変換は暗黙 | pass_result_propagation で変換 | ✅ 動作中 |
+| 4 | test 内の `!` は `.unwrap()` | 実装済み | ✅ |
+| 5 | guard else は Never/戻り値型を受け入れる | Rust codegen レベルで解決 | ⚠ 型チェッカーは未対応 |
+| 6 | auto-unwrap は無効、`!` で明示 | コメントアウト済み | ✅ 意図的 |
+| 7 | `effect fn main()` → `Result<(), String>` | Termination trait で動作 | ✅ |
+| 8 | args パラメータの受け渡し | 未定義 | ❌ |
+| 9 | `?` 演算子のパース | `r?` → 変数名扱い、`r ?` → OK | ⚠ パーサーの空白依存 |
+| 10 | test 内で effect fn を `!` で呼ぶ | 不要（test は直接呼べる） | ✅ だが非直感的 |
+
+## 9. 決定が必要な事項
+
+### 9.1 `?` のパース: `r?` vs `r ?`
+- 現状: `r?` が変数名 `r?` として解釈される
+- 提案: `?` を後置演算子としてパーサーで認識し、空白不要にする
+
+### 9.2 test 内での effect fn 呼び出し
+- 現状: test は `is_effect=true` なので effect fn を直接呼べる。結果の型は T（Result 包装前）
+- 問題: `!` を付けるとエラー（「String に ! は使えない」）
+- 提案: test 内での effect fn 呼び出しは暗黙的に unwrap される仕様を明文化
+
+### 9.3 Never 型の導入
+- 現状: `process.exit()` は Rust 側で `-> !` だが、Almide の型システムに Never がない
+- 提案: `Ty::Never` を追加し、型チェッカーで bottom type として扱う
+- 影響: guard else, if then, match arm の型整合性チェックが改善
+
+### 9.4 `effect fn main(args: List[String])`
+- 現状: 未定義
+- 提案: `process.args()` で取得する方式（Go 式）。main の引数は使わない

--- a/runtime/rs/src/process.rs
+++ b/runtime/rs/src/process.rs
@@ -18,7 +18,7 @@ pub fn almide_rt_process_exec(cmd: String, args: Vec<String>) -> Result<String, 
     }
 }
 
-pub fn almide_rt_process_exit(code: i64) {
+pub fn almide_rt_process_exit(code: i64) -> ! {
     std::process::exit(code as i32);
 }
 

--- a/runtime/rs/src/process.rs
+++ b/runtime/rs/src/process.rs
@@ -22,6 +22,10 @@ pub fn almide_rt_process_exit(code: i64) -> ! {
     std::process::exit(code as i32);
 }
 
+pub fn almide_rt_process_args() -> Vec<String> {
+    std::env::args().collect()
+}
+
 pub fn almide_rt_process_stdin_lines() -> Result<Vec<String>, String> {
     use std::io::BufRead;
     std::io::stdin()

--- a/spec/lang/result_option_matrix_test.almd
+++ b/spec/lang/result_option_matrix_test.almd
@@ -1,0 +1,280 @@
+// ═══════════════════════════════════════════════════════════════════
+// Result / Option / Effect operator matrix test
+// Tests every combination of ! ? ?? with Result/Option in every context.
+// ═══════════════════════════════════════════════════════════════════
+
+// ── Helper functions ──
+
+fn make_ok() -> Result[Int, String] = ok(42)
+fn make_err() -> Result[Int, String] = err("bad")
+fn make_some() -> Option[Int] = some(10)
+fn make_none() -> Option[Int] = none
+
+effect fn effect_ok() -> Int = make_ok()!
+effect fn effect_err_catch() -> Int = make_err() ?? -1
+
+// ═══════════════════════════════════════════════════════════════════
+// 1. ?? operator (UnwrapOr) — works in any context
+// ═══════════════════════════════════════════════════════════════════
+
+test "?? Result ok" {
+  assert_eq(make_ok() ?? 0, 42)
+}
+
+test "?? Result err" {
+  assert_eq(make_err() ?? 0, 0)
+}
+
+test "?? Option some" {
+  assert_eq(make_some() ?? 0, 10)
+}
+
+test "?? Option none" {
+  assert_eq(make_none() ?? 0, 0)
+}
+
+// ?? with inline values
+test "?? inline Result" {
+  let r: Result[String, String] = ok("yes")
+  assert_eq(r ?? "no", "yes")
+}
+
+test "?? inline Option" {
+  let o: Option[String] = none
+  assert_eq(o ?? "default", "default")
+}
+
+// ?? chained
+test "?? chained" {
+  let o1: Option[Int] = none
+  let o2: Option[Int] = none
+  let o3: Option[Int] = some(99)
+  assert_eq(o1 ?? o2 ?? o3 ?? 0, 99)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 2. ? operator (ToOption) — works in any context
+// ═══════════════════════════════════════════════════════════════════
+
+test "? Result ok → some" {
+  let r: Result[Int, String] = ok(42)
+  assert_eq(r?, some(42))
+}
+
+test "? Result err → none" {
+  let r: Result[Int, String] = err("x")
+  assert_eq(r?, none)
+}
+
+test "? Option some → identity" {
+  let o: Option[Int] = some(5)
+  assert_eq(o?, some(5))
+}
+
+test "? Option none → identity" {
+  let o: Option[Int] = none
+  assert_eq(o?, none)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 3. ! operator (Unwrap) — in test context
+// ═══════════════════════════════════════════════════════════════════
+
+test "! Result ok in test" {
+  let r: Result[Int, String] = ok(42)
+  assert_eq(r!, 42)
+}
+
+test "! Option some in test" {
+  let o: Option[Int] = some(10)
+  assert_eq(o!, 10)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 4. ! operator (Unwrap) — in effect fn context
+// ═══════════════════════════════════════════════════════════════════
+
+effect fn unwrap_result_ok() -> Int = {
+  let r: Result[Int, String] = ok(42)
+  r!
+}
+
+effect fn unwrap_option_some() -> Int = {
+  let o: Option[Int] = some(10)
+  o!
+}
+
+test "! Result ok in effect fn" {
+  assert_eq(unwrap_result_ok(), 42)
+}
+
+test "! Option some in effect fn" {
+  assert_eq(unwrap_option_some(), 10)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 5. effect fn — implicit Result wrapping
+// ═══════════════════════════════════════════════════════════════════
+
+effect fn returns_int() -> Int = 42
+effect fn returns_string() -> String = "hello"
+// NOTE: effect fn calling another effect fn works via direct call.
+// The type checker sees T (not Result[T, String]) since wrapping happens in codegen.
+// This means ! and ?? cannot be used between effect fns — direct call is the pattern.
+effect fn calls_effect() -> Int = returns_int()
+
+test "effect fn returns value directly" {
+  assert_eq(returns_int(), 42)
+  assert_eq(returns_string(), "hello")
+}
+
+test "effect fn calls another effect fn" {
+  assert_eq(calls_effect(), 42)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 6. guard else — type compatibility
+// ═══════════════════════════════════════════════════════════════════
+
+fn guard_pure(x: Int) -> Int = {
+  guard x > 0 else { 0 }
+  x * 2
+}
+
+effect fn guard_effect(x: Int) -> Int = {
+  guard x > 0 else { err("negative")! }
+  x * 2
+}
+
+test "guard in pure fn" {
+  assert_eq(guard_pure(5), 10)
+  assert_eq(guard_pure(-1), 0)
+}
+
+test "guard in effect fn with err propagation" {
+  assert_eq(guard_effect(5), 10)
+}
+
+// guard in loop
+test "guard in for loop" {
+  var sum = 0
+  for x in [1, -2, 3, -4, 5] {
+    guard x > 0 else { continue }
+    sum = sum + x
+  }
+  assert_eq(sum, 9)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 7. if then with Result/Option
+// ═══════════════════════════════════════════════════════════════════
+
+test "if with ??" {
+  let r: Result[Int, String] = err("x")
+  let v = if true then r ?? 0 else -1
+  assert_eq(v, 0)
+}
+
+test "if with ?" {
+  let r: Result[Int, String] = ok(42)
+  let v = if true then r? else none
+  assert_eq(v, some(42))
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 8. match with Result/Option
+// ═══════════════════════════════════════════════════════════════════
+
+test "match on Result" {
+  let r: Result[Int, String] = ok(42)
+  let v = match r {
+    ok(n) => n,
+    err(_) => 0,
+  }
+  assert_eq(v, 42)
+}
+
+test "match on Option" {
+  let o: Option[Int] = some(10)
+  let v = match o {
+    some(n) => n,
+    none => 0,
+  }
+  assert_eq(v, 10)
+}
+
+test "match on Result err" {
+  let r: Result[Int, String] = err("bad")
+  let v = match r {
+    ok(n) => n,
+    err(msg) => string.len(msg),
+  }
+  assert_eq(v, 3)
+}
+
+test "match on Option none" {
+  let o: Option[String] = none
+  let v = match o {
+    some(s) => s,
+    none => "empty",
+  }
+  assert_eq(v, "empty")
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 9. Nested Result/Option operations
+// ═══════════════════════════════════════════════════════════════════
+
+test "nested: Result inside Option via ??" {
+  let r: Result[Int, String] = ok(42)
+  let o: Option[Int] = some(r ?? 0)
+  assert_eq(o ?? -1, 42)
+}
+
+test "nested: Option to Result via match" {
+  let o: Option[Int] = some(5)
+  let r: Result[Int, String] = match o {
+    some(n) => ok(n),
+    none => err("missing"),
+  }
+  assert_eq(r ?? 0, 5)
+}
+
+effect fn nested_unwrap() -> Int = {
+  let r: Result[Option[Int], String] = ok(some(42))
+  let o = r!
+  o!
+}
+
+test "nested: unwrap Result then Option" {
+  assert_eq(nested_unwrap(), 42)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 10. Edge cases
+// ═══════════════════════════════════════════════════════════════════
+
+test "?? preserves type: string" {
+  let o: Option[String] = some("hello")
+  assert_eq(o ?? "", "hello")
+}
+
+test "?? preserves type: list" {
+  let o: Option[List[Int]] = none
+  assert_eq(o ?? [], [])
+}
+
+test "?? preserves type: bool" {
+  let o: Option[Bool] = some(true)
+  assert_eq(o ?? false, true)
+}
+
+test "? then ?? chain" {
+  let r: Result[Int, String] = ok(42)
+  assert_eq(r? ?? 0, 42)
+}
+
+test "? then ?? chain on err" {
+  let r: Result[Int, String] = err("x")
+  assert_eq(r? ?? 0, 0)
+}

--- a/src/codegen/emit_wasm/expressions.rs
+++ b/src/codegen/emit_wasm/expressions.rs
@@ -526,6 +526,7 @@ impl FuncCompiler<'_> {
                         i32_const(0);
                         i32_ne;
                         if_empty;
+                        // Err path: propagate the Result pointer (early return)
                         local_get(scratch);
                         return_;
                         end;

--- a/src/codegen/emit_wasm/statements.rs
+++ b/src/codegen/emit_wasm/statements.rs
@@ -610,8 +610,7 @@ fn scan_stmt(stmt: &IrStmt, locals: &mut Vec<(VarId, ValType)>, vt: &crate::ir::
             // Resolve bind type.
             // For Try(Call(...)) (effect fn unwrap), use the Result's inner type, not Result itself.
             let effective_ty = if let IrExprKind::Try { expr: inner }
-                | IrExprKind::Unwrap { expr: inner }
-                | IrExprKind::ToOption { expr: inner } = &value.kind {
+                | IrExprKind::Unwrap { expr: inner } = &value.kind {
                 if let Ty::Applied(crate::types::constructor::TypeConstructorId::Result, args) = &value.ty {
                     args.first().cloned().unwrap_or(value.ty.clone())
                 } else if let Ty::Applied(crate::types::constructor::TypeConstructorId::Result, args) = &inner.ty {

--- a/src/codegen/emit_wasm/values.rs
+++ b/src/codegen/emit_wasm/values.rs
@@ -13,7 +13,7 @@ pub fn ty_to_valtype(ty: &Ty) -> Option<ValType> {
         Ty::String => Some(ValType::I32), // pointer to [len:i32][data:u8...]
         Ty::Bytes => Some(ValType::I32),  // pointer to [len:i32][data:u8...]
         Ty::Matrix => Some(ValType::I32), // pointer to heap-allocated matrix
-        Ty::Unit => None,
+        Ty::Unit | Ty::Never => None,
         // All heap types (Record, Variant, List, etc.) use i32 pointers
         _ => Some(ValType::I32),
     }

--- a/src/codegen/pass_result_propagation.rs
+++ b/src/codegen/pass_result_propagation.rs
@@ -23,16 +23,16 @@ impl NanoPass for ResultPropagationPass {
     fn run(&self, mut program: IrProgram, target: Target) -> PassResult {
         // Result wrapping is Rust-only: Rust requires `?` which needs Result return type.
         // TS uses async/await (ResultErasurePass handles it). WASM uses traps.
-        let wrap_non_result = matches!(target, Target::Rust);
+        // All targets wrap effect fn return types in Result.
+        // This ensures ! (unwrap) propagates errors consistently across Rust and WASM.
+        let wrap_non_result = matches!(target, Target::Rust | Target::Wasm);
 
-        // Phase 1: Lift effect fn return types from T to Result<T, String>.
-        // Collect fn_name → new Result type so call sites can be updated.
+        // Phase 1a: Collect all effect fn names and lift return types.
         let mut lifted_fns: HashMap<String, Ty> = HashMap::new();
         for func in &mut program.functions {
             if func.is_effect && !func.is_test && wrap_non_result && !func.ret_ty.is_result() {
                 let orig = std::mem::replace(&mut func.ret_ty, Ty::Unit);
                 func.ret_ty = Ty::result(orig, Ty::String);
-                func.body = wrap_tail_in_ok(std::mem::take(&mut func.body));
                 lifted_fns.insert(func.name.to_string(), func.ret_ty.clone());
             }
         }
@@ -41,8 +41,20 @@ impl NanoPass for ResultPropagationPass {
                 if func.is_effect && !func.is_test && wrap_non_result && !func.ret_ty.is_result() {
                     let orig = std::mem::replace(&mut func.ret_ty, Ty::Unit);
                     func.ret_ty = Ty::result(orig, Ty::String);
-                    func.body = wrap_tail_in_ok(std::mem::take(&mut func.body));
                     lifted_fns.insert(func.name.to_string(), func.ret_ty.clone());
+                }
+            }
+        }
+        // Phase 1b: Wrap bodies in Ok(...), skipping calls to other lifted effect fns.
+        for func in &mut program.functions {
+            if lifted_fns.contains_key(func.name.as_str()) {
+                func.body = wrap_tail_in_ok(std::mem::take(&mut func.body), &lifted_fns);
+            }
+        }
+        for module in &mut program.modules {
+            for func in &mut module.functions {
+                if lifted_fns.contains_key(func.name.as_str()) {
+                    func.body = wrap_tail_in_ok(std::mem::take(&mut func.body), &lifted_fns);
                 }
             }
         }
@@ -76,12 +88,12 @@ impl NanoPass for ResultPropagationPass {
 
 /// Wrap the tail expression of an effect fn body in Ok(...).
 /// Called when ret_ty is lifted from T to Result<T, String>.
-fn wrap_tail_in_ok(expr: IrExpr) -> IrExpr {
+fn wrap_tail_in_ok(expr: IrExpr, lifted: &HashMap<String, Ty>) -> IrExpr {
     let ty = expr.ty.clone();
     let span = expr.span;
     match expr.kind {
         IrExprKind::Block { stmts, expr: Some(tail) } => {
-            let wrapped = wrap_tail_in_ok(*tail);
+            let wrapped = wrap_tail_in_ok(*tail, lifted);
             IrExpr {
                 kind: IrExprKind::Block { stmts, expr: Some(Box::new(wrapped)) },
                 ty: Ty::result(ty, Ty::String), span,
@@ -90,8 +102,8 @@ fn wrap_tail_in_ok(expr: IrExpr) -> IrExpr {
         IrExprKind::If { cond, then, else_ } => IrExpr {
             kind: IrExprKind::If {
                 cond,
-                then: Box::new(wrap_tail_in_ok(*then)),
-                else_: Box::new(wrap_tail_in_ok(*else_)),
+                then: Box::new(wrap_tail_in_ok(*then, lifted)),
+                else_: Box::new(wrap_tail_in_ok(*else_, lifted)),
             },
             ty: Ty::result(ty, Ty::String), span,
         },
@@ -100,13 +112,32 @@ fn wrap_tail_in_ok(expr: IrExpr) -> IrExpr {
                 subject,
                 arms: arms.into_iter().map(|arm| IrMatchArm {
                     pattern: arm.pattern, guard: arm.guard,
-                    body: wrap_tail_in_ok(arm.body),
+                    body: wrap_tail_in_ok(arm.body, lifted),
                 }).collect(),
             },
             ty: Ty::result(ty, Ty::String), span,
         },
         // Already Result — don't double-wrap
         IrExprKind::ResultOk { .. } | IrExprKind::ResultErr { .. } => expr,
+        // Call to another lifted effect fn — already returns Result, don't wrap
+        IrExprKind::Call { ref target, .. } => {
+            let callee_name = match target {
+                CallTarget::Named { name } => Some(name.to_string()),
+                _ => None,
+            };
+            if callee_name.as_ref().is_some_and(|n| lifted.contains_key(n)) {
+                // Already returns Result — just pass through
+                expr
+            } else {
+                let result_ty = Ty::result(ty.clone(), Ty::String);
+                IrExpr {
+                    kind: IrExprKind::ResultOk {
+                        expr: Box::new(IrExpr { kind: expr.kind, ty, span }),
+                    },
+                    ty: result_ty, span,
+                }
+            }
+        }
         // Everything else: wrap in Ok(expr)
         other => {
             let result_ty = Ty::result(ty.clone(), Ty::String);
@@ -244,15 +275,10 @@ fn insert_try_for_lifted(expr: IrExpr, lifted: &HashMap<String, Ty>) -> IrExpr {
                     _ => ty.clone(),
                 };
                 let call_with_result_ty = IrExpr { kind: expr.kind, ty: result_ty.clone(), span };
-                // In tests, use .unwrap() instead of ? (tests return (), not Result)
+                // In tests, unwrap the Result (Rust: .unwrap(), WASM: Unwrap IR node)
                 return IrExpr {
-                    kind: IrExprKind::Call {
-                        target: CallTarget::Method {
-                            object: Box::new(call_with_result_ty),
-                            method: "unwrap".into(),
-                        },
-                        args: vec![],
-                        type_args: vec![],
+                    kind: IrExprKind::Unwrap {
+                        expr: Box::new(call_with_result_ty),
                     },
                     ty: inner_ty, span,
                 };

--- a/src/codegen/walker/expressions.rs
+++ b/src/codegen/walker/expressions.rs
@@ -464,6 +464,9 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             let s = render_expr(ctx, inner);
             let f = render_expr(ctx, fallback);
             let when_type = if inner.ty.is_option() { Some("Option") } else { None };
+            // When inner.ty is Unknown, defaults to Result template.
+            // This is correct if type inference produced Unknown due to a bug;
+            // the Rust compiler will catch any mismatch.
             ctx.templates.render_with("unwrap_or_expr", when_type, &[], &[("inner", s.as_str()), ("fallback", f.as_str())])
                 .unwrap_or_else(|| format!("{}.unwrap_or({})", s, f))
         }

--- a/src/codegen/walker/mod.rs
+++ b/src/codegen/walker/mod.rs
@@ -198,6 +198,8 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
         .replace('=', "_eq_").replace('!', "_bang_").replace('?', "_q_")
         .replace('<', "_lt_").replace('>', "_gt_").replace('[', "_").replace(']', "_")
         .replace('|', "_pipe_").replace('&', "_amp_").replace('%', "_mod_");
+    // Strip any remaining non-ASCII characters (e.g., →, ★, etc.)
+    safe_name = safe_name.chars().map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' }).collect();
     // Escape target-specific keywords via template
     let target_keywords = ["while", "for", "if", "else", "match", "loop", "break", "continue",
         "return", "fn", "let", "mut", "use", "mod", "pub", "struct", "enum", "impl", "trait",

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -17,7 +17,7 @@ pub enum TokenType {
     // Literals
     Int, Float, String, InterpolatedString,
     // Identifiers
-    Ident, TypeName, IdentQ,
+    Ident, TypeName,
     // Keywords
     Module, Import, Type, Protocol, Impl, For, In, Fn, Let, Var,
     If, Then, Else, Match, Ok, Err, Some, None, Todo,
@@ -435,17 +435,11 @@ fn lex_ident(chars: &[char], start: usize, line: usize, col: usize) -> (Token, u
     let mut pos = start;
     while pos < chars.len() && (chars[pos].is_ascii_alphanumeric() || chars[pos] == '_') { pos += 1; }
 
-    // Trailing ? for query methods (e.g., is_empty?)
-    if pos < chars.len() && chars[pos] == '?' {
-        pos += 1;
-    }
-
     let value: String = chars[start..pos].iter().collect();
 
     // Check if it's a keyword
     let token_type = keyword(&value).unwrap_or_else(|| {
-        if value.ends_with('?') { TokenType::IdentQ }
-        else if value.chars().next().map_or(false, |c| c.is_uppercase()) { TokenType::TypeName }
+        if value.chars().next().map_or(false, |c| c.is_uppercase()) { TokenType::TypeName }
         else { TokenType::Ident }
     });
 

--- a/src/parser/collections.rs
+++ b/src/parser/collections.rs
@@ -22,7 +22,7 @@ impl Parser {
             return self.parse_spread_record(span, open);
         }
         // Record literal: { field: value, ... }
-        if (self.check(TokenType::Ident) || self.check(TokenType::IdentQ))
+        if self.check(TokenType::Ident)
             && self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::Colon)
         {
             return self.parse_record_literal(span, open);

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -198,7 +198,7 @@ impl Parser {
     }
 
     pub(crate) fn expect_any_name(&mut self) -> Result<Sym, String> {
-        if self.check(TokenType::Ident) || self.check(TokenType::IdentQ) || self.check(TokenType::TypeName) {
+        if self.check(TokenType::Ident) || self.check(TokenType::Ident) || self.check(TokenType::TypeName) {
             return Ok(self.advance_and_get_sym());
         }
         let tok = self.current();
@@ -224,7 +224,7 @@ impl Parser {
         {
             let type_name = self.advance_and_get_value();
             self.advance(); // skip .
-            let method = if self.check(TokenType::Ident) || self.check(TokenType::IdentQ) {
+            let method = if self.check(TokenType::Ident) || self.check(TokenType::Ident) {
                 self.advance_and_get_value()
             } else {
                 let tok = self.current();
@@ -232,7 +232,7 @@ impl Parser {
             };
             return Ok(sym(&format!("{}.{}", type_name, method)));
         }
-        if self.check(TokenType::Ident) || self.check(TokenType::IdentQ) {
+        if self.check(TokenType::Ident) || self.check(TokenType::Ident) {
             return Ok(self.advance_and_get_sym());
         }
         let tok = self.current();

--- a/src/parser/hints/operator.rs
+++ b/src/parser/hints/operator.rs
@@ -59,7 +59,7 @@ fn check_standalone(ctx: &HintContext) -> Option<HintResult> {
         // `|x|` closure syntax — detected via lookahead
         (TokenType::Pipe, _) => {
             if let Some(next) = ctx.next {
-                if matches!(next.token_type, TokenType::Ident | TokenType::IdentQ | TokenType::Underscore) {
+                if matches!(next.token_type, TokenType::Ident | TokenType::Underscore) {
                     return Some(HintResult {
                         message: Some("'|x|' closure syntax is not valid in Almide".into()),
                         hint: "Use '(x) => expr' for lambdas. Example: list.map(xs, (x) => x + 1)".into(),

--- a/src/parser/primary.rs
+++ b/src/parser/primary.rs
@@ -143,7 +143,7 @@ impl Parser {
             let msg = result.message.unwrap_or_else(|| format!("'{}' is not valid here", tok.value));
             return Err(format!("{} at line {}:{}\n  Hint: {}", msg, tok.line, tok.col, result.hint));
         }
-        if self.check(TokenType::Ident) || self.check(TokenType::IdentQ) {
+        if self.check(TokenType::Ident) || self.check(TokenType::Ident) {
             let name = sym(&tok.value);
             self.advance();
             return Ok(Expr::Ident { name, id: self.next_id(), span, resolved_type: None });

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -33,6 +33,9 @@ pub enum Ty {
     Union(Vec<Ty>),
     /// Type variable for user-defined generics (e.g., T, U, A, B)
     TypeVar(Sym),
+    /// Bottom type — returned by functions that never return (process.exit, panic).
+    /// Unifies with any type (subtype of all types).
+    Never,
     /// Error recovery — unifies with everything to prevent cascade errors
     Unknown,
 }
@@ -168,6 +171,7 @@ impl Ty {
                 ms.join(" | ")
             }
             Ty::TypeVar(n) => n.to_string(),
+            Ty::Never => "Never".into(),
             Ty::Unknown => "Unknown".into(),
         }
     }
@@ -206,9 +210,10 @@ impl Ty {
         }
     }
 
-    /// Check if two types are compatible (Unknown matches everything)
+    /// Check if two types are compatible (Unknown and Never match everything)
     pub fn compatible(&self, other: &Ty) -> bool {
-        if *self == Ty::Unknown || *other == Ty::Unknown {
+        if *self == Ty::Unknown || *other == Ty::Unknown
+            || *self == Ty::Never || *other == Ty::Never {
             return true;
         }
         // TypeVars are compatible with anything (they represent polymorphic types)
@@ -310,7 +315,7 @@ impl Ty {
         match self {
             // Leaf types — no children
             Ty::Int | Ty::Float | Ty::String | Ty::Bool | Ty::Unit | Ty::Bytes | Ty::Matrix
-            | Ty::TypeVar(_) | Ty::Unknown => vec![],
+            | Ty::TypeVar(_) | Ty::Never | Ty::Unknown => vec![],
 
             // Parameterized types (List, Option, Result, Map, user-defined)
             Ty::Applied(_, args) => args.iter().collect(),
@@ -357,7 +362,7 @@ impl Ty {
     {
         match self {
             Ty::Int | Ty::Float | Ty::String | Ty::Bool | Ty::Unit | Ty::Bytes | Ty::Matrix
-            | Ty::TypeVar(_) | Ty::Unknown => self.clone(),
+            | Ty::TypeVar(_) | Ty::Never | Ty::Unknown => self.clone(),
 
             Ty::Applied(id, args) => Ty::Applied(id.clone(), args.iter().map(|a| f(a)).collect()),
 
@@ -403,7 +408,7 @@ impl Ty {
     {
         match self {
             Ty::Int | Ty::Float | Ty::String | Ty::Bool | Ty::Unit | Ty::Bytes | Ty::Matrix
-            | Ty::TypeVar(_) | Ty::Unknown => self.clone(),
+            | Ty::TypeVar(_) | Ty::Never | Ty::Unknown => self.clone(),
 
             Ty::Applied(id, args) => Ty::Applied(id.clone(), args.iter().map(|a| f(a)).collect()),
 

--- a/stdlib/defs/process.toml
+++ b/stdlib/defs/process.toml
@@ -11,7 +11,7 @@ ts = "__almd_process.exec({cmd}, {args})"
 description = "Exit the process with the given status code"
 example = 'process.exit(1)'
 params = [{ name = "code", type = "Int" }]
-return = "Unit"
+return = "Never"
 effect = true
 rust = "almide_rt_process_exit({code})"
 ts = "__almd_process.exit({code})"

--- a/stdlib/defs/process.toml
+++ b/stdlib/defs/process.toml
@@ -16,6 +16,15 @@ effect = true
 rust = "almide_rt_process_exit({code})"
 ts = "__almd_process.exit({code})"
 
+[args]
+description = "Get command-line arguments as a list of strings"
+example = 'let args = process.args()'
+params = []
+return = "List[String]"
+effect = false
+rust = "almide_rt_process_args()"
+ts = "__almd_process.args()"
+
 [stdin_lines]
 description = "Read all lines from standard input"
 example = 'let lines = process.stdin_lines()'

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -139,9 +139,9 @@ fn lex_type_name() {
 }
 
 #[test]
-fn lex_predicate_identifier() {
+fn lex_question_as_separate_token() {
     let toks = tokens("empty?");
-    assert_eq!(toks, vec![(TokenType::IdentQ, "empty?".into())]);
+    assert_eq!(toks, vec![(TokenType::Ident, "empty".into()), (TokenType::Question, "?".into())]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Complete spec alignment for Result/Option/effect ahead of 1.0.0. All operators (`!`, `?`, `??`) now behave identically on Rust and WASM targets.

### Result/Option unification
- **WASM now wraps effect fn in Result**, matching Rust behavior. `!` propagates errors via early return instead of trapping.
- **`?` (ToOption) WASM codegen fix**: local variable type was incorrectly resolved as the inner Result type instead of Option, causing `expected i64, found i32` validation errors.
- **`wrap_tail_in_ok` skips calls to other effect fns** to prevent double-wrapping `Ok(Result<T>)`.
- **Test unwrap uses `Unwrap` IR node** instead of Rust-specific `.unwrap()` method call, works on both targets.

### Never type
- Added `Ty::Never` (bottom type) — compatible with all types.
- `process.exit()` returns `Never` in stdlib definition and `-> !` in Rust runtime.

### Parser
- **Removed `IdentQ` token**: `?` is always an independent operator. `r?` works without space.
- **Test name sanitization**: non-ASCII characters (→, ★, etc.) are replaced with `_` in generated Rust test names.

### New
- `process.args()` — get command-line arguments
- Result/Option/effect spec draft (`docs/specs/result-option-effect.md`)
- Matrix test: 34 tests covering every combination of `!`/`?`/`??` × Result/Option × fn/effect fn/test

## Test plan
- [x] `almide test spec/` — 166 files passed
- [x] `almide test spec/ --target wasm` — 163 passed, 3 skipped
- [x] `almide test research/benchmark/exercises/` — 24 files passed
- [x] Matrix test passes on both Rust and WASM targets