### PR TITLE
v0.18.0: mut parameter modifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.17.10"
+version = "0.18.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-codegen/src/pass_borrow_inference.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference.rs
@@ -138,23 +138,28 @@ pub fn infer_borrow_signatures(program: &mut IrProgram) -> HashMap<String, Vec<P
                         borrows[idx] = ParamBorrow::Ref;
                     }
                 }
-                // First param is mutated in place when: Almide fn is marked
-                // `@mutating`, or returns Unit with a Ref-mode container
-                // first arg (common case for `.clear`, `.push`, etc.).
-                // Explicit `@borrow_ref(first_param)` always wins — the
-                // caller has opted into "read-only reference even if
-                // return is Unit" (e.g. `almide_rt_test_assert_some`).
+                // Mutated parameters: explicit `mut` keyword, `@mutating`,
+                // or implicit (returns Unit with Ref-mode container first arg).
+                // `@borrow_ref(param)` always wins over mutation inference.
                 let has_mutating = attrs.iter().any(|a| a.name.as_str() == "mutating");
                 let implicit_mut = is_unit_type_expr(return_type);
-                if has_mutating || implicit_mut {
-                    let first_name = params.first().map(|p| p.name.as_str());
-                    let first_is_borrow_ref = first_name
+                // Collect all mut param indices
+                let mut mut_indices: Vec<usize> = params.iter().enumerate()
+                    .filter(|(_, p)| p.is_mut)
+                    .map(|(i, _)| i)
+                    .collect();
+                if (has_mutating || implicit_mut) && !mut_indices.contains(&0) {
+                    mut_indices.push(0);
+                }
+                for idx in mut_indices {
+                    let param_name = params.get(idx).map(|p| p.name.as_str());
+                    let is_borrow_ref = param_name
                         .map(|n| borrow_ref_names.iter().any(|r| r == &n))
                         .unwrap_or(false);
-                    if !first_is_borrow_ref {
-                        if let Some(first_borrow) = borrows.first_mut() {
-                            if matches!(first_borrow, ParamBorrow::Ref | ParamBorrow::RefSlice) {
-                                *first_borrow = ParamBorrow::RefMut;
+                    if !is_borrow_ref {
+                        if let Some(b) = borrows.get_mut(idx) {
+                            if matches!(b, ParamBorrow::Ref | ParamBorrow::RefSlice) {
+                                *b = ParamBorrow::RefMut;
                             }
                         }
                     }

--- a/crates/almide-frontend/src/bundled_sigs.rs
+++ b/crates/almide-frontend/src/bundled_sigs.rs
@@ -169,6 +169,10 @@ fn build_fn_sig(
         .collect();
     let ret = crate::canonicalize::resolve::resolve_type_expr(return_type, resolver_ctx);
     let is_effect = effect.unwrap_or(false) || r#async.unwrap_or(false);
+    let mut_params: Vec<usize> = params.iter().enumerate()
+        .filter(|(_, p)| p.is_mut)
+        .map(|(i, _)| i)
+        .collect();
     FnSig {
         generics: gnames,
         params: ptys,
@@ -176,5 +180,6 @@ fn build_fn_sig(
         is_effect,
         structural_bounds: HashMap::new(),
         protocol_bounds: HashMap::new(),
+        mut_params,
     }
 }

--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -179,13 +179,17 @@ pub fn register_fn_sig(
         }
     }
     let ptys: Vec<(Sym, Ty)> = params.iter().map(|p| (sym(&p.name), resolve(env, &p.ty))).collect();
+    let mut_params: Vec<usize> = params.iter().enumerate()
+        .filter(|(_, p)| p.is_mut)
+        .map(|(i, _)| i)
+        .collect();
     let ret = resolve(env, return_type);
     for gn in &gnames { env.types.remove(gn); }
     let is_effect = effect.unwrap_or(false) || r#async.unwrap_or(false);
     let key = prefixed_key(prefix, name);
     if prefix.is_none() && is_effect { env.effect_fns.insert(sym(name)); }
     let min_p = params.iter().take_while(|p| p.default.is_none()).count();
-    env.functions.insert(sym(&key), FnSig { params: ptys, ret, is_effect, generics: gnames, structural_bounds: sb, protocol_bounds: pb });
+    env.functions.insert(sym(&key), FnSig { params: ptys, ret, is_effect, generics: gnames, structural_bounds: sb, protocol_bounds: pb, mut_params });
     // Record visibility so `resolve_module_call` can reject cross-module access
     // to `mod fn` / `local fn`. Only non-Public entries need to be stored — the
     // lookup in the checker treats "missing" as Public (stdlib, impl methods,
@@ -226,23 +230,23 @@ pub fn register_derive_sigs(env: &mut TypeEnv, derives: &[Sym], type_name: &str)
             "Eq" => {
                 let fn_key = format!("{}.eq", type_name);
                 if !env.functions.contains_key(&sym(&fn_key)) {
-                    env.functions.insert(sym(&fn_key), FnSig { params: vec![("a".into(), type_ty.clone()), ("b".into(), type_ty.clone())], ret: Ty::Bool, is_effect: false, generics: vec![], structural_bounds: empty_sb.clone(), protocol_bounds: empty_pb.clone() });
+                    env.functions.insert(sym(&fn_key), FnSig { params: vec![("a".into(), type_ty.clone()), ("b".into(), type_ty.clone())], ret: Ty::Bool, is_effect: false, generics: vec![], structural_bounds: empty_sb.clone(), protocol_bounds: empty_pb.clone(), mut_params: vec![] });
                 }
             }
             "Repr" => {
                 let fn_key = format!("{}.repr", type_name);
                 if !env.functions.contains_key(&sym(&fn_key)) {
-                    env.functions.insert(sym(&fn_key), FnSig { params: vec![("v".into(), type_ty.clone())], ret: Ty::String, is_effect: false, generics: vec![], structural_bounds: empty_sb.clone(), protocol_bounds: empty_pb.clone() });
+                    env.functions.insert(sym(&fn_key), FnSig { params: vec![("v".into(), type_ty.clone())], ret: Ty::String, is_effect: false, generics: vec![], structural_bounds: empty_sb.clone(), protocol_bounds: empty_pb.clone(), mut_params: vec![] });
                 }
             }
             "Codec" => {
                 let encode_key = format!("{}.encode", type_name);
                 if !env.functions.contains_key(&sym(&encode_key)) {
-                    env.functions.insert(sym(&encode_key), FnSig { params: vec![("v".into(), type_ty.clone())], ret: value_ty.clone(), is_effect: false, generics: vec![], structural_bounds: empty_sb.clone(), protocol_bounds: empty_pb.clone() });
+                    env.functions.insert(sym(&encode_key), FnSig { params: vec![("v".into(), type_ty.clone())], ret: value_ty.clone(), is_effect: false, generics: vec![], structural_bounds: empty_sb.clone(), protocol_bounds: empty_pb.clone(), mut_params: vec![] });
                 }
                 let decode_key = format!("{}.decode", type_name);
                 if !env.functions.contains_key(&sym(&decode_key)) {
-                    env.functions.insert(sym(&decode_key), FnSig { params: vec![("v".into(), value_ty.clone())], ret: Ty::result(type_ty.clone(), Ty::String), is_effect: false, generics: vec![], structural_bounds: empty_sb.clone(), protocol_bounds: empty_pb.clone() });
+                    env.functions.insert(sym(&decode_key), FnSig { params: vec![("v".into(), value_ty.clone())], ret: Ty::result(type_ty.clone(), Ty::String), is_effect: false, generics: vec![], structural_bounds: empty_sb.clone(), protocol_bounds: empty_pb.clone(), mut_params: vec![] });
                 }
             }
             _ => {}

--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -34,7 +34,10 @@ impl Checker {
                 if self.env.lookup_var(&name).is_some() {
                     let _ = self.infer_expr(callee);
                 }
-                self.check_named_call_spanned(&name, &arg_tys, type_args, callee_span_snapshot)
+                let ret = self.check_named_call_spanned(&name, &arg_tys, type_args, callee_span_snapshot);
+                let arg_refs: Vec<&ast::Expr> = args.iter().collect();
+                self.validate_mut_args(&name, &arg_refs);
+                ret
             }
             ExprKind::TypeName { name, .. } => {
                 if let Some((type_name, case)) = self.env.constructors.get(&sym(name)).cloned() {
@@ -76,6 +79,8 @@ impl Checker {
                 let resolved = self.resolve_static_member(object, field, &arg_tys);
                 self.callee_span_hint = prev;
                 if let Some(result) = resolved {
+                    let arg_refs: Vec<&ast::Expr> = args.iter().collect();
+                    self.validate_mut_args(&format!("{}.{}", if let ExprKind::Ident { name, .. } = &object.kind { name.as_str() } else { "?" }, field), &arg_refs);
                     return result;
                 }
                 // UFCS method: obj.method(args) -> module.method(obj, args)
@@ -346,6 +351,7 @@ impl Checker {
         }
 
         let Some(sig) = sig else {
+            self.last_mut_params = vec![];
             // No function signature found — try constructor, variable, or report error
             if let Some((type_name, case)) = self.env.constructors.get(&sym(name)).cloned() {
                 self.check_constructor_args(name, &case, arg_tys);
@@ -433,6 +439,8 @@ impl Checker {
             self.emit(diag);
             return Ty::Unknown;
         };
+
+        self.last_mut_params = sig.mut_params.clone();
 
         // Effect isolation: pure fn cannot call effect fn
         if sig.is_effect && !self.env.can_call_effect {
@@ -542,6 +550,35 @@ impl Checker {
             return Ty::result(ret, Ty::String);
         }
         ret
+    }
+
+    /// Validate that arguments passed to `mut` parameters are mutable (`var`) bindings.
+    /// Called after `check_named_call_with_type_args` which populates `self.last_mut_params`.
+    pub(crate) fn validate_mut_args(&mut self, fn_name: &str, arg_exprs: &[&ast::Expr]) {
+        let mut_params = std::mem::take(&mut self.last_mut_params);
+        for &idx in &mut_params {
+            if idx >= arg_exprs.len() { continue; }
+            let arg = arg_exprs[idx];
+            let param_name = fn_name.split('.').last().unwrap_or(fn_name);
+            match &arg.kind {
+                ExprKind::Ident { name, .. } => {
+                    if !self.env.mutable_vars.contains(&sym(name)) {
+                        self.emit(super::err(
+                            format!("cannot pass immutable binding '{}' to `mut` parameter of {}()", name, fn_name),
+                            format!("Declare '{}' with `var` instead of `let` to allow mutation", name),
+                            format!("call to {}()", fn_name),
+                        ).with_code("E007"));
+                    }
+                }
+                _ => {
+                    self.emit(super::err(
+                        format!("cannot pass a temporary expression to `mut` parameter of {}()", fn_name),
+                        "Pass a mutable `var` binding instead",
+                        format!("call to {}()", fn_name),
+                    ).with_code("E007"));
+                }
+            }
+        }
     }
 
     /// Create fresh inference variables for a type's generic parameters.

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -57,6 +57,10 @@ pub struct Checker {
     /// rewrite the whole call (UFCS `x.to_uppercase()` →
     /// `string.to_upper(x)`) can target the full range.
     pub(crate) call_span_hint: Option<crate::ast::Span>,
+    /// `mut` parameter indices from the last resolved function signature.
+    /// Set by `check_named_call_with_type_args`, consumed by callers
+    /// that have access to argument expressions for mutability validation.
+    pub(crate) last_mut_params: Vec<usize>,
     pub(crate) constraints: Vec<Constraint>,
     pub(crate) uf: UnionFind,
     /// Module-name prefix active during `infer_module`. `None` for the
@@ -93,6 +97,7 @@ impl Checker {
             current_span: None,
             callee_span_hint: None,
             call_span_hint: None,
+            last_mut_params: Vec::new(),
             constraints: Vec::new(), uf: UnionFind::new(),
             current_module_prefix: None,
             deferred_tuple_indices: Vec::new(),
@@ -503,6 +508,7 @@ impl Checker {
             let ty = self.resolve_type_expr(&p.ty);
             self.env.define_var(&p.name, ty.clone());
             self.env.param_vars.insert(sym(&p.name));
+            if p.is_mut { self.env.mutable_vars.insert(sym(&p.name)); }
             if let Some(ref mut default_expr) = p.default {
                 let dty = self.infer_expr(default_expr);
                 self.constrain(ty, dty, format!("default arg '{}'", p.name));
@@ -543,7 +549,8 @@ impl Checker {
                 self.env.can_call_effect = prev_call;
                 self.env.pop_scope();
             }
-            ast::Decl::TopLet { name, value, .. } => {
+            ast::Decl::TopLet { name, value, mutable, .. } => {
+                if *mutable { self.env.mutable_vars.insert(sym(name)); }
                 let ity = self.infer_expr(value);
                 let resolved = resolve_ty(&ity, &self.uf);
                 // Update env.top_lets with the fully inferred type.

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -579,15 +579,23 @@ fn lower_fn(
         if remaining.is_empty() { None } else { Some(remaining) }
     }).flatten();
 
-    // Resolve @mutating(param_name) → parameter indices
-    let mutated_params = attrs.iter()
-        .filter(|a| a.name.as_str() == "mutating")
-        .flat_map(|a| a.args.iter().filter_map(|arg| {
+    // Resolve mut params: from `mut` keyword and @mutating(param_name) annotation
+    let mut mutated_params: Vec<usize> = params.iter().enumerate()
+        .filter(|(_, p)| p.is_mut)
+        .map(|(i, _)| i)
+        .collect();
+    // Merge @mutating(param_name) indices (backward compat)
+    for attr in attrs.iter().filter(|a| a.name.as_str() == "mutating") {
+        for arg in &attr.args {
             if let almide_lang::ast::AttrValue::Ident { name: pname } = &arg.value {
-                params.iter().position(|p| p.name == *pname)
-            } else { None }
-        }))
-        .collect::<Vec<_>>();
+                if let Some(idx) = params.iter().position(|p| p.name == *pname) {
+                    if !mutated_params.contains(&idx) {
+                        mutated_params.push(idx);
+                    }
+                }
+            }
+        }
+    }
 
     IrFunction {
         name: sym(name), params: ir_params, ret_ty, body: ir_body,

--- a/crates/almide-syntax/src/ast.rs
+++ b/crates/almide-syntax/src/ast.rs
@@ -250,6 +250,10 @@ pub struct Param {
     pub default: Option<Box<Expr>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub attrs: Vec<Attribute>,
+    /// `mut` parameter modifier — the function may mutate this argument in place.
+    /// Caller must pass a `var` binding (not `let` or temporary).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_mut: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/almide-syntax/src/lexer.rs
+++ b/crates/almide-syntax/src/lexer.rs
@@ -19,7 +19,7 @@ pub enum TokenType {
     // Identifiers
     Ident, TypeName,
     // Keywords
-    Module, Import, Type, Protocol, Impl, For, In, Fn, Let, Var,
+    Module, Import, Type, Protocol, Impl, For, In, Fn, Let, Var, Mut,
     If, Then, Else, Match, Ok, Err, Some, None, Todo,
     True, False, Not, And, Or,
     Strict, Pub, Effect, Test,
@@ -453,7 +453,7 @@ fn keyword(s: &str) -> Option<TokenType> {
         "type" => Some(TokenType::Type), "protocol" => Some(TokenType::Protocol),
         "impl" => Some(TokenType::Impl), "for" => Some(TokenType::For),
         "in" => Some(TokenType::In), "fn" => Some(TokenType::Fn),
-        "let" => Some(TokenType::Let), "var" => Some(TokenType::Var),
+        "let" => Some(TokenType::Let), "var" => Some(TokenType::Var), "mut" => Some(TokenType::Mut),
         "if" => Some(TokenType::If), "then" => Some(TokenType::Then),
         "else" => Some(TokenType::Else), "match" => Some(TokenType::Match),
         "ok" | "Ok" => Some(TokenType::Ok), "err" | "Err" => Some(TokenType::Err),

--- a/crates/almide-syntax/src/parser/declarations.rs
+++ b/crates/almide-syntax/src/parser/declarations.rs
@@ -623,6 +623,7 @@ impl Parser {
                 ty: TypeExpr::Simple { name: sym("Self") },
                 default: None,
                 attrs: Vec::new(),
+                is_mut: false,
             });
             self.advance();
             if self.check(TokenType::Comma) { self.advance(); }
@@ -638,6 +639,8 @@ impl Parser {
                 attrs.push(self.parse_attribute()?);
                 self.skip_newlines();
             }
+            let is_mut = self.check(TokenType::Mut);
+            if is_mut { self.advance(); }
             let param_name = self.expect_any_param_name()?;
             self.expect(TokenType::Colon)?;
             let param_type = self.parse_type_expr()?;
@@ -651,7 +654,7 @@ impl Parser {
                 }
                 None
             };
-            params.push(Param { name: param_name, ty: param_type, default, attrs });
+            params.push(Param { name: param_name, ty: param_type, default, attrs, is_mut });
             if self.check(TokenType::Comma) {
                 self.advance();
                 self.skip_newlines();

--- a/crates/almide-syntax/src/parser/hints/syntax_guide.rs
+++ b/crates/almide-syntax/src/parser/hints/syntax_guide.rs
@@ -32,8 +32,8 @@ pub fn check(ctx: &HintContext) -> Option<HintResult> {
     }
 
     // `let mut` → `var`
-    if ctx.expected == Some(TokenType::Ident) || ctx.expected.is_none() {
-        if ctx.got.token_type == TokenType::Ident && ctx.got.value == "mut" {
+    if ctx.expected == Some(TokenType::Ident) || ctx.expected == Some(TokenType::Mut) || ctx.expected.is_none() {
+        if ctx.got.token_type == TokenType::Mut {
             if let Some(prev) = ctx.prev {
                 if prev.token_type == TokenType::Let {
                     return Some(HintResult {

--- a/crates/almide-syntax/src/parser/statements.rs
+++ b/crates/almide-syntax/src/parser/statements.rs
@@ -89,9 +89,9 @@ impl Parser {
         }
 
         // Detect `let mut` (Rust style)
-        if self.check(TokenType::Ident) && self.current().value == "mut" {
+        if self.check(TokenType::Mut) {
             return Err(self.check_hint_or_err(
-                Some(TokenType::Ident), super::hints::HintScope::Block,
+                Some(TokenType::Mut), super::hints::HintScope::Block,
                 "'let mut' is not valid in Almide",
             ));
         }

--- a/crates/almide-types/src/types/mod.rs
+++ b/crates/almide-types/src/types/mod.rs
@@ -134,13 +134,15 @@ pub struct FnSig {
     pub structural_bounds: std::collections::HashMap<Sym, Ty>,
     /// Protocol bounds for generics: TypeVar name → list of protocol names
     pub protocol_bounds: std::collections::HashMap<Sym, Vec<Sym>>,
+    /// Which parameters are `mut` (in-place mutation). Indices into `params`.
+    pub mut_params: Vec<usize>,
 }
 
 /// Convenience macro for creating FnSig without generics (stdlib functions)
 #[macro_export]
 macro_rules! fn_sig {
     (params: $params:expr, ret: $ret:expr, is_effect: $eff:expr) => {
-        FnSig { params: $params, ret: $ret, is_effect: $eff, generics: vec![], structural_bounds: std::collections::HashMap::new(), protocol_bounds: std::collections::HashMap::new() }
+        FnSig { params: $params, ret: $ret, is_effect: $eff, generics: vec![], structural_bounds: std::collections::HashMap::new(), protocol_bounds: std::collections::HashMap::new(), mut_params: vec![] }
     };
 }
 

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.17.10 (prev v0.17.9). Versioned constant codegen, for-in list iteration, @intrinsic mono skip, LICM mutation tracking via @mutating(param), mut parameter modifier roadmap.
+- Current stable: v0.18.0 (prev v0.17.10). `mut` parameter modifier: first-class keyword, checker-enforced mutability at call sites (E007), FnSig.mut_params, stdlib migrated from @mutating to `mut`.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/spec/lang/mut_param_test.almd
+++ b/spec/lang/mut_param_test.almd
@@ -1,0 +1,30 @@
+// mut parameter modifier — checker enforcement tests
+
+fn add_item(mut xs: List[Int], x: Int) -> Unit = {
+  list.push(xs, x)
+}
+
+test "mut param accepts var binding" {
+  var data: List[Int] = []
+  add_item(data, 1)
+  add_item(data, 2)
+  assert(list.len(data) == 2)
+  assert(data[0] == 1)
+  assert(data[1] == 2)
+}
+
+test "mut param with stdlib list.push" {
+  var xs: List[Int] = [10]
+  list.push(xs, 20)
+  list.push(xs, 30)
+  assert(list.len(xs) == 3)
+  assert(xs[2] == 30)
+}
+
+test "mut param with map.insert" {
+  var m = map.new[String, Int]()
+  map.insert(m, "a", 1)
+  map.insert(m, "b", 2)
+  assert(map.len(m) == 2)
+  assert(map.get_or(m, "a", 0) == 1)
+}

--- a/stdlib/bytes.almd
+++ b/stdlib/bytes.almd
@@ -140,8 +140,7 @@ fn pad_left(b: Bytes, target_len: Int, val: Int) -> Bytes = _
 fn pad_right(b: Bytes, target_len: Int, val: Int) -> Bytes = _
 
 @intrinsic("almide_rt_bytes_push")
-@mutating(b)
-fn push(b: Bytes, val: Int) -> Unit = _
+fn push(mut b: Bytes, val: Int) -> Unit = _
 
 @intrinsic("almide_rt_bytes_read_bool")
 fn read_bool(b: Bytes, pos: Int) -> Bool = _

--- a/stdlib/list.almd
+++ b/stdlib/list.almd
@@ -227,8 +227,7 @@ fn binary_search(xs: List[Int], target: Int) -> Option[Int] = _
 // ── mutable (in-place) ──
 
 @intrinsic("almide_rt_list_push")
-@mutating(xs)
-fn push[A](xs: List[A], x: A) -> Unit = _
+fn push[A](mut xs: List[A], x: A) -> Unit = _
 
 // Create an empty list with preallocated capacity. Subsequent `push`es
 // up to `cap` avoid the repeated Vec doublings that dominate tight
@@ -237,12 +236,10 @@ fn push[A](xs: List[A], x: A) -> Unit = _
 fn with_capacity[A](cap: Int) -> List[A] = _
 
 @intrinsic("almide_rt_list_pop")
-@mutating(xs)
-fn pop[A](xs: List[A]) -> Option[A] = _
+fn pop[A](mut xs: List[A]) -> Option[A] = _
 
 @intrinsic("almide_rt_list_clear")
-@mutating(xs)
-fn clear[A](xs: List[A]) -> Unit = _
+fn clear[A](mut xs: List[A]) -> Unit = _
 
 // ── bundled-Almide extensions (non-TOML, pure Almide body) ──
 

--- a/stdlib/map.almd
+++ b/stdlib/map.almd
@@ -83,13 +83,10 @@ fn update[K, V](m: Map[K, V], key: K, f: (V) -> V) -> Map[K, V] = _
 // ── mutable (in-place) ──
 
 @intrinsic("almide_rt_map_insert")
-@mutating(m)
-fn insert[K, V](m: Map[K, V], key: K, value: V) -> Unit = _
+fn insert[K, V](mut m: Map[K, V], key: K, value: V) -> Unit = _
 
 @intrinsic("almide_rt_map_delete")
-@mutating(m)
-fn delete[K, V](m: Map[K, V], key: K) -> Unit = _
+fn delete[K, V](mut m: Map[K, V], key: K) -> Unit = _
 
 @intrinsic("almide_rt_map_clear")
-@mutating(m)
-fn clear[K, V](m: Map[K, V]) -> Unit = _
+fn clear[K, V](mut m: Map[K, V]) -> Unit = _

--- a/tests/hint_test.rs
+++ b/tests/hint_test.rs
@@ -334,16 +334,16 @@ fn syntax_guide_print() {
 #[test]
 fn syntax_guide_let_mut() {
     let prev = tok(TokenType::Let, "let");
-    let got = tok(TokenType::Ident, "mut");
-    let ctx = HintContext { expected: Some(TokenType::Ident), got: &got, prev: Some(&prev), next: None, scope: HintScope::Block };
+    let got = tok(TokenType::Mut, "mut");
+    let ctx = HintContext { expected: Some(TokenType::Mut), got: &got, prev: Some(&prev), next: None, scope: HintScope::Block };
     assert_hint_match(&ctx, "var");
 }
 
 #[test]
 fn syntax_guide_let_mut_needs_let_prev() {
     let prev = tok(TokenType::Ident, "x");
-    let got = tok(TokenType::Ident, "mut");
-    let ctx = HintContext { expected: Some(TokenType::Ident), got: &got, prev: Some(&prev), next: None, scope: HintScope::Block };
+    let got = tok(TokenType::Mut, "mut");
+    let ctx = HintContext { expected: Some(TokenType::Mut), got: &got, prev: Some(&prev), next: None, scope: HintScope::Block };
     // "mut" after a non-let token should not trigger the let mut hint
     let result = check_hint(&ctx);
     if let Some(r) = result {

--- a/tests/types_test.rs
+++ b/tests/types_test.rs
@@ -475,6 +475,7 @@ fn fn_sig_format_params() {
         generics: vec![],
         structural_bounds: std::collections::HashMap::new(),
         protocol_bounds: std::collections::HashMap::new(),
+        mut_params: vec![],
     };
     assert_eq!(sig.format_params(), "a: Int, b: String");
 }
@@ -488,6 +489,7 @@ fn fn_sig_format_params_empty() {
         generics: vec![],
         structural_bounds: std::collections::HashMap::new(),
         protocol_bounds: std::collections::HashMap::new(),
+        mut_params: vec![],
     };
     assert_eq!(sig.format_params(), "");
 }


### PR DESCRIPTION
## Summary

- **`mut` parameter modifier** — first-class language keyword with checker enforcement
- Passing a `let` binding or temporary to a `mut` parameter produces E007
- Stdlib migrated from `@mutating(param)` annotation to `mut param` syntax
- `FnSig.mut_params` carries mutability info through type signatures
- Borrow inference marks `mut` params as `&mut T` in generated Rust

## Changes

### Compiler (15 files)
- Lexer: `mut` keyword token
- Parser: `mut` before param name in fn declarations
- AST: `Param.is_mut: bool`
- Checker: E007 validation, TopLet `var` → mutable_vars bugfix, `mut` params mutable in body
- FnSig: `mut_params: Vec<usize>`
- Lowering: merge `mut` + `@mutating` → `IrFunction.mutated_params`
- Codegen: borrow inference `RefMut` from `is_mut`

### Stdlib (3 files)
- `list.push/pop/clear`, `map.insert/delete/clear`, `bytes.push`: `@mutating` → `mut`

### Tests
- `spec/lang/mut_param_test.almd`: 3 tests (user fn, list.push, map.insert)
- 232/232 almide tests pass

## Test plan
- [x] `almide test` — 232/232 pass
- [x] `cargo test` — all pass
- [x] `almide docs-gen --check` — ok