### PR TITLE
Add Sized Numeric Types arc roadmap (Swift-style numeric types)

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,12 +6,13 @@
 
 ## Active
 
-26 items
+30 items
 
 | Item | Description |
 |------|-------------|
 | [almai — Multi-Provider LLM Client](active/almai-llm-client.md) | almai — multi-provider LLM client library, 8 providers shipped |
 | [Almide Dojo — Continuous MSR Measurement](active/almide-dojo.md) | Daily automated MSR loop — 30 tasks, Claude 100%, Llama 61%, almai integration |
+| [Build Cache (Incremental Compilation)](active/build-cache-incremental.md) | Crate-level incremental build cache keyed by source/compiler/deps hash |
 | [bytes: unify bounds-check semantics](active/bytes-bounds-check.md) | Unify bounds checking across bytes accessors with Option/Result returns |
 | [`cargo test --all` Cache Race](active/cargo-test-cache-race.md) | Fix parallel-cargo-test cache race in fix_test/run_test that masks real failures |
 | [Codegen Ideal Form](active/codegen-ideal-form.md) | WASM codegen redesign toward declarative dispatch and explicit symbol resolution |
@@ -24,13 +25,16 @@
 | [Fan Concurrency — Next Generation](active/fan-concurrency-next.md) | fan as a language-level concurrency primitive with rush/spawn/link/cancel |
 | [Flow[T] — Lazy Streaming Sequences](active/flow-design.md) | Flow[T] lazy streaming sequences with flow.* namespace aligned with list.* verbs |
 | [Flow[T] — User Specification (Draft)](active/flow-spec-draft.md) | Draft user-facing spec for Flow[T] — to be promoted to docs/specs/flow.md after Phase 1 |
+| [Host Binding IDL (Schema-first, Codegen-first)](active/host-binding-idl.md) | Schema-first IDL for typed host bindings, codegen replaces hand-written FFI |
 | [LLM-first Language](active/llm-first-language.md) | Plan to make Almide the language LLMs write most accurately, measured by dojo MSR |
 | [`almide docs-gen` — llms.txt Auto-Generation](active/llms-txt-autogen.md) | Auto-generate llms.txt from canonical sources (CHEATSHEET, diagnostics, stdlib) |
 | [lumen — Pure Graphics Math](active/lumen-graphics-math.md) | lumen — pure graphics math library (vec3, mat4, color), used by webgl/canvas/obsid |
 | [MLIR Backend + Egg Rewrite Engine](active/mlir-backend-adoption.md) | MLIR backend + egg e-graph rewriter for pure-Almide optimal lowering |
+| [Observability: Effect Trace / Runtime Timeline](active/observability-effect-trace.md) | Effect trace, runtime event timeline, pass inspector for debugging and MSR |
 | [`almide update` — Dependency Update Command](active/package-manager-update.md) | Add almide update command to refresh dependencies and rewrite lock file |
 | [Package Version Resolution](active/package-version-resolution.md) | MVS version resolution with semver constraints for almide.toml |
 | [Reimpl Lint: Signature-Match Detection of Stdlib Reimplementations](active/reimpl-lint.md) | Detect user fns whose signature matches a stdlib fn, suggest delegation |
+| [Sized Numeric Types](active/sized-numeric-types.md) | Swift-style Int8/Int32/UInt32/Float32 scalar types; unblocks bytes redesign + Matrix[T] dtype |
 | [Stdlib Declarative Unification — Toward a Single Source of Truth](active/stdlib-declarative-unification.md) | Drive stdlib toward a single source-of-truth: `.almd` + multi-target ABI attributes |
 | [Stdlib Defs / Runtime Consistency Check](active/stdlib-defs-runtime-consistency.md) | CI check that stdlib/defs/*.toml declared types match runtime/rs/src/*.rs signatures |
 | [Stdlib Symmetry Audit](active/stdlib-symmetry-audit.md) | Symmetry audit and lint for stdlib Option/Result/List/Set/Map to remove naming drift |
@@ -39,15 +43,17 @@
 
 ## On Hold
 
-26 items
+29 items
 
 | Item | Description |
 |------|-------------|
+| [Advanced Type System (HKT / GADT / Type-level)](on-hold/advanced-type-system.md) | HKT / GADT / type-level computation as opt-in advanced features, not LLM-recommended |
 | [Almide-to-Almide FFI via almide-lander](on-hold/almide-to-almide-ffi.md) | Use almide-lander to call compiled Almide libraries from Almide via shared library FFI |
 | [Almide UI — Reactive Web Framework as Almide Library](on-hold/almide-ui.md) | SolidJS-like reactive UI framework built as a pure Almide library |
 | [API Diff & Automatic Versioning](on-hold/api-diff-auto-versioning.md) | Automatic semver bump detection via public API diffing |
 | [LLM Benchmark: Next Phase](on-hold/benchmark-next-phase.md) | LLM benchmark Phase 2-3: cross-language comparison, harder problems, publication |
 | [Compile-Time Contracts](on-hold/compile-time-contracts.md) | Compile-time preconditions and type invariants via where clauses |
+| [Doc Test Framework](on-hold/doctest-framework.md) | Auto-compile and run .almide code blocks in docs to prevent example drift |
 | [Error-Fix Database](on-hold/error-fix-db.md) | Structured error-to-fix mapping for LLM auto-repair of compiler errors |
 | [GPU Compute — Matrix Type and Compiler-Driven GPU Execution](on-hold/gpu-compute.md) | Matrix primitive type with compiler-driven CPU/GPU execution |
 | [IR Optimization Tier 2](on-hold/ir-optimization-tier2.md) | CSE and inlining passes for cross-target IR optimization |
@@ -57,6 +63,7 @@
 | [Tiny ML Inference Runtime](on-hold/ml-inference.md) | Tiny ML inference runtime using compile-time model specialization |
 | [Package Registry](on-hold/package-registry.md) | Lock file, semver resolution, and central package registry |
 | [Performance Research: Path to World #1](on-hold/performance-research.md) | Research plan to surpass hand-written Rust via semantic-aware optimization |
+| [Persistence / Sync Primitives](on-hold/persistence-sync-primitives.md) | Local-first storage, CRDT merge, and sync queue primitives for app runtime |
 | [Porta Embedded — Sub-10KB Almide IoT Agents on WASI Hosts](on-hold/porta-embedded.md) | Porta-style WASI agent runtime for IoT: <10KB Almide guests on tiny hosts |
 | [Rainbow Bridge — Wrap External Code as Almide Packages](on-hold/rainbow-bridge.md) | Wrap external Rust/TS/Python code as native Almide packages via @extern |
 | [Research: Modification Survival Rate Paper](on-hold/research-modification-survival-rate-paper.md) | Academic paper measuring LLM code modification survival across languages |

--- a/docs/roadmap/active/sized-numeric-types.md
+++ b/docs/roadmap/active/sized-numeric-types.md
@@ -1,0 +1,314 @@
+<!-- description: Swift-style Int8/Int32/UInt32/Float32 scalar types; unblocks bytes redesign + Matrix[T] dtype -->
+# Sized Numeric Types
+
+## Motivation
+
+Almide today has exactly two numeric scalars: `Int` (i64) and
+`Float` (f64). Every operation that cares about bit-width or
+signedness has to encode that information in **function names**.
+The clearest symptom is `stdlib/defs/bytes.toml`:
+
+```
+read_u32_le / read_u32_be / read_i32_le / read_i32_be / ...
+```
+
+Width × endianness × operation (read / write / set / append) =
+**82 out of 126 fns** in bytes — a combinatorial explosion that
+no type-system-free language can collapse.
+
+Secondary pressures:
+
+- `Matrix[T]` dtype arc (`docs/roadmap/active/matrix-dtype.md`,
+  `project_matrix_dtype_design` memory) assumes a meaningful
+  element-type parameter. Without Int32 / Float32 / etc. the arc
+  has no reasonable `T`.
+- MSR: LLMs fluent in Rust / Swift / Go / C all expect
+  `Int32` / `UInt8` / `Float32`. The current "only Int64" surface
+  forces hallucination-prone workarounds (`n & 0xFFFFFFFF`
+  masking, manual endian swaps).
+- Performance: `f32` arrays take half the bytes of `f64`; without a
+  distinct type the compiler cannot choose the tighter layout.
+
+## Decision
+
+Adopt the **Swift numeric type model**:
+
+```
+Int8, Int16, Int32, Int64     // signed, two's complement
+UInt8, UInt16, UInt32, UInt64 // unsigned, wrapping on overflow disabled by default
+Float32, Float64
+```
+
+Plus the platform-independent aliases (so existing code is
+untouched):
+
+- `Int` = `Int64`
+- `Float` = `Float64`
+
+Swift's model is proven, LLM-familiar (Swift has millions of
+training examples with exactly these names), and carries no
+legacy baggage (unlike Rust's `usize` / `isize` which would pull
+in platform-dependent sizing).
+
+## Type rules
+
+### Literals
+
+Integer and float literals stay untyped at the lexer / AST level.
+The checker infers the concrete type from surrounding context:
+
+```almide
+let a: Int32 = 42        // 42 coerces to Int32
+let b: UInt8 = 0xff      // 0xff coerces to UInt8; out-of-range is an error
+let c = 42               // no context → Int (Int64)
+bytes.read_u32(buf, 0)   // → UInt32; no annotation needed
+```
+
+Out-of-range literals under a concrete type are a compile error
+(`UInt8 = 300` → `E-width-overflow`).
+
+### Arithmetic
+
+Same-type binary ops return the same type:
+
+```almide
+let x: Int32 = 10
+let y: Int32 = 20
+let z = x + y    // z: Int32
+```
+
+Mixed-width ops are an error. Explicit conversion is required:
+
+```almide
+let a: Int32 = 10
+let b: Int64 = 20
+a + b                    // ✗ type error
+a.to_int64() + b         // ✓ Int64
+```
+
+No implicit widening. No implicit narrowing. This matches Swift
+and avoids silent precision loss.
+
+### Protocol membership
+
+- `FixedWidthInteger`: Int8, Int16, Int32, Int64, UInt8, UInt16,
+  UInt32, UInt64. Exposes `.bits`, `.min`, `.max`, `.bit_and`,
+  `.bit_or`, etc.
+- `BinaryFloatingPoint`: Float32, Float64. Exposes `.infinity`,
+  `.is_nan`, `.sqrt`, etc.
+- `Numeric` (superset): all of the above.
+
+These let generic stdlib code like `bytes.read[T: FixedWidthInteger]`
+stay sane.
+
+### Conversion
+
+Explicit only, via UFCS methods that the checker registers per
+type:
+
+```almide
+n.to_int32()       // Int → Int32 (panics on out-of-range? or returns Option?)
+n.to_int32_lossy() // truncating
+n.to_uint8()
+f.to_int64()       // Float64 → Int64, truncates toward zero
+i.to_float32()     // i32 / i64 → f32 (may lose precision)
+```
+
+Decision point: **do we panic, return Option, or saturate on
+out-of-range?** Leaning toward Option (`to_int32() -> Option[Int32]`)
+for safety + `to_int32_wrapping()` / `to_int32_saturating()` when
+explicit.
+
+## Codegen
+
+### Rust target (direct mapping)
+
+| Almide | Rust |
+|---|---|
+| `Int8` / `Int16` / `Int32` / `Int64` | `i8` / `i16` / `i32` / `i64` |
+| `UInt8` / `UInt16` / `UInt32` / `UInt64` | `u8` / `u16` / `u32` / `u64` |
+| `Float32` / `Float64` | `f32` / `f64` |
+
+Runtime fn signatures get the precise Rust type instead of the
+current `i64` catch-all. Example:
+
+```rust
+// Before
+pub fn almide_rt_bytes_read_u32_le(b: &[u8], offset: i64) -> i64 { ... }
+
+// After
+pub fn almide_rt_bytes_read_u32_le(b: &[u8], offset: i64) -> u32 { ... }
+```
+
+### WASM target (lowered)
+
+WASM has only four native value types: `i32`, `i64`, `f32`, `f64`.
+Narrower Almide types compile to the next-wider WASM type with
+masking on stores:
+
+| Almide | WASM repr | Notes |
+|---|---|---|
+| `Int8` | `i32` | load `i8_load_s`, store with sign-extend fitness |
+| `UInt8` | `i32` | load `i8_load_u`, store with `& 0xff` |
+| `Int16` / `UInt16` | `i32` | similar with i16 loads |
+| `Int32` / `UInt32` / `Int64` / `UInt64` | `i32` / `i64` | native |
+| `Float32` / `Float64` | `f32` / `f64` | native |
+
+Well-known territory; both emscripten and `rustc --target wasm32`
+handle this trivially.
+
+## Stdlib integration
+
+### bytes (primary beneficiary)
+
+Post-arc surface for byte IO:
+
+```almide
+// Generic read/write — collapses ~70 fns into 4
+fn read[T: FixedWidthInteger](b: Bytes, offset: Int, endian: Endian) -> T
+fn write[T: FixedWidthInteger](buf: Bytes, value: T, endian: Endian) -> Unit
+fn set[T: FixedWidthInteger](buf: Bytes, offset: Int, value: T, endian: Endian) -> Unit
+fn append[T: FixedWidthInteger](buf: Bytes, value: T, endian: Endian) -> Unit
+```
+
+Plus the float counterparts:
+
+```almide
+fn read_float[T: BinaryFloatingPoint](b: Bytes, offset: Int, endian: Endian) -> T
+// ... etc
+```
+
+Total bytes surface: **~30–40 fns** instead of 126.
+
+### int / float modules
+
+Stay as `Int` (= `Int64`) and `Float` (= `Float64`) first-class
+modules. Add typed variants as method-style UFCS:
+
+```almide
+let x: Int32 = 42
+x.abs()            // Int32 → Int32
+x.to_int64()       // Int32 → Int64
+x.to_string()      // Int32 → String
+```
+
+Each sized type gets its own small stdlib-like module (`int32.*`,
+`uint8.*`, etc.) — likely auto-generated from a single declarative
+source so we don't re-create the 82-fn explosion on the stdlib
+side.
+
+### Matrix[T]
+
+Becomes type-parametric on a `FixedWidthInteger | BinaryFloatingPoint`
+bound. `Matrix[Float32]`, `Matrix[Int32]`, etc. Dtype arc gets
+its `T` foundation.
+
+## Sub-phases
+
+### Stage 1 — Parser + AST + type system (2 weeks)
+
+- Parser: accept `Int8` / `Int16` / ... / `Float32` / `Float64` as
+  new Simple type names.
+- AST: no change (they're already `TypeExpr::Simple { name }`).
+- `almide-types::Ty`: add `Ty::Int8`, `Ty::Int16`, ..., `Ty::UInt64`,
+  `Ty::Float32`. (`Ty::Int` stays as `Int64` alias.)
+- Checker:
+  - Literal coercion: context-directed, range-checked.
+  - Arithmetic: same-type required.
+  - `FixedWidthInteger` / `BinaryFloatingPoint` protocols as
+    built-in.
+- Stdlib: `Int` = `Int64` alias, `Float` = `Float64` alias.
+  Round-trip: every existing `.almd` program compiles with no
+  change.
+
+### Stage 2 — Codegen (1 week)
+
+- Rust: emit `i32` / `u32` / `f32` etc. Walker `render_type`
+  gets new arms.
+- WASM: lower `Int8` / `UInt16` etc. to `i32` with mask-on-store
+  for narrow writes. `values.rs::ty_to_valtype` extended.
+- `BinOp` type dispatch: per-arithmetic operator × per-type
+  variant (`AddInt32`, `AddUInt32`, ...). The existing matrix of
+  `AddInt` / `AddFloat` extends along a new dimension.
+
+### Stage 3 — Conversion UFCS (1 week)
+
+- `n.to_int32() -> Option[Int32]`, `.to_int32_wrapping()`,
+  `.to_int32_saturating()`.
+- Float ↔ Int conversions with lossy / checked variants.
+- Documentation: `docs/specs/type-system.md` gets a sized-
+  numeric section.
+
+### Stage 4 — Stdlib redesign (2-3 weeks)
+
+- `stdlib/bytes.almd` rewritten with generic `read[T]` / `write[T]`
+  primitives. The 82 width×endian×op primitives become internal
+  `almide_rt_bytes_*` calls dispatched from the generic fn.
+- `stdlib/int32.almd`, `stdlib/uint8.almd`, etc. — small modules
+  per sized type, auto-generated or handwritten.
+- Matrix[T] dtype arc picks up from here.
+
+## Non-goals
+
+- **BigInt / arbitrary precision integers.** Keep the numeric
+  tower finite. If users need arbitrary precision they can
+  depend on a package.
+- **Float16 / Bfloat16.** No native support in Rust stable or WASM;
+  revisit when the broader toolchain does.
+- **Decimal / fixed-point.** Domain-specific; belongs in a
+  package, not the stdlib numeric core.
+- **Platform-dependent widths** (`usize`, `isize`). Almide's
+  ABI-agnostic design doesn't admit platform variance in the type
+  system.
+
+## Risks
+
+- **Existing code regressions from literal inference.** Must keep
+  `Int` / `Float` as aliases so `let x = 42` still gives Int64.
+  Any change there breaks every program.
+- **Operator dispatch combinatorics.** `BinOp` already has
+  `AddInt` / `AddFloat` / `AddMatrix` — adding `AddInt8`
+  ... `AddUInt64` × each op is ~10 × 8 = 80 new variants. The
+  cleaner approach is a single `Add { ty: Ty }` operator, which
+  is itself a sub-arc (operator representation refactor).
+- **WASM Int64 / UInt64 ops.** WASM has i64 but signed/unsigned
+  distinction is in the INSTRUCTION, not the TYPE. We'll encode
+  signedness in the op selection.
+- **LLM confusion between `Int` and `Int64`.** Docs must be
+  explicit: `Int` is a typedef, writing `Int` and `Int64`
+  produces identical code.
+
+## Dependencies
+
+- **Blocker for**: `bytes` migration (Stdlib Unification Stage 2c),
+  Matrix[T] dtype arc, any future SIMD work.
+- **Blocked by**: none. The existing type system + codegen
+  architecture already supports adding Ty variants; this arc is
+  pure extension.
+
+## Success criteria
+
+- `let x: UInt32 = 0xffffffff` compiles, runs, round-trips through
+  WASM.
+- `bytes.read[UInt32](buf, 0, .le)` works; the `stdlib/bytes.almd`
+  file is under 40 fns.
+- `Matrix[Float32]` type-checks; element accessors return Float32.
+- MSR baseline: 207+ `.almd` test files pass unchanged (aliases
+  ensure zero regression).
+- Dojo MSR improvement: LLM hallucination rate on bit-width
+  questions ("how do I read a uint32 from bytes") decreases.
+
+## Total scope
+
+**6-7 weeks of focused work**, split across 4 sub-phases. Each
+sub-phase is independently mergeable (opt-in new types, existing
+code untouched until Stage 4 integrates them).
+
+## Relationship to other arcs
+
+| Arc | Relation |
+|---|---|
+| `stdlib-declarative-unification.md` Stage 2c (bytes) | **depends on this** — migrate bytes with new generic API |
+| `matrix-dtype-design.md` (memory) | **depends on this** — `Matrix[T]` uses sized types as T |
+| `mlir-backend-adoption.md` | **enables** — MLIR dialect can tier types naturally once Almide has them |
+| `llm-first-language.md` | **aligned** — Swift-style naming is a known good for LLMs |


### PR DESCRIPTION
## Summary

Adds `docs/roadmap/active/sized-numeric-types.md` — a new arc that introduces Swift-style `Int8` / `Int16` / `Int32` / `Int64` / `UInt8` / `UInt16` / `UInt32` / `UInt64` / `Float32` / `Float64` scalar types to Almide, with `Int` = `Int64` and `Float` = `Float64` as aliases so existing programs compile unchanged.

## Motivation

The `stdlib/defs/bytes.toml` file has 126 functions, 82 of which encode (width × endianness × operation) combinatorics in function names because the type system can't express them. This isn't a bytes-module problem — it's a symptom of Almide lacking bit-width-aware numeric types. Fixing the type system collapses `bytes` to ~30-40 fns and unblocks:

- **Stdlib Unification Stage 2c** (bytes migration, currently deferred pending this arc)
- **Matrix[T] dtype** arc (needs meaningful `T` parameter)
- Future SIMD / GPU work

## Arc structure

Four sub-phases, 6-7 weeks total:

1. Parser + type system (new `Ty::Int8`..`Float64` variants, literal coercion, protocol membership)
2. Codegen (Rust direct mapping + WASM lowering; Int8/UInt16 become i32 with mask-on-store)
3. Conversion UFCS (`.to_int32()`, `.to_uint8_wrapping()`, etc.)
4. Stdlib redesign (generic `bytes.read[T]`, per-type modules)

## Non-goals

BigInt, Float16, Decimal, platform-dependent widths.

## Dependencies

Blocks: bytes migration (Stage 2c), Matrix[T] dtype arc.
Blocked by: nothing — the arc is pure extension, aliases keep existing code working.

## Test plan

- [x] Roadmap README regenerated (`bash docs/roadmap/generate-readme.sh`)
- [x] Doc renders cleanly on GitHub (verified via local preview; will eyeball after merge)