### PR TITLE
v0.16.6: module-level var, cross-module let fix, list.tail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.16.5"
+version = "0.16.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -493,6 +493,9 @@ template = "const {name}: {type} = {value};"
 [top_let_lazy]
 template = "static {name}: std::sync::LazyLock<{type}> = std::sync::LazyLock::new(|| {value});"
 
+[top_var]
+template = "thread_local! { static {name}: std::cell::RefCell<{type}> = std::cell::RefCell::new({value}); }"
+
 [generic_bound]
 template = "{name}: Clone + PartialEq"
 

--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -84,25 +84,78 @@ impl NanoPass for ConcretizeTypesPass {
         // VarTable entries for lambda accumulator params and match-pattern
         // bindings; downstream passes expect the updates to persist.
         let mut prog_vt = std::mem::take(&mut program.var_table);
+
+        // Phase 1: Resolve top_lets first so their types are available
+        // when functions reference cross-module let values.
+        for tl in &mut program.top_lets {
+            concretize_expr(&mut tl.value, &mut prog_vt, &symbols, &Ty::Unknown);
+            if !tl.value.ty.has_unresolved_deep() {
+                if tl.ty.has_unresolved_deep() {
+                    tl.ty = tl.value.ty.clone();
+                }
+                if (tl.var.0 as usize) < prog_vt.len()
+                    && prog_vt.get(tl.var).ty.has_unresolved_deep()
+                {
+                    prog_vt.entries[tl.var.0 as usize].ty = tl.value.ty.clone();
+                }
+            }
+        }
+        for module in &mut program.modules {
+            for tl in &mut module.top_lets {
+                concretize_expr(&mut tl.value, &mut prog_vt, &symbols, &Ty::Unknown);
+                if !tl.value.ty.has_unresolved_deep() {
+                    if tl.ty.has_unresolved_deep() {
+                        tl.ty = tl.value.ty.clone();
+                    }
+                    if (tl.var.0 as usize) < prog_vt.len()
+                        && prog_vt.get(tl.var).ty.has_unresolved_deep()
+                    {
+                        prog_vt.entries[tl.var.0 as usize].ty = tl.value.ty.clone();
+                    }
+                }
+            }
+        }
+
+        // Phase 1b: Propagate top_let types by name into VarTable entries
+        // that are cross-module synthetic references (different VarId, same name).
+        let mut top_let_types: std::collections::HashMap<String, Ty> = std::collections::HashMap::new();
+        for tl in &program.top_lets {
+            if !tl.ty.has_unresolved_deep() {
+                let name = prog_vt.get(tl.var).name.to_string();
+                top_let_types.insert(name, tl.ty.clone());
+            }
+        }
+        for module in &program.modules {
+            for tl in &module.top_lets {
+                if !tl.ty.has_unresolved_deep() {
+                    let name = prog_vt.get(tl.var).name.to_string();
+                    top_let_types.insert(name, tl.ty.clone());
+                }
+            }
+        }
+        if !top_let_types.is_empty() {
+            for entry in &mut prog_vt.entries {
+                if entry.ty.has_unresolved_deep() {
+                    if let Some(ty) = top_let_types.get(entry.name.as_str()) {
+                        entry.ty = ty.clone();
+                    }
+                }
+            }
+        }
+
+        // Phase 2: Now resolve functions (which may reference cross-module lets
+        // whose VarTable types are now populated).
         for func in &mut program.functions {
             let ret = func.ret_ty.clone();
             concretize_expr(&mut func.body, &mut prog_vt, &symbols, &ret);
         }
-        for tl in &mut program.top_lets {
-            concretize_expr(&mut tl.value, &mut prog_vt, &symbols, &Ty::Unknown);
-        }
-        // Module functions / top_lets now index into the unified
-        // program-level VarTable (post `UnifyVarTablesPass`), so we
-        // keep it taken out while we touch them too.
         for module in &mut program.modules {
             for func in &mut module.functions {
                 let ret = func.ret_ty.clone();
                 concretize_expr(&mut func.body, &mut prog_vt, &symbols, &ret);
             }
-            for tl in &mut module.top_lets {
-                concretize_expr(&mut tl.value, &mut prog_vt, &symbols, &Ty::Unknown);
-            }
         }
+
         program.var_table = prog_vt;
         PassResult { program, changed: true }
     }

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -69,7 +69,10 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             // VarId so `lazy_vars` misses it; cross-reference by uppercased
             // name against `lazy_top_let_names` instead.
             let upper = name.to_uppercase();
-            // Mutable top-let: thread_local RefCell — read via .with(|c| ...)
+            // Mutable top-let: Cell (Copy types) or RefCell (non-Copy)
+            if ctx.ann.mutable_top_let_copy.contains(&upper) {
+                return format!("{}.with(|c| c.get())", upper);
+            }
             if ctx.ann.mutable_top_let_names.contains(&upper) {
                 return format!("{}.with(|c| c.borrow().clone())", upper);
             }

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -69,6 +69,10 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             // VarId so `lazy_vars` misses it; cross-reference by uppercased
             // name against `lazy_top_let_names` instead.
             let upper = name.to_uppercase();
+            // Mutable top-let: thread_local RefCell — read via .with(|c| ...)
+            if ctx.ann.mutable_top_let_names.contains(&upper) {
+                return format!("{}.with(|c| c.borrow().clone())", upper);
+            }
             let is_synthetic_lazy = name.starts_with("ALMIDE_RT_")
                 && ctx.ann.lazy_top_let_names.contains(&upper);
             if ctx.ann.lazy_vars.contains(id) || is_synthetic_lazy {

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -363,9 +363,24 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
     for module in &program.modules {
         for tl in &module.top_lets {
             if matches!(tl.kind, TopLetKind::Lazy) {
-                // Post-`UnifyVarTablesPass`, module `tl.var` indexes into
-                // `program.var_table` — the per-module tables are empty.
                 ann.lazy_top_let_names.insert(
+                    ctx.var_table.get(tl.var).name.to_uppercase()
+                );
+            }
+        }
+    }
+    // Index mutable top-let names for unsafe read/write in Rust codegen.
+    for tl in &program.top_lets {
+        if tl.mutable {
+            ann.mutable_top_let_names.insert(
+                ctx.var_table.get(tl.var).name.to_uppercase()
+            );
+        }
+    }
+    for module in &program.modules {
+        for tl in &module.top_lets {
+            if tl.mutable {
+                ann.mutable_top_let_names.insert(
                     ctx.var_table.get(tl.var).name.to_uppercase()
                 );
             }
@@ -452,7 +467,7 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         parts.push(rendered);
     }
 
-    // Top-level lets
+    // Top-level lets and vars
     for tl in &program.top_lets {
         let name = ctx.var_table.get(tl.var).name.clone();
         let ty_str = render_type_fn(&ctx, &tl.ty);
@@ -460,13 +475,17 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         if matches!(tl.kind, TopLetKind::Lazy) {
             ctx.ann.lazy_vars.insert(tl.var);
         }
-        let construct = match tl.kind {
-            TopLetKind::Const => "top_let_const",
-            TopLetKind::Lazy => "top_let_lazy",
-        };
         let name_upper = name.to_uppercase();
-        let mut rendered = ctx.templates.render_with(construct, None, &[], &[("name", name_upper.as_str()), ("type", ty_str.as_str()), ("value", val_str.as_str())])
-            .unwrap_or_else(|| format!("const {} = {};", name, val_str));
+        let mut rendered = if tl.mutable {
+            format!("thread_local! {{ static {}: std::cell::RefCell<{}> = std::cell::RefCell::new({}); }}", name_upper, ty_str, val_str)
+        } else {
+            let construct = match tl.kind {
+                TopLetKind::Const => "top_let_const",
+                TopLetKind::Lazy => "top_let_lazy",
+            };
+            ctx.templates.render_with(construct, None, &[], &[("name", name_upper.as_str()), ("type", ty_str.as_str()), ("value", val_str.as_str())])
+                .unwrap_or_else(|| format!("const {} = {};", name, val_str))
+        };
         if let Some(ref doc) = tl.doc {
             let doc_lines: String = doc.lines()
                 .map(|line| if line.is_empty() { "///".to_string() } else { format!("/// {}", line) })

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -19,6 +19,7 @@ pub use expressions::render_expr;
 pub use statements::{render_stmt, render_pattern};
 
 use almide_ir::*;
+use almide_lang::types::Ty;
 use super::annotations::CodegenAnnotations;
 use super::pass::Target;
 use super::template::TemplateSet;
@@ -369,21 +370,23 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
             }
         }
     }
-    // Index mutable top-let names for unsafe read/write in Rust codegen.
-    for tl in &program.top_lets {
-        if tl.mutable {
-            ann.mutable_top_let_names.insert(
-                ctx.var_table.get(tl.var).name.to_uppercase()
-            );
+    // Index mutable top-let names. Copy types (Int, Float, Bool) use Cell<T>
+    // for zero-cost reads; non-Copy types use RefCell<T>.
+    let register_mutable_top_let = |ann: &mut CodegenAnnotations, tl: &IrTopLet, vt: &VarTable| {
+        if !tl.mutable { return; }
+        let name = vt.get(tl.var).name.to_uppercase();
+        if matches!(tl.ty, Ty::Int | Ty::Float | Ty::Bool) {
+            ann.mutable_top_let_copy.insert(name);
+        } else {
+            ann.mutable_top_let_names.insert(name);
         }
+    };
+    for tl in &program.top_lets {
+        register_mutable_top_let(&mut ann, tl, ctx.var_table);
     }
     for module in &program.modules {
         for tl in &module.top_lets {
-            if tl.mutable {
-                ann.mutable_top_let_names.insert(
-                    ctx.var_table.get(tl.var).name.to_uppercase()
-                );
-            }
+            register_mutable_top_let(&mut ann, tl, ctx.var_table);
         }
     }
     let mut ctx = RenderContext {
@@ -476,7 +479,9 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
             ctx.ann.lazy_vars.insert(tl.var);
         }
         let name_upper = name.to_uppercase();
-        let mut rendered = if tl.mutable {
+        let mut rendered = if tl.mutable && matches!(tl.ty, Ty::Int | Ty::Float | Ty::Bool) {
+            format!("thread_local! {{ static {}: std::cell::Cell<{}> = std::cell::Cell::new({}); }}", name_upper, ty_str, val_str)
+        } else if tl.mutable {
             format!("thread_local! {{ static {}: std::cell::RefCell<{}> = std::cell::RefCell::new({}); }}", name_upper, ty_str, val_str)
         } else {
             let construct = match tl.kind {

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -93,12 +93,15 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
                 .unwrap_or_else(|| format!("let _ = _;"))
         }
         IrStmtKind::Assign { var, value } => {
-            // Push optimization (xs = xs + [v] → xs.push(v)) is now handled
-            // by RustLoweringPass which rewrites to a Call(Method("push")).
             let target_s = ctx.var_name(*var).to_string();
+            let upper = target_s.to_uppercase();
             let value_s = render_expr(ctx, value);
-            ctx.templates.render_with("assignment", None, &[], &[("target", target_s.as_str()), ("value", value_s.as_str())])
-                .unwrap_or_else(|| format!("_ = _;"))
+            if ctx.ann.mutable_top_let_names.contains(&upper) {
+                format!("{}.with(|c| *c.borrow_mut() = ({}).into())", upper, value_s)
+            } else {
+                ctx.templates.render_with("assignment", None, &[], &[("target", target_s.as_str()), ("value", value_s.as_str())])
+                    .unwrap_or_else(|| format!("_ = _;"))
+            }
         }
         IrStmtKind::Expr { expr } => {
             let rendered = render_expr(ctx, expr);

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -96,7 +96,9 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             let target_s = ctx.var_name(*var).to_string();
             let upper = target_s.to_uppercase();
             let value_s = render_expr(ctx, value);
-            if ctx.ann.mutable_top_let_names.contains(&upper) {
+            if ctx.ann.mutable_top_let_copy.contains(&upper) {
+                format!("{}.with(|c| c.set({}))", upper, value_s)
+            } else if ctx.ann.mutable_top_let_names.contains(&upper) {
                 format!("{}.with(|c| *c.borrow_mut() = ({}).into())", upper, value_s)
             } else {
                 ctx.templates.render_with("assignment", None, &[], &[("target", target_s.as_str()), ("value", value_s.as_str())])

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -245,14 +245,15 @@ fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &Type
     // error-recovery `VarId(0)`, and the reference silently aliases the first
     // variable allocated globally (typically a local in the first lowered fn).
     for decl in &prog.decls {
-        if let ast::Decl::TopLet { name, value, .. } = decl {
+        if let ast::Decl::TopLet { name, value, mutable, .. } = decl {
             let prefixed_key = module_prefix
                 .map(|p| almide_base::intern::sym(&format!("{}.{}", p, name.as_str())));
             let val_ty = prefixed_key
                 .and_then(|k| ctx.env.top_lets.get(&k).cloned())
                 .or_else(|| ctx.env.top_lets.get(name).cloned())
                 .unwrap_or_else(|| ctx.expr_ty(value));
-            ctx.define_var(name, val_ty, Mutability::Let, None);
+            let mutability = if *mutable { Mutability::Var } else { Mutability::Let };
+            ctx.define_var(name, val_ty, mutability, None);
         }
     }
 
@@ -290,17 +291,12 @@ fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &Type
                 td.blank_lines_before = blank_lines;
                 type_decls.push(td);
             }
-            ast::Decl::TopLet { name, ty: _, value, .. } => {
-                // VarId was pre-allocated above. Reuse it so any forward
-                // reference earlier in the file (already lowered to point at
-                // this VarId) lines up with the actual definition emitted
-                // here. Type comes from the same priority chain: prefixed
-                // env entry, unprefixed env entry, otherwise inferred.
+            ast::Decl::TopLet { name, ty: _, value, mutable, .. } => {
                 let var = ctx.lookup_var(name).expect("top-level let pre-registered");
                 let val_ty = ctx.var_table.get(var).ty.clone();
                 let ir_value = lower_expr(&mut ctx, value);
                 let kind = classify_top_let_kind(&ir_value);
-                top_lets.push(IrTopLet { var, ty: val_ty, value: ir_value, kind, doc, blank_lines_before: blank_lines, def_id: None });
+                top_lets.push(IrTopLet { var, ty: val_ty, value: ir_value, kind, mutable: *mutable, doc, blank_lines_before: blank_lines, def_id: None });
             }
             ast::Decl::Test { name, body, .. } => {
                 let test_fn = lower_test(&mut ctx, name, body);

--- a/crates/almide-ir/src/annotations.rs
+++ b/crates/almide-ir/src/annotations.rs
@@ -12,10 +12,12 @@ pub struct CodegenAnnotations {
     /// emitting `(*NAME)` — scalar `Const` top_lets (plain `const
     /// NAME: i64 = 42;`) must NOT be dereferenced.
     pub lazy_top_let_names: HashSet<String>,
-    /// Uppercased names of module-level `var` declarations (mutable top-lets).
-    /// The walker wraps reads in `unsafe { NAME }` and writes in
-    /// `unsafe { NAME = value; }` for Rust `static mut` emission.
+    /// Uppercased names of module-level `var` declarations (mutable top-lets)
+    /// that use `RefCell<T>` (non-Copy types: String, List, etc.).
     pub mutable_top_let_names: HashSet<String>,
+    /// Uppercased names of module-level `var` declarations that use `Cell<T>`
+    /// (Copy types: Int, Float, Bool). Read with `.get()`, write with `.set()`.
+    pub mutable_top_let_copy: HashSet<String>,
     pub ctor_to_enum: HashMap<String, String>,
     pub anon_records: HashMap<Vec<String>, String>,
     pub named_records: HashMap<Vec<String>, String>,

--- a/crates/almide-ir/src/annotations.rs
+++ b/crates/almide-ir/src/annotations.rs
@@ -12,6 +12,10 @@ pub struct CodegenAnnotations {
     /// emitting `(*NAME)` — scalar `Const` top_lets (plain `const
     /// NAME: i64 = 42;`) must NOT be dereferenced.
     pub lazy_top_let_names: HashSet<String>,
+    /// Uppercased names of module-level `var` declarations (mutable top-lets).
+    /// The walker wraps reads in `unsafe { NAME }` and writes in
+    /// `unsafe { NAME = value; }` for Rust `static mut` emission.
+    pub mutable_top_let_names: HashSet<String>,
     pub ctor_to_enum: HashMap<String, String>,
     pub anon_records: HashMap<Vec<String>, String>,
     pub named_records: HashMap<Vec<String>, String>,

--- a/crates/almide-ir/src/lib.rs
+++ b/crates/almide-ir/src/lib.rs
@@ -886,6 +886,8 @@ pub struct IrTopLet {
     pub value: IrExpr,
     #[serde(default = "default_top_let_kind")]
     pub kind: TopLetKind,
+    #[serde(default)]
+    pub mutable: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub doc: Option<String>,
     #[serde(default)]

--- a/crates/almide-syntax/src/ast.rs
+++ b/crates/almide-syntax/src/ast.rs
@@ -348,7 +348,7 @@ pub enum Decl {
         body: Option<Expr>,
         #[serde(skip)] span: Option<Span>,
     },
-    TopLet { name: Sym, #[serde(rename = "type")] ty: Option<TypeExpr>, value: Expr, #[serde(default)] visibility: Visibility, #[serde(skip)] span: Option<Span> },
+    TopLet { name: Sym, #[serde(rename = "type")] ty: Option<TypeExpr>, value: Expr, #[serde(default)] mutable: bool, #[serde(default)] visibility: Visibility, #[serde(skip)] span: Option<Span> },
     Protocol { name: Sym, #[serde(default)] generics: Option<Vec<GenericParam>>, methods: Vec<ProtocolMethod>, #[serde(skip)] span: Option<Span> },
     Impl { trait_: Sym, for_: Sym, #[serde(default)] generics: Option<Vec<GenericParam>>, methods: Vec<Decl>, #[serde(skip)] span: Option<Span> },
     Strict { mode: String, #[serde(skip)] span: Option<Span> },

--- a/crates/almide-syntax/src/parser/declarations.rs
+++ b/crates/almide-syntax/src/parser/declarations.rs
@@ -144,7 +144,10 @@ impl Parser {
             return self.parse_impl_decl();
         }
         if self.check(TokenType::Let) {
-            return self.parse_top_let(Visibility::Public);
+            return self.parse_top_let(Visibility::Public, false);
+        }
+        if self.check(TokenType::Var) {
+            return self.parse_top_let(Visibility::Public, true);
         }
         if self.check(TokenType::Fn) || self.check(TokenType::Pub)
             || self.check(TokenType::Effect)
@@ -154,15 +157,23 @@ impl Parser {
                 && self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::Let)
             {
                 self.advance();
-                return self.parse_top_let(Visibility::Public);
+                return self.parse_top_let(Visibility::Public, false);
+            }
+            if self.check(TokenType::Pub)
+                && self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::Var)
+            {
+                self.advance();
+                return self.parse_top_let(Visibility::Public, true);
             }
             if self.check(TokenType::Local) || self.check(TokenType::Mod) {
                 if self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::Type) {
                     return self.parse_type_decl();
                 }
-                if self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::Let) {
+                let peek1 = self.peek_at(1).map(|t| &t.token_type);
+                if peek1 == Some(&TokenType::Let) || peek1 == Some(&TokenType::Var) {
                     let vis = self.parse_visibility();
-                    return self.parse_top_let(vis);
+                    let is_var = self.check(TokenType::Var);
+                    return self.parse_top_let(vis, is_var);
                 }
             }
             return self.parse_fn_decl();
@@ -179,14 +190,18 @@ impl Parser {
             return Err(format!("{} at line {}:{}\n  Hint: {}", msg, tok.line, tok.col, result.hint));
         }
         Err(format!(
-            "Expected top-level declaration (fn, effect fn, type, let, trait, impl, test) at line {}:{} (got {:?} '{}')",
+            "Expected top-level declaration (fn, effect fn, type, let, var, trait, impl, test) at line {}:{} (got {:?} '{}')",
             tok.line, tok.col, tok.token_type, tok.value
         ))
     }
 
-    fn parse_top_let(&mut self, visibility: Visibility) -> Result<Decl, String> {
+    fn parse_top_let(&mut self, visibility: Visibility, mutable: bool) -> Result<Decl, String> {
         let span = self.current_span();
-        self.expect(TokenType::Let)?;
+        if mutable {
+            self.expect(TokenType::Var)?;
+        } else {
+            self.expect(TokenType::Let)?;
+        }
         let name = self.expect_any_name()?;
         let ty = if self.check(TokenType::Colon) {
             self.advance();
@@ -197,7 +212,7 @@ impl Parser {
         self.expect(TokenType::Eq)?;
         self.skip_newlines();
         let value = self.parse_expr()?;
-        Ok(Decl::TopLet { name, ty, value, visibility, span: Some(span) })
+        Ok(Decl::TopLet { name, ty, value, mutable, visibility, span: Some(span) })
     }
 
     /// Parse `@name(args)?` declarations that precede a fn decl.

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.16.5. almide-dialect crate (SSA, MLIR-like), compile-time value parameters (`fn f[N: Int]()`), bit introspection, Hashable protocol.
+- Current stable: v0.16.6. almide-dialect crate (SSA, MLIR-like), compile-time value parameters (`fn f[N: Int]()`), bit introspection, Hashable protocol.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/spec/integration/modules/cross_module_let_test.almd
+++ b/spec/integration/modules/cross_module_let_test.almd
@@ -11,3 +11,24 @@ test "cross-module let composes with stdlib pipes" {
 test "cross-module let alongside cross-module fn" {
   assert_eq(letlib.welcome(), "hello world")
 }
+
+test "cross-module let Float value" {
+  assert(letlib.UNDEFINED == -1.0)
+  assert(letlib.PI > 3.14)
+  assert(letlib.PI < 3.15)
+}
+
+test "cross-module let Int value" {
+  assert(letlib.MAX_ITEMS == 42)
+}
+
+test "cross-module let repeated access" {
+  assert(letlib.UNDEFINED < 0.0)
+  assert(letlib.UNDEFINED == -1.0)
+}
+
+test "cross-module let in expressions" {
+  let half_pi = letlib.PI / 2.0
+  assert(half_pi > 1.57)
+  assert(half_pi < 1.58)
+}

--- a/spec/integration/modules/letlib/src/mod.almd
+++ b/spec/integration/modules/letlib/src/mod.almd
@@ -1,4 +1,7 @@
 let GREETING: String = "hello"
 let NUMBERS: List[Int] = [1, 2, 3]
+let UNDEFINED: Float = -1.0
+let MAX_ITEMS: Int = 42
+let PI: Float = 3.14159
 
 fn welcome() -> String = GREETING + " world"

--- a/spec/lang/module_var_test.almd
+++ b/spec/lang/module_var_test.almd
@@ -1,0 +1,42 @@
+var counter = 0
+var label = "init"
+var items: List[Int] = []
+
+fn bump() -> Unit = {
+  counter = counter + 1
+}
+
+fn set_label(s: String) -> Unit = {
+  label = s
+}
+
+test "module var Int read/write" {
+  assert(counter == 0)
+  bump()
+  assert(counter == 1)
+  bump()
+  bump()
+  assert(counter == 3)
+}
+
+test "module var String read/write" {
+  set_label("hello")
+  assert(label == "hello")
+  set_label("world")
+  assert(label == "world")
+}
+
+test "module var List assignment" {
+  items = [10, 20]
+  assert(list.len(items) == 2)
+  assert(items[0] == 10)
+  items = [10, 20, 30]
+  assert(list.len(items) == 3)
+}
+
+test "module var direct assignment in test" {
+  counter = 100
+  assert(counter == 100)
+  counter = counter + 1
+  assert(counter == 101)
+}


### PR DESCRIPTION
## Summary
- **Module-level `var`** — mutable top-level bindings. Parser accepts `var` at top level. Rust target emits `thread_local! + RefCell`. Reads/writes go through `.with(|c| ...)`.
- **Cross-module `let` type resolution** — ConcretizeTypes now processes top_lets before functions and propagates types by name into synthetic VarTable entries. Eliminates `[POSTCONDITION VIOLATION]` for cross-module let references.
- **`list.tail`** — pure Almide wrapper for `list.drop(xs, 1)`, works on Rust + WASM.
- **Named type field resolution** — `ConcretizeTypes` resolves `Member` access on `Ty::Named` via type declaration lookup. Module-level `type_decls` now indexed in symbol table.

## Known limitations
- Module-level `var` with `list.push` operates on a clone (use `items = items + [v]` instead)
- WASM target for module-level `var` not yet implemented

## Test plan
- [x] `almide test` — 229/229 pass
- [x] `spec/lang/module_var_test.almd` — Int, String, List, direct assignment
- [x] Cross-module let integration tests (Float, Int, repeated access, expressions)
- [x] `cargo build --release` clean