### PR TITLE
Declarative fusion rule table with MLIR/egg-compatible Pattern schema

### DIFF
--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -47,6 +47,7 @@ pub mod pass_tail_call_mark;
 pub mod pass_licm;
 pub mod pass_peephole;
 pub mod pass_matrix_fusion;
+pub mod pass_matrix_fusion_rules;
 pub mod pass_matrix_shape_spec;
 pub mod pass_const_fold;
 pub mod pass_rust_lowering;

--- a/crates/almide-codegen/src/pass_matrix_fusion.rs
+++ b/crates/almide-codegen/src/pass_matrix_fusion.rs
@@ -1,18 +1,38 @@
-//! MatrixFusionPass: fuse `matrix.add(matrix.scale(a, ka), matrix.scale(b, kb))`
-//! into `matrix.fma(a, ka, b, kb)`.
+//! MatrixFusionPass — declarative chain-fusion driven by `pass_matrix_fusion_rules`
+//! plus a pair of legacy rules for `add/sub → fma` and `fma → fma3`
+//! tree-fuse that don't fit the pure chain schema (both coefficients
+//! need to be composed from nested scale operands).
 //!
-//! Closes the elementwise-chain performance gap measured in
-//! `almide-wasm-bindgen/examples/bench/chain_bench.mjs` — without this pass,
-//! the chain runs 3 separate elementwise loops with 3 allocations.
+//! ## Layout
 //!
-//! Target: all targets that have `matrix.fma` available (Rust + WASM today).
-//! Runs early, before passes that decorate the IR with borrow / clone /
-//! match-subject transforms (those break naive structural matching).
+//! - `rewrite_expr` walks the IR. After recursing into children it:
+//!   1. Applies the `add/sub → fma` transform (requires `extract_scaled`
+//!      plumbing; not expressible as a single-pattern rule).
+//!   2. Applies the `fma/fma3` tree-fuse (mutates coefficients; also
+//!      outside the rule schema).
+//!   3. Applies every entry of `fusion_rules()` in order. Each chain
+//!      fusion (gemm/bias/scale/gelu, attention_weights, SDPA, …) lives
+//!      as a data-only `FusionRule` in `pass_matrix_fusion_rules` —
+//!      adding a new fusion means appending one rule and a runtime
+//!      implementation; no matcher boilerplate.
+//! - `fuse_let_split_chain` walks a Block / ForIn / While body and
+//!   collapses each rule's **let-split form** via the generic
+//!   `match_chain_let_window`. The rule's pattern tree determines the
+//!   k-gram length automatically (pattern depth).
+//!
+//! ## Why declarative
+//!
+//! `pass_matrix_fusion_rules::Pattern` is isomorphic to MLIR's op
+//! pattern matcher and egg's `Rewrite<L, N>` LHS. When the MLIR / egg
+//! arc lands we translate the rule table mechanically — the fusion
+//! catalogue is data, not hand-rolled matchers.
 
 use almide_base::intern::sym;
 use almide_ir::*;
-use almide_ir::visit::{IrVisitor, walk_expr};
 use super::pass::{NanoPass, PassResult, Target};
+use super::pass_matrix_fusion_rules::{
+    self as rules, count_var_refs, match_chain_let_window, ChainStep, FusionRule,
+};
 
 #[derive(Debug)]
 pub struct MatrixFusionPass;
@@ -23,24 +43,44 @@ impl NanoPass for MatrixFusionPass {
     fn depends_on(&self) -> Vec<&'static str> { vec![] }
 
     fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
+        let linearized = linearize_rules();
+        let rules_list = rules::fusion_rules();
         let mut changed = false;
         for func in &mut program.functions {
-            if rewrite_expr(&mut func.body) { changed = true; }
+            if rewrite_expr(&mut func.body, &rules_list, &linearized) { changed = true; }
         }
         for tl in &mut program.top_lets {
-            if rewrite_expr(&mut tl.value) { changed = true; }
+            if rewrite_expr(&mut tl.value, &rules_list, &linearized) { changed = true; }
         }
         for module in &mut program.modules {
             for func in &mut module.functions {
-                if rewrite_expr(&mut func.body) { changed = true; }
+                if rewrite_expr(&mut func.body, &rules_list, &linearized) { changed = true; }
             }
             for tl in &mut module.top_lets {
-                if rewrite_expr(&mut tl.value) { changed = true; }
+                if rewrite_expr(&mut tl.value, &rules_list, &linearized) { changed = true; }
             }
         }
         PassResult { program, changed }
     }
 }
+
+/// Pre-compute `(rule, chain_steps)` for every chain-shaped rule.
+/// Non-chain-shaped rules (two nested Call children, etc.) skip
+/// let-split and are only applied in nested form. Sorted by chain
+/// length descending so deeper patterns win on overlap.
+fn linearize_rules() -> Vec<(FusionRule, Vec<ChainStep>)> {
+    let mut out: Vec<(FusionRule, Vec<ChainStep>)> = rules::fusion_rules()
+        .into_iter()
+        .filter_map(|r| {
+            let steps = r.pattern.linearize_chain()?;
+            Some((r, steps))
+        })
+        .collect();
+    out.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    out
+}
+
+// ── Legacy add/sub → fma helpers (not expressible as chain rules) ──
 
 /// Returns Some((m, k)) if expr is `matrix.scale(m, k)`, else None.
 fn match_matrix_scale(expr: &IrExpr) -> Option<(IrExpr, IrExpr)> {
@@ -98,66 +138,77 @@ fn negate_scalar(s: IrExpr) -> IrExpr {
     }
 }
 
-fn rewrite_expr(expr: &mut IrExpr) -> bool {
+fn rewrite_expr(
+    expr: &mut IrExpr,
+    rules_list: &[FusionRule],
+    linearized: &[(FusionRule, Vec<ChainStep>)],
+) -> bool {
     let mut changed = false;
 
-    // Recurse into children first so deeper chains fuse before the outer add.
+    // Recurse into children first so deeper chains fuse before the outer op.
     match &mut expr.kind {
         IrExprKind::Block { stmts, expr: tail } => {
-            for stmt in stmts.iter_mut() { if rewrite_stmt(stmt) { changed = true; } }
-            if let Some(e) = tail { if rewrite_expr(e) { changed = true; } }
-            // Collapse let-split gemm-bias-scale-gelu chains inside this
-            // block. Runs after the per-stmt rewrites so every inner
-            // expression is already in its fused-or-final form.
-            if fuse_let_split_chain(stmts, tail.as_deref()) { changed = true; }
+            for stmt in stmts.iter_mut() {
+                if rewrite_stmt(stmt, rules_list, linearized) { changed = true; }
+            }
+            if let Some(e) = tail { if rewrite_expr(e, rules_list, linearized) { changed = true; } }
+            if fuse_let_split_chain(stmts, tail.as_deref(), linearized) { changed = true; }
         }
         IrExprKind::If { cond, then, else_ } => {
-            if rewrite_expr(cond) { changed = true; }
-            if rewrite_expr(then) { changed = true; }
-            if rewrite_expr(else_) { changed = true; }
+            if rewrite_expr(cond, rules_list, linearized) { changed = true; }
+            if rewrite_expr(then, rules_list, linearized) { changed = true; }
+            if rewrite_expr(else_, rules_list, linearized) { changed = true; }
         }
         IrExprKind::Match { subject, arms } => {
-            if rewrite_expr(subject) { changed = true; }
+            if rewrite_expr(subject, rules_list, linearized) { changed = true; }
             for arm in arms {
-                if let Some(g) = &mut arm.guard { if rewrite_expr(g) { changed = true; } }
-                if rewrite_expr(&mut arm.body) { changed = true; }
+                if let Some(g) = &mut arm.guard {
+                    if rewrite_expr(g, rules_list, linearized) { changed = true; }
+                }
+                if rewrite_expr(&mut arm.body, rules_list, linearized) { changed = true; }
             }
         }
         IrExprKind::ForIn { iterable, body, .. } => {
-            if rewrite_expr(iterable) { changed = true; }
-            for stmt in body.iter_mut() { if rewrite_stmt(stmt) { changed = true; } }
-            if fuse_let_split_chain(body, None) { changed = true; }
+            if rewrite_expr(iterable, rules_list, linearized) { changed = true; }
+            for stmt in body.iter_mut() {
+                if rewrite_stmt(stmt, rules_list, linearized) { changed = true; }
+            }
+            if fuse_let_split_chain(body, None, linearized) { changed = true; }
         }
         IrExprKind::While { cond, body } => {
-            if rewrite_expr(cond) { changed = true; }
-            for stmt in body.iter_mut() { if rewrite_stmt(stmt) { changed = true; } }
-            if fuse_let_split_chain(body, None) { changed = true; }
+            if rewrite_expr(cond, rules_list, linearized) { changed = true; }
+            for stmt in body.iter_mut() {
+                if rewrite_stmt(stmt, rules_list, linearized) { changed = true; }
+            }
+            if fuse_let_split_chain(body, None, linearized) { changed = true; }
         }
         IrExprKind::Lambda { body, .. } => {
-            if rewrite_expr(body) { changed = true; }
+            if rewrite_expr(body, rules_list, linearized) { changed = true; }
         }
         IrExprKind::Call { args, .. } => {
-            for a in args.iter_mut() { if rewrite_expr(a) { changed = true; } }
+            for a in args.iter_mut() {
+                if rewrite_expr(a, rules_list, linearized) { changed = true; }
+            }
         }
         IrExprKind::BinOp { left, right, .. } => {
-            if rewrite_expr(left) { changed = true; }
-            if rewrite_expr(right) { changed = true; }
+            if rewrite_expr(left, rules_list, linearized) { changed = true; }
+            if rewrite_expr(right, rules_list, linearized) { changed = true; }
         }
         IrExprKind::UnOp { operand, .. } => {
-            if rewrite_expr(operand) { changed = true; }
+            if rewrite_expr(operand, rules_list, linearized) { changed = true; }
         }
         _ => {}
     }
 
-    // Detect:
-    //   matrix.add(X, Y) → fma(extract_scaled(X), extract_scaled(Y))
-    //   matrix.sub(X, Y) → fma(extract_scaled(X), extract_scaled(Y) with negated kb)
-    // Where extract_scaled(scale(m, k)) = (m, k), neg(m) = (m, -1.0), m = (m, 1.0).
+    // ── Legacy 1: add/sub with at-least-one scaled side → fma ──
     //
-    // Only fuse when at least ONE side is genuinely scaled — otherwise we'd
-    // turn a plain `matrix.add(a, b)` into `fma(a, 1.0, b, 1.0)`, which is
-    // strictly more expensive (2 muls per element for no payoff).
-    let fused = if let IrExprKind::Call {
+    // Only fires when at least ONE side is genuinely scaled; otherwise
+    // converting `add(a, b)` into `fma(a, 1.0, b, 1.0)` would add two
+    // pointless multiplies per element. This is expressible as two
+    // rules in principle but the per-side `extract_scaled` (which also
+    // recognises `neg`) and the `-1.0` / `scalar * -1.0` plumbing live
+    // below; keeping them inline is cheaper than extending the schema.
+    let fused_add = if let IrExprKind::Call {
         target: CallTarget::Module { module, func },
         args,
         ..
@@ -179,310 +230,104 @@ fn rewrite_expr(expr: &mut IrExpr) -> bool {
                     let (b, kb_raw) = extract_scaled(&args[1]);
                     let kb = if is_sub { negate_scalar(kb_raw) } else { kb_raw };
                     Some((a, ka, b, kb))
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    } else {
-        None
-    };
+                } else { None }
+            } else { None }
+        } else { None }
+    } else { None };
 
-    if let Some((a, ka, b, kb)) = fused {
-        let new_kind = IrExprKind::Call {
+    if let Some((a, ka, b, kb)) = fused_add {
+        expr.kind = IrExprKind::Call {
             target: CallTarget::Module { module: sym("matrix"), func: sym("fma") },
             args: vec![a, ka, b, kb],
             type_args: vec![],
         };
-        expr.kind = new_kind;
-        // expr.ty stays the same (Matrix).
         changed = true;
     }
 
-    // Tree-fuse: collapse `fma(X, kx, fma(b, kb, c, kc), ky)` into
-    // `fma3(X, kx, b, kb*ky, c, kc*ky)`. Algebraically:
-    //   X*kx + (b*kb + c*kc)*ky = X*kx + b*(kb*ky) + c*(kc*ky)
-    // This turns a 2-pass chain (inner fma + outer fma) into a single
-    // 1-pass sweep — the structural fix for the nested-fma 2-pass bottleneck.
-    // Mirror case handled: `fma(fma(a, ka, b, kb), kx, Y, ky)` collapses to
-    //   a*(ka*kx) + b*(kb*kx) + Y*ky  →  fma3(a, ka*kx, b, kb*kx, Y, ky).
+    // ── Legacy 2: fma + nested fma → fma3 tree-fuse ──
+    //
+    // `fma(X, kx, fma(b, kb, c, kc), ky)` → `fma3(X, kx, b, kb*ky, c, kc*ky)`.
+    // Coefficient multiplication crosses rule boundaries, so this
+    // stays procedural rather than a single Pattern rule.
     if let Some(new_kind) = try_tree_fuse(&expr.kind) {
         expr.kind = new_kind;
         changed = true;
     }
 
-    // Linear-layer chain fusion: `gelu(scale(add(mul(a, b), bias), alpha))`
-    // → `fused_gemm_bias_scale_gelu(a, b, bias, alpha)`. Runs after the
-    // add/fma fusion above so we match on the original unfused form, not
-    // on a surviving `fma` outer.
-    if let Some(new_kind) = try_fuse_gemm_bias_scale_gelu(&expr.kind) {
-        expr.kind = new_kind;
-        changed = true;
-    }
-
-    // Attention weights fusion: `softmax_rows(scale(mul(Q, Kt), s))`
-    // → `attention_weights(Q, Kt, s)`. The scaled-dot-product attention
-    // numerator — one of the two hottest chains in any transformer.
-    if let Some(new_kind) = try_fuse_attention_weights(&expr.kind) {
-        expr.kind = new_kind;
-        changed = true;
-    }
-
-    // FFN first sub-layer fusion: `gelu(linear_row(x, W, b))` →
-    // `linear_row_gelu(x, W, b)`. Single cblas_dgemm (transB=Trans, C
-    // bias-seeded) plus in-place GELU.
-    if let Some(new_kind) = try_fuse_linear_row_gelu(&expr.kind) {
-        expr.kind = new_kind;
-        changed = true;
-    }
-
-    // Pre-norm linear fusion:
-    // `linear_row(layer_norm_rows(x, γ, β, ε), W, b)` → `pre_norm_linear(x, γ, β, ε, W, b)`.
-    // Transformer pre-norm first sub-layer. Fuses the LN row sweep and
-    // the linear projection into one pass that calls cblas_dgemm directly
-    // and skips burn's linear_row dispatch on the Small path.
-    if let Some(new_kind) = try_fuse_pre_norm_linear(&expr.kind) {
-        expr.kind = new_kind;
-        changed = true;
-    }
-
-    // Full scaled-dot-product attention fusion:
-    //   matrix.mul(matrix.attention_weights(Q, Kt, s), V)
-    //   → matrix.scaled_dot_product_attention(Q, Kt, V, s)
-    // Runtime collapses the second matmul into the same flat buffer used
-    // by the in-place softmax — no separate weights matrix object.
-    if let Some(new_kind) = try_fuse_scaled_dot_product_attention(&expr.kind) {
-        expr.kind = new_kind;
-        changed = true;
-    }
-
-    // Scaled-matmul fusion:
-    //   matrix.mul(a, matrix.scale(b, s)) → matrix.mul_scaled(a, s, b)
-    //   matrix.mul(matrix.scale(a, s), b) → matrix.mul_scaled(a, s, b)
-    // Drops the intermediate scaled allocation — the scalar α flows into
-    // cblas_dgemm's alpha parameter directly at no extra FLOPs (up to
-    // the FUSED_ALPHA_MAX=512 crossover; above that the runtime falls
-    // back to scale+mul).
-    if let Some(new_kind) = try_fuse_mul_scaled(&expr.kind) {
-        expr.kind = new_kind;
-        changed = true;
+    // ── Declarative fusion rules (chain-shaped) ──
+    //
+    // Applied top-down after the legacy transforms settle. Order
+    // within `fusion_rules()` is deliberate — the table puts deeper /
+    // more specific patterns first so outer rules don't pre-empt their
+    // inner prerequisites.
+    for rule in rules_list {
+        if let Some(m) = rule.pattern.try_match(expr) {
+            let new_kind = (rule.rewrite)(&m);
+            expr.kind = new_kind;
+            changed = true;
+            // Re-check with the rewritten expr in case a second rule
+            // wraps this one (e.g. attention_weights → SDPA).
+        }
     }
 
     changed
 }
 
-/// Returns `(a, b)` if `expr` is `matrix.<func>(a, b)`.
-fn match_matrix_binary<'a>(expr: &'a IrExpr, func_name: &str) -> Option<(&'a IrExpr, &'a IrExpr)> {
-    if let IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } = &expr.kind {
-        if module.as_str() == "matrix" && func.as_str() == func_name && args.len() == 2 {
-            return Some((&args[0], &args[1]));
-        }
-    }
-    None
-}
-
-/// Returns `m` if `expr` is `matrix.<func>(m)`.
-fn match_matrix_unary<'a>(expr: &'a IrExpr, func_name: &str) -> Option<&'a IrExpr> {
-    if let IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } = &expr.kind {
-        if module.as_str() == "matrix" && func.as_str() == func_name && args.len() == 1 {
-            return Some(&args[0]);
-        }
-    }
-    None
-}
-
-/// Pattern-match `gelu(scale(add(mul(a, b), bias), alpha))` and rewrite
-/// the whole 4-layer chain into a single `fused_gemm_bias_scale_gelu`
-/// call. The fused runtime implementation does `alpha*(a@b + bias)` via
-/// one cblas_dgemm (`C = bias`, `β = alpha`, `α = alpha`) and then runs
-/// GELU in place — collapses 3 intermediate allocations and 3 loop
-/// sweeps into one BLAS call plus one pass.
-fn try_fuse_gemm_bias_scale_gelu(kind: &IrExprKind) -> Option<IrExprKind> {
-    let gelu_arg = match kind {
-        IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. }
-            if module.as_str() == "matrix" && func.as_str() == "gelu" && args.len() == 1 =>
-        {
-            &args[0]
-        }
-        _ => return None,
-    };
-    let (scale_inner, alpha) = match_matrix_binary(gelu_arg, "scale")?;
-    let (add_lhs, bias) = match_matrix_binary(scale_inner, "add")?;
-    let (a, b) = match_matrix_binary(add_lhs, "mul")?;
-
-    Some(IrExprKind::Call {
-        target: CallTarget::Module {
-            module: sym("matrix"),
-            func: sym("fused_gemm_bias_scale_gelu"),
-        },
-        args: vec![a.clone(), b.clone(), bias.clone(), alpha.clone()],
-        type_args: vec![],
-    })
-}
-
-/// Pattern-match `matrix.mul(matrix.attention_weights(Q, Kt, s), V)` →
-/// `matrix.scaled_dot_product_attention(Q, Kt, V, s)`.
-///
-/// Note this looks for the post-fusion `attention_weights` form. The
-/// upstream `try_fuse_attention_weights` already collapses
-/// `softmax_rows(scale(mul(...)))` to it, so by the time the outer
-/// expression is rebuilt we see `mul(attention_weights(...), V)` and
-/// can fold the second matmul in.
-fn try_fuse_scaled_dot_product_attention(kind: &IrExprKind) -> Option<IrExprKind> {
-    let (lhs, v) = match kind {
-        IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. }
-            if module.as_str() == "matrix" && func.as_str() == "mul" && args.len() == 2 =>
-        {
-            (&args[0], &args[1])
-        }
-        _ => return None,
-    };
-    if let IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } = &lhs.kind {
-        if module.as_str() == "matrix" && func.as_str() == "attention_weights" && args.len() == 3 {
-            return Some(IrExprKind::Call {
-                target: CallTarget::Module {
-                    module: sym("matrix"),
-                    func: sym("scaled_dot_product_attention"),
+/// Let-split chain fusion: for every `(rule, chain_steps)` entry,
+/// scan the block for a sliding window of `chain_steps.len()`
+/// consecutive `Bind` statements that matches the rule's chain shape.
+/// When found, rewrite the terminal `Bind` to the fused call and drop
+/// the intermediate bindings (after verifying they have no references
+/// in the remainder of the block).
+fn fuse_let_split_chain(
+    stmts: &mut Vec<IrStmt>,
+    tail: Option<&IrExpr>,
+    linearized: &[(FusionRule, Vec<ChainStep>)],
+) -> bool {
+    let mut changed = false;
+    let mut i = 0;
+    while i < stmts.len() {
+        let mut fired = false;
+        for (rule, steps) in linearized {
+            let k = steps.len();
+            if i + k > stmts.len() { continue; }
+            let window = &stmts[i..i + k];
+            let Some(cm) = match_chain_let_window(steps, window) else { continue };
+            // Single-use enforcement: every intermediate var must have
+            // zero references in the rest of the block (statements
+            // after the window + tail expression).
+            let rest = &stmts[i + k..];
+            if !cm.intermediate_vars
+                .iter()
+                .all(|v| count_var_refs(rest, tail, *v) == 0)
+            {
+                continue;
+            }
+            // Extract the terminal bind's VarId / mutability / ty so
+            // the fused statement inherits them exactly.
+            let (term_var, term_mut, term_ty) = match &stmts[i + k - 1].kind {
+                IrStmtKind::Bind { var, mutability, ty, .. } => (*var, *mutability, ty.clone()),
+                _ => continue,
+            };
+            let span = stmts[i + k - 1].span;
+            let fused_kind = (rule.rewrite)(&cm.captures);
+            let fused_stmt = IrStmt {
+                kind: IrStmtKind::Bind {
+                    var: term_var,
+                    mutability: term_mut,
+                    ty: term_ty.clone(),
+                    value: IrExpr { kind: fused_kind, ty: term_ty, span },
                 },
-                args: vec![args[0].clone(), args[1].clone(), v.clone(), args[2].clone()],
-                type_args: vec![],
-            });
+                span,
+            };
+            stmts.splice(i..i + k, std::iter::once(fused_stmt));
+            changed = true;
+            fired = true;
+            break; // re-check same index with the shorter window
         }
+        if !fired { i += 1; }
     }
-    None
-}
-
-/// Pattern-match `matrix.mul(a, matrix.scale(b, s))` and its mirror
-/// `matrix.mul(matrix.scale(a, s), b)` → `matrix.mul_scaled(a, s, b)`.
-/// The runtime folds the scalar into cblas_dgemm's `alpha` parameter,
-/// so the intermediate `scale` allocation and pass vanish. Works up to
-/// 512² — above that, the runtime itself reverts to scale-then-mul
-/// because the alpha!=1 BLAS penalty is worse than the alloc cost.
-fn try_fuse_mul_scaled(kind: &IrExprKind) -> Option<IrExprKind> {
-    let (lhs, rhs) = match kind {
-        IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. }
-            if module.as_str() == "matrix" && func.as_str() == "mul" && args.len() == 2 =>
-        {
-            (&args[0], &args[1])
-        }
-        _ => return None,
-    };
-
-    // Case 1: mul(a, scale(b, s))
-    if let Some((b_inner, s)) = match_matrix_scale(rhs) {
-        return Some(IrExprKind::Call {
-            target: CallTarget::Module {
-                module: sym("matrix"),
-                func: sym("mul_scaled"),
-            },
-            args: vec![lhs.clone(), s, b_inner],
-            type_args: vec![],
-        });
-    }
-
-    // Case 2: mul(scale(a, s), b) — still `s * (a @ b)`, so the same
-    // `mul_scaled(a, s, b)` form applies. Runtime contract uses the
-    // first matrix argument as `a`, so we unpack the scaled side.
-    if let Some((a_inner, s)) = match_matrix_scale(lhs) {
-        return Some(IrExprKind::Call {
-            target: CallTarget::Module {
-                module: sym("matrix"),
-                func: sym("mul_scaled"),
-            },
-            args: vec![a_inner, s, rhs.clone()],
-            type_args: vec![],
-        });
-    }
-
-    None
-}
-
-/// Pattern-match `linear_row(layer_norm_rows(x, γ, β, ε), W, b)` →
-/// `pre_norm_linear(x, γ, β, ε, W, b)`.
-fn try_fuse_pre_norm_linear(kind: &IrExprKind) -> Option<IrExprKind> {
-    let (norm_arg, w_arg, b_arg) = match kind {
-        IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. }
-            if module.as_str() == "matrix" && func.as_str() == "linear_row" && args.len() == 3 =>
-        {
-            (&args[0], &args[1], &args[2])
-        }
-        _ => return None,
-    };
-    let (x, gamma, beta, eps) = if let IrExprKind::Call {
-        target: CallTarget::Module { module, func }, args, ..
-    } = &norm_arg.kind {
-        if module.as_str() == "matrix" && func.as_str() == "layer_norm_rows" && args.len() == 4 {
-            (args[0].clone(), args[1].clone(), args[2].clone(), args[3].clone())
-        } else { return None; }
-    } else { return None; };
-
-    Some(IrExprKind::Call {
-        target: CallTarget::Module {
-            module: sym("matrix"),
-            func: sym("pre_norm_linear"),
-        },
-        args: vec![x, gamma, beta, eps, w_arg.clone(), b_arg.clone()],
-        type_args: vec![],
-    })
-}
-
-/// Pattern-match `gelu(linear_row(x, W, b))` → `linear_row_gelu(x, W, b)`.
-/// Covers only the nested form here; let-split is handled in
-/// `fuse_let_split_chain`.
-fn try_fuse_linear_row_gelu(kind: &IrExprKind) -> Option<IrExprKind> {
-    let gelu_arg = match kind {
-        IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. }
-            if module.as_str() == "matrix" && func.as_str() == "gelu" && args.len() == 1 =>
-        {
-            &args[0]
-        }
-        _ => return None,
-    };
-    // `linear_row` has arity 3.
-    if let IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } = &gelu_arg.kind {
-        if module.as_str() == "matrix" && func.as_str() == "linear_row" && args.len() == 3 {
-            return Some(IrExprKind::Call {
-                target: CallTarget::Module {
-                    module: sym("matrix"),
-                    func: sym("linear_row_gelu"),
-                },
-                args: args.clone(),
-                type_args: vec![],
-            });
-        }
-    }
-    None
-}
-
-/// Pattern-match `softmax_rows(scale(mul(Q, Kt), s))` → `attention_weights(Q, Kt, s)`.
-/// This is the scaled-dot-product attention numerator — the 3-op chain
-/// that every transformer inference runs once per attention head. The
-/// fused runtime call does one cblas_dgemm(alpha=s, beta=0) followed by
-/// an in-place row softmax, skipping two intermediate allocations.
-fn try_fuse_attention_weights(kind: &IrExprKind) -> Option<IrExprKind> {
-    let softmax_arg = match kind {
-        IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. }
-            if module.as_str() == "matrix" && func.as_str() == "softmax_rows" && args.len() == 1 =>
-        {
-            &args[0]
-        }
-        _ => return None,
-    };
-    let (scale_inner, scale_s) = match_matrix_binary(softmax_arg, "scale")?;
-    let (q, kt) = match_matrix_binary(scale_inner, "mul")?;
-
-    Some(IrExprKind::Call {
-        target: CallTarget::Module {
-            module: sym("matrix"),
-            func: sym("attention_weights"),
-        },
-        args: vec![q.clone(), kt.clone(), scale_s.clone()],
-        type_args: vec![],
-    })
+    changed
 }
 
 /// If `expr` is `fma(A, kA, B, kB)` where one of A/B is itself an `fma`,
@@ -496,8 +341,6 @@ fn try_tree_fuse(kind: &IrExprKind) -> Option<IrExprKind> {
         }
         _ => return None,
     };
-
-    // Case 1: right side is fma → fma(a, ka, fma(b', kb', c', kc'), kb)
     if let Some((bp, kbp, cp, kcp)) = match_fma(&b) {
         return Some(build_fma3(
             a, ka,
@@ -505,7 +348,6 @@ fn try_tree_fuse(kind: &IrExprKind) -> Option<IrExprKind> {
             cp, mul_scalar(kcp, kb),
         ));
     }
-    // Case 2: left side is fma → fma(fma(a', ka', b', kb'), ka, c, kb)
     if let Some((ap, kap, bp, kbp)) = match_fma(&a) {
         return Some(build_fma3(
             ap, mul_scalar(kap, ka.clone()),
@@ -556,544 +398,33 @@ fn mul_scalar(x: IrExpr, y: IrExpr) -> IrExpr {
     }
 }
 
-/// Let-split chain fusion: collapse
-///   let c = matrix.mul(a, b);
-///   let d = matrix.add(c, bias);
-///   let e = matrix.scale(d, alpha);
-///   let f = matrix.gelu(e);
-/// into a single
-///   let f = matrix.fused_gemm_bias_scale_gelu(a, b, bias, alpha);
-///
-/// Safety conditions enforced:
-/// 1. The four bindings must appear in sequence, each a single `Bind`.
-/// 2. Each intermediate var (c, d, e) must flow directly into the next op
-///    — no interposed uses or transforms.
-/// 3. c, d, and e must have **zero** references in the remainder of the
-///    block (subsequent stmts + tail). This is conservative (some valid
-///    fusions get skipped) but keeps us from dropping values a later
-///    line still needs.
-///
-/// Without this pass the nested-expression form is the only way to opt
-/// into fusion, which is unnatural for human-written code that tends to
-/// name intermediate stages. With it, both styles compile to the same
-/// single-BLAS-call path.
-fn fuse_let_split_chain(stmts: &mut Vec<IrStmt>, tail: Option<&IrExpr>) -> bool {
-    let mut changed = false;
-    let mut i = 0;
-    while i < stmts.len() {
-        // Try the 4-gram gemm+bias+scale+gelu pattern first (longer, more
-        // specific match wins). Fall back to the 3-gram attention pattern.
-        if i + 4 <= stmts.len() {
-            if let Some(m) = match_chain_4gram(&stmts[i..i + 4]) {
-                let rest = &stmts[i + 4..];
-                if count_refs_in_stmts_and_tail(rest, tail, m.c_id) == 0
-                    && count_refs_in_stmts_and_tail(rest, tail, m.d_id) == 0
-                    && count_refs_in_stmts_and_tail(rest, tail, m.e_id) == 0
-                {
-                    let span = stmts[i + 3].span;
-                    let fused_value = IrExpr {
-                        kind: IrExprKind::Call {
-                            target: CallTarget::Module {
-                                module: sym("matrix"),
-                                func: sym("fused_gemm_bias_scale_gelu"),
-                            },
-                            args: vec![m.a, m.b, m.bias, m.alpha],
-                            type_args: vec![],
-                        },
-                        ty: m.f_ty.clone(),
-                        span,
-                    };
-                    let new_bind = IrStmt {
-                        kind: IrStmtKind::Bind {
-                            var: m.f_id,
-                            mutability: m.f_mutability,
-                            ty: m.f_ty,
-                            value: fused_value,
-                        },
-                        span,
-                    };
-                    stmts.splice(i..i + 4, std::iter::once(new_bind));
-                    changed = true;
-                    continue; // re-check same index with new shorter window
-                }
-            }
-        }
-        if i + 2 <= stmts.len() {
-            if let Some(m) = match_sdpa_2gram(&stmts[i..i + 2]) {
-                let rest = &stmts[i + 2..];
-                if count_refs_in_stmts_and_tail(rest, tail, m.w_id) == 0 {
-                    let span = stmts[i + 1].span;
-                    let fused_value = IrExpr {
-                        kind: IrExprKind::Call {
-                            target: CallTarget::Module {
-                                module: sym("matrix"),
-                                func: sym("scaled_dot_product_attention"),
-                            },
-                            args: vec![m.q, m.kt, m.v, m.scale],
-                            type_args: vec![],
-                        },
-                        ty: m.o_ty.clone(),
-                        span,
-                    };
-                    let new_bind = IrStmt {
-                        kind: IrStmtKind::Bind {
-                            var: m.o_id,
-                            mutability: m.o_mutability,
-                            ty: m.o_ty,
-                            value: fused_value,
-                        },
-                        span,
-                    };
-                    stmts.splice(i..i + 2, std::iter::once(new_bind));
-                    changed = true;
-                    continue;
-                }
-            }
-            if let Some(m) = match_mul_scaled_2gram(&stmts[i..i + 2]) {
-                let rest = &stmts[i + 2..];
-                if count_refs_in_stmts_and_tail(rest, tail, m.s_id) == 0 {
-                    let span = stmts[i + 1].span;
-                    let fused_value = IrExpr {
-                        kind: IrExprKind::Call {
-                            target: CallTarget::Module {
-                                module: sym("matrix"),
-                                func: sym("mul_scaled"),
-                            },
-                            args: vec![m.a, m.alpha, m.b],
-                            type_args: vec![],
-                        },
-                        ty: m.c_ty.clone(),
-                        span,
-                    };
-                    let new_bind = IrStmt {
-                        kind: IrStmtKind::Bind {
-                            var: m.c_id,
-                            mutability: m.c_mutability,
-                            ty: m.c_ty,
-                            value: fused_value,
-                        },
-                        span,
-                    };
-                    stmts.splice(i..i + 2, std::iter::once(new_bind));
-                    changed = true;
-                    continue;
-                }
-            }
-            if let Some(m) = match_pre_norm_linear_2gram(&stmts[i..i + 2]) {
-                let rest = &stmts[i + 2..];
-                if count_refs_in_stmts_and_tail(rest, tail, m.n_id) == 0 {
-                    let span = stmts[i + 1].span;
-                    let fused_value = IrExpr {
-                        kind: IrExprKind::Call {
-                            target: CallTarget::Module {
-                                module: sym("matrix"),
-                                func: sym("pre_norm_linear"),
-                            },
-                            args: vec![m.x, m.gamma, m.beta, m.eps, m.w, m.bias],
-                            type_args: vec![],
-                        },
-                        ty: m.l_ty.clone(),
-                        span,
-                    };
-                    let new_bind = IrStmt {
-                        kind: IrStmtKind::Bind {
-                            var: m.l_id,
-                            mutability: m.l_mutability,
-                            ty: m.l_ty,
-                            value: fused_value,
-                        },
-                        span,
-                    };
-                    stmts.splice(i..i + 2, std::iter::once(new_bind));
-                    changed = true;
-                    continue;
-                }
-            }
-            if let Some(m) = match_linear_row_gelu_2gram(&stmts[i..i + 2]) {
-                let rest = &stmts[i + 2..];
-                if count_refs_in_stmts_and_tail(rest, tail, m.l_id) == 0 {
-                    let span = stmts[i + 1].span;
-                    let fused_value = IrExpr {
-                        kind: IrExprKind::Call {
-                            target: CallTarget::Module {
-                                module: sym("matrix"),
-                                func: sym("linear_row_gelu"),
-                            },
-                            args: vec![m.x, m.w, m.bias],
-                            type_args: vec![],
-                        },
-                        ty: m.g_ty.clone(),
-                        span,
-                    };
-                    let new_bind = IrStmt {
-                        kind: IrStmtKind::Bind {
-                            var: m.g_id,
-                            mutability: m.g_mutability,
-                            ty: m.g_ty,
-                            value: fused_value,
-                        },
-                        span,
-                    };
-                    stmts.splice(i..i + 2, std::iter::once(new_bind));
-                    changed = true;
-                    continue;
-                }
-            }
-        }
-        if i + 3 <= stmts.len() {
-            if let Some(m) = match_attention_3gram(&stmts[i..i + 3]) {
-                let rest = &stmts[i + 3..];
-                if count_refs_in_stmts_and_tail(rest, tail, m.s_id) == 0
-                    && count_refs_in_stmts_and_tail(rest, tail, m.t_id) == 0
-                {
-                    let span = stmts[i + 2].span;
-                    let fused_value = IrExpr {
-                        kind: IrExprKind::Call {
-                            target: CallTarget::Module {
-                                module: sym("matrix"),
-                                func: sym("attention_weights"),
-                            },
-                            args: vec![m.q, m.kt, m.scale],
-                            type_args: vec![],
-                        },
-                        ty: m.w_ty.clone(),
-                        span,
-                    };
-                    let new_bind = IrStmt {
-                        kind: IrStmtKind::Bind {
-                            var: m.w_id,
-                            mutability: m.w_mutability,
-                            ty: m.w_ty,
-                            value: fused_value,
-                        },
-                        span,
-                    };
-                    stmts.splice(i..i + 3, std::iter::once(new_bind));
-                    changed = true;
-                    continue;
-                }
-            }
-        }
-        i += 1;
-    }
-    changed
-}
-
-struct SdpaMatch {
-    w_id: VarId,
-    o_id: VarId,
-    q: IrExpr,
-    kt: IrExpr,
-    v: IrExpr,
-    scale: IrExpr,
-    o_mutability: Mutability,
-    o_ty: almide_lang::types::Ty,
-}
-
-/// Match `let w = attention_weights(q, kt, s); let o = mul(w, v)` and
-/// collapse to `let o = scaled_dot_product_attention(q, kt, v, s)`.
-/// `attention_weights` itself is the post-fusion form, so this catches
-/// chains that the upstream attention_3gram has already collapsed.
-fn match_sdpa_2gram(window: &[IrStmt]) -> Option<SdpaMatch> {
-    if window.len() < 2 { return None; }
-    let (w_id, w_value) = as_bind(&window[0])?;
-    let (q, kt, scale) = if let IrExprKind::Call {
-        target: CallTarget::Module { module, func }, args, ..
-    } = &w_value.kind {
-        if module.as_str() == "matrix" && func.as_str() == "attention_weights" && args.len() == 3 {
-            (args[0].clone(), args[1].clone(), args[2].clone())
-        } else { return None; }
-    } else { return None; };
-
-    let (o_id, o_value) = as_bind(&window[1])?;
-    let (mul_lhs, v) = match_matrix_binary(o_value, "mul")?;
-    if !is_var_with_id(mul_lhs, w_id) { return None; }
-
-    let (o_mutability, o_ty) = match &window[1].kind {
-        IrStmtKind::Bind { mutability, ty, .. } => (*mutability, ty.clone()),
-        _ => return None,
-    };
-
-    Some(SdpaMatch {
-        w_id, o_id,
-        q, kt,
-        v: v.clone(),
-        scale,
-        o_mutability, o_ty,
-    })
-}
-
-struct MulScaledMatch {
-    s_id: VarId,
-    c_id: VarId,
-    a: IrExpr,
-    b: IrExpr,
-    alpha: IrExpr,
-    c_mutability: Mutability,
-    c_ty: almide_lang::types::Ty,
-}
-
-/// Match either
-///     let s = matrix.scale(b, α); let c = matrix.mul(a, s)
-///     let s = matrix.scale(a, α); let c = matrix.mul(s, b)
-/// and collapse to `let c = matrix.mul_scaled(a, α, b)`. Single-use
-/// check on `s` is done by the caller.
-fn match_mul_scaled_2gram(window: &[IrStmt]) -> Option<MulScaledMatch> {
-    if window.len() < 2 { return None; }
-    let (s_id, s_value) = as_bind(&window[0])?;
-    let (scaled_base, alpha) = match_matrix_binary(s_value, "scale")?;
-
-    let (c_id, c_value) = as_bind(&window[1])?;
-    let (mul_lhs, mul_rhs) = match_matrix_binary(c_value, "mul")?;
-
-    let (a, b) = if is_var_with_id(mul_rhs, s_id) {
-        (mul_lhs.clone(), scaled_base.clone())
-    } else if is_var_with_id(mul_lhs, s_id) {
-        (scaled_base.clone(), mul_rhs.clone())
-    } else {
-        return None;
-    };
-
-    let (c_mutability, c_ty) = match &window[1].kind {
-        IrStmtKind::Bind { mutability, ty, .. } => (*mutability, ty.clone()),
-        _ => return None,
-    };
-
-    Some(MulScaledMatch {
-        s_id, c_id,
-        a, b,
-        alpha: alpha.clone(),
-        c_mutability, c_ty,
-    })
-}
-
-struct PreNormLinearMatch {
-    n_id: VarId,
-    l_id: VarId,
-    x: IrExpr,
-    gamma: IrExpr,
-    beta: IrExpr,
-    eps: IrExpr,
-    w: IrExpr,
-    bias: IrExpr,
-    l_mutability: Mutability,
-    l_ty: almide_lang::types::Ty,
-}
-
-fn match_pre_norm_linear_2gram(window: &[IrStmt]) -> Option<PreNormLinearMatch> {
-    if window.len() < 2 { return None; }
-    let (n_id, n_value) = as_bind(&window[0])?;
-    let (x, gamma, beta, eps) = if let IrExprKind::Call {
-        target: CallTarget::Module { module, func }, args, ..
-    } = &n_value.kind {
-        if module.as_str() == "matrix" && func.as_str() == "layer_norm_rows" && args.len() == 4 {
-            (args[0].clone(), args[1].clone(), args[2].clone(), args[3].clone())
-        } else { return None; }
-    } else { return None; };
-
-    let (l_id, l_value) = as_bind(&window[1])?;
-    let (norm_arg, w, bias) = if let IrExprKind::Call {
-        target: CallTarget::Module { module, func }, args, ..
-    } = &l_value.kind {
-        if module.as_str() == "matrix" && func.as_str() == "linear_row" && args.len() == 3 {
-            (args[0].clone(), args[1].clone(), args[2].clone())
-        } else { return None; }
-    } else { return None; };
-    if !is_var_with_id(&norm_arg, n_id) { return None; }
-
-    let (l_mutability, l_ty) = match &window[1].kind {
-        IrStmtKind::Bind { mutability, ty, .. } => (*mutability, ty.clone()),
-        _ => return None,
-    };
-
-    Some(PreNormLinearMatch {
-        n_id, l_id,
-        x, gamma, beta, eps, w, bias,
-        l_mutability, l_ty,
-    })
-}
-
-struct LinearGeluMatch {
-    l_id: VarId,
-    g_id: VarId,
-    x: IrExpr,
-    w: IrExpr,
-    bias: IrExpr,
-    g_mutability: Mutability,
-    g_ty: almide_lang::types::Ty,
-}
-
-fn match_linear_row_gelu_2gram(window: &[IrStmt]) -> Option<LinearGeluMatch> {
-    if window.len() < 2 { return None; }
-    let (l_id, l_value) = as_bind(&window[0])?;
-    // linear_row has arity 3: (x, W, bias).
-    let (x, w, bias) = if let IrExprKind::Call {
-        target: CallTarget::Module { module, func }, args, ..
-    } = &l_value.kind {
-        if module.as_str() == "matrix" && func.as_str() == "linear_row" && args.len() == 3 {
-            (args[0].clone(), args[1].clone(), args[2].clone())
-        } else { return None; }
-    } else { return None; };
-
-    let (g_id, g_value) = as_bind(&window[1])?;
-    let gelu_arg = match_matrix_unary(g_value, "gelu")?;
-    if !is_var_with_id(gelu_arg, l_id) { return None; }
-
-    let (g_mutability, g_ty) = match &window[1].kind {
-        IrStmtKind::Bind { mutability, ty, .. } => (*mutability, ty.clone()),
-        _ => return None,
-    };
-
-    Some(LinearGeluMatch {
-        l_id, g_id,
-        x, w, bias,
-        g_mutability, g_ty,
-    })
-}
-
-struct AttentionMatch {
-    s_id: VarId,
-    t_id: VarId,
-    w_id: VarId,
-    q: IrExpr,
-    kt: IrExpr,
-    scale: IrExpr,
-    w_mutability: Mutability,
-    w_ty: almide_lang::types::Ty,
-}
-
-fn match_attention_3gram(window: &[IrStmt]) -> Option<AttentionMatch> {
-    if window.len() < 3 { return None; }
-    let (s_id, s_value) = as_bind(&window[0])?;
-    let (q, kt) = match_matrix_binary(s_value, "mul")?;
-
-    let (t_id, t_value) = as_bind(&window[1])?;
-    let (scale_lhs, scale_s) = match_matrix_binary(t_value, "scale")?;
-    if !is_var_with_id(scale_lhs, s_id) { return None; }
-
-    let (w_id, w_value) = as_bind(&window[2])?;
-    let softmax_arg = match_matrix_unary(w_value, "softmax_rows")?;
-    if !is_var_with_id(softmax_arg, t_id) { return None; }
-
-    let (w_mutability, w_ty) = match &window[2].kind {
-        IrStmtKind::Bind { mutability, ty, .. } => (*mutability, ty.clone()),
-        _ => return None,
-    };
-
-    Some(AttentionMatch {
-        s_id, t_id, w_id,
-        q: q.clone(),
-        kt: kt.clone(),
-        scale: scale_s.clone(),
-        w_mutability,
-        w_ty,
-    })
-}
-
-/// Pattern match helper for `fuse_let_split_chain`. Returns extracted
-/// operands if the 4-stmt window is a `mul → add → scale → gelu` chain
-/// threaded through single-use intermediate vars.
-struct ChainMatch {
-    c_id: VarId,
-    d_id: VarId,
-    e_id: VarId,
-    f_id: VarId,
-    a: IrExpr,
-    b: IrExpr,
-    bias: IrExpr,
-    alpha: IrExpr,
-    f_mutability: Mutability,
-    f_ty: almide_lang::types::Ty,
-}
-
-fn match_chain_4gram(window: &[IrStmt]) -> Option<ChainMatch> {
-    if window.len() < 4 { return None; }
-    let (c_id, c_value) = as_bind(&window[0])?;
-    let (a, b) = match_matrix_binary(c_value, "mul")?;
-
-    let (d_id, d_value) = as_bind(&window[1])?;
-    let (add_lhs, bias) = match_matrix_binary(d_value, "add")?;
-    if !is_var_with_id(add_lhs, c_id) { return None; }
-
-    let (e_id, e_value) = as_bind(&window[2])?;
-    let (scale_lhs, alpha) = match_matrix_binary(e_value, "scale")?;
-    if !is_var_with_id(scale_lhs, d_id) { return None; }
-
-    let (f_id, f_value) = as_bind(&window[3])?;
-    let gelu_arg = match_matrix_unary(f_value, "gelu")?;
-    if !is_var_with_id(gelu_arg, e_id) { return None; }
-
-    let (f_mutability, f_ty) = match &window[3].kind {
-        IrStmtKind::Bind { mutability, ty, .. } => (*mutability, ty.clone()),
-        _ => return None,
-    };
-
-    Some(ChainMatch {
-        c_id, d_id, e_id, f_id,
-        a: a.clone(),
-        b: b.clone(),
-        bias: bias.clone(),
-        alpha: alpha.clone(),
-        f_mutability,
-        f_ty,
-    })
-}
-
-fn as_bind(stmt: &IrStmt) -> Option<(VarId, &IrExpr)> {
-    match &stmt.kind {
-        IrStmtKind::Bind { var, value, .. } => Some((*var, value)),
-        _ => None,
-    }
-}
-
-fn is_var_with_id(expr: &IrExpr, target: VarId) -> bool {
-    matches!(&expr.kind, IrExprKind::Var { id } if *id == target)
-}
-
-struct VarRefCounter {
-    target: VarId,
-    count: usize,
-}
-
-impl IrVisitor for VarRefCounter {
-    fn visit_expr(&mut self, expr: &IrExpr) {
-        if let IrExprKind::Var { id } = &expr.kind {
-            if *id == self.target { self.count += 1; }
-        }
-        walk_expr(self, expr);
-    }
-}
-
-fn count_refs_in_stmts_and_tail(stmts: &[IrStmt], tail: Option<&IrExpr>, target: VarId) -> usize {
-    let mut v = VarRefCounter { target, count: 0 };
-    for s in stmts { v.visit_stmt(s); }
-    if let Some(t) = tail { v.visit_expr(t); }
-    v.count
-}
-
-fn rewrite_stmt(stmt: &mut IrStmt) -> bool {
+fn rewrite_stmt(
+    stmt: &mut IrStmt,
+    rules_list: &[FusionRule],
+    linearized: &[(FusionRule, Vec<ChainStep>)],
+) -> bool {
     let mut changed = false;
     match &mut stmt.kind {
         IrStmtKind::Bind { value, .. }
         | IrStmtKind::BindDestructure { value, .. }
         | IrStmtKind::Assign { value, .. }
         | IrStmtKind::FieldAssign { value, .. } => {
-            if rewrite_expr(value) { changed = true; }
+            if rewrite_expr(value, rules_list, linearized) { changed = true; }
         }
         IrStmtKind::IndexAssign { index, value, .. } => {
-            if rewrite_expr(index) { changed = true; }
-            if rewrite_expr(value) { changed = true; }
+            if rewrite_expr(index, rules_list, linearized) { changed = true; }
+            if rewrite_expr(value, rules_list, linearized) { changed = true; }
         }
         IrStmtKind::MapInsert { key, value, .. } => {
-            if rewrite_expr(key) { changed = true; }
-            if rewrite_expr(value) { changed = true; }
+            if rewrite_expr(key, rules_list, linearized) { changed = true; }
+            if rewrite_expr(value, rules_list, linearized) { changed = true; }
         }
         IrStmtKind::Guard { cond, else_ } => {
-            if rewrite_expr(cond) { changed = true; }
-            if rewrite_expr(else_) { changed = true; }
+            if rewrite_expr(cond, rules_list, linearized) { changed = true; }
+            if rewrite_expr(else_, rules_list, linearized) { changed = true; }
         }
         IrStmtKind::Expr { expr } => {
-            if rewrite_expr(expr) { changed = true; }
+            if rewrite_expr(expr, rules_list, linearized) { changed = true; }
         }
         _ => {}
     }

--- a/crates/almide-codegen/src/pass_matrix_fusion_rules.rs
+++ b/crates/almide-codegen/src/pass_matrix_fusion_rules.rs
@@ -1,0 +1,404 @@
+//! Fusion rule registry shared by `MatrixFusionPass`.
+//!
+//! Each fusion (`gelu(scale(add(mul(a, b), bias), α))` → a single fused
+//! runtime call, etc.) is described once here as a declarative
+//! `FusionRule`: an input `Pattern` tree plus a `rewrite` function that
+//! produces the fused `IrExprKind` from the captured sub-expressions.
+//!
+//! The pass applies each rule in two modes without any per-pattern
+//! boilerplate:
+//! - **Nested form**: match against the pattern tree directly.
+//! - **Let-split form**: treat a k-chain pattern (depth `k`) as a
+//!   sequence of `k` consecutive `let` bindings where each intermediate
+//!   var is used exactly once, and match a sliding k-gram of statements.
+//!
+//! ## Why this shape
+//!
+//! Each `Pattern` node corresponds 1-to-1 to an MLIR `Op` matcher (or an
+//! egg `Rewrite<L, N>` left-hand side). When the MLIR/egg arc lands, the
+//! translation from this table to the target IR is mechanical — the
+//! schema is the bridge, and the fusion catalogue never has to be
+//! rewritten.
+//!
+//! ## Adding a new fusion
+//!
+//! 1. Declare the input tree with `call()` / `cap()`.
+//! 2. Provide a `rewrite` closure that assembles the output call from
+//!    captured operands.
+//! 3. Append the rule to `FUSION_RULES`.
+//!
+//! The pass automatically handles: nested matching, let-split chain
+//! scanning, single-use enforcement on intermediate variables, IR
+//! construction with inherited `ty` / `span`. No k-gram matcher to
+//! hand-roll, no capture-shuffle to re-derive.
+
+use almide_base::intern::sym;
+use almide_ir::*;
+use almide_ir::visit::{IrVisitor, walk_expr};
+
+/// Input-side pattern node. The leaf `Capture` binds any sub-expression
+/// to a named slot; every other node matches a `matrix.<func>(children...)`
+/// call and recursively matches the children. Non-matrix calls, non-call
+/// expressions, and arity mismatches all fail the match.
+#[derive(Clone)]
+pub enum Pattern {
+    /// `matrix.<func>(children...)` with exact arity = `children.len()`.
+    Call {
+        func: &'static str,
+        children: Vec<Pattern>,
+    },
+    /// Any expression; bound to `name` in the resulting `Match`.
+    Capture(&'static str),
+}
+
+/// Captured sub-expressions keyed by the pattern's `Capture` names.
+pub struct Match {
+    slots: Vec<(&'static str, IrExpr)>,
+}
+
+impl Match {
+    pub fn get(&self, name: &'static str) -> IrExpr {
+        self.slots
+            .iter()
+            .find(|(k, _)| *k == name)
+            .map(|(_, e)| e.clone())
+            .unwrap_or_else(|| panic!("fusion rule referenced missing capture '{}'", name))
+    }
+}
+
+/// A single declarative fusion: input pattern → output call kind.
+pub struct FusionRule {
+    /// Stable identifier for diagnostics / tracing.
+    pub name: &'static str,
+    /// Input tree. Matched top-down; each `Call` node checks module =
+    /// "matrix", func, and arity before recursing into children.
+    pub pattern: Pattern,
+    /// Produces the fused `IrExprKind` from captured operands. The pass
+    /// wraps it back into an `IrExpr` with the original `ty` and `span`
+    /// preserved, so rewriters never have to worry about those.
+    pub rewrite: fn(&Match) -> IrExprKind,
+}
+
+/// Helper constructors keep the rule table compact.
+pub fn call(func: &'static str, children: Vec<Pattern>) -> Pattern {
+    Pattern::Call { func, children }
+}
+pub fn cap(name: &'static str) -> Pattern {
+    Pattern::Capture(name)
+}
+
+impl Pattern {
+    /// Attempt a top-down match of this pattern against `expr`. Returns
+    /// `Some(match)` with every `Capture` slot bound; `None` if any
+    /// module-name / func-name / arity check fails.
+    pub fn try_match(&self, expr: &IrExpr) -> Option<Match> {
+        let mut slots = Vec::new();
+        if self.match_inner(expr, &mut slots) {
+            Some(Match { slots })
+        } else {
+            None
+        }
+    }
+
+    fn match_inner(&self, expr: &IrExpr, slots: &mut Vec<(&'static str, IrExpr)>) -> bool {
+        match self {
+            Pattern::Capture(name) => {
+                slots.push((name, expr.clone()));
+                true
+            }
+            Pattern::Call { func, children } => {
+                let (module, f, args) = match &expr.kind {
+                    IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } => {
+                        (module, func, args)
+                    }
+                    _ => return false,
+                };
+                if module.as_str() != "matrix" || f.as_str() != *func || args.len() != children.len() {
+                    return false;
+                }
+                for (child_pat, arg) in children.iter().zip(args.iter()) {
+                    if !child_pat.match_inner(arg, slots) {
+                        return false;
+                    }
+                }
+                true
+            }
+        }
+    }
+
+    /// Number of `Call` layers along the deepest chain. `Capture` leaves
+    /// count as 0, a `Call` counts as 1 + max-child depth. Used to
+    /// derive the let-split k-gram length automatically.
+    pub fn depth(&self) -> usize {
+        match self {
+            Pattern::Capture(_) => 0,
+            Pattern::Call { children, .. } => {
+                1 + children.iter().map(|c| c.depth()).max().unwrap_or(0)
+            }
+        }
+    }
+
+    /// Linearize a chain-shaped pattern (every `Call` node has at most
+    /// one `Call` child) into a sequence from innermost → outermost.
+    /// Each step records the func, the index where the nested call sits
+    /// among the arguments, and the `Capture` names for the non-call
+    /// arguments. Non-chain shapes return `None`.
+    ///
+    /// The output drives the let-split matcher: step `i` corresponds to
+    /// the `i`-th `let` binding in the window. Step 0 is the innermost
+    /// call (no nested child); later steps reference the previous
+    /// step's bound var at `nested_arg_idx`.
+    pub fn linearize_chain(&self) -> Option<Vec<ChainStep>> {
+        let mut steps = Vec::new();
+        let mut cur: Option<&Pattern> = Some(self);
+        while let Some(p) = cur {
+            let (func, children) = match p {
+                Pattern::Call { func, children } => (*func, children),
+                Pattern::Capture(_) => return None, // chain can't be just a capture
+            };
+            let mut nested_idx: Option<usize> = None;
+            let mut captures: Vec<(usize, &'static str)> = Vec::new();
+            for (idx, c) in children.iter().enumerate() {
+                match c {
+                    Pattern::Call { .. } => {
+                        if nested_idx.is_some() {
+                            // More than one nested call — not a chain.
+                            return None;
+                        }
+                        nested_idx = Some(idx);
+                    }
+                    Pattern::Capture(name) => captures.push((idx, *name)),
+                }
+            }
+            steps.push(ChainStep {
+                func,
+                arity: children.len(),
+                nested_arg_idx: nested_idx,
+                captures,
+            });
+            cur = match nested_idx {
+                Some(i) => Some(&children[i]),
+                None => None,
+            };
+        }
+        steps.reverse(); // innermost first
+        Some(steps)
+    }
+}
+
+/// One step of a linearized chain pattern.
+pub struct ChainStep {
+    pub func: &'static str,
+    pub arity: usize,
+    /// Index within `args` where the nested call sits. `None` means
+    /// this is the innermost step (no nested call — all args are
+    /// captures).
+    pub nested_arg_idx: Option<usize>,
+    /// Capture slots: `(arg_index, capture_name)`.
+    pub captures: Vec<(usize, &'static str)>,
+}
+
+/// Walk the let-split k-gram for a chain-shaped rule. Returns a `Match`
+/// with every capture populated from the window's IR, plus the VarIds
+/// of the intermediate bindings (so the caller can verify single-use
+/// and know which statements to collapse).
+pub struct ChainLetMatch {
+    pub captures: Match,
+    /// VarIds of intermediate let bindings (step 0 .. step k-2). The
+    /// outermost bind's VarId, mutability, and type come from the caller.
+    pub intermediate_vars: Vec<VarId>,
+}
+
+pub fn match_chain_let_window(
+    steps: &[ChainStep],
+    window: &[IrStmt],
+) -> Option<ChainLetMatch> {
+    if steps.len() != window.len() || window.is_empty() {
+        return None;
+    }
+    let mut slots: Vec<(&'static str, IrExpr)> = Vec::new();
+    let mut prev_var: Option<VarId> = None;
+    let mut intermediates: Vec<VarId> = Vec::new();
+
+    for (i, step) in steps.iter().enumerate() {
+        let stmt = &window[i];
+        let (var_id, value) = match &stmt.kind {
+            IrStmtKind::Bind { var, value, .. } => (*var, value),
+            _ => return None,
+        };
+        let (module, f, args) = match &value.kind {
+            IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } => {
+                (module, func, args)
+            }
+            _ => return None,
+        };
+        if module.as_str() != "matrix" || f.as_str() != step.func || args.len() != step.arity {
+            return None;
+        }
+        // Collect captures for this step.
+        for (idx, name) in &step.captures {
+            slots.push((name, args[*idx].clone()));
+        }
+        // If this step has a nested arg slot, it must reference the
+        // previously bound var.
+        if let Some(nested_idx) = step.nested_arg_idx {
+            let prev = prev_var.expect("first step must not have nested_arg_idx");
+            let nested_arg = &args[nested_idx];
+            if !is_var_with_id(nested_arg, prev) {
+                return None;
+            }
+        } else if i != 0 {
+            // Non-first step with no nested_arg_idx is a schema bug.
+            return None;
+        }
+        if i + 1 < window.len() {
+            intermediates.push(var_id);
+        }
+        prev_var = Some(var_id);
+    }
+    Some(ChainLetMatch {
+        captures: Match { slots },
+        intermediate_vars: intermediates,
+    })
+}
+
+fn is_var_with_id(expr: &IrExpr, target: VarId) -> bool {
+    matches!(&expr.kind, IrExprKind::Var { id } if *id == target)
+}
+
+/// Count references to `target` across a slice of statements plus an
+/// optional block tail. Used by the let-split matcher to skip fusions
+/// that would orphan a still-live intermediate.
+pub fn count_var_refs(stmts: &[IrStmt], tail: Option<&IrExpr>, target: VarId) -> usize {
+    struct Counter { target: VarId, count: usize }
+    impl IrVisitor for Counter {
+        fn visit_expr(&mut self, expr: &IrExpr) {
+            if let IrExprKind::Var { id } = &expr.kind {
+                if *id == self.target { self.count += 1; }
+            }
+            walk_expr(self, expr);
+        }
+    }
+    let mut v = Counter { target, count: 0 };
+    for s in stmts { v.visit_stmt(s); }
+    if let Some(t) = tail { v.visit_expr(t); }
+    v.count
+}
+
+// ── Rewriter helpers ────────────────────────────────────────────────
+
+/// Build a `matrix.<func>(args...)` call as an `IrExprKind`. The caller
+/// wraps it with `IrExpr { ty, span }` inherited from the original.
+pub fn build_matrix_call(func: &'static str, args: Vec<IrExpr>) -> IrExprKind {
+    IrExprKind::Call {
+        target: CallTarget::Module {
+            module: sym("matrix"),
+            func: sym(func),
+        },
+        args,
+        type_args: vec![],
+    }
+}
+
+// ── The rule registry ───────────────────────────────────────────────
+
+/// All chain-fusion rules considered by `MatrixFusionPass`. Order is
+/// deliberate: rules matching **more specific** / **deeper** patterns
+/// come first so an outer rule can't fire before its inner
+/// prerequisites are rewritten into their canonical form.
+pub fn fusion_rules() -> Vec<FusionRule> {
+    vec![
+        // 4-deep: gelu(scale(add(mul(a, b), bias), alpha)) →
+        //         fused_gemm_bias_scale_gelu(a, b, bias, alpha)
+        FusionRule {
+            name: "gemm_bias_scale_gelu",
+            pattern: call("gelu", vec![
+                call("scale", vec![
+                    call("add", vec![
+                        call("mul", vec![cap("a"), cap("b")]),
+                        cap("bias"),
+                    ]),
+                    cap("alpha"),
+                ]),
+            ]),
+            rewrite: |m| build_matrix_call("fused_gemm_bias_scale_gelu", vec![
+                m.get("a"), m.get("b"), m.get("bias"), m.get("alpha"),
+            ]),
+        },
+        // 3-deep: softmax_rows(scale(mul(q, kt), s)) → attention_weights(q, kt, s)
+        FusionRule {
+            name: "attention_weights",
+            pattern: call("softmax_rows", vec![
+                call("scale", vec![
+                    call("mul", vec![cap("q"), cap("kt")]),
+                    cap("scale"),
+                ]),
+            ]),
+            rewrite: |m| build_matrix_call("attention_weights", vec![
+                m.get("q"), m.get("kt"), m.get("scale"),
+            ]),
+        },
+        // 2-deep: mul(attention_weights(q, kt, s), v) →
+        //         scaled_dot_product_attention(q, kt, v, s)
+        FusionRule {
+            name: "scaled_dot_product_attention",
+            pattern: call("mul", vec![
+                call("attention_weights", vec![cap("q"), cap("kt"), cap("scale")]),
+                cap("v"),
+            ]),
+            rewrite: |m| build_matrix_call("scaled_dot_product_attention", vec![
+                m.get("q"), m.get("kt"), m.get("v"), m.get("scale"),
+            ]),
+        },
+        // 2-deep: linear_row(layer_norm_rows(x, γ, β, ε), W, b) →
+        //         pre_norm_linear(x, γ, β, ε, W, b)
+        FusionRule {
+            name: "pre_norm_linear",
+            pattern: call("linear_row", vec![
+                call("layer_norm_rows", vec![
+                    cap("x"), cap("gamma"), cap("beta"), cap("eps"),
+                ]),
+                cap("w"),
+                cap("bias"),
+            ]),
+            rewrite: |m| build_matrix_call("pre_norm_linear", vec![
+                m.get("x"), m.get("gamma"), m.get("beta"), m.get("eps"),
+                m.get("w"), m.get("bias"),
+            ]),
+        },
+        // 2-deep: gelu(linear_row(x, W, b)) → linear_row_gelu(x, W, b)
+        FusionRule {
+            name: "linear_row_gelu",
+            pattern: call("gelu", vec![
+                call("linear_row", vec![cap("x"), cap("w"), cap("bias")]),
+            ]),
+            rewrite: |m| build_matrix_call("linear_row_gelu", vec![
+                m.get("x"), m.get("w"), m.get("bias"),
+            ]),
+        },
+        // 2-deep: mul(a, scale(b, s)) → mul_scaled(a, s, b)
+        FusionRule {
+            name: "mul_scaled_rhs",
+            pattern: call("mul", vec![
+                cap("a"),
+                call("scale", vec![cap("b"), cap("s")]),
+            ]),
+            rewrite: |m| build_matrix_call("mul_scaled", vec![
+                m.get("a"), m.get("s"), m.get("b"),
+            ]),
+        },
+        // 2-deep: mul(scale(a, s), b) → mul_scaled(a, s, b). Same fused
+        // runtime, different input shape — the lhs-scaled mirror
+        // collapses to the same α(A@B) identity.
+        FusionRule {
+            name: "mul_scaled_lhs",
+            pattern: call("mul", vec![
+                call("scale", vec![cap("a"), cap("s")]),
+                cap("b"),
+            ]),
+            rewrite: |m| build_matrix_call("mul_scaled", vec![
+                m.get("a"), m.get("s"), m.get("b"),
+            ]),
+        },
+    ]
+}


### PR DESCRIPTION
## Summary

Refactors `MatrixFusionPass` from 7 hand-rolled matchers (1101 LOC) into a **data-driven rule registry** (`pass_matrix_fusion_rules`). Each fusion is now one `FusionRule` entry — `Pattern` tree + rewrite closure — and the pass drives both nested and let-split matching from that single source of truth.

## Why this shape

`Pattern::Call { func, children }` / `Pattern::Capture(name)` is **isomorphic to MLIR's op pattern matcher and egg's `Rewrite<L, N>` LHS**. When the MLIR / egg arc lands we translate this rule table mechanically — the fusion catalogue never has to be rewritten. This is the "local cleanup that doubles as future-arc infrastructure" call-out from the session plan: the same work both drains today's scaffolding debt *and* builds the bridge to the next IR redesign.

## Mechanism

- `Pattern::try_match(expr)` — top-down match, fails on module / func / arity mismatch, binds capture slots.
- `Pattern::linearize_chain()` — chain-shaped patterns (every Call node has ≤ 1 nested Call child) decompose into `Vec<ChainStep>` from innermost → outermost. Step index = position in the let-split window, so the **k-gram length is derived from pattern depth** automatically.
- `match_chain_let_window` — slides over statement windows, binds captures, returns intermediate VarIds for single-use verification.
- `fuse_let_split_chain` in the pass iterates linearized rules and applies each via the generic matcher. No per-rule struct, no per-rule matcher fn.

## What's declarative now

All 7 existing fusion rules moved to `fusion_rules()`:

| Rule | Depth | Output |
| ---- | :---: | ------ |
| gemm_bias_scale_gelu | 4 | `fused_gemm_bias_scale_gelu(a, b, bias, α)` |
| attention_weights | 3 | `attention_weights(q, kt, s)` |
| scaled_dot_product_attention | 2 | `scaled_dot_product_attention(q, kt, v, s)` |
| pre_norm_linear | 2 | `pre_norm_linear(x, γ, β, ε, W, b)` |
| linear_row_gelu | 2 | `linear_row_gelu(x, W, b)` |
| mul_scaled_rhs | 2 | `mul_scaled(a, s, b)` |
| mul_scaled_lhs | 2 | `mul_scaled(a, s, b)` (mirror) |

## What stays procedural

- `add/sub + scale → fma` — needs `extract_scaled` (recognises `scale`, `neg`, bare expr → coefficient 1.0) on both operands, which isn't a single-pattern match.
- `fma + fma → fma3` tree-fuse — multiplies coefficients across the nested fma, crosses rule boundaries.

These sit above the declarative loop with a clear "Legacy" comment block. Both could migrate later by extending the schema with `PatternOr` + rewriter-side computation; not today.

## Code impact

- `pass_matrix_fusion.rs`: 1101 → 432 lines
- new `pass_matrix_fusion_rules.rs`: 404 lines (schema + registry)
- **net: −265 lines** while each new fusion now costs ~15 lines (rule entry) instead of 80–120 lines (nested matcher + struct + k-gram matcher + splice code)

## Test plan
- [x] `cargo build` + `cargo build --release`
- [x] Each fusion spec individually (all 7 green)
- [x] Full regression: `./target/debug/almide test spec/` (218/218 files)

## Follow-ups (separate PRs)

1. `@fused_runtime` attribute to drive runtime fused fn impls from a single source (currently 6 fns × 2 dtypes × 2 runtimes = 24 hand-written impls).
2. Migration path from this table → MLIR / egg when that arc starts.