### PR TITLE
v0.19.1: LSP, cross-module type fix, keyword module names, length aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.18.1"
+version = "0.19.2"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-codegen/src/emit_wasm/calls_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string.rs
@@ -23,7 +23,7 @@ impl FuncCompiler<'_> {
             "trim_start" => Some(StdlibOp::Call1(rt.trim_start)),
             "trim_end"   => Some(StdlibOp::Call1(rt.trim_end)),
             "reverse"    => Some(StdlibOp::Call1(rt.reverse)),
-            "len"        => {
+            "len" | "length" => {
                 // O(1): read byte-length header directly
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { i32_load(0); i64_extend_i32_u; });

--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -1044,18 +1044,11 @@ fn audit_remaining_unresolved(program: &IrProgram) -> Vec<String> {
                 // no bearing on runtime behavior.
                 || matches!(&expr.kind,
                     IrExprKind::List { elements } if elements.is_empty())
-                // `Unwrap { ResultErr(...) }` in the `guard x else err(_)!`
-                // idiom: the inner expression is a compile-time-known `err`
-                // literal, so the "ok path" value the Unwrap would produce
-                // is unreachable. The checker leaves the Unwrap's ty
-                // `Unknown` for the same reason (`err()` doesn't fix the
-                // Ok type). Leaving the Unwrap's ty concrete would
-                // desynchronise the WASM emit — the "ok path" branch in
-                // `emit_wasm/expressions.rs::Unwrap` would try to
-                // `emit_load_at` an i64 value into a function whose sig
-                // returns i32 (the Result pointer), tripping the
-                // validator on otherwise-dead code. Accept the Unknown
-                // here as "harmless: ok branch unreachable".
+                // `ResultErr(...)` or `Unwrap { ResultErr(...) }` in guard-else:
+                // the Ok slot may remain Unknown because the checker can't
+                // determine it from `err()` alone. The ok-path is unreachable
+                // at runtime so the Unknown is harmless.
+                || matches!(&expr.kind, IrExprKind::ResultErr { .. })
                 || matches!(&expr.kind,
                     IrExprKind::Unwrap { expr: inner }
                         if matches!(inner.kind, IrExprKind::ResultErr { .. }))

--- a/crates/almide-codegen/src/pass_result_propagation.rs
+++ b/crates/almide-codegen/src/pass_result_propagation.rs
@@ -172,12 +172,13 @@ fn resolve_err_types(body: &mut IrExpr, ok_ty: &Ty) {
                 _ => {}
             }
 
-            // Block wrapping a single Try/Unwrap { ResultErr }
+            // Block wrapping a single Try/Unwrap { ResultErr } or bare ResultErr
             if let IrExprKind::Block { stmts, expr: Some(tail) } = &expr.kind {
                 if stmts.is_empty() && expr.ty.has_unresolved_deep() {
                     let is_err_wrapper = match &tail.kind {
                         IrExprKind::Try { expr: inner } | IrExprKind::Unwrap { expr: inner }
                             => matches!(&inner.kind, IrExprKind::ResultErr { .. }),
+                        IrExprKind::ResultErr { .. } => true,
                         _ => false,
                     };
                     if is_err_wrapper {

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -731,6 +731,8 @@ impl Checker {
                 }
                 // Deduplicate: prefixed (`mod.Todo`) and unprefixed (`Todo`)
                 // aliases resolve to the same record definition; keep one.
+                // Sort first so dedup_by can catch non-adjacent duplicates.
+                candidates.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
                 candidates.dedup_by(|a, b| {
                     self.env.types.get(&a.0) == self.env.types.get(&b.0)
                 });

--- a/crates/almide-syntax/src/parser/declarations.rs
+++ b/crates/almide-syntax/src/parser/declarations.rs
@@ -1,4 +1,4 @@
-use crate::lexer::TokenType;
+use crate::lexer::{Token, TokenType};
 use crate::ast::*;
 use crate::ast::ExprKind;
 use crate::intern::{Sym, sym};
@@ -117,14 +117,37 @@ impl Parser {
 
     fn parse_module_path(&mut self) -> Result<Vec<Sym>, String> {
         let mut parts = Vec::new();
-        parts.push(self.expect_ident()?);
+        parts.push(self.expect_module_segment()?);
         while self.check(TokenType::Dot)
-            && self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::Ident)
+            && self.peek_at(1).map(|t| Self::is_module_segment(t)).unwrap_or(false)
         {
             self.advance();
-            parts.push(self.expect_ident()?);
+            parts.push(self.expect_module_segment()?);
         }
         Ok(parts)
+    }
+
+    /// Accept an identifier or keyword as a module path segment.
+    /// Allows `import self.protocol` where `protocol` is a keyword.
+    fn expect_module_segment(&mut self) -> Result<Sym, String> {
+        if self.check(TokenType::Ident) {
+            return Ok(self.advance_and_get_sym());
+        }
+        let tok = self.current();
+        if tok.value.chars().next().map_or(false, |c| c.is_ascii_lowercase() || c == '_')
+            && tok.value.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        {
+            let name = sym(&tok.value);
+            self.advance();
+            return Ok(name);
+        }
+        self.expect_ident() // delegate for error message
+    }
+
+    fn is_module_segment(tok: &Token) -> bool {
+        tok.token_type == TokenType::Ident
+            || (tok.value.chars().next().map_or(false, |c| c.is_ascii_lowercase() || c == '_')
+                && tok.value.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'))
     }
 
     // ── Top-level Declarations ────────────────────────────────────

--- a/crates/almide-syntax/src/parser/primary.rs
+++ b/crates/almide-syntax/src/parser/primary.rs
@@ -126,6 +126,14 @@ impl Parser {
             self.advance();
             return self.parse_fan_block();
         }
+        // Keywords used as module names: protocol.parse(...), etc.
+        if self.check(TokenType::Protocol) {
+            if self.peek_at(1).map_or(false, |t| t.token_type == TokenType::Dot) {
+                let span = Some(self.current_span());
+                self.advance();
+                return Ok(Expr::new(self.next_id(), span, ExprKind::Ident { name: sym("protocol") }));
+            }
+        }
         if self.check(TokenType::LBrace) {
             return self.parse_brace_expr();
         }

--- a/crates/almide-types/src/stdlib_info.rs
+++ b/crates/almide-types/src/stdlib_info.rs
@@ -207,6 +207,7 @@ pub fn resolve_ufcs_candidates(method: &str) -> Vec<&'static str> {
 
         // ── ambiguous: string + list + map + set ──
         "len" => vec!["string", "list", "map", "set"],
+        "length" => vec!["string", "list"],
         "contains" => vec!["string", "list", "map", "set"],
         "is_empty" => vec!["string", "list", "map", "set"],
 

--- a/crates/almide-types/src/types/mod.rs
+++ b/crates/almide-types/src/types/mod.rs
@@ -8,6 +8,17 @@ pub use unify::{unify, substitute, contains_typevar};
 pub use constructor::{TypeConstructorId, TypeConstructorRegistry, Kind, AlgebraicLaw};
 use crate::intern::Sym;
 
+/// Strip module prefix from a type name: `"patcher.PatchResult"` → `"PatchResult"`.
+/// Returns the original string if no prefix is present.
+fn bare_type_name(name: &str) -> &str {
+    name.rsplit_once('.').map(|(_, bare)| bare).unwrap_or(name)
+}
+
+/// Compare two type name Syms ignoring module qualification.
+pub(crate) fn names_match(a: Sym, b: Sym) -> bool {
+    a == b || bare_type_name(a.as_str()) == bare_type_name(b.as_str())
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "kind", content = "value", rename_all = "snake_case")]
 pub enum Ty {
@@ -396,10 +407,10 @@ impl Ty {
             (Ty::Applied(id1, args1), Ty::Applied(id2, args2)) if id1 == id2 && args1.len() == args2.len() => {
                 args1.iter().zip(args2.iter()).all(|(a, b)| a.compatible(b))
             }
-            (Ty::Named(a, _), Ty::Named(b, _)) => a == b,
-            (Ty::Variant { name: a, .. }, Ty::Variant { name: b, .. }) => a == b,
-            (Ty::Named(a, _), Ty::Variant { name: b, .. }) => a == b,
-            (Ty::Variant { name: a, .. }, Ty::Named(b, _)) => a == b,
+            (Ty::Named(a, _), Ty::Named(b, _)) => names_match(*a, *b),
+            (Ty::Variant { name: a, .. }, Ty::Variant { name: b, .. }) => names_match(*a, *b),
+            (Ty::Named(a, _), Ty::Variant { name: b, .. }) => names_match(*a, *b),
+            (Ty::Variant { name: a, .. }, Ty::Named(b, _)) => names_match(*a, *b),
             (Ty::Fn { params: p1, ret: r1 }, Ty::Fn { params: p2, ret: r2 }) => {
                 p1.len() == p2.len()
                     && p1.iter().zip(p2.iter()).all(|(a, b)| a.compatible(b))

--- a/crates/almide-types/src/types/unify.rs
+++ b/crates/almide-types/src/types/unify.rs
@@ -61,7 +61,11 @@ pub fn unify(sig_ty: &Ty, actual_ty: &Ty, bindings: &mut std::collections::HashM
             a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| unify(x, y, bindings))
         }
         // Named types with type args: unify each arg to bind TypeVars
-        (Ty::Named(a, a_args), Ty::Named(b, b_args)) if a == b && a_args.len() == b_args.len() => {
+        // Use bare name comparison to handle cross-module qualified names
+        // (e.g. "patcher.PatchResult" vs "PatchResult")
+        (Ty::Named(a, a_args), Ty::Named(b, b_args))
+            if super::names_match(*a, *b) && a_args.len() == b_args.len() =>
+        {
             a_args.iter().zip(b_args.iter()).all(|(x, y)| unify(x, y, bindings))
         }
         // Union: try each member with snapshotted bindings, commit first success

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.19.1 (prev v0.19.0). Full LSP: document symbols, formatting, go-to-def, signature help, workspace symbols, rename, code actions (auto-import/effect fn), cross-file diagnostics. Prev: REPL, LSP Phase 1, Elm-grade errors, RcCow Debug transparency.
+- Current stable: v0.19.2 (prev v0.19.1). Cross-module type inference fix, keyword module names, guard-else err fix, string.length/list.length aliases. Prev: Full LSP, REPL, Elm-grade errors.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/spec/stdlib/list_bundled_test.almd
+++ b/spec/stdlib/list_bundled_test.almd
@@ -35,3 +35,10 @@ test "list.* TOML fns coexist with bundled fns" {
   assert_eq(list.sum([1, 2, 3]), 6)
   assert_eq(list.len([1, 2, 3]), 3)
 }
+
+test "list.length alias" {
+  assert_eq(list.length([1, 2, 3]), 3);
+  let xs: List[Int] = [];
+  assert_eq(list.length(xs), 0);
+  assert_eq(list.length([1, 2, 3]), list.len([1, 2, 3]))
+}

--- a/spec/stdlib/string_test.almd
+++ b/spec/stdlib/string_test.almd
@@ -385,3 +385,9 @@ test "string.is_empty via module" {
   assert(string.is_empty(""));
   assert(not string.is_empty("x"))
 }
+
+test "string.length alias" {
+  assert_eq(string.length("hello"), 5);
+  assert_eq(string.length(""), 0);
+  assert_eq(string.length("hello"), string.len("hello"))
+}

--- a/stdlib/list.almd
+++ b/stdlib/list.almd
@@ -15,6 +15,9 @@
 @intrinsic("almide_rt_list_len")
 fn len[A](xs: List[A]) -> Int = _
 
+@intrinsic("almide_rt_list_len")
+fn length[A](xs: List[A]) -> Int = _
+
 @intrinsic("almide_rt_list_get")
 fn get[A](xs: List[A], i: Int) -> Option[A] = _
 

--- a/stdlib/string.almd
+++ b/stdlib/string.almd
@@ -26,6 +26,9 @@ fn join(list: List[String], sep: String) -> String = _
 @intrinsic("almide_rt_string_len")
 fn len(s: String) -> Int = _
 
+@intrinsic("almide_rt_string_len")
+fn length(s: String) -> Int = _
+
 @intrinsic("almide_rt_string_contains")
 fn contains(s: String, sub: String) -> Bool = _
 

--- a/tests/diagnostics/string-length-alias/broken.almd
+++ b/tests/diagnostics/string-length-alias/broken.almd
@@ -1,1 +1,0 @@
-fn size(s: String) -> Int = string.length(s)

--- a/tests/diagnostics/string-length-alias/fixed.almd
+++ b/tests/diagnostics/string-length-alias/fixed.almd
@@ -1,1 +1,0 @@
-fn size(s: String) -> Int = string.len(s)

--- a/tests/diagnostics/string-length-alias/meta.toml
+++ b/tests/diagnostics/string-length-alias/meta.toml
@@ -1,3 +1,0 @@
-expects_code = "E002"
-expects_error = "undefined function 'string.length'"
-hint_substring = "string.len"

--- a/tests/lsp_test.rs
+++ b/tests/lsp_test.rs
@@ -1,0 +1,370 @@
+//! Automated LSP integration tests.
+//! Spawns `almide lsp` as a subprocess, sends JSON-RPC over stdin/stdout,
+//! and verifies responses.
+
+use std::io::{Read, Write, BufRead, BufReader};
+use std::process::{Command, Stdio};
+use serde_json::{json, Value};
+
+struct LspClient {
+    child: std::process::Child,
+    reader: BufReader<std::process::ChildStdout>,
+}
+
+impl LspClient {
+    fn start() -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_almide"))
+            .arg("lsp")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to start almide lsp");
+        let stdout = child.stdout.take().unwrap();
+        let reader = BufReader::new(stdout);
+        let mut client = LspClient { child, reader };
+        client.initialize();
+        client
+    }
+
+    fn send(&mut self, msg: &Value) {
+        let body = serde_json::to_string(msg).unwrap();
+        let header = format!("Content-Length: {}\r\n\r\n", body.len());
+        let stdin = self.child.stdin.as_mut().unwrap();
+        stdin.write_all(header.as_bytes()).unwrap();
+        stdin.write_all(body.as_bytes()).unwrap();
+        stdin.flush().unwrap();
+    }
+
+    fn recv(&mut self) -> Value {
+        // Read Content-Length header
+        let mut header = String::new();
+        loop {
+            header.clear();
+            self.reader.read_line(&mut header).unwrap();
+            let trimmed = header.trim();
+            if trimmed.is_empty() { break; }
+            if trimmed.starts_with("Content-Length:") {
+                let len: usize = trimmed.split(':').nth(1).unwrap().trim().parse().unwrap();
+                // Read blank line after header
+                let mut blank = String::new();
+                self.reader.read_line(&mut blank).unwrap();
+                // Read body
+                let mut buf = vec![0u8; len];
+                self.reader.read_exact(&mut buf).unwrap();
+                return serde_json::from_slice(&buf).unwrap();
+            }
+        }
+        panic!("no response received");
+    }
+
+    /// Read responses until we find one with the given id.
+    fn recv_response(&mut self, id: i64) -> Value {
+        for _ in 0..50 {
+            let msg = self.recv();
+            if msg.get("id").and_then(|v| v.as_i64()) == Some(id) {
+                return msg;
+            }
+            // skip notifications (diagnostics etc.)
+        }
+        panic!("response id={} not found", id);
+    }
+
+    fn initialize(&mut self) {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "processId": null,
+                "capabilities": {},
+                "rootUri": null
+            }
+        }));
+        let resp = self.recv_response(0);
+        assert!(resp.get("result").is_some(), "initialize should succeed");
+
+        // Send initialized notification
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "method": "initialized",
+            "params": {}
+        }));
+    }
+
+    fn open_file(&mut self, uri: &str, text: &str) {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "almide",
+                    "version": 1,
+                    "text": text
+                }
+            }
+        }));
+        // Consume diagnostic notification
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    fn hover(&mut self, id: i64, uri: &str, line: u32, character: u32) -> Value {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "textDocument/hover",
+            "params": {
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character }
+            }
+        }));
+        self.recv_response(id)
+    }
+
+    fn definition(&mut self, id: i64, uri: &str, line: u32, character: u32) -> Value {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "textDocument/definition",
+            "params": {
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character }
+            }
+        }));
+        self.recv_response(id)
+    }
+
+    fn completion(&mut self, id: i64, uri: &str, line: u32, character: u32) -> Value {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "textDocument/completion",
+            "params": {
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character }
+            }
+        }));
+        self.recv_response(id)
+    }
+
+    fn document_symbols(&mut self, id: i64, uri: &str) -> Value {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "textDocument/documentSymbol",
+            "params": {
+                "textDocument": { "uri": uri }
+            }
+        }));
+        self.recv_response(id)
+    }
+
+    fn shutdown(&mut self) {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": 999,
+            "method": "shutdown",
+            "params": null
+        }));
+        let _ = self.recv_response(999);
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "method": "exit",
+            "params": null
+        }));
+        let _ = self.child.wait();
+    }
+}
+
+const TEST_URI: &str = "file:///tmp/lsp_test.almd";
+
+const TEST_SOURCE: &str = r#"import io
+
+type Color = | Red | Green | Blue
+
+fn greet(name: String) -> String = "Hello, " + name
+
+fn double(x: Int) -> Int = x * 2
+
+let greeting = "world"
+
+effect fn main() -> Unit = {
+  io.print(greet(greeting) + "\n")
+}
+"#;
+
+fn hover_value(resp: &Value) -> String {
+    resp["result"]["contents"]["value"].as_str().unwrap_or("").to_string()
+}
+
+#[test]
+fn lsp_hover_keyword() {
+    let mut c = LspClient::start();
+    c.open_file(TEST_URI, TEST_SOURCE);
+    // "fn" keyword at line 4, col 0
+    let resp = c.hover(1, TEST_URI, 4, 0);
+    assert!(hover_value(&resp).contains("Function declaration"), "hover on 'fn' keyword");
+    c.shutdown();
+}
+
+#[test]
+fn lsp_hover_function() {
+    let mut c = LspClient::start();
+    c.open_file(TEST_URI, TEST_SOURCE);
+    // "greet" at line 4: fn greet(name: String) -> String = ...
+    let resp = c.hover(1, TEST_URI, 4, 4);
+    let val = hover_value(&resp);
+    assert!(val.contains("fn greet"), "hover on fn greet: got {}", val);
+    assert!(val.contains("String"), "hover shows return type");
+    c.shutdown();
+}
+
+#[test]
+fn lsp_hover_variant_constructor() {
+    let mut c = LspClient::start();
+    c.open_file(TEST_URI, TEST_SOURCE);
+    // "Red" at line 2: type Color = | Red | Green | Blue
+    // Find the position of "Red" — after "| "
+    let red_col = TEST_SOURCE.lines().nth(2).unwrap().find("Red").unwrap() as u32;
+    let resp = c.hover(1, TEST_URI, 2, red_col);
+    let val = hover_value(&resp);
+    assert!(val.contains("variant of Color"), "hover on Red: got {}", val);
+    c.shutdown();
+}
+
+#[test]
+fn lsp_hover_type_declaration() {
+    let mut c = LspClient::start();
+    c.open_file(TEST_URI, TEST_SOURCE);
+    // "Color" at line 2
+    let col = TEST_SOURCE.lines().nth(2).unwrap().find("Color").unwrap() as u32;
+    let resp = c.hover(1, TEST_URI, 2, col);
+    let val = hover_value(&resp);
+    assert!(val.contains("| Red"), "hover on type Color shows variants: got {}", val);
+    assert!(val.contains("| Blue"), "hover shows Blue variant");
+    c.shutdown();
+}
+
+#[test]
+fn lsp_hover_top_let() {
+    let mut c = LspClient::start();
+    c.open_file(TEST_URI, TEST_SOURCE);
+    // "greeting" at line 8: let greeting = "world"
+    let col = TEST_SOURCE.lines().nth(8).unwrap().find("greeting").unwrap() as u32;
+    let resp = c.hover(1, TEST_URI, 8, col);
+    let val = hover_value(&resp);
+    assert!(val.contains("greeting") && val.contains("String"), "hover on let greeting: got {}", val);
+    c.shutdown();
+}
+
+#[test]
+fn lsp_hover_primitive_type() {
+    let mut c = LspClient::start();
+    c.open_file(TEST_URI, TEST_SOURCE);
+    // "Int" at line 6: fn double(x: Int) -> Int
+    let col = TEST_SOURCE.lines().nth(6).unwrap().find("Int").unwrap() as u32;
+    let resp = c.hover(1, TEST_URI, 6, col);
+    let val = hover_value(&resp);
+    assert!(val.contains("64-bit"), "hover on Int: got {}", val);
+    c.shutdown();
+}
+
+#[test]
+fn lsp_hover_stdlib_module_func() {
+    let mut c = LspClient::start();
+    // Source with string.to_upper
+    let src = "let x = string.to_upper(\"hello\")\n";
+    c.open_file(TEST_URI, src);
+    // hover on "to_upper" — col after "string."
+    let col = src.find("to_upper").unwrap() as u32;
+    let resp = c.hover(1, TEST_URI, 0, col);
+    let val = hover_value(&resp);
+    assert!(val.contains("fn string.to_upper"), "hover on to_upper: got {}", val);
+    c.shutdown();
+}
+
+#[test]
+fn lsp_definition_fn() {
+    let mut c = LspClient::start();
+    c.open_file(TEST_URI, TEST_SOURCE);
+    // Cmd+click on "greet" in main body (line 11)
+    let col = TEST_SOURCE.lines().nth(11).unwrap().find("greet").unwrap() as u32;
+    let resp = c.definition(1, TEST_URI, 11, col);
+    let result = &resp["result"];
+    assert!(!result.is_null(), "definition should return a location");
+    let def_line = result["range"]["start"]["line"].as_u64().unwrap();
+    assert_eq!(def_line, 4, "greet is declared on line 4");
+    c.shutdown();
+}
+
+#[test]
+fn lsp_definition_variant() {
+    let mut c = LspClient::start();
+    let src = "type Color = | Red | Green | Blue\nlet c = Red\n";
+    c.open_file(TEST_URI, src);
+    // Cmd+click on "Red" at line 1 col 8
+    let col = src.lines().nth(1).unwrap().find("Red").unwrap() as u32;
+    let resp = c.definition(1, TEST_URI, 1, col);
+    let result = &resp["result"];
+    assert!(!result.is_null(), "definition of variant should return location");
+    let def_line = result["range"]["start"]["line"].as_u64().unwrap();
+    assert_eq!(def_line, 0, "Color type is on line 0");
+    c.shutdown();
+}
+
+#[test]
+fn lsp_completion_module() {
+    let mut c = LspClient::start();
+    let src = "let x = string.\n";
+    c.open_file(TEST_URI, src);
+    let resp = c.completion(1, TEST_URI, 0, 15); // after "string."
+    let items = resp["result"].as_array().unwrap();
+    assert!(!items.is_empty(), "completion after string. should return items");
+    let labels: Vec<&str> = items.iter().filter_map(|i| i["label"].as_str()).collect();
+    assert!(labels.contains(&"to_upper"), "should contain to_upper: {:?}", labels);
+    assert!(labels.contains(&"len"), "should contain len: {:?}", labels);
+    c.shutdown();
+}
+
+#[test]
+fn lsp_completion_keyword() {
+    let mut c = LspClient::start();
+    let src = "ma\n";
+    c.open_file(TEST_URI, src);
+    let resp = c.completion(1, TEST_URI, 0, 2); // after "ma"
+    let items = resp["result"].as_array().unwrap();
+    let labels: Vec<&str> = items.iter().filter_map(|i| i["label"].as_str()).collect();
+    assert!(labels.contains(&"match"), "should suggest match: {:?}", labels);
+    c.shutdown();
+}
+
+#[test]
+fn lsp_document_symbols() {
+    let mut c = LspClient::start();
+    c.open_file(TEST_URI, TEST_SOURCE);
+    let resp = c.document_symbols(1, TEST_URI);
+    let symbols = resp["result"].as_array().unwrap();
+    let names: Vec<&str> = symbols.iter().filter_map(|s| s["name"].as_str()).collect();
+    assert!(names.contains(&"greet"), "should contain greet: {:?}", names);
+    assert!(names.contains(&"double"), "should contain double: {:?}", names);
+    assert!(names.contains(&"Color"), "should contain Color: {:?}", names);
+    assert!(names.contains(&"main"), "should contain main: {:?}", names);
+    c.shutdown();
+}
+
+#[test]
+fn lsp_diagnostics_type_error() {
+    let mut c = LspClient::start();
+    let src = "fn bad() -> Int = \"hello\"\n";
+    c.open_file(TEST_URI, src);
+    // Read diagnostic notification
+    let msg = c.recv();
+    let diags = &msg["params"]["diagnostics"];
+    assert!(diags.is_array(), "should receive diagnostics");
+    let arr = diags.as_array().unwrap();
+    assert!(!arr.is_empty(), "should have at least one diagnostic");
+    let codes: Vec<&str> = arr.iter().filter_map(|d| d["code"].as_str()).collect();
+    assert!(codes.contains(&"E001"), "should contain E001: {:?}", codes);
+    c.shutdown();
+}

--- a/tests/snapshots/ide_outline_snapshot_test__stdlib_list_outline.snap
+++ b/tests/snapshots/ide_outline_snapshot_test__stdlib_list_outline.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ide_outline_snapshot_test.rs
+assertion_line: 39
 expression: "run_outline(&[\"@stdlib/list\"])"
 ---
 fn list.all[A](xs: List[A], f: fn(A) -> Bool) -> Bool
@@ -34,6 +35,7 @@ fn list.iterate[T](seed: T, f: fn(T) -> T, n: Int) -> List[T]
 fn list.join(xs: List[String], sep: String) -> String
 fn list.last[A](xs: List[A]) -> Option[A]
 fn list.len[A](xs: List[A]) -> Int
+fn list.length[A](xs: List[A]) -> Int
 fn list.map[A, B](xs: List[A], f: fn(A) -> B) -> List[B]
 fn list.max[A](xs: List[A]) -> Option[A]
 fn list.min[A](xs: List[A]) -> Option[A]

--- a/tests/snapshots/ide_outline_snapshot_test__stdlib_snapshot_default.snap
+++ b/tests/snapshots/ide_outline_snapshot_test__stdlib_snapshot_default.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ide_outline_snapshot_test.rs
+assertion_line: 108
 expression: text
 ---
 # @stdlib/string
@@ -27,6 +28,7 @@ fn string.join(list: List[String], sep: String) -> String
 fn string.last(s: String) -> Option[String]
 fn string.last_index_of(s: String, needle: String) -> Option[Int]
 fn string.len(s: String) -> Int
+fn string.length(s: String) -> Int
 fn string.lines(s: String) -> List[String]
 fn string.pad_end(s: String, n: Int, ch: String) -> String
 fn string.pad_start(s: String, n: Int, ch: String) -> String
@@ -82,6 +84,7 @@ fn list.iterate[T](seed: T, f: fn(T) -> T, n: Int) -> List[T]
 fn list.join(xs: List[String], sep: String) -> String
 fn list.last[A](xs: List[A]) -> Option[A]
 fn list.len[A](xs: List[A]) -> Int
+fn list.length[A](xs: List[A]) -> Int
 fn list.map[A, B](xs: List[A], f: fn(A) -> B) -> List[B]
 fn list.max[A](xs: List[A]) -> Option[A]
 fn list.min[A](xs: List[A]) -> Option[A]

--- a/tests/snapshots/ide_outline_snapshot_test__stdlib_string_outline.snap
+++ b/tests/snapshots/ide_outline_snapshot_test__stdlib_string_outline.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/ide_outline_snapshot_test.rs
+assertion_line: 34
 expression: "run_outline(&[\"@stdlib/string\"])"
 ---
 fn string.capitalize(s: String) -> String
@@ -26,6 +27,7 @@ fn string.join(list: List[String], sep: String) -> String
 fn string.last(s: String) -> Option[String]
 fn string.last_index_of(s: String, needle: String) -> Option[Int]
 fn string.len(s: String) -> Int
+fn string.length(s: String) -> Int
 fn string.lines(s: String) -> List[String]
 fn string.pad_end(s: String, n: Int, ch: String) -> String
 fn string.pad_start(s: String, n: Int, ch: String) -> String


### PR DESCRIPTION
## Summary

- **LSP server**: diagnostics, hover, completion, go-to-definition, rename, code actions, workspace symbols, document formatting
- **LSP integration tests**: 13 automated tests via JSON-RPC stdin/stdout
- **REPL**: `almide` with no args starts interactive session
- **Cross-module type inference fix**: `patcher.PatchResult` == `PatchResult` in generic instantiation (list.map etc.)
- **Keyword module names**: `import self.protocol` and `protocol.parse(...)` now work
- **guard else err() postcondition**: resolve Unknown in bare `err()` without `!` in guard-else
- **`string.length` / `list.length`**: intrinsic aliases for `len`
- Compiler error improvements (E005 caret, fix code, dedup)
- Many other improvements across 1965 commits

## Test plan

- [x] `almide test` — 233 test files pass
- [x] `cargo test` — diagnostic harness, IDE outline snapshots pass
- [x] Manual test: `import self.protocol` + `protocol.parse(...)` works
- [x] New tests: `string.length`, `list.length` aliases