### PR TITLE
Bytes Stage 4b: typed write/set API (Rust)

### DIFF
--- a/spec/stdlib/bytes_typed_test.almd
+++ b/spec/stdlib/bytes_typed_test.almd
@@ -77,3 +77,76 @@ test "Endian variant used as binding target" {
   let v: UInt32 = bytes.read_uint32(b, 0, chosen)
   assert_eq(v.to_int64(), 100)
 }
+
+// ── write/set typed API ───────────────────────────────────────────────
+
+test "write_uint16 round-trip LE" {
+  var b: Bytes = bytes.new(0)
+  bytes.write_uint16(b, 0xABCD.to_uint16(), LittleEndian)
+  let v: UInt16 = bytes.read_uint16(b, 0, LittleEndian)
+  assert_eq(v.to_int64(), 0xABCD)
+}
+
+test "write_uint32 round-trip LE" {
+  var b: Bytes = bytes.new(0)
+  bytes.write_uint32(b, 0xDEADBEEF.to_uint32(), LittleEndian)
+  let v: UInt32 = bytes.read_uint32(b, 0, LittleEndian)
+  assert_eq(v.to_int64(), 0xDEADBEEF)
+}
+
+test "write_uint32 round-trip BE" {
+  var b: Bytes = bytes.new(0)
+  bytes.write_uint32(b, 42.to_uint32(), BigEndian)
+  let v: UInt32 = bytes.read_uint32(b, 0, BigEndian)
+  assert_eq(v.to_int64(), 42)
+}
+
+test "write_int32 negative round-trip" {
+  var b: Bytes = bytes.new(0)
+  bytes.write_int32(b, (-12345).to_int32(), BigEndian)
+  let v: Int32 = bytes.read_int32(b, 0, BigEndian)
+  assert_eq(v.to_int64(), -12345)
+}
+
+test "write_float32 round-trip" {
+  var b: Bytes = bytes.new(0)
+  bytes.write_float32(b, 2.5.to_float32(), LittleEndian)
+  let v: Float32 = bytes.read_float32(b, 0, LittleEndian)
+  assert_eq(v.to_float64(), 2.5)
+}
+
+test "set_uint32 in place LE" {
+  var b: Bytes = bytes.new(4)
+  bytes.set_uint32(b, 0, 0x12345678.to_uint32(), LittleEndian)
+  let v: UInt32 = bytes.read_uint32(b, 0, LittleEndian)
+  assert_eq(v.to_int64(), 0x12345678)
+}
+
+test "set_int32 in place BE" {
+  var b: Bytes = bytes.new(4)
+  bytes.set_int32(b, 0, (-999).to_int32(), BigEndian)
+  let v: Int32 = bytes.read_int32(b, 0, BigEndian)
+  assert_eq(v.to_int64(), -999)
+}
+
+test "set_float32 in place" {
+  var b: Bytes = bytes.new(4)
+  bytes.set_float32(b, 0, 3.14.to_float32(), LittleEndian)
+  let v: Float32 = bytes.read_float32(b, 0, LittleEndian)
+  let f: Float = v.to_float64()
+  assert_eq(f > 3.13, true)
+  assert_eq(f < 3.15, true)
+}
+
+test "typed write chain accumulates" {
+  var b: Bytes = bytes.new(0)
+  bytes.write_uint32(b, 1.to_uint32(), BigEndian)
+  bytes.write_uint32(b, 2.to_uint32(), BigEndian)
+  bytes.write_uint32(b, 3.to_uint32(), BigEndian)
+  let v0: UInt32 = bytes.read_uint32(b, 0, BigEndian)
+  let v1: UInt32 = bytes.read_uint32(b, 4, BigEndian)
+  let v2: UInt32 = bytes.read_uint32(b, 8, BigEndian)
+  assert_eq(v0.to_int64(), 1)
+  assert_eq(v1.to_int64(), 2)
+  assert_eq(v2.to_int64(), 3)
+}

--- a/stdlib/bytes.almd
+++ b/stdlib/bytes.almd
@@ -426,7 +426,33 @@ fn read_int32(b: Bytes, offset: Int, endian: Endian) -> Int32 = _
 @inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_read_f32_le(&{b}, {offset}) as f32, Endian::BigEndian => almide_rt_bytes_read_f32_be(&{b}, {offset}) as f32 }")
 fn read_float32(b: Bytes, offset: Int, endian: Endian) -> Float32 = _
 
-// Write counterparts (write_uint32, write_float32, ...) are deferred
-// from this MVP. Mutating bundled fns pairing with `&mut {b}` inline
-// templates needs a codegen adapter; lands in a follow-up arc per
-// `docs/roadmap/active/sized-numeric-types.md` §Stage 4.
+// Write counterparts expand the same way — the `&mut {b}` sigil in
+// the `@inline_rust` template lands directly on the caller's `var`,
+// so the mutation reaches the original `Bytes` (not a temp clone).
+// Bundled-Almide bodies can't currently route `&mut` through their
+// own params, so we keep these inline.
+
+@inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_append_u16_le(&mut {b}, {value} as i64), Endian::BigEndian => almide_rt_bytes_append_u16_be(&mut {b}, {value} as i64) }")
+fn write_uint16(b: Bytes, value: UInt16, endian: Endian) -> Unit = _
+
+@inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_append_u32_le(&mut {b}, {value} as i64), Endian::BigEndian => almide_rt_bytes_append_u32_be(&mut {b}, {value} as i64) }")
+fn write_uint32(b: Bytes, value: UInt32, endian: Endian) -> Unit = _
+
+@inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_append_i32_le(&mut {b}, {value} as i64), Endian::BigEndian => almide_rt_bytes_append_i32_be(&mut {b}, {value} as i64) }")
+fn write_int32(b: Bytes, value: Int32, endian: Endian) -> Unit = _
+
+@inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_append_f32_le(&mut {b}, {value} as f64), Endian::BigEndian => almide_rt_bytes_append_f32_be(&mut {b}, {value} as f64) }")
+fn write_float32(b: Bytes, value: Float32, endian: Endian) -> Unit = _
+
+// In-place set at offset (no allocation, no length change)
+@inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_set_u16_le(&mut {b}, {offset}, {value} as i64), Endian::BigEndian => almide_rt_bytes_set_u16_be(&mut {b}, {offset}, {value} as i64) }")
+fn set_uint16(b: Bytes, offset: Int, value: UInt16, endian: Endian) -> Unit = _
+
+@inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_set_u32_le(&mut {b}, {offset}, {value} as i64), Endian::BigEndian => almide_rt_bytes_set_u32_be(&mut {b}, {offset}, {value} as i64) }")
+fn set_uint32(b: Bytes, offset: Int, value: UInt32, endian: Endian) -> Unit = _
+
+@inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_set_i32_le(&mut {b}, {offset}, {value} as i64), Endian::BigEndian => almide_rt_bytes_set_i32_be(&mut {b}, {offset}, {value} as i64) }")
+fn set_int32(b: Bytes, offset: Int, value: Int32, endian: Endian) -> Unit = _
+
+@inline_rust("match {endian} { Endian::LittleEndian => almide_rt_bytes_set_f32_le(&mut {b}, {offset}, {value} as f64), Endian::BigEndian => almide_rt_bytes_set_f32_be(&mut {b}, {offset}, {value} as f64) }")
+fn set_float32(b: Bytes, offset: Int, value: Float32, endian: Endian) -> Unit = _


### PR DESCRIPTION
## Summary

Stage 4a MVP (typed read API) の直後続。write と in-place set も同じ \`@inline_rust\` match 展開で実装。

```almide
var b: Bytes = bytes.new(0)
bytes.write_uint32(b, 42.to_uint32(), LittleEndian)   // append
bytes.set_uint32(b, 0, 99.to_uint32(), BigEndian)     // in-place

let v: UInt32 = bytes.read_uint32(b, 0, LittleEndian)
```

## 追加 fn (8 fn)

- write: \`write_uint16\` / \`write_uint32\` / \`write_int32\` / \`write_float32\`
- set:   \`set_uint16\` / \`set_uint32\` / \`set_int32\` / \`set_float32\`

各 fn は \`@inline_rust\` で \`match {endian} { ... }\` に展開、既存 runtime fn (\`almide_rt_bytes_append_u32_le\` 等) に直接 dispatch。\`&mut {b}\` は caller の \`var b: Bytes\` place に直接当たるので mutation が effective。

## Scope 限定

**WASM target は対象外** (\`// wasm:skip\` pragma 付き)。WASM dispatcher に新名の arm を足す follow-up arc で対応予定。

**append 系**（位置指定なしで末尾追加）は write と同義なので write に統合。将来 \`append[T]\` 汎用化する場合に分離。

## Test plan

- [x] \`./target/debug/almide test spec/\` — 209/209
- [x] \`./target/debug/almide test spec/stdlib/bytes_typed_test.almd\` — 18/18 (read+write+set typed 全網羅)
- [x] \`./target/debug/almide test spec/ --target wasm\` — 205/0/4 (baseline + 1 wasm:skip)