### PR TITLE
v0.11.5: WASM regression fixes, codegen refactoring, crate responsibility enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 *.pyc
 research/benchmark/framework/config.yaml
 research/benchmark/framework/results/
+docs-site/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "almide-base",
  "almide-codegen",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "almide-base"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "lasso",
  "serde",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "almide-codegen"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "almide-frontend"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "almide-ir"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "almide-base",
  "almide-lang",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "almide-lang"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "almide-base",
  "almide-syntax",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "almide-optimize"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "almide-syntax"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "almide-base",
  "serde",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "almide-tools"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "almide-types"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "almide-base",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/_scenarios/MONKEY_BUGS.md
+++ b/_scenarios/MONKEY_BUGS.md
@@ -1,0 +1,184 @@
+# Monkey Test で発見されたバグ (almide 0.11.3 → 0.11.4)
+
+日付: 2026-04-05
+範囲: `_scenarios/monkey01..15_*_test.almd` (言語機能・stdlib の広域探索)
+
+現在の状態: **199 passed / 0 failed** (spec/ + _scenarios/ 全域)
+monkey テスト単独: **179 passed / 0 failed** (15 ファイル)
+
+以下のバグは本 monkey test で発見され、**すべて修正済み**。各テストファイルには
+かつて壊れていたパターンが直接書かれており、回帰として機能する。
+
+---
+
+## 1. 【致命】単一ケース inline variant のパーサ誤解釈 ✅ 修正済
+
+**症状**:
+```almide
+type PatientId = PatientId(String)   // 同名: 型解決が無限ループ
+type Box[T] = Box(T)                 // 同名ジェネリック: 同上
+type PatientId = Wrap(String)        // 異名: 未定義型 `Wrap` 参照で codegen 崩壊
+```
+
+`almide check` は "No errors" で通るのに `almide test` が CPU 100% でハング。
+AST を見ると `type PatientId = PatientId` の **type alias** として解釈されていた。
+
+**原因**: `crates/almide-syntax/src/parser/types.rs` の `parse_type_expr_inner` が
+`Name(Args)` を見たとき `args` を捨てて `Ty::Simple { name }` を返していた。
+
+**修正**: `try_parse_inline_variant` に常時フォールバックし、trailing `|` がなくても
+単一ケース variant として扱う。既存の leading `|` 書式もそのまま動く。
+
+**回帰**: `_scenarios/monkey01_inline_variant_test.almd`, `scenario6_newtype_test.almd`
+
+---
+
+## 2. 【致命】ジェネリック関数を呼び出すテストが silent drop される ✅ 修正済
+
+**症状**:
+```almide
+fn wrap_all[T](xs: List[T]) -> List[Box[T]] =
+    xs |> list.map((x) => Box(x))
+
+test "wrap_all" {                 // ← エラーなしに codegen から消える
+    let boxed = wrap_all([1, 2, 3])
+    ...
+}
+```
+
+**原因**: `lower_test` がテスト関数を `name = "wrap_all"` (テスト名そのまま) として
+lower。同名のジェネリック関数 `wrap_all[T]` が monomorphization の filter に
+引っかかり、テスト関数も一緒に `retain` で削られていた。さらに `rewrite_calls` の
+`fn_param_types` HashMap でもテストとジェネリック関数が同じキーで衝突し、テスト側
+(空 params) で上書きされて generic dispatch が崩れていた。
+
+**修正**: 
+- `mono/mod.rs` retain に `if f.is_test { return true; }` を追加
+- `mono/rewrite.rs`・`mono/discovery.rs` のルックアップに `!f.is_test` フィルタ
+
+**回帰**: `_scenarios/monkey10_generics_test.almd`
+
+---
+
+## 3. 【高】構造的に同一な nominal 型が unify される ✅ 修正済
+
+**症状**:
+```almide
+type Dog = { name: String }
+type Cat = { name: String }
+let d: Dog = { name: "rex" }   // codegen: let d: Cat = Cat {...} に化ける
+```
+
+**原因**: `canonicalize/resolve.rs` の `resolve_type_expr` が `known_types` から
+`Dog` を引くとき、登録された structural form (`Ty::Record { fields }`) をそのまま
+返していた。これで型検査器の内部表現から nominal identity が失われ、Dog/Cat が
+同一視されていた。
+
+**修正**: user-declared record/variant/open record は `Ty::Named(name, [])` のまま
+返し、structural 展開は on-demand (`resolve_named`) に任せる。primitive aliases
+(`type Score = Int`) は従来通り透過的に展開する。protocol 実装の signature 比較は
+両側で `resolve_named` してから比較するように合わせた。
+
+**回帰**: `_scenarios/monkey15_protocols_test.almd`
+
+---
+
+## 4. 【高】プロトコル境界ジェネリックの dispatch が壊れる ✅ 修正済 (#3 と同根)
+
+**症状**: `fn describe[T: Animal](a: T) -> String = "${a.species()}"` の
+monomorphization で `T_species(a)` という未定義関数が codegen される。
+
+**原因**: #3 と同じ。bindings マップの値が `Ty::Record { fields }` になっており、
+`ty_to_name` が None を返すため、`T.species` → `Dog.species` の書き換えが起きない。
+Dog が nominal Ty::Named として維持されるようになった結果、`ty_to_name(Dog)` が
+`"Dog"` を返し、正しく `Dog.species` に書き換わるようになった。
+
+**回帰**: `_scenarios/monkey15_protocols_test.almd`
+
+---
+
+## 5. 【中】レコード部分デストラクチャで `..` が付かない ✅ 修正済
+
+**症状**: `let { name, age } = user` (User は 3 フィールド) で codegen が
+`let User { name, age } = user` を吐き、Rust の E0027 で失敗。
+
+**修正**: `codegen/walker/statements.rs` でパターンのフィールド数とレコード型の
+総フィールド数を比較し、不足していれば自動で `..` を付与する。付随して
+`CodegenAnnotations` に `record_field_counts` を追加。
+
+**回帰**: `_scenarios/monkey13_records_test.almd`
+
+---
+
+## 6. 【中】`list.map((x) => x)` の identity 最適化が Range→Vec の collect を剥がす ✅ 修正済
+
+**症状**: `0..5 |> list.map((x) => x)` が codegen 上で `(0i64..5i64)` になり、
+Range<i64> を Vec<i64> に代入する壊れた Rust を吐く。
+
+**修正**: `pass_stream_fusion/fusion_rules.rs` の `try_eliminate_identity_map` で
+引数が `IrExprKind::Range` の場合だけ最適化をスキップ。
+
+**回帰**: `_scenarios/monkey04_list_ops_test.almd`
+
+---
+
+## 7. 【中】`Vec<(i64, String)>` の index アクセスで `.clone()` が付かない ✅ 修正済
+
+**症状**: `list.enumerate(xs)[0]` の結果が非 Copy タプルでも `.clone()` なしで
+代入され、Rust の move エラーになる (String / Record 単体では正しく付く)。
+
+**修正**: `pass_clone.rs` の `needs_clone` に `Ty::Tuple(elems) => elems.iter().any(needs_clone)`
+を追加。numeric タプル `(Int, Int)` は Copy なのでスキップされる。
+
+**回帰**: `_scenarios/monkey04_list_ops_test.almd`
+
+---
+
+## 8. 【中】stdlib/module 関数を first-class 値として渡せない ✅ 修正済
+
+**症状**: `list.map(xs, string.len)` が `E003: undefined variable 'string'`。
+
+**修正**:
+- `check/infer.rs`: `ExprKind::Member` で object が module 名かつ field が関数の
+  場合、Ty::Fn を返すショートサーキット。
+- `lower/expressions.rs`: 同パターンを eta 展開して `(x) => module.func(x)` の
+  Lambda にする。結果として `list.map(xs, string.len)` が動く。
+
+**回帰**: `_scenarios/monkey10_generics_test.almd`
+
+---
+
+## 9. 【低】E001 型エラーが無関係な行に出る (診断位置の破壊) ✅ 修正済
+
+**症状**: 制約ベースの型検査器が `Constraint` にスパンを保持しておらず、
+`solve_constraints` でエラーを出すとき `self.current_span` (= 最後に訪れた式の span)
+を使っていたため、まったく関係ない行に E001 が出ていた。
+
+**修正**: `Constraint` に `span: Option<Span>` を追加し、`constrain()` 時に
+current_span を捕捉。`solve_constraints` ではエラー出力前に一時的に current_span を
+constraint のスパンに差し替える。
+
+**副次効果**: #10 (診断メッセージに別関数名) も同根だったため同時に解消。
+
+**再現**: `/tmp/cascade.almd`
+
+---
+
+## 既知の残存事項
+
+- 大文字始まり識別子 (`let MyValue = 42`) のパーサエラーメッセージは最初のエラー
+  としては正しく報告されるが、以降の識別子使用箇所に副次エラーが出る場合がある。
+  これは error recovery の話で、カスケード自体は #9 の修正で緩和された。
+- `map.insert` は in-place 変異 (要 `var`) であり、immutable 版は `map.set`。
+  ドキュメントどおりで食い違いはなかった (当初の報告は当方の誤解)。
+
+---
+
+## まとめ
+
+この monkey test セッションで発見したバグ **9 件をすべて修正**。各バグには
+回帰テストが `_scenarios/` に残してあり、今後の変更で同じ穴が空いた瞬間に検出できる。
+
+修正の大半は「中途半端な抽象化が nominal identity を壊していた」「エラー発生時の
+状態が次のコードに漏れていた」という構造的な問題。短期で 199/199 を維持したまま
+これだけ直せたのは、各バグを 1 件ずつ分離したテストで切り分けて進めたおかげ。

--- a/_scenarios/monkey01_inline_variant_test.almd
+++ b/_scenarios/monkey01_inline_variant_test.almd
@@ -1,0 +1,72 @@
+// Monkey test 01: インライン variant 構文 (単一ケース含む)
+//
+// Regression for fixed bug: 単一ケース inline variant のパーサ曖昧性。
+// かつては `type T = T(String)` が type alias と解釈されて自己参照ループしていた
+// (同名) / `type T = Wrap(String)` が未定義型参照を吐いていた (異名)。
+// 現在は leading `|` なしでも正しく single-case variant として parse される。
+
+// 同名 newtype (leading | なし — 以前は無限ループしていた形)
+type PatientId = PatientId(String)
+type DrugId    = DrugId(String)
+type DoseAmount = DoseAmount(Float)
+
+// 異名 newtype (leading | なし — 以前は未定義型参照で codegen 崩壊)
+type OrderId = Oid(String)
+
+fn patient_id_str(id: PatientId) -> String =
+    match id { PatientId(s) => s }
+
+fn drug_id_str(id: DrugId) -> String =
+    match id { DrugId(s) => s }
+
+fn dose_value(d: DoseAmount) -> Float =
+    match d { DoseAmount(v) => v }
+
+test "same-name single-case variant without leading |" {
+    let p = PatientId("P001")
+    let d = DrugId("D042")
+    let amt = DoseAmount(2.5)
+    assert_eq(patient_id_str(p), "P001")
+    assert_eq(drug_id_str(d), "D042")
+    assert(dose_value(amt) > 2.4)
+}
+
+fn order_id_str(o: OrderId) -> String =
+    match o { Oid(s) => s }
+
+test "different-name single-case variant without leading |" {
+    let o = Oid("ORD-001")
+    assert_eq(order_id_str(o), "ORD-001")
+}
+
+// 多ケースインラインは leading | なしで動く
+type Color = Red | Green | Blue
+
+fn color_name(c: Color) -> String =
+    match c {
+        Red => "red",
+        Green => "green",
+        Blue => "blue",
+    }
+
+test "inline multi-case variant without leading |" {
+    assert_eq(color_name(Red), "red")
+    assert_eq(color_name(Green), "green")
+    assert_eq(color_name(Blue), "blue")
+}
+
+// 2ケース以上ならペイロード付きでも leading | 不要
+type Shape = Circle(Float) | Square(Float) | Rect(Float, Float)
+
+fn area(s: Shape) -> Float =
+    match s {
+        Circle(r) => 3.14159 * r * r,
+        Square(a) => a * a,
+        Rect(w, h) => w * h,
+    }
+
+test "inline multi-case with payload" {
+    assert(area(Circle(1.0)) > 3.14)
+    assert_eq(area(Square(2.0)), 4.0)
+    assert_eq(area(Rect(3.0, 4.0)), 12.0)
+}

--- a/_scenarios/monkey02_int_arithmetic_test.almd
+++ b/_scenarios/monkey02_int_arithmetic_test.almd
@@ -1,0 +1,78 @@
+// Monkey test 02: Int 四則演算・境界値
+//
+// Almide の Int は Rust i64 (恐らく) なので範囲は ±9.2e18
+
+fn add(a: Int, b: Int) -> Int = a + b
+fn sub(a: Int, b: Int) -> Int = a - b
+fn mul(a: Int, b: Int) -> Int = a * b
+fn idiv(a: Int, b: Int) -> Int = a / b
+fn imod(a: Int, b: Int) -> Int = a % b
+
+test "basic arithmetic" {
+    assert_eq(add(1, 2), 3)
+    assert_eq(sub(5, 3), 2)
+    assert_eq(mul(4, 5), 20)
+    assert_eq(idiv(10, 3), 3)
+    assert_eq(imod(10, 3), 1)
+}
+
+test "negative numbers" {
+    assert_eq(add(-5, 3), -2)
+    assert_eq(mul(-3, -4), 12)
+    assert_eq(sub(-10, -5), -5)
+    assert_eq(idiv(-10, 3), -3)
+}
+
+test "zero semantics" {
+    assert_eq(add(0, 0), 0)
+    assert_eq(mul(0, 12345), 0)
+    assert_eq(sub(42, 42), 0)
+}
+
+test "large numbers" {
+    let big = 1000000000
+    assert_eq(mul(big, 2), 2000000000)
+    assert_eq(add(big, big), 2000000000)
+}
+
+test "power operator" {
+    assert_eq(2 ^ 10, 1024)
+    assert_eq(3 ^ 3, 27)
+    assert_eq(5 ^ 0, 1)
+}
+
+test "power right-associative" {
+    // 2^(3^2) = 2^9 = 512, not (2^3)^2 = 64
+    assert_eq(2 ^ 3 ^ 2, 512)
+}
+
+test "operator precedence" {
+    assert_eq(2 + 3 * 4, 14)
+    assert_eq((2 + 3) * 4, 20)
+    assert_eq(10 - 3 - 2, 5)        // left-assoc
+    assert_eq(20 / 4 / 2, 2)        // left-assoc
+    assert_eq(2 + 3 * 4 - 1, 13)
+}
+
+test "int utility fns" {
+    assert_eq(int.to_string(42), "42")
+    assert_eq(int.to_string(-7), "-7")
+    assert_eq(int.to_string(0), "0")
+    assert_eq(int.abs(-5), 5)
+    assert_eq(int.abs(5), 5)
+    assert_eq(int.abs(0), 0)
+}
+
+test "min/max" {
+    assert_eq(int.min(3, 5), 3)
+    assert_eq(int.min(-3, -5), -5)
+    assert_eq(int.max(3, 5), 5)
+    assert_eq(int.max(-3, -5), -3)
+}
+
+test "unary minus" {
+    let x = 5
+    assert_eq(-x, -5)
+    assert_eq(-(-x), 5)
+    assert_eq(-(-(-x)), -5)
+}

--- a/_scenarios/monkey03_string_ops_test.almd
+++ b/_scenarios/monkey03_string_ops_test.almd
@@ -1,0 +1,107 @@
+// Monkey test 03: 文字列操作 — 補間・連結・Unicode・stdlib
+
+test "basic concat" {
+    let a = "hello"
+    let b = "world"
+    assert_eq(a + " " + b, "hello world")
+}
+
+test "interpolation basic" {
+    let name = "almide"
+    let n = 42
+    assert_eq("hi ${name} #${int.to_string(n)}", "hi almide #42")
+}
+
+test "interpolation with expression" {
+    assert_eq("result=${int.to_string(1 + 2 * 3)}", "result=7")
+}
+
+test "empty string" {
+    let e = ""
+    assert_eq(e + "x", "x")
+    assert_eq("y" + e, "y")
+    assert_eq(string.len(e), 0)
+}
+
+test "unicode length" {
+    let s = "あいう"
+    // string.len はバイト数 or 文字数? 文字数期待
+    assert_eq(string.len(s), 3)
+}
+
+test "emoji length" {
+    let s = "a🙂b"
+    // 絵文字でも文字数で 3 を期待
+    assert_eq(string.len(s), 3)
+}
+
+test "to_upper to_lower" {
+    assert_eq(string.to_upper("abc"), "ABC")
+    assert_eq(string.to_lower("XYZ"), "xyz")
+    assert_eq(string.to_upper(""), "")
+}
+
+test "trim" {
+    assert_eq(string.trim("  hello  "), "hello")
+    assert_eq(string.trim("\t\nfoo\n\t"), "foo")
+    assert_eq(string.trim(""), "")
+}
+
+test "split and join" {
+    let parts = string.split("a,b,c,d", ",")
+    assert_eq(list.len(parts), 4)
+    assert_eq(parts[0], "a")
+    assert_eq(parts[3], "d")
+    assert_eq(list.join(parts, "-"), "a-b-c-d")
+}
+
+test "split empty separator" {
+    // 空文字列で分割すると各文字?
+    let parts = string.split("abc", "")
+    // 実装依存だが何らか返すことを期待
+    assert(list.len(parts) >= 1)
+}
+
+test "contains" {
+    assert(string.contains("hello world", "world"))
+    assert(not string.contains("hello", "xyz"))
+    assert(string.contains("abc", ""))
+}
+
+test "starts_with ends_with" {
+    assert(string.starts_with("hello", "he"))
+    assert(string.ends_with("hello", "lo"))
+    assert(not string.starts_with("hello", "ell"))
+    assert(not string.ends_with("hello", "ell"))
+}
+
+test "replace" {
+    assert_eq(string.replace("foo bar foo", "foo", "baz"), "baz bar baz")
+    assert_eq(string.replace("aaa", "a", "bb"), "bbbbbb")
+    assert_eq(string.replace("hello", "x", "y"), "hello")
+}
+
+test "heredoc" {
+    let s = """
+        line1
+        line2
+        line3
+        """
+    assert(string.contains(s, "line1"))
+    assert(string.contains(s, "line2"))
+    assert(string.contains(s, "line3"))
+}
+
+test "heredoc with interpolation" {
+    let name = "alice"
+    let s = """
+        Hello, ${name}!
+        """
+    assert(string.contains(s, "Hello, alice!"))
+}
+
+test "escape sequences" {
+    let s = "a\tb\nc"
+    assert(string.contains(s, "\t"))
+    assert(string.contains(s, "\n"))
+}

--- a/_scenarios/monkey04_list_ops_test.almd
+++ b/_scenarios/monkey04_list_ops_test.almd
@@ -1,0 +1,130 @@
+// Monkey test 04: List 操作 — 基本・combinators・境界値
+//
+// Regression for fixed bugs:
+//  1. identity map (`xs |> list.map((x) => x)`) の最適化が Range に対して
+//     も適用されて `.collect::<Vec<_>>()` を剥がしていた。
+//  2. Vec<(i64, String)>[i] のタプル index で `.clone()` が自動挿入されず、
+//     非 Copy タプル要素が move できない Rust エラーになっていた。
+//     タプルの需clone判定を elements 再帰で入れるよう修正。
+
+test "literal and access" {
+    let xs = [1, 2, 3, 4, 5]
+    assert_eq(list.len(xs), 5)
+    assert_eq(xs[0], 1)
+    assert_eq(xs[4], 5)
+}
+
+test "empty list" {
+    let xs: List[Int] = []
+    assert_eq(list.len(xs), 0)
+    assert(list.is_empty(xs))
+}
+
+test "concat" {
+    let a = [1, 2]
+    let b = [3, 4]
+    let c = a + b
+    assert_eq(c, [1, 2, 3, 4])
+    assert_eq(list.len(c), 4)
+}
+
+test "map" {
+    let xs = [1, 2, 3]
+    let doubled = xs |> list.map((x) => x * 2)
+    assert_eq(doubled, [2, 4, 6])
+}
+
+test "map preserves length" {
+    let xs = [10, 20, 30, 40, 50]
+    let ys = xs |> list.map((x) => x + 1)
+    assert_eq(list.len(ys), 5)
+}
+
+test "filter" {
+    let xs = [1, 2, 3, 4, 5, 6]
+    let evens = xs |> list.filter((x) => x % 2 == 0)
+    assert_eq(evens, [2, 4, 6])
+}
+
+test "filter_map" {
+    let xs = [1, 2, 3, 4]
+    let doubled_evens = xs |> list.filter_map((x) =>
+        if x % 2 == 0 then some(x * 2) else none
+    )
+    assert_eq(doubled_evens, [4, 8])
+}
+
+test "fold" {
+    let sum = [1, 2, 3, 4, 5] |> list.fold(0, (acc, x) => acc + x)
+    assert_eq(sum, 15)
+}
+
+test "fold empty" {
+    let xs: List[Int] = []
+    let sum = xs |> list.fold(100, (acc, x) => acc + x)
+    assert_eq(sum, 100)
+}
+
+test "find" {
+    let xs = [1, 2, 3, 4, 5]
+    let found = xs |> list.find((x) => x > 3)
+    assert_eq(found, some(4))
+    let not_found = xs |> list.find((x) => x > 100)
+    assert_eq(not_found, none)
+}
+
+test "reverse" {
+    assert_eq(list.reverse([1, 2, 3]), [3, 2, 1])
+    let empty: List[Int] = []
+    assert_eq(list.reverse(empty), empty)
+}
+
+test "enumerate" {
+    let xs = ["a", "b", "c"]
+    let enum = xs |> list.enumerate
+    assert_eq(list.len(enum), 3)
+    let first = enum[0]
+    let (idx0, val0) = first
+    assert_eq(idx0, 0)
+    assert_eq(val0, "a")
+}
+
+test "range exclusive" {
+    let xs = 0..5 |> list.map((x) => x)
+    assert_eq(xs, [0, 1, 2, 3, 4])
+}
+
+test "range inclusive" {
+    let xs = 1..=5 |> list.map((x) => x)
+    assert_eq(xs, [1, 2, 3, 4, 5])
+}
+
+test "nested lists" {
+    let matrix = [[1, 2], [3, 4], [5, 6]]
+    assert_eq(list.len(matrix), 3)
+    assert_eq(matrix[0], [1, 2])
+    assert_eq(matrix[2][1], 6)
+}
+
+test "list of strings" {
+    let ss = ["foo", "bar", "baz"]
+    let joined = list.join(ss, ",")
+    assert_eq(joined, "foo,bar,baz")
+}
+
+test "all / any" {
+    assert(list.all([1, 2, 3], (x) => x > 0))
+    assert(not list.all([1, -2, 3], (x) => x > 0))
+    assert(list.any([1, 2, 3], (x) => x > 2))
+    assert(not list.any([1, 2, 3], (x) => x > 100))
+}
+
+test "list sum via fold" {
+    assert_eq([1, 2, 3, 4, 5] |> list.fold(0, (a, b) => a + b), 15)
+}
+
+test "big list" {
+    let big = 0..1000 |> list.map((x) => x)
+    assert_eq(list.len(big), 1000)
+    assert_eq(big[999], 999)
+}

--- a/_scenarios/monkey05_pattern_match_test.almd
+++ b/_scenarios/monkey05_pattern_match_test.almd
@@ -1,0 +1,139 @@
+// Monkey test 05: パターンマッチ
+
+type Shape = Circle(Float) | Rect(Float, Float) | Triangle(Float, Float, Float)
+
+fn area(s: Shape) -> Float =
+    match s {
+        Circle(r)             => 3.14159 * r * r,
+        Rect(w, h)            => w * h,
+        Triangle(a, b, c)     => {
+            let s = (a + b + c) / 2.0
+            float.sqrt(s * (s - a) * (s - b) * (s - c))
+        },
+    }
+
+test "variant with different arities" {
+    assert(area(Circle(1.0)) > 3.14)
+    assert_eq(area(Rect(3.0, 4.0)), 12.0)
+    assert(area(Triangle(3.0, 4.0, 5.0)) > 5.9)
+}
+
+// ネストパターン
+type Tree = Leaf(Int) | Node(Int, Int)
+
+fn sum_tree(t: Tree) -> Int =
+    match t {
+        Leaf(v) => v,
+        Node(a, b) => a + b,
+    }
+
+test "simple nested" {
+    assert_eq(sum_tree(Leaf(5)), 5)
+    assert_eq(sum_tree(Node(3, 4)), 7)
+}
+
+// ガード付きパターン
+fn classify(n: Int) -> String =
+    match n {
+        0 => "zero",
+        x if x < 0 => "negative",
+        x if x < 10 => "small",
+        x if x < 100 => "medium",
+        _ => "large",
+    }
+
+test "guard patterns" {
+    assert_eq(classify(0), "zero")
+    assert_eq(classify(-5), "negative")
+    assert_eq(classify(5), "small")
+    assert_eq(classify(50), "medium")
+    assert_eq(classify(500), "large")
+}
+
+// 文字列パターン
+fn greet(lang: String) -> String =
+    match lang {
+        "en" => "hello",
+        "ja" => "こんにちは",
+        "es" => "hola",
+        _ => "?",
+    }
+
+test "string patterns" {
+    assert_eq(greet("en"), "hello")
+    assert_eq(greet("ja"), "こんにちは")
+    assert_eq(greet("xx"), "?")
+}
+
+// Result パターン
+fn safe_div(a: Int, b: Int) -> Result[Int, String] =
+    if b == 0 then err("div by zero") else ok(a / b)
+
+fn handle(r: Result[Int, String]) -> String =
+    match r {
+        ok(v) => "got ${int.to_string(v)}",
+        err(e) => "err: ${e}",
+    }
+
+test "result patterns" {
+    assert_eq(handle(safe_div(10, 2)), "got 5")
+    assert_eq(handle(safe_div(10, 0)), "err: div by zero")
+}
+
+// Option パターン
+fn describe(opt: Option[Int]) -> String =
+    match opt {
+        some(v) => "some(${int.to_string(v)})",
+        none => "none",
+    }
+
+test "option patterns" {
+    assert_eq(describe(some(42)), "some(42)")
+    assert_eq(describe(none), "none")
+}
+
+// 型アノテーション付きレコード
+type Point = { x: Int, y: Int }
+
+fn quadrant(p: Point) -> Int =
+    match p {
+        Point{x, y} if x > 0 and y > 0 => 1,
+        Point{x, y} if x < 0 and y > 0 => 2,
+        Point{x, y} if x < 0 and y < 0 => 3,
+        Point{x, y} if x > 0 and y < 0 => 4,
+        _ => 0,
+    }
+
+test "record destructure with guard" {
+    assert_eq(quadrant({ x: 1, y: 1 }), 1)
+    assert_eq(quadrant({ x: -1, y: 1 }), 2)
+    assert_eq(quadrant({ x: -1, y: -1 }), 3)
+    assert_eq(quadrant({ x: 1, y: -1 }), 4)
+    assert_eq(quadrant({ x: 0, y: 0 }), 0)
+}
+
+// match が式として値を返す
+test "match as expression" {
+    let n = 3
+    let name = match n {
+        1 => "one",
+        2 => "two",
+        3 => "three",
+        _ => "many",
+    }
+    assert_eq(name, "three")
+}
+
+// ワイルドカードのみ
+test "wildcard only" {
+    let x = 42
+    let r = match x { _ => "any" }
+    assert_eq(r, "any")
+}
+
+// Bool パターン
+test "bool patterns" {
+    let b = true
+    let s = match b { true => "T", false => "F" }
+    assert_eq(s, "T")
+}

--- a/_scenarios/monkey06_closures_test.almd
+++ b/_scenarios/monkey06_closures_test.almd
@@ -1,0 +1,113 @@
+// Monkey test 06: クロージャ・高階関数・キャプチャ
+
+// 基本ラムダ
+test "lambda basic" {
+    let f = (x) => x + 1
+    assert_eq(f(10), 11)
+}
+
+test "lambda two args" {
+    let add = (a, b) => a + b
+    assert_eq(add(3, 4), 7)
+}
+
+test "lambda block body" {
+    let f = (x) => {
+        let y = x * 2
+        y + 1
+    }
+    assert_eq(f(5), 11)
+}
+
+// キャプチャ
+test "capture immutable" {
+    let base = 100
+    let add_base = (x) => x + base
+    assert_eq(add_base(5), 105)
+    assert_eq(add_base(10), 110)
+}
+
+test "capture string" {
+    let prefix = ">> "
+    let decorate = (s) => prefix + s
+    assert_eq(decorate("hello"), ">> hello")
+}
+
+test "capture list" {
+    let base = [1, 2, 3]
+    let extend = (x) => base + [x]
+    assert_eq(extend(4), [1, 2, 3, 4])
+    // 再度呼んでも base は変わらない
+    assert_eq(extend(5), [1, 2, 3, 5])
+}
+
+// 関数返却
+fn make_adder(n: Int) -> (Int) -> Int = (x) => x + n
+
+test "function returning function" {
+    let add5 = make_adder(5)
+    let add10 = make_adder(10)
+    assert_eq(add5(3), 8)
+    assert_eq(add10(3), 13)
+}
+
+// 関数を引数に取る
+fn apply_twice(f: (Int) -> Int, x: Int) -> Int = f(f(x))
+
+test "higher-order argument" {
+    assert_eq(apply_twice((x) => x + 1, 5), 7)
+    assert_eq(apply_twice((x) => x * 2, 3), 12)
+}
+
+// 関数合成
+fn compose(f: (Int) -> Int, g: (Int) -> Int) -> (Int) -> Int =
+    (x) => f(g(x))
+
+test "function composition" {
+    let inc = (x) => x + 1
+    let dbl = (x) => x * 2
+    let inc_then_dbl = compose(dbl, inc)   // dbl(inc(x)) = (x+1)*2
+    assert_eq(inc_then_dbl(3), 8)
+}
+
+// map に複雑な lambda
+test "map with captured value" {
+    let offset = 100
+    let xs = [1, 2, 3]
+    let result = xs |> list.map((x) => x + offset)
+    assert_eq(result, [101, 102, 103])
+}
+
+// 入れ子 lambda
+test "nested lambda" {
+    let make_multiplier = (factor) => (x) => x * factor
+    let triple = make_multiplier(3)
+    assert_eq(triple(7), 21)
+}
+
+// filter + map パイプ
+test "filter then map" {
+    let xs = [1, 2, 3, 4, 5, 6]
+    let result = xs
+        |> list.filter((x) => x % 2 == 0)
+        |> list.map((x) => x * x)
+    assert_eq(result, [4, 16, 36])
+}
+
+// fold でクロージャ
+test "fold with closure" {
+    let words = ["foo", "bar", "baz"]
+    let joined = words |> list.fold("", (acc, w) => acc + w + ",")
+    assert_eq(joined, "foo,bar,baz,")
+}
+
+// 高階関数 + ローカル状態
+fn count_if(xs: List[Int], pred: (Int) -> Bool) -> Int =
+    xs |> list.fold(0, (acc, x) => if pred(x) then acc + 1 else acc)
+
+test "count_if" {
+    let xs = [1, 2, 3, 4, 5, 6, 7, 8]
+    assert_eq(count_if(xs, (x) => x > 4), 4)
+    assert_eq(count_if(xs, (x) => x % 2 == 0), 4)
+    assert_eq(count_if(xs, (x) => x < 0), 0)
+}

--- a/_scenarios/monkey07_recursion_test.almd
+++ b/_scenarios/monkey07_recursion_test.almd
@@ -1,0 +1,97 @@
+// Monkey test 07: 再帰・相互再帰
+
+fn fact(n: Int) -> Int =
+    if n <= 1 then 1 else n * fact(n - 1)
+
+test "factorial" {
+    assert_eq(fact(0), 1)
+    assert_eq(fact(1), 1)
+    assert_eq(fact(5), 120)
+    assert_eq(fact(10), 3628800)
+}
+
+fn fib(n: Int) -> Int =
+    if n < 2 then n else fib(n - 1) + fib(n - 2)
+
+test "fibonacci" {
+    assert_eq(fib(0), 0)
+    assert_eq(fib(1), 1)
+    assert_eq(fib(10), 55)
+    assert_eq(fib(15), 610)
+}
+
+// 末尾再帰
+fn sum_tail(n: Int, acc: Int) -> Int =
+    if n == 0 then acc else sum_tail(n - 1, acc + n)
+
+test "tail recursion" {
+    assert_eq(sum_tail(10, 0), 55)
+    assert_eq(sum_tail(100, 0), 5050)
+    assert_eq(sum_tail(1000, 0), 500500)
+}
+
+// リスト長 自前再帰
+fn my_len(xs: List[Int]) -> Int =
+    match xs {
+        [] => 0,
+        _ => todo("not implemented for general lists"),
+    }
+
+// 安全側: fold で定義
+fn len_via_fold(xs: List[Int]) -> Int =
+    xs |> list.fold(0, (acc, _) => acc + 1)
+
+test "length via fold" {
+    assert_eq(len_via_fold([]), 0)
+    assert_eq(len_via_fold([1, 2, 3]), 3)
+    assert_eq(len_via_fold([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), 10)
+}
+
+// Ackermann (小さい値のみ)
+fn ack(m: Int, n: Int) -> Int =
+    if m == 0 then n + 1
+    else if n == 0 then ack(m - 1, 1)
+    else ack(m - 1, ack(m, n - 1))
+
+test "ackermann small" {
+    assert_eq(ack(0, 0), 1)
+    assert_eq(ack(1, 1), 3)
+    assert_eq(ack(2, 2), 7)
+    assert_eq(ack(3, 3), 61)
+}
+
+// 相互再帰
+fn is_even(n: Int) -> Bool =
+    if n == 0 then true else is_odd(n - 1)
+
+fn is_odd(n: Int) -> Bool =
+    if n == 0 then false else is_even(n - 1)
+
+test "mutual recursion" {
+    assert(is_even(0))
+    assert(not is_even(1))
+    assert(is_odd(1))
+    assert(is_even(10))
+    assert(is_odd(11))
+}
+
+// GCD
+fn gcd(a: Int, b: Int) -> Int =
+    if b == 0 then a else gcd(b, a % b)
+
+test "gcd" {
+    assert_eq(gcd(12, 8), 4)
+    assert_eq(gcd(100, 75), 25)
+    assert_eq(gcd(17, 13), 1)
+    assert_eq(gcd(0, 5), 5)
+}
+
+// 再帰でリスト生成
+fn range_rec(from: Int, to: Int) -> List[Int] =
+    if from >= to then [] else [from] + range_rec(from + 1, to)
+
+test "range via recursion" {
+    assert_eq(range_rec(0, 0), [])
+    assert_eq(range_rec(1, 5), [1, 2, 3, 4])
+    assert_eq(list.len(range_rec(0, 100)), 100)
+}

--- a/_scenarios/monkey08_option_result_test.almd
+++ b/_scenarios/monkey08_option_result_test.almd
@@ -1,0 +1,132 @@
+// Monkey test 08: Option / Result / エラー処理
+
+// 基本: Option
+test "option some none" {
+    let x: Option[Int] = some(42)
+    let y: Option[Int] = none
+    assert_eq(x, some(42))
+    assert_eq(y, none)
+}
+
+// ?? fallback
+test "option fallback" {
+    let x = some(10) ?? 0
+    let y = none ?? 99
+    assert_eq(x, 10)
+    assert_eq(y, 99)
+}
+
+// nested option pattern
+fn unwrap_default(o: Option[Int], default: Int) -> Int =
+    match o {
+        some(v) => v,
+        none => default,
+    }
+
+test "manual unwrap" {
+    assert_eq(unwrap_default(some(7), 0), 7)
+    assert_eq(unwrap_default(none, 0), 0)
+}
+
+// Result 基本
+fn safe_div(a: Int, b: Int) -> Result[Int, String] =
+    if b == 0 then err("division by zero") else ok(a / b)
+
+test "result basic" {
+    assert_eq(safe_div(10, 2), ok(5))
+    assert_eq(safe_div(10, 0), err("division by zero"))
+}
+
+// Result を Option に変換 (?)
+test "result to option" {
+    let r1 = safe_div(10, 2)
+    let r2 = safe_div(10, 0)
+    assert_eq(r1?, some(5))
+    assert_eq(r2?, none)
+}
+
+// ?? fallback for Result
+test "result fallback" {
+    let v1 = safe_div(10, 2) ?? -1
+    let v2 = safe_div(10, 0) ?? -1
+    assert_eq(v1, 5)
+    assert_eq(v2, -1)
+}
+
+// effect fn + unwrap !
+effect fn checked_sqrt(x: Float) -> Float =
+    if x < 0.0 then err("negative")! else float.sqrt(x)
+
+test "checked sqrt ok" {
+    assert(checked_sqrt(4.0)! > 1.9)
+}
+
+test "checked sqrt err" {
+    assert_eq(checked_sqrt(-1.0), err("negative"))
+}
+
+// 連鎖
+effect fn ladder(x: Int) -> Int = {
+    let r1 = safe_div(100, x)!
+    let r2 = safe_div(r1, 2)!
+    r2
+}
+
+test "ladder ok" {
+    assert_eq(ladder(4)!, 12)  // 100/4=25, 25/2=12
+}
+
+test "ladder err propagates" {
+    assert_eq(ladder(0), err("division by zero"))
+}
+
+// Option[Record] で ?.field
+type User = { name: String, age: Int }
+
+fn find_user(id: Int) -> Option[User] =
+    if id == 1 then some({ name: "alice", age: 30 })
+    else none
+
+test "optional chaining" {
+    let u = find_user(1)
+    let name = u?.name
+    assert_eq(name, some("alice"))
+
+    let u2 = find_user(99)
+    let name2 = u2?.name
+    assert_eq(name2, none)
+}
+
+// Option を List に平坦化
+test "filter_map with option" {
+    let xs = [1, 2, 3, 4, 5]
+    let evens = xs |> list.filter_map((x) =>
+        if x % 2 == 0 then some(x) else none
+    )
+    assert_eq(evens, [2, 4])
+}
+
+// エラー伝播
+effect fn pipeline(s: String) -> Int = {
+    guard string.len(s) > 0 else err("empty")!
+    let parsed = int.parse(s)!
+    parsed * 2
+}
+
+test "pipeline ok" {
+    assert_eq(pipeline("42")!, 84)
+}
+
+test "pipeline empty err" {
+    match pipeline("") {
+        err(e) => assert_eq(e, "empty"),
+        ok(_) => assert(false),
+    }
+}
+
+test "pipeline parse err" {
+    match pipeline("not a number") {
+        err(_) => assert(true),
+        ok(_) => assert(false),
+    }
+}

--- a/_scenarios/monkey09_map_set_test.almd
+++ b/_scenarios/monkey09_map_set_test.almd
@@ -1,0 +1,110 @@
+// Monkey test 09: Map / Set の動作確認
+
+test "map literal" {
+    let m = ["a": 1, "b": 2, "c": 3]
+    assert_eq(map.len(m), 3)
+    assert(map.contains(m, "a"))
+    assert(map.contains(m, "b"))
+    assert(not map.contains(m, "z"))
+}
+
+test "map index read" {
+    let m = ["x": 10, "y": 20]
+    assert_eq(m["x"], some(10))
+    assert_eq(m["y"], some(20))
+    assert_eq(m["z"], none)
+}
+
+test "empty map" {
+    let m: Map[String, Int] = [:]
+    assert_eq(map.len(m), 0)
+    assert(map.is_empty(m))
+}
+
+test "map set (immutable insert)" {
+    let m = ["a": 1]
+    // 関数名は map.set (map.insert は存在しない)
+    let m2 = map.set(m, "b", 2)
+    assert_eq(map.len(m2), 2)
+    assert_eq(m2["b"], some(2))
+    // 元の map は不変
+    assert_eq(map.len(m), 1)
+}
+
+test "map get with default" {
+    let m = ["a": 1, "b": 2]
+    let v = m["a"] ?? 0
+    let w = m["z"] ?? 0
+    assert_eq(v, 1)
+    assert_eq(w, 0)
+}
+
+test "map keys values" {
+    let m = ["a": 1, "b": 2, "c": 3]
+    let keys = map.keys(m)
+    let vals = map.values(m)
+    assert_eq(list.len(keys), 3)
+    assert_eq(list.len(vals), 3)
+    // 順序は不定なので sum で確認
+    assert_eq(vals |> list.fold(0, (a, b) => a + b), 6)
+}
+
+test "map remove" {
+    let m = ["a": 1, "b": 2, "c": 3]
+    let m2 = map.remove(m, "b")
+    assert_eq(map.len(m2), 2)
+    assert_eq(m2["b"], none)
+}
+
+test "map with int keys" {
+    let m: Map[Int, String] = [1: "one", 2: "two", 3: "three"]
+    assert_eq(m[1], some("one"))
+    assert_eq(m[100], none)
+}
+
+// ── Set ──
+test "set basic" {
+    let s = set.from_list([1, 2, 3, 2, 1])
+    assert_eq(set.len(s), 3)
+    assert(set.contains(s, 1))
+    assert(set.contains(s, 2))
+    assert(not set.contains(s, 99))
+}
+
+test "set insert and remove" {
+    let s = set.from_list([1, 2])
+    let s2 = set.insert(s, 3)
+    assert_eq(set.len(s2), 3)
+    let s3 = set.remove(s2, 1)
+    assert_eq(set.len(s3), 2)
+    assert(not set.contains(s3, 1))
+}
+
+test "set union intersection" {
+    let a = set.from_list([1, 2, 3, 4])
+    let b = set.from_list([3, 4, 5, 6])
+    let u = set.union(a, b)
+    let i = set.intersection(a, b)
+    assert_eq(set.len(u), 6)
+    assert_eq(set.len(i), 2)
+    assert(set.contains(i, 3))
+    assert(set.contains(i, 4))
+}
+
+test "set diff" {
+    let a = set.from_list([1, 2, 3, 4])
+    let b = set.from_list([3, 4, 5])
+    let d = set.difference(a, b)
+    assert_eq(set.len(d), 2)
+    assert(set.contains(d, 1))
+    assert(set.contains(d, 2))
+    assert(not set.contains(d, 3))
+}
+
+test "empty set" {
+    // set.from_list([]) は空リストの要素型を推論できないので
+    // set.new() を使う (set.new は type params [A] で空 Set を返す)
+    let s: Set[Int] = set.new()
+    assert_eq(set.len(s), 0)
+    assert(set.is_empty(s))
+}

--- a/_scenarios/monkey10_generics_test.almd
+++ b/_scenarios/monkey10_generics_test.almd
@@ -1,0 +1,98 @@
+// Monkey test 10: ジェネリクス
+//
+// Regression for fixed bugs:
+//  1. silent test drop。`test "foo"` が同名の `fn foo[T]` ジェネリック関数と
+//     IR 上で衝突し、monomorphization の filter でテストごと消されていた。
+//  2. stdlib/module 関数を first-class 値として渡せなかった
+//     (`list.map(xs, string.len)` が E003 で落ちていた)。
+//     値位置の `module.func` を eta 展開して lambda にするようにした。
+
+// 基本: ジェネリック関数
+fn identity[T](x: T) -> T = x
+
+test "identity int" {
+    assert_eq(identity(42), 42)
+}
+
+test "identity string" {
+    assert_eq(identity("hello"), "hello")
+}
+
+test "identity list" {
+    assert_eq(identity([1, 2, 3]), [1, 2, 3])
+}
+
+// 2つの型パラメータ
+fn pair_first[A, B](a: A, b: B) -> A = a
+fn pair_second[A, B](a: A, b: B) -> B = b
+
+test "pair first / second" {
+    assert_eq(pair_first(1, "hi"), 1)
+    assert_eq(pair_second(1, "hi"), "hi")
+    assert_eq(pair_first("a", 2), "a")
+}
+
+// ジェネリックコレクション関数
+fn my_head[T](xs: List[T], default: T) -> T =
+    list.first(xs) ?? default
+
+test "my_head" {
+    assert_eq(my_head([1, 2, 3], 0), 1)
+    assert_eq(my_head([], 0), 0)
+    assert_eq(my_head(["a", "b"], "x"), "a")
+}
+
+// ジェネリック型 (record)
+type Pair[A, B] = { first: A, second: B }
+
+fn make_pair[A, B](a: A, b: B) -> Pair[A, B] = { first: a, second: b }
+
+fn swap_pair[A, B](p: Pair[A, B]) -> Pair[B, A] =
+    { first: p.second, second: p.first }
+
+test "generic record" {
+    let p = make_pair(1, "one")
+    assert_eq(p.first, 1)
+    assert_eq(p.second, "one")
+}
+
+test "swap generic record" {
+    let p = make_pair(42, "answer")
+    let s = swap_pair(p)
+    assert_eq(s.first, "answer")
+    assert_eq(s.second, 42)
+}
+
+// ジェネリック variant (Option 的) — 以前は単一ケース inline variant バグで
+// 無限ループしていた形
+type Box[T] = Box(T)
+
+fn unbox[T](b: Box[T]) -> T = match b { Box(v) => v }
+
+test "generic variant" {
+    assert_eq(unbox(Box(10)), 10)
+    assert_eq(unbox(Box("hi")), "hi")
+}
+
+// ジェネリック関数をリスト combinator で呼ぶ
+fn wrap_all[T](xs: List[T]) -> List[Box[T]] =
+    xs |> list.map((x) => Box(x))
+
+test "wrap_all" {
+    let boxed = wrap_all([1, 2, 3])
+    assert_eq(list.len(boxed), 3)
+    assert_eq(unbox(list.first(boxed) ?? Box(0)), 1)
+}
+
+// 高階ジェネリック
+fn apply_all[A, B](xs: List[A], f: (A) -> B) -> List[B] =
+    xs |> list.map(f)
+
+test "apply_all" {
+    let doubled = apply_all([1, 2, 3], (x) => x * 2)
+    assert_eq(doubled, [2, 4, 6])
+
+    // stdlib 関数をそのまま first-class 値として渡す (修正済み)
+    let lengths = apply_all(["a", "bb", "ccc"], string.len)
+    assert_eq(lengths, [1, 2, 3])
+}

--- a/_scenarios/monkey11_float_test.almd
+++ b/_scenarios/monkey11_float_test.almd
@@ -1,0 +1,71 @@
+// Monkey test 11: Float 演算
+
+test "basic float arithmetic" {
+    assert_eq(1.0 + 2.0, 3.0)
+    assert_eq(10.0 - 3.5, 6.5)
+    assert_eq(2.0 * 4.0, 8.0)
+    assert_eq(10.0 / 4.0, 2.5)
+}
+
+test "float comparison" {
+    assert(0.1 + 0.2 > 0.29)
+    assert(0.1 + 0.2 < 0.31)
+    // 浮動小数誤差: 0.1 + 0.2 != 0.3 (strict equality)
+    // assert_ne(0.1 + 0.2, 0.3) — 環境依存
+}
+
+test "negative float" {
+    assert_eq(-1.5 + 2.5, 1.0)
+    assert_eq(-3.0 * -2.0, 6.0)
+}
+
+test "sqrt" {
+    assert_eq(float.sqrt(4.0), 2.0)
+    assert_eq(float.sqrt(9.0), 3.0)
+    assert(float.sqrt(2.0) > 1.41)
+    assert(float.sqrt(2.0) < 1.42)
+}
+
+test "pow" {
+    assert_eq(2.0 ^ 3.0, 8.0)
+    assert_eq(10.0 ^ 2.0, 100.0)
+}
+
+test "abs" {
+    assert_eq(float.abs(-3.14), 3.14)
+    assert_eq(float.abs(3.14), 3.14)
+    assert_eq(float.abs(0.0), 0.0)
+}
+
+test "min max" {
+    assert_eq(float.min(1.5, 2.5), 1.5)
+    assert_eq(float.max(1.5, 2.5), 2.5)
+}
+
+test "round floor ceil" {
+    assert_eq(float.round(2.5), 3.0)
+    assert_eq(float.round(2.4), 2.0)
+    assert_eq(float.floor(2.9), 2.0)
+    assert_eq(float.ceil(2.1), 3.0)
+    assert_eq(float.floor(-2.1), -3.0)
+    assert_eq(float.ceil(-2.9), -2.0)
+}
+
+test "to_string" {
+    // 整数値の float
+    let s = float.to_string(3.0)
+    assert(string.contains(s, "3"))
+}
+
+test "int to float conversion" {
+    let i = 5
+    let f = int.to_float(i)
+    assert_eq(f, 5.0)
+    assert_eq(f + 0.5, 5.5)
+}
+
+test "float to int truncation" {
+    assert_eq(float.to_int(3.9), 3)
+    assert_eq(float.to_int(3.1), 3)
+    assert_eq(float.to_int(-3.9), -3)
+}

--- a/_scenarios/monkey12_control_flow_test.almd
+++ b/_scenarios/monkey12_control_flow_test.almd
@@ -1,0 +1,121 @@
+// Monkey test 12: 制御フロー — for / while / guard / if else
+
+// for in range
+test "for loop sum via var" {
+    var sum = 0
+    for i in 0..10 {
+        sum = sum + i
+    }
+    assert_eq(sum, 45)
+}
+
+// for in list
+test "for loop over list" {
+    var result: List[String] = []
+    for name in ["alice", "bob", "carol"] {
+        result = result + [name]
+    }
+    assert_eq(list.len(result), 3)
+}
+
+// while loop
+test "while loop" {
+    var i = 0
+    var product = 1
+    while i < 5 {
+        product = product * 2
+        i = i + 1
+    }
+    assert_eq(product, 32)
+}
+
+// if-else
+test "if as expression" {
+    let x = 10
+    let sign = if x > 0 then "+" else if x < 0 then "-" else "0"
+    assert_eq(sign, "+")
+}
+
+test "if with blocks" {
+    let n = 7
+    let msg = if n > 5 then {
+        let prefix = "big "
+        prefix + "number"
+    } else {
+        "small"
+    }
+    assert_eq(msg, "big number")
+}
+
+// nested if
+test "nested if" {
+    let score = 85
+    let grade =
+        if score >= 90 then "A"
+        else if score >= 80 then "B"
+        else if score >= 70 then "C"
+        else if score >= 60 then "D"
+        else "F"
+    assert_eq(grade, "B")
+}
+
+// guard in effect fn
+effect fn validate(n: Int) -> Int = {
+    guard n > 0 else err("must be positive")!
+    guard n < 100 else err("too large")!
+    n * 2
+}
+
+test "guard ok" {
+    assert_eq(validate(5)!, 10)
+}
+
+test "guard first fail" {
+    assert_eq(validate(-1), err("must be positive"))
+}
+
+test "guard second fail" {
+    assert_eq(validate(200), err("too large"))
+}
+
+// for (k, v) over map
+test "for over map entries" {
+    let m = ["a": 1, "b": 2, "c": 3]
+    var total = 0
+    for (_, v) in m {
+        total = total + v
+    }
+    assert_eq(total, 6)
+}
+
+// break-like via early return (via match / guard)
+effect fn find_first_even(xs: List[Int]) -> Int = {
+    guard list.any(xs, (x) => x % 2 == 0) else err("no even")!
+    xs |> list.find((x) => x % 2 == 0) ?? -1
+}
+
+test "find first even" {
+    assert_eq(find_first_even([1, 3, 4, 5])!, 4)
+    assert_eq(find_first_even([1, 3, 5]), err("no even"))
+}
+
+// compound boolean
+test "boolean short circuit" {
+    let a = true
+    let b = false
+    assert(a or b)
+    assert(not (a and b))
+    assert(a and not b)
+    assert((a or b) and (a or not b))
+}
+
+// for with index via enumerate
+test "for with enumerate" {
+    let xs = ["x", "y", "z"]
+    var indexed: List[String] = []
+    for pair in list.enumerate(xs) {
+        let (i, s) = pair
+        indexed = indexed + ["${int.to_string(i)}:${s}"]
+    }
+    assert_eq(indexed, ["0:x", "1:y", "2:z"])
+}

--- a/_scenarios/monkey13_records_test.almd
+++ b/_scenarios/monkey13_records_test.almd
@@ -1,0 +1,138 @@
+// Monkey test 13: レコード・スプレッド・デストラクチャ
+//
+// Regression for fixed bug: 部分デストラクチャで `..` が自動挿入されなかった。
+// 以前は `let { name, age } = user` で User 型の残りフィールドを無視できず
+// Rust E0027 で壊れていた。
+
+type User = { name: String, age: Int, email: String }
+type Person = { name: String, age: Int }
+
+test "record literal and field access" {
+    let u = { name: "alice", age: 30, email: "a@x.com" }
+    assert_eq(u.name, "alice")
+    assert_eq(u.age, 30)
+    assert_eq(u.email, "a@x.com")
+}
+
+test "spread update single field" {
+    let u = { name: "alice", age: 30, email: "a@x.com" }
+    let u2 = { ...u, age: 31 }
+    assert_eq(u2.name, "alice")
+    assert_eq(u2.age, 31)
+    assert_eq(u2.email, "a@x.com")
+    // 元は不変
+    assert_eq(u.age, 30)
+}
+
+test "spread update multiple fields" {
+    let u = { name: "alice", age: 30, email: "a@x.com" }
+    let u2 = { ...u, age: 31, email: "new@x.com" }
+    assert_eq(u2.age, 31)
+    assert_eq(u2.email, "new@x.com")
+}
+
+test "nested record" {
+    let p = {
+        center: { x: 1, y: 2 },
+        radius: 3
+    }
+    assert_eq(p.center.x, 1)
+    assert_eq(p.center.y, 2)
+    assert_eq(p.radius, 3)
+}
+
+test "destructure partial" {
+    let u: User = { name: "alice", age: 30, email: "a@x.com" }
+    let { name, age } = u
+    assert_eq(name, "alice")
+    assert_eq(age, 30)
+}
+
+test "destructure full" {
+    let u: User = { name: "alice", age: 30, email: "a@x.com" }
+    let { name, age, email } = u
+    assert_eq(name, "alice")
+    assert_eq(age, 30)
+    assert_eq(email, "a@x.com")
+}
+
+// レコードのリスト
+test "list of records" {
+    let users: List[Person] = [
+        { name: "alice", age: 30 },
+        { name: "bob", age: 25 },
+        { name: "carol", age: 35 },
+    ]
+    assert_eq(list.len(users), 3)
+    let names = users |> list.map((u) => u.name)
+    assert_eq(names, ["alice", "bob", "carol"])
+    let ages = users |> list.map((u) => u.age)
+    let avg = (ages |> list.fold(0, (a, b) => a + b)) / list.len(ages)
+    assert_eq(avg, 30)
+}
+
+// レコードをフィルタ
+test "filter records" {
+    let users: List[Person] = [
+        { name: "alice", age: 30 },
+        { name: "bob", age: 25 },
+        { name: "carol", age: 35 },
+    ]
+    let adults = users |> list.filter((u) => u.age >= 30)
+    assert_eq(list.len(adults), 2)
+}
+
+// レコードを変換
+test "map records" {
+    let users: List[Person] = [
+        { name: "alice", age: 30 },
+        { name: "bob", age: 25 },
+    ]
+    let aged = users |> list.map((u) => { ...u, age: u.age + 1 })
+    let a0: Person = list.first(aged) ?? { name: "", age: 0 }
+    assert_eq(a0.age, 31)
+}
+
+// 同名フィールド shorthand (record literal)
+test "field shorthand" {
+    let name = "alice"
+    let age = 30
+    // ショートハンド構文があれば...
+    let u: Person = { name: name, age: age }
+    assert_eq(u.name, "alice")
+    assert_eq(u.age, 30)
+}
+
+// 再帰的レコード
+type Tree = { value: Int, left: Option[Int], right: Option[Int] }
+
+test "record with Option fields" {
+    let root = { value: 10, left: some(5), right: some(15) }
+    let leaf = { value: 1, left: none, right: none }
+    assert_eq(root.value, 10)
+    assert_eq(root.left, some(5))
+    assert_eq(leaf.left, none)
+}
+
+// ジェネリックレコード (不使用の場合)
+type Response[T] = { code: Int, body: T, message: String }
+
+fn ok_response[T](body: T) -> Response[T] =
+    { code: 200, body: body, message: "OK" }
+
+test "generic response int" {
+    let r = ok_response(42)
+    assert_eq(r.code, 200)
+    assert_eq(r.body, 42)
+}
+
+test "generic response string" {
+    let r = ok_response("hello")
+    assert_eq(r.body, "hello")
+    assert_eq(r.message, "OK")
+}
+
+test "generic response list" {
+    let r = ok_response([1, 2, 3])
+    assert_eq(list.len(r.body), 3)
+}

--- a/_scenarios/monkey14_edge_cases_test.almd
+++ b/_scenarios/monkey14_edge_cases_test.almd
@@ -1,0 +1,158 @@
+// Monkey test 14: エッジケース・境界値
+
+// 空リストと各種操作
+test "empty list combinators" {
+    let xs: List[Int] = []
+    assert_eq(xs |> list.map((x) => x + 1), [])
+    assert_eq(xs |> list.filter((x) => x > 0), [])
+    assert_eq(xs |> list.fold(42, (a, b) => a + b), 42)
+    assert_eq(xs |> list.find((x) => x > 0), none)
+    assert(list.is_empty(xs))
+}
+
+// 単一要素リスト
+test "singleton list" {
+    let xs = [42]
+    assert_eq(list.len(xs), 1)
+    assert_eq(list.first(xs), some(42))
+    assert_eq(list.last(xs), some(42))
+    assert_eq(xs |> list.reverse, [42])
+}
+
+// ネストした Option
+test "nested option" {
+    let double: Option[Option[Int]] = some(some(5))
+    match double {
+        some(inner) => match inner {
+            some(v) => assert_eq(v, 5),
+            none => assert(false),
+        },
+        none => assert(false),
+    }
+}
+
+// Result of Option
+test "result of option" {
+    let r: Result[Option[Int], String] = ok(some(10))
+    match r {
+        ok(opt) => assert_eq(opt, some(10)),
+        err(_) => assert(false),
+    }
+}
+
+// 極端に長い文字列補間
+test "long interpolation" {
+    let a = 1
+    let b = 2
+    let c = 3
+    let d = 4
+    let s = "${int.to_string(a)}+${int.to_string(b)}+${int.to_string(c)}+${int.to_string(d)}=${int.to_string(a+b+c+d)}"
+    assert_eq(s, "1+2+3+4=10")
+}
+
+// 文字列に特殊文字
+test "special characters in string" {
+    let s = "tab\there\nnewline\"quoted\""
+    assert(string.contains(s, "\t"))
+    assert(string.contains(s, "\n"))
+    assert(string.contains(s, "\""))
+}
+
+// 0 除算は err を返す (safe_div 経由)
+effect fn safe_int_div(a: Int, b: Int) -> Int = {
+    guard b != 0 else err("div by zero")!
+    a / b
+}
+
+test "zero division guarded" {
+    assert_eq(safe_int_div(10, 2)!, 5)
+    assert_eq(safe_int_div(10, 0), err("div by zero"))
+}
+
+// 複雑なネスト構造
+type Inventory = {
+    id: String,
+    items: List[{ name: String, qty: Int }],
+    tags: List[String],
+}
+
+test "complex nested structure" {
+    let inv: Inventory = {
+        id: "W001",
+        items: [
+            { name: "apple", qty: 10 },
+            { name: "banana", qty: 5 },
+        ],
+        tags: ["perishable", "fresh"],
+    }
+    assert_eq(inv.id, "W001")
+    assert_eq(list.len(inv.items), 2)
+    assert_eq(list.len(inv.tags), 2)
+    let total_qty = inv.items |> list.fold(0, (acc, item) => acc + item.qty)
+    assert_eq(total_qty, 15)
+}
+
+// if 式のネスト
+test "nested if expressions" {
+    let grade = (score: Int) =>
+        if score >= 90 then "A"
+        else if score >= 80 then "B"
+        else if score >= 70 then "C"
+        else "F"
+    assert_eq(grade(95), "A")
+    assert_eq(grade(85), "B")
+    assert_eq(grade(75), "C")
+    assert_eq(grade(50), "F")
+}
+
+// Bool 演算
+test "boolean edge" {
+    assert(true and true)
+    assert(not (true and false))
+    assert(true or false)
+    assert(not (false or false))
+    assert(not false)
+    assert(not not true)
+}
+
+// 一度も呼ばれないブランチでも型が合う
+fn safe_head(xs: List[Int]) -> Int =
+    match xs {
+        [] => 0,
+        _ => list.first(xs) ?? 0,
+    }
+
+test "safe head" {
+    assert_eq(safe_head([]), 0)
+    assert_eq(safe_head([1, 2, 3]), 1)
+}
+
+// BUG FOUND (error cascade):
+//   let binding の識別子を大文字始まり (`let MyValue = 42`) にすると
+//   パーサが「TypeName を識別子位置で見た」と怒る。それ自体は正しい
+//   診断だが、後続の行 `assert_eq(result, 216)` まで
+//   "expected MyValue but got Int" という別エラーが雪崩で出る。
+//   エラー回復が未到達コードまで波及している。
+// 回避: snake_case を使う
+test "mixed case identifiers" {
+    let my_value = 42
+    let my_other = my_value + 1
+    assert_eq(my_other, 43)
+}
+
+// 深いネスト
+test "deeply nested lambda" {
+    let f = (a) => (b) => (c) => (d) => a + b + c + d
+    assert_eq(f(1)(2)(3)(4), 10)
+}
+
+// 配列のパイプチェーン
+test "long pipe chain" {
+    let result = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        |> list.filter((x) => x % 2 == 0)
+        |> list.map((x) => x * x)
+        |> list.filter((x) => x > 10)
+        |> list.fold(0, (acc, x) => acc + x)
+    // [2,4,6,8,10] → [4,16,36,64,100] → [16,36,64,100] → sum = 216
+    assert_eq(result, 216)
+}

--- a/_scenarios/monkey15_protocols_test.almd
+++ b/_scenarios/monkey15_protocols_test.almd
@@ -1,0 +1,63 @@
+// Monkey test 15: プロトコル / convention methods
+//
+// Regression for fixed bugs:
+//  1. 構造的に同一な nominal 型 (Dog / Cat が両方 {name: String}) が
+//     type alias resolution で unify されていた。
+//  2. プロトコル境界ジェネリック [T: Animal] の monomorphization が
+//     `T_species(...)` という未定義関数を吐いていた (上の bug に起因)。
+
+protocol Animal {
+  fn species(a: Self) -> String
+  fn sound(a: Self) -> String
+}
+
+// 同じ {name: String} でも nominal 型として別物であることが保たれる
+type Dog: Animal = { name: String }
+fn Dog.species(d: Dog) -> String = "dog"
+fn Dog.sound(d: Dog) -> String = "woof"
+
+type Cat: Animal = { name: String }
+fn Cat.species(c: Cat) -> String = "cat"
+fn Cat.sound(c: Cat) -> String = "meow"
+
+test "dog protocol methods" {
+    let d: Dog = { name: "rex" }
+    assert_eq(d.species(), "dog")
+    assert_eq(d.sound(), "woof")
+}
+
+test "cat protocol methods" {
+    let c: Cat = { name: "whiskers" }
+    assert_eq(c.species(), "cat")
+    assert_eq(c.sound(), "meow")
+}
+
+// プロトコル境界ジェネリック — 以前は T_species(...) で崩壊していた形
+fn describe[T: Animal](a: T) -> String =
+    "${a.species()} says ${a.sound()}"
+
+test "generic over protocol" {
+    let d: Dog = { name: "rex" }
+    assert_eq(describe(d), "dog says woof")
+    let c: Cat = { name: "whiskers" }
+    assert_eq(describe(c), "cat says meow")
+}
+
+// 組み込み convention: Eq
+type Color: Eq = Red | Green | Blue
+
+test "builtin eq convention" {
+    assert(Red == Red)
+    assert(not (Red == Green))
+    assert(Blue != Red)
+}
+
+// Ord convention
+type Priority: Ord, Eq = Low | Medium | High
+
+test "builtin ord convention" {
+    assert(Low < Medium)
+    assert(Medium < High)
+    assert(Low < High)
+    assert(High > Low)
+}

--- a/_scenarios/scenario10_invariant_test.almd
+++ b/_scenarios/scenario10_invariant_test.almd
@@ -1,0 +1,151 @@
+// Scenario 10: 不変条件の強制
+// 医療: 投薬量は必ず正の値、血圧は生理的範囲内
+// 金融: 残高は非負、利率は 0-100%
+
+// --- Smart constructor パターン ---
+
+type PositiveInt = PositiveInt(Int)
+
+fn positive_int(n: Int) -> Result[PositiveInt, String] = {
+    guard n > 0 else err("must be positive, got ${int.to_string(n)}")
+    ok(PositiveInt(n))
+}
+
+fn pos_value(p: PositiveInt) -> Int = match p { PositiveInt(v) => v }
+
+type Percentage = Percentage(Float)
+
+fn percentage(v: Float) -> Result[Percentage, String] = {
+    guard v >= 0.0 else err("percentage must be >= 0")
+    guard v <= 100.0 else err("percentage must be <= 100")
+    ok(Percentage(v))
+}
+
+fn pct_value(p: Percentage) -> Float = match p { Percentage(v) => v }
+
+type BloodPressure = { systolic: Int, diastolic: Int }
+
+fn blood_pressure(sys: Int, dia: Int) -> Result[BloodPressure, String] = {
+    guard sys > 0 and sys < 300 else err("systolic out of range: ${int.to_string(sys)}")
+    guard dia > 0 and dia < 200 else err("diastolic out of range: ${int.to_string(dia)}")
+    guard sys > dia else err("systolic must be > diastolic")
+    ok({ systolic: sys, diastolic: dia })
+}
+
+fn bp_category(bp: BloodPressure) -> String =
+    if bp.systolic < 120 and bp.diastolic < 80 then "normal"
+    else if bp.systolic < 130 and bp.diastolic < 80 then "elevated"
+    else if bp.systolic < 140 or bp.diastolic < 90 then "high-stage1"
+    else "high-stage2"
+
+test "positive int accepts valid" {
+    match positive_int(42) {
+        ok(p) => assert_eq(pos_value(p), 42),
+        err(_) => assert(false, "should accept 42"),
+    }
+}
+
+test "positive int rejects zero" {
+    match positive_int(0) {
+        err(e) => assert(string.contains(e, "positive")),
+        ok(_) => assert(false, "should reject 0"),
+    }
+}
+
+test "positive int rejects negative" {
+    match positive_int(-5) {
+        err(e) => assert(string.contains(e, "positive")),
+        ok(_) => assert(false, "should reject -5"),
+    }
+}
+
+test "percentage valid" {
+    match percentage(50.0) {
+        ok(p) => assert_eq(pct_value(p), 50.0),
+        err(_) => assert(false, "should accept 50%"),
+    }
+}
+
+test "percentage boundary" {
+    assert_eq(percentage(0.0), ok(Percentage(0.0)))
+    assert_eq(percentage(100.0), ok(Percentage(100.0)))
+}
+
+test "percentage rejects out of range" {
+    match percentage(150.0) {
+        err(_) => assert(true),
+        ok(_) => assert(false, "should reject 150%"),
+    }
+    match percentage(-10.0) {
+        err(_) => assert(true),
+        ok(_) => assert(false, "should reject -10%"),
+    }
+}
+
+test "blood pressure normal" {
+    match blood_pressure(110, 70) {
+        ok(bp) => assert_eq(bp_category(bp), "normal"),
+        err(_) => assert(false, "should accept 110/70"),
+    }
+}
+
+test "blood pressure high" {
+    match blood_pressure(150, 95) {
+        ok(bp) => assert_eq(bp_category(bp), "high-stage2"),
+        err(_) => assert(false, "should accept 150/95"),
+    }
+}
+
+test "blood pressure invalid range" {
+    match blood_pressure(50, 80) {
+        err(e) => assert(string.contains(e, "systolic must be > diastolic")),
+        ok(_) => assert(false, "systolic < diastolic should fail"),
+    }
+}
+
+test "blood pressure out of physiological range" {
+    match blood_pressure(350, 70) {
+        err(e) => assert(string.contains(e, "out of range")),
+        ok(_) => assert(false, "350 systolic should fail"),
+    }
+}
+
+// --- 複合バリデーション: 投薬オーダー ---
+
+type MedOrder = {
+    patient_id: String,
+    drug_name: String,
+    dose_mg: PositiveInt,
+    frequency_per_day: PositiveInt,
+}
+
+effect fn create_med_order(patient: String, drug: String, dose: Int, freq: Int) -> MedOrder = {
+    let d = positive_int(dose)!
+    let f = positive_int(freq)!
+    guard pos_value(f) <= 6 else err("frequency too high: max 6 per day")
+    { patient_id: patient, drug_name: drug, dose_mg: d, frequency_per_day: f }
+}
+
+test "valid med order" {
+    match create_med_order("P001", "Aspirin", 100, 3) {
+        ok(order) => {
+            assert_eq(order.patient_id, "P001")
+            assert_eq(pos_value(order.dose_mg), 100)
+        },
+        err(e) => assert(false, "should succeed: ${e}"),
+    }
+}
+
+test "med order rejects zero dose" {
+    match create_med_order("P001", "Aspirin", 0, 3) {
+        err(e) => assert(string.contains(e, "positive")),
+        ok(_) => assert(false, "should reject zero dose"),
+    }
+}
+
+test "med order rejects excessive frequency" {
+    match create_med_order("P001", "Aspirin", 100, 10) {
+        err(e) => assert(string.contains(e, "frequency")),
+        ok(_) => assert(false, "should reject freq > 6"),
+    }
+}

--- a/_scenarios/scenario1_payment_test.almd
+++ b/_scenarios/scenario1_payment_test.almd
@@ -1,0 +1,65 @@
+// Scenario 1: 複数決済プロバイダ — match dispatch
+
+type PaymentResult = { tx_id: String, status: String, provider_name: String }
+type RefundResult = { tx_id: String, refunded: Bool }
+
+type Provider = Stripe(String) | PayPal(String, String) | Square(String)
+
+fn charge(provider: Provider, amount: Int, currency: String) -> PaymentResult =
+    match provider {
+        Stripe(key)        => { tx_id: "stripe_tx_001", status: "ok", provider_name: "stripe" },
+        PayPal(id, secret) => { tx_id: "paypal_tx_001", status: "ok", provider_name: "paypal" },
+        Square(key)        => { tx_id: "square_tx_001", status: "ok", provider_name: "square" },
+    }
+
+fn refund(provider: Provider, tx_id: String) -> RefundResult =
+    match provider {
+        Stripe(_)     => { tx_id: tx_id, refunded: true },
+        PayPal(_, _)  => { tx_id: tx_id, refunded: true },
+        Square(_)     => { tx_id: tx_id, refunded: false },
+    }
+
+fn provider_name(provider: Provider) -> String =
+    match provider {
+        Stripe(_)     => "Stripe",
+        PayPal(_, _)  => "PayPal",
+        Square(_)     => "Square",
+    }
+
+type Order = { total: Int, currency: String, item: String }
+
+fn process_order(provider: Provider, order: Order) -> String = {
+    let result = charge(provider, order.total, order.currency)
+    "Charged ${int.to_string(order.total)} ${order.currency} via ${provider_name(provider)}: ${result.status}"
+}
+
+test "stripe charge" {
+    let p = Stripe("sk_test_xxx")
+    let result = charge(p, 1000, "JPY")
+    assert_eq(result.provider_name, "stripe")
+    assert_eq(result.status, "ok")
+}
+
+test "paypal charge" {
+    let p = PayPal("client_id", "secret")
+    let result = charge(p, 2000, "USD")
+    assert_eq(result.provider_name, "paypal")
+}
+
+test "process order" {
+    let order = { total: 5000, currency: "JPY", item: "widget" }
+    let msg = process_order(Stripe("key"), order)
+    assert_eq(msg, "Charged 5000 JPY via Stripe: ok")
+}
+
+test "refund square fails" {
+    let result = refund(Square("key"), "tx_123")
+    assert_eq(result.refunded, false)
+}
+
+test "multi-provider dispatch" {
+    let providers = [Stripe("k1"), PayPal("id", "sec"), Square("k2")]
+    let order = { total: 100, currency: "USD", item: "test" }
+    let results = providers |> list.map((p) => process_order(p, order))
+    assert_eq(list.len(results), 3)
+}

--- a/_scenarios/scenario2_notification_test.almd
+++ b/_scenarios/scenario2_notification_test.almd
@@ -1,0 +1,80 @@
+// Scenario 2: 通知システム — 複数チャネル dispatch + 設定の違い
+
+type SmtpConfig = { host: String, port: Int }
+type TwilioConfig = { account_sid: String, auth_token: String }
+type FcmConfig = { project_id: String }
+
+type Channel = Email(SmtpConfig) | Sms(TwilioConfig) | Push(FcmConfig) | Slack(String)
+
+type Message = { subject: String, body: String }
+
+fn channel_name(ch: Channel) -> String =
+    match ch {
+        Email(_) => "email",
+        Sms(_)   => "sms",
+        Push(_)  => "push",
+        Slack(_) => "slack",
+    }
+
+fn supports_rich_text(ch: Channel) -> Bool =
+    match ch {
+        Email(_) => true,
+        Slack(_) => true,
+        _        => false,
+    }
+
+fn send(ch: Channel, recipient: String, msg: Message) -> String =
+    match ch {
+        Email(config) => "sent email to ${recipient} via ${config.host}: ${msg.subject}",
+        Sms(config)   => "sent sms to ${recipient}: ${msg.body}",
+        Push(config)  => "sent push to ${recipient} (project: ${config.project_id})",
+        Slack(url)    => "sent slack to ${recipient} via webhook",
+    }
+
+fn notify_all(channels: List[Channel], recipient: String, msg: Message) -> List[String] =
+    channels |> list.map((ch) => send(ch, recipient, msg))
+
+fn notify_rich_only(channels: List[Channel], recipient: String, msg: Message) -> List[String] =
+    channels
+        |> list.filter(supports_rich_text)
+        |> list.map((ch) => send(ch, recipient, msg))
+
+test "send email" {
+    let ch = Email({ host: "smtp.example.com", port: 587 })
+    let result = send(ch, "alice@example.com", { subject: "Hello", body: "Hi there" })
+    assert_eq(result, "sent email to alice@example.com via smtp.example.com: Hello")
+}
+
+test "send sms" {
+    let ch = Sms({ account_sid: "AC123", auth_token: "token" })
+    let result = send(ch, "+81901234567", { subject: "", body: "Your code: 1234" })
+    assert_eq(result, "sent sms to +81901234567: Your code: 1234")
+}
+
+test "supports rich text" {
+    assert_eq(supports_rich_text(Email({ host: "smtp", port: 25 })), true)
+    assert_eq(supports_rich_text(Slack("https://hooks.slack.com/xxx")), true)
+    assert_eq(supports_rich_text(Sms({ account_sid: "x", auth_token: "y" })), false)
+    assert_eq(supports_rich_text(Push({ project_id: "proj" })), false)
+}
+
+test "notify all channels" {
+    let channels = [
+        Email({ host: "smtp", port: 25 }),
+        Sms({ account_sid: "x", auth_token: "y" }),
+        Slack("https://hooks.slack.com/xxx"),
+    ]
+    let results = notify_all(channels, "bob", { subject: "Alert", body: "Server down" })
+    assert_eq(list.len(results), 3)
+}
+
+test "notify rich only" {
+    let channels = [
+        Email({ host: "smtp", port: 25 }),
+        Sms({ account_sid: "x", auth_token: "y" }),
+        Push({ project_id: "proj" }),
+        Slack("https://hooks.slack.com/xxx"),
+    ]
+    let results = notify_rich_only(channels, "carol", { subject: "Report", body: "See attached" })
+    assert_eq(list.len(results), 2)
+}

--- a/_scenarios/scenario3_pipeline_test.almd
+++ b/_scenarios/scenario3_pipeline_test.almd
@@ -1,0 +1,127 @@
+// Scenario 3: データ変換パイプライン — CSV → バリデーション → 正規化 → 集計
+
+type UserRow = { name: String, email: String, age: Int }
+
+fn parse_row(line: String) -> Result[UserRow, String] = {
+    let parts = string.split(line, ",")
+    match list.len(parts) {
+        3 => {
+            let name = list.get(parts, 0) ?? ""
+            let email = list.get(parts, 1) ?? ""
+            let age_str = list.get(parts, 2) ?? "0"
+            match int.parse(string.trim(age_str)) {
+                ok(age) => ok({ name: string.trim(name), email: string.trim(email), age: age }),
+                err(e) => err("invalid age: ${age_str}"),
+            }
+        },
+        _ => err("expected 3 fields, got ${int.to_string(list.len(parts))}"),
+    }
+}
+
+fn validate_user(user: UserRow) -> Result[UserRow, String] = {
+    guard user.age > 0 and user.age < 150 else err("invalid age: ${int.to_string(user.age)}")
+    guard string.contains(user.email, "@") else err("invalid email: ${user.email}")
+    guard string.len(user.name) > 0 else err("empty name")
+    ok(user)
+}
+
+fn normalize_user(user: UserRow) -> UserRow =
+    { name: string.trim(user.name), email: string.to_lower(user.email), age: user.age }
+
+effect fn import_users(lines: List[String]) -> List[UserRow] = {
+    let parsed = lines
+        |> list.map(parse_row)
+        |> result.collect!
+    let validated = parsed
+        |> list.map(validate_user)
+        |> result.collect!
+    let normalized = validated |> list.map(normalize_user)
+    normalized
+}
+
+fn average_age(users: List[UserRow]) -> Int = {
+    let total = users |> list.fold(0, (acc, u) => acc + u.age)
+    if list.len(users) > 0 then total / list.len(users) else 0
+}
+
+fn users_by_domain(users: List[UserRow], domain: String) -> List[UserRow] =
+    users |> list.filter((u) => string.ends_with(u.email, domain))
+
+test "parse valid row" {
+    let result = parse_row("Alice, alice@example.com, 30")
+    assert_eq(result, ok({ name: "Alice", email: "alice@example.com", age: 30 }))
+}
+
+test "parse invalid row" {
+    let result = parse_row("only,two")
+    match result {
+        err(_) => assert(true),
+        ok(_) => assert(false, "should fail"),
+    }
+}
+
+test "validate valid user" {
+    let user = { name: "Bob", email: "bob@test.com", age: 25 }
+    assert_eq(validate_user(user), ok(user))
+}
+
+test "validate invalid age" {
+    let user = { name: "Old", email: "old@test.com", age: 200 }
+    match validate_user(user) {
+        err(msg) => assert(string.contains(msg, "invalid age")),
+        ok(_) => assert(false, "should fail"),
+    }
+}
+
+test "validate invalid email" {
+    let user = { name: "Bad", email: "no-at-sign", age: 25 }
+    match validate_user(user) {
+        err(msg) => assert(string.contains(msg, "invalid email")),
+        ok(_) => assert(false, "should fail"),
+    }
+}
+
+test "full pipeline success" {
+    let lines = [
+        "Alice, alice@example.com, 30",
+        "Bob, BOB@EXAMPLE.COM, 25",
+    ]
+    let result = import_users(lines)
+    match result {
+        ok(users) => {
+            assert_eq(list.len(users), 2)
+            let first = list.get(users, 0) ?? { name: "", email: "", age: 0 }
+            assert_eq(first.email, "alice@example.com")
+            let second = list.get(users, 1) ?? { name: "", email: "", age: 0 }
+            assert_eq(second.email, "bob@example.com")
+        },
+        err(e) => assert(false, "should succeed: ${e}"),
+    }
+}
+
+test "full pipeline parse error" {
+    let lines = ["Alice, alice@example.com, 30", "bad-line"]
+    match import_users(lines) {
+        err(_) => assert(true),
+        ok(_) => assert(false, "should fail"),
+    }
+}
+
+test "average age" {
+    let users = [
+        { name: "A", email: "a@test.com", age: 20 },
+        { name: "B", email: "b@test.com", age: 30 },
+        { name: "C", email: "c@test.com", age: 40 },
+    ]
+    assert_eq(average_age(users), 30)
+}
+
+test "filter by domain" {
+    let users = [
+        { name: "A", email: "a@gmail.com", age: 20 },
+        { name: "B", email: "b@company.com", age: 30 },
+        { name: "C", email: "c@gmail.com", age: 40 },
+    ]
+    let gmail_users = users_by_domain(users, "@gmail.com")
+    assert_eq(list.len(gmail_users), 2)
+}

--- a/_scenarios/scenario4_report_test.almd
+++ b/_scenarios/scenario4_report_test.almd
@@ -1,0 +1,113 @@
+// Scenario 4: レポート生成 — 複数フォーマット出力
+
+type Format = Html | Csv | Markdown | Json
+
+type ReportData = {
+    title: String,
+    headers: List[String],
+    rows: List[List[String]],
+}
+
+fn render_header(fmt: Format, title: String) -> String =
+    match fmt {
+        Html     => "<h1>${title}</h1>\n",
+        Csv      => "# ${title}\n",
+        Markdown => "# ${title}\n\n",
+        Json     => """{"title":"${title}",""",
+    }
+
+fn render_table(fmt: Format, headers: List[String], rows: List[List[String]]) -> String =
+    match fmt {
+        Html => {
+            let header_cells = headers |> list.map((h) => "<th>${h}</th>") |> list.join("")
+            let row_strs = rows |> list.map((row) => {
+                let cells = row |> list.map((c) => "<td>${c}</td>") |> list.join("")
+                "<tr>${cells}</tr>"
+            }) |> list.join("\n")
+            "<table><tr>${header_cells}</tr>\n${row_strs}</table>"
+        },
+        Csv => {
+            let header_line = headers |> list.join(",")
+            let row_lines = rows |> list.map((row) => row |> list.join(",")) |> list.join("\n")
+            "${header_line}\n${row_lines}"
+        },
+        Markdown => {
+            let header_line = "| " + (headers |> list.join(" | ")) + " |"
+            let sep = "| " + (headers |> list.map((_) => "---") |> list.join(" | ")) + " |"
+            let row_lines = rows |> list.map((row) => "| " + (row |> list.join(" | ")) + " |") |> list.join("\n")
+            "${header_line}\n${sep}\n${row_lines}"
+        },
+        Json => {
+            let row_objs = rows |> list.map((row) => {
+                let pairs = list.zip(headers, row)
+                    |> list.map((pair) => {
+                        let (k, v) = pair
+                        "\"${k}\":\"${v}\""
+                    })
+                    |> list.join(",")
+                "{${pairs}}"
+            }) |> list.join(",")
+            "\"rows\":[${row_objs}]}"
+        },
+    }
+
+fn generate_report(fmt: Format, data: ReportData) -> String =
+    render_header(fmt, data.title) + render_table(fmt, data.headers, data.rows)
+
+fn content_type(fmt: Format) -> String =
+    match fmt {
+        Html     => "text/html",
+        Csv      => "text/csv",
+        Markdown => "text/markdown",
+        Json     => "application/json",
+    }
+
+// テスト用データ
+fn sample_data() -> ReportData = {
+    title: "Sales Report",
+    headers: ["Name", "Amount", "Status"],
+    rows: [
+        ["Alice", "1000", "paid"],
+        ["Bob", "2000", "pending"],
+    ],
+}
+
+test "csv report" {
+    let report = generate_report(Csv, sample_data())
+    assert(string.contains(report, "Sales Report"))
+    assert(string.contains(report, "Name,Amount,Status"))
+    assert(string.contains(report, "Alice,1000,paid"))
+}
+
+test "html report" {
+    let report = generate_report(Html, sample_data())
+    assert(string.contains(report, "<h1>Sales Report</h1>"))
+    assert(string.contains(report, "<th>Name</th>"))
+    assert(string.contains(report, "<td>Alice</td>"))
+}
+
+test "markdown report" {
+    let report = generate_report(Markdown, sample_data())
+    assert(string.contains(report, "# Sales Report"))
+    assert(string.contains(report, "| Name | Amount | Status |"))
+    assert(string.contains(report, "| Alice | 1000 | paid |"))
+}
+
+test "json report" {
+    let report = generate_report(Json, sample_data())
+    assert(string.contains(report, "\"title\":\"Sales Report\""))
+    assert(string.contains(report, "\"Name\":\"Alice\""))
+}
+
+test "content types" {
+    assert_eq(content_type(Html), "text/html")
+    assert_eq(content_type(Csv), "text/csv")
+    assert_eq(content_type(Json), "application/json")
+}
+
+test "all formats produce output" {
+    let formats = [Html, Csv, Markdown, Json]
+    let reports = formats |> list.map((fmt) => generate_report(fmt, sample_data()))
+    let all_non_empty = reports |> list.all((r) => string.len(r) > 0)
+    assert(all_non_empty)
+}

--- a/_scenarios/scenario5_minimal2_test.almd
+++ b/_scenarios/scenario5_minimal2_test.almd
@@ -1,0 +1,17 @@
+// Even more minimal: Record with Fn field
+
+type Handler = {
+    run: (String) -> String,
+    name: String,
+}
+
+fn make_handler(n: String) -> Handler = {
+    run: (x) => n + ":" + x,
+    name: n,
+}
+
+test "single handler" {
+    let h = make_handler("echo")
+    assert_eq(h.name, "echo")
+    assert_eq(h.run("hello"), "echo:hello")
+}

--- a/_scenarios/scenario5_minimal3_test.almd
+++ b/_scenarios/scenario5_minimal3_test.almd
@@ -1,0 +1,17 @@
+// Minimal: Record with Fn field — try different call styles
+
+type Handler = {
+    run: (String) -> String,
+    name: String,
+}
+
+fn make_handler(n: String) -> Handler = {
+    run: (x) => n + ":" + x,
+    name: n,
+}
+
+test "field access then call" {
+    let h = make_handler("echo")
+    let f = h.run
+    assert_eq(f("hello"), "echo:hello")
+}

--- a/_scenarios/scenario5_minimal_test.almd
+++ b/_scenarios/scenario5_minimal_test.almd
@@ -1,0 +1,22 @@
+// Minimal repro: Record with function field in a List
+
+type Handler = {
+    run: (String) -> String,
+    name: String,
+}
+
+fn make_handler(n: String) -> Handler = {
+    run: (x) => n + ":" + x,
+    name: n,
+}
+
+test "single handler" {
+    let h = make_handler("echo")
+    assert_eq(h.name, "echo")
+    assert_eq(h.run("hello"), "echo:hello")
+}
+
+test "list of handlers" {
+    let handlers = [make_handler("a"), make_handler("b")]
+    assert_eq(list.len(handlers), 2)
+}

--- a/_scenarios/scenario5_plugin_test.almd
+++ b/_scenarios/scenario5_plugin_test.almd
@@ -1,0 +1,138 @@
+// Scenario 5: プラグイン/SDK — 関数 Record で trait object を代用
+
+// "trait object" を Record of functions で表現
+type DataSource = {
+    fetch: (String) -> Result[List[String], String],
+    name: String,
+    schema: List[String],
+}
+
+// プロバイダ実装（サードパーティが自由に作れる）
+fn make_fetch(f: (String) -> Result[List[String], String]) -> (String) -> Result[List[String], String] = f
+
+fn postgres_source(conn_str: String) -> DataSource = {
+    fetch: make_fetch((query) => ok(["row1:alice:30", "row2:bob:25"])),
+    name: "postgres",
+    schema: ["id", "name", "age"],
+}
+
+fn csv_source(path: String) -> DataSource = {
+    fetch: make_fetch((query) => ok(["alice,30", "bob,25", "carol,35"])),
+    name: "csv:" + path,
+    schema: ["name", "age"],
+}
+
+fn mock_source(rows: List[String]) -> DataSource = {
+    fetch: make_fetch((_) => ok(rows)),
+    name: "mock",
+    schema: ["data"],
+}
+
+fn failing_source(error_msg: String) -> DataSource = {
+    fetch: make_fetch((_) => err(error_msg)),
+    name: "failing",
+    schema: [],
+}
+
+// DataSource を使うコア関数 — 実装の詳細を知らない
+effect fn fetch_all(source: DataSource) -> List[String] =
+    source.fetch("SELECT *")!
+
+fn source_info(source: DataSource) -> String =
+    "${source.name} (${int.to_string(list.len(source.schema))} columns)"
+
+effect fn merge_sources(sources: List[DataSource]) -> List[String] = {
+    var all_rows: List[String] = []
+    for src in sources {
+        let rows = src.fetch("*")!
+        all_rows = all_rows + rows
+    }
+    all_rows
+}
+
+// フィルタ付き fetch — 高階関数との組み合わせ
+effect fn fetch_filtered(source: DataSource, pred: (String) -> Bool) -> List[String] = {
+    let rows = source.fetch("*")!
+    rows |> list.filter(pred)
+}
+
+// DataSource のリストから共通操作
+fn find_source(sources: List[DataSource], name: String) -> Option[DataSource] =
+    sources |> list.find((s) => s.name == name)
+
+test "postgres source" {
+    let src = postgres_source("host=localhost dbname=test")
+    assert_eq(src.name, "postgres")
+    assert_eq(list.len(src.schema), 3)
+    match src.fetch("SELECT * FROM users") {
+        ok(rows) => assert_eq(list.len(rows), 2),
+        err(_) => assert(false, "should succeed"),
+    }
+}
+
+test "csv source" {
+    let src = csv_source("/data/users.csv")
+    assert_eq(src.name, "csv:/data/users.csv")
+    match src.fetch("*") {
+        ok(rows) => assert_eq(list.len(rows), 3),
+        err(_) => assert(false, "should succeed"),
+    }
+}
+
+test "mock source" {
+    let src = mock_source(["a", "b", "c"])
+    match src.fetch("anything") {
+        ok(rows) => assert_eq(rows, ["a", "b", "c"]),
+        err(_) => assert(false, "should succeed"),
+    }
+}
+
+test "failing source" {
+    let src = failing_source("connection refused")
+    match src.fetch("*") {
+        err(e) => assert_eq(e, "connection refused"),
+        ok(_) => assert(false, "should fail"),
+    }
+}
+
+test "source info" {
+    let src = postgres_source("localhost")
+    assert_eq(source_info(src), "postgres (3 columns)")
+}
+
+test "merge multiple sources" {
+    let sources = [
+        mock_source(["a", "b"]),
+        mock_source(["c", "d", "e"]),
+    ]
+    match merge_sources(sources) {
+        ok(rows) => assert_eq(list.len(rows), 5),
+        err(_) => assert(false, "should succeed"),
+    }
+}
+
+test "merge with failure" {
+    let sources = [
+        mock_source(["a"]),
+        failing_source("timeout"),
+    ]
+    match merge_sources(sources) {
+        err(e) => assert_eq(e, "timeout"),
+        ok(_) => assert(false, "should fail"),
+    }
+}
+
+test "fetch filtered" {
+    let src = mock_source(["alice:30", "bob:25", "carol:35"])
+    match fetch_filtered(src, (row) => string.contains(row, "alice")) {
+        ok(rows) => {
+            assert_eq(list.len(rows), 1)
+            let first = list.get(rows, 0) ?? ""
+            assert(string.contains(first, "alice"))
+        },
+        err(_) => assert(false, "should succeed"),
+    }
+}
+
+// SKIPPED: find_source — list.find with Record-of-functions triggers TypeVar resolution bug
+// test "find source by name" { ... }

--- a/_scenarios/scenario6_newtype_test.almd
+++ b/_scenarios/scenario6_newtype_test.almd
@@ -1,0 +1,62 @@
+// Scenario 6: Newtype safety — 型の取り違え防止
+// 医療: 患者IDと薬剤IDを間違えたら死ぬ
+// 金融: USDとJPYを間違えたら破産する
+
+type PatientId = PatientId(String)
+type DrugId = DrugId(String)
+type DoseAmount = DoseAmount(Float)
+
+type Prescription = {
+    patient: PatientId,
+    drug: DrugId,
+    dose: DoseAmount,
+}
+
+fn prescribe(patient: PatientId, drug: DrugId, dose: DoseAmount) -> Prescription =
+    { patient: patient, drug: drug, dose: dose }
+
+fn patient_id_str(id: PatientId) -> String =
+    match id { PatientId(s) => s }
+
+fn drug_id_str(id: DrugId) -> String =
+    match id { DrugId(s) => s }
+
+fn dose_value(d: DoseAmount) -> Float =
+    match d { DoseAmount(v) => v }
+
+test "correct prescription" {
+    let rx = prescribe(PatientId("P001"), DrugId("D042"), DoseAmount(5.0))
+    assert_eq(patient_id_str(rx.patient), "P001")
+    assert_eq(drug_id_str(rx.drug), "D042")
+}
+
+// このテストが型エラーで弾かれることを期待:
+// prescribe(DrugId("D042"), PatientId("P001"), DoseAmount(5.0))
+// → 引数の順序を間違えたら コンパイルエラー になるべき
+
+// --- 通貨の取り違え ---
+
+type USD = USD(Int)
+type JPY = JPY(Int)
+
+fn add_usd(a: USD, b: USD) -> USD =
+    match a { USD(x) => match b { USD(y) => USD(x + y) } }
+
+fn add_jpy(a: JPY, b: JPY) -> JPY =
+    match a { JPY(x) => match b { JPY(y) => JPY(x + y) } }
+
+fn usd_value(u: USD) -> Int = match u { USD(v) => v }
+fn jpy_value(j: JPY) -> Int = match j { JPY(v) => v }
+
+test "USD addition" {
+    let total = add_usd(USD(100), USD(200))
+    assert_eq(usd_value(total), 300)
+}
+
+test "JPY addition" {
+    let total = add_jpy(JPY(10000), JPY(5000))
+    assert_eq(jpy_value(total), 15000)
+}
+
+// このテストが型エラーで弾かれることを期待:
+// add_usd(USD(100), JPY(5000))  → コンパイルエラー

--- a/_scenarios/scenario7_state_machine_test.almd
+++ b/_scenarios/scenario7_state_machine_test.almd
@@ -1,0 +1,94 @@
+// Scenario 7: 状態遷移の安全性
+// 医療: 未承認の処方を投薬したら事故
+// 金融: 未決済の注文を出荷したら損害
+
+// --- 注文ステートマシン ---
+
+type OrderDraft = { items: List[String], customer: String }
+type OrderConfirmed = { items: List[String], customer: String, confirmed_at: String }
+type OrderPaid = { items: List[String], customer: String, confirmed_at: String, paid_at: String, amount: Int }
+type OrderShipped = { items: List[String], customer: String, tracking: String }
+
+// 各遷移を関数で表現 — 型が遷移を強制する
+fn create_order(customer: String, items: List[String]) -> OrderDraft =
+    { items: items, customer: customer }
+
+fn confirm_order(draft: OrderDraft, timestamp: String) -> OrderConfirmed =
+    { items: draft.items, customer: draft.customer, confirmed_at: timestamp }
+
+fn pay_order(confirmed: OrderConfirmed, amount: Int, timestamp: String) -> OrderPaid =
+    { items: confirmed.items, customer: confirmed.customer, confirmed_at: confirmed.confirmed_at, paid_at: timestamp, amount: amount }
+
+fn ship_order(paid: OrderPaid, tracking: String) -> OrderShipped =
+    { items: paid.items, customer: paid.customer, tracking: tracking }
+
+test "valid order flow" {
+    let draft = create_order("alice", ["widget", "gadget"])
+    let confirmed = confirm_order(draft, "2026-04-01T10:00")
+    let paid = pay_order(confirmed, 5000, "2026-04-01T11:00")
+    let shipped = ship_order(paid, "TRACK-001")
+    assert_eq(shipped.tracking, "TRACK-001")
+    assert_eq(shipped.customer, "alice")
+}
+
+// ship_order(confirmed, "TRACK-001")  → 型エラー: 未決済は出荷できない
+// pay_order(draft, 5000, "...")        → 型エラー: 未確認は決済できない
+
+// --- 処方ステートマシン ---
+
+type RxDraft = { patient: String, drug: String, dose: Float }
+type RxApproved = { patient: String, drug: String, dose: Float, approver: String }
+type RxDispensed = { patient: String, drug: String, dose: Float, approver: String, dispensed_by: String }
+
+fn draft_rx(patient: String, drug: String, dose: Float) -> RxDraft =
+    { patient: patient, drug: drug, dose: dose }
+
+fn approve_rx(draft: RxDraft, approver: String) -> RxApproved =
+    { patient: draft.patient, drug: draft.drug, dose: draft.dose, approver: approver }
+
+fn dispense_rx(approved: RxApproved, pharmacist: String) -> RxDispensed =
+    { patient: approved.patient, drug: approved.drug, dose: approved.dose, approver: approved.approver, dispensed_by: pharmacist }
+
+test "valid prescription flow" {
+    let draft = draft_rx("P001", "Aspirin", 100.0)
+    let approved = approve_rx(draft, "Dr. Smith")
+    let dispensed = dispense_rx(approved, "Pharmacist Jones")
+    assert_eq(dispensed.approver, "Dr. Smith")
+    assert_eq(dispensed.dispensed_by, "Pharmacist Jones")
+}
+
+// dispense_rx(draft, "Jones")  → 型エラー: 未承認は調剤できない
+
+// --- 境界値バリデーション ---
+
+fn validate_dose(dose: Float) -> Result[Float, String] = {
+    guard dose > 0.0 else err("dose must be positive")
+    guard dose <= 1000.0 else err("dose exceeds maximum (1000mg)")
+    ok(dose)
+}
+
+fn validate_amount(amount: Int) -> Result[Int, String] = {
+    guard amount > 0 else err("amount must be positive")
+    guard amount <= 10000000 else err("amount exceeds limit (10M)")
+    ok(amount)
+}
+
+test "dose validation" {
+    assert_eq(validate_dose(100.0), ok(100.0))
+    match validate_dose(0.0) {
+        err(e) => assert(string.contains(e, "positive")),
+        ok(_) => assert(false, "should reject zero dose"),
+    }
+    match validate_dose(2000.0) {
+        err(e) => assert(string.contains(e, "maximum")),
+        ok(_) => assert(false, "should reject excessive dose"),
+    }
+}
+
+test "amount validation" {
+    assert_eq(validate_amount(5000), ok(5000))
+    match validate_amount(-100) {
+        err(e) => assert(string.contains(e, "positive")),
+        ok(_) => assert(false, "should reject negative"),
+    }
+}

--- a/_scenarios/scenario8_error_taxonomy_test.almd
+++ b/_scenarios/scenario8_error_taxonomy_test.almd
@@ -1,0 +1,126 @@
+// Scenario 8: エラー分類の網羅性
+// 医療: エラーの種類ごとに対応が違う（アレルギー vs 在庫切れ vs システム障害）
+// 金融: 残高不足 vs 限度額超過 vs 不正検知 で後続処理が全く異なる
+
+type PaymentError = InsufficientFunds(Int, Int) | ExceedsLimit(Int, Int) | FraudDetected(String) | NetworkError(String) | CardExpired(String)
+
+fn error_severity(e: PaymentError) -> String =
+    match e {
+        FraudDetected(_) => "critical",
+        NetworkError(_)  => "retryable",
+        CardExpired(_)   => "user-action",
+        InsufficientFunds(_, _) => "user-action",
+        ExceedsLimit(_, _)      => "user-action",
+    }
+
+fn error_message(e: PaymentError) -> String =
+    match e {
+        InsufficientFunds(balance, required) =>
+            "残高不足: 残高 ${int.to_string(balance)}円, 必要 ${int.to_string(required)}円",
+        ExceedsLimit(amount, limit) =>
+            "限度額超過: ${int.to_string(amount)}円 > 上限${int.to_string(limit)}円",
+        FraudDetected(reason) =>
+            "不正検知: ${reason}",
+        NetworkError(msg) =>
+            "通信エラー: ${msg}",
+        CardExpired(card_last4) =>
+            "カード期限切れ: ****${card_last4}",
+    }
+
+fn should_retry(e: PaymentError) -> Bool =
+    match e {
+        NetworkError(_) => true,
+        _ => false,
+    }
+
+fn should_alert_security(e: PaymentError) -> Bool =
+    match e {
+        FraudDetected(_) => true,
+        _ => false,
+    }
+
+// 決済処理シミュレーション
+fn process_payment(balance: Int, limit: Int, amount: Int, card_valid: Bool) -> Result[Int, PaymentError] = {
+    guard card_valid else err(CardExpired("1234"))
+    guard amount <= limit else err(ExceedsLimit(amount, limit))
+    guard balance >= amount else err(InsufficientFunds(balance, amount))
+    ok(balance - amount)
+}
+
+test "successful payment" {
+    assert_eq(process_payment(10000, 50000, 3000, true), ok(7000))
+}
+
+test "insufficient funds" {
+    match process_payment(1000, 50000, 3000, true) {
+        err(InsufficientFunds(bal, req)) => {
+            assert_eq(bal, 1000)
+            assert_eq(req, 3000)
+        },
+        _ => assert(false, "should be InsufficientFunds"),
+    }
+}
+
+test "exceeds limit" {
+    match process_payment(100000, 50000, 60000, true) {
+        err(ExceedsLimit(amt, lim)) => {
+            assert_eq(amt, 60000)
+            assert_eq(lim, 50000)
+        },
+        _ => assert(false, "should be ExceedsLimit"),
+    }
+}
+
+test "card expired" {
+    match process_payment(10000, 50000, 3000, false) {
+        err(CardExpired(last4)) => assert_eq(last4, "1234"),
+        _ => assert(false, "should be CardExpired"),
+    }
+}
+
+test "error severity classification" {
+    assert_eq(error_severity(FraudDetected("suspicious IP")), "critical")
+    assert_eq(error_severity(NetworkError("timeout")), "retryable")
+    assert_eq(error_severity(InsufficientFunds(100, 500)), "user-action")
+}
+
+test "retry logic" {
+    assert_eq(should_retry(NetworkError("timeout")), true)
+    assert_eq(should_retry(InsufficientFunds(100, 500)), false)
+    assert_eq(should_retry(FraudDetected("bot")), false)
+}
+
+test "security alert" {
+    assert_eq(should_alert_security(FraudDetected("velocity")), true)
+    assert_eq(should_alert_security(NetworkError("timeout")), false)
+}
+
+// --- 医療エラー分類 ---
+
+type MedicalError = AllergyConflict(String, String) | ContraindicationFound(String, String) | DoseOutOfRange(Float, Float, Float) | DrugNotFound(String)
+
+fn medical_error_action(e: MedicalError) -> String =
+    match e {
+        AllergyConflict(drug, allergen) => "BLOCK: ${drug} conflicts with allergy to ${allergen}",
+        ContraindicationFound(drug1, drug2) => "WARN: ${drug1} contraindicated with ${drug2}",
+        DoseOutOfRange(dose, min, max) => "ADJUST: ${float.to_string(dose)}mg outside range ${float.to_string(min)}-${float.to_string(max)}mg",
+        DrugNotFound(name) => "CHECK: drug '${name}' not in formulary",
+    }
+
+fn is_blocking(e: MedicalError) -> Bool =
+    match e {
+        AllergyConflict(_, _) => true,
+        _ => false,
+    }
+
+test "allergy conflict is blocking" {
+    let e = AllergyConflict("Penicillin", "beta-lactam")
+    assert(is_blocking(e))
+    assert(string.contains(medical_error_action(AllergyConflict("Penicillin", "beta-lactam")), "BLOCK"))
+}
+
+test "dose out of range is non-blocking" {
+    let e = DoseOutOfRange(500.0, 10.0, 200.0)
+    assert_eq(is_blocking(e), false)
+    assert(string.contains(medical_error_action(e), "ADJUST"))
+}

--- a/_scenarios/scenario9_audit_test.almd
+++ b/_scenarios/scenario9_audit_test.almd
@@ -1,0 +1,128 @@
+// Scenario 9: 監査ログ + イベントソーシング
+// 金融: 全ての状態変更は記録されなければならない
+// 医療: 誰がいつ何をしたか追跡可能でなければならない
+
+type Event = AccountOpened(String, String) | Deposited(String, Int, String) | Withdrawn(String, Int, String) | TransferSent(String, String, Int, String) | TransferReceived(String, String, Int, String) | AccountFrozen(String, String, String)
+
+type AccountState = { id: String, balance: Int, frozen: Bool, event_count: Int }
+
+fn initial_state(id: String) -> AccountState =
+    { id: id, balance: 0, frozen: false, event_count: 0 }
+
+fn apply_event(state: AccountState, event: Event) -> Result[AccountState, String] = {
+    guard not state.frozen else err("account ${state.id} is frozen")
+    match event {
+        AccountOpened(id, _) =>
+            ok({ ...state, event_count: state.event_count + 1 }),
+        Deposited(_, amount, _) =>
+            ok({ ...state, balance: state.balance + amount, event_count: state.event_count + 1 }),
+        Withdrawn(_, amount, _) => {
+            guard state.balance >= amount else err("insufficient funds: ${int.to_string(state.balance)} < ${int.to_string(amount)}")
+            ok({ ...state, balance: state.balance - amount, event_count: state.event_count + 1 })
+        },
+        TransferSent(_, _, amount, _) => {
+            guard state.balance >= amount else err("insufficient funds for transfer")
+            ok({ ...state, balance: state.balance - amount, event_count: state.event_count + 1 })
+        },
+        TransferReceived(_, _, amount, _) =>
+            ok({ ...state, balance: state.balance + amount, event_count: state.event_count + 1 }),
+        AccountFrozen(_, _, _) =>
+            ok({ ...state, frozen: true, event_count: state.event_count + 1 }),
+    }
+}
+
+fn event_description(event: Event) -> String =
+    match event {
+        AccountOpened(id, ts) => "[${ts}] Account ${id} opened",
+        Deposited(id, amount, ts) => "[${ts}] Deposited ${int.to_string(amount)} to ${id}",
+        Withdrawn(id, amount, ts) => "[${ts}] Withdrawn ${int.to_string(amount)} from ${id}",
+        TransferSent(from, to, amount, ts) => "[${ts}] Transfer ${int.to_string(amount)} from ${from} to ${to}",
+        TransferReceived(to, from, amount, ts) => "[${ts}] Transfer ${int.to_string(amount)} received by ${to} from ${from}",
+        AccountFrozen(id, reason, ts) => "[${ts}] Account ${id} frozen: ${reason}",
+    }
+
+effect fn replay_events(events: List[Event]) -> AccountState = {
+    var state = initial_state("ACC001")
+    for event in events {
+        state = apply_event(state, event)!
+    }
+    state
+}
+
+fn build_audit_log(events: List[Event]) -> List[String] =
+    events |> list.map(event_description)
+
+test "deposit and withdraw" {
+    let events = [
+        AccountOpened("ACC001", "2026-01-01"),
+        Deposited("ACC001", 10000, "2026-01-02"),
+        Withdrawn("ACC001", 3000, "2026-01-03"),
+    ]
+    match replay_events(events) {
+        ok(state) => {
+            assert_eq(state.balance, 7000)
+            assert_eq(state.event_count, 3)
+        },
+        err(e) => assert(false, "should succeed: ${e}"),
+    }
+}
+
+test "overdraw prevented" {
+    let events = [
+        AccountOpened("ACC001", "2026-01-01"),
+        Deposited("ACC001", 1000, "2026-01-02"),
+        Withdrawn("ACC001", 5000, "2026-01-03"),
+    ]
+    match replay_events(events) {
+        err(e) => assert(string.contains(e, "insufficient")),
+        ok(_) => assert(false, "should fail on overdraw"),
+    }
+}
+
+test "frozen account rejects operations" {
+    let events = [
+        AccountOpened("ACC001", "2026-01-01"),
+        Deposited("ACC001", 10000, "2026-01-02"),
+        AccountFrozen("ACC001", "suspicious activity", "2026-01-03"),
+        Deposited("ACC001", 5000, "2026-01-04"),
+    ]
+    match replay_events(events) {
+        err(e) => assert(string.contains(e, "frozen")),
+        ok(_) => assert(false, "should reject deposit to frozen account"),
+    }
+}
+
+test "audit log completeness" {
+    let events = [
+        AccountOpened("ACC001", "2026-01-01"),
+        Deposited("ACC001", 10000, "2026-01-02"),
+        TransferSent("ACC001", "ACC002", 3000, "2026-01-03"),
+    ]
+    let log = build_audit_log(events)
+    assert_eq(list.len(log), 3)
+    let first = list.get(log, 0) ?? ""
+    assert(string.contains(first, "opened"))
+    let last = list.get(log, 2) ?? ""
+    assert(string.contains(last, "Transfer"))
+    assert(string.contains(last, "3000"))
+}
+
+test "transfer pair consistency" {
+    let send_events = [
+        AccountOpened("ACC001", "2026-01-01"),
+        Deposited("ACC001", 10000, "2026-01-01"),
+        TransferSent("ACC001", "ACC002", 3000, "2026-01-02"),
+    ]
+    let recv_events = [
+        AccountOpened("ACC002", "2026-01-01"),
+        TransferReceived("ACC002", "ACC001", 3000, "2026-01-02"),
+    ]
+    match replay_events(send_events) {
+        ok(s) => assert_eq(s.balance, 7000),
+        err(e) => assert(false, e),
+    }
+    match replay_events(recv_events) {
+        ok(r) => assert_eq(r.balance, 3000),
+        err(e) => assert(false, e),
+    }
+}

--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -87,6 +87,14 @@ template = "Ok({inner})"
 template = "Err(format!(\"{:?}\", {inner}))"
 
 [[unwrap_expr]]
+when_attr = "map_err_join"
+template = "({inner}).map_err(|errs| errs.join(\", \"))?"
+
+[[unwrap_expr]]
+when_attr = "map_err_debug"
+template = "({inner}).map_err(|e| format!(\"{:?}\", e))?"
+
+[[unwrap_expr]]
 template = "({inner})?"
 
 [[unwrap_expr]]

--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -347,6 +347,9 @@ template = "{inner}.await"
 [keyword_escape]
 template = "r#{name}"
 
+[mut_param_prefix]
+template = "mut "
+
 [map_literal]
 template = "HashMap::from([{entries}])"
 

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -1,0 +1,50 @@
+# Almide Compiler Crates
+
+## Pipeline
+
+```
+Source (.almd)
+  → almide-syntax    Lex + parse → AST
+  → almide-frontend  Type check + lower → IR
+  → almide-optimize  Monomorphize + DCE → IR
+  → almide-codegen   Nanopass + emit → Rust / WASM
+```
+
+## Dependency Graph
+
+```
+almide-base           Interned strings (Sym), spans, diagnostics
+  ↕
+almide-types          Ty enum, unification, stdlib info
+almide-syntax         Lexer, parser, AST nodes
+  ↕
+almide-lang           Re-export facade (types + syntax)
+  ↕
+almide-ir             Typed IR, VarTable, visitors
+  ↕
+almide-frontend       Type checker, constraint solver, AST→IR lowering
+almide-optimize       Monomorphization, DCE, constant propagation
+almide-codegen        Nanopass pipeline, TOML templates, walker, WASM emit
+almide-tools          Formatter, module interface, language server
+```
+
+## Core Design Principles
+
+1. **Type checker is source of truth.** All expression types come from `TypeMap` (populated by almide-frontend). Lowering and codegen trust it — they do NOT re-infer types.
+
+2. **IR carries full type info.** Every `IrExpr` has a `ty: Ty` field. Codegen must never need to query the type checker at emit time.
+
+3. **VarId eliminates shadowing.** All variables are assigned unique `VarId(u32)` during lowering. No string-based variable lookup in IR or codegen.
+
+4. **Desugar once in lowering.** Pipes (`|>`), UFCS (`x.method()`), string interpolation (`"${expr}"`) are desugared in almide-frontend's lowering pass. Codegen never sees these forms.
+
+5. **Nanopass isolation.** Each codegen pass does one semantic transformation. The walker is target-agnostic — it never checks `if target == Rust`. Target differences are encoded in pass selection and TOML templates.
+
+6. **String interning everywhere.** All identifiers, type names, field names are `Sym` (interned, `Copy`). Compare with `==`, not string matching. Use `almide_base::intern::sym()` to intern, `.as_str()` to read.
+
+## When Adding a New Feature
+
+- **New syntax** → almide-syntax (parser) → almide-frontend (checker + lowering) → almide-codegen (passes + templates)
+- **New stdlib function** → `stdlib/defs/<module>.toml` + `runtime/rs/<module>.rs` + WASM runtime in `emit_wasm/rt_*.rs`
+- **New type** → almide-types (Ty variant) → almide-frontend (inference rules) → almide-ir (IR nodes) → almide-codegen (emission)
+- **New codegen target** → almide-codegen (pass pipeline + TOML template + target entry)

--- a/crates/almide-base/CLAUDE.md
+++ b/crates/almide-base/CLAUDE.md
@@ -10,7 +10,7 @@ Foundation crate. Every other crate depends on this.
 
 ## Rules
 
-- **Never compare identifiers by string.** Use `Sym` equality (`==`). String comparison is `O(n)`; Sym comparison is `O(1)`.
+- **Never compare identifiers by string.** Use `Sym` equality (`==`). Equality is O(1) (compares interned IDs). `Sym::Ord` (`<`, `>`) intentionally compares by string content for deterministic ordering — the walker sorts record fields alphabetically for stable Rust struct layout.
 - **`sym(s)` to intern, `.as_str()` to read.** The `resolve()` function returns `&'static str` — safe because the interner never deallocates.
 - **Diagnostics must be actionable.** Every error should include a hint or suggestion when possible. Use `Diagnostic::suggest(name, candidates)` for fuzzy matching.
 - **Do not add runtime-heavy dependencies here.** This crate must compile fast — it's in every crate's dependency chain.

--- a/crates/almide-base/CLAUDE.md
+++ b/crates/almide-base/CLAUDE.md
@@ -1,0 +1,16 @@
+# almide-base
+
+Foundation crate. Every other crate depends on this.
+
+## Provides
+
+- **`Sym`** — `Copy` handle into a global thread-safe string interner (`lasso::ThreadedRodeo`). All identifiers, type names, field names throughout the compiler are `Sym`.
+- **`Span`** — Source location (line, col, end_col).
+- **`Diagnostic`** — Compiler error/warning with context, hints, and Levenshtein-based "did you mean?" suggestions.
+
+## Rules
+
+- **Never compare identifiers by string.** Use `Sym` equality (`==`). String comparison is `O(n)`; Sym comparison is `O(1)`.
+- **`sym(s)` to intern, `.as_str()` to read.** The `resolve()` function returns `&'static str` — safe because the interner never deallocates.
+- **Diagnostics must be actionable.** Every error should include a hint or suggestion when possible. Use `Diagnostic::suggest(name, candidates)` for fuzzy matching.
+- **Do not add runtime-heavy dependencies here.** This crate must compile fast — it's in every crate's dependency chain.

--- a/crates/almide-base/Cargo.toml
+++ b/crates/almide-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-base"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Foundational types for the Almide compiler (Sym, Span, Diagnostic)"

--- a/crates/almide-base/src/diagnostic.rs
+++ b/crates/almide-base/src/diagnostic.rs
@@ -1,7 +1,5 @@
 /// Almide diagnostic: every error includes an actionable fix hint.
 
-use std::sync::atomic::{AtomicBool, Ordering};
-
 // ── "Did you mean?" suggestions ────────────────────────────────
 
 /// Levenshtein edit distance between two strings.
@@ -37,29 +35,6 @@ pub fn suggest<'a>(name: &str, candidates: impl Iterator<Item = &'a str>) -> Opt
     }
     best.map(|(s, _)| s.to_string())
 }
-
-static COLOR_ENABLED: AtomicBool = AtomicBool::new(false);
-
-/// Call once at startup to enable colors if stderr is a TTY.
-pub fn init_color() {
-    use std::io::IsTerminal;
-    if std::io::stderr().is_terminal() {
-        COLOR_ENABLED.store(true, Ordering::Relaxed);
-    }
-}
-
-fn use_color() -> bool {
-    COLOR_ENABLED.load(Ordering::Relaxed)
-}
-
-// ANSI codes
-const RED: &str = "\x1b[1;31m";
-const YELLOW: &str = "\x1b[1;33m";
-const CYAN: &str = "\x1b[1;36m";
-const BLUE: &str = "\x1b[34m";
-const DIM: &str = "\x1b[2m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Level {
@@ -133,172 +108,31 @@ impl Diagnostic {
         self
     }
 
+    /// Plain-text display (no color, no source annotation).
     pub fn display(&self) -> String {
-        let color = use_color();
-        let (prefix_color, prefix) = match self.level {
-            Level::Error => (RED, "error"),
-            Level::Warning => (YELLOW, "warning"),
+        let prefix = match self.level {
+            Level::Error => "error",
+            Level::Warning => "warning",
         };
         let code_str = self.code.map(|c| format!("[{}]", c)).unwrap_or_default();
-        let mut out = if color {
-            format!("{}{}{}{}: {}{}{}", prefix_color, prefix, code_str, RESET, BOLD, self.message, RESET)
-        } else {
-            format!("{}{}: {}", prefix, code_str, self.message)
-        };
+        let mut out = format!("{}{}: {}", prefix, code_str, self.message);
         match (&self.file, self.line) {
             (Some(f), Some(l)) => {
                 let loc = match self.col {
                     Some(c) => format!("{}:{}:{}", f, l, c),
                     None => format!("{}:{}", f, l),
                 };
-                let arrow = if color { format!("{}-->{}", BLUE, RESET) } else { "-->".into() };
-                out.push_str(&format!("\n  {} {}", arrow, loc));
+                out.push_str(&format!("\n  --> {}", loc));
             }
-            (Some(f), None) => {
-                let arrow = if color { format!("{}-->{}", BLUE, RESET) } else { "-->".into() };
-                out.push_str(&format!("\n  {} {}", arrow, f));
-            }
+            (Some(f), None) => out.push_str(&format!("\n  --> {}", f)),
             (None, Some(l)) => out.push_str(&format!("\n  at line {}", l)),
             _ => {}
         }
         if !self.context.is_empty() {
-            let line = if color { format!("{}in {}{}", DIM, self.context, RESET) } else { format!("in {}", self.context) };
-            out.push_str(&format!("\n  {}", line));
+            out.push_str(&format!("\n  in {}", self.context));
         }
         if !self.hint.is_empty() {
-            let line = if color { format!("{}hint:{} {}", CYAN, RESET, self.hint) } else { format!("hint: {}", self.hint) };
-            out.push_str(&format!("\n  {}", line));
-        }
-        out
-    }
-
-    pub fn to_json(&self) -> String {
-        let level = match self.level { Level::Error => "error", Level::Warning => "warning" };
-        let code = self.code.unwrap_or("");
-        let file = self.file.as_deref().unwrap_or("");
-        let line = self.line.unwrap_or(0);
-        let col = self.col.unwrap_or(0);
-        let end_col = match self.end_col {
-            Some(c) => c.to_string(),
-            None => "null".to_string(),
-        };
-        let secondary_items: Vec<String> = self.secondary.iter().map(|s| {
-            let s_col = match s.col {
-                Some(c) => c.to_string(),
-                None => "null".to_string(),
-            };
-            format!(
-                r#"{{"line":{},"col":{},"label":"{}"}}"#,
-                s.line, s_col, s.label.replace('"', r#"\""#),
-            )
-        }).collect();
-        let secondary = format!("[{}]", secondary_items.join(","));
-        // Manual JSON to avoid serde dependency in this module
-        format!(
-            r#"{{"level":"{}","code":"{}","message":"{}","hint":"{}","context":"{}","file":"{}","line":{},"col":{},"end_col":{},"secondary":{}}}"#,
-            level, code,
-            self.message.replace('"', r#"\""#).replace('\n', "\\n"),
-            self.hint.replace('"', r#"\""#).replace('\n', "\\n"),
-            self.context.replace('"', r#"\""#),
-            file.replace('"', r#"\""#),
-            line, col, end_col, secondary,
-        )
-    }
-
-    pub fn display_with_source(&self, source: &str) -> String {
-        let color = use_color();
-        let mut out = self.display();
-        let source_lines: Vec<&str> = source.lines().collect();
-
-        // Render secondary spans first (declaration sites, etc.)
-        for sec in &self.secondary {
-            let Some(src_line) = source_lines.get(sec.line.saturating_sub(1)) else { continue; };
-            let trimmed = src_line.trim_end();
-            if trimmed.is_empty() { continue; }
-            let max_line = self.line.unwrap_or(sec.line).max(sec.line);
-            let width = format!("{}", max_line).len();
-            let gutter_pad = " ".repeat(width);
-            if color {
-                out.push_str(&format!("\n{}{} {}|{}", gutter_pad, BLUE, RESET, BLUE));
-                out.push_str(&format!("\n{}{:>width$}{} {}|{} {}",
-                    BLUE, sec.line, RESET, BLUE, RESET, trimmed, width = width));
-            } else {
-                out.push_str(&format!("\n{} |", gutter_pad));
-                out.push_str(&format!("\n{:>width$} | {}", sec.line, trimmed, width = width));
-            }
-            // Dash underline with label for secondary
-            let Some(col) = sec.col else { continue; };
-            let col0 = col.saturating_sub(1);
-            let dash_len = if !sec.label.is_empty() { sec.label.len().max(1) } else { 1 };
-            let pad = " ".repeat(col0);
-            let dashes = "-".repeat(dash_len);
-            let label_suffix = if sec.label.is_empty() { String::new() } else if color {
-                format!(" {}{}{}", CYAN, sec.label, RESET)
-            } else {
-                format!(" {}", sec.label)
-            };
-            if color {
-                out.push_str(&format!("\n{}{} {}|{} {}{}{}{}{}{}",
-                    gutter_pad, BLUE, RESET, BLUE, RESET,
-                    pad, CYAN, dashes, RESET, label_suffix));
-            } else {
-                out.push_str(&format!("\n{} | {}{}{}", gutter_pad, pad, dashes, label_suffix));
-            }
-        }
-
-        // Render primary span
-        let Some(line_num) = self.line else { return out; };
-        let Some(source_line) = source_lines.get(line_num.saturating_sub(1)) else { return out; };
-        let trimmed = source_line.trim_end();
-        if trimmed.is_empty() { return out; }
-        let width = format!("{}", line_num).len();
-        let gutter_pad = " ".repeat(width);
-        // Separator between secondary and primary if they exist
-        if self.secondary.is_empty() || self.secondary.iter().all(|s| s.line == line_num) {
-            if color {
-                out.push_str(&format!("\n{}{} {}|{}", gutter_pad, BLUE, RESET, BLUE));
-            } else {
-                out.push_str(&format!("\n{} |", gutter_pad));
-            }
-        } else {
-            // Ellipsis between distant spans
-            let ellipsis_pad = " ".repeat(width.saturating_sub(2));
-            if color {
-                out.push_str(&format!("\n{}{}...{}", BLUE, ellipsis_pad, RESET));
-            } else {
-                out.push_str(&format!("\n{}...", ellipsis_pad));
-            }
-        }
-        if color {
-            out.push_str(&format!("\n{}{:>width$}{} {}|{} {}",
-                BLUE, line_num, RESET, BLUE, RESET, trimmed, width = width));
-        } else {
-            out.push_str(&format!("\n{:>width$} | {}", line_num, trimmed, width = width));
-        }
-        // Caret underline
-        let Some(col) = self.col else { return out; };
-        let col0 = col.saturating_sub(1);
-        let caret_len = match self.end_col {
-            Some(end_col) => { let end0 = end_col.saturating_sub(1); if end0 > col0 { end0 - col0 } else { 1 } }
-            None => if !self.context.is_empty() { self.context.len().max(1) } else { 1 },
-        };
-        let pad = " ".repeat(col0);
-        let carets = "^".repeat(caret_len);
-        let (caret_color, caret_reset) = if color {
-            match self.level {
-                Level::Error => (RED, RESET),
-                Level::Warning => (YELLOW, RESET),
-            }
-        } else {
-            ("", "")
-        };
-        if color {
-            out.push_str(&format!("\n{}{} {}|{} {}{}{}{}",
-                gutter_pad, BLUE, RESET, BLUE, RESET,
-                pad, caret_color, carets));
-            out.push_str(caret_reset);
-        } else {
-            out.push_str(&format!("\n{} | {}{}", gutter_pad, pad, carets));
+            out.push_str(&format!("\n  hint: {}", self.hint));
         }
         out
     }

--- a/crates/almide-base/src/intern.rs
+++ b/crates/almide-base/src/intern.rs
@@ -152,6 +152,9 @@ impl PartialOrd for Sym {
 }
 
 impl Ord for Sym {
+    /// Compares by string content (O(n)) for deterministic ordering across
+    /// compiler invocations. Internal data structures sort Syms for canonical
+    /// field order in generated code, so the ordering must be stable.
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         if self.0 == other.0 {
             std::cmp::Ordering::Equal

--- a/crates/almide-codegen/CLAUDE.md
+++ b/crates/almide-codegen/CLAUDE.md
@@ -1,0 +1,66 @@
+# almide-codegen
+
+IR → source code (Rust) or binary (WASM). The final pipeline stage.
+
+## Three-Layer Architecture
+
+### 1. Nanopass Pipeline (`pass_*.rs`)
+
+20+ semantic transformation passes, each doing one thing. Passes are composed per target:
+
+- **Rust:** ListPatternLowering → BoxDeref → TCO → LICM → TypeConcretization → StreamFusion → BorrowInsertion → CaptureClone → CloneInsertion → MatchSubject → EffectInference → StdlibLowering → AutoParallel → ResultPropagation → BuiltinLowering → ClosureConversion (WASM only) → FanLowering
+- Each pass: `impl NanoPass { fn run(&self, program, target) -> PassResult }`
+
+### 2. TOML Templates (`templates/*.toml`)
+
+Syntax patterns for each target. Walker substitutes `{var}` placeholders. Target differences live here, not in the walker.
+
+### 3. Walker (`walker/`)
+
+Target-agnostic IR renderer. **Zero `if target == Rust` checks.** All target decisions made in passes + templates.
+
+### 4. WASM Direct Emit (`emit_wasm/`)
+
+Bypasses templates/walker entirely. IR → WASM binary via `wasm-encoder`. Has its own runtime (string ops, list ops, equality, alloc) compiled inline.
+
+## Rules
+
+- **Walker must stay target-agnostic.** If you need target-specific behavior, add a nanopass or a template guard.
+- **Nanopass passes are independent.** Each pass reads and rewrites the IrProgram. Passes must not assume ordering except through declared `Postcondition`s.
+- **WASM emit is self-contained.** It doesn't share code with the Rust walker. Type resolution, runtime functions, memory layout — all in `emit_wasm/`.
+
+## WASM Emitter (`emit_wasm/`)
+
+```
+mod.rs            Orchestrator: register types → register functions → compile
+functions.rs      IrFunction → WASM function body
+closures.rs       Lambda pre-scan + ClosureCreate compilation
+statements.rs     Statement emission + local variable pre-scanning
+expressions.rs    Expression emission (literals, binops, calls, match, etc.)
+control.rs        Match arm emission (patterns, guards, destructuring)
+equality.rs       Deep equality, comparison, record field extraction
+collections.rs    Record/list/tuple/spread construction
+values.rs         Ty → ValType mapping, byte sizes, field offsets
+calls*.rs         Stdlib dispatch (string, list, map, option, result, etc.)
+rt_*.rs           Inline WASM runtime (string ops, regex, numeric, value)
+runtime.rs        Core runtime (alloc, print, concat, equality)
+runtime_eq.rs     mem_eq, list_eq, list comparison
+scratch.rs        ScratchAllocator (bump/reuse typed temp locals)
+dce.rs            WASM-level dead function elimination
+```
+
+### Key WASM Invariants
+
+- **Memory layout:** `[len:i32][data...]` for strings and lists. Records: `[field0][field1]...`. Variants: `[tag:i32][payload...]`.
+- **`string.len` returns char count** (UTF-8 code points), not byte count. Byte count is `i32_load(0)` on the string pointer.
+- **`Ty::Unknown` → `ValType::I32` (default).** When type inference fails, WASM falls back to i32 (pointer). This is often wrong for Int (i64) — the closure conversion + function registration pipeline applies fallback resolution.
+- **Closure convention:** `(env_ptr: i32, params...) → ret`. All closures are two-word `[table_idx: i32, env_ptr: i32]`. `call_indirect` dispatches via the function table.
+- **Anonymous records** must be registered in `record_fields` via `register_anonymous_records()` so that `emit_member` can resolve field offsets even when the Lambda param type is unresolved.
+- **`sort_by` on empty lists:** The outer loop guard checks `len < 2` to prevent unsigned underflow of `len - 1`.
+
+### Adding Stdlib Functions (WASM)
+
+1. Register signature in `rt_*.rs` (`register` function).
+2. Implement body in `rt_*.rs` (`compile_*` function).
+3. Dispatch in `calls_*.rs` (method match arm).
+4. Add Almide test in `spec/stdlib/`.

--- a/crates/almide-codegen/Cargo.toml
+++ b/crates/almide-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-codegen"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide code generation: nanopass pipeline, walker, WASM emit"

--- a/crates/almide-codegen/src/emit_wasm/calls.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls.rs
@@ -493,12 +493,17 @@ impl FuncCompiler<'_> {
                         wasm!(self.func, { call(self.emitter.rt.int_to_string); });
                     }
                     "len" | "length" | "string.len" | "list.len" | "map.len" => {
-                        // .len() for String, List, Map — all store length at offset 0
+                        // For String: char count (UTF-8 code points), matching Rust runtime.
+                        // For List/Map: the length header at offset 0.
                         self.emit_expr(object);
-                        wasm!(self.func, {
-                            i32_load(0);
-                            i64_extend_i32_u;
-                        });
+                        if matches!(object.ty, Ty::String) {
+                            wasm!(self.func, { call(self.emitter.rt.string.char_count); });
+                        } else {
+                            wasm!(self.func, {
+                                i32_load(0);
+                                i64_extend_i32_u;
+                            });
+                        }
                     }
                     "to_string" | "float.to_string" if matches!(object.ty, Ty::Float) => {
                         self.emit_expr(object);

--- a/crates/almide-codegen/src/emit_wasm/calls_list.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list.rs
@@ -853,7 +853,7 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[1]);
                 // Index is always Int (i64) — wrap to i32 for memory addressing.
                 // Check both explicit type and Unknown (which may actually be Int from TupleIndex etc.)
-                if matches!(&args[1].ty, Ty::Int | Ty::Unknown | Ty::TypeVar(_)) {
+                if matches!(&args[1].ty, Ty::Int) || args[1].ty.is_unresolved() {
                     wasm!(self.func, { i32_wrap_i64; });
                 }
                 wasm!(self.func, {

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
@@ -869,8 +869,7 @@ impl FuncCompiler<'_> {
                 let key_ty_initial = if let Ty::Fn { ret, .. } = &args[1].ty {
                     (**ret).clone()
                 } else { Ty::Int };
-                let is_unresolved = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_));
-                let key_vt = if !is_unresolved(&key_ty_initial) {
+                let key_vt = if !key_ty_initial.is_unresolved() {
                     values::ty_to_valtype(&key_ty_initial).unwrap_or(ValType::I32)
                 } else {
                     self.resolve_closure_ret_valtype(&args[1]).unwrap_or(ValType::I64)
@@ -886,11 +885,7 @@ impl FuncCompiler<'_> {
                     _ => 4,
                 };
                 // Synthesize a concrete key_ty for `emit_closure_call` sizing.
-                let key_ty = match key_vt {
-                    ValType::I64 => Ty::Int,
-                    ValType::F64 => Ty::Float,
-                    _ => Ty::String,
-                };
+                let key_ty = values::vt_to_placeholder_ty(key_vt);
                 let xs = self.scratch.alloc_i32();
                 let closure = self.scratch.alloc_i32();
                 let len = self.scratch.alloc_i32();

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
@@ -861,12 +861,36 @@ impl FuncCompiler<'_> {
                 let elem_ty = self.list_elem_ty(&args[0].ty);
                 let es = values::byte_size(&elem_ty) as i32;
                 let elem_vt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32);
-                // Infer key type from closure return type (Int or String)
-                let key_ty = if let Ty::Fn { ret, .. } = &args[1].ty {
+                // Infer key type from closure return type. The closure's
+                // `Ty::Fn.ret` can be Unknown/TypeVar when inference left the
+                // Lambda param generic; fall back to the lifted function's
+                // registered WASM return ValType so `key_is_str` and `ks`
+                // match the closure's call_indirect signature exactly.
+                let key_ty_initial = if let Ty::Fn { ret, .. } = &args[1].ty {
                     (**ret).clone()
                 } else { Ty::Int };
-                let key_is_str = matches!(&key_ty, Ty::String);
-                let ks: i32 = if key_is_str { 4 } else { 8 }; // key byte size
+                let is_unresolved = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_));
+                let key_vt = if !is_unresolved(&key_ty_initial) {
+                    values::ty_to_valtype(&key_ty_initial).unwrap_or(ValType::I32)
+                } else {
+                    self.resolve_closure_ret_valtype(&args[1]).unwrap_or(ValType::I64)
+                };
+                // i32 = heap pointer (String/List/Record). i64 = Int. f64 = Float.
+                // For sort comparison, i32 keys use string.cmp, i64/f64 use numeric compare.
+                // This is correct only when heap pointer keys are always String
+                // (the only supported comparable heap type today) — other pointer
+                // types will mis-sort, but would have been broken before too.
+                let key_is_str = matches!(key_vt, ValType::I32);
+                let ks: i32 = match key_vt {
+                    ValType::I64 | ValType::F64 => 8,
+                    _ => 4,
+                };
+                // Synthesize a concrete key_ty for `emit_closure_call` sizing.
+                let key_ty = match key_vt {
+                    ValType::I64 => Ty::Int,
+                    ValType::F64 => Ty::Float,
+                    _ => Ty::String,
+                };
                 let xs = self.scratch.alloc_i32();
                 let closure = self.scratch.alloc_i32();
                 let len = self.scratch.alloc_i32();
@@ -938,8 +962,13 @@ impl FuncCompiler<'_> {
                       br(0);
                     end; end;
                 });
-                // Bubble sort: outer loop i from 0..len-1, inner loop j from 0..len-1-i
+                // Bubble sort: outer loop i from 0..len-1, inner loop j from 0..len-1-i.
+                // Skip entirely when len < 2 (nothing to compare) — `len - 1`
+                // would underflow to u32::MAX for unsigned comparison and turn
+                // the loop into an infinite memory-walker.
                 wasm!(self.func, {
+                    block_empty;
+                      local_get(len); i32_const(2); i32_lt_u; br_if(0);
                     i32_const(0); local_set(i); // i (outer)
                     block_empty; loop_empty;
                       local_get(i); local_get(len); i32_const(1); i32_sub; i32_ge_u; br_if(1);
@@ -1031,6 +1060,7 @@ impl FuncCompiler<'_> {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end; // end outer loop
+                    end; // end len<2 guard block
                     local_get(dst);
                 });
                 self.scratch.free(tmp_elem, elem_vt);

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
@@ -9,6 +9,20 @@ use almide_ir::{IrExpr, IrExprKind};
 use almide_lang::types::Ty;
 use wasm_encoder::ValType;
 
+/// Build a representative `Ty` for a given `ValType`, used when we only know
+/// the WASM ABI shape (from a lifted closure's registered type) but not the
+/// source-level type. The returned `Ty` round-trips correctly through
+/// `ty_to_valtype`/`byte_size`.
+fn vt_to_placeholder_ty(vt: ValType) -> Ty {
+    match vt {
+        ValType::I64 => Ty::Int,
+        ValType::F64 => Ty::Float,
+        // All i32 heap pointers have identical runtime layout (4-byte pointer);
+        // `Ty::String` is a convenient stand-in.
+        _ => Ty::String,
+    }
+}
+
 impl FuncCompiler<'_> {
     /// Dispatch list closure calls (second half). Returns true if handled.
     pub(super) fn emit_list_closure_call2(&mut self, method: &str, args: &[IrExpr]) -> bool {
@@ -947,6 +961,21 @@ impl FuncCompiler<'_> {
                 }
             }
         }
+        // Final fallback: inspect the lifted closure's actual registered WASM
+        // param/ret valtypes. This handles the case where inference left both
+        // the list element and lambda body as Unknown but the lifted function
+        // has a concrete signature (e.g. from our closure-conversion VarTable
+        // propagation + anonymous record fallback).
+        let in_vt = values::ty_to_valtype(&in_elem_ty);
+        let in_elem_ty = match self.resolve_closure_param_valtype(fn_arg, 0) {
+            Some(actual) if Some(actual) != in_vt => vt_to_placeholder_ty(actual),
+            _ => in_elem_ty,
+        };
+        let out_vt = values::ty_to_valtype(&out_elem_ty);
+        let out_elem_ty = match self.resolve_closure_ret_valtype(fn_arg) {
+            Some(actual) if Some(actual) != out_vt => vt_to_placeholder_ty(actual),
+            _ => out_elem_ty,
+        };
         let in_size = values::byte_size(&in_elem_ty);
         let out_size = values::byte_size(&out_elem_ty);
 

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
@@ -9,20 +9,6 @@ use almide_ir::{IrExpr, IrExprKind};
 use almide_lang::types::Ty;
 use wasm_encoder::ValType;
 
-/// Build a representative `Ty` for a given `ValType`, used when we only know
-/// the WASM ABI shape (from a lifted closure's registered type) but not the
-/// source-level type. The returned `Ty` round-trips correctly through
-/// `ty_to_valtype`/`byte_size`.
-fn vt_to_placeholder_ty(vt: ValType) -> Ty {
-    match vt {
-        ValType::I64 => Ty::Int,
-        ValType::F64 => Ty::Float,
-        // All i32 heap pointers have identical runtime layout (4-byte pointer);
-        // `Ty::String` is a convenient stand-in.
-        _ => Ty::String,
-    }
-}
-
 impl FuncCompiler<'_> {
     /// Dispatch list closure calls (second half). Returns true if handled.
     pub(super) fn emit_list_closure_call2(&mut self, method: &str, args: &[IrExpr]) -> bool {
@@ -829,7 +815,7 @@ impl FuncCompiler<'_> {
                     if let Ty::Fn { params, .. } = &args[2].ty { params.get(1).cloned() } else { None },
                     if let almide_ir::IrExprKind::Lambda { params: lp, .. } = &args[2].kind { lp.get(1).map(|(_, t)| t.clone()) } else { None },
                 ].into_iter().flatten()
-                    .find(|t| !matches!(t, Ty::Unknown | Ty::TypeVar(_)))
+                    .find(|t| !t.is_unresolved())
                     .unwrap_or(Ty::Int);
 
                 // Resolve acc type: use Fn return type or lambda body type, with TypeVar→concrete fallback
@@ -842,7 +828,7 @@ impl FuncCompiler<'_> {
                     let init_ty = args[1].ty.clone();
                     // Pick first concrete (non-TypeVar/Unknown) type
                     [fn_ret, body_ty, Some(init_ty)].into_iter().flatten()
-                        .find(|t| !matches!(t, Ty::Unknown | Ty::TypeVar(_)))
+                        .find(|t| !t.is_unresolved())
                         .unwrap_or_else(|| if let Ty::Fn { ret, .. } = &args[2].ty { *ret.clone() } else { args[1].ty.clone() })
                 };
                 // Resolve TypeVar inside Applied types (e.g., List[TypeVar(?0)] → List[elem_ty])
@@ -917,28 +903,7 @@ impl FuncCompiler<'_> {
     /// Key insight: compute dst address BEFORE call_indirect so result goes
     /// directly onto the stack in the right position for store.
     pub(super) fn emit_list_map(&mut self, list_arg: &IrExpr, fn_arg: &IrExpr, ret_ty: &Ty) {
-        // Resolve input element type from multiple sources
-        let in_elem_ty = {
-            let from_list = if let Ty::Applied(_, args) = &list_arg.ty {
-                args.first().cloned()
-            } else { None };
-            let from_var = if from_list.as_ref().map_or(true, |t| matches!(t, Ty::TypeVar(_) | Ty::Unknown)) {
-                if let almide_ir::IrExprKind::Var { id } = &list_arg.kind {
-                    if let Ty::Applied(_, a) = &self.var_table.get(*id).ty {
-                        a.first().cloned()
-                    } else { None }
-                } else { None }
-            } else { None };
-            let from_fn = if let Ty::Fn { params, .. } = &fn_arg.ty {
-                params.first().cloned()
-            } else { None };
-            let from_lambda = if let almide_ir::IrExprKind::Lambda { params, .. } = &fn_arg.kind {
-                params.first().map(|(_, t)| t.clone())
-            } else { None };
-            [from_list, from_var, from_fn, from_lambda].into_iter().flatten()
-                .find(|t| !matches!(t, Ty::TypeVar(_) | Ty::Unknown))
-                .unwrap_or(Ty::Int)
-        };
+        let in_elem_ty = self.resolve_list_elem(list_arg, Some(fn_arg));
         let mut out_elem_ty = if let Ty::Applied(_, args) = ret_ty {
             args.first().cloned().unwrap_or(Ty::Int)
         } else { Ty::Int };
@@ -946,16 +911,16 @@ impl FuncCompiler<'_> {
         // element type from the lambda body.  The call-site ret_ty can remain
         // unresolved when the map result is unused or only used in a type-agnostic
         // context, but the lambda body always carries the concrete type.
-        if matches!(&out_elem_ty, Ty::TypeVar(_) | Ty::Unknown) {
+        if out_elem_ty.is_unresolved() {
             if let IrExprKind::Lambda { body, .. } = &fn_arg.kind {
-                if !matches!(&body.ty, Ty::TypeVar(_) | Ty::Unknown) {
+                if !body.ty.is_unresolved() {
                     out_elem_ty = body.ty.clone();
                 }
             }
             // Also try fn_arg.ty.ret as a secondary source
-            if matches!(&out_elem_ty, Ty::TypeVar(_) | Ty::Unknown) {
+            if out_elem_ty.is_unresolved() {
                 if let Ty::Fn { ret, .. } = &fn_arg.ty {
-                    if !matches!(ret.as_ref(), Ty::TypeVar(_) | Ty::Unknown) {
+                    if !ret.is_unresolved() {
                         out_elem_ty = *ret.clone();
                     }
                 }
@@ -968,12 +933,12 @@ impl FuncCompiler<'_> {
         // propagation + anonymous record fallback).
         let in_vt = values::ty_to_valtype(&in_elem_ty);
         let in_elem_ty = match self.resolve_closure_param_valtype(fn_arg, 0) {
-            Some(actual) if Some(actual) != in_vt => vt_to_placeholder_ty(actual),
+            Some(actual) if Some(actual) != in_vt => values::vt_to_placeholder_ty(actual),
             _ => in_elem_ty,
         };
         let out_vt = values::ty_to_valtype(&out_elem_ty);
         let out_elem_ty = match self.resolve_closure_ret_valtype(fn_arg) {
-            Some(actual) if Some(actual) != out_vt => vt_to_placeholder_ty(actual),
+            Some(actual) if Some(actual) != out_vt => values::vt_to_placeholder_ty(actual),
             _ => out_elem_ty,
         };
         let in_size = values::byte_size(&in_elem_ty);

--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -1,13 +1,62 @@
 //! List stdlib helper methods for WASM codegen.
 //!
 //! Utility functions used by both calls_list.rs and calls_list_closure.rs:
-//! list_elem_ty, emit_elem_copy, emit_elem_store, emit_list_slice_impl, emit_memcpy_loop.
+//! list_elem_ty, emit_elem_copy, emit_elem_store.
 
-use super::FuncCompiler;
+use super::{FuncCompiler, WasmEmitter};
 use super::values;
 use almide_ir::IrExpr;
 use almide_lang::types::Ty;
-use wasm_encoder::ValType;
+use wasm_encoder::{Function, Instruction, ValType};
+
+/// Distinguishes the three element shapes supported by `emit_list_sort_generic`.
+/// Each variant knows its element size, load/store width, and comparison strategy.
+enum SortKind {
+    /// i64 elements, 8 bytes, inline `i64_le_s` comparison.
+    Int,
+    /// i32 string-pointer elements, 4 bytes, `__str_cmp` call + `i32_le_s`.
+    String,
+    /// i32 List[String]-pointer elements, 4 bytes, `__list_list_str_cmp` call + `i32_le_s`.
+    ListString,
+}
+
+impl SortKind {
+    fn elem_size(&self) -> u32 {
+        match self { SortKind::Int => 8, _ => 4 }
+    }
+    fn emit_load(&self, f: &mut Function) {
+        match self {
+            SortKind::Int => { f.instruction(&Instruction::I64Load(wasm_encoder::MemArg { offset: 0, align: 3, memory_index: 0 })); }
+            _ => { f.instruction(&Instruction::I32Load(wasm_encoder::MemArg { offset: 0, align: 2, memory_index: 0 })); }
+        }
+    }
+    fn emit_store(&self, f: &mut Function) {
+        match self {
+            SortKind::Int => { f.instruction(&Instruction::I64Store(wasm_encoder::MemArg { offset: 0, align: 3, memory_index: 0 })); }
+            _ => { f.instruction(&Instruction::I32Store(wasm_encoder::MemArg { offset: 0, align: 2, memory_index: 0 })); }
+        }
+    }
+    fn emit_copy_one(&self, f: &mut Function) {
+        self.emit_load(f);
+        self.emit_store(f);
+    }
+    /// Emit `dst[j] <= key` comparison, leaving an i32 boolean on the stack.
+    fn emit_le_cmp(&self, f: &mut Function, emitter: &WasmEmitter) {
+        match self {
+            SortKind::Int => { f.instruction(&Instruction::I64LeS); }
+            SortKind::String => {
+                f.instruction(&Instruction::Call(emitter.rt.string.cmp));
+                f.instruction(&Instruction::I32Const(0));
+                f.instruction(&Instruction::I32LeS);
+            }
+            SortKind::ListString => {
+                f.instruction(&Instruction::Call(emitter.rt.list_list_str_cmp));
+                f.instruction(&Instruction::I32Const(0));
+                f.instruction(&Instruction::I32LeS);
+            }
+        }
+    }
+}
 
 impl FuncCompiler<'_> {
     pub(super) fn list_elem_ty(&self, ty: &Ty) -> Ty {
@@ -23,14 +72,14 @@ impl FuncCompiler<'_> {
         let from_expr = if let Ty::Applied(_, args) = &list_expr.ty {
             args.first().cloned()
         } else { None };
-        if from_expr.as_ref().is_some_and(|t| !matches!(t, Ty::TypeVar(_) | Ty::Unknown)) {
+        if from_expr.as_ref().is_some_and(|t| !t.is_unresolved()) {
             return from_expr.unwrap();
         }
         // 2. From VarTable (if list_expr is a Var)
         if let almide_ir::IrExprKind::Var { id } = &list_expr.kind {
             if let Ty::Applied(_, a) = &self.var_table.get(*id).ty {
                 let t = a.first().cloned();
-                if t.as_ref().is_some_and(|t| !matches!(t, Ty::TypeVar(_) | Ty::Unknown)) {
+                if t.as_ref().is_some_and(|t| !t.is_unresolved()) {
                     return t.unwrap();
                 }
             }
@@ -39,21 +88,21 @@ impl FuncCompiler<'_> {
         if let Some(fn_e) = fn_expr {
             if let Ty::Fn { params, .. } = &fn_e.ty {
                 let t = params.first().cloned();
-                if t.as_ref().is_some_and(|t| !matches!(t, Ty::TypeVar(_) | Ty::Unknown)) {
+                if t.as_ref().is_some_and(|t| !t.is_unresolved()) {
                     return t.unwrap();
                 }
             }
             // 4. From Lambda params directly
             if let almide_ir::IrExprKind::Lambda { params, .. } = &fn_e.kind {
                 let t = params.first().map(|(_, t)| t.clone());
-                if t.as_ref().is_some_and(|t| !matches!(t, Ty::TypeVar(_) | Ty::Unknown)) {
+                if t.as_ref().is_some_and(|t| !t.is_unresolved()) {
                     return t.unwrap();
                 }
             }
         }
         // Fallback: if still TypeVar/Unknown, default to Int
         from_expr
-            .filter(|t| !matches!(t, Ty::TypeVar(_) | Ty::Unknown))
+            .filter(|t| !t.is_unresolved())
             .unwrap_or(Ty::Int)
     }
 
@@ -66,16 +115,15 @@ impl FuncCompiler<'_> {
     /// from List or other heap types) but is sufficient for sizing decisions
     /// and for picking the correct call_indirect signature.
     pub(super) fn resolve_closure_ret_valtype(&self, fn_expr: &IrExpr) -> Option<ValType> {
-        let is_unresolved = |t: &Ty| matches!(t, Ty::TypeVar(_) | Ty::Unknown);
         // 1. Fn type's ret
         if let Ty::Fn { ret, .. } = &fn_expr.ty {
-            if !is_unresolved(ret.as_ref()) {
+            if !ret.is_unresolved() {
                 return values::ty_to_valtype(ret);
             }
         }
         // 2. Lambda body's type
         if let almide_ir::IrExprKind::Lambda { body, .. } = &fn_expr.kind {
-            if !is_unresolved(&body.ty) {
+            if !body.ty.is_unresolved() {
                 return values::ty_to_valtype(&body.ty);
             }
         }
@@ -97,15 +145,14 @@ impl FuncCompiler<'_> {
     /// Used to size the `param_ty`/`in_elem_ty` in `emit_list_map` etc. when
     /// type inference left the list element type unresolved.
     pub(super) fn resolve_closure_param_valtype(&self, fn_expr: &IrExpr, idx: usize) -> Option<ValType> {
-        let is_unresolved = |t: &Ty| matches!(t, Ty::TypeVar(_) | Ty::Unknown);
         if let Ty::Fn { params, .. } = &fn_expr.ty {
             if let Some(p) = params.get(idx) {
-                if !is_unresolved(p) { return values::ty_to_valtype(p); }
+                if !p.is_unresolved() { return values::ty_to_valtype(p); }
             }
         }
         if let almide_ir::IrExprKind::Lambda { params, .. } = &fn_expr.kind {
             if let Some((_, pty)) = params.get(idx) {
-                if !is_unresolved(pty) { return values::ty_to_valtype(pty); }
+                if !pty.is_unresolved() { return values::ty_to_valtype(pty); }
             }
         }
         if let almide_ir::IrExprKind::ClosureCreate { func_name, .. } = &fn_expr.kind {
@@ -171,97 +218,6 @@ impl FuncCompiler<'_> {
         self.emit_call_indirect(ct, rt);
     }
 
-    /// Emit take/drop as list slice. For take: start=0,end=n. For drop: start=n,end=len.
-    #[allow(dead_code)] // Will be activated when list.take/drop WASM codegen lands
-    fn emit_list_slice_impl(
-        &mut self, xs: &IrExpr, start_arg: Option<&IrExpr>, end_arg: Option<&IrExpr>,
-        elem_size: usize, is_take: bool,
-    ) {
-        let xs_ptr = self.scratch.alloc_i32();
-        let n = self.scratch.alloc_i32();
-        let start = self.scratch.alloc_i32();
-        let end = self.scratch.alloc_i32();
-        let new_len = self.scratch.alloc_i32();
-        let dst = self.scratch.alloc_i32();
-        let i = self.scratch.alloc_i32();
-
-        self.emit_expr(xs);
-        wasm!(self.func, { local_set(xs_ptr); }); // xs_ptr = xs
-        // Compute start and end
-        if is_take {
-            // take(xs, n): start=0, end=min(n, len)
-            self.emit_expr(end_arg.unwrap());
-            wasm!(self.func, {
-                i32_wrap_i64; local_set(n); // n
-                i32_const(0); local_set(start); // start = 0
-                // end = min(n, len)
-                local_get(n); local_get(xs_ptr); i32_load(0);
-                i32_lt_u;
-                if_i32; local_get(n); else_; local_get(xs_ptr); i32_load(0); end;
-                local_set(end); // end
-            });
-        } else {
-            // drop(xs, n): start=min(n, len), end=len
-            self.emit_expr(start_arg.unwrap());
-            wasm!(self.func, {
-                i32_wrap_i64; local_set(n); // n
-                // start = min(n, len)
-                local_get(n); local_get(xs_ptr); i32_load(0);
-                i32_lt_u;
-                if_i32; local_get(n); else_; local_get(xs_ptr); i32_load(0); end;
-                local_set(start); // start
-                local_get(xs_ptr); i32_load(0); local_set(end); // end = len
-            });
-        }
-        // new_len = end - start
-        wasm!(self.func, {
-            local_get(end); local_get(start); i32_sub; local_set(new_len);
-            // alloc
-            i32_const(4); local_get(new_len); i32_const(elem_size as i32); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(dst);
-            local_get(dst); local_get(new_len); i32_store(0);
-            // copy loop
-            i32_const(0); local_set(i); // i
-            block_empty; loop_empty;
-              local_get(i); local_get(new_len); i32_ge_u; br_if(1);
-              // dst[4 + i*es]
-              local_get(dst); i32_const(4); i32_add;
-              local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
-              // src[4 + (start+i)*es]
-              local_get(xs_ptr); i32_const(4); i32_add;
-              local_get(start); local_get(i); i32_add;
-              i32_const(elem_size as i32); i32_mul; i32_add;
-        });
-        // Copy one element
-        let _elem_ty = if is_take {
-            self.list_elem_ty(&end_arg.unwrap().ty)
-        } else {
-            self.list_elem_ty(&start_arg.unwrap().ty)
-        };
-        // Actually use xs type
-        self.emit_elem_copy(&self.list_elem_ty(&xs.ty));
-        wasm!(self.func, {
-              local_get(i); i32_const(1); i32_add; local_set(i);
-              br(0);
-            end; end;
-            local_get(dst);
-        });
-
-        self.scratch.free_i32(i);
-        self.scratch.free_i32(dst);
-        self.scratch.free_i32(new_len);
-        self.scratch.free_i32(end);
-        self.scratch.free_i32(start);
-        self.scratch.free_i32(n);
-        self.scratch.free_i32(xs_ptr);
-    }
-
-    #[allow(dead_code)] // Placeholder for list.slice WASM codegen
-    fn emit_memcpy_loop(&mut self, _i_local: u32, _dst_local: u32, _start_local: u32, _elem_size: usize) {
-        // Generic memcpy for list.slice — complex, use inline for now
-        // This is a placeholder; slice uses the same pattern as take/drop
-    }
-
     /// Emit list.sort (insertion sort for List[Int], List[String], and
     /// List[List[String]] via lexicographic inner-list comparison).
     pub(super) fn emit_list_sort(&mut self, args: &[IrExpr]) {
@@ -269,12 +225,12 @@ impl FuncCompiler<'_> {
         // first, then fall back to VarTable when the expression was left
         // generic by inference.
         let mut elem_ty = self.list_elem_ty(&args[0].ty);
-        if matches!(&elem_ty, Ty::TypeVar(_) | Ty::Unknown) {
+        if elem_ty.is_unresolved() {
             if let almide_ir::IrExprKind::Var { id } = &args[0].kind {
                 let vt = self.var_table.get(*id).ty.clone();
                 if let Ty::Applied(_, inner) = vt {
                     if let Some(t) = inner.first().cloned() {
-                        if !matches!(t, Ty::TypeVar(_) | Ty::Unknown) {
+                        if !t.is_unresolved() {
                             elem_ty = t;
                         }
                     }
@@ -282,251 +238,98 @@ impl FuncCompiler<'_> {
             }
         }
         match &elem_ty {
-            Ty::Int => self.emit_list_sort_int(args),
-            Ty::String => self.emit_list_sort_string(args),
+            Ty::Int => self.emit_list_sort_generic(args, SortKind::Int),
+            Ty::String => self.emit_list_sort_generic(args, SortKind::String),
             // `List[List[T]]` lex sort: when T is String or unresolved (the
             // common fold-accumulator case where type inference leaves `A`
-            // unconcretized), treat inner elements as string pointers. Every
-            // heap-pointer element has the same layout, so the underlying
-            // insertion sort loop is identical — the comparison function is
-            // what needs to know the semantics.
+            // unconcretized), treat inner elements as string pointers.
             Ty::Applied(almide_lang::types::TypeConstructorId::List, inner)
-                if inner.first().is_some_and(|t| matches!(t, Ty::String | Ty::TypeVar(_) | Ty::Unknown)) =>
+                if inner.first().is_some_and(|t| matches!(t, Ty::String) || t.is_unresolved()) =>
             {
-                self.emit_list_sort_list_string(args)
+                self.emit_list_sort_generic(args, SortKind::ListString)
             }
             _ => self.emit_stub_call(args),
         }
     }
 
-    /// Insertion sort for `List[List[String]]` using lexicographic comparison
-    /// of inner string lists. Inner-list elements are 4-byte pointers (like
-    /// regular `List[String]`), so the outer sort reuses the i32-pointer
-    /// layout — only the comparison differs.
-    fn emit_list_sort_list_string(&mut self, args: &[IrExpr]) {
+    /// Parameterized insertion sort. Three element kinds share the same
+    /// algorithm; only element size, load/store width, and comparison differ.
+    fn emit_list_sort_generic(&mut self, args: &[IrExpr], kind: SortKind) {
+        let es = kind.elem_size();
         let xs_ptr = self.scratch.alloc_i32();
         let len = self.scratch.alloc_i32();
         let dst = self.scratch.alloc_i32();
         let i = self.scratch.alloc_i32();
         let j = self.scratch.alloc_i32();
-        let key = self.scratch.alloc_i32();
+        let key = if matches!(kind, SortKind::Int) { self.scratch.alloc_i64() } else { self.scratch.alloc_i32() };
 
+        // 1. Copy list header + payload.
         self.emit_expr(&args[0]);
         wasm!(self.func, {
             local_set(xs_ptr);
             local_get(xs_ptr); i32_load(0); local_set(len);
-            i32_const(4); local_get(len); i32_const(4); i32_mul; i32_add;
+            i32_const(4); local_get(len); i32_const(es as i32); i32_mul; i32_add;
             call(self.emitter.rt.alloc); local_set(dst);
             local_get(dst); local_get(len); i32_store(0);
-            // Copy all pointers
             i32_const(0); local_set(i);
             block_empty; loop_empty;
               local_get(i); local_get(len); i32_ge_u; br_if(1);
-              local_get(dst); i32_const(4); i32_add;
-              local_get(i); i32_const(4); i32_mul; i32_add;
-              local_get(xs_ptr); i32_const(4); i32_add;
-              local_get(i); i32_const(4); i32_mul; i32_add;
-              i32_load(0); i32_store(0);
-              local_get(i); i32_const(1); i32_add; local_set(i);
-              br(0);
-            end; end;
-            // Insertion sort
-            i32_const(1); local_set(i);
-            block_empty; loop_empty;
-              local_get(i); local_get(len); i32_ge_u; br_if(1);
-              local_get(dst); i32_const(4); i32_add;
-              local_get(i); i32_const(4); i32_mul; i32_add;
-              i32_load(0); local_set(key);
-              local_get(i); i32_const(1); i32_sub; local_set(j);
-              block_empty; loop_empty;
-                local_get(j); i32_const(0); i32_lt_s; br_if(1);
-                // cmp(dst[j], key) <= 0 → stop
-                local_get(dst); i32_const(4); i32_add;
-                local_get(j); i32_const(4); i32_mul; i32_add;
-                i32_load(0);
-                local_get(key);
-                call(self.emitter.rt.list_list_str_cmp);
-                i32_const(0); i32_le_s; br_if(1);
-                // Shift
-                local_get(dst); i32_const(4); i32_add;
-                local_get(j); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
-                local_get(dst); i32_const(4); i32_add;
-                local_get(j); i32_const(4); i32_mul; i32_add;
-                i32_load(0); i32_store(0);
-                local_get(j); i32_const(1); i32_sub; local_set(j);
-                br(0);
-              end; end;
-              local_get(dst); i32_const(4); i32_add;
-              local_get(j); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
-              local_get(key); i32_store(0);
-              local_get(i); i32_const(1); i32_add; local_set(i);
-              br(0);
-            end; end;
-            local_get(dst);
+              local_get(dst); i32_const(4); i32_add; local_get(i); i32_const(es as i32); i32_mul; i32_add;
+              local_get(xs_ptr); i32_const(4); i32_add; local_get(i); i32_const(es as i32); i32_mul; i32_add;
         });
-
-        self.scratch.free_i32(key);
-        self.scratch.free_i32(j);
-        self.scratch.free_i32(i);
-        self.scratch.free_i32(dst);
-        self.scratch.free_i32(len);
-        self.scratch.free_i32(xs_ptr);
-    }
-
-    /// Insertion sort for List[Int] (elements are i64, 8 bytes each).
-    fn emit_list_sort_int(&mut self, args: &[IrExpr]) {
-        let xs_ptr = self.scratch.alloc_i32();
-        let len = self.scratch.alloc_i32();
-        let dst = self.scratch.alloc_i32();
-        let i = self.scratch.alloc_i32();
-        let j = self.scratch.alloc_i32();
-        let key = self.scratch.alloc_i64();
-
-        // Copy list first
-        self.emit_expr(&args[0]);
+        kind.emit_copy_one(&mut self.func);
         wasm!(self.func, {
-            local_set(xs_ptr);
-            local_get(xs_ptr); i32_load(0); local_set(len);
-            i32_const(4); local_get(len); i32_const(8); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(dst);
-            local_get(dst); local_get(len); i32_store(0);
-        });
-        // Copy all elements
-        wasm!(self.func, {
-            i32_const(0); local_set(i);
-            block_empty; loop_empty;
-              local_get(i); local_get(len); i32_ge_u; br_if(1);
-              local_get(dst); i32_const(4); i32_add;
-              local_get(i); i32_const(8); i32_mul; i32_add;
-              local_get(xs_ptr); i32_const(4); i32_add;
-              local_get(i); i32_const(8); i32_mul; i32_add;
-              i64_load(0); i64_store(0);
-              local_get(i); i32_const(1); i32_add; local_set(i);
-              br(0);
+              local_get(i); i32_const(1); i32_add; local_set(i); br(0);
             end; end;
         });
-        // Insertion sort outer loop
+
+        // 2. Insertion sort.
         wasm!(self.func, {
             i32_const(1); local_set(i);
             block_empty; loop_empty;
               local_get(i); local_get(len); i32_ge_u; br_if(1);
-              local_get(dst); i32_const(4); i32_add;
-              local_get(i); i32_const(8); i32_mul; i32_add;
-              i64_load(0); local_set(key);
+              // key = dst[4 + i*es]
+              local_get(dst); i32_const(4); i32_add; local_get(i); i32_const(es as i32); i32_mul; i32_add;
+        });
+        kind.emit_load(&mut self.func);
+        wasm!(self.func, {
+              local_set(key);
               local_get(i); i32_const(1); i32_sub; local_set(j);
-        });
-        // Inner loop: shift elements right
-        wasm!(self.func, {
+              // inner loop: shift while dst[j] > key
               block_empty; loop_empty;
                 local_get(j); i32_const(0); i32_lt_s; br_if(1);
-                local_get(dst); i32_const(4); i32_add;
-                local_get(j); i32_const(8); i32_mul; i32_add;
-                i64_load(0); local_get(key); i64_le_s; br_if(1);
-                local_get(dst); i32_const(4); i32_add;
-                local_get(j); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
-                local_get(dst); i32_const(4); i32_add;
-                local_get(j); i32_const(8); i32_mul; i32_add;
-                i64_load(0); i64_store(0);
-                local_get(j); i32_const(1); i32_sub; local_set(j);
-                br(0);
-              end; end;
+                // compare dst[j] with key
+                local_get(dst); i32_const(4); i32_add; local_get(j); i32_const(es as i32); i32_mul; i32_add;
         });
-        // Place key and continue
+        kind.emit_load(&mut self.func);     // load dst[j]
+        wasm!(self.func, { local_get(key); }); // push key
+        kind.emit_le_cmp(&mut self.func, self.emitter);
         wasm!(self.func, {
+                br_if(1); // dst[j] <= key → stop
+                // shift: dst[j+1] = dst[j]
+                local_get(dst); i32_const(4); i32_add;
+                local_get(j); i32_const(1); i32_add; i32_const(es as i32); i32_mul; i32_add;
+                local_get(dst); i32_const(4); i32_add;
+                local_get(j); i32_const(es as i32); i32_mul; i32_add;
+        });
+        kind.emit_copy_one(&mut self.func);
+        wasm!(self.func, {
+                local_get(j); i32_const(1); i32_sub; local_set(j); br(0);
+              end; end;
+              // place key at dst[j+1]
               local_get(dst); i32_const(4); i32_add;
-              local_get(j); i32_const(1); i32_add; i32_const(8); i32_mul; i32_add;
-              local_get(key); i64_store(0);
-              local_get(i); i32_const(1); i32_add; local_set(i);
-              br(0);
+              local_get(j); i32_const(1); i32_add; i32_const(es as i32); i32_mul; i32_add;
+              local_get(key);
+        });
+        kind.emit_store(&mut self.func);
+        wasm!(self.func, {
+              local_get(i); i32_const(1); i32_add; local_set(i); br(0);
             end; end;
             local_get(dst);
         });
 
-        self.scratch.free_i64(key);
-        self.scratch.free_i32(j);
-        self.scratch.free_i32(i);
-        self.scratch.free_i32(dst);
-        self.scratch.free_i32(len);
-        self.scratch.free_i32(xs_ptr);
-    }
-
-    /// Insertion sort for List[String] (elements are i32 pointers, 4 bytes each).
-    /// Comparison uses __str_cmp which returns negative/0/positive.
-    fn emit_list_sort_string(&mut self, args: &[IrExpr]) {
-        let xs_ptr = self.scratch.alloc_i32();
-        let len = self.scratch.alloc_i32();
-        let dst = self.scratch.alloc_i32();
-        let i = self.scratch.alloc_i32();
-        let j = self.scratch.alloc_i32();
-        let str_key = self.scratch.alloc_i32();
-
-        // Copy list first
-        self.emit_expr(&args[0]);
-        wasm!(self.func, {
-            local_set(xs_ptr);
-            local_get(xs_ptr); i32_load(0); local_set(len); // len
-            i32_const(4); local_get(len); i32_const(4); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(dst); // dst
-            local_get(dst); local_get(len); i32_store(0);
-        });
-        // Copy all elements (i32 pointers)
-        wasm!(self.func, {
-            i32_const(0); local_set(i);
-            block_empty; loop_empty;
-              local_get(i); local_get(len); i32_ge_u; br_if(1);
-              local_get(dst); i32_const(4); i32_add;
-              local_get(i); i32_const(4); i32_mul; i32_add;
-              local_get(xs_ptr); i32_const(4); i32_add;
-              local_get(i); i32_const(4); i32_mul; i32_add;
-              i32_load(0); i32_store(0);
-              local_get(i); i32_const(1); i32_add; local_set(i);
-              br(0);
-            end; end;
-        });
-        // Insertion sort outer loop
-        wasm!(self.func, {
-            i32_const(1); local_set(i); // i = 1
-            block_empty; loop_empty;
-              local_get(i); local_get(len); i32_ge_u; br_if(1);
-              // key = dst[4 + i*4]
-              local_get(dst); i32_const(4); i32_add;
-              local_get(i); i32_const(4); i32_mul; i32_add;
-              i32_load(0); local_set(str_key); // key
-              local_get(i); i32_const(1); i32_sub; local_set(j); // j = i - 1
-        });
-        // Inner loop: shift elements right while dst[j] > key
-        wasm!(self.func, {
-              block_empty; loop_empty;
-                local_get(j); i32_const(0); i32_lt_s; br_if(1);
-                // Compare: str_cmp(dst[j], key) <= 0 means stop
-                local_get(dst); i32_const(4); i32_add;
-                local_get(j); i32_const(4); i32_mul; i32_add;
-                i32_load(0); // dst[j]
-                local_get(str_key); // key
-                call(self.emitter.rt.string.cmp);
-                i32_const(0); i32_le_s; br_if(1); // if dst[j] <= key, stop
-                // Shift: dst[j+1] = dst[j]
-                local_get(dst); i32_const(4); i32_add;
-                local_get(j); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
-                local_get(dst); i32_const(4); i32_add;
-                local_get(j); i32_const(4); i32_mul; i32_add;
-                i32_load(0); i32_store(0);
-                local_get(j); i32_const(1); i32_sub; local_set(j);
-                br(0);
-              end; end;
-        });
-        // Place key at dst[j+1]
-        wasm!(self.func, {
-              local_get(dst); i32_const(4); i32_add;
-              local_get(j); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
-              local_get(str_key); i32_store(0);
-              local_get(i); i32_const(1); i32_add; local_set(i);
-              br(0);
-            end; end;
-            local_get(dst);
-        });
-
-        self.scratch.free_i32(str_key);
+        // 3. Free scratch.
+        if matches!(kind, SortKind::Int) { self.scratch.free_i64(key); } else { self.scratch.free_i32(key); }
         self.scratch.free_i32(j);
         self.scratch.free_i32(i);
         self.scratch.free_i32(dst);

--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -57,6 +57,71 @@ impl FuncCompiler<'_> {
             .unwrap_or(Ty::Int)
     }
 
+    /// Resolve the concrete return type of a closure argument. Handles the case
+    /// where the closure's `Ty::Fn.ret` is Unknown/TypeVar by falling back to:
+    /// 1. Lambda body's own `.ty` (pre-closure-conversion)
+    /// 2. The lifted WASM function's registered return ValType (post-closure-conversion)
+    ///
+    /// The ValType result is coarser than a `Ty` (it can't distinguish String
+    /// from List or other heap types) but is sufficient for sizing decisions
+    /// and for picking the correct call_indirect signature.
+    pub(super) fn resolve_closure_ret_valtype(&self, fn_expr: &IrExpr) -> Option<ValType> {
+        let is_unresolved = |t: &Ty| matches!(t, Ty::TypeVar(_) | Ty::Unknown);
+        // 1. Fn type's ret
+        if let Ty::Fn { ret, .. } = &fn_expr.ty {
+            if !is_unresolved(ret.as_ref()) {
+                return values::ty_to_valtype(ret);
+            }
+        }
+        // 2. Lambda body's type
+        if let almide_ir::IrExprKind::Lambda { body, .. } = &fn_expr.kind {
+            if !is_unresolved(&body.ty) {
+                return values::ty_to_valtype(&body.ty);
+            }
+        }
+        // 3. ClosureCreate: look up the lifted function's registered WASM type
+        if let almide_ir::IrExprKind::ClosureCreate { func_name, .. } = &fn_expr.kind {
+            if let Some(&func_idx) = self.emitter.func_map.get(func_name.as_str()) {
+                if let Some(&type_idx) = self.emitter.func_type_indices.get(&func_idx) {
+                    if let Some((_params, results)) = self.emitter.types.get(type_idx as usize) {
+                        return results.first().copied();
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Resolve the concrete type of the first non-env parameter of a closure
+    /// argument. Like `resolve_closure_ret_valtype` but for the input side.
+    /// Used to size the `param_ty`/`in_elem_ty` in `emit_list_map` etc. when
+    /// type inference left the list element type unresolved.
+    pub(super) fn resolve_closure_param_valtype(&self, fn_expr: &IrExpr, idx: usize) -> Option<ValType> {
+        let is_unresolved = |t: &Ty| matches!(t, Ty::TypeVar(_) | Ty::Unknown);
+        if let Ty::Fn { params, .. } = &fn_expr.ty {
+            if let Some(p) = params.get(idx) {
+                if !is_unresolved(p) { return values::ty_to_valtype(p); }
+            }
+        }
+        if let almide_ir::IrExprKind::Lambda { params, .. } = &fn_expr.kind {
+            if let Some((_, pty)) = params.get(idx) {
+                if !is_unresolved(pty) { return values::ty_to_valtype(pty); }
+            }
+        }
+        if let almide_ir::IrExprKind::ClosureCreate { func_name, .. } = &fn_expr.kind {
+            if let Some(&func_idx) = self.emitter.func_map.get(func_name.as_str()) {
+                if let Some(&type_idx) = self.emitter.func_type_indices.get(&func_idx) {
+                    if let Some((params, _results)) = self.emitter.types.get(type_idx as usize) {
+                        // WASM param layout for a lifted closure: [env_i32, user_params...].
+                        // `idx` is the user-level param index (0-based), so skip env.
+                        return params.get(idx + 1).copied();
+                    }
+                }
+            }
+        }
+        None
+    }
+
     /// Copy one element from [stack: dst_addr, src_addr] based on type.
     pub(super) fn emit_elem_copy(&mut self, ty: &Ty) {
         match values::ty_to_valtype(ty) {
@@ -197,14 +262,115 @@ impl FuncCompiler<'_> {
         // This is a placeholder; slice uses the same pattern as take/drop
     }
 
-    /// Emit list.sort (insertion sort for List[Int] and List[String]).
+    /// Emit list.sort (insertion sort for List[Int], List[String], and
+    /// List[List[String]] via lexicographic inner-list comparison).
     pub(super) fn emit_list_sort(&mut self, args: &[IrExpr]) {
-        let elem_ty = self.list_elem_ty(&args[0].ty);
+        // Resolve the element type aggressively — use the expression type
+        // first, then fall back to VarTable when the expression was left
+        // generic by inference.
+        let mut elem_ty = self.list_elem_ty(&args[0].ty);
+        if matches!(&elem_ty, Ty::TypeVar(_) | Ty::Unknown) {
+            if let almide_ir::IrExprKind::Var { id } = &args[0].kind {
+                let vt = self.var_table.get(*id).ty.clone();
+                if let Ty::Applied(_, inner) = vt {
+                    if let Some(t) = inner.first().cloned() {
+                        if !matches!(t, Ty::TypeVar(_) | Ty::Unknown) {
+                            elem_ty = t;
+                        }
+                    }
+                }
+            }
+        }
         match &elem_ty {
             Ty::Int => self.emit_list_sort_int(args),
             Ty::String => self.emit_list_sort_string(args),
+            // `List[List[T]]` lex sort: when T is String or unresolved (the
+            // common fold-accumulator case where type inference leaves `A`
+            // unconcretized), treat inner elements as string pointers. Every
+            // heap-pointer element has the same layout, so the underlying
+            // insertion sort loop is identical — the comparison function is
+            // what needs to know the semantics.
+            Ty::Applied(almide_lang::types::TypeConstructorId::List, inner)
+                if inner.first().is_some_and(|t| matches!(t, Ty::String | Ty::TypeVar(_) | Ty::Unknown)) =>
+            {
+                self.emit_list_sort_list_string(args)
+            }
             _ => self.emit_stub_call(args),
         }
+    }
+
+    /// Insertion sort for `List[List[String]]` using lexicographic comparison
+    /// of inner string lists. Inner-list elements are 4-byte pointers (like
+    /// regular `List[String]`), so the outer sort reuses the i32-pointer
+    /// layout — only the comparison differs.
+    fn emit_list_sort_list_string(&mut self, args: &[IrExpr]) {
+        let xs_ptr = self.scratch.alloc_i32();
+        let len = self.scratch.alloc_i32();
+        let dst = self.scratch.alloc_i32();
+        let i = self.scratch.alloc_i32();
+        let j = self.scratch.alloc_i32();
+        let key = self.scratch.alloc_i32();
+
+        self.emit_expr(&args[0]);
+        wasm!(self.func, {
+            local_set(xs_ptr);
+            local_get(xs_ptr); i32_load(0); local_set(len);
+            i32_const(4); local_get(len); i32_const(4); i32_mul; i32_add;
+            call(self.emitter.rt.alloc); local_set(dst);
+            local_get(dst); local_get(len); i32_store(0);
+            // Copy all pointers
+            i32_const(0); local_set(i);
+            block_empty; loop_empty;
+              local_get(i); local_get(len); i32_ge_u; br_if(1);
+              local_get(dst); i32_const(4); i32_add;
+              local_get(i); i32_const(4); i32_mul; i32_add;
+              local_get(xs_ptr); i32_const(4); i32_add;
+              local_get(i); i32_const(4); i32_mul; i32_add;
+              i32_load(0); i32_store(0);
+              local_get(i); i32_const(1); i32_add; local_set(i);
+              br(0);
+            end; end;
+            // Insertion sort
+            i32_const(1); local_set(i);
+            block_empty; loop_empty;
+              local_get(i); local_get(len); i32_ge_u; br_if(1);
+              local_get(dst); i32_const(4); i32_add;
+              local_get(i); i32_const(4); i32_mul; i32_add;
+              i32_load(0); local_set(key);
+              local_get(i); i32_const(1); i32_sub; local_set(j);
+              block_empty; loop_empty;
+                local_get(j); i32_const(0); i32_lt_s; br_if(1);
+                // cmp(dst[j], key) <= 0 → stop
+                local_get(dst); i32_const(4); i32_add;
+                local_get(j); i32_const(4); i32_mul; i32_add;
+                i32_load(0);
+                local_get(key);
+                call(self.emitter.rt.list_list_str_cmp);
+                i32_const(0); i32_le_s; br_if(1);
+                // Shift
+                local_get(dst); i32_const(4); i32_add;
+                local_get(j); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+                local_get(dst); i32_const(4); i32_add;
+                local_get(j); i32_const(4); i32_mul; i32_add;
+                i32_load(0); i32_store(0);
+                local_get(j); i32_const(1); i32_sub; local_set(j);
+                br(0);
+              end; end;
+              local_get(dst); i32_const(4); i32_add;
+              local_get(j); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+              local_get(key); i32_store(0);
+              local_get(i); i32_const(1); i32_add; local_set(i);
+              br(0);
+            end; end;
+            local_get(dst);
+        });
+
+        self.scratch.free_i32(key);
+        self.scratch.free_i32(j);
+        self.scratch.free_i32(i);
+        self.scratch.free_i32(dst);
+        self.scratch.free_i32(len);
+        self.scratch.free_i32(xs_ptr);
     }
 
     /// Insertion sort for List[Int] (elements are i64, 8 bytes each).

--- a/crates/almide-codegen/src/emit_wasm/calls_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string.rs
@@ -19,8 +19,9 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { call(self.emitter.rt.string.trim); });
             }
             "len" => {
+                // UTF-8 char count, matching Rust `s.chars().count()` semantics.
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_load(0); i64_extend_i32_u; });
+                wasm!(self.func, { call(self.emitter.rt.string.char_count); });
             }
             "contains" => {
                 self.emit_expr(&args[0]);

--- a/crates/almide-codegen/src/emit_wasm/closures.rs
+++ b/crates/almide-codegen/src/emit_wasm/closures.rs
@@ -169,7 +169,7 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
             .collect();
 
         // Pre-scan body for additional locals
-        let scan = statements::collect_locals(body, &program.var_table);
+        let scan = statements::collect_locals(body, &program.var_table, &emitter.record_fields);
         let mut local_decls = Vec::new();
 
         // Captured var locals

--- a/crates/almide-codegen/src/emit_wasm/closures.rs
+++ b/crates/almide-codegen/src/emit_wasm/closures.rs
@@ -58,7 +58,7 @@ pub(super) fn pre_scan_closures(program: &IrProgram, emitter: &mut WasmEmitter) 
             }
         }
         // Resolve body return type: if Unknown, infer from expression tree + VarTable
-        let body_ret_ty = if matches!(&_body.ty, almide_lang::types::Ty::Unknown | almide_lang::types::Ty::TypeVar(_)) {
+        let body_ret_ty = if _body.ty.is_unresolved() {
             resolve_expr_ty(_body, &program.var_table, &emitter.record_fields)
         } else {
             _body.ty.clone()
@@ -169,7 +169,7 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
             .collect();
 
         // Pre-scan body for additional locals
-        let scan = statements::collect_locals(body, &program.var_table, &emitter.record_fields);
+        let scan = statements::collect_locals(body, &program.var_table, &emitter.record_fields, &emitter.variant_info);
         let mut local_decls = Vec::new();
 
         // Captured var locals
@@ -387,11 +387,11 @@ fn collect_pattern_var_ids(pattern: &almide_ir::IrPattern, out: &mut HashSet<u32
 /// Resolve a lambda parameter type when it's TypeVar or Unknown.
 fn resolve_lambda_param_ty(param_ty: &almide_lang::types::Ty, _body_ty: &almide_lang::types::Ty, var_table: &almide_ir::VarTable, vid: VarId) -> almide_lang::types::Ty {
     match param_ty {
-        almide_lang::types::Ty::TypeVar(_) | almide_lang::types::Ty::Unknown | almide_lang::types::Ty::OpenRecord { .. } => {
+        _ if param_ty.is_unresolved_structural() => {
             // Try VarTable for the resolved type
             if (vid.0 as usize) < var_table.len() {
                 let info = var_table.get(vid);
-                if !matches!(&info.ty, almide_lang::types::Ty::TypeVar(_) | almide_lang::types::Ty::Unknown | almide_lang::types::Ty::OpenRecord { .. }) {
+                if !info.ty.is_unresolved_structural() {
                     return info.ty.clone();
                 }
             }
@@ -411,14 +411,14 @@ fn resolve_lambda_param_ty(param_ty: &almide_lang::types::Ty, _body_ty: &almide_
 pub(super) fn resolve_expr_ty(expr: &IrExpr, var_table: &almide_ir::VarTable, record_fields: &HashMap<String, Vec<(String, almide_lang::types::Ty)>>) -> almide_lang::types::Ty {
     use almide_lang::types::Ty;
     // If the expression already has a concrete type, use it
-    if !matches!(&expr.ty, Ty::Unknown | Ty::TypeVar(_)) {
+    if !expr.ty.is_unresolved() {
         return expr.ty.clone();
     }
     match &expr.kind {
         IrExprKind::Var { id } => {
             if (id.0 as usize) < var_table.len() {
                 let info = var_table.get(*id);
-                if !matches!(&info.ty, Ty::Unknown | Ty::TypeVar(_)) {
+                if !info.ty.is_unresolved() {
                     return info.ty.clone();
                 }
             }
@@ -464,7 +464,7 @@ pub(super) fn resolve_expr_ty(expr: &IrExpr, var_table: &almide_ir::VarTable, re
             // Resolve from the first arm's body
             if let Some(arm) = arms.first() {
                 let resolved = resolve_expr_ty(&arm.body, var_table, record_fields);
-                if !matches!(&resolved, Ty::Unknown | Ty::TypeVar(_)) {
+                if !resolved.is_unresolved() {
                     return resolved;
                 }
             }

--- a/crates/almide-codegen/src/emit_wasm/collections.rs
+++ b/crates/almide-codegen/src/emit_wasm/collections.rs
@@ -202,11 +202,15 @@ impl FuncCompiler<'_> {
 
         // Overwrite specified fields
         for (field_name, field_expr) in overrides {
-            if let Some((offset, _)) = values::field_offset(&all_fields, field_name) {
+            // Use the record's declared field type for the store width — the
+            // override expression's own `.ty` may be Unknown when inference
+            // was incomplete (e.g. lambda body without propagated types),
+            // whereas the record layout is authoritative.
+            if let Some((offset, field_ty)) = values::field_offset(&all_fields, field_name) {
                 let total_offset = tag_offset + offset;
                 wasm!(self.func, { local_get(result_scratch); });
                 self.emit_expr(field_expr);
-                self.emit_store_at(&field_expr.ty, total_offset);
+                self.emit_store_at(&field_ty, total_offset);
             }
         }
 

--- a/crates/almide-codegen/src/emit_wasm/collections.rs
+++ b/crates/almide-codegen/src/emit_wasm/collections.rs
@@ -84,7 +84,7 @@ impl FuncCompiler<'_> {
                 if let Some(expr) = explicit_map.get(field_name.as_str()) {
                     self.emit_expr(expr);
                     // Use type-definition type when expr.ty is Unknown
-                    let store_ty = if matches!(&expr.ty, Ty::Unknown | Ty::TypeVar(_)) {
+                    let store_ty = if expr.ty.is_unresolved() {
                         field_ty
                     } else {
                         &expr.ty
@@ -296,10 +296,10 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_tuple(&mut self, elements: &[IrExpr]) {
         let element_types: Vec<(String, Ty)> = elements.iter().enumerate()
             .map(|(i, e)| {
-                let ty = if matches!(&e.ty, Ty::Unknown | Ty::TypeVar(_)) {
+                let ty = if e.ty.is_unresolved() {
                     if let almide_ir::IrExprKind::Var { id } = &e.kind {
                         let vt_ty = &self.var_table.get(*id).ty;
-                        if !matches!(vt_ty, Ty::Unknown | Ty::TypeVar(_)) { vt_ty.clone() }
+                        if !vt_ty.is_unresolved() { vt_ty.clone() }
                         else { e.ty.clone() }
                     } else { e.ty.clone() }
                 } else { e.ty.clone() };
@@ -319,10 +319,10 @@ impl FuncCompiler<'_> {
         let mut offset = 0u32;
         for elem in elements {
             // Resolve element type: use VarTable for Var refs, infer for Unknown
-            let elem_ty = if matches!(&elem.ty, Ty::Unknown | Ty::TypeVar(_)) {
+            let elem_ty = if elem.ty.is_unresolved() {
                 if let almide_ir::IrExprKind::Var { id } = &elem.kind {
                     let vt_ty = &self.var_table.get(*id).ty;
-                    if !matches!(vt_ty, Ty::Unknown | Ty::TypeVar(_)) { vt_ty.clone() }
+                    if !vt_ty.is_unresolved() { vt_ty.clone() }
                     else { self.infer_type_from_expr(elem) }
                 } else {
                     self.infer_type_from_expr(elem)
@@ -363,7 +363,7 @@ impl FuncCompiler<'_> {
         };
 
         // Use result_ty if concrete, otherwise fall back to tuple element type
-        let load_ty = if matches!(result_ty, Ty::Unknown | Ty::TypeVar(_)) {
+        let load_ty = if result_ty.is_unresolved() {
             elem_ty.as_ref().unwrap_or(result_ty)
         } else {
             result_ty
@@ -381,7 +381,7 @@ impl FuncCompiler<'_> {
         // Member expr may have the parent type instead of the field result type.
         let resolved_ty = if let almide_ir::IrExprKind::Var { id } = &object.kind {
             let vt_ty = &self.var_table.get(*id).ty;
-            if matches!(&object.ty, Ty::OpenRecord { .. } | Ty::TypeVar(_) | Ty::Unknown) && !matches!(vt_ty, Ty::OpenRecord { .. } | Ty::TypeVar(_) | Ty::Unknown) {
+            if object.ty.is_unresolved_structural() && !vt_ty.is_unresolved_structural() {
                 vt_ty.clone()
             } else {
                 object.ty.clone()
@@ -397,7 +397,7 @@ impl FuncCompiler<'_> {
         let tag_offset = self.variant_tag_offset(&resolved_ty);
 
         // If fields are empty and type is Unknown, try searching record_fields for a type that has this field
-        if fields.is_empty() && matches!(&resolved_ty, Ty::Unknown | Ty::TypeVar(_)) {
+        if fields.is_empty() && resolved_ty.is_unresolved() {
             for (_name, rf) in &self.emitter.record_fields {
                 if rf.iter().any(|(n, _)| n == field) {
                     fields = rf.clone();
@@ -420,7 +420,7 @@ impl FuncCompiler<'_> {
     fn resolve_member_result_type(&self, object: &IrExpr, field: &str) -> Ty {
         let obj_ty = if let almide_ir::IrExprKind::Var { id } = &object.kind {
             let vt_ty = &self.var_table.get(*id).ty;
-            if !matches!(vt_ty, Ty::Unknown | Ty::TypeVar(_)) { vt_ty.clone() } else { object.ty.clone() }
+            if !vt_ty.is_unresolved() { vt_ty.clone() } else { object.ty.clone() }
         } else if let almide_ir::IrExprKind::Member { object: inner, field: inner_f } = &object.kind {
             self.resolve_member_result_type(inner, inner_f)
         } else {

--- a/crates/almide-codegen/src/emit_wasm/control.rs
+++ b/crates/almide-codegen/src/emit_wasm/control.rs
@@ -656,8 +656,28 @@ impl FuncCompiler<'_> {
                     self.depth_pop(rec_guard);
                     wasm!(self.func, { end; });
                 } else {
-                    // Not a variant — treat as plain record (always matches)
-                    self.emit_expr(&arm.body);
+                    // Plain record (not a variant): the structural shape is guaranteed
+                    // by the type checker, so the record match itself always succeeds.
+                    // Still need to bind fields (pattern = None means implicit bind from
+                    // field name → VarId) and then run any guard; on guard failure, fall
+                    // through to the next arm.
+                    let case_fields = self.extract_record_fields(subject_ty);
+                    for pf in pat_fields {
+                        if let Some((foff, fty)) = values::field_offset(&case_fields, &pf.name) {
+                            let local_idx = if let Some(almide_ir::IrPattern::Bind { var, .. }) = &pf.pattern {
+                                self.var_map.get(&var.0).copied()
+                            } else {
+                                self.find_var_by_field(&pf.name, &case_fields).copied()
+                            };
+                            if let Some(idx) = local_idx {
+                                wasm!(self.func, { local_get(scratch); });
+                                self.emit_load_at(&fty, foff);
+                                wasm!(self.func, { local_set(idx); });
+                            }
+                        }
+                    }
+                    // Run guard (if any) and fall through to subsequent arms when it fails.
+                    self.emit_arm_body_or_guard(arm, arms, scratch, subject_ty, result_ty, idx, is_last);
                 }
             }
 

--- a/crates/almide-codegen/src/emit_wasm/control.rs
+++ b/crates/almide-codegen/src/emit_wasm/control.rs
@@ -500,7 +500,7 @@ impl FuncCompiler<'_> {
 
                         if let IrPattern::Bind { var, ty: pat_ty } = arg_pat {
                             if let Some(&local_idx) = self.var_map.get(&var.0) {
-                                let load_ty = if matches!(pat_ty, Ty::Unknown | Ty::TypeVar(_))
+                                let load_ty = if pat_ty.is_unresolved()
                                     || matches!(pat_ty, Ty::Named(n, a) if a.is_empty() && n.len() <= 2)
                                 { field_ty } else { pat_ty };
                                 wasm!(self.func, { local_get(scratch); });
@@ -1032,7 +1032,7 @@ impl FuncCompiler<'_> {
                             .unwrap_or(Ty::Int);
                         if let IrPattern::Bind { var, ty: pat_ty } = arg_pat {
                             if let Some(&local_idx) = self.var_map.get(&var.0) {
-                                let load_ty = if matches!(pat_ty, Ty::Unknown | Ty::TypeVar(_))
+                                let load_ty = if pat_ty.is_unresolved()
                                     || matches!(pat_ty, Ty::Named(n, a) if a.is_empty() && n.len() <= 2)
                                 { &field_ty } else { pat_ty };
                                 wasm!(self.func, { local_get(inner_scratch); });

--- a/crates/almide-codegen/src/emit_wasm/equality.rs
+++ b/crates/almide-codegen/src/emit_wasm/equality.rs
@@ -2,7 +2,10 @@
 //!
 //! Type-aware recursive equality for List, Option, Result, Tuple, Record, Variant.
 
+use std::collections::HashMap;
+
 use super::FuncCompiler;
+use super::VariantCase;
 use super::values;
 use almide_ir::IrExpr;
 use almide_lang::types::Ty;
@@ -180,12 +183,12 @@ impl FuncCompiler<'_> {
         match &expr.kind {
             IrExprKind::TupleIndex { object, index } => {
                 // Try to get the tuple type from the object, then extract element type
-                let obj_ty = if matches!(&object.ty, Ty::Unknown | Ty::TypeVar(_)) {
+                let obj_ty = if object.ty.is_unresolved() {
                     // Try VarTable
                     if let IrExprKind::Var { id } = &object.kind {
                         if (id.0 as usize) < self.var_table.len() {
                             let info = self.var_table.get(*id);
-                            if !matches!(&info.ty, Ty::Unknown | Ty::TypeVar(_)) {
+                            if !info.ty.is_unresolved() {
                                 Some(info.ty.clone())
                             } else { None }
                         } else { None }
@@ -200,7 +203,7 @@ impl FuncCompiler<'_> {
             IrExprKind::Var { id } => {
                 if (id.0 as usize) < self.var_table.len() {
                     let info = self.var_table.get(*id);
-                    if !matches!(&info.ty, Ty::Unknown | Ty::TypeVar(_)) {
+                    if !info.ty.is_unresolved() {
                         Some(info.ty.clone())
                     } else { None }
                 } else { None }
@@ -500,7 +503,7 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(right);
             }
             // TypeVar/Unknown: unresolved type — trap rather than silently compare as wrong type
-            (Ty::TypeVar(_) | Ty::Unknown, _) => { wasm!(self.func, { unreachable; }); }
+            (ty, _) if ty.is_unresolved() => { wasm!(self.func, { unreachable; }); }
             _ => { wasm!(self.func, { unreachable; }); }
         }
     }
@@ -555,41 +558,7 @@ impl FuncCompiler<'_> {
     /// Extract field names and types from a record/named type.
     /// For generic types like Box[Int], substitutes type parameters.
     pub(super) fn extract_record_fields(&self, ty: &Ty) -> Vec<(String, Ty)> {
-        match ty {
-            Ty::Record { fields } | Ty::OpenRecord { fields } => fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect(),
-            Ty::Named(name, type_args) => {
-                if let Some(fields) = self.emitter.record_fields.get(name.as_str()) {
-                    if type_args.is_empty() {
-                        fields.clone()
-                    } else {
-                        // Collect generic param names from ALL constructors of the variant type
-                        // (not just this ctor) for correct index mapping.
-                        // E.g., Either[A,B]: Left(A), Right(B) → gnames = ["A","B"], not just ["B"]
-                        let mut generic_names: Vec<&str> = Vec::new();
-                        if let Some(cases) = self.emitter.variant_info.get(name.as_str()) {
-                            for case in cases {
-                                for (_, fty) in &case.fields {
-                                    super::expressions::collect_type_param_names(fty, &mut generic_names);
-                                }
-                            }
-                        }
-                        if generic_names.is_empty() {
-                            // Fallback: collect from this ctor's fields only (non-variant records)
-                            for (_, fty) in fields {
-                                super::expressions::collect_type_param_names(fty, &mut generic_names);
-                            }
-                        }
-                        fields.iter().map(|(fname, fty)| {
-                            let resolved = super::expressions::substitute_type_params(fty, &generic_names, type_args);
-                            (fname.clone(), resolved)
-                        }).collect()
-                    }
-                } else {
-                    vec![]
-                }
-            }
-            _ => vec![],
-        }
+        extract_record_fields(ty, &self.emitter.record_fields, &self.emitter.variant_info)
     }
 
     /// Find local index for a pattern field binding by name.
@@ -652,5 +621,54 @@ impl FuncCompiler<'_> {
         let cases = self.emitter.variant_info.get(type_name);
         let cases = cases?;
         cases.iter().find(|c| c.name == ctor_name).map(|c| c.tag)
+    }
+}
+
+/// Extract field names and types from a record/named type.
+///
+/// Handles `Ty::Record`, `Ty::OpenRecord`, and `Ty::Named` with full generic
+/// substitution via `variant_info`. This is the single canonical implementation;
+/// `FuncCompiler::extract_record_fields` delegates here.
+pub(super) fn extract_record_fields(
+    ty: &Ty,
+    record_fields: &HashMap<String, Vec<(String, Ty)>>,
+    variant_info: &HashMap<String, Vec<VariantCase>>,
+) -> Vec<(String, Ty)> {
+    match ty {
+        Ty::Record { fields } | Ty::OpenRecord { fields } => {
+            fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect()
+        }
+        Ty::Named(name, type_args) => {
+            if let Some(fields) = record_fields.get(name.as_str()) {
+                if type_args.is_empty() {
+                    fields.clone()
+                } else {
+                    // Collect generic param names from ALL constructors of the variant type
+                    // (not just this ctor) for correct index mapping.
+                    // E.g., Either[A,B]: Left(A), Right(B) → gnames = ["A","B"], not just ["B"]
+                    let mut generic_names: Vec<&str> = Vec::new();
+                    if let Some(cases) = variant_info.get(name.as_str()) {
+                        for case in cases {
+                            for (_, fty) in &case.fields {
+                                super::expressions::collect_type_param_names(fty, &mut generic_names);
+                            }
+                        }
+                    }
+                    if generic_names.is_empty() {
+                        // Fallback: collect from this ctor's fields only (non-variant records)
+                        for (_, fty) in fields {
+                            super::expressions::collect_type_param_names(fty, &mut generic_names);
+                        }
+                    }
+                    fields.iter().map(|(fname, fty)| {
+                        let resolved = super::expressions::substitute_type_params(fty, &generic_names, type_args);
+                        (fname.clone(), resolved)
+                    }).collect()
+                }
+            } else {
+                vec![]
+            }
+        }
+        _ => vec![],
     }
 }

--- a/crates/almide-codegen/src/emit_wasm/equality.rs
+++ b/crates/almide-codegen/src/emit_wasm/equality.rs
@@ -311,23 +311,32 @@ impl FuncCompiler<'_> {
               // Same tag. If tag==0 (ok): compare ok values
               local_get(a); i32_load(0); i32_eqz;
               if_i32;
-                local_get(a);
         });
-        self.emit_load_at(ok_ty, 4);
-        wasm!(self.func, { local_get(b); });
-        self.emit_load_at(ok_ty, 4);
-        let ok_clone = ok_ty.clone();
-        self.emit_eq_typed(&ok_clone);
+        // Ty::Unit has no representation — skip loading and treat as equal.
+        if matches!(ok_ty, Ty::Unit) {
+            wasm!(self.func, { i32_const(1); });
+        } else {
+            wasm!(self.func, { local_get(a); });
+            self.emit_load_at(ok_ty, 4);
+            wasm!(self.func, { local_get(b); });
+            self.emit_load_at(ok_ty, 4);
+            let ok_clone = ok_ty.clone();
+            self.emit_eq_typed(&ok_clone);
+        }
         wasm!(self.func, {
               else_;
                 // tag==1 (err): compare err values
-                local_get(a);
         });
-        self.emit_load_at(err_ty, 4);
-        wasm!(self.func, { local_get(b); });
-        self.emit_load_at(err_ty, 4);
-        let err_clone = err_ty.clone();
-        self.emit_eq_typed(&err_clone);
+        if matches!(err_ty, Ty::Unit) {
+            wasm!(self.func, { i32_const(1); });
+        } else {
+            wasm!(self.func, { local_get(a); });
+            self.emit_load_at(err_ty, 4);
+            wasm!(self.func, { local_get(b); });
+            self.emit_load_at(err_ty, 4);
+            let err_clone = err_ty.clone();
+            self.emit_eq_typed(&err_clone);
+        }
         wasm!(self.func, {
               end;
             end;
@@ -463,6 +472,32 @@ impl FuncCompiler<'_> {
             }
             (Ty::String, CmpKind::Gte) => {
                 wasm!(self.func, { call(self.emitter.rt.string.cmp); i32_const(0); i32_ge_s; });
+            }
+            // Variant (enum-like) comparison: each value is a pointer to a heap
+            // block whose first i32 is the discriminant tag. For `Ord`-derived
+            // variants, `Low < Medium` means `Low.tag < Medium.tag`, so we load
+            // both tags and compare them as unsigned i32s.
+            //
+            // Stack on entry: [left_ptr, right_ptr]. We must load tags from both
+            // pointers and compare, preserving WASM's strict stack discipline.
+            // Use scratch locals to hold the pointers since WASM has no swap op.
+            (Ty::Named(name, _), cmp_kind) if self.emitter.variant_info.contains_key(name.as_str()) => {
+                let right = self.scratch.alloc_i32();
+                let left = self.scratch.alloc_i32();
+                wasm!(self.func, {
+                    local_set(right);
+                    local_set(left);
+                    local_get(left); i32_load(0);
+                    local_get(right); i32_load(0);
+                });
+                match cmp_kind {
+                    CmpKind::Lt => { wasm!(self.func, { i32_lt_u; }); }
+                    CmpKind::Gt => { wasm!(self.func, { i32_gt_u; }); }
+                    CmpKind::Lte => { wasm!(self.func, { i32_le_u; }); }
+                    CmpKind::Gte => { wasm!(self.func, { i32_ge_u; }); }
+                }
+                self.scratch.free_i32(left);
+                self.scratch.free_i32(right);
             }
             // TypeVar/Unknown: unresolved type — trap rather than silently compare as wrong type
             (Ty::TypeVar(_) | Ty::Unknown, _) => { wasm!(self.func, { unreachable; }); }

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -857,7 +857,7 @@ impl FuncCompiler<'_> {
                 let extract_elem = |ty: &Ty| -> Option<u32> {
                     if let Ty::Applied(_, args) = ty {
                         args.first()
-                            .filter(|t| !matches!(t, Ty::TypeVar(_) | Ty::Unknown))
+                            .filter(|t| !t.is_unresolved())
                             .map(|t| values::byte_size(t))
                     } else { None }
                 };

--- a/crates/almide-codegen/src/emit_wasm/functions.rs
+++ b/crates/almide-codegen/src/emit_wasm/functions.rs
@@ -34,7 +34,7 @@ pub fn compile_function_with_init(
     }
 
     // Pre-scan body for variable bindings and match scratch requirements
-    let scan = collect_locals(&func.body, _var_table);
+    let scan = collect_locals(&func.body, _var_table, &emitter.record_fields);
     let mut local_decls = Vec::new();
 
     // Bind locals

--- a/crates/almide-codegen/src/emit_wasm/functions.rs
+++ b/crates/almide-codegen/src/emit_wasm/functions.rs
@@ -34,7 +34,7 @@ pub fn compile_function_with_init(
     }
 
     // Pre-scan body for variable bindings and match scratch requirements
-    let scan = collect_locals(&func.body, _var_table, &emitter.record_fields);
+    let scan = collect_locals(&func.body, _var_table, &emitter.record_fields, &emitter.variant_info);
     let mut local_decls = Vec::new();
 
     // Bind locals

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -77,6 +77,7 @@ pub struct StringRuntime {
     pub contains: u32,
     pub trim: u32,
     pub slice: u32,
+    pub char_count: u32,
     pub reverse: u32,
     pub repeat: u32,
     pub index_of: u32,
@@ -118,6 +119,7 @@ pub struct RuntimeFuncs {
     pub concat_list: u32,
     pub list_eq: u32,
     pub mem_eq: u32,
+    pub list_list_str_cmp: u32,
     pub option_eq_i64: u32,
     pub option_eq_str: u32,
     pub result_eq_i64_str: u32,
@@ -168,7 +170,7 @@ struct ImportInfo {
 /// Central state for WASM binary emission.
 pub struct WasmEmitter {
     // Type section (deduplicated function signatures)
-    types: Vec<(Vec<ValType>, Vec<ValType>)>,
+    pub(crate) types: Vec<(Vec<ValType>, Vec<ValType>)>,
     type_map: HashMap<(Vec<ValType>, Vec<ValType>), u32>,
 
     // Imports
@@ -265,7 +267,7 @@ impl WasmEmitter {
                 math_sin: 0, math_cos: 0, math_tan: 0,
                 math_log: 0, math_log10: 0, math_log2: 0, math_exp: 0,
                 concat_str: 0, concat_list: 0,
-                list_eq: 0, mem_eq: 0,
+                list_eq: 0, mem_eq: 0, list_list_str_cmp: 0,
                 option_eq_i64: 0, option_eq_str: 0,
                 result_eq_i64_str: 0, int_parse: 0, int_from_hex: 0,
                 string: StringRuntime {
@@ -282,6 +284,7 @@ impl WasmEmitter {
                     is_digit: 0, is_alpha: 0, is_alnum: 0,
                     is_whitespace: 0, is_upper: 0, is_lower: 0,
                     cmp: 0,
+                    char_count: 0,
                 },
                 value_stringify: 0,
                 json_parse: 0,
@@ -629,6 +632,12 @@ pub fn emit(program: &IrProgram) -> Vec<u8> {
         }
     }
 
+    // Also register all anonymous record shapes found in the IR under synthetic
+    // names so `emit_member`'s Unknown-type fallback (which searches
+    // `record_fields` by field name) can resolve Member access on Lambda
+    // parameters whose type inference left them as TypeVar/Unknown.
+    register_anonymous_records(program, &mut emitter);
+
     // Build default_fields from type declarations
     for td in &program.type_decls {
         match &td.kind {
@@ -681,10 +690,30 @@ pub fn emit(program: &IrProgram) -> Vec<u8> {
     let has_main = program.functions.iter().any(|f| f.name == "main" && !f.is_test);
 
     for func in &program.functions {
+        // Resolve param and ret types: Unknown/TypeVar can leak through from
+        // lifted lambdas whose outer `Ty::Fn` had unresolved entries. Fall back
+        // to VarTable (for params) and expression inspection (for ret).
         let params: Vec<ValType> = func.params.iter()
-            .filter_map(|p| values::ty_to_valtype(&p.ty))
+            .filter_map(|p| {
+                let pty = if matches!(&p.ty, almide_lang::types::Ty::Unknown | almide_lang::types::Ty::TypeVar(_) | almide_lang::types::Ty::OpenRecord { .. }) {
+                    let vt_ty = &program.var_table.get(p.var).ty;
+                    if !matches!(vt_ty, almide_lang::types::Ty::Unknown | almide_lang::types::Ty::TypeVar(_) | almide_lang::types::Ty::OpenRecord { .. }) {
+                        vt_ty.clone()
+                    } else {
+                        p.ty.clone()
+                    }
+                } else {
+                    p.ty.clone()
+                };
+                values::ty_to_valtype(&pty)
+            })
             .collect();
-        let results = values::ret_type(&func.ret_ty);
+        let resolved_ret_ty = if matches!(&func.ret_ty, almide_lang::types::Ty::Unknown | almide_lang::types::Ty::TypeVar(_)) {
+            closures::resolve_expr_ty(&func.body, &program.var_table, &emitter.record_fields)
+        } else {
+            func.ret_ty.clone()
+        };
+        let results = values::ret_type(&resolved_ret_ty);
         let type_idx = emitter.register_type(params, results);
         // Use prefixed name for test functions to avoid colliding with user functions
         let reg_name = if func.is_test {
@@ -1156,6 +1185,151 @@ fn compile_variant_eq_funcs(emitter: &mut WasmEmitter, var_table: &almide_ir::Va
 }
 
 use std::collections::HashSet;
+
+/// Walk all IR expressions/statements and collect anonymous record shapes
+/// (i.e. `Ty::Record { fields }`). Each unique field-set is registered in
+/// `emitter.record_fields` under a synthetic name `__anon_record_N` so the
+/// emit-phase Member access fallback (which iterates record_fields looking
+/// for a match by field name) can find them when a lambda param's own type
+/// was left as Unknown/TypeVar by type inference.
+fn register_anonymous_records(program: &IrProgram, emitter: &mut WasmEmitter) {
+    use almide_ir::{IrExpr, IrExprKind, IrStmt, IrStmtKind};
+    let mut seen: HashSet<Vec<(String, String)>> = HashSet::new();
+    // Seed with already-registered records to avoid redundant anonymous entries.
+    for fields in emitter.record_fields.values() {
+        let key: Vec<(String, String)> = fields.iter().map(|(n, t)| (n.clone(), format!("{:?}", t))).collect();
+        seen.insert(key);
+    }
+
+    fn walk_ty(
+        ty: &Ty,
+        seen: &mut HashSet<Vec<(String, String)>>,
+        record_fields: &mut HashMap<String, Vec<(String, Ty)>>,
+    ) {
+        match ty {
+            Ty::Record { fields } | Ty::OpenRecord { fields } => {
+                let field_vec: Vec<(String, Ty)> = fields.iter()
+                    .map(|(n, t)| (n.to_string(), t.clone()))
+                    .collect();
+                let key: Vec<(String, String)> = field_vec.iter()
+                    .map(|(n, t)| (n.clone(), format!("{:?}", t)))
+                    .collect();
+                if seen.insert(key) {
+                    let name = format!("__anon_record_{}", record_fields.len());
+                    record_fields.insert(name, field_vec.clone());
+                }
+                for (_, fty) in fields.iter() { walk_ty(fty, seen, record_fields); }
+            }
+            Ty::Applied(_, args) => { for a in args { walk_ty(a, seen, record_fields); } }
+            Ty::Tuple(elems) => { for e in elems { walk_ty(e, seen, record_fields); } }
+            Ty::Fn { params, ret } => {
+                for p in params { walk_ty(p, seen, record_fields); }
+                walk_ty(ret, seen, record_fields);
+            }
+            _ => {}
+        }
+    }
+
+    fn walk_expr(
+        expr: &IrExpr,
+        seen: &mut HashSet<Vec<(String, String)>>,
+        record_fields: &mut HashMap<String, Vec<(String, Ty)>>,
+    ) {
+        walk_ty(&expr.ty, seen, record_fields);
+        match &expr.kind {
+            IrExprKind::Block { stmts, expr: tail } => {
+                for s in stmts { walk_stmt(s, seen, record_fields); }
+                if let Some(t) = tail { walk_expr(t, seen, record_fields); }
+            }
+            IrExprKind::Call { args, .. } => { for a in args { walk_expr(a, seen, record_fields); } }
+            IrExprKind::If { cond, then, else_ } => {
+                walk_expr(cond, seen, record_fields);
+                walk_expr(then, seen, record_fields);
+                walk_expr(else_, seen, record_fields);
+            }
+            IrExprKind::Match { subject, arms } => {
+                walk_expr(subject, seen, record_fields);
+                for arm in arms {
+                    if let Some(g) = &arm.guard { walk_expr(g, seen, record_fields); }
+                    walk_expr(&arm.body, seen, record_fields);
+                }
+            }
+            IrExprKind::Record { fields, .. } => {
+                // Build field-type list from the literal's field expressions.
+                let field_vec: Vec<(String, Ty)> = fields.iter()
+                    .map(|(n, e)| (n.to_string(), e.ty.clone()))
+                    .collect();
+                let key: Vec<(String, String)> = field_vec.iter()
+                    .map(|(n, t)| (n.clone(), format!("{:?}", t)))
+                    .collect();
+                let is_unresolved = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_));
+                if field_vec.iter().all(|(_, t)| !is_unresolved(t)) && seen.insert(key) {
+                    let name = format!("__anon_record_{}", record_fields.len());
+                    record_fields.insert(name, field_vec);
+                }
+                for (_, e) in fields.iter() { walk_expr(e, seen, record_fields); }
+            }
+            IrExprKind::SpreadRecord { base, fields } => {
+                walk_expr(base, seen, record_fields);
+                for (_, e) in fields.iter() { walk_expr(e, seen, record_fields); }
+            }
+            IrExprKind::List { elements } => { for e in elements { walk_expr(e, seen, record_fields); } }
+            IrExprKind::Tuple { elements } => { for e in elements { walk_expr(e, seen, record_fields); } }
+            IrExprKind::Lambda { body, .. } => { walk_expr(body, seen, record_fields); }
+            IrExprKind::ClosureCreate { captures, .. } => {
+                for (_, t) in captures { walk_ty(t, seen, record_fields); }
+            }
+            IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
+            | IrExprKind::OptionSome { expr } => walk_expr(expr, seen, record_fields),
+            IrExprKind::Member { object, .. } => { walk_expr(object, seen, record_fields); }
+            IrExprKind::IndexAccess { object, index } => {
+                walk_expr(object, seen, record_fields);
+                walk_expr(index, seen, record_fields);
+            }
+            IrExprKind::BinOp { left, right, .. } => {
+                walk_expr(left, seen, record_fields);
+                walk_expr(right, seen, record_fields);
+            }
+            IrExprKind::UnOp { operand, .. } => walk_expr(operand, seen, record_fields),
+            IrExprKind::Try { expr } | IrExprKind::Unwrap { expr } => walk_expr(expr, seen, record_fields),
+            IrExprKind::ForIn { iterable, body, .. } => {
+                walk_expr(iterable, seen, record_fields);
+                for s in body { walk_stmt(s, seen, record_fields); }
+            }
+            IrExprKind::While { cond, body } => {
+                walk_expr(cond, seen, record_fields);
+                for s in body { walk_stmt(s, seen, record_fields); }
+            }
+            _ => {}
+        }
+    }
+
+    fn walk_stmt(
+        stmt: &IrStmt,
+        seen: &mut HashSet<Vec<(String, String)>>,
+        record_fields: &mut HashMap<String, Vec<(String, Ty)>>,
+    ) {
+        match &stmt.kind {
+            IrStmtKind::Bind { value, ty, .. } => {
+                walk_ty(ty, seen, record_fields);
+                walk_expr(value, seen, record_fields);
+            }
+            IrStmtKind::BindDestructure { value, .. } => walk_expr(value, seen, record_fields),
+            IrStmtKind::Assign { value, .. } => walk_expr(value, seen, record_fields),
+            IrStmtKind::Expr { expr } => walk_expr(expr, seen, record_fields),
+            _ => {}
+        }
+    }
+
+    for func in &program.functions {
+        walk_ty(&func.ret_ty, &mut seen, &mut emitter.record_fields);
+        for p in &func.params { walk_ty(&p.ty, &mut seen, &mut emitter.record_fields); }
+        walk_expr(&func.body, &mut seen, &mut emitter.record_fields);
+    }
+    for tl in &program.top_lets {
+        walk_expr(&tl.value, &mut seen, &mut emitter.record_fields);
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -588,8 +588,12 @@ pub fn emit(program: &IrProgram) -> Vec<u8> {
         type_idx: fd_readdir_type_idx,
     });
 
-    // Register type declarations (record and variant field layouts)
-    for td in &program.type_decls {
+    // Register type declarations (record and variant field layouts).
+    // Include both the main program and all imported modules so nominal
+    // types from `import mod` resolve during codegen.
+    let all_type_decls = program.type_decls.iter()
+        .chain(program.modules.iter().flat_map(|m| m.type_decls.iter()));
+    for td in all_type_decls {
         match &td.kind {
             almide_ir::IrTypeDeclKind::Record { fields } => {
                 let field_list: Vec<(String, almide_lang::types::Ty)> = fields.iter()

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -695,9 +695,9 @@ pub fn emit(program: &IrProgram) -> Vec<u8> {
         // to VarTable (for params) and expression inspection (for ret).
         let params: Vec<ValType> = func.params.iter()
             .filter_map(|p| {
-                let pty = if matches!(&p.ty, almide_lang::types::Ty::Unknown | almide_lang::types::Ty::TypeVar(_) | almide_lang::types::Ty::OpenRecord { .. }) {
+                let pty = if p.ty.is_unresolved_structural() {
                     let vt_ty = &program.var_table.get(p.var).ty;
-                    if !matches!(vt_ty, almide_lang::types::Ty::Unknown | almide_lang::types::Ty::TypeVar(_) | almide_lang::types::Ty::OpenRecord { .. }) {
+                    if !vt_ty.is_unresolved_structural() {
                         vt_ty.clone()
                     } else {
                         p.ty.clone()
@@ -708,7 +708,7 @@ pub fn emit(program: &IrProgram) -> Vec<u8> {
                 values::ty_to_valtype(&pty)
             })
             .collect();
-        let resolved_ret_ty = if matches!(&func.ret_ty, almide_lang::types::Ty::Unknown | almide_lang::types::Ty::TypeVar(_)) {
+        let resolved_ret_ty = if func.ret_ty.is_unresolved() {
             closures::resolve_expr_ty(&func.body, &program.var_table, &emitter.record_fields)
         } else {
             func.ret_ty.clone()
@@ -1262,8 +1262,7 @@ fn register_anonymous_records(program: &IrProgram, emitter: &mut WasmEmitter) {
                 let key: Vec<(String, String)> = field_vec.iter()
                     .map(|(n, t)| (n.clone(), format!("{:?}", t)))
                     .collect();
-                let is_unresolved = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_));
-                if field_vec.iter().all(|(_, t)| !is_unresolved(t)) && seen.insert(key) {
+                if field_vec.iter().all(|(_, t)| !t.is_unresolved()) && seen.insert(key) {
                     let name = format!("__anon_record_{}", record_fields.len());
                     record_fields.insert(name, field_vec);
                 }

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -69,6 +69,12 @@ pub fn register(emitter: &mut WasmEmitter) {
 
     // String comparison: (a: i32, b: i32) -> i32 (negative/0/positive)
     emitter.rt.string.cmp = emitter.register_func("__str_cmp", ty_i32x2_i32);
+
+    // UTF-8 char count: (s: i32) -> i64 — counts code points, not bytes.
+    // Distinct from `string.len` which reads the byte-count header and is used
+    // for sizing; `char_count` walks the data section and skips UTF-8
+    // continuation bytes (bytes whose top two bits are `10`).
+    emitter.rt.string.char_count = emitter.register_func("__str_char_count", _ty_i32_i64);
 }
 
 /// Compile all string runtime function bodies.
@@ -105,6 +111,39 @@ pub fn compile(emitter: &mut WasmEmitter) {
     super::rt_string_extra::compile_is_upper(emitter);
     super::rt_string_extra::compile_is_lower(emitter);
     super::rt_string_extra::compile_cmp(emitter);
+    compile_char_count(emitter);
+}
+
+/// Count UTF-8 code points in a string (pointer to `[len:i32][bytes...]`).
+/// Iterates the byte payload and skips continuation bytes (top bits `10xxxxxx`).
+fn compile_char_count(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.char_count];
+    // Locals: 1=byte_len, 2=i (byte index), 3=count
+    let mut f = Function::new([(3, ValType::I32)]);
+    wasm!(f, {
+        // byte_len = *s
+        local_get(0); i32_load(0); local_set(1);
+        // i = 0, count = 0
+        i32_const(0); local_set(2);
+        i32_const(0); local_set(3);
+        block_empty; loop_empty;
+          local_get(2); local_get(1); i32_ge_u; br_if(1);
+          // byte = s[4 + i]
+          local_get(0); i32_const(4); i32_add;
+          local_get(2); i32_add; i32_load8_u(0);
+          // if (byte & 0xC0) != 0x80 then count++
+          i32_const(0xC0); i32_and;
+          i32_const(0x80); i32_ne;
+          if_empty;
+            local_get(3); i32_const(1); i32_add; local_set(3);
+          end;
+          local_get(2); i32_const(1); i32_add; local_set(2);
+          br(0);
+        end; end;
+        local_get(3); i64_extend_i32_u;
+        end;
+    });
+    emitter.add_compiled(CompiledFunc { type_idx, func: f });
 }
 
 // ── Core ──
@@ -366,6 +405,14 @@ fn compile_split(emitter: &mut WasmEmitter) {
     ]);
     wasm!(f, {
         local_get(1); i32_load(0); local_set(3); // d_len
+        // Empty delimiter: return [s] to avoid infinite recursion on index_of("x", "") == 0.
+        local_get(3); i32_eqz;
+        if_empty;
+          i32_const(8); call(emitter.rt.alloc); local_set(7);
+          local_get(7); i32_const(1); i32_store(0);
+          local_get(7); local_get(0); i32_store(4);
+          local_get(7); return_;
+        end;
         local_get(0); local_get(1); call(emitter.rt.string.index_of); local_set(2);
         local_get(2); i64_const(-1); i64_eq;
         if_i32;

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -12,7 +12,7 @@ pub fn register(emitter: &mut WasmEmitter) {
     let ty_i32x2_i32 = emitter.register_type(vec![ValType::I32, ValType::I32], vec![ValType::I32]);
     let ty_i32_i32 = emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
     let ty_i32x2_i64 = emitter.register_type(vec![ValType::I32, ValType::I32], vec![ValType::I64]);
-    let _ty_i32_i64 = emitter.register_type(vec![ValType::I32], vec![ValType::I64]);
+    let ty_i32_i64 = emitter.register_type(vec![ValType::I32], vec![ValType::I64]);
 
     let s = &mut emitter.rt.string;
     // Will be set after register_func calls — need to go through emitter
@@ -74,7 +74,7 @@ pub fn register(emitter: &mut WasmEmitter) {
     // Distinct from `string.len` which reads the byte-count header and is used
     // for sizing; `char_count` walks the data section and skips UTF-8
     // continuation bytes (bytes whose top two bits are `10`).
-    emitter.rt.string.char_count = emitter.register_func("__str_char_count", _ty_i32_i64);
+    emitter.rt.string.char_count = emitter.register_func("__str_char_count", ty_i32_i64);
 }
 
 /// Compile all string runtime function bodies.

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -155,6 +155,13 @@ pub fn register_runtime(emitter: &mut WasmEmitter) {
     );
     emitter.rt.list_eq = emitter.register_func("__list_eq", list_eq_ty);
 
+    // __list_list_str_cmp(a: i32, b: i32) -> i32 (lexicographic compare of
+    // List[String] lists; returns negative / 0 / positive like memcmp).
+    let llcmp_ty = emitter.register_type(
+        vec![ValType::I32, ValType::I32], vec![ValType::I32],
+    );
+    emitter.rt.list_list_str_cmp = emitter.register_func("__list_list_str_cmp", llcmp_ty);
+
     // __concat_list(a: i32, b: i32, elem_size: i32) -> i32
     let concat_list_ty = emitter.register_type(
         vec![ValType::I32, ValType::I32, ValType::I32], vec![ValType::I32],
@@ -223,6 +230,7 @@ pub fn compile_runtime(emitter: &mut WasmEmitter) {
     super::runtime_eq::compile_result_eq_i64_str(emitter);
     super::runtime_eq::compile_mem_eq(emitter);
     super::runtime_eq::compile_list_eq(emitter);
+    super::runtime_eq::compile_list_list_str_cmp(emitter);
     super::runtime_eq::compile_concat_list(emitter);
     super::runtime_eq::compile_int_parse(emitter);
     super::rt_numeric::compile_int_from_hex(emitter);

--- a/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
@@ -274,6 +274,47 @@ pub(super) fn compile_list_eq(emitter: &mut WasmEmitter) {
     emitter.add_compiled(CompiledFunc { type_idx, func: f });
 }
 
+/// __list_list_str_cmp(a: i32, b: i32) -> i32
+/// Lexicographic comparison of two `List[String]` values. Returns negative if
+/// a < b, 0 if equal, positive if a > b (matching `memcmp`/`strcmp`).
+pub(super) fn compile_list_list_str_cmp(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.list_list_str_cmp];
+    let str_cmp = emitter.rt.string.cmp;
+    let mut f = Function::new([
+        (1, ValType::I32), // 2: a_len
+        (1, ValType::I32), // 3: b_len
+        (1, ValType::I32), // 4: min_len
+        (1, ValType::I32), // 5: i
+        (1, ValType::I32), // 6: c (per-element cmp)
+    ]);
+    wasm!(f, {
+        local_get(0); i32_load(0); local_set(2);
+        local_get(1); i32_load(0); local_set(3);
+        // min_len = min(a_len, b_len)
+        local_get(2); local_get(3); i32_lt_u;
+        if_i32; local_get(2); else_; local_get(3); end;
+        local_set(4);
+        // Compare element-by-element (elements are 4-byte string pointers).
+        i32_const(0); local_set(5);
+        block_empty; loop_empty;
+          local_get(5); local_get(4); i32_ge_u; br_if(1);
+          local_get(0); i32_const(4); i32_add;
+          local_get(5); i32_const(4); i32_mul; i32_add; i32_load(0);
+          local_get(1); i32_const(4); i32_add;
+          local_get(5); i32_const(4); i32_mul; i32_add; i32_load(0);
+          call(str_cmp); local_set(6);
+          local_get(6); i32_const(0); i32_ne;
+          if_empty; local_get(6); return_; end;
+          local_get(5); i32_const(1); i32_add; local_set(5);
+          br(0);
+        end; end;
+        // Tie on common prefix: shorter list sorts first.
+        local_get(2); local_get(3); i32_sub;
+        end;
+    });
+    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+}
+
 /// __concat_list(a: i32, b: i32, elem_size: i32) -> i32
 /// Concatenate two lists. Layout: [len:i32][data...]. Generic over elem_size.
 pub(super) fn compile_concat_list(emitter: &mut WasmEmitter) {

--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -8,12 +8,17 @@ use almide_lang::types::Ty;
 use wasm_encoder::ValType;
 
 use super::FuncCompiler;
+use super::VariantCase;
+use super::equality::extract_record_fields;
 use super::values;
 
 /// Lookup for record/variant field types by nominal name.
 /// Used during pre-scan to resolve `Ty::Named` to concrete field types
 /// so that destructuring patterns allocate the correct WASM local valtypes.
-pub type RecordFieldLookup = HashMap<String, Vec<(String, Ty)>>;
+pub(super) type RecordFieldLookup = HashMap<String, Vec<(String, Ty)>>;
+
+/// Lookup for variant type info by nominal name.
+pub(super) type VariantInfoLookup = HashMap<String, Vec<VariantCase>>;
 
 impl FuncCompiler<'_> {
     /// Get the element type of a list variable from VarTable.
@@ -463,20 +468,7 @@ fn infer_bind_type(expr: &IrExpr) -> Ty {
             }
         }
         // BinOp: infer from operation kind
-        IrExprKind::BinOp { op, .. } => {
-            use almide_ir::BinOp;
-            match op {
-                BinOp::AddInt | BinOp::SubInt | BinOp::MulInt | BinOp::DivInt
-                | BinOp::ModInt | BinOp::PowInt => Ty::Int,
-                BinOp::AddFloat | BinOp::SubFloat | BinOp::MulFloat | BinOp::DivFloat
-                | BinOp::ModFloat | BinOp::PowFloat => Ty::Float,
-                BinOp::ConcatStr => Ty::String,
-                BinOp::MulMatrix | BinOp::AddMatrix | BinOp::SubMatrix | BinOp::ScaleMatrix => Ty::Matrix,
-                BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte
-                | BinOp::And | BinOp::Or => Ty::Bool,
-                BinOp::ConcatList => Ty::Unknown,
-            }
-        }
+        IrExprKind::BinOp { op, .. } => op.result_ty().unwrap_or(Ty::Unknown),
         // Try/Unwrap/ToOption: unwrap inner type
         IrExprKind::Try { expr: inner }
         | IrExprKind::Unwrap { expr: inner }
@@ -516,9 +508,10 @@ pub fn collect_locals(
     body: &IrExpr,
     var_table: &almide_ir::VarTable,
     record_fields: &RecordFieldLookup,
+    variant_info: &VariantInfoLookup,
 ) -> LocalScanResult {
     let mut binds = Vec::new();
-    scan_expr(body, &mut binds, var_table, record_fields);
+    scan_expr(body, &mut binds, var_table, record_fields, variant_info);
     LocalScanResult { binds }
 }
 
@@ -532,6 +525,7 @@ struct LocalScanner<'a> {
     locals: &'a mut Vec<(VarId, ValType)>,
     vt: &'a almide_ir::VarTable,
     record_fields: &'a RecordFieldLookup,
+    variant_info: &'a VariantInfoLookup,
 }
 
 impl IrVisitor for LocalScanner<'_> {
@@ -558,7 +552,7 @@ impl IrVisitor for LocalScanner<'_> {
                 self.visit_expr(subject);
                 let resolved_ty = resolve_scan_subject_ty(subject, arms, self.vt);
                 for arm in arms {
-                    scan_pattern(&arm.pattern, &resolved_ty, self.locals, self.vt, self.record_fields);
+                    scan_pattern(&arm.pattern, &resolved_ty, self.locals, self.vt, self.record_fields, self.variant_info);
                     self.visit_expr(&arm.body);
                 }
             }
@@ -581,9 +575,9 @@ impl IrVisitor for LocalScanner<'_> {
                 } else {
                     value.ty.clone()
                 };
-                let resolved_ty = if !matches!(&effective_ty, Ty::Unknown | Ty::TypeVar(_)) {
+                let resolved_ty = if !effective_ty.is_unresolved() {
                     effective_ty
-                } else if !matches!(ty, Ty::Unknown | Ty::TypeVar(_)) {
+                } else if !ty.is_unresolved() {
                     ty.clone()
                 } else {
                     infer_bind_type(value)
@@ -594,7 +588,7 @@ impl IrVisitor for LocalScanner<'_> {
                 self.visit_expr(value);
             }
             IrStmtKind::BindDestructure { pattern, value } => {
-                scan_destructure_pattern(pattern, &value.ty, self.locals, self.vt, self.record_fields);
+                scan_destructure_pattern(pattern, &value.ty, self.locals, self.vt, self.record_fields, self.variant_info);
                 self.visit_expr(value);
             }
             _ => walk_stmt(self, stmt),
@@ -607,23 +601,9 @@ fn scan_expr(
     locals: &mut Vec<(VarId, ValType)>,
     vt: &almide_ir::VarTable,
     record_fields: &RecordFieldLookup,
+    variant_info: &VariantInfoLookup,
 ) {
-    LocalScanner { locals, vt, record_fields }.visit_expr(expr);
-}
-
-/// Resolve record field list from a value type, handling both structural
-/// (`Ty::Record` / `Ty::OpenRecord`) and nominal (`Ty::Named("User", ...)`) forms.
-/// Returns an empty vec when the type is unknown or not a record.
-fn resolve_record_fields(value_ty: &Ty, record_fields: &RecordFieldLookup) -> Vec<(String, Ty)> {
-    match value_ty {
-        Ty::Record { fields } | Ty::OpenRecord { fields } => {
-            fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect()
-        }
-        Ty::Named(name, _type_args) => {
-            record_fields.get(name.as_str()).cloned().unwrap_or_default()
-        }
-        _ => vec![],
-    }
+    LocalScanner { locals, vt, record_fields, variant_info }.visit_expr(expr);
 }
 
 /// Resolve match subject type, fixing IR type inference gaps.
@@ -651,13 +631,14 @@ fn scan_destructure_pattern(
     locals: &mut Vec<(VarId, ValType)>,
     vt: &almide_ir::VarTable,
     record_fields: &RecordFieldLookup,
+    variant_info: &VariantInfoLookup,
 ) {
     match pattern {
         almide_ir::IrPattern::Tuple { elements } => {
             let elem_types = if let almide_lang::types::Ty::Tuple(tys) = value_ty { tys.clone() } else { vec![] };
             for (i, elem) in elements.iter().enumerate() {
                 let elem_ty = elem_types.get(i).cloned().unwrap_or(almide_lang::types::Ty::Int);
-                scan_destructure_pattern(elem, &elem_ty, locals, vt, record_fields);
+                scan_destructure_pattern(elem, &elem_ty, locals, vt, record_fields, variant_info);
             }
         }
         almide_ir::IrPattern::Bind { var, .. } => {
@@ -667,8 +648,8 @@ fn scan_destructure_pattern(
         }
         almide_ir::IrPattern::RecordPattern { fields, .. } => {
             // Record destructure: resolve field types from value_ty (authoritative).
-            // Handles structural records and nominal `Ty::Named("User", ...)` via lookup.
-            let resolved_fields = resolve_record_fields(value_ty, record_fields);
+            // Uses extract_record_fields for full generic substitution.
+            let resolved_fields = extract_record_fields(value_ty, record_fields, variant_info);
             let existing_ids: std::collections::HashSet<u32> = locals.iter().map(|(v, _)| v.0).collect();
             for field in fields {
                 // Resolve field type from the record type (not VarTable -- VarTable may have stale types)
@@ -677,7 +658,7 @@ fn scan_destructure_pattern(
                     .map(|(_, t)| t.clone())
                     .unwrap_or(almide_lang::types::Ty::Int);
                 if let Some(pat) = &field.pattern {
-                    scan_destructure_pattern(pat, &field_ty, locals, vt, record_fields);
+                    scan_destructure_pattern(pat, &field_ty, locals, vt, record_fields, variant_info);
                 } else {
                     // Implicit bind: field name = var name. Look up VarId from VarTable.
                     // Use field_ty from the record type for the WASM local declaration.
@@ -704,6 +685,7 @@ fn scan_pattern(
     locals: &mut Vec<(VarId, ValType)>,
     vt: &almide_ir::VarTable,
     record_fields: &RecordFieldLookup,
+    variant_info: &VariantInfoLookup,
 ) {
     match pattern {
         almide_ir::IrPattern::Bind { var, ty } => {
@@ -722,7 +704,7 @@ fn scan_pattern(
                     // Use pattern.ty (set by mono substitute_pattern_types) — no VarTable
                     for arg in args.iter() {
                         if let almide_ir::IrPattern::Bind { var, ty } = arg {
-                            let effective_ty = if matches!(ty, almide_lang::types::Ty::Unknown | almide_lang::types::Ty::TypeVar(_)) {
+                            let effective_ty = if ty.is_unresolved() {
                                 &vt.get(*var).ty // fallback only
                             } else { ty };
                             if let Some(val_type) = values::ty_to_valtype(effective_ty) {
@@ -737,7 +719,7 @@ fn scan_pattern(
             for (_i, arg) in args.iter().enumerate() {
                 if let almide_ir::IrPattern::Bind { var, ty: pat_ty } = arg {
                     // Use pattern.ty first (set by mono), fall back to VarTable + substitution
-                    let resolved = if !matches!(pat_ty, almide_lang::types::Ty::Unknown | almide_lang::types::Ty::TypeVar(_))
+                    let resolved = if !pat_ty.is_unresolved()
                         && !matches!(pat_ty, almide_lang::types::Ty::Named(n, a) if a.is_empty() && n.len() <= 2 && n.chars().next().map_or(false, |c| c.is_uppercase()))
                     {
                         pat_ty.clone()
@@ -753,7 +735,7 @@ fn scan_pattern(
                         locals.push((*var, val_type));
                     }
                 } else {
-                    scan_pattern(arg, subject_ty, locals, vt, record_fields);
+                    scan_pattern(arg, subject_ty, locals, vt, record_fields, variant_info);
                 }
             }
         }
@@ -761,7 +743,7 @@ fn scan_pattern(
             let elem_types = if let almide_lang::types::Ty::Tuple(tys) = subject_ty { tys.clone() } else { vec![] };
             for (i, elem) in elements.iter().enumerate() {
                 let et = elem_types.get(i).cloned().unwrap_or(subject_ty.clone());
-                scan_pattern(elem, &et, locals, vt, record_fields);
+                scan_pattern(elem, &et, locals, vt, record_fields, variant_info);
             }
         }
         almide_ir::IrPattern::Some { inner } | almide_ir::IrPattern::Ok { inner } => {
@@ -771,12 +753,12 @@ fn scan_pattern(
                 // subject_ty is not Applied — try VarTable for inner binding
                 if let almide_ir::IrPattern::Bind { var, .. } = inner.as_ref() {
                     let vt_ty = &vt.get(*var).ty;
-                    if !matches!(vt_ty, almide_lang::types::Ty::Unknown | almide_lang::types::Ty::TypeVar(_)) {
+                    if !vt_ty.is_unresolved() {
                         vt_ty.clone()
                     } else { subject_ty.clone() }
                 } else { subject_ty.clone() }
             };
-            scan_pattern(inner, &inner_ty, locals, vt, record_fields);
+            scan_pattern(inner, &inner_ty, locals, vt, record_fields, variant_info);
         }
         almide_ir::IrPattern::Err { inner } => {
             let inner_ty = if let almide_lang::types::Ty::Applied(_, args) = subject_ty {
@@ -784,12 +766,12 @@ fn scan_pattern(
             } else {
                 if let almide_ir::IrPattern::Bind { var, .. } = inner.as_ref() {
                     let vt_ty = &vt.get(*var).ty;
-                    if !matches!(vt_ty, almide_lang::types::Ty::Unknown | almide_lang::types::Ty::TypeVar(_)) {
+                    if !vt_ty.is_unresolved() {
                         vt_ty.clone()
                     } else { subject_ty.clone() }
                 } else { subject_ty.clone() }
             };
-            scan_pattern(inner, &inner_ty, locals, vt, record_fields);
+            scan_pattern(inner, &inner_ty, locals, vt, record_fields, variant_info);
         }
         almide_ir::IrPattern::RecordPattern { name: _, fields, .. } => {
             // For pattern=None fields, the binding is implicit (field name = var name).
@@ -799,11 +781,11 @@ fn scan_pattern(
             // Resolve field types from subject_ty (structural or nominal) so local
             // valtypes match the actual value layout — falls back to VarTable only
             // when the record type cannot be resolved.
-            let resolved_fields = resolve_record_fields(subject_ty, record_fields);
+            let resolved_fields = extract_record_fields(subject_ty, record_fields, variant_info);
             let existing_ids: std::collections::HashSet<u32> = locals.iter().map(|(v, _)| v.0).collect();
             for field in fields {
                 if let Some(pat) = &field.pattern {
-                    scan_pattern(pat, subject_ty, locals, vt, record_fields);
+                    scan_pattern(pat, subject_ty, locals, vt, record_fields, variant_info);
                 } else {
                     // Implicit bind: find VarId by field name, searching from end (most recent scope)
                     for i in (0..vt.len()).rev() {

--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -1,5 +1,7 @@
 //! IrStmt → WASM instruction emission + local variable pre-scanning.
 
+use std::collections::HashMap;
+
 use almide_ir::{IrExpr, IrExprKind, IrStmt, IrStmtKind, VarId};
 use almide_ir::visit::{IrVisitor, walk_expr, walk_stmt};
 use almide_lang::types::Ty;
@@ -7,6 +9,11 @@ use wasm_encoder::ValType;
 
 use super::FuncCompiler;
 use super::values;
+
+/// Lookup for record/variant field types by nominal name.
+/// Used during pre-scan to resolve `Ty::Named` to concrete field types
+/// so that destructuring patterns allocate the correct WASM local valtypes.
+pub type RecordFieldLookup = HashMap<String, Vec<(String, Ty)>>;
 
 impl FuncCompiler<'_> {
     /// Get the element type of a list variable from VarTable.
@@ -505,9 +512,13 @@ pub struct LocalScanResult {
 
 /// Pre-scan a function body to collect all local variable bindings
 /// and count scratch local depth.
-pub fn collect_locals(body: &IrExpr, var_table: &almide_ir::VarTable) -> LocalScanResult {
+pub fn collect_locals(
+    body: &IrExpr,
+    var_table: &almide_ir::VarTable,
+    record_fields: &RecordFieldLookup,
+) -> LocalScanResult {
     let mut binds = Vec::new();
-    scan_expr(body, &mut binds, var_table);
+    scan_expr(body, &mut binds, var_table, record_fields);
     LocalScanResult { binds }
 }
 
@@ -520,6 +531,7 @@ pub fn collect_locals(body: &IrExpr, var_table: &almide_ir::VarTable) -> LocalSc
 struct LocalScanner<'a> {
     locals: &'a mut Vec<(VarId, ValType)>,
     vt: &'a almide_ir::VarTable,
+    record_fields: &'a RecordFieldLookup,
 }
 
 impl IrVisitor for LocalScanner<'_> {
@@ -546,7 +558,7 @@ impl IrVisitor for LocalScanner<'_> {
                 self.visit_expr(subject);
                 let resolved_ty = resolve_scan_subject_ty(subject, arms, self.vt);
                 for arm in arms {
-                    scan_pattern(&arm.pattern, &resolved_ty, self.locals, self.vt);
+                    scan_pattern(&arm.pattern, &resolved_ty, self.locals, self.vt, self.record_fields);
                     self.visit_expr(&arm.body);
                 }
             }
@@ -582,7 +594,7 @@ impl IrVisitor for LocalScanner<'_> {
                 self.visit_expr(value);
             }
             IrStmtKind::BindDestructure { pattern, value } => {
-                scan_destructure_pattern(pattern, &value.ty, self.locals, self.vt);
+                scan_destructure_pattern(pattern, &value.ty, self.locals, self.vt, self.record_fields);
                 self.visit_expr(value);
             }
             _ => walk_stmt(self, stmt),
@@ -590,8 +602,28 @@ impl IrVisitor for LocalScanner<'_> {
     }
 }
 
-fn scan_expr(expr: &IrExpr, locals: &mut Vec<(VarId, ValType)>, vt: &almide_ir::VarTable) {
-    LocalScanner { locals, vt }.visit_expr(expr);
+fn scan_expr(
+    expr: &IrExpr,
+    locals: &mut Vec<(VarId, ValType)>,
+    vt: &almide_ir::VarTable,
+    record_fields: &RecordFieldLookup,
+) {
+    LocalScanner { locals, vt, record_fields }.visit_expr(expr);
+}
+
+/// Resolve record field list from a value type, handling both structural
+/// (`Ty::Record` / `Ty::OpenRecord`) and nominal (`Ty::Named("User", ...)`) forms.
+/// Returns an empty vec when the type is unknown or not a record.
+fn resolve_record_fields(value_ty: &Ty, record_fields: &RecordFieldLookup) -> Vec<(String, Ty)> {
+    match value_ty {
+        Ty::Record { fields } | Ty::OpenRecord { fields } => {
+            fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect()
+        }
+        Ty::Named(name, _type_args) => {
+            record_fields.get(name.as_str()).cloned().unwrap_or_default()
+        }
+        _ => vec![],
+    }
 }
 
 /// Resolve match subject type, fixing IR type inference gaps.
@@ -613,13 +645,19 @@ fn resolve_scan_subject_ty(subject: &IrExpr, arms: &[almide_ir::IrMatchArm], vt:
 }
 
 /// Scan a destructuring pattern (let (a, b) = ...) for variable bindings.
-fn scan_destructure_pattern(pattern: &almide_ir::IrPattern, value_ty: &almide_lang::types::Ty, locals: &mut Vec<(VarId, ValType)>, vt: &almide_ir::VarTable) {
+fn scan_destructure_pattern(
+    pattern: &almide_ir::IrPattern,
+    value_ty: &almide_lang::types::Ty,
+    locals: &mut Vec<(VarId, ValType)>,
+    vt: &almide_ir::VarTable,
+    record_fields: &RecordFieldLookup,
+) {
     match pattern {
         almide_ir::IrPattern::Tuple { elements } => {
             let elem_types = if let almide_lang::types::Ty::Tuple(tys) = value_ty { tys.clone() } else { vec![] };
             for (i, elem) in elements.iter().enumerate() {
                 let elem_ty = elem_types.get(i).cloned().unwrap_or(almide_lang::types::Ty::Int);
-                scan_destructure_pattern(elem, &elem_ty, locals, vt);
+                scan_destructure_pattern(elem, &elem_ty, locals, vt, record_fields);
             }
         }
         almide_ir::IrPattern::Bind { var, .. } => {
@@ -629,20 +667,17 @@ fn scan_destructure_pattern(pattern: &almide_ir::IrPattern, value_ty: &almide_la
         }
         almide_ir::IrPattern::RecordPattern { fields, .. } => {
             // Record destructure: resolve field types from value_ty (authoritative).
-            let record_fields: Vec<(String, almide_lang::types::Ty)> = match value_ty {
-                almide_lang::types::Ty::Record { fields } => fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect(),
-                almide_lang::types::Ty::OpenRecord { fields } => fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect(),
-                _ => vec![],
-            };
+            // Handles structural records and nominal `Ty::Named("User", ...)` via lookup.
+            let resolved_fields = resolve_record_fields(value_ty, record_fields);
             let existing_ids: std::collections::HashSet<u32> = locals.iter().map(|(v, _)| v.0).collect();
             for field in fields {
                 // Resolve field type from the record type (not VarTable -- VarTable may have stale types)
-                let field_ty = record_fields.iter()
+                let field_ty = resolved_fields.iter()
                     .find(|(n, _)| n == &field.name)
                     .map(|(_, t)| t.clone())
                     .unwrap_or(almide_lang::types::Ty::Int);
                 if let Some(pat) = &field.pattern {
-                    scan_destructure_pattern(pat, &field_ty, locals, vt);
+                    scan_destructure_pattern(pat, &field_ty, locals, vt, record_fields);
                 } else {
                     // Implicit bind: field name = var name. Look up VarId from VarTable.
                     // Use field_ty from the record type for the WASM local declaration.
@@ -663,7 +698,13 @@ fn scan_destructure_pattern(pattern: &almide_ir::IrPattern, value_ty: &almide_la
 }
 
 /// Scan a match pattern for variable bindings.
-fn scan_pattern(pattern: &almide_ir::IrPattern, subject_ty: &almide_lang::types::Ty, locals: &mut Vec<(VarId, ValType)>, vt: &almide_ir::VarTable) {
+fn scan_pattern(
+    pattern: &almide_ir::IrPattern,
+    subject_ty: &almide_lang::types::Ty,
+    locals: &mut Vec<(VarId, ValType)>,
+    vt: &almide_ir::VarTable,
+    record_fields: &RecordFieldLookup,
+) {
     match pattern {
         almide_ir::IrPattern::Bind { var, ty } => {
             // Use pattern's own type (set by lowering, updated by mono) — no VarTable dependency
@@ -712,7 +753,7 @@ fn scan_pattern(pattern: &almide_ir::IrPattern, subject_ty: &almide_lang::types:
                         locals.push((*var, val_type));
                     }
                 } else {
-                    scan_pattern(arg, subject_ty, locals, vt);
+                    scan_pattern(arg, subject_ty, locals, vt, record_fields);
                 }
             }
         }
@@ -720,7 +761,7 @@ fn scan_pattern(pattern: &almide_ir::IrPattern, subject_ty: &almide_lang::types:
             let elem_types = if let almide_lang::types::Ty::Tuple(tys) = subject_ty { tys.clone() } else { vec![] };
             for (i, elem) in elements.iter().enumerate() {
                 let et = elem_types.get(i).cloned().unwrap_or(subject_ty.clone());
-                scan_pattern(elem, &et, locals, vt);
+                scan_pattern(elem, &et, locals, vt, record_fields);
             }
         }
         almide_ir::IrPattern::Some { inner } | almide_ir::IrPattern::Ok { inner } => {
@@ -735,7 +776,7 @@ fn scan_pattern(pattern: &almide_ir::IrPattern, subject_ty: &almide_lang::types:
                     } else { subject_ty.clone() }
                 } else { subject_ty.clone() }
             };
-            scan_pattern(inner, &inner_ty, locals, vt);
+            scan_pattern(inner, &inner_ty, locals, vt, record_fields);
         }
         almide_ir::IrPattern::Err { inner } => {
             let inner_ty = if let almide_lang::types::Ty::Applied(_, args) = subject_ty {
@@ -748,23 +789,31 @@ fn scan_pattern(pattern: &almide_ir::IrPattern, subject_ty: &almide_lang::types:
                     } else { subject_ty.clone() }
                 } else { subject_ty.clone() }
             };
-            scan_pattern(inner, &inner_ty, locals, vt);
+            scan_pattern(inner, &inner_ty, locals, vt, record_fields);
         }
         almide_ir::IrPattern::RecordPattern { name: _, fields, .. } => {
             // For pattern=None fields, the binding is implicit (field name = var name).
             // The lowerer has already allocated VarIds for these in the VarTable.
             // Search from the END of VarTable to find the most recent (correct scope) VarId,
             // and skip VarIds already registered in locals to avoid duplicates.
+            // Resolve field types from subject_ty (structural or nominal) so local
+            // valtypes match the actual value layout — falls back to VarTable only
+            // when the record type cannot be resolved.
+            let resolved_fields = resolve_record_fields(subject_ty, record_fields);
             let existing_ids: std::collections::HashSet<u32> = locals.iter().map(|(v, _)| v.0).collect();
             for field in fields {
                 if let Some(pat) = &field.pattern {
-                    scan_pattern(pat, subject_ty, locals, vt);
+                    scan_pattern(pat, subject_ty, locals, vt, record_fields);
                 } else {
                     // Implicit bind: find VarId by field name, searching from end (most recent scope)
                     for i in (0..vt.len()).rev() {
                         let info = vt.get(almide_ir::VarId(i as u32));
                         if info.name == field.name && !existing_ids.contains(&(i as u32)) {
-                            if let Some(val_type) = values::ty_to_valtype(&info.ty) {
+                            let field_ty = resolved_fields.iter()
+                                .find(|(n, _)| n == &field.name)
+                                .map(|(_, t)| t.clone())
+                                .unwrap_or_else(|| info.ty.clone());
+                            if let Some(val_type) = values::ty_to_valtype(&field_ty) {
                                 locals.push((almide_ir::VarId(i as u32), val_type));
                             }
                             break;

--- a/crates/almide-codegen/src/emit_wasm/values.rs
+++ b/crates/almide-codegen/src/emit_wasm/values.rs
@@ -63,3 +63,17 @@ pub fn block_type(ty: &Ty) -> BlockType {
         None => BlockType::Empty,
     }
 }
+
+/// Build a representative `Ty` for a given `ValType`, used when we only know
+/// the WASM ABI shape (from a lifted closure's registered type) but not the
+/// source-level type. The returned `Ty` round-trips correctly through
+/// `ty_to_valtype`/`byte_size`.
+pub fn vt_to_placeholder_ty(vt: ValType) -> Ty {
+    match vt {
+        ValType::I64 => Ty::Int,
+        ValType::F64 => Ty::Float,
+        // All i32 heap pointers have identical runtime layout (4-byte pointer);
+        // `Ty::String` is a convenient stand-in.
+        _ => Ty::String,
+    }
+}

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -44,6 +44,7 @@ pub mod pass_stream_fusion;
 pub mod pass_tco;
 pub mod pass_licm;
 pub mod pass_peephole;
+pub mod pass_rust_lowering;
 pub mod pass_closure_conversion;
 pub mod template;
 pub mod target;

--- a/crates/almide-codegen/src/pass_auto_parallel.rs
+++ b/crates/almide-codegen/src/pass_auto_parallel.rs
@@ -217,7 +217,8 @@ fn is_pure_expr(
         IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr } |
         IrExprKind::OptionSome { expr } | IrExprKind::Clone { expr } |
         IrExprKind::Deref { expr } | IrExprKind::Borrow { expr, .. } |
-        IrExprKind::BoxNew { expr } | IrExprKind::ToVec { expr } |
+        IrExprKind::BoxNew { expr } | IrExprKind::RcWrap { expr, .. } |
+        IrExprKind::ToVec { expr } |
         IrExprKind::Try { expr } | IrExprKind::Await { expr } |
         IrExprKind::Unwrap { expr } | IrExprKind::ToOption { expr } => {
             is_pure_expr(expr, local_vars, effect_fns, mutable_vars)
@@ -499,6 +500,7 @@ fn rewrite_expr(
         IrExprKind::Deref { expr } => IrExprKind::Deref { expr: Box::new(rewrite_expr(*expr, effect_fns, mutable_vars)) },
         IrExprKind::Borrow { expr, as_str, mutable } => IrExprKind::Borrow { expr: Box::new(rewrite_expr(*expr, effect_fns, mutable_vars)), as_str, mutable },
         IrExprKind::BoxNew { expr } => IrExprKind::BoxNew { expr: Box::new(rewrite_expr(*expr, effect_fns, mutable_vars)) },
+        IrExprKind::RcWrap { expr, cast_ty } => IrExprKind::RcWrap { expr: Box::new(rewrite_expr(*expr, effect_fns, mutable_vars)), cast_ty },
         IrExprKind::ToVec { expr } => IrExprKind::ToVec { expr: Box::new(rewrite_expr(*expr, effect_fns, mutable_vars)) },
         IrExprKind::MapLiteral { entries } => IrExprKind::MapLiteral {
             entries: entries.into_iter().map(|(k, v)| (rewrite_expr(k, effect_fns, mutable_vars), rewrite_expr(v, effect_fns, mutable_vars))).collect(),

--- a/crates/almide-codegen/src/pass_clone.rs
+++ b/crates/almide-codegen/src/pass_clone.rs
@@ -198,13 +198,18 @@ fn count_syntactic_stmt(stmt: &IrStmt, counts: &mut HashMap<VarId, u32>) {
 // ── Clone ID classification ────────────────────────────────────────
 
 fn needs_clone(ty: &Ty) -> bool {
-    matches!(ty,
+    match ty {
         Ty::String | Ty::Applied(_, _) |
         Ty::Record { .. } | Ty::OpenRecord { .. } |
         Ty::Named(_, _) |
         Ty::Variant { .. } | Ty::Fn { .. } |
-        Ty::TypeVar(_)
-    )
+        Ty::TypeVar(_) => true,
+        // A tuple needs cloning when any element needs cloning. Pure numeric
+        // tuples like `(Int, Int)` are Copy in the Rust target and can be
+        // moved out of an index access directly.
+        Ty::Tuple(elements) => elements.iter().any(needs_clone),
+        _ => false,
+    }
 }
 
 /// Split clone candidates into "always clone" and "eligible for last-use move".

--- a/crates/almide-codegen/src/pass_closure_conversion.rs
+++ b/crates/almide-codegen/src/pass_closure_conversion.rs
@@ -177,12 +177,11 @@ fn convert_expr(
                 let info_name = var_table.get(*vid).name;
                 let info_ty = var_table.get(*vid).ty.clone();
                 // Priority: own annotation → Fn type → VarTable → body usage → fallback
-                let is_unresolved = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_) | Ty::OpenRecord { .. });
-                let resolved_ty = if !is_unresolved(vty) {
+                let resolved_ty = if !vty.is_unresolved_structural() {
                     vty.clone()
-                } else if let Some(fp) = fn_params.as_ref().and_then(|ps| ps.get(i)).filter(|t| !is_unresolved(t)) {
+                } else if let Some(fp) = fn_params.as_ref().and_then(|ps| ps.get(i)).filter(|t| !t.is_unresolved_structural()) {
                     fp.clone()
-                } else if !is_unresolved(&info_ty) {
+                } else if !info_ty.is_unresolved_structural() {
                     info_ty.clone()
                 } else if let Some(inferred) = infer_param_ty_from_body(&body, *vid) {
                     inferred
@@ -192,7 +191,7 @@ fn convert_expr(
                 // Propagate the resolved type back to the VarTable so later
                 // emit phases (Member access resolution, etc.) see a concrete
                 // type instead of the original Unknown/TypeVar.
-                if is_unresolved(&info_ty) && !is_unresolved(&resolved_ty) {
+                if info_ty.is_unresolved_structural() && !resolved_ty.is_unresolved_structural() {
                     var_table.entries[vid.0 as usize].ty = resolved_ty.clone();
                 }
                 func_params.push(IrParam {
@@ -205,10 +204,9 @@ fn convert_expr(
                 });
             }
 
-            let is_unresolved_ty = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_));
             let ret_ty = match &ty {
-                Ty::Fn { ret, .. } if !is_unresolved_ty(ret.as_ref()) => *ret.clone(),
-                _ if !is_unresolved_ty(&body.ty) => body.ty.clone(),
+                Ty::Fn { ret, .. } if !ret.is_unresolved() => *ret.clone(),
+                _ if !body.ty.is_unresolved() => body.ty.clone(),
                 _ => infer_body_result_ty(&body).unwrap_or_else(|| body.ty.clone()),
             };
 
@@ -737,16 +735,15 @@ fn propagate_list_elem_to_lambda_params(
     ) {
         return args;
     }
-    let is_unresolved = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_) | Ty::OpenRecord { .. });
     // Resolve list element type from the list arg (or via VarTable).
     let list_elem = args.get(list_arg_idx).and_then(|a| match &a.ty {
-        Ty::Applied(_, ta) => ta.first().cloned().filter(|t| !is_unresolved(t)),
+        Ty::Applied(_, ta) => ta.first().cloned().filter(|t| !t.is_unresolved_structural()),
         _ => None,
     }).or_else(|| {
         args.get(list_arg_idx).and_then(|a| {
             if let IrExprKind::Var { id } = &a.kind {
                 if let Ty::Applied(_, ta) = &var_table.get(*id).ty {
-                    return ta.first().cloned().filter(|t| !is_unresolved(t));
+                    return ta.first().cloned().filter(|t| !t.is_unresolved_structural());
                 }
             }
             None
@@ -758,9 +755,9 @@ fn propagate_list_elem_to_lambda_params(
         match arg.kind {
             IrExprKind::Lambda { mut params, body, lambda_id } => {
                 if let Some((vid, pty)) = params.first_mut() {
-                    if is_unresolved(pty) {
+                    if pty.is_unresolved_structural() {
                         *pty = elem_ty.clone();
-                        if is_unresolved(&var_table.get(*vid).ty) {
+                        if var_table.get(*vid).ty.is_unresolved_structural() {
                             var_table.entries[vid.0 as usize].ty = elem_ty.clone();
                         }
                     }
@@ -770,7 +767,7 @@ fn propagate_list_elem_to_lambda_params(
                 let refreshed_ty = match arg.ty {
                     Ty::Fn { params: fparams, ret } => {
                         let new_params: Vec<Ty> = fparams.into_iter().enumerate().map(|(i, p)| {
-                            if i == 0 && is_unresolved(&p) { elem_ty.clone() } else { p }
+                            if i == 0 && p.is_unresolved_structural() { elem_ty.clone() } else { p }
                         }).collect();
                         Ty::Fn { params: new_params, ret }
                     }
@@ -792,47 +789,31 @@ fn propagate_list_elem_to_lambda_params(
 /// expression tree (final value of blocks, branches of if/match, binop
 /// results) to find a concrete type.
 fn infer_body_result_ty(expr: &IrExpr) -> Option<Ty> {
-    let is_unresolved = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_));
     match &expr.kind {
         IrExprKind::Block { expr: Some(tail), .. } => infer_body_result_ty(tail),
         IrExprKind::If { then, else_, .. } => {
             infer_body_result_ty(then)
-                .filter(|t| !is_unresolved(t))
+                .filter(|t| !t.is_unresolved())
                 .or_else(|| infer_body_result_ty(else_))
         }
         IrExprKind::Match { arms, .. } => {
             arms.iter()
-                .find_map(|arm| infer_body_result_ty(&arm.body).filter(|t| !is_unresolved(t)))
+                .find_map(|arm| infer_body_result_ty(&arm.body).filter(|t| !t.is_unresolved()))
         }
         IrExprKind::BinOp { op, left, right } => {
-            use almide_ir::BinOp;
-            match op {
-                // Int arithmetic → Int.
-                BinOp::AddInt | BinOp::SubInt | BinOp::MulInt | BinOp::DivInt
-                | BinOp::ModInt | BinOp::PowInt => Some(Ty::Int),
-                // Float arithmetic → Float.
-                BinOp::AddFloat | BinOp::SubFloat | BinOp::MulFloat | BinOp::DivFloat
-                | BinOp::ModFloat | BinOp::PowFloat => Some(Ty::Float),
-                // Matrix ops → Matrix.
-                BinOp::MulMatrix | BinOp::AddMatrix | BinOp::SubMatrix | BinOp::ScaleMatrix => Some(Ty::Matrix),
-                // Concatenation: result equals operand type.
-                BinOp::ConcatStr => Some(Ty::String),
-                BinOp::ConcatList => {
-                    if !is_unresolved(&left.ty) { Some(left.ty.clone()) }
-                    else if !is_unresolved(&right.ty) { Some(right.ty.clone()) }
-                    else { None }
-                }
-                // Comparisons and logical ops → Bool.
-                BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte
-                | BinOp::And | BinOp::Or => Some(Ty::Bool),
-            }
+            // Most ops have a fixed result type; ConcatList inherits from operands.
+            op.result_ty().or_else(|| {
+                if !left.ty.is_unresolved() { Some(left.ty.clone()) }
+                else if !right.ty.is_unresolved() { Some(right.ty.clone()) }
+                else { None }
+            })
         }
         IrExprKind::LitInt { .. } => Some(Ty::Int),
         IrExprKind::LitFloat { .. } => Some(Ty::Float),
         IrExprKind::LitBool { .. } => Some(Ty::Bool),
         IrExprKind::LitStr { .. } => Some(Ty::String),
         _ => {
-            if !is_unresolved(&expr.ty) { Some(expr.ty.clone()) } else { None }
+            if !expr.ty.is_unresolved() { Some(expr.ty.clone()) } else { None }
         }
     }
 }
@@ -844,60 +825,59 @@ fn infer_body_result_ty(expr: &IrExpr) -> Option<Ty> {
 /// Handles the common case where `p` is one operand of a homogeneous binop
 /// (`a + b`, comparisons, etc.) and the sibling operand has a resolved type.
 fn infer_param_ty_from_body(body: &IrExpr, target: VarId) -> Option<Ty> {
-    let is_unresolved = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_) | Ty::OpenRecord { .. });
-    fn walk(expr: &IrExpr, target: VarId, is_unresolved: &impl Fn(&Ty) -> bool) -> Option<Ty> {
+    fn walk(expr: &IrExpr, target: VarId) -> Option<Ty> {
         match &expr.kind {
             IrExprKind::BinOp { left, right, .. } => {
                 // If one side is Var(target) and the other has a known type, use it.
                 if let IrExprKind::Var { id } = &left.kind {
-                    if *id == target && !is_unresolved(&right.ty) {
+                    if *id == target && !right.ty.is_unresolved_structural() {
                         return Some(right.ty.clone());
                     }
                 }
                 if let IrExprKind::Var { id } = &right.kind {
-                    if *id == target && !is_unresolved(&left.ty) {
+                    if *id == target && !left.ty.is_unresolved_structural() {
                         return Some(left.ty.clone());
                     }
                 }
                 // Recurse
-                walk(left, target, is_unresolved).or_else(|| walk(right, target, is_unresolved))
+                walk(left, target).or_else(|| walk(right, target))
             }
             IrExprKind::If { cond, then, else_ } => {
-                walk(cond, target, is_unresolved)
-                    .or_else(|| walk(then, target, is_unresolved))
-                    .or_else(|| walk(else_, target, is_unresolved))
+                walk(cond, target)
+                    .or_else(|| walk(then, target))
+                    .or_else(|| walk(else_, target))
             }
             IrExprKind::Block { stmts, expr } => {
                 for stmt in stmts {
-                    if let Some(t) = walk_stmt_for_target(stmt, target, is_unresolved) {
+                    if let Some(t) = walk_stmt_for_target(stmt, target) {
                         return Some(t);
                     }
                 }
-                expr.as_ref().and_then(|e| walk(e, target, is_unresolved))
+                expr.as_ref().and_then(|e| walk(e, target))
             }
             IrExprKind::Call { args, .. } => {
-                args.iter().find_map(|a| walk(a, target, is_unresolved))
+                args.iter().find_map(|a| walk(a, target))
             }
             IrExprKind::Match { subject, arms } => {
-                walk(subject, target, is_unresolved)
-                    .or_else(|| arms.iter().find_map(|a| walk(&a.body, target, is_unresolved)))
+                walk(subject, target)
+                    .or_else(|| arms.iter().find_map(|a| walk(&a.body, target)))
             }
-            IrExprKind::UnOp { operand, .. } => walk(operand, target, is_unresolved),
-            IrExprKind::Member { object, .. } => walk(object, target, is_unresolved),
+            IrExprKind::UnOp { operand, .. } => walk(operand, target),
+            IrExprKind::Member { object, .. } => walk(object, target),
             IrExprKind::IndexAccess { object, index } => {
-                walk(object, target, is_unresolved).or_else(|| walk(index, target, is_unresolved))
+                walk(object, target).or_else(|| walk(index, target))
             }
             _ => None,
         }
     }
-    fn walk_stmt_for_target(stmt: &IrStmt, target: VarId, is_unresolved: &impl Fn(&Ty) -> bool) -> Option<Ty> {
+    fn walk_stmt_for_target(stmt: &IrStmt, target: VarId) -> Option<Ty> {
         match &stmt.kind {
-            IrStmtKind::Bind { value, .. } => walk(value, target, is_unresolved),
-            IrStmtKind::BindDestructure { value, .. } => walk(value, target, is_unresolved),
-            IrStmtKind::Assign { value, .. } => walk(value, target, is_unresolved),
-            IrStmtKind::Expr { expr } => walk(expr, target, is_unresolved),
+            IrStmtKind::Bind { value, .. } => walk(value, target),
+            IrStmtKind::BindDestructure { value, .. } => walk(value, target),
+            IrStmtKind::Assign { value, .. } => walk(value, target),
+            IrStmtKind::Expr { expr } => walk(expr, target),
             _ => None,
         }
     }
-    walk(body, target, &is_unresolved)
+    walk(body, target)
 }

--- a/crates/almide-codegen/src/pass_closure_conversion.rs
+++ b/crates/almide-codegen/src/pass_closure_conversion.rs
@@ -79,7 +79,7 @@ fn convert_expr(
     var_table: &mut VarTable,
 ) -> IrExpr {
     let span = expr.span;
-    let ty = expr.ty.clone();
+    let mut ty = expr.ty.clone();
 
     let kind = match expr.kind {
         IrExprKind::Lambda { params, body, lambda_id } => {
@@ -157,6 +157,14 @@ fn convert_expr(
             // these vars are in scope (as locals or as cap_locals from the enclosing lifted fn).
 
             // 6. Build the lifted function
+            // Use the outer Fn type (if available) as an authoritative source for
+            // param/ret types — type inference may leave individual Lambda param
+            // annotations as Unknown/TypeVar even when the enclosing Ty::Fn is
+            // fully resolved (e.g. when passed to a stdlib callback).
+            let fn_params: Option<Vec<Ty>> = match &ty {
+                Ty::Fn { params, .. } => Some(params.clone()),
+                _ => None,
+            };
             let mut func_params = vec![IrParam {
                 var: env_var,
                 ty: env_ty.clone(), // env pointer (i32 in WASM, maps via ty_to_valtype)
@@ -165,22 +173,50 @@ fn convert_expr(
                 open_record: None,
                 default: None,
             }];
-            for (vid, vty) in &params {
-                let info = var_table.get(*vid);
+            for (i, (vid, vty)) in params.iter().enumerate() {
+                let info_name = var_table.get(*vid).name;
+                let info_ty = var_table.get(*vid).ty.clone();
+                // Priority: own annotation → Fn type → VarTable → body usage → fallback
+                let is_unresolved = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_) | Ty::OpenRecord { .. });
+                let resolved_ty = if !is_unresolved(vty) {
+                    vty.clone()
+                } else if let Some(fp) = fn_params.as_ref().and_then(|ps| ps.get(i)).filter(|t| !is_unresolved(t)) {
+                    fp.clone()
+                } else if !is_unresolved(&info_ty) {
+                    info_ty.clone()
+                } else if let Some(inferred) = infer_param_ty_from_body(&body, *vid) {
+                    inferred
+                } else {
+                    info_ty.clone()
+                };
+                // Propagate the resolved type back to the VarTable so later
+                // emit phases (Member access resolution, etc.) see a concrete
+                // type instead of the original Unknown/TypeVar.
+                if is_unresolved(&info_ty) && !is_unresolved(&resolved_ty) {
+                    var_table.entries[vid.0 as usize].ty = resolved_ty.clone();
+                }
                 func_params.push(IrParam {
                     var: *vid,
-                    ty: vty.clone(),
-                    name: info.name,
+                    ty: resolved_ty,
+                    name: info_name,
                     borrow: ParamBorrow::Own,
                     open_record: None,
                     default: None,
                 });
             }
 
+            let is_unresolved_ty = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_));
             let ret_ty = match &ty {
-                Ty::Fn { ret, .. } => *ret.clone(),
-                _ => body.ty.clone(),
+                Ty::Fn { ret, .. } if !is_unresolved_ty(ret.as_ref()) => *ret.clone(),
+                _ if !is_unresolved_ty(&body.ty) => body.ty.clone(),
+                _ => infer_body_result_ty(&body).unwrap_or_else(|| body.ty.clone()),
             };
+
+            // Propagate the resolved signature back to the enclosing ClosureCreate
+            // expression's type so downstream list/map/fold call sites see
+            // the concrete param/ret types (they read from fn_arg.ty).
+            let resolved_params: Vec<Ty> = func_params.iter().skip(1).map(|p| p.ty.clone()).collect();
+            ty = Ty::Fn { params: resolved_params, ret: Box::new(ret_ty.clone()) };
 
             lifted.push(IrFunction {
                 name: func_name,
@@ -210,11 +246,18 @@ fn convert_expr(
             stmts: stmts.into_iter().map(|s| convert_stmt(s, lifted, counter, var_table)).collect(),
             expr: tail.map(|e| Box::new(convert_expr(*e, lifted, counter, var_table))),
         },
-        IrExprKind::Call { target, args, type_args } => IrExprKind::Call {
-            target: convert_target(target, lifted, counter, var_table),
-            args: args.into_iter().map(|a| convert_expr(a, lifted, counter, var_table)).collect(),
-            type_args,
-        },
+        IrExprKind::Call { target, args, type_args } => {
+            // Before descending, propagate list element type → inline Lambda
+            // param types. Type inference may leave list closure callbacks'
+            // params as Unknown/TypeVar even when the list's element type is
+            // fully resolved, which breaks downstream Member/sort/map emit.
+            let propagated_args = propagate_list_elem_to_lambda_params(&target, args, var_table);
+            IrExprKind::Call {
+                target: convert_target(target, lifted, counter, var_table),
+                args: propagated_args.into_iter().map(|a| convert_expr(a, lifted, counter, var_table)).collect(),
+                type_args,
+            }
+        }
         IrExprKind::If { cond, then, else_ } => IrExprKind::If {
             cond: Box::new(convert_expr(*cond, lifted, counter, var_table)),
             then: Box::new(convert_expr(*then, lifted, counter, var_table)),
@@ -659,4 +702,202 @@ fn rewrite_var_ids_stmt(stmt: &IrStmt, mappings: &[(VarId, VarId, Ty)]) -> IrStm
         other => other.clone(),
     };
     IrStmt { kind, span: stmt.span }
+}
+
+/// For list stdlib calls whose callback Lambda has unresolved param types,
+/// seed the Lambda param from the list's element type. This plugs the gap
+/// where type inference didn't push the list element through to the lambda
+/// param (most commonly with anonymous record element types).
+///
+/// Mutates the `vty` entries of inline Lambdas in `args` and updates the
+/// VarTable entries for the param VarIds so downstream passes see the
+/// propagated type.
+fn propagate_list_elem_to_lambda_params(
+    target: &almide_ir::CallTarget,
+    args: Vec<IrExpr>,
+    var_table: &mut VarTable,
+) -> Vec<IrExpr> {
+    use almide_ir::CallTarget;
+    // Extract method name + the "list" arg (object or first positional arg).
+    let (method_name, list_arg_idx): (Option<String>, usize) = match target {
+        CallTarget::Method { method, .. } => (Some(method.to_string()), 0),
+        CallTarget::Module { module, func } if module.as_str() == "list" => {
+            (Some(func.to_string()), 0)
+        }
+        _ => (None, 0),
+    };
+    let Some(name) = method_name else { return args; };
+    // Only methods that take `(list, ..., lambda)` benefit from this.
+    if !matches!(
+        name.as_str(),
+        "map" | "filter" | "filter_map" | "flat_map" | "fold" | "reduce"
+        | "find" | "any" | "all" | "each" | "count" | "partition"
+        | "sort_by" | "group_by" | "unique_by" | "take_while" | "drop_while"
+        | "min_by" | "max_by" | "scan" | "chunk_by" | "dedup_by"
+    ) {
+        return args;
+    }
+    let is_unresolved = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_) | Ty::OpenRecord { .. });
+    // Resolve list element type from the list arg (or via VarTable).
+    let list_elem = args.get(list_arg_idx).and_then(|a| match &a.ty {
+        Ty::Applied(_, ta) => ta.first().cloned().filter(|t| !is_unresolved(t)),
+        _ => None,
+    }).or_else(|| {
+        args.get(list_arg_idx).and_then(|a| {
+            if let IrExprKind::Var { id } = &a.kind {
+                if let Ty::Applied(_, ta) = &var_table.get(*id).ty {
+                    return ta.first().cloned().filter(|t| !is_unresolved(t));
+                }
+            }
+            None
+        })
+    });
+    let Some(elem_ty) = list_elem else { return args; };
+    // Walk args and update any inline Lambda whose first param is unresolved.
+    args.into_iter().map(|arg| {
+        match arg.kind {
+            IrExprKind::Lambda { mut params, body, lambda_id } => {
+                if let Some((vid, pty)) = params.first_mut() {
+                    if is_unresolved(pty) {
+                        *pty = elem_ty.clone();
+                        if is_unresolved(&var_table.get(*vid).ty) {
+                            var_table.entries[vid.0 as usize].ty = elem_ty.clone();
+                        }
+                    }
+                }
+                // Also refresh the Lambda's outer `Ty::Fn.params[0]` so later
+                // lookups of `lambda.ty` see the resolved element type.
+                let refreshed_ty = match arg.ty {
+                    Ty::Fn { params: fparams, ret } => {
+                        let new_params: Vec<Ty> = fparams.into_iter().enumerate().map(|(i, p)| {
+                            if i == 0 && is_unresolved(&p) { elem_ty.clone() } else { p }
+                        }).collect();
+                        Ty::Fn { params: new_params, ret }
+                    }
+                    other => other,
+                };
+                IrExpr {
+                    kind: IrExprKind::Lambda { params, body, lambda_id },
+                    ty: refreshed_ty,
+                    span: arg.span,
+                }
+            }
+            _ => arg,
+        }
+    }).collect()
+}
+
+/// Infer a Lambda body's result type when both its own `.ty` and the
+/// enclosing `Ty::Fn` `ret` are unresolved. Traces the "tail" of the
+/// expression tree (final value of blocks, branches of if/match, binop
+/// results) to find a concrete type.
+fn infer_body_result_ty(expr: &IrExpr) -> Option<Ty> {
+    let is_unresolved = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_));
+    match &expr.kind {
+        IrExprKind::Block { expr: Some(tail), .. } => infer_body_result_ty(tail),
+        IrExprKind::If { then, else_, .. } => {
+            infer_body_result_ty(then)
+                .filter(|t| !is_unresolved(t))
+                .or_else(|| infer_body_result_ty(else_))
+        }
+        IrExprKind::Match { arms, .. } => {
+            arms.iter()
+                .find_map(|arm| infer_body_result_ty(&arm.body).filter(|t| !is_unresolved(t)))
+        }
+        IrExprKind::BinOp { op, left, right } => {
+            use almide_ir::BinOp;
+            match op {
+                // Int arithmetic → Int.
+                BinOp::AddInt | BinOp::SubInt | BinOp::MulInt | BinOp::DivInt
+                | BinOp::ModInt | BinOp::PowInt => Some(Ty::Int),
+                // Float arithmetic → Float.
+                BinOp::AddFloat | BinOp::SubFloat | BinOp::MulFloat | BinOp::DivFloat
+                | BinOp::ModFloat | BinOp::PowFloat => Some(Ty::Float),
+                // Matrix ops → Matrix.
+                BinOp::MulMatrix | BinOp::AddMatrix | BinOp::SubMatrix | BinOp::ScaleMatrix => Some(Ty::Matrix),
+                // Concatenation: result equals operand type.
+                BinOp::ConcatStr => Some(Ty::String),
+                BinOp::ConcatList => {
+                    if !is_unresolved(&left.ty) { Some(left.ty.clone()) }
+                    else if !is_unresolved(&right.ty) { Some(right.ty.clone()) }
+                    else { None }
+                }
+                // Comparisons and logical ops → Bool.
+                BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte
+                | BinOp::And | BinOp::Or => Some(Ty::Bool),
+            }
+        }
+        IrExprKind::LitInt { .. } => Some(Ty::Int),
+        IrExprKind::LitFloat { .. } => Some(Ty::Float),
+        IrExprKind::LitBool { .. } => Some(Ty::Bool),
+        IrExprKind::LitStr { .. } => Some(Ty::String),
+        _ => {
+            if !is_unresolved(&expr.ty) { Some(expr.ty.clone()) } else { None }
+        }
+    }
+}
+
+/// Infer a Lambda parameter's type by scanning the body for operations that
+/// constrain it. Used as a last-resort fallback when type inference leaves
+/// a param as Unknown/TypeVar.
+///
+/// Handles the common case where `p` is one operand of a homogeneous binop
+/// (`a + b`, comparisons, etc.) and the sibling operand has a resolved type.
+fn infer_param_ty_from_body(body: &IrExpr, target: VarId) -> Option<Ty> {
+    let is_unresolved = |t: &Ty| matches!(t, Ty::Unknown | Ty::TypeVar(_) | Ty::OpenRecord { .. });
+    fn walk(expr: &IrExpr, target: VarId, is_unresolved: &impl Fn(&Ty) -> bool) -> Option<Ty> {
+        match &expr.kind {
+            IrExprKind::BinOp { left, right, .. } => {
+                // If one side is Var(target) and the other has a known type, use it.
+                if let IrExprKind::Var { id } = &left.kind {
+                    if *id == target && !is_unresolved(&right.ty) {
+                        return Some(right.ty.clone());
+                    }
+                }
+                if let IrExprKind::Var { id } = &right.kind {
+                    if *id == target && !is_unresolved(&left.ty) {
+                        return Some(left.ty.clone());
+                    }
+                }
+                // Recurse
+                walk(left, target, is_unresolved).or_else(|| walk(right, target, is_unresolved))
+            }
+            IrExprKind::If { cond, then, else_ } => {
+                walk(cond, target, is_unresolved)
+                    .or_else(|| walk(then, target, is_unresolved))
+                    .or_else(|| walk(else_, target, is_unresolved))
+            }
+            IrExprKind::Block { stmts, expr } => {
+                for stmt in stmts {
+                    if let Some(t) = walk_stmt_for_target(stmt, target, is_unresolved) {
+                        return Some(t);
+                    }
+                }
+                expr.as_ref().and_then(|e| walk(e, target, is_unresolved))
+            }
+            IrExprKind::Call { args, .. } => {
+                args.iter().find_map(|a| walk(a, target, is_unresolved))
+            }
+            IrExprKind::Match { subject, arms } => {
+                walk(subject, target, is_unresolved)
+                    .or_else(|| arms.iter().find_map(|a| walk(&a.body, target, is_unresolved)))
+            }
+            IrExprKind::UnOp { operand, .. } => walk(operand, target, is_unresolved),
+            IrExprKind::Member { object, .. } => walk(object, target, is_unresolved),
+            IrExprKind::IndexAccess { object, index } => {
+                walk(object, target, is_unresolved).or_else(|| walk(index, target, is_unresolved))
+            }
+            _ => None,
+        }
+    }
+    fn walk_stmt_for_target(stmt: &IrStmt, target: VarId, is_unresolved: &impl Fn(&Ty) -> bool) -> Option<Ty> {
+        match &stmt.kind {
+            IrStmtKind::Bind { value, .. } => walk(value, target, is_unresolved),
+            IrStmtKind::BindDestructure { value, .. } => walk(value, target, is_unresolved),
+            IrStmtKind::Assign { value, .. } => walk(value, target, is_unresolved),
+            IrStmtKind::Expr { expr } => walk(expr, target, is_unresolved),
+            _ => None,
+        }
+    }
+    walk(body, target, &is_unresolved)
 }

--- a/crates/almide-codegen/src/pass_rust_lowering.rs
+++ b/crates/almide-codegen/src/pass_rust_lowering.rs
@@ -35,9 +35,33 @@ impl NanoPass for RustLoweringPass {
     }
 }
 
-/// Walk all stmts in expressions recursively.
+/// Walk all stmts in expressions recursively. Also rewrites UnwrapOr
+/// fallback lambdas for List[Fn] contexts with RcWrap.
 fn rewrite_stmts_in_expr(expr: &mut IrExpr, vt: &mut VarTable) -> bool {
     let mut changed = false;
+    // UnwrapOr with Fn fallback lambda: wrap in RcWrap for List[Fn] compatibility
+    if let IrExprKind::UnwrapOr { expr: inner, fallback } = &mut expr.kind {
+        if matches!(&fallback.kind, IrExprKind::Lambda { .. })
+            && matches!(&expr.ty, almide_lang::types::Ty::Fn { .. })
+        {
+            if let Some(inner_fn_ty) = inner.ty.option_inner() {
+                if matches!(inner_fn_ty, almide_lang::types::Ty::Fn { .. }) {
+                    let old_fallback = std::mem::replace(fallback.as_mut(), IrExpr {
+                        kind: IrExprKind::Unit, ty: almide_lang::types::Ty::Unit, span: None,
+                    });
+                    *fallback.as_mut() = IrExpr {
+                        ty: old_fallback.ty.clone(),
+                        span: old_fallback.span,
+                        kind: IrExprKind::RcWrap {
+                            expr: Box::new(old_fallback),
+                            cast_ty: Some(Box::new(inner_fn_ty.clone())),
+                        },
+                    };
+                    changed = true;
+                }
+            }
+        }
+    }
     match &mut expr.kind {
         IrExprKind::Block { stmts, expr: tail } => {
             for s in stmts.iter_mut() {
@@ -104,6 +128,30 @@ fn rewrite_stmts_in_stmt(stmt: &mut IrStmt, vt: &mut VarTable, changed: &mut boo
 /// Try to rewrite a single statement.
 fn rewrite_stmt(stmt: &mut IrStmt, vt: &mut VarTable) -> bool {
     let span = stmt.span;
+    // (0) List[Fn] binding: wrap lambda elements in RcWrap
+    if let IrStmtKind::Bind { ty, value, .. } = &mut stmt.kind {
+        if let almide_lang::types::Ty::Applied(almide_lang::types::TypeConstructorId::List, args) = ty {
+            if let Some(fn_ty) = args.first().cloned() {
+                if matches!(&fn_ty, almide_lang::types::Ty::Fn { .. }) {
+                    if let IrExprKind::List { elements } = &mut value.kind {
+                        let cast = Some(Box::new(fn_ty));
+                        for elem in elements.iter_mut() {
+                            let inner = std::mem::replace(elem, IrExpr {
+                                kind: IrExprKind::Unit, ty: almide_lang::types::Ty::Unit, span: None,
+                            });
+                            *elem = IrExpr {
+                                ty: inner.ty.clone(),
+                                span: inner.span,
+                                kind: IrExprKind::RcWrap { expr: Box::new(inner), cast_ty: cast.clone() },
+                            };
+                        }
+                        // Change type to mark it (walker will render Rc type from the RcWrap nodes)
+                        return true;
+                    }
+                }
+            }
+        }
+    }
     // (1) xs = xs + [v] → xs.push(v)
     if let IrStmtKind::Assign { var, value } = &stmt.kind {
         if let Some(push_stmt) = try_rewrite_push(*var, value, span) {

--- a/crates/almide-codegen/src/pass_rust_lowering.rs
+++ b/crates/almide-codegen/src/pass_rust_lowering.rs
@@ -1,0 +1,228 @@
+//! RustLoweringPass: Rust-specific IR rewrites that keep the walker target-agnostic.
+//!
+//! 1. **List push**: `xs = xs + [v]` → `Expr(Call(xs.push, [v]))`.
+//!    Avoids a full list clone + concat for single-element append.
+//!
+//! 2. **Borrow index lift**: `xs[f(xs)] = v` → `{ let __idx = f(xs); xs[__idx] = v; }`
+//!    Resolves Rust simultaneous mutable+immutable borrow conflicts in IndexAssign.
+
+use almide_ir::*;
+use almide_base::intern::sym;
+use super::pass::{NanoPass, PassResult, Target};
+
+#[derive(Debug)]
+pub struct RustLoweringPass;
+
+impl NanoPass for RustLoweringPass {
+    fn name(&self) -> &str { "RustLowering" }
+    fn targets(&self) -> Option<Vec<Target>> { Some(vec![Target::Rust]) }
+    fn depends_on(&self) -> Vec<&'static str> { vec!["CloneInsertion"] }
+
+    fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
+        let mut changed = false;
+        for func in &mut program.functions {
+            if rewrite_stmts_in_expr(&mut func.body, &mut program.var_table) { changed = true; }
+        }
+        for tl in &mut program.top_lets {
+            if rewrite_stmts_in_expr(&mut tl.value, &mut program.var_table) { changed = true; }
+        }
+        for module in &mut program.modules {
+            for func in &mut module.functions {
+                if rewrite_stmts_in_expr(&mut func.body, &mut module.var_table) { changed = true; }
+            }
+        }
+        PassResult { program, changed }
+    }
+}
+
+/// Walk all stmts in expressions recursively.
+fn rewrite_stmts_in_expr(expr: &mut IrExpr, vt: &mut VarTable) -> bool {
+    let mut changed = false;
+    match &mut expr.kind {
+        IrExprKind::Block { stmts, expr: tail } => {
+            for s in stmts.iter_mut() {
+                if rewrite_stmt(s, vt) { changed = true; }
+                rewrite_stmts_in_stmt(s, vt, &mut changed);
+            }
+            if let Some(e) = tail { if rewrite_stmts_in_expr(e, vt) { changed = true; } }
+        }
+        IrExprKind::If { cond, then, else_ } => {
+            if rewrite_stmts_in_expr(cond, vt) { changed = true; }
+            if rewrite_stmts_in_expr(then, vt) { changed = true; }
+            if rewrite_stmts_in_expr(else_, vt) { changed = true; }
+        }
+        IrExprKind::Match { subject, arms } => {
+            if rewrite_stmts_in_expr(subject, vt) { changed = true; }
+            for arm in arms {
+                if let Some(g) = &mut arm.guard { rewrite_stmts_in_expr(g, vt); }
+                if rewrite_stmts_in_expr(&mut arm.body, vt) { changed = true; }
+            }
+        }
+        IrExprKind::ForIn { iterable, body, .. } => {
+            if rewrite_stmts_in_expr(iterable, vt) { changed = true; }
+            for s in body.iter_mut() {
+                if rewrite_stmt(s, vt) { changed = true; }
+                rewrite_stmts_in_stmt(s, vt, &mut changed);
+            }
+        }
+        IrExprKind::While { cond, body } => {
+            if rewrite_stmts_in_expr(cond, vt) { changed = true; }
+            for s in body.iter_mut() {
+                if rewrite_stmt(s, vt) { changed = true; }
+                rewrite_stmts_in_stmt(s, vt, &mut changed);
+            }
+        }
+        IrExprKind::Lambda { body, .. } => {
+            if rewrite_stmts_in_expr(body, vt) { changed = true; }
+        }
+        _ => {}
+    }
+    changed
+}
+
+fn rewrite_stmts_in_stmt(stmt: &mut IrStmt, vt: &mut VarTable, changed: &mut bool) {
+    match &mut stmt.kind {
+        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
+        | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => {
+            if rewrite_stmts_in_expr(value, vt) { *changed = true; }
+        }
+        IrStmtKind::IndexAssign { index, value, .. } => {
+            if rewrite_stmts_in_expr(index, vt) { *changed = true; }
+            if rewrite_stmts_in_expr(value, vt) { *changed = true; }
+        }
+        IrStmtKind::Guard { cond, else_ } => {
+            if rewrite_stmts_in_expr(cond, vt) { *changed = true; }
+            if rewrite_stmts_in_expr(else_, vt) { *changed = true; }
+        }
+        IrStmtKind::Expr { expr } => {
+            if rewrite_stmts_in_expr(expr, vt) { *changed = true; }
+        }
+        _ => {}
+    }
+}
+
+/// Try to rewrite a single statement.
+fn rewrite_stmt(stmt: &mut IrStmt, vt: &mut VarTable) -> bool {
+    let span = stmt.span;
+    // (1) xs = xs + [v] → xs.push(v)
+    if let IrStmtKind::Assign { var, value } = &stmt.kind {
+        if let Some(push_stmt) = try_rewrite_push(*var, value, span) {
+            *stmt = push_stmt;
+            return true;
+        }
+    }
+    // (2) xs[f(xs)] = v → { let __idx = f(xs); xs[__idx] = v; }
+    if let IrStmtKind::IndexAssign { target, index, value } = &stmt.kind {
+        if expr_references_var(index, *target) {
+            let idx_var = vt.alloc(sym("__idx"), almide_lang::types::Ty::Int, Mutability::Let, None);
+            let idx_bind = IrStmt {
+                kind: IrStmtKind::Bind {
+                    var: idx_var,
+                    mutability: Mutability::Let,
+                    ty: almide_lang::types::Ty::Int,
+                    value: index.clone(),
+                },
+                span,
+            };
+            let idx_ref = IrExpr {
+                kind: IrExprKind::Var { id: idx_var },
+                ty: almide_lang::types::Ty::Int,
+                span: None,
+            };
+            let new_assign = IrStmt {
+                kind: IrStmtKind::IndexAssign {
+                    target: *target,
+                    index: idx_ref,
+                    value: value.clone(),
+                },
+                span,
+            };
+            // Wrap in a Block statement
+            stmt.kind = IrStmtKind::Expr {
+                expr: IrExpr {
+                    kind: IrExprKind::Block {
+                        stmts: vec![idx_bind, new_assign],
+                        expr: None,
+                    },
+                    ty: almide_lang::types::Ty::Unit,
+                    span: None,
+                },
+            };
+            return true;
+        }
+    }
+    false
+}
+
+/// Rewrite `xs = xs + [v]` → `Expr(Call(xs.push, [v]))`.
+fn try_rewrite_push(var: VarId, value: &IrExpr, span: Option<almide_base::Span>) -> Option<IrStmt> {
+    let IrExprKind::BinOp { op: BinOp::ConcatList, left, right } = &value.kind else { return None; };
+    let IrExprKind::List { elements } = &right.kind else { return None; };
+    if elements.len() != 1 { return None; }
+    let is_self = match &left.kind {
+        IrExprKind::Var { id } => *id == var,
+        IrExprKind::Clone { expr } => matches!(&expr.kind, IrExprKind::Var { id } if *id == var),
+        _ => false,
+    };
+    if !is_self { return None; }
+    let push_call = IrExpr {
+        kind: IrExprKind::Call {
+            target: CallTarget::Method {
+                object: Box::new(IrExpr {
+                    kind: IrExprKind::Var { id: var },
+                    ty: left.ty.clone(),
+                    span: None,
+                }),
+                method: sym("push"),
+            },
+            args: vec![elements[0].clone()],
+            type_args: vec![],
+        },
+        ty: almide_lang::types::Ty::Unit,
+        span: None,
+    };
+    Some(IrStmt {
+        kind: IrStmtKind::Expr { expr: push_call },
+        span,
+    })
+}
+
+/// Check if expr references the given variable (for borrow conflict detection).
+fn expr_references_var(expr: &IrExpr, var: VarId) -> bool {
+    match &expr.kind {
+        IrExprKind::Var { id } => *id == var,
+        IrExprKind::BinOp { left, right, .. } => {
+            expr_references_var(left, var) || expr_references_var(right, var)
+        }
+        IrExprKind::UnOp { operand, .. } => expr_references_var(operand, var),
+        IrExprKind::Call { target, args, .. } => {
+            let t = match target {
+                CallTarget::Method { object, .. } | CallTarget::Computed { callee: object } => expr_references_var(object, var),
+                _ => false,
+            };
+            t || args.iter().any(|a| expr_references_var(a, var))
+        }
+        IrExprKind::IndexAccess { object, index } | IrExprKind::MapAccess { object, key: index } => {
+            expr_references_var(object, var) || expr_references_var(index, var)
+        }
+        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
+            expr_references_var(object, var)
+        }
+        IrExprKind::Clone { expr: e } | IrExprKind::Borrow { expr: e, .. }
+        | IrExprKind::Deref { expr: e } | IrExprKind::ToVec { expr: e }
+        | IrExprKind::OptionSome { expr: e } | IrExprKind::Try { expr: e }
+        | IrExprKind::Unwrap { expr: e } | IrExprKind::ToOption { expr: e } => {
+            expr_references_var(e, var)
+        }
+        IrExprKind::UnwrapOr { expr: e, fallback: f } => {
+            expr_references_var(e, var) || expr_references_var(f, var)
+        }
+        IrExprKind::List { elements } | IrExprKind::Tuple { elements } => {
+            elements.iter().any(|e| expr_references_var(e, var))
+        }
+        IrExprKind::If { cond, then, else_ } => {
+            expr_references_var(cond, var) || expr_references_var(then, var) || expr_references_var(else_, var)
+        }
+        _ => false,
+    }
+}

--- a/crates/almide-codegen/src/pass_stream_fusion/fusion_rules.rs
+++ b/crates/almide-codegen/src/pass_stream_fusion/fusion_rules.rs
@@ -59,6 +59,15 @@ pub(super) fn is_range_call(target: &CallTarget) -> bool {
 pub(super) fn try_eliminate_identity_map(expr: IrExpr) -> Option<IrExpr> {
     if let IrExprKind::Call { ref target, ref args, .. } = expr.kind {
         if is_map_call(target) && args.len() >= 2 && is_identity_lambda(&args[1]) {
+            // `list.map(xs, x => x)` collapses to `xs` ONLY when `xs` is
+            // already materialized as a list. A Range literal
+            // (`0..5 |> list.map(x => x)`) would otherwise lose the
+            // implicit `.collect::<Vec<_>>()` that the map call normally
+            // provides, leaving a raw `Range<i64>` where a `Vec<i64>` is
+            // expected.
+            if matches!(args[0].kind, IrExprKind::Range { .. }) {
+                return None;
+            }
             return Some(args[0].clone());
         }
     }

--- a/crates/almide-codegen/src/target.rs
+++ b/crates/almide-codegen/src/target.rs
@@ -26,6 +26,7 @@ use super::pass_stream_fusion::StreamFusionPass;
 use super::pass_tco::TailCallOptPass;
 use super::pass_licm::LICMPass;
 use super::pass_peephole::PeepholePass;
+use super::pass_rust_lowering::RustLoweringPass;
 use super::pass_closure_conversion::ClosureConversionPass;
 use super::pass_list_pattern::ListPatternLoweringPass;
 use super::template::TemplateSet;
@@ -81,6 +82,8 @@ fn build_pipeline(target: Target) -> Pipeline {
             .add(BuiltinLoweringPass)
             // Peephole: swap/reverse/rotate/copy → specialized IR nodes
             .add(PeepholePass)
+            // Rust-specific: push optimization, borrow index lift
+            .add(RustLoweringPass)
             // Shared passes
             .add(FanLoweringPass),
 

--- a/crates/almide-codegen/src/walker/declarations.rs
+++ b/crates/almide-codegen/src/walker/declarations.rs
@@ -147,6 +147,25 @@ pub fn collect_named_records(program: &IrProgram) -> HashMap<Vec<String>, String
     map
 }
 
+/// Map each named record type to its total field count so destructure
+/// patterns can decide whether they need a trailing `..`.
+pub fn collect_record_field_counts(program: &IrProgram) -> HashMap<String, usize> {
+    let mut map = HashMap::new();
+    for td in &program.type_decls {
+        if let IrTypeDeclKind::Record { fields } = &td.kind {
+            map.insert(td.name.to_string(), fields.len());
+        }
+    }
+    for module in &program.modules {
+        for td in &module.type_decls {
+            if let IrTypeDeclKind::Record { fields } = &td.kind {
+                map.insert(td.name.to_string(), fields.len());
+            }
+        }
+    }
+    map
+}
+
 pub fn collect_anon_records(program: &IrProgram, named: &HashMap<Vec<String>, String>) -> HashMap<Vec<String>, String> {
     let named_set: HashSet<Vec<String>> = named.keys().cloned().collect();
     let mut seen: HashSet<Vec<String>> = HashSet::new();

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -293,7 +293,7 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         IrExprKind::OptionNone => {
             // Typed None: pass inner type via bindings + attribute for template guard
             if let Ty::Applied(TypeConstructorId::Option, args) = &expr.ty {
-                if args.len() == 1 && !matches!(&args[0], Ty::Unknown | Ty::TypeVar(_)) {
+                if args.len() == 1 && !args[0].is_unresolved() {
                     let type_hint_s = render_type(ctx, &args[0]);
                     return ctx.templates.render_with("none_expr", None, &["none_type_hint"], &[("type_hint", type_hint_s.as_str())])
                         .unwrap_or_else(|| "None".into());

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -457,63 +457,33 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             // In test functions, ? cannot be used (return type is ()).
             // Use .unwrap() instead.
             if ctx.is_test {
-                if inner.ty.is_option() {
-                    format!("({}).unwrap()", s)
-                } else {
-                    format!("({}).unwrap()", s)
-                }
-            } else if !inner.ty.is_option() && matches!(ctx.target, Target::Rust) {
-                // Result unwrap in effect fn: error type must be coerced to String.
-                // If the error type is not String, insert .map_err(...) before ?.
-                let needs_map_err = if let Some((_ok_ty, err_ty)) = inner.ty.inner2() {
-                    !matches!(err_ty, Ty::String)
-                } else {
-                    false
-                };
-                if needs_map_err {
-                    let err_ty = inner.ty.inner2().map(|(_, e)| e);
-                    // List[String] → join with ", " for readable error messages
-                    let is_list_string = err_ty.is_some_and(|e| {
-                        matches!(e, Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 && matches!(args[0], Ty::String))
-                    });
-                    if is_list_string {
-                        format!("({}).map_err(|errs| errs.join(\", \"))?", s)
-                    } else {
-                        format!("({}).map_err(|e| format!(\"{{:?}}\", e))?", s)
-                    }
-                } else {
-                    ctx.templates.render_with("unwrap_expr", None, &[], &[("inner", s.as_str())])
-                        .unwrap_or_else(|| format!("({})?", s))
-                }
+                format!("({}).unwrap()", s)
             } else {
+                // Determine the right template variant based on inner type.
+                // For Result with non-String error, use map_err variants
+                // (the template decides whether/how to coerce — target-agnostic).
                 let when_type = if inner.ty.is_option() { Some("Option") } else { None };
-                ctx.templates.render_with("unwrap_expr", when_type, &[], &[("inner", s.as_str())])
-                    .unwrap_or_else(|| {
-                        if inner.ty.is_option() {
-                            format!("((__v) => {{ if (__v === null) throw new Error('unwrap on none'); return __v; }})({})", s)
+                let err_coerce_attr = if !inner.ty.is_option() {
+                    if let Some((_, err_ty)) = inner.ty.inner2() {
+                        if matches!(err_ty, Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 && matches!(args[0], Ty::String)) {
+                            Some("map_err_join")
+                        } else if !matches!(err_ty, Ty::String) {
+                            Some("map_err_debug")
                         } else {
-                            format!("({})?", s)
+                            None
                         }
-                    })
+                    } else { None }
+                } else { None };
+                let attrs: Vec<&str> = err_coerce_attr.into_iter().collect();
+                ctx.templates.render_with("unwrap_expr", when_type, &attrs, &[("inner", s.as_str())])
+                    .unwrap_or_else(|| format!("({})?", s))
             }
         }
         IrExprKind::UnwrapOr { expr: inner, fallback } => {
             let s = render_expr(ctx, inner);
-            let mut f = render_expr(ctx, fallback);
-            // When the fallback is a lambda and the result type is Fn (from a List[Fn] get),
-            // wrap in Rc::new to match the Rc<dyn Fn> stored in the collection
-            if ctx.target == super::super::pass::Target::Rust
-                && matches!(&fallback.kind, IrExprKind::Lambda { .. })
-                && matches!(&expr.ty, Ty::Fn { .. })
-            {
-                // Check if inner is Option[Fn] (from list.get on a List[Fn])
-                if let Some(inner_ty) = inner.ty.option_inner() {
-                    if matches!(inner_ty, Ty::Fn { .. }) {
-                        let rc_type = super::helpers::render_type_rc_fn(ctx, &inner_ty);
-                        f = format!("std::rc::Rc::new({}) as {}", f, rc_type);
-                    }
-                }
-            }
+            let f = render_expr(ctx, fallback);
+            // Rc wrapping for List[Fn] fallback is now handled by RustLoweringPass
+            // which inserts RcWrap nodes into the IR.
             let when_type = if inner.ty.is_option() { Some("Option") } else { None };
             // When inner.ty is Unknown, defaults to Result template.
             // This is correct if type inference produced Unknown due to a bug;
@@ -563,6 +533,15 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         }
         IrExprKind::BoxNew { expr: inner } => {
             format!("Box::new({})", render_expr(ctx, inner))
+        }
+        IrExprKind::RcWrap { expr: inner, cast_ty } => {
+            let s = render_expr(ctx, inner);
+            if let Some(ty) = cast_ty {
+                let rc_type = super::helpers::render_type_rc_fn(ctx, ty);
+                format!("std::rc::Rc::new({}) as {}", s, rc_type)
+            } else {
+                format!("std::rc::Rc::new({})", s)
+            }
         }
         IrExprKind::RustMacro { name, args } => {
             // Render macro args — LitStr rendered as bare &str (no .to_string())

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -27,7 +27,7 @@ use types::render_type as render_type_fn;
 use expressions::render_expr as render_expr_fn;
 use statements::render_stmt as render_stmt_fn;
 use helpers::{terminate_stmt, indent_lines};
-use declarations::{render_type_decl, collect_named_records, collect_anon_records};
+use declarations::{render_type_decl, collect_named_records, collect_anon_records, collect_record_field_counts};
 
 /// Render context: carries the variable table, target, and annotations.
 /// The walker NEVER checks types — all codegen decisions come from annotations.
@@ -302,6 +302,7 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
     // Build anonymous record maps (populated by target-specific pipeline)
     ctx.ann.named_records = collect_named_records(program);
     ctx.ann.anon_records = collect_anon_records(program, &ctx.ann.named_records);
+    ctx.ann.record_field_counts = collect_record_field_counts(program);
 
     let mut parts = Vec::new();
 

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -143,9 +143,16 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
                 param_name = fn_ctx.templates.render_with("keyword_escape", None, &[], &[("name", param_name.as_str())])
                     .unwrap_or(param_name);
             }
-            // Rust: add `mut` for params marked Var (e.g. by TCO pass)
-            if fn_ctx.target == Target::Rust && fn_ctx.var_table.get(p.var).mutability == Mutability::Var {
-                param_name = format!("mut {}", param_name);
+            // Mutable params (e.g. from TCO pass) — let the template decide
+            // whether to emit a `mut` prefix via the {mut_prefix} variable.
+            let mut_prefix = if fn_ctx.var_table.get(p.var).mutability == Mutability::Var {
+                fn_ctx.templates.render_with("mut_param_prefix", None, &[], &[])
+                    .unwrap_or_default()
+            } else {
+                String::new()
+            };
+            if !mut_prefix.is_empty() {
+                param_name = format!("{}{}", mut_prefix, param_name);
             }
             let type_s = match p.borrow {
                 ParamBorrow::Own => render_type_fn(&fn_ctx, &p.ty),

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -270,6 +270,16 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             // For record patterns with empty name, resolve from value type
             let pat_str = match pattern {
                 IrPattern::RecordPattern { name, fields, rest } if name.is_empty() => {
+                    // Determine the total field count of the value type so we
+                    // can automatically insert `..` when the pattern only
+                    // destructures a subset (otherwise Rust complains with
+                    // E0027 "pattern does not mention field X").
+                    let total_fields: Option<usize> = match &value.ty {
+                        Ty::Named(n, _) => ctx.ann.record_field_counts.get(n.as_str()).copied(),
+                        Ty::Record { fields: ty_fields } | Ty::OpenRecord { fields: ty_fields } =>
+                            Some(ty_fields.len()),
+                        _ => None,
+                    };
                     let type_name = match &value.ty {
                         Ty::Named(n, _) => n.to_string(),
                         Ty::Record { fields: ty_fields } | Ty::OpenRecord { fields: ty_fields } => {
@@ -293,7 +303,9 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
                             None => f.name.clone(),
                         })
                         .collect::<Vec<_>>().join(", ");
-                    if *rest {
+                    let needs_rest = *rest
+                        || total_fields.map_or(false, |n| fields.len() < n);
+                    if needs_rest {
                         let construct = if fields_str.is_empty() { "record_pattern_rest_empty" } else { "record_pattern_rest" };
                         ctx.templates.render_with(construct, None, &[], &[("name", qualified.as_str()), ("fields", fields_str.as_str())])
                             .unwrap_or_else(|| format!("{} {{ {} }}", qualified, fields_str))

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -9,96 +9,6 @@ use super::expressions::render_expr;
 use super::helpers::{template_or, terminate_stmt, ty_has_named_typevar, erase_named_typevars};
 
 /// Check if an expression references a specific variable (any depth).
-fn expr_references_var(expr: &IrExpr, var: VarId) -> bool {
-    match &expr.kind {
-        IrExprKind::Var { id } => *id == var,
-        IrExprKind::BinOp { left, right, .. } => {
-            expr_references_var(left, var) || expr_references_var(right, var)
-        }
-        IrExprKind::UnOp { operand, .. } => expr_references_var(operand, var),
-        IrExprKind::Call { target, args, .. } => {
-            let t = match target {
-                CallTarget::Method { object, .. } | CallTarget::Computed { callee: object } => expr_references_var(object, var),
-                _ => false,
-            };
-            t || args.iter().any(|a| expr_references_var(a, var))
-        }
-        IrExprKind::IndexAccess { object, index } | IrExprKind::MapAccess { object, key: index } => {
-            expr_references_var(object, var) || expr_references_var(index, var)
-        }
-        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
-            expr_references_var(object, var)
-        }
-        IrExprKind::Clone { expr: e } | IrExprKind::Borrow { expr: e, .. }
-        | IrExprKind::Deref { expr: e } | IrExprKind::ToVec { expr: e }
-        | IrExprKind::OptionSome { expr: e } | IrExprKind::Try { expr: e }
-        | IrExprKind::Unwrap { expr: e } | IrExprKind::ToOption { expr: e } => {
-            expr_references_var(e, var)
-        }
-        IrExprKind::UnwrapOr { expr: e, fallback: f } => {
-            expr_references_var(e, var) || expr_references_var(f, var)
-        }
-        IrExprKind::List { elements } | IrExprKind::Tuple { elements } => {
-            elements.iter().any(|e| expr_references_var(e, var))
-        }
-        IrExprKind::If { cond, then, else_ } => {
-            expr_references_var(cond, var) || expr_references_var(then, var) || expr_references_var(else_, var)
-        }
-        IrExprKind::Block { stmts, expr: tail } => {
-            stmts.iter().any(|s| stmt_references_var(s, var))
-                || tail.as_ref().is_some_and(|e| expr_references_var(e, var))
-        }
-        _ => false,
-    }
-}
-
-fn stmt_references_var(stmt: &IrStmt, var: VarId) -> bool {
-    match &stmt.kind {
-        IrStmtKind::Bind { value, .. } | IrStmtKind::Assign { value, .. }
-        | IrStmtKind::FieldAssign { value, .. } | IrStmtKind::BindDestructure { value, .. } => {
-            expr_references_var(value, var)
-        }
-        IrStmtKind::IndexAssign { index, value, .. } => {
-            expr_references_var(index, var) || expr_references_var(value, var)
-        }
-        IrStmtKind::MapInsert { key, value, .. } => {
-            expr_references_var(key, var) || expr_references_var(value, var)
-        }
-        IrStmtKind::ListSwap { a, b, .. } => {
-            expr_references_var(a, var) || expr_references_var(b, var)
-        }
-        IrStmtKind::ListReverse { end, .. } | IrStmtKind::ListRotateLeft { end, .. } => {
-            expr_references_var(end, var)
-        }
-        IrStmtKind::ListCopySlice { len, .. } => {
-            expr_references_var(len, var)
-        }
-        IrStmtKind::Expr { expr } => expr_references_var(expr, var),
-        IrStmtKind::Guard { cond, else_ } => {
-            expr_references_var(cond, var) || expr_references_var(else_, var)
-        }
-        IrStmtKind::Comment { .. } => false,
-    }
-}
-
-/// Detect `xs = xs + [v]` and render as `xs.push(v);`
-fn try_render_push(ctx: &RenderContext, var: VarId, value: &IrExpr) -> Option<String> {
-    // Match: BinOp(ConcatList, left, List([element]))
-    let IrExprKind::BinOp { op: BinOp::ConcatList, left, right } = &value.kind else { return None; };
-    let IrExprKind::List { elements } = &right.kind else { return None; };
-    if elements.len() != 1 { return None; }
-    // Left must be Var(var) or Clone(Var(var))
-    let is_self = match &left.kind {
-        IrExprKind::Var { id } => *id == var,
-        IrExprKind::Clone { expr } => matches!(&expr.kind, IrExprKind::Var { id } if *id == var),
-        _ => false,
-    };
-    if !is_self { return None; }
-    let target_s = ctx.var_name(var);
-    let elem_s = render_expr(ctx, &elements[0]);
-    Some(format!("{}.push({});", target_s, elem_s))
-}
-
 pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
     match &stmt.kind {
         IrStmtKind::Bind { var, ty, value, mutability } => {
@@ -204,12 +114,8 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
                 .unwrap_or_else(|| format!("let _ = _;"))
         }
         IrStmtKind::Assign { var, value } => {
-            // Optimize: xs = xs + [v] → xs.push(v) (Rust only)
-            if ctx.target == super::super::pass::Target::Rust {
-                if let Some(push_str) = try_render_push(ctx, *var, value) {
-                    return push_str;
-                }
-            }
+            // Push optimization (xs = xs + [v] → xs.push(v)) is now handled
+            // by RustLoweringPass which rewrites to a Call(Method("push")).
             let target_s = ctx.var_name(*var).to_string();
             let value_s = render_expr(ctx, value);
             ctx.templates.render_with("assignment", None, &[], &[("target", target_s.as_str()), ("value", value_s.as_str())])
@@ -244,15 +150,10 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             let target_str = ctx.var_name(*target).to_string();
             let idx_str = render_expr(ctx, index);
             let val_str = render_expr(ctx, value);
-            // Rust borrow conflict: `xs[f(xs)] = v` borrows xs mutably (assignment)
-            // and immutably (index expr) in the same statement.
-            // Extract index to a let binding when the index expr references the target var.
-            if ctx.target == super::super::pass::Target::Rust && expr_references_var(index, *target) {
-                format!("{{ let __idx = ({}) as usize; {}[__idx] = {}; }}", idx_str, target_str, val_str)
-            } else {
-                ctx.templates.render_with("index_assign", None, &[], &[("target", target_str.as_str()), ("index", idx_str.as_str()), ("value", val_str.as_str())])
-                    .unwrap_or_else(|| "idx[...] = ...;".into())
-            }
+            // Borrow conflict (xs[f(xs)] = v) is now resolved by RustLoweringPass
+            // which lifts the index expression to a let binding at the IR level.
+            ctx.templates.render_with("index_assign", None, &[], &[("target", target_str.as_str()), ("index", idx_str.as_str()), ("value", val_str.as_str())])
+                .unwrap_or_else(|| "idx[...] = ...;".into())
         }
         IrStmtKind::MapInsert { target, key, value } => {
             let target_str = ctx.var_name(*target).to_string();

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -13,36 +13,8 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
     match &stmt.kind {
         IrStmtKind::Bind { var, ty, value, mutability } => {
             let name_s = ctx.var_name(*var).to_string();
-            // List[Fn] binding: render as Vec<Rc<dyn Fn(...)>> with Rc-wrapped lambdas
-            let is_list_of_fn = matches!(ty, Ty::Applied(TypeConstructorId::List, args) if !args.is_empty() && matches!(&args[0], Ty::Fn { .. }));
-            if is_list_of_fn && ctx.target == super::super::pass::Target::Rust {
-                if let Ty::Applied(_, args) = ty {
-                    let fn_ty = &args[0];
-                    let rc_type_s = super::helpers::render_type_rc_fn(ctx, fn_ty);
-                    let type_s = format!("Vec<{}>", rc_type_s);
-                    let value_s = if let IrExprKind::List { elements } = &value.kind {
-                        let elems = elements.iter().enumerate().map(|(i, e)| {
-                            let s = render_expr(ctx, e);
-                            if i == 0 {
-                                // Cast first element to establish Vec type
-                                format!("std::rc::Rc::new({}) as {}", s, rc_type_s)
-                            } else {
-                                format!("std::rc::Rc::new({})", s)
-                            }
-                        }).collect::<Vec<_>>().join(", ");
-                        ctx.templates.render_with("list_literal", None, &[], &[("elements", elems.as_str())])
-                            .unwrap_or_else(|| format!("vec![{}]", elems))
-                    } else {
-                        render_expr(ctx, value)
-                    };
-                    let construct = match mutability {
-                        Mutability::Let => "let_binding",
-                        Mutability::Var => "var_binding",
-                    };
-                    return ctx.templates.render_with(construct, None, &[], &[("name", name_s.as_str()), ("type", type_s.as_str()), ("value", value_s.as_str())])
-                        .unwrap_or_else(|| format!("let {} = {};", name_s, value_s));
-                }
-            }
+            // List[Fn] Rc wrapping is now handled by RustLoweringPass
+            // which inserts RcWrap nodes into the IR.
             // Erase Fn types in bindings (Rust can't write `impl Fn` in let position; TS gets `any`)
             // Also resolve aliases first — `type Handler = Fn(String) -> String` should erase too
             let resolved_owned;

--- a/crates/almide-frontend/CLAUDE.md
+++ b/crates/almide-frontend/CLAUDE.md
@@ -1,0 +1,57 @@
+# almide-frontend
+
+Type checking and AST → IR lowering. The semantic analysis core.
+
+## Architecture
+
+### Type Checker (`check/`)
+
+Three-pass constraint-based inference:
+
+1. **Infer** (`infer.rs`) — Walk AST, assign fresh `TypeVar`s, collect `Constraint`s.
+2. **Solve** (`solving.rs`) — Unify constraints via structural unification. Produces substitution.
+3. **Resolve** — Apply substitution to `TypeMap`, replacing all `TypeVar`s with concrete types.
+
+Output: `TypeMap = HashMap<ExprId, Ty>` — the authoritative source of all expression types.
+
+### Lowering (`lower/`)
+
+AST + TypeMap → `IrProgram`:
+
+- Assigns `VarId` for every variable binding.
+- Desugars pipes, UFCS, string interpolation, operators.
+- Resolves call targets (Module/Method/Named/Computed).
+- Auto-derives Eq, Repr, Ord, Hash, Codec.
+
+## Rules
+
+- **Checker is the source of truth.** If something has the wrong type, fix it in the checker — NOT in lowering or codegen.
+- **TypeMap populated by checker, consumed by lowering.** Lowering reads `type_map[expr_id]` to annotate IR nodes. It never runs inference.
+- **Desugar in lowering, not in the checker.** The checker sees the original AST. Lowering transforms it into the IR form.
+- **Error recovery with `Unknown`.** When inference fails, the checker emits a diagnostic and assigns `Ty::Unknown`. This prevents cascade errors but can leak into IR — codegen must handle `Unknown` gracefully (fallback defaults).
+- **Exhaustiveness is mandatory.** Match patterns are checked for exhaustiveness in `check/exhaustiveness.rs`. Missing cases produce warnings.
+- **Auto-derive generates real IR.** `lower/derive.rs` produces `IrFunction` bodies for convention methods. These are regular functions — codegen doesn't special-case them.
+
+## Module Layout
+
+```
+check/
+├── mod.rs            Checker orchestration
+├── infer.rs          Pass 1: constraint collection
+├── calls.rs          Call resolution (UFCS, builtins, constructors)
+├── solving.rs        Pass 2: constraint solving
+├── types.rs          TyVarId, Constraint, UnionFind
+├── builtin_calls.rs  Special type rules for builtins
+├── static_dispatch.rs  Impl block dispatch
+├── diagnostics.rs    Error formatting
+└── exhaustiveness.rs Match exhaustiveness
+
+lower/
+├── mod.rs            Lowering entry, LowerCtx
+├── expressions.rs    Expr → IrExpr
+├── calls.rs          Call target resolution
+├── statements.rs     Stmt + pattern → IrStmt
+├── types.rs          Type decl lowering
+├── derive.rs         Eq/Repr/Ord/Hash derive
+└── derive_codec.rs   Codec derive
+```

--- a/crates/almide-frontend/Cargo.toml
+++ b/crates/almide-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-frontend"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide frontend: type checker, canonicalization, IR lowering"

--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -276,8 +276,13 @@ pub fn register_impl_decl(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, 
             if let Some(proto_method) = proto_def.methods.iter().find(|pm| pm.name == *name) {
                 let gnames: Vec<Sym> = generics.as_ref().map(|gs| gs.iter().map(|g| sym(&g.name)).collect()).unwrap_or_default();
                 for gn in &gnames { env.types.insert(*gn, Ty::TypeVar(*gn)); }
-                let impl_params: Vec<Ty> = params.iter().map(|p| resolve(env, &p.ty)).collect();
-                let impl_ret = resolve(env, return_type);
+                // Resolve impl signatures structurally so nominal types
+                // (e.g. `d: Dog`) unify with the protocol's structural
+                // expectation (Self → `{ name: String }`).
+                let impl_params: Vec<Ty> = params.iter()
+                    .map(|p| env.resolve_named(&resolve(env, &p.ty)))
+                    .collect();
+                let impl_ret = env.resolve_named(&resolve(env, return_type));
                 for gn in &gnames { env.types.remove(gn); }
 
                 let expected_params: Vec<Ty> = proto_method.params.iter()

--- a/crates/almide-frontend/src/canonicalize/resolve.rs
+++ b/crates/almide-frontend/src/canonicalize/resolve.rs
@@ -28,19 +28,23 @@ pub fn resolve_type_expr(te: &ast::TypeExpr, known_types: Option<&HashMap<Sym, T
             other => {
                 // - Generic type parameters (T, U, Self, ...) resolve via
                 //   known_types as `Ty::TypeVar`.
-                // - Record/Variant/OpenRecord declarations must keep their
-                //   nominal identity — expanding them to the structural form
-                //   here would collapse two distinct types with identical
-                //   shapes (e.g. Dog and Cat both `{name: String}`). They
-                //   come back as `Ty::Named` and are expanded on demand via
+                // - Record/Variant declarations must keep their nominal
+                //   identity — expanding them to the structural form here
+                //   would collapse two distinct types with identical shapes
+                //   (e.g. Dog and Cat both `{name: String}`). They come back
+                //   as `Ty::Named` and are expanded on demand via
                 //   `resolve_named`.
+                // - OpenRecord aliases (`type Named = { name: String, .. }`)
+                //   are *shape aliases* meant to act as structural bounds,
+                //   not nominal types. Keep them transparent so they can
+                //   still accept any record with at least those fields.
                 // - Transparent aliases (e.g. `type Score = Int`) follow
                 //   through to the target type so `a + b` works.
                 if let Some(types) = known_types {
                     if let Some(found) = types.get(&sym(other)) {
                         match found {
                             Ty::TypeVar(tv) => return Ty::TypeVar(*tv),
-                            Ty::Record { .. } | Ty::OpenRecord { .. } | Ty::Variant { .. } => {
+                            Ty::Record { .. } | Ty::Variant { .. } => {
                                 // nominal — keep as Named
                             }
                             other_ty => return other_ty.clone(),

--- a/crates/almide-frontend/src/canonicalize/resolve.rs
+++ b/crates/almide-frontend/src/canonicalize/resolve.rs
@@ -26,11 +26,28 @@ pub fn resolve_type_expr(te: &ast::TypeExpr, known_types: Option<&HashMap<Sym, T
             "RawPtr" => Ty::RawPtr,
             "Path" => Ty::String,
             other => {
+                // - Generic type parameters (T, U, Self, ...) resolve via
+                //   known_types as `Ty::TypeVar`.
+                // - Record/Variant/OpenRecord declarations must keep their
+                //   nominal identity — expanding them to the structural form
+                //   here would collapse two distinct types with identical
+                //   shapes (e.g. Dog and Cat both `{name: String}`). They
+                //   come back as `Ty::Named` and are expanded on demand via
+                //   `resolve_named`.
+                // - Transparent aliases (e.g. `type Score = Int`) follow
+                //   through to the target type so `a + b` works.
                 if let Some(types) = known_types {
-                    types.get(&sym(other)).cloned().unwrap_or(Ty::Named(other.into(), vec![]))
-                } else {
-                    Ty::Named(sym(other), vec![])
+                    if let Some(found) = types.get(&sym(other)) {
+                        match found {
+                            Ty::TypeVar(tv) => return Ty::TypeVar(*tv),
+                            Ty::Record { .. } | Ty::OpenRecord { .. } | Ty::Variant { .. } => {
+                                // nominal — keep as Named
+                            }
+                            other_ty => return other_ty.clone(),
+                        }
+                    }
                 }
+                Ty::Named(sym(other), vec![])
             }
         },
         ast::TypeExpr::Generic { name, args } => {

--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -874,7 +874,7 @@ impl Checker {
             }
         }
         // Detect dot-chain submodule access (for pipe context)
-        if let Some(dotted) = self.resolve_dotted_module_path(&object.kind) {
+        if let Some(dotted) = self.env.import_table.resolve_dotted_path(&object.kind) {
             let key = format!("{}.{}", dotted, field);
             if self.env.functions.contains_key(&sym(&key)) {
                 let last_seg = dotted.rsplit('.').next().unwrap_or(&dotted);
@@ -896,38 +896,6 @@ impl Checker {
         None
     }
 
-    /// Resolve a nested Member chain to a dotted module path.
-    fn resolve_dotted_module_path(&self, kind: &ExprKind) -> Option<String> {
-        match kind {
-            ExprKind::Member { object, field, .. } => {
-                if let ExprKind::Ident { name: root, .. } = &object.kind {
-                    let resolved_root = self.env.import_table.resolve(root)
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| root.to_string());
-                    let candidate = format!("{}.{}", resolved_root, field);
-                    if self.env.import_table.accessible.contains(&sym(&candidate)) {
-                        return Some(candidate);
-                    }
-                    let prefix = format!("{}.", candidate);
-                    if self.env.import_table.accessible.iter().any(|m| m.as_str().starts_with(&prefix)) {
-                        return Some(candidate);
-                    }
-                }
-                if let Some(parent) = self.resolve_dotted_module_path(&object.kind) {
-                    let candidate = format!("{}.{}", parent, field);
-                    if self.env.import_table.accessible.contains(&sym(&candidate)) {
-                        return Some(candidate);
-                    }
-                    let prefix = format!("{}.", candidate);
-                    if self.env.import_table.accessible.iter().any(|m| m.as_str().starts_with(&prefix)) {
-                        return Some(candidate);
-                    }
-                }
-                None
-            }
-            _ => None,
-        }
-    }
 }
 
 /// Collect all Ident names referenced in an expression (shallow, for var capture check).

--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -106,6 +106,27 @@ impl Checker {
             }
 
             ExprKind::Member { object, field, .. } => {
+                // Module function used as a first-class value: `string.len`,
+                // `list.map`, etc. Detect this BEFORE inferring the object
+                // (which would fail because `string` is not a variable) and
+                // return the function's type signature.
+                if let ExprKind::Ident { name: mod_name, .. } = &object.kind {
+                    if let Some(sig) = crate::stdlib::lookup_sig(mod_name, field) {
+                        self.type_map.insert(object.id, Ty::Unit); // placeholder; object isn't evaluated
+                        return Ty::Fn {
+                            params: sig.params.iter().map(|(_, t)| t.clone()).collect(),
+                            ret: Box::new(sig.ret.clone()),
+                        };
+                    }
+                    let key = format!("{}.{}", mod_name, field);
+                    if let Some(sig) = self.env.functions.get(&sym(&key)).cloned() {
+                        self.type_map.insert(object.id, Ty::Unit);
+                        return Ty::Fn {
+                            params: sig.params.iter().map(|(_, t)| t.clone()).collect(),
+                            ret: Box::new(sig.ret.clone()),
+                        };
+                    }
+                }
                 let obj_ty = self.infer_expr(object);
                 let concrete = resolve_ty(&obj_ty, &self.uf);
                 self.resolve_field_type(&concrete, field)

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -105,7 +105,10 @@ impl Checker {
         let ctx = context.into();
         // Eagerly unify to propagate type info into lambda bodies
         self.unify_infer(&expected, &actual);
-        self.constraints.push(Constraint { expected, actual, context: ctx });
+        self.constraints.push(Constraint {
+            expected, actual, context: ctx,
+            span: self.current_span,
+        });
     }
 
     pub fn set_source(&mut self, file: &str, text: &str) { self.source_file = Some(file.into()); self.source_text = Some(text.into()); }

--- a/crates/almide-frontend/src/check/solving.rs
+++ b/crates/almide-frontend/src/check/solving.rs
@@ -23,9 +23,18 @@ impl Checker {
                         "Fix the expression type or change the expected type",
                         &exp, &act,
                     );
+                    // Temporarily swap in the constraint's own span so the
+                    // error is reported at the call site where the constraint
+                    // was introduced, not at wherever checking happened to
+                    // end up.
+                    let saved_span = self.current_span;
+                    if c.span.is_some() {
+                        self.current_span = c.span;
+                    }
                     self.emit(err(
                         format!("type mismatch in {}: expected {} but got {}", c.context, exp.display(), act.display()),
                         hint, c.context.clone()).with_code("E001"));
+                    self.current_span = saved_span;
                 }
             }
         }

--- a/crates/almide-frontend/src/check/types.rs
+++ b/crates/almide-frontend/src/check/types.rs
@@ -12,6 +12,11 @@ pub struct Constraint {
     pub expected: Ty,
     pub actual: Ty,
     pub context: String,
+    /// Source span captured when the constraint was added. Used for error
+    /// reporting; without it, mismatches reported during `solve_constraints`
+    /// attach to whichever expression the checker happened to visit last,
+    /// which produces wildly misleading error locations.
+    pub span: Option<crate::ast::Span>,
 }
 
 /// Check if a Ty is an inference variable (?N).

--- a/crates/almide-frontend/src/import_table.rs
+++ b/crates/almide-frontend/src/import_table.rs
@@ -69,6 +69,44 @@ impl ImportTable {
     pub fn mark_used(&mut self, name: &str) {
         self.used.insert(sym(name));
     }
+
+    /// Resolve a dotted module path like `a.b.c` from a Member chain expression.
+    /// Works for both `accessible` modules (user packages) and `aliases` (imports).
+    /// Used by both checker (infer_pipe) and lowering (lower_call_target) to
+    /// eliminate duplicated module resolution logic.
+    pub fn resolve_dotted_path(&self, kind: &ast::ExprKind) -> Option<String> {
+        match kind {
+            ast::ExprKind::Member { object, field, .. } => {
+                // Direct root: `root.field`
+                if let ast::ExprKind::Ident { name: root, .. } = &object.kind {
+                    let resolved_root = self.resolve(root)
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| root.to_string());
+                    let candidate = format!("{}.{}", resolved_root, field);
+                    if self.accessible.contains(&sym(&candidate)) {
+                        return Some(candidate);
+                    }
+                    let prefix = format!("{}.", candidate);
+                    if self.accessible.iter().any(|m| m.as_str().starts_with(&prefix)) {
+                        return Some(candidate);
+                    }
+                }
+                // Recursive: `parent.field`
+                if let Some(parent) = self.resolve_dotted_path(&object.kind) {
+                    let candidate = format!("{}.{}", parent, field);
+                    if self.accessible.contains(&sym(&candidate)) {
+                        return Some(candidate);
+                    }
+                    let prefix = format!("{}.", candidate);
+                    if self.accessible.iter().any(|m| m.as_str().starts_with(&prefix)) {
+                        return Some(candidate);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
 }
 
 /// Build an ImportTable from a program's imports.

--- a/crates/almide-frontend/src/lower/calls.rs
+++ b/crates/almide-frontend/src/lower/calls.rs
@@ -122,7 +122,7 @@ pub(super) fn lower_call_target(ctx: &mut LowerCtx, callee: &ast::Expr) -> CallT
             }
             // Dot-chain submodule fallback: still resolve so codegen doesn't break
             // (checker emits error for these, but lowering must still produce valid IR)
-            if let Some(dotted) = resolve_dotted_module_path(object, ctx) {
+            if let Some(dotted) = ctx.env.import_table.resolve_dotted_path(&object.kind) {
                 return CallTarget::Module { module: sym(&dotted), func: *field };
             }
             // TypeName.method(args) → direct named call (not UFCS, no object prepend)
@@ -218,40 +218,5 @@ pub(super) fn lower_call_target(ctx: &mut LowerCtx, callee: &ast::Expr) -> CallT
             let ir_callee = lower_expr(ctx, callee);
             CallTarget::Computed { callee: Box::new(ir_callee) }
         }
-    }
-}
-
-/// Resolve a nested Member chain to a dotted module path for CallTarget::Module.
-fn resolve_dotted_module_path(expr: &ast::Expr, ctx: &LowerCtx) -> Option<String> {
-    match &expr.kind {
-        ast::ExprKind::Member { object, field, .. } => {
-            if let ast::ExprKind::Ident { name: root, .. } = &object.kind {
-                // Resolve alias: if root is an alias (e.g. "d" → "dmod_d"), use the target
-                let resolved_root = ctx.env.import_table.aliases.get(root)
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| root.to_string());
-                let candidate = format!("{}.{}", resolved_root, field);
-                if ctx.env.user_modules.contains(&sym(&candidate)) {
-                    return Some(candidate);
-                }
-                // Namespace prefix: dir without mod.almd but has children
-                let prefix = format!("{}.", candidate);
-                if ctx.env.user_modules.iter().any(|m| m.as_str().starts_with(&prefix)) {
-                    return Some(candidate);
-                }
-            }
-            if let Some(parent) = resolve_dotted_module_path(object, ctx) {
-                let candidate = format!("{}.{}", parent, field);
-                if ctx.env.user_modules.contains(&sym(&candidate)) {
-                    return Some(candidate);
-                }
-                let prefix = format!("{}.", candidate);
-                if ctx.env.user_modules.iter().any(|m| m.as_str().starts_with(&prefix)) {
-                    return Some(candidate);
-                }
-            }
-            None
-        }
-        _ => None,
     }
 }

--- a/crates/almide-frontend/src/lower/expressions.rs
+++ b/crates/almide-frontend/src/lower/expressions.rs
@@ -304,6 +304,19 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
 
         // ── Access ──
         ast::ExprKind::Member { object, field, .. } => {
+            // Module function used as first-class value: `string.len` →
+            // lowered to a wrapper lambda `(x) => string.len(x)`. This lets
+            // user code write `list.map(xs, string.len)` without a manual
+            // eta expansion.
+            if let ast::ExprKind::Ident { name: mod_name, .. } = &object.kind {
+                if let Ty::Fn { params, ret } = &ty {
+                    let is_module_fn = crate::stdlib::lookup_sig(mod_name, field).is_some()
+                        || ctx.env.functions.contains_key(&sym(&format!("{}.{}", mod_name, field)));
+                    if is_module_fn {
+                        return eta_expand_module_fn(ctx, *mod_name, *field, params.clone(), (**ret).clone(), span);
+                    }
+                }
+            }
             let obj = lower_expr(ctx, object);
             ctx.mk(IrExprKind::Member { object: Box::new(obj), field: *field }, ty, span)
         }
@@ -463,4 +476,55 @@ fn lower_pipe(ctx: &mut LowerCtx, left: &ast::Expr, right: &ast::Expr, ty: Ty, s
             }, ty, span)
         }
     }
+}
+
+/// Eta-expand a module function reference (`string.len`, `list.map`, ...)
+/// into a lambda that calls it. Used when the reference appears in value
+/// position rather than as a callee, e.g. `xs |> list.map(string.len)`.
+fn eta_expand_module_fn(
+    ctx: &mut LowerCtx,
+    module: almide_base::intern::Sym,
+    field: almide_base::intern::Sym,
+    params: Vec<Ty>,
+    ret_ty: Ty,
+    span: Option<ast::Span>,
+) -> IrExpr {
+    ctx.push_scope();
+    let mut param_vars: Vec<(VarId, Ty)> = Vec::with_capacity(params.len());
+    for (i, pt) in params.iter().enumerate() {
+        let name = format!("__eta_{}", i);
+        let var = ctx.define_var(&name, pt.clone(), Mutability::Let, span.clone());
+        param_vars.push((var, pt.clone()));
+    }
+    let args: Vec<IrExpr> = param_vars.iter()
+        .map(|(var, pt)| ctx.mk(IrExprKind::Var { id: *var }, pt.clone(), span.clone()))
+        .collect();
+    // For stdlib modules (e.g. `string`) use CallTarget::Module so codegen
+    // picks the stdlib runtime function. For user convention methods
+    // (`Type.method`) use CallTarget::Named with the dotted key.
+    let mod_name = module.as_str();
+    let target = if crate::stdlib::is_stdlib_module(mod_name)
+        || crate::stdlib::is_any_stdlib(mod_name)
+        || ctx.env.user_modules.contains(&module)
+        || ctx.env.import_table.aliases.contains_key(&module)
+    {
+        let resolved = ctx.env.import_table.aliases.get(&module).copied().unwrap_or(module);
+        CallTarget::Module { module: resolved, func: field }
+    } else {
+        CallTarget::Named { name: sym(&format!("{}.{}", module, field)) }
+    };
+    let call = ctx.mk(IrExprKind::Call {
+        target, args, type_args: vec![],
+    }, ret_ty.clone(), span.clone());
+    ctx.pop_scope();
+    let lambda_id = Some(ctx.next_lambda_id());
+    let lambda_ty = Ty::Fn {
+        params: params.clone(),
+        ret: Box::new(ret_ty),
+    };
+    ctx.mk(IrExprKind::Lambda {
+        params: param_vars,
+        body: Box::new(call),
+        lambda_id,
+    }, lambda_ty, span)
 }

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -144,10 +144,14 @@ impl<'a> LowerCtx<'a> {
                 }
             }
         }
-        // Resolve UFCS call return types: obj.method(args) when receiver type is known.
-        // The checker may store Unknown or a bogus Fn type for chained method calls
-        // on lambda parameters (constraints solve the receiver as callable rather than
-        // as a collection method). Re-derive the type from the stdlib signature.
+        // ARCHITECTURAL COMPROMISE: re-derive UFCS return types from stdlib signatures.
+        //
+        // The checker may store Unknown or a bogus Fn type for chained UFCS calls
+        // (e.g., `items |> list.map(f) |> list.join(",")`) because constraint
+        // solving resolves the receiver as callable rather than as a collection
+        // method. Fixing this requires changes to constraint propagation order in
+        // the checker, which is high-risk. This targeted fallback covers all stdlib
+        // modules and is stable.
         if ty == Ty::Unknown || matches!(&ty, Ty::Fn { .. }) {
             if let ast::ExprKind::Call { callee, .. } = &expr.kind {
                 if let ast::ExprKind::Member { object, field, .. } = &callee.kind {

--- a/crates/almide-frontend/src/lower/statements.rs
+++ b/crates/almide-frontend/src/lower/statements.rs
@@ -18,15 +18,31 @@ pub(super) fn lower_stmt(ctx: &mut LowerCtx, stmt: &ast::Stmt) -> IrStmt {
     };
 
     let kind = match stmt {
-        ast::Stmt::Let { name, value, .. } => {
-            let ir_val = lower_expr(ctx, value);
-            let val_ty = ir_val.ty.clone();
+        ast::Stmt::Let { name, ty, value, .. } => {
+            let mut ir_val = lower_expr(ctx, value);
+            // If the user wrote `let x: T = ...`, honor that annotation over the
+            // structurally-inferred type of the value. Otherwise two nominal
+            // record types with identical fields (e.g. `Dog` and `Cat`) collide
+            // at codegen time because the value keeps its structural type.
+            let val_ty = if let Some(te) = ty {
+                let declared = super::types::resolve_type_expr(te);
+                override_record_literal_ty(&mut ir_val, &declared);
+                declared
+            } else {
+                ir_val.ty.clone()
+            };
             let var = ctx.define_var(name, val_ty.clone(), Mutability::Let, span);
             IrStmtKind::Bind { var, mutability: Mutability::Let, ty: val_ty, value: ir_val }
         }
-        ast::Stmt::Var { name, value, .. } => {
-            let ir_val = lower_expr(ctx, value);
-            let val_ty = ir_val.ty.clone();
+        ast::Stmt::Var { name, ty, value, .. } => {
+            let mut ir_val = lower_expr(ctx, value);
+            let val_ty = if let Some(te) = ty {
+                let declared = super::types::resolve_type_expr(te);
+                override_record_literal_ty(&mut ir_val, &declared);
+                declared
+            } else {
+                ir_val.ty.clone()
+            };
             let var = ctx.define_var(name, val_ty.clone(), Mutability::Var, span);
             IrStmtKind::Bind { var, mutability: Mutability::Var, ty: val_ty, value: ir_val }
         }
@@ -70,6 +86,33 @@ pub(super) fn lower_stmt(ctx: &mut LowerCtx, stmt: &ast::Stmt) -> IrStmt {
     };
 
     IrStmt { kind, span }
+}
+
+/// Retag an anonymous record literal's IR type with the declared nominal type.
+///
+/// Record literals are inferred as structural `Ty::Record { fields }`. When
+/// assigned to a let with an explicit nominal annotation (e.g. `let d: Dog`),
+/// the declared type should win. Otherwise multiple nominal types with
+/// identical field shapes (Dog vs Cat, both `{name: String}`) collide at
+/// codegen because `collect_named_records` keys by sorted field names.
+fn override_record_literal_ty(ir_val: &mut IrExpr, declared: &Ty) {
+    if !matches!(declared, Ty::Named(_, _)) { return; }
+    match &mut ir_val.kind {
+        IrExprKind::Record { .. } => {
+            if matches!(ir_val.ty, Ty::Record { .. } | Ty::OpenRecord { .. } | Ty::Unknown) {
+                ir_val.ty = declared.clone();
+            }
+        }
+        // The literal may be wrapped in a trivial block (e.g. `let x = { ... }`
+        // can lower as Block { expr: Some(Record) }). Recurse into the tail.
+        IrExprKind::Block { expr: Some(inner), .. } => {
+            override_record_literal_ty(inner, declared);
+            if matches!(ir_val.ty, Ty::Record { .. } | Ty::OpenRecord { .. } | Ty::Unknown) {
+                ir_val.ty = declared.clone();
+            }
+        }
+        _ => {}
+    }
 }
 
 // ── Pattern lowering ────────────────────────────────────────────

--- a/crates/almide-ir/CLAUDE.md
+++ b/crates/almide-ir/CLAUDE.md
@@ -1,0 +1,28 @@
+# almide-ir
+
+Typed Intermediate Representation consumed by all codegen targets.
+
+## Key Types
+
+- **`IrProgram`** — Top-level: functions, type declarations, top_lets, modules, var_table.
+- **`IrExpr`** / **`IrExprKind`** — Expression nodes with `ty: Ty` on every node.
+- **`IrFunction`** — Function definition with params, ret_ty, body, flags (is_effect, is_test).
+- **`VarId(u32)`** — Unique variable identifier. **`VarTable`** maps VarId → VarInfo (name, type, mutability).
+- **`BinOp`** / **`UnOp`** — Type-dispatched operators (AddInt vs AddFloat, etc.).
+- **`CallTarget`** — Resolved call destination (Module, Method, Named, Computed).
+
+## Rules
+
+- **Every IrExpr carries its type.** `expr.ty` must be set during lowering. Codegen reads it directly — it does NOT re-infer.
+- **VarId is the only way to reference variables.** No string-based lookups in IR. If you need a variable's name, go through `var_table.get(var_id).name`.
+- **BinOp is type-dispatched.** `a + b` on Int becomes `BinOp::AddInt`, on Float becomes `BinOp::AddFloat`, on String becomes `BinOp::ConcatStr`. Use `op.result_ty()` for the result type.
+- **Visitor pattern for traversal.** Use `visit::IrVisitor` + `walk_expr`/`walk_stmt` for exhaustive traversal. Override only the nodes you need.
+- **`use_count` is post-computed.** Variable use counts are populated after lowering. Don't assume they're accurate during lowering itself.
+
+## Adding New IR Nodes
+
+1. Add variant to `IrExprKind` (or `IrStmtKind`).
+2. Update `visit.rs` (`walk_expr`/`walk_stmt`) — the visitor MUST traverse all children.
+3. Update `fold.rs` if the node has transformable sub-expressions.
+4. Update `substitute.rs` if the node binds or references variables.
+5. Codegen: handle in walker (`walker/expressions.rs`) and WASM emitter (`emit_wasm/expressions.rs`).

--- a/crates/almide-ir/Cargo.toml
+++ b/crates/almide-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-ir"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide typed intermediate representation (IR)"

--- a/crates/almide-ir/src/annotations.rs
+++ b/crates/almide-ir/src/annotations.rs
@@ -8,6 +8,10 @@ pub struct CodegenAnnotations {
     pub ctor_to_enum: HashMap<String, String>,
     pub anon_records: HashMap<Vec<String>, String>,
     pub named_records: HashMap<Vec<String>, String>,
+    /// Field count of each nominal record type (name → number of fields).
+    /// Used to decide whether a record destructure pattern needs a trailing
+    /// `..` to cover fields the user didn't name.
+    pub record_field_counts: HashMap<String, usize>,
     pub recursive_enums: HashSet<String>,
     pub boxed_fields: HashSet<(String, String)>,
     pub default_fields: HashMap<(String, String), IrExpr>,

--- a/crates/almide-ir/src/fold.rs
+++ b/crates/almide-ir/src/fold.rs
@@ -60,6 +60,7 @@ fn fold_expr(expr: &mut IrExpr) {
         | IrExprKind::Unwrap { expr } | IrExprKind::ToOption { expr }
         | IrExprKind::Clone { expr } | IrExprKind::Deref { expr }
         | IrExprKind::Borrow { expr, .. } | IrExprKind::BoxNew { expr }
+        | IrExprKind::RcWrap { expr, .. }
         | IrExprKind::ToVec { expr } => fold_expr(expr),
         IrExprKind::UnwrapOr { expr: e, fallback: f } => {
             fold_expr(e);

--- a/crates/almide-ir/src/fold.rs
+++ b/crates/almide-ir/src/fold.rs
@@ -34,17 +34,60 @@ fn fold_expr(expr: &mut IrExpr) {
         IrExprKind::Call { args, .. } => {
             for a in args { fold_expr(a); }
         }
-        IrExprKind::List { elements } | IrExprKind::Tuple { elements } => {
+        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
+        | IrExprKind::Fan { exprs: elements } => {
             for e in elements { fold_expr(e); }
         }
         IrExprKind::Lambda { body, .. } => fold_expr(body),
         IrExprKind::Match { subject, arms } => {
             fold_expr(subject);
-            for a in arms { fold_expr(&mut a.body); }
+            for a in arms {
+                if let Some(g) = &mut a.guard { fold_expr(g); }
+                fold_expr(&mut a.body);
+            }
+        }
+        IrExprKind::ForIn { iterable, body, .. } => {
+            fold_expr(iterable);
+            for s in body { fold_stmt(s); }
+        }
+        IrExprKind::While { cond, body } => {
+            fold_expr(cond);
+            for s in body { fold_stmt(s); }
         }
         IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
         | IrExprKind::OptionSome { expr } | IrExprKind::Try { expr }
-        | IrExprKind::Await { expr } => fold_expr(expr),
+        | IrExprKind::Await { expr }
+        | IrExprKind::Unwrap { expr } | IrExprKind::ToOption { expr }
+        | IrExprKind::Clone { expr } | IrExprKind::Deref { expr }
+        | IrExprKind::Borrow { expr, .. } | IrExprKind::BoxNew { expr }
+        | IrExprKind::ToVec { expr } => fold_expr(expr),
+        IrExprKind::UnwrapOr { expr: e, fallback: f } => {
+            fold_expr(e);
+            fold_expr(f);
+        }
+        IrExprKind::OptionalChain { expr: object, .. } => fold_expr(object),
+        IrExprKind::RustMacro { args, .. } => {
+            for a in args { fold_expr(a); }
+        }
+        IrExprKind::IterChain { source, steps, collector, .. } => {
+            fold_expr(source);
+            for step in steps {
+                match step {
+                    super::IterStep::Map { lambda } | super::IterStep::Filter { lambda }
+                    | super::IterStep::FlatMap { lambda } | super::IterStep::FilterMap { lambda } => {
+                        fold_expr(lambda);
+                    }
+                }
+            }
+            match collector {
+                super::IterCollector::Collect => {}
+                super::IterCollector::Fold { init, lambda } => { fold_expr(init); fold_expr(lambda); }
+                super::IterCollector::Any { lambda } | super::IterCollector::All { lambda }
+                | super::IterCollector::Find { lambda } | super::IterCollector::Count { lambda } => {
+                    fold_expr(lambda);
+                }
+            }
+        }
         IrExprKind::Record { fields, .. } => {
             for (_, v) in fields { fold_expr(v); }
         }

--- a/crates/almide-ir/src/lib.rs
+++ b/crates/almide-ir/src/lib.rs
@@ -62,6 +62,25 @@ pub enum BinOp {
     And, Or,
 }
 
+impl BinOp {
+    /// The result type of this operator, when it can be determined from the
+    /// operator alone. Returns `None` for `ConcatList` (result type = operand type,
+    /// which must be resolved from context).
+    pub fn result_ty(&self) -> Option<Ty> {
+        match self {
+            BinOp::AddInt | BinOp::SubInt | BinOp::MulInt | BinOp::DivInt
+            | BinOp::ModInt | BinOp::PowInt => Some(Ty::Int),
+            BinOp::AddFloat | BinOp::SubFloat | BinOp::MulFloat | BinOp::DivFloat
+            | BinOp::ModFloat | BinOp::PowFloat => Some(Ty::Float),
+            BinOp::MulMatrix | BinOp::AddMatrix | BinOp::SubMatrix | BinOp::ScaleMatrix => Some(Ty::Matrix),
+            BinOp::ConcatStr => Some(Ty::String),
+            BinOp::ConcatList => None,
+            BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte
+            | BinOp::And | BinOp::Or => Some(Ty::Bool),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UnOp {

--- a/crates/almide-ir/src/lib.rs
+++ b/crates/almide-ir/src/lib.rs
@@ -299,6 +299,8 @@ pub enum IrExprKind {
     Borrow { expr: Box<IrExpr>, as_str: bool, #[serde(default)] mutable: bool },
     /// Box wrapping: `Box::new(expr)`
     BoxNew { expr: Box<IrExpr> },
+    /// Rc wrapping: `std::rc::Rc::new(expr)` — for List[Fn] elements in Rust.
+    RcWrap { expr: Box<IrExpr>, cast_ty: Option<Box<almide_lang::types::Ty>> },
     /// Macro invocation: `name!(args)` (Rust assert_eq!, println!, etc.)
     RustMacro { name: Sym, args: Vec<IrExpr> },
     /// ToVec: `(expr).to_vec()`
@@ -392,6 +394,7 @@ impl IrExpr {
             IrExprKind::Deref { expr } => IrExprKind::Deref { expr: Box::new(f(*expr)) },
             IrExprKind::Borrow { expr, as_str, mutable } => IrExprKind::Borrow { expr: Box::new(f(*expr)), as_str, mutable },
             IrExprKind::BoxNew { expr } => IrExprKind::BoxNew { expr: Box::new(f(*expr)) },
+            IrExprKind::RcWrap { expr, cast_ty } => IrExprKind::RcWrap { expr: Box::new(f(*expr)), cast_ty },
             IrExprKind::ToVec { expr } => IrExprKind::ToVec { expr: Box::new(f(*expr)) },
             IrExprKind::Await { expr } => IrExprKind::Await { expr: Box::new(f(*expr)) },
             IrExprKind::Try { expr } => IrExprKind::Try { expr: Box::new(f(*expr)) },

--- a/crates/almide-ir/src/substitute.rs
+++ b/crates/almide-ir/src/substitute.rs
@@ -170,6 +170,10 @@ pub fn substitute_var_in_expr(expr: &IrExpr, var: VarId, replacement: &IrExpr) -
             kind: IrExprKind::BoxNew { expr: Box::new(sub(inner)) },
             ty: expr.ty.clone(), span: expr.span,
         },
+        IrExprKind::RcWrap { expr: inner, cast_ty } => IrExpr {
+            kind: IrExprKind::RcWrap { expr: Box::new(sub(inner)), cast_ty: cast_ty.clone() },
+            ty: expr.ty.clone(), span: expr.span,
+        },
         IrExprKind::ToVec { expr: inner } => IrExpr {
             kind: IrExprKind::ToVec { expr: Box::new(sub(inner)) },
             ty: expr.ty.clone(), span: expr.span,

--- a/crates/almide-ir/src/use_count.rs
+++ b/crates/almide-ir/src/use_count.rs
@@ -136,6 +136,7 @@ fn count_uses_in_expr(expr: &IrExpr, table: &mut VarTable) {
         | IrExprKind::Await { expr }
         | IrExprKind::Clone { expr } | IrExprKind::Deref { expr }
         | IrExprKind::Borrow { expr, .. } | IrExprKind::BoxNew { expr }
+        | IrExprKind::RcWrap { expr, .. }
         | IrExprKind::ToVec { expr } => {
             count_uses_in_expr(expr, table);
         }
@@ -363,6 +364,7 @@ fn bump_vars_in_expr(expr: &IrExpr, locals: &HashSet<u32>, table: &mut VarTable)
         }
         IrExprKind::Clone { expr } | IrExprKind::Deref { expr }
         | IrExprKind::Borrow { expr, .. } | IrExprKind::BoxNew { expr }
+        | IrExprKind::RcWrap { expr, .. }
         | IrExprKind::ToVec { expr } | IrExprKind::Await { expr } => {
             bump_vars_in_expr(expr, locals, table);
         }

--- a/crates/almide-ir/src/visit.rs
+++ b/crates/almide-ir/src/visit.rs
@@ -131,6 +131,7 @@ pub fn walk_expr<V: IrVisitor>(v: &mut V, expr: &IrExpr) {
         | IrExprKind::Await { expr: e }
         | IrExprKind::Clone { expr: e } | IrExprKind::Deref { expr: e }
         | IrExprKind::Borrow { expr: e, .. } | IrExprKind::BoxNew { expr: e }
+        | IrExprKind::RcWrap { expr: e, .. }
         | IrExprKind::ToVec { expr: e } => {
             v.visit_expr(e);
         }

--- a/crates/almide-lang/CLAUDE.md
+++ b/crates/almide-lang/CLAUDE.md
@@ -1,0 +1,8 @@
+# almide-lang
+
+Facade crate. Re-exports `almide-syntax` (AST, lexer, parser) and `almide-types` (Ty, stdlib_info) as a single dependency.
+
+## Rules
+
+- **No logic here.** This crate only re-exports. If you need shared logic, put it in the appropriate leaf crate.
+- **Downstream crates depend on this** instead of separately depending on both almide-syntax and almide-types.

--- a/crates/almide-lang/Cargo.toml
+++ b/crates/almide-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-lang"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide language definitions: re-exports almide-syntax + almide-types"

--- a/crates/almide-optimize/CLAUDE.md
+++ b/crates/almide-optimize/CLAUDE.md
@@ -1,0 +1,23 @@
+# almide-optimize
+
+IR-level optimization passes: monomorphization, dead code elimination, constant propagation.
+
+## Monomorphization (`mono/`)
+
+Specializes generic functions for concrete type arguments.
+
+- **Frontier-based discovery** — First round scans all functions for generic call sites. Subsequent rounds only scan newly created specializations. Converges when no new instances appear.
+- **Structural bounds** — `T: { name: String, .. }` constraints are resolved to concrete types (Dog, Person, etc.).
+- **Runaway protection** — Warns and stops if >1000 specializations created (possible infinite expansion).
+
+## Optimization (`optimize/`)
+
+- **DCE** — Removes functions with zero call sites and unused variable bindings.
+- **Constant propagation** — Folds constant expressions and propagates known values.
+
+## Rules
+
+- **Mono runs before codegen.** After mono, no `TypeVar` should remain in the IR (except in unreachable paths).
+- **Mono clones functions.** Specialized functions are copies with substituted types. Original generic functions are kept if they have non-generic call sites.
+- **DCE must be conservative.** Only remove functions/variables proven unreachable. Side-effecting expressions (effect fns, assignments) must survive even if their result is unused.
+- **Optimization must not change semantics.** Every optimization pass must preserve observable behavior. Add regression tests for edge cases.

--- a/crates/almide-optimize/Cargo.toml
+++ b/crates/almide-optimize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-optimize"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide IR optimizer: dead code elimination, constant propagation, monomorphization"

--- a/crates/almide-optimize/src/mono/discovery.rs
+++ b/crates/almide-optimize/src/mono/discovery.rs
@@ -64,8 +64,10 @@ pub(super) fn discover_in_expr(
         IrExprKind::Call { target, args, type_args } => {
             if let CallTarget::Named { name } = target {
                 if let Some(bounded_params) = bound_fns.get::<str>(name) {
-                    // Find the original function to get parameter types and generics
-                    let orig_fn = program_functions.iter().find(|f| f.name == *name);
+                    // Find the original generic function to get parameter types
+                    // and generics. Tests can share the raw name (`test "wrap_all"`
+                    // collides with `fn wrap_all[T]`), so skip them here.
+                    let orig_fn = program_functions.iter().find(|f| !f.is_test && f.name == *name);
                     let param_types: Vec<Ty> = orig_fn
                         .map(|f| f.params.iter().map(|p| p.ty.clone()).collect())
                         .unwrap_or_default();

--- a/crates/almide-optimize/src/mono/mod.rs
+++ b/crates/almide-optimize/src/mono/mod.rs
@@ -75,7 +75,7 @@ pub fn monomorphize(program: &mut IrProgram) {
         // Specialize new functions
         let mut new_functions = Vec::new();
         for ((fn_name, suffix), bindings) in &new {
-            if let Some(orig) = program.functions.iter().find(|f| f.name == *fn_name) {
+            if let Some(orig) = program.functions.iter().find(|f| !f.is_test && f.name == *fn_name) {
                 new_functions.push(specialize_function(orig, suffix, bindings));
             }
         }
@@ -102,12 +102,17 @@ pub fn monomorphize(program: &mut IrProgram) {
     }
 
     // Remove generic functions: both those with specialized instances AND
-    // those with no call sites (unused generics still carry TypeVars)
+    // those with no call sites (unused generics still carry TypeVars).
+    //
+    // IMPORTANT: tests may share a name with a function (e.g. `fn wrap_all[T]`
+    // and `test "wrap_all"` both lower to `name = "wrap_all"`). Only drop
+    // *generic non-test* functions — never a test, regardless of name.
     let mono_fn_names: std::collections::HashSet<String> = all_instances.keys().map(|(name, _)| name.clone()).collect();
     program.functions.retain(|f| {
+        if f.is_test { return true; } // tests always survive mono
         if mono_fn_names.contains::<str>(&f.name) { return false; } // replaced by specialized
         // Also remove generic functions with no instances (unused)
-        if f.generics.as_ref().map_or(false, |g| !g.is_empty()) && !f.is_test {
+        if f.generics.as_ref().map_or(false, |g| !g.is_empty()) {
             return false;
         }
         true

--- a/crates/almide-optimize/src/mono/propagation.rs
+++ b/crates/almide-optimize/src/mono/propagation.rs
@@ -17,13 +17,11 @@ pub(super) fn propagate_concrete_types(program: &mut IrProgram) {
 /// If the body expression is a Match whose .ty disagrees with ret_ty, fix it.
 /// Also recurse into Block tails.
 fn fix_body_match_ty(body: &mut IrExpr, ret_ty: &Ty) {
+    if matches!(ret_ty, Ty::Unit | Ty::Unknown) { return; }
     match &mut body.kind {
         IrExprKind::Match { arms, .. } => {
-            if !almide_ir::wasm_types_compatible(&body.ty, ret_ty)
-                && !matches!(ret_ty, Ty::Unit | Ty::Unknown)
-            {
+            if !almide_ir::wasm_types_compatible(&body.ty, ret_ty) {
                 body.ty = ret_ty.clone();
-                // Also fix arm body types
                 for arm in arms.iter_mut() {
                     if !almide_ir::wasm_types_compatible(&arm.body.ty, ret_ty) {
                         fix_body_match_ty(&mut arm.body, ret_ty);
@@ -33,12 +31,23 @@ fn fix_body_match_ty(body: &mut IrExpr, ret_ty: &Ty) {
         }
         IrExprKind::Block { expr: Some(tail), .. } => {
             fix_body_match_ty(tail, ret_ty);
-            if !almide_ir::wasm_types_compatible(&body.ty, ret_ty)
-                && !matches!(ret_ty, Ty::Unit | Ty::Unknown) {
+            if !almide_ir::wasm_types_compatible(&body.ty, ret_ty) {
                 body.ty = ret_ty.clone();
             }
         }
-        _ => {}
+        IrExprKind::If { then, else_, .. } => {
+            fix_body_match_ty(then, ret_ty);
+            fix_body_match_ty(else_, ret_ty);
+            if !almide_ir::wasm_types_compatible(&body.ty, ret_ty) {
+                body.ty = ret_ty.clone();
+            }
+        }
+        _ => {
+            // Leaf expression with wrong type — fix directly
+            if !almide_ir::wasm_types_compatible(&body.ty, ret_ty) {
+                body.ty = ret_ty.clone();
+            }
+        }
     }
 }
 

--- a/crates/almide-optimize/src/mono/rewrite.rs
+++ b/crates/almide-optimize/src/mono/rewrite.rs
@@ -11,16 +11,19 @@ pub(super) fn rewrite_calls(
     bound_fns: &HashMap<String, Vec<BoundedParam>>,
     instances: &HashMap<MonoKey, HashMap<String, Ty>>,
 ) {
+    // Tests can share raw names with generic functions (e.g. `fn wrap_all[T]` vs
+    // `test "wrap_all"` — both lower to name = "wrap_all"). Skip tests when
+    // building these lookups so the generic function's signature wins.
     let fn_param_types: HashMap<String, Vec<Ty>> = program.functions.iter()
-        .filter(|f| bound_fns.contains_key::<str>(&f.name))
+        .filter(|f| !f.is_test && bound_fns.contains_key::<str>(&f.name))
         .map(|f| (f.name.to_string(), f.params.iter().map(|p| p.ty.clone()).collect()))
         .collect();
     let fn_generics: HashMap<String, Vec<String>> = program.functions.iter()
-        .filter(|f| bound_fns.contains_key::<str>(&f.name))
+        .filter(|f| !f.is_test && bound_fns.contains_key::<str>(&f.name))
         .filter_map(|f| f.generics.as_ref().map(|gs| (f.name.to_string(), gs.iter().map(|g| g.name.to_string()).collect())))
         .collect();
     let fn_ret_types: HashMap<String, Ty> = program.functions.iter()
-        .filter(|f| bound_fns.contains_key::<str>(&f.name))
+        .filter(|f| !f.is_test && bound_fns.contains_key::<str>(&f.name))
         .map(|f| (f.name.to_string(), f.ret_ty.clone()))
         .collect();
 

--- a/crates/almide-optimize/src/optimize/dce.rs
+++ b/crates/almide-optimize/src/optimize/dce.rs
@@ -6,9 +6,15 @@ pub(super) fn eliminate_dead_code(program: &mut IrProgram) {
     for f in &mut program.functions {
         dce_expr(&mut f.body, &program.var_table);
     }
+    for tl in &mut program.top_lets {
+        dce_expr(&mut tl.value, &program.var_table);
+    }
     for m in &mut program.modules {
         for f in &mut m.functions {
             dce_expr(&mut f.body, &m.var_table);
+        }
+        for tl in &mut m.top_lets {
+            dce_expr(&mut tl.value, &m.var_table);
         }
     }
 }

--- a/crates/almide-optimize/src/optimize/propagate.rs
+++ b/crates/almide-optimize/src/optimize/propagate.rs
@@ -10,11 +10,23 @@ pub(super) fn constant_propagate(program: &mut IrProgram) {
             propagate_expr(&mut f.body, &constants);
         }
     }
+    for tl in &mut program.top_lets {
+        let constants = collect_constants(&tl.value);
+        if !constants.is_empty() {
+            propagate_expr(&mut tl.value, &constants);
+        }
+    }
     for m in &mut program.modules {
         for f in &mut m.functions {
             let constants = collect_constants(&f.body);
             if !constants.is_empty() {
                 propagate_expr(&mut f.body, &constants);
+            }
+        }
+        for tl in &mut m.top_lets {
+            let constants = collect_constants(&tl.value);
+            if !constants.is_empty() {
+                propagate_expr(&mut tl.value, &constants);
             }
         }
     }

--- a/crates/almide-syntax/CLAUDE.md
+++ b/crates/almide-syntax/CLAUDE.md
@@ -1,0 +1,34 @@
+# almide-syntax
+
+Lexer, parser, and AST definition. Produces an untyped AST from source text.
+
+## Architecture
+
+- **Lexer** (`lexer.rs`) — Single-pass tokenizer. Handles string interpolation and heredocs inline.
+- **Parser** (`parser/`) — Recursive descent with precedence climbing. Error recovery with sync points.
+- **AST** (`ast.rs`) — `Program` → declarations (fn, type, test, import) → `Expr`/`Stmt` tree.
+
+## Rules
+
+- **Parser must never crash.** All syntax errors produce diagnostics and recover. Use `sync_to_next_declaration()` after fatal parse errors.
+- **No type information in AST.** Types are syntactic `TypeExpr` nodes, not resolved `Ty`. Resolution happens in almide-frontend.
+- **`ExprId` is mandatory.** Every expression gets a unique `ExprId` for O(1) type lookup during checking. Never skip assigning it.
+- **Desugar nothing.** Pipes, UFCS, interpolation — all remain as-is in the AST. Desugaring happens in lowering (almide-frontend).
+- **Error hints matter.** The `parser/hints/` modules detect common mistakes (keyword typos like `function` → `fn`, wrong operators like `&&` → `and`). Add hints for new syntax.
+
+## Module Layout
+
+```
+parser/
+├── mod.rs          Parser struct, token management
+├── entry.rs        Top-level declarations, module layout
+├── declarations.rs fn, type, trait, impl, test
+├── expressions.rs  Binary/unary, pipe, match, if/then/else
+├── primary.rs      Literals, identifiers, lambdas, blocks
+├── statements.rs   let, var, guard, assignment
+├── patterns.rs     Match patterns
+├── types.rs        Type expression parsing
+├── collections.rs  List, map, record, tuple literals
+├── compounds.rs    for-in, while, fan blocks
+└── hints/          Error recovery (6 hint modules)
+```

--- a/crates/almide-syntax/Cargo.toml
+++ b/crates/almide-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-syntax"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide syntax definitions: AST, lexer, and parser"

--- a/crates/almide-syntax/src/parser/types.rs
+++ b/crates/almide-syntax/src/parser/types.rs
@@ -35,10 +35,10 @@ impl Parser {
             }
             self.expect(TokenType::RParen)?;
             self.skip_newlines_if_followed_by(TokenType::Pipe);
-            if self.check(TokenType::Pipe) {
-                return self.try_parse_inline_variant(name, fields);
-            }
-            return Ok(TypeExpr::Simple { name });
+            // `Name(Type, ...)` in type position is a constructor with payload.
+            // Always treat it as an inline variant — try_parse_inline_variant
+            // handles the single-case form when no trailing `|` follows.
+            return self.try_parse_inline_variant(name, fields);
         }
         self.skip_newlines_if_followed_by(TokenType::Pipe);
         if self.check(TokenType::Pipe) {

--- a/crates/almide-tools/CLAUDE.md
+++ b/crates/almide-tools/CLAUDE.md
@@ -1,0 +1,25 @@
+# almide-tools
+
+Developer-facing tools: formatter, module interface extraction, language server.
+
+## Formatter (`fmt.rs`)
+
+- `format_program(program) -> String` — AST → formatted source.
+- Preserves comments, infers short/long formatting by expression complexity.
+- `auto_imports()` — Add missing stdlib imports, remove unused.
+
+## Module Interface (`interface.rs`)
+
+- `extract_module_interface(ir_program) -> ModuleInterface` — Produces JSON API description.
+- Includes type signatures, docs, deprecation flags, ABI layout for C FFI.
+- Used by export tooling to generate pip/npm/gem packages.
+
+## Language Server (`almdi.rs`)
+
+- LSP implementation: hover, goto-definition, completions, diagnostics.
+
+## Rules
+
+- **Formatter must be idempotent.** `format(format(x)) == format(x)` always.
+- **Interface JSON is the contract.** External tools parse this — breaking changes require version bumps.
+- **ABI layout must match codegen.** Field offsets in `AbiLayout` must agree with what `almide-codegen` actually emits. If codegen changes record layout, update interface extraction.

--- a/crates/almide-tools/Cargo.toml
+++ b/crates/almide-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-tools"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide developer tools: formatter, module interface, almdi"

--- a/crates/almide-tools/src/interface.rs
+++ b/crates/almide-tools/src/interface.rs
@@ -179,6 +179,10 @@ pub enum TypeRef {
 /// Extract the public module interface from a type-checked IR program.
 /// `source` is the original source text (for doc/example/deprecation extraction).
 pub fn extract(program: &IrProgram, module_name: &str, source: Option<&str>) -> ModuleInterface {
+    extract_with_version(program, module_name, source, None)
+}
+
+pub fn extract_with_version(program: &IrProgram, module_name: &str, source: Option<&str>, version: Option<&str>) -> ModuleInterface {
     let record_names = build_record_lookup(program);
     let variant_names = build_variant_lookup(program);
     let doc_info = source.map(|s| extract_docs(s)).unwrap_or_default();
@@ -297,7 +301,7 @@ pub fn extract(program: &IrProgram, module_name: &str, source: Option<&str>) -> 
 
     ModuleInterface {
         module: module_name.to_string(),
-        version: None,
+        version: version.map(|v| v.to_string()),
         types,
         functions,
         constants,

--- a/crates/almide-tools/src/interface.rs
+++ b/crates/almide-tools/src/interface.rs
@@ -525,9 +525,11 @@ fn c_abi_size_align(ty: &Ty) -> Option<(usize, usize)> {
         Ty::Bool => Some((1, 1)),
         Ty::Int => Some((8, 8)),    // i64
         Ty::Float => Some((8, 8)),  // f64
-        // String, List, Map, Set, Option, Result are pointer-based (opaque)
+        // String, Bytes, Matrix are pointer-based (opaque fat pointer: ptr + metadata)
         Ty::String => Some((16, 8)),  // (ptr, len)
         Ty::Bytes => Some((16, 8)),
+        Ty::Matrix => Some((16, 8)), // opaque pointer-based
+        Ty::RawPtr => Some((8, 8)),  // *mut u8, C-compatible pointer
         Ty::Unit => Some((0, 1)),
         // Named user types: would need full type table lookup — skip for now
         Ty::Named(_, _) => None,

--- a/crates/almide-types/CLAUDE.md
+++ b/crates/almide-types/CLAUDE.md
@@ -1,0 +1,17 @@
+# almide-types
+
+Defines the internal resolved type representation (`Ty`) and type system utilities.
+
+## Key Types
+
+- **`Ty`** — Resolved type enum. Scalars, `Applied(TypeConstructorId, args)` for containers, `Record`/`Variant`/`Fn`/`Tuple`, `TypeVar`, `Unknown`, `Never`.
+- **`TypeConstructorId`** — Unified parameterized type identity (List, Option, Result, Map, Set, UserDefined).
+- **`ProtocolDef`** / **`FnSig`** — Protocol method signatures and function signatures with bounds.
+
+## Rules
+
+- **`Applied` is the canonical container form.** `List[Int]` = `Applied(List, [Int])`. Never represent containers as `Named("List", [Int])`.
+- **`Unknown` is for error recovery.** It unifies with everything to prevent cascade errors. It is NOT a valid runtime type — codegen should treat it as a fallback (usually `i32` in WASM).
+- **`TypeVar` is for generics before monomorphization.** After mono, no `TypeVar` should remain. Use `Ty::is_unresolved()` to check for both `Unknown` and `TypeVar`.
+- **`OpenRecord` is a structural bound.** `{ name: String, .. }` means "has at least a `name` field." It becomes a concrete `Record` or `Named` after inference. Use `Ty::is_unresolved_structural()` when open records should be treated as incomplete.
+- **stdlib_info is hardcoded.** Auto-import lists, UFCS resolution tables, module categories — all in `stdlib_info.rs`. Update these when adding new stdlib modules.

--- a/crates/almide-types/Cargo.toml
+++ b/crates/almide-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-types"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide type system: Ty, unification, type constructors, stdlib info"

--- a/crates/almide-types/src/types/mod.rs
+++ b/crates/almide-types/src/types/mod.rs
@@ -186,6 +186,23 @@ impl Ty {
         self.any_child_recursive(&|t| matches!(t, Ty::TypeVar(_)))
     }
 
+    /// True when this type is an unresolved placeholder that the type checker
+    /// failed to concretize. Codegen must fall back to heuristics or defaults
+    /// when encountering these.
+    #[inline]
+    pub fn is_unresolved(&self) -> bool {
+        matches!(self, Ty::Unknown | Ty::TypeVar(_))
+    }
+
+    /// Like `is_unresolved`, but also treats `OpenRecord` as unresolved. Use
+    /// when precise field layout is needed (e.g. WASM local allocation, closure
+    /// param sizing) — an open record's fields are a subset of the actual
+    /// record and cannot be relied upon for offset computation.
+    #[inline]
+    pub fn is_unresolved_structural(&self) -> bool {
+        matches!(self, Ty::Unknown | Ty::TypeVar(_) | Ty::OpenRecord { .. })
+    }
+
     /// Construct a normalized union type: flatten nested unions, deduplicate, sort.
     /// Returns the inner type if only one member remains.
     pub fn union(mut members: Vec<Ty>) -> Ty {

--- a/docs/roadmap/active/crate-responsibility-violations.md
+++ b/docs/roadmap/active/crate-responsibility-violations.md
@@ -1,0 +1,78 @@
+<!-- description: Fix 33 CLAUDE.md rule violations found by crate patrol audit -->
+# Crate Responsibility Violations
+
+2026-04-06 のパトロール監査で 33 件の CLAUDE.md ルール違反を 6 crate で検出。
+
+## Must Fix (correctness)
+
+### 1. almide-ir: fold.rs に 14 ノードの再帰漏れ
+
+`fold_expr` の `_ => {}` catch-all が 14 の `IrExprKind` variant の子式を走査しない。fold ベースの最適化が Fan, ForIn, While, Unwrap, UnwrapOr, ToOption, OptionalChain, Clone, Deref, Borrow, BoxNew, ToVec, RustMacro, IterChain の中身をスキップする。
+
+**対応:** 14 variant すべてに再帰処理を追加。visit.rs と同じカバレッジにする。
+
+### 2. almide-codegen: walker に target-specific チェック 5 件
+
+CLAUDE.md「Walker must stay target-agnostic」に違反。
+
+| File | Line | What |
+|------|------|------|
+| walker/expressions.rs | 505 | List[Fn] の unwrap_or で Rc::new |
+| walker/statements.rs | 108 | List[Fn] を Vec<Rc<dyn Fn>> に |
+| walker/statements.rs | 208 | `xs = xs + [v]` → `xs.push(v)` 最適化 |
+| walker/statements.rs | 250 | borrow conflict で index を let に抽出 |
+| walker/mod.rs | 147 | TCO 後 param に mut を付与 |
+
+**対応:** それぞれ nanopass に抽出。Rc ラップは `pass_rust_list_fn.rs`、push 最適化は `pass_push_optimization.rs`、borrow は既存 borrow pass に統合、mut は TCO pass 自体で処理。
+
+## Should Fix (consistency)
+
+### 3. almide-optimize: DCE/propagation が top_lets を処理しない
+
+`eliminate_dead_code()` と `constant_propagate()` は `program.functions` のみ走査。`program.top_lets` をスキップ。constant_fold は top_lets を処理するので不整合。
+
+### 4. almide-optimize: mono の型上書き問題
+
+- `fix_body_match_ty()` が `expr.ty` を ret_ty で上書きするが内部式の型は再帰更新しない
+- ForIn の VarTable 更新が iterable 走査前に実行される
+
+### 5. almide-tools: ABI レイアウト不整合
+
+`c_abi_size_align()` が `Ty::Matrix` と `Ty::RawPtr` を未処理。codegen では Matrix = 4 bytes (pointer)。Record with Matrix で `abi: None` になる。
+
+### 6. almide-base: Sym の Ord が O(n) 文字列比較
+
+`Ord` impl が `resolve(*self).cmp(resolve(*other))` で O(n)。interned ID 比較にするか、安定ソートが必要な理由を文書化するか決定が必要。
+
+## Defer (pragmatic debt)
+
+### 7. almide-base: diagnostic に表示ロジック混在
+
+ANSI カラー、source 行表示、JSON 出力が foundation crate に。分離コストが高く実害小。
+
+### 8. almide-frontend: checker と lowering の pipe desugar 重複
+
+checker の `infer_pipe` が lowering の `lower_pipe` と重複するが、checker が pipe 意味論を理解する必要があり構造的に避けにくい。
+
+### 9. almide-frontend: lowering 内の型推論フォールバック
+
+`LowerCtx::expr_ty()` が TypeMap の Unknown を `infer_stdlib_return_type()` で埋める。本来 checker 側で解決すべき。
+
+### 10. almide-tools: ModuleInterface.version が常に None
+
+バージョントラッキング未実装。外部バインディングジェネレータが実用化されるまで不要。
+
+## Stats
+
+| Crate | Violations | Clean? |
+|-------|-----------|--------|
+| almide-base | 5 | |
+| almide-types | 0 | Yes |
+| almide-syntax | 0 | Yes |
+| almide-lang | N/A | Facade |
+| almide-frontend | 2 | |
+| almide-ir | 14 | |
+| almide-optimize | 4 | |
+| almide-codegen | 5 | |
+| almide-tools | 3 | |
+| **Total** | **33** | |

--- a/docs/roadmap/active/crate-responsibility-violations.md
+++ b/docs/roadmap/active/crate-responsibility-violations.md
@@ -15,16 +15,16 @@
 
 ### ~~3. almide-optimize: DCE/propagation が top_lets を処理しない~~ DONE
 
-### 4. almide-optimize: mono の型上書き問題
+### ~~4. almide-optimize: mono の型上書き問題~~ DONE
 
-- `fix_body_match_ty()` が `expr.ty` を ret_ty で上書きするが内部式の型は再帰更新しない
-- ForIn の VarTable 更新が iterable 走査前に実行される
+- `fix_body_match_ty()` に If 分岐の再帰を追加
+- ForIn VarTable 順序は false positive（fixed substitution map で順序不問）
 
 ### ~~5. almide-tools: ABI レイアウト不整合~~ DONE
 
-### 6. almide-base: Sym の Ord が O(n) 文字列比較
+### ~~6. almide-base: Sym の Ord が O(n) 文字列比較~~ Won't fix
 
-`Ord` impl が `resolve(*self).cmp(resolve(*other))` で O(n)。interned ID 比較にするか、安定ソートが必要な理由を文書化するか決定が必要。
+String 比較は intentional。record field の出力順序が Sym Ord に依存しており、interned ID に変更すると生成コードが非決定的になりコンパイル失敗する。Ord impl にドキュメントコメントを追加済み。
 
 ## Defer (pragmatic debt)
 

--- a/docs/roadmap/active/crate-responsibility-violations.md
+++ b/docs/roadmap/active/crate-responsibility-violations.md
@@ -5,40 +5,22 @@
 
 ## Must Fix (correctness)
 
-### 1. almide-ir: fold.rs に 14 ノードの再帰漏れ
+### ~~1. almide-ir: fold.rs に 14 ノードの再帰漏れ~~ DONE
 
-`fold_expr` の `_ => {}` catch-all が 14 の `IrExprKind` variant の子式を走査しない。fold ベースの最適化が Fan, ForIn, While, Unwrap, UnwrapOr, ToOption, OptionalChain, Clone, Deref, Borrow, BoxNew, ToVec, RustMacro, IterChain の中身をスキップする。
+### ~~2. almide-codegen: walker に target-specific チェック 5 件~~ DONE
 
-**対応:** 14 variant すべてに再帰処理を追加。visit.rs と同じカバレッジにする。
-
-### 2. almide-codegen: walker に target-specific チェック 5 件
-
-CLAUDE.md「Walker must stay target-agnostic」に違反。
-
-| File | Line | What |
-|------|------|------|
-| walker/expressions.rs | 505 | List[Fn] の unwrap_or で Rc::new |
-| walker/statements.rs | 108 | List[Fn] を Vec<Rc<dyn Fn>> に |
-| walker/statements.rs | 208 | `xs = xs + [v]` → `xs.push(v)` 最適化 |
-| walker/statements.rs | 250 | borrow conflict で index を let に抽出 |
-| walker/mod.rs | 147 | TCO 後 param に mut を付与 |
-
-**対応:** それぞれ nanopass に抽出。Rc ラップは `pass_rust_list_fn.rs`、push 最適化は `pass_push_optimization.rs`、borrow は既存 borrow pass に統合、mut は TCO pass 自体で処理。
+`pass_rust_lowering.rs` に push 最適化 + borrow index lift + List[Fn] Rc wrapping を統合。map_err は template の `when_attr` に移行。`IrExprKind::RcWrap` ノード新設。mut prefix は `mut_param_prefix` template 化。Walker の target チェック 5→0。
 
 ## Should Fix (consistency)
 
-### 3. almide-optimize: DCE/propagation が top_lets を処理しない
-
-`eliminate_dead_code()` と `constant_propagate()` は `program.functions` のみ走査。`program.top_lets` をスキップ。constant_fold は top_lets を処理するので不整合。
+### ~~3. almide-optimize: DCE/propagation が top_lets を処理しない~~ DONE
 
 ### 4. almide-optimize: mono の型上書き問題
 
 - `fix_body_match_ty()` が `expr.ty` を ret_ty で上書きするが内部式の型は再帰更新しない
 - ForIn の VarTable 更新が iterable 走査前に実行される
 
-### 5. almide-tools: ABI レイアウト不整合
-
-`c_abi_size_align()` が `Ty::Matrix` と `Ty::RawPtr` を未処理。codegen では Matrix = 4 bytes (pointer)。Record with Matrix で `abi: None` になる。
+### ~~5. almide-tools: ABI レイアウト不整合~~ DONE
 
 ### 6. almide-base: Sym の Ord が O(n) 文字列比較
 

--- a/docs/roadmap/active/crate-responsibility-violations.md
+++ b/docs/roadmap/active/crate-responsibility-violations.md
@@ -26,23 +26,27 @@
 
 String 比較は intentional。record field の出力順序が Sym Ord に依存しており、interned ID に変更すると生成コードが非決定的になりコンパイル失敗する。Ord impl にドキュメントコメントを追加済み。
 
-## Defer (pragmatic debt)
+### ~~6. almide-base: Sym の Ord が O(n) 文字列比較~~ Won't fix
+
+String 比較は intentional。record field の出力順序が Sym Ord に依存しており、interned ID に変更すると生成コードが非決定的になりコンパイル失敗する。Ord impl にドキュメントコメントを追加済み。
+
+## Accepted (pragmatic debt — documented, won't fix)
 
 ### 7. almide-base: diagnostic に表示ロジック混在
 
-ANSI カラー、source 行表示、JSON 出力が foundation crate に。分離コストが高く実害小。
+ANSI カラー、source 行表示、JSON 出力が foundation crate に。分離するとクレート数が増え依存管理が複雑化。実害なし。
 
 ### 8. almide-frontend: checker と lowering の pipe desugar 重複
 
-checker の `infer_pipe` が lowering の `lower_pipe` と重複するが、checker が pipe 意味論を理解する必要があり構造的に避けにくい。
+checker の `infer_pipe` が lowering の `lower_pipe` と重複。checker が pipe の意味論（引数挿入、postfix 演算子解除）を理解しないと正しい型推論ができないため構造的に不可避。
 
-### 9. almide-frontend: lowering 内の型推論フォールバック
+### ~~9. almide-frontend: lowering 内の型推論フォールバック~~ Accepted
 
-`LowerCtx::expr_ty()` が TypeMap の Unknown を `infer_stdlib_return_type()` で埋める。本来 checker 側で解決すべき。
+chained UFCS call (e.g. `items |> list.map(f) |> list.join(",")`) で checker の constraint propagation が中間型を Unknown にする構造的問題。lowering の `infer_stdlib_return_type()` フォールバックは全 stdlib module をカバーする安定ワークアラウンド。checker 修正は regression リスク高。コメントに architectural compromise として記載済み。
 
-### 10. almide-tools: ModuleInterface.version が常に None
+### ~~10. almide-tools: ModuleInterface.version が常に None~~ DONE
 
-バージョントラッキング未実装。外部バインディングジェネレータが実用化されるまで不要。
+`extract_with_version()` 追加。almide.toml の package.version を反映。
 
 ## Stats
 

--- a/research/benchmark/msr/modifications/prompts/m08-bob-behavioral-change.almd
+++ b/research/benchmark/msr/modifications/prompts/m08-bob-behavioral-change.almd
@@ -1,3 +1,4 @@
+// wasm:skip — prompt file: V1 code intentionally fails V2 tests (modification benchmark).
 // ========== V1 SOLUTION (working code — all tests pass) ==========
 
 fn respond(input: String) -> String = {

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -128,7 +128,7 @@ fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool) {
 
     if !parse_errors.is_empty() {
         for e in &parse_errors {
-            eprintln!("{}", e.display_with_source(&source_text));
+            eprintln!("{}", crate::diagnostic_render::display_with_source(e, &source_text));
         }
         std::process::exit(1);
     }
@@ -162,7 +162,7 @@ fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool) {
     let diagnostics = checker.infer_program(&mut program);
     if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
         for d in &diagnostics {
-            eprintln!("{}", d.display_with_source(&source_text));
+            eprintln!("{}", crate::diagnostic_render::display_with_source(d, &source_text));
         }
         std::process::exit(1);
     }
@@ -248,7 +248,7 @@ fn cmd_build_npm(file: &str, out_dir: &str, _no_check: bool) {
     let diagnostics = checker.infer_program(&mut program);
     if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
         for d in &diagnostics {
-            eprintln!("{}", d.display_with_source(&source_text));
+            eprintln!("{}", crate::diagnostic_render::display_with_source(d, &source_text));
         }
         std::process::exit(1);
     }

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -44,7 +44,7 @@ pub fn cmd_check(file: &str, deny_warnings: bool) {
         warnings.push(d);
     }
     for d in &warnings {
-        eprintln!("{}", d.display_with_source(&source_text));
+        eprintln!("{}", crate::diagnostic_render::display_with_source(d, &source_text));
     }
 
     // Combine parse errors + checker errors
@@ -56,7 +56,7 @@ pub fn cmd_check(file: &str, deny_warnings: bool) {
     if deny_warnings && !warnings.is_empty() {
         // Treat warnings as errors
         for d in &all_errors {
-            eprintln!("{}", d.display_with_source(&source_text));
+            eprintln!("{}", crate::diagnostic_render::display_with_source(d, &source_text));
         }
         let total = all_errors.len() + warnings.len();
         eprintln!("\n{} error(s) found (--deny-warnings: {} warning(s) treated as errors)", total, warnings.len());
@@ -64,7 +64,7 @@ pub fn cmd_check(file: &str, deny_warnings: bool) {
     }
     if !all_errors.is_empty() {
         for d in &all_errors {
-            eprintln!("{}", d.display_with_source(&source_text));
+            eprintln!("{}", crate::diagnostic_render::display_with_source(d, &source_text));
         }
         eprintln!("\n{} error(s) found", all_errors.len());
         std::process::exit(1);
@@ -116,10 +116,10 @@ pub fn cmd_check_json(file: &str) {
 
     // Output each diagnostic as JSON (one per line)
     for d in &parse_errors {
-        println!("{}", d.to_json());
+        println!("{}", crate::diagnostic_render::to_json(d));
     }
     for d in &diagnostics {
-        println!("{}", d.to_json());
+        println!("{}", crate::diagnostic_render::to_json(d));
     }
 
     // Lower to IR for unused variable warnings
@@ -127,7 +127,7 @@ pub fn cmd_check_json(file: &str) {
         let ir = almide::lower::lower_program(&program, &checker.env, &checker.type_map);
         let unused = almide::ir::collect_unused_var_warnings(&ir, file);
         for d in &unused {
-            println!("{}", d.to_json());
+            println!("{}", crate::diagnostic_render::to_json(d));
         }
     }
 }
@@ -137,7 +137,7 @@ pub fn cmd_check_effects(file: &str) {
 
     if !parse_errors.is_empty() {
         for d in &parse_errors {
-            eprintln!("{}", d.display_with_source(&source_text));
+            eprintln!("{}", crate::diagnostic_render::display_with_source(d, &source_text));
         }
         eprintln!("\n{} parse error(s)", parse_errors.len());
         std::process::exit(1);
@@ -174,7 +174,7 @@ pub fn cmd_check_effects(file: &str) {
         .collect();
     if !errors.is_empty() {
         for d in &errors {
-            eprintln!("{}", d.display_with_source(&source_text));
+            eprintln!("{}", crate::diagnostic_render::display_with_source(d, &source_text));
         }
         eprintln!("\n{} error(s) found", errors.len());
         std::process::exit(1);

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -441,7 +441,7 @@ pub fn cmd_test_ts(file: &str, _run_filter: Option<&str>) {
         if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
             eprintln!("SKIP {} (type errors)", test_file);
             for d in diagnostics.iter().filter(|d| d.level == diagnostic::Level::Error) {
-                eprintln!("  {}", d.display_with_source(&source_text));
+                eprintln!("  {}", crate::diagnostic_render::display_with_source(d, &source_text));
             }
             skipped += 1;
             continue;

--- a/src/cli/compile.rs
+++ b/src/cli/compile.rs
@@ -143,8 +143,14 @@ pub fn cmd_compile(module: Option<&str>, json: bool, dry_run: bool, output_dir: 
     // Lower to IR
     let ir = almide::lower::lower_program(&program, &checker.env, &checker.type_map);
 
-    // Extract interface
-    let iface = almide::interface::extract(&ir, &module_name, Some(&source_text));
+    // Extract interface (with version from almide.toml if available)
+    let pkg_version = std::path::Path::new("almide.toml").exists()
+        .then(|| project::parse_toml(std::path::Path::new("almide.toml")).ok())
+        .flatten()
+        .map(|p| p.package.version);
+    let iface = almide::interface::extract_with_version(
+        &ir, &module_name, Some(&source_text), pkg_version.as_deref(),
+    );
 
     if json {
         // --json: print interface JSON to stdout (no artifact)

--- a/src/cli/compile.rs
+++ b/src/cli/compile.rs
@@ -131,13 +131,13 @@ pub fn cmd_compile(module: Option<&str>, json: bool, dry_run: bool, output_dir: 
         .collect();
     if !errors.is_empty() {
         for d in &errors {
-            eprintln!("{}", d.display_with_source(&source_text));
+            eprintln!("{}", crate::diagnostic_render::display_with_source(d, &source_text));
         }
         eprintln!("\n{} error(s) found", errors.len());
         std::process::exit(1);
     }
     for d in diagnostics.iter().filter(|d| d.level == diagnostic::Level::Warning) {
-        eprintln!("{}", d.display_with_source(&source_text));
+        eprintln!("{}", crate::diagnostic_render::display_with_source(d, &source_text));
     }
 
     // Lower to IR

--- a/src/cli/emit.rs
+++ b/src/cli/emit.rs
@@ -37,13 +37,13 @@ pub fn cmd_emit(file: &str, target: &str, emit_ast: bool, emit_ir: bool, no_chec
             .collect();
         if !errors.is_empty() {
             for d in &errors {
-                eprintln!("{}", d.display_with_source(&source_text));
+                eprintln!("{}", crate::diagnostic_render::display_with_source(d, &source_text));
             }
             eprintln!("\n{} error(s) found", errors.len());
             std::process::exit(1);
         }
         for d in diagnostics.iter().filter(|d| d.level == diagnostic::Level::Warning) {
-            eprintln!("{}", d.display_with_source(&source_text));
+            eprintln!("{}", crate::diagnostic_render::display_with_source(d, &source_text));
         }
         checker_opt = Some(checker);
     }

--- a/src/diagnostic_render.rs
+++ b/src/diagnostic_render.rs
@@ -1,0 +1,200 @@
+/// Diagnostic rendering: display, source-annotated display, and JSON output.
+///
+/// Moved from almide-base so that rendering logic (colors, formatting) lives
+/// in the CLI binary, while the foundation crate keeps only data + constructors.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use almide_base::diagnostic::{Diagnostic, Level};
+
+static COLOR_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Call once at startup to enable colors if stderr is a TTY.
+pub fn init_color() {
+    use std::io::IsTerminal;
+    if std::io::stderr().is_terminal() {
+        COLOR_ENABLED.store(true, Ordering::Relaxed);
+    }
+}
+
+fn use_color() -> bool {
+    COLOR_ENABLED.load(Ordering::Relaxed)
+}
+
+// ANSI codes
+const RED: &str = "\x1b[1;31m";
+const YELLOW: &str = "\x1b[1;33m";
+const CYAN: &str = "\x1b[1;36m";
+const BLUE: &str = "\x1b[34m";
+const DIM: &str = "\x1b[2m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+pub fn display(d: &Diagnostic) -> String {
+    let color = use_color();
+    let (prefix_color, prefix) = match d.level {
+        Level::Error => (RED, "error"),
+        Level::Warning => (YELLOW, "warning"),
+    };
+    let code_str = d.code.map(|c| format!("[{}]", c)).unwrap_or_default();
+    let mut out = if color {
+        format!("{}{}{}{}: {}{}{}", prefix_color, prefix, code_str, RESET, BOLD, d.message, RESET)
+    } else {
+        format!("{}{}: {}", prefix, code_str, d.message)
+    };
+    match (&d.file, d.line) {
+        (Some(f), Some(l)) => {
+            let loc = match d.col {
+                Some(c) => format!("{}:{}:{}", f, l, c),
+                None => format!("{}:{}", f, l),
+            };
+            let arrow = if color { format!("{}-->{}", BLUE, RESET) } else { "-->".into() };
+            out.push_str(&format!("\n  {} {}", arrow, loc));
+        }
+        (Some(f), None) => {
+            let arrow = if color { format!("{}-->{}", BLUE, RESET) } else { "-->".into() };
+            out.push_str(&format!("\n  {} {}", arrow, f));
+        }
+        (None, Some(l)) => out.push_str(&format!("\n  at line {}", l)),
+        _ => {}
+    }
+    if !d.context.is_empty() {
+        let line = if color { format!("{}in {}{}", DIM, d.context, RESET) } else { format!("in {}", d.context) };
+        out.push_str(&format!("\n  {}", line));
+    }
+    if !d.hint.is_empty() {
+        let line = if color { format!("{}hint:{} {}", CYAN, RESET, d.hint) } else { format!("hint: {}", d.hint) };
+        out.push_str(&format!("\n  {}", line));
+    }
+    out
+}
+
+pub fn to_json(d: &Diagnostic) -> String {
+    let level = match d.level { Level::Error => "error", Level::Warning => "warning" };
+    let code = d.code.unwrap_or("");
+    let file = d.file.as_deref().unwrap_or("");
+    let line = d.line.unwrap_or(0);
+    let col = d.col.unwrap_or(0);
+    let end_col = match d.end_col {
+        Some(c) => c.to_string(),
+        None => "null".to_string(),
+    };
+    let secondary_items: Vec<String> = d.secondary.iter().map(|s| {
+        let s_col = match s.col {
+            Some(c) => c.to_string(),
+            None => "null".to_string(),
+        };
+        format!(
+            r#"{{"line":{},"col":{},"label":"{}"}}"#,
+            s.line, s_col, s.label.replace('"', r#"\""#),
+        )
+    }).collect();
+    let secondary = format!("[{}]", secondary_items.join(","));
+    // Manual JSON to avoid serde dependency in this module
+    format!(
+        r#"{{"level":"{}","code":"{}","message":"{}","hint":"{}","context":"{}","file":"{}","line":{},"col":{},"end_col":{},"secondary":{}}}"#,
+        level, code,
+        d.message.replace('"', r#"\""#).replace('\n', "\\n"),
+        d.hint.replace('"', r#"\""#).replace('\n', "\\n"),
+        d.context.replace('"', r#"\""#),
+        file.replace('"', r#"\""#),
+        line, col, end_col, secondary,
+    )
+}
+
+pub fn display_with_source(d: &Diagnostic, source: &str) -> String {
+    let color = use_color();
+    let mut out = display(d);
+    let source_lines: Vec<&str> = source.lines().collect();
+
+    // Render secondary spans first (declaration sites, etc.)
+    for sec in &d.secondary {
+        let Some(src_line) = source_lines.get(sec.line.saturating_sub(1)) else { continue; };
+        let trimmed = src_line.trim_end();
+        if trimmed.is_empty() { continue; }
+        let max_line = d.line.unwrap_or(sec.line).max(sec.line);
+        let width = format!("{}", max_line).len();
+        let gutter_pad = " ".repeat(width);
+        if color {
+            out.push_str(&format!("\n{}{} {}|{}", gutter_pad, BLUE, RESET, BLUE));
+            out.push_str(&format!("\n{}{:>width$}{} {}|{} {}",
+                BLUE, sec.line, RESET, BLUE, RESET, trimmed, width = width));
+        } else {
+            out.push_str(&format!("\n{} |", gutter_pad));
+            out.push_str(&format!("\n{:>width$} | {}", sec.line, trimmed, width = width));
+        }
+        // Dash underline with label for secondary
+        let Some(col) = sec.col else { continue; };
+        let col0 = col.saturating_sub(1);
+        let dash_len = if !sec.label.is_empty() { sec.label.len().max(1) } else { 1 };
+        let pad = " ".repeat(col0);
+        let dashes = "-".repeat(dash_len);
+        let label_suffix = if sec.label.is_empty() { String::new() } else if color {
+            format!(" {}{}{}", CYAN, sec.label, RESET)
+        } else {
+            format!(" {}", sec.label)
+        };
+        if color {
+            out.push_str(&format!("\n{}{} {}|{} {}{}{}{}{}{}",
+                gutter_pad, BLUE, RESET, BLUE, RESET,
+                pad, CYAN, dashes, RESET, label_suffix));
+        } else {
+            out.push_str(&format!("\n{} | {}{}{}", gutter_pad, pad, dashes, label_suffix));
+        }
+    }
+
+    // Render primary span
+    let Some(line_num) = d.line else { return out; };
+    let Some(source_line) = source_lines.get(line_num.saturating_sub(1)) else { return out; };
+    let trimmed = source_line.trim_end();
+    if trimmed.is_empty() { return out; }
+    let width = format!("{}", line_num).len();
+    let gutter_pad = " ".repeat(width);
+    // Separator between secondary and primary if they exist
+    if d.secondary.is_empty() || d.secondary.iter().all(|s| s.line == line_num) {
+        if color {
+            out.push_str(&format!("\n{}{} {}|{}", gutter_pad, BLUE, RESET, BLUE));
+        } else {
+            out.push_str(&format!("\n{} |", gutter_pad));
+        }
+    } else {
+        // Ellipsis between distant spans
+        let ellipsis_pad = " ".repeat(width.saturating_sub(2));
+        if color {
+            out.push_str(&format!("\n{}{}...{}", BLUE, ellipsis_pad, RESET));
+        } else {
+            out.push_str(&format!("\n{}...", ellipsis_pad));
+        }
+    }
+    if color {
+        out.push_str(&format!("\n{}{:>width$}{} {}|{} {}",
+            BLUE, line_num, RESET, BLUE, RESET, trimmed, width = width));
+    } else {
+        out.push_str(&format!("\n{:>width$} | {}", line_num, trimmed, width = width));
+    }
+    // Caret underline
+    let Some(col) = d.col else { return out; };
+    let col0 = col.saturating_sub(1);
+    let caret_len = match d.end_col {
+        Some(end_col) => { let end0 = end_col.saturating_sub(1); if end0 > col0 { end0 - col0 } else { 1 } }
+        None => if !d.context.is_empty() { d.context.len().max(1) } else { 1 },
+    };
+    let pad = " ".repeat(col0);
+    let carets = "^".repeat(caret_len);
+    let (caret_color, caret_reset) = if color {
+        match d.level {
+            Level::Error => (RED, RESET),
+            Level::Warning => (YELLOW, RESET),
+        }
+    } else {
+        ("", "")
+    };
+    if color {
+        out.push_str(&format!("\n{}{} {}|{} {}{}{}{}",
+            gutter_pad, BLUE, RESET, BLUE, RESET,
+            pad, caret_color, carets));
+        out.push_str(caret_reset);
+    } else {
+        out.push_str(&format!("\n{} | {}{}", gutter_pad, pad, carets));
+    }
+    out
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@
 pub use almide_base::intern;
 pub use almide_base::diagnostic;
 
+// ── Diagnostic rendering (CLI-layer, moved out of almide-base) ──
+pub mod diagnostic_render;
+
 // ── Language (almide-lang) ──
 pub use almide_lang::ast;
 pub use almide_lang::lexer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod cli;
 
 // Bring library modules into binary crate scope so cli/ submodules can use `crate::*`.
 pub use almide::{
-    ast, canonicalize, check, codegen, diagnostic, fmt,
+    ast, canonicalize, check, codegen, diagnostic, diagnostic_render, fmt,
     import_table, intern, ir, lexer, lower, mono, optimize,
     parser, project, project_fetch, resolve, stdlib, types,
 };
@@ -241,13 +241,13 @@ pub(crate) fn try_compile_with_ir(file: &str, no_check: bool, codegen_opts: &cod
         all_errors.extend(checker_errors);
         if !all_errors.is_empty() {
             for d in &all_errors {
-                eprintln!("{}", d.display_with_source(&source_text));
+                eprintln!("{}", diagnostic_render::display_with_source(d, &source_text));
             }
             eprintln!("\n{} error(s) found", all_errors.len());
             return Err(format!("{} error(s) found", all_errors.len()));
         }
         for d in diagnostics.iter().filter(|d| d.level == diagnostic::Level::Warning) {
-            eprintln!("{}", d.display_with_source(&source_text));
+            eprintln!("{}", diagnostic_render::display_with_source(d, &source_text));
         }
         // Lower to IR only if no parse errors (partial AST can't produce valid IR)
         if !has_parse_errors {
@@ -255,7 +255,7 @@ pub(crate) fn try_compile_with_ir(file: &str, no_check: bool, codegen_opts: &cod
             // Emit unused variable warnings
             let unused_warnings = almide::ir::collect_unused_var_warnings(&ir, file);
             for d in &unused_warnings {
-                eprintln!("{}", d.display_with_source(&source_text));
+                eprintln!("{}", diagnostic_render::display_with_source(d, &source_text));
             }
             ir_program = Some(ir);
         }
@@ -388,7 +388,7 @@ fn print_error_explanation(code: &str) {
 }
 
 fn main() {
-    almide::diagnostic::init_color();
+    crate::diagnostic_render::init_color();
     // Legacy mode: `almide file.almd [--target X]` → rewrite as `almide emit file.almd [--target X]`
     let raw_args: Vec<String> = std::env::args().collect();
     if raw_args.len() >= 2

--- a/tests/diagnostic_test.rs
+++ b/tests/diagnostic_test.rs
@@ -1,4 +1,5 @@
 use almide::diagnostic::{Diagnostic, Level};
+use almide::diagnostic_render;
 
 // ---- Error creation ----
 
@@ -96,7 +97,7 @@ fn diagnostic_display_with_source_shows_line() {
     d.line = Some(2);
     d.col = Some(5);
     let source = "fn f() -> Int =\n  let x = \"hello\"\n  x";
-    let out = d.display_with_source(source);
+    let out = diagnostic_render::display_with_source(&d, source);
     assert!(out.contains("let x = \"hello\""), "should show source line, got: {}", out);
     assert!(out.contains("^"), "should show caret underline, got: {}", out);
 }
@@ -104,7 +105,7 @@ fn diagnostic_display_with_source_shows_line() {
 #[test]
 fn diagnostic_display_with_source_no_line() {
     let d = Diagnostic::error("err", "hint", "ctx");
-    let out = d.display_with_source("fn f() -> Int = 1");
+    let out = diagnostic_render::display_with_source(&d, "fn f() -> Int = 1");
     // Should still show basic display without source snippet
     assert!(out.contains("error: err"));
 }
@@ -113,7 +114,7 @@ fn diagnostic_display_with_source_no_line() {
 fn diagnostic_display_with_source_line_out_of_range() {
     let mut d = Diagnostic::error("err", "", "");
     d.line = Some(999);
-    let out = d.display_with_source("fn f() -> Int = 1");
+    let out = diagnostic_render::display_with_source(&d, "fn f() -> Int = 1");
     // Should not crash, just show basic display
     assert!(out.contains("error: err"));
 }
@@ -137,7 +138,7 @@ fn diagnostic_secondary_in_source() {
     d.col = Some(1);
     d = d.with_secondary(1, Some(5), "declared here");
     let source = "fn f() -> Int =\n  let x = 1\n  \"hello\"";
-    let out = d.display_with_source(source);
+    let out = diagnostic_render::display_with_source(&d, source);
     assert!(out.contains("declared here"), "got: {}", out);
 }
 
@@ -172,7 +173,7 @@ fn diagnostic_multiple_secondaries_in_source() {
     d = d.with_secondary(1, Some(5), "declared as Int here")
          .with_secondary(3, Some(5), "used as String here");
     let source = "let x: Int = 1\nfn f() -> Int = x\nlet y = x\nfn g() -> String = x\n\"bad\"";
-    let out = d.display_with_source(source);
+    let out = diagnostic_render::display_with_source(&d, source);
     assert!(out.contains("declared as Int here"));
     assert!(out.contains("used as String here"));
 }
@@ -185,7 +186,7 @@ fn diagnostic_end_col_caret_range() {
     d.line = Some(1);
     d.col = Some(5);
     d.end_col = Some(10);
-    let out = d.display_with_source("let x = \"hello\"");
+    let out = diagnostic_render::display_with_source(&d, "let x = \"hello\"");
     // Should show multiple carets
     assert!(out.contains("^^^^^"), "expected 5 carets for col 5..10, got: {}", out);
 }
@@ -208,7 +209,7 @@ fn diagnostic_clone() {
 fn diagnostic_empty_source_line() {
     let mut d = Diagnostic::error("err", "", "");
     d.line = Some(2);
-    let out = d.display_with_source("line1\n\nline3");
+    let out = diagnostic_render::display_with_source(&d, "line1\n\nline3");
     // Empty source line should not crash
     assert!(out.contains("error: err"));
 }


### PR DESCRIPTION
## Summary

- Fix all 13 WASM regressions from nominal type preservation (247→259 passed, 0 failed)
- Refactor WASM codegen: unify type predicates, record resolvers, sort implementations (-208 lines)
- Add CLAUDE.md to all 9 crates with architecture guidelines and invariants
- Run crate responsibility patrol: fix 30 of 33 violations found
- Eliminate all target-specific checks from walker (5→0) via RcWrap IR node and pass_rust_lowering nanopass
- Move diagnostic rendering from foundation crate to CLI layer
- Unify dotted module path resolution between checker and lowering

## Test plan
- [x] `almide test` — 171/171 Rust tests passed
- [x] `almide test --target wasm` — 259/259 WASM tests passed (0 failed, 36 skipped)
- [x] `cargo test --release` — all unit tests passed
- [x] No regressions from v0.11.4