### PR TITLE
Release v0.15.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-syntax/src/parser/expressions.rs
+++ b/crates/almide-syntax/src/parser/expressions.rs
@@ -60,7 +60,18 @@ impl Parser {
 
         loop {
             // Allow operators on next line for multiline expressions
+            let saved_before_skip = self.pos;
             self.skip_newlines_if_followed_by_any(Self::INFIX_TOKENS);
+            // Disambiguate: a leading `-` on a new line that is attached to its
+            // operand (no whitespace, e.g. `-1`, `-x`) is a unary on a new
+            // statement, not binary continuation. `a\n  - b` (with spaces) still
+            // continues as binary subtraction.
+            if self.pos != saved_before_skip
+                && self.check(TokenType::Minus)
+                && self.minus_attached_to_operand()
+            {
+                self.pos = saved_before_skip;
+            }
 
             // Error hints for invalid operators
             if self.check(TokenType::PipePipe) {
@@ -148,6 +159,17 @@ impl Parser {
         }
 
         Ok(left)
+    }
+
+    /// Whether the current `Minus` token is immediately followed by its operand
+    /// with no whitespace (e.g. `-1`, `-x`). Used to disambiguate a leading `-`
+    /// on a new line: attached → unary on a new statement; spaced → binary
+    /// continuation of the previous expression.
+    fn minus_attached_to_operand(&self) -> bool {
+        if !self.check(TokenType::Minus) { return false; }
+        let cur = self.current();
+        let Some(next) = self.peek_at(1) else { return false; };
+        next.line == cur.line && next.col == cur.end_col
     }
 
     fn parse_unary(&mut self) -> Result<Expr, String> {

--- a/llms.txt
+++ b/llms.txt
@@ -207,7 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.15.2. `almide install <repo>` for clone-and-build CLI installs (go-install style); cross-module `let` at Swift/TS parity; full
-  WASM matrix op coverage (SDPA, Llama 1-block); mono dispatch hardening.
+- Current stable: v0.15.3. Parser fix: leading `-N` (attached, no space) on a new line in a block is now correctly parsed as a unary statement instead of binary subtraction continuing the previous line.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/tests/parser_test.rs
+++ b/tests/parser_test.rs
@@ -544,6 +544,47 @@ fn parse_unary_negation() {
     }
 }
 
+#[test]
+fn parse_block_attached_minus_is_unary_new_stmt() {
+    // `{ stmt; -N }` where `-N` is on its own line and attached to its operand
+    // (no space between `-` and the literal/ident) must parse as a new
+    // expression statement, not as binary subtraction continuing the previous
+    // line. Regression for codegen-time `block { effect_call; -1 }` mismatch.
+    let prog = parse(
+        "effect fn f() -> Int = {\n  io.print(\"hi\")\n  -1\n}",
+    );
+    let Decl::Fn { body, .. } = &prog.decls[0] else { panic!("expected fn") };
+    let body = body.as_ref().expect("fn body");
+    let ExprKind::Block { stmts, expr } = &body.kind else {
+        panic!("expected block body, got {:?}", body.kind);
+    };
+    // First stmt: io.print call (Stmt::Expr wrapping Call/Pipe-style)
+    assert_eq!(stmts.len(), 1, "expected 1 lead stmt, got {:?}", stmts);
+    // Tail expression: unary `-` applied to `1`, NOT a binary subtraction.
+    let tail = expr.as_ref().expect("expected tail expr").as_ref();
+    match &tail.kind {
+        ExprKind::Unary { op, .. } => assert_eq!(op, "-"),
+        other => panic!("expected unary `-` tail, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_block_spaced_minus_still_continues() {
+    // `a\n  - b` (with space after `-`) keeps multi-line binary continuation.
+    let expr = parse_expr("10\n  - 3");
+    match &expr.kind {
+        ExprKind::Binary { op, .. } => assert_eq!(op, "-"),
+        other => panic!("expected binary subtraction, got {:?}", other),
+    }
+}
+
+#[test]
+fn parse_block_leading_plus_continues() {
+    // Leading `+` continuation (no unary `+` exists) still works.
+    let expr = parse_expr("xs\n  + [1]\n  + ys");
+    assert!(matches!(expr.kind, ExprKind::Binary { .. }));
+}
+
 // ---- Expressions: not ----
 
 #[test]


### PR DESCRIPTION
## Summary
- Parser fix: leading `-N` on a new line in a block (attached to operand, no space) is now parsed as a unary statement instead of binary subtraction continuing the previous line. Resolves codegen mismatch on `block { effect_call; -1 }`.
- Version bump 0.15.2 → 0.15.3.

## Test plan
- [x] cargo test --release (all suites green)
- [x] almide test (all 221 .almd test files green)
- [x] new parser regression tests cover attached unary `-`, spaced binary `-` continuation, and leading `+` continuation