### PR TITLE
v0.17.7: RcCow ownership fixes, syntax_guide false-positive, BorrowInference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.17.6"
+version = "0.17.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-codegen/src/pass_borrow_inference.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference.rs
@@ -614,6 +614,7 @@ fn check_needs_ownership(expr: &IrExpr, var: VarId, needs: &mut bool) {
         // ── Control flow: recurse ──
         IrExprKind::If { cond, then, else_ } => {
             check_needs_ownership(cond, var, needs);
+            if is_var(then, var) || is_var(else_, var) { *needs = true; return; }
             check_needs_ownership(then, var, needs);
             check_needs_ownership(else_, var, needs);
         }
@@ -624,6 +625,7 @@ fn check_needs_ownership(expr: &IrExpr, var: VarId, needs: &mut bool) {
             check_needs_ownership(subject, var, needs);
             for arm in arms {
                 if let Some(g) = &arm.guard { check_needs_ownership(g, var, needs); }
+                if is_var(&arm.body, var) { *needs = true; return; }
                 check_needs_ownership(&arm.body, var, needs);
             }
         }

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -15,6 +15,18 @@ fn render_stmts(ctx: &RenderContext, stmts: &[IrStmt]) -> Vec<String> {
     stmts.iter().map(|s| render_stmt(ctx, s)).collect()
 }
 
+/// Render an expression ensuring an owned value (not RcCow wrapper).
+/// For RcCow vars, produces `(*var).clone()` to yield the unwrapped T.
+/// Used at sites that need owned T: function args, record fields, concat operands.
+fn render_expr_owned(ctx: &RenderContext, expr: &IrExpr) -> String {
+    if let IrExprKind::Var { id } = &expr.kind {
+        if ctx.ann.is_rc_cow(id) {
+            return format!("(*{}).clone()", ctx.var_name(*id));
+        }
+    }
+    render_expr(ctx, expr)
+}
+
 pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
     match &expr.kind {
         // ── Literals ──
@@ -350,9 +362,9 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             let ctor_name_str = name.as_ref().map(|s| s.as_str()).unwrap_or("");
             let explicit_names: std::collections::HashSet<&str> = fields.iter().map(|(k, _)| &**k).collect();
             let mut field_strs: Vec<String> = Vec::new();
-            // Render explicit fields
+            // Render explicit fields (owned: RcCow vars unwrapped to T)
             for (k, v) in fields.iter() {
-                let mut val_str = render_expr(ctx, v);
+                let mut val_str = render_expr_owned(ctx, v);
                 // Box recursive fields (annotation is target-aware — empty for non-Rust)
                 if let Some(cn) = name {
                     if ctx.ann.boxed_fields.contains(&(cn.to_string(), k.to_string())) {
@@ -875,7 +887,10 @@ fn render_binop(ctx: &RenderContext, op: BinOp, left: &IrExpr, right: &IrExpr, _
     match op {
         BinOp::ConcatStr | BinOp::ConcatList => {
             let ty_tag = if op == BinOp::ConcatStr { "String" } else { "List" };
-            ctx.templates.render_with("concat_expr", Some(ty_tag), &[], &[("left", l.as_str()), ("right", r.as_str())])
+            // Unwrap RcCow operands to owned T for concat
+            let lo = render_expr_owned(ctx, left);
+            let ro = render_expr_owned(ctx, right);
+            ctx.templates.render_with("concat_expr", Some(ty_tag), &[], &[("left", lo.as_str()), ("right", ro.as_str())])
                 .unwrap_or_else(|| format!("concat(_, _)"))
         }
         BinOp::MulMatrix => {
@@ -1033,7 +1048,7 @@ fn render_generic_call(ctx: &RenderContext, target: &CallTarget, args: &[IrExpr]
         }
         CallTarget::Module { .. } => unreachable!(),
     };
-    let args_str = args.iter().map(|a| render_expr(ctx, a)).collect::<Vec<_>>().join(", ");
+    let args_str = args.iter().map(|a| render_expr_owned(ctx, a)).collect::<Vec<_>>().join(", ");
     ctx.templates.render_with("call_expr", None, &[], &[("callee", callee.as_str()), ("args", args_str.as_str())])
         .unwrap_or_else(|| format!("call(...)"))
 }

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -18,7 +18,7 @@ fn render_stmts(ctx: &RenderContext, stmts: &[IrStmt]) -> Vec<String> {
 /// Render an expression ensuring an owned value (not RcCow wrapper).
 /// For RcCow vars, produces `(*var).clone()` to yield the unwrapped T.
 /// Used at sites that need owned T: function args, record fields, concat operands.
-fn render_expr_owned(ctx: &RenderContext, expr: &IrExpr) -> String {
+pub(crate) fn render_expr_owned(ctx: &RenderContext, expr: &IrExpr) -> String {
     if let IrExprKind::Var { id } = &expr.kind {
         if ctx.ann.is_rc_cow(id) {
             return format!("(*{}).clone()", ctx.var_name(*id));
@@ -309,8 +309,8 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             }
             // BorrowInsertion wraps args with Borrow / Clone IR nodes
             // based on the `@intrinsic` fn's derived signature
-            // (`intrinsic_borrow_mode`). The walker just renders.
-            let args_str = args.iter().map(|a| render_expr(ctx, a))
+            // (`intrinsic_borrow_mode`). Unwrap bare RcCow vars to owned T.
+            let args_str = args.iter().map(|a| render_expr_owned(ctx, a))
                 .collect::<Vec<_>>().join(", ");
             format!("{}({})", symbol.as_str(), args_str)
         }
@@ -320,7 +320,7 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             match target {
                 CallTarget::Module { module, func } => {
                     // Module calls: use template (TS/JS) or runtime function (Rust)
-                    let args_str = args.iter().map(|a| render_expr(ctx, a)).collect::<Vec<_>>().join(", ");
+                    let args_str = args.iter().map(|a| render_expr_owned(ctx, a)).collect::<Vec<_>>().join(", ");
                     let mod_ident = module.replace('.', "_");
                     let func_ident = func.replace('.', "_");
                     ctx.templates.render_with("module_call", None, &[], &[("module", mod_ident.as_str()), ("func", func_ident.as_str()), ("args", args_str.as_str())])
@@ -352,7 +352,7 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                     return rendered;
                 }
             }
-            let elems = elements.iter().map(|e| render_expr(ctx, e)).collect::<Vec<_>>().join(", ");
+            let elems = elements.iter().map(|e| render_expr_owned(ctx, e)).collect::<Vec<_>>().join(", ");
             ctx.templates.render_with("list_literal", None, &[], &[("elements", elems.as_str())])
                 .unwrap_or_else(|| format!("[...]"))
         }
@@ -441,9 +441,9 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
 
         // ── Option / Result ──
         IrExprKind::OptionSome { expr: inner } => {
-            let inner_s = render_expr(ctx, inner);
+            let inner_s = render_expr_owned(ctx, inner);
             ctx.templates.render_with("some_expr", None, &[], &[("inner", inner_s.as_str())])
-                .unwrap_or_else(|| format!("Some({})", render_expr(ctx, inner)))
+                .unwrap_or_else(|| format!("Some({})", inner_s))
         }
         IrExprKind::OptionNone => {
             // Typed None: pass inner type via bindings + attribute for template guard
@@ -457,9 +457,9 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             template_or(ctx, "none_expr", &[], "None")
         }
         IrExprKind::ResultOk { expr: inner } => {
-            let inner_s = render_expr(ctx, inner);
+            let inner_s = render_expr_owned(ctx, inner);
             ctx.templates.render_with("ok_expr", None, &[], &[("inner", inner_s.as_str())])
-                .unwrap_or_else(|| format!("Ok({})", render_expr(ctx, inner)))
+                .unwrap_or_else(|| format!("Ok({})", inner_s))
         }
         IrExprKind::ResultErr { expr: inner } => {
             let inner_str = render_expr(ctx, inner);
@@ -545,7 +545,7 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
 
         // ── Tuple ──
         IrExprKind::Tuple { elements } => {
-            let parts = elements.iter().map(|e| render_expr(ctx, e)).collect::<Vec<_>>().join(", ");
+            let parts = elements.iter().map(|e| render_expr_owned(ctx, e)).collect::<Vec<_>>().join(", ");
             ctx.templates.render_with("tuple_literal", None, &[], &[("elements", parts.as_str())])
                 .unwrap_or_else(|| "tuple(...)".into())
         }

--- a/crates/almide-codegen/src/walker/helpers.rs
+++ b/crates/almide-codegen/src/walker/helpers.rs
@@ -82,7 +82,7 @@ pub fn render_body_content(ctx: &RenderContext, expr: &almide_ir::IrExpr) -> Str
                 .map(|s| terminate_stmt(ctx, super::statements::render_stmt(ctx, s)))
                 .collect();
             if let Some(e) = tail {
-                let expr_str = super::expressions::render_expr(ctx, e);
+                let expr_str = super::expressions::render_expr_owned(ctx, e);
                 let is_control = matches!(&e.kind, IrExprKind::Break | IrExprKind::Continue);
                 if is_control {
                     parts.push(expr_str);
@@ -93,7 +93,7 @@ pub fn render_body_content(ctx: &RenderContext, expr: &almide_ir::IrExpr) -> Str
             }
             parts.join("\n")
         }
-        _ => super::expressions::render_expr(ctx, expr),
+        _ => super::expressions::render_expr_owned(ctx, expr),
     }
 }
 

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -334,7 +334,7 @@ pub fn render_match_arm(ctx: &RenderContext, arm: &IrMatchArm, match_ty: &almide
     let body = if matches!(&arm.body.kind, IrExprKind::ResultErr { .. }) && !match_ty.is_result() {
         format!("return {}", render_expr(ctx, &arm.body))
     } else {
-        render_expr(ctx, &arm.body)
+        super::expressions::render_expr_owned(ctx, &arm.body)
     };
     // Append guard to pattern if present
     let full_pattern = if let Some(ref guard) = arm.guard {

--- a/crates/almide-syntax/src/parser/hints/syntax_guide.rs
+++ b/crates/almide-syntax/src/parser/hints/syntax_guide.rs
@@ -4,11 +4,29 @@ use super::{HintContext, HintResult, HintScope};
 /// Guide users from other languages toward Almide idioms.
 /// Covers: return, null, throw, catch, loop, print, let mut, etc.
 pub fn check(ctx: &HintContext) -> Option<HintResult> {
-    // Expression-level rejected keywords
+    // Expression-level rejected keywords — only when the ident is used
+    // as a keyword (e.g. `new Foo()`), not as a normal identifier
+    // (e.g. `new.kind`, `new == old`, param name `new: View`).
     if ctx.scope == HintScope::Expression || ctx.scope == HintScope::Block {
         if ctx.got.token_type == TokenType::Ident {
-            if let Some(r) = check_rejected_ident(ctx.got.value.as_str()) {
-                return Some(r);
+            let is_used_as_identifier = ctx.next.map_or(false, |next| matches!(
+                next.token_type,
+                TokenType::Dot | TokenType::Colon | TokenType::Comma
+                | TokenType::RParen | TokenType::RBracket | TokenType::RBrace
+                | TokenType::Eq | TokenType::EqEq | TokenType::BangEq
+                | TokenType::LBracket | TokenType::LParen
+                | TokenType::Plus | TokenType::Minus | TokenType::Star | TokenType::Slash
+                | TokenType::Percent | TokenType::LAngle | TokenType::RAngle
+                | TokenType::LtEq | TokenType::GtEq | TokenType::Pipe
+                | TokenType::PipeArrow | TokenType::Caret
+                | TokenType::Newline | TokenType::EOF
+            ) || (next.token_type == TokenType::Ident && matches!(
+                next.value.as_str(), "and" | "or" | "then" | "else"
+            )));
+            if !is_used_as_identifier {
+                if let Some(r) = check_rejected_ident(ctx.got.value.as_str()) {
+                    return Some(r);
+                }
             }
         }
     }

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,10 +6,11 @@
 
 ## Active
 
-10 items
+12 items
 
 | Item | Description |
 |------|-------------|
+| [Ceangal Widget System](active/ceangal-widget-system.md) | Ceangal UI framework — widget system, reactive state, GPU rendering pipeline |
 | [DX: `almide test` stderr & `almide explain`](active/dx-testing-explain.md) | almide test stderr passthrough + almide explain <code> subcommand |
 | [Capability-Based Effect System](active/effect-system-capability.md) | Capability-based effect system for sandboxed AI agent containers |
 | [Error-Fix Database](active/error-fix-db.md) | Structured error-to-fix mapping for LLM auto-repair of compiler errors |
@@ -18,6 +19,7 @@
 | [LLM Integration](active/llm-integration.md) | Built-in LLM commands for library generation, auto-fix, and code explanation |
 | [LSP Server](active/lsp.md) | Language Server Protocol for editor completion, diagnostics, and navigation |
 | [MLIR Backend + Egg Rewrite Engine](active/mlir-backend-adoption.md) | Stage 2 progressive lowering — dialect walker passes all 227 spec tests |
+| [Name Resolution Pass — Unified Cross-Package Symbol Resolution](active/name-resolution-pass.md) |  |
 | [Package Version Resolution](active/package-version-resolution.md) | MVS version resolution with semver constraints for almide.toml |
 | [Secure by Design](active/secure-by-design.md) | Five-layer security model making web vulnerabilities compile-time errors |
 
@@ -56,10 +58,10 @@
 
 ## Done
 
-231 items
+232 items
 
 <details>
-<summary>Show all 231 completed items</summary>
+<summary>Show all 232 completed items</summary>
 
 | Done | Item | Description |
 |------|------|-------------|

--- a/docs/roadmap/active/ceangal-widget-system.md
+++ b/docs/roadmap/active/ceangal-widget-system.md
@@ -1,0 +1,142 @@
+<!-- description: Ceangal UI framework — widget system, reactive state, GPU rendering pipeline -->
+# Ceangal Widget System
+
+> **Active scope: Phase 1-3** — View type + diff, cell + memo, each + key reconciliation.
+> Scroll/virtual list foundation ✅ complete (24 tests, 1000 items 60fps).
+> **Exit criteria**: Todo app running with cell-based reactivity at 60fps.
+
+Ceangal is the UI framework for Almide. Mission: **"LLM が最も正確に UI を実現できるフレームワーク"**.
+
+## Architecture
+
+```
+Application (.almd)
+  ↓ import
+Ceangal (dubhlux/ceangal) — View, cell, memo, scroll, virtual list
+  ↓ import
+almide-web (almide/almide-web) — DOM, fetch, timer, console
+  ↓ import
+almide-wasm-bindgen (almide/almide-wasm-bindgen) — ABI / type marshalling
+  ↓ compile
+almide (almide/almide) — .almd → .wasm
+  ↓ render
+snaidhm (dubhlux/snaidhm) — GPU tiled path renderer
+```
+
+## Core API (7 concepts)
+
+| API | Role |
+|-----|------|
+| `cell(initial)` | Reactive state (global or local) |
+| `.get()` | Read value (dependency tracking) |
+| `.set(value)` | Write value (triggers update) |
+| `.update(fn)` | Atomic update `(old) -> new` |
+| `memo(fn)` | Derived data (cached if deps unchanged) |
+| `each(items, key, render)` | Key-based list rendering |
+| `on_mount(fn)` | Lifecycle (return value = cleanup) |
+
+## Rendering Model
+
+```
+cell.set(value)
+  → app() re-execution (0.14ms / 100 nodes)
+  → memo/each cache hit for unchanged data
+  → diff old vs new View tree (0.01ms / 100 nodes)
+  → GPU patch (changed nodes only)
+```
+
+v1: Full tree rebuild + diff. v2 (future): Lazy children → O(1) build.
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Widget name | View | SwiftUI proven, LLM 100% accuracy |
+| Styling | record `{}` + pipe `\|>` | 2 patterns only. Tailwind-inspired utility chain |
+| State | cell + memo | Minimal API. No signals/hooks ceremony |
+| State management | Thin core (React/Flutter model) | Patterns in examples, not enforced |
+| Rendering | app() rebuild + diff | 0.14ms/100 nodes, within frame budget |
+| List | each with key-based reconciliation | O(N) scan + O(changed) rebuild |
+| Interaction | ViewState (hovered/pressed/focused) | Separate from cell tracking, GPU paint-only |
+
+## Ecosystem: almide-web
+
+Browser API bindings extracted from Ceangal into `almide/almide-web`:
+
+| Module | APIs |
+|--------|------|
+| dom | Element creation, attributes, styles, string interning |
+| fetch | HTTP GET/POST with async callback |
+| timer | setTimeout, setInterval, requestAnimationFrame |
+| console | log, warn, error |
+
+almide-js archived — replaced by almide-web.
+
+## Phases
+
+### Phase 1: View + Diff ← current
+- [ ] View type + constructors (text, col, row, box)
+- [ ] Pipe utilities (bg, padding, font, gap, grow, etc.)
+- [ ] Recursive diff (benchmarked: 0.09ms / 1000 nodes)
+- [ ] Bench harness
+
+### Phase 2: Cell + Dispatch
+- [ ] cell type (.get / .set / .update)
+- [ ] Dependency tracking (get records current context)
+- [ ] memo (computed cache + reference equality propagation)
+- [ ] Dispatch: cell change → app() rebuild → diff → patch
+
+### Phase 3: each + Key Reconciliation
+- [ ] Key-based item scan
+- [ ] Per-item rebuild (COW reference skip)
+- [ ] Subtree identity (key = local cell lifetime)
+
+### Phase 4: Render Pipeline
+- [ ] View tree → LayoutNode conversion
+- [ ] layout.almd (flexbox, 56 tests)
+- [ ] LayoutRect → GPU commands (snaidhm)
+- [ ] Paint-only vs layout change detection
+
+### Phase 5: Interaction
+- [ ] ViewState (hovered, pressed, focused)
+- [ ] (View) -> Value pipe re-evaluation
+- [ ] Hit test integration (scroll.almd)
+- [ ] on_mount / cleanup lifecycle
+
+### Phase 6: Widgets + Theme
+- [ ] button, checkbox, text input
+- [ ] Design tokens (colors, spacing, radius)
+- [ ] Virtual list integration
+- [ ] Music player demo restoration
+
+## Completed Foundation
+
+| Module | Tests | Status |
+|--------|-------|--------|
+| scroll.almd | 24 | Multi-region, nested bubble, scrollbar, hit test |
+| virtual_list.almd | — | GPU procedural rendering, 1000 items 60fps |
+| layout.almd | 56 | Yoga-aligned Flexbox |
+| dom.almd | — | DOM overlay for text selection |
+| snaidhm | — | Tiled path renderer + SDF text + content-space tiling |
+
+## Benchmark Results
+
+| Metric | Value | Target |
+|--------|-------|--------|
+| diff: 1000 nodes unchanged | 0.087ms | < 2ms ✅ |
+| diff: 1000 nodes 1 paint | 0.108ms | < 2ms ✅ |
+| diff: 5000 nodes unchanged | 0.884ms | — ✅ |
+| build: 100 nodes | 0.13ms | < 3ms ✅ |
+| build: 1000 nodes | 4.9ms | < 16.7ms 🟡 |
+| build: 5000 nodes | 146ms | ❌ (virtual list required) |
+
+## Compiler Requirements
+
+| Requirement | Status |
+|-------------|--------|
+| COW List index assign (WASM) | ✅ 0.17.3 |
+| COW List index assign (Rust) | ✅ 0.17.5 |
+| syntax_guide false positive fix | ✅ 0.17.6 |
+| @export annotation string | ✅ 0.17.6 |
+| COW List → Vec (Rust codegen) | ❌ pending |
+| Record spread `{ ...r, field: val }` | ❌ pending (pipe utility ergonomics) |

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.17.6. almide-dialect crate (SSA, MLIR-like), compile-time value parameters (`fn f[N: Int]()`), bit introspection, Hashable protocol.
+- Current stable: v0.17.7. almide-dialect crate (SSA, MLIR-like), compile-time value parameters (`fn f[N: Int]()`), bit introspection, Hashable protocol.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/spec/lang/syntax_guide_false_positive_test.almd
+++ b/spec/lang/syntax_guide_false_positive_test.almd
@@ -1,0 +1,29 @@
+// Verify that syntax_guide hints don't reject valid identifiers
+// that happen to match other-language keywords.
+
+type View = { kind: Int, value: String }
+
+fn diff(old: View, new: View) -> Int =
+  if old.kind != new.kind then 1 else 0
+
+test "new as param name" {
+  let a = View { kind: 1, value: "a" }
+  let b = View { kind: 2, value: "b" }
+  assert(diff(a, b) == 1)
+  assert(diff(a, a) == 0)
+}
+
+test "new as variable name" {
+  let new = 42
+  assert(new == 42)
+}
+
+test "null as variable name" {
+  let null = "not null"
+  assert(null == "not null")
+}
+
+test "void as variable name" {
+  let void = 0
+  assert(void == 0)
+}


### PR DESCRIPTION
## Summary
- **syntax_guide false-positive**: Identifiers like `new`, `null`, `void` no longer rejected when used as param/variable names. Hints still fire for keyword-like usage (e.g. `new Foo()`)
- **RcCow auto-unwrap**: `render_expr_owned` helper ensures RcCow vars produce owned T at all 13 contexts: function args, record fields, concat, tuples, list literals, Some/Ok, match arms, if/else branches, RuntimeCall/Module call args
- **BorrowInference**: Fixed `check_needs_ownership` missing bare Var in if/else branches and match arm bodies — params were incorrectly borrowed as `&[T]` when returned as owned `Vec<T>`

## Test plan
- [x] 230/230 almide tests pass
- [x] ceangal src/ 2/2 test files pass (74+24 tests)
- [x] 13 RcCow contexts verified in exhaustive test