### PR TITLE
bump version to 0.15.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.15.1"
+version = "0.15.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/llms.txt
+++ b/llms.txt
@@ -207,7 +207,7 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.15.1. Cross-module `let` at Swift/TS parity; full
+- Current stable: v0.15.2. `almide install <repo>` for clone-and-build CLI installs (go-install style); cross-module `let` at Swift/TS parity; full
   WASM matrix op coverage (SDPA, Llama 1-block); mono dispatch hardening.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.


### PR DESCRIPTION
Routine version bump for the upcoming release. develop already contains \`almide install\` (#240) which is the headline change for v0.15.2.

## Test plan
- [x] \`cargo build\` clean (verified locally on the install branch)
- [ ] CI green on this PR
- [ ] After merge, tag v0.15.2 on the resulting develop tip → release.yml fires