### PR TITLE
emit_wasm: KV-cache-aware causal mask in mha_core

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
@@ -2727,8 +2727,17 @@ impl FuncCompiler<'_> {
                 });
                 if causal {
                     wasm!(self.func, {
-                          // Add -1e9 if j > i
-                          local_get(j); local_get(i); i32_gt_u;
+                          // KV-cache-aware causal mask: query row i (one of
+                          // the sq new tokens) attends to key row j iff
+                          // j <= (sk - sq) + i. When sq == sk this reduces
+                          // to j <= i. When sq < sk (single-token gen step
+                          // with cached K of length sk - sq) the cached
+                          // prefix is always visible, and the new query
+                          // sees its own key plus everything before.
+                          local_get(j);
+                          local_get(sk); local_get(sq); i32_sub;
+                          local_get(i); i32_add;
+                          i32_gt_u;
                           if_f64; f64_const(-1.0e9); else_; f64_const(0.0); end;
                           local_get(acc); f64_add; local_set(acc);
                     });


### PR DESCRIPTION
## Summary
- mha_core の causal mask が \`j > i\` で書かれていて、sq (query 行数) と sk (key 行数) が違う KV-cache gen step で **過去のキャッシュを全部マスクしてしまう** バグ
- PR #222 で native 側 (\`runtime/rs/src/matrix.rs\`) は \`j > (sk - sq) + i\` に修正済だったが、WASM emit 側の取りこぼしだった
- Fix: WASM emit も \`j > (sk - sq) + i\` に揃える

## Impact
bonsai-almide browser demo で KV-cache streaming が token Tokyo の後 \`:::\` 無限ループに陥っていた原因。修正後は greedy で \`\" Tokyo. The capital of Japan is Tokyo. ...\"\` と coherent 出力に復帰。

## Test plan
- [x] \`cargo test --release\` green
- [x] \`almide test\` (221/221 files) green
- [x] bonsai-almide \`bench_wasm_kv_stream\` greedy が no-KV path と bit 一致