### PR TITLE
Add almide-egg-lab feasibility PoC

### DIFF
--- a/.github/workflows/ci-feature.yml
+++ b/.github/workflows/ci-feature.yml
@@ -43,7 +43,10 @@ jobs:
         run: cargo build --release
 
       - name: Cargo tests
-        run: cargo test
+        # --test-threads=1: fix_test spawns `almide run` as a sub-process
+        # and relies on cargo's incremental build cache; parallel runs
+        # hit the known race and flake. Matches ci.yml.
+        run: cargo test -- --test-threads=1
 
       - name: Run exercises (Rust target)
         continue-on-error: true  # TODO: re-enable after stdlib reconnection

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "almide-egg-lab"
+version = "0.1.0"
+dependencies = [
+ "egg",
+]
+
+[[package]]
 name = "almide-frontend"
 version = "0.12.2"
 dependencies = [
@@ -217,6 +224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,10 +313,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "egg"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb749745461743bb477fba3ef87c663d5965876155c676c9489cfe0963de5ab"
+dependencies = [
+ "env_logger",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "log",
+ "num-bigint",
+ "num-traits",
+ "quanta",
+ "rustc-hash",
+ "saturating",
+ "smallvec",
+ "symbol_table",
+ "symbolic_expressions",
+ "thiserror",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -380,6 +423,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -438,6 +483,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lasso"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +540,25 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -568,6 +642,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +746,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +781,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "saturating"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
 
 [[package]]
 name = "scopeguard"
@@ -755,6 +871,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "symbol_table"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f19bffd69fb182e684d14e3c71d04c0ef33d1641ac0b9e81c712c734e83703bc"
+dependencies = [
+ "crossbeam-utils",
+ "foldhash",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "symbolic_expressions"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c68d531d83ec6c531150584c42a4290911964d5f0d79132b193b67252a23b71"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +909,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -859,6 +1012,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +1033,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -930,6 +1134,38 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/almide-base", "crates/almide-syntax", "crates/almide-types", "crates/almide-lang", "crates/almide-ir", "crates/almide-codegen", "crates/almide-optimize", "crates/almide-frontend", "crates/almide-tools"]
+members = [".", "crates/almide-base", "crates/almide-syntax", "crates/almide-types", "crates/almide-lang", "crates/almide-ir", "crates/almide-codegen", "crates/almide-optimize", "crates/almide-frontend", "crates/almide-tools", "crates/almide-egg-lab"]
 resolver = "3"
 
 [package]

--- a/crates/almide-egg-lab/Cargo.toml
+++ b/crates/almide-egg-lab/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "almide-egg-lab"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Experimental crate: egg-based equality saturation over a minimal Almide IR subset"
+
+[dependencies]
+egg = "0.10"

--- a/crates/almide-egg-lab/README.md
+++ b/crates/almide-egg-lab/README.md
@@ -1,0 +1,80 @@
+# almide-egg-lab
+
+**Feasibility PoC for egg (equality saturation) on a minimal Almide IR subset.**
+
+This crate exists to answer one question before we commit to the
+10-month [MLIR Backend + Egg Rewrite Engine](../../docs/roadmap/active/mlir-backend-adoption.md)
+arc: *can egg actually express Almide's existing stream-fusion rules,
+terminate quickly, and pick the fused form?*
+
+## Verdict
+
+**Yes.** The 5 tests below pass in 1.5s on release build, covering
+the three most common fusion shapes plus transitive / cross-rule
+composition.
+
+| Test | What it proves |
+|---|---|
+| `identity_map_collapses` | `map(xs, identity) ≡ xs` — single-rule rewrite |
+| `map_map_fuses` | `map(map(xs, f), g) ≡ map(xs, g ∘ f)` — functor law |
+| `filter_filter_fuses` | `filter(filter(xs, p), q) ≡ filter(xs, p ∧ q)` — predicate conjunction |
+| `triple_map_fuses_transitively` | Three-stage chain folds to one traversal — saturation converges under iter/node budgets |
+| `identity_inside_map_chain_eliminates` | Identity elimination **+** map fusion compose **without explicit phase ordering** — the core motivation for choosing egg over priority-ordered rewriters (GHC RULES, MLIR PDL) |
+
+The last test is the key one. In the imperative `pass_stream_fusion`
+we have to decide the order: eliminate identity first, then fuse? Or
+fuse first, then notice the collapse? Each ordering misses some
+programs. With egg, we don't pick — saturation holds both alternatives
+in the e-graph and the extractor picks the cheapest.
+
+## Scope (intentionally small)
+
+- Models only the IR shapes needed for the three rules: `map`, `filter`,
+  `fold`, `lam`, `compose`, `and-pred`, plus numeric / symbolic atoms.
+- Does not substitute lambdas — uses `compose` / `and-pred` pseudo-ops
+  as markers. A later lowering step (Stage 1 of the arc) would
+  beta-reduce them into real lambdas.
+- Not wired into the main compiler pipeline. No codegen impact,
+  deletable with zero blast radius.
+
+## What this does NOT yet answer
+
+Tracked as open questions in the arc document:
+
+- **Type-aware rules.** Real Almide rules depend on element types
+  (`List[Int]` vs `List[String]`). egg supports this via `Analysis`
+  but we haven't exercised it.
+- **Large IR scale.** Tested up to three-stage chains. Stage 1 will
+  benchmark on programs of 100–1000 IR nodes to see if saturation
+  time stays tolerable.
+- **Cost-function calibration for targets.** The current `FusionCost`
+  just penalizes loops. Real target-aware costs (Rust iter-collect
+  vs WASM manual loop vs GPU offload) are a Stage 3 concern.
+- **Integration with `almide-ir::IrExpr`.** Translation in both
+  directions (`IrExpr` ↔ `RecExpr<AlmideExpr>`) is Stage 1 scope.
+
+## Running
+
+```bash
+cargo test -p almide-egg-lab --release
+```
+
+## Next step if kept
+
+If this PoC passes review, Stage 1 of the MLIR adoption arc (see
+`docs/roadmap/active/mlir-backend-adoption.md`) will:
+
+1. Expand the language to cover the full `IrExpr` enum
+2. Replace `lam`/`compose`/`and-pred` pseudo-ops with real lambda
+   substitution (custom `Applier`)
+3. Add type-parametric rules
+4. Port the remaining 4 `pass_stream_fusion` rules
+5. Run equality saturation as an opt-in pass before the existing
+   Nanopass pipeline
+
+## Next step if rejected
+
+If saturation proves intractable on real Almide programs, we fall
+back to GHC RULES-style priority rewriting inside the existing
+Nanopass framework. The MLIR adoption arc continues without egg.
+This crate gets deleted, no other code changes.

--- a/crates/almide-egg-lab/src/lib.rs
+++ b/crates/almide-egg-lab/src/lib.rs
@@ -1,0 +1,209 @@
+//! almide-egg-lab — Feasibility PoC for egg (equality saturation) on a
+//! minimal Almide IR subset.
+//!
+//! **Goal**: validate that egg can express and apply Almide's existing
+//! stream-fusion rewrite rules before we commit to the 10-month
+//! `mlir-backend-adoption` arc. This crate is intentionally isolated
+//! from the main compiler pipeline — if the experiment fails, we
+//! delete this crate with no blast radius.
+//!
+//! ## What this PoC proves / disproves
+//!
+//! - [x] `egg::define_language!` can model Almide-ish expressions
+//! - [x] Fusion rules port cleanly from imperative passes
+//! - [x] A custom cost function picks the fused form
+//! - [x] Equality saturation terminates inside a small iteration budget
+//!
+//! ## What this PoC intentionally omits
+//!
+//! - Real lambda substitution (we use `compose` / `and-pred` pseudo-ops
+//!   as markers; a later lowering step would beta-reduce them into
+//!   honest lambdas). egg supports substitution via custom `Applier`
+//!   impls, but that's Stage-1 work — not feasibility.
+//! - Full Almide IR coverage (we model only list combinators + lambda
+//!   shape needed for the 3 target rules).
+//! - Integration with `almide-ir::IrExpr` (the real lowering will
+//!   happen in Stage 1 if this PoC passes).
+
+use egg::*;
+
+define_language! {
+    /// Minimal Almide IR fragment for fusion experiments.
+    ///
+    /// `map`, `filter`, `fold` are modeled as loop-bearing ops (high
+    /// cost). `compose` / `and-pred` are zero-cost markers that stand
+    /// in for "the optimizer has fused two stages into one body"
+    /// without actually rebuilding the lambda.
+    ///
+    /// Atoms (`xs`, `identity`, variable names) are represented as
+    /// the default `Symbol` variant. Named lambda references use the
+    /// unary `(lam f)` form, where `f` is itself a `Symbol` node.
+    pub enum AlmideExpr {
+        // ── Numeric literal ───────────────────────────────────────
+        Num(i64),
+
+        // ── List combinators (each represents one traversal) ──────
+        "map" = Map([Id; 2]),        // (map xs f)
+        "filter" = Filter([Id; 2]),  // (filter xs p)
+        "fold" = Fold([Id; 3]),      // (fold xs init f)
+
+        // ── Lambda reference ──────────────────────────────────────
+        // `(lam f)` — opaque reference to a lambda named `f`. In a
+        // real lowering these would be IrExpr::Lambda nodes; the PoC
+        // treats them as atoms keyed by their Symbol payload.
+        "lam" = Lam([Id; 1]),
+
+        // ── Fusion markers (zero-cost pseudo-ops) ─────────────────
+        // `(compose g f)` means `λx. g(f(x))`. A later pass would
+        // replace this with a real lambda IR node.
+        "compose" = Compose([Id; 2]),
+        // `(and-pred p q)` means `λx. p(x) and q(x)`.
+        "and-pred" = AndPred([Id; 2]),
+
+        // ── Default variant ───────────────────────────────────────
+        // Any bare atom: variable name (`xs`), lambda marker
+        // (`identity`), user-supplied fn symbol (`f`, `g`, `p`).
+        Symbol(Symbol),
+    }
+}
+
+/// Rewrite rules mirroring the behavior of the imperative
+/// `pass_stream_fusion` in `almide-codegen`.
+///
+/// These three are the minimum needed to demonstrate that egg
+/// subsumes the existing fusion logic. Adding more (`map_fold`,
+/// `flatmap_flatmap`, `filter_map_fold`, …) follows the same shape.
+pub fn fusion_rules() -> Vec<Rewrite<AlmideExpr, ()>> {
+    vec![
+        // FunctorIdentity: map(xs, (x => x)) ≡ xs
+        rewrite!("identity-map"; "(map ?xs identity)" => "?xs"),
+
+        // Functor law: map(map(xs, f), g) ≡ map(xs, g ∘ f)
+        rewrite!("map-map-fuse";
+            "(map (map ?xs ?f) ?g)"
+            => "(map ?xs (compose ?g ?f))"),
+
+        // Predicate conjunction: filter(filter(xs, p), q) ≡ filter(xs, p ∧ q)
+        rewrite!("filter-filter-fuse";
+            "(filter (filter ?xs ?p) ?q)"
+            => "(filter ?xs (and-pred ?p ?q))"),
+    ]
+}
+
+/// Cost function that reflects Almide's real target preference:
+/// each list-traversing op (`map` / `filter` / `fold`) pays a loop
+/// penalty, while fusion markers (`compose`, `and-pred`) are free.
+///
+/// The penalty picks "one loop" over "two loops" even when the node
+/// count is equal, which is what the StreamFusion imperative pass
+/// does implicitly.
+pub struct FusionCost;
+
+impl CostFunction<AlmideExpr> for FusionCost {
+    type Cost = u64;
+
+    fn cost<C>(&mut self, enode: &AlmideExpr, mut costs: C) -> u64
+    where
+        C: FnMut(Id) -> u64,
+    {
+        let self_cost: u64 = match enode {
+            AlmideExpr::Map(_) | AlmideExpr::Filter(_) | AlmideExpr::Fold(_) => 100,
+            AlmideExpr::Compose(_) | AlmideExpr::AndPred(_) => 1,
+            _ => 1,
+        };
+        enode.fold(self_cost, |acc, id| acc.saturating_add(costs(id)))
+    }
+}
+
+/// Run equality saturation on `input` and extract the optimal form
+/// under `FusionCost`. Returns the best expression plus the number of
+/// iterations used.
+pub fn optimize(input: &str) -> (RecExpr<AlmideExpr>, usize) {
+    let expr: RecExpr<AlmideExpr> = input.parse().expect("parse AlmideExpr");
+    let runner = Runner::default()
+        .with_iter_limit(64)
+        .with_node_limit(10_000)
+        .with_expr(&expr)
+        .run(&fusion_rules());
+    let root = runner.roots[0];
+    let extractor = Extractor::new(&runner.egraph, FusionCost);
+    let (_cost, best) = extractor.find_best(root);
+    (best, runner.iterations.len())
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expect_rewrite(input: &str, expected: &str) {
+        let (best, iters) = optimize(input);
+        let best_str = best.to_string();
+        let expected_expr: RecExpr<AlmideExpr> = expected.parse().expect("parse expected");
+        assert_eq!(
+            best_str,
+            expected_expr.to_string(),
+            "\n  input:    {}\n  expected: {}\n  got:      {}\n  iters:    {}",
+            input, expected, best_str, iters,
+        );
+        // Feasibility sanity: saturation should converge quickly for
+        // these tiny fragments. If this ever explodes we want to know.
+        assert!(iters < 32, "unexpectedly many iterations: {}", iters);
+    }
+
+    #[test]
+    fn identity_map_collapses() {
+        expect_rewrite("(map xs identity)", "xs");
+    }
+
+    #[test]
+    fn map_map_fuses() {
+        expect_rewrite(
+            "(map (map xs (lam f)) (lam g))",
+            "(map xs (compose (lam g) (lam f)))",
+        );
+    }
+
+    #[test]
+    fn filter_filter_fuses() {
+        expect_rewrite(
+            "(filter (filter xs (lam p)) (lam q))",
+            "(filter xs (and-pred (lam p) (lam q)))",
+        );
+    }
+
+    /// Transitive fusion: three chained maps should fold into one
+    /// with a nested compose marker. This is the property that makes
+    /// egg interesting — imperative fusion needs an explicit loop to
+    /// converge, equality saturation handles it by fixpoint.
+    #[test]
+    fn triple_map_fuses_transitively() {
+        let (best, _) = optimize("(map (map (map xs (lam f)) (lam g)) (lam h))");
+        let best_str = best.to_string();
+        // We don't care about the exact parenthesization of the
+        // compose chain, only that the outer form is a single map
+        // and both inner lambdas appear inside a compose.
+        assert!(
+            best_str.starts_with("(map xs "),
+            "expected single outer map, got: {}",
+            best_str,
+        );
+        assert!(
+            best_str.contains("compose"),
+            "expected compose marker, got: {}",
+            best_str,
+        );
+    }
+
+    /// Identity interacts with fusion: map(map(xs, id), f) should
+    /// collapse to map(xs, f) by way of (identity-map ∘ nothing).
+    /// This checks that equality saturation composes rules without
+    /// manual ordering — the feasibility proof for phase-order-free
+    /// optimization.
+    #[test]
+    fn identity_inside_map_chain_eliminates() {
+        let (best, _) = optimize("(map (map xs identity) (lam f))");
+        assert_eq!(best.to_string(), "(map xs (lam f))");
+    }
+}


### PR DESCRIPTION
## Summary

Feasibility PoC for the egg (equality saturation) side of the
[MLIR Backend + Egg Rewrite Engine](../blob/develop/docs/roadmap/active/mlir-backend-adoption.md)
arc. Independent, opt-in crate — main pipeline untouched.

**Verdict**: 🟢 egg fits Almide IR. Arc can proceed.

Key property demonstrated: identity elimination + map fusion compose
across rules **without manual phase ordering** — the core reason to
pick egg over priority-ordered rewriters (GHC RULES / MLIR PDL).

Also includes a CI fix: `ci-feature.yml` was missing the
`--test-threads=1` flag that `ci.yml` already had for the
pre-existing `fix_test` cache race. Orthogonal to the PoC but
blocks this branch from going green without it.

## Test plan

- [x] `cargo test -p almide-egg-lab --release` — 5 passed in 1.5s
- [x] `cargo test --release -- --test-threads=1` — full suite green
- [x] Feature Branch CI green on the latest commit