### PR TITLE
Update llms.txt version reference to 0.15.0

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,7 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.14.8. In development: 0.14.8 (Ideal Form arc).
+- Current stable: v0.15.0. Cross-module `let` at Swift/TS parity; full
+  WASM matrix op coverage (SDPA, Llama 1-block); mono dispatch hardening.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.


### PR DESCRIPTION
## Summary
- Follow-up to #219: the `docs_gen --check` test enforces that `llms.txt` mentions the current `Cargo.toml` version. The v0.15.0 bump missed updating `llms.txt`, which was still pinned to v0.14.8, so main's CI went red immediately after the release merge.
- This PR bumps the `Current stable:` line to v0.15.0 and refreshes the one-line release description. Release `v0.15.0` itself was already cut by the workflow — this only unsticks main.

## Test plan
- [x] `cargo test --release --test docs_gen_test` green