### PR TITLE
fix: promote let → let mut for Bytes/Vec/HashMap bindings

### DIFF
--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -78,7 +78,18 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             } else {
                 render_expr(ctx, value)
             };
+            // Promote let → let mut for types that are commonly mutated
+            // (Bytes, Vec/List, HashMap/Map) to avoid borrow errors in
+            // generated Rust when push/append/insert methods are called.
+            let needs_mut = matches!(mutability, Mutability::Let) && {
+                let ty_str = type_s.as_str();
+                ty_str == "Vec<u8>"
+                    || ty_str.starts_with("Vec<")
+                    || ty_str.starts_with("HashMap<")
+                    || ctx.ann.mut_promoted_vars.contains(var)
+            };
             let construct = match mutability {
+                Mutability::Let if needs_mut => "var_binding",
                 Mutability::Let => "let_binding",
                 Mutability::Var => "var_binding",
             };

--- a/crates/almide-ir/src/annotations.rs
+++ b/crates/almide-ir/src/annotations.rs
@@ -26,4 +26,7 @@ pub struct CodegenAnnotations {
     /// derive `PartialEq` (a field transitively blocks equality — e.g.
     /// contains a Matrix or a function pointer).
     pub eq_blocked_types: HashSet<String>,
+    /// Variables bound with `let` that need `let mut` in Rust because
+    /// they are passed to mutating methods (bytes.push, list.push, etc.)
+    pub mut_promoted_vars: HashSet<VarId>,
 }


### PR DESCRIPTION
## Summary
- When a `let` binding holds a `Bytes`, `Vec`, or `HashMap`, emit `let mut` in generated Rust
- Fixes mutating method calls (`bytes.push`, `list.push`, `map.insert`, etc.) causing borrow errors

## Test
```almide
effect fn main() -> Unit = {
  let out = bytes.new(0)
  bytes.push(out, 42)
  bytes.append_u32_le(out, 12345)
  println(int.to_string(bytes.len(out)))
}
```
Before: `cannot borrow out as mutable, as it is not declared as mutable`
After: prints `5`

Fixes #248