### PR TITLE
v0.17.0 patch: COW detection fix + WASM COW runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.16.7"
+version = "0.17.0"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -121,6 +121,8 @@ pub struct StringRuntime {
 pub struct RuntimeFuncs {
     pub fd_write: u32,
     pub alloc: u32,
+    pub rc_inc: u32,
+    pub cow_check: u32,
     pub heap_save: u32,
     pub heap_restore: u32,
     pub println_str: u32,
@@ -309,7 +311,7 @@ impl WasmEmitter {
             // First byte is newline at NEWLINE_OFFSET
             data_bytes: vec![0x0A],
             rt: RuntimeFuncs {
-                fd_write: 0, alloc: 0,
+                fd_write: 0, alloc: 0, rc_inc: 0, cow_check: 0,
                 heap_save: 0, heap_restore: 0,
                 println_str: 0, println_int: 0,
                 int_to_string: 0, float_to_string: 0,

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -135,6 +135,13 @@ pub fn register_runtime_functions(emitter: &mut WasmEmitter) {
     let alloc_ty = emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
     emitter.rt.alloc = emitter.register_func("__alloc", alloc_ty);
 
+    // __rc_inc(ptr: i32) -> i32 — increment refcount at ptr-4, return ptr
+    emitter.rt.rc_inc = emitter.register_func("__rc_inc", alloc_ty);
+
+    // __cow_check(ptr: i32, size: i32) -> i32 — if rc>1, copy data, dec old rc, return new ptr
+    let cow_check_ty = emitter.register_type(vec![ValType::I32, ValType::I32], vec![ValType::I32]);
+    emitter.rt.cow_check = emitter.register_func("__cow_check", cow_check_ty);
+
     // __heap_save() -> i32   — return current heap pointer
     let heap_save_ty = emitter.register_type(vec![], vec![ValType::I32]);
     emitter.rt.heap_save = emitter.register_func("__heap_save", heap_save_ty);
@@ -282,6 +289,8 @@ pub fn register_runtime_functions(emitter: &mut WasmEmitter) {
 /// Compile all runtime function bodies.
 pub fn compile_runtime(emitter: &mut WasmEmitter) {
     compile_alloc(emitter);
+    compile_rc_inc(emitter);
+    compile_cow_check(emitter);
     compile_heap_save(emitter);
     compile_heap_restore(emitter);
     compile_println_str(emitter);
@@ -336,14 +345,17 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(1, ValType::I32)]); // local 1: $ptr
 
     wasm!(f, {
+        // COW: allocate size+4 for refcount header, return ptr+4.
+        // Refcount at ptr-4 is initialized to 1.
         // Align heap_ptr up to 8-byte boundary: ptr = (heap_ptr + 7) & ~7
         global_get(emitter.heap_ptr_global);
         i32_const(7); i32_add; i32_const(-8); i32_and;
         local_set(1);
-        // Advance heap_ptr past the allocation: heap_ptr = ptr + size
+        // Advance heap_ptr past the allocation: heap_ptr = ptr + size + 4
         local_get(1);
         local_get(0);
         i32_add;
+        i32_const(4); i32_add;
         global_set(emitter.heap_ptr_global);
         // Grow memory if needed: while heap_ptr > memory.size * 64KB.
         // Compare in i64 because `memory_size * 65536` overflows i32 once
@@ -366,10 +378,74 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
           if_empty; unreachable; end;
           br(0);
         end; end;
+        // Write refcount = 1 at ptr
         local_get(1);
+        i32_const(1);
+        i32_store(2, 0);  // store rc=1 at ptr (align=4)
+        // Return ptr + 4 (data starts after refcount header)
+        local_get(1);
+        i32_const(4); i32_add;
         end;
     });
 
+    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+}
+
+// __rc_inc(ptr: i32) -> i32
+// Increment refcount at ptr-4, return ptr unchanged.
+fn compile_rc_inc(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.rc_inc];
+    let mut f = Function::new([]);
+    wasm!(f, {
+        // rc = load(ptr - 4)
+        local_get(0); i32_const(4); i32_sub;
+        local_get(0); i32_const(4); i32_sub;
+        i32_load(2, 0);
+        // rc + 1
+        i32_const(1); i32_add;
+        // store(ptr - 4, rc + 1)
+        i32_store(2, 0);
+        // return ptr
+        local_get(0);
+        end;
+    });
+    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+}
+
+// __cow_check(ptr: i32, size: i32) -> i32
+// If refcount > 1: allocate new buffer, memcpy, decrement old rc, return new ptr.
+// If refcount == 1: return ptr unchanged (in-place mutation is safe).
+fn compile_cow_check(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.cow_check];
+    let mut f = Function::new([(1, ValType::I32)]); // local 2: $new_ptr
+    wasm!(f, {
+        // if load(ptr - 4) <= 1 then return ptr (unique owner)
+        local_get(0); i32_const(4); i32_sub;
+        i32_load(2, 0);
+        i32_const(1); i32_le_u;
+        if_empty;
+            local_get(0);
+            return_;
+        end;
+        // Shared: allocate new buffer of `size` bytes
+        local_get(1);
+        call(emitter.rt.alloc);
+        local_set(2);
+        // memcpy: new_ptr[0..size] = ptr[0..size]
+        local_get(2); // dst
+        local_get(0); // src
+        local_get(1); // size
+        memory_copy(0, 0);
+        // Decrement old refcount
+        local_get(0); i32_const(4); i32_sub;
+        local_get(0); i32_const(4); i32_sub;
+        i32_load(2, 0);
+        i32_const(1); i32_sub;
+        i32_store(2, 0);
+        // Return new ptr
+        local_get(2);
+        end;
+    });
     emitter.add_compiled(CompiledFunc { type_idx, func: f });
 }
 

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -422,31 +422,56 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         }
     }
     // Rc-wrap function-local `var` bindings of non-Copy types for COW.
-    // Exclude module-level vars and function params.
-    let mut exclude_var_ids: std::collections::HashSet<u32> = std::collections::HashSet::new();
-    for tl in &program.top_lets {
-        if tl.mutable { exclude_var_ids.insert(tl.var.0); }
-    }
-    for module in &program.modules {
-        for tl in &module.top_lets {
-            if tl.mutable { exclude_var_ids.insert(tl.var.0); }
+    // Scan IR Bind statements (not VarTable) because use_count demotes
+    // unused-assigned vars from Var to Let. We need the original mutability.
+    {
+        let mut exclude: std::collections::HashSet<u32> = std::collections::HashSet::new();
+        // Exclude module-level vars and function params
+        for tl in &program.top_lets {
+            if tl.mutable { exclude.insert(tl.var.0); }
         }
-    }
-    // Exclude function params (they're borrowed or owned, not Val-wrapped)
-    for func in &program.functions {
-        for p in &func.params { exclude_var_ids.insert(p.var.0); }
-    }
-    for module in &program.modules {
-        for func in &module.functions {
-            for p in &func.params { exclude_var_ids.insert(p.var.0); }
+        for module in &program.modules {
+            for tl in &module.top_lets {
+                if tl.mutable { exclude.insert(tl.var.0); }
+            }
         }
-    }
-    for (idx, entry) in program.var_table.entries.iter().enumerate() {
-        if entry.mutability == almide_ir::Mutability::Var
-            && !matches!(entry.ty, Ty::Int | Ty::Float | Ty::Bool | Ty::Unit | Ty::Unknown)
-            && !exclude_var_ids.contains(&(idx as u32))
-        {
-            ann.rc_wrapped_vars.insert(VarId(idx as u32));
+        for func in &program.functions {
+            for p in &func.params { exclude.insert(p.var.0); }
+        }
+        for module in &program.modules {
+            for func in &module.functions {
+                for p in &func.params { exclude.insert(p.var.0); }
+            }
+        }
+        // Scan IR Bind stmts for Mutability::Var
+        struct VarBindCollector { vars: std::collections::HashSet<u32> }
+        impl almide_ir::visit::IrVisitor for VarBindCollector {
+            fn visit_stmt(&mut self, stmt: &IrStmt) {
+                if let IrStmtKind::Bind { var, mutability: almide_ir::Mutability::Var, ty, .. } = &stmt.kind {
+                    if !matches!(ty, Ty::Int | Ty::Float | Ty::Bool | Ty::Unit | Ty::Unknown) {
+                        self.vars.insert(var.0);
+                    }
+                }
+                almide_ir::visit::walk_stmt(self, stmt);
+            }
+            fn visit_expr(&mut self, expr: &IrExpr) {
+                almide_ir::visit::walk_expr(self, expr);
+            }
+        }
+        let mut collector = VarBindCollector { vars: std::collections::HashSet::new() };
+        use almide_ir::visit::IrVisitor;
+        for func in &program.functions {
+            collector.visit_expr(&func.body);
+        }
+        for module in &program.modules {
+            for func in &module.functions {
+                collector.visit_expr(&func.body);
+            }
+        }
+        for var_id in collector.vars {
+            if !exclude.contains(&var_id) {
+                ann.rc_wrapped_vars.insert(VarId(var_id));
+            }
         }
     }
     let mut ctx = RenderContext {

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -78,20 +78,31 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             } else {
                 render_expr(ctx, value)
             };
-            // Check if value is a Clone of a Val-wrapped var → use inferred type
+            // Check if value comes from a RcCow-wrapped var (Clone or direct)
             let is_val_clone = match &value.kind {
                 IrExprKind::Clone { expr: inner } => {
                     if let IrExprKind::Var { id } = &inner.kind {
                         ctx.ann.rc_wrapped_vars.contains(id)
                     } else { false }
                 }
+                IrExprKind::Var { id } => ctx.ann.rc_wrapped_vars.contains(id),
                 _ => false,
             };
             let (type_s, value_s) = if is_val_clone {
-                // Clone of Val returns T (via deref). Re-wrap in Val for COW binding.
-                let val_type = format!("RcCow<{}>", type_s);
-                let val_value = format!("RcCow::new({})", value_s);
-                (val_type, val_value)
+                match &value.kind {
+                    // Direct Var from RcCow: use .clone() (Rc::clone O(1))
+                    IrExprKind::Var { .. } => {
+                        let val_type = format!("RcCow<{}>", type_s);
+                        let val_value = format!("{}.clone()", value_s);
+                        (val_type, val_value)
+                    }
+                    // Clone of RcCow var: deref+clone returned T, re-wrap
+                    _ => {
+                        let val_type = format!("RcCow<{}>", type_s);
+                        let val_value = format!("RcCow::new({})", value_s);
+                        (val_type, val_value)
+                    }
+                }
             } else {
                 (type_s, value_s)
             };


### PR DESCRIPTION
## Summary
- Fix COW var detection: scan IR Bind mutability instead of VarTable (use_count demotes vars)
- Handle direct Var-to-let assignment (no Clone node) with `.clone()` for Rc sharing
- WASM COW runtime: allocator refcount header, `__rc_inc`, `__cow_check`

## Test plan
- [x] 229/229 pass
- [x] COW snapshot test verified