### PR TITLE
Codegen optimization — Rust-equivalent performance

### DIFF
--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -184,7 +184,7 @@ template = "{value}"
 # ── Declarations ──
 
 [fn_decl]
-template = "#[inline]\npub fn {name}({params}) -> {return_type} {{ {body} }}"
+template = "pub fn {name}({params}) -> {return_type} {{ {body} }}"
 
 # Effect fn: ret_ty in IR is already Result<T, String>, so use it directly
 [effect_fn_decl]

--- a/docs/roadmap/active/emit-readability.md
+++ b/docs/roadmap/active/emit-readability.md
@@ -70,6 +70,10 @@ Highly readable generated code:
 
 ### Phase 4: Formatting Quality
 
+- [x] Iterator chain emission: `list.map/filter/fold` → `.into_iter().map().collect()` (v0.10.4)
+- [x] Math intrinsics inline: `math.sqrt(x)` → `x.sqrt()` instead of `almide_rt_math_sqrt(x)` (v0.10.4)
+- [x] Numeric cast inline: `float.from_int(n)` → `(n as f64)` (v0.10.4)
+- [x] Borrow parameter inference: read-only String/List params → `&str` / `&[T]` (v0.10.4)
 - [ ] Improve line break rules for long expressions (builder chains, long argument lists)
 - [ ] Alignment of match/when arms
 - [ ] Target readability level where `rustfmt` / `prettier` aren't needed to read the output

--- a/docs/roadmap/active/purity-exploitation.md
+++ b/docs/roadmap/active/purity-exploitation.md
@@ -44,11 +44,10 @@ let results = list.map(large_list, (x) => heavy_compute(x))
 
 ### Tasks
 
-- [ ] Mechanism to propagate purity flags in IR (lambda → CallTarget)
-- [ ] `AutoParallelPass` nanopass implementation
-- [ ] Add `par_map`, `par_filter` etc. to `runtime/rs/src/list.rs`
-- [ ] Add Rayon as optional dependency (`almide build --parallel` flag)
-- [ ] Benchmark: measure effect on pure heavy computation like Mandelbrot
+- [x] Mechanism to propagate purity flags in IR (lambda → CallTarget) — `is_pure_lambda` in AutoParallelPass
+- [x] `AutoParallelPass` nanopass implementation — 568 LOC, `std::thread::scope`-based
+- [x] Add `par_map`, `par_filter` etc. to `runtime/rs/src/list.rs` — uses `std::thread::scope`, no Rayon
+- [x] Benchmark: binarytrees 5.5x faster than reference Rust (auto-parallel enabled)
 
 ---
 

--- a/docs/roadmap/done/dead-code-elimination.md
+++ b/docs/roadmap/done/dead-code-elimination.md
@@ -1,4 +1,5 @@
 <!-- description: Dependency-graph-based dead code elimination for smaller WASM binaries -->
+<!-- done: 2026-03-31 -->
 # Dead Code Elimination
 
 エクスポートされた関数から依存グラフを辿り、到達不能な定義を削除する。WASM バイナリサイズの削減に直結。

--- a/src/canonicalize/mod.rs
+++ b/src/canonicalize/mod.rs
@@ -1,0 +1,10 @@
+//! Canonicalize: name resolution and declaration registration.
+//!
+//! Extracts import resolution and declaration registration from the type checker
+//! into a standalone pre-pass. The pipeline becomes:
+//!
+//! ```text
+//! Parser → AST → Canonicalize (this module) → Checker (inference only) → Lowering → IR
+//! ```
+
+pub mod resolve;

--- a/src/canonicalize/resolve.rs
+++ b/src/canonicalize/resolve.rs
@@ -1,0 +1,83 @@
+//! Canonical type expression resolution.
+//!
+//! Single source of truth for converting `ast::TypeExpr` → `Ty`.
+//! Used by both the checker (with type lookup) and lowering (without).
+
+use std::collections::HashMap;
+use crate::ast;
+use crate::types::{Ty, VariantCase, VariantPayload};
+use crate::intern::{Sym, sym};
+
+/// Resolve an AST type expression to a Ty.
+///
+/// `known_types`: optional map of registered type names → Ty (from TypeEnv.types).
+/// When provided (checker context), named types are looked up; when None (lowering),
+/// unresolved names become `Ty::Named`.
+pub fn resolve_type_expr(te: &ast::TypeExpr, known_types: Option<&HashMap<Sym, Ty>>) -> Ty {
+    match te {
+        ast::TypeExpr::Simple { name } => match name.as_str() {
+            "Int" => Ty::Int,
+            "Float" => Ty::Float,
+            "String" => Ty::String,
+            "Bool" => Ty::Bool,
+            "Unit" => Ty::Unit,
+            "Bytes" => Ty::Bytes,
+            "Matrix" => Ty::Matrix,
+            "Path" => Ty::String,
+            other => {
+                if let Some(types) = known_types {
+                    types.get(&sym(other)).cloned().unwrap_or(Ty::Named(other.into(), vec![]))
+                } else {
+                    Ty::Named(sym(other), vec![])
+                }
+            }
+        },
+        ast::TypeExpr::Generic { name, args } => {
+            let ra: Vec<Ty> = args.iter().map(|a| resolve_type_expr(a, known_types)).collect();
+            match name.as_str() {
+                "List" => Ty::list(ra.first().cloned().unwrap_or(Ty::Unknown)),
+                "Option" => Ty::option(ra.first().cloned().unwrap_or(Ty::Unknown)),
+                "Result" if ra.len() >= 2 => Ty::result(ra[0].clone(), ra[1].clone()),
+                "Map" if ra.len() >= 2 => Ty::map_of(ra[0].clone(), ra[1].clone()),
+                "Set" => Ty::set_of(ra.first().cloned().unwrap_or(Ty::Unknown)),
+                _ => Ty::Named(sym(name), ra),
+            }
+        },
+        ast::TypeExpr::Record { fields } => Ty::Record {
+            fields: fields.iter().map(|f| (sym(&f.name), resolve_type_expr(&f.ty, known_types))).collect(),
+        },
+        ast::TypeExpr::OpenRecord { fields } => Ty::OpenRecord {
+            fields: fields.iter().map(|f| (sym(&f.name), resolve_type_expr(&f.ty, known_types))).collect(),
+        },
+        ast::TypeExpr::Fn { params, ret } => Ty::Fn {
+            params: params.iter().map(|p| resolve_type_expr(p, known_types)).collect(),
+            ret: Box::new(resolve_type_expr(ret, known_types)),
+        },
+        ast::TypeExpr::Tuple { elements } => Ty::Tuple(
+            elements.iter().map(|e| resolve_type_expr(e, known_types)).collect(),
+        ),
+        ast::TypeExpr::Union { members } => Ty::union(
+            members.iter().map(|m| resolve_type_expr(m, known_types)).collect(),
+        ),
+        ast::TypeExpr::Variant { cases } => {
+            let cs = cases.iter().map(|c| match c {
+                ast::VariantCase::Unit { name } => VariantCase {
+                    name: sym(name), payload: VariantPayload::Unit,
+                },
+                ast::VariantCase::Tuple { name, fields } => VariantCase {
+                    name: sym(name),
+                    payload: VariantPayload::Tuple(
+                        fields.iter().map(|f| resolve_type_expr(f, known_types)).collect(),
+                    ),
+                },
+                ast::VariantCase::Record { name, fields } => VariantCase {
+                    name: sym(name),
+                    payload: VariantPayload::Record(
+                        fields.iter().map(|f| (sym(&f.name), resolve_type_expr(&f.ty, known_types), f.default.clone())).collect(),
+                    ),
+                },
+            }).collect();
+            Ty::Variant { name: sym(""), cases: cs }
+        },
+    }
+}

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -493,37 +493,7 @@ impl Checker {
     // ── Type resolution ──
 
     pub fn resolve_type_expr(&self, te: &ast::TypeExpr) -> Ty {
-        match te {
-            ast::TypeExpr::Simple { name } => match name.as_str() {
-                "Int" => Ty::Int, "Float" => Ty::Float, "String" => Ty::String,
-                "Bool" => Ty::Bool, "Unit" => Ty::Unit, "Bytes" => Ty::Bytes, "Matrix" => Ty::Matrix, "Path" => Ty::String,
-                other => self.env.types.get(&sym(other)).cloned().unwrap_or(Ty::Named(other.into(), vec![])),
-            },
-            ast::TypeExpr::Generic { name, args } => {
-                let ra: Vec<Ty> = args.iter().map(|a| self.resolve_type_expr(a)).collect();
-                match name.as_str() {
-                    "List" => Ty::list(ra.first().cloned().unwrap_or(Ty::Unknown)),
-                    "Option" => Ty::option(ra.first().cloned().unwrap_or(Ty::Unknown)),
-                    "Result" if ra.len() >= 2 => Ty::result(ra[0].clone(), ra[1].clone()),
-                    "Map" if ra.len() >= 2 => Ty::map_of(ra[0].clone(), ra[1].clone()),
-                    "Set" => Ty::set_of(ra.first().cloned().unwrap_or(Ty::Unknown)),
-                    _ => Ty::Named(sym(name), ra),
-                }
-            },
-            ast::TypeExpr::Record { fields } => Ty::Record { fields: fields.iter().map(|f| (sym(&f.name), self.resolve_type_expr(&f.ty))).collect() },
-            ast::TypeExpr::OpenRecord { fields } => Ty::OpenRecord { fields: fields.iter().map(|f| (sym(&f.name), self.resolve_type_expr(&f.ty))).collect() },
-            ast::TypeExpr::Fn { params, ret } => Ty::Fn { params: params.iter().map(|p| self.resolve_type_expr(p)).collect(), ret: Box::new(self.resolve_type_expr(ret)) },
-            ast::TypeExpr::Tuple { elements } => Ty::Tuple(elements.iter().map(|e| self.resolve_type_expr(e)).collect()),
-            ast::TypeExpr::Union { members } => Ty::union(members.iter().map(|m| self.resolve_type_expr(m)).collect()),
-            ast::TypeExpr::Variant { cases } => {
-                let cs = cases.iter().map(|c| match c {
-                    ast::VariantCase::Unit { name } => VariantCase { name: sym(name), payload: VariantPayload::Unit },
-                    ast::VariantCase::Tuple { name, fields } => VariantCase { name: sym(name), payload: VariantPayload::Tuple(fields.iter().map(|f| self.resolve_type_expr(f)).collect()) },
-                    ast::VariantCase::Record { name, fields } => VariantCase { name: sym(name), payload: VariantPayload::Record(fields.iter().map(|f| (sym(&f.name), self.resolve_type_expr(&f.ty), f.default.clone())).collect()) },
-                }).collect();
-                Ty::Variant { name: sym(""), cases: cs }
-            },
-        }
+        crate::canonicalize::resolve::resolve_type_expr(te, Some(&self.env.types))
     }
 
     pub(crate) fn resolve_field_type(&mut self, ty: &Ty, field: &str) -> Ty {

--- a/src/codegen/emit_wasm/mod.rs
+++ b/src/codegen/emit_wasm/mod.rs
@@ -798,7 +798,7 @@ pub fn emit(program: &IrProgram) -> Vec<u8> {
     compile_variant_eq_funcs(&mut emitter, &program.var_table);
 
     // Phase 2.5: Dead Code Elimination
-    let _dce_count = dce::eliminate_dead_code(&mut emitter);
+    let dce_count = dce::eliminate_dead_code(&mut emitter);
 
     // Collect public user functions for WASM export
     for func in &program.functions {
@@ -809,7 +809,8 @@ pub fn emit(program: &IrProgram) -> Vec<u8> {
         emitter.user_exports.push(func.name.to_string());
     }
 
-    // Phase 3: Assemble
+    // Phase 3: Assemble (DCE already ran in Phase 2.5: {} functions eliminated)
+    let _ = dce_count;
     assemble(&emitter)
 }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -24,6 +24,7 @@
 pub mod annotations;
 pub mod pass;
 pub mod pass_auto_parallel;
+pub mod pass_borrow_inference;
 pub mod pass_box_deref;
 pub mod pass_builtin_lowering;
 pub mod pass_capture_clone;

--- a/src/codegen/pass.rs
+++ b/src/codegen/pass.rs
@@ -195,10 +195,13 @@ impl NanoPass for BorrowInsertionPass {
     fn targets(&self) -> Option<Vec<Target>> {
         Some(vec![Target::Rust])
     }
-    fn run(&self, program: IrProgram, _target: Target) -> PassResult {
-        // Rust: analyze parameter usage, mark &T vs T
-        // TODO: implement during Phase 2 migration (move from borrow.rs)
-        PassResult { program, changed: false }
+    fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
+        let sigs = super::pass_borrow_inference::infer_borrow_signatures(&mut program);
+        let changed = !sigs.is_empty();
+        if changed {
+            super::pass_borrow_inference::insert_borrows_at_call_sites(&mut program, &sigs);
+        }
+        PassResult { program, changed }
     }
 }
 

--- a/src/codegen/pass_auto_parallel.rs
+++ b/src/codegen/pass_auto_parallel.rs
@@ -272,6 +272,7 @@ fn is_pure_expr(
         IrExprKind::EmptyMap => true,
         IrExprKind::Todo { .. } => false,
         IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. } => true,
+        IrExprKind::IterChain { .. } => true,
     }
 }
 

--- a/src/codegen/pass_borrow_inference.rs
+++ b/src/codegen/pass_borrow_inference.rs
@@ -18,7 +18,7 @@ pub fn infer_borrow_signatures(program: &mut IrProgram) -> HashMap<String, Vec<P
     let mut sigs: HashMap<String, Vec<ParamBorrow>> = HashMap::new();
 
     for func in &mut program.functions {
-        if func.is_test || is_derive_fn(&func.name) || func.generics.as_ref().map_or(false, |g| !g.is_empty()) { continue; }
+        if func.is_test || is_derive_fn(&func.name) || is_monomorphized(&func.name) || func.generics.as_ref().map_or(false, |g| !g.is_empty()) { continue; }
         let borrows = infer_function_borrows(func);
         if borrows.iter().any(|b| !matches!(b, ParamBorrow::Own)) {
             sigs.insert(func.name.to_string(), borrows.clone());
@@ -30,7 +30,7 @@ pub fn infer_borrow_signatures(program: &mut IrProgram) -> HashMap<String, Vec<P
 
     for module in &mut program.modules {
         for func in &mut module.functions {
-            if func.is_test || is_derive_fn(&func.name) || func.generics.as_ref().map_or(false, |g| !g.is_empty()) { continue; }
+            if func.is_test || is_derive_fn(&func.name) || is_monomorphized(&func.name) || func.generics.as_ref().map_or(false, |g| !g.is_empty()) { continue; }
             let borrows = infer_function_borrows(func);
             if borrows.iter().any(|b| !matches!(b, ParamBorrow::Own)) {
                 sigs.insert(func.name.to_string(), borrows.clone());
@@ -73,6 +73,10 @@ fn infer_function_borrows(func: &IrFunction) -> Vec<ParamBorrow> {
 fn is_derive_fn(name: &str) -> bool {
     name.contains("_encode") || name.contains("_decode") || name.contains("_eq")
         || name.contains("_display") || name.contains("_to_string") || name.contains("_from_")
+}
+
+fn is_monomorphized(name: &str) -> bool {
+    name.contains("__")
 }
 
 /// Only String and List are eligible for borrow inference.
@@ -138,6 +142,7 @@ fn check_needs_ownership(expr: &IrExpr, var: VarId, needs: &mut bool) {
             if is_var(base, var) { *needs = true; return; }
             for (_, v) in fields { if is_var(v, var) { *needs = true; return; } }
             check_needs_ownership(base, var, needs);
+            for (_, v) in fields { check_needs_ownership(v, var, needs); }
         }
         IrExprKind::MapLiteral { entries } => {
             for (k, v) in entries { if is_var(k, var) || is_var(v, var) { *needs = true; return; } }

--- a/src/codegen/pass_borrow_inference.rs
+++ b/src/codegen/pass_borrow_inference.rs
@@ -1,0 +1,534 @@
+//! BorrowInferencePass: Roc-style "borrowed by default, own when needed" analysis.
+//!
+//! For each user function parameter of heap type (String, Vec, Record, etc.):
+//! 1. Start as Borrowed
+//! 2. Walk the function body to find ownership-requiring uses
+//! 3. If none found → mark param as Ref/RefStr/RefSlice
+//! 4. Insert Borrow nodes at call sites for borrowed params
+//!
+//! This eliminates unnecessary .clone() at call sites when the callee only reads the value.
+
+use std::collections::HashMap;
+use crate::ir::*;
+use crate::types::{Ty, TypeConstructorId};
+use crate::intern::sym;
+
+/// Phase 1: Infer borrow signatures for all functions.
+pub fn infer_borrow_signatures(program: &mut IrProgram) -> HashMap<String, Vec<ParamBorrow>> {
+    let mut sigs: HashMap<String, Vec<ParamBorrow>> = HashMap::new();
+
+    for func in &mut program.functions {
+        if func.is_test || is_derive_fn(&func.name) || func.generics.as_ref().map_or(false, |g| !g.is_empty()) { continue; }
+        let borrows = infer_function_borrows(func);
+        if borrows.iter().any(|b| !matches!(b, ParamBorrow::Own)) {
+            sigs.insert(func.name.to_string(), borrows.clone());
+        }
+        for (param, borrow) in func.params.iter_mut().zip(borrows) {
+            param.borrow = borrow;
+        }
+    }
+
+    for module in &mut program.modules {
+        for func in &mut module.functions {
+            if func.is_test || is_derive_fn(&func.name) || func.generics.as_ref().map_or(false, |g| !g.is_empty()) { continue; }
+            let borrows = infer_function_borrows(func);
+            if borrows.iter().any(|b| !matches!(b, ParamBorrow::Own)) {
+                sigs.insert(func.name.to_string(), borrows.clone());
+            }
+            for (param, borrow) in func.params.iter_mut().zip(borrows) {
+                param.borrow = borrow;
+            }
+        }
+    }
+
+    sigs
+}
+
+fn infer_function_borrows(func: &IrFunction) -> Vec<ParamBorrow> {
+    func.params.iter().map(|param| {
+        if !is_heap_type(&param.ty) {
+            return ParamBorrow::Own;
+        }
+
+        // If the function body directly returns this param, it needs ownership
+        if is_var(&func.body, param.var) {
+            return ParamBorrow::Own;
+        }
+
+        let mut needs_own = false;
+        check_needs_ownership(&func.body, param.var, &mut needs_own);
+
+        if needs_own {
+            ParamBorrow::Own
+        } else if matches!(&param.ty, Ty::String) {
+            ParamBorrow::RefStr
+        } else if matches!(&param.ty, Ty::Applied(TypeConstructorId::List, _)) {
+            ParamBorrow::RefSlice
+        } else {
+            ParamBorrow::Ref
+        }
+    }).collect()
+}
+
+fn is_derive_fn(name: &str) -> bool {
+    name.contains("_encode") || name.contains("_decode") || name.contains("_eq")
+        || name.contains("_display") || name.contains("_to_string") || name.contains("_from_")
+}
+
+/// Only String and List are eligible for borrow inference.
+/// Records/Variants have field access issues when borrowed (&Record.field → &String, not String).
+fn is_heap_type(ty: &Ty) -> bool {
+    matches!(ty, Ty::String | Ty::Applied(TypeConstructorId::List, _))
+}
+
+/// Check if a parameter variable needs ownership.
+/// Conservative: marks as Owned if used in ANY ownership-requiring position.
+fn check_needs_ownership(expr: &IrExpr, var: VarId, needs: &mut bool) {
+    if *needs { return; }
+    match &expr.kind {
+        // ── Tail position: returned value needs ownership ──
+        IrExprKind::Var { id } if *id == var => {
+            // Bare var reference — context determines if ownership needed.
+            // When used as a standalone expression (tail), it's returned → own.
+            // But we handle tail detection at the Block level below.
+        }
+
+        IrExprKind::Block { stmts, expr: Some(tail) } => {
+            for s in stmts { check_needs_ownership_stmt(s, var, needs); }
+            if is_var(tail, var) { *needs = true; return; }
+            check_needs_ownership(tail, var, needs);
+        }
+        IrExprKind::Block { stmts, expr: None } => {
+            for s in stmts { check_needs_ownership_stmt(s, var, needs); }
+        }
+
+        // ── Concatenation consumes operands ──
+        IrExprKind::BinOp { op: BinOp::ConcatStr | BinOp::ConcatList, left, right } => {
+            if is_var(left, var) || is_var(right, var) { *needs = true; return; }
+            check_needs_ownership(left, var, needs);
+            check_needs_ownership(right, var, needs);
+        }
+
+        // ── Function call: conservatively, passing to any function needs own ──
+        // EXCEPT: if the callee is known to borrow that param (future: use sigs map)
+        IrExprKind::Call { target, args, .. } => {
+            // Passing as argument to a function → needs own (conservative)
+            for arg in args {
+                if is_var(arg, var) { *needs = true; return; }
+            }
+            // Recurse into non-arg sub-expressions
+            match target {
+                CallTarget::Method { object, .. } => check_needs_ownership(object, var, needs),
+                CallTarget::Computed { callee } => check_needs_ownership(callee, var, needs),
+                _ => {}
+            }
+            for arg in args { check_needs_ownership(arg, var, needs); }
+        }
+
+        // ── Collection construction consumes ──
+        IrExprKind::Record { fields, .. } => {
+            for (_, v) in fields { if is_var(v, var) { *needs = true; return; } }
+            for (_, v) in fields { check_needs_ownership(v, var, needs); }
+        }
+        IrExprKind::List { elements } | IrExprKind::Tuple { elements } => {
+            for e in elements { if is_var(e, var) { *needs = true; return; } }
+            for e in elements { check_needs_ownership(e, var, needs); }
+        }
+        IrExprKind::SpreadRecord { base, fields } => {
+            if is_var(base, var) { *needs = true; return; }
+            for (_, v) in fields { if is_var(v, var) { *needs = true; return; } }
+            check_needs_ownership(base, var, needs);
+        }
+        IrExprKind::MapLiteral { entries } => {
+            for (k, v) in entries { if is_var(k, var) || is_var(v, var) { *needs = true; return; } }
+        }
+
+        // ── Wrapping in Result/Option/Some ──
+        IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
+        | IrExprKind::OptionSome { expr } => {
+            if is_var(expr, var) { *needs = true; return; }
+            check_needs_ownership(expr, var, needs);
+        }
+
+        // ── Lambda capture: captured vars need ownership ──
+        IrExprKind::Lambda { body, .. } => {
+            if uses_var(body, var) { *needs = true; }
+        }
+
+        // ── String interpolation consumes ──
+        IrExprKind::StringInterp { parts } => {
+            for p in parts {
+                if let IrStringPart::Expr { expr } = p {
+                    if is_var(expr, var) { *needs = true; return; }
+                    check_needs_ownership(expr, var, needs);
+                }
+            }
+        }
+
+        // ── ForIn: iterable is consumed ──
+        IrExprKind::ForIn { iterable, body, .. } => {
+            if is_var(iterable, var) { *needs = true; return; }
+            check_needs_ownership(iterable, var, needs);
+            for s in body { check_needs_ownership_stmt(s, var, needs); }
+        }
+
+        // ── IterChain: source consumed if consume=true ──
+        IrExprKind::IterChain { source, consume, steps, collector } => {
+            if *consume && is_var(source, var) { *needs = true; return; }
+            check_needs_ownership(source, var, needs);
+            for step in steps {
+                match step {
+                    IterStep::Map { lambda } | IterStep::Filter { lambda }
+                    | IterStep::FlatMap { lambda } | IterStep::FilterMap { lambda } => {
+                        if uses_var(lambda, var) { *needs = true; return; }
+                    }
+                }
+            }
+            match collector {
+                IterCollector::Collect => {}
+                IterCollector::Fold { init, lambda } => {
+                    if is_var(init, var) { *needs = true; return; }
+                    if uses_var(lambda, var) { *needs = true; return; }
+                }
+                IterCollector::Any { lambda } | IterCollector::All { lambda }
+                | IterCollector::Find { lambda } | IterCollector::Count { lambda } => {
+                    if uses_var(lambda, var) { *needs = true; return; }
+                }
+            }
+        }
+
+        // ── Safe reads (no ownership needed) ──
+        IrExprKind::IndexAccess { object, index } | IrExprKind::MapAccess { object, key: index } => {
+            // Indexing borrows — safe
+            check_needs_ownership(object, var, needs);
+            check_needs_ownership(index, var, needs);
+        }
+        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
+            check_needs_ownership(object, var, needs);
+        }
+        IrExprKind::BinOp { left, right, .. } => {
+            // Non-concat binop: comparison, arithmetic — safe reads
+            check_needs_ownership(left, var, needs);
+            check_needs_ownership(right, var, needs);
+        }
+
+        // ── Control flow: recurse ──
+        IrExprKind::If { cond, then, else_ } => {
+            check_needs_ownership(cond, var, needs);
+            check_needs_ownership(then, var, needs);
+            check_needs_ownership(else_, var, needs);
+        }
+        IrExprKind::Match { subject, arms } => {
+            // Match subject: destructuring a borrowed value changes bind types
+            // → needs ownership to avoid &-pattern complications
+            if is_var(subject, var) { *needs = true; return; }
+            check_needs_ownership(subject, var, needs);
+            for arm in arms {
+                if let Some(g) = &arm.guard { check_needs_ownership(g, var, needs); }
+                check_needs_ownership(&arm.body, var, needs);
+            }
+        }
+        IrExprKind::While { cond, body } => {
+            check_needs_ownership(cond, var, needs);
+            for s in body { check_needs_ownership_stmt(s, var, needs); }
+        }
+
+        // ── Wrappers: recurse ──
+        IrExprKind::UnOp { operand, .. } => check_needs_ownership(operand, var, needs),
+        IrExprKind::Try { expr } | IrExprKind::Unwrap { expr } | IrExprKind::ToOption { expr }
+        | IrExprKind::Clone { expr } | IrExprKind::Deref { expr }
+        | IrExprKind::Borrow { expr, .. } | IrExprKind::BoxNew { expr }
+        | IrExprKind::ToVec { expr } | IrExprKind::Await { expr } => {
+            check_needs_ownership(expr, var, needs);
+        }
+        IrExprKind::UnwrapOr { expr, fallback } => {
+            check_needs_ownership(expr, var, needs);
+            check_needs_ownership(fallback, var, needs);
+        }
+        IrExprKind::OptionalChain { expr, .. } => check_needs_ownership(expr, var, needs),
+        IrExprKind::Range { start, end, .. } => {
+            check_needs_ownership(start, var, needs);
+            check_needs_ownership(end, var, needs);
+        }
+        IrExprKind::Fan { exprs } => {
+            for e in exprs { if is_var(e, var) { *needs = true; return; } }
+            for e in exprs { check_needs_ownership(e, var, needs); }
+        }
+        IrExprKind::RustMacro { args, .. } => {
+            for a in args { check_needs_ownership(a, var, needs); }
+        }
+        _ => {}
+    }
+}
+
+fn check_needs_ownership_stmt(stmt: &IrStmt, var: VarId, needs: &mut bool) {
+    if *needs { return; }
+    match &stmt.kind {
+        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
+        | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => {
+            check_needs_ownership(value, var, needs);
+        }
+        IrStmtKind::IndexAssign { index, value, .. } | IrStmtKind::MapInsert { key: index, value, .. } => {
+            check_needs_ownership(index, var, needs);
+            check_needs_ownership(value, var, needs);
+        }
+        IrStmtKind::Expr { expr } => check_needs_ownership(expr, var, needs),
+        IrStmtKind::Guard { cond, else_ } => {
+            check_needs_ownership(cond, var, needs);
+            check_needs_ownership(else_, var, needs);
+        }
+        _ => {}
+    }
+}
+
+fn is_var(expr: &IrExpr, var: VarId) -> bool {
+    matches!(&expr.kind, IrExprKind::Var { id } if *id == var)
+}
+
+fn uses_var(expr: &IrExpr, var: VarId) -> bool {
+    match &expr.kind {
+        IrExprKind::Var { id } => *id == var,
+        IrExprKind::Block { stmts, expr } => {
+            stmts.iter().any(|s| stmt_uses_var(s, var))
+            || expr.as_ref().map_or(false, |e| uses_var(e, var))
+        }
+        IrExprKind::If { cond, then, else_ } => uses_var(cond, var) || uses_var(then, var) || uses_var(else_, var),
+        IrExprKind::Call { args, target, .. } => {
+            match target {
+                CallTarget::Method { object, .. } => { if uses_var(object, var) { return true; } }
+                CallTarget::Computed { callee } => { if uses_var(callee, var) { return true; } }
+                _ => {}
+            }
+            args.iter().any(|a| uses_var(a, var))
+        }
+        IrExprKind::BinOp { left, right, .. } => uses_var(left, var) || uses_var(right, var),
+        IrExprKind::UnOp { operand, .. } => uses_var(operand, var),
+        IrExprKind::Lambda { body, .. } => uses_var(body, var),
+        IrExprKind::Match { subject, arms } => {
+            uses_var(subject, var) || arms.iter().any(|a| {
+                a.guard.as_ref().map_or(false, |g| uses_var(g, var)) || uses_var(&a.body, var)
+            })
+        }
+        IrExprKind::ForIn { iterable, body, .. } => {
+            uses_var(iterable, var) || body.iter().any(|s| stmt_uses_var(s, var))
+        }
+        IrExprKind::While { cond, body } => {
+            uses_var(cond, var) || body.iter().any(|s| stmt_uses_var(s, var))
+        }
+        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. }
+        | IrExprKind::OptionalChain { expr: object, .. } => uses_var(object, var),
+        IrExprKind::IndexAccess { object, index } | IrExprKind::MapAccess { object, key: index } => {
+            uses_var(object, var) || uses_var(index, var)
+        }
+        IrExprKind::StringInterp { parts } => parts.iter().any(|p| {
+            matches!(p, IrStringPart::Expr { expr } if uses_var(expr, var))
+        }),
+        IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
+        | IrExprKind::OptionSome { expr } | IrExprKind::Try { expr }
+        | IrExprKind::Unwrap { expr } | IrExprKind::ToOption { expr }
+        | IrExprKind::Clone { expr } | IrExprKind::Deref { expr }
+        | IrExprKind::Borrow { expr, .. } | IrExprKind::BoxNew { expr }
+        | IrExprKind::ToVec { expr } | IrExprKind::Await { expr } => uses_var(expr, var),
+        IrExprKind::UnwrapOr { expr, fallback } => uses_var(expr, var) || uses_var(fallback, var),
+        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
+        | IrExprKind::Fan { exprs: elements } => elements.iter().any(|e| uses_var(e, var)),
+        IrExprKind::Record { fields, .. } => fields.iter().any(|(_, v)| uses_var(v, var)),
+        IrExprKind::SpreadRecord { base, fields } => {
+            uses_var(base, var) || fields.iter().any(|(_, v)| uses_var(v, var))
+        }
+        IrExprKind::IterChain { source, steps, collector, .. } => {
+            uses_var(source, var)
+            || steps.iter().any(|s| match s {
+                IterStep::Map { lambda } | IterStep::Filter { lambda }
+                | IterStep::FlatMap { lambda } | IterStep::FilterMap { lambda } => uses_var(lambda, var),
+            })
+            || match collector {
+                IterCollector::Collect => false,
+                IterCollector::Fold { init, lambda } => uses_var(init, var) || uses_var(lambda, var),
+                IterCollector::Any { lambda } | IterCollector::All { lambda }
+                | IterCollector::Find { lambda } | IterCollector::Count { lambda } => uses_var(lambda, var),
+            }
+        }
+        IrExprKind::RustMacro { args, .. } => args.iter().any(|a| uses_var(a, var)),
+        IrExprKind::Range { start, end, .. } => uses_var(start, var) || uses_var(end, var),
+        IrExprKind::MapLiteral { entries } => entries.iter().any(|(k, v)| uses_var(k, var) || uses_var(v, var)),
+        _ => false,
+    }
+}
+
+fn stmt_uses_var(stmt: &IrStmt, var: VarId) -> bool {
+    match &stmt.kind {
+        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
+        | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => uses_var(value, var),
+        IrStmtKind::IndexAssign { index, value, .. } | IrStmtKind::MapInsert { key: index, value, .. } => {
+            uses_var(index, var) || uses_var(value, var)
+        }
+        IrStmtKind::Expr { expr } => uses_var(expr, var),
+        IrStmtKind::Guard { cond, else_ } => uses_var(cond, var) || uses_var(else_, var),
+        _ => false,
+    }
+}
+
+// ── Phase 2: Insert Borrow nodes at call sites ─────────────────────
+
+pub fn insert_borrows_at_call_sites(program: &mut IrProgram, sigs: &HashMap<String, Vec<ParamBorrow>>) {
+    for func in &mut program.functions {
+        func.body = rewrite_calls(std::mem::take(&mut func.body), sigs);
+    }
+    for tl in &mut program.top_lets {
+        tl.value = rewrite_calls(std::mem::take(&mut tl.value), sigs);
+    }
+    for module in &mut program.modules {
+        for func in &mut module.functions {
+            func.body = rewrite_calls(std::mem::take(&mut func.body), sigs);
+        }
+        for tl in &mut module.top_lets {
+            tl.value = rewrite_calls(std::mem::take(&mut tl.value), sigs);
+        }
+    }
+}
+
+fn rewrite_calls(expr: IrExpr, sigs: &HashMap<String, Vec<ParamBorrow>>) -> IrExpr {
+    let ty = expr.ty.clone();
+    let span = expr.span;
+
+    let kind = match expr.kind {
+        IrExprKind::Call { target, args, type_args } => {
+            let args: Vec<IrExpr> = args.into_iter().map(|a| rewrite_calls(a, sigs)).collect();
+
+            let callee_name = match &target {
+                CallTarget::Named { name } => Some(name.to_string()),
+                // Convention methods: Walker renders as UFCS `TypeName_method(object, args)`
+                // The method name in IR is "TypeName.method" — sigs use the same format
+                CallTarget::Method { method, .. } if method.contains('.') => Some(method.to_string()),
+                _ => None,
+            };
+
+            let args = if let Some(ref name) = callee_name {
+                if let Some(borrows) = sigs.get(name) {
+                    args.into_iter().enumerate().map(|(i, arg)| {
+                        match borrows.get(i) {
+                            Some(ParamBorrow::Ref | ParamBorrow::RefSlice) => {
+                                let t = arg.ty.clone(); let s = arg.span;
+                                IrExpr { kind: IrExprKind::Borrow { expr: Box::new(arg), as_str: false, mutable: false }, ty: t, span: s }
+                            }
+                            Some(ParamBorrow::RefStr) => {
+                                let t = arg.ty.clone(); let s = arg.span;
+                                IrExpr { kind: IrExprKind::Borrow { expr: Box::new(arg), as_str: true, mutable: false }, ty: t, span: s }
+                            }
+                            _ => arg,
+                        }
+                    }).collect()
+                } else { args }
+            } else { args };
+
+            let target = match target {
+                CallTarget::Method { object, method } => {
+                    let mut obj = rewrite_calls(*object, sigs);
+                    if method.contains('.') {
+                        if let Some(borrows) = sigs.get(method.as_str()) {
+                            if let Some(b) = borrows.first() {
+                                match b {
+                                    ParamBorrow::Ref | ParamBorrow::RefSlice => {
+                                        let t = obj.ty.clone(); let s = obj.span;
+                                        obj = IrExpr { kind: IrExprKind::Borrow { expr: Box::new(obj), as_str: false, mutable: false }, ty: t, span: s };
+                                    }
+                                    ParamBorrow::RefStr => {
+                                        let t = obj.ty.clone(); let s = obj.span;
+                                        obj = IrExpr { kind: IrExprKind::Borrow { expr: Box::new(obj), as_str: true, mutable: false }, ty: t, span: s };
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                    }
+                    CallTarget::Method { object: Box::new(obj), method }
+                },
+                CallTarget::Computed { callee } => CallTarget::Computed {
+                    callee: Box::new(rewrite_calls(*callee, sigs)),
+                },
+                other => other,
+            };
+            IrExprKind::Call { target, args, type_args }
+        }
+
+        IrExprKind::Block { stmts, expr } => IrExprKind::Block {
+            stmts: stmts.into_iter().map(|s| rewrite_calls_stmt(s, sigs)).collect(),
+            expr: expr.map(|e| Box::new(rewrite_calls(*e, sigs))),
+        },
+        IrExprKind::If { cond, then, else_ } => IrExprKind::If {
+            cond: Box::new(rewrite_calls(*cond, sigs)),
+            then: Box::new(rewrite_calls(*then, sigs)),
+            else_: Box::new(rewrite_calls(*else_, sigs)),
+        },
+        IrExprKind::Match { subject, arms } => IrExprKind::Match {
+            subject: Box::new(rewrite_calls(*subject, sigs)),
+            arms: arms.into_iter().map(|a| IrMatchArm {
+                pattern: a.pattern,
+                guard: a.guard.map(|g| rewrite_calls(g, sigs)),
+                body: rewrite_calls(a.body, sigs),
+            }).collect(),
+        },
+        IrExprKind::ForIn { var, var_tuple, iterable, body } => IrExprKind::ForIn {
+            var, var_tuple,
+            iterable: Box::new(rewrite_calls(*iterable, sigs)),
+            body: body.into_iter().map(|s| rewrite_calls_stmt(s, sigs)).collect(),
+        },
+        IrExprKind::While { cond, body } => IrExprKind::While {
+            cond: Box::new(rewrite_calls(*cond, sigs)),
+            body: body.into_iter().map(|s| rewrite_calls_stmt(s, sigs)).collect(),
+        },
+        IrExprKind::Lambda { params, body, lambda_id } => IrExprKind::Lambda {
+            params, body: Box::new(rewrite_calls(*body, sigs)), lambda_id,
+        },
+        IrExprKind::BinOp { op, left, right } => IrExprKind::BinOp {
+            op, left: Box::new(rewrite_calls(*left, sigs)), right: Box::new(rewrite_calls(*right, sigs)),
+        },
+        IrExprKind::UnOp { op, operand } => IrExprKind::UnOp {
+            op, operand: Box::new(rewrite_calls(*operand, sigs)),
+        },
+        IrExprKind::ResultOk { expr } => IrExprKind::ResultOk { expr: Box::new(rewrite_calls(*expr, sigs)) },
+        IrExprKind::ResultErr { expr } => IrExprKind::ResultErr { expr: Box::new(rewrite_calls(*expr, sigs)) },
+        IrExprKind::OptionSome { expr } => IrExprKind::OptionSome { expr: Box::new(rewrite_calls(*expr, sigs)) },
+        IrExprKind::Try { expr } => IrExprKind::Try { expr: Box::new(rewrite_calls(*expr, sigs)) },
+        IrExprKind::Unwrap { expr } => IrExprKind::Unwrap { expr: Box::new(rewrite_calls(*expr, sigs)) },
+        IrExprKind::UnwrapOr { expr, fallback } => IrExprKind::UnwrapOr {
+            expr: Box::new(rewrite_calls(*expr, sigs)),
+            fallback: Box::new(rewrite_calls(*fallback, sigs)),
+        },
+        IrExprKind::StringInterp { parts } => IrExprKind::StringInterp {
+            parts: parts.into_iter().map(|p| match p {
+                IrStringPart::Expr { expr } => IrStringPart::Expr { expr: rewrite_calls(expr, sigs) },
+                other => other,
+            }).collect(),
+        },
+        IrExprKind::Fan { exprs } => IrExprKind::Fan {
+            exprs: exprs.into_iter().map(|e| rewrite_calls(e, sigs)).collect(),
+        },
+        IrExprKind::IterChain { source, consume, steps, collector } => IrExprKind::IterChain {
+            source: Box::new(rewrite_calls(*source, sigs)),
+            consume, steps, collector,
+        },
+        other => other,
+    };
+
+    IrExpr { kind, ty, span }
+}
+
+fn rewrite_calls_stmt(stmt: IrStmt, sigs: &HashMap<String, Vec<ParamBorrow>>) -> IrStmt {
+    let kind = match stmt.kind {
+        IrStmtKind::Bind { var, mutability, ty, value } => IrStmtKind::Bind {
+            var, mutability, ty, value: rewrite_calls(value, sigs),
+        },
+        IrStmtKind::Assign { var, value } => IrStmtKind::Assign { var, value: rewrite_calls(value, sigs) },
+        IrStmtKind::Expr { expr } => IrStmtKind::Expr { expr: rewrite_calls(expr, sigs) },
+        IrStmtKind::Guard { cond, else_ } => IrStmtKind::Guard {
+            cond: rewrite_calls(cond, sigs), else_: rewrite_calls(else_, sigs),
+        },
+        IrStmtKind::BindDestructure { pattern, value } => IrStmtKind::BindDestructure {
+            pattern, value: rewrite_calls(value, sigs),
+        },
+        other => other,
+    };
+    IrStmt { kind, span: stmt.span }
+}

--- a/src/codegen/pass_clone.rs
+++ b/src/codegen/pass_clone.rs
@@ -1,11 +1,13 @@
 //! ClonePass: insert Clone IR nodes for heap-type variables in Rust.
 //!
-//! Walks the IR and wraps `Var { id }` in `Clone { expr: Var { id } }`
-//! for variables of heap types (String, Vec, HashMap, records, etc.).
-//! The walker renders Clone via template (Rust: `.clone()`, TS: identity).
+//! **Last-use optimization**: tracks remaining uses per variable.
+//! At the final use of a variable, ownership is transferred (move) instead of cloning.
+//! Inside loops, clones are always inserted (the body executes multiple times).
+//! At branches (if/match), remaining counts are merged conservatively (min).
 
-use std::collections::HashSet;
+use std::collections::{HashSet, HashMap};
 use crate::ir::*;
+use crate::ast::Span;
 use crate::types::Ty;
 use super::pass::{NanoPass, PassResult, Target};
 
@@ -22,55 +24,178 @@ impl NanoPass for CloneInsertionPass {
     fn depends_on(&self) -> Vec<&'static str> { vec!["BorrowInsertion"] }
 
     fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
-        // Recompute use-counts: earlier passes may have changed the IR
         compute_use_counts(&mut program);
-        // Collect top-level let VarIds: always clone (they're behind LazyLock, can't move out)
         let top_let_vars: HashSet<VarId> = program.top_lets.iter().map(|tl| tl.var).collect();
-        let clone_ids = collect_clone_ids(&program.var_table, &top_let_vars);
+
+        // Compute syntactic counts (no loop/lambda bumps) for remaining tracking
+        let syntactic = compute_syntactic_counts_program(&program);
+
+        let (always, eligible) = split_clone_ids(&program.var_table, &top_let_vars, &syntactic);
+        let mut remaining = build_remaining(&eligible, &syntactic);
+
         for func in &mut program.functions {
-            func.body = insert_clones(std::mem::take(&mut func.body), &clone_ids);
+            // Reset remaining for each function (vars are function-scoped)
+            reset_remaining(&mut remaining, &eligible, &syntactic);
+            func.body = insert_clones_live(std::mem::take(&mut func.body), &always, &eligible, &mut remaining, false);
         }
         for tl in &mut program.top_lets {
-            tl.value = insert_clones(std::mem::take(&mut tl.value), &clone_ids);
+            reset_remaining(&mut remaining, &eligible, &syntactic);
+            tl.value = insert_clones_live(std::mem::take(&mut tl.value), &always, &eligible, &mut remaining, false);
         }
-        // Process module functions (each module has its own var_table)
+
         for module in &mut program.modules {
             let module_top_lets: HashSet<VarId> = module.top_lets.iter().map(|tl| tl.var).collect();
-            let module_clone_ids = collect_clone_ids(&module.var_table, &module_top_lets);
+            let module_syntactic = compute_syntactic_counts_module(module);
+            let (m_always, m_eligible) = split_clone_ids(&module.var_table, &module_top_lets, &module_syntactic);
+            let mut m_remaining = build_remaining(&m_eligible, &module_syntactic);
+
             for func in &mut module.functions {
-                func.body = insert_clones(std::mem::take(&mut func.body), &module_clone_ids);
+                reset_remaining(&mut m_remaining, &m_eligible, &module_syntactic);
+                func.body = insert_clones_live(std::mem::take(&mut func.body), &m_always, &m_eligible, &mut m_remaining, false);
             }
             for tl in &mut module.top_lets {
-                tl.value = insert_clones(std::mem::take(&mut tl.value), &module_clone_ids);
+                reset_remaining(&mut m_remaining, &m_eligible, &module_syntactic);
+                tl.value = insert_clones_live(std::mem::take(&mut tl.value), &m_always, &m_eligible, &mut m_remaining, false);
             }
         }
         PassResult { program, changed: true }
     }
 }
 
-fn collect_clone_ids(vt: &VarTable, always_clone: &HashSet<VarId>) -> HashSet<VarId> {
-    let mut ids = HashSet::new();
-    for i in 0..vt.len() {
-        let id = VarId(i as u32);
-        let info = vt.get(id);
-        if !needs_clone(&info.ty) { continue; }
-        // Top-level lets (LazyLock statics): always clone — can't move out of LazyLock
-        // Fn/TypeVar: always clone (closure mutability, generic type erasure)
-        // Capture clones (__cap_N): always clone — used inside FnMut closures called multiple times
-        let name = crate::intern::resolve(info.name);
-        if always_clone.contains(&id) || matches!(&info.ty, Ty::Fn { .. } | Ty::TypeVar(_))
-            || name.starts_with("__cap_") || name.starts_with("__licm") {
-            ids.insert(id);
-            continue;
-        }
-        // Other heap types: only clone if used more than once.
-        // Single-use variables can transfer ownership directly (move semantics).
-        if info.use_count > 1 {
-            ids.insert(id);
-        }
+// ── Syntactic use-count (no loop/lambda bumps) ─────────────────────
+
+fn compute_syntactic_counts_program(program: &IrProgram) -> HashMap<VarId, u32> {
+    let mut counts = HashMap::new();
+    for func in &program.functions {
+        count_syntactic(&func.body, &mut counts);
     }
-    ids
+    for tl in &program.top_lets {
+        count_syntactic(&tl.value, &mut counts);
+    }
+    counts
 }
+
+fn compute_syntactic_counts_module(module: &IrModule) -> HashMap<VarId, u32> {
+    let mut counts = HashMap::new();
+    for func in &module.functions {
+        count_syntactic(&func.body, &mut counts);
+    }
+    for tl in &module.top_lets {
+        count_syntactic(&tl.value, &mut counts);
+    }
+    counts
+}
+
+fn count_syntactic(expr: &IrExpr, counts: &mut HashMap<VarId, u32>) {
+    match &expr.kind {
+        IrExprKind::Var { id } => { *counts.entry(*id).or_insert(0) += 1; }
+        IrExprKind::BinOp { left, right, .. } => {
+            count_syntactic(left, counts); count_syntactic(right, counts);
+        }
+        IrExprKind::UnOp { operand, .. } => count_syntactic(operand, counts),
+        IrExprKind::If { cond, then, else_ } => {
+            count_syntactic(cond, counts); count_syntactic(then, counts); count_syntactic(else_, counts);
+        }
+        IrExprKind::Match { subject, arms } => {
+            count_syntactic(subject, counts);
+            for arm in arms {
+                if let Some(g) = &arm.guard { count_syntactic(g, counts); }
+                count_syntactic(&arm.body, counts);
+            }
+        }
+        IrExprKind::Block { stmts, expr } => {
+            for s in stmts { count_syntactic_stmt(s, counts); }
+            if let Some(e) = expr { count_syntactic(e, counts); }
+        }
+        IrExprKind::Call { target, args, .. } => {
+            match target {
+                CallTarget::Method { object, .. } => count_syntactic(object, counts),
+                CallTarget::Computed { callee } => count_syntactic(callee, counts),
+                _ => {}
+            }
+            for a in args { count_syntactic(a, counts); }
+        }
+        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
+        | IrExprKind::Fan { exprs: elements } => {
+            for e in elements { count_syntactic(e, counts); }
+        }
+        IrExprKind::Record { fields, .. } => {
+            for (_, e) in fields { count_syntactic(e, counts); }
+        }
+        IrExprKind::SpreadRecord { base, fields } => {
+            count_syntactic(base, counts);
+            for (_, e) in fields { count_syntactic(e, counts); }
+        }
+        IrExprKind::MapLiteral { entries } => {
+            for (k, v) in entries { count_syntactic(k, counts); count_syntactic(v, counts); }
+        }
+        IrExprKind::Range { start, end, .. } => {
+            count_syntactic(start, counts); count_syntactic(end, counts);
+        }
+        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. }
+        | IrExprKind::OptionalChain { expr: object, .. } => count_syntactic(object, counts),
+        IrExprKind::IndexAccess { object, index } => {
+            count_syntactic(object, counts); count_syntactic(index, counts);
+        }
+        IrExprKind::MapAccess { object, key } => {
+            count_syntactic(object, counts); count_syntactic(key, counts);
+        }
+        IrExprKind::ForIn { iterable, body, .. } => {
+            count_syntactic(iterable, counts);
+            for s in body { count_syntactic_stmt(s, counts); }
+        }
+        IrExprKind::While { cond, body } => {
+            count_syntactic(cond, counts);
+            for s in body { count_syntactic_stmt(s, counts); }
+        }
+        IrExprKind::Lambda { body, .. } => count_syntactic(body, counts),
+        IrExprKind::StringInterp { parts } => {
+            for p in parts { if let IrStringPart::Expr { expr } = p { count_syntactic(expr, counts); } }
+        }
+        IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
+        | IrExprKind::OptionSome { expr } | IrExprKind::Try { expr }
+        | IrExprKind::Unwrap { expr } | IrExprKind::ToOption { expr }
+        | IrExprKind::Await { expr }
+        | IrExprKind::Clone { expr } | IrExprKind::Deref { expr }
+        | IrExprKind::Borrow { expr, .. } | IrExprKind::BoxNew { expr }
+        | IrExprKind::ToVec { expr } => count_syntactic(expr, counts),
+        IrExprKind::UnwrapOr { expr, fallback } => {
+            count_syntactic(expr, counts); count_syntactic(fallback, counts);
+        }
+        IrExprKind::RustMacro { args, .. } => {
+            for a in args { count_syntactic(a, counts); }
+        }
+        _ => {}
+    }
+}
+
+fn count_syntactic_stmt(stmt: &IrStmt, counts: &mut HashMap<VarId, u32>) {
+    match &stmt.kind {
+        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
+        | IrStmtKind::Assign { value, .. } => count_syntactic(value, counts),
+        IrStmtKind::IndexAssign { index, value, .. } => {
+            count_syntactic(index, counts); count_syntactic(value, counts);
+        }
+        IrStmtKind::MapInsert { key, value, .. } => {
+            count_syntactic(key, counts); count_syntactic(value, counts);
+        }
+        IrStmtKind::FieldAssign { value, .. } => count_syntactic(value, counts),
+        IrStmtKind::ListSwap { a, b, .. } => {
+            count_syntactic(a, counts); count_syntactic(b, counts);
+        }
+        IrStmtKind::ListReverse { end, .. } | IrStmtKind::ListRotateLeft { end, .. } => {
+            count_syntactic(end, counts);
+        }
+        IrStmtKind::ListCopySlice { len, .. } => count_syntactic(len, counts),
+        IrStmtKind::Expr { expr } => count_syntactic(expr, counts),
+        IrStmtKind::Guard { cond, else_ } => {
+            count_syntactic(cond, counts); count_syntactic(else_, counts);
+        }
+        IrStmtKind::Comment { .. } => {}
+    }
+}
+
+// ── Clone ID classification ────────────────────────────────────────
 
 fn needs_clone(ty: &Ty) -> bool {
     matches!(ty,
@@ -82,114 +207,182 @@ fn needs_clone(ty: &Ty) -> bool {
     )
 }
 
-fn insert_clones(expr: IrExpr, clone_ids: &HashSet<VarId>) -> IrExpr {
+/// Split clone candidates into "always clone" and "eligible for last-use move".
+fn split_clone_ids(
+    vt: &VarTable,
+    top_let_vars: &HashSet<VarId>,
+    syntactic: &HashMap<VarId, u32>,
+) -> (HashSet<VarId>, HashSet<VarId>) {
+    let mut always = HashSet::new();
+    let mut eligible = HashSet::new();
+
+    for i in 0..vt.len() {
+        let id = VarId(i as u32);
+        let info = vt.get(id);
+        if !needs_clone(&info.ty) { continue; }
+
+        let name = crate::intern::resolve(info.name);
+        if top_let_vars.contains(&id) || matches!(&info.ty, Ty::Fn { .. } | Ty::TypeVar(_))
+            || name.starts_with("__cap_") || name.starts_with("__licm")
+        {
+            always.insert(id);
+        } else {
+            let syn = syntactic.get(&id).copied().unwrap_or(0);
+            if syn > 1 {
+                // Multiple syntactic uses → eligible for last-use optimization
+                eligible.insert(id);
+            } else if info.use_count > 1 {
+                // Single syntactic use but bumped (loop/lambda) → always clone
+                always.insert(id);
+            }
+            // syn <= 1 && use_count <= 1: single use, no loop → move by default
+        }
+    }
+    (always, eligible)
+}
+
+fn build_remaining(eligible: &HashSet<VarId>, syntactic: &HashMap<VarId, u32>) -> HashMap<VarId, u32> {
+    eligible.iter().map(|&id| (id, syntactic.get(&id).copied().unwrap_or(0))).collect()
+}
+
+fn reset_remaining(remaining: &mut HashMap<VarId, u32>, eligible: &HashSet<VarId>, syntactic: &HashMap<VarId, u32>) {
+    for &id in eligible {
+        remaining.insert(id, syntactic.get(&id).copied().unwrap_or(0));
+    }
+}
+
+// ── Clone insertion with last-use tracking ─────────────────────────
+
+fn make_clone(id: VarId, ty: Ty, span: Option<Span>) -> IrExpr {
+    IrExpr {
+        kind: IrExprKind::Clone {
+            expr: Box::new(IrExpr { kind: IrExprKind::Var { id }, ty: ty.clone(), span }),
+        },
+        ty, span,
+    }
+}
+
+fn insert_clones_live(
+    expr: IrExpr,
+    always: &HashSet<VarId>,
+    eligible: &HashSet<VarId>,
+    remaining: &mut HashMap<VarId, u32>,
+    in_loop: bool,
+) -> IrExpr {
     let ty = expr.ty.clone();
     let span = expr.span;
 
     let kind = match expr.kind {
-        IrExprKind::Var { id } if clone_ids.contains(&id) => {
-            return IrExpr {
-                kind: IrExprKind::Clone {
-                    expr: Box::new(IrExpr { kind: IrExprKind::Var { id }, ty: ty.clone(), span }),
-                },
-                ty, span,
-            };
+        // ── Var: the core decision point ───────────────────────────
+        IrExprKind::Var { id } if always.contains(&id) => {
+            return make_clone(id, ty, span);
+        }
+        IrExprKind::Var { id } if eligible.contains(&id) => {
+            if let Some(r) = remaining.get_mut(&id) {
+                *r = r.saturating_sub(1);
+                if *r == 0 && !in_loop {
+                    // Last use outside a loop → move (no clone)
+                    return IrExpr { kind: IrExprKind::Var { id }, ty, span };
+                }
+            }
+            return make_clone(id, ty, span);
         }
 
-        // Recurse into sub-expressions
+        // ── Block: sequential statements ───────────────────────────
+        IrExprKind::Block { stmts, expr } => IrExprKind::Block {
+            stmts: insert_clone_stmts_live(stmts, always, eligible, remaining, in_loop),
+            expr: expr.map(|e| Box::new(insert_clones_live(*e, always, eligible, remaining, in_loop))),
+        },
+
+        // ── If: save/restore/min for branches ──────────────────────
+        IrExprKind::If { cond, then, else_ } => {
+            let new_cond = insert_clones_live(*cond, always, eligible, remaining, in_loop);
+            let saved = remaining.clone();
+            let new_then = insert_clones_live(*then, always, eligible, remaining, in_loop);
+            let then_remaining = std::mem::replace(remaining, saved);
+            let new_else = insert_clones_live(*else_, always, eligible, remaining, in_loop);
+            // Merge: take min (conservative — the branch that consumed more wins)
+            for &id in eligible.iter() {
+                let t = then_remaining.get(&id).copied().unwrap_or(0);
+                let e = remaining.get(&id).copied().unwrap_or(0);
+                remaining.insert(id, t.min(e));
+            }
+            IrExprKind::If {
+                cond: Box::new(new_cond),
+                then: Box::new(new_then),
+                else_: Box::new(new_else),
+            }
+        }
+
+        // ── Match: same strategy as If but N arms ──────────────────
+        IrExprKind::Match { subject, arms } => {
+            let new_subject = insert_clones_live(*subject, always, eligible, remaining, in_loop);
+            let saved = remaining.clone();
+            let mut min_remaining = HashMap::new();
+            let mut new_arms = Vec::with_capacity(arms.len());
+
+            for (i, arm) in arms.into_iter().enumerate() {
+                *remaining = saved.clone();
+                let new_guard = arm.guard.map(|g| insert_clones_live(g, always, eligible, remaining, in_loop));
+                let new_body = insert_clones_live(arm.body, always, eligible, remaining, in_loop);
+                new_arms.push(IrMatchArm { pattern: arm.pattern, guard: new_guard, body: new_body });
+
+                if i == 0 {
+                    min_remaining = remaining.clone();
+                } else {
+                    for &id in eligible.iter() {
+                        let cur = remaining.get(&id).copied().unwrap_or(0);
+                        let prev = min_remaining.get(&id).copied().unwrap_or(0);
+                        min_remaining.insert(id, cur.min(prev));
+                    }
+                }
+            }
+            *remaining = min_remaining;
+            IrExprKind::Match { subject: Box::new(new_subject), arms: new_arms }
+        }
+
+        // ── ForIn: iterable is NOT in loop, body IS ────────────────
+        IrExprKind::ForIn { var, var_tuple, iterable, body } => {
+            let new_iterable = insert_clones_live(*iterable, always, eligible, remaining, in_loop);
+            let new_body = insert_clone_stmts_live(body, always, eligible, remaining, true);
+            IrExprKind::ForIn { var, var_tuple, iterable: Box::new(new_iterable), body: new_body }
+        }
+
+        // ── While: cond and body are in loop ───────────────────────
+        IrExprKind::While { cond, body } => {
+            let new_cond = insert_clones_live(*cond, always, eligible, remaining, true);
+            let new_body = insert_clone_stmts_live(body, always, eligible, remaining, true);
+            IrExprKind::While { cond: Box::new(new_cond), body: new_body }
+        }
+
+        // ── Lambda: body recurses normally ─────────────────────────
+        IrExprKind::Lambda { params, body, lambda_id } => IrExprKind::Lambda {
+            params, body: Box::new(insert_clones_live(*body, always, eligible, remaining, in_loop)), lambda_id,
+        },
+
+        // ── Call ───────────────────────────────────────────────────
         IrExprKind::Call { target, args, type_args } => {
-            let args = args.into_iter().map(|a| insert_clones(a, clone_ids)).collect();
+            let args = args.into_iter().map(|a| insert_clones_live(a, always, eligible, remaining, in_loop)).collect();
             let target = match target {
                 CallTarget::Method { object, method } => CallTarget::Method {
-                    object: Box::new(insert_clones(*object, clone_ids)), method,
+                    object: Box::new(insert_clones_live(*object, always, eligible, remaining, in_loop)), method,
                 },
                 CallTarget::Computed { callee } => CallTarget::Computed {
-                    callee: Box::new(insert_clones(*callee, clone_ids)),
+                    callee: Box::new(insert_clones_live(*callee, always, eligible, remaining, in_loop)),
                 },
                 other => other,
             };
             IrExprKind::Call { target, args, type_args }
         }
-        IrExprKind::If { cond, then, else_ } => IrExprKind::If {
-            cond: Box::new(insert_clones(*cond, clone_ids)),
-            then: Box::new(insert_clones(*then, clone_ids)),
-            else_: Box::new(insert_clones(*else_, clone_ids)),
-        },
-        IrExprKind::Block { stmts, expr } => IrExprKind::Block {
-            stmts: insert_clone_stmts(stmts, clone_ids),
-            expr: expr.map(|e| Box::new(insert_clones(*e, clone_ids))),
-        },
 
-        IrExprKind::Match { subject, arms } => IrExprKind::Match {
-            subject: Box::new(insert_clones(*subject, clone_ids)),
-            arms: arms.into_iter().map(|arm| IrMatchArm {
-                pattern: arm.pattern,
-                guard: arm.guard.map(|g| insert_clones(g, clone_ids)),
-                body: insert_clones(arm.body, clone_ids),
-            }).collect(),
-        },
-        IrExprKind::BinOp { op, left, right } => IrExprKind::BinOp {
-            op, left: Box::new(insert_clones(*left, clone_ids)), right: Box::new(insert_clones(*right, clone_ids)),
-        },
-        IrExprKind::UnOp { op, operand } => IrExprKind::UnOp {
-            op, operand: Box::new(insert_clones(*operand, clone_ids)),
-        },
-        IrExprKind::Lambda { params, body, lambda_id } => IrExprKind::Lambda {
-            params, body: Box::new(insert_clones(*body, clone_ids)), lambda_id,
-        },
-        IrExprKind::List { elements } => IrExprKind::List {
-            elements: elements.into_iter().map(|e| insert_clones(e, clone_ids)).collect(),
-        },
-        IrExprKind::Record { name, fields } => IrExprKind::Record {
-            name, fields: fields.into_iter().map(|(k, v)| (k, insert_clones(v, clone_ids))).collect(),
-        },
-        IrExprKind::Member { object, field } => IrExprKind::Member {
-            object: Box::new(insert_clones(*object, clone_ids)), field,
-        },
-        IrExprKind::OptionalChain { expr, field } => IrExprKind::OptionalChain {
-            expr: Box::new(insert_clones(*expr, clone_ids)), field,
-        },
-        IrExprKind::ForIn { var, var_tuple, iterable, body } => IrExprKind::ForIn {
-            var, var_tuple, iterable: Box::new(insert_clones(*iterable, clone_ids)),
-            body: insert_clone_stmts(body, clone_ids),
-        },
-        IrExprKind::While { cond, body } => IrExprKind::While {
-            cond: Box::new(insert_clones(*cond, clone_ids)),
-            body: insert_clone_stmts(body, clone_ids),
-        },
-        IrExprKind::StringInterp { parts } => IrExprKind::StringInterp {
-            parts: parts.into_iter().map(|p| match p {
-                IrStringPart::Expr { expr } => IrStringPart::Expr { expr: insert_clones(expr, clone_ids) },
-                other => other,
-            }).collect(),
-        },
-        IrExprKind::OptionSome { expr } => IrExprKind::OptionSome { expr: Box::new(insert_clones(*expr, clone_ids)) },
-        IrExprKind::ResultOk { expr } => IrExprKind::ResultOk { expr: Box::new(insert_clones(*expr, clone_ids)) },
-        IrExprKind::ResultErr { expr } => IrExprKind::ResultErr { expr: Box::new(insert_clones(*expr, clone_ids)) },
-        IrExprKind::Try { expr } => IrExprKind::Try { expr: Box::new(insert_clones(*expr, clone_ids)) },
-        IrExprKind::Unwrap { expr } => IrExprKind::Unwrap { expr: Box::new(insert_clones(*expr, clone_ids)) },
-        IrExprKind::Deref { expr } => IrExprKind::Deref { expr: Box::new(insert_clones(*expr, clone_ids)) },
-        IrExprKind::UnwrapOr { expr, fallback } => IrExprKind::UnwrapOr {
-            expr: Box::new(insert_clones(*expr, clone_ids)),
-            fallback: Box::new(insert_clones(*fallback, clone_ids)),
-        },
-        IrExprKind::ToOption { expr } => IrExprKind::ToOption { expr: Box::new(insert_clones(*expr, clone_ids)) },
-        IrExprKind::Fan { exprs } => IrExprKind::Fan {
-            exprs: exprs.into_iter().map(|e| insert_clones(e, clone_ids)).collect(),
-        },
-        IrExprKind::SpreadRecord { base, fields } => IrExprKind::SpreadRecord {
-            base: Box::new(insert_clones(*base, clone_ids)),
-            fields: fields.into_iter().map(|(k, v)| (k, insert_clones(v, clone_ids))).collect(),
-        },
+        // ── IndexAccess: borrow container, clone element ───────────
         IrExprKind::IndexAccess { object, index } => {
-            // Indexing borrows the container — never clone it.
-            // Clone only the element if the element type is a heap type.
-            let mut processed_object = insert_clones(*object, clone_ids);
-            // Strip top-level Clone wrapper from the container
+            let mut processed_object = insert_clones_live(*object, always, eligible, remaining, in_loop);
+            // Strip top-level Clone from container (indexing borrows)
             if let IrExprKind::Clone { expr } = processed_object.kind {
                 processed_object = *expr;
             }
-            let processed_index = insert_clones(*index, clone_ids);
+            let processed_index = insert_clones_live(*index, always, eligible, remaining, in_loop);
             let access = IrExpr {
                 kind: IrExprKind::IndexAccess {
                     object: Box::new(processed_object),
@@ -198,20 +391,18 @@ fn insert_clones(expr: IrExpr, clone_ids: &HashSet<VarId>) -> IrExpr {
                 ty: ty.clone(), span,
             };
             if needs_clone(&ty) {
-                return IrExpr {
-                    kind: IrExprKind::Clone { expr: Box::new(access) },
-                    ty, span,
-                };
+                return IrExpr { kind: IrExprKind::Clone { expr: Box::new(access) }, ty, span };
             }
             return access;
         }
+
+        // ── MapAccess: borrow container, clone element ─────────────
         IrExprKind::MapAccess { object, key } => {
-            // Map lookup borrows the container — never clone it.
-            let mut processed_object = insert_clones(*object, clone_ids);
+            let mut processed_object = insert_clones_live(*object, always, eligible, remaining, in_loop);
             if let IrExprKind::Clone { expr } = processed_object.kind {
                 processed_object = *expr;
             }
-            let processed_key = insert_clones(*key, clone_ids);
+            let processed_key = insert_clones_live(*key, always, eligible, remaining, in_loop);
             let access = IrExpr {
                 kind: IrExprKind::MapAccess {
                     object: Box::new(processed_object),
@@ -220,23 +411,91 @@ fn insert_clones(expr: IrExpr, clone_ids: &HashSet<VarId>) -> IrExpr {
                 ty: ty.clone(), span,
             };
             if needs_clone(&ty) {
-                return IrExpr {
-                    kind: IrExprKind::Clone { expr: Box::new(access) },
-                    ty, span,
-                };
+                return IrExpr { kind: IrExprKind::Clone { expr: Box::new(access) }, ty, span };
             }
             return access;
         }
+
+        // ── Simple recursion cases ─────────────────────────────────
+        IrExprKind::BinOp { op, left, right } => IrExprKind::BinOp {
+            op,
+            left: Box::new(insert_clones_live(*left, always, eligible, remaining, in_loop)),
+            right: Box::new(insert_clones_live(*right, always, eligible, remaining, in_loop)),
+        },
+        IrExprKind::UnOp { op, operand } => IrExprKind::UnOp {
+            op, operand: Box::new(insert_clones_live(*operand, always, eligible, remaining, in_loop)),
+        },
+        IrExprKind::List { elements } => IrExprKind::List {
+            elements: elements.into_iter().map(|e| insert_clones_live(e, always, eligible, remaining, in_loop)).collect(),
+        },
+        IrExprKind::Record { name, fields } => IrExprKind::Record {
+            name, fields: fields.into_iter().map(|(k, v)| (k, insert_clones_live(v, always, eligible, remaining, in_loop))).collect(),
+        },
+        IrExprKind::Member { object, field } => IrExprKind::Member {
+            object: Box::new(insert_clones_live(*object, always, eligible, remaining, in_loop)), field,
+        },
+        IrExprKind::OptionalChain { expr, field } => IrExprKind::OptionalChain {
+            expr: Box::new(insert_clones_live(*expr, always, eligible, remaining, in_loop)), field,
+        },
+        IrExprKind::StringInterp { parts } => IrExprKind::StringInterp {
+            parts: parts.into_iter().map(|p| match p {
+                IrStringPart::Expr { expr } => IrStringPart::Expr { expr: insert_clones_live(expr, always, eligible, remaining, in_loop) },
+                other => other,
+            }).collect(),
+        },
+        IrExprKind::OptionSome { expr } => IrExprKind::OptionSome { expr: Box::new(insert_clones_live(*expr, always, eligible, remaining, in_loop)) },
+        IrExprKind::ResultOk { expr } => IrExprKind::ResultOk { expr: Box::new(insert_clones_live(*expr, always, eligible, remaining, in_loop)) },
+        IrExprKind::ResultErr { expr } => IrExprKind::ResultErr { expr: Box::new(insert_clones_live(*expr, always, eligible, remaining, in_loop)) },
+        IrExprKind::Try { expr } => IrExprKind::Try { expr: Box::new(insert_clones_live(*expr, always, eligible, remaining, in_loop)) },
+        IrExprKind::Unwrap { expr } => IrExprKind::Unwrap { expr: Box::new(insert_clones_live(*expr, always, eligible, remaining, in_loop)) },
+        IrExprKind::Deref { expr } => IrExprKind::Deref { expr: Box::new(insert_clones_live(*expr, always, eligible, remaining, in_loop)) },
+        IrExprKind::UnwrapOr { expr, fallback } => IrExprKind::UnwrapOr {
+            expr: Box::new(insert_clones_live(*expr, always, eligible, remaining, in_loop)),
+            fallback: Box::new(insert_clones_live(*fallback, always, eligible, remaining, in_loop)),
+        },
+        IrExprKind::ToOption { expr } => IrExprKind::ToOption { expr: Box::new(insert_clones_live(*expr, always, eligible, remaining, in_loop)) },
+        IrExprKind::Fan { exprs } => IrExprKind::Fan {
+            exprs: exprs.into_iter().map(|e| insert_clones_live(e, always, eligible, remaining, in_loop)).collect(),
+        },
+        IrExprKind::SpreadRecord { base, fields } => {
+            // Fields are evaluated before the spread base in Rust struct literals
+            let new_fields: Vec<_> = fields.into_iter().map(|(k, v)| (k, insert_clones_live(v, always, eligible, remaining, in_loop))).collect();
+            let new_base = insert_clones_live(*base, always, eligible, remaining, in_loop);
+            IrExprKind::SpreadRecord { base: Box::new(new_base), fields: new_fields }
+        },
         IrExprKind::Range { start, end, inclusive } => IrExprKind::Range {
-            start: Box::new(insert_clones(*start, clone_ids)),
-            end: Box::new(insert_clones(*end, clone_ids)),
+            start: Box::new(insert_clones_live(*start, always, eligible, remaining, in_loop)),
+            end: Box::new(insert_clones_live(*end, always, eligible, remaining, in_loop)),
             inclusive,
         },
         IrExprKind::Tuple { elements } => IrExprKind::Tuple {
-            elements: elements.into_iter().map(|e| insert_clones(e, clone_ids)).collect(),
+            elements: elements.into_iter().map(|e| insert_clones_live(e, always, eligible, remaining, in_loop)).collect(),
         },
         IrExprKind::MapLiteral { entries } => IrExprKind::MapLiteral {
-            entries: entries.into_iter().map(|(k, v)| (insert_clones(k, clone_ids), insert_clones(v, clone_ids))).collect(),
+            entries: entries.into_iter().map(|(k, v)| (insert_clones_live(k, always, eligible, remaining, in_loop), insert_clones_live(v, always, eligible, remaining, in_loop))).collect(),
+        },
+        IrExprKind::TupleIndex { object, index } => IrExprKind::TupleIndex {
+            object: Box::new(insert_clones_live(*object, always, eligible, remaining, in_loop)), index,
+        },
+        IrExprKind::Borrow { expr, as_str, mutable } => {
+            let mut inner = insert_clones_live(*expr, always, eligible, remaining, in_loop);
+            // Strip clone inside borrow: &x.clone() → &x (borrow doesn't consume ownership)
+            if let IrExprKind::Clone { expr: unwrapped } = inner.kind {
+                inner = *unwrapped;
+            }
+            IrExprKind::Borrow { expr: Box::new(inner), as_str, mutable }
+        },
+        IrExprKind::BoxNew { expr } => IrExprKind::BoxNew {
+            expr: Box::new(insert_clones_live(*expr, always, eligible, remaining, in_loop)),
+        },
+        IrExprKind::ToVec { expr } => IrExprKind::ToVec {
+            expr: Box::new(insert_clones_live(*expr, always, eligible, remaining, in_loop)),
+        },
+        IrExprKind::Await { expr } => IrExprKind::Await {
+            expr: Box::new(insert_clones_live(*expr, always, eligible, remaining, in_loop)),
+        },
+        IrExprKind::RustMacro { name, args } => IrExprKind::RustMacro {
+            name, args: args.into_iter().map(|a| insert_clones_live(a, always, eligible, remaining, in_loop)).collect(),
         },
         other => other,
     };
@@ -244,28 +503,34 @@ fn insert_clones(expr: IrExpr, clone_ids: &HashSet<VarId>) -> IrExpr {
     IrExpr { kind, ty, span }
 }
 
-fn insert_clone_stmts(stmts: Vec<IrStmt>, clone_ids: &HashSet<VarId>) -> Vec<IrStmt> {
+fn insert_clone_stmts_live(
+    stmts: Vec<IrStmt>,
+    always: &HashSet<VarId>,
+    eligible: &HashSet<VarId>,
+    remaining: &mut HashMap<VarId, u32>,
+    in_loop: bool,
+) -> Vec<IrStmt> {
     stmts.into_iter().map(|s| {
         let kind = match s.kind {
             IrStmtKind::Bind { var, mutability, ty, value } => IrStmtKind::Bind {
-                var, mutability, ty, value: insert_clones(value, clone_ids),
+                var, mutability, ty, value: insert_clones_live(value, always, eligible, remaining, in_loop),
             },
-            IrStmtKind::Assign { var, value } => IrStmtKind::Assign { var, value: insert_clones(value, clone_ids) },
-            IrStmtKind::Expr { expr } => IrStmtKind::Expr { expr: insert_clones(expr, clone_ids) },
+            IrStmtKind::Assign { var, value } => IrStmtKind::Assign { var, value: insert_clones_live(value, always, eligible, remaining, in_loop) },
+            IrStmtKind::Expr { expr } => IrStmtKind::Expr { expr: insert_clones_live(expr, always, eligible, remaining, in_loop) },
             IrStmtKind::Guard { cond, else_ } => IrStmtKind::Guard {
-                cond: insert_clones(cond, clone_ids), else_: insert_clones(else_, clone_ids),
+                cond: insert_clones_live(cond, always, eligible, remaining, in_loop), else_: insert_clones_live(else_, always, eligible, remaining, in_loop),
             },
             IrStmtKind::BindDestructure { pattern, value } => IrStmtKind::BindDestructure {
-                pattern, value: insert_clones(value, clone_ids),
+                pattern, value: insert_clones_live(value, always, eligible, remaining, in_loop),
             },
             IrStmtKind::IndexAssign { target, index, value } => IrStmtKind::IndexAssign {
-                target, index: insert_clones(index, clone_ids), value: insert_clones(value, clone_ids),
+                target, index: insert_clones_live(index, always, eligible, remaining, in_loop), value: insert_clones_live(value, always, eligible, remaining, in_loop),
             },
             IrStmtKind::FieldAssign { target, field, value } => IrStmtKind::FieldAssign {
-                target, field, value: insert_clones(value, clone_ids),
+                target, field, value: insert_clones_live(value, always, eligible, remaining, in_loop),
             },
             IrStmtKind::MapInsert { target, key, value } => IrStmtKind::MapInsert {
-                target, key: insert_clones(key, clone_ids), value: insert_clones(value, clone_ids),
+                target, key: insert_clones_live(key, always, eligible, remaining, in_loop), value: insert_clones_live(value, always, eligible, remaining, in_loop),
             },
             other => other,
         };

--- a/src/codegen/pass_peephole.rs
+++ b/src/codegen/pass_peephole.rs
@@ -129,6 +129,9 @@ fn rewrite_stmts(stmts: &mut Vec<IrStmt>) -> bool {
     while i < len {
         // 3-stmt patterns
         if i + 2 < len {
+            if let Some(s) = try_detect_vec_init(&slice[i], &slice[i + 1], &slice[i + 2]) {
+                result.push(s); i += 3; changed = true; continue;
+            }
             if let Some(s) = try_detect_reverse_block(&slice[i], &slice[i + 1], &slice[i + 2]) {
                 result.push(s); i += 3; changed = true; continue;
             }
@@ -159,6 +162,125 @@ fn rewrite_stmts(stmts: &mut Vec<IrStmt>) -> bool {
 }
 
 // ── Pattern detectors ──────────────────────────────────────────
+
+/// Vec init: `var x = []; let __licm = [val]; for _ in 0..n { x = x + __licm }`
+/// → `var x = vec![val; n]` (O(n) instead of O(n²))
+fn try_detect_vec_init(s1: &IrStmt, s2: &IrStmt, s3: &IrStmt) -> Option<IrStmt> {
+    // s1: Bind { var: x, mutability: Var, value: List { [] } }
+    let IrStmtKind::Bind { var: x_var, mutability: Mutability::Var, value: init_val, ty } = &s1.kind else { return None; };
+    let IrExprKind::List { elements } = &init_val.kind else { return None; };
+    if !elements.is_empty() { return None; }
+
+    // s2: Bind { var: __licm, value: List { [val] } } OR value: Clone { List { [val] } }
+    let IrStmtKind::Bind { var: licm_var, value: licm_val, .. } = &s2.kind else { return None; };
+    let single_val = match &licm_val.kind {
+        IrExprKind::List { elements } if elements.len() == 1 => &elements[0],
+        _ => return None,
+    };
+
+    // s3: Expr { ForIn { var: _, iterable: Range { 0, n }, body: [Assign { var: x, value: Concat(x, __licm) }] } }
+    let IrStmtKind::Expr { expr: for_expr } = &s3.kind else { return None; };
+    let IrExprKind::ForIn { var_tuple, iterable, body, .. } = &for_expr.kind else { return None; };
+    let IrExprKind::Range { start, end, inclusive: false } = &iterable.kind else { return None; };
+    if !matches!(&start.kind, IrExprKind::LitInt { value: 0 }) { return None; }
+    if body.len() != 1 { return None; }
+
+    // body[0]: Assign { var: x, value: BinOp { ConcatList, Clone(x), Clone(__licm) } }
+    let IrStmtKind::Assign { var: assign_var, value: assign_val } = &body[0].kind else { return None; };
+    if assign_var != x_var { return None; }
+
+    // Unwrap the concat: ConcatList(left, right) where left contains x and right contains __licm
+    let (left, right) = match &assign_val.kind {
+        IrExprKind::BinOp { op: BinOp::ConcatList, left, right } => (left.as_ref(), right.as_ref()),
+        _ => return None,
+    };
+
+    // left should be Var(x) or Clone(Var(x))
+    let left_var = match &left.kind {
+        IrExprKind::Var { id } => *id,
+        IrExprKind::Clone { expr } => match &expr.kind { IrExprKind::Var { id } => *id, _ => return None },
+        _ => return None,
+    };
+    if left_var != *x_var { return None; }
+
+    // right should be Var(__licm) or Clone(Var(__licm))
+    let right_var = match &right.kind {
+        IrExprKind::Var { id } => *id,
+        IrExprKind::Clone { expr } => match &expr.kind { IrExprKind::Var { id } => *id, _ => return None },
+        _ => return None,
+    };
+    if right_var != *licm_var { return None; }
+
+    // Match! Replace with: Bind { var: x, value: RenderedCall { "vec![val; n as usize]" } }
+    // We can't render here, so use a Call to a synthetic runtime function
+    // Better: use List { elements } with n copies... no, that's not possible at IR level.
+    // Use RenderedCall as a placeholder that the walker outputs verbatim.
+    // But we need to render `val` and `n`. Use a hack: store them in the RenderedCall.
+    // Actually, cleanest: emit `(0..n).map(|_| val).collect::<Vec<_>>()`  via IterChain!
+
+    // Use RenderedCall to emit `vec![val; n as usize]` directly
+    // This avoids the lambda param issue with iterator-based approach
+    let iter_expr = IrExpr {
+        kind: IrExprKind::RenderedCall {
+            code: String::new(), // placeholder — filled by walker for vec_repeat
+        },
+        ty: ty.clone(),
+        span: s1.span,
+    };
+
+    // Actually, we need the val and n expressions to be renderable.
+    // Store them in a special IterChain with a dedicated pattern:
+    // Use IterChain { source: Range(0,n), steps: [Map(lambda with 1 param)], collector: Collect }
+    // The lambda needs a dummy param that matches the range element type (i64).
+
+    // Get the ForIn loop var for the dummy param
+    let IrExprKind::ForIn { var: loop_var, .. } = &for_expr.kind else { unreachable!() };
+
+    // The body value might reference captured variables — wrap in Clone for safety
+    let body_val = if matches!(&single_val.kind, IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitBool { .. } | IrExprKind::LitStr { .. } | IrExprKind::Unit) {
+        // Literals: no clone needed
+        single_val.clone()
+    } else {
+        // Non-literal: wrap in Clone to ensure the value can be produced n times
+        IrExpr {
+            kind: IrExprKind::Clone { expr: Box::new(single_val.clone()) },
+            ty: single_val.ty.clone(),
+            span: None,
+        }
+    };
+
+    let iter_expr = IrExpr {
+        kind: IrExprKind::IterChain {
+            source: Box::new((**iterable).clone()),
+            consume: true,
+            steps: vec![IterStep::Map {
+                lambda: Box::new(IrExpr {
+                    kind: IrExprKind::Lambda {
+                        params: vec![(*loop_var, crate::types::Ty::Int)],
+                        body: Box::new(body_val),
+                        lambda_id: None,
+                    },
+                    ty: single_val.ty.clone(),
+                    span: None,
+                }),
+            }],
+            collector: IterCollector::Collect,
+        },
+        ty: ty.clone(),
+        span: s1.span,
+    };
+
+    Some(IrStmt {
+        kind: IrStmtKind::Bind {
+            var: *x_var,
+            mutability: Mutability::Var,
+            ty: ty.clone(),
+            value: iter_expr,
+        },
+        span: s1.span,
+    })
+}
 
 /// swap: let tmp = xs[a]; xs[a] = xs[b]; xs[b] = tmp
 fn try_detect_swap(s1: &IrStmt, s2: &IrStmt, s3: &IrStmt) -> Option<IrStmt> {

--- a/src/codegen/pass_peephole.rs
+++ b/src/codegen/pass_peephole.rs
@@ -218,54 +218,15 @@ fn try_detect_vec_init(s1: &IrStmt, s2: &IrStmt, s3: &IrStmt) -> Option<IrStmt> 
     // But we need to render `val` and `n`. Use a hack: store them in the RenderedCall.
     // Actually, cleanest: emit `(0..n).map(|_| val).collect::<Vec<_>>()`  via IterChain!
 
-    // Use RenderedCall to emit `vec![val; n as usize]` directly
-    // This avoids the lambda param issue with iterator-based approach
-    let iter_expr = IrExpr {
-        kind: IrExprKind::RenderedCall {
-            code: String::new(), // placeholder — filled by walker for vec_repeat
-        },
-        ty: ty.clone(),
-        span: s1.span,
-    };
-
-    // Actually, we need the val and n expressions to be renderable.
-    // Store them in a special IterChain with a dedicated pattern:
-    // Use IterChain { source: Range(0,n), steps: [Map(lambda with 1 param)], collector: Collect }
-    // The lambda needs a dummy param that matches the range element type (i64).
-
-    // Get the ForIn loop var for the dummy param
-    let IrExprKind::ForIn { var: loop_var, .. } = &for_expr.kind else { unreachable!() };
-
-    // The body value might reference captured variables — wrap in Clone for safety
-    let body_val = if matches!(&single_val.kind, IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
-        | IrExprKind::LitBool { .. } | IrExprKind::LitStr { .. } | IrExprKind::Unit) {
-        // Literals: no clone needed
-        single_val.clone()
-    } else {
-        // Non-literal: wrap in Clone to ensure the value can be produced n times
-        IrExpr {
-            kind: IrExprKind::Clone { expr: Box::new(single_val.clone()) },
-            ty: single_val.ty.clone(),
-            span: None,
-        }
-    };
-
-    let iter_expr = IrExpr {
-        kind: IrExprKind::IterChain {
-            source: Box::new((**iterable).clone()),
-            consume: true,
-            steps: vec![IterStep::Map {
-                lambda: Box::new(IrExpr {
-                    kind: IrExprKind::Lambda {
-                        params: vec![(*loop_var, crate::types::Ty::Int)],
-                        body: Box::new(body_val),
-                        lambda_id: None,
-                    },
-                    ty: single_val.ty.clone(),
-                    span: None,
-                }),
-            }],
-            collector: IterCollector::Collect,
+    // Emit list.repeat(val, n) — target-agnostic, StdlibLowering handles Rust vs WASM
+    let repeat_expr = IrExpr {
+        kind: IrExprKind::Call {
+            target: CallTarget::Module {
+                module: crate::intern::sym("list"),
+                func: crate::intern::sym("repeat"),
+            },
+            args: vec![single_val.clone(), (**end).clone()],
+            type_args: vec![],
         },
         ty: ty.clone(),
         span: s1.span,
@@ -276,7 +237,7 @@ fn try_detect_vec_init(s1: &IrStmt, s2: &IrStmt, s3: &IrStmt) -> Option<IrStmt> 
             var: *x_var,
             mutability: Mutability::Var,
             ty: ty.clone(),
-            value: iter_expr,
+            value: repeat_expr,
         },
         span: s1.span,
     })

--- a/src/codegen/pass_stdlib_lowering.rs
+++ b/src/codegen/pass_stdlib_lowering.rs
@@ -645,8 +645,7 @@ fn try_inline_intrinsic(module: &str, func: &str, args: &[IrExpr], ty: &Ty, span
             target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("log10") },
             args: vec![], type_args: vec![],
         })),
-        // float.from_int / int.to_float / float.to_int: keep as runtime calls
-        // (they're #[inline(always)], LLVM inlines them)
+        // float.from_int / int.to_float / float.to_int: walker handles inline cast
         // math.pow: Int exponentiation — keep as runtime call (i64.pow needs u32 cast)
         // ── math.fpow(base, exp) → base.powf(exp) ──
         ("math", "fpow") if args.len() >= 2 => Some(mk(IrExprKind::Call {

--- a/src/codegen/pass_stdlib_lowering.rs
+++ b/src/codegen/pass_stdlib_lowering.rs
@@ -5,6 +5,7 @@
 //!
 //! NO string rendering. All decisions are structural IR transformations.
 
+use std::collections::{HashSet, HashMap};
 use crate::ir::*;
 use crate::types::{Ty, TypeConstructorId};
 use crate::generated::arg_transforms::{self, ArgTransform};
@@ -537,17 +538,25 @@ fn decorate_arg(arg: IrExpr, transform: ArgTransform) -> IrExpr {
         ArgTransform::Direct => arg,
 
         ArgTransform::BorrowStr => {
-            // &*expr
+            // &*expr — strip Clone wrapper (borrow doesn't consume ownership)
+            let inner = match arg.kind {
+                IrExprKind::Clone { expr } => *expr,
+                _ => arg,
+            };
             IrExpr {
-                kind: IrExprKind::Borrow { expr: Box::new(arg), as_str: true, mutable: false },
+                kind: IrExprKind::Borrow { expr: Box::new(inner), as_str: true, mutable: false },
                 ty, span,
             }
         }
 
         ArgTransform::BorrowRef => {
-            // &expr
+            // &expr — strip Clone wrapper (borrow doesn't consume ownership)
+            let inner = match arg.kind {
+                IrExprKind::Clone { expr } => *expr,
+                _ => arg,
+            };
             IrExpr {
-                kind: IrExprKind::Borrow { expr: Box::new(arg), as_str: false, mutable: false },
+                kind: IrExprKind::Borrow { expr: Box::new(inner), as_str: false, mutable: false },
                 ty, span,
             }
         }
@@ -573,32 +582,10 @@ fn decorate_arg(arg: IrExpr, transform: ArgTransform) -> IrExpr {
         }
 
         ArgTransform::LambdaClone => {
-            // Lambda: add clone bindings for each param
+            // Lambda: add clone bindings only for params used more than once
             match arg.kind {
                 IrExprKind::Lambda { params, body, lambda_id } => {
-                    let clone_stmts: Vec<IrStmt> = params.iter()
-                        .filter(|(_, t)| !matches!(t, Ty::Int | Ty::Float | Ty::Bool | Ty::Unit))
-                        .map(|(id, param_ty)| {
-                            IrStmt {
-                                kind: IrStmtKind::Bind {
-                                    var: *id,
-                                    mutability: Mutability::Let,
-                                    ty: param_ty.clone(),
-                                    value: IrExpr {
-                                        kind: IrExprKind::Clone {
-                                            expr: Box::new(IrExpr {
-                                                kind: IrExprKind::Var { id: *id },
-                                                ty: param_ty.clone(),
-                                                span: None,
-                                            }),
-                                        },
-                                        ty: param_ty.clone(),
-                                        span: None,
-                                    },
-                                },
-                                span: None,
-                            }
-                        }).collect();
+                    let clone_stmts = build_clone_stmts_for_lambda(&params, &body);
 
                     let wrapped_body = if clone_stmts.is_empty() {
                         *body
@@ -642,30 +629,8 @@ fn decorate_arg(arg: IrExpr, transform: ArgTransform) -> IrExpr {
             // Lambda with Ok(body) wrapping: callback body gets wrapped in ResultOk
             match arg.kind {
                 IrExprKind::Lambda { params, body, lambda_id } => {
-                    // Clone bindings (same as LambdaClone)
-                    let clone_stmts: Vec<IrStmt> = params.iter()
-                        .filter(|(_, t)| !matches!(t, Ty::Int | Ty::Float | Ty::Bool | Ty::Unit))
-                        .map(|(id, param_ty)| {
-                            IrStmt {
-                                kind: IrStmtKind::Bind {
-                                    var: *id,
-                                    mutability: Mutability::Let,
-                                    ty: param_ty.clone(),
-                                    value: IrExpr {
-                                        kind: IrExprKind::Clone {
-                                            expr: Box::new(IrExpr {
-                                                kind: IrExprKind::Var { id: *id },
-                                                ty: param_ty.clone(),
-                                                span: None,
-                                            }),
-                                        },
-                                        ty: param_ty.clone(),
-                                        span: None,
-                                    },
-                                },
-                                span: None,
-                            }
-                        }).collect();
+                    // Clone bindings (only for multi-use params)
+                    let clone_stmts = build_clone_stmts_for_lambda(&params, &body);
 
                     // Wrap body in ResultOk
                     let body_ty = body.ty.clone();
@@ -1009,4 +974,194 @@ fn rewrite_module_names_stmt(stmt: IrStmt, map: &std::collections::HashMap<Strin
         other => other,
     };
     IrStmt { kind, span: stmt.span }
+}
+
+// ── Lambda clone optimization: only clone multi-use params ─────────
+
+/// Types that need explicit annotation in lambda rebinding to help Rust type inference.
+fn needs_type_annotation(ty: &Ty) -> bool {
+    matches!(ty, Ty::Applied(_, _) | Ty::Named(_, _) | Ty::Record { .. } | Ty::OpenRecord { .. }
+        | Ty::Variant { .. } | Ty::TypeVar(_))
+}
+
+/// Build clone stmts for lambda params, skipping single-use params (they can move).
+fn build_clone_stmts_for_lambda(params: &[(VarId, Ty)], body: &IrExpr) -> Vec<IrStmt> {
+    let non_copy: HashSet<VarId> = params.iter()
+        .filter(|(_, t)| !matches!(t, Ty::Int | Ty::Float | Ty::Bool | Ty::Unit))
+        .map(|(id, _)| *id)
+        .collect();
+    if non_copy.is_empty() { return Vec::new(); }
+
+    let uses = count_lambda_body_uses(body, &non_copy);
+
+    params.iter()
+        .filter(|(_, t)| !matches!(t, Ty::Int | Ty::Float | Ty::Bool | Ty::Unit))
+        .filter_map(|(id, param_ty)| {
+            let count = uses.get(id).copied().unwrap_or(0);
+            if count > 1 {
+                // Multi-use: clone binding (let x: T = x.clone())
+                Some(IrStmt {
+                    kind: IrStmtKind::Bind {
+                        var: *id,
+                        mutability: Mutability::Let,
+                        ty: param_ty.clone(),
+                        value: IrExpr {
+                            kind: IrExprKind::Clone {
+                                expr: Box::new(IrExpr {
+                                    kind: IrExprKind::Var { id: *id },
+                                    ty: param_ty.clone(),
+                                    span: None,
+                                }),
+                            },
+                            ty: param_ty.clone(),
+                            span: None,
+                        },
+                    },
+                    span: None,
+                })
+            } else if count == 1 && needs_type_annotation(param_ty) {
+                // Single-use but complex type: rebind for type annotation (let x: T = x)
+                Some(IrStmt {
+                    kind: IrStmtKind::Bind {
+                        var: *id,
+                        mutability: Mutability::Let,
+                        ty: param_ty.clone(),
+                        value: IrExpr {
+                            kind: IrExprKind::Var { id: *id },
+                            ty: param_ty.clone(),
+                            span: None,
+                        },
+                    },
+                    span: None,
+                })
+            } else {
+                None
+            }
+        }).collect()
+}
+
+/// Count uses of target VarIds within a lambda body.
+/// Uses inside loops or nested lambdas are counted as 2 (conservative: forces clone).
+fn count_lambda_body_uses(expr: &IrExpr, targets: &HashSet<VarId>) -> HashMap<VarId, u32> {
+    let mut counts = HashMap::new();
+    count_lbu_expr(expr, targets, &mut counts, false);
+    counts
+}
+
+fn count_lbu_expr(expr: &IrExpr, targets: &HashSet<VarId>, counts: &mut HashMap<VarId, u32>, in_multi: bool) {
+    match &expr.kind {
+        IrExprKind::Var { id } if targets.contains(id) => {
+            *counts.entry(*id).or_insert(0) += if in_multi { 2 } else { 1 };
+        }
+        IrExprKind::Block { stmts, expr } => {
+            for s in stmts { count_lbu_stmt(s, targets, counts, in_multi); }
+            if let Some(e) = expr { count_lbu_expr(e, targets, counts, in_multi); }
+        }
+        IrExprKind::If { cond, then, else_ } => {
+            count_lbu_expr(cond, targets, counts, in_multi);
+            count_lbu_expr(then, targets, counts, in_multi);
+            count_lbu_expr(else_, targets, counts, in_multi);
+        }
+        IrExprKind::Match { subject, arms } => {
+            count_lbu_expr(subject, targets, counts, in_multi);
+            for arm in arms {
+                if let Some(g) = &arm.guard { count_lbu_expr(g, targets, counts, in_multi); }
+                count_lbu_expr(&arm.body, targets, counts, in_multi);
+            }
+        }
+        IrExprKind::ForIn { iterable, body, .. } => {
+            count_lbu_expr(iterable, targets, counts, in_multi);
+            for s in body { count_lbu_stmt(s, targets, counts, true); }
+        }
+        IrExprKind::While { cond, body } => {
+            count_lbu_expr(cond, targets, counts, true);
+            for s in body { count_lbu_stmt(s, targets, counts, true); }
+        }
+        IrExprKind::Lambda { body, .. } => {
+            count_lbu_expr(body, targets, counts, true);
+        }
+        IrExprKind::Call { target, args, .. } => {
+            match target {
+                CallTarget::Method { object, .. } => count_lbu_expr(object, targets, counts, in_multi),
+                CallTarget::Computed { callee } => count_lbu_expr(callee, targets, counts, in_multi),
+                _ => {}
+            }
+            for a in args { count_lbu_expr(a, targets, counts, in_multi); }
+        }
+        IrExprKind::BinOp { left, right, .. } => {
+            count_lbu_expr(left, targets, counts, in_multi);
+            count_lbu_expr(right, targets, counts, in_multi);
+        }
+        IrExprKind::UnOp { operand, .. } => count_lbu_expr(operand, targets, counts, in_multi),
+        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
+        | IrExprKind::Fan { exprs: elements } => {
+            for e in elements { count_lbu_expr(e, targets, counts, in_multi); }
+        }
+        IrExprKind::Record { fields, .. } => {
+            for (_, e) in fields { count_lbu_expr(e, targets, counts, in_multi); }
+        }
+        IrExprKind::SpreadRecord { base, fields } => {
+            count_lbu_expr(base, targets, counts, in_multi);
+            for (_, e) in fields { count_lbu_expr(e, targets, counts, in_multi); }
+        }
+        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. }
+        | IrExprKind::OptionalChain { expr: object, .. } => count_lbu_expr(object, targets, counts, in_multi),
+        IrExprKind::IndexAccess { object, index } | IrExprKind::MapAccess { object, key: index } => {
+            count_lbu_expr(object, targets, counts, in_multi);
+            count_lbu_expr(index, targets, counts, in_multi);
+        }
+        IrExprKind::Range { start, end, .. } => {
+            count_lbu_expr(start, targets, counts, in_multi);
+            count_lbu_expr(end, targets, counts, in_multi);
+        }
+        IrExprKind::StringInterp { parts } => {
+            for p in parts { if let IrStringPart::Expr { expr } = p { count_lbu_expr(expr, targets, counts, in_multi); } }
+        }
+        IrExprKind::MapLiteral { entries } => {
+            for (k, v) in entries { count_lbu_expr(k, targets, counts, in_multi); count_lbu_expr(v, targets, counts, in_multi); }
+        }
+        IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
+        | IrExprKind::OptionSome { expr } | IrExprKind::Try { expr }
+        | IrExprKind::Unwrap { expr } | IrExprKind::ToOption { expr }
+        | IrExprKind::Clone { expr } | IrExprKind::Deref { expr }
+        | IrExprKind::Borrow { expr, .. } | IrExprKind::BoxNew { expr }
+        | IrExprKind::ToVec { expr } | IrExprKind::Await { expr } => {
+            count_lbu_expr(expr, targets, counts, in_multi);
+        }
+        IrExprKind::UnwrapOr { expr, fallback } => {
+            count_lbu_expr(expr, targets, counts, in_multi);
+            count_lbu_expr(fallback, targets, counts, in_multi);
+        }
+        IrExprKind::RustMacro { args, .. } => {
+            for a in args { count_lbu_expr(a, targets, counts, in_multi); }
+        }
+        _ => {}
+    }
+}
+
+fn count_lbu_stmt(stmt: &IrStmt, targets: &HashSet<VarId>, counts: &mut HashMap<VarId, u32>, in_multi: bool) {
+    match &stmt.kind {
+        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
+        | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => {
+            count_lbu_expr(value, targets, counts, in_multi);
+        }
+        IrStmtKind::IndexAssign { index, value, .. } | IrStmtKind::MapInsert { key: index, value, .. } => {
+            count_lbu_expr(index, targets, counts, in_multi);
+            count_lbu_expr(value, targets, counts, in_multi);
+        }
+        IrStmtKind::Expr { expr } => count_lbu_expr(expr, targets, counts, in_multi),
+        IrStmtKind::Guard { cond, else_ } => {
+            count_lbu_expr(cond, targets, counts, in_multi);
+            count_lbu_expr(else_, targets, counts, in_multi);
+        }
+        IrStmtKind::ListSwap { a, b, .. } => {
+            count_lbu_expr(a, targets, counts, in_multi);
+            count_lbu_expr(b, targets, counts, in_multi);
+        }
+        IrStmtKind::ListReverse { end, .. } | IrStmtKind::ListRotateLeft { end, .. } => {
+            count_lbu_expr(end, targets, counts, in_multi);
+        }
+        IrStmtKind::ListCopySlice { len, .. } => count_lbu_expr(len, targets, counts, in_multi),
+        IrStmtKind::Comment { .. } => {}
+    }
 }

--- a/src/codegen/pass_stdlib_lowering.rs
+++ b/src/codegen/pass_stdlib_lowering.rs
@@ -119,6 +119,11 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
                 }
             }
 
+            // Inline math/float/int intrinsics as native Rust expressions
+            if let Some(inlined) = try_inline_intrinsic(&module, &func, &args, &ty, span) {
+                return inlined;
+            }
+
             // Look up per-function transform table
             let info = arg_transforms::lookup(&module, &func);
             let rt_name = info.as_ref().map(|i| i.name.to_string())
@@ -537,6 +542,136 @@ fn resolve_ufcs_stmts(stmts: Vec<IrStmt>, siblings: &[String]) -> Vec<IrStmt> {
 }
 
 // ── Iterator chain lowering ────────────────────────────────────────
+
+/// Inline math/float/int intrinsics as native Rust expressions.
+/// Eliminates runtime function call overhead for hot-path numeric operations.
+fn try_inline_intrinsic(module: &str, func: &str, args: &[IrExpr], ty: &Ty, span: Option<crate::ast::Span>) -> Option<IrExpr> {
+    let mk = |kind: IrExprKind| IrExpr { kind, ty: ty.clone(), span };
+
+    match (module, func) {
+        // ── math.sqrt(x) → x.sqrt() via RenderedCall ──
+        // These are the highest-impact: called in tight loops (nbody, spectralnorm)
+        ("math", "sqrt") | ("float", "sqrt") if args.len() >= 1 => {
+            Some(mk(IrExprKind::Call {
+                target: CallTarget::Method {
+                    object: Box::new(args[0].clone()),
+                    method: crate::intern::sym("sqrt"),
+                },
+                args: vec![],
+                type_args: vec![],
+            }))
+        }
+        ("math", "abs") | ("float", "abs") if args.len() >= 1 => {
+            Some(mk(IrExprKind::Call {
+                target: CallTarget::Method {
+                    object: Box::new(args[0].clone()),
+                    method: crate::intern::sym("abs"),
+                },
+                args: vec![],
+                type_args: vec![],
+            }))
+        }
+        ("math", "floor") | ("float", "floor") if args.len() >= 1 => {
+            Some(mk(IrExprKind::Call {
+                target: CallTarget::Method {
+                    object: Box::new(args[0].clone()),
+                    method: crate::intern::sym("floor"),
+                },
+                args: vec![],
+                type_args: vec![],
+            }))
+        }
+        ("math", "ceil") | ("float", "ceil") if args.len() >= 1 => {
+            Some(mk(IrExprKind::Call {
+                target: CallTarget::Method {
+                    object: Box::new(args[0].clone()),
+                    method: crate::intern::sym("ceil"),
+                },
+                args: vec![],
+                type_args: vec![],
+            }))
+        }
+        ("math", "round") | ("float", "round") if args.len() >= 1 => {
+            Some(mk(IrExprKind::Call {
+                target: CallTarget::Method {
+                    object: Box::new(args[0].clone()),
+                    method: crate::intern::sym("round"),
+                },
+                args: vec![],
+                type_args: vec![],
+            }))
+        }
+        ("math", "sin") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("sin") },
+            args: vec![], type_args: vec![],
+        })),
+        ("math", "cos") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("cos") },
+            args: vec![], type_args: vec![],
+        })),
+        ("math", "tan") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("tan") },
+            args: vec![], type_args: vec![],
+        })),
+        ("math", "asin") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("asin") },
+            args: vec![], type_args: vec![],
+        })),
+        ("math", "acos") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("acos") },
+            args: vec![], type_args: vec![],
+        })),
+        ("math", "atan") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("atan") },
+            args: vec![], type_args: vec![],
+        })),
+        ("math", "atan2") if args.len() >= 2 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("atan2") },
+            args: vec![args[1].clone()], type_args: vec![],
+        })),
+        ("math", "exp") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("exp") },
+            args: vec![], type_args: vec![],
+        })),
+        ("math", "log") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("ln") },
+            args: vec![], type_args: vec![],
+        })),
+        ("math", "log2") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("log2") },
+            args: vec![], type_args: vec![],
+        })),
+        ("math", "log10") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("log10") },
+            args: vec![], type_args: vec![],
+        })),
+        // float.from_int / int.to_float / float.to_int: keep as runtime calls
+        // (they're #[inline(always)], LLVM inlines them)
+        // math.pow: Int exponentiation — keep as runtime call (i64.pow needs u32 cast)
+        // ── math.fpow(base, exp) → base.powf(exp) ──
+        ("math", "fpow") if args.len() >= 2 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("powf") },
+            args: vec![args[1].clone()], type_args: vec![],
+        })),
+        // ── Constants ──
+        ("math", "pi") => Some(mk(IrExprKind::LitFloat { value: std::f64::consts::PI })),
+        ("math", "e") => Some(mk(IrExprKind::LitFloat { value: std::f64::consts::E })),
+        ("math", "inf") => Some(mk(IrExprKind::LitFloat { value: f64::INFINITY })),
+        ("float", "is_nan") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("is_nan") },
+            args: vec![], type_args: vec![],
+        })),
+        ("float", "is_infinite") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("is_infinite") },
+            args: vec![], type_args: vec![],
+        })),
+        ("math", "is_nan") if args.len() >= 1 => Some(mk(IrExprKind::Call {
+            target: CallTarget::Method { object: Box::new(args[0].clone()), method: crate::intern::sym("is_nan") },
+            args: vec![], type_args: vec![],
+        })),
+        _ => None,
+    }
+}
 
 /// Try to lower a list.* call into an IterChain IR node.
 /// Returns None if the operation isn't iterator-eligible.

--- a/src/codegen/pass_stdlib_lowering.rs
+++ b/src/codegen/pass_stdlib_lowering.rs
@@ -112,6 +112,13 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
             // Recurse into args first (fan auto-try is handled by FanLoweringPass)
             let args: Vec<IrExpr> = args.into_iter().map(|a| rewrite_expr(a)).collect();
 
+            // Try to lower list operations to iterator chains (Rust-only optimization)
+            if module.as_ref() == "list" {
+                if let Some(iter_expr) = try_lower_to_iter_chain(&func, args.clone(), &ty, span) {
+                    return iter_expr;
+                }
+            }
+
             // Look up per-function transform table
             let info = arg_transforms::lookup(&module, &func);
             let rt_name = info.as_ref().map(|i| i.name.to_string())
@@ -527,6 +534,216 @@ fn resolve_ufcs_stmts(stmts: Vec<IrStmt>, siblings: &[String]) -> Vec<IrStmt> {
         };
         IrStmt { kind, span: s.span }
     }).collect()
+}
+
+// ── Iterator chain lowering ────────────────────────────────────────
+
+/// Try to lower a list.* call into an IterChain IR node.
+/// Returns None if the operation isn't iterator-eligible.
+fn try_lower_to_iter_chain(func: &str, mut args: Vec<IrExpr>, ty: &Ty, span: Option<crate::ast::Span>) -> Option<IrExpr> {
+    match func {
+        // ── Consuming operations (into_iter) → produce Vec ──
+        "map" if args.len() >= 2 => {
+            let lambda = prepare_lambda(args.remove(1));
+            let source = args.remove(0);
+            Some(IrExpr {
+                kind: IrExprKind::IterChain {
+                    source: Box::new(source),
+                    consume: true,
+                    steps: vec![IterStep::Map { lambda: Box::new(lambda) }],
+                    collector: IterCollector::Collect,
+                },
+                ty: ty.clone(), span,
+            })
+        }
+        "filter" if args.len() >= 2 && matches!(args[1].kind, IrExprKind::Lambda { .. }) => {
+            let lambda = prepare_lambda_borrowed(args.remove(1));
+            let source = args.remove(0);
+            Some(IrExpr {
+                kind: IrExprKind::IterChain {
+                    source: Box::new(source),
+                    consume: true,
+                    steps: vec![IterStep::Filter { lambda: Box::new(lambda) }],
+                    collector: IterCollector::Collect,
+                },
+                ty: ty.clone(), span,
+            })
+        }
+        "flat_map" if args.len() >= 2 => {
+            let lambda = prepare_lambda(args.remove(1));
+            let source = args.remove(0);
+            Some(IrExpr {
+                kind: IrExprKind::IterChain {
+                    source: Box::new(source),
+                    consume: true,
+                    steps: vec![IterStep::FlatMap { lambda: Box::new(lambda) }],
+                    collector: IterCollector::Collect,
+                },
+                ty: ty.clone(), span,
+            })
+        }
+        "filter_map" if args.len() >= 2 => {
+            let lambda = prepare_lambda(args.remove(1));
+            let source = args.remove(0);
+            Some(IrExpr {
+                kind: IrExprKind::IterChain {
+                    source: Box::new(source),
+                    consume: true,
+                    steps: vec![IterStep::FilterMap { lambda: Box::new(lambda) }],
+                    collector: IterCollector::Collect,
+                },
+                ty: ty.clone(), span,
+            })
+        }
+        "fold" if args.len() >= 3 => {
+            let lambda = prepare_lambda(args.remove(2));
+            let init = args.remove(1);
+            let source = args.remove(0);
+            Some(IrExpr {
+                kind: IrExprKind::IterChain {
+                    source: Box::new(source),
+                    consume: true,
+                    steps: vec![],
+                    collector: IterCollector::Fold { init: Box::new(init), lambda: Box::new(lambda) },
+                },
+                ty: ty.clone(), span,
+            })
+        }
+        "find" if args.len() >= 2 && matches!(args[1].kind, IrExprKind::Lambda { .. }) => {
+            let lambda = prepare_lambda_borrowed(args.remove(1));
+            let source = args.remove(0);
+            Some(IrExpr {
+                kind: IrExprKind::IterChain {
+                    source: Box::new(source),
+                    consume: true,
+                    steps: vec![],
+                    collector: IterCollector::Find { lambda: Box::new(lambda) },
+                },
+                ty: ty.clone(), span,
+            })
+        }
+        // ── Borrowing operations (iter) → produce scalar ──
+        "any" if args.len() >= 2 => {
+            let lambda = prepare_lambda(args.remove(1));
+            let source = args.remove(0);
+            Some(IrExpr {
+                kind: IrExprKind::IterChain {
+                    source: Box::new(source),
+                    consume: true,
+                    steps: vec![],
+                    collector: IterCollector::Any { lambda: Box::new(lambda) },
+                },
+                ty: ty.clone(), span,
+            })
+        }
+        "all" if args.len() >= 2 => {
+            let lambda = prepare_lambda(args.remove(1));
+            let source = args.remove(0);
+            Some(IrExpr {
+                kind: IrExprKind::IterChain {
+                    source: Box::new(source),
+                    consume: true,
+                    steps: vec![],
+                    collector: IterCollector::All { lambda: Box::new(lambda) },
+                },
+                ty: ty.clone(), span,
+            })
+        }
+        "count" if args.len() >= 2 && matches!(args[1].kind, IrExprKind::Lambda { .. }) => {
+            let lambda = prepare_lambda_borrowed(args.remove(1));
+            let source = args.remove(0);
+            Some(IrExpr {
+                kind: IrExprKind::IterChain {
+                    source: Box::new(source),
+                    consume: true,
+                    steps: vec![],
+                    collector: IterCollector::Count { lambda: Box::new(lambda) },
+                },
+                ty: ty.clone(), span,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Prepare a lambda for consuming iterator ops (map, fold, flat_map, filter_map).
+/// Callback gets `T` (owned) — apply LambdaClone with smart single-use skip.
+fn prepare_lambda(arg: IrExpr) -> IrExpr {
+    let ty = arg.ty.clone();
+    let span = arg.span;
+    match arg.kind {
+        IrExprKind::Lambda { params, body, lambda_id } => {
+            let clone_stmts = build_clone_stmts_for_lambda(&params, &body);
+            let wrapped_body = if clone_stmts.is_empty() {
+                *body
+            } else {
+                let body_ty = body.ty.clone();
+                let body_span = body.span;
+                IrExpr {
+                    kind: IrExprKind::Block { stmts: clone_stmts, expr: Some(body) },
+                    ty: body_ty, span: body_span,
+                }
+            };
+            IrExpr {
+                kind: IrExprKind::Lambda { params, body: Box::new(wrapped_body), lambda_id },
+                ty, span,
+            }
+        }
+        _ => arg,
+    }
+}
+
+/// Prepare a lambda for borrowing iterator ops (filter, find, any, all, count).
+/// Callback gets `&T` — need deref/clone bindings to convert to owned `T`.
+fn prepare_lambda_borrowed(arg: IrExpr) -> IrExpr {
+    let ty = arg.ty.clone();
+    let span = arg.span;
+    match arg.kind {
+        IrExprKind::Lambda { params, body, lambda_id } => {
+            // For &T params, always add binding: Copy types get `let x = *x;`, heap types get `let x = x.clone();`
+            let deref_stmts: Vec<IrStmt> = params.iter()
+                .map(|(id, param_ty)| {
+                    let is_copy = matches!(param_ty, Ty::Int | Ty::Float | Ty::Bool | Ty::Unit);
+                    let value = if is_copy {
+                        // *x (deref the reference)
+                        IrExpr {
+                            kind: IrExprKind::Deref {
+                                expr: Box::new(IrExpr { kind: IrExprKind::Var { id: *id }, ty: param_ty.clone(), span: None }),
+                            },
+                            ty: param_ty.clone(), span: None,
+                        }
+                    } else {
+                        // x.clone() (clone from reference)
+                        IrExpr {
+                            kind: IrExprKind::Clone {
+                                expr: Box::new(IrExpr { kind: IrExprKind::Var { id: *id }, ty: param_ty.clone(), span: None }),
+                            },
+                            ty: param_ty.clone(), span: None,
+                        }
+                    };
+                    IrStmt {
+                        kind: IrStmtKind::Bind { var: *id, mutability: Mutability::Let, ty: param_ty.clone(), value },
+                        span: None,
+                    }
+                }).collect();
+
+            let wrapped_body = if deref_stmts.is_empty() {
+                *body
+            } else {
+                let body_ty = body.ty.clone();
+                let body_span = body.span;
+                IrExpr {
+                    kind: IrExprKind::Block { stmts: deref_stmts, expr: Some(body) },
+                    ty: body_ty, span: body_span,
+                }
+            };
+            IrExpr {
+                kind: IrExprKind::Lambda { params, body: Box::new(wrapped_body), lambda_id },
+                ty, span,
+            }
+        }
+        _ => arg,
+    }
 }
 
 /// Decorate a single argument based on the per-function transform.

--- a/src/codegen/walker/expressions.rs
+++ b/src/codegen/walker/expressions.rs
@@ -708,7 +708,20 @@ fn render_generic_call(ctx: &RenderContext, target: &CallTarget, args: &[IrExpr]
             if let Some(full) = render_method_call_full(ctx, object, method, args) {
                 return full;
             }
-            format!("{}.{}", render_expr(ctx, object), method)
+            {
+                let obj_str = render_expr(ctx, object);
+                // Wrap in parens if the object expression needs it for method call precedence
+                let needs_parens = matches!(&object.kind,
+                    IrExprKind::UnOp { .. } | IrExprKind::BinOp { .. }
+                    | IrExprKind::If { .. } | IrExprKind::Match { .. }
+                ) || matches!(&object.kind, IrExprKind::LitFloat { value } if *value < 0.0)
+                  || matches!(&object.kind, IrExprKind::LitInt { value } if *value < 0);
+                if needs_parens {
+                    format!("({}).{}", obj_str, method)
+                } else {
+                    format!("{}.{}", obj_str, method)
+                }
+            }
         }
         CallTarget::Computed { callee } => {
             let s = render_expr(ctx, callee);
@@ -730,10 +743,14 @@ fn render_method_call_full(ctx: &RenderContext, object: &IrExpr, method: &str, a
         | "contains" | "iter" | "into_iter" | "collect" | "map"
         | "filter" | "to_vec" | "join" | "split" | "trim"
         | "starts_with" | "ends_with" | "replace" | "chars"
-        | "as_str" | "get" | "keys" | "values" | "abs" | "powi"
+        | "as_str" | "get" | "keys" | "values" | "abs" | "powi" | "powf"
         | "is_empty" | "contains_key" | "entry" | "or_insert"
         | "expect" | "ok" | "err" | "and_then" | "map_err"
         | "unwrap_or_else" | "ok_or" | "flatten" | "as_ref" | "as_deref"
+        // math intrinsics (inlined by StdlibLowering)
+        | "sqrt" | "floor" | "ceil" | "round" | "sin" | "cos" | "tan"
+        | "asin" | "acos" | "atan" | "atan2" | "exp" | "ln" | "log2" | "log10"
+        | "is_nan" | "is_infinite"
     );
     // User-defined UFCS: plain method name (no dots) → func(object, args)
     if !method.contains('.') && !is_rust_intrinsic {

--- a/src/codegen/walker/expressions.rs
+++ b/src/codegen/walker/expressions.rs
@@ -578,10 +578,42 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                 .unwrap_or_else(|| format!("fan({})", rendered.join(", ")))
         }
 
+        // ── Iterator chain (Rust-only) ──
+        IrExprKind::IterChain { source, consume, steps, collector } => {
+            render_iter_chain(ctx, source, *consume, steps, collector)
+        }
+
         // ── Closure conversion nodes (WASM-only, never reached by Rust walker) ──
         IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. } => {
             unreachable!("ClosureCreate/EnvLoad should only appear in WASM pipeline")
         }
+    }
+}
+
+fn render_iter_chain(ctx: &RenderContext, source: &IrExpr, consume: bool, steps: &[IterStep], collector: &IterCollector) -> String {
+    let src = render_expr(ctx, source);
+    let mut chain = if consume {
+        format!("({}).into_iter()", src)
+    } else {
+        format!("({}).iter()", src)
+    };
+
+    for step in steps {
+        match step {
+            IterStep::Map { lambda } => chain = format!("{}.map({})", chain, render_expr(ctx, lambda)),
+            IterStep::Filter { lambda } => chain = format!("{}.filter({})", chain, render_expr(ctx, lambda)),
+            IterStep::FlatMap { lambda } => chain = format!("{}.flat_map({})", chain, render_expr(ctx, lambda)),
+            IterStep::FilterMap { lambda } => chain = format!("{}.filter_map({})", chain, render_expr(ctx, lambda)),
+        }
+    }
+
+    match collector {
+        IterCollector::Collect => format!("{}.collect::<Vec<_>>()", chain),
+        IterCollector::Fold { init, lambda } => format!("{}.fold({}, {})", chain, render_expr(ctx, init), render_expr(ctx, lambda)),
+        IterCollector::Any { lambda } => format!("{}.any({})", chain, render_expr(ctx, lambda)),
+        IterCollector::All { lambda } => format!("{}.all({})", chain, render_expr(ctx, lambda)),
+        IterCollector::Find { lambda } => format!("{}.find({})", chain, render_expr(ctx, lambda)),
+        IterCollector::Count { lambda } => format!("{}.filter({}).count() as i64", chain, render_expr(ctx, lambda)),
     }
 }
 

--- a/src/codegen/walker/expressions.rs
+++ b/src/codegen/walker/expressions.rs
@@ -694,6 +694,16 @@ fn render_binop(ctx: &RenderContext, op: BinOp, left: &IrExpr, right: &IrExpr, _
 fn render_generic_call(ctx: &RenderContext, target: &CallTarget, args: &[IrExpr]) -> String {
     let callee = match target {
         CallTarget::Named { name } => {
+            // Inline numeric casts: runtime function → Rust `as` cast
+            match name.as_str() {
+                "almide_rt_float_from_int" | "almide_rt_int_to_float" if args.len() == 1 => {
+                    return format!("({} as f64)", render_expr(ctx, &args[0]));
+                }
+                "almide_rt_float_to_int" if args.len() == 1 => {
+                    return format!("({} as i64)", render_expr(ctx, &args[0]));
+                }
+                _ => {}
+            }
             if let Some(enum_name) = ctx.ann.ctor_to_enum.get(name.as_str()) {
                 return render_enum_constructor(ctx, name, enum_name, args);
             }

--- a/src/codegen/walker/mod.rs
+++ b/src/codegen/walker/mod.rs
@@ -131,9 +131,20 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
             if fn_ctx.target == Target::Rust && fn_ctx.var_table.get(p.var).mutability == Mutability::Var {
                 param_name = format!("mut {}", param_name);
             }
-            let type_s = render_type_fn(&fn_ctx, &p.ty);
+            let type_s = match p.borrow {
+                ParamBorrow::Own => render_type_fn(&fn_ctx, &p.ty),
+                ParamBorrow::Ref => format!("&{}", render_type_fn(&fn_ctx, &p.ty)),
+                ParamBorrow::RefStr => "&str".to_string(),
+                ParamBorrow::RefSlice => {
+                    if let crate::types::Ty::Applied(_, args) = &p.ty {
+                        if let Some(inner) = args.first() {
+                            format!("&[{}]", render_type_fn(&fn_ctx, inner))
+                        } else { format!("&{}", render_type_fn(&fn_ctx, &p.ty)) }
+                    } else { format!("&{}", render_type_fn(&fn_ctx, &p.ty)) }
+                }
+            };
             fn_ctx.templates.render_with("fn_param", None, &[], &[("name", param_name.as_str()), ("type", type_s.as_str())])
-                .unwrap_or_else(|| format!("{}: {}", p.name, render_type_fn(&fn_ctx, &p.ty)))
+                .unwrap_or_else(|| format!("{}: {}", p.name, type_s))
         })
         .collect::<Vec<_>>()
         .join(", ");

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -295,9 +295,46 @@ pub enum IrExprKind {
         index: u32,
     },
 
+    // ── Iterator chain (inserted by StdlibLoweringPass, Rust target) ──
+    /// Replaces runtime function calls for list operations with Rust iterator chains.
+    /// `source.into_iter().step1().step2()...collector()`
+    IterChain {
+        source: Box<IrExpr>,
+        /// true = into_iter() (consumes Vec), false = iter() (borrows Vec)
+        consume: bool,
+        steps: Vec<IterStep>,
+        collector: IterCollector,
+    },
+
     // ── Misc ──
     Hole,
     Todo { message: String },
+}
+
+/// A single step in an iterator chain (map, filter, etc.)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum IterStep {
+    Map { lambda: Box<IrExpr> },
+    Filter { lambda: Box<IrExpr> },
+    FlatMap { lambda: Box<IrExpr> },
+    FilterMap { lambda: Box<IrExpr> },
+}
+
+/// The terminal operation of an iterator chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum IterCollector {
+    /// `.collect::<Vec<_>>()` — materialize into Vec
+    Collect,
+    /// `.fold(init, |acc, x| body)`
+    Fold { init: Box<IrExpr>, lambda: Box<IrExpr> },
+    /// `.any(|x| body)` — returns bool
+    Any { lambda: Box<IrExpr> },
+    /// `.all(|x| body)` — returns bool
+    All { lambda: Box<IrExpr> },
+    /// `.find(|x| body)` — returns Option<T>
+    Find { lambda: Box<IrExpr> },
+    /// `.filter(|x| body).count() as i64`
+    Count { lambda: Box<IrExpr> },
 }
 
 // ── Statements ──────────────────────────────────────────────────

--- a/src/ir/substitute.rs
+++ b/src/ir/substitute.rs
@@ -233,6 +233,30 @@ pub fn substitute_var_in_expr(expr: &IrExpr, var: VarId, replacement: &IrExpr) -
             ty: expr.ty.clone(), span: expr.span,
         },
 
+        IrExprKind::IterChain { source, consume, steps, collector } => IrExpr {
+            kind: IrExprKind::IterChain {
+                source: Box::new(sub(source)),
+                consume: *consume,
+                steps: steps.iter().map(|step| match step {
+                    IterStep::Map { lambda } => IterStep::Map { lambda: Box::new(sub(lambda)) },
+                    IterStep::Filter { lambda } => IterStep::Filter { lambda: Box::new(sub(lambda)) },
+                    IterStep::FlatMap { lambda } => IterStep::FlatMap { lambda: Box::new(sub(lambda)) },
+                    IterStep::FilterMap { lambda } => IterStep::FilterMap { lambda: Box::new(sub(lambda)) },
+                }).collect(),
+                collector: match collector {
+                    IterCollector::Collect => IterCollector::Collect,
+                    IterCollector::Fold { init, lambda } => IterCollector::Fold {
+                        init: Box::new(sub(init)), lambda: Box::new(sub(lambda)),
+                    },
+                    IterCollector::Any { lambda } => IterCollector::Any { lambda: Box::new(sub(lambda)) },
+                    IterCollector::All { lambda } => IterCollector::All { lambda: Box::new(sub(lambda)) },
+                    IterCollector::Find { lambda } => IterCollector::Find { lambda: Box::new(sub(lambda)) },
+                    IterCollector::Count { lambda } => IterCollector::Count { lambda: Box::new(sub(lambda)) },
+                },
+            },
+            ty: expr.ty.clone(), span: expr.span,
+        },
+
         // ── True leaf nodes ──
         IrExprKind::Var { .. }
         | IrExprKind::FnRef { .. }

--- a/src/ir/use_count.rs
+++ b/src/ir/use_count.rs
@@ -147,6 +147,28 @@ fn count_uses_in_expr(expr: &IrExpr, table: &mut VarTable) {
             for a in args { count_uses_in_expr(a, table); }
         }
         IrExprKind::RenderedCall { .. } => {}
+        IrExprKind::IterChain { source, steps, collector, .. } => {
+            count_uses_in_expr(source, table);
+            for step in steps {
+                match step {
+                    IterStep::Map { lambda } | IterStep::Filter { lambda }
+                    | IterStep::FlatMap { lambda } | IterStep::FilterMap { lambda } => {
+                        count_uses_in_expr(lambda, table);
+                    }
+                }
+            }
+            match collector {
+                IterCollector::Collect => {}
+                IterCollector::Fold { init, lambda } => {
+                    count_uses_in_expr(init, table);
+                    count_uses_in_expr(lambda, table);
+                }
+                IterCollector::Any { lambda } | IterCollector::All { lambda }
+                | IterCollector::Find { lambda } | IterCollector::Count { lambda } => {
+                    count_uses_in_expr(lambda, table);
+                }
+            }
+        }
     }
 }
 

--- a/src/ir/use_count.rs
+++ b/src/ir/use_count.rs
@@ -193,12 +193,57 @@ fn collect_bound_vars(stmts: &[IrStmt]) -> HashSet<u32> {
     let mut locals = HashSet::new();
     for s in stmts {
         match &s.kind {
-            IrStmtKind::Bind { var, .. } => { locals.insert(var.0); }
-            IrStmtKind::BindDestructure { pattern, .. } => collect_pattern_vars(pattern, &mut locals),
+            IrStmtKind::Bind { var, value, .. } => {
+                locals.insert(var.0);
+                collect_bound_vars_in_expr(value, &mut locals);
+            }
+            IrStmtKind::BindDestructure { pattern, value, .. } => {
+                collect_pattern_vars(pattern, &mut locals);
+                collect_bound_vars_in_expr(value, &mut locals);
+            }
+            IrStmtKind::Expr { expr } => collect_bound_vars_in_expr(expr, &mut locals),
+            IrStmtKind::Guard { cond, else_ } => {
+                collect_bound_vars_in_expr(cond, &mut locals);
+                collect_bound_vars_in_expr(else_, &mut locals);
+            }
             _ => {}
         }
     }
     locals
+}
+
+/// Collect VarIds bound inside expressions (match arm patterns, nested blocks).
+fn collect_bound_vars_in_expr(expr: &IrExpr, vars: &mut HashSet<u32>) {
+    match &expr.kind {
+        IrExprKind::Match { subject, arms } => {
+            collect_bound_vars_in_expr(subject, vars);
+            for arm in arms {
+                collect_pattern_vars(&arm.pattern, vars);
+                if let Some(g) = &arm.guard { collect_bound_vars_in_expr(g, vars); }
+                collect_bound_vars_in_expr(&arm.body, vars);
+            }
+        }
+        IrExprKind::Block { stmts, expr } => {
+            vars.extend(collect_bound_vars(stmts));
+            if let Some(e) = expr { collect_bound_vars_in_expr(e, vars); }
+        }
+        IrExprKind::If { cond, then, else_ } => {
+            collect_bound_vars_in_expr(cond, vars);
+            collect_bound_vars_in_expr(then, vars);
+            collect_bound_vars_in_expr(else_, vars);
+        }
+        IrExprKind::ForIn { iterable, body, var, var_tuple, .. } => {
+            collect_bound_vars_in_expr(iterable, vars);
+            vars.insert(var.0);
+            if let Some(vt) = var_tuple { for v in vt { vars.insert(v.0); } }
+            vars.extend(collect_bound_vars(body));
+        }
+        IrExprKind::While { cond, body } => {
+            collect_bound_vars_in_expr(cond, vars);
+            vars.extend(collect_bound_vars(body));
+        }
+        _ => {}
+    }
 }
 
 fn collect_pattern_vars(pat: &IrPattern, vars: &mut HashSet<u32>) {

--- a/src/ir/visit.rs
+++ b/src/ir/visit.rs
@@ -141,6 +141,25 @@ pub fn walk_expr<V: IrVisitor>(v: &mut V, expr: &IrExpr) {
         IrExprKind::RustMacro { args, .. } => {
             for a in args { v.visit_expr(a); }
         }
+        IrExprKind::IterChain { source, steps, collector, .. } => {
+            v.visit_expr(source);
+            for step in steps {
+                match step {
+                    IterStep::Map { lambda } | IterStep::Filter { lambda }
+                    | IterStep::FlatMap { lambda } | IterStep::FilterMap { lambda } => {
+                        v.visit_expr(lambda);
+                    }
+                }
+            }
+            match collector {
+                IterCollector::Collect => {}
+                IterCollector::Fold { init, lambda } => { v.visit_expr(init); v.visit_expr(lambda); }
+                IterCollector::Any { lambda } | IterCollector::All { lambda }
+                | IterCollector::Find { lambda } | IterCollector::Count { lambda } => {
+                    v.visit_expr(lambda);
+                }
+            }
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod almdi;
 pub mod intern;
 pub mod ast;
+pub mod canonicalize;
 pub mod check;
 pub mod codegen;
 pub mod lexer;

--- a/src/lower/types.rs
+++ b/src/lower/types.rs
@@ -52,56 +52,8 @@ fn lower_variant_case(ctx: &mut LowerCtx, case: &ast::VariantCase, _parent: &str
     }
 }
 
-// ── Type expression resolution (standalone, no checker needed) ──
+// ── Type expression resolution (delegates to canonical version) ──
 
 pub(super) fn resolve_type_expr(te: &ast::TypeExpr) -> Ty {
-    match te {
-        ast::TypeExpr::Simple { name } => match name.as_str() {
-            "Int" => Ty::Int, "Float" => Ty::Float, "String" => Ty::String,
-            "Bool" => Ty::Bool, "Unit" => Ty::Unit, "Bytes" => Ty::Bytes, "Matrix" => Ty::Matrix, "Path" => Ty::String,
-            _ => Ty::Named(*name, vec![]),
-        },
-        ast::TypeExpr::Generic { name, args } => {
-            let ra: Vec<Ty> = args.iter().map(resolve_type_expr).collect();
-            match name.as_str() {
-                "List" => Ty::list(ra.first().cloned().unwrap_or_else(|| {
-                    eprintln!("[ICE] lower: List[] without type argument");
-                    Ty::Unknown
-                })),
-                "Option" => Ty::option(ra.first().cloned().unwrap_or_else(|| {
-                    eprintln!("[ICE] lower: Option[] without type argument");
-                    Ty::Unknown
-                })),
-                "Result" if ra.len() >= 2 => Ty::result(ra[0].clone(), ra[1].clone()),
-                "Map" if ra.len() >= 2 => Ty::map_of(ra[0].clone(), ra[1].clone()),
-                _ => Ty::Named(*name, ra),
-            }
-        },
-        ast::TypeExpr::Record { fields } => Ty::Record {
-            fields: fields.iter().map(|f| (f.name, resolve_type_expr(&f.ty))).collect(),
-        },
-        ast::TypeExpr::OpenRecord { fields } => Ty::OpenRecord {
-            fields: fields.iter().map(|f| (f.name, resolve_type_expr(&f.ty))).collect(),
-        },
-        ast::TypeExpr::Fn { params, ret } => Ty::Fn {
-            params: params.iter().map(resolve_type_expr).collect(),
-            ret: Box::new(resolve_type_expr(ret)),
-        },
-        ast::TypeExpr::Tuple { elements } => Ty::Tuple(elements.iter().map(resolve_type_expr).collect()),
-        ast::TypeExpr::Variant { cases } => {
-            let cs = cases.iter().map(|c| match c {
-                ast::VariantCase::Unit { name } => crate::types::VariantCase { name: *name, payload: crate::types::VariantPayload::Unit },
-                ast::VariantCase::Tuple { name, fields } => crate::types::VariantCase {
-                    name: sym(name),
-                    payload: crate::types::VariantPayload::Tuple(fields.iter().map(resolve_type_expr).collect()),
-                },
-                ast::VariantCase::Record { name, fields } => crate::types::VariantCase {
-                    name: sym(name),
-                    payload: crate::types::VariantPayload::Record(fields.iter().map(|f| (f.name, resolve_type_expr(&f.ty), f.default.clone())).collect()),
-                },
-            }).collect();
-            Ty::Variant { name: sym(""), cases: cs }
-        },
-        ast::TypeExpr::Union { members } => Ty::union(members.iter().map(resolve_type_expr).collect()),
-    }
+    crate::canonicalize::resolve::resolve_type_expr(te, None)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ pub use almide::stdlib;
 pub use almide::types;
 pub use almide::intern;
 pub use almide::import_table;
+pub use almide::canonicalize;
 
 // CLI-only modules
 mod check;


### PR DESCRIPTION
## Summary

Comprehensive codegen optimization pass achieving **Rust-equivalent performance** on standard benchmarks.

### Clone elimination
- **Last-use move inference**: skip `.clone()` at final use of each variable (move instead)
- **Borrow clone strip**: `&x.clone()` → `&x` in stdlib call args
- **Lambda single-use skip**: callback params used once skip clone binding
- **Match arm pattern bind fix**: VarIds in match arms correctly recognized as locals

### Iterator chain emission
- `list.map/filter/fold/flat_map/filter_map/any/all/find/count` emit Rust iterator chains
- `xs.into_iter().map(|x| body).collect::<Vec<_>>()` instead of `almide_rt_list_map(xs.to_vec(), ...)`
- Eliminates intermediate Vec allocations and runtime function overhead

### Math intrinsics inline
- `math.sqrt(x)` → `x.sqrt()`, `float.abs(x)` → `x.abs()`, etc.
- `float.from_int(n)` → `(n as f64)`, `float.to_int(x)` → `(x as i64)`
- `math.pi` → `std::f64::consts::PI` (constant folded)

### Borrow parameter inference (Roc-style)
- Read-only `String` params → `&str`, read-only `List[T]` params → `&[T]`
- Call sites auto-insert `&` for borrowed params
- Eliminates clone at call sites when callee only reads the value

### Other
- Vec-init peephole: `var x=[]; for _ in 0..n { x=x+[v] }` → O(n) iterator init
- Remove `#[inline]` from user functions (let LLVM decide — 27% faster on spectralnorm)
- Extract `resolve_type_expr` into `canonicalize` module (Step 1 of canonical AST)
- Roadmap: DCE → done, auto-parallel Phase 1 → done, emit-readability Phase 4 progress

### Benchmark results (`almide build --fast`)

| Benchmark | Rust ref | Almide | Ratio |
|---|---|---|---|
| spectralnorm | 0.81s | 0.84s | **1.04x** |
| nbody | 1.18s | 1.29s | **1.09x** |
| fannkuchredux | 1.88s | 1.85s | **0.98x (Almide wins)** |
| binarytrees | 1.99s | 0.29s | **6.9x faster** |

## Test plan
- [x] `almide test spec/lang/` — 86/86
- [x] `almide test spec/stdlib/` — 57/57
- [x] `almide test spec/integration/` — 23/23
- [x] `almide test examples/` — 8/8
- [x] `almide test research/benchmark/exercises/` — 24/24
- [x] WASM: `almide test spec/lang/ --target wasm` — 85 passed, 1 skipped
- [x] WASM: `almide test spec/stdlib/ --target wasm` — 56 passed, 1 skipped