### PR TITLE
Flip ConcretizeTypes postcondition to hard contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ each entry groups by diagnostic-/tooling-/language-/stdlib-facing intent
 because that's what downstream consumers (LLM harnesses, editors, users)
 care about.
 
+## [Unreleased]
+
+### S2 flip — ConcretizeTypes postcondition is now a hard contract
+
+`expr.ty` is trustworthy by contract. The Pipeline harness
+(`crates/almide-codegen/src/pass.rs`) no longer reads `ALMIDE_CHECK_IR` /
+`ALMIDE_VERIFY_IR`; inter-pass IR verification and every pass's
+`Postcondition` list run on every build. Debug builds panic on
+violation (so CI and local `cargo test` never ship a program with an
+unresolved type); release builds print the same
+`[POSTCONDITION VIOLATION]` / `[IR CHECK]` diagnostic to stderr and keep
+compiling, so an end-user `almide build` does not crash on a compiler
+bug.
+
+After this flip, downstream passes (closure conversion, WASM emit,
+stdlib dispatch, `resolve_list_elem`, etc.) may rely on non-Unknown
+`IrExpr.ty` unconditionally. Defensive "if the type is still
+Unknown, try emit-time fallback X" shims added under v0.14.6–0.14.7
+become deletable as a follow-up.
+
+Residual WASM-target lifted-lambda TypeVars produced by
+`ClosureConversion` remain as a pre-existing pass-boundary issue
+tracked in S3 (`pass_resolve_calls` Phase 1b-c); they do not surface
+under the default spec/ sweep.
+
+Removed surface:
+- `ALMIDE_CHECK_IR` / `ALMIDE_VERIFY_IR` env vars (no replacement —
+  contract always enforced).
+
 ## [0.14.8] — 2026-04-17
 
 Hotfix for a v0.14.7 regression: external package dispatch (e.g. `almai`

--- a/crates/almide-codegen/src/pass.rs
+++ b/crates/almide-codegen/src/pass.rs
@@ -91,7 +91,10 @@ pub trait NanoPass: std::fmt::Debug {
     fn depends_on(&self) -> Vec<&'static str> { vec![] }
 
     /// Postconditions: structural invariants guaranteed after this pass runs.
-    /// Verified automatically in debug/CI builds (ALMIDE_CHECK_IR=1).
+    /// Verified on every build. Debug builds panic on violation; release
+    /// builds print a `[POSTCONDITION VIOLATION]` diagnostic and keep
+    /// running. Violations are compiler bugs — downstream passes may rely
+    /// on the invariants unconditionally.
     fn postconditions(&self) -> Vec<Postcondition> { vec![] }
 
     /// Run the pass. Takes ownership of the program, returns modified program
@@ -237,8 +240,14 @@ impl Pipeline {
             .filter(|s| *s != "all")
             .map(|s| s.split(',').map(str::trim).collect())
             .unwrap_or_default();
-        let check_ir = std::env::var("ALMIDE_CHECK_IR").is_ok()
-            || std::env::var("ALMIDE_VERIFY_IR").is_ok();
+        // Contract-level checks (IR verifier + pass postconditions) run on
+        // every build. Debug builds escalate violations to `panic!` so CI
+        // and local `cargo test` catch them; release builds print the same
+        // diagnostic and keep running so an end-user `almide build` does
+        // not crash on a compiler bug. `ALMIDE_CHECK_IR` /
+        // `ALMIDE_VERIFY_IR` used to gate this — removed in S2 flip
+        // (v0.14.7-phase3.2); `expr.ty` is now trustworthy by contract.
+        let hard_fail = cfg!(debug_assertions);
 
         for pass in &self.passes {
             // Skip passes not relevant to this target
@@ -276,26 +285,26 @@ impl Pipeline {
                 eprintln!("── end {} ──\n", pass_name);
             }
 
-            // Inter-pass IR verification (opt-in via ALMIDE_CHECK_IR=1 or ALMIDE_VERIFY_IR=1)
-            if check_ir {
-                let errors = almide_ir::verify_program(&program);
-                if !errors.is_empty() {
-                    eprintln!("[IR CHECK] {} error(s) after pass '{}':", errors.len(), pass_name);
-                    for e in &errors {
-                        eprintln!("  {}", e);
-                    }
+            // Inter-pass IR verification — always on.
+            let errors = almide_ir::verify_program(&program);
+            if !errors.is_empty() {
+                eprintln!("[IR CHECK] {} error(s) after pass '{}':", errors.len(), pass_name);
+                for e in &errors {
+                    eprintln!("  {}", e);
+                }
+                if hard_fail {
                     panic!("IR verification failed after pass '{}'", pass_name);
                 }
             }
 
-            // Postcondition verification (always on — these are structural invariants)
+            // Postcondition verification — always on.
             let postconds = pass.postconditions();
             if !postconds.is_empty() {
                 let violations = verify_postconditions(pass_name, &program, &postconds);
                 for v in &violations {
                     eprintln!("[POSTCONDITION VIOLATION] {}", v);
                 }
-                if !violations.is_empty() && check_ir {
+                if !violations.is_empty() && hard_fail {
                     panic!("Postcondition violation after pass '{}'", pass_name);
                 }
             }

--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -60,16 +60,16 @@ impl NanoPass for ConcretizeTypesPass {
     }
 
     fn postconditions(&self) -> Vec<Postcondition> {
-        // S2 (v0.14.7-phase3.1): audit runs on every build; violations are
-        // printed by the harness as `[POSTCONDITION VIOLATION] ...` and
-        // escalate to a panic under `ALMIDE_CHECK_IR=1`. spec/ runs clean
-        // on Rust at default + ALMIDE_CHECK_IR=1. WASM target on
-        // ALMIDE_CHECK_IR=1 still trips on lifted-lambda TypeVar residue
-        // produced by ClosureConversion (the second `ConcretizeTypes`
-        // pass cannot fully recover the lambda param type from VarTable
-        // when the source generic was already specialized away). Closing
-        // that gap is part of S3 (pass_resolve_calls Phase 1b-c) — see
-        // codegen-ideal-form.md §Phase 3 Arc.
+        // S2 flip (v0.14.7-phase3.2): audit is a hard contract. Debug
+        // builds panic on violation so CI and local dev never ship a
+        // program with unresolved `IrExpr.ty`; release builds print the
+        // diagnostic and keep compiling. Downstream passes (closure
+        // conversion, WASM emit, stdlib dispatch) rely on non-Unknown
+        // `expr.ty` unconditionally and no longer carry defensive
+        // fallbacks. Residual WASM-target lifted-lambda TypeVars produced
+        // by ClosureConversion are tracked separately in S3
+        // (pass_resolve_calls Phase 1b-c) — see codegen-ideal-form.md
+        // §Phase 3 Arc.
         vec![Postcondition::Custom(audit_remaining_unresolved)]
     }
 
@@ -871,9 +871,11 @@ fn reconcile_binop(op: BinOp, lt: &Ty, rt: &Ty) -> Option<BinOp> {
 // ── Audit: count remaining unresolved types (diagnostic) ────────────
 
 /// Postcondition audit: report any reachable IrExpr with an unresolved
-/// type after this pass. Emitted only under ALMIDE_CHECK_IR=1. Treated
-/// as informational — some cases (Break/Continue, error recovery paths)
-/// legitimately have unresolved types.
+/// type after this pass. Runs on every build. Violations are the
+/// harness's responsibility (panic in debug, diagnostic in release).
+/// A few node shapes (Break/Continue, `err(_)!` guards, OpenRecord
+/// constraints) legitimately carry unresolved types at runtime and are
+/// skipped below.
 fn audit_remaining_unresolved(program: &IrProgram) -> Vec<String> {
     struct Auditor {
         location: String,

--- a/crates/almide-codegen/src/pass_resolve_calls.rs
+++ b/crates/almide-codegen/src/pass_resolve_calls.rs
@@ -8,8 +8,8 @@
 //!
 //! Walks every `CallTarget::Module { module, func }` and either:
 //! - **Verifies**: a TOML-backed stdlib fn or a user-module fn exists; if
-//!   neither matches, emits a postcondition violation (compile-time ICE
-//!   under `ALMIDE_CHECK_IR=1`).
+//!   neither matches, emits a postcondition violation — a hard contract
+//!   (panic in debug, diagnostic in release; S2 flip).
 //! - **Rewrites**: a bundled-Almide stdlib fn (`(m, f)` not in TOML, but
 //!   present as `IrFunction` inside `program.modules[m]`) → rewrite the
 //!   call target to `CallTarget::Named { name: "almide_rt_<m>_<f>" }`,

--- a/docs/roadmap/active/codegen-ideal-form.md
+++ b/docs/roadmap/active/codegen-ideal-form.md
@@ -306,18 +306,22 @@ arc picks up at `active/mlir-backend-adoption.md`.
 **見積**: 2-3h、1 commit。#7 (stub 廃止) の前にやる必要がある
 (option/result で引っかかるため)。
 
-### Step S2 — ConcretizeTypes hard postcondition `0.14.7-phase3.1`
+### Step S2 — ConcretizeTypes hard postcondition `0.14.7-phase3.2` *(shipped)*
 
-codegen-ideal-form #4 の完成。既存の `ALMIDE_AUDIT_TYPES=1` soft audit を
-hard postcondition に flip:
+codegen-ideal-form #4 の完成。phase3.1 で audit を常時実行 + `ALMIDE_CHECK_IR`
+での panic escalate まで到達、phase3.2 で **flip to hard** を完了:
 
-- 既知残 gap を close (list.zip 系 `Option[Unknown]` 6件の specific 源泉に
-  対処)
-- debug build で panic、release build で diagnostic error
-- env var を削除
-- nn モジュールを含む regression sweep
+- spec/ WASM sweep の ConcretizeTypes audit: 3 class → 0 (PRs #194–#198)
+  - list.zip 系 `Option[Unknown]` 含む 15-21 件の実ケースを
+    empty-list elem ty / ResultErr Ok slot / fold acc back-prop / Match
+    subject → pattern bindings / OpenRecord skip の組合せで closure
+- `pass.rs` の `ALMIDE_CHECK_IR` / `ALMIDE_VERIFY_IR` gating 削除
+- debug build で IR verify + Postcondition violation を常時 panic、
+  release build では diagnostic (非 panic) として stderr に出す
+- CHANGELOG 「`expr.ty` is now trustworthy by contract」で entry
 
-**見積**: 2h、1 commit。S3 の safety net。
+残 WASM lifted-lambda TypeVar は `ClosureConversion` 由来の pass boundary
+issue で、S3 (pass_resolve_calls Phase 1b-c) で自然に解消する見込み。
 
 ### Step S3 — pass_resolve_calls Phase 1b-c + stub 廃止 `0.14.7-phase3.2`
 

--- a/docs/specs/codegen.md
+++ b/docs/specs/codegen.md
@@ -103,7 +103,10 @@ pub trait NanoPass: std::fmt::Debug {
 Passes compose into a `Pipeline`. The pipeline runner:
 - Skips passes not relevant to the current target
 - Validates declared dependencies (panics if a dependency has not executed)
-- Optionally verifies IR integrity between passes (`ALMIDE_VERIFY_IR=1`)
+- Verifies IR integrity and declared `Postcondition`s between passes on every
+  build — violations panic in debug and print as diagnostics in release. No
+  opt-in env var (`ALMIDE_CHECK_IR` / `ALMIDE_VERIFY_IR` removed in
+  v0.14.7-phase3.2); `expr.ty` is trustworthy by contract
 
 ### Rust Pipeline (in order)
 


### PR DESCRIPTION
## Summary

Closes codegen-ideal-form §Phase 3 Arc Step S2 (`0.14.7-phase3.2`). After PR #198 drove the `ConcretizeTypes` spec-sweep audit to zero violations, this PR completes the flip: the harness no longer reads `ALMIDE_CHECK_IR` / `ALMIDE_VERIFY_IR`. IR verification and every pass's declared `Postcondition` list now run unconditionally.

- **Debug builds** — violations `panic!` so `cargo test`, local dev, and CI catch them the moment they appear.
- **Release builds** — violations print the same `[POSTCONDITION VIOLATION]` / `[IR CHECK]` diagnostic to stderr and keep compiling, so an end-user `almide build` does not crash on a compiler bug.

## Why this matters (trust-by-contract)

`expr.ty` is now trustworthy. Downstream passes (closure conversion, WASM emit, `pass_stdlib_lowering`, `resolve_list_elem`, bundled-stdlib dispatch, …) may read `IrExpr.ty` without re-deriving or falling back to "if still Unknown, guess X" shims. The defensive shims accumulated under v0.14.6–0.14.7 become deletable as follow-ups, and S3 (`pass_resolve_calls` Phase 1b-c, lifted-lambda TypeVar residue) can assume a clean starting IR.

## Effect

- `crates/almide-codegen/src/pass.rs`: removed the `check_ir` env-var read; IR verify + postcondition verify run every pass; debug escalates to `panic!`, release prints.
- `pass_concretize_types.rs` / `pass_resolve_calls.rs`: comments updated to reflect the hard contract; no runtime-behavior change beyond what `pass.rs` drives.
- `docs/specs/codegen.md`: Pipeline bullet describes the always-on contract and removed env vars.
- `docs/roadmap/active/codegen-ideal-form.md §S2`: marked shipped (`0.14.7-phase3.2`).
- `CHANGELOG.md`: new `[Unreleased]` section describes the flip and the `ALMIDE_CHECK_IR` / `ALMIDE_VERIFY_IR` removal.

## Test plan

- [x] `./target/debug/almide test spec/` — **208/208 passed** on Rust target with hard contract enabled (debug build).
- [x] `./target/debug/almide test spec/ --target wasm` — **205 passed / 0 failed / 3 skipped** on WASM target with hard contract enabled. The three skips are the pre-existing explicit `wasm:skip` files; no audit violations panic anywhere.
- [x] `./target/debug/almide test` in `../nn` — **12 files / 66 subtests pass** with hard contract enabled.
- [x] `cargo test --release --workspace --exclude almide` — all crate tests green. (`almide` bin's `fix_test` flake is pre-existing and also fails on develop; see repo memory `feedback_cargo_test_cache_race.md`.)
- [x] `cargo build --release` clean.

## Non-scope

- Deleting downstream defensive fallback shims enabled by this flip (best done per-call-site as S3 / Sized Numeric land and the shims turn into dead branches).
- WASM-target lifted-lambda TypeVar residue from `ClosureConversion` — separate pass-boundary issue, closed naturally in S3 (`pass_resolve_calls` Phase 1b-c).