### PR TITLE
Sized Types Stage 1c + Stage 4a MVP (Endian variant + typed read API)

### DIFF
--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -301,7 +301,19 @@ impl Checker {
                                     format!("operator '{}' requires numeric types but got {} and {}", op, lc.display(), rc.display()),
                                     "Use numeric types (Int or Float)", format!("operator {}", op)));
                             }
-                            if lc.compatible(&rc) && is_sized_scalar(&lc) {
+                            // Stage 1c: reject mixed-sized-width arithmetic.
+                            // See `infer_plus_op` for rationale.
+                            if is_sized_scalar(&lc) && is_sized_scalar(&rc) && lc != rc {
+                                self.emit(super::err(
+                                    format!(
+                                        "operator '{}' mixes sized numeric types {} and {} — \
+                                         explicit conversion required (e.g. `.to_{}()`)",
+                                        op, lc.display(), rc.display(),
+                                        lc.display().to_lowercase()),
+                                    "Convert one side with `.to_intN()` / `.to_floatN()` before the op",
+                                    format!("operator {}", op)));
+                                lc
+                            } else if lc.compatible(&rc) && is_sized_scalar(&lc) {
                                 lc
                             } else if lc == Ty::Float || rc == Ty::Float { Ty::Float } else { lt }
                         }
@@ -1023,6 +1035,23 @@ impl Checker {
                 | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 | Ty::UInt64
                 | Ty::Float32
         );
+        // Sized Numeric Types (Stage 1c): both sides sized AND widths
+        // differ is a type error. The permissive `Ty::Int` / `Ty::Float`
+        // canonical pair stays (it carries the literal-coercion slot for
+        // `let x: Int32 = 42` style bindings). Mixing `Int32` and `Int16`
+        // has no such cover — it's always wrong, always needs explicit
+        // `.to_intN()`.
+        if is_sized_scalar(lc) && is_sized_scalar(rc) && lc != rc {
+            self.emit(super::err(
+                format!(
+                    "operator '+' mixes sized numeric types {} and {} — \
+                     explicit conversion required (e.g. `.to_{}()`)",
+                    lc.display(), rc.display(),
+                    lc.display().to_lowercase()),
+                "Convert one side with `.to_intN()` / `.to_floatN()` before the op",
+                format!("operator +")));
+            return lc.clone();
+        }
         if lc.compatible(rc) && is_sized_scalar(lc) {
             return lc.clone();
         }

--- a/spec/lang/sized_numeric_types_test.almd
+++ b/spec/lang/sized_numeric_types_test.almd
@@ -107,6 +107,20 @@ test "Int16 modulo" { assert_eq(mod_i16(23, 5), 3) }
 test "Float32 addition" { assert_eq(add_f32(1.5, 2.5), 4.0) }
 test "UInt64 subtraction" { assert_eq(sub_u64(1000, 200), 800) }
 
+// Mixed-width arithmetic with explicit conversion — compiles and runs.
+// The negative path (unconverted mix is a compile error) is covered by
+// `tests/check_sized_numeric_mixed_width.rs` at the Rust-side checker
+// layer because `.almd` has no negative-test syntax.
+fn a32_plus_b8_via_i32(a: Int32, b: Int8) -> Int32 = a + b.to_int32()
+fn f32_plus_i32_via_float(a: Float32, b: Int32) -> Float32 = a + b.to_float32()
+
+test "Int32 + Int8 via .to_int32()" {
+  assert_eq(a32_plus_b8_via_i32(100, 5), 105)
+}
+test "Float32 + Int32 via .to_float32()" {
+  assert_eq(f32_plus_i32_via_float(1.5, 3), 4.5)
+}
+
 // ── Stage 3: UFCS conversion methods ─────────────────────────────
 
 test "Int32 to Int64" {

--- a/spec/stdlib/bytes_typed_test.almd
+++ b/spec/stdlib/bytes_typed_test.almd
@@ -1,0 +1,79 @@
+// wasm:skip — typed bytes API is Rust-only at the MVP layer. The WASM
+// dispatcher needs an arm in `emit_bytes_call` for each new name
+// (`read_uint32` etc.) before it can cover this surface. Follow-up.
+//
+// Stage 4a MVP: typed byte IO via `Endian` variant.
+//
+// Exercises the new `bytes.read_uintN` / `read_intN` / `read_float32`
+// family that replaces the combinatorial `_le` / `_be` suffixes with
+// a parameterized `Endian` arg. The old named fns stay for now; this
+// test locks the new shape against regression.
+
+import bytes
+
+test "read_uint16 LE round-trip" {
+  var b: Bytes = bytes.new(2)
+  bytes.set_u16_le(b, 0, 0xABCD)
+  let v: UInt16 = bytes.read_uint16(b, 0, LittleEndian)
+  assert_eq(v.to_int64(), 0xABCD)
+}
+
+test "read_uint16 BE round-trip" {
+  var b: Bytes = bytes.new(2)
+  bytes.set_u16_be(b, 0, 0x1234)
+  let v: UInt16 = bytes.read_uint16(b, 0, BigEndian)
+  assert_eq(v.to_int64(), 0x1234)
+}
+
+test "read_uint32 LE round-trip" {
+  var b: Bytes = bytes.new(4)
+  bytes.set_u32_le(b, 0, 0x12345678)
+  let v: UInt32 = bytes.read_uint32(b, 0, LittleEndian)
+  assert_eq(v.to_int64(), 0x12345678)
+}
+
+test "read_uint32 BE round-trip" {
+  var b: Bytes = bytes.new(4)
+  bytes.set_u32_be(b, 0, 0x12345678)
+  let v: UInt32 = bytes.read_uint32(b, 0, BigEndian)
+  assert_eq(v.to_int64(), 0x12345678)
+}
+
+test "read_int32 LE negative round-trip" {
+  var b: Bytes = bytes.new(4)
+  bytes.set_i32_le(b, 0, -42)
+  let v: Int32 = bytes.read_int32(b, 0, LittleEndian)
+  assert_eq(v.to_int64(), -42)
+}
+
+test "read_int32 BE positive round-trip" {
+  var b: Bytes = bytes.new(4)
+  bytes.set_i32_be(b, 0, 123456)
+  let v: Int32 = bytes.read_int32(b, 0, BigEndian)
+  assert_eq(v.to_int64(), 123456)
+}
+
+test "read_float32 LE round-trip" {
+  var b: Bytes = bytes.new(4)
+  bytes.set_f32_le(b, 0, 3.14)
+  let v: Float32 = bytes.read_float32(b, 0, LittleEndian)
+  let f: Float = v.to_float64()
+  assert_eq(f > 3.13, true)
+  assert_eq(f < 3.15, true)
+}
+
+test "read_float32 BE round-trip" {
+  var b: Bytes = bytes.new(4)
+  bytes.set_f32_be(b, 0, -1.5)
+  let v: Float32 = bytes.read_float32(b, 0, BigEndian)
+  let f: Float = v.to_float64()
+  assert_eq(f, -1.5)
+}
+
+test "Endian variant used as binding target" {
+  let chosen: Endian = BigEndian
+  var b: Bytes = bytes.new(4)
+  bytes.set_u32_be(b, 0, 100)
+  let v: UInt32 = bytes.read_uint32(b, 0, chosen)
+  assert_eq(v.to_int64(), 100)
+}

--- a/stdlib/bytes.almd
+++ b/stdlib/bytes.almd
@@ -387,3 +387,46 @@ fn write_u8(b: Bytes, val: Int) -> Unit = _
 
 @intrinsic("almide_rt_bytes_xor")
 fn xor(a: Bytes, b: Bytes) -> Bytes = _
+
+// ── Typed byte IO (Stage 4a, Sized Numeric Types integration) ──
+//
+// The new preferred surface: one function per (operation × width × kind),
+// parameterized by `Endian` instead of burnt into the name. Replaces
+// `read_u32_le` / `read_u32_be` / ... with `read_uint32(b, pos, .le)` /
+// `read_uint32(b, pos, .be)`. The old names stay for now; a later arc
+// will flip usage and delete them. Each typed wrapper dispatches at
+// compile time (match on a unit-variant arm), so there is no runtime
+// overhead over calling the legacy fn directly.
+//
+// Covered in this MVP:
+//   - read/write × {UInt16, UInt32, Int32, Float32}
+//
+// Follow-ups (not blocking this arc):
+//   - UInt8 / Int8 / Int16 / UInt64 / Int64 / Float64
+//   - `set[T]` / `append[T]` typed families
+//   - `FixedWidthInteger` / `BinaryFloatingPoint` protocols once the
+//     generic-dispatch infrastructure lands
+
+type Endian = | LittleEndian | BigEndian
+
+// Typed read wrappers expand inline via `@inline_rust` so the bundled-
+// Almide body layer never sits between the caller's `Bytes` value and
+// the `&{b}`-borrowing runtime fn. This avoids the bundled-body +
+// `&mut` template combinatorics the follow-up arc will address.
+
+@inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_read_u16_le(&{b}, {offset}) as u16, Endian::BigEndian => almide_rt_bytes_read_u16_be(&{b}, {offset}) as u16 }")
+fn read_uint16(b: Bytes, offset: Int, endian: Endian) -> UInt16 = _
+
+@inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_read_u32_le(&{b}, {offset}) as u32, Endian::BigEndian => almide_rt_bytes_read_u32_be(&{b}, {offset}) as u32 }")
+fn read_uint32(b: Bytes, offset: Int, endian: Endian) -> UInt32 = _
+
+@inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_read_i32_le(&{b}, {offset}) as i32, Endian::BigEndian => almide_rt_bytes_read_i32_be(&{b}, {offset}) as i32 }")
+fn read_int32(b: Bytes, offset: Int, endian: Endian) -> Int32 = _
+
+@inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_read_f32_le(&{b}, {offset}) as f32, Endian::BigEndian => almide_rt_bytes_read_f32_be(&{b}, {offset}) as f32 }")
+fn read_float32(b: Bytes, offset: Int, endian: Endian) -> Float32 = _
+
+// Write counterparts (write_uint32, write_float32, ...) are deferred
+// from this MVP. Mutating bundled fns pairing with `&mut {b}` inline
+// templates needs a codegen adapter; lands in a follow-up arc per
+// `docs/roadmap/active/sized-numeric-types.md` §Stage 4.

--- a/tests/checker_test.rs
+++ b/tests/checker_test.rs
@@ -905,3 +905,64 @@ fn exhaust_guard_not_counted() {
     );
     assert!(errs.iter().any(|e| e.contains("B")), "guarded B should not count, got: {:?}", errs);
 }
+
+// ── Sized Numeric Types Stage 1c: mixed-width arithmetic rejection ──
+
+#[test]
+fn sized_mixed_width_int8_int32_rejected() {
+    let errs = errors(
+        "fn f(a: Int8, b: Int32) -> Int32 = a + b"
+    );
+    assert!(errs.iter().any(|e| e.contains("mixes sized numeric")),
+        "should reject Int8 + Int32, got: {:?}", errs);
+}
+
+#[test]
+fn sized_mixed_width_float32_int32_rejected() {
+    let errs = errors(
+        "fn f(a: Float32, b: Int32) -> Float32 = a + b"
+    );
+    assert!(errs.iter().any(|e| e.contains("mixes sized numeric")),
+        "should reject Float32 + Int32, got: {:?}", errs);
+}
+
+#[test]
+fn sized_mixed_width_uint16_int16_rejected() {
+    let errs = errors(
+        "fn f(a: UInt16, b: Int16) -> Int16 = a * b"
+    );
+    assert!(errs.iter().any(|e| e.contains("mixes sized numeric")),
+        "should reject UInt16 * Int16 (even same width, different signedness), got: {:?}", errs);
+}
+
+#[test]
+fn sized_same_width_arith_ok() {
+    has_no_errors("fn f(a: Int32, b: Int32) -> Int32 = a + b");
+    has_no_errors("fn f(a: UInt8, b: UInt8) -> UInt8 = a - b");
+    has_no_errors("fn f(a: Float32, b: Float32) -> Float32 = a * b");
+}
+
+#[test]
+fn sized_literal_coercion_ok() {
+    has_no_errors("fn f(a: Int32) -> Int32 = a + 5");
+    has_no_errors("fn f(a: Int32) -> Int32 = 10 + a");
+    has_no_errors("fn f(a: Float32) -> Float32 = a + 1.5");
+}
+
+#[test]
+fn sized_canonical_int_plus_sized_ok() {
+    // `Int` / `Float` canonical types stay permissive to preserve the
+    // literal-coercion story. `Int + Int32` is therefore accepted (the
+    // right-hand side collapses to the sized variant at emit time).
+    has_no_errors("fn f(a: Int, b: Int32) -> Int32 = a + b");
+}
+
+#[test]
+fn sized_mixed_all_ops_rejected() {
+    for op in ["-", "*", "/", "%", "^"] {
+        let src = format!("fn f(a: Int8, b: Int32) -> Int32 = a {} b", op);
+        let errs = errors(&src);
+        assert!(errs.iter().any(|e| e.contains("mixes sized numeric")),
+            "operator '{}' should reject mixed sized types, got: {:?}", op, errs);
+    }
+}


### PR DESCRIPTION
## Summary

Sized Numeric Types arc の次段 — Stage 1c 完遂 + Stage 4a MVP。

### Stage 1c: 異幅算術 reject

checker で狭義 sized-numeric (Int8/16/32, UInt8-64, Float32) 同士の異幅算術をエラー化。`Int + Int32` の literal-coercion は温存 (`Int64` = `Ty::Int` alias の制約上、狭義 sized 同士のみ厳密)。

Before:
```almide
let a: Int8 = 1
let b: Int32 = 2
let c = a + b  // checker 通過 → rustc が i8 + i32 で reject
```

After:
```
error: operator '+' mixes sized numeric types Int8 and Int32 — explicit conversion required (e.g. `.to_int8()`)
```

### Stage 4a MVP: `Endian` variant + typed read API

`bytes.read_u32_le` / `read_u32_be` の width×endian 組み合わせ爆発を畳む布石。

```almide
let v: UInt32 = bytes.read_uint32(buf, 0, LittleEndian)
let w: Float32 = bytes.read_float32(buf, 4, BigEndian)
```

MVP 範囲: `read_uint16` / `read_uint32` / `read_int32` / `read_float32`。各 fn は `@inline_rust` で match 式に展開 → 既存 runtime fn (`almide_rt_bytes_read_u32_le` 等) にそのまま dispatch。ゼロ runtime overhead。

非対象 (follow-up arc):
- write/set/append 系 typed fn (`@inline_rust` の `&mut {b}` 経由の bundled-Almide body サポートが必要)
- WASM dispatch (`emit_bytes_call` に arm 追加が必要、spec test は `// wasm:skip` で迂回)
- `FixedWidthInteger` / `BinaryFloatingPoint` 汎用化 (`read[T]`)

## Changes

### Stage 1c
- \`crates/almide-frontend/src/check/infer.rs\` — \`infer_plus_op\` + \`-/*///%/^\` arm に「両辺 sized AND 異なる → error」ルール
- \`spec/lang/sized_numeric_types_test.almd\` — explicit conversion 経由の mixed arith positive test 追加
- \`tests/checker_test.rs\` — 7 個の checker-level 否定テスト

### Stage 4a MVP
- \`stdlib/bytes.almd\` — \`type Endian\` + 4 typed \`@inline_rust\` fn
- \`spec/stdlib/bytes_typed_test.almd\` — 9 test (read × {u16/u32/i32/f32} × {LE/BE} + Endian-as-var)

## Test plan

- [x] \`cargo test --test checker_test sized_\` — 7/7
- [x] \`./target/debug/almide test spec/\` — 209/209 (new typed test file included)
- [x] \`./target/debug/almide test spec/ --target wasm\` — 205/0/4 (1 extra skip = the wasm:skip opt-out)
- [x] \`./target/debug/almide test spec/lang/sized_numeric_types_test.almd\` — 28/28
- [x] \`./target/debug/almide test spec/stdlib/bytes_typed_test.almd\` — 9/9
