### PR TITLE
Improve diagnostics: assignment-in-expression and Unit-vs-List

### DIFF
--- a/crates/almide-frontend/src/check/diagnostics.rs
+++ b/crates/almide-frontend/src/check/diagnostics.rs
@@ -13,9 +13,14 @@ impl Checker {
             (Ty::String, Ty::Float) => Some("use `float.parse(s)` to convert String to Float (returns Result[Float, String])".to_string()),
             (Ty::Float, Ty::Int) => Some("use `to_int(x)` to convert Float to Int (truncates)".to_string()),
             (Ty::Int, Ty::Float) => Some("use `to_float(x)` to convert Int to Float".to_string()),
-            // list.push/pop/clear return Unit; suggest `+` for immutable list building
+            // Unit where a List was expected: three common causes.
+            // - `list.push/pop/clear` mutate and return Unit
+            // - `for x in xs { ... }` is a side-effect loop returning Unit
+            // - `println(...)` / other effect calls returning Unit
             (Ty::Unit, Ty::Applied(crate::types::TypeConstructorId::List, _)) =>
-                Some("`list.push` mutates a var and returns Unit. For immutable lists, use `+` to build: `xs + [item]`".to_string()),
+                Some("Got Unit where a List was expected. \
+                      `list.push`/`pop`/`clear` mutate and return Unit — use `xs + [item]` for an immutable append. \
+                      `for x in xs { ... }` is a side-effect loop (Unit); for element transforms, use `list.map(xs, (x) => ...)`.".to_string()),
             // Option[Unit] vs Option[List[T]] — same pattern wrapped in Option
             (Ty::Applied(crate::types::TypeConstructorId::Option, a_args),
              Ty::Applied(crate::types::TypeConstructorId::Option, e_args))

--- a/crates/almide-syntax/src/parser/primary.rs
+++ b/crates/almide-syntax/src/parser/primary.rs
@@ -159,6 +159,20 @@ impl Parser {
             return Err(format!("{} at line {}:{}", msg, tok.line, tok.col));
         }
 
+        // Bare `=` in expression position usually means the user tried to
+        // chain assignment (`let r = x = 5`) or start an assignment where
+        // an expression is required. Almide assignments are statements that
+        // return Unit, so they can't appear on the right of `let`.
+        if tok.token_type == TokenType::Eq {
+            let msg = "Assignments return Unit and can't appear here";
+            let hint = "Almide assignment `x = 5` is a statement, not an expression. \
+                        Use separate statements: `x = 5; let r = x` — or pick the value \
+                        directly: `let r = 5`.";
+            let diag = self.diag_error(msg, hint, "assignment-in-expr");
+            self.errors.push(diag);
+            return Err(format!("{} at line {}:{}", msg, tok.line, tok.col));
+        }
+
         Err(format!(
             "Expected expression at line {}:{} (got {:?} '{}')",
             tok.line, tok.col, tok.token_type, tok.value


### PR DESCRIPTION
Addresses the remaining checklist items in #150.

## Status of #150 checklist

Verified on current develop before this PR:

- [x] \`string.get_char\` → suggests \`string.char_at\` (already working)
- [x] \`foldLeft\`/\`reduce\` → suggests \`list.fold\` (already working)
- [x] Incomplete match arms → shows missing patterns (already working)
- [ ] **Assignment in expression position** — fixed here
- [ ] **\`for\` loop returning List[Unit]** — partially improved here

## Changes

### Assignment in expression position

\`let r = x = 5\` used to hit a generic \"Expected expression (got Eq '=')\" with no guidance. Now the parser emits a dedicated diagnostic:

\`\`\`
error: Assignments return Unit and can't appear here
  --> x.almd:3:13
  in assignment-in-expr
  hint: Almide assignment \`x = 5\` is a statement, not an expression. Use
  separate statements: \`x = 5; let r = x\` — or pick the value directly:
  \`let r = 5\`.
\`\`\`

### Unit where a List was expected

The existing hint only covered \`list.push\`. Extended to also call out the other common source — a \`for x in xs { ... }\` loop (Unit-returning side-effect loop) being used where a list was expected. New text points at \`list.map\` for element-to-element transforms.

## Test plan

- [x] Added dedicated reproducer scripts match expected output
- [x] \`almide test\` — 196 test files pass
- [x] \`cargo test --release\` — all pass
- [ ] CI passes