### PR TITLE
Release v0.15.6: type-inference fixes for nested-pipe folds and effect fn lambdas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.15.5"
+version = "0.15.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -475,24 +475,28 @@ impl Checker {
             }
         }
         let ret = if final_bindings.is_empty() { sig.ret.clone() } else { crate::types::substitute(&sig.ret, &final_bindings) };
-        // In test blocks, user-defined effect fn calls that return non-Result T are reported as Result[T, String].
-        // This removes the implicit auto-unwrap and lets users choose: `!` to unwrap, or match on ok/err.
-        // Only user-defined fns are wrapped — stdlib effect fns are not lifted by codegen,
-        // so their runtime implementations return raw values (not Result).
-        //
-        // `env.functions.contains_key` covered the pre-bundled world where
-        // stdlib sigs lived in a parallel table. Once a stdlib module is
-        // migrated to `stdlib/<m>.almd` and loaded via `lower_module`,
-        // its fns also land in `env.functions` under `<module>.<fn>`
-        // keys — matching the check above and wrongly wrapping their
-        // return type in the test block. Gate the wrap by "not a bundled
-        // stdlib module": bundled stdlib fns generate runtime calls that
-        // return raw values (their `@inline_rust` templates carry their
-        // own `?` when the Rust runtime truly returns `Result`).
+        // User-defined effect fn calls that return non-Result T are reported
+        // as Result[T, String] in two contexts:
+        //   1. test blocks — there's no enclosing effect fn to auto-`?`
+        //      against, so the test sees the raw lifted Result.
+        //   2. lambda bodies — codegen's ResultPropagation lifts the callee's
+        //      return type but doesn't recurse into lambdas (closures can't
+        //      `?`-propagate to the enclosing fn). Letting the lambda body's
+        //      type stay `T` here means a `(n) => worker(n)` passes
+        //      type-checking against `list.map`'s `(A) -> B` slot, only to
+        //      blow up at codegen with `expected Vec<i64>, found
+        //      Vec<Result<i64, String>>`. Surfacing the Result at the call
+        //      site instead steers the user toward `match worker(n)
+        //      { ok(v) => v, err(_) => ... }` — a real type error, not an
+        //      "Almide bug" diagnostic.
+        // Bundled stdlib effect fns are excluded — their `@inline_rust` /
+        // `@intrinsic` templates carry their own propagation and never get
+        // lifted by ResultPropagation, so their callers see raw `T`.
         let is_bundled_stdlib_call = name.split_once('.')
             .map(|(m, _)| almide_lang::stdlib_info::is_bundled_module(m))
             .unwrap_or(false);
-        if self.env.in_test_block && sig.is_effect && !ret.is_result()
+        let in_lifting_context = self.env.in_test_block || self.env.lambda_depth > 0;
+        if in_lifting_context && sig.is_effect && !ret.is_result()
             && self.env.functions.contains_key(&sym(name))
             && !is_bundled_stdlib_call
         {

--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -298,12 +298,28 @@ impl Checker {
 
             ExprKind::TupleIndex { object, index, .. } => {
                 let obj_ty = self.infer_expr(object);
-                match &obj_ty {
+                if let Ty::Tuple(elems) = &obj_ty {
+                    if *index < elems.len() { return elems[*index].clone(); }
+                }
+                let concrete = resolve_ty(&obj_ty, &self.uf);
+                match &concrete {
                     Ty::Tuple(elems) if *index < elems.len() => elems[*index].clone(),
-                    _ => {
-                        let concrete = resolve_ty(&obj_ty, &self.uf);
-                        match &concrete { Ty::Tuple(elems) if *index < elems.len() => elems[*index].clone(), _ => Ty::Unknown }
+                    // Object's type is still an open inference var (e.g. a
+                    // fresh lambda param yet to be bound by its call site).
+                    // Park a fresh result var and resolve it once the
+                    // union-find binds the object to a concrete `Tuple`
+                    // (see `Checker::resolve_deferred_tuple_indices`).
+                    // Without this deferral the body type freezes to
+                    // `Unknown` here and propagates outward — breaking
+                    // chains like `xs |> list.map((p) => p.1) |>
+                    // list.fold(0.0, (a, b) => a + b)` where the fold's
+                    // element-typed lambda param gets no constraint.
+                    Ty::TypeVar(name) if name.starts_with('?') => {
+                        let result = self.fresh_var();
+                        self.deferred_tuple_indices.push((obj_ty, *index, result.clone()));
+                        result
                     }
+                    _ => Ty::Unknown,
                 }
             }
 

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -66,6 +66,13 @@ pub struct Checker {
     /// top_lets without explicit ascription regress to `Ty::Unknown`
     /// and codegen emits `LazyLock<_>`.
     pub(crate) current_module_prefix: Option<String>,
+    /// Deferred resolution targets for expressions whose types depend on
+    /// a yet-unbound TypeVar's structure (e.g. `p.1` on a fresh lambda
+    /// param). Each entry is `(object_ty, index, result_var)`: once
+    /// `object_ty` resolves to a `Tuple`, `result_var` is unified with
+    /// `elems[index]`. Drained iteratively after `solve_constraints`
+    /// to give the union-find a chance to propagate before resolution.
+    pub(crate) deferred_tuple_indices: Vec<(Ty, usize, Ty)>,
 }
 
 impl Checker {
@@ -80,6 +87,7 @@ impl Checker {
             call_span_hint: None,
             constraints: Vec::new(), uf: UnionFind::new(),
             current_module_prefix: None,
+            deferred_tuple_indices: Vec::new(),
         }
     }
 
@@ -180,6 +188,35 @@ impl Checker {
 
     pub fn set_source(&mut self, file: &str, text: &str) { self.source_file = Some(file.into()); self.source_text = Some(text.into()); }
 
+    /// Drain pending TupleIndex deferrals to a fixed point. A deferral
+    /// is registered when `obj.N` is inferred while `obj` is a fresh
+    /// inference var — there's no Tuple to index into yet, so the
+    /// result is bound to a fresh var and the resolution is parked.
+    /// Once the union-find binds `obj_ty` to a concrete `Tuple`, we
+    /// unify the parked result with the indexed element. We loop
+    /// because a successful unify may unblock another deferral whose
+    /// `obj_ty` was itself the parked result of an earlier one.
+    pub(crate) fn resolve_deferred_tuple_indices(&mut self) {
+        loop {
+            let pending = std::mem::take(&mut self.deferred_tuple_indices);
+            if pending.is_empty() { break; }
+            let mut still_pending = Vec::new();
+            let mut progressed = false;
+            for (obj_ty, index, result_ty) in pending {
+                let resolved = resolve_ty(&obj_ty, &self.uf);
+                match &resolved {
+                    Ty::Tuple(elems) if index < elems.len() => {
+                        self.unify_infer(&result_ty, &elems[index]);
+                        progressed = true;
+                    }
+                    _ => still_pending.push((obj_ty, index, result_ty)),
+                }
+            }
+            self.deferred_tuple_indices = still_pending;
+            if !progressed { break; }
+        }
+    }
+
     // ── Main entry point ──
 
     /// Type-check a program whose environment was pre-populated by `canonicalize_program`.
@@ -187,6 +224,7 @@ impl Checker {
     pub fn infer_program(&mut self, program: &mut ast::Program) -> Vec<Diagnostic> {
         for decl in program.decls.iter_mut() { self.check_decl(decl); }
         self.solve_constraints();
+        self.resolve_deferred_tuple_indices();
         resolve_type_map(&mut self.type_map, &self.uf);
         // Unused import warnings
         for imp in &program.imports {
@@ -340,6 +378,7 @@ impl Checker {
         );
         for decl in prog.decls.iter_mut() { self.check_decl(decl); }
         self.solve_constraints();
+        self.resolve_deferred_tuple_indices();
         resolve_type_map(&mut self.type_map, &self.uf);
         self.current_module_prefix = saved_prefix;
 

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.15.5. Codegen fix: removed the unsound `value_*` name-prefix rewrite in BuiltinLoweringPass that mangled user functions whose names happened to start with `value_` into non-existent runtime symbols. Added `NormalizeRuntimeCallsPass` at the pipeline tail that collapses any leftover `Named { "almide_rt_*" }` into `RuntimeCall { symbol }`, plus a walker assertion that `Named.name` cannot carry the runtime prefix. The IR now keeps `Named` (user calls) and `RuntimeCall` (runtime helpers) structurally disjoint at the walker boundary.
+- Current stable: v0.15.6. Frontend inference fixes: (1) `TupleIndex` on an unresolved object (e.g. `p.1` on a fresh lambda param) now defers via a fresh inference var and resolves once the union-find binds the object — so `xs |> list.map((p) => p.1) |> list.fold(0.0, (a, b) => a + b)` infers cleanly without `(a: Float, b: Float)` annotations. (2) User-defined effect fn calls inside lambda bodies surface as `Result[T, String]` (matching the test-block treatment), turning the previously cryptic codegen error into an actionable type-checker E001 at the call site.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/spec/lang/effect_fn_in_map_test.almd
+++ b/spec/lang/effect_fn_in_map_test.almd
@@ -1,0 +1,32 @@
+// Regression: a user-defined effect fn (whose return type is lifted to
+// Result by codegen) called inside a lambda body must surface as
+// `Result[T, String]` at the frontend type level. Without this, a
+// `(n) => worker(n)` lambda passes type-checking against `list.map`'s
+// `(A) -> B` slot but blows up at codegen with `expected Vec<i64>,
+// found Vec<Result<i64, String>>` — a "codegen produced invalid Rust"
+// failure that violates Almide's "every error has a clean diagnostic"
+// promise. Surfacing the Result lets the user choose `match`, `?`, or
+// a recursive helper.
+
+effect fn worker(n: Int) -> Int = n * 2
+
+test "lambda body sees user effect fn return as Result" {
+  let xs: List[Int] = [1, 2, 3];
+  // The lambda's body type is Result<Int, String>; matching on it
+  // produces an Int that flows back into list.map's element slot.
+  let ys: List[Int] = xs |> list.map((n) => match worker(n) {
+    ok(v)  => v,
+    err(_) => 0,
+  });
+  assert_eq(ys, [2, 4, 6])
+}
+
+test "list.fold over user effect fn requires unwrapping" {
+  let xs: List[Int] = [1, 2, 3];
+  // Same shape inside fold's accumulator-element callback.
+  let total = xs |> list.fold(0, (acc, n) => match worker(n) {
+    ok(v)  => acc + v,
+    err(_) => acc,
+  });
+  assert_eq(total, 12)
+}

--- a/spec/lang/fold_lambda_param_inference_test.almd
+++ b/spec/lang/fold_lambda_param_inference_test.almd
@@ -1,0 +1,30 @@
+// Regression: list.fold's accumulator-element lambda params must be
+// inferred end-to-end across pipe chains, even when the upstream
+// list.map's lambda body is initially unresolved (e.g. tuple
+// indexing on a yet-unbound param).
+
+test "fold over mapped tuple-index pipe" {
+  let pairs: List[(Bool, Float)] = [(true, 1.0), (true, 2.0), (true, 3.0)];
+  let sum = pairs |> list.map((p) => p.1) |> list.fold(0.0, (a, b) => a + b);
+  assert_eq(sum, 6.0)
+}
+
+test "fold over mapped tuple-index without pipe" {
+  let pairs: List[(Bool, Float)] = [(true, 1.0), (true, 2.0), (true, 3.0)];
+  let nums = list.map(pairs, (p) => p.1);
+  let sum = list.fold(nums, 0.0, (a, b) => a + b);
+  assert_eq(sum, 6.0)
+}
+
+test "fold over mapped tuple-index intermediate let" {
+  let pairs: List[(Bool, Float)] = [(true, 1.0), (true, 2.0), (true, 3.0)];
+  let nums = pairs |> list.map((p) => p.1);
+  let sum = nums |> list.fold(0.0, (a, b) => a + b);
+  assert_eq(sum, 6.0)
+}
+
+test "fold accumulator drives second lambda param" {
+  let xs: List[Float] = [1.0, 2.0, 3.0];
+  let sum = xs |> list.fold(0.0, (a, b) => a + b);
+  assert_eq(sum, 6.0)
+}


### PR DESCRIPTION
## Summary

- Defer `TupleIndex` resolution when the object is still an open inference variable, so chains like `xs |> list.map((p) => p.1) |> list.fold(0.0, (a, b) => a + b)` infer cleanly without explicit lambda param annotations.
- Lift user-defined effect fn return types to `Result[T, String]` inside lambda bodies (mirroring the existing test-block treatment), so `(n) => worker(n)` inside `list.map` surfaces as a frontend type error instead of a "codegen produced invalid Rust" failure.

## Why

Both bugs hit a downstream user (vitals CLI) building on v0.15.5: Bug 1 forced `(a: Float, b: Float)` annotations on every fold lambda fed by a `list.map` over a tuple; Bug 2 forced replacing `list.map` with a hand-rolled recursive helper whenever an effect fn was the body. Each manifested as the catastrophic "Almide bug — codegen produced invalid Rust" hint at compile time, despite the inputs being plausibly idiomatic.

## Test plan

- [x] `almide test` — 224/224 test files pass (added `spec/lang/fold_lambda_param_inference_test.almd` + `spec/lang/effect_fn_in_map_test.almd`)
- [x] `cargo test --release -- --test-threads=1` — all green
- [x] Downstream `O6lvl4-vitals/src/main.almd` re-checks cleanly without the workarounds

## Commits

- `Defer TupleIndex on unresolved objects to fix nested-pipe lambda inference`
- `Lift user effect fn return type to Result inside lambda bodies`
- `bump version to 0.15.6`