### PR TITLE
Release v0.15.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.15.3"
+version = "0.15.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -206,6 +206,23 @@ fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &Type
     let mut top_lets = Vec::new();
     let mut type_decls = Vec::new();
 
+    // Pre-pass: register every top-level `let` binding in the root scope so that
+    // forward references from earlier function bodies resolve to the correct
+    // VarId. Without this, the lookup misses, the resolver falls back to the
+    // error-recovery `VarId(0)`, and the reference silently aliases the first
+    // variable allocated globally (typically a local in the first lowered fn).
+    for decl in &prog.decls {
+        if let ast::Decl::TopLet { name, value, .. } = decl {
+            let prefixed_key = module_prefix
+                .map(|p| almide_base::intern::sym(&format!("{}.{}", p, name.as_str())));
+            let val_ty = prefixed_key
+                .and_then(|k| ctx.env.top_lets.get(&k).cloned())
+                .or_else(|| ctx.env.top_lets.get(name).cloned())
+                .unwrap_or_else(|| ctx.expr_ty(value));
+            ctx.define_var(name, val_ty, Mutability::Let, None);
+        }
+    }
+
     for (decl_idx, decl) in prog.decls.iter().enumerate() {
         let doc = prog.doc_map.get(decl_idx).cloned().flatten();
         let blank_lines = prog.blank_lines_map.get(decl_idx).copied().unwrap_or(0);
@@ -241,20 +258,13 @@ fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &Type
                 type_decls.push(td);
             }
             ast::Decl::TopLet { name, ty: _, value, .. } => {
-                // `env.top_lets` keys are prefixed (`util.RES` for a module-
-                // scoped `let RES`). Checker registration writes the
-                // ascription-resolved type under the prefixed key; the
-                // unprefixed lookup misses it in module lowering and the
-                // ascription gets dropped (a `Result[Int, String]`
-                // top_let would regress to `Result<i64, _>` in generated
-                // Rust). Try prefixed first, then unprefixed, then infer.
-                let prefixed_key = module_prefix
-                    .map(|p| almide_base::intern::sym(&format!("{}.{}", p, name.as_str())));
-                let val_ty = prefixed_key
-                    .and_then(|k| ctx.env.top_lets.get(&k).cloned())
-                    .or_else(|| ctx.env.top_lets.get(name).cloned())
-                    .unwrap_or_else(|| ctx.expr_ty(value));
-                let var = ctx.define_var(name, val_ty.clone(), Mutability::Let, None);
+                // VarId was pre-allocated above. Reuse it so any forward
+                // reference earlier in the file (already lowered to point at
+                // this VarId) lines up with the actual definition emitted
+                // here. Type comes from the same priority chain: prefixed
+                // env entry, unprefixed env entry, otherwise inferred.
+                let var = ctx.lookup_var(name).expect("top-level let pre-registered");
+                let val_ty = ctx.var_table.get(var).ty.clone();
                 let ir_value = lower_expr(&mut ctx, value);
                 let kind = classify_top_let_kind(&ir_value);
                 top_lets.push(IrTopLet { var, ty: val_ty, value: ir_value, kind, doc, blank_lines_before: blank_lines });

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.15.3. Parser fix: leading `-N` (attached, no space) on a new line in a block is now correctly parsed as a unary statement instead of binary subtraction continuing the previous line.
+- Current stable: v0.15.4. Lowering fix: top-level `let` bindings are pre-registered in the root scope so forward references from earlier fn bodies resolve to the correct VarId instead of falling back to VarId(0) and silently aliasing the first global variable.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/tests/lower_test.rs
+++ b/tests/lower_test.rs
@@ -532,6 +532,43 @@ fn lower_multiple_top_lets() {
     assert_eq!(ir.top_lets.len(), 2);
 }
 
+#[test]
+fn lower_top_let_forward_ref_resolves_correctly() {
+    // Regression: a top-level `let X` declared *after* a fn that references
+    // it must resolve to the same VarId as the let binding, not fall back to
+    // VarId(0) (which would alias the first variable allocated globally —
+    // typically a local in the first lowered fn).
+    let src = "\
+fn rate(s: String) -> Int = if s == \"q\" then Q_QUIT else 0
+fn outer(q: Int) -> Int = if q == Q_QUIT then Q_QUIT else q
+let Q_QUIT: Int = -2";
+    let ir = lower(src);
+    let top_let_var = ir.top_lets.iter().find(|tl| ir.var_table.get(tl.var).name == "Q_QUIT")
+        .expect("Q_QUIT top_let exists").var;
+
+    // Walk both fn bodies; every Var referencing the name `Q_QUIT` must
+    // share the same VarId as the top_let definition.
+    struct VarCollector { ids: Vec<VarId> }
+    impl almide::ir::visit::IrVisitor for VarCollector {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if let IrExprKind::Var { id } = &e.kind { self.ids.push(*id); }
+            almide::ir::visit::walk_expr(self, e);
+        }
+    }
+    for f in &ir.functions {
+        let mut vc = VarCollector { ids: Vec::new() };
+        almide::ir::visit::IrVisitor::visit_expr(&mut vc, &f.body);
+        for id in vc.ids {
+            let info = ir.var_table.get(id);
+            if info.name == "Q_QUIT" {
+                assert_eq!(id, top_let_var,
+                    "Q_QUIT reference in fn `{}` resolves to VarId({}) instead of top_let VarId({})",
+                    f.name.as_str(), id.0, top_let_var.0);
+            }
+        }
+    }
+}
+
 // ---- Float operators ----
 
 #[test]


### PR DESCRIPTION
## Summary
- Lowering fix: top-level `let` bindings are pre-registered in the root scope before any fn body is lowered. Forward references from earlier fn bodies (e.g. `Q_QUIT` used before `let Q_QUIT: Int = -2`) now resolve to the correct VarId instead of falling back to the error-recovery `VarId(0)` and silently aliasing the first global variable (causing generated Rust to refer to an unrelated local from another fn).
- Version bump 0.15.3 → 0.15.4.

## Test plan
- [x] cargo test --release (all suites green)
- [x] almide test (all 221 .almd test files green)
- [x] new lower_test regression: `lower_top_let_forward_ref_resolves_correctly` walks fn bodies and asserts every `Q_QUIT` reference shares the top_let's VarId
- [x] manual repro `/tmp/repro-fwd3.almd` (effect fn referencing later top-level `let Q_QUIT`/`Q_SKIP`) builds cleanly