### PR TITLE
Update stdlib outline snapshots for Int64/Float64

### DIFF
--- a/tests/snapshots/ide_outline_snapshot_test__stdlib_int_outline.snap
+++ b/tests/snapshots/ide_outline_snapshot_test__stdlib_int_outline.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/ide_outline_snapshot_test.rs
-assertion_line: 44
 expression: "run_outline(&[\"@stdlib/int\"])"
 ---
 fn int.abs(n: Int) -> Int
@@ -20,11 +19,11 @@ fn int.rotate_left(a: Int, n: Int, bits: Int) -> Int
 fn int.rotate_right(a: Int, n: Int, bits: Int) -> Int
 fn int.to_float(n: Int) -> Float
 fn int.to_float32(n: Int) -> Float32
-fn int.to_float64(n: Int) -> Float
+fn int.to_float64(n: Int) -> Float64
 fn int.to_hex(n: Int) -> String
 fn int.to_int16(n: Int) -> Int16
 fn int.to_int32(n: Int) -> Int32
-fn int.to_int64(n: Int) -> Int
+fn int.to_int64(n: Int) -> Int64
 fn int.to_int8(n: Int) -> Int8
 fn int.to_string(n: Int) -> String
 fn int.to_u32(a: Int) -> Int

--- a/tests/snapshots/ide_outline_snapshot_test__stdlib_snapshot_default.snap
+++ b/tests/snapshots/ide_outline_snapshot_test__stdlib_snapshot_default.snap
@@ -132,11 +132,11 @@ fn int.rotate_left(a: Int, n: Int, bits: Int) -> Int
 fn int.rotate_right(a: Int, n: Int, bits: Int) -> Int
 fn int.to_float(n: Int) -> Float
 fn int.to_float32(n: Int) -> Float32
-fn int.to_float64(n: Int) -> Float
+fn int.to_float64(n: Int) -> Float64
 fn int.to_hex(n: Int) -> String
 fn int.to_int16(n: Int) -> Int16
 fn int.to_int32(n: Int) -> Int32
-fn int.to_int64(n: Int) -> Int
+fn int.to_int64(n: Int) -> Int64
 fn int.to_int8(n: Int) -> Int8
 fn int.to_string(n: Int) -> String
 fn int.to_u32(a: Int) -> Int


### PR DESCRIPTION
## Summary
PR #207 introduced Int64/Float64 Ty variants but never ran `cargo insta review`. The ide_outline_snapshot_test has been failing on develop ever since.

`cargo insta accept` regenerated the two drifted snapshots:
- `ide_outline_snapshot_test__stdlib_int_outline.snap` — `int.to_int64` / `to_float64` return types now read `Int64` / `Float64`
- `ide_outline_snapshot_test__stdlib_snapshot_default.snap` — same fix in the default-outline view

## Test plan
- [x] `cargo test --test ide_outline_snapshot_test` (13 passed)