### PR TITLE
Release v0.15.5: codegen name-collision fix + Named/RuntimeCall disjoin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.15.4"
+version = "0.15.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -39,6 +39,7 @@ pub mod pass_result_erasure;
 pub mod pass_result_propagation;
 pub mod pass_shadow_resolve;
 pub mod pass_intrinsic_lowering;
+pub mod pass_normalize_runtime_calls;
 pub mod pass_stdlib_lowering;
 pub mod pass_effect_inference;
 pub mod pass_tco;

--- a/crates/almide-codegen/src/pass_builtin_lowering.rs
+++ b/crates/almide-codegen/src/pass_builtin_lowering.rs
@@ -8,10 +8,17 @@
 //! - assert_ne(a, b) → RustMacro { "assert_ne", [a, b] }
 //! - assert_some(x) → RustMacro { "assert", [x.is_some()] }
 //! - println(x) → RustMacro { "println", ["{}", x] }
-//! - value_*(x) → Named { "almide_rt_value_*" }
 //! - __encode_list_T / __decode_list_T → appropriate runtime call
 //! - Type.method(x) → Named { "Type_method" }
 //! - Method { "encode"/"decode" } → Named { "Type_encode"/"Type_decode" }
+//!
+//! NOTE: stdlib intrinsic dispatch (e.g. `value.as_float(v)` →
+//! `almide_rt_value_as_float`) is the responsibility of the
+//! `@intrinsic`-driven `IntrinsicLoweringPass`. This pass MUST NOT
+//! rewrite calls based purely on a name prefix like `value_*`,
+//! because user-defined functions can legitimately use such names
+//! (`fn value_to_float(...)`) and the prefix carries no information
+//! about whether the call resolves to a real runtime symbol.
 
 use almide_ir::*;
 use almide_lang::types::Ty;
@@ -108,13 +115,6 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
                         let mut macro_args = vec![IrExpr { kind: IrExprKind::LitStr { value: "{}".into() }, ty: Ty::String, span: None }];
                         macro_args.extend(args);
                         return IrExpr { kind: IrExprKind::RustMacro { name: name.clone(), args: macro_args }, ty, span };
-                    }
-                    // value_* → almide_rt_value_*
-                    if name.starts_with("value_") {
-                        return IrExpr { kind: IrExprKind::Call {
-                            target: CallTarget::Named { name: format!("almide_rt_{}", name).into() },
-                            args, type_args,
-                        }, ty, span };
                     }
                     // __encode_list_T / __decode_list_T
                     if name.starts_with("__encode_list_") || name.starts_with("__decode_list_") {

--- a/crates/almide-codegen/src/pass_normalize_runtime_calls.rs
+++ b/crates/almide-codegen/src/pass_normalize_runtime_calls.rs
@@ -1,0 +1,109 @@
+//! NormalizeRuntimeCallsPass: collapse the legacy `Named { "almide_rt_*" }`
+//! representation into the canonical `RuntimeCall { symbol, args }` IR
+//! node before the walker / WASM emitter run.
+//!
+//! ## Why this pass exists
+//!
+//! Historically, several upstream passes (`ResolveCalls`, `StdlibLowering`,
+//! `ResultPropagation`, `BuiltinLowering` UFCS arm, ...) produce
+//! `IrExprKind::Call { target: CallTarget::Named { name: "almide_rt_..." }, ... }`
+//! to represent stdlib runtime calls. `IntrinsicLoweringPass` ran early
+//! and converted only the calls visible at that point; anything created
+//! later leaked through to the walker as a regular `Named` call.
+//!
+//! That dual representation conflates two distinct intents in a single
+//! IR node:
+//! * **User call** — a `Named { name }` referring to a user-defined or
+//!   imported `IrFunction`.
+//! * **Runtime call** — a call into the bundled Rust/WASM runtime,
+//!   identified by the `almide_rt_<module>_<func>` symbol.
+//!
+//! Conflating them previously enabled a real bug: a user function named
+//! `value_to_float` was indistinguishable from the runtime symbol
+//! `almide_rt_value_to_float`, and a name-prefix hack rewrote the user
+//! call into a non-existent runtime symbol.
+//!
+//! ## What this pass does
+//!
+//! After every other pass has finished generating the IR, this pass
+//! sweeps the program and rewrites every `Named { name }` whose name
+//! starts with `almide_rt_` (the reserved runtime-symbol prefix) into
+//! `RuntimeCall { symbol: name, args }`. The walker may then assume
+//! a clean invariant:
+//!
+//!   * `RuntimeCall { symbol }` ⇒ runtime helper, prefixed `almide_rt_*`.
+//!   * `Named { name }` ⇒ user function, never prefixed `almide_rt_*`.
+//!
+//! Combined with the walker assertion (see
+//! `walker/expressions.rs::render_generic_call`), this makes the
+//! "user call gets mangled into a non-existent runtime symbol" class
+//! of bugs structurally impossible: there is no syntactic path from a
+//! user-named call to a runtime emission.
+//!
+//! ## Pipeline placement
+//!
+//! Runs LAST, after every other pass on every Rust-target build. The
+//! intent is to be a thin uniformity guarantee for downstream emit, not
+//! a semantic transformation. As individual generators migrate to
+//! produce `RuntimeCall` directly (the long-term goal), this pass
+//! becomes a no-op on those paths and can eventually be retired.
+
+use almide_ir::*;
+use almide_ir::visit_mut::{IrMutVisitor, walk_expr_mut, walk_stmt_mut};
+use super::pass::{NanoPass, PassResult, Target};
+
+const RUNTIME_PREFIX: &str = "almide_rt_";
+
+#[derive(Debug)]
+pub struct NormalizeRuntimeCallsPass;
+
+impl NanoPass for NormalizeRuntimeCallsPass {
+    fn name(&self) -> &str { "NormalizeRuntimeCalls" }
+
+    fn targets(&self) -> Option<Vec<Target>> { Some(vec![Target::Rust]) }
+
+    fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
+        struct Rewriter;
+        impl IrMutVisitor for Rewriter {
+            fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
+                walk_expr_mut(self, expr);
+                let IrExprKind::Call { target, args, .. } = &mut expr.kind else { return };
+                let CallTarget::Named { name } = target else { return };
+                if !name.as_str().starts_with(RUNTIME_PREFIX) { return }
+                let symbol = *name;
+                let args = std::mem::take(args);
+                expr.kind = IrExprKind::RuntimeCall { symbol, args };
+            }
+            fn visit_stmt_mut(&mut self, stmt: &mut IrStmt) {
+                walk_stmt_mut(self, stmt);
+            }
+        }
+
+        let mut rw = Rewriter;
+        for func in &mut program.functions {
+            rw.visit_expr_mut(&mut func.body);
+        }
+        for tl in &mut program.top_lets {
+            rw.visit_expr_mut(&mut tl.value);
+        }
+        for mi in 0..program.modules.len() {
+            for fi in 0..program.modules[mi].functions.len() {
+                let mut body = std::mem::replace(
+                    &mut program.modules[mi].functions[fi].body,
+                    IrExpr::default(),
+                );
+                rw.visit_expr_mut(&mut body);
+                program.modules[mi].functions[fi].body = body;
+            }
+            for ti in 0..program.modules[mi].top_lets.len() {
+                let mut val = std::mem::replace(
+                    &mut program.modules[mi].top_lets[ti].value,
+                    IrExpr::default(),
+                );
+                rw.visit_expr_mut(&mut val);
+                program.modules[mi].top_lets[ti].value = val;
+            }
+        }
+        PassResult { program, changed: true }
+    }
+}

--- a/crates/almide-codegen/src/target.rs
+++ b/crates/almide-codegen/src/target.rs
@@ -19,6 +19,7 @@ use super::pass_clone::CloneInsertionPass;
 use super::pass_builtin_lowering::BuiltinLoweringPass;
 use super::pass_result_propagation::ResultPropagationPass;
 use super::pass_intrinsic_lowering::IntrinsicLoweringPass;
+use super::pass_normalize_runtime_calls::NormalizeRuntimeCallsPass;
 use super::pass_stdlib_lowering::StdlibLoweringPass;
 use super::pass_match_subject::MatchSubjectPass;
 use super::pass_effect_inference::EffectInferencePass;
@@ -136,6 +137,10 @@ fn build_pipeline(target: Target) -> Pipeline {
                 .add(RustLoweringPass)
                 // Shared passes
                 .add(FanLoweringPass)
+                // Final normalization: collapse legacy `Named { "almide_rt_*" }`
+                // into `RuntimeCall { symbol }`. Establishes the walker
+                // invariant `Named.name does NOT start with "almide_rt_"`.
+                .add(NormalizeRuntimeCallsPass)
         }
 
         Target::TypeScript => Pipeline::new(), // TS codegen removed — use --target wasm for JS runtimes

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -238,8 +238,21 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             out
         }
 
-        // ── Pre-resolved runtime call (from @intrinsic) ──
+        // ── Pre-resolved runtime call (from @intrinsic / NormalizeRuntimeCalls) ──
         IrExprKind::RuntimeCall { symbol, args } => {
+            // Inline numeric casts: a runtime function call that has a
+            // direct Rust equivalent (`x as f64` / `x as i64`). Emitted
+            // here so the cost is paid as a single language-level cast
+            // instead of a runtime helper call.
+            match symbol.as_str() {
+                "almide_rt_float_from_int" | "almide_rt_int_to_float" if args.len() == 1 => {
+                    return format!("({} as f64)", render_expr(ctx, &args[0]));
+                }
+                "almide_rt_float_to_int" if args.len() == 1 => {
+                    return format!("({} as i64)", render_expr(ctx, &args[0]));
+                }
+                _ => {}
+            }
             // BorrowInsertion wraps args with Borrow / Clone IR nodes
             // based on the `@intrinsic` fn's derived signature
             // (`intrinsic_borrow_mode`). The walker just renders.
@@ -868,16 +881,20 @@ fn render_binop(ctx: &RenderContext, op: BinOp, left: &IrExpr, right: &IrExpr, _
 fn render_generic_call(ctx: &RenderContext, target: &CallTarget, args: &[IrExpr]) -> String {
     let callee = match target {
         CallTarget::Named { name } => {
-            // Inline numeric casts: runtime function → Rust `as` cast
-            match name.as_str() {
-                "almide_rt_float_from_int" | "almide_rt_int_to_float" if args.len() == 1 => {
-                    return format!("({} as f64)", render_expr(ctx, &args[0]));
-                }
-                "almide_rt_float_to_int" if args.len() == 1 => {
-                    return format!("({} as i64)", render_expr(ctx, &args[0]));
-                }
-                _ => {}
-            }
+            // Invariant: NormalizeRuntimeCallsPass collapses every
+            // `Named { "almide_rt_*" }` into `RuntimeCall { symbol }`.
+            // A `Named` target reaching the walker therefore must
+            // refer to a user-defined or external function — never
+            // a runtime helper. If this assertion fires, a generator
+            // produced a `Named { "almide_rt_*" }` after the
+            // normalize pass, or the pass was removed from the
+            // pipeline.
+            assert!(
+                !name.as_str().starts_with("almide_rt_"),
+                "walker received Named call with reserved runtime prefix: {} \
+                 (expected RuntimeCall — see pass_normalize_runtime_calls)",
+                name.as_str()
+            );
             if let Some(enum_name) = ctx.ann.ctor_to_enum.get(name.as_str()) {
                 return render_enum_constructor(ctx, name, enum_name, args);
             }

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.15.4. Lowering fix: top-level `let` bindings are pre-registered in the root scope so forward references from earlier fn bodies resolve to the correct VarId instead of falling back to VarId(0) and silently aliasing the first global variable.
+- Current stable: v0.15.5. Codegen fix: removed the unsound `value_*` name-prefix rewrite in BuiltinLoweringPass that mangled user functions whose names happened to start with `value_` into non-existent runtime symbols. Added `NormalizeRuntimeCallsPass` at the pipeline tail that collapses any leftover `Named { "almide_rt_*" }` into `RuntimeCall { symbol }`, plus a walker assertion that `Named.name` cannot carry the runtime prefix. The IR now keeps `Named` (user calls) and `RuntimeCall` (runtime helpers) structurally disjoint at the walker boundary.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/spec/lang/user_fn_namespace_collision_test.almd
+++ b/spec/lang/user_fn_namespace_collision_test.almd
@@ -1,0 +1,35 @@
+// User-defined functions whose names happen to start with a stdlib
+// module prefix (e.g. `value_*`, `string_*`, `int_*`) must not be
+// rewritten into runtime intrinsics. The codegen pipeline must
+// distinguish actual stdlib intrinsic dispatch (driven by the
+// `@intrinsic(...)` annotation in `stdlib/<module>.almd`) from
+// regular user calls.
+//
+// Regression: BuiltinLoweringPass previously rewrote any call to a
+// `value_*`-named function into `almide_rt_value_*`, which collided
+// with user code and produced a non-existent runtime symbol such as
+// `almide_rt_value_to_float`.
+
+fn value_to_float(n: Int) -> Float = int.to_float(n) + 0.5
+
+fn value_helper(s: String) -> String = s + "!"
+
+fn int_double(n: Int) -> Int = n * 2
+
+fn string_shout(s: String) -> String = string.to_upper(s)
+
+test "user fn `value_to_float` is not redirected to runtime" {
+  assert_eq(value_to_float(2), 2.5)
+}
+
+test "user fn `value_helper` is not redirected to runtime" {
+  assert_eq(value_helper("ok"), "ok!")
+}
+
+test "user fn `int_double` keeps user binding even with stdlib head" {
+  assert_eq(int_double(3), 6)
+}
+
+test "user fn `string_shout` keeps user binding even with stdlib head" {
+  assert_eq(string_shout("hi"), "HI")
+}


### PR DESCRIPTION
## Summary

- Remove unsound `value_*` name-prefix rewrite in `BuiltinLoweringPass` that mangled user-defined functions whose names happened to start with `value_` into non-existent runtime symbols.
- Add `NormalizeRuntimeCallsPass` at the pipeline tail that collapses any remaining `Named { "almide_rt_*" }` calls into the canonical `RuntimeCall { symbol }` IR node.
- Add a walker assertion that `Named { name }` never carries the `almide_rt_` runtime prefix, making the conflation between user calls and runtime helpers structurally impossible.
- Bump version to 0.15.5.

## Why

A user call like \`fn value_to_float(...)\` was being rewritten by the codegen into \`almide_rt_value_to_float(...)\` — a runtime symbol that does not exist. The compiler emitted invalid Rust with the (correct) hint \`this is an Almide bug\`. Root cause: a name-prefix-based interception that could not distinguish stdlib intrinsic dispatch from a user function whose name coincidentally shared the prefix. The fix removes the prefix interception and elevates the user call vs. runtime call distinction to the IR by pinning \`Named\` and \`RuntimeCall\` to disjoint roles at the walker boundary.

## Test plan

- [x] New regression test \`spec/lang/user_fn_namespace_collision_test.almd\` covering \`value_to_float\`, \`value_helper\`, \`int_double\`, \`string_shout\` (passes; previously failed with codegen error)
- [x] Full \`almide test\` (222 .almd test files, all green)
- [x] Full \`cargo test --release\` (all green)
- [x] Sample stdlib call \`value.float(3.14)\` / \`value.as_float(v)\` end-to-end OK
- [x] Downstream \`O6lvl4-vitals\` project builds and runs correctly

## Commits

- \`bc0eb465\` Remove unsound value_* prefix rewrite that mangled user functions
- \`7332bc0e\` Disjoin Named and RuntimeCall IR via end-of-pipeline normalize pass
- \`43e6fdb0\` bump version to 0.15.5