### PR TITLE
Register stdlib [[types]] with type env (PR 2 of ideal named types)

### DIFF
--- a/crates/almide-frontend/src/canonicalize/mod.rs
+++ b/crates/almide-frontend/src/canonicalize/mod.rs
@@ -52,6 +52,11 @@ pub fn canonicalize_program<'a>(
     // 1. Built-in protocols
     protocols::register_builtin_protocols(&mut env);
 
+    // 1b. Register stdlib named types (from [[types]] blocks in
+    //     stdlib/defs/*.toml). Each is stored under "module.Name" so
+    //     user code can reference `process.ProcessStatus` etc.
+    register_stdlib_named_types(&mut env);
+
     // 2. Register user modules (with prefix)
     for (name, mod_prog, is_self) in modules {
         register_module(&mut env, &mut diagnostics, name, mod_prog, is_self);
@@ -67,4 +72,75 @@ pub fn canonicalize_program<'a>(
     registration::register_decls(&mut env, &mut diagnostics, &program.decls, None);
 
     CanonicalizationResult { env, diagnostics }
+}
+
+/// Parse a TOML type string (as written in `stdlib/defs/*.toml [[types]]`
+/// field declarations) into a `Ty`. Primitives only for this PR —
+/// List[T] / Option[T] / user-defined named types land with the
+/// downstream codegen PRs that actually need to resolve them.
+fn parse_stdlib_field_ty(ty_str: &str) -> almide_lang::types::Ty {
+    use almide_lang::types::Ty;
+    match ty_str {
+        "Int" => Ty::Int,
+        "Float" => Ty::Float,
+        "String" => Ty::String,
+        "Bool" => Ty::Bool,
+        "Unit" => Ty::Unit,
+        "Bytes" => Ty::Bytes,
+        _ => Ty::Unknown,
+    }
+}
+
+fn register_stdlib_named_types(env: &mut TypeEnv) {
+    use almide_base::intern::sym;
+    use almide_lang::types::Ty;
+    for t in crate::generated::stdlib_types::STDLIB_TYPES {
+        let fields: Vec<(almide_base::intern::Sym, Ty)> = t
+            .fields
+            .iter()
+            .map(|f| (sym(f.name), parse_stdlib_field_ty(f.ty)))
+            .collect();
+        let record = Ty::Record { fields };
+        // Mirror register_type_decl: "module.Name" (what the resolver matches
+        // against module-qualified type expressions) AND bare "Name" (what
+        // resolve_named falls back to via Ty::Named).
+        let key = format!("{}.{}", t.module, t.name);
+        env.types.insert(sym(&key), record.clone());
+        env.types.insert(sym(t.name), record);
+    }
+}
+
+#[cfg(test)]
+mod stdlib_types_registration_tests {
+    use super::*;
+    use almide_base::intern::sym;
+    use almide_lang::types::Ty;
+
+    #[test]
+    fn process_status_registered_with_correct_fields() {
+        let mut env = TypeEnv::new();
+        register_stdlib_named_types(&mut env);
+
+        // Both the module-qualified key and the bare key are populated.
+        let qualified = env.types.get(&sym("process.ProcessStatus"));
+        let bare = env.types.get(&sym("ProcessStatus"));
+        assert!(qualified.is_some(), "process.ProcessStatus should be registered");
+        assert!(bare.is_some(), "bare ProcessStatus should be registered as fallback");
+
+        // Field shape matches the [[types]] declaration.
+        match qualified.unwrap() {
+            Ty::Record { fields } => {
+                let got: Vec<(&str, &Ty)> =
+                    fields.iter().map(|(n, t)| (n.as_str(), t)).collect();
+                assert_eq!(got.len(), 3);
+                assert_eq!(got[0].0, "code");
+                assert!(matches!(got[0].1, Ty::Int));
+                assert_eq!(got[1].0, "stdout");
+                assert!(matches!(got[1].1, Ty::String));
+                assert_eq!(got[2].0, "stderr");
+                assert!(matches!(got[2].1, Ty::String));
+            }
+            other => panic!("expected Ty::Record, got {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
Builds on #159. Stdlib named types declared via \`[[types]]\` in \`stdlib/defs/*.toml\` are now visible to the type checker.

## What's in this PR

\`canonicalize\` walks the \`STDLIB_TYPES\` table and registers each record in \`TypeEnv::types\` under both:

- The module-qualified key (\`process.ProcessStatus\`) — matches \`let s: process.ProcessStatus = ...\` annotations.
- The bare key (\`ProcessStatus\`) — matches the \`Ty::Named\` fallback path used by \`resolve_named\`.

Primitive fields only for this PR (\`Int/Float/String/Bool/Unit/Bytes\`). List/Option/named-type fields come when the downstream codegen actually needs to resolve them.

## Effect on user code

\`\`\`almide
import process

fn take(s: process.ProcessStatus) -> Int = s.code
\`\`\`

- \`almide check\` on the snippet passes with correct types: \`s.code\` infers as \`Int\`.
- Assigning the field to a \`String\` annotation produces the expected \`type mismatch\` diagnostic.

## Not in this PR

- Rust / WASM codegen doesn't emit a matching struct yet — \`almide build\` on a program that uses \`ProcessStatus\` doesn't link. That's PR 3.
- \`process.exec_status\` still returns a tuple. Migrating to \`Result[process.ProcessStatus, String]\` lands with PR 4.

## Test plan

- [x] New unit test in \`canonicalize/mod.rs\` verifying the two-key registration + field shape
- [x] \`cargo test --release -p almide-frontend stdlib_types\` passes
- [x] \`almide test\` — 200 files pass unchanged
- [ ] CI passes