### PR TITLE
v0.16.5: list.tail, Named type field resolution in ConcretizeTypes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.16.4"
+version = "0.16.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -153,7 +153,7 @@ fn build_symbol_table(program: &IrProgram) -> SymbolTable {
         }
     }
     let mut record_fields = std::collections::HashMap::new();
-    for decl in &program.type_decls {
+    let mut register_type_decl = |decl: &almide_ir::IrTypeDecl| {
         match &decl.kind {
             almide_ir::IrTypeDeclKind::Record { fields } => {
                 let fs: Vec<_> = fields.iter()
@@ -172,6 +172,14 @@ fn build_symbol_table(program: &IrProgram) -> SymbolTable {
                 }
             }
             _ => {}
+        }
+    };
+    for decl in &program.type_decls {
+        register_type_decl(decl);
+    }
+    for module in &program.modules {
+        for decl in &module.type_decls {
+            register_type_decl(decl);
         }
     }
     SymbolTable { sigs, record_fields }
@@ -626,6 +634,11 @@ fn resolve_node_ty(expr: &IrExpr, vt: &VarTable, symbols: &SymbolTable) -> Optio
                         .find(|(n, _)| n == field.as_str())
                         .map(|(_, t)| t.clone())
                         .filter(|t| !t.has_unresolved_deep())
+                }
+                Ty::Named(name, _) => {
+                    symbols.lookup_field(name.as_str(), field.as_str())
+                        .filter(|t| !t.has_unresolved_deep())
+                        .cloned()
                 }
                 _ => None,
             }

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.16.4. almide-dialect crate (SSA, MLIR-like), compile-time value parameters (`fn f[N: Int]()`), bit introspection, Hashable protocol.
+- Current stable: v0.16.5. almide-dialect crate (SSA, MLIR-like), compile-time value parameters (`fn f[N: Int]()`), bit introspection, Hashable protocol.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/stdlib/list.almd
+++ b/stdlib/list.almd
@@ -56,6 +56,8 @@ fn take[A](xs: List[A], n: Int) -> List[A] = _
 @consume(xs)
 fn drop[A](xs: List[A], n: Int) -> List[A] = _
 
+fn tail[A](xs: List[A]) -> List[A] = list.drop(xs, 1)
+
 @intrinsic("almide_rt_list_unique")
 fn unique[A](xs: List[A]) -> List[A] = _
 

--- a/tests/snapshots/ide_outline_snapshot_test__stdlib_list_outline.snap
+++ b/tests/snapshots/ide_outline_snapshot_test__stdlib_list_outline.snap
@@ -55,6 +55,7 @@ fn list.sort_by[A, B](xs: List[A], f: fn(A) -> B) -> List[A]
 fn list.split_at[T](xs: List[T], n: Int) -> (List[T], List[T])
 fn list.sum(xs: List[Int]) -> Int
 fn list.swap[A](xs: List[A], i: Int, j: Int) -> List[A]
+fn list.tail[A](xs: List[A]) -> List[A]
 fn list.take[A](xs: List[A], n: Int) -> List[A]
 fn list.take_end[A](xs: List[A], n: Int) -> List[A]
 fn list.take_while[A](xs: List[A], f: fn(A) -> Bool) -> List[A]

--- a/tests/snapshots/ide_outline_snapshot_test__stdlib_snapshot_default.snap
+++ b/tests/snapshots/ide_outline_snapshot_test__stdlib_snapshot_default.snap
@@ -103,6 +103,7 @@ fn list.sort_by[A, B](xs: List[A], f: fn(A) -> B) -> List[A]
 fn list.split_at[T](xs: List[T], n: Int) -> (List[T], List[T])
 fn list.sum(xs: List[Int]) -> Int
 fn list.swap[A](xs: List[A], i: Int, j: Int) -> List[A]
+fn list.tail[A](xs: List[A]) -> List[A]
 fn list.take[A](xs: List[A], n: Int) -> List[A]
 fn list.take_end[A](xs: List[A], n: Int) -> List[A]
 fn list.take_while[A](xs: List[A], f: fn(A) -> Bool) -> List[A]


### PR DESCRIPTION
## Summary
- Add `list.tail` as pure Almide wrapper for `list.drop(xs, 1)`
- Fix Named type field resolution in `ConcretizeTypes` pass — cross-module `Named(T, [])` fields now resolve instead of staying `Unknown`
- Register module-level `type_decls` in `ConcretizeTypes` symbol table (previously only top-level decls were indexed)

## Test plan
- [x] `almide test` — 228/228 pass
- [x] `list.tail` — Rust + WASM verified
- [x] `cargo build --release` clean