### PR TITLE
Emit stdlib [[types]] as native type decls (PR 3 of ideal named types)

### DIFF
--- a/crates/almide-frontend/src/canonicalize/mod.rs
+++ b/crates/almide-frontend/src/canonicalize/mod.rs
@@ -52,6 +52,11 @@ pub fn canonicalize_program<'a>(
     // 1. Built-in protocols
     protocols::register_builtin_protocols(&mut env);
 
+    // 1b. Register stdlib named types (from [[types]] blocks in
+    //     stdlib/defs/*.toml). Each is stored under "module.Name" so
+    //     user code can reference `process.ProcessStatus` etc.
+    register_stdlib_named_types(&mut env);
+
     // 2. Register user modules (with prefix)
     for (name, mod_prog, is_self) in modules {
         register_module(&mut env, &mut diagnostics, name, mod_prog, is_self);
@@ -67,4 +72,75 @@ pub fn canonicalize_program<'a>(
     registration::register_decls(&mut env, &mut diagnostics, &program.decls, None);
 
     CanonicalizationResult { env, diagnostics }
+}
+
+/// Parse a TOML type string (as written in `stdlib/defs/*.toml [[types]]`
+/// field declarations) into a `Ty`. Primitives only for this PR —
+/// List[T] / Option[T] / user-defined named types land with the
+/// downstream codegen PRs that actually need to resolve them.
+fn parse_stdlib_field_ty(ty_str: &str) -> almide_lang::types::Ty {
+    use almide_lang::types::Ty;
+    match ty_str {
+        "Int" => Ty::Int,
+        "Float" => Ty::Float,
+        "String" => Ty::String,
+        "Bool" => Ty::Bool,
+        "Unit" => Ty::Unit,
+        "Bytes" => Ty::Bytes,
+        _ => Ty::Unknown,
+    }
+}
+
+fn register_stdlib_named_types(env: &mut TypeEnv) {
+    use almide_base::intern::sym;
+    use almide_lang::types::Ty;
+    for t in crate::generated::stdlib_types::STDLIB_TYPES {
+        let fields: Vec<(almide_base::intern::Sym, Ty)> = t
+            .fields
+            .iter()
+            .map(|f| (sym(f.name), parse_stdlib_field_ty(f.ty)))
+            .collect();
+        let record = Ty::Record { fields };
+        // Mirror register_type_decl: "module.Name" (what the resolver matches
+        // against module-qualified type expressions) AND bare "Name" (what
+        // resolve_named falls back to via Ty::Named).
+        let key = format!("{}.{}", t.module, t.name);
+        env.types.insert(sym(&key), record.clone());
+        env.types.insert(sym(t.name), record);
+    }
+}
+
+#[cfg(test)]
+mod stdlib_types_registration_tests {
+    use super::*;
+    use almide_base::intern::sym;
+    use almide_lang::types::Ty;
+
+    #[test]
+    fn process_status_registered_with_correct_fields() {
+        let mut env = TypeEnv::new();
+        register_stdlib_named_types(&mut env);
+
+        // Both the module-qualified key and the bare key are populated.
+        let qualified = env.types.get(&sym("process.ProcessStatus"));
+        let bare = env.types.get(&sym("ProcessStatus"));
+        assert!(qualified.is_some(), "process.ProcessStatus should be registered");
+        assert!(bare.is_some(), "bare ProcessStatus should be registered as fallback");
+
+        // Field shape matches the [[types]] declaration.
+        match qualified.unwrap() {
+            Ty::Record { fields } => {
+                let got: Vec<(&str, &Ty)> =
+                    fields.iter().map(|(n, t)| (n.as_str(), t)).collect();
+                assert_eq!(got.len(), 3);
+                assert_eq!(got[0].0, "code");
+                assert!(matches!(got[0].1, Ty::Int));
+                assert_eq!(got[1].0, "stdout");
+                assert!(matches!(got[1].1, Ty::String));
+                assert_eq!(got[2].0, "stderr");
+                assert!(matches!(got[2].1, Ty::String));
+            }
+            other => panic!("expected Ty::Record, got {:?}", other),
+        }
+    }
 }

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -256,6 +256,36 @@ fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &Type
         }
     }
 
+    // Inject synthetic IrTypeDecl entries for stdlib [[types]] declarations
+    // so the walker emits a matching `pub struct` per stdlib named type.
+    // Without this, user code written against `process.ProcessStatus` would
+    // type-check but fail to link against a Rust struct.
+    for t in crate::generated::stdlib_types::STDLIB_TYPES {
+        let fields: Vec<IrFieldDecl> = t.fields.iter().map(|f| IrFieldDecl {
+            name: almide_base::intern::sym(f.name),
+            ty: match f.ty {
+                "Int" => almide_lang::types::Ty::Int,
+                "Float" => almide_lang::types::Ty::Float,
+                "String" => almide_lang::types::Ty::String,
+                "Bool" => almide_lang::types::Ty::Bool,
+                "Unit" => almide_lang::types::Ty::Unit,
+                "Bytes" => almide_lang::types::Ty::Bytes,
+                _ => almide_lang::types::Ty::Unknown,
+            },
+            default: None,
+            alias: None,
+        }).collect();
+        type_decls.push(IrTypeDecl {
+            name: almide_base::intern::sym(t.name),
+            kind: IrTypeDeclKind::Record { fields },
+            deriving: None,
+            generics: None,
+            visibility: IrVisibility::Public,
+            doc: Some(format!("Stdlib named type: {}.{}", t.module, t.name)),
+            blank_lines_before: 0,
+        });
+    }
+
     // Auto-derive: generate convention functions for types that declare deriving but lack custom impl
     let auto_derived = generate_auto_derives(&mut ctx, &type_decls, &functions);
     functions.extend(auto_derived);

--- a/spec/stdlib/process_named_type_test.almd
+++ b/spec/stdlib/process_named_type_test.almd
@@ -1,0 +1,21 @@
+// Stdlib [[types]] declarations emit matching Rust/WASM structs. A
+// program referencing process.ProcessStatus now compiles end-to-end.
+import process
+
+fn mk(c: Int, o: String, e: String) -> process.ProcessStatus =
+  { code: c, stdout: o, stderr: e }
+
+fn code_of(r: process.ProcessStatus) -> Int = r.code
+fn out_of(r: process.ProcessStatus) -> String = r.stdout
+
+test "construct and read fields" {
+  let s = mk(42, "hello", "err")
+  assert_eq(code_of(s), 42)
+  assert_eq(out_of(s), "hello")
+  assert_eq(s.stderr, "err")
+}
+
+test "annotated literal shape matches" {
+  let s: process.ProcessStatus = { code: 7, stdout: "a", stderr: "b" }
+  assert_eq(s.code + 1, 8)
+}


### PR DESCRIPTION
Builds on #159 and #160. Closes the loop on the named stdlib types path: types declared in \`stdlib/defs/*.toml [[types]]\` now produce actual Rust structs and WASM record layouts, so programs referencing them compile end-to-end.

## What's in this PR

Lowering injects one synthetic \`IrTypeDecl\` per entry in \`STDLIB_TYPES\` (generated in PR #159) before running auto-derive. From the walker's point of view these look identical to user-defined records, so no new special cases are needed downstream:

- Rust codegen emits \`pub struct ProcessStatus { ... }\` (with the same attribute handling as user records)
- WASM codegen picks up the record layout
- Field access, struct literals, and type-annotated parameters / returns all work

### Verified end-to-end

Program:

\`\`\`almide
import process

fn mk(c: Int, o: String, e: String) -> process.ProcessStatus =
  { code: c, stdout: o, stderr: e }

effect fn main() -> () = {
  let s = mk(42, \"hi\", \"\")
  println(int.to_string(s.code))
  println(s.stdout)
}
\`\`\`

- \`almide run\` — prints \`42\` / \`hi\`
- \`almide build --target wasm\` + \`wasmtime\` — same output

## Test plan

- [x] Added \`spec/stdlib/process_named_type_test.almd\` covering construction, annotated literals, field reads
- [x] \`almide test\` — 201 test files pass (including the new test)
- [x] Native + WASM both emit and execute correctly
- [ ] CI passes

## Not in this PR

- \`process.exec_status\` / \`fs.stat\` still return tuples. Migrating them to named records + the build-time consistency check land in PR 4.