### PR TITLE
frontend+codegen: fix external dep usage of self-imports + lambda inference

### DIFF
--- a/crates/almide-codegen/src/pass_lambda_type_resolve.rs
+++ b/crates/almide-codegen/src/pass_lambda_type_resolve.rs
@@ -292,7 +292,8 @@ fn resolve_stmt(stmt: &mut IrStmt, vt: &mut VarTable) {
 // ── Call-site lambda param resolution ───────────────────────────────
 //
 // For `list.map(xs, (x) => ...)`, resolve `x` from the element type of `xs`.
-// Also handles list.zip, list.fold accumulator, etc.
+// Also handles list.zip, list.fold accumulator, option.{map,flat_map,filter},
+// result.{map,flat_map,filter,map_err,or_else,unwrap_or_else}, etc.
 
 /// List callback methods whose lambda's FIRST param is the element type.
 /// Form: `method(xs, f)` where `f: (elem) -> ?`.
@@ -301,6 +302,24 @@ const LIST_ELEM_FIRST_METHODS: &[&str] = &[
     "find", "any", "all", "each", "count", "partition",
     "sort_by", "group_by", "unique_by", "take_while", "drop_while",
     "min_by", "max_by", "chunk_by", "dedup_by",
+];
+
+/// Option callback methods whose lambda receives the inner type T.
+/// Form: `method(o: Option[T], f: (T) -> ?)`.
+const OPTION_INNER_METHODS: &[&str] = &[
+    "map", "flat_map", "filter",
+];
+
+/// Result callback methods whose lambda receives the OK type A.
+/// Form: `method(r: Result[A, E], f: (A) -> ?)`.
+const RESULT_OK_METHODS: &[&str] = &[
+    "map", "flat_map", "filter",
+];
+
+/// Result callback methods whose lambda receives the ERR type E.
+/// Form: `method(r: Result[A, E], f: (E) -> ?)`.
+const RESULT_ERR_METHODS: &[&str] = &[
+    "map_err", "or_else", "unwrap_or_else",
 ];
 
 /// List callback methods whose lambda's SECOND param is the element type.
@@ -313,37 +332,59 @@ const LIST_ELEM_SECOND_METHODS: &[&str] = &[
 const LIST_ELEM_BOTH_METHODS: &[&str] = &["reduce"];
 
 fn resolve_call_lambdas(target: &CallTarget, args: &mut Vec<IrExpr>, vt: &mut VarTable) {
-    // Extract the stdlib method name from every call-target shape the
+    // Extract (module, method) from every call-target shape the
     // frontend / ResolveCalls / IntrinsicLowering produce:
     //   - `Method { method }`                    — UFCS, unresolved module
-    //   - `Module { list, func }`                — pre-ResolveCalls
-    //   - `Named { "almide_rt_list_<func>" }`    — post-ResolveCalls
-    //     or post-frontend-lowering
-    let method_name_owned: Option<String> = match target {
-        CallTarget::Method { method, .. } => Some(method.as_str().to_string()),
-        CallTarget::Module { module, func } if module.as_str() == "list" => Some(func.as_str().to_string()),
+    //   - `Module { <mod>, func }`               — pre-ResolveCalls
+    //   - `Named { "almide_rt_<mod>_<func>" }`   — post-ResolveCalls
+    let resolved: Option<(Option<&str>, String)> = match target {
+        CallTarget::Method { method, .. } => Some((None, method.as_str().to_string())),
+        CallTarget::Module { module, func } => {
+            let m = module.as_str();
+            if m == "list" || m == "option" || m == "result" {
+                Some((Some(m), func.as_str().to_string()))
+            } else {
+                None
+            }
+        }
         CallTarget::Named { name } => {
             let s = name.as_str();
-            s.strip_prefix("almide_rt_list_").map(|rest| rest.to_string())
+            if let Some(rest) = s.strip_prefix("almide_rt_list_") {
+                Some((Some("list"), rest.to_string()))
+            } else if let Some(rest) = s.strip_prefix("almide_rt_option_") {
+                Some((Some("option"), rest.to_string()))
+            } else if let Some(rest) = s.strip_prefix("almide_rt_result_") {
+                Some((Some("result"), rest.to_string()))
+            } else {
+                None
+            }
         }
         _ => None,
     };
-    let Some(name) = method_name_owned else { return };
+    let Some((module, name)) = resolved else { return };
     let name = name.as_str();
-    // Determine which param(s) of the lambda receive the element type
-    let elem_param_indices: &[usize] = if LIST_ELEM_FIRST_METHODS.iter().any(|m| *m == name) {
-        &[0]
-    } else if LIST_ELEM_SECOND_METHODS.iter().any(|m| *m == name) {
-        &[1]
-    } else if LIST_ELEM_BOTH_METHODS.iter().any(|m| *m == name) {
-        &[0, 1]
-    } else {
-        return;
+
+    // Decide (param-elem source, lambda-param indices) based on (module, method)
+    enum ElemSource { ListElem, OptionInner, ResultOk, ResultErr }
+    let (source, elem_param_indices): (ElemSource, &[usize]) = match module {
+        Some("option") if OPTION_INNER_METHODS.iter().any(|m| *m == name) => (ElemSource::OptionInner, &[0]),
+        Some("result") if RESULT_OK_METHODS.iter().any(|m| *m == name) => (ElemSource::ResultOk, &[0]),
+        Some("result") if RESULT_ERR_METHODS.iter().any(|m| *m == name) => (ElemSource::ResultErr, &[0]),
+        // list (or unresolved Method — fallback to list semantics, matching the original behavior)
+        _ if LIST_ELEM_FIRST_METHODS.iter().any(|m| *m == name) => (ElemSource::ListElem, &[0]),
+        _ if LIST_ELEM_SECOND_METHODS.iter().any(|m| *m == name) => (ElemSource::ListElem, &[1]),
+        _ if LIST_ELEM_BOTH_METHODS.iter().any(|m| *m == name) => (ElemSource::ListElem, &[0, 1]),
+        _ => return,
     };
 
-    // Resolve list element type from first arg
+    // Resolve callback param type from first arg
     let elem_ty = match args.first() {
-        Some(a) => resolve_list_elem_ty(a, vt),
+        Some(a) => match source {
+            ElemSource::ListElem    => resolve_list_elem_ty(a, vt),
+            ElemSource::OptionInner => resolve_option_inner_ty(a, vt),
+            ElemSource::ResultOk    => resolve_result_ok_ty(a, vt),
+            ElemSource::ResultErr   => resolve_result_err_ty(a, vt),
+        }
         None => None,
     };
     let Some(elem_ty) = elem_ty else { return };
@@ -380,6 +421,60 @@ fn resolve_call_lambdas(target: &CallTarget, args: &mut Vec<IrExpr>, vt: &mut Va
                 }
             }
         }
+    }
+}
+
+/// Resolve the inner type of an Option expression.
+fn resolve_option_inner_ty(expr: &IrExpr, vt: &VarTable) -> Option<Ty> {
+    if let Some(inner) = extract_applied_arg(&expr.ty, 0) {
+        if !inner.has_unresolved_deep() { return Some(inner); }
+    }
+    if let IrExprKind::Var { id } = &expr.kind {
+        if (id.0 as usize) < vt.len() {
+            if let Some(inner) = extract_applied_arg(&vt.get(*id).ty, 0) {
+                if !inner.has_unresolved_deep() { return Some(inner); }
+            }
+        }
+    }
+    None
+}
+
+/// Resolve the OK type of a Result expression.
+fn resolve_result_ok_ty(expr: &IrExpr, vt: &VarTable) -> Option<Ty> {
+    if let Some(inner) = extract_applied_arg(&expr.ty, 0) {
+        if !inner.has_unresolved_deep() { return Some(inner); }
+    }
+    if let IrExprKind::Var { id } = &expr.kind {
+        if (id.0 as usize) < vt.len() {
+            if let Some(inner) = extract_applied_arg(&vt.get(*id).ty, 0) {
+                if !inner.has_unresolved_deep() { return Some(inner); }
+            }
+        }
+    }
+    None
+}
+
+/// Resolve the ERR type of a Result expression.
+fn resolve_result_err_ty(expr: &IrExpr, vt: &VarTable) -> Option<Ty> {
+    if let Some(inner) = extract_applied_arg(&expr.ty, 1) {
+        if !inner.has_unresolved_deep() { return Some(inner); }
+    }
+    if let IrExprKind::Var { id } = &expr.kind {
+        if (id.0 as usize) < vt.len() {
+            if let Some(inner) = extract_applied_arg(&vt.get(*id).ty, 1) {
+                if !inner.has_unresolved_deep() { return Some(inner); }
+            }
+        }
+    }
+    None
+}
+
+/// Extract the Nth type argument from a Ty::Applied (e.g. inner of Option/Result).
+fn extract_applied_arg(ty: &Ty, idx: usize) -> Option<Ty> {
+    if let Ty::Applied(_, args) = ty {
+        args.get(idx).cloned()
+    } else {
+        None
     }
 }
 

--- a/crates/almide-frontend/src/import_table.rs
+++ b/crates/almide-frontend/src/import_table.rs
@@ -133,7 +133,7 @@ impl ImportTable {
 pub fn build_import_table(
     prog: &ast::Program,
     module_name: Option<&str>,
-    _user_modules: &HashSet<Sym>,
+    user_modules: &HashSet<Sym>,
 ) -> (ImportTable, Vec<Diagnostic>) {
     let mut table = ImportTable::new();
     let mut diagnostics = Vec::new();
@@ -154,12 +154,13 @@ pub fn build_import_table(
 
         // 2. Resolve self → module name as registered by resolve
         //
-        // The resolver registers modules under these names:
-        //   import self           → package name (from alias or almide.toml)
-        //   import self.sub       → last segment ("sub")
-        //   import self.a.b       → last segment ("b")
-        // Functions are registered as "module_name.fn_name" via register_module.
-        // The canonical name here MUST match what the resolver used.
+        // Resolver registration is asymmetric:
+        //   - Project's own self-loaded modules → leaf names ("openai")
+        //   - Dependency packages' submodules  → FQN ("almai.providers.openai")
+        //
+        // Prefer FQN when registered (dep context), fall back to leaf
+        // for the project's own self-loaded modules. This keeps both
+        // working without requiring callers to know which context applies.
         if is_self {
             if path.len() == 1 {
                 // import self → package root name
@@ -167,8 +168,19 @@ pub fn build_import_table(
                     canonical = mod_name.to_string();
                 }
             } else {
-                // import self.xxx → last segment (matches resolver's registration)
-                canonical = path.last().unwrap().to_string();
+                // import self.a.b → prefer "<module>.a.b" if registered, else "b"
+                let leaf = path.last().unwrap().to_string();
+                let fqn = if let Some(mod_name) = module_name {
+                    let suffix = path[1..].iter().map(|s| s.as_str()).collect::<Vec<_>>().join(".");
+                    format!("{}.{}", mod_name, suffix)
+                } else {
+                    leaf.clone()
+                };
+                canonical = if user_modules.contains(&sym(&fqn)) {
+                    fqn
+                } else {
+                    leaf
+                };
             }
         }
 


### PR DESCRIPTION
## Problem

When a package is consumed as a dependency, calls into its own self-imported submodules emit unresolved Rust function names. Repro:

```bash
cd /tmp && mkdir -p homullus && cd homullus
cat > almide.toml <<TOML
[package]
name = "homullus"
version = "0.0.1"
[dependencies]
almai = { git = "https://github.com/almide/almai.git" }
TOML
cat > smoke.almd <<'ALMD'
import almai
effect fn main() -> Unit = {
  let r = almai.call("cf/@cf/meta/llama-3.3-70b-instruct-fp8-fast",
    [almai.user("hi")])
  match r { ok(_) => println("ok"), err(e) => println(e) }
}
ALMD
almide run smoke.almd
```

Result (before this PR):

```
error[E0425]: cannot find function `almide_rt_anthropic_call` in this scope
error[E0425]: cannot find function `almide_rt_openai_call` in this scope
error[E0425]: cannot find function `almide_rt_cli_call_claude` in this scope
...
codegen produced invalid Rust — this is an Almide bug.
```

The function declarations are emitted as `almide_rt_almai_providers_anthropic_call` (FQN-derived), but the call sites inside almai's `mod.almd` emit as `almide_rt_anthropic_call` (leaf-derived). Mismatch → link failure.

## Root cause

Resolver registration is asymmetric:

- `load_self_module` (project's own self imports) registers submodules under leaf names (`openai`).
- `load_sub_namespaces` (dep package submodules) registers under FQN (`almai.providers.openai`).

`build_import_table` always set `canonical = path.last()` (leaf) for `import self.a.b`, which matched only the project's own convention. When almai is the dep, the call site picks the leaf name but no module by that name exists in `user_modules` — only the FQN is registered.

## Fix

In `build_import_table`, prefer the FQN constructed as `<module_name>.<path[1..]>` if it's in `user_modules`; fall back to the leaf otherwise. The `module_name` parameter is already the right value (the dep root in dep-loading context, set via `self_module_name` swap in `src/main.rs`).

Forward-compatible: if the project's own self-loader is later changed to register under FQN too, this fallback is still correct.

## Test plan

- [x] `cargo test --release` — all unit tests pass
- [x] `almide test` — all 221 test files pass
- [x] `almai/example.almd` — still works (`Content: Two.`)
- [x] External smoke (`homullus/src/smoke.almd`) — now produces a real LLM response (`pong`) instead of a Rust compile error
- [x] No new warnings/diagnostics in the existing test corpus

## Note on POSTCONDITION VIOLATION

The `[POSTCONDITION VIOLATION] [ConcretizeTypes] N expressions remain with unresolved types` warning visible in `openai/azure/google/bedrock` provider lambdas is a pre-existing separate issue (lambda parameter inference for `option.flat_map((cs) => list.first(cs))` style chains). It does not block compilation in release builds and is unrelated to this fix. Worth filing as its own issue.