### PR TITLE
Close ConcretizeTypes audit residue: fold acc back-prop + guard/OpenRecord skip

### DIFF
--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -79,24 +79,30 @@ impl NanoPass for ConcretizeTypesPass {
         // return types without deferring to emit-time guessing.
         let symbols = build_symbol_table(&program);
 
+        // Take var_table out of program so we can mutate it while also
+        // mutating program.functions. Back-propagation (below) updates
+        // VarTable entries for lambda accumulator params and match-pattern
+        // bindings; downstream passes expect the updates to persist.
+        let mut prog_vt = std::mem::take(&mut program.var_table);
         for func in &mut program.functions {
-            let vt = program.var_table.clone();
             let ret = func.ret_ty.clone();
-            concretize_expr(&mut func.body, &vt, &symbols, &ret);
+            concretize_expr(&mut func.body, &mut prog_vt, &symbols, &ret);
         }
         for tl in &mut program.top_lets {
-            let vt = program.var_table.clone();
-            concretize_expr(&mut tl.value, &vt, &symbols, &Ty::Unknown);
+            concretize_expr(&mut tl.value, &mut prog_vt, &symbols, &Ty::Unknown);
         }
+        program.var_table = prog_vt;
+
         for module in &mut program.modules {
-            let vt = module.var_table.clone();
+            let mut mod_vt = std::mem::take(&mut module.var_table);
             for func in &mut module.functions {
                 let ret = func.ret_ty.clone();
-                concretize_expr(&mut func.body, &vt, &symbols, &ret);
+                concretize_expr(&mut func.body, &mut mod_vt, &symbols, &ret);
             }
             for tl in &mut module.top_lets {
-                concretize_expr(&mut tl.value, &vt, &symbols, &Ty::Unknown);
+                concretize_expr(&mut tl.value, &mut mod_vt, &symbols, &Ty::Unknown);
             }
+            module.var_table = mod_vt;
         }
         PassResult { program, changed: true }
     }
@@ -228,15 +234,193 @@ fn propagate_expected_ty(expr: &mut IrExpr, expected: &Ty) {
     }
 }
 
+// ── Generic back-propagation helpers ────────────────────────────────
+
+/// Shape-aware merge: returns the most concrete type when `a` and `b`
+/// share a shape but differ in `Unknown` slots. Returns `None` when the
+/// shapes disagree (can't safely merge). Leaves TypeVar alone since the
+/// pre-pass is already expected to have substituted generics.
+fn merge_more_concrete(a: &Ty, b: &Ty) -> Option<Ty> {
+    use almide_lang::types::constructor::TypeConstructorId;
+    let _ = TypeConstructorId::List; // silence unused warning in some builds
+    match (a, b) {
+        (Ty::Unknown, other) | (other, Ty::Unknown) => Some(other.clone()),
+        (Ty::Applied(c1, a1), Ty::Applied(c2, a2)) if c1 == c2 && a1.len() == a2.len() => {
+            let merged: Option<Vec<Ty>> = a1.iter().zip(a2.iter())
+                .map(|(x, y)| merge_more_concrete(x, y))
+                .collect();
+            merged.map(|m| Ty::Applied(c1.clone(), m))
+        }
+        (Ty::Tuple(e1), Ty::Tuple(e2)) if e1.len() == e2.len() => {
+            let merged: Option<Vec<Ty>> = e1.iter().zip(e2.iter())
+                .map(|(x, y)| merge_more_concrete(x, y))
+                .collect();
+            merged.map(Ty::Tuple)
+        }
+        (Ty::Fn { params: p1, ret: r1 }, Ty::Fn { params: p2, ret: r2 })
+            if p1.len() == p2.len() =>
+        {
+            let merged_params: Option<Vec<Ty>> = p1.iter().zip(p2.iter())
+                .map(|(x, y)| merge_more_concrete(x, y))
+                .collect();
+            let merged_ret = merge_more_concrete(r1, r2);
+            match (merged_params, merged_ret) {
+                (Some(ps), Some(r)) => Some(Ty::Fn { params: ps, ret: Box::new(r) }),
+                _ => None,
+            }
+        }
+        (x, y) if x == y => Some(x.clone()),
+        _ => None,
+    }
+}
+
+/// Push `expected` down into `expr`, recursing into wrappers (OptionSome,
+/// Result*, List, Tuple). Updates expr.ty and any matching sub-expressions
+/// whose own types have unresolved slots compatible with `expected`.
+fn propagate_ty_down(expr: &mut IrExpr, expected: &Ty) {
+    use almide_lang::types::constructor::TypeConstructorId as TCI;
+    if let Some(merged) = merge_more_concrete(&expr.ty, expected) {
+        expr.ty = merged;
+    }
+    match (&mut expr.kind, expected) {
+        (IrExprKind::OptionSome { expr: inner }, Ty::Applied(TCI::Option, args))
+            if args.len() == 1 =>
+        {
+            propagate_ty_down(inner, &args[0]);
+        }
+        (IrExprKind::ResultOk { expr: inner }, Ty::Applied(TCI::Result, args))
+            if !args.is_empty() =>
+        {
+            propagate_ty_down(inner, &args[0]);
+        }
+        (IrExprKind::ResultErr { expr: inner }, Ty::Applied(TCI::Result, args))
+            if args.len() >= 2 =>
+        {
+            propagate_ty_down(inner, &args[1]);
+        }
+        (IrExprKind::List { elements }, Ty::Applied(TCI::List, args))
+            if args.len() == 1 =>
+        {
+            for e in elements.iter_mut() { propagate_ty_down(e, &args[0]); }
+        }
+        (IrExprKind::Tuple { elements }, Ty::Tuple(ts)) if elements.len() == ts.len() => {
+            for (e, t) in elements.iter_mut().zip(ts.iter()) {
+                propagate_ty_down(e, t);
+            }
+        }
+        (IrExprKind::If { then, else_, .. }, _) => {
+            propagate_ty_down(then, expected);
+            propagate_ty_down(else_, expected);
+        }
+        (IrExprKind::Block { expr: Some(tail), .. }, _) => {
+            propagate_ty_down(tail, expected);
+        }
+        (IrExprKind::Match { arms, .. }, _) => {
+            for arm in arms.iter_mut() {
+                propagate_ty_down(&mut arm.body, expected);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Propagate a subject type into a match pattern, updating `Bind` pattern
+/// ty + the matching VarTable entry. Supports Some/Ok/Err/Tuple destructuring
+/// (the shapes that actually surface in spec/).
+fn propagate_pattern_ty(pat: &mut IrPattern, subj_ty: &Ty, vt: &mut VarTable) {
+    use almide_lang::types::constructor::TypeConstructorId as TCI;
+    match (pat, subj_ty) {
+        (IrPattern::Bind { var, ty }, t) => {
+            if ty.has_unresolved_deep() && !t.has_unresolved_deep() {
+                *ty = t.clone();
+                if (var.0 as usize) < vt.len() {
+                    vt.entries[var.0 as usize].ty = t.clone();
+                }
+            }
+        }
+        (IrPattern::Some { inner }, Ty::Applied(TCI::Option, args)) if args.len() == 1 => {
+            propagate_pattern_ty(inner, &args[0], vt);
+        }
+        (IrPattern::Ok { inner }, Ty::Applied(TCI::Result, args)) if !args.is_empty() => {
+            propagate_pattern_ty(inner, &args[0], vt);
+        }
+        (IrPattern::Err { inner }, Ty::Applied(TCI::Result, args)) if args.len() >= 2 => {
+            propagate_pattern_ty(inner, &args[1], vt);
+        }
+        (IrPattern::Tuple { elements }, Ty::Tuple(ts)) if elements.len() == ts.len() => {
+            for (e, t) in elements.iter_mut().zip(ts.iter()) {
+                propagate_pattern_ty(e, t, vt);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_fold_like_call(expr: &IrExpr) -> bool {
+    match &expr.kind {
+        IrExprKind::Call { target: CallTarget::Module { module, func }, .. } => {
+            module.as_str() == "list" && matches!(func.as_str(), "fold" | "scan")
+        }
+        _ => false,
+    }
+}
+
+/// For `list.fold(xs, init, f)` where `f: (acc, t) -> acc`: merge `init.ty`
+/// with `f.body.ty` and, if the merged type is strictly more concrete than
+/// `init.ty`, push it back into the init sub-expression + the lambda's acc
+/// parameter (IR annotation + VarTable). Returns true when changes were made.
+fn back_propagate_fold_acc(expr: &mut IrExpr, vt: &mut VarTable) -> bool {
+    let args = match &mut expr.kind {
+        IrExprKind::Call { args, .. } => args,
+        _ => return false,
+    };
+    if args.len() < 3 { return false; }
+
+    let body_ty = match &args[2].kind {
+        IrExprKind::Lambda { body, .. } => body.ty.clone(),
+        _ => return false,
+    };
+    if body_ty.has_unresolved_deep() { return false; }
+
+    let init_ty = args[1].ty.clone();
+    let Some(merged) = merge_more_concrete(&init_ty, &body_ty) else { return false; };
+    if merged == init_ty { return false; }
+
+    // Push merged into the init sub-expression
+    propagate_ty_down(&mut args[1], &merged);
+
+    // Update lambda's acc param (IR + VarTable) and the Ty::Fn wrapper
+    if let IrExprKind::Lambda { params, .. } = &mut args[2].kind {
+        if let Some((vid, pty)) = params.get_mut(0) {
+            if pty.has_unresolved_deep() {
+                *pty = merged.clone();
+                if (vid.0 as usize) < vt.len() {
+                    vt.entries[vid.0 as usize].ty = merged.clone();
+                }
+            }
+        }
+    }
+    if let Ty::Fn { params: ps, ret } = &mut args[2].ty {
+        if let Some(p0) = ps.get_mut(0) {
+            if p0.has_unresolved_deep() { *p0 = merged.clone(); }
+        }
+        if ret.has_unresolved_deep() { **ret = merged.clone(); }
+    }
+
+    // Update Call's own ty
+    expr.ty = merged;
+    true
+}
+
 // ── Core walker ────────────────────────────────────────────────────
 
-fn concretize_expr(expr: &mut IrExpr, vt: &VarTable, symbols: &SymbolTable, enclosing_ret: &Ty) {
+fn concretize_expr(expr: &mut IrExpr, vt: &mut VarTable, symbols: &SymbolTable, enclosing_ret: &Ty) {
     let mut c = Concretizer { vt, symbols, enclosing_ret };
     c.visit_expr_mut(expr);
 }
 
 struct Concretizer<'a> {
-    vt: &'a VarTable,
+    vt: &'a mut VarTable,
     symbols: &'a SymbolTable,
     /// Return type of the enclosing IrFunction (post-`ResultPropagation`
     /// lift when applicable). Used to fill in the `Ok` slot of a
@@ -247,6 +431,45 @@ struct Concretizer<'a> {
 
 impl<'a> IrMutVisitor for Concretizer<'a> {
     fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
+        // Custom Match handling: propagate subject ty into pattern bindings
+        // (updating both the pattern's declared ty and the VarTable entry)
+        // BEFORE visiting arm bodies, so Var references to pattern-bound
+        // names pick up the refreshed ty during the bottom-up walk.
+        if let IrExprKind::Match { subject, arms } = &mut expr.kind {
+            self.visit_expr_mut(subject);
+            let sty = subject.ty.clone();
+            if !sty.has_unresolved_deep() {
+                for arm in arms.iter_mut() {
+                    propagate_pattern_ty(&mut arm.pattern, &sty, self.vt);
+                }
+            }
+            for arm in arms.iter_mut() {
+                if let Some(g) = &mut arm.guard { self.visit_expr_mut(g); }
+                self.visit_expr_mut(&mut arm.body);
+            }
+            // After arms are fully resolved, push any concrete arm body ty
+            // into sibling arms whose body is an unresolved shape wrapper
+            // (e.g. `none => none` has body ty Option[Unknown] but the
+            // sibling `some(...)` arm resolves to Option[List[String]]).
+            let concrete_arm_ty = arms.iter().find_map(|arm| {
+                if !arm.body.ty.has_unresolved_deep() { Some(arm.body.ty.clone()) } else { None }
+            });
+            if let Some(cty) = concrete_arm_ty {
+                for arm in arms.iter_mut() {
+                    if arm.body.ty.has_unresolved_deep() {
+                        propagate_ty_down(&mut arm.body, &cty);
+                    }
+                }
+            }
+            // Resolve the Match node itself
+            if expr.ty.has_unresolved_deep() {
+                if let Some(ty) = resolve_node_ty(expr, self.vt, self.symbols) {
+                    expr.ty = ty;
+                }
+            }
+            return;
+        }
+
         // Recurse into children FIRST (bottom-up) so nested types are
         // concrete before we use them here.
         walk_expr_mut(self, expr);
@@ -287,6 +510,28 @@ impl<'a> IrMutVisitor for Concretizer<'a> {
                     if let Some(expected) = self.symbols.lookup_field(&rname, fname.as_str()) {
                         if !expected.has_unresolved_deep() {
                             propagate_expected_ty(fvalue, expected);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Generic-accumulator back-propagation for `list.fold` / `list.scan`:
+        // both `init` arg and lambda `body.ty` represent the accumulator A.
+        // After the bottom-up walk, body.ty may be strictly more concrete
+        // than init.ty (because init started from a literal like `some([])`
+        // whose empty list has element type Unknown). Merge, push the
+        // merged shape back into init's sub-expressions, and update the
+        // lambda's acc param + VarTable so arm Var refs refresh on the
+        // re-visit below.
+        if is_fold_like_call(expr) {
+            if back_propagate_fold_acc(expr, self.vt) {
+                // Re-visit the lambda body so pattern bindings and Var
+                // references pick up the refreshed acc type.
+                if let IrExprKind::Call { args, .. } = &mut expr.kind {
+                    if let Some(lambda) = args.get_mut(2) {
+                        if let IrExprKind::Lambda { body, .. } = &mut lambda.kind {
+                            self.visit_expr_mut(body);
                         }
                     }
                 }

--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -365,10 +365,12 @@ fn is_fold_like_call(expr: &IrExpr) -> bool {
     }
 }
 
-/// For `list.fold(xs, init, f)` where `f: (acc, t) -> acc`: merge `init.ty`
-/// with `f.body.ty` and, if the merged type is strictly more concrete than
-/// `init.ty`, push it back into the init sub-expression + the lambda's acc
-/// parameter (IR annotation + VarTable). Returns true when changes were made.
+/// For `list.fold(xs, init, f)` where `f: (acc, t) -> acc`: the accumulator
+/// type `A` has two sources — `init.ty` and `f.body.ty` — which must agree.
+/// Pick the most concrete form available, then push it back into the init
+/// sub-expression, the lambda's acc parameter (IR annotation + VarTable),
+/// the Ty::Fn wrapper, and the Call's own ty. Returns true when changes
+/// were made.
 fn back_propagate_fold_acc(expr: &mut IrExpr, vt: &mut VarTable) -> bool {
     let args = match &mut expr.kind {
         IrExprKind::Call { args, .. } => args,
@@ -380,36 +382,61 @@ fn back_propagate_fold_acc(expr: &mut IrExpr, vt: &mut VarTable) -> bool {
         IrExprKind::Lambda { body, .. } => body.ty.clone(),
         _ => return false,
     };
-    if body_ty.has_unresolved_deep() { return false; }
-
     let init_ty = args[1].ty.clone();
-    let Some(merged) = merge_more_concrete(&init_ty, &body_ty) else { return false; };
-    if merged == init_ty { return false; }
 
-    // Push merged into the init sub-expression
-    propagate_ty_down(&mut args[1], &merged);
+    // Accumulator type: merge init and body, picking the most concrete
+    // shape when both are known and compatible. Fall back to whichever is
+    // concrete when only one side has a type.
+    let acc_ty = if !init_ty.has_unresolved_deep() && !body_ty.has_unresolved_deep() {
+        merge_more_concrete(&init_ty, &body_ty)
+    } else if !init_ty.has_unresolved_deep() {
+        Some(init_ty.clone())
+    } else if !body_ty.has_unresolved_deep() {
+        Some(body_ty.clone())
+    } else {
+        None
+    };
+    let Some(acc_ty) = acc_ty else { return false; };
+
+    let mut changed = false;
+
+    // Push acc_ty into the init sub-expression when init has weaker shape
+    if init_ty != acc_ty {
+        propagate_ty_down(&mut args[1], &acc_ty);
+        changed = true;
+    }
 
     // Update lambda's acc param (IR + VarTable) and the Ty::Fn wrapper
     if let IrExprKind::Lambda { params, .. } = &mut args[2].kind {
         if let Some((vid, pty)) = params.get_mut(0) {
             if pty.has_unresolved_deep() {
-                *pty = merged.clone();
+                *pty = acc_ty.clone();
                 if (vid.0 as usize) < vt.len() {
-                    vt.entries[vid.0 as usize].ty = merged.clone();
+                    vt.entries[vid.0 as usize].ty = acc_ty.clone();
                 }
+                changed = true;
             }
         }
     }
     if let Ty::Fn { params: ps, ret } = &mut args[2].ty {
         if let Some(p0) = ps.get_mut(0) {
-            if p0.has_unresolved_deep() { *p0 = merged.clone(); }
+            if p0.has_unresolved_deep() {
+                *p0 = acc_ty.clone();
+                changed = true;
+            }
         }
-        if ret.has_unresolved_deep() { **ret = merged.clone(); }
+        if ret.has_unresolved_deep() {
+            **ret = acc_ty.clone();
+            changed = true;
+        }
     }
 
-    // Update Call's own ty
-    expr.ty = merged;
-    true
+    // Update Call's own ty if it's still unresolved
+    if expr.ty.has_unresolved_deep() {
+        expr.ty = acc_ty;
+        changed = true;
+    }
+    changed
 }
 
 // ── Core walker ────────────────────────────────────────────────────
@@ -888,7 +915,27 @@ fn audit_remaining_unresolved(program: &IrProgram) -> Vec<String> {
                 // here as "harmless: ok branch unreachable".
                 || matches!(&expr.kind,
                     IrExprKind::Unwrap { expr: inner }
-                        if matches!(inner.kind, IrExprKind::ResultErr { .. }));
+                        if matches!(inner.kind, IrExprKind::ResultErr { .. }))
+                // `Block` whose sole tail is the same skipped `Unwrap`
+                // pattern — the block is just the desugared `else
+                // { err(...)! }` wrapper that lowering emits for
+                // `guard` statements. `Block.ty` mirrors `tail.ty`, so
+                // marking only the Unwrap would leave the outer Block
+                // as a spurious violation.
+                || matches!(&expr.kind,
+                    IrExprKind::Block { stmts, expr: Some(tail) }
+                        if stmts.is_empty()
+                            && matches!(&tail.kind,
+                                IrExprKind::Unwrap { expr: inner }
+                                    if matches!(inner.kind, IrExprKind::ResultErr { .. })))
+                // OpenRecord-typed expressions: an open-record bound
+                // (`fn f(x: { name: String, .. })`) is a structural
+                // constraint, not an inference failure. The Var node
+                // for such a param trivially carries its declared
+                // OpenRecord ty through monomorphization's `__Unknown`
+                // fallback path. Emit handles OpenRecord via its
+                // structural dispatch — no Unknown slot to fill.
+                || matches!(&expr.ty, Ty::OpenRecord { .. });
                 if !skip {
                     self.remaining += 1;
                     if self.samples.len() < 5 {


### PR DESCRIPTION
## Summary

Closes the three remaining `ConcretizeTypes` audit violation classes catalogued in codegen-ideal-form §Phase 3 Arc S2. After this PR, `ALMIDE_AUDIT_TYPES=1` sweep over `spec/` on WASM reports **zero violations** — S2 `flip to hard` is unblocked.

### 1. `is_balanced` deep-generic chain (14 exprs)

The bottom-up walk resolves a fold lambda's `body.ty` (e.g. `Option[List[String]]`) while the sibling `init` arg stays `Option[List[Unknown]]` because its empty list literal has no inference context. `ConcretizeTypes` now:

- Takes `VarTable` by `&mut` so pattern / acc updates persist into later passes.
- Handles `Match` subject.ty → pattern bindings (Some/Ok/Err/Tuple) before visiting arm bodies, so Var refs refresh on bottom-up.
- Propagates concrete sibling-arm body.ty into arms whose body is still a shape wrapper (`none => none` inherits from the `some` arm).
- For `list.fold` / `list.scan` Calls, picks the most-concrete accumulator type between `init.ty` and `lambda.body.ty` and pushes it into the weaker side — init sub-expression, lambda's acc param, VarTable entry, Fn wrapper, Call ty — then re-visits the body.

### 2. `guard_effect` Block Unknown (1 expr)

The `guard x else { err(_)! }` desugar lowers to a `Block { stmts: [], tail: Unwrap(ResultErr(..)) }`. The inner `Unwrap(ResultErr)` was already audit-skipped (ok-branch unreachable); `Block.ty` mirrors `tail.ty`, so the block now inherits the same skip.

### 3. `chain_b__Unknown` OpenRecord (1 expr)

Open-record bounds (`fn f(x: { name: String, .. })`) are structural constraints, not inference failures — the monomorphizer's `__Unknown` fallback variant legitimately carries the declared `OpenRecord` ty. Audit skip extended to `Ty::OpenRecord`.

### 4. `lookup_token` fold acc Unknown (bonus)

The fold back-propagation was tightened to also cover the `list.fold(xs, "", f)` case where `init.ty` is already concrete but the lambda's acc param was left `Unknown` by the checker. `nn/tokenizer`'s `lookup_token` is now clean on the ConcretizeTypes side.

## Effect

- `ALMIDE_AUDIT_TYPES=1` sweep over `spec/` WASM: **3 classes → 0**.
- 208 spec tests pass on the Rust target.
- `nn` `almide test` (12 files, 66 subtests) pass.
- Remaining panics on `ALMIDE_CHECK_IR=1` WASM sweep are all unrelated: `process.env` stub elimination is S3 territory; the `nn` `lookup_token` `LambdaTypeResolve` postcondition is a pre-existing pass-boundary issue, not ConcretizeTypes residue.

## Test plan

- [x] `almide test` (208 test files pass)
- [x] `ALMIDE_AUDIT_TYPES=1` sweep over `spec/` WASM (zero violations)
- [x] `cd ../nn && almide test` (12 files pass, no regressions)
- [x] `cargo test --release --workspace --exclude almide` green (the `fix_test` flake on the `almide` package predates this branch and also fails on develop)
