### PR TITLE
Release v0.14.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ each entry groups by diagnostic-/tooling-/language-/stdlib-facing intent
 because that's what downstream consumers (LLM harnesses, editors, users)
 care about.
 
+## [0.14.8] — 2026-04-17
+
+Hotfix for a v0.14.7 regression: external package dispatch (e.g. `almai`
+loaded from `[dependencies]` in `almide.toml`) failed to link because the
+Phase 1b `ResolveCallsPass` rewrote every `CallTarget::Module` — including
+user-package modules — to a non-versioned mangled name. The walker then
+emitted those functions under their versioned identifier
+(`almide_rt_<pkg>_v<major>_<fn>`) while the call sites referenced the
+unversioned form (`almide_rt_<pkg>_<fn>`), producing Rust E0425 at
+compile time.
+
+### Fix
+
+`ResolveCallsPass` now gates its Module → Named rewrite on
+`stdlib_info::is_any_stdlib(m)`. Only bundled-Almide stdlib modules
+(`args`, `path`, `list`, …) — which never carry a `versioned_name` — are
+rewritten. User-package calls stay as `CallTarget::Module` and continue
+to flow through `StdlibLoweringPass::rewrite_module_names` (Rust) or the
+WASM `func_map` bare-name fallback, both of which know how to look up
+the versioned symbol.
+
+No surface changes. `almide test` (206 files) and `cargo test` pass;
+downstream `almide-dojo` (13 tests using `almai.defaults` /
+`almai.with_system` / `almai.call_with`) compiles and runs again.
+
 ## [0.14.7] — 2026-04-17
 
 Phase 3 "Ideal Form Migration" arc. Six ship points (`-phase3.1`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.14.7"
+version = "0.14.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-codegen/src/pass_resolve_calls.rs
+++ b/crates/almide-codegen/src/pass_resolve_calls.rs
@@ -69,14 +69,24 @@ impl NanoPass for ResolveCallsPass {
                     if let CallTarget::Module { module, func } = target {
                         let m = module.as_str();
                         let f = func.as_str();
-                        // bundled-Almide fn (in IR module, no TOML entry)
+                        // bundled-Almide stdlib fn (in IR module, no TOML entry)
                         // → rewrite to Named with the codegen-registered
                         // mangled name. Leaves TOML-backed stdlib calls as
                         // Module so the per-target dispatcher can apply
                         // arg decoration / inline emit.
+                        //
+                        // User-package modules (external deps loaded from
+                        // almide.toml) are NOT rewritten here: they carry a
+                        // `versioned_name` that the walker uses as the emit
+                        // prefix (`almide_rt_<pkg>_v<major>_<fn>`), and the
+                        // later `StdlibLoweringPass::rewrite_module_names`
+                        // (Rust) / direct Module dispatch (WASM) handle the
+                        // versioned lookup. Rewriting to a non-versioned
+                        // `almide_rt_<pkg>_<fn>` here would break the link.
+                        let is_stdlib = almide_lang::stdlib_info::is_any_stdlib(m);
                         let toml_has = arg_transforms::lookup(m, f).is_some();
                         let bundled_has = self.symbols.module_has_fn(m, f);
-                        if !toml_has && bundled_has {
+                        if is_stdlib && !toml_has && bundled_has {
                             let mangled = format!(
                                 "almide_rt_{}_{}",
                                 m.replace('.', "_"),

--- a/docs/roadmap/active/codegen-ideal-form.md
+++ b/docs/roadmap/active/codegen-ideal-form.md
@@ -107,6 +107,45 @@ Postcondition: `CallTarget::Module` / bare `CallTarget::Named` は全て `Resolv
 
 これが達成できれば、今回の `is_unresolved_structural()` vs `has_deep_unresolved()` vs `is_unresolved()` の地獄が解消する。
 
+**残 gap (v0.14.7 時点、21 件 on WASM `ALMIDE_CHECK_IR=1` audit)**:
+
+`ALMIDE_CHECK_IR=1` で spec/ を WASM 走らせると 15-21 件が audit 違反で panic。内訳:
+
+| pattern | 例 | 件数 |
+|---|---|---|
+| empty list/collection literal の element 型逆推論失敗 | `fn fan.map empty list: List[Unknown]` / `fn empty for: List[Unknown]` | 10+ |
+| Codec auto-derive の empty field | `fn decode_container: List[Unknown]` / `fn derive Codec: empty list field` | 3-4 |
+| Result/Option ok/some() で inner 型未決 | `fn safe_div: Result[Unknown, String]` / `fn validate_age` | 2-3 |
+| OpenRecord → concrete record 解決未 | `fn chain_b__Unknown: OpenRecord { name: String }` | 1 |
+| 深い generic context | `fn is_balanced: Option[List[Unknown]]` | 1 |
+| Event/Tuple empty payload | `fn extract_click_positions: List[Tuple[Unknown, Unknown]]` | 1 |
+
+default (no env var) では WASM emit 側の defensive fallback
+(`resolve_list_elem` の 4 段 fallback、`Unknown` → i32 assumption) が
+吸収するので 203/206 pass。潜在 risk: empty list が i32 element
+alloc されて後から i64 要素 push で layout 不整合、等。spec test に
+該当 pattern が無いだけで user code で踏み得る。
+
+**Fix の分解 (0.14.8 以降の sub-phase 候補)**:
+
+- (a) Empty literal の consumer 逆推論: `fn f(xs: List[Int]) = f([])`
+  で `[]: List[Int]` を引き当てる。checker 拡張、半日〜1日
+- (b) `ok(x)` / `some(x)` wrapper の inner 型推論: wrapper の引数型
+  を wrapper の expected ret_ty から逆引き。半日
+- (c) Codec auto-derive の empty field: `derive.rs` で empty list
+  field の element type を default に固定。1-2時間
+- (d) OpenRecord → concrete resolve: checker の open → closed 解決
+  path 整理。数日
+- (e) Event/Tuple empty payload: variant constructor の payload
+  types を variant sig から伝播。半日
+
+(a) + (b) + (c) で 17/21 、(d) + (e) で残 4。total 1 週間 scope。
+
+**当面のスタンス**: default では無害なので release blocker ではない。
+dojo measurement で user code に顕在化するパターンが出たら priority
+上げて潰す。stdlib-declarative-unification arc の合間に進めるのが
+自然 (両者とも WASM emit の精度向上という共通方向)。
+
 ### 5. VarTable の責務明確化
 
 **現状**:

--- a/llms.txt
+++ b/llms.txt
@@ -201,6 +201,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.14.7. In development: 0.14.7 (Ideal Form arc).
+- Current stable: v0.14.8. In development: 0.14.8 (Ideal Form arc).
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.


### PR DESCRIPTION
## Summary

Hotfix for a v0.14.7 regression: `ResolveCallsPass` rewrote every
`CallTarget::Module` — including user-package modules — to a
non-versioned mangled name. User packages (e.g. `almai` loaded from
`[dependencies]`) then failed to link because the walker emitted their
functions under the versioned identifier while the call sites referenced
the unversioned form.

Gate the rewrite on `stdlib_info::is_any_stdlib(m)` so only bundled-Almide
stdlib modules go through the Named path; user packages stay as `Module`
and continue flowing through `StdlibLoweringPass::rewrite_module_names`
(Rust) or the WASM `func_map` bare-name fallback.

## Test plan

- [x] `cargo test --release` — all passing
- [x] `almide test` — 206/206 files passing
- [x] `almide-dojo` local: `almide test src/main.almd` — 13/13 passing
- [x] CI green on develop