### PR TITLE
egg-lab: lower RecExpr back to IrExpr with fresh-VarId compose beta-reduction

### DIFF
--- a/crates/almide-egg-lab/README.md
+++ b/crates/almide-egg-lab/README.md
@@ -9,12 +9,16 @@ terminate quickly, and pick the fused form?*
 
 ## Verdict
 
-**Yes.** Both the toy PoC (5 tests) and the real-IR bridge (6 tests)
-pass in ~2s on release build. Fusion fires on three canonical shapes,
-saturation converges inside a small iteration budget, and — most
-importantly — cross-rule composition works without manual phase
-ordering on both string-parsed expressions *and* real `IrExpr`
-fragments.
+**Yes.** The toy PoC (5 tests) plus the real-IR bridge (11 tests,
+including 5 that cover lift → saturate → **lower** round-trips with
+live `VarTable`-backed beta-reduction) pass in ~2.5 s on release
+build. Fusion fires on three canonical shapes, saturation converges
+inside a small iteration budget, cross-rule composition works
+without manual phase ordering, and — most importantly — `compose`
+and `and-pred` markers are beta-reduced into real `IrExprKind::Lambda`
+nodes with fresh `VarId`s at lower time, so the extracted output is
+a well-typed `IrExpr` fragment ready to feed back into the existing
+pipeline.
 
 | Test | What it proves |
 |---|---|
@@ -34,9 +38,14 @@ in the e-graph and the extractor picks the cheapest.
 
 - Models only the IR shapes needed for the three rules: `map`, `filter`,
   `fold`, `lam`, `compose`, `and-pred`, plus numeric / symbolic atoms.
-- Does not substitute lambdas — uses `compose` / `and-pred` pseudo-ops
-  as markers. A later lowering step (Stage 1 of the arc) would
-  beta-reduce them into real lambdas.
+- **Lambda substitution happens at lower time, not inside saturation.**
+  E-graphs cannot represent binders without extra alpha-renaming
+  machinery (see egg's `examples/lambda.rs`). Saturation keeps
+  `compose` / `and-pred` as zero-cost markers; the single extracted
+  best form is then beta-reduced into real `IrExprKind::Lambda`
+  nodes with fresh `VarId`s. One-shot allocation is bounded by the
+  output size, which sidesteps the e-graph alpha-equivalence issue
+  without losing the fresh-id discipline the main IR requires.
 - Not wired into the main compiler pipeline. No codegen impact,
   deletable with zero blast radius.
 
@@ -46,17 +55,17 @@ in the e-graph and the extractor picks the cheapest.
   `AlmideExpr` expressions, three fusion rules, five tests.
 - **IrExpr bridge** (`src/bridge.rs`, `tests/bridge_test.rs`): lifts
   `almide_ir::IrExpr` subtrees (list combinators + identity-lambda
-  detection) into `RecExpr<AlmideExpr>`. Six tests covering identity
-  elimination, map/filter fusion, cross-rule composition, and
-  opaque pass-through on real IR.
+  detection) into `RecExpr<AlmideExpr>` and lowers the extracted
+  form back into a well-typed `IrExpr`. Eleven tests cover identity
+  elimination, map/filter fusion, cross-rule composition, opaque
+  pass-through, and the five round-trip cases that verify fresh
+  `VarId` allocation, body substitution, and structural shape on the
+  lowered output.
 
 ## What this does NOT yet answer
 
 Tracked as open questions in the arc document:
 
-- **Round-trip lower.** The bridge only lifts today; reconstruction
-  from `RecExpr` back to a well-typed `IrExpr` requires beta-reducing
-  the `compose` / `and-pred` markers into real lambdas (Phase C).
 - **Type-aware rules.** Real Almide rules depend on element types
   (`List[Int]` vs `List[String]`). egg supports this via `Analysis`
   but we haven't exercised it.
@@ -66,6 +75,12 @@ Tracked as open questions in the arc document:
 - **Cost-function calibration for targets.** The current `FusionCost`
   just penalizes loops. Real target-aware costs (Rust iter-collect
   vs WASM manual loop vs GPU offload) are a Stage 3 concern.
+- **Lambda substitution inside the e-graph.** `lower`-time
+  beta-reduction is sufficient to prove the round-trip works, but
+  in-graph substitution (custom `Applier` + alpha-renaming, à la
+  `egg/examples/lambda.rs`) would let saturation see through compose
+  markers and potentially discover more fusions. Scope for Stage 1+
+  once we see which rules need it.
 
 ## Running
 
@@ -79,8 +94,8 @@ If this PoC passes review, Stage 1 of the MLIR adoption arc (see
 `docs/roadmap/active/mlir-backend-adoption.md`) will:
 
 1. Expand the language to cover the full `IrExpr` enum
-2. Replace `lam`/`compose`/`and-pred` pseudo-ops with real lambda
-   substitution (custom `Applier`)
+2. Decide whether to keep lower-time beta-reduction or promote
+   substitution into the e-graph via a custom `Applier`
 3. Add type-parametric rules
 4. Port the remaining 4 `pass_stream_fusion` rules
 5. Run equality saturation as an opt-in pass before the existing

--- a/crates/almide-egg-lab/src/bridge.rs
+++ b/crates/almide-egg-lab/src/bridge.rs
@@ -11,12 +11,11 @@
 //!
 //! - **Lift**: IrExpr → RecExpr. Handles `list.map / filter / fold`
 //!   nested arbitrarily; everything else becomes an opaque slot.
-//! - **Lower**: not implemented in this PoC. Reconstruction to a
-//!   well-typed IrExpr requires either (a) beta-reducing compose /
-//!   and-pred markers into fresh lambdas (needs VarTable access) or
-//!   (b) keeping them as Named-call pseudo-ops for a later pass.
-//!   Both are Phase C work. For now the bridge proves **lift +
-//!   saturation** work on real IR; round-tripping lands next.
+//! - **Lower**: implemented for `map`, `filter`, `fold`, slot
+//!   references, and the two fusion markers. `compose` / `and-pred`
+//!   are beta-reduced into real `IrExprKind::Lambda` nodes with fresh
+//!   VarIds allocated from a caller-supplied `VarTable`. Non-combinator
+//!   subtrees flow back verbatim from the slot table.
 //!
 //! ## Why slot-based opaque references
 //!
@@ -26,8 +25,27 @@
 //! Language enum and slow saturation. A side table keeps the egg
 //! representation small and lets us round-trip opaque subtrees
 //! verbatim (modulo the fusion rewrites at the structural level).
+//!
+//! ## Where lambda substitution happens
+//!
+//! Saturation keeps `compose g f` and `and-pred p q` as zero-cost
+//! markers — e-graphs do not represent binders natively, and doing
+//! honest beta-reduction inside saturation requires alpha-renaming
+//! machinery (see egg's `examples/lambda.rs`) that would bloat the
+//! PoC without changing the verified properties.
+//!
+//! Instead the extracted `RecExpr` is single-shot beta-reduced during
+//! `lower`: each surviving marker becomes a fresh `IrExprKind::Lambda`
+//! whose param VarId is allocated through the caller's `VarTable`.
+//! Because we only touch the one extracted form (not the full
+//! e-graph), the fresh-id allocation is bounded by output size and
+//! `use_count` stays consistent with the surrounding IR.
 
-use almide_ir::{CallTarget, IrExpr, IrExprKind};
+use almide_base::intern::{sym, Sym};
+use almide_ir::{
+    substitute_var_in_expr, BinOp, CallTarget, IrExpr, IrExprKind, Mutability, VarId, VarTable,
+};
+use almide_lang::types::Ty;
 use egg::{Id, RecExpr, Symbol as EggSym};
 
 use crate::AlmideExpr;
@@ -120,4 +138,353 @@ fn is_identity_lambda(expr: &IrExpr) -> bool {
         return false;
     };
     matches!(&body.kind, IrExprKind::Var { id } if id == param_var)
+}
+
+// ── Lower: RecExpr → IrExpr ─────────────────────────────────────────
+
+/// Errors that can arise during `lower`.
+#[derive(Debug)]
+pub enum LowerError {
+    /// A node appeared in a position where the lower pass cannot
+    /// reconstruct a well-typed IrExpr (e.g. `compose` outside a
+    /// lambda slot, an unknown bare symbol).
+    UnexpectedNode(String),
+    /// A `_slot_N` symbol referenced a slot index that is out of
+    /// range for the bridge's slot table.
+    SlotOutOfRange(usize),
+    /// A slot expected to hold a unary lambda did not.
+    NotUnaryLambda,
+    /// The element type of a combinator's list argument could not be
+    /// resolved from the IR; lowering cannot synthesize a well-typed
+    /// lambda param.
+    MissingElementType,
+}
+
+impl std::fmt::Display for LowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnexpectedNode(msg) => write!(f, "unexpected node: {msg}"),
+            Self::SlotOutOfRange(idx) => write!(f, "slot index {idx} out of range"),
+            Self::NotUnaryLambda => write!(f, "slot is not a unary lambda"),
+            Self::MissingElementType => write!(f, "could not resolve list element type"),
+        }
+    }
+}
+
+impl std::error::Error for LowerError {}
+
+impl Bridge {
+    /// Lower an `egg::RecExpr` back into `IrExpr`, allocating fresh
+    /// VarIds through `vt` for any `compose` / `and-pred` markers that
+    /// need to become real `IrExprKind::Lambda` nodes.
+    ///
+    /// The root of the `RecExpr` is taken to be its last node, which
+    /// matches egg's post-order numbering after extraction.
+    pub fn lower(
+        &self,
+        rec: &RecExpr<AlmideExpr>,
+        vt: &mut VarTable,
+    ) -> Result<IrExpr, LowerError> {
+        let nodes = rec.as_ref();
+        assert!(!nodes.is_empty(), "cannot lower an empty RecExpr");
+        let root = Id::from(nodes.len() - 1);
+        self.lower_expr(rec, root, vt)
+    }
+
+    fn lower_expr(
+        &self,
+        rec: &RecExpr<AlmideExpr>,
+        id: Id,
+        vt: &mut VarTable,
+    ) -> Result<IrExpr, LowerError> {
+        match &rec[id] {
+            AlmideExpr::Symbol(s) => self.resolve_symbol_expr(s.as_str()),
+            AlmideExpr::Num(n) => Ok(IrExpr {
+                kind: IrExprKind::LitInt { value: *n },
+                ty: Ty::Int,
+                span: None,
+            }),
+            AlmideExpr::Map([xs_id, f_id]) => {
+                let xs = self.lower_expr(rec, *xs_id, vt)?;
+                let elem_ty = list_elem_ty(&xs.ty).ok_or(LowerError::MissingElementType)?;
+                let f = self.lower_lambda_arg(rec, *f_id, &[elem_ty.clone()], vt)?;
+                let ret_elem = lambda_ret_ty(&f).unwrap_or(elem_ty);
+                Ok(IrExpr {
+                    kind: IrExprKind::Call {
+                        target: CallTarget::Module {
+                            module: sym("list"),
+                            func: sym("map"),
+                        },
+                        args: vec![xs, f],
+                        type_args: vec![],
+                    },
+                    ty: Ty::list(ret_elem),
+                    span: None,
+                })
+            }
+            AlmideExpr::Filter([xs_id, p_id]) => {
+                let xs = self.lower_expr(rec, *xs_id, vt)?;
+                let elem_ty = list_elem_ty(&xs.ty).ok_or(LowerError::MissingElementType)?;
+                let p = self.lower_lambda_arg(rec, *p_id, &[elem_ty.clone()], vt)?;
+                Ok(IrExpr {
+                    kind: IrExprKind::Call {
+                        target: CallTarget::Module {
+                            module: sym("list"),
+                            func: sym("filter"),
+                        },
+                        args: vec![xs, p],
+                        type_args: vec![],
+                    },
+                    ty: Ty::list(elem_ty),
+                    span: None,
+                })
+            }
+            AlmideExpr::Fold([xs_id, init_id, f_id]) => {
+                let xs = self.lower_expr(rec, *xs_id, vt)?;
+                let init = self.lower_expr(rec, *init_id, vt)?;
+                let elem_ty = list_elem_ty(&xs.ty).ok_or(LowerError::MissingElementType)?;
+                let acc_ty = init.ty.clone();
+                let f =
+                    self.lower_lambda_arg(rec, *f_id, &[acc_ty.clone(), elem_ty], vt)?;
+                Ok(IrExpr {
+                    kind: IrExprKind::Call {
+                        target: CallTarget::Module {
+                            module: sym("list"),
+                            func: sym("fold"),
+                        },
+                        args: vec![xs, init, f],
+                        type_args: vec![],
+                    },
+                    ty: acc_ty,
+                    span: None,
+                })
+            }
+            AlmideExpr::Lam(_)
+            | AlmideExpr::Compose(_)
+            | AlmideExpr::AndPred(_) => Err(LowerError::UnexpectedNode(
+                "lambda-position marker in expression position".into(),
+            )),
+        }
+    }
+
+    /// Lower a node that sits in lambda position — i.e. the second
+    /// arg of `map`/`filter` or the third of `fold`. Accepts
+    /// `(lam _slot)`, bare `identity`, `compose`, and `and-pred`.
+    ///
+    /// `param_tys` describes the types the lambda expects. For map /
+    /// filter this is a single element type; for fold it is
+    /// `[acc_ty, elem_ty]`. Compose / and-pred are only legal in the
+    /// unary case (map / filter), not fold.
+    fn lower_lambda_arg(
+        &self,
+        rec: &RecExpr<AlmideExpr>,
+        id: Id,
+        param_tys: &[Ty],
+        vt: &mut VarTable,
+    ) -> Result<IrExpr, LowerError> {
+        match &rec[id] {
+            AlmideExpr::Lam([slot_id]) => {
+                let AlmideExpr::Symbol(s) = &rec[*slot_id] else {
+                    return Err(LowerError::UnexpectedNode(
+                        "(lam ...) child must be a slot symbol".into(),
+                    ));
+                };
+                let slot_idx = parse_slot_index(s.as_str())?;
+                let lam = self
+                    .slots
+                    .get(slot_idx)
+                    .cloned()
+                    .ok_or(LowerError::SlotOutOfRange(slot_idx))?;
+                if !matches!(&lam.kind, IrExprKind::Lambda { .. }) {
+                    return Err(LowerError::NotUnaryLambda);
+                }
+                Ok(lam)
+            }
+            AlmideExpr::Symbol(s) if s.as_str() == "identity" => {
+                let [elem_ty] = param_tys else {
+                    return Err(LowerError::UnexpectedNode(
+                        "identity marker requires exactly one param type".into(),
+                    ));
+                };
+                Ok(build_identity_lambda(elem_ty.clone(), vt))
+            }
+            AlmideExpr::Symbol(s) => {
+                // Bare slot symbol lifted as a lambda without the
+                // `(lam ...)` wrapper — happens when the original IR
+                // put a non-literal lambda-shaped slot straight into
+                // the combinator. Fall back to slot lookup.
+                let slot_idx = parse_slot_index(s.as_str())?;
+                self.slots
+                    .get(slot_idx)
+                    .cloned()
+                    .ok_or(LowerError::SlotOutOfRange(slot_idx))
+            }
+            AlmideExpr::Compose([g_id, f_id]) => {
+                let [elem_ty] = param_tys else {
+                    return Err(LowerError::UnexpectedNode(
+                        "compose marker only valid for unary lambda position".into(),
+                    ));
+                };
+                let f = self.lower_lambda_arg(rec, *f_id, &[elem_ty.clone()], vt)?;
+                let f_ret = lambda_ret_ty(&f).unwrap_or_else(|| elem_ty.clone());
+                let g = self.lower_lambda_arg(rec, *g_id, &[f_ret], vt)?;
+                compose_lambdas_fresh(&f, &g, vt)
+            }
+            AlmideExpr::AndPred([p_id, q_id]) => {
+                let [elem_ty] = param_tys else {
+                    return Err(LowerError::UnexpectedNode(
+                        "and-pred marker only valid for unary lambda position".into(),
+                    ));
+                };
+                let p = self.lower_lambda_arg(rec, *p_id, &[elem_ty.clone()], vt)?;
+                let q = self.lower_lambda_arg(rec, *q_id, &[elem_ty.clone()], vt)?;
+                compose_predicates_fresh(&p, &q, vt)
+            }
+            AlmideExpr::Map(_) | AlmideExpr::Filter(_) | AlmideExpr::Fold(_) | AlmideExpr::Num(_) => {
+                Err(LowerError::UnexpectedNode(
+                    "non-lambda node in lambda position".into(),
+                ))
+            }
+        }
+    }
+
+    fn resolve_symbol_expr(&self, name: &str) -> Result<IrExpr, LowerError> {
+        let slot_idx = parse_slot_index(name)?;
+        self.slots
+            .get(slot_idx)
+            .cloned()
+            .ok_or(LowerError::SlotOutOfRange(slot_idx))
+    }
+}
+
+fn parse_slot_index(name: &str) -> Result<usize, LowerError> {
+    name.strip_prefix("_slot_")
+        .and_then(|rest| rest.parse::<usize>().ok())
+        .ok_or_else(|| LowerError::UnexpectedNode(format!("unknown bare symbol `{name}`")))
+}
+
+fn list_elem_ty(ty: &Ty) -> Option<Ty> {
+    ty.inner().cloned()
+}
+
+fn lambda_ret_ty(expr: &IrExpr) -> Option<Ty> {
+    match &expr.ty {
+        Ty::Fn { ret, .. } => Some((**ret).clone()),
+        _ => None,
+    }
+}
+
+fn fresh_sym() -> Sym {
+    sym("__egg_v")
+}
+
+fn build_identity_lambda(elem_ty: Ty, vt: &mut VarTable) -> IrExpr {
+    let var = vt.alloc(fresh_sym(), elem_ty.clone(), Mutability::Let, None);
+    IrExpr {
+        kind: IrExprKind::Lambda {
+            params: vec![(var, elem_ty.clone())],
+            body: Box::new(IrExpr {
+                kind: IrExprKind::Var { id: var },
+                ty: elem_ty.clone(),
+                span: None,
+            }),
+            lambda_id: None,
+        },
+        ty: Ty::Fn {
+            params: vec![elem_ty.clone()],
+            ret: Box::new(elem_ty),
+        },
+        span: None,
+    }
+}
+
+/// Beta-reduce `compose g f` into `λv. g(f(v))` with a fresh VarId.
+/// Both f and g are expected to be unary `IrExprKind::Lambda`.
+fn compose_lambdas_fresh(
+    f: &IrExpr,
+    g: &IrExpr,
+    vt: &mut VarTable,
+) -> Result<IrExpr, LowerError> {
+    let (f_param_id, f_param_ty, f_body) = unary_lambda_parts(f)?;
+    let (g_param_id, _g_param_ty, g_body) = unary_lambda_parts(g)?;
+
+    let fresh = vt.alloc(fresh_sym(), f_param_ty.clone(), Mutability::Let, None);
+    let fresh_var = IrExpr {
+        kind: IrExprKind::Var { id: fresh },
+        ty: f_param_ty.clone(),
+        span: None,
+    };
+    // First rename f's own param to fresh so f_body references fresh,
+    // then substitute g's param with the renamed f_body.
+    let f_body_fresh = substitute_var_in_expr(f_body, f_param_id, &fresh_var);
+    let composed_body = substitute_var_in_expr(g_body, g_param_id, &f_body_fresh);
+
+    let ret_ty = lambda_ret_ty(g).unwrap_or_else(|| composed_body.ty.clone());
+
+    Ok(IrExpr {
+        kind: IrExprKind::Lambda {
+            params: vec![(fresh, f_param_ty.clone())],
+            body: Box::new(composed_body),
+            lambda_id: None,
+        },
+        ty: Ty::Fn {
+            params: vec![f_param_ty],
+            ret: Box::new(ret_ty),
+        },
+        span: None,
+    })
+}
+
+/// Beta-reduce `and-pred p q` into `λv. p(v) && q(v)` with a fresh
+/// VarId. Both p and q are expected to be unary predicates — i.e.
+/// `IrExprKind::Lambda` whose body has type `Bool`.
+fn compose_predicates_fresh(
+    p: &IrExpr,
+    q: &IrExpr,
+    vt: &mut VarTable,
+) -> Result<IrExpr, LowerError> {
+    let (p_param_id, p_param_ty, p_body) = unary_lambda_parts(p)?;
+    let (q_param_id, _q_param_ty, q_body) = unary_lambda_parts(q)?;
+
+    let fresh = vt.alloc(fresh_sym(), p_param_ty.clone(), Mutability::Let, None);
+    let fresh_var = IrExpr {
+        kind: IrExprKind::Var { id: fresh },
+        ty: p_param_ty.clone(),
+        span: None,
+    };
+    let p_body_fresh = substitute_var_in_expr(p_body, p_param_id, &fresh_var);
+    let q_body_fresh = substitute_var_in_expr(q_body, q_param_id, &fresh_var);
+
+    let and_body = IrExpr {
+        kind: IrExprKind::BinOp {
+            op: BinOp::And,
+            left: Box::new(p_body_fresh),
+            right: Box::new(q_body_fresh),
+        },
+        ty: Ty::Bool,
+        span: None,
+    };
+
+    Ok(IrExpr {
+        kind: IrExprKind::Lambda {
+            params: vec![(fresh, p_param_ty.clone())],
+            body: Box::new(and_body),
+            lambda_id: None,
+        },
+        ty: Ty::Fn {
+            params: vec![p_param_ty],
+            ret: Box::new(Ty::Bool),
+        },
+        span: None,
+    })
+}
+
+fn unary_lambda_parts(expr: &IrExpr) -> Result<(VarId, Ty, &IrExpr), LowerError> {
+    let IrExprKind::Lambda { params, body, .. } = &expr.kind else {
+        return Err(LowerError::NotUnaryLambda);
+    };
+    let [(id, ty)] = params.as_slice() else {
+        return Err(LowerError::NotUnaryLambda);
+    };
+    Ok((*id, ty.clone(), body.as_ref()))
 }

--- a/crates/almide-egg-lab/src/lib.rs
+++ b/crates/almide-egg-lab/src/lib.rs
@@ -28,7 +28,7 @@
 use egg::*;
 
 pub mod bridge;
-pub use bridge::Bridge;
+pub use bridge::{Bridge, LowerError};
 
 define_language! {
     /// Minimal Almide IR fragment for fusion experiments.

--- a/crates/almide-egg-lab/tests/bridge_test.rs
+++ b/crates/almide-egg-lab/tests/bridge_test.rs
@@ -9,9 +9,21 @@
 
 use almide_base::intern::sym;
 use almide_egg_lab::{fusion_rules, AlmideExpr, Bridge, FusionCost};
-use almide_ir::{CallTarget, IrExpr, IrExprKind, VarId};
+use almide_ir::{BinOp, CallTarget, IrExpr, IrExprKind, Mutability, VarId, VarTable};
 use almide_lang::types::{Ty, TypeConstructorId};
 use egg::{Extractor, RecExpr, Runner};
+
+/// Seed a `VarTable` so that `VarId(n)` for each n up to `max` is a
+/// valid entry. Mirrors the state real lowering leaves the table in
+/// after it has already named every var in the subject IR; lets us
+/// predict the next id the bridge's `lower` will allocate.
+fn seeded_var_table(max_existing_id: u32) -> VarTable {
+    let mut vt = VarTable::new();
+    for i in 0..=max_existing_id {
+        vt.alloc(sym(&format!("pre_{i}")), Ty::Int, Mutability::Let, None);
+    }
+    vt
+}
 
 // ── Helpers: build IrExpr fragments ─────────────────────────────────
 
@@ -62,6 +74,34 @@ fn opaque_lambda(param_id: u32, lambda_id: u32) -> IrExpr {
             params: vec![Ty::Int],
             ret: Box::new(Ty::Int),
         },
+        span: None,
+    }
+}
+
+/// `(x: Int) => x + incr` — a non-identity lambda that references its
+/// own param, so we can verify that beta-reduction rewrites both the
+/// param reference and the surrounding structure.
+fn incr_lambda(param_id: u32, lambda_id: u32, incr: i64) -> IrExpr {
+    let body = IrExpr {
+        kind: IrExprKind::BinOp {
+            op: BinOp::AddInt,
+            left: Box::new(var(param_id, Ty::Int)),
+            right: Box::new(IrExpr {
+                kind: IrExprKind::LitInt { value: incr },
+                ty: Ty::Int,
+                span: None,
+            }),
+        },
+        ty: Ty::Int,
+        span: None,
+    };
+    IrExpr {
+        kind: IrExprKind::Lambda {
+            params: vec![(VarId(param_id), Ty::Int)],
+            body: Box::new(body),
+            lambda_id: Some(lambda_id),
+        },
+        ty: Ty::Fn { params: vec![Ty::Int], ret: Box::new(Ty::Int) },
         span: None,
     }
 }
@@ -212,6 +252,254 @@ fn lift_of_plain_var_is_opaque() {
     let rec_str = rec.to_string();
     assert_eq!(rec_str, "_slot_0");
     assert_eq!(bridge.slots().len(), 1);
+}
+
+// ── Lower (round-trip) tests ────────────────────────────────────────
+
+fn saturate(ir: &IrExpr) -> (Bridge, RecExpr<AlmideExpr>) {
+    let mut bridge = Bridge::new();
+    let (rec, root) = bridge.lift(ir);
+    let runner = Runner::default()
+        .with_iter_limit(64)
+        .with_node_limit(10_000)
+        .with_expr(&rec)
+        .run(&fusion_rules());
+    let canonical = runner.egraph.find(root);
+    let iters = runner.iterations.len();
+    assert!(iters < 64, "saturation hit iter limit: {iters}");
+    let extractor = Extractor::new(&runner.egraph, FusionCost);
+    let (_, best) = extractor.find_best(canonical);
+    (bridge, best)
+}
+
+fn collect_var_ids(expr: &IrExpr, out: &mut Vec<VarId>) {
+    match &expr.kind {
+        IrExprKind::Var { id } => out.push(*id),
+        IrExprKind::Lambda { params, body, .. } => {
+            for (id, _) in params {
+                out.push(*id);
+            }
+            collect_var_ids(body, out);
+        }
+        IrExprKind::Call { args, .. } => {
+            for a in args {
+                collect_var_ids(a, out);
+            }
+        }
+        IrExprKind::BinOp { left, right, .. } => {
+            collect_var_ids(left, out);
+            collect_var_ids(right, out);
+        }
+        _ => {}
+    }
+}
+
+/// `list.map(xs, identity)` lifts, saturates under identity-map, and
+/// lowers back to just `xs`. No fresh VarId should be allocated —
+/// identity-map eliminates the lambda outright.
+#[test]
+fn lower_identity_map_returns_xs_unchanged() {
+    let xs = var(0, list_int());
+    let id_lam = identity_lambda(0, Ty::Int);
+    let ir = list_call("map", vec![xs.clone(), id_lam], list_int());
+
+    let (bridge, best) = saturate(&ir);
+    let mut vt = seeded_var_table(0);
+    let before = vt.len();
+    let lowered = bridge.lower(&best, &mut vt).expect("lower succeeds");
+
+    assert_eq!(vt.len(), before, "no fresh VarId expected after identity elim");
+    match &lowered.kind {
+        IrExprKind::Var { id } => assert_eq!(id.0, 0, "lowered form should be xs"),
+        other => panic!("expected xs (Var), got {other:?}"),
+    }
+    assert_eq!(lowered.ty, list_int());
+}
+
+/// `list.map(list.map(xs, f), g)` lifts, saturates to
+/// `(map xs (compose g f))`, and lowers into a single
+/// `list.map` whose lambda body is g applied to f applied to a
+/// fresh param. Verifies the beta-reduction mechanics:
+/// - one fresh VarId is allocated (the new lambda param)
+/// - that VarId appears inside the body exactly where the param
+///   should flow (no stray references to f's / g's old params)
+/// - the outer shape is still `list.map(xs, Lambda(...))`
+#[test]
+fn lower_map_map_fuses_into_single_map_with_composed_lambda() {
+    let xs = var(0, list_int());
+    // f: (x) => x + 1 — references its own param, so substitution is
+    // observable in the composed body.
+    let f = incr_lambda(1, 101, 1);
+    // g: (y) => y + 10 — distinct body + distinct param VarId so we
+    // can see the two lambdas keep their operations separate after
+    // beta-reduction.
+    let g = incr_lambda(2, 102, 10);
+    let inner = list_call("map", vec![xs, f], list_int());
+    let outer = list_call("map", vec![inner, g], list_int());
+
+    let (bridge, best) = saturate(&outer);
+    let mut vt = seeded_var_table(2);
+    let before = vt.len();
+    let lowered = bridge.lower(&best, &mut vt).expect("lower succeeds");
+
+    // Outer shape: list.map(xs, Lambda(..))
+    let IrExprKind::Call { target, args, .. } = &lowered.kind else {
+        panic!("expected Call, got {:?}", lowered.kind);
+    };
+    match target {
+        CallTarget::Module { module, func } => {
+            assert_eq!(module.as_str(), "list");
+            assert_eq!(func.as_str(), "map");
+        }
+        other => panic!("expected Module target, got {other:?}"),
+    }
+    assert_eq!(args.len(), 2);
+    // arg 0 is xs (opaque slot roundtrip).
+    match &args[0].kind {
+        IrExprKind::Var { id } => assert_eq!(id.0, 0),
+        other => panic!("expected xs (Var), got {other:?}"),
+    }
+    // arg 1 is the composed Lambda.
+    let IrExprKind::Lambda { params, body, lambda_id } = &args[1].kind else {
+        panic!("expected composed Lambda, got {:?}", args[1].kind);
+    };
+    assert_eq!(params.len(), 1, "composed lambda must be unary");
+    assert!(lambda_id.is_none(), "fresh lambda should not reuse lambda_id");
+    let (fresh_param, fresh_ty) = &params[0];
+    assert_eq!(fresh_ty, &Ty::Int);
+
+    // Exactly one fresh VarId was allocated.
+    assert_eq!(vt.len(), before + 1, "one fresh VarId expected");
+    assert_eq!(fresh_param.0 as usize, before, "fresh id matches alloc order");
+
+    // Body must reference only the fresh param — f's (1) and g's (2)
+    // old param VarIds must not survive (both were substituted out).
+    let mut ids = Vec::new();
+    collect_var_ids(body, &mut ids);
+    assert!(
+        ids.iter().any(|id| *id == *fresh_param),
+        "composed body should reference the fresh param, got ids: {ids:?}",
+    );
+    assert!(
+        !ids.iter().any(|id| id.0 == 1 || id.0 == 2),
+        "f's and g's old param VarIds must be substituted away, got: {ids:?}",
+    );
+}
+
+/// `list.filter(list.filter(xs, p), q)` should lower into a single
+/// `list.filter` whose predicate is `p(v) && q(v)` — one fresh VarId,
+/// a BinOp::And body, and no leftover references to p's / q's old
+/// param VarIds.
+#[test]
+fn lower_filter_filter_fuses_into_conjunctive_predicate() {
+    let xs = var(0, list_int());
+    // p: (x: Int) => true
+    let p = IrExpr {
+        kind: IrExprKind::Lambda {
+            params: vec![(VarId(1), Ty::Int)],
+            body: Box::new(IrExpr {
+                kind: IrExprKind::LitBool { value: true },
+                ty: Ty::Bool,
+                span: None,
+            }),
+            lambda_id: Some(201),
+        },
+        ty: Ty::Fn { params: vec![Ty::Int], ret: Box::new(Ty::Bool) },
+        span: None,
+    };
+    // q: (x: Int) => false (distinct body to ensure it survives into
+    // the right side of the AND)
+    let q = IrExpr {
+        kind: IrExprKind::Lambda {
+            params: vec![(VarId(2), Ty::Int)],
+            body: Box::new(IrExpr {
+                kind: IrExprKind::LitBool { value: false },
+                ty: Ty::Bool,
+                span: None,
+            }),
+            lambda_id: Some(202),
+        },
+        ty: Ty::Fn { params: vec![Ty::Int], ret: Box::new(Ty::Bool) },
+        span: None,
+    };
+    let inner = list_call("filter", vec![xs, p], list_int());
+    let outer = list_call("filter", vec![inner, q], list_int());
+
+    let (bridge, best) = saturate(&outer);
+    let mut vt = seeded_var_table(2);
+    let before = vt.len();
+    let lowered = bridge.lower(&best, &mut vt).expect("lower succeeds");
+
+    let IrExprKind::Call { args, target, .. } = &lowered.kind else {
+        panic!("expected Call, got {:?}", lowered.kind);
+    };
+    match target {
+        CallTarget::Module { module, func } => {
+            assert_eq!(module.as_str(), "list");
+            assert_eq!(func.as_str(), "filter");
+        }
+        other => panic!("expected Module target, got {other:?}"),
+    }
+    let IrExprKind::Lambda { params, body, .. } = &args[1].kind else {
+        panic!("expected composed Lambda");
+    };
+    assert_eq!(params.len(), 1);
+    assert_eq!(vt.len(), before + 1, "one fresh VarId expected");
+
+    // Body = (p_body) AND (q_body_with_fresh_param)
+    let IrExprKind::BinOp { op, left, right } = &body.kind else {
+        panic!("expected BinOp, got {:?}", body.kind);
+    };
+    assert!(matches!(op, BinOp::And));
+    assert_eq!(body.ty, Ty::Bool);
+    assert!(matches!(&left.kind, IrExprKind::LitBool { value: true }));
+    assert!(matches!(&right.kind, IrExprKind::LitBool { value: false }));
+}
+
+/// Cross-rule: `list.map(list.map(xs, id), f)` should collapse the
+/// identity inside the e-graph and lower into `list.map(xs, f)` —
+/// no fresh VarId at all, because the surviving lambda is retrieved
+/// verbatim from the slot table.
+#[test]
+fn lower_identity_inside_map_chain_reuses_original_lambda() {
+    let xs = var(0, list_int());
+    let id_lam = identity_lambda(0, Ty::Int);
+    // f: (x) => x + 7 — non-identity, so it survives the identity-map
+    // collapse and we can see it flow back through the slot table.
+    let f = incr_lambda(2, 303, 7);
+    let inner = list_call("map", vec![xs, id_lam], list_int());
+    let outer = list_call("map", vec![inner, f], list_int());
+
+    let (bridge, best) = saturate(&outer);
+    let mut vt = seeded_var_table(2);
+    let before = vt.len();
+    let lowered = bridge.lower(&best, &mut vt).expect("lower succeeds");
+
+    assert_eq!(vt.len(), before, "identity elim path needs no fresh id");
+    let IrExprKind::Call { args, .. } = &lowered.kind else {
+        panic!("expected Call");
+    };
+    let IrExprKind::Lambda { params, lambda_id, .. } = &args[1].kind else {
+        panic!("expected original f Lambda");
+    };
+    assert_eq!(params[0].0 .0, 2, "original f param VarId preserved");
+    assert_eq!(*lambda_id, Some(303), "original lambda_id preserved");
+}
+
+/// Lower of a plain Var IrExpr (no combinators) round-trips verbatim
+/// through the opaque slot table — the lower pass must not crash on
+/// inputs the bridge represents as a single `_slot_0`.
+#[test]
+fn lower_of_plain_var_roundtrips_via_slot() {
+    let xs = var(0, list_int());
+    let mut bridge = Bridge::new();
+    let (rec, _root) = bridge.lift(&xs);
+    let mut vt = seeded_var_table(0);
+    let lowered = bridge.lower(&rec, &mut vt).expect("lower succeeds");
+    match &lowered.kind {
+        IrExprKind::Var { id } => assert_eq!(id.0, 0),
+        other => panic!("expected Var(0), got {other:?}"),
+    }
 }
 
 /// Sanity: a RecExpr parsed from the pure-string egg-lab API and the


### PR DESCRIPTION
## Summary

Lands phase C of the MLIR backend adoption arc (`docs/roadmap/active/mlir-backend-adoption.md`): the egg-lab bridge can now round-trip `IrExpr → egg RecExpr → saturated best → IrExpr`, with `compose` / `and-pred` markers beta-reduced into real `IrExprKind::Lambda` nodes carrying fresh `VarId`s allocated through a caller-supplied `VarTable`.

- `Bridge::lower(rec, &mut vt)` walks the extracted RecExpr, reconstructs `list.map`/`filter`/`fold` calls, retrieves opaque subtrees from the slot table, and beta-reduces fusion markers on the fly.
- `compose g f` → `λv. g(f(v))` and `and-pred p q` → `λv. p(v) && q(v)` both allocate exactly one fresh `VarId` per marker and substitute both bodies so no stale `f`/`g`/`p`/`q` param references survive.
- e-graph layer is unchanged: saturation keeps markers as zero-cost pseudo-ops; we pay the alpha-freshness cost only once per extracted form, which sidesteps the e-graph binder problem without needing capture-avoiding substitution inside saturation.

## What's verified

- 5 new round-trip tests in `tests/bridge_test.rs` covering identity-map collapse, map-map fusion with fresh-VarId bookkeeping, filter-filter fusion into `BinOp::And`, identity elimination preserving the surviving lambda verbatim, and plain-var slot round-trip.
- All 11 bridge tests + 5 toy-language tests pass under `cargo test -p almide-egg-lab --release -- --test-threads=1` in ~2.5 s.
- Full `cargo test --release -- --test-threads=1` and `almide test` (206 files) — regression 0.
- egg-lab stays isolated: no edit outside `crates/almide-egg-lab/`, nothing wired into the main pipeline.

## Scope / non-goals

- `Map`/`Filter`/`Fold` only — other IR shapes still flow through opaque slots.
- No in-graph lambda substitution: upgrading to a custom `Applier` is left for Stage 1 when we see which rules actually benefit (documented in the README and arc doc).
- No type-parametric rules yet (Stage 1+).

## Test plan

- [x] `cargo test -p almide-egg-lab --release -- --test-threads=1`
- [x] `cargo test --release -- --test-threads=1`
- [x] `almide test` (all 206 `.almd` test files)