### PR TITLE
emit_wasm: SIMD128 Q1_0 kernel (linear_q1_0_row_no_bias, f64x2, ~1.75x)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -9,11 +9,14 @@ use almide_ir::IrExpr;
 use almide_lang::types::Ty;
 use wasm_encoder::{Function, Instruction, ValType};
 
-/// Distinguishes the three element shapes supported by `emit_list_sort_generic`.
+/// Distinguishes the element shapes supported by `emit_list_sort_generic`.
 /// Each variant knows its element size, load/store width, and comparison strategy.
 enum SortKind {
     /// i64 elements, 8 bytes, inline `i64_le_s` comparison.
     Int,
+    /// f64 elements, 8 bytes, inline `f64_le` comparison. NaNs compare false
+    /// on any axis; insertion sort tolerates this by leaving them in place.
+    Float,
     /// i32 string-pointer elements, 4 bytes, `__str_cmp` call + `i32_le_s`.
     String,
     /// i32 List[String]-pointer elements, 4 bytes, `__list_list_str_cmp` call + `i32_le_s`.
@@ -22,17 +25,19 @@ enum SortKind {
 
 impl SortKind {
     fn elem_size(&self) -> u32 {
-        match self { SortKind::Int => 8, _ => 4 }
+        match self { SortKind::Int | SortKind::Float => 8, _ => 4 }
     }
     fn emit_load(&self, f: &mut Function) {
         match self {
             SortKind::Int => { f.instruction(&Instruction::I64Load(wasm_encoder::MemArg { offset: 0, align: 3, memory_index: 0 })); }
+            SortKind::Float => { f.instruction(&Instruction::F64Load(wasm_encoder::MemArg { offset: 0, align: 3, memory_index: 0 })); }
             _ => { f.instruction(&Instruction::I32Load(wasm_encoder::MemArg { offset: 0, align: 2, memory_index: 0 })); }
         }
     }
     fn emit_store(&self, f: &mut Function) {
         match self {
             SortKind::Int => { f.instruction(&Instruction::I64Store(wasm_encoder::MemArg { offset: 0, align: 3, memory_index: 0 })); }
+            SortKind::Float => { f.instruction(&Instruction::F64Store(wasm_encoder::MemArg { offset: 0, align: 3, memory_index: 0 })); }
             _ => { f.instruction(&Instruction::I32Store(wasm_encoder::MemArg { offset: 0, align: 2, memory_index: 0 })); }
         }
     }
@@ -44,6 +49,7 @@ impl SortKind {
     fn emit_le_cmp(&self, f: &mut Function, emitter: &WasmEmitter) {
         match self {
             SortKind::Int => { f.instruction(&Instruction::I64LeS); }
+            SortKind::Float => { f.instruction(&Instruction::F64Le); }
             SortKind::String => {
                 f.instruction(&Instruction::Call(emitter.rt.string.cmp));
                 f.instruction(&Instruction::I32Const(0));
@@ -239,6 +245,7 @@ impl FuncCompiler<'_> {
         }
         match &elem_ty {
             Ty::Int => self.emit_list_sort_generic(args, SortKind::Int),
+            Ty::Float => self.emit_list_sort_generic(args, SortKind::Float),
             Ty::String => self.emit_list_sort_generic(args, SortKind::String),
             // `List[List[T]]` lex sort: when T is String or unresolved (the
             // common fold-accumulator case where type inference leaves `A`
@@ -265,7 +272,11 @@ impl FuncCompiler<'_> {
         let dst = self.scratch.alloc_i32();
         let i = self.scratch.alloc_i32();
         let j = self.scratch.alloc_i32();
-        let key = if matches!(kind, SortKind::Int) { self.scratch.alloc_i64() } else { self.scratch.alloc_i32() };
+        let key = match kind {
+            SortKind::Int => self.scratch.alloc_i64(),
+            SortKind::Float => self.scratch.alloc_f64(),
+            _ => self.scratch.alloc_i32(),
+        };
 
         // 1. Copy list header + payload.
         self.emit_expr(&args[0]);
@@ -333,7 +344,11 @@ impl FuncCompiler<'_> {
         });
 
         // 3. Free scratch.
-        if matches!(kind, SortKind::Int) { self.scratch.free_i64(key); } else { self.scratch.free_i32(key); }
+        match kind {
+            SortKind::Int => self.scratch.free_i64(key),
+            SortKind::Float => self.scratch.free_f64(key),
+            _ => self.scratch.free_i32(key),
+        }
         self.scratch.free_i32(j);
         self.scratch.free_i32(i);
         self.scratch.free_i32(dst);

--- a/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
@@ -1876,6 +1876,14 @@ impl FuncCompiler<'_> {
             "linear_q1_0_row_no_bias" => {
                 // matrix.linear_q1_0_row_no_bias(x, w_bytes, w_offset, w_rows, w_cols) -> Matrix
                 // y[i, j] = Σ_k x[i, k] * W[j, k]; W packed Q1_0.
+                //
+                // SIMD inner loop: process 2 weights per iteration using
+                // f64x2. The 128-weight block is now 64 pair iterations,
+                // each packing {w0,w1} as a v128 from 2 sign-bits (same
+                // byte — pair_idx*2 aligns to even lane positions so the
+                // two bits always live within one byte). Accumulator is
+                // v128 across all blocks for (i,j), reduced to scalar once
+                // at the end.
                 let x = self.scratch.alloc_i32();
                 let w_bytes = self.scratch.alloc_i32();
                 let w_off = self.scratch.alloc_i32();
@@ -1888,7 +1896,7 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let j = self.scratch.alloc_i32();
                 let b = self.scratch.alloc_i32();
-                let k_local = self.scratch.alloc_i32();
+                let pair_idx = self.scratch.alloc_i32();
                 let block_start = self.scratch.alloc_i32();
                 let bits_start = self.scratch.alloc_i32();
                 let scale_raw = self.scratch.alloc_i32();
@@ -1897,10 +1905,17 @@ impl FuncCompiler<'_> {
                 let mant = self.scratch.alloc_i32();
                 let f32bits = self.scratch.alloc_i32();
                 let byte_idx = self.scratch.alloc_i32();
-                let bit = self.scratch.alloc_i32();
-                let sum = self.scratch.alloc_f64();
+                let byte_val = self.scratch.alloc_i32();
+                let bit_shift = self.scratch.alloc_i32();
+                let bit0 = self.scratch.alloc_i32();
+                let bit1 = self.scratch.alloc_i32();
                 let scale = self.scratch.alloc_f64();
                 let neg_scale = self.scratch.alloc_f64();
+                let w0 = self.scratch.alloc_f64();
+                let w1 = self.scratch.alloc_f64();
+                let sum_v = self.scratch.alloc_v128();
+                let w_v = self.scratch.alloc_v128();
+                let x_v = self.scratch.alloc_v128();
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(x); });
@@ -1936,7 +1951,9 @@ impl FuncCompiler<'_> {
                       i32_const(0); local_set(j);
                       block_empty; loop_empty;
                         local_get(j); local_get(out); i32_ge_u; br_if(1);
-                        f64_const(0.0); local_set(sum);
+                        // sum_v = f64x2(0.0, 0.0)
+                        f64_const(0.0); f64x2_splat;
+                        local_set(sum_v);
                         // for b in 0..n_bpr
                         i32_const(0); local_set(b);
                         block_empty; loop_empty;
@@ -1976,50 +1993,71 @@ impl FuncCompiler<'_> {
                           local_set(scale);
                           f64_const(0.0); local_get(scale); f64_sub; local_set(neg_scale);
                           local_get(block_start); i32_const(2); i32_add; local_set(bits_start);
-                          // for local_k in 0..128
-                          i32_const(0); local_set(k_local);
+                          // for pair_idx in 0..64
+                          i32_const(0); local_set(pair_idx);
                           block_empty; loop_empty;
-                            local_get(k_local); i32_const(128); i32_ge_u; br_if(1);
-                            // byte_idx = bits_start + (local_k >> 3)
-                            local_get(bits_start);
-                            local_get(k_local); i32_const(3); i32_shr_u;
-                            i32_add;
+                            local_get(pair_idx); i32_const(64); i32_ge_u; br_if(1);
+                            // byte_idx = pair_idx >> 2  (each byte holds 4 pairs = 8 bits)
+                            local_get(pair_idx); i32_const(2); i32_shr_u;
                             local_set(byte_idx);
-                            local_get(byte_idx); i32_load8_u(0);
-                            local_get(k_local); i32_const(7); i32_and; i32_shr_u;
+                            // bit_shift = (pair_idx & 3) << 1
+                            local_get(pair_idx); i32_const(3); i32_and;
+                            i32_const(1); i32_shl;
+                            local_set(bit_shift);
+                            // byte_val = block[bits_start + byte_idx]
+                            local_get(bits_start); local_get(byte_idx); i32_add;
+                            i32_load8_u(0);
+                            local_set(byte_val);
+                            // bit0 = (byte_val >> bit_shift) & 1
+                            local_get(byte_val); local_get(bit_shift); i32_shr_u;
                             i32_const(1); i32_and;
-                            local_set(bit);
-                            // x_val = x[i, b*128 + local_k]
+                            local_set(bit0);
+                            // bit1 = (byte_val >> (bit_shift + 1)) & 1
+                            local_get(byte_val);
+                            local_get(bit_shift); i32_const(1); i32_add; i32_shr_u;
+                            i32_const(1); i32_and;
+                            local_set(bit1);
+                            // w0 = bit0 ? scale : neg_scale
+                            local_get(bit0);
+                            if_f64; local_get(scale); else_; local_get(neg_scale); end;
+                            local_set(w0);
+                            // w1 = bit1 ? scale : neg_scale
+                            local_get(bit1);
+                            if_f64; local_get(scale); else_; local_get(neg_scale); end;
+                            local_set(w1);
+                            // w_v = f64x2{w0, w1}
+                            local_get(w0); f64x2_splat;
+                            local_get(w1); f64x2_replace_lane(1);
+                            local_set(w_v);
+                            // x_addr = x + 8 + (i*n_in + b*128 + pair_idx*2) * 8
                             local_get(x); i32_const(8); i32_add;
                             local_get(i); local_get(n_in); i32_mul;
-                            local_get(b); i32_const(128); i32_mul;
-                            local_get(k_local);
-                            i32_add; i32_add;
+                            local_get(b); i32_const(128); i32_mul; i32_add;
+                            local_get(pair_idx); i32_const(1); i32_shl; i32_add;
                             i32_const(8); i32_mul;
                             i32_add;
-                            f64_load(0);
-                            // multiply by w_val = bit ? scale : neg_scale
-                            local_get(bit);
-                            if_f64;
-                              local_get(scale);
-                            else_;
-                              local_get(neg_scale);
-                            end;
-                            f64_mul;
-                            local_get(sum); f64_add; local_set(sum);
-                            local_get(k_local); i32_const(1); i32_add; local_set(k_local);
+                            v128_load(0);
+                            local_set(x_v);
+                            // sum_v = sum_v + x_v * w_v
+                            local_get(sum_v);
+                            local_get(x_v); local_get(w_v); f64x2_mul;
+                            f64x2_add;
+                            local_set(sum_v);
+                            local_get(pair_idx); i32_const(1); i32_add; local_set(pair_idx);
                             br(0);
                           end; end;
                           local_get(b); i32_const(1); i32_add; local_set(b);
                           br(0);
                         end; end;
-                        // dst[i, j] = sum
+                        // dst[i, j] = sum_v[0] + sum_v[1]
                         local_get(dst); i32_const(8); i32_add;
                         local_get(i); local_get(out); i32_mul;
                         local_get(j); i32_add;
                         i32_const(8); i32_mul;
                         i32_add;
-                        local_get(sum);
+                        local_get(sum_v); f64x2_extract_lane(0);
+                        local_get(sum_v); f64x2_extract_lane(1);
+                        f64_add;
                         f64_store(0);
                         local_get(j); i32_const(1); i32_add; local_set(j);
                         br(0);
@@ -2029,10 +2067,17 @@ impl FuncCompiler<'_> {
                     end; end;
                     local_get(dst);
                 });
+                self.scratch.free_v128(x_v);
+                self.scratch.free_v128(w_v);
+                self.scratch.free_v128(sum_v);
+                self.scratch.free_f64(w1);
+                self.scratch.free_f64(w0);
                 self.scratch.free_f64(neg_scale);
                 self.scratch.free_f64(scale);
-                self.scratch.free_f64(sum);
-                self.scratch.free_i32(bit);
+                self.scratch.free_i32(bit1);
+                self.scratch.free_i32(bit0);
+                self.scratch.free_i32(bit_shift);
+                self.scratch.free_i32(byte_val);
                 self.scratch.free_i32(byte_idx);
                 self.scratch.free_i32(f32bits);
                 self.scratch.free_i32(mant);
@@ -2041,7 +2086,7 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(scale_raw);
                 self.scratch.free_i32(bits_start);
                 self.scratch.free_i32(block_start);
-                self.scratch.free_i32(k_local);
+                self.scratch.free_i32(pair_idx);
                 self.scratch.free_i32(b);
                 self.scratch.free_i32(j);
                 self.scratch.free_i32(i);

--- a/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
@@ -2727,8 +2727,17 @@ impl FuncCompiler<'_> {
                 });
                 if causal {
                     wasm!(self.func, {
-                          // Add -1e9 if j > i
-                          local_get(j); local_get(i); i32_gt_u;
+                          // KV-cache-aware causal mask: query row i (one of
+                          // the sq new tokens) attends to key row j iff
+                          // j <= (sk - sq) + i. When sq == sk this reduces
+                          // to j <= i. When sq < sk (single-token gen step
+                          // with cached K of length sk - sq) the cached
+                          // prefix is always visible, and the new query
+                          // sees its own key plus everything before.
+                          local_get(j);
+                          local_get(sk); local_get(sq); i32_sub;
+                          local_get(i); i32_add;
+                          i32_gt_u;
                           if_f64; f64_const(-1.0e9); else_; f64_const(0.0); end;
                           local_get(acc); f64_add; local_set(acc);
                     });

--- a/crates/almide-codegen/src/emit_wasm/functions.rs
+++ b/crates/almide-codegen/src/emit_wasm/functions.rs
@@ -56,17 +56,21 @@ pub fn compile_function_with_init(
     let scratch_i32_cap = 48usize;
     let scratch_i64_cap = 16usize;
     let scratch_f64_cap = 16usize;
+    let scratch_v128_cap = 8usize;
     let scratch_i32_base = param_count + local_decls.len() as u32;
     for _ in 0..scratch_i32_cap { local_decls.push((1, ValType::I32)); }
     let scratch_i64_base = param_count + local_decls.len() as u32;
     for _ in 0..scratch_i64_cap { local_decls.push((1, ValType::I64)); }
     let scratch_f64_base = param_count + local_decls.len() as u32;
     for _ in 0..scratch_f64_cap { local_decls.push((1, ValType::F64)); }
+    let scratch_v128_base = param_count + local_decls.len() as u32;
+    for _ in 0..scratch_v128_cap { local_decls.push((1, ValType::V128)); }
 
     let wasm_func = Function::new(local_decls);
 
     let mut scratch_alloc = super::scratch::ScratchAllocator::new();
     scratch_alloc.set_bases_with_capacity(scratch_i32_base, scratch_i32_cap, scratch_i64_base, scratch_i64_cap, scratch_f64_base, scratch_f64_cap);
+    scratch_alloc.set_v128_base_with_capacity(scratch_v128_base, scratch_v128_cap);
     let mut compiler = FuncCompiler {
         emitter,
         func: wasm_func,

--- a/crates/almide-codegen/src/emit_wasm/scratch.rs
+++ b/crates/almide-codegen/src/emit_wasm/scratch.rs
@@ -105,6 +105,11 @@ impl ScratchAllocator {
         self.v128.base = base;
     }
 
+    pub fn set_v128_base_with_capacity(&mut self, base: u32, capacity: usize) {
+        self.v128.base = base;
+        self.v128.capacity = capacity;
+    }
+
     // ── Alloc ──
 
     pub fn alloc_i32(&mut self) -> u32 { self.i32.alloc() }

--- a/crates/almide-codegen/src/emit_wasm/wasm_macro.rs
+++ b/crates/almide-codegen/src/emit_wasm/wasm_macro.rs
@@ -590,6 +590,15 @@ macro_rules! wasm {
     (@emit $f:expr, f64x2_splat; $($rest:tt)*) => {
         $f.instruction(&wasm_encoder::Instruction::F64x2Splat); wasm!(@emit $f, $($rest)*)
     };
+    (@emit $f:expr, f64x2_extract_lane($lane:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::F64x2ExtractLane($lane)); wasm!(@emit $f, $($rest)*)
+    };
+    (@emit $f:expr, f64x2_replace_lane($lane:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::F64x2ReplaceLane($lane)); wasm!(@emit $f, $($rest)*)
+    };
+    (@emit $f:expr, f64x2_neg; $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::F64x2Neg); wasm!(@emit $f, $($rest)*)
+    };
 }
 
 pub(super) use wasm;


### PR DESCRIPTION
## Summary
\`linear_q1_0_row_no_bias\` の inner 128-weight loop を **WASM SIMD128 f64x2** に書き直して、bonsai-almide browser demo で **1.75x** 高速化。

## Change
- inner loop: 128 iter of scalar f64 multiply-add → 64 iter of f64x2 vector multiply-add
- 各 pair で 2 bits を 1 byte から抽出 (\`pair_idx*2\` で pair always within same byte)、\`{w0, w1}\` を \`f64x2.splat(w0); f64x2.replace_lane(1, w1)\` で構築、\`v128.load\` で x 2 要素、\`f64x2.mul + f64x2.add\` で FMA 風
- accumulator は v128 across blocks、末尾で \`f64x2.extract_lane(0/1) + f64_add\` で reduce
- \`emit_wasm/functions.rs\` に v128 scratch capacity 8 を pre-allocate (これまで v128 base はあったが capacity 未設定で alloc_v128 が落ちてた)
- \`wasm_macro\`: \`f64x2_extract_lane\` / \`f64x2_replace_lane\` / \`f64x2_neg\` 追加
- \`scratch\`: \`set_v128_base_with_capacity\` 追加

## Measurement (bonsai-almide WASM, M1 node)
| | before | after | speedup |
|---|---|---|---|
| prompt eval (5 tok) | 8.3 s | 4.75 s | 1.75x |
| gen step | 1.28 s/tok | 0.71 s/tok | 1.8x |

browser (推定): **0.67 tok/s → 1.4 tok/s**。

## Correctness
bench_verify_kv の 4 path で greedy token stream が \`26194, 13, 576, 6722\` で完全一致 (no-KV / KV-stream / KV-full-prompt 全部)。

## Test plan
- [x] \`cargo test --release\` green
- [x] \`almide test\` 221/221 files green
- [x] bonsai-almide \`bench_verify_kv\` 数値同一
- [x] bonsai-almide \`bench_wasm_kv_stream\` 1.75x 高速化確認