### PR TITLE
Strict Matrix[Float32] ↔ bare Matrix discrimination (Task C)

### DIFF
--- a/crates/almide-frontend/src/check/builtin_calls.rs
+++ b/crates/almide-frontend/src/check/builtin_calls.rs
@@ -29,10 +29,17 @@ pub(crate) fn builtin_module_for_type(ty: &Ty) -> Option<&'static str> {
     }
 }
 
-/// Check if two types are mismatched (neither Unknown, not compatible in either direction).
+/// Check if an argument type mismatches a parameter slot.
+///
+/// Matches the "expected accepts actual" semantic: the provided value
+/// must be assignable to the parameter. Asymmetric compat rules (e.g.
+/// `Matrix.compatible(Matrix[T])` = true but the reverse is false)
+/// depend on this directional check; the bidirectional variant used
+/// before P5 Matrix[T] discrimination let narrowing assignments slip
+/// through silently.
 pub(crate) fn types_mismatch(expected: &Ty, actual: &Ty) -> bool {
     *expected != Ty::Unknown && *actual != Ty::Unknown
-        && !expected.compatible(actual) && !actual.compatible(expected)
+        && !expected.compatible(actual)
 }
 
 impl Checker {

--- a/crates/almide-types/src/types/mod.rs
+++ b/crates/almide-types/src/types/mod.rs
@@ -363,17 +363,25 @@ impl Ty {
             (Ty::Unit, Ty::Unit) => true,
             (Ty::Bytes, Ty::Bytes) => true,
             (Ty::Matrix, Ty::Matrix) => true,
-            // Matrix ↔ Matrix[T] — bidirectional interop (lenient).
-            // pre-P4 stdlib accepts typed values; post-P4 typed fn
-            // sites accept bare `Matrix` values via the symmetric
-            // `types_mismatch` check. Strict one-way discrimination
-            // (reject bare `Matrix` at a typed call site) requires
-            // threading an asymmetric "accepts" relation through the
-            // full inference + mono pipeline — queued for a follow-up
-            // arc once the plumbing is ready to distinguish call-site
-            // narrowing from value upcasting.
-            (Ty::Matrix, Ty::Applied(TypeConstructorId::Matrix, _))
-            | (Ty::Applied(TypeConstructorId::Matrix, _), Ty::Matrix) => true,
+            // Matrix ↔ Matrix[T] — asymmetric discrimination:
+            //   - `Matrix.compatible(Matrix[T])` = true for all T
+            //     (bare param accepts any typed value — pre-P4 stdlib
+            //     `matrix.shape(m: Matrix)` stays usable with
+            //     `matrix.zeros_f32` results).
+            //   - `Matrix[Ty::Float].compatible(Matrix)` = true only
+            //     for the `Float` dtype (`Matrix` is the alias for
+            //     `Matrix[Float]`; bare runtime repr is f64).
+            //   - `Matrix[Ty::Float32].compatible(Matrix)` etc = false,
+            //     enforced by falling through to the default arm: a
+            //     typed-arity fn like `mul_f32(a: Matrix[Float32])`
+            //     REJECTS a bare `Matrix` value, since the bare form
+            //     carries no f32 guarantee.
+            // `types_mismatch` is single-directional so this
+            // asymmetry reaches call-site diagnostics unaltered.
+            (Ty::Matrix, Ty::Applied(TypeConstructorId::Matrix, _)) => true,
+            (Ty::Applied(TypeConstructorId::Matrix, args), Ty::Matrix) => {
+                args.len() == 1 && matches!(args[0], Ty::Float | Ty::Float64)
+            }
             (Ty::RawPtr, Ty::RawPtr) => true,
             (Ty::Applied(id1, args1), Ty::Applied(id2, args2)) if id1 == id2 && args1.len() == args2.len() => {
                 args1.iter().zip(args2.iter()).all(|(a, b)| a.compatible(b))

--- a/spec/stdlib/matrix_f32_test.almd
+++ b/spec/stdlib/matrix_f32_test.almd
@@ -48,22 +48,28 @@ test "mul_f32 on scaled ones × ones" {
   assert(approx_eq(matrix.get(r, 1, 1), 1.5, 0.00001))
 }
 
-test "mul_f32 of ones(3,3) * 0.5 × ones(3,3) * 0.5 = all 0.75" {
-  let a = matrix.ones_f32(3, 3) |> (m) => matrix.scale(m, 0.5)
-  let b = matrix.ones_f32(3, 3) |> (m) => matrix.scale(m, 0.5)
+test "mul_f32 of ones × ones = all 3.0" {
+  // Post strict-Matrix-discrimination: piping Matrix[Float32] through
+  // bare `matrix.scale` drops the type tag (returns bare `Matrix`),
+  // which a subsequent `mul_f32` correctly rejects. The previous form
+  // of this test relied on the runtime tag leaking back; the
+  // equivalent typed test uses the f32-typed constructors directly
+  // and folds any alpha through `mul_f32_scaled`.
+  let a: Matrix[Float32] = matrix.ones_f32(3, 3)
+  let b: Matrix[Float32] = matrix.ones_f32(3, 3)
   let r = matrix.mul_f32(a, b)
-  // Each element: sum of 3 * (0.5 * 0.5) = 0.75
-  assert(approx_eq(matrix.get(r, 0, 0), 0.75, 0.00001))
-  assert(approx_eq(matrix.get(r, 2, 2), 0.75, 0.00001))
+  // Each element: sum of 3 * (1.0 * 1.0) = 3.0
+  assert(approx_eq(matrix.get(r, 0, 0), 3.0, 0.00001))
+  assert(approx_eq(matrix.get(r, 2, 2), 3.0, 0.00001))
 }
 
 test "mul_f32_scaled fuses alpha through cblas_sgemm alpha" {
-  let a = matrix.ones_f32(2, 2) |> (m) => matrix.scale(m, 0.5)
-  let b = matrix.ones_f32(2, 2) |> (m) => matrix.scale(m, 0.5)
-  // alpha=4, A*B element is 2 * 0.25 = 0.5, scaled by 4 -> 2.0
+  let a: Matrix[Float32] = matrix.ones_f32(2, 2)
+  let b: Matrix[Float32] = matrix.ones_f32(2, 2)
+  // alpha=4, A*B element is 2 * 1.0 = 2, scaled by 4 -> 8
   let r = matrix.mul_f32_scaled(a, 4.0, b)
-  assert(approx_eq(matrix.get(r, 0, 0), 2.0, 0.00001))
-  assert(approx_eq(matrix.get(r, 1, 1), 2.0, 0.00001))
+  assert(approx_eq(matrix.get(r, 0, 0), 8.0, 0.00001))
+  assert(approx_eq(matrix.get(r, 1, 1), 8.0, 0.00001))
 }
 
 test "mul_f32_t computes A @ B^T without a transpose copy" {
@@ -81,22 +87,22 @@ test "mul_f32_t computes A @ B^T without a transpose copy" {
 }
 
 test "mul_f32_t on SmallF32 inputs agrees with transpose-then-mul" {
-  let a = matrix.ones_f32(4, 3) |> (m) => matrix.scale(m, 0.25)
-  let b = matrix.ones_f32(4, 3) |> (m) => matrix.scale(m, 0.25)
-  // a @ b^T where both are (4,3), result is (4,4). Each element is
-  // sum of 3 * (0.25 * 0.25) = 0.1875.
+  let a: Matrix[Float32] = matrix.ones_f32(4, 3)
+  let b: Matrix[Float32] = matrix.ones_f32(4, 3)
+  // a @ b^T where both are (4,3), result is (4,4). Each element
+  // is sum of 3 * (1.0 * 1.0) = 3.0.
   let r = matrix.mul_f32_t(a, b)
   let (rr, rc) = matrix.shape(r)
   assert_eq(rr, 4)
   assert_eq(rc, 4)
-  assert(approx_eq(matrix.get(r, 0, 0), 0.1875, 0.00001))
-  assert(approx_eq(matrix.get(r, 3, 3), 0.1875, 0.00001))
+  assert(approx_eq(matrix.get(r, 0, 0), 3.0, 0.00001))
+  assert(approx_eq(matrix.get(r, 3, 3), 3.0, 0.00001))
 }
 
 test "mul_f32_t_scaled applies alpha" {
-  let a = matrix.ones_f32(3, 2) |> (m) => matrix.scale(m, 0.5)
-  let b = matrix.ones_f32(3, 2) |> (m) => matrix.scale(m, 0.5)
-  // a @ b^T: each element = 2 * 0.25 = 0.5. With alpha=10 -> 5.0.
+  let a: Matrix[Float32] = matrix.ones_f32(3, 2)
+  let b: Matrix[Float32] = matrix.ones_f32(3, 2)
+  // a @ b^T: each element = 2 * 1.0 = 2.0. With alpha=10 -> 20.0.
   let r = matrix.mul_f32_t_scaled(a, 10.0, b)
-  assert(approx_eq(matrix.get(r, 0, 0), 5.0, 0.00001))
+  assert(approx_eq(matrix.get(r, 0, 0), 20.0, 0.00001))
 }

--- a/tests/checker_test.rs
+++ b/tests/checker_test.rs
@@ -1027,3 +1027,37 @@ fn sized_int_and_int64_interop_ok() {
     has_no_errors("fn f(a: Int, b: Int64) -> Int64 = b");
     has_no_errors("fn f(a: Int64) -> Int = a");
 }
+
+// ── Strict Matrix[T] discrimination (post-C) ──
+
+#[test]
+fn strict_matrix_f32_rejects_bare_matrix() {
+    // A fn that asks for `Matrix[Float32]` MUST NOT accept a bare
+    // `Matrix` value — bare carries no f32 guarantee.
+    let errs = errors(
+        "fn needs_f32(m: Matrix[Float32]) -> Int = matrix.rows(m)\nfn use_bare() -> Int = needs_f32(matrix.zeros(3, 3))"
+    );
+    assert!(errs.iter().any(|e| e.contains("expects")),
+        "should reject bare Matrix passed to Matrix[Float32] param, got: {:?}", errs);
+}
+
+#[test]
+fn strict_matrix_bare_accepts_typed() {
+    // `matrix.shape(m: Matrix)` still accepts `Matrix[Float32]`
+    // (bare widens to typed downstream via the runtime tag).
+    has_no_errors(
+        "fn row_count_f32(m: Matrix[Float32]) -> Int = matrix.rows(m)"
+    );
+}
+
+#[test]
+fn strict_matrix_float_alias_interop() {
+    // `Matrix[Float]` is the legacy alias for bare `Matrix` — both
+    // directions stay compatible at the checker layer.
+    has_no_errors(
+        "fn f(m: Matrix[Float]) -> Int = matrix.rows(m)\nfn g() -> Int = f(matrix.zeros(3, 3))"
+    );
+    has_no_errors(
+        "fn f(m: Matrix) -> Int = matrix.rows(m)\nfn g() -> Int = {\n  let m: Matrix[Float] = matrix.zeros(3, 3)\n  f(m)\n}"
+    );
+}


### PR DESCRIPTION
## Summary

previously-deferred follow-up #2 から完遂。型安全性を締め、\`matrix.mul_f32(a: Matrix[Float32])\` 等の typed 関数が **bare \`Matrix\` 値を reject** するようになる。

## 変更内容

### Asymmetric compat rule (\`types/mod.rs\`)
- \`Matrix.compatible(Matrix[T])\` = true (bare param が typed value を accept — widening)
- \`Matrix[Float].compatible(Matrix)\` = true (\`Matrix\` は \`Matrix[Float]\` alias、bidir alias)
- \`Matrix[Float64].compatible(Matrix)\` = true (同上)
- **\`Matrix[Float32].compatible(Matrix)\` = false** (bare は f32 保証なし、narrowing reject)
- \`Matrix[Int32/UInt32/etc].compatible(Matrix)\` = false (同上)

### Single-direction \`types_mismatch\` (\`check/builtin_calls.rs\`)
- Before: \`!expected.compatible(actual) && !actual.compatible(expected)\` (両方向 fail で mismatch)
- After: \`!expected.compatible(actual)\` のみ (expected が actual を accept するか)
- 非対称 compat rule がそのまま call-site diagnostic に反映される

### テスト修正 (\`matrix_f32_test.almd\`)
- \`matrix.ones_f32(3,3) |> (m) => matrix.scale(m, 0.5)\` のパイプは \`Matrix[Float32] → Matrix\` narrowing を経由してしまうため、ones_f32 直接渡し + mul_f32_scaled の alpha 融合に書き換え
- 期待値も alpha 前 scale を省いた形に更新

### Negative checker tests (\`tests/checker_test.rs\`)
- \`strict_matrix_f32_rejects_bare_matrix\` — bare → \`Matrix[Float32]\` reject
- \`strict_matrix_bare_accepts_typed\` — \`Matrix[Float32]\` → bare accept
- \`strict_matrix_float_alias_interop\` — \`Matrix[Float]\` ↔ \`Matrix\` bidir

## Test plan

- [x] \`cargo test --test checker_test\` — 143/143 (+3 new)
- [x] \`./target/debug/almide test spec/\` — 211/211
- [x] \`./target/debug/almide test spec/ --target wasm\` — 208/0/3 (pre-existing skip のみ)

## Why

P4 Matrix[T] 導入で parametric 型が入ったが、compat が対称だったので \`mul_f32(a: Matrix[Float32])\` が bare \`Matrix\` を素通し。runtime の SmallF32 tag に依存した silent failure を起こせた。非対称 compat + single-direction check で call-site narrowing を static reject、dtype 不変量が型安全に保たれる。

## Non-goal

- Sized numeric 型同士の asymmetry (既存の literal coercion bidir は温存)
- \`Matrix[Int32]\` 等非 Float dtype の stdlib 拡張 (別 arc)