### PR TITLE
v0.18.1: Opaque types, SafeHtml/SafePath, DefId name resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.17.10"
+version = "0.18.0"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-codegen/src/emit_wasm/calls.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls.rs
@@ -285,7 +285,7 @@ impl FuncCompiler<'_> {
                         if let Some(dot) = name.find('.') {
                             let module = &name[..dot];
                             let func = &name[dot+1..];
-                            let target = CallTarget::Module { module: almide_base::intern::sym(module), func: almide_base::intern::sym(func) };
+                            let target = CallTarget::Module { module: almide_base::intern::sym(module), func: almide_base::intern::sym(func), def_id: None };
                             self.emit_call(&target, args, _ret_ty);
                             return;
                         }
@@ -373,7 +373,7 @@ impl FuncCompiler<'_> {
                 }
             }
 
-            CallTarget::Module { module, func } => {
+            CallTarget::Module { module, func, .. } => {
                 // Sized numeric conversion modules (`int8`, ..., `uint64`,
                 // `float32`) live in bundled `.almd` + `@inline_rust` only.
                 // On WASM they surface as `CallTarget::Module` here and get
@@ -749,22 +749,22 @@ impl FuncCompiler<'_> {
                     }
                     "sort" | "list.sort" if matches!(&object.ty, Ty::Applied(_, _)) => {
                         let fake = [(**object).clone()];
-                        let target = CallTarget::Module { module: "list".into(), func: "sort".into() };
+                        let target = CallTarget::Module { module: "list".into(), func: "sort".into(), def_id: None };
                         self.emit_call(&target, &fake, _ret_ty);
                     }
                     "reverse" | "list.reverse" if matches!(&object.ty, Ty::Applied(_, _)) => {
                         let fake = [(**object).clone()];
-                        let target = CallTarget::Module { module: "list".into(), func: "reverse".into() };
+                        let target = CallTarget::Module { module: "list".into(), func: "reverse".into(), def_id: None };
                         self.emit_call(&target, &fake, _ret_ty);
                     }
                     "filter" | "list.filter" if matches!(&object.ty, Ty::Applied(_, _)) => {
                         let fake = [(**object).clone(), args[0].clone()];
-                        let target = CallTarget::Module { module: "list".into(), func: "filter".into() };
+                        let target = CallTarget::Module { module: "list".into(), func: "filter".into(), def_id: None };
                         self.emit_call(&target, &fake, _ret_ty);
                     }
                     "fold" | "list.fold" if matches!(&object.ty, Ty::Applied(_, _)) => {
                         let fake = [(**object).clone(), args[0].clone(), args[1].clone()];
-                        let target = CallTarget::Module { module: "list".into(), func: "fold".into() };
+                        let target = CallTarget::Module { module: "list".into(), func: "fold".into(), def_id: None };
                         self.emit_call(&target, &fake, _ret_ty);
                     }
                     "map" | "list.map" if matches!(&object.ty, Ty::Applied(_, _)) => {
@@ -841,6 +841,7 @@ impl FuncCompiler<'_> {
                         let target = CallTarget::Module {
                             module: almide_base::intern::sym(src_module),
                             func: almide_base::intern::sym(bare_method),
+                            def_id: None,
                         };
                         self.emit_call(&target, &fake_args, _ret_ty);
                     }
@@ -892,6 +893,7 @@ impl FuncCompiler<'_> {
                         let target = CallTarget::Module {
                             module: almide_base::intern::sym(src_module),
                             func: almide_base::intern::sym(bare_method),
+                            def_id: None,
                         };
                         self.emit_call(&target, &fake_args, _ret_ty);
                     }
@@ -1056,6 +1058,7 @@ impl FuncCompiler<'_> {
                 let target = CallTarget::Module {
                     module: almide_base::intern::sym("error"),
                     func: almide_base::intern::sym(func),
+                    def_id: None,
                 };
                 self.emit_call(&target, args, ret_ty);
                 true

--- a/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
@@ -25,7 +25,7 @@ impl FuncCompiler<'_> {
         if method == "mul_scaled" || method == "mul_f32_scaled" {
             let mul_call = IrExpr {
                 kind: IrExprKind::Call {
-                    target: CallTarget::Module { module: sym("matrix"), func: sym("mul") },
+                    target: CallTarget::Module { module: sym("matrix"), func: sym("mul"), def_id: None },
                     args: vec![args[0].clone(), args[2].clone()],
                     type_args: vec![],
                 },
@@ -39,7 +39,7 @@ impl FuncCompiler<'_> {
         if method == "mul_f32_t" {
             let transpose_call = IrExpr {
                 kind: IrExprKind::Call {
-                    target: CallTarget::Module { module: sym("matrix"), func: sym("transpose") },
+                    target: CallTarget::Module { module: sym("matrix"), func: sym("transpose"), def_id: None },
                     args: vec![args[1].clone()],
                     type_args: vec![],
                 },
@@ -51,7 +51,7 @@ impl FuncCompiler<'_> {
         if method == "mul_f32_t_scaled" {
             let transpose_call = IrExpr {
                 kind: IrExprKind::Call {
-                    target: CallTarget::Module { module: sym("matrix"), func: sym("transpose") },
+                    target: CallTarget::Module { module: sym("matrix"), func: sym("transpose"), def_id: None },
                     args: vec![args[2].clone()],
                     type_args: vec![],
                 },

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -1048,6 +1048,7 @@ impl FuncCompiler<'_> {
                 let target = almide_ir::CallTarget::Module {
                     module: almide_base::intern::sym("matrix"),
                     func: almide_base::intern::sym(func_name),
+                    def_id: None,
                 };
                 self.emit_call(&target, &[left.clone(), right.clone()], &Ty::Matrix);
             }

--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -589,7 +589,7 @@ fn infer_bind_type(expr: &IrExpr) -> Ty {
         // Call: infer return type from module+func name
         IrExprKind::Call { target, .. } => {
             match target {
-                almide_ir::CallTarget::Module { module, func } => {
+                almide_ir::CallTarget::Module { module, func, .. } => {
                     match (module.as_str(), func.as_str()) {
                         ("random", "int") | ("datetime", _)
                         | ("env", "unix_timestamp") | ("env", "millis")

--- a/crates/almide-codegen/src/pass_borrow_inference.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference.rs
@@ -475,7 +475,7 @@ fn check_needs_ownership(expr: &IrExpr, var: VarId, needs: &mut bool) {
             // Bytes-only stdlib-aware: only skip ownership for Bytes args in
             // stdlib Module calls. Lists/Strings keep the old conservative
             // behaviour to avoid lambda-typing regressions in filter/map.
-            if let CallTarget::Module { module, func } = target {
+            if let CallTarget::Module { module, func, .. } = target {
                 if almide_lang::stdlib_info::is_bundled_module(module.as_str()) {
                     for (i, arg) in args.iter().enumerate() {
                         let borrowed = bundled_borrow_at(module.as_str(), func.as_str(), i)
@@ -749,7 +749,7 @@ fn check_needs_refmut(expr: &IrExpr, var: VarId, needs: &mut bool) {
         IrExprKind::Call { target, args, .. } => {
             let callee_sig: Option<Vec<ParamBorrow>> = match target {
                 CallTarget::Named { name } => lookup_user_borrows(name.as_str()),
-                CallTarget::Module { module, func } => {
+                CallTarget::Module { module, func, .. } => {
                     let key = format!("{}::{}", module, func);
                     SIGS_SNAPSHOT.with(|s| s.borrow().get(&key).cloned())
                 }
@@ -942,7 +942,7 @@ fn rewrite_calls(expr: IrExpr, sigs: &HashMap<String, Vec<ParamBorrow>>, mod_sco
             // and the IR `args` align to params 1..N (not 0..N).
             let (callee_name, is_method_with_self) = match &target {
                 CallTarget::Named { name } => (Some(name.to_string()), false),
-                CallTarget::Module { module, func } => (Some(format!("{}::{}", module, func)), false),
+                CallTarget::Module { module, func, .. } => (Some(format!("{}::{}", module, func)), false),
                 CallTarget::Method { method, .. } if method.contains('.') => (Some(method.to_string()), true),
                 _ => (None, false),
             };

--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -432,7 +432,7 @@ fn propagate_pattern_ty(pat: &mut IrPattern, subj_ty: &Ty, vt: &mut VarTable) {
 
 fn is_fold_like_call(expr: &IrExpr) -> bool {
     match &expr.kind {
-        IrExprKind::Call { target: CallTarget::Module { module, func }, .. } => {
+        IrExprKind::Call { target: CallTarget::Module { module, func, .. }, .. } => {
             module.as_str() == "list" && matches!(func.as_str(), "fold" | "scan")
         }
         _ => false,
@@ -829,7 +829,7 @@ fn resolve_call_ret_ty(
 
     // 1. User-defined function lookup
     match target {
-        CallTarget::Module { module, func } => {
+        CallTarget::Module { module, func, .. } => {
             if let Some(ret) = symbols.lookup_module(module.as_str(), func.as_str()) {
                 if !ret.has_unresolved_deep() {
                     return Some(ret.clone());
@@ -851,7 +851,7 @@ fn resolve_call_ret_ty(
     //   - `Named { "almide_rt_list_map" }`       — post-ResolveCalls or
     //                                              frontend mangling
     let (module_owned, func_owned): (String, String) = match target {
-        CallTarget::Module { module, func } => (module.as_str().to_string(), func.as_str().to_string()),
+        CallTarget::Module { module, func, .. } => (module.as_str().to_string(), func.as_str().to_string()),
         CallTarget::Named { name } => {
             let s = name.as_str();
             if let Some(rest) = s.strip_prefix("almide_rt_") {

--- a/crates/almide-codegen/src/pass_effect_inference.rs
+++ b/crates/almide-codegen/src/pass_effect_inference.rs
@@ -365,7 +365,7 @@ fn collect_callees(expr: &IrExpr, callees: &mut HashSet<String>) {
                 collect_callees(arg, callees);
             }
         }
-        IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } => {
+        IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. } => {
             callees.insert(format!("{}.{}", module, func));
             for arg in args {
                 collect_callees(arg, callees);

--- a/crates/almide-codegen/src/pass_egg_saturation.rs
+++ b/crates/almide-codegen/src/pass_egg_saturation.rs
@@ -92,7 +92,7 @@ impl<'a> IrMutVisitor for EggVisitor<'a> {
 /// Other list calls (e.g. `list.len`) lift as opaque slots — cheap
 /// but skippable, so we avoid paying saturation cost for them.
 fn is_saturation_target(expr: &IrExpr) -> bool {
-    let IrExprKind::Call { target: almide_ir::CallTarget::Module { module, func }, .. } = &expr.kind else {
+    let IrExprKind::Call { target: almide_ir::CallTarget::Module { module, func, .. }, .. } = &expr.kind else {
         return false;
     };
     match module.as_str() {

--- a/crates/almide-codegen/src/pass_intrinsic_lowering.rs
+++ b/crates/almide-codegen/src/pass_intrinsic_lowering.rs
@@ -72,7 +72,7 @@ impl NanoPass for IntrinsicLoweringPass {
                 walk_expr_mut(self, expr);
                 let IrExprKind::Call { target, args, .. } = &mut expr.kind else { return };
                 match target {
-                    CallTarget::Module { module, func } => {
+                    CallTarget::Module { module, func, .. } => {
                         let Some(&symbol) = self.map.get(&(*module, *func)) else { return };
                         let mut args = std::mem::take(args);
                         self.fill_defaults(symbol, &mut args);

--- a/crates/almide-codegen/src/pass_lambda_type_resolve.rs
+++ b/crates/almide-codegen/src/pass_lambda_type_resolve.rs
@@ -339,7 +339,7 @@ fn resolve_call_lambdas(target: &CallTarget, args: &mut Vec<IrExpr>, vt: &mut Va
     //   - `Named { "almide_rt_<mod>_<func>" }`   — post-ResolveCalls
     let resolved: Option<(Option<&str>, String)> = match target {
         CallTarget::Method { method, .. } => Some((None, method.as_str().to_string())),
-        CallTarget::Module { module, func } => {
+        CallTarget::Module { module, func, .. } => {
             let m = module.as_str();
             if m == "list" || m == "option" || m == "result" {
                 Some((Some(m), func.as_str().to_string()))
@@ -589,7 +589,7 @@ fn resolve_list_elem_ty(expr: &IrExpr, vt: &VarTable) -> Option<Ty> {
     // `Named { "almide_rt_list_zip" }`, and post-IntrinsicLowering
     // `RuntimeCall { symbol: "almide_rt_list_zip", .. }`.
     let zip_args: Option<&Vec<IrExpr>> = match &expr.kind {
-        IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. }
+        IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. }
             if module.as_str() == "list" && func.as_str() == "zip" => Some(args),
         IrExprKind::Call { target: CallTarget::Named { name }, args, .. }
             if name.as_str() == "almide_rt_list_zip" => Some(args),
@@ -749,7 +749,7 @@ pub(crate) fn infer_param_ty_from_body(body: &IrExpr, target: VarId) -> Option<T
 fn compute_stdlib_call_ret(target: &CallTarget, args: &[IrExpr], vt: &VarTable) -> Option<Ty> {
     use almide_lang::types::constructor::TypeConstructorId as TCI;
     let (module, func): (&str, &str) = match target {
-        CallTarget::Module { module, func } => (module.as_str(), func.as_str()),
+        CallTarget::Module { module, func, .. } => (module.as_str(), func.as_str()),
         CallTarget::Named { name } => {
             let s = name.as_str();
             let rest = s.strip_prefix("almide_rt_")?;

--- a/crates/almide-codegen/src/pass_licm.rs
+++ b/crates/almide-codegen/src/pass_licm.rs
@@ -303,7 +303,7 @@ fn collect_defined_vars_expr(expr: &IrExpr, defined: &mut HashSet<VarId>, mm: &M
         // param in place (`list.push`, `map.insert`, ...). Mark the
         // caller-side Var as defined so LICM doesn't wrongly hoist
         // something that depends on it.
-        IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } => {
+        IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. } => {
             for (i, arg) in args.iter().enumerate() {
                 if let IrExprKind::Var { id } = &arg.kind {
                     if mm.get(&(*module, *func)).map_or(false, |mp| mp.contains(&i)) {
@@ -622,7 +622,7 @@ fn is_pure(expr: &IrExpr, pure_fns: &HashSet<Sym>) -> bool {
         // Function calls: pure if target is known-pure and all args are pure.
         IrExprKind::Call { target, args, .. } => {
             let call_pure = match target {
-                CallTarget::Module { module, func } => {
+                CallTarget::Module { module, func, .. } => {
                     let key = almide_base::intern::sym(&format!("{}.{}", module, func));
                     pure_fns.contains(&key)
                 }
@@ -854,7 +854,7 @@ fn expr_is_pure_with(expr: &IrExpr, pure_fns: &HashSet<Sym>) -> bool {
 
         IrExprKind::Call { target, args, .. } => {
             let call_pure = match target {
-                CallTarget::Module { module, func } => {
+                CallTarget::Module { module, func, .. } => {
                     let key = almide_base::intern::sym(&format!("{}.{}", module, func));
                     pure_fns.contains(&key)
                 }

--- a/crates/almide-codegen/src/pass_list_pattern.rs
+++ b/crates/almide-codegen/src/pass_list_pattern.rs
@@ -183,7 +183,7 @@ fn build_list_if_chain(subject: &IrExpr, arms: &[IrMatchArm], result_ty: &Ty, vt
             // Build condition: list.len(subject) == N
             let len_call = IrExpr {
                 kind: IrExprKind::Call {
-                    target: CallTarget::Module { module: sym("list"), func: sym("len") },
+                    target: CallTarget::Module { module: sym("list"), func: sym("len"), def_id: None },
                     args: vec![subject.clone()],
                     type_args: vec![],
                 },
@@ -341,7 +341,7 @@ fn build_list_if_chain(subject: &IrExpr, arms: &[IrMatchArm], result_ty: &Ty, vt
                         // Length check
                         let len_call = IrExpr {
                             kind: IrExprKind::Call {
-                                target: CallTarget::Module { module: sym("list"), func: sym("len") },
+                                target: CallTarget::Module { module: sym("list"), func: sym("len"), def_id: None },
                                 args: vec![elem_access.clone()],
                                 type_args: vec![],
                             },

--- a/crates/almide-codegen/src/pass_matrix_shape_spec.rs
+++ b/crates/almide-codegen/src/pass_matrix_shape_spec.rs
@@ -96,7 +96,7 @@ struct Shape { rows: i64, cols: i64, dtype: Dtype }
 
 /// Extract `matrix.<func>(args)`-style Module calls.
 fn match_module_call<'a>(expr: &'a IrExpr) -> Option<(&'a str, &'a str, &'a [IrExpr])> {
-    if let IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } = &expr.kind {
+    if let IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. } = &expr.kind {
         return Some((module.as_str(), func.as_str(), args.as_slice()));
     }
     None

--- a/crates/almide-codegen/src/pass_peephole.rs
+++ b/crates/almide-codegen/src/pass_peephole.rs
@@ -224,6 +224,7 @@ fn try_detect_vec_init(s1: &IrStmt, s2: &IrStmt, s3: &IrStmt) -> Option<IrStmt> 
             target: CallTarget::Module {
                 module: almide_base::intern::sym("list"),
                 func: almide_base::intern::sym("repeat"),
+                def_id: None,
             },
             args: vec![single_val.clone(), (**end).clone()],
             type_args: vec![],

--- a/crates/almide-codegen/src/pass_resolve_calls.rs
+++ b/crates/almide-codegen/src/pass_resolve_calls.rs
@@ -8,7 +8,7 @@
 //!
 //! ## What this pass does
 //!
-//! Walks every `CallTarget::Module { module, func }` and either:
+//! Walks every `CallTarget::Module { module, func, .. }` and either:
 //! - **Verifies**: a TOML-backed stdlib fn or a user-module fn exists; if
 //!   neither matches, emits a postcondition violation — a hard contract
 //!   (panic in debug, diagnostic in release; S2 flip).
@@ -67,7 +67,7 @@ impl NanoPass for ResolveCallsPass {
             fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
                 walk_expr_mut(self, expr);
                 if let IrExprKind::Call { target, .. } = &mut expr.kind {
-                    if let CallTarget::Module { module, func } = target {
+                    if let CallTarget::Module { module, func, .. } = target {
                         let m = module.as_str();
                         let f = func.as_str();
                         // bundled-Almide stdlib fn (in IR module, no TOML entry)
@@ -154,7 +154,7 @@ fn verify_all_calls_resolved(program: &IrProgram) -> Vec<String> {
     impl<'a> IrVisitor for CallChecker<'a> {
         fn visit_expr(&mut self, expr: &IrExpr) {
             if let IrExprKind::Call { target, .. } = &expr.kind {
-                if let CallTarget::Module { module, func } = target {
+                if let CallTarget::Module { module, func, .. } = target {
                     let m = module.as_str();
                     let f = func.as_str();
                     let is_stdlib = almide_lang::stdlib_info::is_any_stdlib(m);

--- a/crates/almide-codegen/src/pass_stdlib_lowering.rs
+++ b/crates/almide-codegen/src/pass_stdlib_lowering.rs
@@ -346,7 +346,7 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
     let span = expr.span;
 
     let kind = match expr.kind {
-        IrExprKind::Call { target: CallTarget::Module { module, func }, args, type_args } => {
+        IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, type_args } => {
             // Stage 3c: list operations migrate to bundled `@inline_rust`
             // like every other module, BUT the Rust target needs the
             // fused-iterator lowering (`IterChain`) for isolated closure
@@ -442,7 +442,7 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
                 let args: Vec<IrExpr> = args.into_iter().map(|a| rewrite_expr(a)).collect();
                 return IrExpr {
                     kind: IrExprKind::Call {
-                        target: CallTarget::Module { module, func },
+                        target: CallTarget::Module { module, func, def_id: None },
                         args,
                         type_args,
                     },
@@ -473,7 +473,7 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
             // stale alias that should remain visible to the walker.
             return IrExpr {
                 kind: IrExprKind::Call {
-                    target: CallTarget::Module { module, func },
+                    target: CallTarget::Module { module, func, def_id: None },
                     args,
                     type_args,
                 },
@@ -495,7 +495,7 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
                             call_args.extend(args);
                             let module_call = IrExpr {
                                 kind: IrExprKind::Call {
-                                    target: CallTarget::Module { module: module.to_string().into(), func: method },
+                                    target: CallTarget::Module { module: module.to_string().into(), func: method, def_id: None },
                                     args: call_args, type_args,
                                 },
                                 ty: ty.clone(), span, def_id: None,
@@ -529,7 +529,7 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
                         call_args.extend(args);
                         let module_call = IrExpr {
                             kind: IrExprKind::Call {
-                                target: CallTarget::Module { module: mod_name.into(), func: func_name.into() },
+                                target: CallTarget::Module { module: mod_name.into(), func: func_name.into(), def_id: None },
                                 args: call_args, type_args,
                             },
                             ty: ty.clone(), span, def_id: None,
@@ -743,7 +743,7 @@ fn resolve_unresolved_ufcs(expr: IrExpr, siblings: &[String]) -> IrExpr {
             if let Some(module) = module {
                 return rewrite_expr(IrExpr {
                     kind: IrExprKind::Call {
-                        target: CallTarget::Module { module: module.to_string().into(), func: name },
+                        target: CallTarget::Module { module: module.to_string().into(), func: name, def_id: None },
                         args, type_args,
                     },
                     ty, span, def_id: None,
@@ -769,7 +769,7 @@ fn resolve_unresolved_ufcs(expr: IrExpr, siblings: &[String]) -> IrExpr {
                 call_args.extend(args);
                 return rewrite_expr(IrExpr {
                     kind: IrExprKind::Call {
-                        target: CallTarget::Module { module: module.to_string().into(), func: method },
+                        target: CallTarget::Module { module: module.to_string().into(), func: method, def_id: None },
                         args: call_args, type_args,
                     },
                     ty, span, def_id: None,
@@ -1170,11 +1170,11 @@ fn rewrite_module_names(expr: IrExpr, map: &std::collections::HashMap<String, St
     // Only CallTarget::Module needs special handling; everything else just recurses.
     if let IrExprKind::Call { target: CallTarget::Module { module, .. }, .. } = &expr.kind {
         if map.contains_key(&**module) {
-            let IrExprKind::Call { target: CallTarget::Module { module, func }, args, type_args } = expr.kind else { unreachable!() };
+            let IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, type_args } = expr.kind else { unreachable!() };
             let new_module = map.get(&*module).map(|v| sym(v)).unwrap_or(module);
             let args = args.into_iter().map(|a| rewrite_module_names(a, map)).collect();
             return IrExpr {
-                kind: IrExprKind::Call { target: CallTarget::Module { module: new_module, func }, args, type_args },
+                kind: IrExprKind::Call { target: CallTarget::Module { module: new_module, func, def_id: None }, args, type_args },
                 ty: expr.ty, span: expr.span, def_id: None,
             };
         }

--- a/crates/almide-codegen/src/walker/declarations.rs
+++ b/crates/almide-codegen/src/walker/declarations.rs
@@ -127,6 +127,14 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
             if matches!(target, Ty::Fn { .. }) {
                 return String::new();
             }
+            // Opaque (mod/local) aliases → newtype struct
+            if matches!(td.visibility, IrVisibility::Mod | IrVisibility::Private) {
+                let type_s = render_type(ctx, target);
+                return format!(
+                    "#[derive(Clone, Debug, PartialEq)]\npub struct {}({});",
+                    td.name, type_s
+                );
+            }
             let type_s = render_type(ctx, target);
             ctx.templates.render_with("type_alias", None, &[], &[("name", td.name.as_str()), ("type", type_s.as_str())])
                 .unwrap_or_else(|| format!("type {} = {};", td.name, render_type(ctx, target)))

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -301,7 +301,7 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         // ── Calls ──
         IrExprKind::Call { target, args, .. } | IrExprKind::TailCall { target, args } => {
             match target {
-                CallTarget::Module { module, func } => {
+                CallTarget::Module { module, func, .. } => {
                     // Module calls: use template (TS/JS) or runtime function (Rust)
                     let args_str = args.iter().map(|a| render_expr_owned(ctx, a)).collect::<Vec<_>>().join(", ");
                     let mod_ident = module.replace('.', "_");

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -352,7 +352,12 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
     let mut generic_types = std::collections::HashSet::new();
     for td in &program.type_decls {
         match &td.kind {
-            IrTypeDeclKind::Alias { target } => { type_aliases.insert(td.name, target.clone()); }
+            IrTypeDeclKind::Alias { target } => {
+                // Opaque (mod/local) aliases are newtypes — don't expand transparently
+                if matches!(td.visibility, IrVisibility::Public) {
+                    type_aliases.insert(td.name, target.clone());
+                }
+            }
             _ => {}
         }
         // Track types with generic parameters

--- a/crates/almide-dialect/src/lower.rs
+++ b/crates/almide-dialect/src/lower.rs
@@ -180,7 +180,7 @@ impl<'a> LowerCtx<'a> {
                     .map(|a| self.lower_expr_into(a, ops))
                     .collect();
                 match target {
-                    CallTarget::Module { module, func } => {
+                    CallTarget::Module { module, func, .. } => {
                         let callee = almide_base::intern::sym(&format!("{}.{}", module, func));
                         self.emit(ops, result_ty, OpKind::CallOp { callee, args: arg_vals })
                     }

--- a/crates/almide-egg-lab/src/bridge.rs
+++ b/crates/almide-egg-lab/src/bridge.rs
@@ -90,7 +90,7 @@ impl Bridge {
 
     fn lift_node(&mut self, expr: &IrExpr, rec: &mut RecExpr<AlmideExpr>) -> Id {
         if let IrExprKind::Call { target, args, .. } = &expr.kind {
-            if let CallTarget::Module { module, func } = target {
+            if let CallTarget::Module { module, func, .. } = target {
                 let m = module.as_str();
                 let f = func.as_str();
 
@@ -340,6 +340,7 @@ impl Bridge {
                         target: CallTarget::Module {
                             module: sym("list"),
                             func: sym("map"),
+                            def_id: None,
                         },
                         args: vec![xs, f],
                         type_args: vec![],
@@ -357,6 +358,7 @@ impl Bridge {
                         target: CallTarget::Module {
                             module: sym("list"),
                             func: sym("filter"),
+                            def_id: None,
                         },
                         args: vec![xs, p],
                         type_args: vec![],
@@ -377,6 +379,7 @@ impl Bridge {
                         target: CallTarget::Module {
                             module: sym("list"),
                             func: sym("fold"),
+                            def_id: None,
                         },
                         args: vec![xs, init, f],
                         type_args: vec![],
@@ -436,6 +439,7 @@ impl Bridge {
                         target: CallTarget::Module {
                             module: sym("list"),
                             func: sym("flat_map"),
+                            def_id: None,
                         },
                         args: vec![xs, f],
                         type_args: vec![],
@@ -458,6 +462,7 @@ impl Bridge {
                         target: CallTarget::Module {
                             module: sym("list"),
                             func: sym("filter_map"),
+                            def_id: None,
                         },
                         args: vec![xs, f],
                         type_args: vec![],
@@ -502,6 +507,7 @@ impl Bridge {
                 target: CallTarget::Module {
                     module: sym("matrix"),
                     func: sym(func),
+                    def_id: None,
                 },
                 args: lowered,
                 type_args: vec![],
@@ -1017,6 +1023,7 @@ fn compose_flatmaps_fresh(
             target: CallTarget::Module {
                 module: sym("list"),
                 func: sym("flat_map"),
+                def_id: None,
             },
             args: vec![f_body.clone(), g.clone()],
             type_args: vec![],

--- a/crates/almide-egg-lab/tests/bridge_test.rs
+++ b/crates/almide-egg-lab/tests/bridge_test.rs
@@ -372,7 +372,7 @@ fn lower_map_map_fuses_into_single_map_with_composed_lambda() {
         panic!("expected Call, got {:?}", lowered.kind);
     };
     match target {
-        CallTarget::Module { module, func } => {
+        CallTarget::Module { module, func, .. } => {
             assert_eq!(module.as_str(), "list");
             assert_eq!(func.as_str(), "map");
         }
@@ -459,7 +459,7 @@ fn lower_filter_filter_fuses_into_conjunctive_predicate() {
         panic!("expected Call, got {:?}", lowered.kind);
     };
     match target {
-        CallTarget::Module { module, func } => {
+        CallTarget::Module { module, func, .. } => {
             assert_eq!(module.as_str(), "list");
             assert_eq!(func.as_str(), "filter");
         }
@@ -589,7 +589,7 @@ fn matrix_mul_lifts_and_lowers_verbatim() {
     let mut vt = seeded_var_table(1);
     let lowered = bridge.lower(&rec, &mut vt).expect("lower succeeds");
     match &lowered.kind {
-        IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } => {
+        IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. } => {
             assert_eq!(module.as_str(), "matrix");
             assert_eq!(func.as_str(), "mul");
             assert_eq!(args.len(), 2);
@@ -630,7 +630,7 @@ fn matrix_gemm_chain_fuses_on_real_ir() {
     let mut vt = seeded_var_table(3);
     let lowered = bridge.lower(&best, &mut vt).expect("lower succeeds");
     match &lowered.kind {
-        IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } => {
+        IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. } => {
             assert_eq!(module.as_str(), "matrix");
             assert_eq!(func.as_str(), "fused_gemm_bias_scale_gelu");
             assert_eq!(args.len(), 4);

--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -465,7 +465,7 @@ pub fn register_impl_decl(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, 
 }
 
 pub fn register_type_decl(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, name: &str, ty: &ast::TypeExpr, deriving: &Option<Vec<Sym>>,
-                       generics: &Option<Vec<ast::GenericParam>>, prefix: Option<&str>) {
+                       generics: &Option<Vec<ast::GenericParam>>, prefix: Option<&str>, visibility: ast::Visibility) {
     if let Some(derives) = deriving {
         validate_protocols(env, diagnostics, derives, name);
     }
@@ -473,6 +473,20 @@ pub fn register_type_decl(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, 
     for gn in &gnames { env.types.insert(*gn, Ty::TypeVar(*gn)); }
     let mut resolved = resolve(env, ty);
     for gn in &gnames { env.types.remove(gn); }
+    // mod/local type alias → nominal newtype (opaque constructor)
+    let is_opaque_alias = !matches!(visibility, ast::Visibility::Public)
+        && !matches!(resolved, Ty::Variant { .. })
+        && !matches!(resolved, Ty::Record { .. });
+    if is_opaque_alias {
+        // Store the inner target type for codegen
+        env.opaque_alias_targets.insert(sym(name), resolved.clone());
+        // Register as nominal type (not transparent alias)
+        let generic_args: Vec<Ty> = gnames.iter().map(|g| Ty::TypeVar(*g)).collect();
+        resolved = Ty::Named(sym(name), generic_args);
+        // Register constructor with visibility restriction
+        env.opaque_alias_visibility.insert(sym(name), visibility);
+        env.opaque_alias_module.insert(sym(name), prefix.map(|p| sym(p)));
+    }
     if let Ty::Variant { name: ref mut vn, ref cases } = resolved {
         *vn = sym(name);
         for case in cases { env.constructors.insert(case.name, (sym(name), case.clone())); }
@@ -549,8 +563,8 @@ pub fn register_decls(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, decl
                 }
                 seen_test.insert(test_key, span.clone());
             }
-            ast::Decl::Type { name, ty, deriving, generics, .. } => {
-                register_type_decl(env, diagnostics, name, ty, deriving, generics, prefix);
+            ast::Decl::Type { name, ty, deriving, generics, visibility, .. } => {
+                register_type_decl(env, diagnostics, name, ty, deriving, generics, prefix, *visibility);
                 if let Some(derives) = deriving {
                     for d in derives {
                         env.type_protocols

--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -538,6 +538,13 @@ pub fn register_decls(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, decl
                     seen_fn.insert(key, span.clone());
                 }
                 register_fn_sig(env, name, params, return_type, effect, r#async, generics, prefix, span.as_ref(), *visibility);
+                // Register in DefTable
+                let fn_key = prefixed_key(prefix, name);
+                let pkg = prefix.and_then(|p| p.split('.').next()).unwrap_or("");
+                let mod_path = prefix.unwrap_or("");
+                let ret = env.functions.get(&sym(&fn_key)).map(|s| s.ret.clone()).unwrap_or(Ty::Unknown);
+                let did = env.def_table.alloc(sym(pkg), sym(mod_path), sym(name), almide_ir::DefKind::Function, ret);
+                env.def_map.insert(sym(&fn_key), did);
             }
             ast::Decl::Test { name, span, .. } => {
                 let test_key = name.to_string();
@@ -565,6 +572,13 @@ pub fn register_decls(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, decl
             }
             ast::Decl::Type { name, ty, deriving, generics, visibility, .. } => {
                 register_type_decl(env, diagnostics, name, ty, deriving, generics, prefix, *visibility);
+                // Register in DefTable
+                let type_key = prefixed_key(prefix, name);
+                let pkg = prefix.and_then(|p| p.split('.').next()).unwrap_or("");
+                let mod_path = prefix.unwrap_or("");
+                let resolved_ty = env.types.get(&sym(&type_key)).cloned().unwrap_or(Ty::Unknown);
+                let did = env.def_table.alloc(sym(pkg), sym(mod_path), sym(name), almide_ir::DefKind::Type, resolved_ty);
+                env.def_map.insert(sym(&type_key), did);
                 if let Some(derives) = deriving {
                     for d in derives {
                         env.type_protocols
@@ -583,7 +597,12 @@ pub fn register_decls(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, decl
             ast::Decl::TopLet { name, ty, value, .. } => {
                 let rt = ty.as_ref().map(|te| resolve(env, te)).unwrap_or_else(|| infer_literal_type(value));
                 let key = prefixed_key(prefix, name);
-                env.top_lets.insert(sym(&key), rt);
+                env.top_lets.insert(sym(&key), rt.clone());
+                // Register in DefTable
+                let pkg = prefix.and_then(|p| p.split('.').next()).unwrap_or("");
+                let mod_path = prefix.unwrap_or("");
+                let did = env.def_table.alloc(sym(pkg), sym(mod_path), sym(name), almide_ir::DefKind::TopLet, rt);
+                env.def_map.insert(sym(&key), did);
             }
             _ => {}
         }

--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -360,21 +360,28 @@ impl Checker {
         } else {
             None
         };
-        let sig = self.env.functions.get(&sym(name)).cloned().or_else(|| {
-            if let Some(ref rn) = resolved_name {
-                self.env.functions.get(&sym(rn)).cloned()
-            } else {
-                None
-            }
-        }).or_else(|| {
-            let (module, func) = name.split_once('.')?;
-            crate::stdlib::lookup_sig(module, func)
-        }).or_else(|| {
-            let q = qualified_via_direct.as_ref()?;
-            let (module, func) = q.split_once('.')?;
-            crate::stdlib::lookup_sig(module, func)
-                .or_else(|| self.env.functions.get(&sym(q)).cloned())
-        });
+        // DefId-based resolution: try def_map first for canonical lookup
+        let sig = self.env.def_map.get(&sym(name))
+            .and_then(|_did| self.env.functions.get(&sym(name)).cloned())
+            .or_else(|| {
+                if let Some(ref rn) = resolved_name {
+                    self.env.def_map.get(&sym(rn))
+                        .and_then(|_did| self.env.functions.get(&sym(rn)).cloned())
+                        .or_else(|| self.env.functions.get(&sym(rn)).cloned())
+                } else {
+                    None
+                }
+            })
+            .or_else(|| self.env.functions.get(&sym(name)).cloned())
+            .or_else(|| {
+                let (module, func) = name.split_once('.')?;
+                crate::stdlib::lookup_sig(module, func)
+            }).or_else(|| {
+                let q = qualified_via_direct.as_ref()?;
+                let (module, func) = q.split_once('.')?;
+                crate::stdlib::lookup_sig(module, func)
+                    .or_else(|| self.env.functions.get(&sym(q)).cloned())
+            });
 
         // Mark the source module as used (for unused-import diagnostic).
         if qualified_via_direct.is_some() {

--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -66,6 +66,39 @@ impl Checker {
                         }
                     }
                     Ty::Named(type_name, generic_args)
+                } else if let Some(target_ty) = self.env.opaque_alias_targets.get(&sym(name)).cloned() {
+                    // Opaque alias constructor: SafeHtml("hello")
+                    let vis = self.env.opaque_alias_visibility.get(&sym(name)).copied()
+                        .unwrap_or(ast::Visibility::Public);
+                    if !matches!(vis, ast::Visibility::Public) {
+                        // Check if we're in the defining module
+                        let defining_module = self.env.opaque_alias_module.get(&sym(name))
+                            .cloned().flatten();
+                        let current_module = self.env.self_module_name
+                            .or(self.current_module_prefix.as_ref().map(|p| sym(p)));
+                        let allowed = match (&defining_module, &current_module) {
+                            (None, None) => true,       // defined in main, used in main
+                            (Some(def), Some(cur)) => def == cur, // same module
+                            _ => false,                 // cross-module
+                        };
+                        if !allowed {
+                            self.emit(super::err(
+                                format!("cannot construct opaque type '{}' outside its defining module", name),
+                                format!("Use the module's public API to create '{}' values", name),
+                                format!("constructor {}()", name),
+                            ).with_code("E008"));
+                        }
+                    }
+                    if arg_tys.len() != 1 {
+                        self.emit(super::err(
+                            format!("{}() takes exactly 1 argument but got {}", name, arg_tys.len()),
+                            "Opaque type constructor wraps a single value",
+                            format!("constructor {}()", name),
+                        ).with_code("E004"));
+                    } else {
+                        self.constrain(target_ty, arg_tys[0].clone(), format!("constructor {}()", name));
+                    }
+                    Ty::Named(sym(name), vec![])
                 } else { Ty::Named(sym(name), vec![]) }
             }
             // Module call: string.trim(s), list.map(xs, f), etc.

--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -1040,6 +1040,14 @@ impl Checker {
                             _ => vec![],
                         })
                         .unwrap_or_default(),
+                    // Opaque alias destructure: SafeHtml(s) → inner type
+                    Ty::Named(tname, _) => {
+                        if let Some(target) = self.env.opaque_alias_targets.get(tname).cloned() {
+                            vec![target]
+                        } else {
+                            vec![]
+                        }
+                    }
                     _ => vec![],
                 };
                 for (i, arg) in args.iter().enumerate() {

--- a/crates/almide-frontend/src/lower/calls.rs
+++ b/crates/almide-frontend/src/lower/calls.rs
@@ -21,7 +21,7 @@ pub(super) fn lower_call(ctx: &mut LowerCtx, callee: &ast::Expr, args: &[ast::Ex
                         args: vec![ir_arg], type_args: vec![],
                     }, Ty::Named("Value".into(), vec![]), span);
                     return ctx.mk(IrExprKind::Call {
-                        target: CallTarget::Module { module: sym(module), func: sym("stringify") },
+                        target: CallTarget::Module { module: sym(module), func: sym("stringify"), def_id: ctx.def_map.get(&sym(&format!("{}.stringify", module))).copied() },
                         args: vec![encoded], type_args: vec![],
                     }, Ty::String, span);
                 }
@@ -33,7 +33,7 @@ pub(super) fn lower_call(ctx: &mut LowerCtx, callee: &ast::Expr, args: &[ast::Ex
                 let ir_arg = lower_expr(ctx, &args[0]);
                 // json.decode[T](text) → T.decode(json.parse(text)?)
                 let parsed = ctx.mk(IrExprKind::Try { expr: Box::new(ctx.mk(IrExprKind::Call {
-                    target: CallTarget::Module { module: sym(module), func: sym("parse") },
+                    target: CallTarget::Module { module: sym(module), func: sym("parse"), def_id: ctx.def_map.get(&sym(&format!("{}.parse", module))).copied() },
                     args: vec![ir_arg], type_args: vec![],
                 }, Ty::result(Ty::Named("Value".into(), vec![]), Ty::String), span)) },
                 Ty::Named("Value".into(), vec![]), span);
@@ -74,7 +74,7 @@ pub(super) fn lower_call(ctx: &mut LowerCtx, callee: &ast::Expr, args: &[ast::Ex
             if mod_str.chars().next().map_or(false, |c| c.is_lowercase()) {
                 let obj_expr = (**object).clone();
                 ir_args.insert(0, obj_expr);
-                target = CallTarget::Module { module: sym(mod_str), func: sym(func_str) };
+                target = CallTarget::Module { module: sym(mod_str), func: sym(func_str), def_id: ctx.def_map.get(&sym(&format!("{}.{}", mod_str, func_str))).copied() };
             }
         }
     }
@@ -139,7 +139,7 @@ pub(super) fn lower_call(ctx: &mut LowerCtx, callee: &ast::Expr, args: &[ast::Ex
                 }
             }
         }
-    } else if let CallTarget::Module { module, func } = &target {
+    } else if let CallTarget::Module { module, func, .. } = &target {
         if let Some(sig) = crate::stdlib::lookup_sig(module.as_str(), func.as_str()) {
             for (i, (_, param_ty)) in sig.params.iter().enumerate() {
                 if let Some(arg) = ir_args.get_mut(i) {
@@ -168,7 +168,7 @@ pub(super) fn lower_call_target(ctx: &mut LowerCtx, callee: &ast::Expr) -> CallT
             // Selective import: bare `from_string` → Module { json, from_string }.
             // (used-mark happens in checker pass; lowering only rewrites.)
             if let Some(module) = ctx.env.import_table.direct.get(name).copied() {
-                return CallTarget::Module { module, func: *name };
+                return CallTarget::Module { module, func: *name, def_id: ctx.def_map.get(&sym(&format!("{}.{}", module, name))).copied() };
             }
             CallTarget::Named { name: *name }
         }
@@ -192,7 +192,7 @@ pub(super) fn lower_call_target(ctx: &mut LowerCtx, callee: &ast::Expr) -> CallT
                     }
                     let resolved = ctx.env.import_table.aliases.get(module).copied()
                         .unwrap_or(*module);
-                    return CallTarget::Module { module: resolved, func: *field };
+                    return CallTarget::Module { module: resolved, func: *field, def_id: ctx.def_map.get(&sym(&format!("{}.{}", resolved, field))).copied() };
                 }
                 // Ident that's not a module: check if Type.method (protocol impl, e.g. Val.double)
                 if ctx.lookup_var(module).is_none() {
@@ -207,7 +207,7 @@ pub(super) fn lower_call_target(ctx: &mut LowerCtx, callee: &ast::Expr) -> CallT
             // Dot-chain submodule fallback: still resolve so codegen doesn't break
             // (checker emits error for these, but lowering must still produce valid IR)
             if let Some(dotted) = ctx.env.import_table.resolve_dotted_path(&object.kind) {
-                return CallTarget::Module { module: sym(&dotted), func: *field };
+                return CallTarget::Module { module: sym(&dotted), func: *field, def_id: ctx.def_map.get(&sym(&format!("{}.{}", dotted, field))).copied() };
             }
             // TypeName.method(args) → direct named call (not UFCS, no object prepend)
             if let ast::ExprKind::TypeName { name: type_name, .. } = &object.kind {

--- a/crates/almide-frontend/src/lower/derive_codec.rs
+++ b/crates/almide-frontend/src/lower/derive_codec.rs
@@ -37,7 +37,7 @@ pub(super) fn auto_derive_encode(vt: &mut VarTable, type_name: &str, type_ty: &T
 
     let body = IrExpr {
         kind: IrExprKind::Call {
-            target: CallTarget::Module { module: sym("value"), func: sym("object") },
+            target: CallTarget::Module { module: sym("value"), func: sym("object"), def_id: None },
             args: vec![pairs_list],
             type_args: vec![],
         },
@@ -109,7 +109,7 @@ fn encode_field_value(field_expr: &IrExpr, field_ty: &Ty, value_ty: &Ty) -> IrEx
     };
     IrExpr {
         kind: IrExprKind::Call {
-            target: CallTarget::Module { module: sym(module), func: sym(func) },
+            target: CallTarget::Module { module: sym(module), func: sym(func), def_id: None },
             args: vec![field_expr.clone()],
             type_args: vec![],
         },
@@ -136,7 +136,7 @@ pub(super) fn auto_derive_decode(vt: &mut VarTable, type_name: &str, type_ty: &T
         // value.field(_v, "key") — returns Result[Value, String]
         let get_field_call = IrExpr {
             kind: IrExprKind::Call {
-                target: CallTarget::Module { module: sym("value"), func: sym("field") },
+                target: CallTarget::Module { module: sym("value"), func: sym("field"), def_id: None },
                 args: vec![
                     IrExpr { kind: IrExprKind::Var { id: var_v }, ty: value_ty.clone(), span: None, def_id: None },
                     IrExpr { kind: IrExprKind::LitStr { value: key_name(f) }, ty: Ty::String, span: None, def_id: None },
@@ -290,7 +290,7 @@ fn decode_field_value(get_field_expr: IrExpr, field_ty: &Ty, _value_ty: &Ty) -> 
     IrExpr {
         kind: IrExprKind::Try { expr: Box::new(IrExpr {
             kind: IrExprKind::Call {
-                target: CallTarget::Module { module: sym(module), func: sym(func) },
+                target: CallTarget::Module { module: sym(module), func: sym(func), def_id: None },
                 args: vec![get_field_expr],
                 type_args: vec![],
             },

--- a/crates/almide-frontend/src/lower/expressions.rs
+++ b/crates/almide-frontend/src/lower/expressions.rs
@@ -712,7 +712,7 @@ fn eta_expand_module_fn(
         || ctx.env.import_table.aliases.contains_key(&module)
     {
         let resolved = ctx.env.import_table.aliases.get(&module).copied().unwrap_or(module);
-        CallTarget::Module { module: resolved, func: field }
+        CallTarget::Module { module: resolved, func: field, def_id: ctx.def_map.get(&sym(&format!("{}.{}", resolved, field))).copied() }
     } else {
         CallTarget::Named { name: sym(&format!("{}.{}", module, field)) }
     };

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -64,8 +64,8 @@ impl<'a> LowerCtx<'a> {
             protocol_bounds: HashMap::new(),
             lambda_id_counter: 0,
             const_param_vars: HashMap::new(),
-            def_table: almide_ir::DefTable::new(),
-            def_map: HashMap::new(),
+            def_table: env.def_table.clone(),
+            def_map: env.def_map.iter().map(|(k, v)| (*k, *v)).collect(),
         }
     }
 

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -194,21 +194,18 @@ pub fn lower_program(prog: &ast::Program, env: &TypeEnv, type_map: &TypeMap) -> 
 fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &TypeMap, module_prefix: Option<&str>) -> IrProgram {
     let mut ctx = LowerCtx::new(env, type_map);
 
-    // Build DefTable from all known top-level lets (including cross-package).
-    // Each "module.name" key in env.top_lets gets a DefId.
+    // Register cross-package top-level lets that weren't in register_decls
+    // (dependency packages populate env.top_lets during project fetch).
     for (qual_name, ty) in &env.top_lets {
+        if ctx.def_map.contains_key(qual_name) { continue; }
         let qual = qual_name.as_str();
         if let Some(dot_pos) = qual.rfind('.') {
             let module = &qual[..dot_pos];
             let name = &qual[dot_pos + 1..];
-            // Extract package name (first segment)
             let package = module.split('.').next().unwrap_or(module);
             let def_id = ctx.def_table.alloc(
-                sym(package),
-                sym(module),
-                sym(name),
-                almide_ir::DefKind::TopLet,
-                ty.clone(),
+                sym(package), sym(module), sym(name),
+                almide_ir::DefKind::TopLet, ty.clone(),
             );
             ctx.def_map.insert(*qual_name, def_id);
         }
@@ -296,7 +293,8 @@ fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &Type
                 let val_ty = ctx.var_table.get(var).ty.clone();
                 let ir_value = lower_expr(&mut ctx, value);
                 let kind = classify_top_let_kind(&ir_value);
-                top_lets.push(IrTopLet { var, ty: val_ty, value: ir_value, kind, mutable: *mutable, doc, blank_lines_before: blank_lines, def_id: None });
+                let tl_def_id = ctx.def_map.get(&sym(name)).copied();
+                top_lets.push(IrTopLet { var, ty: val_ty, value: ir_value, kind, mutable: *mutable, doc, blank_lines_before: blank_lines, def_id: tl_def_id });
             }
             ast::Decl::Test { name, body, .. } => {
                 let test_fn = lower_test(&mut ctx, name, body);
@@ -605,7 +603,7 @@ fn lower_fn(
         attrs: attrs.to_vec(),
         visibility: vis,
         doc: None, blank_lines_before: 0,
-        def_id: None,
+        def_id: ctx.def_map.get(&sym(name)).copied(),
         mutated_params,
     }
 }

--- a/crates/almide-frontend/src/lower/statements.rs
+++ b/crates/almide-frontend/src/lower/statements.rs
@@ -286,6 +286,13 @@ fn get_constructor_payload_tys_from_subject(ctx: &LowerCtx, ctor_name: &str, sub
             crate::types::VariantPayload::Record(fs) => fs.iter().map(|(_, t)| t.clone()).collect(),
             crate::types::VariantPayload::Unit => vec![],
         }
+    } else if let Ty::Named(tname, _) = subject_ty {
+        // Opaque alias destructure: SafeHtml(s) → inner target type
+        if let Some(target) = ctx.env.opaque_alias_targets.get(tname) {
+            vec![target.clone()]
+        } else {
+            vec![]
+        }
     } else {
         vec![]
     }

--- a/crates/almide-frontend/src/type_env.rs
+++ b/crates/almide-frontend/src/type_env.rs
@@ -90,6 +90,12 @@ pub struct TypeEnv {
     /// Used by expression lowering to generate correct cross-module constant names.
     pub module_versioned_names: std::collections::HashMap<Sym, Sym>,
 
+    /// DefTable: canonical definitions for all symbols (functions, types, top-lets).
+    /// Populated during register_decls, used for cross-package name resolution.
+    pub def_table: almide_ir::DefTable,
+    /// Qualified name → DefId lookup: "list.push" → DefId(42), "SafeHtml" → DefId(99)
+    pub def_map: std::collections::HashMap<Sym, almide_ir::DefId>,
+
     /// Opaque type aliases: `mod type SafeHtml = String` → stores inner target type.
     pub opaque_alias_targets: std::collections::HashMap<Sym, Ty>,
     /// Opaque type alias constructor visibility.
@@ -135,6 +141,8 @@ impl TypeEnv {
             in_test_block: false,
             failed_fn_names: std::collections::HashSet::new(),
             module_versioned_names: std::collections::HashMap::new(),
+            def_table: almide_ir::DefTable::new(),
+            def_map: std::collections::HashMap::new(),
             opaque_alias_targets: std::collections::HashMap::new(),
             opaque_alias_visibility: std::collections::HashMap::new(),
             opaque_alias_module: std::collections::HashMap::new(),

--- a/crates/almide-frontend/src/type_env.rs
+++ b/crates/almide-frontend/src/type_env.rs
@@ -89,6 +89,13 @@ pub struct TypeEnv {
     /// e.g. "snaidhm.web.gpu" → "snaidhm_v0.web.gpu"
     /// Used by expression lowering to generate correct cross-module constant names.
     pub module_versioned_names: std::collections::HashMap<Sym, Sym>,
+
+    /// Opaque type aliases: `mod type SafeHtml = String` → stores inner target type.
+    pub opaque_alias_targets: std::collections::HashMap<Sym, Ty>,
+    /// Opaque type alias constructor visibility.
+    pub opaque_alias_visibility: std::collections::HashMap<Sym, crate::ast::Visibility>,
+    /// Which module defined each opaque alias (None = main file).
+    pub opaque_alias_module: std::collections::HashMap<Sym, Option<Sym>>,
 }
 
 impl TypeEnv {
@@ -128,6 +135,9 @@ impl TypeEnv {
             in_test_block: false,
             failed_fn_names: std::collections::HashSet::new(),
             module_versioned_names: std::collections::HashMap::new(),
+            opaque_alias_targets: std::collections::HashMap::new(),
+            opaque_alias_visibility: std::collections::HashMap::new(),
+            opaque_alias_module: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/almide-ir/src/lib.rs
+++ b/crates/almide-ir/src/lib.rs
@@ -240,7 +240,7 @@ pub enum CallTarget {
     /// Free function: `foo(x)`, `println(x)`, variant constructor `Some(x)`
     Named { name: Sym },
     /// Resolved module function: stdlib `string.trim(s)` or UFCS `s.trim()`
-    Module { module: Sym, func: Sym },
+    Module { module: Sym, func: Sym, #[serde(default, skip_serializing_if = "Option::is_none")] def_id: Option<DefId> },
     /// Unresolved method call: `obj.method(args)` — emitter decides UFCS vs method
     Method { object: Box<IrExpr>, method: Sym },
     /// Computed callee: `(fn_expr)(args)`

--- a/crates/almide-ir/src/verify.rs
+++ b/crates/almide-ir/src/verify.rs
@@ -160,7 +160,7 @@ impl<'a> IrVisitor for Verifier<'a> {
                         }
                         // else: could be stdlib, builtin, or test function — skip
                     }
-                    CallTarget::Module { module, func } => {
+                    CallTarget::Module { module, func, .. } => {
                         // Only validate user modules (present in known_module_functions).
                         // Stdlib modules are not in known_module_functions and are handled by codegen.
                         if let Some(funcs) = self.known_module_functions.get::<str>(module) {

--- a/crates/almide-optimize/src/mono/mod.rs
+++ b/crates/almide-optimize/src/mono/mod.rs
@@ -192,7 +192,7 @@ fn monomorphize_module_fns(program: &mut IrProgram) {
         impl<'a> IrMutVisitor for Discover<'a> {
             fn visit_expr_mut(&mut self, expr: &mut almide_ir::IrExpr) {
                 walk_expr_mut(self, expr);
-                if let IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } = &expr.kind {
+                if let IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. } = &expr.kind {
                     let m = module.as_str();
                     let f = func.as_str();
                     for (gi, g) in self.generics.iter().enumerate() {
@@ -312,7 +312,7 @@ fn monomorphize_module_fns(program: &mut IrProgram) {
     impl<'a> IrMutVisitor for Rewriter<'a> {
         fn visit_expr_mut(&mut self, expr: &mut almide_ir::IrExpr) {
             walk_expr_mut(self, expr);
-            if let IrExprKind::Call { target: CallTarget::Module { module, func }, args, .. } = &mut expr.kind {
+            if let IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. } = &mut expr.kind {
                 let m = module.as_str().to_string();
                 let f = func.as_str().to_string();
                 for (gi, g) in self.generics.iter().enumerate() {

--- a/crates/almide-types/src/stdlib_info.rs
+++ b/crates/almide-types/src/stdlib_info.rs
@@ -23,7 +23,7 @@ pub const BUNDLED_MODULES: &[&str] = &[
     "error", "math", "datetime", "value", "option", "result",
     "map", "set", "string",
     "env", "io", "random", "regex", "testing",
-    "process", "fs", "http", "json", "matrix",
+    "process", "fs", "http", "html", "json", "matrix",
     "int8", "int16", "int32",
     "uint8", "uint16", "uint32", "uint64",
     "float32",

--- a/docs/roadmap/active/name-resolution-pass.md
+++ b/docs/roadmap/active/name-resolution-pass.md
@@ -3,10 +3,13 @@
 ## Status: Active (partially implemented)
 
 ### Progress
-- Phase 1 (DefId/DefTable infrastructure): ✅ `DefId`, `DefTable`, `DefInfo`, `DefKind` exist in `almide-ir`. Cross-module TopLet alloc works.
-- v0.17.10 workaround: `module_versioned_names` in TypeEnv resolves versioned constant names (e.g. `snaidhm_v0.web.gpu`). Parent-path fallback for submodules.
-- ceangal/snaidhm blocker: **mitigated** (versioned name workaround), not structurally resolved.
-- Phase 2-4: not started.
+- Phase 1 (DefId/DefTable infrastructure): ✅ `DefId`, `DefTable`, `DefInfo`, `DefKind` in `almide-ir`.
+- Phase 2a (populate DefTable): ✅ `register_decls` registers all Function, Type, TopLet. `def_map` (qualified name → DefId) in TypeEnv.
+- Phase 2b (IR propagation): ✅ `IrFunction.def_id` and `IrTopLet.def_id` populated from def_map during lowering.
+- Phase 2c (checker integration): ✅ def_map-first lookup in `check_named_call_with_type_args`.
+- Phase 3 (CallTarget DefId): ✅ `CallTarget::Module` gains `def_id: Option<DefId>`. Lowering populates from def_map. 31 files updated.
+- v0.17.10 workaround: `module_versioned_names` still in place (to be removed in Phase 4).
+- Phase 4 (remove ad-hoc resolution): not started. Best done while building ceangal cross-package.
 
 ## Problem
 

--- a/docs/roadmap/active/name-resolution-pass.md
+++ b/docs/roadmap/active/name-resolution-pass.md
@@ -1,6 +1,12 @@
 # Name Resolution Pass — Unified Cross-Package Symbol Resolution
 
-## Status: Active (blocker for ceangal/snaidhm integration)
+## Status: Active (partially implemented)
+
+### Progress
+- Phase 1 (DefId/DefTable infrastructure): ✅ `DefId`, `DefTable`, `DefInfo`, `DefKind` exist in `almide-ir`. Cross-module TopLet alloc works.
+- v0.17.10 workaround: `module_versioned_names` in TypeEnv resolves versioned constant names (e.g. `snaidhm_v0.web.gpu`). Parent-path fallback for submodules.
+- ceangal/snaidhm blocker: **mitigated** (versioned name workaround), not structurally resolved.
+- Phase 2-4: not started.
 
 ## Problem
 

--- a/docs/roadmap/done/mut-parameter-modifier.md
+++ b/docs/roadmap/done/mut-parameter-modifier.md
@@ -1,7 +1,7 @@
 <!-- description: mut parameter modifier for in-place mutation (Swift inout / Mojo mut) -->
 # `mut` Parameter Modifier
 
-> **Status: Active** — design finalized, implementation pending.
+> **Status: Done** — shipped in v0.18.0.
 > **Predecessor**: `@mutating(param)` annotation (shipped in 0.17.10) provides the IR
 > infrastructure (`IrFunction.mutated_params`). This roadmap item promotes it to a
 > first-class language feature.

--- a/docs/roadmap/on-hold/secure-by-design.md
+++ b/docs/roadmap/on-hold/secure-by-design.md
@@ -1,11 +1,11 @@
 <!-- description: Five-layer security model making web vulnerabilities compile-time errors -->
 # Secure by Design
 
-> **Status: On Hold** — language feature complete, stdlib integration deferred.
+> **Status: On Hold** — Phase 1 complete, Phase 2-4 blocked on infrastructure.
 > Layer 0-1 (effect isolation, @extern) ✅ complete.
 > Phase 1a (opaque type language feature) ✅ complete (v0.18.0): `mod type T = U` creates nominal newtype with E008 cross-module constructor rejection.
-> Phase 1b (stdlib SafeHtml/SafeSql/SafePath builders) deferred — requires web framework / I/O API.
-> Phase 2-4 on hold.
+> Phase 1b (stdlib opaque types) ✅ complete: `html.SafeHtml` (escape/raw/to_string/concat), `path.SafePath` (from_string with traversal rejection/trusted/to_string). `sql.SafeSql` deferred until DB driver exists.
+> Phase 2-4 on hold (requires @extern platform tags, package registry).
 
 ## Thesis
 

--- a/docs/roadmap/on-hold/secure-by-design.md
+++ b/docs/roadmap/on-hold/secure-by-design.md
@@ -1,9 +1,11 @@
 <!-- description: Five-layer security model making web vulnerabilities compile-time errors -->
 # Secure by Design
 
-> **Active scope: Phase 1** — opaque types (`Html`, `Sql`, `Path`, `Command`)。
-> **Exit criteria**: XSS/SQLi/path-traversal/command-injection が型エラーになる。
-> Layer 0-1 (effect isolation, @extern) は ✅ 完了。Phase 2+ は on-hold。
+> **Status: On Hold** — language feature complete, stdlib integration deferred.
+> Layer 0-1 (effect isolation, @extern) ✅ complete.
+> Phase 1a (opaque type language feature) ✅ complete (v0.18.0): `mod type T = U` creates nominal newtype with E008 cross-module constructor rejection.
+> Phase 1b (stdlib SafeHtml/SafeSql/SafePath builders) deferred — requires web framework / I/O API.
+> Phase 2-4 on hold.
 
 ## Thesis
 
@@ -68,7 +70,7 @@ let doc = Html { p { user_input } }
 Response.html(doc |> render)  // ← returns SafeHtml
 ```
 
-**Status: ❌ Opaque types are not implemented.** Requires addition to parser + checker + codegen as a language feature.
+**Status: ✅ Opaque types implemented (v0.18.0).** `mod type SafeHtml = String` creates a nominal newtype. Cross-module constructor calls rejected with E008. Pattern match unwrap works within defining module. Stdlib builders (SafeHtml, SafeSql, SafePath) deferred to web framework integration.
 
 ### Layer 4: Capability Inference — Compiler infers package permissions
 

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.18.0 (prev v0.17.10). `mut` parameter modifier: first-class keyword, checker-enforced mutability at call sites (E007), FnSig.mut_params, stdlib migrated from @mutating to `mut`.
+- Current stable: v0.18.1 (prev v0.18.0). Opaque types (`mod type T = U`), html.SafeHtml/path.SafePath, DefId name resolution (Phase 1-3), CallTarget::Module def_id.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/spec/lang/opaque_type_test.almd
+++ b/spec/lang/opaque_type_test.almd
@@ -1,0 +1,47 @@
+// opaque type — comprehensive test for mod type (nominal newtype)
+
+mod type SafeHtml = String
+
+// ── Construction ──
+fn escape(s: String) -> SafeHtml = SafeHtml(s)
+
+// ── Unwrap (pattern match) ──
+fn unwrap_html(h: SafeHtml) -> String = match h {
+  SafeHtml(s) => s,
+}
+
+// ── Pass opaque type around ──
+fn wrap_in_div(inner: String) -> SafeHtml = SafeHtml("<div>" + inner + "</div>")
+
+// ── Equality ──
+fn html_eq(a: SafeHtml, b: SafeHtml) -> Bool = a == b
+
+test "construction inside module" {
+  let html = escape("hello")
+  let inner = unwrap_html(html)
+  assert(inner == "hello")
+}
+
+test "unwrap via pattern match" {
+  let html = wrap_in_div("content")
+  let raw = unwrap_html(html)
+  assert(raw == "<div>content</div>")
+}
+
+test "opaque type equality" {
+  let a = escape("hello")
+  let b = escape("hello")
+  assert(html_eq(a, b))
+  assert(html_eq(a, escape("world")) == false)
+}
+
+test "opaque type in list" {
+  let items: List[SafeHtml] = [escape("a"), escape("b"), escape("c")]
+  assert(list.len(items) == 3)
+  assert(unwrap_html(items[0]) == "a")
+}
+
+test "opaque type pipe" {
+  let raw = "hello" |> escape |> unwrap_html
+  assert(raw == "hello")
+}

--- a/stdlib/html.almd
+++ b/stdlib/html.almd
@@ -1,0 +1,37 @@
+// html — safe HTML construction (secure-by-design Layer 3)
+//
+// `SafeHtml` is an opaque type: external modules cannot construct it
+// directly from String. All construction goes through escape() or raw().
+// This makes XSS a compile-time type error.
+
+mod type SafeHtml = String
+
+// Escape HTML special characters: & < > " '
+fn escape(s: String) -> SafeHtml = {
+  let escaped = s
+    |> string.replace("&", "&amp;")
+    |> string.replace("<", "&lt;")
+    |> string.replace(">", "&gt;")
+    |> string.replace("\"", "&quot;")
+    |> string.replace("'", "&#39;")
+  SafeHtml(escaped)
+}
+
+// Trust raw HTML — explicit opt-in for pre-sanitized content.
+// Use only for trusted sources (e.g., markdown renderer output).
+fn raw(s: String) -> SafeHtml = SafeHtml(s)
+
+// Unwrap SafeHtml to String (for rendering)
+fn to_string(h: SafeHtml) -> String = match h {
+  SafeHtml(s) => s,
+}
+
+// Concatenate two SafeHtml values
+fn concat(a: SafeHtml, b: SafeHtml) -> SafeHtml = {
+  let sa = to_string(a)
+  let sb = to_string(b)
+  SafeHtml(sa + sb)
+}
+
+// Empty SafeHtml
+fn empty() -> SafeHtml = SafeHtml("")

--- a/stdlib/http.almd
+++ b/stdlib/http.almd
@@ -29,6 +29,12 @@ effect fn serve(port: Int, f: (Request) -> Response) -> Unit = _
 @intrinsic("almide_rt_http_response")
 fn response(status: Int, body: String) -> Response = _
 
+// Safe HTML response — body must be SafeHtml (XSS-proof by construction).
+// Use html.escape() or html.raw() to create SafeHtml values.
+// Note: http is a bundled stdlib module and cannot import html directly.
+// Users call: http.response(status, html.to_string(body))
+// A convenience wrapper will be added when cross-bundled-module calls are supported.
+
 @intrinsic("almide_rt_http_json")
 fn json(status: Int, body: String) -> Response = _
 

--- a/stdlib/path.almd
+++ b/stdlib/path.almd
@@ -1,5 +1,27 @@
-// path — file path manipulation
+// path — file path manipulation (secure-by-design Layer 3)
 // Bundled stdlib module (written in Almide, auto multi-target)
+//
+// `SafePath` is an opaque type: external modules cannot construct it
+// from raw String. Construction goes through from_string() which
+// rejects path traversal attempts (.. segments).
+
+mod type SafePath = String
+
+// Validate and construct a SafePath. Rejects paths containing ".." segments.
+fn from_string(s: String) -> Result[SafePath, String] = {
+  let segments = string.split(s, "/")
+  let has_traversal = list.any(segments, (seg) => seg == "..")
+  if has_traversal then err("path traversal rejected: " + s)
+  else ok(SafePath(s))
+}
+
+// Trust a raw path — explicit opt-in for known-safe paths.
+fn trusted(s: String) -> SafePath = SafePath(s)
+
+// Unwrap SafePath to String
+fn to_string(p: SafePath) -> String = match p {
+  SafePath(s) => s,
+}
 
 fn join(base: String, child: String) -> String = {
   // If child is absolute, it replaces base (matches Rust Path::join behavior)

--- a/tests/codegen_v3_compare.rs
+++ b/tests/codegen_v3_compare.rs
@@ -28,6 +28,7 @@ fn make_test_program() -> IrProgram {
             target: CallTarget::Module {
                 module: "list".into(),
                 func: "find".into(),
+                def_id: None,
             },
             args: vec![
                 IrExpr { kind: IrExprKind::Var { id: v_products }, ty: Ty::list(Ty::String), span: None, def_id: None },

--- a/tests/ir_test.rs
+++ b/tests/ir_test.rs
@@ -247,8 +247,8 @@ fn call_target_named() {
 
 #[test]
 fn call_target_module() {
-    let t = CallTarget::Module { module: "string".into(), func: "trim".into() };
-    if let CallTarget::Module { module, func } = &t {
+    let t = CallTarget::Module { module: "string".into(), func: "trim".into(), def_id: None };
+    if let CallTarget::Module { module, func, .. } = &t {
         assert_eq!(module, "string");
         assert_eq!(func, "trim");
     }

--- a/tests/lower_test.rs
+++ b/tests/lower_test.rs
@@ -305,7 +305,7 @@ fn lower_for_in() {
 #[test]
 fn lower_stdlib_call() {
     let ir = lower("fn f(s: String) -> String = string.trim(s)");
-    if let IrExprKind::Call { target: CallTarget::Module { module, func }, .. } = &ir.functions[0].body.kind {
+    if let IrExprKind::Call { target: CallTarget::Module { module, func, .. }, .. } = &ir.functions[0].body.kind {
         assert_eq!(module, "string");
         assert_eq!(func, "trim");
     } else {
@@ -448,7 +448,7 @@ fn lower_guard() {
 #[test]
 fn lower_list_map_call() {
     let ir = lower("fn f(xs: List[Int]) -> List[Int] = list.map(xs, (x) => x + 1)");
-    if let IrExprKind::Call { target: CallTarget::Module { module, func }, .. } = &ir.functions[0].body.kind {
+    if let IrExprKind::Call { target: CallTarget::Module { module, func, .. }, .. } = &ir.functions[0].body.kind {
         assert_eq!(module, "list");
         assert_eq!(func, "map");
     } else {
@@ -459,7 +459,7 @@ fn lower_list_map_call() {
 #[test]
 fn lower_int_to_string_call() {
     let ir = lower("fn f(n: Int) -> String = int.to_string(n)");
-    if let IrExprKind::Call { target: CallTarget::Module { module, func }, .. } = &ir.functions[0].body.kind {
+    if let IrExprKind::Call { target: CallTarget::Module { module, func, .. }, .. } = &ir.functions[0].body.kind {
         assert_eq!(module, "int");
         assert_eq!(func, "to_string");
     } else {

--- a/tests/nanopass_test.rs
+++ b/tests/nanopass_test.rs
@@ -223,7 +223,7 @@ mod effect_inference {
         // fn read() -> String = fs.read_text("file.txt")
         let mut vt = VarTable::new();
         let body = mk_expr(IrExprKind::Call {
-            target: CallTarget::Module { module: sym("fs"), func: sym("read_text") },
+            target: CallTarget::Module { module: sym("fs"), func: sym("read_text"), def_id: None },
             args: vec![mk_expr(IrExprKind::LitStr { value: "file.txt".into() }, Ty::String)],
             type_args: vec![],
         }, Ty::String);
@@ -339,7 +339,7 @@ mod borrow_insertion {
         let p = mk_param(&mut vt, "name", Ty::String);
         let var_id = p.var;
         let body = mk_expr(IrExprKind::Call {
-            target: CallTarget::Module { module: sym("string"), func: sym("len") },
+            target: CallTarget::Module { module: sym("string"), func: sym("len"), def_id: None },
             args: vec![mk_expr(IrExprKind::Var { id: var_id }, Ty::String)],
             type_args: vec![],
         }, Ty::Int);
@@ -518,7 +518,7 @@ mod stdlib_lowering {
         let var_id = p.var;
 
         let body = mk_expr(IrExprKind::Call {
-            target: CallTarget::Module { module: sym("string"), func: sym("slice") },
+            target: CallTarget::Module { module: sym("string"), func: sym("slice"), def_id: None },
             args: vec![
                 mk_expr(IrExprKind::Var { id: var_id }, Ty::String),
                 mk_expr(IrExprKind::LitInt { value: 0 }, Ty::Int),
@@ -535,7 +535,7 @@ mod stdlib_lowering {
         // lowering happens in IntrinsicLoweringPass which runs before it
         // in the full pipeline.
         match &result.functions[0].body.kind {
-            IrExprKind::Call { target: CallTarget::Module { module, func }, .. } => {
+            IrExprKind::Call { target: CallTarget::Module { module, func, .. }, .. } => {
                 assert_eq!(module.as_str(), "string");
                 assert_eq!(func.as_str(), "slice");
             }


### PR DESCRIPTION
## Summary

- **Opaque types**: `mod type T = U` creates nominal newtype with private constructor (E008)
- **Secure-by-design Phase 1**: `html.SafeHtml` (escape/raw/to_string), `path.SafePath` (traversal rejection)
- **Name resolution Phase 1-3**: DefTable populated for all decls, DefId on IrFunction/IrTopLet/CallTarget::Module

## Changes

### Opaque Types (8 files)
- `mod type SafeHtml = String` → Rust newtype struct, cross-module constructor rejected
- Pattern match unwrap works within defining module
- Codegen: non-Public alias emits newtype, skips transparent expansion

### Stdlib (3 files)
- `html.almd`: SafeHtml with escape(), raw(), to_string(), concat()
- `path.almd`: SafePath with from_string() (rejects `..`), trusted(), to_string()
- `http.almd`: documents SafeHtml integration pattern

### Name Resolution (31 files)
- DefTable/def_map populated in register_decls for all Function/Type/TopLet
- IrFunction.def_id and IrTopLet.def_id populated during lowering
- CallTarget::Module gains `def_id: Option<DefId>`
- Checker: def_map-first lookup in call resolution

### Roadmap
- mut-parameter-modifier → done
- secure-by-design → on-hold (Phase 1 complete)
- name-resolution-pass → Phase 1-3 complete

## Test plan
- [x] `almide test` — 233/233 pass
- [x] `almide docs-gen --check` — ok