### PR TITLE
codegen: top-level auto-Try + match subjects + preserve declared-Result let

### DIFF
--- a/crates/almide-codegen/src/pass_result_propagation.rs
+++ b/crates/almide-codegen/src/pass_result_propagation.rs
@@ -115,10 +115,21 @@ impl NanoPass for ResultPropagationPass {
         }
 
         // Phase 2: Update call-site types for lifted functions, then insert Try.
+        //
+        // Auto-? insertion: any non-test effect fn (top-level or module
+        // level) that calls another lifted effect fn needs Try wrapping
+        // at non-tail positions, otherwise Rust sees a let-binding /
+        // pattern type mismatch (`expected T, found Result<T, String>`).
+        // Test fns continue with insert_try_for_lifted + insert_try_in_fan
+        // (which use .unwrap() so failed assertions surface as panics).
         let mut retyped_vars: HashMap<u32, Ty> = HashMap::new();
         for func in &mut program.functions {
             if !lifted_fns.is_empty() {
                 func.body = update_call_types(std::mem::take(&mut func.body), &lifted_fns);
+                if !func.is_test {
+                    let returns_result = func.ret_ty.is_result();
+                    func.body = insert_try_body(std::mem::take(&mut func.body), returns_result);
+                }
             }
             // fan blocks in tests still need Try insertion for effect fn calls
             if func.is_test {
@@ -678,14 +689,23 @@ fn insert_try(expr: IrExpr, in_match_subject: bool) -> IrExpr {
             then: Box::new(insert_try(*then, false)),
             else_: Box::new(insert_try(*else_, false)),
         },
-        // Match: subject is NOT wrapped, but arm bodies ARE
-        IrExprKind::Match { subject, arms } => IrExprKind::Match {
-            subject: Box::new(insert_try(*subject, true)), // don't wrap subject
-            arms: arms.into_iter().map(|arm| IrMatchArm {
-                pattern: arm.pattern,
-                guard: arm.guard.map(|g| insert_try(g, false)),
-                body: insert_try(arm.body, false),
-            }).collect(),
+        // Match: arm bodies are visited; subject handling depends on the
+        // arm patterns. If any arm uses Ok/Err patterns, the user is
+        // matching on the Result directly so leave subject alone.
+        // Otherwise the subject's lifted Result must be unwrapped via
+        // Try so the inner-type patterns (Some/None, plain values, etc.)
+        // can match.
+        IrExprKind::Match { subject, arms } => {
+            let arms_match_result = arms.iter().any(|a|
+                matches!(&a.pattern, IrPattern::Ok { .. } | IrPattern::Err { .. }));
+            IrExprKind::Match {
+                subject: Box::new(insert_try(*subject, arms_match_result)),
+                arms: arms.into_iter().map(|arm| IrMatchArm {
+                    pattern: arm.pattern,
+                    guard: arm.guard.map(|g| insert_try(g, false)),
+                    body: insert_try(arm.body, false),
+                }).collect(),
+            }
         },
         IrExprKind::BinOp { op, left, right } => IrExprKind::BinOp {
             op,
@@ -803,7 +823,13 @@ fn insert_try_stmt(stmt: IrStmt) -> IrStmt {
             let mut new_value = insert_try(value, false);
             // If the value wasn't already wrapped by insert_try (e.g. ok()/err() which
             // are not Call nodes), wrap it here at the binding site.
-            if !matches!(&new_value.kind, IrExprKind::Try { .. }) && is_result_value(&new_value) {
+            // Skip when the binding's declared type is itself Result — the
+            // user wrote `let r: Result[T, E] = ...` deliberately and wants
+            // to keep it for explicit matching.
+            if !matches!(&new_value.kind, IrExprKind::Try { .. })
+                && is_result_value(&new_value)
+                && !ty.is_result()
+            {
                 let inner_ty = match &new_value.ty {
                     Ty::Applied(TypeConstructorId::Result, args) if args.len() == 2 => args[0].clone(),
                     _ => new_value.ty.clone(),


### PR DESCRIPTION
Three small but related codegen fixes that complete the auto-Try story for non-test effect fns. Together they make idiomatic almide code (REPL loops, agent dispatchers, anywhere effect fns nest) actually compile.

## What changed

### 1. Top-level non-test effect fns get \`insert_try_body\`

Previously only module-level effect fns (after [#233](https://github.com/almide/almide/pull/233)) and test fns went through the Try-insertion pass. Top-level non-test fns relied solely on \`update_call_types\` + \`wrap_tail_in_ok\`, which handles tail positions only. Any non-tail call to a lifted effect fn (let bindings, if conditions, match subjects) emitted bare \`Result<T, String>\` where Rust expected T.

\`\`\`almide
// repro: src/main.almd
effect fn handle_slash(...) -> Option[State] = ...

effect fn repl(state: State) -> Unit = {
  match handle_slash(state, ...) {  // <-- handle_slash returns lifted Result<Option<State>, String>
    none => println("Bye!")          //     match arms expect Option, fail to compile
    some(next) => repl(next)
  }
}
\`\`\`

\`\`\`
error[E0308]: mismatched types
  Some(parts) => match handle_slash(...) {
                       ------------- this expression has type \`Result<Option<State>, String>\`
    None => { ... }
    ^^^^ expected \`Result<...>\`, found \`Option<_>\`
\`\`\`

### 2. \`insert_try\` unwraps match subjects when arms aren't Ok/Err

The original \`insert_try\` always passed \`in_match_subject = true\` to subject expressions, which means lifted Result-returning calls in match position never got \`?\` inserted. That's correct *only* when the user is matching on the Result directly (\`ok(_) =>\` / \`err(_) =>\` arms). For Option / variant / value-pattern arms, the subject's lifted Result must be unwrapped first.

Now: \`in_match_subject = arms_match_result\`. If any arm uses Ok/Err patterns, leave the subject alone (match-on-Result style); otherwise unwrap.

### 3. \`insert_try_stmt\` respects declared-Result let bindings

The let-binding wrap inside \`insert_try_stmt\` would aggressively unwrap any Result-typed RHS — including \`let r: Result[T, E] = ok(1)\` where the user explicitly wants to keep the Result for later matching. Now we skip the unwrap when the binding's declared type is itself Result.

\`\`\`almide
// before: cond got unwrapped to i64, breaking the match
let cond: Result[Int, String] = ok(1)
match cond {
  ok(_) => ...
  err(_) => ...
}
\`\`\`

## Why this matters

The combination unblocks idiomatic top-level effect fns in any project that uses sub-modules and/or returns Option/Result from internal helpers. \`almide/homullus\` (a Claude Code-style agent CLI written in almide) was the trigger: its REPL function calls a slash-command dispatcher returning \`Option[State]\`, and the agent loop's history threading uses match heavily. With these fixes, \`MODEL=cli/claude almide run src/main.almd\` runs an interactive REPL that successfully drives Claude Code as a turnkey provider, end-to-end:

\`\`\`
homullus v0.0.1
model: cli/claude    trust: bypass    /help for commands
> list the .almd files in src/ using a tool. just give me the list
- src/tools.almd
- src/smoke.almd
- src/main.almd
- src/agent_check.almd
- src/permission.almd
- src/agent.almd
\`\`\`

## Test plan

- [x] \`cargo test --release\` — all unit tests pass
- [x] \`almide test\` — **All 221 test file(s) passed** (including the previously-failing-during-iteration \`match_arm_effect_unify_test\` and \`result_option_matrix_test\`)
- [x] homullus \`agent_check.almd\` — 24 integration assertions pass (provider injection, tool roundtrip, multi-round tool loop, history threading, provider error)
- [x] homullus \`smoke.almd\` (cf provider) — still works
- [x] homullus REPL with cli/claude — interactive use, slash commands + real LLM dispatch + multi-turn all working

## Notes

The repro test from #233's PR description is also covered here as part of \`agent_check.almd\` indirectly — the multi-round tool loop hits all three of these code paths (top-level non-test fn, match subject unwrap, history threading with let bindings).