### PR TITLE
Delete emit_stub_call helpers in favor of inline panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,24 @@ Removed surface:
 - `ALMIDE_CHECK_IR` / `ALMIDE_VERIFY_IR` env vars (no replacement —
   contract always enforced).
 
+### S3 Phase 1d — delete `emit_stub_call` / `emit_stub_call_named` helpers
+
+The two helpers sitting in `emit_wasm/calls.rs` existed only to `panic!`
+with an `[ICE]` message when a stdlib dispatcher's `_` arm was reached.
+Every call site has been replaced with an inline
+`panic!("[ICE] emit_wasm: no WASM dispatch for `<m>.<func>` — ...")`
+carrying the specific module / dispatcher name so the diagnostic points
+straight at the missing arm. With no remaining callers, the helpers
+themselves are deleted — `calls.rs`, `calls_io.rs`, `calls_value.rs`,
+`calls_http.rs`, `calls_datetime.rs`, `calls_process.rs`, `calls_fs.rs`,
+`calls_env.rs`, `calls_random.rs`, `calls_regex.rs`,
+`calls_list_helpers.rs` all go through inline panics now.
+
+Behavior is unchanged: reaching a dispatcher fallback was already a
+compile-time ICE under S2 flip. The cleanup removes one layer of
+indirection and surfaces the correct module / dispatcher in the error
+message.
+
 ## [0.14.8] — 2026-04-17
 
 Hotfix for a v0.14.7 regression: external package dispatch (e.g. `almai`

--- a/crates/almide-codegen/src/emit_wasm/calls.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls.rs
@@ -360,27 +360,47 @@ impl FuncCompiler<'_> {
                 match (module.as_str(), func.as_str()) {
                     _ if module == "int" => {
                         if !self.emit_int_call(func, args) {
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     _ if module == "float" => {
                         if !self.emit_float_call(func, args) {
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     _ if module == "string" => {
                         if !self.emit_string_call(func, args) {
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     _ if module == "option" => {
                         if !self.emit_option_call(func, args) {
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     _ if module == "result" => {
                         if !self.emit_result_call(func, args) {
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     _ if module == "list" => {
@@ -392,17 +412,29 @@ impl FuncCompiler<'_> {
                             // Anything that gets here is a TOML stdlib fn whose
                             // dispatch is missing in emit_list_call. Hard ICE so the
                             // gap is fixed at the source, not papered over.
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     _ if module == "bytes" => {
                         if !self.emit_bytes_call(func, args) {
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     _ if module == "matrix" => {
                         if !self.emit_matrix_call(func, args) {
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     _ if module == "base64" => {
@@ -417,7 +449,11 @@ impl FuncCompiler<'_> {
                             self.emit_expr(&args[0]);
                             wasm!(self.func, { call(rt); });
                         } else {
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     _ if module == "hex" => {
@@ -431,17 +467,29 @@ impl FuncCompiler<'_> {
                             self.emit_expr(&args[0]);
                             wasm!(self.func, { call(rt); });
                         } else {
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     _ if module == "map" => {
                         if !self.emit_map_call(func, args) {
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     _ if module == "math" => {
                         if !self.emit_math_call(func, args) {
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     ("error", "message") => {
@@ -528,7 +576,11 @@ impl FuncCompiler<'_> {
                     }
                     _ if module == "set" => {
                         if !self.emit_set_call(func, args) {
-                            self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                         }
                     }
                     _ if module == "fan" => {
@@ -600,7 +652,11 @@ impl FuncCompiler<'_> {
                                     for arg in args { self.emit_expr(arg); }
                                     wasm!(self.func, { call(func_idx); });
                                 } else {
-                                    self.emit_stub_call_named(module.as_str(), func.as_str(), args);
+                                    panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
+                                 add an arm in emit_{}_call or resolve upstream",
+                                module.as_str(), func.as_str(), module.as_str()
+                            );
                                 }
                             }
                         }
@@ -686,7 +742,12 @@ impl FuncCompiler<'_> {
                         fake_args.extend(args.iter().cloned());
                         let m = method.strip_prefix("option.").unwrap_or(method);
                         if !self.emit_option_call(m, &fake_args) {
-                            self.emit_stub_call(args);
+                            panic!(
+                                "[ICE] emit_wasm: no WASM dispatch for Option method \
+                                 `{}` (stripped: `{}`) — add an arm in emit_option_call \
+                                 or resolve upstream",
+                                method, m
+                            );
                         }
                     }
                     _ if matches!(&object.ty, Ty::Applied(almide_lang::types::constructor::TypeConstructorId::Result, _)) => {
@@ -801,12 +862,12 @@ impl FuncCompiler<'_> {
                             wasm!(self.func, { call(func_idx); });
                             return;
                         }
-                        // Fallback: stub
-                        self.emit_expr(object);
-                        if values::ty_to_valtype(&object.ty).is_some() {
-                            wasm!(self.func, { drop; });
-                        }
-                        self.emit_stub_call(args);
+                        panic!(
+                            "[ICE] emit_wasm: unresolved method call `.{}` on \
+                             object ty={:?} — expected TypeName.method or func_map \
+                             hit, but both lookups missed",
+                            method, object.ty
+                        );
                     }
                 }
             }
@@ -936,32 +997,6 @@ impl FuncCompiler<'_> {
         }
     }
 
-    /// S3 (v0.14.7-phase3.2): the WASM dispatcher used to route unknown
-    /// stdlib calls to `emit_stub_call`, which deferred the failure to a
-    /// runtime `unreachable` trap. spec/ + nn (v0.14.6 stub-panic sweep)
-    /// proved every reachable code path resolves before reaching here, so
-    /// reaching the stub now is a compile-time ICE — there is no runtime
-    /// trap to debug. If you hit this panic, it means a `module.func` call
-    /// survived `pass_resolve_calls` without a TOML or bundled IR target;
-    /// add the missing dispatch arm or fix the resolver, do not relax this
-    /// panic.
-    pub(super) fn emit_stub_call_named(&mut self, module: &str, func: &str, _args: &[IrExpr]) -> ! {
-        panic!(
-            "[ICE] WASM emit reached emit_stub_call_named for `{}.{}`. \
-             No runtime stub remains; resolve the call (TOML / bundled IR) \
-             or add a dispatch arm in emit_wasm/calls_*.rs.",
-            module, func
-        );
-    }
-
-    pub(super) fn emit_stub_call(&mut self, _args: &[IrExpr]) -> ! {
-        panic!(
-            "[ICE] WASM emit reached emit_stub_call (no module/func context). \
-             A stdlib dispatcher returned false without going through \
-             emit_stub_call_named — fix the caller."
-        );
-    }
-
     /// Emit a safe default value for a given type.
     /// String → empty string, List → empty list, Option → none, Bool → false, etc.
     pub(super) fn emit_typed_default(&mut self, ty: &Ty) {
@@ -1028,8 +1063,8 @@ impl FuncCompiler<'_> {
         }
     }
 
-    /// Emit assert_eq(left, right): compare values, trap if not equal.
-    /// UFCS fallback: try func_map lookup for user-defined functions before stubbing.
+    /// UFCS fallback: try func_map lookup for user-defined functions.
+    /// Panics on miss — a resolved call should never reach here unresolved.
     fn emit_ufcs_fallback(&mut self, object: &IrExpr, method: &str, args: &[IrExpr]) {
         // Try bare method name in func_map (user-defined function)
         let bare = method.split('.').last().unwrap_or(method);
@@ -1046,12 +1081,11 @@ impl FuncCompiler<'_> {
             wasm!(self.func, { call(func_idx); });
             return;
         }
-        // Stub
-        self.emit_expr(object);
-        if values::ty_to_valtype(&object.ty).is_some() {
-            wasm!(self.func, { drop; });
-        }
-        self.emit_stub_call(args);
+        panic!(
+            "[ICE] emit_wasm: UFCS fallback for `.{}` (object ty={:?}) found \
+             no entry in func_map — resolve upstream or register the function",
+            method, object.ty
+        );
     }
 
     /// Stage 3 of the sized-numeric-types arc: emit WASM conversion
@@ -1406,9 +1440,11 @@ impl FuncCompiler<'_> {
                 }
                 self.scratch.free_i32(closure);
             }
-            _ => {
-                self.emit_stub_call(args);
-            }
+            _ => panic!(
+                "[ICE] emit_wasm: no WASM dispatch for `fan.{}` — \
+                 add an arm in emit_fan_call or resolve upstream",
+                func
+            ),
         }
     }
 

--- a/crates/almide-codegen/src/emit_wasm/calls_datetime.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_datetime.rs
@@ -439,9 +439,11 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(s);
             }
-            _ => {
-                self.emit_stub_call_named("datetime", func, args);
-            }
+            _ => panic!(
+                "[ICE] emit_wasm: no WASM dispatch for `datetime.{}` — \
+                 add an arm in emit_datetime_call or resolve upstream",
+                func
+            ),
         }
     }
 

--- a/crates/almide-codegen/src/emit_wasm/calls_env.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_env.rs
@@ -59,9 +59,11 @@ impl FuncCompiler<'_> {
                 let s = self.emitter.intern_string("/tmp");
                 wasm!(self.func, { i32_const(s as i32); });
             }
-            _ => {
-                self.emit_stub_call_named("env", func, args);
-            }
+            _ => panic!(
+                "[ICE] emit_wasm: no WASM dispatch for `env.{}` — \
+                 add an arm in emit_env_call or resolve upstream",
+                func
+            ),
         }
     }
 

--- a/crates/almide-codegen/src/emit_wasm/calls_fs.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_fs.rs
@@ -1519,9 +1519,11 @@ impl FuncCompiler<'_> {
                 let s = self.emitter.intern_string("/tmp");
                 wasm!(self.func, { i32_const(s as i32); });
             }
-            _ => {
-                self.emit_stub_call_named("fs", func, args);
-            }
+            _ => panic!(
+                "[ICE] emit_wasm: no WASM dispatch for `fs.{}` — \
+                 add an arm in emit_fs_call or resolve upstream",
+                func
+            ),
         }
     }
 

--- a/crates/almide-codegen/src/emit_wasm/calls_http.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_http.rs
@@ -338,9 +338,11 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(tuple);
                 self.scratch.free_i32(s);
             }
-            _ => {
-                self.emit_stub_call_named("http", func, args);
-            }
+            _ => panic!(
+                "[ICE] emit_wasm: no WASM dispatch for `http.{}` — \
+                 add an arm in emit_http_call or resolve upstream",
+                func
+            ),
         }
     }
 

--- a/crates/almide-codegen/src/emit_wasm/calls_io.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_io.rs
@@ -411,9 +411,11 @@ impl FuncCompiler<'_> {
                     self.scratch.free_i32(list_ptr);
                 }
             }
-            _ => {
-                self.emit_stub_call_named("io", func, args);
-            }
+            _ => panic!(
+                "[ICE] emit_wasm: no WASM dispatch for `io.{}` — \
+                 add an arm in emit_io_call or resolve upstream",
+                func
+            ),
         }
     }
 }

--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -248,7 +248,11 @@ impl FuncCompiler<'_> {
             {
                 self.emit_list_sort_generic(args, SortKind::ListString)
             }
-            _ => self.emit_stub_call(args),
+            _ => panic!(
+                "[ICE] emit_wasm: no WASM dispatch for `list.sort` with \
+                 unsupported element type `{:?}` — extend emit_list_sort_*",
+                elem_ty
+            ),
         }
     }
 

--- a/crates/almide-codegen/src/emit_wasm/calls_process.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_process.rs
@@ -268,9 +268,11 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(capacity);
                 self.scratch.free_i32(buf);
             }
-            _ => {
-                self.emit_stub_call_named("process", func, args);
-            }
+            _ => panic!(
+                "[ICE] emit_wasm: no WASM dispatch for `process.{}` — \
+                 add an arm in emit_process_call or resolve upstream",
+                func
+            ),
         }
 }
 }

--- a/crates/almide-codegen/src/emit_wasm/calls_random.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_random.rs
@@ -210,9 +210,11 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(dst);
                 self.scratch.free_i32(src);
             }
-            _ => {
-                self.emit_stub_call_named("random", func, args);
-            }
+            _ => panic!(
+                "[ICE] emit_wasm: no WASM dispatch for `random.{}` — \
+                 add an arm in emit_random_call or resolve upstream",
+                func
+            ),
         }
     }
 

--- a/crates/almide-codegen/src/emit_wasm/calls_regex.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_regex.rs
@@ -25,7 +25,11 @@ impl FuncCompiler<'_> {
             "replace_first" => self.emit_regex_replace_first(args),
             "split" => self.emit_regex_split(args),
             "captures" => self.emit_regex_captures(args),
-            _ => self.emit_stub_call(args),
+            _ => panic!(
+                "[ICE] emit_wasm: no WASM dispatch for `regex.{}` — \
+                 add an arm in emit_regex_call or resolve upstream",
+                func
+            ),
         }
     }
 

--- a/crates/almide-codegen/src/emit_wasm/calls_value.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_value.rs
@@ -210,9 +210,11 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(v);
             }
-            _ => {
-                self.emit_stub_call_named("value", func, args);
-            }
+            _ => panic!(
+                "[ICE] emit_wasm: no WASM dispatch for `value.{}` — \
+                 add an arm in emit_value_call or resolve upstream",
+                func
+            ),
         }
     }
 
@@ -346,9 +348,11 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[1]);
                 wasm!(self.func, { call(self.emitter.rt.json_remove_path); });
             }
-            _ => {
-                self.emit_stub_call_named("value", func, args);
-            }
+            _ => panic!(
+                "[ICE] emit_wasm: no WASM dispatch for `value.{}` — \
+                 add an arm in emit_value_call or resolve upstream",
+                func
+            ),
         }
     }
 

--- a/crates/almide-codegen/src/pass_resolve_calls.rs
+++ b/crates/almide-codegen/src/pass_resolve_calls.rs
@@ -1,8 +1,10 @@
 //! Call Resolution pass: verify-and-rewrite for every `CallTarget::Module`.
 //!
 //! Phase 1a (v0.14.5): user-module call verification.
-//! Phase 1b (v0.14.7-phase3.5, this revision): IR rewrite + stdlib coverage.
+//! Phase 1b (v0.14.7-phase3.5): IR rewrite + stdlib coverage.
 //! Phase 1c (v0.14.7-phase3.2): `emit_stub_call*` panic on reach.
+//! Phase 1d (v0.14.7-phase3.3): `emit_stub_call*` helpers deleted; each
+//! WASM dispatcher fallback is an inline `panic!("[ICE] ...")`.
 //!
 //! ## What this pass does
 //!

--- a/crates/almide-optimize/src/mono/mod.rs
+++ b/crates/almide-optimize/src/mono/mod.rs
@@ -151,9 +151,9 @@ fn monomorphize_module_fns(program: &mut IrProgram) {
                 // expands to `almide_rt_list_len(&{xs})` regardless of `A`.
                 // Specializing them just produces bare-body clones whose
                 // names (`len__Int`) the WASM dispatcher's per-module match
-                // arms cannot recognise, which is exactly the gap the
-                // `emit_stub_call_named` panic plugs after the fact. Skip
-                // them here so the call site stays `Module { list, len }`
+                // arms cannot recognise, which would trip the inline
+                // `panic!("[ICE] ...")` fallback each dispatcher carries.
+                // Skip them here so the call site stays `Module { list, len }`
                 // and the dispatcher sees the unsuffixed name.
                 let is_template_dispatch = f.attrs.iter().any(|a|
                     matches!(a.name.as_str(), "inline_rust" | "wasm_intrinsic"));

--- a/docs/roadmap/active/codegen-ideal-form.md
+++ b/docs/roadmap/active/codegen-ideal-form.md
@@ -323,22 +323,29 @@ codegen-ideal-form #4 の完成。phase3.1 で audit を常時実行 + `ALMIDE_C
 残 WASM lifted-lambda TypeVar は `ClosureConversion` 由来の pass boundary
 issue で、S3 (pass_resolve_calls Phase 1b-c) で自然に解消する見込み。
 
-### Step S3 — pass_resolve_calls Phase 1b-c + stub 廃止 `0.14.7-phase3.2`
+### Step S3 — pass_resolve_calls Phase 1b-d + stub 廃止
 
-codegen-ideal-form #1 の Phase 1b (IR 書き換え) と 1c (`emit_stub_call` 削除)
-を完遂。私の arc 提案の step 3 + 4 を 1 PR にまとめる:
+codegen-ideal-form #1 / #7 を段階的に完遂するアーク。
 
-- `CallTarget::Module` / `CallTarget::Named` 全てを `CallTarget::Resolved`
-  (or `Named` で resolved symbol) に書き換える mutating pass
+- **Phase 1b** *(shipped, `0.14.7-phase3.5`)* — bundled-Almide stdlib fn の
+  `CallTarget::Module` → `CallTarget::Named { almide_rt_<m>_<f> }` 書き換え。
+- **Phase 1c** *(shipped, `0.14.7-phase3.2`)* — `emit_stub_call*` を
+  compile-time panic 化 (runtime trap 廃止)。
+- **Phase 1d** *(shipped, `0.14.7-phase3.3`)* — `emit_stub_call_named` /
+  `emit_stub_call` helper を完全削除し、各 WASM dispatcher の `_` fallback を
+  inline `panic!("[ICE] emit_wasm: no WASM dispatch for ...")` に置換。
+  S2 flip 下で既に compile-time ICE だったので behavior 不変、診断文が
+  module / dispatcher 固有になった。
+
+残タスク (Phase 1e+):
+
 - Rust + WASM 両 dispatch entry を `dispatch_module_call` 1 本に統合
   - priority: (a) IR に user/bundled fn → user-fn call / (b) TOML → inline emit
     / (c) どちらも無し → compile-time ICE
-- `emit_stub_call_named` を削除、全 `_` fall-through を compile-time error に
 - WASM emit 側 `emit_list_call` / `emit_int_call` 等の match arm に fallback
   が不要になる (resolve パスが事前解決)
 
-**見積**: 4-6h、実装は複数 sub-commit に分割 (resolve pass 拡張 / Rust dispatch
-統合 / WASM dispatch 統合 / stub 削除)。arc の主軸。
+**見積**: Phase 1e は 4-6h、resolve pass 拡張 + Rust/WASM dispatch 統合。arc の主軸。
 
 ### Step S4 — Monomorphize coverage 拡張 `0.14.7-phase3.3`
 


### PR DESCRIPTION
## Summary

S3 Phase 1d of codegen-ideal-form §Phase 3 Arc (`0.14.7-phase3.3`). With S2 flip landed (PR #199) the `_` fallback in every WASM stdlib dispatcher is guaranteed to be a compile-time ICE. The `emit_stub_call_named` / `emit_stub_call` helpers in `emit_wasm/calls.rs` added nothing beyond re-wrapping a generic `panic!("[ICE] ...")`, so they are replaced with inline panics that name the specific module and dispatcher.

## Before

```rust
_ if module == "int" => {
    if !self.emit_int_call(func, args) {
        self.emit_stub_call_named(module.as_str(), func.as_str(), args);
    }
}
```

Panic message: `WASM emit reached emit_stub_call_named for int.<func> ...` — vague, suggests the issue is the helper.

## After

```rust
_ if module == "int" => {
    if !self.emit_int_call(func, args) {
        panic!(
            "[ICE] emit_wasm: no WASM dispatch for `{}.{}` — \
             add an arm in emit_{}_call or resolve upstream",
            module.as_str(), func.as_str(), module.as_str()
        );
    }
}
```

Panic message: `[ICE] emit_wasm: no WASM dispatch for int.<func> — add an arm in emit_int_call or resolve upstream`. Points straight at the missing arm.

All 6 `emit_stub_call(args)` call sites (option method fallback, generic method fallback, UFCS fallback, fan default, regex, list-sort) get their own tailored panic message using the context they already carry (`method`, `object.ty`, `func`, `elem_ty`).

## Touched

- `emit_wasm/calls.rs`: 14 dispatcher arms + 4 non-`_named` call sites converted; helpers deleted (-27 lines of helper code, +119 lines of better error messages).
- `emit_wasm/calls_{io,value,http,datetime,process,fs,env,random,regex}.rs` + `calls_list_helpers.rs`: 10 more call sites converted.
- `pass_resolve_calls.rs` / `mono/mod.rs`: comment refresh for the helpers' disappearance.
- `CHANGELOG.md`: `[Unreleased]` entry under `S3 Phase 1d`.
- `docs/roadmap/active/codegen-ideal-form.md §S3`: Phase 1b/c/d marked shipped, Phase 1e (dispatch unification) spelled out as the next step.

## Test plan

- [x] `cargo build` / `cargo build --release` clean.
- [x] `./target/debug/almide test spec/` — 208/208 pass (Rust target).
- [x] `./target/debug/almide test spec/ --target wasm` — 205 pass / 0 fail / 3 skip (WASM target, same three pre-existing explicit `wasm:skip` files).
- [x] `./target/debug/almide test` in `../nn` — 12 files / 66 subtests pass.
- [x] `cargo test --release --workspace --exclude almide` — all green.

No change in behavior under the happy path: every dispatcher `_` arm remains unreachable on the current spec + nn sweep. If a future regression hits one, the panic now names the missing dispatcher directly.

## Non-scope

- S3 Phase 1e (unify Rust + WASM dispatch into a single `dispatch_module_call` / drop per-module `emit_*_call` match-on-func fallbacks) — separate arc, ~4-6h, next up after this lands.