### PR TITLE
v0.16.6 patch: list.push on module var, WASM module-level var

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -93,7 +93,18 @@ impl FuncCompiler<'_> {
                 let local_idx = match self.var_map.get(&var.0) {
                     Some(&idx) => idx,
                     None => {
-                        // Variable not in local scope — skip (closure captures handled at closure level)
+                        // Check if this is a module-level var (top_let global)
+                        let name = if (var.0 as usize) < self.var_table.len() {
+                            self.var_table.get(*var).name.as_str()
+                        } else { "" };
+                        if let Some(&(global_idx, _)) = self.emitter.top_let_globals_by_name.get(name)
+                            .or_else(|| self.emitter.top_let_globals.get(&var.0))
+                        {
+                            self.emit_expr(value);
+                            wasm!(self.func, { global_set(global_idx); });
+                            return;
+                        }
+                        // Variable not in local scope — skip
                         self.emit_expr(value);
                         if values::ty_to_valtype(&value.ty).is_some() {
                             wasm!(self.func, { drop; });

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -260,6 +260,31 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                 }
                 _ => {}
             }
+            // Mutating stdlib calls (push, pop, clear) on module-level var:
+            // emit NAME.with(|c| { runtime_fn(&mut *c.borrow_mut(), args) })
+            // so the mutation applies to the RefCell directly, not a clone.
+            if !args.is_empty() {
+                let is_mutating = matches!(symbol.as_str(),
+                    "almide_rt_list_push" | "almide_rt_list_pop" | "almide_rt_list_clear");
+                if is_mutating {
+                    if let IrExprKind::Borrow { expr: inner, .. } | IrExprKind::Clone { expr: inner } = &args[0].kind {
+                        if let IrExprKind::Var { id } = &inner.kind {
+                            let name = ctx.var_name(*id).to_string();
+                            let upper = name.to_uppercase();
+                            if ctx.ann.mutable_top_let_names.contains(&upper) {
+                                let rest_args = args[1..].iter().map(|a| render_expr(ctx, a))
+                                    .collect::<Vec<_>>().join(", ");
+                                let call_args = if rest_args.is_empty() {
+                                    "&mut *c.borrow_mut()".to_string()
+                                } else {
+                                    format!("&mut *c.borrow_mut(), {}", rest_args)
+                                };
+                                return format!("{}.with(|c| {}({}))", upper, symbol.as_str(), call_args);
+                            }
+                        }
+                    }
+                }
+            }
             // BorrowInsertion wraps args with Borrow / Clone IR nodes
             // based on the `@intrinsic` fn's derived signature
             // (`intrinsic_borrow_mode`). The walker just renders.

--- a/spec/lang/module_var_test.almd
+++ b/spec/lang/module_var_test.almd
@@ -34,6 +34,15 @@ test "module var List assignment" {
   assert(list.len(items) == 3)
 }
 
+test "module var list.push" {
+  items = []
+  list.push(items, 100)
+  list.push(items, 200)
+  assert(list.len(items) == 2)
+  assert(items[0] == 100)
+  assert(items[1] == 200)
+}
+
 test "module var direct assignment in test" {
   counter = 100
   assert(counter == 100)


### PR DESCRIPTION
## Summary
- **list.push on module var** — Rust codegen detects mutating stdlib calls (push/pop/clear) on module-level `var` and emits `NAME.with(|c| runtime_fn(&mut *c.borrow_mut(), args))` instead of operating on a clone
- **WASM module-level var assignment** — `Assign` targeting top_let globals now emits `global.set` instead of dropping the value
- **Cell for Copy types** — Int/Float/Bool module vars use `Cell<T>` with zero-cost `.get()`/`.set()`

## Test plan
- [x] `almide test` — 229/229 pass
- [x] `spec/lang/module_var_test.almd` — list.push test added
- [x] WASM build with module var verified