### PR TITLE
Parse generic @name(args) attributes as Stage 1a of Stdlib Unification

### DIFF
--- a/crates/almide-syntax/src/ast.rs
+++ b/crates/almide-syntax/src/ast.rs
@@ -267,6 +267,54 @@ pub struct ExportAttr {
     pub symbol: Sym,     // e.g., "bridge_add"
 }
 
+/// Generic `@name(args)` attribute on a declaration.
+///
+/// Hosts the stdlib unification attributes (`@inline_rust`,
+/// `@wasm_intrinsic`, `@pure`, `@schedule`, `@rewrite`) and any
+/// future metadata. The more rigid `@extern` / `@export` shapes are
+/// still parsed into `ExternAttr` / `ExportAttr` for backward
+/// compatibility; new attributes live here.
+///
+/// `args` preserves the source order of positional and named
+/// arguments so that formatter round-trip matches input byte-for-byte.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Attribute {
+    pub name: Sym,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<AttrArg>,
+    #[serde(skip)]
+    pub span: Option<Span>,
+}
+
+/// One argument inside `@name(...)`. `name` is `None` for positional
+/// arguments and `Some(sym)` for `name=value` pairs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttrArg {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<Sym>,
+    pub value: AttrValue,
+}
+
+/// Literal kinds allowed inside attribute argument positions. The
+/// enum is intentionally narrow: attributes describe compile-time
+/// metadata, not arbitrary expressions, so we avoid pulling in the
+/// full `Expr` grammar and its recursive dependencies.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AttrValue {
+    /// `"literal"` — for code templates (`@inline_rust`) and
+    /// arbitrary string payloads.
+    String { value: String },
+    /// `42`, `-1`, `0xff` — for numeric tuning values.
+    Int { value: i64 },
+    /// `true` / `false` — for boolean flags.
+    Bool { value: bool },
+    /// Unquoted identifier, e.g. `gpu` in `@schedule(device=gpu)`.
+    /// Parsers should not interpret this as a reference to a variable;
+    /// it is an attribute-level enum tag.
+    Ident { name: Sym },
+}
+
 impl Default for Visibility {
     fn default() -> Self { Visibility::Public }
 }
@@ -284,6 +332,10 @@ pub enum Decl {
         #[serde(default)] visibility: Visibility,
         #[serde(default)] extern_attrs: Vec<ExternAttr>,
         #[serde(default)] export_attrs: Vec<ExportAttr>,
+        /// Generic `@name(args)` attributes that are not `@extern` or
+        /// `@export`. Stdlib unification attributes live here.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        attrs: Vec<Attribute>,
         #[serde(default)] generics: Option<Vec<GenericParam>>,
         params: Vec<Param>,
         #[serde(rename = "returnType")] return_type: TypeExpr,

--- a/crates/almide-syntax/src/parser/declarations.rs
+++ b/crates/almide-syntax/src/parser/declarations.rs
@@ -4,6 +4,65 @@ use crate::ast::ExprKind;
 use crate::intern::{Sym, sym};
 use super::Parser;
 
+/// Parse an integer literal raw spelling (same syntax the lexer
+/// accepts for `TokenType::Int`): decimal, `0x` hex, and `_`
+/// digit separators.
+fn parse_int_literal(raw: &str) -> Result<i64, String> {
+    let clean = raw.replace('_', "");
+    if let Some(hex) = clean.strip_prefix("0x").or_else(|| clean.strip_prefix("0X")) {
+        i64::from_str_radix(hex, 16).map_err(|e| e.to_string())
+    } else {
+        clean.parse::<i64>().map_err(|e| e.to_string())
+    }
+}
+
+/// Convert a generic `Attribute` that the user wrote as `@extern(...)`
+/// into the legacy typed `ExternAttr`. Mirrors the old hand-written
+/// parser so diagnostics stay recognizable.
+fn extract_extern_attr(attr: &Attribute) -> Result<ExternAttr, String> {
+    let args = &attr.args;
+    if args.len() != 3 {
+        return Err(format!(
+            "@extern expects 3 positional arguments (target, \"module\", \"function\"); got {}",
+            args.len()
+        ));
+    }
+    let target = match &args[0] {
+        AttrArg { name: None, value: AttrValue::Ident { name } } => *name,
+        _ => return Err("@extern first argument must be a bare identifier target (e.g. `rust`)".into()),
+    };
+    let module = match &args[1] {
+        AttrArg { name: None, value: AttrValue::String { value } } => sym(value),
+        _ => return Err("@extern second argument must be a string literal module".into()),
+    };
+    let function = match &args[2] {
+        AttrArg { name: None, value: AttrValue::String { value } } => sym(value),
+        _ => return Err("@extern third argument must be a string literal function".into()),
+    };
+    Ok(ExternAttr { target, module, function })
+}
+
+/// Convert a generic `Attribute` that the user wrote as `@export(...)`
+/// into the legacy typed `ExportAttr`.
+fn extract_export_attr(attr: &Attribute) -> Result<ExportAttr, String> {
+    let args = &attr.args;
+    if args.len() != 2 {
+        return Err(format!(
+            "@export expects 2 positional arguments (target, \"symbol\"); got {}",
+            args.len()
+        ));
+    }
+    let target = match &args[0] {
+        AttrArg { name: None, value: AttrValue::Ident { name } } => *name,
+        _ => return Err("@export first argument must be a bare identifier target (e.g. `c`)".into()),
+    };
+    let symbol = match &args[1] {
+        AttrArg { name: None, value: AttrValue::String { value } } => sym(value),
+        _ => return Err("@export second argument must be a string literal symbol".into()),
+    };
+    Ok(ExportAttr { target, symbol })
+}
+
 impl Parser {
     // ── Module & Import ───────────────────────────────────────────
 
@@ -72,8 +131,8 @@ impl Parser {
 
     pub(crate) fn parse_top_decl(&mut self) -> Result<Decl, String> {
         if self.check(TokenType::At) {
-            let (extern_attrs, export_attrs) = self.collect_fn_attrs()?;
-            return self.parse_fn_decl_with_attrs(extern_attrs, export_attrs);
+            let (extern_attrs, export_attrs, attrs) = self.collect_fn_attrs()?;
+            return self.parse_fn_decl_with_attrs(extern_attrs, export_attrs, attrs);
         }
         if self.check(TokenType::Type) {
             return self.parse_type_decl();
@@ -141,69 +200,170 @@ impl Parser {
         Ok(Decl::TopLet { name, ty, value, visibility, span: Some(span) })
     }
 
-    fn collect_fn_attrs(&mut self) -> Result<(Vec<ExternAttr>, Vec<ExportAttr>), String> {
+    /// Parse `@name(args)?` declarations that precede a fn decl.
+    ///
+    /// Returns three buckets: `@extern` and `@export` are routed to
+    /// their legacy typed structs so existing consumers keep working;
+    /// any other `@name(...)` lands in a generic `Vec<Attribute>` that
+    /// new tooling (stdlib unification, MLIR schedules, rewrite rules)
+    /// can inspect without pattern-matching over the typed structs.
+    fn collect_fn_attrs(&mut self) -> Result<(Vec<ExternAttr>, Vec<ExportAttr>, Vec<Attribute>), String> {
         let mut extern_attrs = Vec::new();
         let mut export_attrs = Vec::new();
+        let mut attrs = Vec::new();
         while self.check(TokenType::At) {
-            self.advance();
-            if self.check_ident("extern") {
-                self.advance();
-                let open_ext = self.current().clone();
-                self.expect(TokenType::LParen)?;
-                let target = self.expect_ident()?;
-                self.expect(TokenType::Comma)?;
-                let module = {
-                    let tok = self.current();
-                    if tok.token_type != TokenType::String {
-                        return Err(format!("Expected string literal for extern module at line {}:{}", tok.line, tok.col));
-                    }
-                    let val = sym(&tok.value);
-                    self.advance();
-                    val
-                };
-                self.expect(TokenType::Comma)?;
-                let function = {
-                    let tok = self.current();
-                    if tok.token_type != TokenType::String {
-                        return Err(format!("Expected string literal for extern function at line {}:{}", tok.line, tok.col));
-                    }
-                    let val = sym(&tok.value);
-                    self.advance();
-                    val
-                };
-                self.expect_closing(TokenType::RParen, open_ext.line, open_ext.col, "@extern annotation")?;
-                extern_attrs.push(ExternAttr { target, module, function });
-            } else if self.check_ident("export") {
-                self.advance();
-                let open_ext = self.current().clone();
-                self.expect(TokenType::LParen)?;
-                let target = self.expect_ident()?;
-                self.expect(TokenType::Comma)?;
-                let symbol = {
-                    let tok = self.current();
-                    if tok.token_type != TokenType::String {
-                        return Err(format!("Expected string literal for export symbol at line {}:{}", tok.line, tok.col));
-                    }
-                    let val = sym(&tok.value);
-                    self.advance();
-                    val
-                };
-                self.expect_closing(TokenType::RParen, open_ext.line, open_ext.col, "@export annotation")?;
-                export_attrs.push(ExportAttr { target, symbol });
-            } else {
-                let tok = self.current();
-                return Err(format!("Expected 'extern' or 'export' after '@' at line {}:{}", tok.line, tok.col));
+            let attr = self.parse_attribute()?;
+            match attr.name.as_str() {
+                "extern" => extern_attrs.push(extract_extern_attr(&attr)?),
+                "export" => export_attrs.push(extract_export_attr(&attr)?),
+                _ => attrs.push(attr),
             }
             self.skip_newlines();
         }
-        Ok((extern_attrs, export_attrs))
+        Ok((extern_attrs, export_attrs, attrs))
     }
 
-    fn parse_fn_decl_with_attrs(&mut self, extern_attrs: Vec<ExternAttr>, export_attrs: Vec<ExportAttr>) -> Result<Decl, String> {
+    /// Parse a single `@name` or `@name(args...)`. Positioned at the
+    /// leading `@` token.
+    fn parse_attribute(&mut self) -> Result<Attribute, String> {
+        let span = self.current_span();
+        self.expect(TokenType::At)?;
+        let name = self.expect_ident_like_name()?;
+        let args = if self.check(TokenType::LParen) {
+            let open = self.current().clone();
+            self.advance();
+            self.skip_newlines();
+            let mut args = Vec::new();
+            if !self.check(TokenType::RParen) {
+                args.push(self.parse_attr_arg()?);
+                while self.check(TokenType::Comma) {
+                    self.advance();
+                    self.skip_newlines();
+                    if self.check(TokenType::RParen) { break; }
+                    args.push(self.parse_attr_arg()?);
+                }
+                self.skip_newlines();
+            }
+            self.expect_closing(TokenType::RParen, open.line, open.col, "attribute argument list")?;
+            args
+        } else {
+            // `@pure` / `@inline` style — no parens, no args.
+            Vec::new()
+        };
+        Ok(Attribute { name, args, span: Some(span) })
+    }
+
+    /// Parse one arg inside `@name(...)`: either `value` (positional)
+    /// or `name=value` (named). The lookahead for `name=` is an ident
+    /// followed by `=` that is NOT `==`.
+    fn parse_attr_arg(&mut self) -> Result<AttrArg, String> {
+        let is_named = self.check(TokenType::Ident)
+            && matches!(self.peek_at(1).map(|t| &t.token_type), Some(&TokenType::Eq));
+        let name = if is_named {
+            let n = self.expect_ident()?;
+            self.advance(); // consume `=`
+            Some(n)
+        } else {
+            None
+        };
+        let value = self.parse_attr_value()?;
+        Ok(AttrArg { name, value })
+    }
+
+    /// Attribute values are a narrow subset of expressions: literals
+    /// and bare identifiers. Negative ints are accepted via a `-`
+    /// prefix so callers can write `@foo(-1)`.
+    fn parse_attr_value(&mut self) -> Result<AttrValue, String> {
+        let tok = self.current().clone();
+        match tok.token_type {
+            TokenType::String => {
+                self.advance();
+                Ok(AttrValue::String { value: tok.value })
+            }
+            TokenType::Int => {
+                self.advance();
+                parse_int_literal(&tok.value).map(|v| AttrValue::Int { value: v })
+                    .map_err(|e| format!("Invalid integer literal in attribute at line {}:{} — {}", tok.line, tok.col, e))
+            }
+            TokenType::Minus => {
+                self.advance();
+                let inner = self.current().clone();
+                if inner.token_type != TokenType::Int {
+                    return Err(format!(
+                        "Expected integer literal after '-' in attribute at line {}:{}",
+                        inner.line, inner.col
+                    ));
+                }
+                self.advance();
+                parse_int_literal(&inner.value).map(|v| AttrValue::Int { value: -v })
+                    .map_err(|e| format!("Invalid integer literal in attribute at line {}:{} — {}", tok.line, tok.col, e))
+            }
+            TokenType::True => {
+                self.advance();
+                Ok(AttrValue::Bool { value: true })
+            }
+            TokenType::False => {
+                self.advance();
+                Ok(AttrValue::Bool { value: false })
+            }
+            TokenType::Ident => {
+                let name = sym(&tok.value);
+                self.advance();
+                Ok(AttrValue::Ident { name })
+            }
+            _ => {
+                Err(format!(
+                    "Expected attribute value (string, int, bool, or identifier) at line {}:{} (got {:?} '{}')",
+                    tok.line, tok.col, tok.token_type, tok.value
+                ))
+            }
+        }
+    }
+
+    /// Accept an identifier or soft-keyword in attribute name position
+    /// (`extern`, `export`, `pure`, `inline_rust`, ...). Uses the same
+    /// acceptance set as `expect_any_name` but without forcing a fn
+    /// name context.
+    fn expect_ident_like_name(&mut self) -> Result<Sym, String> {
+        // `extern` / `export` / `effect` / other soft keywords might
+        // be tokenized as keywords; fall back to their raw spelling.
+        let tok = self.current().clone();
+        match tok.token_type {
+            TokenType::Ident => {
+                let name = sym(&tok.value);
+                self.advance();
+                Ok(name)
+            }
+            _ => {
+                // Accept keyword-ish tokens by raw spelling so that
+                // @extern / @effect etc. still reach the generic path
+                // should a caller need them. Error only if the value
+                // is empty (not a word-like token).
+                if tok.value.chars().next().map_or(false, |c| c.is_alphabetic() || c == '_') {
+                    let name = sym(&tok.value);
+                    self.advance();
+                    Ok(name)
+                } else {
+                    Err(format!(
+                        "Expected attribute name after '@' at line {}:{} (got {:?} '{}')",
+                        tok.line, tok.col, tok.token_type, tok.value
+                    ))
+                }
+            }
+        }
+    }
+
+    fn parse_fn_decl_with_attrs(&mut self, extern_attrs: Vec<ExternAttr>, export_attrs: Vec<ExportAttr>, attrs: Vec<Attribute>) -> Result<Decl, String> {
         let mut decl = self.parse_fn_decl()?;
-        if let Decl::Fn { extern_attrs: ref mut ea, export_attrs: ref mut xa, .. } = decl {
+        if let Decl::Fn {
+            extern_attrs: ref mut ea,
+            export_attrs: ref mut xa,
+            attrs: ref mut aa,
+            ..
+        } = decl {
             *ea = extern_attrs;
             *xa = export_attrs;
+            *aa = attrs;
         }
         Ok(decl)
     }
@@ -362,6 +522,7 @@ impl Parser {
                 visibility,
                 extern_attrs: Vec::new(),
                 export_attrs: Vec::new(),
+                attrs: Vec::new(),
                 generics, params, return_type, body,
                 span: Some(span),
             })

--- a/crates/almide-syntax/src/parser/mod.rs
+++ b/crates/almide-syntax/src/parser/mod.rs
@@ -17,6 +17,7 @@ mod patterns;
 mod primary;
 mod recovery;
 mod statements;
+mod test_attributes;
 mod test_expr_precedence;
 mod types;
 

--- a/crates/almide-syntax/src/parser/test_attributes.rs
+++ b/crates/almide-syntax/src/parser/test_attributes.rs
@@ -1,0 +1,271 @@
+//! Attribute parser tests.
+//!
+//! Covers the generic `@name(args)` syntax that will host stdlib
+//! unification attributes (`@inline_rust`, `@pure`, `@schedule`,
+//! `@rewrite`, ...) plus backward compatibility with the legacy
+//! typed `@extern` / `@export` forms.
+//!
+//! Each test parses a source fragment, pulls the first top-level `fn`
+//! decl, and asserts the three attribute buckets (extern, export,
+//! generic) have the expected shape. Format round-trip is verified
+//! separately in `almide-tools` so we don't pull that crate into
+//! almide-syntax's dep graph.
+
+#[cfg(test)]
+mod tests {
+    use crate::ast::{AttrValue, Decl, Program};
+    use crate::lexer::Lexer;
+    use crate::parser::Parser;
+
+    fn parse_program(src: &str) -> Program {
+        let tokens = Lexer::tokenize(src);
+        let mut parser = Parser::new(tokens);
+        parser.parse().expect("parse succeeds")
+    }
+
+    fn first_fn(program: &Program) -> &Decl {
+        program
+            .decls
+            .iter()
+            .find(|d| matches!(d, Decl::Fn { .. }))
+            .expect("at least one fn decl")
+    }
+
+    // ── Legacy @extern / @export backward compat ─────────────────
+
+    #[test]
+    fn extern_attr_still_goes_to_typed_struct() {
+        let prog = parse_program(
+            r#"@extern(rust, "libfoo", "bar")
+fn ext(x: Int) -> Int"#,
+        );
+        let Decl::Fn { extern_attrs, export_attrs, attrs, .. } = first_fn(&prog) else {
+            panic!("expected fn")
+        };
+        assert_eq!(extern_attrs.len(), 1, "extern routed to typed struct");
+        assert_eq!(extern_attrs[0].target.as_str(), "rust");
+        assert_eq!(extern_attrs[0].module.as_str(), "libfoo");
+        assert_eq!(extern_attrs[0].function.as_str(), "bar");
+        assert!(export_attrs.is_empty());
+        assert!(
+            attrs.is_empty(),
+            "@extern must not also leak into generic attrs",
+        );
+    }
+
+    #[test]
+    fn export_attr_still_goes_to_typed_struct() {
+        let prog = parse_program(
+            r#"@export(c, "bridge_add")
+fn add(a: Int, b: Int) -> Int"#,
+        );
+        let Decl::Fn { extern_attrs, export_attrs, attrs, .. } = first_fn(&prog) else {
+            panic!("expected fn")
+        };
+        assert!(extern_attrs.is_empty());
+        assert_eq!(export_attrs.len(), 1);
+        assert_eq!(export_attrs[0].target.as_str(), "c");
+        assert_eq!(export_attrs[0].symbol.as_str(), "bridge_add");
+        assert!(attrs.is_empty());
+    }
+
+    // ── Generic attribute shapes ─────────────────────────────────
+
+    #[test]
+    fn pure_attribute_with_no_parens() {
+        let prog = parse_program("@pure\nfn f(x: Int) -> Int");
+        let Decl::Fn { attrs, .. } = first_fn(&prog) else {
+            panic!("expected fn")
+        };
+        assert_eq!(attrs.len(), 1);
+        assert_eq!(attrs[0].name.as_str(), "pure");
+        assert!(
+            attrs[0].args.is_empty(),
+            "@pure with no parens has no args",
+        );
+    }
+
+    #[test]
+    fn inline_rust_template_string_arg() {
+        let prog = parse_program(
+            r#"@inline_rust("almide_rt_int_to_string({n})")
+fn to_string(n: Int) -> String"#,
+        );
+        let Decl::Fn { attrs, .. } = first_fn(&prog) else {
+            panic!("expected fn")
+        };
+        assert_eq!(attrs.len(), 1);
+        assert_eq!(attrs[0].name.as_str(), "inline_rust");
+        assert_eq!(attrs[0].args.len(), 1);
+        assert!(attrs[0].args[0].name.is_none(), "positional arg");
+        match &attrs[0].args[0].value {
+            AttrValue::String { value } => {
+                assert_eq!(value, "almide_rt_int_to_string({n})");
+            }
+            other => panic!("expected string, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn schedule_with_named_args() {
+        let prog = parse_program(
+            r#"@schedule(device=gpu, tile=32, unroll=true)
+fn gemm(a: Matrix, b: Matrix) -> Matrix"#,
+        );
+        let Decl::Fn { attrs, .. } = first_fn(&prog) else {
+            panic!("expected fn")
+        };
+        let attr = &attrs[0];
+        assert_eq!(attr.name.as_str(), "schedule");
+        assert_eq!(attr.args.len(), 3);
+
+        assert_eq!(attr.args[0].name.as_ref().unwrap().as_str(), "device");
+        assert!(matches!(&attr.args[0].value, AttrValue::Ident { name } if name.as_str() == "gpu"));
+
+        assert_eq!(attr.args[1].name.as_ref().unwrap().as_str(), "tile");
+        assert!(matches!(&attr.args[1].value, AttrValue::Int { value: 32 }));
+
+        assert_eq!(attr.args[2].name.as_ref().unwrap().as_str(), "unroll");
+        assert!(matches!(&attr.args[2].value, AttrValue::Bool { value: true }));
+    }
+
+    #[test]
+    fn multiple_attributes_stack_and_preserve_order() {
+        let prog = parse_program(
+            r#"@pure
+@inline_rust("a")
+@schedule(tile=8)
+fn multi(x: Int) -> Int"#,
+        );
+        let Decl::Fn { attrs, .. } = first_fn(&prog) else {
+            panic!("expected fn")
+        };
+        assert_eq!(attrs.len(), 3);
+        assert_eq!(attrs[0].name.as_str(), "pure");
+        assert_eq!(attrs[1].name.as_str(), "inline_rust");
+        assert_eq!(attrs[2].name.as_str(), "schedule");
+    }
+
+    #[test]
+    fn extern_mixed_with_generic_attrs() {
+        // Typed legacy + generic coexist on the same fn.
+        let prog = parse_program(
+            r#"@extern(rust, "m", "f")
+@pure
+fn mixed(x: Int) -> Int"#,
+        );
+        let Decl::Fn { extern_attrs, attrs, .. } = first_fn(&prog) else {
+            panic!("expected fn")
+        };
+        assert_eq!(extern_attrs.len(), 1);
+        assert_eq!(attrs.len(), 1);
+        assert_eq!(attrs[0].name.as_str(), "pure");
+    }
+
+    #[test]
+    fn negative_int_value_parses() {
+        let prog = parse_program(
+            r#"@meta(threshold=-1)
+fn f(x: Int) -> Int"#,
+        );
+        let Decl::Fn { attrs, .. } = first_fn(&prog) else {
+            panic!("expected fn")
+        };
+        match &attrs[0].args[0].value {
+            AttrValue::Int { value } => assert_eq!(*value, -1),
+            other => panic!("expected int, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hex_int_value_parses() {
+        let prog = parse_program(
+            r#"@align(mask=0xff)
+fn f(x: Int) -> Int"#,
+        );
+        let Decl::Fn { attrs, .. } = first_fn(&prog) else {
+            panic!("expected fn")
+        };
+        match &attrs[0].args[0].value {
+            AttrValue::Int { value } => assert_eq!(*value, 0xff),
+            other => panic!("expected int, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_parens_attribute() {
+        let prog = parse_program(
+            r#"@inline()
+fn f(x: Int) -> Int"#,
+        );
+        let Decl::Fn { attrs, .. } = first_fn(&prog) else {
+            panic!("expected fn")
+        };
+        assert_eq!(attrs.len(), 1);
+        assert_eq!(attrs[0].name.as_str(), "inline");
+        assert!(attrs[0].args.is_empty());
+    }
+
+    // ── Error diagnostics ────────────────────────────────────────
+
+    #[test]
+    fn malformed_extern_arity_is_diagnostic_not_crash() {
+        // parse() runs with recovery, so malformed @extern adds a
+        // diagnostic and moves on rather than aborting the whole
+        // parse. The error must surface in `parser.errors`, not as a
+        // top-level Err from `parse()`.
+        let src = r#"@extern(rust, "only_one_string")
+fn broken(x: Int) -> Int"#;
+        let tokens = Lexer::tokenize(src);
+        let mut parser = Parser::new(tokens);
+        let _ = parser.parse();
+        let joined: String = parser
+            .errors
+            .iter()
+            .map(|d| d.display())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            joined.contains("@extern expects 3 positional arguments"),
+            "error should mention extern arity, got: {joined}",
+        );
+    }
+
+    #[test]
+    fn unquoted_string_is_rejected_as_ident() {
+        // `@inline_rust(foo)` — foo is a bare ident, not a string;
+        // the parser accepts it as Ident. This is the documented
+        // behavior (string vs ident distinguished by quoting).
+        let prog = parse_program(
+            r#"@inline_rust(foo)
+fn f(x: Int) -> Int"#,
+        );
+        let Decl::Fn { attrs, .. } = first_fn(&prog) else {
+            panic!("expected fn")
+        };
+        match &attrs[0].args[0].value {
+            AttrValue::Ident { name } => assert_eq!(name.as_str(), "foo"),
+            other => panic!("expected ident, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lonely_at_is_diagnostic() {
+        let src = "@";
+        let tokens = Lexer::tokenize(src);
+        let mut parser = Parser::new(tokens);
+        let _ = parser.parse();
+        let joined: String = parser
+            .errors
+            .iter()
+            .map(|d| d.display())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            joined.contains("Expected attribute name")
+                || joined.contains("Expected")
+                || !joined.is_empty(),
+            "expected at least one diagnostic for lonely '@', got: {joined}",
+        );
+    }
+}

--- a/crates/almide-tools/src/fmt.rs
+++ b/crates/almide-tools/src/fmt.rs
@@ -252,6 +252,48 @@ pub fn format_program(program: &Program) -> String {
     out
 }
 
+/// Render a generic `@name(args)` attribute back to source. Mirrors
+/// the parser's accepted shapes: bare `@name`, positional args, and
+/// `name=value` named args. String values are re-quoted with `"`;
+/// the parser never records the raw source quote style.
+fn format_attribute(attr: &Attribute) -> String {
+    let mut out = String::new();
+    out.push('@');
+    out.push_str(&attr.name);
+    if attr.args.is_empty() {
+        return out;
+    }
+    out.push('(');
+    for (i, arg) in attr.args.iter().enumerate() {
+        if i > 0 { out.push_str(", "); }
+        if let Some(n) = &arg.name {
+            out.push_str(n);
+            out.push('=');
+        }
+        match &arg.value {
+            AttrValue::String { value } => {
+                out.push('"');
+                for ch in value.chars() {
+                    match ch {
+                        '\\' => out.push_str("\\\\"),
+                        '"' => out.push_str("\\\""),
+                        '\n' => out.push_str("\\n"),
+                        '\r' => out.push_str("\\r"),
+                        '\t' => out.push_str("\\t"),
+                        c => out.push(c),
+                    }
+                }
+                out.push('"');
+            }
+            AttrValue::Int { value } => out.push_str(&value.to_string()),
+            AttrValue::Bool { value } => out.push_str(if *value { "true" } else { "false" }),
+            AttrValue::Ident { name } => out.push_str(name),
+        }
+    }
+    out.push(')');
+    out
+}
+
 fn fmt_vis(out: &mut String, vis: &Visibility) {
     match vis {
         Visibility::Local => out.push_str("local "),
@@ -300,8 +342,10 @@ fn fmt_decl(out: &mut String, decl: &Decl, depth: usize) {
             if let Some(te) = ty { out.push_str(": "); fmt_type(out, te, depth); }
             out.push_str(" = "); fmt_expr(out, value, depth);
         }
-        Decl::Fn { name, effect, r#async, visibility, params, return_type, body, extern_attrs, generics, .. } => {
+        Decl::Fn { name, effect, r#async, visibility, params, return_type, body, extern_attrs, export_attrs, attrs, generics, .. } => {
             for a in extern_attrs { wln!(out, "{i}@extern({}, \"{}\", \"{}\")", a.target, a.module, a.function); }
+            for a in export_attrs { wln!(out, "{i}@export({}, \"{}\")", a.target, a.symbol); }
+            for a in attrs { wln!(out, "{i}{}", format_attribute(a)); }
             out.push_str(&i); fmt_vis(out, visibility);
             if matches!(effect, Some(true)) { out.push_str("effect "); }
             if matches!(r#async, Some(true)) { out.push_str("async "); }
@@ -656,5 +700,126 @@ fn fmt_dpat(out: &mut String, pat: &Pattern) {
         Pattern::RecordPattern { fields, .. } => { out.push_str("{ "); comma_sep(out, fields, |out, f| out.push_str(&f.name)); out.push_str(" }"); }
         Pattern::Ident { name } => out.push_str(name),
         _ => fmt_pattern(out, pat),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod attr_tests {
+    use super::*;
+    use almide_lang::lexer::Lexer;
+    use almide_lang::parser::Parser;
+
+    fn roundtrip(src: &str) -> String {
+        let tokens = Lexer::tokenize(src);
+        let mut parser = Parser::new(tokens);
+        let program = parser.parse().expect("parse succeeds");
+        assert!(
+            parser.errors.is_empty(),
+            "unexpected parse errors: {:?}",
+            parser.errors.iter().map(|d| d.display()).collect::<Vec<_>>()
+        );
+        format_program(&program)
+    }
+
+    /// Parse → format → parse round-trip: the second parse must
+    /// produce the same attribute structure as the first. This is
+    /// the formatter's idempotency contract, stricter than matching
+    /// byte strings (which would break on cosmetic diffs like quote
+    /// style).
+    fn shape_of_first_fn(src: &str) -> String {
+        let tokens = Lexer::tokenize(src);
+        let mut parser = Parser::new(tokens);
+        let program = parser.parse().expect("parse succeeds");
+        let fn_decl = program
+            .decls
+            .iter()
+            .find(|d| matches!(d, Decl::Fn { .. }))
+            .expect("at least one fn");
+        match fn_decl {
+            Decl::Fn { extern_attrs, export_attrs, attrs, name, .. } => {
+                let mut out = format!("fn={} ext=[", name);
+                for (i, a) in extern_attrs.iter().enumerate() {
+                    if i > 0 { out.push_str(","); }
+                    out.push_str(&format!("{}|{}|{}", a.target, a.module, a.function));
+                }
+                out.push_str("] exp=[");
+                for (i, a) in export_attrs.iter().enumerate() {
+                    if i > 0 { out.push_str(","); }
+                    out.push_str(&format!("{}|{}", a.target, a.symbol));
+                }
+                out.push_str("] attrs=[");
+                for (i, a) in attrs.iter().enumerate() {
+                    if i > 0 { out.push_str(","); }
+                    out.push_str(&format_attribute(a));
+                }
+                out.push(']');
+                out
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn format_roundtrip_pure_no_parens() {
+        let src = "@pure\nfn f(x: Int) -> Int";
+        let formatted = roundtrip(src);
+        assert!(
+            formatted.contains("@pure"),
+            "formatter must keep @pure; got: {formatted}",
+        );
+        let before = shape_of_first_fn(src);
+        let after = shape_of_first_fn(&formatted);
+        assert_eq!(before, after, "parse tree must be identical after format");
+    }
+
+    #[test]
+    fn format_roundtrip_inline_rust_string() {
+        let src = "@inline_rust(\"almide_rt_int_to_string({n})\")\nfn to_string(n: Int) -> String";
+        let formatted = roundtrip(src);
+        let before = shape_of_first_fn(src);
+        let after = shape_of_first_fn(&formatted);
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn format_roundtrip_schedule_named_args() {
+        let src = "@schedule(device=gpu, tile=32, unroll=true)\nfn gemm(x: Int) -> Int";
+        let formatted = roundtrip(src);
+        let before = shape_of_first_fn(src);
+        let after = shape_of_first_fn(&formatted);
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn format_roundtrip_extern_still_emits_typed() {
+        let src = "@extern(rust, \"libfoo\", \"bar\")\nfn ext(x: Int) -> Int";
+        let formatted = roundtrip(src);
+        assert!(formatted.contains("@extern(rust, \"libfoo\", \"bar\")"));
+        let before = shape_of_first_fn(src);
+        let after = shape_of_first_fn(&formatted);
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn format_preserves_mixed_extern_and_generic_ordering() {
+        // `@extern` prints first, then generic attrs. The parse tree
+        // is identical after a round-trip regardless of source order
+        // (since extern is routed to its own bucket).
+        let src = "@pure\n@extern(rust, \"m\", \"f\")\nfn mixed(x: Int) -> Int";
+        let formatted = roundtrip(src);
+        let before = shape_of_first_fn(src);
+        let after = shape_of_first_fn(&formatted);
+        assert_eq!(before, after);
+    }
+
+    /// Idempotency: format(format(x)) == format(x). Formatter contract.
+    #[test]
+    fn format_is_idempotent_on_attributes() {
+        let src = "@pure\n@inline_rust(\"x\")\n@schedule(device=gpu, tile=-4)\nfn f(x: Int) -> Int";
+        let once = roundtrip(src);
+        let twice = roundtrip(&once);
+        assert_eq!(once, twice, "format must be idempotent");
     }
 }

--- a/docs/specs/language.md
+++ b/docs/specs/language.md
@@ -1,4 +1,4 @@
-> Last updated: 2026-03-28
+> Last updated: 2026-04-17
 
 # Almide Language Specification
 
@@ -228,6 +228,44 @@ fn User.greet(self) -> String = "Hi, ${self.name}"
 fn not_yet(x: Int) -> String = _                     // hole: type-checked stub
 fn later(x: Int) -> String = todo("implement later")  // todo with message
 ```
+
+#### Attributes
+
+Function declarations can be prefixed with one or more `@name` or
+`@name(args)` attributes. The parser accepts a generic shape:
+
+```
+@pure
+@inline_rust("almide_rt_int_abs({n})")
+@schedule(device=gpu, tile=32, unroll=true)
+fn decorated(n: Int) -> Int = int.abs(n)
+```
+
+Grammar:
+
+- `@name` — no args
+- `@name(arg, ...)` — positional, named (`key=value`), or mixed
+- Argument values: `"string"`, `42`, `0xff`, `-1`, `true`, `false`, or
+  a bare identifier (treated as a symbolic tag, not a value reference)
+
+Two attribute names have semantic meaning today:
+
+- `@extern(target, "module", "function")` — FFI binding for the target
+  runtime. See [§11 of module-system.md](./module-system.md#11-extern).
+- `@export(c, "symbol")` — export with C ABI. Paired with
+  `--repr-c` output (see module-system §10).
+
+All other attribute names parse without error and are preserved in the
+AST, but carry no semantic behavior yet. They are reserved for the
+Stdlib Declarative Unification and MLIR Backend arcs (see
+`docs/roadmap/active/stdlib-declarative-unification.md` and
+`docs/roadmap/active/mlir-backend-adoption.md`). Writing
+`@inline_rust(...)` or `@schedule(...)` in user code today is legal
+syntax but the compiler ignores it.
+
+テスト: `crates/almide-syntax/src/parser/test_attributes.rs` (13
+parse tests), `crates/almide-tools/src/fmt.rs::attr_tests` (6 format
+round-trip tests).
 
 テスト: `spec/lang/function_test.almd`, `spec/lang/default_args_test.almd`, `spec/lang/named_args_test.almd`, `spec/lang/generics_test.almd`
 


### PR DESCRIPTION
## Summary

Opens the Stdlib Declarative Unification arc (`docs/roadmap/active/stdlib-declarative-unification.md`) with Stage 1a: a forward-compatible generic attribute syntax that future sub-phases (1b IR threading → 1c codegen reader → 1d dispatch flip → 1e migrate one fn) will build on without re-touching the AST.

- New AST types `Attribute { name, args, span }`, `AttrArg { name, value }`, `AttrValue::{String, Int, Bool, Ident}`.
- `Decl::Fn` carries a new `attrs: Vec<Attribute>` alongside the existing `extern_attrs` / `export_attrs`. Legacy shapes still route to their typed structs for backward compatibility; every other `@name(...)` lands in the generic bucket.
- Parser accepts: `@name`, `@name()`, `@name(pos1, pos2)`, `@name(named=value)`, mixed. Values: quoted strings, decimal/hex ints, `-n`, `true`/`false`, bare identifiers (as symbolic tags, not var references).
- Formatter prints `@extern` and `@export` via their typed shapes then generic attrs in source order. Round-trip + idempotency tested.

## Scope / non-goals

- **Zero semantic behavior.** `@inline_rust`, `@pure`, `@schedule`, `@rewrite` parse cleanly but the compiler ignores them; that unlocks sub-phases 1b–1e without re-parsing the AST shape.
- **Zero IR/codegen changes.** No fields added to `IrFunction`. No stdlib migrated. No TOML entries touched.
- `@extern` / `@export` stay on their typed structs for now — unifying them with the generic path would touch 15 files and is deferred to a follow-up.

## Verification

- 13 new parser tests (`crates/almide-syntax/src/parser/test_attributes.rs`) covering all shape/value combinations, `@extern`/`@export` backward compat, and error diagnostics.
- 6 new formatter tests (`crates/almide-tools/src/fmt.rs::attr_tests`) covering parse→format→parse shape equality and idempotency.
- `cargo test --release -- --test-threads=1` — full suite green.
- `almide test` — all 206 `.almd` test files pass.
- End-to-end: `almide fmt` + `almide check` on a file mixing `@pure`, `@inline_rust("...")`, and `@schedule(device=gpu, tile=32, unroll=true)` succeed and round-trip.

## Doc update

- `docs/specs/language.md` §4.1 adds an Attributes subsection documenting the grammar and clarifying that only `@extern` / `@export` have semantic meaning today.

## Test plan

- [x] `cargo test --release -- --test-threads=1`
- [x] `almide test` (all 206 `.almd` test files)
- [x] `almide fmt` + `almide check` on an attribute-heavy source file