### PR TITLE
v0.17.8 → main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.17.7"
+version = "0.17.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-codegen/Cargo.toml
+++ b/crates/almide-codegen/Cargo.toml
@@ -15,6 +15,9 @@ wasm-encoder = "0.225"
 toml = "0.8"
 serde_json = "1"
 
+[dev-dependencies]
+wasmparser = "0.225"
+
 [build-dependencies]
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -27,26 +27,26 @@ impl SortKind {
     fn elem_size(&self) -> u32 {
         match self { SortKind::Int | SortKind::Float => 8, _ => 4 }
     }
-    fn emit_load(&self, f: &mut Function) {
+    fn emit_load(&self, f: &mut super::TrackedFunction) {
         match self {
             SortKind::Int => { f.instruction(&Instruction::I64Load(wasm_encoder::MemArg { offset: 0, align: 3, memory_index: 0 })); }
             SortKind::Float => { f.instruction(&Instruction::F64Load(wasm_encoder::MemArg { offset: 0, align: 3, memory_index: 0 })); }
             _ => { f.instruction(&Instruction::I32Load(wasm_encoder::MemArg { offset: 0, align: 2, memory_index: 0 })); }
         }
     }
-    fn emit_store(&self, f: &mut Function) {
+    fn emit_store(&self, f: &mut super::TrackedFunction) {
         match self {
             SortKind::Int => { f.instruction(&Instruction::I64Store(wasm_encoder::MemArg { offset: 0, align: 3, memory_index: 0 })); }
             SortKind::Float => { f.instruction(&Instruction::F64Store(wasm_encoder::MemArg { offset: 0, align: 3, memory_index: 0 })); }
             _ => { f.instruction(&Instruction::I32Store(wasm_encoder::MemArg { offset: 0, align: 2, memory_index: 0 })); }
         }
     }
-    fn emit_copy_one(&self, f: &mut Function) {
+    fn emit_copy_one(&self, f: &mut super::TrackedFunction) {
         self.emit_load(f);
         self.emit_store(f);
     }
     /// Emit `dst[j] <= key` comparison, leaving an i32 boolean on the stack.
-    fn emit_le_cmp(&self, f: &mut Function, emitter: &WasmEmitter) {
+    fn emit_le_cmp(&self, f: &mut super::TrackedFunction, emitter: &WasmEmitter) {
         match self {
             SortKind::Int => { f.instruction(&Instruction::I64LeS); }
             SortKind::Float => { f.instruction(&Instruction::F64Le); }

--- a/crates/almide-codegen/src/emit_wasm/closures.rs
+++ b/crates/almide-codegen/src/emit_wasm/closures.rs
@@ -224,7 +224,7 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
         let scratch_f64_base = local_idx;
         for _ in 0..scratch_f64_cap { local_decls.push((1, ValType::F64)); local_idx += 1; }
 
-        let mut wasm_func = wasm_encoder::Function::new(local_decls);
+        let mut wasm_func = super::TrackedFunction::new(local_decls);
 
         // Load captured vars from env
         for (ci, (vid, ty)) in capture_list.iter().enumerate() {
@@ -282,7 +282,7 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
             compiler.func
         };
 
-        emitter.add_compiled(CompiledFunc::new(type_idx, compiled_func));
+        emitter.add_compiled(CompiledFunc::tracked(type_idx, compiled_func));
     }
 
     // Compile FnRef wrappers

--- a/crates/almide-codegen/src/emit_wasm/closures.rs
+++ b/crates/almide-codegen/src/emit_wasm/closures.rs
@@ -282,7 +282,7 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
             compiler.func
         };
 
-        emitter.add_compiled(CompiledFunc { type_idx, func: compiled_func });
+        emitter.add_compiled(CompiledFunc::new(type_idx, compiled_func));
     }
 
     // Compile FnRef wrappers
@@ -304,7 +304,7 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
                 f.instruction(&wasm_encoder::Instruction::Call(orig_func_idx));
                 f.instruction(&wasm_encoder::Instruction::End);
 
-                emitter.add_compiled(CompiledFunc { type_idx: wrapper_type_idx, func: f });
+                emitter.add_compiled(CompiledFunc::new(wrapper_type_idx, f));
             }
         }
     }

--- a/crates/almide-codegen/src/emit_wasm/closures.rs
+++ b/crates/almide-codegen/src/emit_wasm/closures.rs
@@ -296,7 +296,7 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
                 wrapper_params.extend_from_slice(&orig_params);
                 let wrapper_type_idx = emitter.register_type(wrapper_params, orig_results);
 
-                let mut f = wasm_encoder::Function::new([]);
+                let mut f = super::TrackedFunction::new([]);
                 // Skip env (local 0), pass remaining params to original
                 for i in 0..orig_params.len() {
                     f.instruction(&wasm_encoder::Instruction::LocalGet((i + 1) as u32));
@@ -304,7 +304,7 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
                 f.instruction(&wasm_encoder::Instruction::Call(orig_func_idx));
                 f.instruction(&wasm_encoder::Instruction::End);
 
-                emitter.add_compiled(CompiledFunc::new(wrapper_type_idx, f));
+                emitter.add_compiled(CompiledFunc::tracked(wrapper_type_idx, f));
             }
         }
     }

--- a/crates/almide-codegen/src/emit_wasm/collections.rs
+++ b/crates/almide-codegen/src/emit_wasm/collections.rs
@@ -405,9 +405,7 @@ impl FuncCompiler<'_> {
         };
         let mut fields = self.extract_record_fields(&resolved_ty);
         let tag_offset = self.variant_tag_offset(&resolved_ty);
-        if fields.is_empty() {
-            eprintln!("[MEMBER-DBG] EMPTY fields for field='{}' resolved_ty={:?} obj.ty={:?}", field, resolved_ty, object.ty);
-        }
+        // (debug removed)
 
         // If fields are empty and type is Unknown, try searching record_fields for a type that has this field
         if fields.is_empty() && resolved_ty.is_unresolved() {
@@ -425,7 +423,6 @@ impl FuncCompiler<'_> {
             let total_offset = tag_offset + field_offset;
             self.emit_load_at(&field_ty, total_offset);
         } else {
-            eprintln!("[MEMBER-UNREACHABLE] field='{}' resolved_ty={:?} fields={:?}", field, resolved_ty, fields);
             wasm!(self.func, { unreachable; });
         }
     }

--- a/crates/almide-codegen/src/emit_wasm/dce.rs
+++ b/crates/almide-codegen/src/emit_wasm/dce.rs
@@ -50,14 +50,7 @@ pub fn eliminate_dead_code(emitter: &mut WasmEmitter) -> usize {
     let mut call_graph: Vec<Vec<u32>> = Vec::with_capacity(num_compiled);
 
     for cf in &emitter.compiled {
-        // Prefer explicitly tracked call targets (type-safe, no opcode parsing).
-        // Fall back to bytecode scanning for hand-written runtime functions.
-        let calls = if let Some(ref targets) = cf.call_targets {
-            targets.clone()
-        } else {
-            extract_call_targets(&cf.func)
-        };
-        call_graph.push(calls);
+        call_graph.push(cf.call_targets.clone());
     }
 
     // Step 3: BFS from entry points to find reachable set

--- a/crates/almide-codegen/src/emit_wasm/dce.rs
+++ b/crates/almide-codegen/src/emit_wasm/dce.rs
@@ -233,6 +233,77 @@ fn extract_call_targets(func: &Function) -> Vec<u32> {
                     pos += consumed;
                 }
             }
+            // 0xFC prefix: multi-byte instructions (saturating trunc, bulk memory)
+            0xFC => {
+                if pos < bytes.len() {
+                    let (sub_opcode, consumed) = read_leb128_u32(&bytes[pos..]);
+                    pos += consumed;
+                    match sub_opcode {
+                        // memory.init: segment_idx + memory_idx
+                        0x08 => {
+                            let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                            let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                        }
+                        // data.drop: segment_idx
+                        0x09 => {
+                            let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                        }
+                        // memory.copy: dst_mem + src_mem
+                        0x0A => {
+                            let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                            let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                        }
+                        // memory.fill: memory_idx
+                        0x0B => {
+                            let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                        }
+                        // table.init: elem_idx + table_idx
+                        0x0C => {
+                            let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                            let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                        }
+                        // elem.drop: elem_idx
+                        0x0D => {
+                            let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                        }
+                        // table.copy: dst_table + src_table
+                        0x0E => {
+                            let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                            let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                        }
+                        // table.grow, table.size, table.fill: table_idx
+                        0x0F | 0x10 | 0x11 => {
+                            let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                        }
+                        // 0x00-0x07: saturating truncation (no extra operands)
+                        _ => {}
+                    }
+                }
+            }
+            // 0xFD prefix: SIMD instructions (V128)
+            0xFD => {
+                if pos < bytes.len() {
+                    let (sub_opcode, consumed) = read_leb128_u32(&bytes[pos..]);
+                    pos += consumed;
+                    // v128.load/store variants have memarg (align + offset)
+                    if sub_opcode <= 11 || (sub_opcode >= 84 && sub_opcode <= 91)
+                        || (sub_opcode >= 92 && sub_opcode <= 95)
+                    {
+                        let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                        let (_, c) = read_leb128_u32(&bytes[pos..]); pos += c;
+                    } else if sub_opcode == 12 {
+                        // v128.const: 16 bytes
+                        pos += 16;
+                    } else if sub_opcode == 13 {
+                        // i8x16.shuffle: 16 lane indices
+                        pos += 16;
+                    } else if sub_opcode >= 21 && sub_opcode <= 34 {
+                        // extract/replace lane: 1 byte lane index
+                        pos += 1;
+                    }
+                    // All other SIMD: no extra operands
+                }
+            }
             // All other single-byte instructions (no immediate)
             // 0x00 unreachable, 0x01 nop, 0x05 else, 0x0B end, 0x0F return,
             // 0x1A drop, 0x1B select, 0x45-0xC4 numeric ops, etc.

--- a/crates/almide-codegen/src/emit_wasm/dce.rs
+++ b/crates/almide-codegen/src/emit_wasm/dce.rs
@@ -50,7 +50,13 @@ pub fn eliminate_dead_code(emitter: &mut WasmEmitter) -> usize {
     let mut call_graph: Vec<Vec<u32>> = Vec::with_capacity(num_compiled);
 
     for cf in &emitter.compiled {
-        let calls = extract_call_targets(&cf.func);
+        // Prefer explicitly tracked call targets (type-safe, no opcode parsing).
+        // Fall back to bytecode scanning for hand-written runtime functions.
+        let calls = if let Some(ref targets) = cf.call_targets {
+            targets.clone()
+        } else {
+            extract_call_targets(&cf.func)
+        };
         call_graph.push(calls);
     }
 

--- a/crates/almide-codegen/src/emit_wasm/dce.rs
+++ b/crates/almide-codegen/src/emit_wasm/dce.rs
@@ -651,4 +651,191 @@ mod tests {
         assert_eq!(after_len - before_len, 3,
             "memory.fill encoding changed — update DCE scanner's 0xFC handler");
     }
+
+    // ══════════════════════════════════════════════════════════════════
+    // Cross-validation: TrackedFunction vs wasmparser (reference impl)
+    // ══════════════════════════════════════════════════════════════════
+    //
+    // These tests build a TrackedFunction, then independently parse its
+    // bytecode with `wasmparser` to extract call targets. If the two
+    // disagree, TrackedFunction has a recording bug.
+
+    use super::super::TrackedFunction;
+
+    /// Extract call targets from raw function bytes using wasmparser.
+    /// This is the "ground truth" — wasmparser is battle-tested across
+    /// the entire WASM ecosystem.
+    fn wasmparser_call_targets(tf: &TrackedFunction) -> Vec<u32> {
+        use wasmparser::{Parser, Payload, Operator};
+        // Build a minimal valid WASM module containing just this function
+        let mut module = wasm_encoder::Module::new();
+        // Type section: () -> ()
+        let mut types = wasm_encoder::TypeSection::new();
+        types.ty().function([], []);
+        module.section(&types);
+        // Function section
+        let mut funcs = wasm_encoder::FunctionSection::new();
+        funcs.function(0);
+        module.section(&funcs);
+        // Code section
+        let mut code = wasm_encoder::CodeSection::new();
+        code.function(&tf.inner);
+        module.section(&code);
+        let wasm_bytes = module.finish();
+
+        let mut targets = Vec::new();
+        for payload in Parser::new(0).parse_all(&wasm_bytes) {
+            if let Ok(Payload::CodeSectionEntry(body)) = payload {
+                let ops = body.get_operators_reader().expect("valid body");
+                for op in ops {
+                    match op {
+                        Ok(Operator::Call { function_index }) => targets.push(function_index),
+                        Ok(Operator::ReturnCall { function_index }) => targets.push(function_index),
+                        _ => {}
+                    }
+                }
+            }
+        }
+        targets
+    }
+
+    /// Cross-validate: TrackedFunction recording == wasmparser scan
+    fn assert_tracked_matches_wasmparser(tf: &TrackedFunction) {
+        let tracked = &tf.call_targets;
+        let parsed = wasmparser_call_targets(tf);
+        assert_eq!(tracked, &parsed,
+            "TrackedFunction disagrees with wasmparser!\n  tracked: {:?}\n  wasmparser: {:?}",
+            tracked, parsed);
+    }
+
+    #[test]
+    fn cross_validate_simple() {
+        let mut tf = TrackedFunction::new([]);
+        tf.instruction(&Instruction::Call(5));
+        tf.instruction(&Instruction::Call(10));
+        tf.instruction(&Instruction::End);
+        assert_tracked_matches_wasmparser(&tf);
+    }
+
+    #[test]
+    fn cross_validate_no_calls() {
+        let mut tf = TrackedFunction::new([]);
+        tf.instruction(&Instruction::I32Const(42));
+        tf.instruction(&Instruction::Drop);
+        tf.instruction(&Instruction::End);
+        assert_tracked_matches_wasmparser(&tf);
+    }
+
+    #[test]
+    fn cross_validate_memory_ops() {
+        let mut tf = TrackedFunction::new([]);
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::I32Const(8));
+        tf.instruction(&Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
+        tf.instruction(&Instruction::Call(99));
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::I32Const(4));
+        tf.instruction(&Instruction::MemoryFill(0));
+        tf.instruction(&Instruction::Call(100));
+        tf.instruction(&Instruction::End);
+        assert_tracked_matches_wasmparser(&tf);
+    }
+
+    #[test]
+    fn cross_validate_complex_control_flow() {
+        let mut tf = TrackedFunction::new([(1, wasm_encoder::ValType::I32)]);
+        tf.instruction(&Instruction::Call(1));
+        tf.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+        tf.instruction(&Instruction::Call(2));
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::BrIf(0));
+        tf.instruction(&Instruction::Call(3));
+        tf.instruction(&Instruction::End);
+        tf.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
+        tf.instruction(&Instruction::Call(4));
+        tf.instruction(&Instruction::I32Const(1));
+        tf.instruction(&Instruction::BrIf(0));
+        tf.instruction(&Instruction::End);
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        tf.instruction(&Instruction::Call(5));
+        tf.instruction(&Instruction::Else);
+        tf.instruction(&Instruction::Call(6));
+        tf.instruction(&Instruction::End);
+        tf.instruction(&Instruction::Call(7));
+        tf.instruction(&Instruction::End);
+        assert_tracked_matches_wasmparser(&tf);
+    }
+
+    #[test]
+    fn cross_validate_all_instruction_families() {
+        let mut tf = TrackedFunction::new([(1, wasm_encoder::ValType::I32)]);
+        // Constants
+        tf.instruction(&Instruction::I32Const(0x7FFFFFFF));
+        tf.instruction(&Instruction::Drop);
+        tf.instruction(&Instruction::I64Const(0x7FFFFFFFFFFFFFFF));
+        tf.instruction(&Instruction::Drop);
+        tf.instruction(&Instruction::F64Const(f64::MAX));
+        tf.instruction(&Instruction::Drop);
+        // Local/global
+        tf.instruction(&Instruction::LocalGet(0));
+        tf.instruction(&Instruction::LocalSet(0));
+        tf.instruction(&Instruction::LocalTee(0));
+        tf.instruction(&Instruction::Drop);
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::GlobalSet(0));
+        tf.instruction(&Instruction::GlobalGet(0));
+        tf.instruction(&Instruction::Drop);
+        // Memory
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::I32Load(wasm_encoder::MemArg { offset: 100, align: 2, memory_index: 0 }));
+        tf.instruction(&Instruction::Drop);
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::I64Load(wasm_encoder::MemArg { offset: 0, align: 3, memory_index: 0 }));
+        tf.instruction(&Instruction::Drop);
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::F64Load(wasm_encoder::MemArg { offset: 0, align: 3, memory_index: 0 }));
+        tf.instruction(&Instruction::Drop);
+        // Bulk memory (0xFC)
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::I32Const(16));
+        tf.instruction(&Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::I32Const(16));
+        tf.instruction(&Instruction::MemoryFill(0));
+        // br_table
+        tf.instruction(&Instruction::I32Const(0));
+        tf.instruction(&Instruction::BrTable(std::borrow::Cow::Borrowed(&[0, 0, 0]), 0));
+        // Numeric ops
+        tf.instruction(&Instruction::I32Const(1));
+        tf.instruction(&Instruction::I32Const(2));
+        tf.instruction(&Instruction::I32Add);
+        tf.instruction(&Instruction::Drop);
+        // Call — THE target we must find
+        tf.instruction(&Instruction::Call(42));
+        tf.instruction(&Instruction::Call(999));
+        tf.instruction(&Instruction::End);
+        assert_tracked_matches_wasmparser(&tf);
+    }
+
+    /// Stress test: many calls interleaved with diverse instructions.
+    #[test]
+    fn cross_validate_stress() {
+        let mut tf = TrackedFunction::new([(1, wasm_encoder::ValType::I32)]);
+        for i in 0..50u32 {
+            tf.instruction(&Instruction::I32Const(i as i32));
+            tf.instruction(&Instruction::LocalSet(0));
+            tf.instruction(&Instruction::Call(i));
+            tf.instruction(&Instruction::I32Const(0));
+            tf.instruction(&Instruction::I32Const(0));
+            tf.instruction(&Instruction::I32Const(4));
+            tf.instruction(&Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
+        }
+        tf.instruction(&Instruction::End);
+        assert_tracked_matches_wasmparser(&tf);
+    }
 }

--- a/crates/almide-codegen/src/emit_wasm/dce.rs
+++ b/crates/almide-codegen/src/emit_wasm/dce.rs
@@ -397,3 +397,265 @@ fn block_type_size(bytes: &[u8]) -> usize {
         consumed
     }
 }
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_encoder::Instruction;
+
+    /// Build a Function with given instructions and extract its call targets.
+    fn calls_in(instrs: &[Instruction]) -> Vec<u32> {
+        let mut f = Function::new([]);
+        for i in instrs { f.instruction(i); }
+        f.instruction(&Instruction::End);
+        extract_call_targets(&f)
+    }
+
+    #[test]
+    fn simple_call() {
+        let targets = calls_in(&[Instruction::Call(42)]);
+        assert_eq!(targets, vec![42]);
+    }
+
+    #[test]
+    fn multiple_calls() {
+        let targets = calls_in(&[
+            Instruction::Call(1),
+            Instruction::Call(2),
+            Instruction::Call(3),
+        ]);
+        assert_eq!(targets, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn no_calls() {
+        let targets = calls_in(&[
+            Instruction::I32Const(0),
+            Instruction::Drop,
+        ]);
+        assert!(targets.is_empty());
+    }
+
+    // ── 0xFC prefix: bulk memory ops must not desync the scanner ──
+
+    #[test]
+    fn call_after_memory_copy() {
+        let targets = calls_in(&[
+            Instruction::I32Const(0),
+            Instruction::I32Const(0),
+            Instruction::I32Const(8),
+            Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 },
+            Instruction::Call(99),
+        ]);
+        assert_eq!(targets, vec![99]);
+    }
+
+    #[test]
+    fn call_after_memory_fill() {
+        let targets = calls_in(&[
+            Instruction::I32Const(0),
+            Instruction::I32Const(0),
+            Instruction::I32Const(8),
+            Instruction::MemoryFill(0),
+            Instruction::Call(77),
+        ]);
+        assert_eq!(targets, vec![77]);
+    }
+
+    #[test]
+    fn calls_around_memory_copy() {
+        let targets = calls_in(&[
+            Instruction::Call(10),
+            Instruction::I32Const(0),
+            Instruction::I32Const(0),
+            Instruction::I32Const(4),
+            Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 },
+            Instruction::Call(20),
+            Instruction::I32Const(0),
+            Instruction::I32Const(0),
+            Instruction::I32Const(4),
+            Instruction::MemoryFill(0),
+            Instruction::Call(30),
+        ]);
+        assert_eq!(targets, vec![10, 20, 30]);
+    }
+
+    // ── Regression: multiple memory ops in sequence (init_globals pattern) ──
+
+    #[test]
+    fn many_memory_ops_then_call() {
+        let mut instrs = Vec::new();
+        for _ in 0..10 {
+            instrs.push(Instruction::I32Const(0));
+            instrs.push(Instruction::I32Const(0));
+            instrs.push(Instruction::I32Const(16));
+            instrs.push(Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
+        }
+        instrs.push(Instruction::Call(55));
+        let targets = calls_in(&instrs);
+        assert_eq!(targets, vec![55]);
+    }
+
+    // ── Other multi-byte instructions that must not confuse the scanner ──
+
+    #[test]
+    fn call_after_block_and_loop() {
+        let targets = calls_in(&[
+            Instruction::Block(wasm_encoder::BlockType::Empty),
+            Instruction::Call(1),
+            Instruction::End,
+            Instruction::Loop(wasm_encoder::BlockType::Empty),
+            Instruction::Call(2),
+            Instruction::End,
+        ]);
+        assert_eq!(targets, vec![1, 2]);
+    }
+
+    #[test]
+    fn call_after_br_table() {
+        let targets = calls_in(&[
+            Instruction::I32Const(0),
+            Instruction::BrTable(
+                std::borrow::Cow::Borrowed(&[0, 1]),
+                2,
+            ),
+            Instruction::Call(42),
+        ]);
+        assert_eq!(targets, vec![42]);
+    }
+
+    #[test]
+    fn call_after_i64_const() {
+        let targets = calls_in(&[
+            Instruction::I64Const(0x7FFF_FFFF_FFFF),
+            Instruction::Drop,
+            Instruction::Call(88),
+        ]);
+        assert_eq!(targets, vec![88]);
+    }
+
+    #[test]
+    fn call_after_f64_const() {
+        let targets = calls_in(&[
+            Instruction::F64Const(3.14159),
+            Instruction::Drop,
+            Instruction::Call(66),
+        ]);
+        assert_eq!(targets, vec![66]);
+    }
+
+    #[test]
+    fn call_after_global_set() {
+        let targets = calls_in(&[
+            Instruction::I32Const(0),
+            Instruction::GlobalSet(5),
+            Instruction::Call(33),
+        ]);
+        assert_eq!(targets, vec![33]);
+    }
+
+    #[test]
+    fn call_after_memory_load_store() {
+        let targets = calls_in(&[
+            Instruction::I32Const(0),
+            Instruction::I32Load(wasm_encoder::MemArg { offset: 0, align: 2, memory_index: 0 }),
+            Instruction::I32Const(0),
+            Instruction::I32Store(wasm_encoder::MemArg { offset: 4, align: 2, memory_index: 0 }),
+            Instruction::Call(44),
+        ]);
+        assert_eq!(targets, vec![44]);
+    }
+
+    // ── Exhaustive coverage: every instruction type the emitter uses ──
+
+    /// Verify the scanner stays in sync through a function body that
+    /// exercises every instruction family the WASM emitter produces.
+    /// If a new instruction type is added without updating the scanner,
+    /// the call at the end will be missed and this test will fail.
+    #[test]
+    fn exhaustive_instruction_coverage() {
+        let mut f = Function::new([(1, wasm_encoder::ValType::I32)]);
+        // Numeric constants
+        f.instruction(&Instruction::I32Const(999));
+        f.instruction(&Instruction::I64Const(0x7FFF_FFFF_FFFF));
+        f.instruction(&Instruction::F64Const(3.14));
+        f.instruction(&Instruction::Drop);
+        f.instruction(&Instruction::Drop);
+        // Local/global access
+        f.instruction(&Instruction::LocalGet(0));
+        f.instruction(&Instruction::LocalSet(0));
+        f.instruction(&Instruction::LocalTee(0));
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::GlobalGet(0));
+        f.instruction(&Instruction::GlobalSet(0));
+        // Memory load/store
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::I32Load(wasm_encoder::MemArg { offset: 0, align: 2, memory_index: 0 }));
+        f.instruction(&Instruction::Drop);
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::I32Store(wasm_encoder::MemArg { offset: 4, align: 2, memory_index: 0 }));
+        f.instruction(&Instruction::MemorySize(0));
+        f.instruction(&Instruction::Drop);
+        // 0xFC prefix: bulk memory
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::I32Const(4));
+        f.instruction(&Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::I32Const(4));
+        f.instruction(&Instruction::MemoryFill(0));
+        // Control flow: block, br, br_if, if
+        f.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+        f.instruction(&Instruction::Br(0));
+        f.instruction(&Instruction::End);
+        f.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+        f.instruction(&Instruction::I32Const(1));
+        f.instruction(&Instruction::BrIf(0));
+        f.instruction(&Instruction::End);
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        f.instruction(&Instruction::End);
+        // br_table
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::BrTable(std::borrow::Cow::Borrowed(&[0]), 0));
+        // call_indirect
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::CallIndirect { type_index: 0, table_index: 0 });
+        f.instruction(&Instruction::Drop);
+        // THE call — must be found after all the above
+        f.instruction(&Instruction::Call(777));
+        f.instruction(&Instruction::End);
+        let targets = extract_call_targets(&f);
+        assert!(targets.contains(&777),
+            "scanner lost sync after exhaustive instruction mix: call(777) not found in {:?}", targets);
+    }
+
+    /// Cross-validation: build the same function via instructions AND check
+    /// that the byte-count is exactly what we expect. This catches the case
+    /// where wasm_encoder changes its encoding and the scanner drifts.
+    #[test]
+    fn memory_copy_encoding_size() {
+        let mut f = Function::new([]);
+        let before_len = f.clone().into_raw_body().len();
+        f.instruction(&Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
+        let after_len = f.clone().into_raw_body().len();
+        // memory.copy encodes as: 0xFC 0x0A 0x00 0x00 = 4 bytes
+        assert_eq!(after_len - before_len, 4,
+            "memory.copy encoding changed — update DCE scanner's 0xFC handler");
+    }
+
+    #[test]
+    fn memory_fill_encoding_size() {
+        let mut f = Function::new([]);
+        let before_len = f.clone().into_raw_body().len();
+        f.instruction(&Instruction::MemoryFill(0));
+        let after_len = f.clone().into_raw_body().len();
+        // memory.fill encodes as: 0xFC 0x0B 0x00 = 3 bytes
+        assert_eq!(after_len - before_len, 3,
+            "memory.fill encoding changed — update DCE scanner's 0xFC handler");
+    }
+}

--- a/crates/almide-codegen/src/emit_wasm/equality.rs
+++ b/crates/almide-codegen/src/emit_wasm/equality.rs
@@ -705,7 +705,14 @@ pub(super) fn extract_record_fields(
             fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect()
         }
         Ty::Named(name, type_args) => {
-            if let Some(fields) = record_fields.get(name.as_str()) {
+            // Try full qualified name first (e.g. "todoapp.Todo"), then bare name ("Todo").
+            // Module-qualified types from submodules carry the prefix in the IR, but
+            // record_fields is keyed by the declaration name (unprefixed).
+            let fields_opt = record_fields.get(name.as_str()).or_else(|| {
+                let bare = name.as_str().rsplit('.').next().unwrap_or(name.as_str());
+                if bare != name.as_str() { record_fields.get(bare) } else { None }
+            });
+            if let Some(fields) = fields_opt {
                 if type_args.is_empty() {
                     fields.clone()
                 } else {

--- a/crates/almide-codegen/src/emit_wasm/functions.rs
+++ b/crates/almide-codegen/src/emit_wasm/functions.rs
@@ -66,7 +66,7 @@ pub fn compile_function_with_init(
     let scratch_v128_base = param_count + local_decls.len() as u32;
     for _ in 0..scratch_v128_cap { local_decls.push((1, ValType::V128)); }
 
-    let wasm_func = Function::new(local_decls);
+    let wasm_func = super::TrackedFunction::new(local_decls);
 
     let mut scratch_alloc = super::scratch::ScratchAllocator::new();
     scratch_alloc.set_bases_with_capacity(scratch_i32_base, scratch_i32_cap, scratch_i64_base, scratch_i64_cap, scratch_f64_base, scratch_f64_cap);
@@ -102,5 +102,5 @@ pub fn compile_function_with_init(
 
     wasm!(compiler.func, { end; });
 
-    CompiledFunc::new(type_idx, compiler.func)
+    CompiledFunc::tracked(type_idx, compiler.func)
 }

--- a/crates/almide-codegen/src/emit_wasm/functions.rs
+++ b/crates/almide-codegen/src/emit_wasm/functions.rs
@@ -102,8 +102,5 @@ pub fn compile_function_with_init(
 
     wasm!(compiler.func, { end; });
 
-    CompiledFunc {
-        type_idx,
-        func: compiler.func,
-    }
+    CompiledFunc::new(type_idx, compiler.func)
 }

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -1493,7 +1493,7 @@ fn compile_init_globals(emitter: &mut WasmEmitter, program: &IrProgram) {
 /// Compile a test runner function that calls each test, printing results.
 fn compile_test_runner(emitter: &mut WasmEmitter, tests: &[(u32, String)], init_globals: Option<u32>) {
     let void_type = emitter.register_type(vec![], vec![]);
-    let mut f = Function::new([]);
+    let mut f = TrackedFunction::new([]);
 
     // Initialize globals if needed
     if let Some(init_idx) = init_globals {
@@ -1516,7 +1516,7 @@ fn compile_test_runner(emitter: &mut WasmEmitter, tests: &[(u32, String)], init_
     }
 
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc::new(void_type, f));
+    emitter.add_compiled(CompiledFunc::tracked(void_type, f));
 }
 
 /// Pre-register variant deep-equality functions for all variant types with pointer fields.

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -78,6 +78,16 @@ const NEWLINE_OFFSET: u32 = 48;
 pub struct CompiledFunc {
     pub type_idx: u32,
     pub func: Function,
+    /// Call targets recorded during compilation. When `Some`, DCE uses this
+    /// instead of bytecode scanning — immune to opcode parsing bugs.
+    /// Runtime helpers use `None` (bytecode scan fallback).
+    pub call_targets: Option<Vec<u32>>,
+}
+
+impl CompiledFunc {
+    pub fn new(type_idx: u32, func: Function) -> Self {
+        Self { type_idx, func, call_targets: None }
+    }
 }
 
 /// String stdlib runtime function indices.
@@ -1437,7 +1447,7 @@ fn compile_init_globals(emitter: &mut WasmEmitter, program: &IrProgram) {
         f
     };
 
-    emitter.add_compiled(CompiledFunc { type_idx: void_type, func: compiled_func });
+    emitter.add_compiled(CompiledFunc::new(void_type, compiled_func));
 }
 
 /// Compile a test runner function that calls each test, printing results.
@@ -1466,7 +1476,7 @@ fn compile_test_runner(emitter: &mut WasmEmitter, tests: &[(u32, String)], init_
     }
 
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc { type_idx: void_type, func: f });
+    emitter.add_compiled(CompiledFunc::new(void_type, f));
 }
 
 /// Pre-register variant deep-equality functions for all variant types with pointer fields.
@@ -1589,7 +1599,7 @@ fn compile_variant_eq_funcs(emitter: &mut WasmEmitter, var_table: &almide_ir::Va
             compiler.func
         };
 
-        emitter.add_compiled(CompiledFunc { type_idx, func: compiled_func });
+        emitter.add_compiled(CompiledFunc::new(type_idx, compiled_func));
     }
 }
 

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -115,23 +115,24 @@ impl Clone for TrackedFunction {
 }
 
 /// A compiled WASM function ready for the code section.
+///
+/// All functions MUST be constructed via `CompiledFunc::tracked()` to ensure
+/// DCE has a complete call graph. Direct construction is impossible — the
+/// `call_targets` field is always populated by TrackedFunction.
 pub struct CompiledFunc {
     pub type_idx: u32,
     pub func: Function,
-    /// Call targets recorded during compilation. When `Some`, DCE uses this
-    /// instead of bytecode scanning — immune to opcode parsing bugs.
-    /// Runtime helpers use `None` (bytecode scan fallback).
-    pub call_targets: Option<Vec<u32>>,
+    /// Call targets recorded during compilation. DCE uses this directly —
+    /// no bytecode scanning needed. Guaranteed non-empty by construction
+    /// (TrackedFunction records all `call` instructions automatically).
+    pub call_targets: Vec<u32>,
 }
 
 impl CompiledFunc {
-    /// Runtime helpers: raw Function, no call tracking (falls back to bytecode scan).
-    pub fn new(type_idx: u32, func: Function) -> Self {
-        Self { type_idx, func, call_targets: None }
-    }
-    /// User/module functions via FuncCompiler: extracts tracked call targets.
+    /// Construct from a TrackedFunction. This is the ONLY constructor —
+    /// enforces that call_targets is always populated.
     pub fn tracked(type_idx: u32, tf: TrackedFunction) -> Self {
-        Self { type_idx, func: tf.inner, call_targets: Some(tf.call_targets) }
+        Self { type_idx, func: tf.inner, call_targets: tf.call_targets }
     }
 }
 

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -74,6 +74,46 @@ use almide_lang::types::Ty;
 const SCRATCH_ITOA: u32 = 16;
 const NEWLINE_OFFSET: u32 = 48;
 
+/// Wrapper around `wasm_encoder::Function` that automatically records
+/// `call` targets as instructions are emitted. Used by `FuncCompiler`
+/// so DCE gets a type-safe call graph without bytecode scanning.
+pub struct TrackedFunction {
+    pub inner: Function,
+    pub call_targets: Vec<u32>,
+}
+
+impl TrackedFunction {
+    pub fn new<I>(locals: I) -> Self
+    where
+        I: IntoIterator<Item = (u32, ValType)>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        Self { inner: Function::new(locals), call_targets: Vec::new() }
+    }
+
+    /// Emit an instruction, recording call targets automatically.
+    pub fn instruction(&mut self, i: &wasm_encoder::Instruction) -> &mut Self {
+        match i {
+            wasm_encoder::Instruction::Call(idx) => self.call_targets.push(*idx),
+            wasm_encoder::Instruction::ReturnCall(idx) => self.call_targets.push(*idx),
+            _ => {}
+        }
+        self.inner.instruction(i);
+        self
+    }
+
+    /// Consume into a raw body (delegates to inner Function).
+    pub fn into_raw_body(self) -> Vec<u8> {
+        self.inner.into_raw_body()
+    }
+}
+
+impl Clone for TrackedFunction {
+    fn clone(&self) -> Self {
+        Self { inner: self.inner.clone(), call_targets: self.call_targets.clone() }
+    }
+}
+
 /// A compiled WASM function ready for the code section.
 pub struct CompiledFunc {
     pub type_idx: u32,
@@ -85,8 +125,13 @@ pub struct CompiledFunc {
 }
 
 impl CompiledFunc {
+    /// Runtime helpers: raw Function, no call tracking (falls back to bytecode scan).
     pub fn new(type_idx: u32, func: Function) -> Self {
         Self { type_idx, func, call_targets: None }
+    }
+    /// User/module functions via FuncCompiler: extracts tracked call targets.
+    pub fn tracked(type_idx: u32, tf: TrackedFunction) -> Self {
+        Self { type_idx, func: tf.inner, call_targets: Some(tf.call_targets) }
     }
 }
 
@@ -458,7 +503,7 @@ impl DepthGuard {
 /// Per-function compilation state.
 pub struct FuncCompiler<'a> {
     pub emitter: &'a mut WasmEmitter,
-    pub func: Function,
+    pub func: TrackedFunction,
     pub var_map: HashMap<u32, u32>,
     pub depth: u32,
     pub loop_stack: Vec<LoopLabels>,
@@ -1380,7 +1425,7 @@ fn compile_init_globals(emitter: &mut WasmEmitter, program: &IrProgram) {
     let scratch_v128_base = local_decls.len() as u32;
     for _ in 0..scratch_v128_cap { local_decls.push((1, ValType::V128)); }
 
-    let wasm_func = Function::new(local_decls);
+    let wasm_func = TrackedFunction::new(local_decls);
     let compiled_func = {
         let mut scratch_alloc = scratch::ScratchAllocator::new();
         scratch_alloc.set_bases_with_capacity(scratch_i32_base, scratch_i32_cap, scratch_i64_base, scratch_i64_cap, scratch_f64_base, scratch_f64_cap);
@@ -1447,7 +1492,7 @@ fn compile_init_globals(emitter: &mut WasmEmitter, program: &IrProgram) {
         f
     };
 
-    emitter.add_compiled(CompiledFunc::new(void_type, compiled_func));
+    emitter.add_compiled(CompiledFunc::tracked(void_type, compiled_func));
 }
 
 /// Compile a test runner function that calls each test, printing results.
@@ -1532,7 +1577,7 @@ fn compile_variant_eq_funcs(emitter: &mut WasmEmitter, var_table: &almide_ir::Va
         let scratch_f64_base = scratch_i64_base + scratch_i64_cap as u32;
         for _ in 0..scratch_f64_cap { local_decls.push((1, ValType::F64)); }
 
-        let wasm_func = wasm_encoder::Function::new(local_decls);
+        let wasm_func = TrackedFunction::new(local_decls);
         let mut scratch_alloc = scratch::ScratchAllocator::new();
         scratch_alloc.set_bases_with_capacity(
             scratch_i32_base, scratch_i32_cap,
@@ -1599,7 +1644,7 @@ fn compile_variant_eq_funcs(emitter: &mut WasmEmitter, var_table: &almide_ir::Va
             compiler.func
         };
 
-        emitter.add_compiled(CompiledFunc::new(type_idx, compiled_func));
+        emitter.add_compiled(CompiledFunc::tracked(type_idx, compiled_func));
     }
 }
 

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -834,11 +834,6 @@ pub fn emit(program: &IrProgram) -> Vec<u8> {
     let all_type_decls = program.modules.iter().flat_map(|m| m.type_decls.iter())
         .chain(program.type_decls.iter());
     for td in all_type_decls {
-        if td.name.as_str() == "TextLine" {
-            if let almide_ir::IrTypeDeclKind::Record { fields } = &td.kind {
-                eprintln!("[TYPE-DBG] TextLine fields: {:?}", fields.iter().map(|f| f.name.as_str()).collect::<Vec<_>>());
-            }
-        }
         match &td.kind {
             almide_ir::IrTypeDeclKind::Record { fields } => {
                 let field_list: Vec<(String, almide_lang::types::Ty)> = fields.iter()

--- a/crates/almide-codegen/src/emit_wasm/rt_encoding.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_encoding.rs
@@ -12,7 +12,8 @@
 //!   hex alphabet (upper):      0..9 → '0'+i, 10..15 → 'A'+(i-10)
 
 use super::{CompiledFunc, WasmEmitter};
-use wasm_encoder::{Function, ValType};
+use wasm_encoder::{ValType};
+use super::TrackedFunction as Function;
 
 /// __base64_encode(buf_ptr) -> string_ptr.
 /// `url_safe = true` swaps '+'/'/' for '-'/'_' and omits '=' padding.
@@ -204,7 +205,7 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
         end; // end function
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// Emit code that consumes nothing and pushes the alphabet character for
@@ -412,7 +413,7 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
         end; // end function
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// Emit a base64 character → 0..63 lookup. Pops one i32 (char), pushes one i32
@@ -501,7 +502,7 @@ pub(super) fn compile_hex_encode(emitter: &mut WasmEmitter, upper: bool) {
         local_get(3);
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn emit_hex_nibble_to_char(f: &mut Function, nibble_local: u32, alpha_offset: i32) {
@@ -578,7 +579,7 @@ pub(super) fn compile_hex_decode(emitter: &mut WasmEmitter) {
         local_get(7);
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn emit_hex_char_to_nibble(f: &mut Function) {

--- a/crates/almide-codegen/src/emit_wasm/rt_encoding.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_encoding.rs
@@ -204,7 +204,7 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
         end; // end function
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// Emit code that consumes nothing and pushes the alphabet character for
@@ -412,7 +412,7 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
         end; // end function
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// Emit a base64 character → 0..63 lookup. Pops one i32 (char), pushes one i32
@@ -501,7 +501,7 @@ pub(super) fn compile_hex_encode(emitter: &mut WasmEmitter, upper: bool) {
         local_get(3);
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn emit_hex_nibble_to_char(f: &mut Function, nibble_local: u32, alpha_offset: i32) {
@@ -578,7 +578,7 @@ pub(super) fn compile_hex_decode(emitter: &mut WasmEmitter) {
         local_get(7);
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn emit_hex_char_to_nibble(f: &mut Function) {

--- a/crates/almide-codegen/src/emit_wasm/rt_numeric.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_numeric.rs
@@ -153,7 +153,7 @@ pub(super) fn compile_int_from_hex(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// Emit the err return for int_from_hex: alloc [tag=1][str_ptr] and return.
@@ -339,7 +339,7 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// Emit the err return for float_parse: alloc [tag=1][str_ptr] and return.
@@ -522,7 +522,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __float_pow(base: f64, exp: f64) -> f64
@@ -657,7 +657,7 @@ pub(super) fn compile_float_pow(emitter: &mut WasmEmitter) {
 
     wasm!(f, { end; }); // end function
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __math_sin(x: f64) -> f64
@@ -724,7 +724,7 @@ pub(super) fn compile_math_sin(emitter: &mut WasmEmitter) {
     }
 
     wasm!(f, { local_get(3); end; });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __math_cos(x: f64) -> f64
@@ -791,7 +791,7 @@ pub(super) fn compile_math_cos(emitter: &mut WasmEmitter) {
     }
 
     wasm!(f, { local_get(3); end; });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __math_tan(x: f64) -> f64
@@ -806,7 +806,7 @@ pub(super) fn compile_math_tan(emitter: &mut WasmEmitter) {
         f64_div;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __math_log(x: f64) -> f64
@@ -939,7 +939,7 @@ pub(super) fn compile_math_log(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __math_log10(x: f64) -> f64
@@ -980,7 +980,7 @@ pub(super) fn compile_math_log10(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __math_log2(x: f64) -> f64
@@ -1021,7 +1021,7 @@ pub(super) fn compile_math_log2(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __math_exp(x: f64) -> f64
@@ -1143,5 +1143,5 @@ pub(super) fn compile_math_exp(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/rt_numeric.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_numeric.rs
@@ -3,7 +3,8 @@
 //! Called from `compile_runtime()` in runtime.rs.
 
 use super::{CompiledFunc, WasmEmitter};
-use wasm_encoder::{Function, Instruction, ValType};
+use wasm_encoder::{Instruction, ValType};
+use super::TrackedFunction as Function;
 
 /// __int_from_hex(s: i32) -> i32
 /// Parses a hex string (e.g. "ff", "FF", "0xff") to i64, returns Result[Int, String].
@@ -153,7 +154,7 @@ pub(super) fn compile_int_from_hex(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// Emit the err return for int_from_hex: alloc [tag=1][str_ptr] and return.
@@ -339,7 +340,7 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// Emit the err return for float_parse: alloc [tag=1][str_ptr] and return.
@@ -522,7 +523,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __float_pow(base: f64, exp: f64) -> f64
@@ -657,7 +658,7 @@ pub(super) fn compile_float_pow(emitter: &mut WasmEmitter) {
 
     wasm!(f, { end; }); // end function
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __math_sin(x: f64) -> f64
@@ -724,7 +725,7 @@ pub(super) fn compile_math_sin(emitter: &mut WasmEmitter) {
     }
 
     wasm!(f, { local_get(3); end; });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __math_cos(x: f64) -> f64
@@ -791,7 +792,7 @@ pub(super) fn compile_math_cos(emitter: &mut WasmEmitter) {
     }
 
     wasm!(f, { local_get(3); end; });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __math_tan(x: f64) -> f64
@@ -806,7 +807,7 @@ pub(super) fn compile_math_tan(emitter: &mut WasmEmitter) {
         f64_div;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __math_log(x: f64) -> f64
@@ -939,7 +940,7 @@ pub(super) fn compile_math_log(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __math_log10(x: f64) -> f64
@@ -980,7 +981,7 @@ pub(super) fn compile_math_log10(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __math_log2(x: f64) -> f64
@@ -1021,7 +1022,7 @@ pub(super) fn compile_math_log2(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __math_exp(x: f64) -> f64
@@ -1143,5 +1144,5 @@ pub(super) fn compile_math_exp(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/rt_regex.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_regex.rs
@@ -25,7 +25,8 @@
 //! String layout: [len:i32][bytes:u8...]
 
 use super::{CompiledFunc, WasmEmitter};
-use wasm_encoder::{Function, ValType};
+use wasm_encoder::{ValType};
+use super::TrackedFunction as Function;
 
 /// Regex-related runtime function indices.
 #[derive(Default, Clone)]
@@ -127,7 +128,7 @@ fn compile_skip_class(emitter: &mut WasmEmitter) {
         end; end;
     });
     wasm!(f, { local_get(2); end; });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ─── match_class(pat, pat_pos_at_bracket, byte) -> i32 ───
@@ -197,7 +198,7 @@ fn compile_match_class(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ─── match_atom(pat, text, pat_pos, text_pos) -> i32 ───
@@ -297,7 +298,7 @@ fn compile_match_atom(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ─── atom_len(pat, pat_pos) -> i32 ───
@@ -334,7 +335,7 @@ fn compile_atom_len(emitter: &mut WasmEmitter) {
     // Everything else (literal, dot): 1 byte
     wasm!(f, { i32_const(1); end; });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ─── skip_group(pat, pat_pos) -> i32 ───
@@ -380,7 +381,7 @@ fn compile_skip_group(emitter: &mut WasmEmitter) {
 
     wasm!(f, { local_get(2); end; });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ─── match_anchored(pat, text, pat_pos, text_pos) -> i32 ───
@@ -574,7 +575,7 @@ fn compile_match_anchored(emitter: &mut WasmEmitter) {
     wasm!(f, { end; end; }); // end loop, block
     wasm!(f, { local_get(3); end; }); // success
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ─── match_search(pat, text, start) -> i32 ───
@@ -638,7 +639,7 @@ fn compile_match_search(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ─── captures_inner(pat, text, pat_pos, text_pos, cap_buf, cap_count) -> i32 ───
@@ -781,7 +782,7 @@ fn compile_captures_inner(emitter: &mut WasmEmitter) {
     wasm!(f, { end; end; }); // end loop, block
     wasm!(f, { local_get(3); end; });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ─── captures_search(pat, text, start) -> i32 ───
@@ -879,7 +880,7 @@ fn compile_captures_search(emitter: &mut WasmEmitter) {
 
     wasm!(f, { i32_const(0); end; }); // no match
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// Helper: initialize cap_buf entries to -1

--- a/crates/almide-codegen/src/emit_wasm/rt_regex.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_regex.rs
@@ -127,7 +127,7 @@ fn compile_skip_class(emitter: &mut WasmEmitter) {
         end; end;
     });
     wasm!(f, { local_get(2); end; });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ─── match_class(pat, pat_pos_at_bracket, byte) -> i32 ───
@@ -197,7 +197,7 @@ fn compile_match_class(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ─── match_atom(pat, text, pat_pos, text_pos) -> i32 ───
@@ -297,7 +297,7 @@ fn compile_match_atom(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ─── atom_len(pat, pat_pos) -> i32 ───
@@ -334,7 +334,7 @@ fn compile_atom_len(emitter: &mut WasmEmitter) {
     // Everything else (literal, dot): 1 byte
     wasm!(f, { i32_const(1); end; });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ─── skip_group(pat, pat_pos) -> i32 ───
@@ -380,7 +380,7 @@ fn compile_skip_group(emitter: &mut WasmEmitter) {
 
     wasm!(f, { local_get(2); end; });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ─── match_anchored(pat, text, pat_pos, text_pos) -> i32 ───
@@ -574,7 +574,7 @@ fn compile_match_anchored(emitter: &mut WasmEmitter) {
     wasm!(f, { end; end; }); // end loop, block
     wasm!(f, { local_get(3); end; }); // success
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ─── match_search(pat, text, start) -> i32 ───
@@ -638,7 +638,7 @@ fn compile_match_search(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ─── captures_inner(pat, text, pat_pos, text_pos, cap_buf, cap_count) -> i32 ───
@@ -781,7 +781,7 @@ fn compile_captures_inner(emitter: &mut WasmEmitter) {
     wasm!(f, { end; end; }); // end loop, block
     wasm!(f, { local_get(3); end; });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ─── captures_search(pat, text, start) -> i32 ───
@@ -879,7 +879,7 @@ fn compile_captures_search(emitter: &mut WasmEmitter) {
 
     wasm!(f, { i32_const(0); end; }); // no match
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// Helper: initialize cap_buf entries to -1

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -143,7 +143,7 @@ fn compile_char_count(emitter: &mut WasmEmitter) {
         local_get(3); i64_extend_i32_u;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ── Core ──
@@ -177,7 +177,7 @@ fn compile_eq(emitter: &mut WasmEmitter) {
         end; end;
     });
     wasm!(f, { i32_const(0); end; });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_contains(emitter: &mut WasmEmitter) {
@@ -210,7 +210,7 @@ fn compile_contains(emitter: &mut WasmEmitter) {
         end; end;
         i32_const(0); end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_trim(emitter: &mut WasmEmitter) {
@@ -260,7 +260,7 @@ fn compile_trim(emitter: &mut WasmEmitter) {
         call(emitter.rt.string.slice);
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ── Slice / transform ──
@@ -283,7 +283,7 @@ fn compile_slice(emitter: &mut WasmEmitter) {
         end; end;
         local_get(3); end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_reverse(emitter: &mut WasmEmitter) {
@@ -305,7 +305,7 @@ fn compile_reverse(emitter: &mut WasmEmitter) {
         end; end;
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_repeat(emitter: &mut WasmEmitter) {
@@ -327,7 +327,7 @@ fn compile_repeat(emitter: &mut WasmEmitter) {
         end; end;
         local_get(3); end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_index_of(emitter: &mut WasmEmitter) {
@@ -363,7 +363,7 @@ fn compile_index_of(emitter: &mut WasmEmitter) {
         end; end;
         i64_const(-1); end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_replace(emitter: &mut WasmEmitter) {
@@ -390,7 +390,7 @@ fn compile_replace(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// Recursive split using index_of. Supports multi-char delimiter.
@@ -462,7 +462,7 @@ fn compile_split(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_join(emitter: &mut WasmEmitter) {
@@ -496,7 +496,7 @@ fn compile_join(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_count(emitter: &mut WasmEmitter) {
@@ -526,7 +526,7 @@ fn compile_count(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ── Padding / trimming ──
@@ -545,7 +545,7 @@ fn compile_pad_start(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_pad_end(emitter: &mut WasmEmitter) {
@@ -562,7 +562,7 @@ fn compile_pad_end(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_trim_start(emitter: &mut WasmEmitter) {
@@ -589,7 +589,7 @@ fn compile_trim_start(emitter: &mut WasmEmitter) {
         call(emitter.rt.string.slice);
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_trim_end(emitter: &mut WasmEmitter) {
@@ -614,7 +614,7 @@ fn compile_trim_end(emitter: &mut WasmEmitter) {
         call(emitter.rt.string.slice);
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ── Case transform ──
@@ -656,7 +656,7 @@ fn compile_case_transform(emitter: &mut WasmEmitter, type_idx: u32, lo: i32, hi:
         end; end;
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ── Decompose ──
@@ -686,7 +686,7 @@ fn compile_chars(emitter: &mut WasmEmitter) {
         end; end;
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_lines(emitter: &mut WasmEmitter) {
@@ -707,7 +707,7 @@ fn compile_lines(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_from_bytes(emitter: &mut WasmEmitter) {
@@ -729,7 +729,7 @@ fn compile_from_bytes(emitter: &mut WasmEmitter) {
         end; end;
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 fn compile_to_bytes(emitter: &mut WasmEmitter) {
@@ -751,6 +751,6 @@ fn compile_to_bytes(emitter: &mut WasmEmitter) {
         end; end;
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -3,7 +3,8 @@
 //! All `__str_*` runtime function registration and compilation lives here.
 
 use super::{CompiledFunc, WasmEmitter};
-use wasm_encoder::{Function, ValType};
+use wasm_encoder::{ValType};
+use super::TrackedFunction as Function;
 
 /// Register all string runtime function signatures.
 pub fn register(emitter: &mut WasmEmitter) {
@@ -143,7 +144,7 @@ fn compile_char_count(emitter: &mut WasmEmitter) {
         local_get(3); i64_extend_i32_u;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ── Core ──
@@ -177,7 +178,7 @@ fn compile_eq(emitter: &mut WasmEmitter) {
         end; end;
     });
     wasm!(f, { i32_const(0); end; });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_contains(emitter: &mut WasmEmitter) {
@@ -210,7 +211,7 @@ fn compile_contains(emitter: &mut WasmEmitter) {
         end; end;
         i32_const(0); end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_trim(emitter: &mut WasmEmitter) {
@@ -260,7 +261,7 @@ fn compile_trim(emitter: &mut WasmEmitter) {
         call(emitter.rt.string.slice);
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ── Slice / transform ──
@@ -283,7 +284,7 @@ fn compile_slice(emitter: &mut WasmEmitter) {
         end; end;
         local_get(3); end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_reverse(emitter: &mut WasmEmitter) {
@@ -305,7 +306,7 @@ fn compile_reverse(emitter: &mut WasmEmitter) {
         end; end;
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_repeat(emitter: &mut WasmEmitter) {
@@ -327,7 +328,7 @@ fn compile_repeat(emitter: &mut WasmEmitter) {
         end; end;
         local_get(3); end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_index_of(emitter: &mut WasmEmitter) {
@@ -363,7 +364,7 @@ fn compile_index_of(emitter: &mut WasmEmitter) {
         end; end;
         i64_const(-1); end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_replace(emitter: &mut WasmEmitter) {
@@ -390,7 +391,7 @@ fn compile_replace(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// Recursive split using index_of. Supports multi-char delimiter.
@@ -462,7 +463,7 @@ fn compile_split(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_join(emitter: &mut WasmEmitter) {
@@ -496,7 +497,7 @@ fn compile_join(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_count(emitter: &mut WasmEmitter) {
@@ -526,7 +527,7 @@ fn compile_count(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ── Padding / trimming ──
@@ -545,7 +546,7 @@ fn compile_pad_start(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_pad_end(emitter: &mut WasmEmitter) {
@@ -562,7 +563,7 @@ fn compile_pad_end(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_trim_start(emitter: &mut WasmEmitter) {
@@ -589,7 +590,7 @@ fn compile_trim_start(emitter: &mut WasmEmitter) {
         call(emitter.rt.string.slice);
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_trim_end(emitter: &mut WasmEmitter) {
@@ -614,7 +615,7 @@ fn compile_trim_end(emitter: &mut WasmEmitter) {
         call(emitter.rt.string.slice);
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ── Case transform ──
@@ -656,7 +657,7 @@ fn compile_case_transform(emitter: &mut WasmEmitter, type_idx: u32, lo: i32, hi:
         end; end;
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ── Decompose ──
@@ -686,7 +687,7 @@ fn compile_chars(emitter: &mut WasmEmitter) {
         end; end;
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_lines(emitter: &mut WasmEmitter) {
@@ -707,7 +708,7 @@ fn compile_lines(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_from_bytes(emitter: &mut WasmEmitter) {
@@ -729,7 +730,7 @@ fn compile_from_bytes(emitter: &mut WasmEmitter) {
         end; end;
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_to_bytes(emitter: &mut WasmEmitter) {
@@ -751,6 +752,6 @@ fn compile_to_bytes(emitter: &mut WasmEmitter) {
         end; end;
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 

--- a/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
@@ -30,7 +30,7 @@ pub(super) fn compile_replace_first(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 pub(super) fn compile_last_index_of(emitter: &mut WasmEmitter) {
@@ -64,7 +64,7 @@ pub(super) fn compile_last_index_of(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 pub(super) fn compile_strip_prefix(emitter: &mut WasmEmitter) {
@@ -95,7 +95,7 @@ pub(super) fn compile_strip_prefix(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 pub(super) fn compile_strip_suffix(emitter: &mut WasmEmitter) {
@@ -125,7 +125,7 @@ pub(super) fn compile_strip_suffix(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // ── Predicates ──
@@ -157,7 +157,7 @@ pub(super) fn compile_byte_predicate_range(emitter: &mut WasmEmitter, func_idx: 
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 pub(super) fn compile_is_digit(emitter: &mut WasmEmitter) {
@@ -196,7 +196,7 @@ pub(super) fn compile_is_alpha(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// is_alnum: alpha or digit. Empty string returns false.
@@ -229,7 +229,7 @@ pub(super) fn compile_is_alnum(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// is_whitespace: space(32), tab(9), LF(10), CR(13). Empty string returns false.
@@ -261,7 +261,7 @@ pub(super) fn compile_is_whitespace(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// is_upper: all alpha chars in [A-Z], non-alpha chars allowed, empty=false
@@ -305,7 +305,7 @@ fn compile_case_predicate(emitter: &mut WasmEmitter, func_idx: u32, lo: i32, hi:
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __str_cmp(a: i32, b: i32) -> i32
@@ -354,5 +354,5 @@ pub(super) fn compile_cmp(emitter: &mut WasmEmitter) {
     f.instruction(&LocalGet(1)).instruction(&I32Load(mem0));
     f.instruction(&I32Sub);
     f.instruction(&End);
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
@@ -4,7 +4,8 @@
 //! called from `compile()` in rt_string.rs.
 
 use super::{CompiledFunc, WasmEmitter};
-use wasm_encoder::{Function, ValType};
+use wasm_encoder::{ValType};
+use super::TrackedFunction as Function;
 
 // ── Replace/search variants ──
 
@@ -30,7 +31,7 @@ pub(super) fn compile_replace_first(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 pub(super) fn compile_last_index_of(emitter: &mut WasmEmitter) {
@@ -64,7 +65,7 @@ pub(super) fn compile_last_index_of(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 pub(super) fn compile_strip_prefix(emitter: &mut WasmEmitter) {
@@ -95,7 +96,7 @@ pub(super) fn compile_strip_prefix(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 pub(super) fn compile_strip_suffix(emitter: &mut WasmEmitter) {
@@ -125,7 +126,7 @@ pub(super) fn compile_strip_suffix(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // ── Predicates ──
@@ -157,7 +158,7 @@ pub(super) fn compile_byte_predicate_range(emitter: &mut WasmEmitter, func_idx: 
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 pub(super) fn compile_is_digit(emitter: &mut WasmEmitter) {
@@ -196,7 +197,7 @@ pub(super) fn compile_is_alpha(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// is_alnum: alpha or digit. Empty string returns false.
@@ -229,7 +230,7 @@ pub(super) fn compile_is_alnum(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// is_whitespace: space(32), tab(9), LF(10), CR(13). Empty string returns false.
@@ -261,7 +262,7 @@ pub(super) fn compile_is_whitespace(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// is_upper: all alpha chars in [A-Z], non-alpha chars allowed, empty=false
@@ -305,7 +306,7 @@ fn compile_case_predicate(emitter: &mut WasmEmitter, func_idx: u32, lo: i32, hi:
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __str_cmp(a: i32, b: i32) -> i32
@@ -354,5 +355,5 @@ pub(super) fn compile_cmp(emitter: &mut WasmEmitter) {
     f.instruction(&LocalGet(1)).instruction(&I32Load(mem0));
     f.instruction(&I32Sub);
     f.instruction(&End);
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/rt_value.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_value.rs
@@ -7,7 +7,8 @@
 //!   Minimal recursive descent JSON parser.
 
 use super::{CompiledFunc, WasmEmitter};
-use wasm_encoder::{Function, ValType};
+use wasm_encoder::{ValType};
+use super::TrackedFunction as Function;
 
 /// Register runtime function signatures.
 pub(super) fn register(emitter: &mut WasmEmitter) {
@@ -86,7 +87,7 @@ fn compile_json_escape_string(emitter: &mut WasmEmitter) {
     wasm!(f, { local_get(1); i32_const(cr_char as i32); i32_const(esc_cr as i32); call(replace); local_set(1); });
     wasm!(f, { local_get(1); end; });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __value_stringify(v: i32) -> i32
@@ -238,7 +239,7 @@ fn compile_value_stringify(emitter: &mut WasmEmitter) {
     // Fallback
     wasm!(f, { i32_const(null_str as i32); end; });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __json_parse(s: i32) -> i32 (Result[Value, String])
@@ -268,7 +269,7 @@ fn compile_json_parse(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 
     compile_json_parse_at(emitter);
 }
@@ -425,7 +426,7 @@ fn compile_json_parse_at(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// Parse optional JSON exponent (e/E followed by optional +/- and digits).
@@ -1179,7 +1180,7 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __json_set_path(value: i32, path: i32, new_val: i32) -> i32 (Result[Value, String])
@@ -1483,7 +1484,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __json_remove_path(value: i32, path: i32) -> i32 (Value)
@@ -1791,5 +1792,5 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/rt_value.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_value.rs
@@ -86,7 +86,7 @@ fn compile_json_escape_string(emitter: &mut WasmEmitter) {
     wasm!(f, { local_get(1); i32_const(cr_char as i32); i32_const(esc_cr as i32); call(replace); local_set(1); });
     wasm!(f, { local_get(1); end; });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __value_stringify(v: i32) -> i32
@@ -238,7 +238,7 @@ fn compile_value_stringify(emitter: &mut WasmEmitter) {
     // Fallback
     wasm!(f, { i32_const(null_str as i32); end; });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __json_parse(s: i32) -> i32 (Result[Value, String])
@@ -268,7 +268,7 @@ fn compile_json_parse(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 
     compile_json_parse_at(emitter);
 }
@@ -425,7 +425,7 @@ fn compile_json_parse_at(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// Parse optional JSON exponent (e/E followed by optional +/- and digits).
@@ -1179,7 +1179,7 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __json_set_path(value: i32, path: i32, new_val: i32) -> i32 (Result[Value, String])
@@ -1483,7 +1483,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __json_remove_path(value: i32, path: i32) -> i32 (Value)
@@ -1791,5 +1791,5 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -4,7 +4,8 @@
 //! Only fd_write is imported from WASI.
 
 use super::{CompiledFunc, WasmEmitter, SCRATCH_ITOA, NEWLINE_OFFSET};
-use wasm_encoder::{Function, ValType};
+use wasm_encoder::{ValType};
+use super::TrackedFunction as Function;
 
 /// Register WASI host imports only. Must be called before any register_func.
 /// After this, callers may register additional imports (e.g. @extern(wasm))
@@ -388,7 +389,7 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // __rc_inc(ptr: i32) -> i32
@@ -409,7 +410,7 @@ fn compile_rc_inc(emitter: &mut WasmEmitter) {
         local_get(0);
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // __cow_check(ptr: i32, size: i32) -> i32
@@ -446,7 +447,7 @@ fn compile_cow_check(emitter: &mut WasmEmitter) {
         local_get(2);
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // __heap_save() -> i32
@@ -458,7 +459,7 @@ fn compile_heap_save(emitter: &mut WasmEmitter) {
     let mut f = Function::new([]);
     f.instruction(&wasm_encoder::Instruction::GlobalGet(emitter.heap_ptr_global));
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 // __heap_restore(ptr: i32) -> ()
@@ -471,7 +472,7 @@ fn compile_heap_restore(emitter: &mut WasmEmitter) {
     f.instruction(&wasm_encoder::Instruction::LocalGet(0));
     f.instruction(&wasm_encoder::Instruction::GlobalSet(emitter.heap_ptr_global));
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __println_str(ptr: i32)
@@ -523,7 +524,7 @@ fn compile_println_str(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __int_to_string(n: i64) -> i32
@@ -702,7 +703,7 @@ fn compile_int_to_string(emitter: &mut WasmEmitter) {
     // return $result
     wasm!(f, { local_get(6); end; });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __float_to_string(f: f64) -> i32
@@ -797,7 +798,7 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __println_int(n: i64)
@@ -813,7 +814,7 @@ fn compile_println_int(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __concat_str(left: i32, right: i32) -> i32
@@ -888,7 +889,7 @@ fn compile_concat_str(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { local_get(5); end; });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// Emit a byte-by-byte copy loop: dst[dst_off+i] = src[src_off+i], 0..len
@@ -1001,7 +1002,7 @@ fn compile_init_preopen_dirs(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __resolve_path(path_ptr: i32, path_len: i32) → i32 (result_ptr)
@@ -1146,7 +1147,7 @@ fn compile_resolve_path(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 
@@ -1215,5 +1216,5 @@ pub(super) fn compile_bytes_f16_to_f64(emitter: &mut WasmEmitter) {
         end;
         end;  // close function body
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -388,7 +388,7 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // __rc_inc(ptr: i32) -> i32
@@ -409,7 +409,7 @@ fn compile_rc_inc(emitter: &mut WasmEmitter) {
         local_get(0);
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // __cow_check(ptr: i32, size: i32) -> i32
@@ -446,7 +446,7 @@ fn compile_cow_check(emitter: &mut WasmEmitter) {
         local_get(2);
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // __heap_save() -> i32
@@ -458,7 +458,7 @@ fn compile_heap_save(emitter: &mut WasmEmitter) {
     let mut f = Function::new([]);
     f.instruction(&wasm_encoder::Instruction::GlobalGet(emitter.heap_ptr_global));
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 // __heap_restore(ptr: i32) -> ()
@@ -471,7 +471,7 @@ fn compile_heap_restore(emitter: &mut WasmEmitter) {
     f.instruction(&wasm_encoder::Instruction::LocalGet(0));
     f.instruction(&wasm_encoder::Instruction::GlobalSet(emitter.heap_ptr_global));
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __println_str(ptr: i32)
@@ -523,7 +523,7 @@ fn compile_println_str(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __int_to_string(n: i64) -> i32
@@ -702,7 +702,7 @@ fn compile_int_to_string(emitter: &mut WasmEmitter) {
     // return $result
     wasm!(f, { local_get(6); end; });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __float_to_string(f: f64) -> i32
@@ -797,7 +797,7 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __println_int(n: i64)
@@ -813,7 +813,7 @@ fn compile_println_int(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __concat_str(left: i32, right: i32) -> i32
@@ -888,7 +888,7 @@ fn compile_concat_str(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { local_get(5); end; });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// Emit a byte-by-byte copy loop: dst[dst_off+i] = src[src_off+i], 0..len
@@ -1001,7 +1001,7 @@ fn compile_init_preopen_dirs(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __resolve_path(path_ptr: i32, path_len: i32) → i32 (result_ptr)
@@ -1146,7 +1146,7 @@ fn compile_resolve_path(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 
@@ -1215,5 +1215,5 @@ pub(super) fn compile_bytes_f16_to_f64(emitter: &mut WasmEmitter) {
         end;
         end;  // close function body
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
@@ -4,7 +4,8 @@
 //! called from `compile_runtime()` in runtime.rs.
 
 use super::{CompiledFunc, WasmEmitter};
-use wasm_encoder::{Function, ValType};
+use wasm_encoder::{ValType};
+use super::TrackedFunction as Function;
 
 pub(super) fn compile_option_eq_i64(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.option_eq_i64];
@@ -44,7 +45,7 @@ pub(super) fn compile_option_eq_i64(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __option_eq_str(a: i32, b: i32) -> i32
@@ -82,7 +83,7 @@ pub(super) fn compile_option_eq_str(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __result_eq_i64_str(a: i32, b: i32) -> i32
@@ -127,7 +128,7 @@ pub(super) fn compile_result_eq_i64_str(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __str_contains(haystack: i32, needle: i32) -> i32 (bool)
@@ -184,7 +185,7 @@ pub(super) fn compile_mem_eq(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { i32_const(0); end; });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __list_eq(a: i32, b: i32, elem_size: i32) -> i32
@@ -271,7 +272,7 @@ pub(super) fn compile_list_eq(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { i32_const(0); end; });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __list_list_str_cmp(a: i32, b: i32) -> i32
@@ -312,7 +313,7 @@ pub(super) fn compile_list_list_str_cmp(emitter: &mut WasmEmitter) {
         local_get(2); local_get(3); i32_sub;
         end;
     });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __concat_list(a: i32, b: i32, elem_size: i32) -> i32
@@ -397,7 +398,7 @@ pub(super) fn compile_concat_list(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { local_get(6); end; });
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// __int_parse(s: i32) -> i32 (Result[Int, String])
@@ -582,5 +583,5 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::new(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
@@ -44,7 +44,7 @@ pub(super) fn compile_option_eq_i64(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __option_eq_str(a: i32, b: i32) -> i32
@@ -82,7 +82,7 @@ pub(super) fn compile_option_eq_str(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __result_eq_i64_str(a: i32, b: i32) -> i32
@@ -127,7 +127,7 @@ pub(super) fn compile_result_eq_i64_str(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __str_contains(haystack: i32, needle: i32) -> i32 (bool)
@@ -184,7 +184,7 @@ pub(super) fn compile_mem_eq(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { i32_const(0); end; });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __list_eq(a: i32, b: i32, elem_size: i32) -> i32
@@ -271,7 +271,7 @@ pub(super) fn compile_list_eq(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { i32_const(0); end; });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __list_list_str_cmp(a: i32, b: i32) -> i32
@@ -312,7 +312,7 @@ pub(super) fn compile_list_list_str_cmp(emitter: &mut WasmEmitter) {
         local_get(2); local_get(3); i32_sub;
         end;
     });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __concat_list(a: i32, b: i32, elem_size: i32) -> i32
@@ -397,7 +397,7 @@ pub(super) fn compile_concat_list(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { local_get(6); end; });
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }
 
 /// __int_parse(s: i32) -> i32 (Result[Int, String])
@@ -582,5 +582,5 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc { type_idx, func: f });
+    emitter.add_compiled(CompiledFunc::new(type_idx, f));
 }

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -288,65 +288,7 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         }
 
         // ── Pre-resolved runtime call (from @intrinsic / NormalizeRuntimeCalls) ──
-        IrExprKind::RuntimeCall { symbol, args } => {
-            // Inline numeric casts: a runtime function call that has a
-            // direct Rust equivalent (`x as f64` / `x as i64`). Emitted
-            // here so the cost is paid as a single language-level cast
-            // instead of a runtime helper call.
-            match symbol.as_str() {
-                "almide_rt_float_from_int" | "almide_rt_int_to_float" if args.len() == 1 => {
-                    return format!("({} as f64)", render_expr(ctx, &args[0]));
-                }
-                "almide_rt_float_to_int" if args.len() == 1 => {
-                    return format!("({} as i64)", render_expr(ctx, &args[0]));
-                }
-                _ => {}
-            }
-            // Mutating stdlib calls (push, pop, clear) on module-level or RcCow var:
-            // dispatch by VarStorage for COW-correct mutation.
-            if !args.is_empty() {
-                let is_mutating = matches!(symbol.as_str(),
-                    "almide_rt_list_push" | "almide_rt_list_pop" | "almide_rt_list_clear");
-                if is_mutating {
-                    if let IrExprKind::Borrow { expr: inner, .. } | IrExprKind::Clone { expr: inner } = &args[0].kind {
-                        if let IrExprKind::Var { id } = &inner.kind {
-                            let name = ctx.var_name(*id).to_string();
-                            let upper = name.to_uppercase();
-                            match ctx.ann.get_var_storage(id, &name) {
-                                VarStorage::ModuleRc => {
-                                    let rest_args = args[1..].iter().map(|a| render_expr(ctx, a))
-                                        .collect::<Vec<_>>().join(", ");
-                                    let rc_mut = "std::rc::Rc::make_mut(&mut *c.borrow_mut())";
-                                    let call_args = if rest_args.is_empty() {
-                                        rc_mut.to_string()
-                                    } else {
-                                        format!("{}, {}", rc_mut, rest_args)
-                                    };
-                                    return format!("{}.with(|c| {}({}))", upper, symbol.as_str(), call_args);
-                                }
-                                VarStorage::RcCow => {
-                                    let rest_args = args[1..].iter().map(|a| render_expr(ctx, a))
-                                        .collect::<Vec<_>>().join(", ");
-                                    let call_args = if rest_args.is_empty() {
-                                        format!("{}.make_mut()", name)
-                                    } else {
-                                        format!("{}.make_mut(), {}", name, rest_args)
-                                    };
-                                    return format!("{}({})", symbol.as_str(), call_args);
-                                }
-                                _ => {}
-                            }
-                        }
-                    }
-                }
-            }
-            // BorrowInsertion wraps args with Borrow / Clone IR nodes
-            // based on the `@intrinsic` fn's derived signature
-            // (`intrinsic_borrow_mode`). Unwrap bare RcCow vars to owned T.
-            let args_str = args.iter().map(|a| render_expr_owned(ctx, a))
-                .collect::<Vec<_>>().join(", ");
-            format!("{}({})", symbol.as_str(), args_str)
-        }
+        IrExprKind::RuntimeCall { symbol, args } => render_runtime_call(ctx, symbol, args),
 
         // ── Calls ──
         IrExprKind::Call { target, args, .. } | IrExprKind::TailCall { target, args } => {
@@ -519,53 +461,7 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         }
 
         // ── String interpolation ──
-        IrExprKind::StringInterp { parts } => {
-            // Collect format string and args separately
-            let mut fmt_parts = Vec::new();
-            let mut arg_parts = Vec::new();
-            for part in parts {
-                match part {
-                    IrStringPart::Lit { value } => {
-                        // Escape special chars for format!-style templates.
-                        // Include control chars so they don't land as real
-                        // source newlines in the format string — otherwise
-                        // rustfmt continuation indent leaks into runtime
-                        // output. Bug seen with "foo\n" + "${var}" chains.
-                        fmt_parts.push(value
-                            .replace('\\', "\\\\")
-                            .replace('"', "\\\"")
-                            .replace('\n', "\\n")
-                            .replace('\t', "\\t")
-                            .replace('\r', "\\r")
-                            .replace('{', "{{")
-                            .replace('}', "}}"));
-                    }
-                    IrStringPart::Expr { expr } => {
-                        fmt_parts.push("{}".to_string());
-                        arg_parts.push(render_expr(ctx, expr));
-                    }
-                }
-            }
-            let format_str_s = fmt_parts.join("");
-            let args_s = arg_parts.join(", ");
-            let template_str_s = {
-                // For TS-style template literals: `${expr}`
-                let mut s = String::new();
-                for part in parts {
-                    match part {
-                        IrStringPart::Lit { value } => s.push_str(value),
-                        IrStringPart::Expr { expr } => {
-                            s.push_str("${");
-                            s.push_str(&render_expr(ctx, expr));
-                            s.push('}');
-                        }
-                    }
-                }
-                s
-            };
-            ctx.templates.render_with("string_interp", None, &[], &[("format_str", format_str_s.as_str()), ("args", args_s.as_str()), ("template_str", template_str_s.as_str())])
-                .unwrap_or_else(|| format!("\"...\""))
-        }
+        IrExprKind::StringInterp { parts } => render_string_interp(ctx, parts),
 
         // ── Range ──
         IrExprKind::Range { start, end, inclusive } => {
@@ -834,42 +730,7 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         }
 
         // ── Fan (concurrency) — fully template-driven ──
-        IrExprKind::Fan { exprs } => {
-            let rendered: Vec<String> = exprs.iter().map(|e| {
-                let mut body = render_expr(ctx, e);
-                // Strip trailing ? from body (fan closures return raw Result)
-                if e.ty.is_result() && body.ends_with('?') {
-                    body.pop();
-                }
-                body
-            }).collect();
-            let exprs_s = rendered.join(", ");
-            let count_s = format!("{}", exprs.len());
-            // Build spawn/join parts for thread-based template
-            let handles: Vec<String> = (0..exprs.len()).map(|i| format!("__fan_h{}", i)).collect();
-            let spawns: Vec<String> = rendered.iter().enumerate()
-                .map(|(i, body)| format!("let {} = __s.spawn(move || {{ {} }});", handles[i], body))
-                .collect();
-            let any_result = exprs.iter().any(|e| e.ty.is_result());
-            let joins: Vec<String> = exprs.iter().enumerate().map(|(i, e)| {
-                if e.ty.is_result() {
-                    if ctx.auto_unwrap {
-                        format!("{}.join().unwrap()?", handles[i])
-                    } else {
-                        format!("{}.join().unwrap().unwrap()", handles[i])
-                    }
-                } else {
-                    format!("{}.join().unwrap()", handles[i])
-                }
-            }).collect();
-            let join_expr = if joins.len() == 1 { joins[0].clone() }
-                else { format!("({})", joins.join(", ")) };
-            let spawns_s = spawns.join(" ");
-            // Select template variant
-            let construct = if any_result && ctx.auto_unwrap { "fan_effect" } else { "fan_expr" };
-            ctx.templates.render_with(construct, None, &[], &[("exprs", exprs_s.as_str()), ("count", count_s.as_str()), ("spawns", spawns_s.as_str()), ("join_expr", join_expr.as_str())])
-                .unwrap_or_else(|| format!("fan({})", rendered.join(", ")))
-        }
+        IrExprKind::Fan { exprs } => render_fan(ctx, exprs),
 
         // ── Iterator chain (Rust-only) ──
         IrExprKind::IterChain { source, consume, steps, collector } => {
@@ -1229,4 +1090,128 @@ fn coerce_to_owned_string(rendered: &str, expr: &IrExpr) -> String {
     } else {
         rendered.to_string()
     }
+}
+
+// ── Extracted sub-functions (reduce render_expr complexity) ──
+
+fn render_runtime_call(ctx: &RenderContext, symbol: &almide_base::intern::Sym, args: &[IrExpr]) -> String {
+    // Inline numeric casts
+    match symbol.as_str() {
+        "almide_rt_float_from_int" | "almide_rt_int_to_float" if args.len() == 1 => {
+            return format!("({} as f64)", render_expr(ctx, &args[0]));
+        }
+        "almide_rt_float_to_int" if args.len() == 1 => {
+            return format!("({} as i64)", render_expr(ctx, &args[0]));
+        }
+        _ => {}
+    }
+    // Mutating stdlib calls (push, pop, clear) on module-level or RcCow var
+    if !args.is_empty() {
+        let is_mutating = matches!(symbol.as_str(),
+            "almide_rt_list_push" | "almide_rt_list_pop" | "almide_rt_list_clear");
+        if is_mutating {
+            if let IrExprKind::Borrow { expr: inner, .. } | IrExprKind::Clone { expr: inner } = &args[0].kind {
+                if let IrExprKind::Var { id } = &inner.kind {
+                    let name = ctx.var_name(*id).to_string();
+                    let upper = name.to_uppercase();
+                    match ctx.ann.get_var_storage(id, &name) {
+                        VarStorage::ModuleRc => {
+                            let rest_args = args[1..].iter().map(|a| render_expr(ctx, a))
+                                .collect::<Vec<_>>().join(", ");
+                            let rc_mut = "std::rc::Rc::make_mut(&mut *c.borrow_mut())";
+                            let call_args = if rest_args.is_empty() {
+                                rc_mut.to_string()
+                            } else {
+                                format!("{}, {}", rc_mut, rest_args)
+                            };
+                            return format!("{}.with(|c| {}({}))", upper, symbol.as_str(), call_args);
+                        }
+                        VarStorage::RcCow => {
+                            let rest_args = args[1..].iter().map(|a| render_expr(ctx, a))
+                                .collect::<Vec<_>>().join(", ");
+                            let call_args = if rest_args.is_empty() {
+                                format!("{}.make_mut()", name)
+                            } else {
+                                format!("{}.make_mut(), {}", name, rest_args)
+                            };
+                            return format!("{}({})", symbol.as_str(), call_args);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    // Default: render all args as owned
+    let args_str = args.iter().map(|a| render_expr_owned(ctx, a))
+        .collect::<Vec<_>>().join(", ");
+    format!("{}({})", symbol.as_str(), args_str)
+}
+
+fn render_string_interp(ctx: &RenderContext, parts: &[IrStringPart]) -> String {
+    let mut fmt_parts = Vec::new();
+    let mut arg_parts = Vec::new();
+    for part in parts {
+        match part {
+            IrStringPart::Lit { value } => {
+                fmt_parts.push(value
+                    .replace('\\', "\\\\")
+                    .replace('"', "\\\"")
+                    .replace('\n', "\\n")
+                    .replace('\t', "\\t")
+                    .replace('\r', "\\r")
+                    .replace('{', "{{")
+                    .replace('}', "}}"));
+            }
+            IrStringPart::Expr { expr } => {
+                fmt_parts.push("{}".to_string());
+                arg_parts.push(render_expr(ctx, expr));
+            }
+        }
+    }
+    let format_str_s = fmt_parts.join("");
+    let args_s = arg_parts.join(", ");
+    let template_str_s = {
+        let mut s = String::new();
+        for part in parts {
+            match part {
+                IrStringPart::Lit { value } => s.push_str(value),
+                IrStringPart::Expr { expr } => {
+                    s.push_str("${");
+                    s.push_str(&render_expr(ctx, expr));
+                    s.push('}');
+                }
+            }
+        }
+        s
+    };
+    ctx.templates.render_with("string_interp", None, &[], &[("format_str", format_str_s.as_str()), ("args", args_s.as_str()), ("template_str", template_str_s.as_str())])
+        .unwrap_or_else(|| "\"...\"".into())
+}
+
+fn render_fan(ctx: &RenderContext, exprs: &[IrExpr]) -> String {
+    let rendered: Vec<String> = exprs.iter().map(|e| {
+        let mut body = render_expr(ctx, e);
+        if e.ty.is_result() && body.ends_with('?') { body.pop(); }
+        body
+    }).collect();
+    let exprs_s = rendered.join(", ");
+    let count_s = format!("{}", exprs.len());
+    let handles: Vec<String> = (0..exprs.len()).map(|i| format!("__fan_h{}", i)).collect();
+    let spawns: Vec<String> = rendered.iter().enumerate()
+        .map(|(i, body)| format!("let {} = __s.spawn(move || {{ {} }});", handles[i], body))
+        .collect();
+    let any_result = exprs.iter().any(|e| e.ty.is_result());
+    let joins: Vec<String> = exprs.iter().enumerate().map(|(i, e)| {
+        if e.ty.is_result() {
+            if ctx.auto_unwrap { format!("{}.join().unwrap()?", handles[i]) }
+            else { format!("{}.join().unwrap().unwrap()", handles[i]) }
+        } else { format!("{}.join().unwrap()", handles[i]) }
+    }).collect();
+    let join_expr = if joins.len() == 1 { joins[0].clone() }
+        else { format!("({})", joins.join(", ")) };
+    let spawns_s = spawns.join(" ");
+    let construct = if any_result && ctx.auto_unwrap { "fan_effect" } else { "fan_expr" };
+    ctx.templates.render_with(construct, None, &[], &[("exprs", exprs_s.as_str()), ("count", count_s.as_str()), ("spawns", spawns_s.as_str()), ("join_expr", join_expr.as_str())])
+        .unwrap_or_else(|| format!("fan({})", rendered.join(", ")))
 }

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -15,6 +15,39 @@ fn render_stmts(ctx: &RenderContext, stmts: &[IrStmt]) -> Vec<String> {
     stmts.iter().map(|s| render_stmt(ctx, s)).collect()
 }
 
+/// Mangle a type into the monomorphization suffix form (mirrors mono/utils.rs).
+fn mangle_ty_for_mono(ty: &Ty) -> String {
+    match ty {
+        Ty::Int => "Int".into(),
+        Ty::Float => "Float".into(),
+        Ty::String => "String".into(),
+        Ty::Bool => "Bool".into(),
+        Ty::Int8 => "Int8".into(),
+        Ty::Int16 => "Int16".into(),
+        Ty::Int32 => "Int32".into(),
+        Ty::UInt8 => "UInt8".into(),
+        Ty::UInt16 => "UInt16".into(),
+        Ty::UInt32 => "UInt32".into(),
+        Ty::UInt64 => "UInt64".into(),
+        Ty::Float32 => "Float32".into(),
+        Ty::Bytes => "Bytes".into(),
+        Ty::Unit => "Unit".into(),
+        Ty::Named(name, args) => {
+            if args.is_empty() { name.to_string() }
+            else { format!("{}_{}", name, args.iter().map(mangle_ty_for_mono).collect::<Vec<_>>().join("_")) }
+        }
+        Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 =>
+            format!("List_{}", mangle_ty_for_mono(&args[0])),
+        Ty::Applied(id, args) => {
+            let name = format!("{:?}", id);
+            if args.is_empty() { name } else {
+                format!("{}_{}", name, args.iter().map(mangle_ty_for_mono).collect::<Vec<_>>().join("_"))
+            }
+        }
+        _ => "Unknown".into(),
+    }
+}
+
 /// Render an expression ensuring an owned value (not RcCow wrapper).
 /// For RcCow vars, produces `(*var).clone()` to yield the unwrapped T.
 /// Used at sites that need owned T: function args, record fields, concat operands.
@@ -1056,6 +1089,27 @@ fn render_generic_call(ctx: &RenderContext, target: &CallTarget, args: &[IrExpr]
 /// Render a method call as a full expression for UFCS and module.func patterns.
 /// Returns Some(full_expr) if the method call was handled, None for normal obj.method calls.
 fn render_method_call_full(ctx: &RenderContext, object: &IrExpr, method: &str, args: &[IrExpr]) -> Option<String> {
+    // User-defined types (Ty::Named): always UFCS — they have no Rust methods.
+    // Derive monomorphized name from type args when present.
+    if let Ty::Named(type_name, type_args) = &object.ty {
+        if !method.contains('.') {
+            let obj_str = render_expr_owned(ctx, object);
+            let mut all_args = vec![obj_str];
+            all_args.extend(args.iter().map(|a| render_expr_owned(ctx, a)));
+            let func_name = if type_args.is_empty() {
+                method.to_string()
+            } else {
+                // Monomorphized name: method__TypeArg1_TypeArg2
+                let suffix = type_args.iter()
+                    .map(|t| mangle_ty_for_mono(t))
+                    .collect::<Vec<_>>().join("_");
+                let mono_name = format!("{}__{}", method, suffix);
+                mono_name
+            };
+            return Some(format!("{}({})", func_name, all_args.join(", ")));
+        }
+    }
+
     let is_rust_intrinsic = matches!(method,
         "clone" | "is_some" | "is_none" | "unwrap" | "unwrap_or"
         | "to_string" | "len" | "push" | "pop" | "insert" | "remove"

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -1088,10 +1088,26 @@ fn render_generic_call(ctx: &RenderContext, target: &CallTarget, args: &[IrExpr]
 
 /// Render a method call as a full expression for UFCS and module.func patterns.
 /// Returns Some(full_expr) if the method call was handled, None for normal obj.method calls.
+///
+/// Dispatch strategy (type-driven):
+///   1. join fallback (StdlibLowering miss)
+///   2. Dot-qualified → module/convention
+///   3. User-defined type (Ty::Named) → ALWAYS UFCS free function
+///   4. Builtin type + native Rust method → None (emit obj.method())
+///   5. Builtin type + non-native method → UFCS (user fn on builtin type)
 fn render_method_call_full(ctx: &RenderContext, object: &IrExpr, method: &str, args: &[IrExpr]) -> Option<String> {
-    // User-defined types (Ty::Named): always UFCS — they have no Rust methods.
-    // Derive monomorphized name from type args when present.
-    if let Ty::Named(type_name, type_args) = &object.ty {
+    // 1. join fallback: route to almide_rt_list_join when StdlibLowering missed it
+    if method == "join" && args.len() == 1 {
+        let obj_str = render_expr(ctx, object);
+        let sep_str = render_expr(ctx, &args[0]);
+        return Some(format!("almide_rt_list_join(&{}, &*{})", obj_str, sep_str));
+    }
+
+    // 2. Dot-qualified: handled after type-based dispatch (below)
+
+    // 3. User-defined types: ALWAYS UFCS — Rust structs have no methods.
+    //    Derive monomorphized name from type args when generic.
+    if let Ty::Named(_type_name, type_args) = &object.ty {
         if !method.contains('.') {
             let obj_str = render_expr_owned(ctx, object);
             let mut all_args = vec![obj_str];
@@ -1099,42 +1115,43 @@ fn render_method_call_full(ctx: &RenderContext, object: &IrExpr, method: &str, a
             let func_name = if type_args.is_empty() {
                 method.to_string()
             } else {
-                // Monomorphized name: method__TypeArg1_TypeArg2
                 let suffix = type_args.iter()
                     .map(|t| mangle_ty_for_mono(t))
                     .collect::<Vec<_>>().join("_");
-                let mono_name = format!("{}__{}", method, suffix);
-                mono_name
+                format!("{}__{}", method, suffix)
             };
             return Some(format!("{}({})", func_name, all_args.join(", ")));
         }
     }
 
-    let is_rust_intrinsic = matches!(method,
-        "clone" | "is_some" | "is_none" | "unwrap" | "unwrap_or"
-        | "to_string" | "len" | "push" | "pop" | "insert" | "remove"
-        | "contains" | "iter" | "into_iter" | "collect" | "map"
-        | "filter" | "to_vec" | "split" | "trim"
-        | "starts_with" | "ends_with" | "replace" | "chars"
-        | "to_owned" | "as_str" | "get" | "keys" | "values" | "abs" | "powi" | "powf"
-        | "is_empty" | "contains_key" | "entry" | "or_insert"
-        | "expect" | "ok" | "err" | "and_then" | "map_err"
-        | "unwrap_or_else" | "ok_or" | "flatten" | "as_ref" | "as_deref"
-        // math intrinsics (inlined by StdlibLowering)
-        | "sqrt" | "floor" | "ceil" | "round" | "sin" | "cos" | "tan"
-        | "asin" | "acos" | "atan" | "atan2" | "exp" | "ln" | "log2" | "log10"
-        | "is_nan" | "is_infinite"
+    // 4+5. Builtin types: distinguish native Rust methods from user UFCS.
+    //    Native methods exist on the Rust type and should remain as obj.method().
+    //    Non-native methods are user-defined UFCS → func(obj, args).
+    let is_native_rust_method = matches!(method,
+        // Universal traits (Clone, Display)
+        "clone" | "to_string"
+        // Vec<T>
+        | "len" | "push" | "pop" | "insert" | "remove" | "contains"
+        | "iter" | "into_iter" | "collect" | "is_empty" | "to_vec" | "get"
+        // HashMap<K,V>
+        | "keys" | "values" | "contains_key" | "entry" | "or_insert"
+        // String
+        | "split" | "trim" | "starts_with" | "ends_with" | "replace" | "chars"
+        | "to_owned" | "as_str"
+        // Option<T> / Result<T,E>
+        | "is_some" | "is_none" | "unwrap" | "unwrap_or" | "expect"
+        | "ok" | "err" | "and_then" | "map_err" | "unwrap_or_else"
+        | "ok_or" | "flatten" | "as_ref" | "as_deref"
+        // Iterator adapters (from collect/filter chains)
+        | "map" | "filter"
+        // f64 math
+        | "abs" | "powi" | "powf" | "sqrt" | "floor" | "ceil" | "round"
+        | "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "atan2"
+        | "exp" | "ln" | "log2" | "log10" | "is_nan" | "is_infinite"
     );
-    // Fallback for `join`: always route to almide_rt_list_join even when
-    // StdlibLowering couldn't resolve the list type. We add borrows
-    // explicitly since BorrowInsertion didn't process this call.
-    if method == "join" && args.len() == 1 {
-        let obj_str = render_expr(ctx, object);
-        let sep_str = render_expr(ctx, &args[0]);
-        return Some(format!("almide_rt_list_join(&{}, &*{})", obj_str, sep_str));
-    }
-    // User-defined UFCS: plain method name (no dots) → func(object, args)
-    if !method.contains('.') && !is_rust_intrinsic {
+
+    if !method.contains('.') && !is_native_rust_method {
+        // 5. Non-native method on builtin type → UFCS
         let obj_str = render_expr(ctx, object);
         let mut all_args = vec![obj_str];
         all_args.extend(args.iter().map(|a| render_expr(ctx, a)));

--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -140,6 +140,29 @@ impl Checker {
                     all_args.extend(arg_tys.iter().cloned());
                     return self.check_named_call(&field, &all_args);
                 }
+                // Cross-module UFCS: find the module that defines the object's type,
+                // then check if module.method exists.
+                let cross_type_name = match &obj_concrete {
+                    Ty::Named(n, _) => Some(n.to_string()),
+                    _ => None,
+                };
+                if let Some(type_name) = cross_type_name {
+                    let defining_module = self.env.types.keys()
+                        .find(|k| {
+                            let s = k.as_str();
+                            s.ends_with(&format!(".{}", type_name))
+                                && s.len() > type_name.len() + 1
+                        })
+                        .map(|k| k.as_str()[..k.as_str().len() - type_name.len() - 1].to_string());
+                    if let Some(module) = defining_module {
+                        let key = format!("{}.{}", module, field);
+                        if self.env.functions.contains_key(&sym(&key)) {
+                            let mut all_args = vec![obj_ty];
+                            all_args.extend(arg_tys.iter().cloned());
+                            return self.check_named_call(&key, &all_args);
+                        }
+                    }
+                }
                 // Almide-specific hint: method-call syntax isn't supported.
                 // If obj_ty maps to a stdlib module, suggest the module-call
                 // form (plus the closest existing name if there's a typo).

--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -763,6 +763,13 @@ impl Checker {
                 }
             }
             ExprKind::EmptyMap => Ty::map_of(self.fresh_var(), self.fresh_var()),
+
+            ExprKind::TypeAscription { expr, ty } => {
+                let inferred = self.infer_expr(expr);
+                let ascribed = self.resolve_type_expr(ty);
+                self.constrain(ascribed.clone(), inferred, "type ascription");
+                ascribed
+            }
         }
     }
 

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -742,6 +742,18 @@ impl Checker {
                     self.unify_infer(&result, &field_ty);
                     field_ty
                 } else {
+                    // Ambiguous candidates (e.g. Cubic.a: Vec2, Color.a: Float).
+                    // If this is an inference var, defer — once the type resolves
+                    // the field lookup will succeed unambiguously.
+                    if tv.as_str().starts_with('?') {
+                        let result = self.fresh_var();
+                        self.deferred_field_accesses.push((
+                            ty.clone(),
+                            almide_base::intern::sym(field),
+                            result.clone(),
+                        ));
+                        return result;
+                    }
                     Ty::Unknown
                 }
             }

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -73,6 +73,11 @@ pub struct Checker {
     /// `elems[index]`. Drained iteratively after `solve_constraints`
     /// to give the union-find a chance to propagate before resolution.
     pub(crate) deferred_tuple_indices: Vec<(Ty, usize, Ty)>,
+    /// Deferred field accesses: `(object_ty, field_name, result_var)`.
+    /// Registered when `obj.field` is inferred while `obj` is an unresolved
+    /// inference var. After solving, `object_ty` should be concrete and the
+    /// field type can be looked up and unified with `result_var`.
+    pub(crate) deferred_field_accesses: Vec<(Ty, almide_base::intern::Sym, Ty)>,
     /// Map literal key types to validate after constraint solving.
     /// Each entry: (key_type, span) — checked via `is_hash()` once types are resolved.
     pub(crate) deferred_map_key_checks: Vec<(Ty, Option<crate::ast::Span>)>,
@@ -91,6 +96,7 @@ impl Checker {
             constraints: Vec::new(), uf: UnionFind::new(),
             current_module_prefix: None,
             deferred_tuple_indices: Vec::new(),
+            deferred_field_accesses: Vec::new(),
             deferred_map_key_checks: Vec::new(),
         }
     }
@@ -217,6 +223,27 @@ impl Checker {
                 }
             }
             self.deferred_tuple_indices = still_pending;
+            if !progressed { break; }
+        }
+        // Drain deferred field accesses: `obj.field` where `obj` was an
+        // unresolved inference var at inference time. Now that constraints
+        // are solved, resolve the field type and unify.
+        loop {
+            let pending = std::mem::take(&mut self.deferred_field_accesses);
+            if pending.is_empty() { break; }
+            let mut still_pending = Vec::new();
+            let mut progressed = false;
+            for (obj_ty, field, result_ty) in pending {
+                let resolved = resolve_ty(&obj_ty, &self.uf);
+                let field_ty = self.resolve_field_type(&resolved, field.as_str());
+                if !matches!(field_ty, Ty::Unknown) {
+                    self.unify_infer(&result_ty, &field_ty);
+                    progressed = true;
+                } else {
+                    still_pending.push((obj_ty, field, result_ty));
+                }
+            }
+            self.deferred_field_accesses = still_pending;
             if !progressed { break; }
         }
     }
@@ -691,16 +718,50 @@ impl Checker {
                         _ => {}
                     }
                 }
+                // Deduplicate: prefixed (`mod.Todo`) and unprefixed (`Todo`)
+                // aliases resolve to the same record definition; keep one.
+                candidates.dedup_by(|a, b| {
+                    self.env.types.get(&a.0) == self.env.types.get(&b.0)
+                });
                 if candidates.len() == 1 {
                     let (type_name, field_ty) = candidates.pop().unwrap();
                     let named = Ty::Named(type_name, vec![]);
                     self.unify_infer(ty, &named);
                     field_ty
+                } else if !candidates.is_empty() && candidates.iter().all(|(_, t)| *t == candidates[0].1) {
+                    // Multiple types share the same field name+type: safe to return
+                    // the type but don't unify the object (ambiguous which type it is).
+                    // Deferred field access will resolve once the parent chain is concrete.
+                    let field_ty = candidates[0].1.clone();
+                    let result = self.fresh_var();
+                    self.deferred_field_accesses.push((
+                        ty.clone(),
+                        almide_base::intern::sym(field),
+                        result.clone(),
+                    ));
+                    self.unify_infer(&result, &field_ty);
+                    field_ty
                 } else {
                     Ty::Unknown
                 }
             }
-            _ => Ty::Unknown,
+            _ => {
+                // The type might be an inference variable that hasn't been
+                // resolved yet (e.g. lambda param `t` whose type `?x` will
+                // be unified with a record type after constraint solving).
+                // Defer the field access: park a fresh var and unify it
+                // once the object type is concrete.
+                if matches!(&resolved, Ty::TypeVar(n) if n.as_str().starts_with('?')) {
+                    let result = self.fresh_var();
+                    self.deferred_field_accesses.push((
+                        ty.clone(),
+                        almide_base::intern::sym(field),
+                        result.clone(),
+                    ));
+                    return result;
+                }
+                Ty::Unknown
+            },
         }
     }
 }

--- a/crates/almide-frontend/src/lower/calls.rs
+++ b/crates/almide-frontend/src/lower/calls.rs
@@ -62,7 +62,22 @@ pub(super) fn lower_call(ctx: &mut LowerCtx, callee: &ast::Expr, args: &[ast::Ex
     }
 
     ir_args.extend(args.iter().map(|a| lower_expr(ctx, a)));
-    let target = lower_call_target(ctx, callee);
+    let mut target = lower_call_target(ctx, callee);
+
+    // Cross-module UFCS: Method { object, "module.func" } → Module { module, func }
+    // with object prepended to args. This lets module-level mono discover and rename.
+    if let CallTarget::Method { ref object, ref method } = target {
+        if let Some(dot) = method.as_str().find('.') {
+            let mod_str = &method.as_str()[..dot];
+            let func_str = &method.as_str()[dot+1..];
+            // Only convert if it's a user module (not Convention like Dog.repr)
+            if mod_str.chars().next().map_or(false, |c| c.is_lowercase()) {
+                let obj_expr = (**object).clone();
+                ir_args.insert(0, obj_expr);
+                target = CallTarget::Module { module: sym(mod_str), func: sym(func_str) };
+            }
+        }
+    }
 
     // Named args: resolve to positional order using function signature
     if let (false, CallTarget::Named { name }) = (named_args.is_empty(), &target) {
@@ -311,6 +326,24 @@ pub(super) fn lower_call_target(ctx: &mut LowerCtx, callee: &ast::Expr) -> CallT
                                 return CallTarget::Method { object: Box::new(ir_obj), method: convention_key };
                             }
                         }
+                    }
+                }
+            }
+            // Cross-module UFCS: object type is Named → find defining module
+            if let Ty::Named(type_name, _) = &obj_ty {
+                let defining_module = ctx.env.types.keys()
+                    .find(|k| {
+                        let s = k.as_str();
+                        s.ends_with(&format!(".{}", type_name.as_str()))
+                            && s.len() > type_name.as_str().len() + 1
+                    })
+                    .map(|k| k.as_str()[..k.as_str().len() - type_name.as_str().len() - 1].to_string());
+                if let Some(module) = defining_module {
+                    let key = format!("{}.{}", module, field);
+                    if ctx.env.functions.contains_key(&sym(&key)) {
+                        let ir_obj = lower_expr(ctx, object);
+                        // Return Method with "module.func" key — lower_call converts to Module target
+                        return CallTarget::Method { object: Box::new(ir_obj), method: sym(&key) };
                     }
                 }
             }

--- a/crates/almide-frontend/src/lower/expressions.rs
+++ b/crates/almide-frontend/src/lower/expressions.rs
@@ -585,6 +585,7 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
 
         // ── Misc ──
         ast::ExprKind::Paren { expr, .. } => lower_expr(ctx, expr),
+        ast::ExprKind::TypeAscription { expr, .. } => lower_expr(ctx, expr),
         ast::ExprKind::Hole => ctx.mk(IrExprKind::Hole, ty, span),
         ast::ExprKind::Todo { message, .. } => ctx.mk(IrExprKind::Todo { message: message.clone() }, ty, span),
         ast::ExprKind::Error => ctx.mk(IrExprKind::Unit, Ty::Unknown, span),

--- a/crates/almide-optimize/src/mono/discovery.rs
+++ b/crates/almide-optimize/src/mono/discovery.rs
@@ -62,6 +62,46 @@ pub(super) fn discover_in_expr(
 ) {
     match &expr.kind {
         IrExprKind::Call { target, args, type_args } => {
+            // UFCS Method calls: check if method name matches a generic function.
+            // Treat as Named call with object prepended to args.
+            if let CallTarget::Method { object, method } = target {
+                if let Some(bounded_params) = bound_fns.get::<str>(method) {
+                    let orig_fn = program_functions.iter().find(|f| !f.is_test && f.name == *method);
+                    let param_types: Vec<Ty> = orig_fn
+                        .map(|f| f.params.iter().map(|p| p.ty.clone()).collect())
+                        .unwrap_or_default();
+                    // Synthetic args: [object, ...args]
+                    let mut ufcs_args: Vec<&IrExpr> = vec![object];
+                    ufcs_args.extend(args.iter());
+                    let ufcs_exprs: Vec<IrExpr> = ufcs_args.iter().map(|e| (*e).clone()).collect();
+                    let mut bindings = collect_mono_bindings(bounded_params, &ufcs_exprs, &param_types);
+                    // Infer from return type
+                    if bindings.values().any(|ty| matches!(ty, Ty::Unknown)) || bindings.is_empty() {
+                        if let Some(func) = orig_fn {
+                            if let Some(ref generics) = func.generics {
+                                let ret_ty = &func.ret_ty;
+                                for g in generics {
+                                    if !bindings.contains_key(&*g.name) || matches!(bindings.get(&*g.name), Some(Ty::Unknown)) {
+                                        let extracted = extract_typevar_binding(ret_ty, &expr.ty, &g.name);
+                                        if !matches!(extracted, Ty::Unknown) {
+                                            bindings.insert(g.name.to_string(), extracted);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    let all_concrete = !bindings.is_empty() && bindings.values().all(|ty|
+                        !matches!(ty, Ty::Unknown) && !ty.contains_unknown()
+                        && !matches!(ty, Ty::TypeVar(_))
+                        && !ty.contains_typevar()
+                    );
+                    if all_concrete {
+                        let suffix = mangle_suffix(&bindings);
+                        instances.insert((method.to_string(), suffix), bindings);
+                    }
+                }
+            }
             if let CallTarget::Named { name } = target {
                 if let Some(bounded_params) = bound_fns.get::<str>(name) {
                     // Find the original generic function to get parameter types

--- a/crates/almide-optimize/src/mono/discovery.rs
+++ b/crates/almide-optimize/src/mono/discovery.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use almide_ir::*;
+use almide_ir::visit::{IrVisitor, walk_expr};
 use almide_lang::types::Ty;
 use super::utils::{MonoKey, BoundedParam, mangle_suffix};
 
@@ -27,219 +28,147 @@ pub(super) fn discover_instances(
     program: &IrProgram,
     bound_fns: &HashMap<String, Vec<BoundedParam>>,
 ) -> HashMap<MonoKey, HashMap<String, Ty>> {
-    let mut instances: HashMap<MonoKey, HashMap<String, Ty>> = HashMap::new();
-
-    let fns = &program.functions;
-    for func in fns {
-        discover_in_expr(&func.body, bound_fns, fns, &mut instances);
+    let mut visitor = DiscoverVisitor {
+        bound_fns,
+        program_functions: &program.functions,
+        instances: HashMap::new(),
+    };
+    for func in &program.functions {
+        visitor.visit_expr(&func.body);
     }
     for tl in &program.top_lets {
-        discover_in_expr(&tl.value, bound_fns, fns, &mut instances);
+        visitor.visit_expr(&tl.value);
     }
-
-    instances
+    visitor.instances
 }
 
 /// Discover instances only in the given frontier functions (newly added specializations).
-/// Uses all_fns for looking up original function signatures.
 pub(super) fn discover_instances_in_frontier(
     frontier: &[IrFunction],
     bound_fns: &HashMap<String, Vec<BoundedParam>>,
     all_fns: &[IrFunction],
 ) -> HashMap<MonoKey, HashMap<String, Ty>> {
-    let mut instances: HashMap<MonoKey, HashMap<String, Ty>> = HashMap::new();
+    let mut visitor = DiscoverVisitor {
+        bound_fns,
+        program_functions: all_fns,
+        instances: HashMap::new(),
+    };
     for func in frontier {
-        discover_in_expr(&func.body, bound_fns, all_fns, &mut instances);
+        visitor.visit_expr(&func.body);
     }
-    instances
+    visitor.instances
 }
 
+/// Also used by monomorphize_module_fns (which supplies its own expr).
 pub(super) fn discover_in_expr(
     expr: &IrExpr,
     bound_fns: &HashMap<String, Vec<BoundedParam>>,
     program_functions: &[IrFunction],
     instances: &mut HashMap<MonoKey, HashMap<String, Ty>>,
 ) {
-    match &expr.kind {
-        IrExprKind::Call { target, args, type_args } => {
-            // UFCS Method calls: check if method name matches a generic function.
-            // Treat as Named call with object prepended to args.
-            if let CallTarget::Method { object, method } = target {
-                if let Some(bounded_params) = bound_fns.get::<str>(method) {
-                    let orig_fn = program_functions.iter().find(|f| !f.is_test && f.name == *method);
-                    let param_types: Vec<Ty> = orig_fn
-                        .map(|f| f.params.iter().map(|p| p.ty.clone()).collect())
-                        .unwrap_or_default();
-                    // Synthetic args: [object, ...args]
-                    let mut ufcs_args: Vec<&IrExpr> = vec![object];
-                    ufcs_args.extend(args.iter());
-                    let ufcs_exprs: Vec<IrExpr> = ufcs_args.iter().map(|e| (*e).clone()).collect();
-                    let mut bindings = collect_mono_bindings(bounded_params, &ufcs_exprs, &param_types);
-                    // Infer from return type
-                    if bindings.values().any(|ty| matches!(ty, Ty::Unknown)) || bindings.is_empty() {
-                        if let Some(func) = orig_fn {
-                            if let Some(ref generics) = func.generics {
-                                let ret_ty = &func.ret_ty;
-                                for g in generics {
-                                    if !bindings.contains_key(&*g.name) || matches!(bindings.get(&*g.name), Some(Ty::Unknown)) {
-                                        let extracted = extract_typevar_binding(ret_ty, &expr.ty, &g.name);
-                                        if !matches!(extracted, Ty::Unknown) {
-                                            bindings.insert(g.name.to_string(), extracted);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    let all_concrete = !bindings.is_empty() && bindings.values().all(|ty|
-                        !matches!(ty, Ty::Unknown) && !ty.contains_unknown()
-                        && !matches!(ty, Ty::TypeVar(_))
-                        && !ty.contains_typevar()
-                    );
-                    if all_concrete {
-                        let suffix = mangle_suffix(&bindings);
-                        instances.insert((method.to_string(), suffix), bindings);
-                    }
-                }
-            }
-            if let CallTarget::Named { name } = target {
-                if let Some(bounded_params) = bound_fns.get::<str>(name) {
-                    // Find the original generic function to get parameter types
-                    // and generics. Tests can share the raw name (`test "wrap_all"`
-                    // collides with `fn wrap_all[T]`), so skip them here.
-                    let orig_fn = program_functions.iter().find(|f| !f.is_test && f.name == *name);
-                    let param_types: Vec<Ty> = orig_fn
-                        .map(|f| f.params.iter().map(|p| p.ty.clone()).collect())
-                        .unwrap_or_default();
+    let mut visitor = DiscoverVisitor { bound_fns, program_functions, instances: HashMap::new() };
+    visitor.visit_expr(expr);
+    instances.extend(visitor.instances);
+}
 
-                    let mut bindings = collect_mono_bindings(bounded_params, args, &param_types);
+// ── Visitor implementation ────────────────────────────────────────
 
-                    // Also collect bindings from explicit type_args (e.g., stack_new[Int]())
-                    if !type_args.is_empty() {
-                        if let Some(func) = orig_fn {
-                            if let Some(ref generics) = func.generics {
-                                for (g, ta) in generics.iter().zip(type_args.iter()) {
-                                    if !bindings.contains_key(&*g.name) {
-                                        bindings.insert(g.name.to_string(), ta.clone());
-                                    }
-                                }
-                            }
-                        }
-                    }
+struct DiscoverVisitor<'a> {
+    bound_fns: &'a HashMap<String, Vec<BoundedParam>>,
+    program_functions: &'a [IrFunction],
+    instances: HashMap<MonoKey, HashMap<String, Ty>>,
+}
 
-                    // Also try: infer from return type usage
-                    // If the call result is stored in a typed variable, use that type
-                    if bindings.values().any(|ty| matches!(ty, Ty::Unknown)) || bindings.is_empty() {
-                        if let Some(func) = orig_fn {
-                            if let Some(ref generics) = func.generics {
-                                // Try to infer from call expr.ty vs function ret_ty
-                                let ret_ty = &func.ret_ty;
-                                for g in generics {
-                                    if !bindings.contains_key(&*g.name) || matches!(bindings.get(&*g.name), Some(Ty::Unknown)) {
-                                        let extracted = extract_typevar_binding(ret_ty, &expr.ty, &g.name);
-                                        if !matches!(extracted, Ty::Unknown) {
-                                            bindings.insert(g.name.to_string(), extracted);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // Skip bindings with Unknown, TypeVars, or unresolved inference vars
-                    let all_concrete = !bindings.is_empty() && bindings.values().all(|ty|
-                        !matches!(ty, Ty::Unknown) && !ty.contains_unknown()
-                        && !matches!(ty, Ty::TypeVar(_))
-                        && !ty.contains_typevar()
-                    );
-                    if all_concrete {
-                        let suffix = mangle_suffix(&bindings);
-                        instances.insert((name.to_string(), suffix), bindings);
-                    }
-                }
-            }
-            for arg in args { discover_in_expr(arg, bound_fns, program_functions, instances); }
-            match target {
-                CallTarget::Method { object, .. } | CallTarget::Computed { callee: object } => {
-                    discover_in_expr(object, bound_fns, program_functions, instances);
-                }
-                _ => {}
-            }
+impl<'a> IrVisitor for DiscoverVisitor<'a> {
+    fn visit_expr(&mut self, expr: &IrExpr) {
+        if let IrExprKind::Call { target, args, type_args } = &expr.kind {
+            self.check_call(expr, target, args, type_args);
         }
-        IrExprKind::BinOp { left, right, .. } => {
-            discover_in_expr(left, bound_fns, program_functions, instances);
-            discover_in_expr(right, bound_fns, program_functions, instances);
-        }
-        IrExprKind::UnOp { operand, .. } => discover_in_expr(operand, bound_fns, program_functions, instances),
-        IrExprKind::If { cond, then, else_ } => {
-            discover_in_expr(cond, bound_fns, program_functions, instances);
-            discover_in_expr(then, bound_fns, program_functions, instances);
-            discover_in_expr(else_, bound_fns, program_functions, instances);
-        }
-        IrExprKind::Match { subject, arms } => {
-            discover_in_expr(subject, bound_fns, program_functions, instances);
-            for arm in arms {
-                if let Some(g) = &arm.guard { discover_in_expr(g, bound_fns, program_functions, instances); }
-                discover_in_expr(&arm.body, bound_fns, program_functions, instances);
-            }
-        }
-        IrExprKind::Block { stmts, expr } => {
-            for s in stmts { discover_in_stmt(s, bound_fns, program_functions, instances); }
-            if let Some(e) = expr { discover_in_expr(e, bound_fns, program_functions, instances); }
-        }
-        IrExprKind::ForIn { iterable, body, .. } => {
-            discover_in_expr(iterable, bound_fns, program_functions, instances);
-            for s in body { discover_in_stmt(s, bound_fns, program_functions, instances); }
-        }
-        IrExprKind::While { cond, body } => {
-            discover_in_expr(cond, bound_fns, program_functions, instances);
-            for s in body { discover_in_stmt(s, bound_fns, program_functions, instances); }
-        }
-        IrExprKind::List { elements } | IrExprKind::Tuple { elements } => {
-            for e in elements { discover_in_expr(e, bound_fns, program_functions, instances); }
-        }
-        IrExprKind::Record { fields, .. } => {
-            for (_, e) in fields { discover_in_expr(e, bound_fns, program_functions, instances); }
-        }
-        IrExprKind::SpreadRecord { base, fields } => {
-            discover_in_expr(base, bound_fns, program_functions, instances);
-            for (_, e) in fields { discover_in_expr(e, bound_fns, program_functions, instances); }
-        }
-        IrExprKind::MapLiteral { entries } => {
-            for (k, v) in entries {
-                discover_in_expr(k, bound_fns, program_functions, instances);
-                discover_in_expr(v, bound_fns, program_functions, instances);
-            }
-        }
-        IrExprKind::Range { start, end, .. } => {
-            discover_in_expr(start, bound_fns, program_functions, instances);
-            discover_in_expr(end, bound_fns, program_functions, instances);
-        }
-        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
-            discover_in_expr(object, bound_fns, program_functions, instances);
-        }
-        IrExprKind::IndexAccess { object, index } => {
-            discover_in_expr(object, bound_fns, program_functions, instances);
-            discover_in_expr(index, bound_fns, program_functions, instances);
-        }
-        IrExprKind::MapAccess { object, key } => {
-            discover_in_expr(object, bound_fns, program_functions, instances);
-            discover_in_expr(key, bound_fns, program_functions, instances);
-        }
-        IrExprKind::Lambda { body, .. } => discover_in_expr(body, bound_fns, program_functions, instances),
-        IrExprKind::StringInterp { parts } => {
-            for part in parts {
-                if let IrStringPart::Expr { expr } = part {
-                    discover_in_expr(expr, bound_fns, program_functions, instances);
-                }
-            }
-        }
-        IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
-        | IrExprKind::OptionSome { expr } | IrExprKind::Try { expr }
-        | IrExprKind::Await { expr } => discover_in_expr(expr, bound_fns, program_functions, instances),
-        _ => {}
+        walk_expr(self, expr);
     }
 }
+
+impl<'a> DiscoverVisitor<'a> {
+    fn check_call(&mut self, expr: &IrExpr, target: &CallTarget, args: &[IrExpr], type_args: &[Ty]) {
+        // UFCS Method calls: check if method name matches a generic function.
+        if let CallTarget::Method { object, method } = target {
+            if let Some(bounded_params) = self.bound_fns.get::<str>(method) {
+                let orig_fn = self.program_functions.iter().find(|f| !f.is_test && f.name == *method);
+                let param_types: Vec<Ty> = orig_fn
+                    .map(|f| f.params.iter().map(|p| p.ty.clone()).collect())
+                    .unwrap_or_default();
+                // Synthetic args: [object, ...args]
+                let mut ufcs_args: Vec<IrExpr> = vec![(**object).clone()];
+                ufcs_args.extend(args.iter().cloned());
+                let mut bindings = collect_mono_bindings(bounded_params, &ufcs_args, &param_types);
+                // Infer from return type
+                self.infer_from_return_type(orig_fn, expr, &mut bindings);
+                self.try_insert(method.to_string(), bindings);
+            }
+        }
+        if let CallTarget::Named { name } = target {
+            if let Some(bounded_params) = self.bound_fns.get::<str>(name) {
+                let orig_fn = self.program_functions.iter().find(|f| !f.is_test && f.name == *name);
+                let param_types: Vec<Ty> = orig_fn
+                    .map(|f| f.params.iter().map(|p| p.ty.clone()).collect())
+                    .unwrap_or_default();
+                let mut bindings = collect_mono_bindings(bounded_params, args, &param_types);
+                // Explicit type_args
+                if !type_args.is_empty() {
+                    if let Some(func) = orig_fn {
+                        if let Some(ref generics) = func.generics {
+                            for (g, ta) in generics.iter().zip(type_args.iter()) {
+                                if !bindings.contains_key(&*g.name) {
+                                    bindings.insert(g.name.to_string(), ta.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+                // Infer from return type
+                self.infer_from_return_type(orig_fn, expr, &mut bindings);
+                self.try_insert(name.to_string(), bindings);
+            }
+        }
+    }
+
+    fn infer_from_return_type(
+        &self,
+        orig_fn: Option<&IrFunction>,
+        expr: &IrExpr,
+        bindings: &mut HashMap<String, Ty>,
+    ) {
+        if bindings.values().any(|ty| matches!(ty, Ty::Unknown)) || bindings.is_empty() {
+            if let Some(func) = orig_fn {
+                if let Some(ref generics) = func.generics {
+                    let ret_ty = &func.ret_ty;
+                    for g in generics {
+                        if !bindings.contains_key(&*g.name) || matches!(bindings.get(&*g.name), Some(Ty::Unknown)) {
+                            let extracted = extract_typevar_binding(ret_ty, &expr.ty, &g.name);
+                            if !matches!(extracted, Ty::Unknown) {
+                                bindings.insert(g.name.to_string(), extracted);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn try_insert(&mut self, name: String, bindings: HashMap<String, Ty>) {
+        let all_concrete = !bindings.is_empty() && bindings.values().all(|ty|
+            !matches!(ty, Ty::Unknown) && !ty.contains_unknown()
+            && !matches!(ty, Ty::TypeVar(_))
+            && !ty.contains_typevar()
+        );
+        if all_concrete {
+            let suffix = mangle_suffix(&bindings);
+            self.instances.insert((name, suffix), bindings);
+        }
+    }
+}
+
+// ── Statement discovery (delegated to visitor via walk) ──────────
 
 pub(super) fn discover_in_stmt(
     stmt: &IrStmt,
@@ -247,47 +176,19 @@ pub(super) fn discover_in_stmt(
     program_functions: &[IrFunction],
     instances: &mut HashMap<MonoKey, HashMap<String, Ty>>,
 ) {
-    match &stmt.kind {
-        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
-        | IrStmtKind::Assign { value, .. } => discover_in_expr(value, bound_fns, program_functions, instances),
-        IrStmtKind::IndexAssign { index, value, .. } => {
-            discover_in_expr(index, bound_fns, program_functions, instances);
-            discover_in_expr(value, bound_fns, program_functions, instances);
-        }
-        IrStmtKind::MapInsert { key, value, .. } => {
-            discover_in_expr(key, bound_fns, program_functions, instances);
-            discover_in_expr(value, bound_fns, program_functions, instances);
-        }
-        IrStmtKind::FieldAssign { value, .. } => discover_in_expr(value, bound_fns, program_functions, instances),
-        IrStmtKind::ListSwap { a, b, .. } => {
-            discover_in_expr(a, bound_fns, program_functions, instances);
-            discover_in_expr(b, bound_fns, program_functions, instances);
-        }
-        IrStmtKind::ListReverse { end, .. } | IrStmtKind::ListRotateLeft { end, .. } => {
-            discover_in_expr(end, bound_fns, program_functions, instances);
-        }
-        IrStmtKind::ListCopySlice { len, .. } => {
-            discover_in_expr(len, bound_fns, program_functions, instances);
-        }
-        IrStmtKind::Expr { expr } => discover_in_expr(expr, bound_fns, program_functions, instances),
-        IrStmtKind::Guard { cond, else_ } => {
-            discover_in_expr(cond, bound_fns, program_functions, instances);
-            discover_in_expr(else_, bound_fns, program_functions, instances);
-        }
-        IrStmtKind::Comment { .. } => {}
-    }
+    use almide_ir::visit::walk_stmt;
+    let mut visitor = DiscoverVisitor { bound_fns, program_functions, instances: HashMap::new() };
+    visitor.visit_stmt(stmt);
+    instances.extend(visitor.instances);
 }
 
 /// Extract the concrete type for a TypeVar by matching parameter type structure against argument type.
-/// Uses Ty::constructor_id() and type_args() for uniform container matching.
 pub(super) fn extract_typevar_binding(param_ty: &Ty, arg_ty: &Ty, var_name: &str) -> Ty {
     match (param_ty, arg_ty) {
         (Ty::TypeVar(n), _) if n == var_name => arg_ty.clone(),
         (Ty::Named(n, _), _) if n == var_name => arg_ty.clone(),
-        // OpenRecord param (or its Named alias) maps directly to the concrete arg type
         (Ty::OpenRecord { .. }, _) if var_name.starts_with("__open_") => arg_ty.clone(),
         (Ty::Named(_, _), _) if var_name.starts_with("__open_") => arg_ty.clone(),
-        // Fn types: match params and return type
         (Ty::Fn { params: p_params, ret: p_ret }, Ty::Fn { params: a_params, ret: a_ret }) if p_params.len() == a_params.len() => {
             for (p, a) in p_params.iter().zip(a_params.iter()) {
                 let r = extract_typevar_binding(p, a, var_name);
@@ -296,7 +197,6 @@ pub(super) fn extract_typevar_binding(param_ty: &Ty, arg_ty: &Ty, var_name: &str
             extract_typevar_binding(p_ret, a_ret, var_name)
         }
         _ => {
-            // If same constructor, recursively match type args
             if param_ty.constructor_id() == arg_ty.constructor_id() {
                 let p_args = param_ty.type_args();
                 let a_args = arg_ty.type_args();
@@ -307,17 +207,15 @@ pub(super) fn extract_typevar_binding(param_ty: &Ty, arg_ty: &Ty, var_name: &str
                     }
                 }
             }
-            // Tuple: same logic via children()
             if let (Ty::Tuple(pts), Ty::Tuple(ats)) = (param_ty, arg_ty) {
                 if pts.len() == ats.len() {
                     for (p, a) in pts.iter().zip(ats.iter()) {
                         let r = extract_typevar_binding(p, a, var_name);
                         if !matches!(r, Ty::Unknown) { return r; }
                     }
-                    return Ty::Unknown;
                 }
             }
-            Ty::Unknown // no match for this var_name in this branch
+            Ty::Unknown
         }
     }
 }

--- a/crates/almide-optimize/src/mono/rewrite.rs
+++ b/crates/almide-optimize/src/mono/rewrite.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use almide_ir::*;
+use almide_ir::visit_mut::{IrMutVisitor, walk_expr_mut, walk_stmt_mut};
 use almide_lang::types::Ty;
 use super::utils::{MonoKey, BoundedParam, mangle_suffix};
 use super::discovery::{collect_mono_bindings, extract_typevar_binding};
@@ -11,9 +12,6 @@ pub(super) fn rewrite_calls(
     bound_fns: &HashMap<String, Vec<BoundedParam>>,
     instances: &HashMap<MonoKey, HashMap<String, Ty>>,
 ) {
-    // Tests can share raw names with generic functions (e.g. `fn wrap_all[T]` vs
-    // `test "wrap_all"` — both lower to name = "wrap_all"). Skip tests when
-    // building these lookups so the generic function's signature wins.
     let fn_param_types: HashMap<String, Vec<Ty>> = program.functions.iter()
         .filter(|f| !f.is_test && bound_fns.contains_key::<str>(&f.name))
         .map(|f| (f.name.to_string(), f.params.iter().map(|p| p.ty.clone()).collect()))
@@ -27,209 +25,127 @@ pub(super) fn rewrite_calls(
         .map(|f| (f.name.to_string(), f.ret_ty.clone()))
         .collect();
 
+    let mut rw = RewriteVisitor {
+        bound_fns,
+        instances,
+        fn_param_types: &fn_param_types,
+        fn_generics: &fn_generics,
+        fn_ret_types: &fn_ret_types,
+    };
     for func in &mut program.functions {
-        rewrite_expr_calls(&mut func.body, bound_fns, instances, &fn_param_types, &fn_generics, &fn_ret_types);
+        rw.visit_expr_mut(&mut func.body);
     }
     for tl in &mut program.top_lets {
-        rewrite_expr_calls(&mut tl.value, bound_fns, instances, &fn_param_types, &fn_generics, &fn_ret_types);
+        rw.visit_expr_mut(&mut tl.value);
     }
 }
 
-fn rewrite_expr_calls(
-    expr: &mut IrExpr,
-    bound_fns: &HashMap<String, Vec<BoundedParam>>,
-    instances: &HashMap<MonoKey, HashMap<String, Ty>>,
-    fn_param_types: &HashMap<String, Vec<Ty>>,
-    fn_generics: &HashMap<String, Vec<String>>,
-    fn_ret_types: &HashMap<String, Ty>,
-) {
-    match &mut expr.kind {
-        IrExprKind::Call { target, args, type_args } => {
-            for a in args.iter_mut() { rewrite_expr_calls(a, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types); }
-            if let CallTarget::Named { name } = target {
-                if let Some(bounded_params) = bound_fns.get(name.as_str()) {
-                    let param_types = fn_param_types.get(name.as_str());
-                    let pt = param_types.map(|pts| pts.as_slice()).unwrap_or(&[]);
-                    let mut bindings = collect_mono_bindings(bounded_params, args, pt);
+// ── Visitor implementation ────────────────────────────────────────
 
-                    // Supplement from explicit type_args
-                    if !type_args.is_empty() {
-                        if let Some(gnames) = fn_generics.get(name.as_str()) {
-                            for (gname, ta) in gnames.iter().zip(type_args.iter()) {
-                                if !bindings.contains_key(gname) || matches!(bindings.get(gname), Some(Ty::Unknown)) {
-                                    bindings.insert(gname.clone(), ta.clone());
-                                }
-                            }
-                        }
-                    }
+struct RewriteVisitor<'a> {
+    bound_fns: &'a HashMap<String, Vec<BoundedParam>>,
+    instances: &'a HashMap<MonoKey, HashMap<String, Ty>>,
+    fn_param_types: &'a HashMap<String, Vec<Ty>>,
+    fn_generics: &'a HashMap<String, Vec<String>>,
+    fn_ret_types: &'a HashMap<String, Ty>,
+}
 
-                    // Infer from call expr.ty vs function ret_ty (for paramless generics)
-                    if bindings.is_empty() || bindings.values().any(|v| matches!(v, Ty::Unknown)) {
-                        if let Some(gnames) = fn_generics.get(name.as_str()) {
-                            if let Some(ret_ty) = fn_ret_types.get(name.as_str()) {
-                                for gname in gnames {
-                                    if !bindings.contains_key(gname) || matches!(bindings.get(gname), Some(Ty::Unknown)) {
-                                        let extracted = extract_typevar_binding(ret_ty, &expr.ty, gname);
-                                        if !matches!(extracted, Ty::Unknown) {
-                                            bindings.insert(gname.clone(), extracted);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    if !bindings.is_empty() {
-                        let suffix = mangle_suffix(&bindings);
-                        if instances.contains_key(&(name.to_string(), suffix.clone())) {
-                            *name = format!("{}__{}", name, suffix).into();
-                            expr.ty = substitute_ty(&expr.ty, &bindings);
-                        }
-                    }
-                }
-            }
-            // Rewrite UFCS Method calls to Named calls when method matches a monomorphized function
-            if let CallTarget::Method { object, method } = target {
-                rewrite_expr_calls(object, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-                if let Some(bounded_params) = bound_fns.get(method.as_str()) {
-                    let param_types = fn_param_types.get(method.as_str());
-                    let pt = param_types.map(|pts| pts.as_slice()).unwrap_or(&[]);
-                    // Synthetic args: [object, ...args]
-                    let mut ufcs_args: Vec<IrExpr> = vec![(**object).clone()];
-                    ufcs_args.extend(args.iter().cloned());
-                    let mut bindings = collect_mono_bindings(bounded_params, &ufcs_args, pt);
-                    // Infer from return type
-                    if bindings.is_empty() || bindings.values().any(|v| matches!(v, Ty::Unknown)) {
-                        if let Some(gnames) = fn_generics.get(method.as_str()) {
-                            if let Some(ret_ty) = fn_ret_types.get(method.as_str()) {
-                                for gname in gnames {
-                                    if !bindings.contains_key(gname) || matches!(bindings.get(gname), Some(Ty::Unknown)) {
-                                        let extracted = extract_typevar_binding(ret_ty, &expr.ty, gname);
-                                        if !matches!(extracted, Ty::Unknown) {
-                                            bindings.insert(gname.clone(), extracted);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    let all_concrete = !bindings.is_empty() && bindings.values().all(|ty|
-                        !matches!(ty, Ty::Unknown) && !ty.contains_unknown()
-                        && !matches!(ty, Ty::TypeVar(_)) && !ty.contains_typevar()
-                    );
-                    if all_concrete {
-                        let suffix = mangle_suffix(&bindings);
-                        if instances.contains_key(&(method.to_string(), suffix.clone())) {
-                            let mono_name = format!("{}__{}", method, suffix);
-                            // Convert Method → Named with object prepended to args
-                            let obj_expr = (**object).clone();
-                            let mut new_args: Vec<IrExpr> = vec![obj_expr];
-                            new_args.extend(args.drain(..));
-                            *args = new_args;
-                            *target = CallTarget::Named { name: mono_name.into() };
-                            expr.ty = substitute_ty(&expr.ty, &bindings);
-                        }
-                    }
-                }
-            } else if let CallTarget::Computed { callee: object } = target {
-                rewrite_expr_calls(object, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            }
+impl<'a> IrMutVisitor for RewriteVisitor<'a> {
+    fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
+        // Recurse into children first (bottom-up rewriting)
+        walk_expr_mut(self, expr);
+        // Then rewrite call targets at this node
+        if let IrExprKind::Call { target, args, type_args } = &mut expr.kind {
+            self.rewrite_call(expr.ty.clone(), target, args, type_args, &mut expr.ty);
         }
-        IrExprKind::BinOp { left, right, .. } => {
-            rewrite_expr_calls(left, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            rewrite_expr_calls(right, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-        }
-        IrExprKind::UnOp { operand, .. } => rewrite_expr_calls(operand, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types),
-        IrExprKind::If { cond, then, else_ } => {
-            rewrite_expr_calls(cond, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            rewrite_expr_calls(then, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            rewrite_expr_calls(else_, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-        }
-        IrExprKind::Match { subject, arms } => {
-            rewrite_expr_calls(subject, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            for arm in arms {
-                if let Some(g) = &mut arm.guard { rewrite_expr_calls(g, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types); }
-                rewrite_expr_calls(&mut arm.body, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            }
-        }
-        IrExprKind::Block { stmts, expr } => {
-            for s in stmts { rewrite_stmt_calls(s, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types); }
-            if let Some(e) = expr { rewrite_expr_calls(e, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types); }
-        }
-        IrExprKind::ForIn { iterable, body, .. } => {
-            rewrite_expr_calls(iterable, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            for s in body { rewrite_stmt_calls(s, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types); }
-        }
-        IrExprKind::While { cond, body } => {
-            rewrite_expr_calls(cond, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            for s in body { rewrite_stmt_calls(s, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types); }
-        }
-        IrExprKind::List { elements } | IrExprKind::Tuple { elements } => {
-            for e in elements { rewrite_expr_calls(e, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types); }
-        }
-        IrExprKind::Record { fields, .. } => {
-            for (_, e) in fields { rewrite_expr_calls(e, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types); }
-        }
-        IrExprKind::SpreadRecord { base, fields } => {
-            rewrite_expr_calls(base, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            for (_, e) in fields { rewrite_expr_calls(e, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types); }
-        }
-        IrExprKind::MapLiteral { entries } => {
-            for (k, v) in entries {
-                rewrite_expr_calls(k, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-                rewrite_expr_calls(v, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            }
-        }
-        IrExprKind::Range { start, end, .. } => {
-            rewrite_expr_calls(start, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            rewrite_expr_calls(end, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-        }
-        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => {
-            rewrite_expr_calls(object, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-        }
-        IrExprKind::IndexAccess { object, index } => {
-            rewrite_expr_calls(object, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            rewrite_expr_calls(index, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-        }
-        IrExprKind::MapAccess { object, key } => {
-            rewrite_expr_calls(object, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-            rewrite_expr_calls(key, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-        }
-        IrExprKind::Lambda { body, .. } => rewrite_expr_calls(body, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types),
-        IrExprKind::StringInterp { parts } => {
-            for part in parts {
-                if let IrStringPart::Expr { expr } = part {
-                    rewrite_expr_calls(expr, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-                }
-            }
-        }
-        IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
-        | IrExprKind::OptionSome { expr } | IrExprKind::Try { expr }
-        | IrExprKind::Await { expr } => rewrite_expr_calls(expr, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types),
-        _ => {}
+    }
+    fn visit_stmt_mut(&mut self, stmt: &mut IrStmt) {
+        walk_stmt_mut(self, stmt);
     }
 }
 
-fn rewrite_stmt_calls(
-    stmt: &mut IrStmt,
-    bound_fns: &HashMap<String, Vec<BoundedParam>>,
-    instances: &HashMap<MonoKey, HashMap<String, Ty>>,
-    fn_param_types: &HashMap<String, Vec<Ty>>,
-    fn_generics: &HashMap<String, Vec<String>>,
-    fn_ret_types: &HashMap<String, Ty>,
-) {
-    let rw = |e: &mut IrExpr| rewrite_expr_calls(e, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
-    match &mut stmt.kind {
-        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
-        | IrStmtKind::Assign { value, .. } => rw(value),
-        IrStmtKind::IndexAssign { index, value, .. } => { rw(index); rw(value); }
-        IrStmtKind::MapInsert { key, value, .. } => { rw(key); rw(value); }
-        IrStmtKind::FieldAssign { value, .. } => rw(value),
-        IrStmtKind::ListSwap { a, b, .. } => { rw(a); rw(b); }
-        IrStmtKind::ListReverse { end, .. } | IrStmtKind::ListRotateLeft { end, .. } => { rw(end); }
-        IrStmtKind::ListCopySlice { len, .. } => { rw(len); }
-        IrStmtKind::Expr { expr } => rw(expr),
-        IrStmtKind::Guard { cond, else_ } => { rw(cond); rw(else_); }
-        IrStmtKind::Comment { .. } => {}
+impl<'a> RewriteVisitor<'a> {
+    fn rewrite_call(
+        &self,
+        _orig_ty: Ty,
+        target: &mut CallTarget,
+        args: &mut Vec<IrExpr>,
+        type_args: &[Ty],
+        expr_ty: &mut Ty,
+    ) {
+        if let CallTarget::Named { name } = target {
+            if let Some(bounded_params) = self.bound_fns.get(name.as_str()) {
+                let pt = self.fn_param_types.get(name.as_str())
+                    .map(|pts| pts.as_slice()).unwrap_or(&[]);
+                let mut bindings = collect_mono_bindings(bounded_params, args, pt);
+
+                // Supplement from explicit type_args
+                if !type_args.is_empty() {
+                    if let Some(gnames) = self.fn_generics.get(name.as_str()) {
+                        for (gname, ta) in gnames.iter().zip(type_args.iter()) {
+                            if !bindings.contains_key(gname) || matches!(bindings.get(gname), Some(Ty::Unknown)) {
+                                bindings.insert(gname.clone(), ta.clone());
+                            }
+                        }
+                    }
+                }
+
+                // Infer from return type
+                self.infer_from_return_type(name.as_str(), expr_ty, &mut bindings);
+
+                if !bindings.is_empty() {
+                    let suffix = mangle_suffix(&bindings);
+                    if self.instances.contains_key(&(name.to_string(), suffix.clone())) {
+                        *name = format!("{}__{}", name, suffix).into();
+                        *expr_ty = substitute_ty(expr_ty, &bindings);
+                    }
+                }
+            }
+        } else if let CallTarget::Method { object, method } = target {
+            if let Some(bounded_params) = self.bound_fns.get(method.as_str()) {
+                let pt = self.fn_param_types.get(method.as_str())
+                    .map(|pts| pts.as_slice()).unwrap_or(&[]);
+                let mut ufcs_args: Vec<IrExpr> = vec![(**object).clone()];
+                ufcs_args.extend(args.iter().cloned());
+                let mut bindings = collect_mono_bindings(bounded_params, &ufcs_args, pt);
+
+                // Infer from return type
+                self.infer_from_return_type(method.as_str(), expr_ty, &mut bindings);
+
+                let all_concrete = !bindings.is_empty() && bindings.values().all(|ty|
+                    !matches!(ty, Ty::Unknown) && !ty.contains_unknown()
+                    && !matches!(ty, Ty::TypeVar(_)) && !ty.contains_typevar()
+                );
+                if all_concrete {
+                    let suffix = mangle_suffix(&bindings);
+                    if self.instances.contains_key(&(method.to_string(), suffix.clone())) {
+                        let mono_name = format!("{}__{}", method, suffix);
+                        let obj_expr = (**object).clone();
+                        let mut new_args: Vec<IrExpr> = vec![obj_expr];
+                        new_args.extend(args.drain(..));
+                        *args = new_args;
+                        *target = CallTarget::Named { name: mono_name.into() };
+                        *expr_ty = substitute_ty(expr_ty, &bindings);
+                    }
+                }
+            }
+        }
+    }
+
+    fn infer_from_return_type(&self, fn_name: &str, expr_ty: &Ty, bindings: &mut HashMap<String, Ty>) {
+        if bindings.is_empty() || bindings.values().any(|v| matches!(v, Ty::Unknown)) {
+            if let Some(gnames) = self.fn_generics.get(fn_name) {
+                if let Some(ret_ty) = self.fn_ret_types.get(fn_name) {
+                    for gname in gnames {
+                        if !bindings.contains_key(gname) || matches!(bindings.get(gname), Some(Ty::Unknown)) {
+                            let extracted = extract_typevar_binding(ret_ty, expr_ty, gname);
+                            if !matches!(extracted, Ty::Unknown) {
+                                bindings.insert(gname.clone(), extracted);
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/almide-optimize/src/mono/rewrite.rs
+++ b/crates/almide-optimize/src/mono/rewrite.rs
@@ -88,11 +88,51 @@ fn rewrite_expr_calls(
                     }
                 }
             }
-            match target {
-                CallTarget::Method { object, .. } | CallTarget::Computed { callee: object } => {
-                    rewrite_expr_calls(object, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
+            // Rewrite UFCS Method calls to Named calls when method matches a monomorphized function
+            if let CallTarget::Method { object, method } = target {
+                rewrite_expr_calls(object, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
+                if let Some(bounded_params) = bound_fns.get(method.as_str()) {
+                    let param_types = fn_param_types.get(method.as_str());
+                    let pt = param_types.map(|pts| pts.as_slice()).unwrap_or(&[]);
+                    // Synthetic args: [object, ...args]
+                    let mut ufcs_args: Vec<IrExpr> = vec![(**object).clone()];
+                    ufcs_args.extend(args.iter().cloned());
+                    let mut bindings = collect_mono_bindings(bounded_params, &ufcs_args, pt);
+                    // Infer from return type
+                    if bindings.is_empty() || bindings.values().any(|v| matches!(v, Ty::Unknown)) {
+                        if let Some(gnames) = fn_generics.get(method.as_str()) {
+                            if let Some(ret_ty) = fn_ret_types.get(method.as_str()) {
+                                for gname in gnames {
+                                    if !bindings.contains_key(gname) || matches!(bindings.get(gname), Some(Ty::Unknown)) {
+                                        let extracted = extract_typevar_binding(ret_ty, &expr.ty, gname);
+                                        if !matches!(extracted, Ty::Unknown) {
+                                            bindings.insert(gname.clone(), extracted);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    let all_concrete = !bindings.is_empty() && bindings.values().all(|ty|
+                        !matches!(ty, Ty::Unknown) && !ty.contains_unknown()
+                        && !matches!(ty, Ty::TypeVar(_)) && !ty.contains_typevar()
+                    );
+                    if all_concrete {
+                        let suffix = mangle_suffix(&bindings);
+                        if instances.contains_key(&(method.to_string(), suffix.clone())) {
+                            let mono_name = format!("{}__{}", method, suffix);
+                            // Convert Method → Named with object prepended to args
+                            let obj_expr = (**object).clone();
+                            let mut new_args: Vec<IrExpr> = vec![obj_expr];
+                            new_args.extend(args.drain(..));
+                            *args = new_args;
+                            *target = CallTarget::Named { name: mono_name.into() };
+                            expr.ty = substitute_ty(&expr.ty, &bindings);
+                        }
+                    }
                 }
-                _ => {}
+            } else if let CallTarget::Computed { callee: object } = target {
+                rewrite_expr_calls(object, bound_fns, instances, fn_param_types, fn_generics, fn_ret_types);
             }
         }
         IrExprKind::BinOp { left, right, .. } => {

--- a/crates/almide-syntax/src/ast.rs
+++ b/crates/almide-syntax/src/ast.rs
@@ -194,6 +194,8 @@ pub enum ExprKind {
     Some { expr: Box<Expr> },
     Ok { expr: Box<Expr> },
     Err { expr: Box<Expr> },
+    /// Type ascription: `expr: Type` (e.g. `[]: List[Int]` in call args).
+    TypeAscription { expr: Box<Expr>, #[serde(rename = "type")] ty: TypeExpr },
     /// Placeholder for a parse error — allows partial AST construction.
     Error,
 }
@@ -490,6 +492,7 @@ pub fn visit_expr_mut(expr: &mut Expr, f: &mut impl FnMut(&mut Expr)) {
                 if let StringPart::Expr { expr: e } = part { visit_expr_mut(e, f); }
             }
         }
+        ExprKind::TypeAscription { expr, .. } => visit_expr_mut(expr, f),
         ExprKind::Int { .. } | ExprKind::Float { .. } | ExprKind::String { .. } |
         ExprKind::Bool { .. } | ExprKind::Ident { .. } | ExprKind::TypeName { .. } |
         ExprKind::EmptyMap | ExprKind::Hole | ExprKind::Todo { .. } |

--- a/crates/almide-syntax/src/parser/expressions.rs
+++ b/crates/almide-syntax/src/parser/expressions.rs
@@ -423,7 +423,20 @@ impl Parser {
                 let tok = self.current();
                 return Err(format!("positional argument after named argument at line {}:{}", tok.line, tok.col));
             }
-            args.push(self.parse_expr()?);
+            let expr = self.parse_expr()?;
+            // Type ascription: `[]: List[Int]`, `[:]: Map[K,V]`, `(expr): Type`
+            // Disambiguated from named args because those are consumed above
+            // (only triggered when expr is NOT a bare Ident).
+            if self.check(TokenType::Colon) && self.peek_at(1).map(|t| &t.token_type) != Some(&TokenType::Colon) {
+                let span = expr.span;
+                self.advance(); // skip :
+                let ty = self.parse_type_expr()?;
+                args.push(Expr::new(self.next_id(), span, ExprKind::TypeAscription {
+                    expr: Box::new(expr), ty,
+                }));
+            } else {
+                args.push(expr);
+            }
         }
         Ok(())
     }

--- a/crates/almide-tools/src/fmt.rs
+++ b/crates/almide-tools/src/fmt.rs
@@ -580,6 +580,11 @@ fn fmt_expr(out: &mut String, expr: &Expr, depth: usize) {
             });
             out.push_str(") => "); fmt_expr(out, body, depth);
         }
+        ExprKind::TypeAscription { expr, ty } => {
+            fmt_expr(out, expr, depth);
+            out.push_str(": ");
+            fmt_type(out, ty, depth);
+        }
     }
 }
 

--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -256,6 +256,8 @@ let x = 1                   // immutable
 let x: Int = 1              // with type annotation
 var y = 2                   // mutable
 y = y + 1                   // reassign (var only)
+f([]: List[Int])            // type ascription in call args
+f([:]: Map[String, Int])    // typed empty map in call args
 ```
 
 ### Destructuring

--- a/docs/roadmap/active/ceangal-widget-system.md
+++ b/docs/roadmap/active/ceangal-widget-system.md
@@ -140,6 +140,6 @@ almide-js archived — replaced by almide-web.
 | @export annotation string | ✅ 0.17.6 |
 | COW List → Vec (Rust codegen) | ❌ pending |
 | Record spread `{ ...r, field: val }` | ✅ works (tested, pipe utilities use it) |
-| UFCS on generic types (Rust codegen) | ❌ pending 0.17.7 partial fix — cell.get()/set()/update() blocked |
+| UFCS on generic types (Rust codegen) | ✅ 0.17.7 — mono discovery + cross-module type checker + lowering |
 | almide-web created | ✅ (DOM, fetch, timer, console) |
 | almide-js archived | ✅ |

--- a/docs/roadmap/active/ceangal-widget-system.md
+++ b/docs/roadmap/active/ceangal-widget-system.md
@@ -139,4 +139,7 @@ almide-js archived — replaced by almide-web.
 | syntax_guide false positive fix | ✅ 0.17.6 |
 | @export annotation string | ✅ 0.17.6 |
 | COW List → Vec (Rust codegen) | ❌ pending |
-| Record spread `{ ...r, field: val }` | ❌ pending (pipe utility ergonomics) |
+| Record spread `{ ...r, field: val }` | ✅ works (tested, pipe utilities use it) |
+| UFCS on generic types (Rust codegen) | ❌ pending 0.17.7 partial fix — cell.get()/set()/update() blocked |
+| almide-web created | ✅ (DOM, fetch, timer, console) |
+| almide-js archived | ✅ |

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.17.7. almide-dialect crate (SSA, MLIR-like), compile-time value parameters (`fn f[N: Int]()`), bit introspection, Hashable protocol.
+- Current stable: v0.17.8. almide-dialect crate (SSA, MLIR-like), compile-time value parameters (`fn f[N: Int]()`), bit introspection, Hashable protocol.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/spec/lang/type_ascription_test.almd
+++ b/spec/lang/type_ascription_test.almd
@@ -1,0 +1,24 @@
+// Type ascription: `expr: Type` in call arguments
+
+fn identity[T](x: T) -> T = x
+
+test "empty list with ascription" {
+  let xs = identity([]: List[Int])
+  assert(list.len(xs) == 0)
+}
+
+test "empty map with ascription" {
+  let m = identity([:]: Map[String, Int])
+  assert(map.len(m) == 0)
+}
+
+test "ascription preserves type" {
+  let xs = identity([]: List[String])
+  let ys = xs + ["hello"]
+  assert(list.len(ys) == 1)
+}
+
+test "ascription in nested call" {
+  let n = list.len(identity([]: List[Float]))
+  assert(n == 0)
+}


### PR DESCRIPTION
## Summary

- Type ascription in call arguments (`[]: List[Type]`)
- Cross-module type resolution fixes (dedup aliases, deferred field access)
- WASM DCE: TrackedFunction eliminates bytecode scanner dependency (type-enforced)
- WASM record field lookup for module-qualified type names
- wasmparser cross-validation tests (22 total DCE tests)
- mono/discovery + rewrite refactored to IrVisitor (-186 lines)
- Cross-module UFCS on generics
- 231 almide tests pass, Ceangal WASM builds cleanly

## Test plan

- [x] `almide test` — 231 files pass
- [x] `cargo test -p almide-codegen` — 22 DCE tests + wasmparser cross-validation
- [x] Ceangal WASM build — clean (no POSTCONDITION violations, no MEMBER-UNREACHABLE)
- [x] CI green on develop