### PR TITLE
codegen: include module type_decls when building default_fields map

### DIFF
--- a/crates/almide-codegen/src/pass_box_deref.rs
+++ b/crates/almide-codegen/src/pass_box_deref.rs
@@ -68,8 +68,11 @@ impl NanoPass for BoxDerefPass {
             })
             .collect();
 
-        // Build default_fields: for each variant/record constructor with default field values
+        // Build default_fields: for each variant/record constructor with default field values.
+        // Chain module type_decls so types declared in submodules also fill defaults at
+        // construction sites in cross-module callers.
         program.codegen_annotations.default_fields = program.type_decls.iter()
+            .chain(program.modules.iter().flat_map(|m| m.type_decls.iter()))
             .flat_map(|td| match &td.kind {
                 IrTypeDeclKind::Variant { cases, .. } => cases.iter()
                     .filter_map(|c| match &c.kind {


### PR DESCRIPTION
## Problem

Default field values on a record / variant declared in a sub-module are dropped when the record is constructed from outside that module. Repro:

```almide
// src/mod.almd
type Foo = {
  id: Int,
  name: String = "anon",
  tags: List[String] = [],
}
fn make(id: Int) -> Foo = Foo { id: id }   // missing 2 fields at codegen time
```

```almide
// src/main.almd
import self as dmt
effect fn main() -> Unit = {
  let f = dmt.make(1)
  println(f.name)
}
```

```
error[E0063]: missing fields `tags` and `name` in initializer of `Foo`
```

(Single-file usage works fine — only cross-module is broken.)

## Root cause

`pass_box_deref.rs` builds the `default_fields` annotation only from `program.type_decls.iter()`. It does NOT chain in `program.modules.iter().flat_map(|m| m.type_decls.iter())`, even though `boxed_fields` (a few lines above in the same pass) does.

So defaults declared in a sub-module never make it into the codegen annotation, and the walker emits incomplete struct literals.

## Fix

Chain module type_decls when building the map, matching `boxed_fields`'s behaviour exactly. One-line addition.

## Test plan

- [x] `cargo test --release` — all unit tests pass
- [x] `almide test` — **All 221 test file(s) passed**
- [x] Minimal repro (sub-module record + cross-module call site) now compiles and prints expected default values
- [x] No new diagnostics in the existing test corpus