### PR TITLE
Sized Numeric Types Stage 1c: arithmetic + equality

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/equality.rs
+++ b/crates/almide-codegen/src/emit_wasm/equality.rs
@@ -42,6 +42,18 @@ impl FuncCompiler<'_> {
         match ty {
             Ty::Int => { wasm!(self.func, { i64_eq; }); }
             Ty::Float => { wasm!(self.func, { f64_eq; }); }
+            // Sized Numeric Types (Stage 1c): narrow ints ride in i32
+            // at the WASM level, so equality uses `i32.eq`. `UInt64`
+            // stays i64. `Float32` uses `f32.eq` via the Instruction
+            // API (macro lacks an `f32_eq` rule).
+            Ty::Int8 | Ty::Int16 | Ty::Int32
+            | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 => {
+                wasm!(self.func, { i32_eq; });
+            }
+            Ty::UInt64 => { wasm!(self.func, { i64_eq; }); }
+            Ty::Float32 => {
+                self.func.instruction(&wasm_encoder::Instruction::F32Eq);
+            }
             Ty::Bool => { wasm!(self.func, { i32_eq; }); }
             Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
 

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -782,52 +782,108 @@ impl FuncCompiler<'_> {
 
     pub(super) fn emit_binop(&mut self, op: BinOp, left: &IrExpr, right: &IrExpr) {
         // BinOp is already reconciled with operand types by ConcretizeTypes pass.
+        // Pick WASM arithmetic width from the operand's valtype. All
+        // sized integer variants (Int8/Int16/Int32/UInt8/UInt16/UInt32)
+        // lower to `i32`; `UInt64` and canonical `Int` stay `i64`. For
+        // unsigned div/mod the distinction matters (div_u vs div_s),
+        // tracked via `is_unsigned_int`.
+        let is_i32_int = matches!(
+            left.ty,
+            Ty::Int8 | Ty::Int16 | Ty::Int32
+                | Ty::UInt8 | Ty::UInt16 | Ty::UInt32
+        );
+        let is_unsigned_int = matches!(
+            left.ty,
+            Ty::UInt8 | Ty::UInt16 | Ty::UInt32 | Ty::UInt64
+        );
+        let is_f32 = matches!(left.ty, Ty::Float32);
+
         match op {
             // ── Arithmetic ──
             BinOp::AddInt => {
                 self.emit_expr(left);
                 self.emit_expr(right);
-                wasm!(self.func, { i64_add; });
+                if is_i32_int {
+                    wasm!(self.func, { i32_add; });
+                } else {
+                    wasm!(self.func, { i64_add; });
+                }
             }
             BinOp::SubInt => {
                 self.emit_expr(left);
                 self.emit_expr(right);
-                wasm!(self.func, { i64_sub; });
+                if is_i32_int {
+                    wasm!(self.func, { i32_sub; });
+                } else {
+                    wasm!(self.func, { i64_sub; });
+                }
             }
             BinOp::MulInt => {
                 self.emit_expr(left);
                 self.emit_expr(right);
-                wasm!(self.func, { i64_mul; });
+                if is_i32_int {
+                    wasm!(self.func, { i32_mul; });
+                } else {
+                    wasm!(self.func, { i64_mul; });
+                }
             }
             BinOp::DivInt => {
                 self.emit_expr(left);
                 self.emit_expr(right);
-                wasm!(self.func, { i64_div_s; });
+                let instr = match (is_i32_int, is_unsigned_int) {
+                    (true, true) => wasm_encoder::Instruction::I32DivU,
+                    (true, false) => wasm_encoder::Instruction::I32DivS,
+                    (false, true) => wasm_encoder::Instruction::I64DivU,
+                    (false, false) => wasm_encoder::Instruction::I64DivS,
+                };
+                self.func.instruction(&instr);
             }
             BinOp::ModInt => {
                 self.emit_expr(left);
                 self.emit_expr(right);
-                wasm!(self.func, { i64_rem_s; });
+                let instr = match (is_i32_int, is_unsigned_int) {
+                    (true, true) => wasm_encoder::Instruction::I32RemU,
+                    (true, false) => wasm_encoder::Instruction::I32RemS,
+                    (false, true) => wasm_encoder::Instruction::I64RemU,
+                    (false, false) => wasm_encoder::Instruction::I64RemS,
+                };
+                self.func.instruction(&instr);
             }
             BinOp::AddFloat => {
                 self.emit_expr(left);
                 self.emit_expr(right);
-                wasm!(self.func, { f64_add; });
+                if is_f32 {
+                    self.func.instruction(&wasm_encoder::Instruction::F32Add);
+                } else {
+                    wasm!(self.func, { f64_add; });
+                }
             }
             BinOp::SubFloat => {
                 self.emit_expr(left);
                 self.emit_expr(right);
-                wasm!(self.func, { f64_sub; });
+                if is_f32 {
+                    self.func.instruction(&wasm_encoder::Instruction::F32Sub);
+                } else {
+                    wasm!(self.func, { f64_sub; });
+                }
             }
             BinOp::MulFloat => {
                 self.emit_expr(left);
                 self.emit_expr(right);
-                wasm!(self.func, { f64_mul; });
+                if is_f32 {
+                    self.func.instruction(&wasm_encoder::Instruction::F32Mul);
+                } else {
+                    wasm!(self.func, { f64_mul; });
+                }
             }
             BinOp::DivFloat => {
                 self.emit_expr(left);
                 self.emit_expr(right);
-                wasm!(self.func, { f64_div; });
+                if is_f32 {
+                    self.func.instruction(&wasm_encoder::Instruction::F32Div);
+                } else {
+                    wasm!(self.func, { f64_div; });
+                }
             }
             BinOp::ModFloat => {
                 // WASM has no f64.rem; compute via: a - trunc(a/b) * b

--- a/crates/almide-codegen/src/pass_builtin_lowering.rs
+++ b/crates/almide-codegen/src/pass_builtin_lowering.rs
@@ -63,6 +63,20 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
                             let fmt = IrExpr { kind: IrExprKind::LitStr { value: "{}".into() }, ty: Ty::String, span: None };
                             return IrExpr { kind: IrExprKind::RustMacro { name: *name, args: vec![cond, fmt, msg] }, ty, span };
                         }
+                        // Sized Numeric Types (Stage 1c): `assert_eq(x,
+                        // 30)` where `x: Int32` needs the `30` literal
+                        // retyped to `Int32` so `rustc`'s `assert_eq!`
+                        // macro sees matching operand widths. The
+                        // assertion itself isn't a typed fn call, so
+                        // the usual arg-coercion in `lower_call` doesn't
+                        // reach here — patch at the macro build site.
+                        let mut args = args;
+                        if args.len() == 2 {
+                            let l_ty = args[0].ty.clone();
+                            let r_ty = args[1].ty.clone();
+                            coerce_macro_arg(&mut args[1], &l_ty);
+                            coerce_macro_arg(&mut args[0], &r_ty);
+                        }
                         return IrExpr { kind: IrExprKind::RustMacro { name: *name, args }, ty, span };
                     }
                     // assert_some → assert!(x.is_some())
@@ -305,6 +319,34 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
     };
 
     IrExpr { kind, ty, span }
+}
+
+/// Retype a bare Int / Float literal whose IR type is `Ty::Int` /
+/// `Ty::Float` so it matches a sized-typed peer in the same macro
+/// call. See the `assert_eq` site above for the motivation.
+fn coerce_macro_arg(arg: &mut IrExpr, peer_ty: &Ty) {
+    let sized = matches!(
+        peer_ty,
+        Ty::Int8 | Ty::Int16 | Ty::Int32
+            | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 | Ty::UInt64
+            | Ty::Float32
+    );
+    if !sized { return; }
+    match &mut arg.kind {
+        IrExprKind::LitInt { .. } if arg.ty == Ty::Int => {
+            arg.ty = peer_ty.clone();
+        }
+        IrExprKind::LitFloat { .. } if arg.ty == Ty::Float => {
+            arg.ty = peer_ty.clone();
+        }
+        IrExprKind::UnOp { op: UnOp::NegInt, operand } => {
+            if matches!(&operand.kind, IrExprKind::LitInt { .. }) && operand.ty == Ty::Int {
+                operand.ty = peer_ty.clone();
+                arg.ty = peer_ty.clone();
+            }
+        }
+        _ => {}
+    }
 }
 
 fn rewrite_stmts(stmts: Vec<IrStmt>) -> Vec<IrStmt> {

--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -281,13 +281,29 @@ impl Checker {
                         if lc == Ty::Matrix || rc == Ty::Matrix {
                             Ty::Matrix
                         } else {
-                            let is_numeric = |t: &Ty| matches!(t, Ty::Int | Ty::Float | Ty::Unknown | Ty::TypeVar(_));
+                            // Sized Numeric Types (Stage 1c): same-width
+                            // arithmetic accepts every sized numeric variant.
+                            let is_numeric = |t: &Ty| matches!(
+                                t,
+                                Ty::Int | Ty::Float | Ty::Unknown | Ty::TypeVar(_)
+                                    | Ty::Int8 | Ty::Int16 | Ty::Int32
+                                    | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 | Ty::UInt64
+                                    | Ty::Float32
+                            );
+                            let is_sized_scalar = |t: &Ty| matches!(
+                                t,
+                                Ty::Int8 | Ty::Int16 | Ty::Int32
+                                    | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 | Ty::UInt64
+                                    | Ty::Float32
+                            );
                             if !is_numeric(&lc) || !is_numeric(&rc) {
                                 self.emit(super::err(
                                     format!("operator '{}' requires numeric types but got {} and {}", op, lc.display(), rc.display()),
                                     "Use numeric types (Int or Float)", format!("operator {}", op)));
                             }
-                            if lc == Ty::Float || rc == Ty::Float { Ty::Float } else { lt }
+                            if lc.compatible(&rc) && is_sized_scalar(&lc) {
+                                lc
+                            } else if lc == Ty::Float || rc == Ty::Float { Ty::Float } else { lt }
                         }
                     }
                     "++" => {
@@ -980,11 +996,35 @@ impl Checker {
         if *lc == Ty::Matrix || *rc == Ty::Matrix {
             return Ty::Matrix;
         }
-        let is_numeric = |t: &Ty| matches!(t, Ty::Int | Ty::Float | Ty::Unknown | Ty::TypeVar(_));
+        // Sized Numeric Types (Stage 1c): arithmetic accepts canonical
+        // `Int` / `Float` plus every sized variant. Same-type pairing is
+        // enforced below; mixing widths is an explicit conversion.
+        let is_numeric = |t: &Ty| matches!(
+            t,
+            Ty::Int | Ty::Float | Ty::Unknown | Ty::TypeVar(_)
+                | Ty::Int8 | Ty::Int16 | Ty::Int32
+                | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 | Ty::UInt64
+                | Ty::Float32
+        );
         if !is_numeric(lc) || !is_numeric(rc) {
             self.emit(super::err(
                 format!("operator '+' requires numeric, String, or List types but got {} and {}", lc.display(), rc.display()),
                 "Use + with numeric types, String, or List", format!("operator +")));
+        }
+        // Result type resolution:
+        //   - Same sized type on both sides → that sized type.
+        //   - Canonical Float promotes Int mixes to Float (legacy rule).
+        //   - Mixed sized widths are rejected; the diagnostic is
+        //     emitted by `compatible` / `unify_infer` callers, so here
+        //     we just fall through with `lt` to avoid an extra error.
+        let is_sized_scalar = |t: &Ty| matches!(
+            t,
+            Ty::Int8 | Ty::Int16 | Ty::Int32
+                | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 | Ty::UInt64
+                | Ty::Float32
+        );
+        if lc.compatible(rc) && is_sized_scalar(lc) {
+            return lc.clone();
         }
         if *lc == Ty::Float || *rc == Ty::Float { Ty::Float } else { lt }
     }

--- a/crates/almide-frontend/src/lower/calls.rs
+++ b/crates/almide-frontend/src/lower/calls.rs
@@ -85,6 +85,17 @@ pub(super) fn lower_call(ctx: &mut LowerCtx, callee: &ast::Expr, args: &[ast::Ex
     // so `f(42)` where `f(x: UInt32)` emits `f(42u32)` instead of an
     // `i64` / `u32` codegen mismatch.
     if let CallTarget::Named { name } = &target {
+        // Builtin comparison macros (assert_eq / assert_ne) aren't
+        // registered in env.functions, but their semantics demand
+        // width-matched operands on both targets. Coerce literal-side
+        // args toward their typed peer here, before the target-specific
+        // lowering picks up a Macro / RustMacro / direct-emit path.
+        if matches!(name.as_str(), "assert_eq" | "assert_ne") && ir_args.len() == 2 {
+            let l_ty = ir_args[0].ty.clone();
+            let r_ty = ir_args[1].ty.clone();
+            super::statements::coerce_literal_to_sized(&mut ir_args[1], &l_ty);
+            super::statements::coerce_literal_to_sized(&mut ir_args[0], &r_ty);
+        }
         if let Some(sig) = ctx.env.functions.get(name).cloned() {
             for (i, (_, param_ty)) in sig.params.iter().enumerate() {
                 if let Some(arg) = ir_args.get_mut(i) {

--- a/crates/almide-frontend/src/lower/expressions.rs
+++ b/crates/almide-frontend/src/lower/expressions.rs
@@ -135,8 +135,16 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
 
         // ── Operators ──
         ast::ExprKind::Binary { op, left, right, .. } => {
-            let l = lower_expr(ctx, left);
-            let r = lower_expr(ctx, right);
+            let mut l = lower_expr(ctx, left);
+            let mut r = lower_expr(ctx, right);
+            // Sized Numeric Types (Stage 1c): when one operand is a
+            // sized type and the other is a bare Int/Float literal,
+            // retype the literal so the resulting BinOp has matching
+            // operand widths. Mirrors the fn-arg and let-binding
+            // coercion rules — the same authoritative-context rule
+            // applies to any pairing where one side locks the width.
+            super::statements::coerce_literal_to_sized(&mut r, &l.ty);
+            super::statements::coerce_literal_to_sized(&mut l, &r.ty);
             // Resolve operand types: if expr.ty is Unknown, try VarTable lookup
             let left_ty = if l.ty == Ty::Unknown {
                 if let IrExprKind::Var { id } = &l.kind { ctx.var_table.get(*id).ty.clone() } else { l.ty.clone() }
@@ -168,13 +176,31 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
                 ("*", Ty::Matrix, Ty::Matrix) => BinOp::MulMatrix,
                 ("*", Ty::Matrix, Ty::Float) | ("*", Ty::Float, Ty::Matrix) => BinOp::ScaleMatrix,
                 ("*", Ty::Matrix, Ty::Int) | ("*", Ty::Int, Ty::Matrix) => BinOp::ScaleMatrix,
-                ("+", Ty::Float, _) | ("+", _, Ty::Float) => BinOp::AddFloat,
+                // Float dispatch covers canonical `Float` plus the sized
+                // `Float32`. Any other numeric type (Int / Int8 ... /
+                // UInt64) takes the Int path. The *width* of the
+                // arithmetic op (i32_add vs i64_add vs f32_add vs
+                // f64_add) is resolved at WASM emit time from the
+                // operand's valtype; Rust codegen emits plain `a + b`
+                // and lets rustc pick.
+                ("+", Ty::Float, _) | ("+", _, Ty::Float)
+                | ("+", Ty::Float32, _) | ("+", _, Ty::Float32) => BinOp::AddFloat,
                 ("+", _, _) => BinOp::AddInt,
-                ("-", Ty::Float, _) | ("-", _, Ty::Float) => BinOp::SubFloat, ("-", _, _) => BinOp::SubInt,
-                ("*", Ty::Float, _) | ("*", _, Ty::Float) => BinOp::MulFloat, ("*", _, _) => BinOp::MulInt,
-                ("/", Ty::Float, _) | ("/", _, Ty::Float) => BinOp::DivFloat, ("/", _, _) => BinOp::DivInt,
-                ("%", Ty::Float, _) | ("%", _, Ty::Float) => BinOp::ModFloat, ("%", _, _) => BinOp::ModInt,
-                ("^", Ty::Float, _) | ("^", _, Ty::Float) => BinOp::PowFloat, ("^", _, _) => BinOp::PowInt,
+                ("-", Ty::Float, _) | ("-", _, Ty::Float)
+                | ("-", Ty::Float32, _) | ("-", _, Ty::Float32) => BinOp::SubFloat,
+                ("-", _, _) => BinOp::SubInt,
+                ("*", Ty::Float, _) | ("*", _, Ty::Float)
+                | ("*", Ty::Float32, _) | ("*", _, Ty::Float32) => BinOp::MulFloat,
+                ("*", _, _) => BinOp::MulInt,
+                ("/", Ty::Float, _) | ("/", _, Ty::Float)
+                | ("/", Ty::Float32, _) | ("/", _, Ty::Float32) => BinOp::DivFloat,
+                ("/", _, _) => BinOp::DivInt,
+                ("%", Ty::Float, _) | ("%", _, Ty::Float)
+                | ("%", Ty::Float32, _) | ("%", _, Ty::Float32) => BinOp::ModFloat,
+                ("%", _, _) => BinOp::ModInt,
+                ("^", Ty::Float, _) | ("^", _, Ty::Float)
+                | ("^", Ty::Float32, _) | ("^", _, Ty::Float32) => BinOp::PowFloat,
+                ("^", _, _) => BinOp::PowInt,
                 ("==", _, _) => BinOp::Eq, ("!=", _, _) => BinOp::Neq,
                 ("<", _, _) => BinOp::Lt, (">", _, _) => BinOp::Gt,
                 ("<=", _, _) => BinOp::Lte, (">=", _, _) => BinOp::Gte,

--- a/crates/almide-ir/src/verify.rs
+++ b/crates/almide-ir/src/verify.rs
@@ -455,6 +455,23 @@ fn is_unresolved(ty: &Ty) -> bool {
 
 fn ty_matches(actual: &Ty, expected: &Ty) -> bool {
     if is_unresolved(actual) { return true; }
+    // Sized Numeric Types (Stage 1c): every sized integer is accepted
+    // wherever `Ty::Int` is expected, and `Ty::Float32` where `Ty::Float`
+    // is expected. The BinOp variants in IR (`AddInt`, `AddFloat`, ...)
+    // are not width-parameterized; the actual WASM / Rust op is chosen
+    // at emit time from the operand's ty.
+    if expected == &Ty::Int
+        && matches!(
+            actual,
+            Ty::Int8 | Ty::Int16 | Ty::Int32
+                | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 | Ty::UInt64
+        )
+    {
+        return true;
+    }
+    if expected == &Ty::Float && matches!(actual, Ty::Float32) {
+        return true;
+    }
     std::mem::discriminant(actual) == std::mem::discriminant(expected)
 }
 

--- a/spec/lang/sized_numeric_types_test.almd
+++ b/spec/lang/sized_numeric_types_test.almd
@@ -88,3 +88,21 @@ test "Float64 fn" {
   let r = id_float64(2.5)
   assert_eq(r, 2.5)
 }
+
+// ── Stage 1c: same-type arithmetic ───────────────────────────────
+
+fn add_i32(a: Int32, b: Int32) -> Int32 = a + b
+fn sub_i32(a: Int32, b: Int32) -> Int32 = a - b
+fn mul_u8(a: UInt8, b: UInt8) -> UInt8 = a * b
+fn div_u32(a: UInt32, b: UInt32) -> UInt32 = a / b
+fn mod_i16(a: Int16, b: Int16) -> Int16 = a % b
+fn add_f32(a: Float32, b: Float32) -> Float32 = a + b
+fn sub_u64(a: UInt64, b: UInt64) -> UInt64 = a - b
+
+test "Int32 addition" { assert_eq(add_i32(10, 20), 30) }
+test "Int32 subtraction" { assert_eq(sub_i32(50, 20), 30) }
+test "UInt8 multiplication" { assert_eq(mul_u8(10, 5), 50) }
+test "UInt32 division (unsigned)" { assert_eq(div_u32(100, 4), 25) }
+test "Int16 modulo" { assert_eq(mod_i16(23, 5), 3) }
+test "Float32 addition" { assert_eq(add_f32(1.5, 2.5), 4.0) }
+test "UInt64 subtraction" { assert_eq(sub_u64(1000, 200), 800) }


### PR DESCRIPTION
## Summary

Third sub-phase of the Sized Numeric Types arc. Adds same-width arithmetic (`+` `-` `*` `/` `%`) and `==` / `!=` support for all sized numeric types on both Rust and WASM targets. The `BinOp` enum stays unchanged — operand widths are resolved at emit time from `expr.ty`, so we avoid an 80-variant explosion. Literal coercion extended from let / fn-arg sites to BinOp operands and `assert_eq` / `assert_ne` macro args.

## What landed

**Type checker (`almide-frontend/src/check/infer.rs`)**
- `is_numeric` predicate extended: Int/Float + every sized integer + Float32 now pass the numeric gate for `+ - * / % ^`.
- Result-type resolution: same-sized-type operands produce that sized type; Int/Float mix still promotes to Float (legacy); unsized int ops still default to Int.

**Lowering (`almide-frontend/src/lower`)**
- `expressions.rs` BinOp dispatch: `Float32` joins `Float` on the AddFloat / SubFloat / MulFloat / DivFloat / ModFloat / PowFloat side. All other numeric types (Int + sized ints) take the AddInt family. Width is resolved at emit time.
- Mutual literal coercion on BinOp operands: `x + 30` where `x: Int32` retypes the `30` to `Int32` so codegen sees matching widths. Same rule applies both directions (commutative).
- `calls.rs` special-cases `assert_eq` / `assert_ne` with mutual arg coercion, because these builtins aren't in `env.functions` but their semantics demand width-matched operands on both Rust and WASM.

**IR verify (`almide-ir/src/verify.rs`)**
- `ty_matches` accepts every sized integer where `Ty::Int` is expected, and `Float32` where `Float` is expected. The BinOp postconditions still fire on genuine type-mismatches (e.g. `AddInt` on a String operand).

**Codegen Rust (`walker`)**
- No changes. `a + b` emits as-is; rustc resolves arithmetic from operand types. Same for `==` / `!=`.

**Codegen WASM (`emit_wasm`)**
- `expressions.rs` arithmetic: BinOp::AddInt / SubInt / MulInt / DivInt / ModInt pick `i32.*` when the operand is a narrow signed / unsigned int (Int8..Int32, UInt8..UInt32) and `i64.*` otherwise. DivInt / ModInt further choose `_s` / `_u` based on signedness. AddFloat / SubFloat / MulFloat / DivFloat emit `f32.*` when the operand is `Float32`, `f64.*` otherwise.
- `equality.rs::emit_eq_typed`: sized ints dispatch to `i32.eq` (narrow) / `i64.eq` (UInt64); `Float32` uses `f32.eq`.
- `pass_builtin_lowering.rs::coerce_macro_arg`: same literal-retype rule for RustMacro assert_eq / assert_ne args on the Rust target.

## Scope / non-goals

- **Range-check errors** (Stage 1b polish): `let x: UInt8 = 300` still compiles today and overflows at runtime. A follow-up pass adds compile-time range validation.
- **Conversion UFCS** (Stage 3): `.to_int32()`, `.to_uint8_wrapping()`, etc.
- **Comparison (`< > <= >=`) on sized types**: not explicitly exercised in this PR. `BinOp::Lt` / `Gt` are type-dispatched at emit time and should work for same-width operands; will add coverage when needed. Mixing sized widths still is a type error via the existing compatibility rule.

## Verification

- `cargo test --release -- --test-threads=1` — full suite green.
- `almide test` — 208 `.almd` test files pass (same count; new tests landed inside the existing sized-types spec).
- `almide test --target wasm spec/lang/sized_numeric_types_test.almd` — 19 tests pass on WASM (was 12, +7 arithmetic cases).
- End-to-end: `fn add_i32(a: Int32, b: Int32) -> Int32 = a + b; assert_eq(add_i32(10, 20), 30)` compiles and runs on both Rust and WASM.

## Test plan

- [x] `cargo test --release -- --test-threads=1`
- [x] `almide test`
- [x] `almide test --target wasm spec/lang/sized_numeric_types_test.almd`