### PR TITLE
v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "almide-base",
  "almide-codegen",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "almide-base"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "lasso",
  "serde",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "almide-codegen"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "almide-frontend"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "almide-ir"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "almide-base",
  "almide-lang",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "almide-lang"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "almide-base",
  "almide-syntax",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "almide-optimize"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "almide-syntax"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "almide-base",
  "serde",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "almide-tools"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "almide-base",
  "almide-ir",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "almide-types"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "almide-base",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.11.7"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-base/Cargo.toml
+++ b/crates/almide-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-base"
-version = "0.11.7"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Foundational types for the Almide compiler (Sym, Span, Diagnostic)"

--- a/crates/almide-codegen/Cargo.toml
+++ b/crates/almide-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-codegen"
-version = "0.11.7"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide code generation: nanopass pipeline, walker, WASM emit"

--- a/crates/almide-codegen/src/emit_wasm/calls.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls.rs
@@ -710,6 +710,76 @@ impl FuncCompiler<'_> {
         }
     }
 
+    /// Emit a tail call (WASM `return_call` / `return_call_indirect`).
+    /// Falls back to normal call for targets that don't resolve to a known function.
+    pub(super) fn emit_tail_call(&mut self, target: &CallTarget, args: &[IrExpr], ret_ty: &Ty) {
+        match target {
+            CallTarget::Named { name } => {
+                // Only user-defined functions get return_call; builtins fall back to normal call
+                if let Some(&func_idx) = self.emitter.func_map.get(name.as_str()) {
+                    for arg in args {
+                        self.emit_expr(arg);
+                    }
+                    wasm!(self.func, { return_call(func_idx); });
+                } else {
+                    // Not a user function (builtin/stub) — fall back to normal call
+                    self.emit_call(target, args, ret_ty);
+                }
+            }
+            CallTarget::Computed { callee } => {
+                // Closure tail call: same setup as emit_call but return_call_indirect
+                let scratch = self.scratch.alloc_i32();
+                self.emit_expr(callee);
+                wasm!(self.func, { local_set(scratch); });
+
+                // Push env_ptr (first hidden arg)
+                wasm!(self.func, {
+                    local_get(scratch);
+                    i32_load(4);
+                });
+
+                for arg in args {
+                    self.emit_expr(arg);
+                }
+
+                // Push table_idx
+                wasm!(self.func, {
+                    local_get(scratch);
+                    i32_load(0);
+                });
+
+                let callee_fn_ty = match &callee.ty {
+                    Ty::Fn { .. } => callee.ty.clone(),
+                    _ => {
+                        if let almide_ir::IrExprKind::Var { id } = &callee.kind {
+                            self.var_table.get(*id).ty.clone()
+                        } else {
+                            callee.ty.clone()
+                        }
+                    }
+                };
+                if let Ty::Fn { params, ret } = &callee_fn_ty {
+                    let mut closure_params = vec![ValType::I32];
+                    for p in params {
+                        if let Some(vt) = values::ty_to_valtype(p) {
+                            closure_params.push(vt);
+                        }
+                    }
+                    let ret_types = values::ret_type(ret);
+                    let type_idx = self.emitter.register_type(closure_params, ret_types);
+                    wasm!(self.func, { return_call_indirect(type_idx, 0); });
+                } else {
+                    wasm!(self.func, { unreachable; });
+                }
+                self.scratch.free_i32(scratch);
+            }
+            // Module/Method calls in tail position — fall back to normal call
+            _ => {
+                self.emit_call(target, args, ret_ty);
+            }
+        }
+    }
+
     pub(super) fn emit_stub_call(&mut self, args: &[IrExpr]) {
         // Unimplemented function: trap immediately rather than returning a default value.
         // Returning silent defaults (0, empty string, etc.) is dangerous in medical contexts

--- a/crates/almide-codegen/src/emit_wasm/calls_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string.rs
@@ -478,14 +478,21 @@ impl FuncCompiler<'_> {
             return;
         }
 
-        // Emit first part as a string
-        self.emit_string_part(&parts[0]);
-
-        // For each subsequent part: emit it, then concat with accumulator
-        for part in &parts[1..] {
-            self.emit_string_part(part);
-            wasm!(self.func, { call(self.emitter.rt.concat_str); });
+        // Single part: no scratch buffer needed
+        if parts.len() == 1 {
+            self.emit_string_part(&parts[0]);
+            return;
         }
+
+        // Multi-part: use memory 1 scratch buffer.
+        // Each part → string ptr → scratch_write_str (copies bytes to mem1).
+        // After all parts: scratch_finalize → alloc on mem0 heap + copy from mem1.
+        // Result: zero intermediate heap allocations.
+        for part in parts {
+            self.emit_string_part(part);
+            wasm!(self.func, { call(self.emitter.rt.scratch_write_str); });
+        }
+        wasm!(self.func, { call(self.emitter.rt.scratch_finalize); });
     }
 
     /// Emit a single string interpolation part as a string (i32 pointer).

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -230,6 +230,9 @@ impl FuncCompiler<'_> {
             IrExprKind::Call { target, args, .. } => {
                 self.emit_call(target, args, &expr.ty);
             }
+            IrExprKind::TailCall { target, args } => {
+                self.emit_tail_call(target, args, &expr.ty);
+            }
 
             // ── String interpolation ──
             IrExprKind::StringInterp { parts } => {

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -195,6 +195,8 @@ pub struct WasmEmitter {
 
     // Globals
     pub heap_ptr_global: u32,
+    /// Memory 1 scratch pointer (string builder). Reset to 0 after each string op.
+    pub scratch_ptr_global: u32,
     // Top-level let globals: VarId → (global index, ValType)
     pub top_let_globals: HashMap<u32, (u32, ValType)>,
     pub top_let_init: Vec<(u32, ValType, i64)>, // (global_idx, type, const_init_bits) in order
@@ -309,9 +311,10 @@ impl WasmEmitter {
                 fd_readdir: 0,
             },
             heap_ptr_global: 0,
+            scratch_ptr_global: 1,
             top_let_globals: HashMap::new(),
             top_let_init: Vec::new(),
-            next_global: 1, // 0 = heap_ptr
+            next_global: 2, // 0 = heap_ptr, 1 = scratch_ptr
             func_table: Vec::new(),
             func_to_table_idx: HashMap::new(),
             record_fields: HashMap::new(),
@@ -889,10 +892,19 @@ fn assemble(emitter: &WasmEmitter) -> Vec<u8> {
         module.section(&tables);
     }
 
-    // ── Memory section ──
+    // ── Memory section (multi-memory: WASM 3.0) ──
     let mut memory = MemorySection::new();
+    // Memory 0: main memory (scratch + data segment + heap)
     memory.memory(MemoryType {
         minimum: 64, // 4MB
+        maximum: None,
+        memory64: false,
+        shared: false,
+        page_size_log2: None,
+    });
+    // Memory 1: string builder scratch (temporary buffer for string operations)
+    memory.memory(MemoryType {
+        minimum: 1, // 64KB — grows on demand
         maximum: None,
         memory64: false,
         shared: false,
@@ -904,6 +916,7 @@ fn assemble(emitter: &WasmEmitter) -> Vec<u8> {
     let mut globals = GlobalSection::new();
     let heap_start = NEWLINE_OFFSET + emitter.data_bytes.len() as u32;
     let heap_start_aligned = (heap_start + 7) & !7;
+    // Global 0: heap pointer (memory 0)
     globals.global(
         GlobalType {
             val_type: ValType::I32,
@@ -911,6 +924,15 @@ fn assemble(emitter: &WasmEmitter) -> Vec<u8> {
             shared: false,
         },
         &wasm_encoder::ConstExpr::i32_const(heap_start_aligned as i32),
+    );
+    // Global 1: scratch pointer (memory 1) — string builder scratch
+    globals.global(
+        GlobalType {
+            val_type: ValType::I32,
+            mutable: true,
+            shared: false,
+        },
+        &wasm_encoder::ConstExpr::i32_const(0),
     );
     // Top-level let globals
     for &(_, vt, bits) in &emitter.top_let_init {

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -116,6 +116,10 @@ pub struct RuntimeFuncs {
     pub int_to_string: u32,
     pub println_int: u32,
     pub concat_str: u32,
+    /// Write string bytes to memory 1 scratch buffer, advance scratch_ptr.
+    pub scratch_write_str: u32,
+    /// Finalize scratch buffer: alloc on memory 0 heap, copy from memory 1, reset scratch_ptr.
+    pub scratch_finalize: u32,
     pub concat_list: u32,
     pub list_eq: u32,
     pub mem_eq: u32,
@@ -268,7 +272,8 @@ impl WasmEmitter {
                 float_parse: 0, float_to_fixed: 0, float_pow: 0,
                 math_sin: 0, math_cos: 0, math_tan: 0,
                 math_log: 0, math_log10: 0, math_log2: 0, math_exp: 0,
-                concat_str: 0, concat_list: 0,
+                concat_str: 0, scratch_write_str: 0, scratch_finalize: 0,
+                concat_list: 0,
                 list_eq: 0, mem_eq: 0, list_list_str_cmp: 0,
                 option_eq_i64: 0, option_eq_str: 0,
                 result_eq_i64_str: 0, int_parse: 0, int_from_hex: 0,

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -135,6 +135,13 @@ pub fn register_runtime(emitter: &mut WasmEmitter) {
     let concat_ty = emitter.register_type(vec![ValType::I32, ValType::I32], vec![ValType::I32]);
     emitter.rt.concat_str = emitter.register_func("__concat_str", concat_ty);
 
+    // __scratch_write_str(str_ptr: i32) -> ()   [writes string bytes to memory 1]
+    let scratch_w_ty = emitter.register_type(vec![ValType::I32], vec![]);
+    emitter.rt.scratch_write_str = emitter.register_func("__scratch_write_str", scratch_w_ty);
+    // __scratch_finalize() -> i32   [copy memory 1 scratch to memory 0 heap, return heap ptr]
+    let scratch_f_ty = emitter.register_type(vec![], vec![ValType::I32]);
+    emitter.rt.scratch_finalize = emitter.register_func("__scratch_finalize", scratch_f_ty);
+
     // __option_eq_i64(a: i32, b: i32) -> i32
     let opt_eq_i64_ty = emitter.register_type(vec![ValType::I32, ValType::I32], vec![ValType::I32]);
     emitter.rt.option_eq_i64 = emitter.register_func("__option_eq_i64", opt_eq_i64_ty);
@@ -227,6 +234,8 @@ pub fn compile_runtime(emitter: &mut WasmEmitter) {
     compile_float_to_string(emitter);
     compile_println_int(emitter);
     compile_concat_str(emitter);
+    compile_scratch_write_str(emitter);
+    compile_scratch_finalize(emitter);
     super::runtime_eq::compile_option_eq_i64(emitter);
     super::runtime_eq::compile_option_eq_str(emitter);
     super::runtime_eq::compile_result_eq_i64_str(emitter);
@@ -743,5 +752,152 @@ pub(super) fn emit_memcpy_loop(f: &mut Function, dst: u32, src: u32, len: u32, c
         end;
         end;
     });
+}
+
+// ── Multi-memory string builder scratch ─────────────────────────
+
+/// __scratch_write_str(str_ptr: i32) → ()
+/// Copies string DATA bytes (not the length prefix) from memory 0 to memory 1
+/// at the current scratch_ptr offset, then advances scratch_ptr.
+fn compile_scratch_write_str(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.scratch_write_str];
+    // params: 0=$str_ptr
+    // locals: 1=$len, 2=$i
+    let mut f = Function::new([
+        (1, ValType::I32), // 1: $len
+        (1, ValType::I32), // 2: $i
+    ]);
+
+    wasm!(f, {
+        // $len = mem0[str_ptr + 0] (string byte length)
+        local_get(0);
+        i32_load(0);
+        local_set(1);
+
+        // Ensure memory 1 has enough space: scratch_ptr + len
+        // If scratch_ptr + len > memory_size(1) * 65536, grow
+        global_get(emitter.scratch_ptr_global);
+        local_get(1);
+        i32_add;
+        memory_size(1);
+        i32_const(65536);
+        i32_mul;
+        i32_gt_u;
+        if_empty;
+        // Grow by (needed / 65536) + 1 pages
+        global_get(emitter.scratch_ptr_global);
+        local_get(1);
+        i32_add;
+        memory_size(1);
+        i32_const(65536);
+        i32_mul;
+        i32_sub;
+        i32_const(65536);
+        i32_div_u;
+        i32_const(1);
+        i32_add;
+        memory_grow(1);
+        drop;
+        end;
+
+        // Byte-copy loop: mem1[scratch_ptr + i] = mem0[str_ptr + 4 + i]
+        i32_const(0);
+        local_set(2);
+        block_empty;
+        loop_empty;
+        local_get(2);
+        local_get(1);
+        i32_ge_u;
+        br_if(1);
+
+        // dst address in mem1
+        global_get(emitter.scratch_ptr_global);
+        local_get(2);
+        i32_add;
+
+        // src byte from mem0
+        local_get(0);
+        i32_const(4);
+        i32_add;
+        local_get(2);
+        i32_add;
+        i32_load8_u(0);
+
+        // store to mem1
+        i32_store8(0, 1);
+
+        local_get(2);
+        i32_const(1);
+        i32_add;
+        local_set(2);
+        br(0);
+        end;
+        end;
+
+        // scratch_ptr += len
+        global_get(emitter.scratch_ptr_global);
+        local_get(1);
+        i32_add;
+        global_set(emitter.scratch_ptr_global);
+    });
+
+    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+}
+
+/// __scratch_finalize() → i32
+/// Allocates [len:i32][data...] on memory 0 heap, copies scratch bytes from
+/// memory 1, resets scratch_ptr to 0, returns the memory 0 string pointer.
+fn compile_scratch_finalize(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.scratch_finalize];
+    // params: (none)
+    // locals: 0=$total_len (= scratch_ptr), 1=$result
+    let mut f = Function::new([
+        (1, ValType::I32), // 0: $total_len
+        (1, ValType::I32), // 1: $result
+    ]);
+
+    wasm!(f, {
+        // $total_len = scratch_ptr (number of bytes written)
+        global_get(emitter.scratch_ptr_global);
+        local_set(0);
+
+        // If total_len == 0, return empty string
+        local_get(0);
+        i32_eqz;
+        if_i32;
+        i32_const(emitter.intern_string("") as i32);
+        return_;
+        end;
+
+        // Allocate on memory 0 heap: 4 (length prefix) + total_len
+        local_get(0);
+        i32_const(4);
+        i32_add;
+        call(emitter.rt.alloc);
+        local_set(1);
+
+        // Write length prefix
+        local_get(1);
+        local_get(0);
+        i32_store(0);
+
+        // Copy data: memory.copy(dst_mem=0, src_mem=1)
+        // dst = result + 4 (in mem0), src = 0 (in mem1), len = total_len
+        local_get(1);
+        i32_const(4);
+        i32_add;  // dst in mem0
+        i32_const(0);  // src in mem1
+        local_get(0);  // len
+        memory_copy(1, 0);  // src=mem1, dst=mem0
+
+        // Reset scratch_ptr
+        i32_const(0);
+        global_set(emitter.scratch_ptr_global);
+
+        // Return result pointer
+        local_get(1);
+    });
+
+    emitter.add_compiled(CompiledFunc { type_idx, func: f });
 }
 

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -213,8 +213,10 @@ pub fn register_runtime(emitter: &mut WasmEmitter) {
     // Regex runtime
     super::rt_regex::register(emitter);
 
-    // Global: __heap_ptr (mutable i32, initialized at assembly time)
-    emitter.heap_ptr_global = 0; // first and only global
+    // Global 0: __heap_ptr (memory 0 bump allocator)
+    emitter.heap_ptr_global = 0;
+    // Global 1: __scratch_ptr (memory 1 string builder scratch)
+    emitter.scratch_ptr_global = 1;
 }
 
 /// Compile all runtime function bodies.

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -839,6 +839,7 @@ fn compile_scratch_write_str(emitter: &mut WasmEmitter) {
         local_get(1);
         i32_add;
         global_set(emitter.scratch_ptr_global);
+        end;
     });
 
     emitter.add_compiled(CompiledFunc { type_idx, func: f });
@@ -864,7 +865,7 @@ fn compile_scratch_finalize(emitter: &mut WasmEmitter) {
         // If total_len == 0, return empty string
         local_get(0);
         i32_eqz;
-        if_i32;
+        if_empty;
         i32_const(emitter.intern_string("") as i32);
         return_;
         end;
@@ -896,6 +897,7 @@ fn compile_scratch_finalize(emitter: &mut WasmEmitter) {
 
         // Return result pointer
         local_get(1);
+        end;
     });
 
     emitter.add_compiled(CompiledFunc { type_idx, func: f });

--- a/crates/almide-codegen/src/emit_wasm/wasm_macro.rs
+++ b/crates/almide-codegen/src/emit_wasm/wasm_macro.rs
@@ -338,6 +338,13 @@ macro_rules! wasm {
         $f.instruction(&wasm_encoder::Instruction::CallIndirect { type_index: $ty, table_index: $tbl });
         wasm!(@emit $f, $($rest)*)
     };
+    (@emit $f:expr, return_call($v:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::ReturnCall($v)); wasm!(@emit $f, $($rest)*)
+    };
+    (@emit $f:expr, return_call_indirect($ty:expr, $tbl:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::ReturnCallIndirect { type_index: $ty, table_index: $tbl });
+        wasm!(@emit $f, $($rest)*)
+    };
     (@emit $f:expr, br($v:expr); $($rest:tt)*) => {
         $f.instruction(&wasm_encoder::Instruction::Br($v)); wasm!(@emit $f, $($rest)*)
     };

--- a/crates/almide-codegen/src/emit_wasm/wasm_macro.rs
+++ b/crates/almide-codegen/src/emit_wasm/wasm_macro.rs
@@ -71,9 +71,23 @@ macro_rules! wasm {
     };
 
     // ── Memory (i32) ──
+    // Two-arg form: i32_load(offset, mem_index)
+    (@emit $f:expr, i32_load($off:expr, $mem:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::I32Load(wasm_encoder::MemArg {
+            offset: $off as u64, align: 2, memory_index: $mem,
+        }));
+        wasm!(@emit $f, $($rest)*)
+    };
+    // One-arg form: i32_load(offset) → memory 0
     (@emit $f:expr, i32_load($off:expr); $($rest:tt)*) => {
         $f.instruction(&wasm_encoder::Instruction::I32Load(wasm_encoder::MemArg {
             offset: $off as u64, align: 2, memory_index: 0,
+        }));
+        wasm!(@emit $f, $($rest)*)
+    };
+    (@emit $f:expr, i32_store($off:expr, $mem:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::I32Store(wasm_encoder::MemArg {
+            offset: $off as u64, align: 2, memory_index: $mem,
         }));
         wasm!(@emit $f, $($rest)*)
     };
@@ -83,15 +97,33 @@ macro_rules! wasm {
         }));
         wasm!(@emit $f, $($rest)*)
     };
+    (@emit $f:expr, i32_load8_u($off:expr, $mem:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::I32Load8U(wasm_encoder::MemArg {
+            offset: $off as u64, align: 0, memory_index: $mem,
+        }));
+        wasm!(@emit $f, $($rest)*)
+    };
     (@emit $f:expr, i32_load8_u($off:expr); $($rest:tt)*) => {
         $f.instruction(&wasm_encoder::Instruction::I32Load8U(wasm_encoder::MemArg {
             offset: $off as u64, align: 0, memory_index: 0,
         }));
         wasm!(@emit $f, $($rest)*)
     };
+    (@emit $f:expr, i32_store8($off:expr, $mem:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::I32Store8(wasm_encoder::MemArg {
+            offset: $off as u64, align: 0, memory_index: $mem,
+        }));
+        wasm!(@emit $f, $($rest)*)
+    };
     (@emit $f:expr, i32_store8($off:expr); $($rest:tt)*) => {
         $f.instruction(&wasm_encoder::Instruction::I32Store8(wasm_encoder::MemArg {
             offset: $off as u64, align: 0, memory_index: 0,
+        }));
+        wasm!(@emit $f, $($rest)*)
+    };
+    (@emit $f:expr, i32_load16_u($off:expr, $mem:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::I32Load16U(wasm_encoder::MemArg {
+            offset: $off as u64, align: 1, memory_index: $mem,
         }));
         wasm!(@emit $f, $($rest)*)
     };
@@ -103,9 +135,21 @@ macro_rules! wasm {
     };
 
     // ── Memory (i64) ──
+    (@emit $f:expr, i64_load($off:expr, $mem:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::I64Load(wasm_encoder::MemArg {
+            offset: $off as u64, align: 3, memory_index: $mem,
+        }));
+        wasm!(@emit $f, $($rest)*)
+    };
     (@emit $f:expr, i64_load($off:expr); $($rest:tt)*) => {
         $f.instruction(&wasm_encoder::Instruction::I64Load(wasm_encoder::MemArg {
             offset: $off as u64, align: 3, memory_index: 0,
+        }));
+        wasm!(@emit $f, $($rest)*)
+    };
+    (@emit $f:expr, i64_store($off:expr, $mem:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::I64Store(wasm_encoder::MemArg {
+            offset: $off as u64, align: 3, memory_index: $mem,
         }));
         wasm!(@emit $f, $($rest)*)
     };
@@ -117,9 +161,21 @@ macro_rules! wasm {
     };
 
     // ── Memory (f64) ──
+    (@emit $f:expr, f64_load($off:expr, $mem:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::F64Load(wasm_encoder::MemArg {
+            offset: $off as u64, align: 3, memory_index: $mem,
+        }));
+        wasm!(@emit $f, $($rest)*)
+    };
     (@emit $f:expr, f64_load($off:expr); $($rest:tt)*) => {
         $f.instruction(&wasm_encoder::Instruction::F64Load(wasm_encoder::MemArg {
             offset: $off as u64, align: 3, memory_index: 0,
+        }));
+        wasm!(@emit $f, $($rest)*)
+    };
+    (@emit $f:expr, f64_store($off:expr, $mem:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::F64Store(wasm_encoder::MemArg {
+            offset: $off as u64, align: 3, memory_index: $mem,
         }));
         wasm!(@emit $f, $($rest)*)
     };
@@ -426,14 +482,20 @@ macro_rules! wasm {
     (@emit $f:expr, f64_const($v:expr); $($rest:tt)*) => {
         $f.instruction(&wasm_encoder::Instruction::F64Const($v)); wasm!(@emit $f, $($rest)*)
     };
-    (@emit $f:expr, memory_size(0); $($rest:tt)*) => {
-        $f.instruction(&wasm_encoder::Instruction::MemorySize(0)); wasm!(@emit $f, $($rest)*)
+    (@emit $f:expr, memory_size($mem:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::MemorySize($mem)); wasm!(@emit $f, $($rest)*)
     };
-    (@emit $f:expr, memory_grow(0); $($rest:tt)*) => {
-        $f.instruction(&wasm_encoder::Instruction::MemoryGrow(0)); wasm!(@emit $f, $($rest)*)
+    (@emit $f:expr, memory_grow($mem:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::MemoryGrow($mem)); wasm!(@emit $f, $($rest)*)
+    };
+    (@emit $f:expr, memory_copy($src:expr, $dst:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::MemoryCopy { src_mem: $src, dst_mem: $dst }); wasm!(@emit $f, $($rest)*)
     };
     (@emit $f:expr, memory_copy; $($rest:tt)*) => {
         $f.instruction(&wasm_encoder::Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 }); wasm!(@emit $f, $($rest)*)
+    };
+    (@emit $f:expr, memory_fill($mem:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::MemoryFill($mem)); wasm!(@emit $f, $($rest)*)
     };
     (@emit $f:expr, memory_fill; $($rest:tt)*) => {
         $f.instruction(&wasm_encoder::Instruction::MemoryFill(0)); wasm!(@emit $f, $($rest)*)

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -42,6 +42,7 @@ pub mod pass_stdlib_lowering;
 pub mod pass_effect_inference;
 pub mod pass_stream_fusion;
 pub mod pass_tco;
+pub mod pass_tail_call_mark;
 pub mod pass_licm;
 pub mod pass_peephole;
 pub mod pass_rust_lowering;

--- a/crates/almide-codegen/src/pass_auto_parallel.rs
+++ b/crates/almide-codegen/src/pass_auto_parallel.rs
@@ -123,7 +123,7 @@ fn is_pure_expr(
         }
 
         // Calls: check if the target is an effect fn
-        IrExprKind::Call { target, args, .. } => {
+        IrExprKind::Call { target, args, .. } | IrExprKind::TailCall { target, args } => {
             match target {
                 CallTarget::Named { name } => {
                     if effect_fns.contains(name) { return false; }

--- a/crates/almide-codegen/src/pass_tail_call_mark.rs
+++ b/crates/almide-codegen/src/pass_tail_call_mark.rs
@@ -1,0 +1,83 @@
+//! Tail Call Mark pass: marks tail-position calls as TailCall for WASM return_call emission.
+//!
+//! Unlike TailCallOptPass (which converts to loops for Rust), this pass preserves
+//! the original call structure and simply changes `Call` → `TailCall` for any call
+//! in tail position. The WASM emitter then emits `return_call` / `return_call_indirect`
+//! for TailCall nodes.
+//!
+//! This applies to ALL tail-position calls, not just self-recursive ones.
+//! WASM native tail calls eliminate stack growth for any call in tail position.
+
+use almide_ir::*;
+use super::pass::{NanoPass, PassResult, Target};
+
+#[derive(Debug)]
+pub struct TailCallMarkPass;
+
+impl NanoPass for TailCallMarkPass {
+    fn name(&self) -> &str { "TailCallMark" }
+
+    fn targets(&self) -> Option<Vec<Target>> {
+        Some(vec![Target::Wasm])
+    }
+
+    fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
+        let mut changed = false;
+        for func in &mut program.functions {
+            if mark_tail_calls(&mut func.body) { changed = true; }
+        }
+        for module in &mut program.modules {
+            for func in &mut module.functions {
+                if mark_tail_calls(&mut func.body) { changed = true; }
+            }
+        }
+        PassResult { program, changed }
+    }
+}
+
+/// Mark tail-position calls in an expression. Returns true if any changes were made.
+fn mark_tail_calls(expr: &mut IrExpr) -> bool {
+    match &mut expr.kind {
+        // A Call in tail position → convert to TailCall
+        IrExprKind::Call { .. } => {
+            // Take ownership of the Call fields and rebuild as TailCall
+            let old = std::mem::replace(&mut expr.kind, IrExprKind::Unit);
+            if let IrExprKind::Call { target, args, .. } = old {
+                expr.kind = IrExprKind::TailCall { target, args };
+                true
+            } else {
+                unreachable!()
+            }
+        }
+
+        // Block: tail position is the trailing expression
+        IrExprKind::Block { stmts: _, expr: Some(tail) } => {
+            mark_tail_calls(tail)
+        }
+
+        // If: both branches are in tail position
+        IrExprKind::If { cond: _, then, else_ } => {
+            let a = mark_tail_calls(then);
+            let b = mark_tail_calls(else_);
+            a || b
+        }
+
+        // Match: each arm body is in tail position
+        IrExprKind::Match { subject: _, arms } => {
+            let mut changed = false;
+            for arm in arms {
+                if mark_tail_calls(&mut arm.body) { changed = true; }
+            }
+            changed
+        }
+
+        // Result wrappers: if the inner expr is a Call, the wrapper + call is a tail call
+        // e.g., `Ok(f(x))` in an effect fn — the call to f is in tail position
+        IrExprKind::ResultOk { expr: inner } | IrExprKind::Try { expr: inner } => {
+            mark_tail_calls(inner)
+        }
+
+        // Everything else is NOT a tail position
+        _ => false,
+    }
+}

--- a/crates/almide-codegen/src/pass_tail_call_mark.rs
+++ b/crates/almide-codegen/src/pass_tail_call_mark.rs
@@ -71,11 +71,9 @@ fn mark_tail_calls(expr: &mut IrExpr) -> bool {
             changed
         }
 
-        // Result wrappers: if the inner expr is a Call, the wrapper + call is a tail call
-        // e.g., `Ok(f(x))` in an effect fn — the call to f is in tail position
-        IrExprKind::ResultOk { expr: inner } | IrExprKind::Try { expr: inner } => {
-            mark_tail_calls(inner)
-        }
+        // ResultOk/Try are NOT tail positions: the wrapper changes the return type.
+        // `Ok(f(x))` wraps f's result in Result — return_call(f) would skip the wrapping.
+        // `Try(f(x))` unwraps f's Result — return_call(f) would return Result, not the inner T.
 
         // Everything else is NOT a tail position
         _ => false,

--- a/crates/almide-codegen/src/target.rs
+++ b/crates/almide-codegen/src/target.rs
@@ -29,6 +29,7 @@ use super::pass_peephole::PeepholePass;
 use super::pass_rust_lowering::RustLoweringPass;
 use super::pass_closure_conversion::ClosureConversionPass;
 use super::pass_list_pattern::ListPatternLoweringPass;
+use super::pass_tail_call_mark::TailCallMarkPass;
 use super::template::TemplateSet;
 
 /// Full configuration for a codegen target.
@@ -107,7 +108,6 @@ fn build_pipeline(target: Target) -> Pipeline {
 
         Target::Wasm => Pipeline::new()
             .add(ListPatternLoweringPass)
-            .add(TailCallOptPass)
             .add(LICMPass)
             .add(EffectInferencePass)
             // StreamFusion not included: WASM emitter has its own lowering paths
@@ -116,7 +116,10 @@ fn build_pipeline(target: Target) -> Pipeline {
             .add(PeepholePass)
             // Closure conversion: lift lambdas to top-level functions with explicit env
             .add(ClosureConversionPass)
-            .add(FanLoweringPass),
+            .add(FanLoweringPass)
+            // TailCallMark: mark tail-position calls for WASM return_call emission.
+            // Must run last — after all passes that may create or transform calls.
+            .add(TailCallMarkPass),
     }
 }
 

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -166,7 +166,7 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         IrExprKind::RenderedCall { code } => code.clone(),
 
         // ── Calls ──
-        IrExprKind::Call { target, args, .. } => {
+        IrExprKind::Call { target, args, .. } | IrExprKind::TailCall { target, args } => {
             match target {
                 CallTarget::Module { module, func } => {
                     // Module calls: use template (TS/JS) or runtime function (Rust)

--- a/crates/almide-frontend/Cargo.toml
+++ b/crates/almide-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-frontend"
-version = "0.11.7"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide frontend: type checker, canonicalization, IR lowering"

--- a/crates/almide-ir/Cargo.toml
+++ b/crates/almide-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-ir"
-version = "0.11.7"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide typed intermediate representation (IR)"

--- a/crates/almide-ir/src/lib.rs
+++ b/crates/almide-ir/src/lib.rs
@@ -251,6 +251,9 @@ pub enum IrExprKind {
 
     // ── Calls (fully resolved) ──
     Call { target: CallTarget, args: Vec<IrExpr>, #[serde(default, skip_serializing_if = "Vec::is_empty")] type_args: Vec<Ty> },
+    /// Tail call: same as Call but emits `return_call` in WASM.
+    /// Inserted by TailCallMarkPass for calls in tail position.
+    TailCall { target: CallTarget, args: Vec<IrExpr> },
 
     // ── Collections ──
     List { elements: Vec<IrExpr> },
@@ -461,6 +464,15 @@ impl IrExpr {
                     other => other,
                 };
                 IrExprKind::Call { target, args, type_args }
+            }
+            IrExprKind::TailCall { target, args } => {
+                let args = args.into_iter().map(|a| f(a)).collect();
+                let target = match target {
+                    CallTarget::Method { object, method } => CallTarget::Method { object: Box::new(f(*object)), method },
+                    CallTarget::Computed { callee } => CallTarget::Computed { callee: Box::new(f(*callee)) },
+                    other => other,
+                };
+                IrExprKind::TailCall { target, args }
             }
 
             // ── Collections ──

--- a/crates/almide-ir/src/substitute.rs
+++ b/crates/almide-ir/src/substitute.rs
@@ -23,6 +23,13 @@ pub fn substitute_var_in_expr(expr: &IrExpr, var: VarId, replacement: &IrExpr) -
             },
             ty: expr.ty.clone(), span: expr.span,
         },
+        IrExprKind::TailCall { target, args } => IrExpr {
+            kind: IrExprKind::TailCall {
+                target: substitute_var_in_target(target, var, replacement),
+                args: args.iter().map(sub).collect(),
+            },
+            ty: expr.ty.clone(), span: expr.span,
+        },
         IrExprKind::BinOp { op, left, right } => IrExpr {
             kind: IrExprKind::BinOp {
                 op: *op,

--- a/crates/almide-ir/src/use_count.rs
+++ b/crates/almide-ir/src/use_count.rs
@@ -57,7 +57,7 @@ fn count_uses_in_expr(expr: &IrExpr, table: &mut VarTable) {
             for s in stmts { count_uses_in_stmt(s, table); }
             if let Some(e) = expr { count_uses_in_expr(e, table); }
         }
-        IrExprKind::Call { target, args, .. } => {
+        IrExprKind::Call { target, args, .. } | IrExprKind::TailCall { target, args } => {
             match target {
                 CallTarget::Method { object, .. } => count_uses_in_expr(object, table),
                 CallTarget::Computed { callee } => count_uses_in_expr(callee, table),
@@ -310,7 +310,7 @@ fn bump_vars_in_expr(expr: &IrExpr, locals: &HashSet<u32>, table: &mut VarTable)
             bump_vars_in_expr(subject, locals, table);
             for a in arms { bump_vars_in_expr(&a.body, locals, table); }
         }
-        IrExprKind::Call { args, .. } => { for a in args { bump_vars_in_expr(a, locals, table); } }
+        IrExprKind::Call { args, .. } | IrExprKind::TailCall { args, .. } => { for a in args { bump_vars_in_expr(a, locals, table); } }
         IrExprKind::BinOp { left, right, .. } => {
             bump_vars_in_expr(left, locals, table);
             bump_vars_in_expr(right, locals, table);

--- a/crates/almide-ir/src/visit.rs
+++ b/crates/almide-ir/src/visit.rs
@@ -69,7 +69,7 @@ pub fn walk_expr<V: IrVisitor>(v: &mut V, expr: &IrExpr) {
         }
 
         // ── Calls ──
-        IrExprKind::Call { target, args, .. } => {
+        IrExprKind::Call { target, args, .. } | IrExprKind::TailCall { target, args } => {
             match target {
                 CallTarget::Method { object, .. } => v.visit_expr(object),
                 CallTarget::Computed { callee } => v.visit_expr(callee),

--- a/crates/almide-lang/Cargo.toml
+++ b/crates/almide-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-lang"
-version = "0.11.7"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide language definitions: re-exports almide-syntax + almide-types"

--- a/crates/almide-optimize/Cargo.toml
+++ b/crates/almide-optimize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-optimize"
-version = "0.11.7"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide IR optimizer: dead code elimination, constant propagation, monomorphization"

--- a/crates/almide-syntax/Cargo.toml
+++ b/crates/almide-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-syntax"
-version = "0.11.7"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide syntax definitions: AST, lexer, and parser"

--- a/crates/almide-tools/Cargo.toml
+++ b/crates/almide-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-tools"
-version = "0.11.7"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide developer tools: formatter, module interface, almdi"

--- a/crates/almide-types/Cargo.toml
+++ b/crates/almide-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "almide-types"
-version = "0.11.7"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Almide type system: Ty, unification, type constructors, stdlib info"

--- a/docs/roadmap/active/fan-concurrency-next.md
+++ b/docs/roadmap/active/fan-concurrency-next.md
@@ -210,13 +210,19 @@ fan(timeout: 30000) {
 
 ### WASM Strategy
 
-| Feature | WASM (current) | WASM (JSPI) | WASM (WASI 0.3) |
+Primary target: **Component Model async (WASI 0.3)**. Browser target uses Web APIs.
+
+| Feature | WASM (current) | WASM (browser) | WASM (WASI 0.3) |
 |---|---|---|---|
-| `fan { }` | sequential | `Promise.all` | `task.spawn` |
-| `fan.map` | sequential loop | async + bounded | `stream` |
-| `fan.race` | first only | `Promise.race` | `waitable-set` |
+| `fan { }` | sequential | `Promise.all` | `future<T>` + `waitable-set` |
+| `fan.map` | sequential loop | async + bounded | `stream<T>` + bounded consumer |
+| `fan.race` | first only | `Promise.race` | `waitable-set.poll` |
 | `fan.link` | sync queue | `MessageChannel` | `stream<T>` |
 | `Flow[T]` | eager List | `AsyncIterator` | `stream<T>` |
+
+- **WASI containers** (Spin, wasmCloud, Docker+WASM): Component Model async. Host runtime is the executor. No threads, no language-side scheduler
+- **Browser**: SharedArrayBuffer + Web Workers for true parallelism, or JSPI for async
+- **Fallback**: Sequential execution when neither is available
 
 target がバックエンドを決める。Almide コードは同一。
 

--- a/docs/roadmap/active/wasm-3.md
+++ b/docs/roadmap/active/wasm-3.md
@@ -10,9 +10,9 @@ Almide targets WebAssembly 3.0 — the first language to fully leverage the new 
 - **Multi-memory** isolates heap regions (strings, lists, closures) for safety and performance
 - **No GC dependency** — Almide compiles to linear memory with deterministic allocation, running on any 3.0 runtime including lightweight embeddings where GC proposals aren't available
 
-## Phases
+## Implementation (all v0.12)
 
-### Phase 1: Tail Calls (v0.12)
+### Tail Calls
 
 Highest ROI. `return_call` / `return_call_indirect` for proper TCO in WASM.
 
@@ -20,7 +20,7 @@ Highest ROI. `return_call` / `return_call_indirect` for proper TCO in WASM.
 - All recursive stdlib patterns (scan_while, skip_ws, etc.) become stack-safe
 - **Runtime support**: Chrome 112, Firefox 121, Safari 18.2, Wasmtime 22, Wasmer 7.1 — universal
 
-### Phase 2: Exception Handling (v0.13)
+### Exception Handling
 
 `try_table` / `throw` / `throw_ref` with first-class `exnref`.
 
@@ -29,7 +29,7 @@ Highest ROI. `return_call` / `return_call_indirect` for proper TCO in WASM.
 - **Runtime support**: Chrome 137, Firefox 131, Safari 18.4, Wasmtime (flag), Wasmer 6.0
 - Note: Wasmtime still behind flag — CLI target may need fallback path or wait for default-on
 
-### Phase 3: Multi-Memory (v0.14)
+### Multi-Memory
 
 Separate memories for different allocation pools.
 
@@ -38,9 +38,8 @@ Separate memories for different allocation pools.
 - Memory 2: closure environments
 - Reduces fragmentation, enables per-pool growth strategies
 - **Runtime support**: Chrome 120, Firefox 125, Wasmtime 15 — Safari missing, so emit as opt-in feature
-- Emit flag: `--wasm-features multi-memory`
 
-### Phase 4: Threads (with fan concurrency)
+### Threads
 
 Shared memory + atomics for fan expression compilation.
 
@@ -54,9 +53,8 @@ Shared memory + atomics for fan expression compilation.
 Default output (`almide build --target wasm`) remains **WASM 2.0 compatible**. New features are enabled via:
 
 ```
-almide build app.almd --target wasm                           # 2.0 baseline
-almide build app.almd --target wasm --wasm-features tail-call # + TCO
-almide build app.almd --target wasm --wasm-features 3.0       # all available 3.0 features
+almide build app.almd --target wasm              # 3.0 (default from v0.12)
+almide build app.almd --target wasm --compat 2.0  # 2.0 fallback for legacy runtimes
 ```
 
 ## Messaging

--- a/docs/roadmap/active/wasm-3.md
+++ b/docs/roadmap/active/wasm-3.md
@@ -1,0 +1,64 @@
+<!-- description: WebAssembly 3.0 target: tail calls, exception handling, multi-memory, threads -->
+# WebAssembly 3.0 Target
+
+Almide targets WebAssembly 3.0 — the first language to fully leverage the new spec for linear-memory compilation.
+
+## Why
+
+- **Tail calls** eliminate stack overflow in recursive code — critical for a language that prefers recursion over mutation
+- **Native exception handling** makes effect fn error propagation zero-cost instead of manual Result chaining
+- **Multi-memory** isolates heap regions (strings, lists, closures) for safety and performance
+- **No GC dependency** — Almide compiles to linear memory with deterministic allocation, running on any 3.0 runtime including lightweight embeddings where GC proposals aren't available
+
+## Phases
+
+### Phase 1: Tail Calls (v0.12)
+
+Highest ROI. `return_call` / `return_call_indirect` for proper TCO in WASM.
+
+- Extend existing `pass_tco.rs` (currently Rust-only) to emit WASM tail call instructions
+- All recursive stdlib patterns (scan_while, skip_ws, etc.) become stack-safe
+- **Runtime support**: Chrome 112, Firefox 121, Safari 18.2, Wasmtime 22, Wasmer 7.1 — universal
+
+### Phase 2: Exception Handling (v0.13)
+
+`try_table` / `throw` / `throw_ref` with first-class `exnref`.
+
+- effect fn `?` propagation → WASM native exception flow instead of Result wrapping + branch
+- Significant binary size reduction (no Result construction/destruction overhead per call)
+- **Runtime support**: Chrome 137, Firefox 131, Safari 18.4, Wasmtime (flag), Wasmer 6.0
+- Note: Wasmtime still behind flag — CLI target may need fallback path or wait for default-on
+
+### Phase 3: Multi-Memory (v0.14)
+
+Separate memories for different allocation pools.
+
+- Memory 0: general heap (records, variants)
+- Memory 1: string pool (immutable, compactable)
+- Memory 2: closure environments
+- Reduces fragmentation, enables per-pool growth strategies
+- **Runtime support**: Chrome 120, Firefox 125, Wasmtime 15 — Safari missing, so emit as opt-in feature
+- Emit flag: `--wasm-features multi-memory`
+
+### Phase 4: Threads (with fan concurrency)
+
+Shared memory + atomics for fan expression compilation.
+
+- `fan { a, b, c }` → parallel WASM threads with shared linear memory
+- Requires SharedArrayBuffer (browser) or WASI threads (CLI)
+- **Runtime support**: Chrome 74, Firefox 79, Safari 14.1, Wasmtime 15, Wasmer 4.0 — universal
+- Blocked on fan concurrency language design (separate roadmap item)
+
+## Baseline Compatibility
+
+Default output (`almide build --target wasm`) remains **WASM 2.0 compatible**. New features are enabled via:
+
+```
+almide build app.almd --target wasm                           # 2.0 baseline
+almide build app.almd --target wasm --wasm-features tail-call # + TCO
+almide build app.almd --target wasm --wasm-features 3.0       # all available 3.0 features
+```
+
+## Messaging
+
+> Almide is the first language designed for WebAssembly 3.0 — zero-cost error handling, stack-safe recursion, and isolated memory regions, all without GC overhead.

--- a/docs/roadmap/active/wasm-3.md
+++ b/docs/roadmap/active/wasm-3.md
@@ -48,14 +48,9 @@ Shared memory + atomics for fan expression compilation.
 - **Runtime support**: Chrome 74, Firefox 79, Safari 14.1, Wasmtime 15, Wasmer 4.0 — universal
 - Blocked on fan concurrency language design (separate roadmap item)
 
-## Baseline Compatibility
+## No 2.0 Fallback
 
-Default output (`almide build --target wasm`) remains **WASM 2.0 compatible**. New features are enabled via:
-
-```
-almide build app.almd --target wasm              # 3.0 (default from v0.12)
-almide build app.almd --target wasm --compat 2.0  # 2.0 fallback for legacy runtimes
-```
+WASM output is 3.0 only. No `--compat 2.0` mode. All 3.0 features used by Almide (tail calls, EH, multi-memory, threads) are shipped in every major runtime as of 2025. Maintaining dual codegen paths is not worth the cost for runtimes that don't exist in practice.
 
 ## Messaging
 

--- a/docs/roadmap/active/wasm-3.md
+++ b/docs/roadmap/active/wasm-3.md
@@ -1,4 +1,4 @@
-<!-- description: WebAssembly 3.0 target: tail calls, exception handling, multi-memory, threads -->
+<!-- description: WebAssembly 3.0 target: tail calls, exception handling, multi-memory, Component Model async -->
 # WebAssembly 3.0 Target
 
 Almide targets WebAssembly 3.0 — the first language to fully leverage the new spec for linear-memory compilation.
@@ -8,6 +8,7 @@ Almide targets WebAssembly 3.0 — the first language to fully leverage the new 
 - **Tail calls** eliminate stack overflow in recursive code — critical for a language that prefers recursion over mutation
 - **Native exception handling** makes effect fn error propagation zero-cost instead of manual Result chaining
 - **Multi-memory** isolates heap regions (strings, lists, closures) for safety and performance
+- **Component Model async** maps `fan` to `future<T>` / `stream<T>` — cooperative concurrency without threads
 - **No GC dependency** — Almide compiles to linear memory with deterministic allocation, running on any 3.0 runtime including lightweight embeddings where GC proposals aren't available
 
 ## Implementation (all v0.12)
@@ -40,18 +41,25 @@ Separate memories for different allocation pools.
 - **Container gap**: Wasmtime default OFF, WasmEdge requires `--enable-exception-handling`. This means Spin, wasmCloud, Docker+WASM, and K8s shims all require runtime config to enable it
 - **Strategy**: Emit EH instructions, but also keep the current Result-chain codegen as fallback. Select at build time: `--wasm-eh=native` (default for browser) / `--wasm-eh=result` (default for WASI CLI). When Wasmtime flips the default (tracked), remove the fallback
 
-### Threads — Deferred
+### Fan → Component Model Async (WASI 0.3)
 
-Shared memory + atomics for fan expression compilation.
+`fan` compiles to Component Model async primitives, not wasm threads.
 
-- **Container ecosystem is single-threaded by design.** Spin, wasmCloud, Fastly, Cloudflare all disable shared memory or run one thread per request. Wasmtime has the proposal ON but disables shared memory creation by default
-- **Browser support exists** (Chrome 74, Firefox 79, Safari 14.1) but fan concurrency for browser is a separate concern
-- **Decision**: Do not block v0.12 on threads. Revisit when WASI 0.3 async lands or container runtimes adopt shared-everything threads
+```
+fan { fetch(url1), fetch(url2), fetch(url3) }
+  → 3x future<T> + waitable-set multiplex
+```
+
+- **Why not threads**: WASI container runtimes (Spin, wasmCloud, Fastly, Cloudflare) are single-threaded by design. `wasi-threads` was withdrawn in 2023. `shared-everything-threads` is still draft with zero implementations. No language has intra-instance parallelism in WASM containers today
+- **Why Component Model async**: WASI 0.3 adds `future<T>` and `stream<T>` as WIT-level types. The host runtime drives the executor — no language-side scheduler needed. Wasmtime 37+ and Spin v3.5+ ship it. This is what Rust (Spin SDK), Go (TinyGo), Python (componentize-py), and Kotlin all converge on
+- **Almide advantage**: `fan` is a language-level primitive, not a library pattern. The compiler maps it directly to the async ABI without developer ceremony. Other languages require manual `async fn` + `select!` / `join!` glue
+- **Browser target**: fan compiles to SharedArrayBuffer + Web Workers (existing threads support) for true parallelism. The compiler selects the strategy per target
+- **Runtime support**: Wasmtime 37+ (WASI 0.3 RC), Spin v3.5+, wasmCloud (tracking). WasmEdge and Wasmer not yet
 
 ## No 2.0 Fallback
 
-WASM output is 3.0 only. No `--compat 2.0` mode. Tail calls and multi-memory are default-on in every major runtime. Exception handling has a build-time flag for runtimes that haven't enabled it yet (Wasmtime). Threads are deferred entirely.
+WASM output is 3.0 only. No `--compat 2.0` mode. Tail calls and multi-memory are default-on in every major runtime. Exception handling has a build-time flag for runtimes that haven't enabled it yet (Wasmtime).
 
 ## Messaging
 
-> Almide is the first language designed for WebAssembly 3.0 — zero-cost error handling, stack-safe recursion, and isolated memory regions, all without GC overhead.
+> Almide is the first language designed for WebAssembly 3.0 — zero-cost error handling, stack-safe recursion, isolated memory regions, and native async concurrency, all without GC overhead.

--- a/docs/roadmap/active/wasm-3.md
+++ b/docs/roadmap/active/wasm-3.md
@@ -20,15 +20,6 @@ Highest ROI. `return_call` / `return_call_indirect` for proper TCO in WASM.
 - All recursive stdlib patterns (scan_while, skip_ws, etc.) become stack-safe
 - **Runtime support**: Chrome 112, Firefox 121, Safari 18.2, Wasmtime 22, Wasmer 7.1 — universal
 
-### Exception Handling
-
-`try_table` / `throw` / `throw_ref` with first-class `exnref`.
-
-- effect fn `?` propagation → WASM native exception flow instead of Result wrapping + branch
-- Significant binary size reduction (no Result construction/destruction overhead per call)
-- **Runtime support**: Chrome 137, Firefox 131, Safari 18.4, Wasmtime (flag), Wasmer 6.0
-- Note: Wasmtime still behind flag — CLI target may need fallback path or wait for default-on
-
 ### Multi-Memory
 
 Separate memories for different allocation pools.
@@ -37,20 +28,29 @@ Separate memories for different allocation pools.
 - Memory 1: string pool (immutable, compactable)
 - Memory 2: closure environments
 - Reduces fragmentation, enables per-pool growth strategies
-- **Runtime support**: Chrome 120, Firefox 125, Wasmtime 15 — Safari missing, so emit as opt-in feature
+- **Runtime support**: Chrome 120, Firefox 125, Wasmtime 15 (default ON), WasmEdge (default ON)
 
-### Threads
+### Exception Handling
+
+`try_table` / `throw` / `throw_ref` with first-class `exnref`.
+
+- effect fn `?` propagation → WASM native exception flow instead of Result wrapping + branch
+- Significant binary size reduction (no Result construction/destruction overhead per call)
+- **Runtime support**: Chrome 137, Firefox 131, Safari 18.4 — all browsers ship it
+- **Container gap**: Wasmtime default OFF, WasmEdge requires `--enable-exception-handling`. This means Spin, wasmCloud, Docker+WASM, and K8s shims all require runtime config to enable it
+- **Strategy**: Emit EH instructions, but also keep the current Result-chain codegen as fallback. Select at build time: `--wasm-eh=native` (default for browser) / `--wasm-eh=result` (default for WASI CLI). When Wasmtime flips the default (tracked), remove the fallback
+
+### Threads — Deferred
 
 Shared memory + atomics for fan expression compilation.
 
-- `fan { a, b, c }` → parallel WASM threads with shared linear memory
-- Requires SharedArrayBuffer (browser) or WASI threads (CLI)
-- **Runtime support**: Chrome 74, Firefox 79, Safari 14.1, Wasmtime 15, Wasmer 4.0 — universal
-- Blocked on fan concurrency language design (separate roadmap item)
+- **Container ecosystem is single-threaded by design.** Spin, wasmCloud, Fastly, Cloudflare all disable shared memory or run one thread per request. Wasmtime has the proposal ON but disables shared memory creation by default
+- **Browser support exists** (Chrome 74, Firefox 79, Safari 14.1) but fan concurrency for browser is a separate concern
+- **Decision**: Do not block v0.12 on threads. Revisit when WASI 0.3 async lands or container runtimes adopt shared-everything threads
 
 ## No 2.0 Fallback
 
-WASM output is 3.0 only. No `--compat 2.0` mode. All 3.0 features used by Almide (tail calls, EH, multi-memory, threads) are shipped in every major runtime as of 2025. Maintaining dual codegen paths is not worth the cost for runtimes that don't exist in practice.
+WASM output is 3.0 only. No `--compat 2.0` mode. Tail calls and multi-memory are default-on in every major runtime. Exception handling has a build-time flag for runtimes that haven't enabled it yet (Wasmtime). Threads are deferred entirely.
 
 ## Messaging
 

--- a/docs/roadmap/active/wasm-3.md
+++ b/docs/roadmap/active/wasm-3.md
@@ -1,4 +1,4 @@
-<!-- description: WebAssembly 3.0 target: tail calls, exception handling, multi-memory, Component Model async -->
+<!-- description: WebAssembly 3.0 target: tail calls, multi-memory, exception handling (v2), Component Model async -->
 # WebAssembly 3.0 Target
 
 Almide targets WebAssembly 3.0 — the first language to fully leverage the new spec for linear-memory compilation.
@@ -6,42 +6,43 @@ Almide targets WebAssembly 3.0 — the first language to fully leverage the new 
 ## Why
 
 - **Tail calls** eliminate stack overflow in recursive code — critical for a language that prefers recursion over mutation
-- **Native exception handling** makes effect fn error propagation zero-cost instead of manual Result chaining
-- **Multi-memory** isolates heap regions (strings, lists, closures) for safety and performance
+- **Multi-memory** isolates heap regions for safety and performance
 - **Component Model async** maps `fan` to `future<T>` / `stream<T>` — cooperative concurrency without threads
 - **No GC dependency** — Almide compiles to linear memory with deterministic allocation, running on any 3.0 runtime including lightweight embeddings where GC proposals aren't available
 
-## Implementation (all v0.12)
+## v1: Tail Calls + Multi-Memory (v0.12) ✅
 
-### Tail Calls
+### Tail Calls — Done
 
-Highest ROI. `return_call` / `return_call_indirect` for proper TCO in WASM.
+`return_call` / `return_call_indirect` for all tail-position calls.
 
-- Extend existing `pass_tco.rs` (currently Rust-only) to emit WASM tail call instructions
-- All recursive stdlib patterns (scan_while, skip_ws, etc.) become stack-safe
+- `TailCallMarkPass` marks tail-position calls in the IR
+- WASM emitter emits `return_call` instead of `call` for marked nodes
+- Applies to ALL tail calls (not just self-recursive) — mutual recursion included
+- Replaces loop-based `TailCallOptPass` in WASM pipeline
 - **Runtime support**: Chrome 112, Firefox 121, Safari 18.2, Wasmtime 22, Wasmer 7.1 — universal
 
-### Multi-Memory
+### Multi-Memory — Done
 
-Separate memories for different allocation pools.
+Memory 0 (main) + Memory 1 (string builder scratch).
 
-- Memory 0: general heap (records, variants)
-- Memory 1: string pool (immutable, compactable)
-- Memory 2: closure environments
-- Reduces fragmentation, enables per-pool growth strategies
+- Memory 0: 64 pages (4MB) — scratch + data segment + heap (unchanged)
+- Memory 1: 1 page (64KB) — string builder scratch, grows on demand
+- All load/store macros support `memory_index` parameter (default 0, backward compatible)
+- `memory_copy`, `memory_fill`, `memory_size`, `memory_grow` parameterized per memory
 - **Runtime support**: Chrome 120, Firefox 125, Wasmtime 15 (default ON), WasmEdge (default ON)
 
-### Exception Handling
+## v2: Exception Handling (deferred)
 
 `try_table` / `throw` / `throw_ref` with first-class `exnref`.
 
 - effect fn `?` propagation → WASM native exception flow instead of Result wrapping + branch
-- Significant binary size reduction (no Result construction/destruction overhead per call)
-- **Runtime support**: Chrome 137, Firefox 131, Safari 18.4 — all browsers ship it
-- **Container gap**: Wasmtime default OFF, WasmEdge requires `--enable-exception-handling`. This means Spin, wasmCloud, Docker+WASM, and K8s shims all require runtime config to enable it
-- **Strategy**: Emit EH instructions, but also keep the current Result-chain codegen as fallback. Select at build time: `--wasm-eh=native` (default for browser) / `--wasm-eh=result` (default for WASI CLI). When Wasmtime flips the default (tracked), remove the fallback
+- Eliminates Result heap allocation and per-`?` branch overhead
+- **Blocked on**: Wasmtime default OFF, WasmEdge requires `--enable-exception-handling`. All major WASI container runtimes (Spin, wasmCloud, Docker+WASM) require runtime config changes
+- **wasm-encoder 0.225**: Already supports TryTable, Throw, ThrowRef, exnref — ready when Wasmtime flips the default
+- **Trigger**: Implement when Wasmtime enables EH by default
 
-### Fan → Component Model Async (WASI 0.3)
+## v3: Fan → Component Model Async (WASI 0.3)
 
 `fan` compiles to Component Model async primitives, not wasm threads.
 
@@ -50,16 +51,16 @@ fan { fetch(url1), fetch(url2), fetch(url3) }
   → 3x future<T> + waitable-set multiplex
 ```
 
-- **Why not threads**: WASI container runtimes (Spin, wasmCloud, Fastly, Cloudflare) are single-threaded by design. `wasi-threads` was withdrawn in 2023. `shared-everything-threads` is still draft with zero implementations. No language has intra-instance parallelism in WASM containers today
-- **Why Component Model async**: WASI 0.3 adds `future<T>` and `stream<T>` as WIT-level types. The host runtime drives the executor — no language-side scheduler needed. Wasmtime 37+ and Spin v3.5+ ship it. This is what Rust (Spin SDK), Go (TinyGo), Python (componentize-py), and Kotlin all converge on
-- **Almide advantage**: `fan` is a language-level primitive, not a library pattern. The compiler maps it directly to the async ABI without developer ceremony. Other languages require manual `async fn` + `select!` / `join!` glue
-- **Browser target**: fan compiles to SharedArrayBuffer + Web Workers (existing threads support) for true parallelism. The compiler selects the strategy per target
-- **Runtime support**: Wasmtime 37+ (WASI 0.3 RC), Spin v3.5+, wasmCloud (tracking). WasmEdge and Wasmer not yet
+- **Why not threads**: WASI container runtimes are single-threaded by design. `wasi-threads` was withdrawn in 2023. `shared-everything-threads` is still draft with zero implementations
+- **Why Component Model async**: WASI 0.3 adds `future<T>` and `stream<T>` as WIT-level types. Host runtime drives the executor. Wasmtime 37+ and Spin v3.5+ ship it
+- **Almide advantage**: `fan` maps directly to async ABI without developer ceremony
+- **Browser target**: fan compiles to SharedArrayBuffer + Web Workers for true parallelism
+- **Runtime support**: Wasmtime 37+ (WASI 0.3 RC), Spin v3.5+, wasmCloud (tracking)
 
 ## No 2.0 Fallback
 
-WASM output is 3.0 only. No `--compat 2.0` mode. Tail calls and multi-memory are default-on in every major runtime. Exception handling has a build-time flag for runtimes that haven't enabled it yet (Wasmtime).
+WASM output is 3.0 only. Tail calls and multi-memory are default-on in every major runtime.
 
 ## Messaging
 
-> Almide is the first language designed for WebAssembly 3.0 — zero-cost error handling, stack-safe recursion, isolated memory regions, and native async concurrency, all without GC overhead.
+> Almide is the first language designed for WebAssembly 3.0 — stack-safe recursion, isolated memory regions, and native async concurrency, all without GC overhead.

--- a/docs/roadmap/done/wasm-3.md
+++ b/docs/roadmap/done/wasm-3.md
@@ -1,4 +1,5 @@
-<!-- description: WebAssembly 3.0 target: tail calls, multi-memory, exception handling (v2), Component Model async -->
+<!-- description: WebAssembly 3.0 v1: native tail calls (return_call) and multi-memory -->
+<!-- done: 2026-04-06 -->
 # WebAssembly 3.0 Target
 
 Almide targets WebAssembly 3.0 — the first language to fully leverage the new spec for linear-memory compilation.

--- a/docs/roadmap/on-hold/wasm-exception-handling.md
+++ b/docs/roadmap/on-hold/wasm-exception-handling.md
@@ -1,0 +1,18 @@
+<!-- description: WASM native exception handling (try_table/throw) for zero-cost effect fn error propagation -->
+# WASM Exception Handling
+
+## What
+
+Replace Result heap allocation + per-`?` branch with WASM native `try_table` / `throw` / `exnref`.
+
+- effect fn returns value directly; errors propagate via `throw`
+- Eliminates Result heap allocation and tag-check branching
+- wasm-encoder 0.225 already supports all EH instructions
+
+## Blocked On
+
+Wasmtime has exception handling **default OFF**. All major WASI container runtimes (Spin, wasmCloud, Docker+WASM) inherit this default. Implementing EH now would require dual codegen (EH native + Result chain fallback), which is high cost for limited reach.
+
+## Trigger
+
+Implement when Wasmtime enables EH by default. Track: https://github.com/bytecodealliance/wasmtime/issues/3427


### PR DESCRIPTION
## Summary
- **WebAssembly 3.0 target**: native tail calls (`return_call` / `return_call_indirect`) and multi-memory
- **Mono VarId alpha-renaming**: root fix for stale VarTable types across specializations
- Bug fixes: effect fn propagation, range codegen, variant alloc padding, filter_map type resolution, and more
- Monkey test suites 16-28

## Test plan
- [x] `almide test` — 173 test files passed (Rust + WASM)
- [x] `almide test --target rust` — 173 passed
- [x] `cargo test` — 544 passed