### PR TITLE
v0.11.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "almide-base",
  "almide-codegen",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "almide-base"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "lasso",
  "serde",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "almide-codegen"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "almide-frontend"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "almide-ir"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "almide-base",
  "almide-lang",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "almide-lang"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "almide-base",
  "almide-syntax",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "almide-optimize"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "almide-syntax"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "almide-base",
  "serde",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "almide-tools"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "almide-types"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "almide-base",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-base/Cargo.toml
+++ b/crates/almide-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-base"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Foundational types for the Almide compiler (Sym, Span, Diagnostic)"

--- a/crates/almide-codegen/Cargo.toml
+++ b/crates/almide-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-codegen"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide code generation: nanopass pipeline, walker, WASM emit"

--- a/crates/almide-frontend/Cargo.toml
+++ b/crates/almide-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-frontend"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide frontend: type checker, canonicalization, IR lowering"

--- a/crates/almide-ir/Cargo.toml
+++ b/crates/almide-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-ir"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide typed intermediate representation (IR)"

--- a/crates/almide-lang/Cargo.toml
+++ b/crates/almide-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-lang"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide language definitions: re-exports almide-syntax + almide-types"

--- a/crates/almide-optimize/Cargo.toml
+++ b/crates/almide-optimize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-optimize"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide IR optimizer: dead code elimination, constant propagation, monomorphization"

--- a/crates/almide-syntax/Cargo.toml
+++ b/crates/almide-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-syntax"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide syntax definitions: AST, lexer, and parser"

--- a/crates/almide-tools/Cargo.toml
+++ b/crates/almide-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-tools"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide developer tools: formatter, module interface, almdi"

--- a/crates/almide-types/Cargo.toml
+++ b/crates/almide-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-types"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide type system: Ty, unification, type constructors, stdlib info"


### PR DESCRIPTION
## Summary
- Per-specialization VarId alpha-renaming in monomorphization — root fix for stale VarTable types across specializations
- Remove `update_var_table_types` (no longer needed with fresh VarIds)
- Remove `collect_var_types` workaround in capture clone pass
- Fix ok(x)! short-circuit, LICM guard hoist, capture clone mono VarTable stale type
- Fix range expression codegen, nested RecordPattern, filter_map type resolution
- Fix variant alloc size padding, mixed variant unit eq, mono 12-variant traversal gap
- Add monkey test suites 16-28

## Test plan
- [x] `almide test` — 173 test files passed
- [x] `cargo test` — all passed