### PR TITLE
Compiler hardening: monomorphization fix, postcondition framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "almide-base",
  "almide-codegen",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "almide-base"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "lasso",
  "serde",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "almide-codegen"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "almide-frontend"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "almide-ir"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "almide-base",
  "almide-lang",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "almide-lang"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "almide-base",
  "almide-syntax",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "almide-optimize"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "almide-syntax"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "almide-base",
  "serde",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "almide-tools"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "almide-types"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "almide-base",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-base/Cargo.toml
+++ b/crates/almide-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-base"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Foundational types for the Almide compiler (Sym, Span, Diagnostic)"

--- a/crates/almide-codegen/Cargo.toml
+++ b/crates/almide-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-codegen"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide code generation: nanopass pipeline, walker, WASM emit"

--- a/crates/almide-codegen/src/pass.rs
+++ b/crates/almide-codegen/src/pass.rs
@@ -8,7 +8,7 @@
 //! - MLIR dialect conversion patterns
 //! - NLLB-200 Mixture of Experts (shared + language-specific)
 
-use almide_ir::IrProgram;
+use almide_ir::{IrProgram, IrExprKind, IrPattern, IrVisitor};
 use almide_lang::types::Ty;
 
 // ── Pass Result ──
@@ -90,9 +90,123 @@ pub trait NanoPass: std::fmt::Debug {
     /// Default: no dependencies.
     fn depends_on(&self) -> Vec<&'static str> { vec![] }
 
+    /// Postconditions: structural invariants guaranteed after this pass runs.
+    /// Verified automatically in debug/CI builds (ALMIDE_CHECK_IR=1).
+    fn postconditions(&self) -> Vec<Postcondition> { vec![] }
+
     /// Run the pass. Takes ownership of the program, returns modified program
     /// and whether any changes were made.
     fn run(&self, program: IrProgram, target: Target) -> PassResult;
+}
+
+/// Structural invariants a pass guarantees after execution.
+#[derive(Debug)]
+pub enum Postcondition {
+    /// No IR pattern of this kind remains (e.g., "List" after ListPatternLowering)
+    NoPatternKind(&'static str),
+    /// No TypeVar remains in any function signature or body type
+    NoTypeVars,
+    /// All Ty nodes are concrete (no Unknown, no TypeVar)
+    AllTypesConcrete,
+    /// Custom check: returns list of violation messages (empty = OK)
+    Custom(fn(&IrProgram) -> Vec<String>),
+}
+
+/// Verify postconditions for a pass. Returns list of violations.
+pub fn verify_postconditions(pass_name: &str, program: &IrProgram, postconditions: &[Postcondition]) -> Vec<String> {
+    use almide_lang::types::Ty;
+    let mut violations = Vec::new();
+
+    for pc in postconditions {
+        match pc {
+            Postcondition::NoPatternKind(kind) => {
+                let count = count_pattern_kind(program, kind);
+                if count > 0 {
+                    violations.push(format!(
+                        "[{}] {} '{}' pattern(s) remain after pass (expected 0)",
+                        pass_name, count, kind
+                    ));
+                }
+            }
+            Postcondition::NoTypeVars => {
+                let count = count_typevars_in_functions(program);
+                if count > 0 {
+                    violations.push(format!(
+                        "[{}] {} TypeVar(s) remain in active functions (expected 0)",
+                        pass_name, count
+                    ));
+                }
+            }
+            Postcondition::AllTypesConcrete => {
+                let (unknowns, typevars) = count_incomplete_types(program);
+                if unknowns > 0 {
+                    violations.push(format!(
+                        "[{}] {} Unknown type(s) in IR (expected 0)",
+                        pass_name, unknowns
+                    ));
+                }
+                if typevars > 0 {
+                    violations.push(format!(
+                        "[{}] {} TypeVar(s) in IR (expected 0)",
+                        pass_name, typevars
+                    ));
+                }
+            }
+            Postcondition::Custom(check) => {
+                violations.extend(check(program));
+            }
+        }
+    }
+    violations
+}
+
+fn count_pattern_kind(program: &IrProgram, kind: &str) -> usize {
+    use almide_ir::*;
+    struct PatternCounter { kind: String, count: usize }
+    impl IrVisitor for PatternCounter {
+        fn visit_pattern(&mut self, pat: &IrPattern) {
+            let matches = match (&pat, self.kind.as_str()) {
+                (IrPattern::List { .. }, "List") => true,
+                _ => false,
+            };
+            if matches { self.count += 1; }
+            almide_ir::walk_pattern(self, pat);
+        }
+    }
+    let mut counter = PatternCounter { kind: kind.to_string(), count: 0 };
+    for func in &program.functions { counter.visit_expr(&func.body); }
+    counter.count
+}
+
+fn count_typevars_in_functions(program: &IrProgram) -> usize {
+    use almide_lang::types::Ty;
+    fn has_typevar(ty: &Ty) -> bool {
+        match ty {
+            Ty::TypeVar(_) => true,
+            _ => ty.children().iter().any(|c| has_typevar(c)),
+        }
+    }
+    let mut count = 0;
+    for func in &program.functions {
+        if has_typevar(&func.ret_ty) { count += 1; }
+        for p in &func.params { if has_typevar(&p.ty) { count += 1; } }
+    }
+    count
+}
+
+fn count_incomplete_types(program: &IrProgram) -> (usize, usize) {
+    use almide_lang::types::Ty;
+    let mut unknowns = 0;
+    let mut typevars = 0;
+    for func in &program.functions {
+        if func.ret_ty.contains_unknown() { unknowns += 1; }
+        if func.ret_ty.contains_typevar() { typevars += 1; }
+        for p in &func.params {
+            if p.ty.contains_unknown() { unknowns += 1; }
+            if p.ty.contains_typevar() { typevars += 1; }
+        }
+    }
+    (unknowns, typevars)
 }
 
 // ── Pass Pipeline ──
@@ -171,6 +285,18 @@ impl Pipeline {
                         eprintln!("  {}", e);
                     }
                     panic!("IR verification failed after pass '{}'", pass_name);
+                }
+            }
+
+            // Postcondition verification (always on — these are structural invariants)
+            let postconds = pass.postconditions();
+            if !postconds.is_empty() {
+                let violations = verify_postconditions(pass_name, &program, &postconds);
+                for v in &violations {
+                    eprintln!("[POSTCONDITION VIOLATION] {}", v);
+                }
+                if !violations.is_empty() && check_ir {
+                    panic!("Postcondition violation after pass '{}'", pass_name);
                 }
             }
 

--- a/crates/almide-codegen/src/pass_list_pattern.rs
+++ b/crates/almide-codegen/src/pass_list_pattern.rs
@@ -57,9 +57,19 @@ impl NanoPass for ListPatternLoweringPass {
     }
 }
 
-/// Check if a match has any list pattern arms.
+/// Check if a match has any list pattern arms (recursively checks nested patterns).
 fn has_list_patterns(arms: &[IrMatchArm]) -> bool {
-    arms.iter().any(|arm| matches!(&arm.pattern, IrPattern::List { .. }))
+    arms.iter().any(|arm| pattern_contains_list(&arm.pattern))
+}
+
+fn pattern_contains_list(pat: &IrPattern) -> bool {
+    match pat {
+        IrPattern::List { .. } => true,
+        IrPattern::Tuple { elements } => elements.iter().any(pattern_contains_list),
+        IrPattern::Some { inner } | IrPattern::Ok { inner } | IrPattern::Err { inner } => pattern_contains_list(inner),
+        IrPattern::Constructor { args, .. } => args.iter().any(pattern_contains_list),
+        _ => false,
+    }
 }
 
 /// Recursively rewrite expressions, desugaring match with list patterns.
@@ -297,6 +307,127 @@ fn build_list_if_chain(subject: &IrExpr, arms: &[IrMatchArm], result_ty: &Ty, vt
                 kind: IrExprKind::If {
                     cond: Box::new(combined_cond),
                     then: Box::new(then_body),
+                    else_: Box::new(else_body),
+                },
+                ty: result_ty.clone(),
+                span: None,
+            }
+        }
+        // Tuple containing list patterns: extract list checks from tuple elements
+        IrPattern::Tuple { elements } if elements.iter().any(pattern_contains_list) => {
+            // Build conditions for list elements within the tuple
+            let tuple_tys = match &subject.ty {
+                Ty::Tuple(tys) => tys.clone(),
+                _ => vec![Ty::Unknown; elements.len()],
+            };
+            let mut conds: Vec<IrExpr> = Vec::new();
+            let mut stmts: Vec<IrStmt> = Vec::new();
+
+            for (i, elem_pat) in elements.iter().enumerate() {
+                let elem_access = IrExpr {
+                    kind: IrExprKind::TupleIndex {
+                        object: Box::new(subject.clone()),
+                        index: i,
+                    },
+                    ty: tuple_tys.get(i).cloned().unwrap_or(Ty::Unknown),
+                    span: None,
+                };
+                match elem_pat {
+                    IrPattern::List { elements: list_elems } => {
+                        // Length check
+                        let len_call = IrExpr {
+                            kind: IrExprKind::Call {
+                                target: CallTarget::Module { module: sym("list"), func: sym("len") },
+                                args: vec![elem_access.clone()],
+                                type_args: vec![],
+                            },
+                            ty: Ty::Int,
+                            span: None,
+                        };
+                        conds.push(IrExpr {
+                            kind: IrExprKind::BinOp {
+                                op: BinOp::Eq,
+                                left: Box::new(len_call),
+                                right: Box::new(IrExpr {
+                                    kind: IrExprKind::LitInt { value: list_elems.len() as i64 },
+                                    ty: Ty::Int,
+                                    span: None,
+                                }),
+                            },
+                            ty: Ty::Bool,
+                            span: None,
+                        });
+                        // Bind list elements
+                        let inner_elem_ty = match tuple_tys.get(i) {
+                            Some(Ty::Applied(TypeConstructorId::List, args)) if !args.is_empty() => args[0].clone(),
+                            _ => Ty::Unknown,
+                        };
+                        for (j, lp) in list_elems.iter().enumerate() {
+                            if let IrPattern::Bind { var, .. } = lp {
+                                stmts.push(IrStmt {
+                                    kind: IrStmtKind::Bind {
+                                        var: *var,
+                                        mutability: Mutability::Let,
+                                        ty: inner_elem_ty.clone(),
+                                        value: IrExpr {
+                                            kind: IrExprKind::IndexAccess {
+                                                object: Box::new(elem_access.clone()),
+                                                index: Box::new(IrExpr {
+                                                    kind: IrExprKind::LitInt { value: j as i64 },
+                                                    ty: Ty::Int,
+                                                    span: None,
+                                                }),
+                                            },
+                                            ty: inner_elem_ty.clone(),
+                                            span: None,
+                                        },
+                                    },
+                                    span: None,
+                                });
+                            }
+                        }
+                    }
+                    IrPattern::Bind { var, .. } => {
+                        stmts.push(IrStmt {
+                            kind: IrStmtKind::Bind {
+                                var: *var,
+                                mutability: Mutability::Let,
+                                ty: tuple_tys.get(i).cloned().unwrap_or(Ty::Unknown),
+                                value: elem_access,
+                            },
+                            span: None,
+                        });
+                    }
+                    _ => {} // Wildcard — no action
+                }
+            }
+
+            // Combine conditions
+            let combined_cond = if conds.is_empty() {
+                IrExpr { kind: IrExprKind::LitBool { value: true }, ty: Ty::Bool, span: None }
+            } else {
+                conds.into_iter().reduce(|a, b| IrExpr {
+                    kind: IrExprKind::BinOp { op: BinOp::And, left: Box::new(a), right: Box::new(b) },
+                    ty: Ty::Bool,
+                    span: None,
+                }).unwrap()
+            };
+
+            let body = if stmts.is_empty() {
+                arm.body.clone()
+            } else {
+                IrExpr {
+                    kind: IrExprKind::Block { stmts, expr: Some(Box::new(arm.body.clone())) },
+                    ty: result_ty.clone(),
+                    span: None,
+                }
+            };
+
+            let else_body = build_list_if_chain(subject, rest, result_ty, vt);
+            IrExpr {
+                kind: IrExprKind::If {
+                    cond: Box::new(combined_cond),
+                    then: Box::new(body),
                     else_: Box::new(else_body),
                 },
                 ty: result_ty.clone(),

--- a/crates/almide-codegen/src/pass_list_pattern.rs
+++ b/crates/almide-codegen/src/pass_list_pattern.rs
@@ -28,6 +28,9 @@ pub struct ListPatternLoweringPass;
 impl NanoPass for ListPatternLoweringPass {
     fn name(&self) -> &str { "ListPatternLowering" }
     fn targets(&self) -> Option<Vec<Target>> { None }
+    fn postconditions(&self) -> Vec<super::pass::Postcondition> {
+        vec![super::pass::Postcondition::NoPatternKind("List")]
+    }
 
     fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
         let mut changed = false;

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -130,6 +130,12 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
 
         // ── Loops ──
         IrExprKind::ForIn { var, var_tuple, iterable, body } => {
+            // Optimize: for loop over empty list literal → skip entirely
+            if let IrExprKind::List { elements } = &iterable.kind {
+                if elements.is_empty() {
+                    return "{}".to_string();
+                }
+            }
             let var_name = if let Some(tuple_vars) = var_tuple {
                 let names: Vec<String> = tuple_vars.iter().map(|id| ctx.var_name(*id).to_string()).collect();
                 let vars_s = names.join(", ");

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -40,6 +40,8 @@ pub struct RenderContext<'a> {
     pub is_test: bool,
     pub ann: CodegenAnnotations,
     pub type_aliases: std::collections::HashMap<almide_base::intern::Sym, almide_lang::types::Ty>,
+    /// Type names that have generic parameters (for erasing to `_` when args are missing)
+    pub generic_types: std::collections::HashSet<almide_base::intern::Sym>,
     /// Use minimal generic bounds (Clone only) for bundled .almd module functions.
     pub minimal_generic_bounds: bool,
     /// Emit `#[repr(C)]` on structs/enums for stable C ABI layout.
@@ -48,7 +50,7 @@ pub struct RenderContext<'a> {
 
 impl<'a> RenderContext<'a> {
     pub fn new(templates: &'a TemplateSet, var_table: &'a VarTable) -> Self {
-        Self { templates, var_table, indent: 0, target: Target::Rust, auto_unwrap: false, is_test: false, ann: CodegenAnnotations::default(), type_aliases: std::collections::HashMap::new(), minimal_generic_bounds: false, repr_c: false }
+        Self { templates, var_table, indent: 0, target: Target::Rust, auto_unwrap: false, is_test: false, ann: CodegenAnnotations::default(), type_aliases: std::collections::HashMap::new(), generic_types: std::collections::HashSet::new(), minimal_generic_bounds: false, repr_c: false }
     }
 
     pub fn with_target(mut self, target: Target) -> Self {
@@ -97,6 +99,7 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
         is_test: func.is_test,
         ann: ctx.ann.clone(),
         type_aliases: ctx.type_aliases.clone(),
+        generic_types: ctx.generic_types.clone(),
         minimal_generic_bounds: ctx.minimal_generic_bounds,
         repr_c: ctx.repr_c,
     };
@@ -264,9 +267,15 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
     // Build constructor → enum name map
     // Build type alias map for transparent expansion
     let mut type_aliases = std::collections::HashMap::new();
+    let mut generic_types = std::collections::HashSet::new();
     for td in &program.type_decls {
-        if let IrTypeDeclKind::Alias { target } = &td.kind {
-            type_aliases.insert(td.name, target.clone());
+        match &td.kind {
+            IrTypeDeclKind::Alias { target } => { type_aliases.insert(td.name, target.clone()); }
+            _ => {}
+        }
+        // Track types with generic parameters
+        if td.generics.as_ref().map_or(false, |g| !g.is_empty()) {
+            generic_types.insert(td.name);
         }
     }
     let mut ctx = RenderContext {
@@ -278,6 +287,7 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         is_test: ctx.is_test,
         ann: ctx.ann.clone(),
         type_aliases,
+        generic_types,
         minimal_generic_bounds: false,
         repr_c: ctx.repr_c,
     };
@@ -403,6 +413,7 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
             is_test: false,
             ann: ctx.ann.clone(),
             type_aliases: ctx.type_aliases.clone(),
+            generic_types: ctx.generic_types.clone(),
             minimal_generic_bounds: is_bundled,
             repr_c: ctx.repr_c,
         };

--- a/crates/almide-codegen/src/walker/types.rs
+++ b/crates/almide-codegen/src/walker/types.rs
@@ -2,7 +2,7 @@
 
 use almide_lang::types::{Ty, TypeConstructorId};
 use super::RenderContext;
-use super::helpers::{template_or, render_type_boxed_fn, render_type_rc_fn};
+use super::helpers::{template_or, render_type_boxed_fn, render_type_rc_fn, ty_has_named_typevar};
 
 pub fn render_type(ctx: &RenderContext, ty: &Ty) -> String {
     match ty {
@@ -47,6 +47,11 @@ pub fn render_type(ctx: &RenderContext, ty: &Ty) -> String {
                 }
             }
             if args.is_empty() {
+                // If the type has generic parameters but no type arguments,
+                // emit `_` to let Rust infer the concrete type
+                if ctx.generic_types.contains(name) {
+                    return "_".to_string();
+                }
                 name.to_string()
             } else {
                 let args_str = args.iter().map(|a| render_type(ctx, a)).collect::<Vec<_>>().join(", ");
@@ -58,6 +63,10 @@ pub fn render_type(ctx: &RenderContext, ty: &Ty) -> String {
             names.sort();
             // Check named records first (user-defined types)
             if let Some(n) = ctx.ann.named_records.get(&names) {
+                // If the struct is generic but no type args are present, let Rust infer
+                if ctx.generic_types.contains(&almide_base::intern::sym(n)) {
+                    return "_".to_string();
+                }
                 return n.clone();
             }
             // Check anonymous records

--- a/crates/almide-frontend/Cargo.toml
+++ b/crates/almide-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-frontend"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide frontend: type checker, canonicalization, IR lowering"

--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -290,7 +290,7 @@ impl Checker {
     }
 
     /// Create fresh inference variables for a type's generic parameters.
-    fn instantiate_type_generics(&mut self, type_name: &str) -> Vec<Ty> {
+    pub(crate) fn instantiate_type_generics(&mut self, type_name: &str) -> Vec<Ty> {
         // Count generics by finding TypeVars in the type definition
         if let Some(ty_def) = self.env.types.get(&sym(type_name)).cloned() {
             let mut type_vars = Vec::new();

--- a/crates/almide-ir/Cargo.toml
+++ b/crates/almide-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-ir"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide typed intermediate representation (IR)"

--- a/crates/almide-lang/Cargo.toml
+++ b/crates/almide-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-lang"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide language definitions: re-exports almide-syntax + almide-types"

--- a/crates/almide-optimize/Cargo.toml
+++ b/crates/almide-optimize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-optimize"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide IR optimizer: dead code elimination, constant propagation, monomorphization"

--- a/crates/almide-optimize/src/mono/discovery.rs
+++ b/crates/almide-optimize/src/mono/discovery.rs
@@ -104,10 +104,11 @@ pub(super) fn discover_in_expr(
                         }
                     }
 
-                    // Skip bindings with Unknown or unresolved inference vars
+                    // Skip bindings with Unknown, TypeVars, or unresolved inference vars
                     let all_concrete = !bindings.is_empty() && bindings.values().all(|ty|
                         !matches!(ty, Ty::Unknown) && !ty.contains_unknown()
-                        && !matches!(ty, Ty::TypeVar(n) if n.starts_with('?'))
+                        && !matches!(ty, Ty::TypeVar(_))
+                        && !ty.contains_typevar()
                     );
                     if all_concrete {
                         let suffix = mangle_suffix(&bindings);

--- a/crates/almide-optimize/src/mono/mod.rs
+++ b/crates/almide-optimize/src/mono/mod.rs
@@ -92,11 +92,13 @@ pub fn monomorphize(program: &mut IrProgram) {
 
         // Rewrite call sites (all instances, including previous rounds)
         all_instances.extend(new);
-        rewrite_calls(program, &bound_fns, &all_instances);
 
-        // Track frontier: next round only scans these new functions
+        // Add new specialized functions BEFORE rewriting, so self-recursive
+        // calls within specialized functions also get rewritten.
         frontier_start = Some(program.functions.len());
         program.functions.extend(new_functions);
+
+        rewrite_calls(program, &bound_fns, &all_instances);
     }
 
     // Remove generic functions: both those with specialized instances AND

--- a/crates/almide-syntax/Cargo.toml
+++ b/crates/almide-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-syntax"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide syntax definitions: AST, lexer, and parser"

--- a/crates/almide-syntax/src/parser/helpers.rs
+++ b/crates/almide-syntax/src/parser/helpers.rs
@@ -69,10 +69,11 @@ impl Parser {
             && {
                 let mut j = i + 1;
                 while self.peek_at(j).map(|t| &t.token_type) == Some(&TokenType::Newline) { j += 1; }
-                // { ident: ... } or { ...spread }
+                // { ident: ... } or { ...spread } or { } (empty record with all defaults)
                 (self.peek_at(j).map(|t| &t.token_type) == Some(&TokenType::Ident)
                     && self.peek_at(j + 1).map(|t| &t.token_type) == Some(&TokenType::Colon))
                 || self.peek_at(j).map(|t| &t.token_type) == Some(&TokenType::DotDotDot)
+                || self.peek_at(j).map(|t| &t.token_type) == Some(&TokenType::RBrace)
             }
     }
 

--- a/crates/almide-tools/Cargo.toml
+++ b/crates/almide-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-tools"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide developer tools: formatter, module interface, almdi"

--- a/crates/almide-types/Cargo.toml
+++ b/crates/almide-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-types"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide type system: Ty, unification, type constructors, stdlib info"

--- a/crates/almide-types/src/types/mod.rs
+++ b/crates/almide-types/src/types/mod.rs
@@ -182,6 +182,10 @@ impl Ty {
         self.any_child_recursive(&|t| matches!(t, Ty::Unknown))
     }
 
+    pub fn contains_typevar(&self) -> bool {
+        self.any_child_recursive(&|t| matches!(t, Ty::TypeVar(_)))
+    }
+
     /// Construct a normalized union type: flatten nested unions, deduplicate, sort.
     /// Returns the inner type if only one member remains.
     pub fn union(mut members: Vec<Ty>) -> Ty {

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,13 +6,11 @@
 
 ## Active
 
-6 items
+4 items
 
 | Item | Description |
 |------|-------------|
-| [C FFI — Call C Libraries from Almide](active/c-ffi.md) | Call C libraries from Almide via @extern(c, ...) and extern "C" codegen |
-| [Exhaustiveness Strengthening — Nested Patterns](active/exhaustiveness-strengthening.md) | Nested pattern exhaustiveness via Maranget's algorithm |
-| [Fan Async Backend](active/fan-async-backend.md) | Migrate fan runtime from std::thread to tokio async |
+| [Fan Concurrency — Next Generation](active/fan-concurrency-next.md) | fan as a language-level concurrency primitive with Flow[T] and compiler-driven optimization |
 | [Flexible Error Types](active/flexible-error-types.md) | Allow user-defined error types in Result and effect fn |
 | [`almide update` — Dependency Update Command](active/package-manager-update.md) | Add almide update command to refresh dependencies and rewrite lock file |
 | [Package Version Resolution](active/package-version-resolution.md) | MVS version resolution with semver constraints for almide.toml |
@@ -49,10 +47,10 @@
 
 ## Done
 
-186 items
+188 items
 
 <details>
-<summary>Show all 186 completed items</summary>
+<summary>Show all 188 completed items</summary>
 
 | Done | Item | Description |
 |------|------|-------------|


### PR DESCRIPTION
## Summary
- Fix monomorphization ICE for recursive generic functions with multiple type parameters (`tree_fold[T, U]`)
- Fix codegen for generic struct instantiation without explicit type arguments
- Fix parser to recognize empty named records (`Config {}`) with all default fields
- Support list patterns inside tuple patterns (`([], _)`)
- Optimize empty list for loops to no-op
- Add postcondition framework to nanopass pipeline for structural invariant verification

## Postcondition Framework

Passes can now declare structural invariants they guarantee:

```rust
fn postconditions(&self) -> Vec<Postcondition> {
    vec![Postcondition::NoPatternKind("List")]
}
```

Available postconditions:
- `NoPatternKind("X")` — no pattern of kind X remains in IR
- `NoTypeVars` — no TypeVar in active function signatures
- `AllTypesConcrete` — no Unknown or TypeVar in IR types
- `Custom(fn)` — arbitrary check function

Violations are printed as warnings. With `ALMIDE_CHECK_IR=1`, violations panic (strict mode for CI).

## Test plan
- [x] `almide test` — 169/169 files pass
- [x] `cargo test` — all pass
- [x] `ALMIDE_CHECK_IR=1` — no postcondition violations
- [x] Monkey tested: recursive generics, empty records, tuple+list patterns, empty for loops