### PR TITLE
Propagate variant pattern bindings + tighten ResolveCalls verify

### DIFF
--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -266,6 +266,18 @@ fn resolve_node_ty(expr: &IrExpr, vt: &VarTable, symbols: &SymbolTable) -> Optio
             if elem_tys.iter().any(Ty::has_unresolved_deep) { None }
             else { Some(Ty::Tuple(elem_tys)) }
         }
+        IrExprKind::OptionSome { expr } => {
+            // `some(x)` has type `Option[x.ty]`; recover when the type
+            // checker left an `Option[Unknown]` placeholder (typical for
+            // payloads built from pattern-bound names).
+            if expr.ty.has_unresolved_deep() { None }
+            else {
+                Some(Ty::Applied(
+                    almide_lang::types::constructor::TypeConstructorId::Option,
+                    vec![expr.ty.clone()],
+                ))
+            }
+        }
         IrExprKind::LitInt { .. } => Some(Ty::Int),
         IrExprKind::LitFloat { .. } => Some(Ty::Float),
         IrExprKind::LitBool { .. } => Some(Ty::Bool),

--- a/crates/almide-codegen/src/pass_resolve_calls.rs
+++ b/crates/almide-codegen/src/pass_resolve_calls.rs
@@ -157,13 +157,20 @@ fn verify_all_calls_resolved(program: &IrProgram) -> Vec<String> {
                     let f = func.as_str();
                     let is_stdlib = almide_lang::stdlib_info::is_any_stdlib(m);
                     let resolved = if is_stdlib {
-                        // Post-unification: every stdlib module lives in
-                        // `stdlib/<m>.almd` as an `@inline_rust`-bundled IR
-                        // module. The rewriter above moves plain-bundled fns
-                        // to Named; any `Module {stdlib, f}` surviving here
-                        // has `@inline_rust` and is resolved by the
-                        // per-target lowering pass.
-                        self.symbols.module_has_fn(m, f)
+                        // Post-unification every stdlib module lives in
+                        // `stdlib/<m>.almd`. When the user code imports it,
+                        // resolve.rs lowers the bundled module into
+                        // `program.modules` and the symbol table sees it.
+                        // When the call-site code uses a stdlib module
+                        // without importing it (e.g. `bytes.push` from a
+                        // file that already pulled in `bytes` via UFCS),
+                        // the per-target dispatcher (`emit_bytes_call` /
+                        // `pass_stdlib_lowering` template) still handles
+                        // the call — fall back to a parse of the bundled
+                        // source so the verify trusts the actual codegen
+                        // surface, not just whichever modules happened to
+                        // get loaded into the IR for this build.
+                        self.symbols.module_has_fn(m, f) || bundled_has_fn(m, f)
                     } else if self.symbols.has_user_module(m) {
                         self.symbols.module_has_fn(m, f)
                     } else {
@@ -271,4 +278,23 @@ impl SymbolTable {
     fn has_codegen_override(&self, module: &str, func: &str) -> bool {
         self.codegen_override.contains(&(module.to_string(), func.to_string()))
     }
+}
+
+/// Does `module.func` exist in the bundled `.almd` source for `module`?
+/// Used by the verify pass when a stdlib call site is reached without
+/// the corresponding bundled IR being loaded into `program.modules`
+/// (call sites that touch a stdlib module the user did not explicitly
+/// `import`). The per-target dispatcher renders these via
+/// `emit_<module>_call` / `pass_stdlib_lowering` template substitution,
+/// so the verify accepts them as long as the bundled source declares
+/// the fn.
+fn bundled_has_fn(module: &str, func: &str) -> bool {
+    use almide_lang::ast::Decl;
+    let Some(source) = almide_lang::stdlib_info::bundled_source(module) else {
+        return false;
+    };
+    let Some(program) = almide_lang::parse_cached(source) else { return false; };
+    program.decls.iter().any(|decl| {
+        matches!(decl, Decl::Fn { name, .. } if name.as_str() == func)
+    })
 }

--- a/crates/almide-frontend/src/lower/expressions.rs
+++ b/crates/almide-frontend/src/lower/expressions.rs
@@ -36,7 +36,25 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
         // ── Variables ──
         ast::ExprKind::Ident { name, .. } => {
             if let Some(var_id) = ctx.lookup_var(name) {
-                ctx.mk(IrExprKind::Var { id: var_id }, ty, span)
+                // The type checker fills `ty` from `expr_types`. Names bound
+                // by record / variant patterns can land here as `Unknown`
+                // because the checker doesn't propagate the variant case's
+                // field types into the binding occurrence (the pattern
+                // lowering puts the field type into VarTable, but the
+                // checker's `expr_types` for the bare identifier reference
+                // hasn't been re-resolved post-pattern). Promote to the
+                // VarTable type only when the checker truly has nothing
+                // (`Unknown`) and the VarTable has a fully concrete type —
+                // we never want to fold a `TypeVar` from a generic body's
+                // VarTable into a call-site IR expression, since that would
+                // confuse mono's binding discovery.
+                let resolved = if matches!(ty, Ty::Unknown) {
+                    let vt_ty = ctx.var_table.get(var_id).ty.clone();
+                    if !vt_ty.contains_unknown() && !vt_ty.contains_typevar() {
+                        vt_ty
+                    } else { ty }
+                } else { ty };
+                ctx.mk(IrExprKind::Var { id: var_id }, resolved, span)
             } else if let Ty::Fn { params: param_tys, ret } = &ty {
                 // Function/top-let used as a value → eta-expand to lambda
                 // so borrow insertion handles param types correctly (e.g. String → &str).
@@ -118,8 +136,20 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
         }
         ast::ExprKind::EmptyMap => ctx.mk(IrExprKind::EmptyMap, ty, span),
         ast::ExprKind::Tuple { elements, .. } => {
-            let elems = elements.iter().map(|e| lower_expr(ctx, e)).collect();
-            ctx.mk(IrExprKind::Tuple { elements: elems }, ty, span)
+            let elems: Vec<IrExpr> = elements.iter().map(|e| lower_expr(ctx, e)).collect();
+            // Type-checker fills `ty` from `expr_types`; for a tuple whose
+            // element exprs depend on a pattern-bound name, that ty can be
+            // `Tuple([Unknown, ..])` even when the lowered elements now
+            // carry concrete types (see the same fix on `Ident`). Rebuild
+            // the tuple ty from the lowered elements when the checker's ty
+            // is unresolved so downstream `Some(tuple)` / `List[tuple]`
+            // chains get a clean propagation path.
+            let resolved_ty = if ty.has_unresolved_deep()
+                && elems.iter().all(|e| !e.ty.has_unresolved_deep())
+            {
+                Ty::Tuple(elems.iter().map(|e| e.ty.clone()).collect())
+            } else { ty };
+            ctx.mk(IrExprKind::Tuple { elements: elems }, resolved_ty, span)
         }
 
         // ── Records ──


### PR DESCRIPTION
## Summary

Three lowering / codegen-verify fixes that close the audit
violation classes Stage 2.5 surfaced now that the IR is
consistent with what codegen emits:

1. **`Ident` lowering** falls back to the VarTable's concrete
   ty when `expr_types[name]` is `Unknown` (record / variant
   pattern binding occurrences). Restricted to fully concrete
   fallbacks so generic bodies cannot fold a TypeVar into a
   call site.

2. **`Tuple` lowering** rebuilds the tuple's ty from the lowered
   element tys when the checker leaves it unresolved. Pairs
   with #1 so `Tuple { (x, y) }` from a `Click { x, y, .. }`
   pattern is `Tuple([Int, Int])` end-to-end.

3. **`ConcretizeTypes::OptionSome`** lifts `x.ty` into
   `Option[x.ty]` so the rest of the `Option / List / Match /
   Lambda` chain inherits the concrete payload type.

4. **`ResolveCalls` verify** falls back to a `parse_cached`
   lookup of the bundled `.almd` declarations for stdlib calls
   reached without the bundled IR loaded (e.g. `bytes.push`
   from a file that never `import bytes`'d).

## Test plan

- [x] `cargo build --release`
- [x] `almide test` — 208 / 208 native pass
- [x] `almide test --target wasm spec/` — 205 pass / 0 fail / 3
      skipped (only explicit `// wasm:skip`)
- [x] `cargo test --release --workspace` — only `fix_test`'s
      pre-existing flakes (already on develop)
- [x] `[ConcretizeTypes] Tuple([Unknown, Unknown])` violation in
      `extract_click_positions` gone
- [x] `[ResolveCalls] Unresolved call: bytes.*` violations in
      `licm_test` gone

## Out of scope

Remaining ConcretizeTypes audit residue (empty `[]` elem-ty
inference, `OpenRecord -> Record` resolution, deep generic
chains in `is_balanced`, `Result[Unknown, _]` in effect-context
guards) is a separate class of gaps and stays soft for now —
flipping the audit to a hard postcondition is unblocked by
these fixes but waits on those follow-ups.