### PR TITLE
codegen: skip Try unwrap on let-bindings later used as Result match subjects

### DIFF
--- a/crates/almide-codegen/src/pass_result_propagation.rs
+++ b/crates/almide-codegen/src/pass_result_propagation.rs
@@ -838,6 +838,26 @@ fn insert_try(expr: IrExpr, in_match_subject: bool) -> IrExpr {
         IrExprKind::MapLiteral { entries } => IrExprKind::MapLiteral {
             entries: entries.into_iter().map(|(k, v)| (insert_try(k, false), insert_try(v, false))).collect(),
         },
+        // Unwrap (`!`) / Try / ToOption / UnwrapOr already perform the
+        // result-handling for their inner expression — we mustn't wrap
+        // it again. But the inner expression's OWN args (e.g. nested
+        // effect calls inside `agent.run_turn(..., read_threshold(),
+        // ...)!`) still need Try insertion. Recurse "in match subject"
+        // mode: that suppresses the outer wrap on the immediate inner
+        // call but lets its args get processed normally.
+        IrExprKind::Unwrap { expr: inner } => IrExprKind::Unwrap {
+            expr: Box::new(insert_try(*inner, true)),
+        },
+        IrExprKind::Try { expr: inner } => IrExprKind::Try {
+            expr: Box::new(insert_try(*inner, true)),
+        },
+        IrExprKind::ToOption { expr: inner } => IrExprKind::ToOption {
+            expr: Box::new(insert_try(*inner, true)),
+        },
+        IrExprKind::UnwrapOr { expr: inner, fallback } => IrExprKind::UnwrapOr {
+            expr: Box::new(insert_try(*inner, true)),
+            fallback: Box::new(insert_try(*fallback, false)),
+        },
         // Leaf nodes — return as-is
         other => other,
     };

--- a/crates/almide-codegen/src/pass_result_propagation.rs
+++ b/crates/almide-codegen/src/pass_result_propagation.rs
@@ -608,11 +608,19 @@ fn insert_try_for_lifted_stmt(stmt: IrStmt, lifted: &HashMap<String, Ty>, skip_u
 }
 
 /// Insert Try in function body — skip final expression if fn returns Result.
+/// Also skip Try insertion for any binding whose var is later used as the
+/// subject of a match with Ok/Err patterns. The user wrote that match
+/// because they want to inspect the Result directly; auto-unwrapping
+/// would replace the Result with the inner T and then the match arms
+/// fail to type-check.
 fn insert_try_body(expr: IrExpr, fn_returns_result: bool) -> IrExpr {
     if fn_returns_result {
         match expr.kind {
             IrExprKind::Block { stmts, expr: Some(tail) } => {
-                let stmts = stmts.into_iter().map(insert_try_stmt).collect();
+                let skip_unwrap = collect_result_match_vars(&stmts, Some(&tail));
+                let stmts = stmts.into_iter()
+                    .map(|s| insert_try_stmt_with_skip(s, &skip_unwrap))
+                    .collect();
                 let tail = insert_try(*tail, false);
                 let tail = strip_tail_try(tail);
                 return IrExpr {
@@ -626,7 +634,43 @@ fn insert_try_body(expr: IrExpr, fn_returns_result: bool) -> IrExpr {
             }
         }
     }
+    // Non-Result-returning fn: still need to skip unwrap on Result-match vars.
+    if let IrExprKind::Block { stmts, expr: tail } = expr.kind {
+        let skip_unwrap = collect_result_match_vars(&stmts, tail.as_deref());
+        let stmts = stmts.into_iter()
+            .map(|s| insert_try_stmt_with_skip(s, &skip_unwrap))
+            .collect();
+        let tail = tail.map(|e| Box::new(insert_try(*e, false)));
+        return IrExpr {
+            kind: IrExprKind::Block { stmts, expr: tail },
+            ty: expr.ty, span: expr.span,
+        };
+    }
     insert_try(expr, false)
+}
+
+/// insert_try_stmt variant that respects a skip-list of VarIds (those
+/// whose binding values must remain Result for downstream Ok/Err matches).
+fn insert_try_stmt_with_skip(stmt: IrStmt, skip: &HashSet<u32>) -> IrStmt {
+    if let IrStmtKind::Bind { var, .. } = &stmt.kind {
+        if skip.contains(&var.0) {
+            // Process the value but DON'T wrap it in Try at the binding site.
+            if let IrStmtKind::Bind { var, mutability, ty, value } = stmt.kind {
+                let new_value = insert_try(value, false);
+                // If insert_try added a Try (from a recursive Call wrap inside),
+                // strip the outer Try so the value remains Result-typed.
+                let unwrapped = match new_value.kind {
+                    IrExprKind::Try { expr: inner } if inner.ty.is_result() => *inner,
+                    _ => new_value,
+                };
+                return IrStmt {
+                    kind: IrStmtKind::Bind { var, mutability, ty, value: unwrapped },
+                    span: stmt.span,
+                };
+            }
+        }
+    }
+    insert_try_stmt(stmt)
 }
 
 /// Recursively strip Try from tail positions of a Result-returning expression.

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -612,6 +612,20 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         // ── Codegen nodes (inserted by passes — walker just renders) ──
         IrExprKind::Clone { expr: inner } => {
             let expr_s = render_expr(ctx, inner);
+            // Special case: cloning a String-typed Var that's a fn param
+            // (so it's actually emitted as `&str` in Rust). `.clone()` on
+            // `&str` returns `&str`, not `String`. Use `.to_string()` so
+            // the surrounding context (which expects an owned `String`)
+            // type-checks.
+            let is_borrowed_string_param = matches!(ctx.target, super::super::pass::Target::Rust)
+                && matches!(inner.ty, Ty::String)
+                && match &inner.kind {
+                    IrExprKind::Var { id } => ctx.ref_params.contains(id),
+                    _ => false,
+                };
+            if is_borrowed_string_param {
+                return format!("{}.to_string()", expr_s);
+            }
             ctx.templates.render_with("clone_expr", None, &[], &[("expr", expr_s.as_str())])
                 .unwrap_or_else(|| format!("{}.clone()", expr_s))
         }


### PR DESCRIPTION
## Problem

After PR #234 extended auto-Try to top-level non-test effect fns, this snippet (which is exactly almai's \`example.almd\`) regressed:

\`\`\`almide
effect fn main() -> Unit = {
  let response = almai.call(\"cf/...\", [almai.user(\"hi\")])
  match response {
    ok(r) => println(r.content)
    err(e) => println(\"err: \" + e)
  }
}
\`\`\`

\`almai.call\` is declared \`Result[LLMResponse, String]\` (already-Result, not lifted). \`insert_try\` wraps the Call in \`Try\`, then \`insert_try_stmt\` lets the Bind absorb the new value's unwrapped type — \`response\` ends up bound to \`LLMResponse\` (the inner type) instead of the original \`Result\`. The subsequent \`match response { ok(r) => ..., err(e) => ... }\` then fails to compile: \`expected \`LLMResponse\`, found \`Result<_, _>\`\`.

The test-mode pass already had the right shape: \`insert_try_for_lifted\` collects vars used as match subjects with Ok/Err patterns and refuses to wrap their bindings (\`collect_result_match_vars\`). Non-test mode (\`insert_try_body\`) wasn't using the same protection.

## Fix

Mirror the test-mode flow:

- \`insert_try_body\` now scans its block for vars whose binding is later matched on with Ok/Err patterns
- A new \`insert_try_stmt_with_skip\` consults that skip list and unwraps the outer \`Try\` from the Bind value when the var is on the list, so the binding stays Result-typed
- Applies to BOTH the Result-returning fn-body branch and the non-Result fn-body branch (both can have intermediate let bindings followed by match-on-Result)

## Repro / verify

Before this PR (against current develop tip):
\`\`\`bash
cd almide/almai
almide run example.almd
# error[E0308]: mismatched types — expected \`LLMResponse\`, found \`Result<_, _>\`
\`\`\`

After:
\`\`\`bash
cd almide/almai
almide run example.almd
# Content: Two.
# Model: @cf/meta/llama-3.3-70b-instruct-fp8-fast
\`\`\`

## Test plan

- [x] \`almide test\` — All 221 test file(s) passed
- [x] almai \`almide test\` — 31 tests, 2 file(s) passed
- [x] homullus \`almide run src/agent_check.almd\` — 24 assertions pass
- [x] homullus REPL with groq+streaming+tools — pass
- [x] almai \`example.almd\` against live cf provider — pass (regression closed)