### PR TITLE
Matrix[T] P4 kickoff: parametric dtype type syntax

### DIFF
--- a/crates/almide-codegen/src/walker/types.rs
+++ b/crates/almide-codegen/src/walker/types.rs
@@ -26,6 +26,14 @@ pub fn render_type(ctx: &RenderContext, ty: &Ty) -> String {
         Ty::Unit => template_or(ctx, "type_unit", &[], "()"),
         Ty::Bytes => template_or(ctx, "type_bytes", &[], "Vec<u8>"),
         Ty::Matrix => template_or(ctx, "type_matrix", &[], "AlmideMatrix"),
+        // Matrix[T] parametric form (Sized Numeric Types arc P4 kickoff):
+        // runtime representation stays `AlmideMatrix` (a tagged enum that
+        // dispatches to SmallF32 / Vec<Vec<f64>> backends). The `T`
+        // parameter gates type-level distinction only — user code can
+        // mix `Matrix[Float32]` / `Matrix[Float64]` annotations without
+        // a separate Rust type surface yet. Type-specialised layouts
+        // will fold into this arm in a follow-up codegen arc.
+        Ty::Applied(TypeConstructorId::Matrix, _) => template_or(ctx, "type_matrix", &[], "AlmideMatrix"),
         Ty::RawPtr => "*mut u8".to_string(),
         Ty::Applied(TypeConstructorId::Option, args) if args.len() == 1 => {
             let inner = &args[0];

--- a/crates/almide-frontend/src/canonicalize/resolve.rs
+++ b/crates/almide-frontend/src/canonicalize/resolve.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 use almide_lang::ast;
-use crate::types::{Ty, VariantCase, VariantPayload};
+use crate::types::{Ty, TypeConstructorId, VariantCase, VariantPayload};
 use almide_base::intern::{Sym, sym};
 
 /// Resolve an AST type expression to a Ty.
@@ -97,6 +97,12 @@ pub fn resolve_type_expr(te: &ast::TypeExpr, known_types: Option<&HashMap<Sym, T
                 "Result" if ra.len() >= 2 => Ty::result(ra[0].clone(), ra[1].clone()),
                 "Map" if ra.len() >= 2 => Ty::map_of(ra[0].clone(), ra[1].clone()),
                 "Set" => Ty::set_of(ra.first().cloned().unwrap_or(Ty::Unknown)),
+                // Sized Numeric Types P4 kickoff: `Matrix[T]` resolves
+                // to `Applied(Matrix, [T])` so the checker can discriminate
+                // `Matrix[Float32]` / `Matrix[Float64]`. Bare `Matrix`
+                // (no args) stays as `Ty::Matrix` — the compat rule in
+                // `types/mod.rs` bridges bare `Matrix` ↔ `Matrix[Float]`.
+                "Matrix" => Ty::Applied(TypeConstructorId::Matrix, ra),
                 _ => {
                     let resolved_name = name.as_str().rsplit_once('.').map(|(_, bare)| sym(bare)).unwrap_or(*name);
                     Ty::Named(resolved_name, ra)

--- a/crates/almide-types/src/types/constructor.rs
+++ b/crates/almide-types/src/types/constructor.rs
@@ -182,10 +182,15 @@ impl TypeConstructorRegistry {
             kind: Kind::Star,
             laws: vec![],
         });
+        // Matrix: * -> * — parametric dtype (Sized Numeric Types P4).
+        // Pre-arc: `Matrix` was non-parametric (kind *). Now `Matrix[T]`
+        // parses and resolves to `Applied(Matrix, [T])`; bare `Matrix`
+        // keeps compatibility via the `compatible(Ty::Matrix,
+        // Applied(Matrix, [Float]))` rule.
         self.register(TypeConstructorInfo {
             id: TypeConstructorId::Matrix,
             name: "Matrix".into(),
-            kind: Kind::Star,
+            kind: Kind::star_to_star(),
             laws: vec![],
         });
 

--- a/crates/almide-types/src/types/mod.rs
+++ b/crates/almide-types/src/types/mod.rs
@@ -335,6 +335,16 @@ impl Ty {
             (Ty::Unit, Ty::Unit) => true,
             (Ty::Bytes, Ty::Bytes) => true,
             (Ty::Matrix, Ty::Matrix) => true,
+            // Matrix[T] parametric form — the P4 arc introduces
+            // `Matrix[Float32]`, `Matrix[Float64]`, etc. Bare `Matrix`
+            // (legacy, unparameterised) is treated as the default
+            // `Matrix[Float64]` so existing `Matrix` code interops with
+            // typed code that asks for `Matrix[Float]`. Typed-typed
+            // pairings fall through to the generic `Applied` arm below.
+            (Ty::Matrix, Ty::Applied(TypeConstructorId::Matrix, args))
+            | (Ty::Applied(TypeConstructorId::Matrix, args), Ty::Matrix) => {
+                args.len() == 1 && matches!(args[0], Ty::Float)
+            }
             (Ty::RawPtr, Ty::RawPtr) => true,
             (Ty::Applied(id1, args1), Ty::Applied(id2, args2)) if id1 == id2 && args1.len() == args2.len() => {
                 args1.iter().zip(args2.iter()).all(|(a, b)| a.compatible(b))

--- a/spec/stdlib/matrix_dtype_test.almd
+++ b/spec/stdlib/matrix_dtype_test.almd
@@ -1,0 +1,59 @@
+// wasm:skip — `Matrix[T]` parametric type is the P4 kickoff for the
+// Sized Numeric Types arc. Runtime representation stays `AlmideMatrix`
+// for now (SmallF32 tagged enum); WASM emit picks up in a follow-up
+// once the codegen dispatcher reads `Applied(Matrix, [T])`.
+
+// Matrix[T] typed matrix handles — MVP scope
+//
+// Landing in this session:
+//   - `Matrix[T]` syntax parses + resolves to `Ty::Applied(Matrix, [T])`
+//   - Compat rule: bare `Matrix` interops with `Matrix[Float]` both ways
+//   - Codegen `render_type` treats parametric form as `AlmideMatrix`
+//     (runtime representation unchanged)
+//
+// Not covered yet (follow-up arcs):
+//   - Per-dtype runtime dispatch at the IR layer (stays via runtime tag)
+//   - `matrix.zeros[T]()` generic form → needs `T: Numeric` protocol
+//   - WASM target
+//   - `Matrix[Int32]` etc beyond the Float pair
+
+fn row_count(m: Matrix[Float]) -> Int = matrix.rows(m)
+fn double_matrix(m: Matrix) -> Matrix = matrix.scale(m, 2.0)
+
+test "Matrix[Float] annotation binds to bare Matrix value" {
+  let m: Matrix[Float] = matrix.zeros(3, 3)
+  assert_eq(row_count(m), 3)
+}
+
+test "bare Matrix interops with Matrix[Float] param" {
+  let m: Matrix = matrix.ones(2, 5)
+  assert_eq(row_count(m), 2)
+}
+
+test "Matrix[Float] return can feed bare Matrix caller" {
+  let m: Matrix[Float] = matrix.zeros(4, 4)
+  let scaled = double_matrix(m)
+  let (r, c) = matrix.shape(scaled)
+  assert_eq(r, 4)
+  assert_eq(c, 4)
+}
+
+test "Matrix[Float] shape accessor" {
+  let m: Matrix[Float] = matrix.ones(7, 2)
+  let (r, c) = matrix.shape(m)
+  assert_eq(r, 7)
+  assert_eq(c, 2)
+}
+
+test "Matrix[Float] and Matrix unify in let" {
+  let a: Matrix = matrix.zeros(2, 2)
+  let b: Matrix[Float] = a
+  let (r, _) = matrix.shape(b)
+  assert_eq(r, 2)
+}
+
+test "Matrix[Float] arith returns Matrix[Float] at type level" {
+  let a: Matrix[Float] = matrix.ones(3, 3)
+  let b: Matrix[Float] = matrix.scale(a, 0.5)
+  assert_eq(matrix.get(b, 0, 0), 0.5)
+}


### PR DESCRIPTION
## Summary

Sized Numeric Types arc の P4 (`Matrix[T]` parametric) kickoff。型レベルで dtype を区別できる基盤を導入。既存の `Matrix` (runtime tagged) surface は無傷。

## 変更内容

### Type system
- \`TypeConstructorId::Matrix\` の kind を \`Star\` → \`star_to_star()\` に昇格
- \`Matrix[T]\` syntax → \`Ty::Applied(Matrix, [T])\` に resolve (resolve.rs Generic arm 拡張)
- 互換性 rule: bare \`Matrix\` ↔ \`Matrix[Float]\` 相互可 (legacy code 保護)
- \`Matrix[Float32]\` / \`Matrix[Float64]\` / etc は **区別される型** として扱われ、annotation から transfer されない (T mismatch は error)

### Codegen
- \`walker/types.rs\` に \`Ty::Applied(TypeConstructorId::Matrix, _)\` arm 追加 → \`AlmideMatrix\` emit (runtime 表現は従来の tagged enum で維持)

### Test
- \`spec/stdlib/matrix_dtype_test.almd\` — 6 test (bare/typed interop、shape、arith round-trip)

## 非 goal (follow-up)

- \`matrix.zeros[T]()\` 汎用形 (→ \`T: Numeric\` protocol が必要、P3 の sub-arc)
- IR レベル per-dtype dispatch (現状は \`AlmideMatrix::SmallF32\` の runtime tag でカバー)
- WASM target (\`// wasm:skip\` で opt-out、emit dispatcher が \`Applied(Matrix, [T])\` を読み取る機構が要)
- \`Matrix[Int32]\` 等 Float 以外 (runtime に Int 対応無し)

## Test plan

- [x] \`./target/debug/almide test spec/\` — 210/210 (6 new)
- [x] \`./target/debug/almide test spec/ --target wasm\` — 205/0/5 (1 new wasm:skip)
- [x] \`cargo test --workspace --exclude almide\` — pass

## 次段

P5 (BLAS f32 dispatch on \`Matrix[Float32]\`) もしくは \`T: Numeric\` protocol による \`matrix.zeros[T]()\` 汎用化。