### PR TITLE
Backtick escaping for keyword identifiers

### DIFF
--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -116,7 +116,21 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             // Val-wrap: var of non-Copy type → RcCow<T> with RcCow::new(value) for COW
             if ctx.ann.is_rc_cow(var) {
                 let val_type = format!("RcCow<{}>", type_s);
-                let val_value = format!("RcCow::new({})", value_s);
+                // If the value is a fn param passed by reference (&Vec<u8>, &[T]),
+                // clone it to get an owned value for RcCow::new().
+                let needs_clone = match &value.kind {
+                    IrExprKind::Var { id } => ctx.ref_params.contains(id),
+                    IrExprKind::Clone { expr: inner } => match &inner.kind {
+                        IrExprKind::Var { id } => ctx.ref_params.contains(id),
+                        _ => false,
+                    },
+                    _ => false,
+                };
+                let val_value = if needs_clone {
+                    format!("RcCow::new({}.clone())", value_s)
+                } else {
+                    format!("RcCow::new({})", value_s)
+                };
                 return ctx.templates.render_with("var_binding", None, &[], &[("name", name_s.as_str()), ("type", val_type.as_str()), ("value", val_value.as_str())])
                     .unwrap_or_else(|| format!("let mut {} = {};", name_s, val_value));
             }

--- a/crates/almide-syntax/src/lexer.rs
+++ b/crates/almide-syntax/src/lexer.rs
@@ -149,6 +149,16 @@ impl Lexer {
                 continue;
             }
 
+            // Backtick-escaped identifier: `protocol`, `type`, etc.
+            // Allows keywords to be used as identifiers (Swift-style).
+            if ch == '`' {
+                let (tok, new_pos) = lex_backtick_ident(&chars, pos, line, col);
+                let len = new_pos - pos;
+                tokens.push(tok);
+                pos = new_pos; col += len;
+                continue;
+            }
+
             // Identifier or keyword (lone `_` falls through to operator lexing → Underscore)
             if ch.is_ascii_alphabetic() || (ch == '_' && pos + 1 < chars.len() && (chars[pos + 1].is_ascii_alphanumeric() || chars[pos + 1] == '_')) {
                 let (tok, new_pos) = lex_ident(&chars, pos, line, col);
@@ -443,6 +453,29 @@ fn lex_ident(chars: &[char], start: usize, line: usize, col: usize) -> (Token, u
         else { TokenType::Ident }
     });
 
+    let end_col = col + (pos - start);
+    (Token { token_type, value, line, col, end_col }, pos)
+}
+
+/// Lex a backtick-escaped identifier: `protocol`, `type`, etc.
+/// The backticks are consumed but not included in the token value.
+/// The result is always TokenType::Ident regardless of keyword status.
+fn lex_backtick_ident(chars: &[char], start: usize, line: usize, col: usize) -> (Token, usize) {
+    let mut pos = start + 1; // skip opening backtick
+    let ident_start = pos;
+    while pos < chars.len() && (chars[pos].is_ascii_alphanumeric() || chars[pos] == '_') {
+        pos += 1;
+    }
+    let value: String = chars[ident_start..pos].iter().collect();
+    // Consume closing backtick if present
+    if pos < chars.len() && chars[pos] == '`' {
+        pos += 1;
+    }
+    let token_type = if value.chars().next().map_or(false, |c| c.is_uppercase()) {
+        TokenType::TypeName
+    } else {
+        TokenType::Ident
+    };
     let end_col = col + (pos - start);
     (Token { token_type, value, line, col, end_col }, pos)
 }

--- a/crates/almide-syntax/src/parser/declarations.rs
+++ b/crates/almide-syntax/src/parser/declarations.rs
@@ -1,4 +1,4 @@
-use crate::lexer::{Token, TokenType};
+use crate::lexer::TokenType;
 use crate::ast::*;
 use crate::ast::ExprKind;
 use crate::intern::{Sym, sym};
@@ -117,37 +117,28 @@ impl Parser {
 
     fn parse_module_path(&mut self) -> Result<Vec<Sym>, String> {
         let mut parts = Vec::new();
-        parts.push(self.expect_module_segment()?);
+        parts.push(self.expect_ident()?);
         while self.check(TokenType::Dot)
-            && self.peek_at(1).map(|t| Self::is_module_segment(t)).unwrap_or(false)
+            && self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::Ident)
         {
             self.advance();
-            parts.push(self.expect_module_segment()?);
+            parts.push(self.expect_ident()?);
+        }
+        // Hint: `import self.protocol` → suggest backtick escaping
+        if self.check(TokenType::Dot) {
+            if let Some(next) = self.peek_at(1) {
+                let v = &next.value;
+                if !v.is_empty() && v.chars().next().map_or(false, |c| c.is_ascii_lowercase()) {
+                    return Err(format!(
+                        "'{}' is a keyword and cannot be used as a module name directly.\n  Hint: Use backtick escaping: import {}.`{}`",
+                        v,
+                        parts.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("."),
+                        v
+                    ));
+                }
+            }
         }
         Ok(parts)
-    }
-
-    /// Accept an identifier or keyword as a module path segment.
-    /// Allows `import self.protocol` where `protocol` is a keyword.
-    fn expect_module_segment(&mut self) -> Result<Sym, String> {
-        if self.check(TokenType::Ident) {
-            return Ok(self.advance_and_get_sym());
-        }
-        let tok = self.current();
-        if tok.value.chars().next().map_or(false, |c| c.is_ascii_lowercase() || c == '_')
-            && tok.value.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-        {
-            let name = sym(&tok.value);
-            self.advance();
-            return Ok(name);
-        }
-        self.expect_ident() // delegate for error message
-    }
-
-    fn is_module_segment(tok: &Token) -> bool {
-        tok.token_type == TokenType::Ident
-            || (tok.value.chars().next().map_or(false, |c| c.is_ascii_lowercase() || c == '_')
-                && tok.value.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'))
     }
 
     // ── Top-level Declarations ────────────────────────────────────

--- a/crates/almide-syntax/src/parser/primary.rs
+++ b/crates/almide-syntax/src/parser/primary.rs
@@ -126,14 +126,8 @@ impl Parser {
             self.advance();
             return self.parse_fan_block();
         }
-        // Keywords used as module names: protocol.parse(...), etc.
-        if self.check(TokenType::Protocol) {
-            if self.peek_at(1).map_or(false, |t| t.token_type == TokenType::Dot) {
-                let span = Some(self.current_span());
-                self.advance();
-                return Ok(Expr::new(self.next_id(), span, ExprKind::Ident { name: sym("protocol") }));
-            }
-        }
+        // Backtick-escaped keywords are lexed as Ident, so they reach
+        // the normal Ident path below. No special handling needed here.
         if self.check(TokenType::LBrace) {
             return self.parse_brace_expr();
         }


### PR DESCRIPTION
## Summary

- Replace ad-hoc keyword-as-module handling with Swift-style backtick escaping
- `\`protocol\`` lexed as Ident, bypassing keyword resolution
- Works for any keyword in any context (imports, expressions, bindings)
- Parser hint when keyword follows `.` in import path

## Test plan

- [x] `almide test` — 233 test files pass
- [x] `cargo test` — diagnostic harness, IDE snapshots pass
- [x] Manual: `import self.\`protocol\`` + `\`protocol\`.parse(...)` works
- [x] Manual: bare `import self.protocol` shows helpful hint