### PR TITLE
Fix TCO/BorrowInsertion call-site mismatch for String params

### DIFF
--- a/crates/almide-codegen/src/pass_tco.rs
+++ b/crates/almide-codegen/src/pass_tco.rs
@@ -21,7 +21,7 @@
 //! WASM where the stack is limited and there is no native tail call support.
 
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use almide_ir::*;
 use almide_lang::types::Ty;
 use almide_lang::types::constructor::TypeConstructorId;
@@ -46,18 +46,80 @@ impl NanoPass for TailCallOptPass {
     }
 
     fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
-        run_tco(&mut program.functions, &mut program.var_table);
+        // Collect: TCO'd function name → param positions whose borrow annotation
+        // was forced back to Own by the loop rewrite (i.e. NOT in the
+        // Bytes-borrow-preserved set). External call sites targeting these
+        // functions need their Borrow wrappers stripped to match the new
+        // signature — otherwise a &str arg is passed where String is expected.
+        let mut reverted: HashMap<almide_base::intern::Sym, HashSet<usize>> = HashMap::new();
+        run_tco(&mut program.functions, &mut program.var_table, &mut reverted);
         for module in &mut program.modules {
-            run_tco(&mut module.functions, &mut module.var_table);
+            run_tco(&mut module.functions, &mut module.var_table, &mut reverted);
+        }
+        if !reverted.is_empty() {
+            strip_borrows_at_tco_calls(&mut program, &reverted);
         }
         PassResult { program, changed: true }
     }
 }
 
-fn run_tco(functions: &mut [IrFunction], var_table: &mut VarTable) {
+fn run_tco(
+    functions: &mut [IrFunction],
+    var_table: &mut VarTable,
+    reverted: &mut HashMap<almide_base::intern::Sym, HashSet<usize>>,
+) {
     for func in functions.iter_mut() {
         if is_tco_candidate(func) {
-            rewrite_to_loop(func, var_table);
+            let fn_name = func.name.clone();
+            let reverted_here = rewrite_to_loop(func, var_table);
+            if !reverted_here.is_empty() {
+                reverted.insert(fn_name, reverted_here);
+            }
+        }
+    }
+}
+
+/// Visit every Call/TailCall in the program; for any target that was TCO'd and
+/// had borrows reverted, strip the Borrow wrapper at the affected arg positions.
+struct TcoCallStripper<'a> {
+    reverted: &'a HashMap<almide_base::intern::Sym, HashSet<usize>>,
+}
+
+impl<'a> IrMutVisitor for TcoCallStripper<'a> {
+    fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
+        if let IrExprKind::Call { target: CallTarget::Named { name }, args, .. }
+            | IrExprKind::TailCall { target: CallTarget::Named { name }, args } = &mut expr.kind
+        {
+            if let Some(positions) = self.reverted.get(name) {
+                for (i, arg) in args.iter_mut().enumerate() {
+                    if positions.contains(&i) {
+                        if let IrExprKind::Borrow { expr: inner, .. } = &mut arg.kind {
+                            let taken = std::mem::replace(inner.as_mut(), IrExpr {
+                                kind: IrExprKind::Unit,
+                                ty: Ty::Unit,
+                                span: None,
+                            });
+                            *arg = taken;
+                        }
+                    }
+                }
+            }
+        }
+        walk_expr_mut(self, expr);
+    }
+}
+
+fn strip_borrows_at_tco_calls(
+    program: &mut IrProgram,
+    reverted: &HashMap<almide_base::intern::Sym, HashSet<usize>>,
+) {
+    let mut stripper = TcoCallStripper { reverted };
+    for func in &mut program.functions {
+        stripper.visit_expr_mut(&mut func.body);
+    }
+    for module in &mut program.modules {
+        for func in &mut module.functions {
+            stripper.visit_expr_mut(&mut func.body);
         }
     }
 }
@@ -321,7 +383,7 @@ fn scan_non_tail_stmt(stmt: &IrStmt, fn_name: &str) -> (bool, bool) {
 }
 
 /// Rewrite a TCO-eligible function body from recursive form to a loop.
-fn rewrite_to_loop(func: &mut IrFunction, var_table: &mut VarTable) {
+fn rewrite_to_loop(func: &mut IrFunction, var_table: &mut VarTable) -> HashSet<usize> {
     let fn_name = func.name.clone();
     // For effect fns returning Result[T, E], the TCO result variable should hold T
     // because the Rust codegen auto-unwraps Result via `?` operator.
@@ -347,6 +409,7 @@ fn rewrite_to_loop(func: &mut IrFunction, var_table: &mut VarTable) {
     // is a no-op lifetime-wise. Keep the borrow there; force ownership
     // everywhere else.
     let mut bytes_borrowed_params: HashSet<usize> = HashSet::new();
+    let mut reverted_to_own: HashSet<usize> = HashSet::new();
     for (i, param) in func.params.iter_mut().enumerate() {
         var_table.entries[param.var.0 as usize].mutability = Mutability::Var;
         let keep_borrow = matches!(param.ty, Ty::Bytes)
@@ -354,6 +417,12 @@ fn rewrite_to_loop(func: &mut IrFunction, var_table: &mut VarTable) {
         if keep_borrow {
             bytes_borrowed_params.insert(i);
         } else {
+            // If BorrowInsertion had previously marked this param as Borrow,
+            // external call sites are now emitting &str / &Vec where we now
+            // expect owned. Record so the call-site walker can strip wrappers.
+            if !matches!(param.borrow, almide_ir::ParamBorrow::Own) {
+                reverted_to_own.insert(i);
+            }
             param.borrow = almide_ir::ParamBorrow::Own;
         }
     }
@@ -459,6 +528,8 @@ fn rewrite_to_loop(func: &mut IrFunction, var_table: &mut VarTable) {
         ty: func.ret_ty.clone(),
         span: func.body.span,
     };
+
+    reverted_to_own
 }
 
 /// Rewrite an expression in tail position:


### PR DESCRIPTION
Closes #151.

## Problem

A recursive function with `String` parameters that gets TCO'd fails to compile because the callee's signature is `fn(String, String, ..)` but call sites pass `&str`.

Root cause: `BorrowInsertion` rewrites both the function signature and its call sites to use `&str`. Then `TailCallOpt` forces every non-Bytes param back to `ParamBorrow::Own` (so the param can be reassigned across loop iterations), but **external call sites were never updated** to match the reverted signature.

## Fix

`run_tco` now collects a `(fn_name → reverted_positions)` map and, after the loop-rewrite phase, runs a `TcoCallStripper` visitor across the entire program, removing `Borrow` wrappers at the arg positions whose param ownership flipped back to `Own`.

Bytes params continue to preserve their borrow across iterations (reassigning `&Vec<u8>` to a derived `&Vec<u8>` is lifetime-safe), so those positions are left alone — only the positions actually flipped to Own get stripped.

## Verification

- Original repro from #151 now compiles and runs
- `almide test` — all 196 test files pass
- `cargo test --release` — all pass

## Test plan

- [x] Reproducer compiles
- [x] Full test suite green
- [ ] PR CI passes