### PR TITLE
codegen: insert Try around lifted effect fn calls in module-level fns

### DIFF
--- a/crates/almide-codegen/src/pass_result_propagation.rs
+++ b/crates/almide-codegen/src/pass_result_propagation.rs
@@ -129,8 +129,14 @@ impl NanoPass for ResultPropagationPass {
             for func in &mut module.functions {
                 if !lifted_fns.is_empty() {
                     func.body = update_call_types(std::mem::take(&mut func.body), &lifted_fns);
+                    // Auto-? insertion: module-level effect fns calling other
+                    // lifted effect fns need Try wrapping the same way the
+                    // top-level pipeline does for non-test fns. Without this,
+                    // Rust sees a let-binding type mismatch
+                    // (`expected T, found Result<T, String>`).
+                    let returns_result = func.ret_ty.is_result();
+                    func.body = insert_try_body(std::mem::take(&mut func.body), returns_result);
                 }
-                // Auto-? insertion disabled for modules too
             }
         }
 


### PR DESCRIPTION
## Problem

When a module-level effect fn calls another lifted effect fn whose declared return is a non-Result type (e.g. \`Bool\`, \`(String, Bool)\`, \`List[T]\`), codegen emits Rust that fails to type-check:

\`\`\`almide
// in src/agent.almd
effect fn execute_tool(mode: String, call: ToolCall) -> (String, Bool) = {
  let allowed = perm.check(mode, call.name, args_json)  // declared Bool
  if not allowed then ...
}
\`\`\`

\`\`\`
error[E0308]: mismatched types
let allowed: bool = almide_rt_permission_check(...);
            -^^^^ expected \`bool\`, found \`Result<bool, String>\`
\`\`\`

ResultPropagation lifts the callee's return type from \`Bool\` to \`Result<bool, String>\` (the auto-wrap), retypes the call site via \`update_call_types\` — but **never inserts \`?\`** at the call site for module functions. The call returns Result, the binding is annotated bool → rustc fails.

## Root cause

\`pass_result_propagation.rs\` ran \`insert_try_for_lifted\` only on top-level test functions. Module-level functions had a comment \"Auto-? insertion disabled for modules too\" with no replacement. Top-level non-test fns happened to work as long as bodies kept the lifted call at tail position (where \`wrap_tail_in_ok\` handles it); any non-tail use (let bindings, intermediate statements, args) broke.

## Fix

Run \`insert_try_body\` (the existing pipeline meant exactly for this) over module function bodies, with the right \`fn_returns_result\` flag. \`insert_try_body\` calls \`insert_try\` to wrap Result-returning calls in Try, then \`strip_tail_try\` to undo Try at tail positions for fns whose body is supposed to remain Result.

Side benefit: lets users write idiomatic almide module code that mixes effect fn calls and plain control flow, exactly as the docs describe.

## Repro

Smallest:

\`\`\`almide
// src/perm.almd
effect fn check() -> Bool = true

// src/main.almd
import self.perm as perm
effect fn outer() -> Bool = {
  let ok = perm.check()  // <- failed here before this PR
  ok
}
effect fn main() -> Unit = {
  let _ = outer()
}
\`\`\`

\`almide run src/main.almd\` failed with the rustc E0308 mismatch above. With this fix, it compiles and runs.

A larger end-to-end check lives in [almide/homullus#TBD](https://github.com/almide/homullus): \`src/agent_check.almd\` exercises a 5-test integration suite (tool roundtrip, multi-round tool loop, history threading, provider error, no-tool path) — all green after this fix, all failing before.

## Test plan

- [x] \`cargo test --release\` — all unit tests pass
- [x] \`almide test\` — **All 221 test file(s) passed**
- [x] homullus \`agent_check.almd\` — 24 checks pass end-to-end (was: rustc fail)
- [x] homullus \`smoke.almd\` (cf provider) — still works