### PR TITLE
Diagnostic improvements: LLM-friendly errors + duplicate detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-base/src/diagnostic.rs
+++ b/crates/almide-base/src/diagnostic.rs
@@ -21,9 +21,11 @@ fn levenshtein(a: &str, b: &str) -> usize {
 }
 
 /// Find the best "did you mean?" suggestion from a list of candidates.
-/// Returns None if no candidate is close enough (threshold: distance < name.len()/3 + 1).
+/// Returns None if no candidate is close enough.
+/// Threshold grows with name length: `max(3, name.len() / 2)` so that
+/// longer names like `to_code_points` → `codepoint` (dist 5) still match.
 pub fn suggest<'a>(name: &str, candidates: impl Iterator<Item = &'a str>) -> Option<String> {
-    let threshold = name.len() / 3 + 1;
+    let threshold = (name.len() / 2).max(3);
     let mut best: Option<(&str, usize)> = None;
     for c in candidates {
         let dist = levenshtein(name, c);

--- a/crates/almide-frontend/src/canonicalize/mod.rs
+++ b/crates/almide-frontend/src/canonicalize/mod.rs
@@ -71,6 +71,9 @@ pub fn canonicalize_program<'a>(
     // 4. Register main program declarations
     registration::register_decls(&mut env, &mut diagnostics, &program.decls, None);
 
+    // 5. Carry parse-failure fn names so checker can suppress cascades.
+    env.failed_fn_names.extend(program.failed_fn_names.iter().cloned());
+
     CanonicalizationResult { env, diagnostics }
 }
 

--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -388,10 +388,65 @@ pub fn register_type_decl(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, 
 
 /// Walk all declarations and register them into the type environment.
 pub fn register_decls(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, decls: &[ast::Decl], prefix: Option<&str>) {
+    // Catch duplicate `fn <name>` / `test "<name>"` at the Almide stage so that
+    // rustc's E0428 "defined multiple times" never leaks to the user with a
+    // src/main.rs span. Tracked per (kind, name), remembering the first span.
+    let mut seen_fn: HashMap<String, Option<ast::Span>> = HashMap::new();
+    let mut seen_test: HashMap<String, Option<ast::Span>> = HashMap::new();
+
     for decl in decls {
         match decl {
-            ast::Decl::Fn { name, params, return_type, effect, r#async, generics, span, visibility, .. } => {
+            ast::Decl::Fn { name, params, return_type, effect, r#async, generics, span, visibility, extern_attrs, .. } => {
+                // Skip duplicates that come from @extern re-export (name may appear twice by design).
+                if extern_attrs.is_empty() {
+                    let key = prefixed_key(prefix, name);
+                    if let Some(first_span) = seen_fn.get(&key) {
+                        let mut diag = err(
+                            format!("duplicate function '{}'", name),
+                            format!("Rename one of the definitions, or remove the earlier one. Almide requires each function name to be unique within a module."),
+                            format!("fn {}", name),
+                        ).with_code("E012");
+                        if let Some(s) = span {
+                            diag.line = Some(s.line);
+                            diag.col = Some(s.col);
+                        }
+                        if let Some(first) = first_span {
+                            diag.secondary.push(almide_base::diagnostic::SecondarySpan {
+                                line: first.line,
+                                col: Some(first.col),
+                                label: format!("first definition of '{}' here", name),
+                            });
+                        }
+                        diagnostics.push(diag);
+                        continue;
+                    }
+                    seen_fn.insert(key, span.clone());
+                }
                 register_fn_sig(env, name, params, return_type, effect, r#async, generics, prefix, span.as_ref(), *visibility);
+            }
+            ast::Decl::Test { name, span, .. } => {
+                let test_key = name.to_string();
+                if let Some(first_span) = seen_test.get(&test_key) {
+                    let mut diag = err(
+                        format!("duplicate test '{}'", name),
+                        format!("Rename one of the tests, or merge them. Each test name must be unique within a file."),
+                        format!("test \"{}\"", name),
+                    ).with_code("E012");
+                    if let Some(s) = span {
+                        diag.line = Some(s.line);
+                        diag.col = Some(s.col);
+                    }
+                    if let Some(first) = first_span {
+                        diag.secondary.push(almide_base::diagnostic::SecondarySpan {
+                            line: first.line,
+                            col: Some(first.col),
+                            label: format!("first test '{}' here", name),
+                        });
+                    }
+                    diagnostics.push(diag);
+                    continue;
+                }
+                seen_test.insert(test_key, span.clone());
             }
             ast::Decl::Type { name, ty, deriving, generics, .. } => {
                 register_type_decl(env, diagnostics, name, ty, deriving, generics, prefix);

--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -132,6 +132,30 @@ impl Checker {
                     all_args.extend(arg_tys.iter().cloned());
                     return self.check_named_call(&field, &all_args);
                 }
+                // Almide-specific hint: method-call syntax isn't supported.
+                // If obj_ty maps to a stdlib module, suggest the module-call
+                // form (plus the closest existing name if there's a typo).
+                if let Some(module) = builtin_module {
+                    let module_funcs = crate::stdlib::module_functions(module);
+                    let suggestion = almide_base::diagnostic::suggest(&field, module_funcs.iter().copied());
+                    let hint = if let Some(close) = suggestion {
+                        format!(
+                            "Almide doesn't use method-call syntax. Write `{m}.{close}(x)` (or `x |> {m}.{close}`). Method syntax `x.{field}()` is not supported.",
+                            m = module, close = close, field = field
+                        )
+                    } else {
+                        format!(
+                            "Almide doesn't use method-call syntax. Write `{m}.<fn>(x)` (or `x |> {m}.<fn>`) — there is no method `{field}` on `{m}`. Run `almide explain E002` for examples.",
+                            m = module, field = field
+                        )
+                    };
+                    self.emit(super::err(
+                        format!("undefined method '{}' on {}", field, module),
+                        hint,
+                        format!("method call .{}()", field)
+                    ).with_code("E002"));
+                    return Ty::Unknown;
+                }
                 let ret = self.fresh_var();
                 self.constrain(obj_ty, Ty::Fn { params: arg_tys.to_vec(), ret: Box::new(ret.clone()) }, "method call");
                 ret
@@ -254,6 +278,12 @@ impl Checker {
                     }
                 }
             };
+            // Cascade suppression: if `name` belongs to a fn whose body failed
+            // to parse, the real error is already on top. Skip emitting E002
+            // so the LLM focuses on the parse error, not N identical cascades.
+            if self.env.failed_fn_names.contains(name) {
+                return Ty::Unknown;
+            }
             self.emit(super::err(format!("undefined function '{}'", name), hint, format!("call to {}()", name)).with_code("E002"));
             return Ty::Unknown;
         };
@@ -361,9 +391,18 @@ impl Checker {
             for (i, (aty, ety)) in arg_tys.iter().zip(expected_tys.iter()).enumerate() {
                 let concrete_arg = resolve_ty(aty, &self.uf);
                 if concrete_arg != Ty::Unknown && !ety.compatible(&concrete_arg) {
+                    // Richer hint: show the constructor signature + a conversion
+                    // suggestion when the argument type is numeric / string-like.
+                    let sig_shape = expected_tys.iter()
+                        .map(|t| t.display()).collect::<Vec<_>>().join(", ");
+                    let base = format!(
+                        "{}({}) expects argument #{} to be {}, got {}",
+                        name, sig_shape, i + 1, ety.display(), concrete_arg.display()
+                    );
+                    let hint = Self::hint_with_conversion(&base, ety, &concrete_arg);
                     self.emit(super::err(
                         format!("{}() argument {} expects {} but got {}", name, i + 1, ety.display(), concrete_arg.display()),
-                        "Fix the argument type", format!("constructor {}()", name)).with_code("E005"));
+                        hint, format!("constructor {}()", name)).with_code("E005"));
                 }
             }
         }

--- a/crates/almide-frontend/src/check/solving.rs
+++ b/crates/almide-frontend/src/check/solving.rs
@@ -19,10 +19,12 @@ impl Checker {
                 let exp = resolve_ty(&c.expected, &self.uf);
                 let act = resolve_ty(&c.actual, &self.uf);
                 if exp != Ty::Unknown && act != Ty::Unknown {
-                    let hint = Self::hint_with_conversion(
-                        "Fix the expression type or change the expected type",
-                        &exp, &act,
-                    );
+                    let base = match c.context.as_str() {
+                        "match arm" => "All match arms must share the same type. Change the mismatched arm to return the same type as the others, or change the first arm",
+                        "if branches" | "if arm" => "Both branches of `if/then/else` must have the same type",
+                        _ => "Fix the expression type or change the expected type",
+                    };
+                    let hint = Self::hint_with_conversion(base, &exp, &act);
                     // Temporarily swap in the constraint's own span so the
                     // error is reported at the call site where the constraint
                     // was introduced, not at wherever checking happened to

--- a/crates/almide-frontend/src/type_env.rs
+++ b/crates/almide-frontend/src/type_env.rs
@@ -75,6 +75,10 @@ pub struct TypeEnv {
     pub fn_decl_spans: std::collections::HashMap<Sym, (usize, usize)>,
     /// Whether we're inside a test block (effect fn calls return Result[T, String])
     pub in_test_block: bool,
+    /// Fn names whose parse failed mid-body. Checker suppresses cascading
+    /// "undefined function 'name'" diagnostics for calls to these — the real
+    /// cause is the parse error already surfaced.
+    pub failed_fn_names: std::collections::HashSet<String>,
 }
 
 impl TypeEnv {
@@ -111,6 +115,7 @@ impl TypeEnv {
             impl_validated: std::collections::HashSet::new(),
             fn_decl_spans: std::collections::HashMap::new(),
             in_test_block: false,
+            failed_fn_names: std::collections::HashSet::new(),
         }
     }
 

--- a/crates/almide-syntax/src/ast.rs
+++ b/crates/almide-syntax/src/ast.rs
@@ -314,6 +314,10 @@ pub struct Program {
     /// Number of blank lines before each decl (parallel to `decls`).
     #[serde(skip)]
     pub blank_lines_map: Vec<u32>,
+    /// Names of fn declarations whose body parse failed. Lets the checker
+    /// suppress cascading "undefined function" diagnostics from call sites.
+    #[serde(skip)]
+    pub failed_fn_names: std::collections::HashSet<String>,
 }
 
 // ── Generic AST visitor ──

--- a/crates/almide-syntax/src/parser/declarations.rs
+++ b/crates/almide-syntax/src/parser/declarations.rs
@@ -310,55 +310,67 @@ impl Parser {
         if self.check(TokenType::Effect) { self.advance(); effect = true; }
         self.expect(TokenType::Fn)?;
         let name = self.expect_any_fn_name()?;
-        let generics = self.try_parse_generic_params()?;
-        let open_fn = self.current().clone();
-        self.expect(TokenType::LParen)?;
-        let params = self.parse_param_list()?;
-        self.expect_closing(TokenType::RParen, open_fn.line, open_fn.col, "function parameters")?;
-        self.expect(TokenType::Arrow)?;
-        let return_type = self.parse_type_expr()?;
+        // Once the fn name is known, any later parse error in this decl is a
+        // cascading source — record the name so the checker can suppress
+        // downstream "undefined function 'name'" noise from call sites.
+        let recorded_name = name.clone();
+        let mut failed = true;
+        let result = (|| -> Result<Decl, String> {
+            let generics = self.try_parse_generic_params()?;
+            let open_fn = self.current().clone();
+            self.expect(TokenType::LParen)?;
+            let params = self.parse_param_list()?;
+            self.expect_closing(TokenType::RParen, open_fn.line, open_fn.col, "function parameters")?;
+            self.expect(TokenType::Arrow)?;
+            let return_type = self.parse_type_expr()?;
 
-        if self.check(TokenType::LBrace) {
-            let tok = self.current();
-            return Err(format!(
-                "Missing '=' before function body at line {}:{}\n  Hint: Almide requires '=' before the body. Write: fn {}(...) -> Type = {{ ... }}",
-                tok.line, tok.col, name
-            ));
-        }
-
-        let body = if self.check(TokenType::Eq) {
-            self.advance();
-            self.skip_newlines();
-            let mut body = if self.check(TokenType::Let) || self.check(TokenType::Var)
-                || self.check(TokenType::Guard)
-            {
-                self.parse_braceless_block()?
-            } else {
-                self.parse_expr()?
-            };
-
-            let returns_result = matches!(&return_type,
-                TypeExpr::Generic { name, .. } if name == "Result"
-            );
-            if effect && returns_result {
-                body = self.wrap_effect_result_body(body);
+            if self.check(TokenType::LBrace) {
+                let tok = self.current();
+                return Err(format!(
+                    "Missing '=' before function body at line {}:{}\n  Hint: Almide requires '=' before the body. Write: fn {}(...) -> Type = {{ ... }}",
+                    tok.line, tok.col, name
+                ));
             }
 
-            Some(body)
-        } else {
-            None
-        };
+            let body = if self.check(TokenType::Eq) {
+                self.advance();
+                self.skip_newlines();
+                let mut body = if self.check(TokenType::Let) || self.check(TokenType::Var)
+                    || self.check(TokenType::Guard)
+                {
+                    self.parse_braceless_block()?
+                } else {
+                    self.parse_expr()?
+                };
 
-        Ok(Decl::Fn {
-            name,
-            r#async: if async_ { Some(true) } else { None },
-            effect: if effect { Some(true) } else { None },
-            visibility,
-            extern_attrs: Vec::new(),
-            export_attrs: Vec::new(),
-            generics, params, return_type, body,
-            span: Some(span),
-        })
+                let returns_result = matches!(&return_type,
+                    TypeExpr::Generic { name, .. } if name == "Result"
+                );
+                if effect && returns_result {
+                    body = self.wrap_effect_result_body(body);
+                }
+
+                Some(body)
+            } else {
+                None
+            };
+
+            Ok(Decl::Fn {
+                name: name.clone(),
+                r#async: if async_ { Some(true) } else { None },
+                effect: if effect { Some(true) } else { None },
+                visibility,
+                extern_attrs: Vec::new(),
+                export_attrs: Vec::new(),
+                generics, params, return_type, body,
+                span: Some(span),
+            })
+        })();
+        if result.is_ok() { failed = false; }
+        if failed {
+            self.failed_fn_names.insert(recorded_name.to_string());
+        }
+        result
     }
 
     fn wrap_effect_result_body(&mut self, body: Expr) -> Expr {

--- a/crates/almide-syntax/src/parser/entry.rs
+++ b/crates/almide-syntax/src/parser/entry.rs
@@ -33,6 +33,7 @@ impl Parser {
             comment_map: Vec::new(),
             doc_map: Vec::new(),
             blank_lines_map: Vec::new(),
+            failed_fn_names: std::collections::HashSet::new(),
         };
 
         let (mut pending, mut gap_blanks) = self.skip_newlines_collect_comments();
@@ -78,10 +79,15 @@ impl Parser {
             program.comment_map.push(std::mem::take(&mut pending));
             gap_blanks = 0;
 
+            let pre_err_len = self.errors.len();
             match self.parse_top_decl() {
                 Ok(decl) => program.decls.push(decl),
                 Err(msg) => {
-                    self.errors.push(self.string_to_diagnostic(&msg));
+                    // If parse_top_decl (or anything it called) already pushed
+                    // a rich diagnostic, skip the string-form duplicate.
+                    if self.errors.len() == pre_err_len {
+                        self.errors.push(self.string_to_diagnostic(&msg));
+                    }
                     self.skip_to_next_decl();
                 }
             }
@@ -99,6 +105,7 @@ impl Parser {
             return Err(messages.join("\n"));
         }
 
+        program.failed_fn_names = std::mem::take(&mut self.failed_fn_names);
         Ok(program)
     }
 }

--- a/crates/almide-syntax/src/parser/mod.rs
+++ b/crates/almide-syntax/src/parser/mod.rs
@@ -33,11 +33,15 @@ pub struct Parser {
     pub(crate) file: Option<String>,
     pub(crate) next_expr_id: u32,
     pub(crate) depth: usize,
+    /// Names of fn declarations whose body failed to parse. Downstream checker
+    /// consults this set to suppress cascading "undefined function" diagnostics
+    /// so LLMs see the real parse error on top instead of 3× E002 repeats.
+    pub failed_fn_names: std::collections::HashSet<String>,
 }
 
 impl Parser {
     pub fn new(tokens: Vec<Token>) -> Self {
-        Parser { tokens, pos: 0, errors: Vec::new(), file: None, next_expr_id: 0, depth: 0 }
+        Parser { tokens, pos: 0, errors: Vec::new(), file: None, next_expr_id: 0, depth: 0, failed_fn_names: std::collections::HashSet::new() }
     }
 
     pub(crate) fn next_id(&mut self) -> ExprId {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -372,10 +372,31 @@ fn cargo_build_test_with_native(
             }
         }
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        if rendered.is_empty() {
-            return Err(stderr);
-        }
-        return Err(format!("{}\n{}", rendered.join("\n"), stderr));
+        let combined = if rendered.is_empty() {
+            stderr
+        } else {
+            format!("{}\n{}", rendered.join("\n"), stderr)
+        };
+        // Wrap: rustc errors that leaked through the Almide checker mean our
+        // codegen produced invalid Rust. Surfacing `src/main.rs` paths to users
+        // is useless (it's not their source). Replace with a bug-report banner.
+        let mentions_main_rs = combined.contains("src/main.rs");
+        let final_err = if mentions_main_rs {
+            let scrubbed = combined
+                .replace("src/main.rs", "<generated.rs>")
+                .replace("almide-out", "almide-generated");
+            format!(
+                "codegen produced invalid Rust — this is an Almide bug.\n\
+                 Please file a minimal repro at https://github.com/almide/almide/issues\n\
+                 \n\
+                 --- rustc output (edited to hide generated paths) ---\n\
+                 {}",
+                scrubbed
+            )
+        } else {
+            combined
+        };
+        return Err(final_err);
     }
 
     // Parse the JSON output to find the test binary path


### PR DESCRIPTION
## Summary

Ships the LLM-friendly diagnostic work driven by almide-dojo retry-loop data, plus an upstream catch for the rustc `E0428` leak.

### Checker improvements
- **Parse-error cascade suppression**: when `fn foo` fails to parse its body, downstream `undefined function 'foo'` diagnostics from call sites are suppressed. Parser tracks failed fn names; checker consults `env.failed_fn_names`.
- **Method-syntax hint**: `n.to_uppercase()` on a `String` now emits `E002: undefined method 'to_uppercase' on string` with `hint: Almide doesn't use method-call syntax. Write 'string.to_upper(x)' (or 'x |> string.to_upper')`. Includes closest-name suggestion.
- **Wider "did you mean" threshold**: `name.len() / 2` (was `/ 3 + 1`), so `string.to_code_points` now suggests `string.codepoint`.
- **E001 match-arm hint**: `hint: All match arms must share the same type. Change the mismatched arm ...`
- **E005 richer hint**: shows full constructor signature + conversion helper, e.g. `Pt(Int, Int) expects argument #1 to be Int, got String. Or use 'int.parse(s)' ...`

### Upstream rustc leak catches (E0428)
- **E012 duplicate fn / duplicate test** caught at the Almide checker stage with the real `.almd` line. rustc's `E0428: defined multiple times --> src/main.rs:40:5` no longer reaches users in these cases.
- **Safety net**: any leaked rustc output that still mentions `src/main.rs` is wrapped in `codegen produced invalid Rust — this is an Almide bug. Please file a minimal repro...`, with `src/main.rs` rewritten to `<generated.rs>` and `almide-out` → `almide-generated`.

### Dedupe
- Parse-error duplicate (rich diag + plain-text string form) deduplicated at `entry.rs`.

## Test plan

- [x] All 205 Almide spec files pass on Rust target
- [x] Parse cascade: 3 errors → 1 for the reported `sum_digits` example
- [x] Method syntax: `n.to_uppercase()` → Almide-specific hint with `string.to_upper` suggestion
- [x] Did-you-mean: `string.to_code_points` / `string.from_code_points` both get `codepoint` / `from_codepoint` suggestion
- [x] Duplicate test: `rustc E0428` replaced with `E012` at line 2
- [ ] CI (Linux / macOS / Windows build + test)

## Notes

Version bump deferred until after CI green.