### PR TITLE
v0.23.0: test where — unified test context syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.22.2"
+version = "0.23.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -713,56 +713,52 @@ impl<'a> IrMutVisitor for Concretizer<'a> {
 
 /// Infer a lambda param's type by scanning how it's used in the body.
 /// e.g., `(a, b) => a + b` where body is BinOp::AddInt → a: Int, b: Int
+fn binop_operand_type(op: &BinOp, left: &IrExpr, right: &IrExpr, var: VarId) -> Option<Ty> {
+    let fixed_ty = match op {
+        BinOp::AddInt | BinOp::SubInt | BinOp::MulInt | BinOp::DivInt | BinOp::ModInt | BinOp::PowInt => Some(Ty::Int),
+        BinOp::AddFloat | BinOp::SubFloat | BinOp::MulFloat | BinOp::DivFloat => Some(Ty::Float),
+        BinOp::ConcatStr => Some(Ty::String),
+        BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte =>
+            infer_from_other_side(left, right, var),
+        _ => None,
+    };
+    if let Some(ref ty) = fixed_ty {
+        if matches!(&left.kind, IrExprKind::Var { id } if *id == var) { return Some(ty.clone()); }
+        if matches!(&right.kind, IrExprKind::Var { id } if *id == var) { return Some(ty.clone()); }
+    }
+    None
+}
+
+fn infer_from_other_side(left: &IrExpr, right: &IrExpr, var: VarId) -> Option<Ty> {
+    if matches!(&left.kind, IrExprKind::Var { id } if *id == var) {
+        if !right.ty.has_unresolved_deep() { Some(right.ty.clone()) } else { None }
+    } else if matches!(&right.kind, IrExprKind::Var { id } if *id == var) {
+        if !left.ty.has_unresolved_deep() { Some(left.ty.clone()) } else { None }
+    } else { None }
+}
+
 pub fn infer_var_type_from_body(body: &IrExpr, var: VarId) -> Option<Ty> {
     match &body.kind {
-        // BinOp: if operand is our var, infer from the op's expected type
-        IrExprKind::BinOp { op, left, right } => {
-            let operand_ty = match op {
-                BinOp::AddInt | BinOp::SubInt | BinOp::MulInt | BinOp::DivInt | BinOp::ModInt | BinOp::PowInt => Some(Ty::Int),
-                BinOp::AddFloat | BinOp::SubFloat | BinOp::MulFloat | BinOp::DivFloat => Some(Ty::Float),
-                BinOp::ConcatStr => Some(Ty::String),
-                BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => {
-                    // Comparison: both sides same type, check the other side
-                    if matches!(&left.kind, IrExprKind::Var { id } if *id == var) {
-                        if !right.ty.has_unresolved_deep() { Some(right.ty.clone()) } else { None }
-                    } else if matches!(&right.kind, IrExprKind::Var { id } if *id == var) {
-                        if !left.ty.has_unresolved_deep() { Some(left.ty.clone()) } else { None }
-                    } else { None }
-                }
-                _ => None,
-            };
-            if let Some(ref ty) = operand_ty {
-                if matches!(&left.kind, IrExprKind::Var { id } if *id == var) { return Some(ty.clone()); }
-                if matches!(&right.kind, IrExprKind::Var { id } if *id == var) { return Some(ty.clone()); }
-            }
-            infer_var_type_from_body(left, var).or_else(|| infer_var_type_from_body(right, var))
-        }
-        // Call: if arg is our var, infer from call's param type
-        IrExprKind::Call { args, .. } | IrExprKind::RuntimeCall { args, .. } => {
-            for arg in args {
-                if let Some(ty) = infer_var_type_from_body(arg, var) { return Some(ty); }
-            }
-            None
-        }
-        // Block: check stmts and tail
+        IrExprKind::BinOp { op, left, right } =>
+            binop_operand_type(op, left, right, var)
+                .or_else(|| infer_var_type_from_body(left, var))
+                .or_else(|| infer_var_type_from_body(right, var)),
+        IrExprKind::Call { args, .. } | IrExprKind::RuntimeCall { args, .. } =>
+            args.iter().find_map(|a| infer_var_type_from_body(a, var)),
         IrExprKind::Block { stmts, expr } => {
-            for s in stmts {
-                if let IrStmtKind::Bind { value, .. } | IrStmtKind::Expr { expr: value } = &s.kind {
-                    if let Some(ty) = infer_var_type_from_body(value, var) { return Some(ty); }
-                }
-            }
-            expr.as_ref().and_then(|e| infer_var_type_from_body(e, var))
+            stmts.iter().find_map(|s| match &s.kind {
+                IrStmtKind::Bind { value, .. } | IrStmtKind::Expr { expr: value } =>
+                    infer_var_type_from_body(value, var),
+                _ => None,
+            }).or_else(|| expr.as_ref().and_then(|e| infer_var_type_from_body(e, var)))
         }
-        // If/Match: recurse
-        IrExprKind::If { cond, then, else_ } => {
+        IrExprKind::If { cond, then, else_ } =>
             infer_var_type_from_body(cond, var)
                 .or_else(|| infer_var_type_from_body(then, var))
-                .or_else(|| infer_var_type_from_body(else_, var))
-        }
-        IrExprKind::Match { subject, arms } => {
+                .or_else(|| infer_var_type_from_body(else_, var)),
+        IrExprKind::Match { subject, arms } =>
             infer_var_type_from_body(subject, var)
-                .or_else(|| arms.iter().find_map(|a| infer_var_type_from_body(&a.body, var)))
-        }
+                .or_else(|| arms.iter().find_map(|a| infer_var_type_from_body(&a.body, var))),
         _ => None,
     }
 }

--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -575,6 +575,22 @@ impl<'a> IrMutVisitor for Concretizer<'a> {
         // concrete before we use them here.
         walk_expr_mut(self, expr);
 
+        // Resolve Unknown lambda params from body usage (e.g. `(a,b) => a + b` → Int)
+        if let IrExprKind::Lambda { params, body, .. } = &mut expr.kind {
+            let mut patched = false;
+            for (var_id, var_ty) in params.iter_mut() {
+                if matches!(var_ty, Ty::Unknown) {
+                    if let Some(inferred) = infer_var_type_from_body(body, *var_id) {
+                        *var_ty = inferred.clone();
+                        self.vt.entries[var_id.0 as usize].ty = inferred;
+                        patched = true;
+                    }
+                }
+            }
+            // Re-visit body to propagate patched param types into Var nodes
+            if patched { walk_expr_mut(self, body); }
+        }
+
         // Rewrite BinOp when operand types disagree with the op kind.
         // Type checker may have picked `AddInt` for polymorphic code that
         // later specialized to Float (e.g. via list element type). Without
@@ -695,6 +711,62 @@ impl<'a> IrMutVisitor for Concretizer<'a> {
 
 // ── Resolution logic ───────────────────────────────────────────────
 
+/// Infer a lambda param's type by scanning how it's used in the body.
+/// e.g., `(a, b) => a + b` where body is BinOp::AddInt → a: Int, b: Int
+fn infer_var_type_from_body(body: &IrExpr, var: VarId) -> Option<Ty> {
+    match &body.kind {
+        // BinOp: if operand is our var, infer from the op's expected type
+        IrExprKind::BinOp { op, left, right } => {
+            let operand_ty = match op {
+                BinOp::AddInt | BinOp::SubInt | BinOp::MulInt | BinOp::DivInt | BinOp::ModInt | BinOp::PowInt => Some(Ty::Int),
+                BinOp::AddFloat | BinOp::SubFloat | BinOp::MulFloat | BinOp::DivFloat => Some(Ty::Float),
+                BinOp::ConcatStr => Some(Ty::String),
+                BinOp::Eq | BinOp::Neq | BinOp::Lt | BinOp::Gt | BinOp::Lte | BinOp::Gte => {
+                    // Comparison: both sides same type, check the other side
+                    if matches!(&left.kind, IrExprKind::Var { id } if *id == var) {
+                        if !right.ty.has_unresolved_deep() { Some(right.ty.clone()) } else { None }
+                    } else if matches!(&right.kind, IrExprKind::Var { id } if *id == var) {
+                        if !left.ty.has_unresolved_deep() { Some(left.ty.clone()) } else { None }
+                    } else { None }
+                }
+                _ => None,
+            };
+            if let Some(ref ty) = operand_ty {
+                if matches!(&left.kind, IrExprKind::Var { id } if *id == var) { return Some(ty.clone()); }
+                if matches!(&right.kind, IrExprKind::Var { id } if *id == var) { return Some(ty.clone()); }
+            }
+            infer_var_type_from_body(left, var).or_else(|| infer_var_type_from_body(right, var))
+        }
+        // Call: if arg is our var, infer from call's param type
+        IrExprKind::Call { args, .. } | IrExprKind::RuntimeCall { args, .. } => {
+            for arg in args {
+                if let Some(ty) = infer_var_type_from_body(arg, var) { return Some(ty); }
+            }
+            None
+        }
+        // Block: check stmts and tail
+        IrExprKind::Block { stmts, expr } => {
+            for s in stmts {
+                if let IrStmtKind::Bind { value, .. } | IrStmtKind::Expr { expr: value } = &s.kind {
+                    if let Some(ty) = infer_var_type_from_body(value, var) { return Some(ty); }
+                }
+            }
+            expr.as_ref().and_then(|e| infer_var_type_from_body(e, var))
+        }
+        // If/Match: recurse
+        IrExprKind::If { cond, then, else_ } => {
+            infer_var_type_from_body(cond, var)
+                .or_else(|| infer_var_type_from_body(then, var))
+                .or_else(|| infer_var_type_from_body(else_, var))
+        }
+        IrExprKind::Match { subject, arms } => {
+            infer_var_type_from_body(subject, var)
+                .or_else(|| arms.iter().find_map(|a| infer_var_type_from_body(&a.body, var)))
+        }
+        _ => None,
+    }
+}
+
 fn resolve_node_ty(expr: &IrExpr, vt: &VarTable, symbols: &SymbolTable) -> Option<Ty> {
     match &expr.kind {
         IrExprKind::Var { id } => {
@@ -752,7 +824,6 @@ fn resolve_node_ty(expr: &IrExpr, vt: &VarTable, symbols: &SymbolTable) -> Optio
                 .find_map(|arm| if !(arm.body.ty).has_unresolved_deep() { Some(arm.body.ty.clone()) } else { None })
         }
         IrExprKind::Lambda { params, body, .. } => {
-            // Build Ty::Fn from resolved params + body.ty (if concrete)
             let fparams: Vec<Ty> = params.iter().map(|(_, t)| t.clone()).collect();
             if fparams.iter().any(Ty::has_unresolved_deep) || (body.ty).has_unresolved_deep() {
                 return None;

--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -713,7 +713,7 @@ impl<'a> IrMutVisitor for Concretizer<'a> {
 
 /// Infer a lambda param's type by scanning how it's used in the body.
 /// e.g., `(a, b) => a + b` where body is BinOp::AddInt → a: Int, b: Int
-fn infer_var_type_from_body(body: &IrExpr, var: VarId) -> Option<Ty> {
+pub fn infer_var_type_from_body(body: &IrExpr, var: VarId) -> Option<Ty> {
     match &body.kind {
         // BinOp: if operand is our var, infer from the op's expected type
         IrExprKind::BinOp { op, left, right } => {

--- a/crates/almide-codegen/src/pass_lambda_type_resolve.rs
+++ b/crates/almide-codegen/src/pass_lambda_type_resolve.rs
@@ -151,6 +151,18 @@ fn resolve_expr(expr: &mut IrExpr, vt: &mut VarTable) {
             if let IrExprKind::Lambda { body, .. } = &mut expr.kind {
                 resolve_expr(body, vt);
             }
+            // Bottom-up: infer still-Unknown params from body usage
+            if let IrExprKind::Lambda { params, body, .. } = &mut expr.kind {
+                for (vid, pty) in params.iter_mut() {
+                    if pty.has_unresolved_deep() {
+                        if let Some(inferred) = super::pass_concretize_types::infer_var_type_from_body(body, *vid) {
+                            *pty = inferred.clone();
+                            vt.entries[vid.0 as usize].ty = inferred;
+                        }
+                    }
+                }
+                refresh_lambda_fn_ty(expr, vt);
+            }
         }
         IrExprKind::Block { stmts, expr: tail } => {
             for s in stmts.iter_mut() { resolve_stmt(s, vt); }

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -555,6 +555,10 @@ impl Checker {
                 self.env.can_call_effect = prev_call;
                 self.env.pop_scope();
             }
+            ast::Decl::TestWhereDef { clauses, .. } => {
+                let wcs = clauses.clone();
+                for wc in &wcs { self.infer_test_where_inner(wc); }
+            }
             ast::Decl::TopLet { name, value, mutable, .. } => {
                 if *mutable { self.env.mutable_vars.insert(sym(name)); }
                 let ity = self.infer_expr(value);

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -598,8 +598,29 @@ impl Checker {
                 let resolved = resolve_ty(&ty, &self.uf);
                 self.env.define_var(name.as_str(), resolved);
             }
-            ast::TestWhere::Override { value, .. } => { let mut v = value.clone(); self.infer_expr(&mut v); }
-            ast::TestWhere::CallResponse { response, .. } => { let mut r = response.clone(); self.infer_expr(&mut r); }
+            ast::TestWhere::Override { path, value } => {
+                let mut v = value.clone();
+                let ty = self.infer_expr(&mut v);
+                let resolved = resolve_ty(&ty, &self.uf);
+                let override_name = format!("__where_{}", path.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("_"));
+                self.env.define_var(&override_name, resolved);
+            }
+            ast::TestWhere::CallResponse { target, params, response } => {
+                let param_vars: Vec<_> = params.iter().filter_map(|pat| {
+                    if let ast::Pattern::Ident { name } = pat { Some(*name) } else { None }
+                }).collect();
+                let param_tys: Vec<_> = param_vars.iter().map(|pname| {
+                    let tv = self.fresh_var();
+                    self.env.define_var(pname.as_str(), tv.clone());
+                    tv
+                }).collect();
+                let mut r = response.clone();
+                let ret_ty = self.infer_expr(&mut r);
+                let ret_resolved = resolve_ty(&ret_ty, &self.uf);
+                let fn_ty = Ty::Fn { params: param_tys, ret: Box::new(ret_resolved) };
+                let override_name = format!("__where_{}", target.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("_"));
+                self.env.define_var(&override_name, fn_ty);
+            }
             ast::TestWhere::Case { bindings, .. } => {
                 for b in bindings { self.infer_test_where_inner(b); }
             }

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -606,13 +606,19 @@ impl Checker {
                 self.env.define_var(&override_name, resolved);
             }
             ast::TestWhere::CallResponse { target, params, response } => {
+                // Resolve param types from original function signature
+                let target_name = if target.len() == 1 { *target.first().unwrap() }
+                    else { sym(&target.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(".")) };
+                let sig_params: Vec<Ty> = self.env.functions.get(&target_name)
+                    .map(|sig| sig.params.iter().map(|(_, t)| t.clone()).collect())
+                    .unwrap_or_default();
                 let param_vars: Vec<_> = params.iter().filter_map(|pat| {
                     if let ast::Pattern::Ident { name } = pat { Some(*name) } else { None }
                 }).collect();
-                let param_tys: Vec<_> = param_vars.iter().map(|pname| {
-                    let tv = self.fresh_var();
-                    self.env.define_var(pname.as_str(), tv.clone());
-                    tv
+                let param_tys: Vec<_> = param_vars.iter().enumerate().map(|(i, pname)| {
+                    let ty = sig_params.get(i).cloned().unwrap_or_else(|| self.fresh_var());
+                    self.env.define_var(pname.as_str(), ty.clone());
+                    ty
                 }).collect();
                 let mut r = response.clone();
                 let ret_ty = self.infer_expr(&mut r);

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -544,10 +544,12 @@ impl Checker {
             ast::Decl::Fn { name, params, return_type, body: Some(body), effect, generics, .. } => {
                 self.check_fn_decl(name, params, return_type, body, effect, generics);
             }
-            ast::Decl::Test { body, .. } => {
+            ast::Decl::Test { body, where_clauses, .. } => {
+                let wcs = where_clauses.clone();
                 self.env.push_scope();
                 let prev_call = self.env.can_call_effect; self.env.can_call_effect = true;
                 let prev_test = self.env.in_test_block; self.env.in_test_block = true;
+                for wc in &wcs { self.infer_test_where_inner(wc); }
                 self.infer_expr(body);
                 self.env.in_test_block = prev_test;
                 self.env.can_call_effect = prev_call;
@@ -588,6 +590,21 @@ impl Checker {
 
     // ── Exhaustiveness ──
 
+    fn infer_test_where_inner(&mut self, wc: &ast::TestWhere) {
+        match wc {
+            ast::TestWhere::Bind { name, value } => {
+                let mut val = value.clone();
+                let ty = self.infer_expr(&mut val);
+                let resolved = resolve_ty(&ty, &self.uf);
+                self.env.define_var(name.as_str(), resolved);
+            }
+            ast::TestWhere::Override { value, .. } => { let mut v = value.clone(); self.infer_expr(&mut v); }
+            ast::TestWhere::CallResponse { response, .. } => { let mut r = response.clone(); self.infer_expr(&mut r); }
+            ast::TestWhere::Case { bindings, .. } => {
+                for b in bindings { self.infer_test_where_inner(b); }
+            }
+        }
+    }
 }
 
 /// Infer types for default value expressions in type declarations.
@@ -604,6 +621,7 @@ fn infer_default_exprs(checker: &mut Checker, ty: &mut ast::TypeExpr) {
             }
         }
     }
+
 }
 
 impl Checker {

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -255,6 +255,11 @@ fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &Type
         }
     }
 
+    // Pre-pass: collect file-scoped test where clauses
+    let file_test_wheres: Vec<ast::TestWhere> = prog.decls.iter().filter_map(|d| {
+        if let ast::Decl::TestWhereDef { clauses, .. } = d { Some(clauses.clone()) } else { None }
+    }).flatten().collect();
+
     for (decl_idx, decl) in prog.decls.iter().enumerate() {
         let doc = prog.doc_map.get(decl_idx).cloned().flatten();
         let blank_lines = prog.blank_lines_map.get(decl_idx).copied().unwrap_or(0);
@@ -297,14 +302,15 @@ fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &Type
                 let tl_def_id = ctx.def_map.get(&sym(name)).copied();
                 top_lets.push(IrTopLet { var, ty: val_ty, value: ir_value, kind, mutable: *mutable, doc, blank_lines_before: blank_lines, def_id: tl_def_id });
             }
+            ast::Decl::TestWhereDef { .. } => {} // collected in pre-pass below
             ast::Decl::Test { name, body, where_clauses, .. } => {
                 let cases: Vec<_> = where_clauses.iter()
                     .filter_map(|wc| match wc { ast::TestWhere::Case { name, bindings } => Some((name.clone(), bindings.clone())), _ => None })
                     .collect();
-                let top_binds: Vec<_> = where_clauses.iter()
+                let mut top_binds: Vec<_> = file_test_wheres.clone();
+                top_binds.extend(where_clauses.iter()
                     .filter(|wc| !matches!(wc, ast::TestWhere::Case { .. }))
-                    .cloned()
-                    .collect();
+                    .cloned());
                 if cases.is_empty() {
                     let test_fn = lower_test_with_where(&mut ctx, name, body, &top_binds);
                     functions.push(test_fn);
@@ -822,16 +828,18 @@ fn lower_where_override(ctx: &mut LowerCtx, path: &[Sym], value: &ast::Expr, stm
     if let IrExprKind::Lambda { params: ir_params, body, .. } = &mut ir_val.kind {
         if ir_params.iter().any(|(_, ty)| matches!(ty, Ty::Unknown)) {
             if let Some(Ty::Fn { params: sig_tys, ret }) = resolve_target_fn_type(ctx, path) {
+                let erased: Vec<Ty> = sig_tys.iter().map(erase_typevars).collect();
                 for (i, (var_id, var_ty)) in ir_params.iter_mut().enumerate() {
-                    if let Some(concrete) = sig_tys.get(i) {
+                    if let Some(concrete) = erased.get(i) {
                         if !matches!(concrete, Ty::Unknown) {
                             *var_ty = concrete.clone();
                             ctx.var_table.entries[var_id.0 as usize].ty = concrete.clone();
                         }
                     }
                 }
-                if matches!(body.ty, Ty::Unknown) { body.ty = *ret; }
-                ir_val.ty = Ty::Fn { params: sig_tys, ret: Box::new(body.ty.clone()) };
+                let erased_ret = erase_typevars(&ret);
+                if matches!(body.ty, Ty::Unknown) { body.ty = erased_ret.clone(); }
+                ir_val.ty = Ty::Fn { params: erased, ret: Box::new(body.ty.clone()) };
             }
         }
     }
@@ -858,11 +866,11 @@ fn lower_where_call_response(ctx: &mut LowerCtx, target: &[Sym], params: &[ast::
     // the lambda's IR param VarIds so WASM codegen gets correct types.
     let original_fn_ty = resolve_target_fn_type(ctx, target);
     let sig_param_tys: Vec<Ty> = match &original_fn_ty {
-        Some(Ty::Fn { params: ptys, .. }) => ptys.clone(),
+        Some(Ty::Fn { params: ptys, .. }) => ptys.iter().map(erase_typevars).collect(),
         _ => params.iter().map(|_| Ty::Unknown).collect(),
     };
     let sig_ret_ty = match &original_fn_ty {
-        Some(Ty::Fn { ret, .. }) => (**ret).clone(),
+        Some(Ty::Fn { ret, .. }) => erase_typevars(ret),
         _ => Ty::Unknown,
     };
     // Patch lambda IR: update param VarIds in var_table with concrete types
@@ -912,6 +920,19 @@ fn resolve_target_fn_type(ctx: &LowerCtx, target: &[Sym]) -> Option<Ty> {
         }
     }
     None
+}
+
+/// Erase TypeVars from a type — replace with Unknown so Rust emits `_` instead of `A`.
+fn erase_typevars(ty: &Ty) -> Ty {
+    match ty {
+        Ty::TypeVar(_) => Ty::Unknown,
+        Ty::Fn { params, ret } => Ty::Fn {
+            params: params.iter().map(erase_typevars).collect(),
+            ret: Box::new(erase_typevars(ret)),
+        },
+        Ty::Applied(tc, args) => Ty::Applied(tc.clone(), args.iter().map(erase_typevars).collect()),
+        other => other.clone(),
+    }
 }
 
 fn where_override_name(path: &[Sym]) -> String {

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -750,14 +750,76 @@ fn lower_fn(
     }
 }
 
+/// Rewrite calls in an AST expression: replace `module.func(args)` with `override_var(args)`.
+fn rewrite_calls_in_expr(expr: &mut ast::Expr, path: &[Sym], override_name: &str) {
+    // Match: Call { callee: Member { object: Ident(module), field: func }, args }
+    // where [module, func] matches path
+    let is_match = if let ast::ExprKind::Call { callee, .. } = &expr.kind {
+        match path.len() {
+            1 => matches!(&callee.kind, ast::ExprKind::Ident { name } if *name == path[0]),
+            2 => {
+                if let ast::ExprKind::Member { object, field, .. } = &callee.kind {
+                    if let ast::ExprKind::Ident { name } = &object.kind {
+                        *name == path[0] && *field == path[1]
+                    } else { false }
+                } else { false }
+            }
+            _ => false,
+        }
+    } else { false };
+
+    if is_match {
+        if let ast::ExprKind::Call { args, named_args, .. } = &mut expr.kind {
+            let new_callee = ast::Expr::new(ast::ExprId(0), None, ast::ExprKind::Ident { name: sym(override_name) });
+            expr.kind = ast::ExprKind::Call {
+                callee: Box::new(new_callee),
+                args: std::mem::take(args),
+                named_args: std::mem::take(named_args),
+                type_args: None,
+            };
+        }
+        return; // already rewritten, don't recurse into the replacement
+    }
+
+    // Recurse into all sub-expressions
+    ast::visit_expr_mut(expr, &mut |e| {
+        // Check and rewrite each sub-expression
+        let sub_match = if let ast::ExprKind::Call { callee, .. } = &e.kind {
+            match path.len() {
+                1 => matches!(&callee.kind, ast::ExprKind::Ident { name } if *name == path[0]),
+                2 => {
+                    if let ast::ExprKind::Member { object, field, .. } = &callee.kind {
+                        if let ast::ExprKind::Ident { name } = &object.kind {
+                            *name == path[0] && *field == path[1]
+                        } else { false }
+                    } else { false }
+                }
+                _ => false,
+            }
+        } else { false };
+        if sub_match {
+            if let ast::ExprKind::Call { args, named_args, .. } = &mut e.kind {
+                let new_callee = ast::Expr::new(ast::ExprId(0), None, ast::ExprKind::Ident { name: sym(override_name) });
+                e.kind = ast::ExprKind::Call {
+                    callee: Box::new(new_callee),
+                    args: std::mem::take(args),
+                    named_args: std::mem::take(named_args),
+                    type_args: None,
+                };
+            }
+        }
+    });
+}
+
 fn lower_test(ctx: &mut LowerCtx, name: &str, body: &ast::Expr) -> IrFunction {
     lower_test_with_where(ctx, name, body, &[])
 }
 
 fn lower_test_with_where(ctx: &mut LowerCtx, name: &str, body: &ast::Expr, where_clauses: &[ast::TestWhere]) -> IrFunction {
     ctx.push_scope();
-    // Lower where bindings as let statements before the body
     let mut stmts: Vec<IrStmt> = Vec::new();
+    // Collect override targets for AST rewriting
+    let mut overrides: Vec<(Vec<Sym>, String)> = Vec::new(); // (path, override_var_name)
     for wc in where_clauses {
         match wc {
             ast::TestWhere::Bind { name: bind_name, value } => {
@@ -769,14 +831,56 @@ fn lower_test_with_where(ctx: &mut LowerCtx, name: &str, body: &ast::Expr, where
                     span: None,
                 });
             }
-            // Override and CallResponse: Phase 2/3 — emit a warning for now
-            ast::TestWhere::Override { .. } | ast::TestWhere::CallResponse { .. } => {
-                // TODO: implement in Phase 2/3
+            ast::TestWhere::Override { path, value } => {
+                let override_name = format!("__where_{}", path.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("_"));
+                let ir_val = lower_expr(ctx, value);
+                let ty = ir_val.ty.clone();
+                let var = ctx.define_var(&override_name, ty.clone(), Mutability::Let, None);
+                stmts.push(IrStmt {
+                    kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val },
+                    span: None,
+                });
+                overrides.push((path.clone(), override_name));
+            }
+            ast::TestWhere::CallResponse { target, params, response } => {
+                let override_name = format!("__where_{}", target.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("_"));
+                // Build lambda: (params...) => response
+                let lambda_params: Vec<ast::LambdaParam> = params.iter().enumerate().map(|(i, pat)| {
+                    let pname = match pat {
+                        ast::Pattern::Ident { name } => name.as_str().to_string(),
+                        ast::Pattern::Wildcard => format!("_arg{}", i),
+                        _ => format!("_arg{}", i),
+                    };
+                    ast::LambdaParam { name: sym(&pname), tuple_names: None, ty: None }
+                }).collect();
+                let lambda = ast::Expr::new(ast::ExprId(0), None, ast::ExprKind::Lambda {
+                    params: lambda_params, body: Box::new(response.clone()),
+                });
+                let ir_val = lower_expr(ctx, &lambda);
+                // Ensure the type is Fn (lambda lowering may produce Unknown if type_map is empty)
+                let ty = match &ir_val.ty {
+                    Ty::Fn { .. } => ir_val.ty.clone(),
+                    _ => {
+                        let param_tys: Vec<Ty> = params.iter().map(|_| Ty::Unknown).collect();
+                        Ty::Fn { params: param_tys, ret: Box::new(Ty::Unknown) }
+                    }
+                };
+                let var = ctx.define_var(&override_name, ty.clone(), Mutability::Let, None);
+                stmts.push(IrStmt {
+                    kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val },
+                    span: None,
+                });
+                overrides.push((target.clone(), override_name));
             }
             ast::TestWhere::Case { .. } => {} // already expanded
         }
     }
-    let ir_body = lower_expr(ctx, body);
+    // Rewrite test body AST: replace overridden calls
+    let mut body_rewritten = body.clone();
+    for (path, override_name) in &overrides {
+        rewrite_calls_in_expr(&mut body_rewritten, path, override_name);
+    }
+    let ir_body = lower_expr(ctx, &body_rewritten);
     let final_body = if stmts.is_empty() {
         ir_body
     } else {

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -856,16 +856,17 @@ fn lower_test_with_where(ctx: &mut LowerCtx, name: &str, body: &ast::Expr, where
                 let lambda = ast::Expr::new(ast::ExprId(0), None, ast::ExprKind::Lambda {
                     params: lambda_params, body: Box::new(response.clone()),
                 });
-                let ir_val = lower_expr(ctx, &lambda);
-                // Ensure the type is Fn (lambda lowering may produce Unknown if type_map is empty)
-                let ty = match &ir_val.ty {
-                    Ty::Fn { .. } => ir_val.ty.clone(),
-                    _ => {
-                        let param_tys: Vec<Ty> = params.iter().map(|_| Ty::Unknown).collect();
-                        Ty::Fn { params: param_tys, ret: Box::new(Ty::Unknown) }
-                    }
+                let mut ir_val = lower_expr(ctx, &lambda);
+                // Force Fn type — lambda lowering may produce Unknown if type_map has no entry
+                let fn_ty = {
+                    let param_tys: Vec<Ty> = params.iter().map(|_| Ty::Unknown).collect();
+                    Ty::Fn { params: param_tys, ret: Box::new(Ty::Unknown) }
                 };
+                let ty = if matches!(&ir_val.ty, Ty::Fn { .. }) { ir_val.ty.clone() } else { fn_ty };
+                ir_val.ty = ty.clone();
                 let var = ctx.define_var(&override_name, ty.clone(), Mutability::Let, None);
+                // Also update the var_table entry to ensure Fn type
+                ctx.var_table.entries[var.0 as usize].ty = ty.clone();
                 stmts.push(IrStmt {
                     kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val },
                     span: None,

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -814,15 +814,46 @@ fn lower_where_call_response(ctx: &mut LowerCtx, target: &[Sym], params: &[ast::
         params: lambda_params, body: Box::new(response.clone()),
     });
     let mut ir_val = lower_expr(ctx, &lambda);
+    // Resolve param types from the original function's signature
+    let original_fn_ty = resolve_target_fn_type(ctx, target);
     let ty = match &ir_val.ty {
         Ty::Fn { .. } => ir_val.ty.clone(),
-        _ => Ty::Fn { params: params.iter().map(|_| Ty::Unknown).collect(), ret: Box::new(Ty::Unknown) },
+        _ => original_fn_ty.unwrap_or_else(|| Ty::Fn {
+            params: params.iter().map(|_| Ty::Unknown).collect(),
+            ret: Box::new(Ty::Unknown),
+        }),
     };
     ir_val.ty = ty.clone();
     let var = ctx.define_var(&override_name, ty.clone(), Mutability::Let, None);
     ctx.var_table.entries[var.0 as usize].ty = ty.clone();
     stmts.push(IrStmt { kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val }, span: None });
     overrides.push((target.to_vec(), override_name));
+}
+
+/// Look up the Fn type of a target path (e.g. ["double"] or ["http","get"]) from the environment.
+fn resolve_target_fn_type(ctx: &LowerCtx, target: &[Sym]) -> Option<Ty> {
+    let name = if target.len() == 1 {
+        target[0]
+    } else {
+        sym(&target.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("."))
+    };
+    // Check local scope first (function defined in same file)
+    if let Some(var_id) = ctx.lookup_var(name.as_str()) {
+        let ty = &ctx.var_table.get(var_id).ty;
+        if matches!(ty, Ty::Fn { .. }) { return Some(ty.clone()); }
+    }
+    // Check environment functions
+    if let Some(sig) = ctx.env.functions.get(&name) {
+        return Some(Ty::Fn { params: sig.params.iter().map(|(_, t)| t.clone()).collect(), ret: Box::new(sig.ret.clone()) });
+    }
+    // For module.func, check module functions
+    if target.len() == 2 {
+        let qual = sym(&format!("{}.{}", target[0], target[1]));
+        if let Some(sig) = ctx.env.functions.get(&qual) {
+            return Some(Ty::Fn { params: sig.params.iter().map(|(_, t)| t.clone()).collect(), ret: Box::new(sig.ret.clone()) });
+        }
+    }
+    None
 }
 
 fn where_override_name(path: &[Sym]) -> String {

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -750,65 +750,83 @@ fn lower_fn(
     }
 }
 
-/// Rewrite calls in an AST expression: replace `module.func(args)` with `override_var(args)`.
-fn rewrite_calls_in_expr(expr: &mut ast::Expr, path: &[Sym], override_name: &str) {
-    // Match: Call { callee: Member { object: Ident(module), field: func }, args }
-    // where [module, func] matches path
-    let is_match = if let ast::ExprKind::Call { callee, .. } = &expr.kind {
-        match path.len() {
-            1 => matches!(&callee.kind, ast::ExprKind::Ident { name } if *name == path[0]),
-            2 => {
-                if let ast::ExprKind::Member { object, field, .. } = &callee.kind {
-                    if let ast::ExprKind::Ident { name } = &object.kind {
-                        *name == path[0] && *field == path[1]
-                    } else { false }
-                } else { false }
-            }
-            _ => false,
-        }
-    } else { false };
-
-    if is_match {
-        if let ast::ExprKind::Call { args, named_args, .. } = &mut expr.kind {
-            let new_callee = ast::Expr::new(ast::ExprId(0), None, ast::ExprKind::Ident { name: sym(override_name) });
-            expr.kind = ast::ExprKind::Call {
-                callee: Box::new(new_callee),
-                args: std::mem::take(args),
-                named_args: std::mem::take(named_args),
-                type_args: None,
-            };
-        }
-        return; // already rewritten, don't recurse into the replacement
+/// Check if a Call expression's callee matches a path (e.g. ["http","get"] or ["double"]).
+fn call_matches_path(expr: &ast::Expr, path: &[Sym]) -> bool {
+    let ast::ExprKind::Call { callee, .. } = &expr.kind else { return false };
+    match path.len() {
+        1 => matches!(&callee.kind, ast::ExprKind::Ident { name } if *name == path[0]),
+        2 => matches!(&callee.kind, ast::ExprKind::Member { object, field, .. }
+            if matches!(&object.kind, ast::ExprKind::Ident { name } if *name == path[0]) && *field == path[1]),
+        _ => false,
     }
+}
 
-    // Recurse into all sub-expressions
+/// Replace the callee of a Call expression with an override variable.
+fn rewrite_call_callee(expr: &mut ast::Expr, override_name: &str) {
+    if let ast::ExprKind::Call { args, named_args, .. } = &mut expr.kind {
+        let new_callee = ast::Expr::new(ast::ExprId(0), None, ast::ExprKind::Ident { name: sym(override_name) });
+        expr.kind = ast::ExprKind::Call {
+            callee: Box::new(new_callee),
+            args: std::mem::take(args),
+            named_args: std::mem::take(named_args),
+            type_args: None,
+        };
+    }
+}
+
+/// Rewrite calls in an AST expression: replace matching calls with override var.
+fn rewrite_calls_in_expr(expr: &mut ast::Expr, path: &[Sym], override_name: &str) {
+    if call_matches_path(expr, path) {
+        rewrite_call_callee(expr, override_name);
+        return;
+    }
     ast::visit_expr_mut(expr, &mut |e| {
-        // Check and rewrite each sub-expression
-        let sub_match = if let ast::ExprKind::Call { callee, .. } = &e.kind {
-            match path.len() {
-                1 => matches!(&callee.kind, ast::ExprKind::Ident { name } if *name == path[0]),
-                2 => {
-                    if let ast::ExprKind::Member { object, field, .. } = &callee.kind {
-                        if let ast::ExprKind::Ident { name } = &object.kind {
-                            *name == path[0] && *field == path[1]
-                        } else { false }
-                    } else { false }
-                }
-                _ => false,
-            }
-        } else { false };
-        if sub_match {
-            if let ast::ExprKind::Call { args, named_args, .. } = &mut e.kind {
-                let new_callee = ast::Expr::new(ast::ExprId(0), None, ast::ExprKind::Ident { name: sym(override_name) });
-                e.kind = ast::ExprKind::Call {
-                    callee: Box::new(new_callee),
-                    args: std::mem::take(args),
-                    named_args: std::mem::take(named_args),
-                    type_args: None,
-                };
-            }
-        }
+        if call_matches_path(e, path) { rewrite_call_callee(e, override_name); }
     });
+}
+
+fn lower_where_bind(ctx: &mut LowerCtx, bind_name: &Sym, value: &ast::Expr) -> IrStmt {
+    let ir_val = lower_expr(ctx, value);
+    let ty = ir_val.ty.clone();
+    let var = ctx.define_var(bind_name.as_str(), ty.clone(), Mutability::Let, None);
+    IrStmt { kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val }, span: None }
+}
+
+fn lower_where_override(ctx: &mut LowerCtx, path: &[Sym], value: &ast::Expr, stmts: &mut Vec<IrStmt>, overrides: &mut Vec<(Vec<Sym>, String)>) {
+    let override_name = where_override_name(path);
+    let ir_val = lower_expr(ctx, value);
+    let ty = ir_val.ty.clone();
+    let var = ctx.define_var(&override_name, ty.clone(), Mutability::Let, None);
+    stmts.push(IrStmt { kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val }, span: None });
+    overrides.push((path.to_vec(), override_name));
+}
+
+fn lower_where_call_response(ctx: &mut LowerCtx, target: &[Sym], params: &[ast::Pattern], response: &ast::Expr, stmts: &mut Vec<IrStmt>, overrides: &mut Vec<(Vec<Sym>, String)>) {
+    let override_name = where_override_name(target);
+    let lambda_params: Vec<ast::LambdaParam> = params.iter().enumerate().map(|(i, pat)| {
+        let pname = match pat {
+            ast::Pattern::Ident { name } => name.as_str().to_string(),
+            _ => format!("_arg{}", i),
+        };
+        ast::LambdaParam { name: sym(&pname), tuple_names: None, ty: None }
+    }).collect();
+    let lambda = ast::Expr::new(ast::ExprId(0), None, ast::ExprKind::Lambda {
+        params: lambda_params, body: Box::new(response.clone()),
+    });
+    let mut ir_val = lower_expr(ctx, &lambda);
+    let ty = match &ir_val.ty {
+        Ty::Fn { .. } => ir_val.ty.clone(),
+        _ => Ty::Fn { params: params.iter().map(|_| Ty::Unknown).collect(), ret: Box::new(Ty::Unknown) },
+    };
+    ir_val.ty = ty.clone();
+    let var = ctx.define_var(&override_name, ty.clone(), Mutability::Let, None);
+    ctx.var_table.entries[var.0 as usize].ty = ty.clone();
+    stmts.push(IrStmt { kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val }, span: None });
+    overrides.push((target.to_vec(), override_name));
+}
+
+fn where_override_name(path: &[Sym]) -> String {
+    format!("__where_{}", path.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("_"))
 }
 
 fn lower_test(ctx: &mut LowerCtx, name: &str, body: &ast::Expr) -> IrFunction {
@@ -818,62 +836,16 @@ fn lower_test(ctx: &mut LowerCtx, name: &str, body: &ast::Expr) -> IrFunction {
 fn lower_test_with_where(ctx: &mut LowerCtx, name: &str, body: &ast::Expr, where_clauses: &[ast::TestWhere]) -> IrFunction {
     ctx.push_scope();
     let mut stmts: Vec<IrStmt> = Vec::new();
-    // Collect override targets for AST rewriting
-    let mut overrides: Vec<(Vec<Sym>, String)> = Vec::new(); // (path, override_var_name)
+    let mut overrides: Vec<(Vec<Sym>, String)> = Vec::new();
     for wc in where_clauses {
         match wc {
-            ast::TestWhere::Bind { name: bind_name, value } => {
-                let ir_val = lower_expr(ctx, value);
-                let ty = ir_val.ty.clone();
-                let var = ctx.define_var(bind_name.as_str(), ty.clone(), Mutability::Let, None);
-                stmts.push(IrStmt {
-                    kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val },
-                    span: None,
-                });
-            }
-            ast::TestWhere::Override { path, value } => {
-                let override_name = format!("__where_{}", path.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("_"));
-                let ir_val = lower_expr(ctx, value);
-                let ty = ir_val.ty.clone();
-                let var = ctx.define_var(&override_name, ty.clone(), Mutability::Let, None);
-                stmts.push(IrStmt {
-                    kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val },
-                    span: None,
-                });
-                overrides.push((path.clone(), override_name));
-            }
-            ast::TestWhere::CallResponse { target, params, response } => {
-                let override_name = format!("__where_{}", target.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("_"));
-                // Build lambda: (params...) => response
-                let lambda_params: Vec<ast::LambdaParam> = params.iter().enumerate().map(|(i, pat)| {
-                    let pname = match pat {
-                        ast::Pattern::Ident { name } => name.as_str().to_string(),
-                        ast::Pattern::Wildcard => format!("_arg{}", i),
-                        _ => format!("_arg{}", i),
-                    };
-                    ast::LambdaParam { name: sym(&pname), tuple_names: None, ty: None }
-                }).collect();
-                let lambda = ast::Expr::new(ast::ExprId(0), None, ast::ExprKind::Lambda {
-                    params: lambda_params, body: Box::new(response.clone()),
-                });
-                let mut ir_val = lower_expr(ctx, &lambda);
-                // Force Fn type — lambda lowering may produce Unknown if type_map has no entry
-                let fn_ty = {
-                    let param_tys: Vec<Ty> = params.iter().map(|_| Ty::Unknown).collect();
-                    Ty::Fn { params: param_tys, ret: Box::new(Ty::Unknown) }
-                };
-                let ty = if matches!(&ir_val.ty, Ty::Fn { .. }) { ir_val.ty.clone() } else { fn_ty };
-                ir_val.ty = ty.clone();
-                let var = ctx.define_var(&override_name, ty.clone(), Mutability::Let, None);
-                // Also update the var_table entry to ensure Fn type
-                ctx.var_table.entries[var.0 as usize].ty = ty.clone();
-                stmts.push(IrStmt {
-                    kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val },
-                    span: None,
-                });
-                overrides.push((target.clone(), override_name));
-            }
-            ast::TestWhere::Case { .. } => {} // already expanded
+            ast::TestWhere::Bind { name: bind_name, value } =>
+                stmts.push(lower_where_bind(ctx, bind_name, value)),
+            ast::TestWhere::Override { path, value } =>
+                lower_where_override(ctx, path, value, &mut stmts, &mut overrides),
+            ast::TestWhere::CallResponse { target, params, response } =>
+                lower_where_call_response(ctx, target, params, response, &mut stmts, &mut overrides),
+            ast::TestWhere::Case { .. } => {}
         }
     }
     // Rewrite test body AST: replace overridden calls

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -297,9 +297,26 @@ fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &Type
                 let tl_def_id = ctx.def_map.get(&sym(name)).copied();
                 top_lets.push(IrTopLet { var, ty: val_ty, value: ir_value, kind, mutable: *mutable, doc, blank_lines_before: blank_lines, def_id: tl_def_id });
             }
-            ast::Decl::Test { name, body, .. } => {
-                let test_fn = lower_test(&mut ctx, name, body);
-                functions.push(test_fn);
+            ast::Decl::Test { name, body, where_clauses, .. } => {
+                let cases: Vec<_> = where_clauses.iter()
+                    .filter_map(|wc| match wc { ast::TestWhere::Case { name, bindings } => Some((name.clone(), bindings.clone())), _ => None })
+                    .collect();
+                let top_binds: Vec<_> = where_clauses.iter()
+                    .filter(|wc| !matches!(wc, ast::TestWhere::Case { .. }))
+                    .cloned()
+                    .collect();
+                if cases.is_empty() {
+                    let test_fn = lower_test_with_where(&mut ctx, name, body, &top_binds);
+                    functions.push(test_fn);
+                } else {
+                    for (case_name, case_binds) in &cases {
+                        let full_name = format!("{} / {}", name, case_name);
+                        let mut merged = top_binds.clone();
+                        merged.extend(case_binds.iter().cloned());
+                        let test_fn = lower_test_with_where(&mut ctx, &full_name, body, &merged);
+                        functions.push(test_fn);
+                    }
+                }
             }
             ast::Decl::Impl { for_, methods, .. } => {
                 for m in methods {
@@ -734,12 +751,44 @@ fn lower_fn(
 }
 
 fn lower_test(ctx: &mut LowerCtx, name: &str, body: &ast::Expr) -> IrFunction {
+    lower_test_with_where(ctx, name, body, &[])
+}
+
+fn lower_test_with_where(ctx: &mut LowerCtx, name: &str, body: &ast::Expr, where_clauses: &[ast::TestWhere]) -> IrFunction {
     ctx.push_scope();
+    // Lower where bindings as let statements before the body
+    let mut stmts: Vec<IrStmt> = Vec::new();
+    for wc in where_clauses {
+        match wc {
+            ast::TestWhere::Bind { name: bind_name, value } => {
+                let ir_val = lower_expr(ctx, value);
+                let ty = ir_val.ty.clone();
+                let var = ctx.define_var(bind_name.as_str(), ty.clone(), Mutability::Let, None);
+                stmts.push(IrStmt {
+                    kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val },
+                    span: None,
+                });
+            }
+            // Override and CallResponse: Phase 2/3 — emit a warning for now
+            ast::TestWhere::Override { .. } | ast::TestWhere::CallResponse { .. } => {
+                // TODO: implement in Phase 2/3
+            }
+            ast::TestWhere::Case { .. } => {} // already expanded
+        }
+    }
     let ir_body = lower_expr(ctx, body);
+    let final_body = if stmts.is_empty() {
+        ir_body
+    } else {
+        // Wrap: { let bindings...; body }
+        let ty = ir_body.ty.clone();
+        let span = ir_body.span;
+        IrExpr { kind: IrExprKind::Block { stmts, expr: Some(Box::new(ir_body)) }, ty, span, def_id: None }
+    };
     ctx.pop_scope();
     IrFunction {
         name: sym(&format!("{}{}", almide_ir::TEST_NAME_PREFIX, name)),
-        params: vec![], ret_ty: Ty::Unit, body: ir_body,
+        params: vec![], ret_ty: Ty::Unit, body: final_body,
         is_effect: true, is_async: false, is_test: true,
         generics: None, extern_attrs: vec![], export_attrs: vec![], attrs: vec![],
         visibility: IrVisibility::Public,

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -824,29 +824,29 @@ fn patch_lambda_params_from_checker(ctx: &mut LowerCtx, ir_val: &mut IrExpr, bin
 fn lower_where_override(ctx: &mut LowerCtx, path: &[Sym], value: &ast::Expr, stmts: &mut Vec<IrStmt>, overrides: &mut Vec<(Vec<Sym>, String)>) {
     let override_name = where_override_name(path);
     let mut ir_val = lower_expr(ctx, value);
-    // If value is a lambda with Unknown params, patch from original function sig
-    if let IrExprKind::Lambda { params: ir_params, body, .. } = &mut ir_val.kind {
-        if ir_params.iter().any(|(_, ty)| matches!(ty, Ty::Unknown)) {
-            if let Some(Ty::Fn { params: sig_tys, ret }) = resolve_target_fn_type(ctx, path) {
-                let erased: Vec<Ty> = sig_tys.iter().map(erase_typevars).collect();
-                for (i, (var_id, var_ty)) in ir_params.iter_mut().enumerate() {
-                    if let Some(concrete) = erased.get(i) {
-                        if !matches!(concrete, Ty::Unknown) {
-                            *var_ty = concrete.clone();
-                            ctx.var_table.entries[var_id.0 as usize].ty = concrete.clone();
-                        }
-                    }
-                }
-                let erased_ret = erase_typevars(&ret);
-                if matches!(body.ty, Ty::Unknown) { body.ty = erased_ret.clone(); }
-                ir_val.ty = Ty::Fn { params: erased, ret: Box::new(body.ty.clone()) };
-            }
-        }
-    }
+    patch_lambda_from_fn_sig(ctx, &mut ir_val, path);
     let ty = ir_val.ty.clone();
     let var = ctx.define_var(&override_name, ty.clone(), Mutability::Let, None);
     stmts.push(IrStmt { kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val }, span: None });
     overrides.push((path.to_vec(), override_name));
+}
+
+fn patch_lambda_from_fn_sig(ctx: &mut LowerCtx, ir_val: &mut IrExpr, path: &[Sym]) {
+    let IrExprKind::Lambda { params: ir_params, body, .. } = &mut ir_val.kind else { return };
+    if !ir_params.iter().any(|(_, ty)| matches!(ty, Ty::Unknown)) { return; }
+    let Some(Ty::Fn { params: sig_tys, ret }) = resolve_target_fn_type(ctx, path) else { return };
+    let erased: Vec<Ty> = sig_tys.iter().map(erase_typevars).collect();
+    for (i, (var_id, var_ty)) in ir_params.iter_mut().enumerate() {
+        if let Some(concrete) = erased.get(i) {
+            if !matches!(concrete, Ty::Unknown) {
+                *var_ty = concrete.clone();
+                ctx.var_table.entries[var_id.0 as usize].ty = concrete.clone();
+            }
+        }
+    }
+    let erased_ret = erase_typevars(&ret);
+    if matches!(body.ty, Ty::Unknown) { body.ty = erased_ret.clone(); }
+    ir_val.ty = Ty::Fn { params: erased, ret: Box::new(body.ty.clone()) };
 }
 
 fn lower_where_call_response(ctx: &mut LowerCtx, target: &[Sym], params: &[ast::Pattern], response: &ast::Expr, stmts: &mut Vec<IrStmt>, overrides: &mut Vec<(Vec<Sym>, String)>) {

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -786,15 +786,55 @@ fn rewrite_calls_in_expr(expr: &mut ast::Expr, path: &[Sym], override_name: &str
 }
 
 fn lower_where_bind(ctx: &mut LowerCtx, bind_name: &Sym, value: &ast::Expr) -> IrStmt {
-    let ir_val = lower_expr(ctx, value);
+    let mut ir_val = lower_expr(ctx, value);
+    // Patch lambda params from checker's inferred Fn type
+    patch_lambda_params_from_checker(ctx, &mut ir_val, bind_name);
     let ty = ir_val.ty.clone();
     let var = ctx.define_var(bind_name.as_str(), ty.clone(), Mutability::Let, None);
     IrStmt { kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val }, span: None }
 }
 
+/// If ir_val is a Lambda with Unknown params, try to resolve from checker's env.
+fn patch_lambda_params_from_checker(ctx: &mut LowerCtx, ir_val: &mut IrExpr, bind_name: &Sym) {
+    let IrExprKind::Lambda { params: ir_params, body, .. } = &mut ir_val.kind else { return };
+    if !ir_params.iter().any(|(_, ty)| matches!(ty, Ty::Unknown)) { return; }
+    // Check if checker stored a Fn type for this binding
+    let fn_ty = ctx.env.lookup_var(bind_name.as_str()).cloned();
+    let Some(Ty::Fn { params: sig_tys, ret }) = fn_ty else { return };
+    for (i, (var_id, var_ty)) in ir_params.iter_mut().enumerate() {
+        if let Some(concrete) = sig_tys.get(i) {
+            if !matches!(concrete, Ty::Unknown) && !matches!(concrete, Ty::TypeVar(_)) {
+                *var_ty = concrete.clone();
+                ctx.var_table.entries[var_id.0 as usize].ty = concrete.clone();
+            }
+        }
+    }
+    if matches!(body.ty, Ty::Unknown) && !matches!(*ret, Ty::Unknown) {
+        body.ty = *ret.clone();
+    }
+    ir_val.ty = Ty::Fn { params: sig_tys, ret };
+}
+
 fn lower_where_override(ctx: &mut LowerCtx, path: &[Sym], value: &ast::Expr, stmts: &mut Vec<IrStmt>, overrides: &mut Vec<(Vec<Sym>, String)>) {
     let override_name = where_override_name(path);
-    let ir_val = lower_expr(ctx, value);
+    let mut ir_val = lower_expr(ctx, value);
+    // If value is a lambda with Unknown params, patch from original function sig
+    if let IrExprKind::Lambda { params: ir_params, body, .. } = &mut ir_val.kind {
+        if ir_params.iter().any(|(_, ty)| matches!(ty, Ty::Unknown)) {
+            if let Some(Ty::Fn { params: sig_tys, ret }) = resolve_target_fn_type(ctx, path) {
+                for (i, (var_id, var_ty)) in ir_params.iter_mut().enumerate() {
+                    if let Some(concrete) = sig_tys.get(i) {
+                        if !matches!(concrete, Ty::Unknown) {
+                            *var_ty = concrete.clone();
+                            ctx.var_table.entries[var_id.0 as usize].ty = concrete.clone();
+                        }
+                    }
+                }
+                if matches!(body.ty, Ty::Unknown) { body.ty = *ret; }
+                ir_val.ty = Ty::Fn { params: sig_tys, ret: Box::new(body.ty.clone()) };
+            }
+        }
+    }
     let ty = ir_val.ty.clone();
     let var = ctx.define_var(&override_name, ty.clone(), Mutability::Let, None);
     stmts.push(IrStmt { kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val }, span: None });
@@ -814,15 +854,33 @@ fn lower_where_call_response(ctx: &mut LowerCtx, target: &[Sym], params: &[ast::
         params: lambda_params, body: Box::new(response.clone()),
     });
     let mut ir_val = lower_expr(ctx, &lambda);
-    // Resolve param types from the original function's signature
+    // Resolve param types from the original function's signature and patch
+    // the lambda's IR param VarIds so WASM codegen gets correct types.
     let original_fn_ty = resolve_target_fn_type(ctx, target);
-    let ty = match &ir_val.ty {
-        Ty::Fn { .. } => ir_val.ty.clone(),
-        _ => original_fn_ty.unwrap_or_else(|| Ty::Fn {
-            params: params.iter().map(|_| Ty::Unknown).collect(),
-            ret: Box::new(Ty::Unknown),
-        }),
+    let sig_param_tys: Vec<Ty> = match &original_fn_ty {
+        Some(Ty::Fn { params: ptys, .. }) => ptys.clone(),
+        _ => params.iter().map(|_| Ty::Unknown).collect(),
     };
+    let sig_ret_ty = match &original_fn_ty {
+        Some(Ty::Fn { ret, .. }) => (**ret).clone(),
+        _ => Ty::Unknown,
+    };
+    // Patch lambda IR: update param VarIds in var_table with concrete types
+    if let IrExprKind::Lambda { params: ir_params, body, .. } = &mut ir_val.kind {
+        for (i, (var_id, var_ty)) in ir_params.iter_mut().enumerate() {
+            if let Some(concrete) = sig_param_tys.get(i) {
+                if !matches!(concrete, Ty::Unknown) {
+                    *var_ty = concrete.clone();
+                    ctx.var_table.entries[var_id.0 as usize].ty = concrete.clone();
+                }
+            }
+        }
+        // Patch body return type if it's Unknown
+        if matches!(body.ty, Ty::Unknown) && !matches!(sig_ret_ty, Ty::Unknown) {
+            body.ty = sig_ret_ty.clone();
+        }
+    }
+    let ty = Ty::Fn { params: sig_param_tys, ret: Box::new(sig_ret_ty) };
     ir_val.ty = ty.clone();
     let var = ctx.define_var(&override_name, ty.clone(), Mutability::Let, None);
     ctx.var_table.entries[var.0 as usize].ty = ty.clone();

--- a/crates/almide-syntax/src/ast.rs
+++ b/crates/almide-syntax/src/ast.rs
@@ -358,7 +358,20 @@ pub enum Decl {
     Protocol { name: Sym, #[serde(default)] generics: Option<Vec<GenericParam>>, methods: Vec<ProtocolMethod>, #[serde(skip)] span: Option<Span> },
     Impl { trait_: Sym, for_: Sym, #[serde(default)] generics: Option<Vec<GenericParam>>, methods: Vec<Decl>, #[serde(skip)] span: Option<Span> },
     Strict { mode: String, #[serde(skip)] span: Option<Span> },
-    Test { name: String, body: Expr, #[serde(skip)] span: Option<Span> },
+    Test { name: String, body: Expr, #[serde(default)] where_clauses: Vec<TestWhere>, #[serde(skip)] span: Option<Span> },
+}
+
+/// A `where` clause in a test declaration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TestWhere {
+    /// `where name = expr` — value binding
+    Bind { name: Sym, value: Expr },
+    /// `where path.to.name = expr` — reference override
+    Override { path: Vec<Sym>, value: Expr },
+    /// `where target(args...) => expr` — call pattern response
+    CallResponse { target: Vec<Sym>, params: Vec<Pattern>, response: Expr },
+    /// `where "case name" { bindings... }` — table-driven test case
+    Case { name: String, bindings: Vec<TestWhere> },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -400,10 +413,21 @@ pub fn visit_decl_exprs_mut(decl: &mut Decl, f: &mut impl FnMut(&mut Expr)) {
             if let Some(b) = body { visit_expr_mut(b, f); }
         }
         Decl::TopLet { value, .. } => visit_expr_mut(value, f),
-        Decl::Test { body, .. } => visit_expr_mut(body, f),
+        Decl::Test { body, where_clauses, .. } => {
+            for wc in where_clauses.iter_mut() { visit_test_where_exprs_mut(wc, f); }
+            visit_expr_mut(body, f);
+        }
         Decl::Impl { methods, .. } => { for m in methods.iter_mut() { visit_decl_exprs_mut(m, f); } }
         Decl::Module { .. } | Decl::Import { .. } | Decl::Type { .. } |
         Decl::Protocol { .. } | Decl::Strict { .. } => {}
+    }
+}
+
+fn visit_test_where_exprs_mut(wc: &mut TestWhere, f: &mut impl FnMut(&mut Expr)) {
+    match wc {
+        TestWhere::Bind { value, .. } | TestWhere::Override { value, .. } => visit_expr_mut(value, f),
+        TestWhere::CallResponse { response, .. } => visit_expr_mut(response, f),
+        TestWhere::Case { bindings, .. } => { for b in bindings.iter_mut() { visit_test_where_exprs_mut(b, f); } }
     }
 }
 

--- a/crates/almide-syntax/src/ast.rs
+++ b/crates/almide-syntax/src/ast.rs
@@ -359,7 +359,12 @@ pub enum Decl {
     Impl { trait_: Sym, for_: Sym, #[serde(default)] generics: Option<Vec<GenericParam>>, methods: Vec<Decl>, #[serde(skip)] span: Option<Span> },
     Strict { mode: String, #[serde(skip)] span: Option<Span> },
     Test { name: String, body: Expr, #[serde(default)] where_clauses: Vec<TestWhere>, #[serde(skip)] span: Option<Span> },
+    /// `local test where { ... }` — file-scoped test environment
+    TestWhereDef { scope: TestWhereScope, clauses: Vec<TestWhere>, #[serde(skip)] span: Option<Span> },
 }
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum TestWhereScope { Local, Module }
 
 /// A `where` clause in a test declaration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -416,6 +421,9 @@ pub fn visit_decl_exprs_mut(decl: &mut Decl, f: &mut impl FnMut(&mut Expr)) {
         Decl::Test { body, where_clauses, .. } => {
             for wc in where_clauses.iter_mut() { visit_test_where_exprs_mut(wc, f); }
             visit_expr_mut(body, f);
+        }
+        Decl::TestWhereDef { clauses, .. } => {
+            for wc in clauses.iter_mut() { visit_test_where_exprs_mut(wc, f); }
         }
         Decl::Impl { methods, .. } => { for m in methods.iter_mut() { visit_decl_exprs_mut(m, f); } }
         Decl::Module { .. } | Decl::Import { .. } | Decl::Type { .. } |

--- a/crates/almide-syntax/src/parser/declarations.rs
+++ b/crates/almide-syntax/src/parser/declarations.rs
@@ -180,6 +180,10 @@ impl Parser {
                 return self.parse_top_let(Visibility::Public, true);
             }
             if self.check(TokenType::Local) || self.check(TokenType::Mod) {
+                // local test where { ... } / mod test where { ... }
+                if self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::Test) {
+                    return self.parse_test_where_def();
+                }
                 if self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::Type) {
                     return self.parse_type_decl();
                 }
@@ -610,6 +614,31 @@ impl Parser {
         self.expect(TokenType::Strict)?;
         let mode = self.expect_ident()?.to_string();
         Ok(Decl::Strict { mode, span: Some(span) })
+    }
+
+    fn parse_test_where_def(&mut self) -> Result<Decl, String> {
+        use crate::ast::{TestWhereScope, TestWhere};
+        let span = self.current_span();
+        let scope = if self.check(TokenType::Local) { self.advance(); TestWhereScope::Local }
+            else { self.advance(); TestWhereScope::Module }; // Mod
+        self.expect(TokenType::Test)?;
+        // consume contextual 'where'
+        if self.current().token_type == TokenType::Ident && self.current().value == "where" {
+            self.advance();
+        }
+        self.expect(TokenType::LBrace)?;
+        let mut clauses = Vec::new();
+        self.skip_newlines();
+        while self.current().token_type != TokenType::RBrace && self.current().token_type != TokenType::EOF {
+            let clause = self.parse_test_where_binding()?;
+            clauses.push(clause);
+            while self.current().token_type == TokenType::Semicolon
+                || self.current().token_type == TokenType::Comma
+                || self.current().token_type == TokenType::Newline
+            { self.advance(); }
+        }
+        self.expect(TokenType::RBrace)?;
+        Ok(Decl::TestWhereDef { scope, clauses, span: Some(span) })
     }
 
     fn parse_test_decl(&mut self) -> Result<Decl, String> {

--- a/crates/almide-syntax/src/parser/declarations.rs
+++ b/crates/almide-syntax/src/parser/declarations.rs
@@ -629,8 +629,22 @@ impl Parser {
             if self.current().token_type == TokenType::Ident && self.current().value == "where" {
                 self.advance(); // consume 'where'
                 self.skip_newlines();
-                let clause = self.parse_single_test_where()?;
-                clauses.push(clause);
+                // Table syntax: where [ "case" [...], "case" [...] ]
+                if self.current().token_type == TokenType::LBracket {
+                    self.advance();
+                    self.skip_newlines();
+                    while self.current().token_type != TokenType::RBracket && self.current().token_type != TokenType::EOF {
+                        let case = self.parse_test_where_case()?;
+                        clauses.push(case);
+                        self.skip_newlines();
+                        if self.current().token_type == TokenType::Comma { self.advance(); }
+                        self.skip_newlines();
+                    }
+                    self.expect(TokenType::RBracket)?;
+                } else {
+                    let clause = self.parse_single_test_where()?;
+                    clauses.push(clause);
+                }
             } else {
                 break;
             }
@@ -640,25 +654,33 @@ impl Parser {
 
     fn parse_single_test_where(&mut self) -> Result<crate::ast::TestWhere, String> {
         use crate::ast::TestWhere;
-        // Case: where "case name" { bindings }
+        // Table-driven [...] is handled in parse_test_where_clauses directly
+        // where "case name" [...] — standalone case (outside table)
         if self.current().token_type == TokenType::String {
-            let case_name = self.current().value.clone();
-            self.advance();
-            self.expect(TokenType::LBrace)?;
-            let mut bindings = Vec::new();
-            self.skip_newlines();
-            while self.current().token_type != TokenType::RBrace && self.current().token_type != TokenType::EOF {
-                let binding = self.parse_test_where_binding()?;
-                bindings.push(binding);
-                // Skip semicolons and newlines between bindings
-                while self.current().token_type == TokenType::Semicolon || self.current().token_type == TokenType::Newline {
-                    self.advance();
-                }
+            let next_tt = self.peek_at(1).map(|t| t.token_type);
+            if matches!(next_tt, Some(TokenType::LBracket)) {
+                return self.parse_test_where_case();
             }
-            self.expect(TokenType::RBrace)?;
-            return Ok(TestWhere::Case { name: case_name, bindings });
         }
         self.parse_test_where_binding()
+    }
+
+    fn parse_test_where_case(&mut self) -> Result<crate::ast::TestWhere, String> {
+        use crate::ast::TestWhere;
+        let case_name = self.current().value.clone();
+        self.expect(TokenType::String)?;
+        self.expect(TokenType::LBracket)?;
+        let mut bindings = Vec::new();
+        self.skip_newlines();
+        while self.current().token_type != TokenType::RBracket && self.current().token_type != TokenType::EOF {
+            let binding = self.parse_test_where_binding()?;
+            bindings.push(binding);
+            while self.current().token_type == TokenType::Comma || self.current().token_type == TokenType::Newline {
+                self.advance();
+            }
+        }
+        self.expect(TokenType::RBracket)?;
+        Ok(TestWhere::Case { name: case_name, bindings })
     }
 
     fn parse_test_where_binding(&mut self) -> Result<crate::ast::TestWhere, String> {

--- a/crates/almide-syntax/src/parser/declarations.rs
+++ b/crates/almide-syntax/src/parser/declarations.rs
@@ -617,8 +617,83 @@ impl Parser {
         self.expect(TokenType::Test)?;
         let name = self.current().value.clone();
         self.expect(TokenType::String)?;
+        let where_clauses = self.parse_test_where_clauses()?;
         let body = self.parse_brace_expr()?;
-        Ok(Decl::Test { name, body, span: Some(span) })
+        Ok(Decl::Test { name, body, where_clauses, span: Some(span) })
+    }
+
+    fn parse_test_where_clauses(&mut self) -> Result<Vec<crate::ast::TestWhere>, String> {
+        let mut clauses = Vec::new();
+        loop {
+            self.skip_newlines();
+            if self.current().token_type == TokenType::Ident && self.current().value == "where" {
+                self.advance(); // consume 'where'
+                self.skip_newlines();
+                let clause = self.parse_single_test_where()?;
+                clauses.push(clause);
+            } else {
+                break;
+            }
+        }
+        Ok(clauses)
+    }
+
+    fn parse_single_test_where(&mut self) -> Result<crate::ast::TestWhere, String> {
+        use crate::ast::TestWhere;
+        // Case: where "case name" { bindings }
+        if self.current().token_type == TokenType::String {
+            let case_name = self.current().value.clone();
+            self.advance();
+            self.expect(TokenType::LBrace)?;
+            let mut bindings = Vec::new();
+            self.skip_newlines();
+            while self.current().token_type != TokenType::RBrace && self.current().token_type != TokenType::EOF {
+                let binding = self.parse_test_where_binding()?;
+                bindings.push(binding);
+                // Skip semicolons and newlines between bindings
+                while self.current().token_type == TokenType::Semicolon || self.current().token_type == TokenType::Newline {
+                    self.advance();
+                }
+            }
+            self.expect(TokenType::RBrace)?;
+            return Ok(TestWhere::Case { name: case_name, bindings });
+        }
+        self.parse_test_where_binding()
+    }
+
+    fn parse_test_where_binding(&mut self) -> Result<crate::ast::TestWhere, String> {
+        use crate::ast::TestWhere;
+        use almide_base::intern::sym;
+        // Collect path segments: name or name.name.name
+        let first = self.expect_ident()?;
+        let mut path = vec![sym(&first)];
+        while self.current().token_type == TokenType::Dot {
+            self.advance();
+            let seg = self.expect_ident()?;
+            path.push(sym(&seg));
+        }
+        // Call response: path(args) => expr
+        if self.current().token_type == TokenType::LParen {
+            self.advance();
+            let mut params = Vec::new();
+            while self.current().token_type != TokenType::RParen && self.current().token_type != TokenType::EOF {
+                let pat = self.parse_pattern()?;
+                params.push(pat);
+                if self.current().token_type == TokenType::Comma { self.advance(); }
+            }
+            self.expect(TokenType::RParen)?;
+            self.expect(TokenType::FatArrow)?;
+            let response = self.parse_expr()?;
+            return Ok(TestWhere::CallResponse { target: path, params, response });
+        }
+        // Value binding or override: path = expr
+        self.expect(TokenType::Eq)?;
+        let value = self.parse_expr()?;
+        if path.len() == 1 {
+            Ok(TestWhere::Bind { name: path[0], value })
+        } else {
+            Ok(TestWhere::Override { path, value })
+        }
     }
 
     fn parse_visibility(&mut self) -> Visibility {

--- a/crates/almide-tools/src/fmt.rs
+++ b/crates/almide-tools/src/fmt.rs
@@ -360,6 +360,7 @@ fn fmt_decl(out: &mut String, decl: &Decl, depth: usize) {
             if let Some(b) = body { out.push_str(" = "); fmt_expr(out, b, depth); }
         }
         Decl::Test { name, body, .. } => { w!(out, "{i}test \"{name}\" "); fmt_expr(out, body, depth); }
+        Decl::TestWhereDef { .. } => {} // test where defs don't need formatting (internal)
         Decl::Protocol { name, methods, .. } => {
             wln!(out, "{i}protocol {name} {{");
             let inner = "  ".repeat(depth + 1);

--- a/docs/roadmap/active/test-where.md
+++ b/docs/roadmap/active/test-where.md
@@ -1,8 +1,8 @@
 <!-- description: test where syntax — unified value/type/mock/table-driven test context -->
 # Test Where Syntax
 
-> **Target: v0.23+**
-> **Status: Spec**
+> **Target: v0.23.0**
+> **Status: Done**
 
 ## Problem
 

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.22.2 (prev v0.22.1). VarStorageClassification: local var uses let mut (no RcCow overhead), RcCow only for lambda captures. Reusable package CI workflow. Roadmaps: test-where, type-where-constraints.
+- Current stable: v0.23.0 (prev v0.22.2). test where: unified test context syntax — value binding, table-driven `where [...]`, reference override, call response `where fn(x) => expr`, `local test where`, `mod test where`. WASM lambda param type inference from body usage. TypeVar erase for generic fn override.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/spec/lang/test_where_monkey_test.almd
+++ b/spec/lang/test_where_monkey_test.almd
@@ -184,14 +184,10 @@ test "option binding"
 
 // ── Edge: deeply nested table cases ──
 
-fn do_add(a: Int, b: Int) -> Int = a + b
-fn do_mul(a: Int, b: Int) -> Int = a * b
-fn do_sub(a: Int, b: Int) -> Int = a - b
-
 test "math operations" where [
-  "add 1+1" [op = do_add, a = 1, b = 1, want = 2],
-  "mul 3*4" [op = do_mul, a = 3, b = 4, want = 12],
-  "sub 10-3" [op = do_sub, a = 10, b = 3, want = 7],
+  "add 1+1" [op = (a, b) => a + b, a = 1, b = 1, want = 2],
+  "mul 3*4" [op = (a, b) => a * b, a = 3, b = 4, want = 12],
+  "sub 10-3" [op = (a, b) => a - b, a = 10, b = 3, want = 7],
 ]
 {
   assert_eq(op(a, b), want)

--- a/spec/lang/test_where_monkey_test.almd
+++ b/spec/lang/test_where_monkey_test.almd
@@ -1,0 +1,181 @@
+// Monkey test: test where edge cases and complex scenarios
+
+// ── Helper functions ──
+
+fn multiply(a: Int, b: Int) -> Int = a * b
+fn divide(a: Int, b: Int) -> Int = if b == 0 then 0 else a / b
+fn concat(a: String, b: String) -> String = a + b
+fn negate(x: Int) -> Int = 0 - x
+fn identity(x: Int) -> Int = x
+
+fn pipeline(x: Int) -> Int = identity(multiply(x, 2))
+
+fn greet(name: String) -> String = "Hello, ${name}!"
+fn farewell(name: String) -> String = "Goodbye, ${name}!"
+fn format_msg(greeting: String, name: String) -> String = "${greeting} ${name}"
+
+// ── Edge: empty where (should still work) ──
+
+test "no where clauses" {
+  assert_eq(multiply(3, 4), 12)
+}
+
+// ── Edge: single value binding ──
+
+test "single binding"
+  where x = 42
+{
+  assert_eq(x, 42)
+}
+
+// ── Edge: binding shadows outer scope ──
+
+let GLOBAL = 100
+
+test "binding uses global"
+  where x = GLOBAL + 1
+{
+  assert_eq(x, 101)
+}
+
+// ── Edge: binding references another binding ──
+
+test "chained bindings"
+  where a = 10
+  where b = 20
+{
+  assert_eq(a + b, 30)
+}
+
+// ── Edge: override with identity (no-op) ──
+
+test "identity override"
+  where multiply = (a, b) => a * b
+{
+  assert_eq(multiply(3, 4), 12)
+}
+
+// ── Edge: override returns constant ──
+
+test "constant override"
+  where multiply(_, _) => 999
+{
+  assert_eq(multiply(3, 4), 999)
+  assert_eq(multiply(0, 0), 999)
+}
+
+// ── Edge: call response with complex match ──
+
+test "complex call response"
+  where divide(a, b) => match b {
+    0 => -1,
+    _ => a / b,
+  }
+{
+  assert_eq(divide(10, 2), 5)
+  assert_eq(divide(10, 0), -1)
+}
+
+// ── Edge: override string function ──
+
+test "string override"
+  where greet(name) => "Yo, ${name}!"
+{
+  assert_eq(greet("Alice"), "Yo, Alice!")
+}
+
+// ── Edge: table-driven with many cases ──
+
+test "many cases"
+  where "a" { x = 1; want = 2 }
+  where "b" { x = 2; want = 4 }
+  where "c" { x = 3; want = 6 }
+  where "d" { x = 4; want = 8 }
+  where "e" { x = 5; want = 10 }
+{
+  assert_eq(multiply(x, 2), want)
+}
+
+// ── Edge: table case with override ──
+
+test "case override"
+  where "double" { negate(x) => x * 2; input = 5; want = 10 }
+  where "triple" { negate(x) => x * 3; input = 5; want = 15 }
+  where "original" { input = 5; want = -5 }
+{
+  assert_eq(negate(input), want)
+}
+
+// ── Edge: where with list operations ──
+
+test "list where"
+  where items = [1, 2, 3, 4, 5]
+  where doubled = items |> list.map((x) => x * 2)
+{
+  assert_eq(list.len(doubled), 5)
+  assert_eq(list.get(doubled, 0) ?? 0, 2)
+  assert_eq(list.get(doubled, 4) ?? 0, 10)
+}
+
+// ── Edge: where with string ──
+
+test "multiline string where"
+  where msg = "hello\nworld"
+{
+  assert(string.contains(msg, "hello"))
+  assert(string.contains(msg, "world"))
+}
+
+// ── Edge: nested function call in override ──
+
+test "nested override"
+  where identity(x) => multiply(x, x)
+{
+  assert_eq(identity(5), 25)
+}
+
+// ── Edge: table with no shared bindings ──
+
+test "independent cases"
+  where "ints" { a = 1; b = 2; want = 3 }
+  where "strings" { a = 10; b = 20; want = 30 }
+{
+  assert_eq(a + b, want)
+}
+
+// ── Edge: where with bool ──
+
+test "bool binding"
+  where flag = true
+  where name = if flag then "yes" else "no"
+{
+  assert_eq(name, "yes")
+}
+
+// ── Edge: where with record ──
+
+type Point = { x: Int, y: Int }
+
+test "record binding"
+  where p = Point { x: 10, y: 20 }
+{
+  assert_eq(p.x + p.y, 30)
+}
+
+// ── Edge: where with option ──
+
+test "option binding"
+  where val = some(42)
+{
+  assert_eq(val ?? 0, 42)
+}
+
+// ── Edge: deeply nested table cases ──
+
+test "math operations"
+  where "add 1+1" { op = (a, b) => a + b; a = 1; b = 1; want = 2 }
+  where "mul 3*4" { op = (a, b) => a * b; a = 3; b = 4; want = 12 }
+  where "sub 10-3" { op = (a, b) => a - b; a = 10; b = 3; want = 7 }
+{
+  assert_eq(op(a, b), want)
+}

--- a/spec/lang/test_where_monkey_test.almd
+++ b/spec/lang/test_where_monkey_test.almd
@@ -50,7 +50,7 @@ test "chained bindings"
 // ── Edge: override with identity (no-op) ──
 
 test "identity override"
-  where multiply = (a, b) => a * b
+  where multiply(a, b) => a * b
 {
   assert_eq(multiply(3, 4), 12)
 }
@@ -128,8 +128,10 @@ test "multiline string where"
 
 // ── Edge: nested function call in override ──
 
+fn square(x: Int) -> Int = x * x
+
 test "nested override"
-  where identity(x) => multiply(x, x)
+  where identity(x) => square(x)
 {
   assert_eq(identity(5), 25)
 }
@@ -172,10 +174,15 @@ test "option binding"
 
 // ── Edge: deeply nested table cases ──
 
-test "math operations"
-  where "add 1+1" [op = (a, b) => a + b, a = 1, b = 1, want = 2]
-  where "mul 3*4" [op = (a, b) => a * b, a = 3, b = 4, want = 12]
-  where "sub 10-3" [op = (a, b) => a - b, a = 10, b = 3, want = 7]
+fn do_add(a: Int, b: Int) -> Int = a + b
+fn do_mul(a: Int, b: Int) -> Int = a * b
+fn do_sub(a: Int, b: Int) -> Int = a - b
+
+test "math operations" where [
+  "add 1+1" [op = do_add, a = 1, b = 1, want = 2],
+  "mul 3*4" [op = do_mul, a = 3, b = 4, want = 12],
+  "sub 10-3" [op = do_sub, a = 10, b = 3, want = 7],
+]
 {
   assert_eq(op(a, b), want)
 }

--- a/spec/lang/test_where_monkey_test.almd
+++ b/spec/lang/test_where_monkey_test.almd
@@ -55,6 +55,16 @@ test "identity override"
   assert_eq(multiply(3, 4), 12)
 }
 
+// ── Edge: override with lambda value ──
+
+fn add_ints(a: Int, b: Int) -> Int = a + b
+
+test "lambda value override"
+  where add_ints = (a, b) => a * b
+{
+  assert_eq(add_ints(3, 4), 12)
+}
+
 // ── Edge: override returns constant ──
 
 test "constant override"

--- a/spec/lang/test_where_monkey_test.almd
+++ b/spec/lang/test_where_monkey_test.almd
@@ -87,11 +87,11 @@ test "string override"
 // ── Edge: table-driven with many cases ──
 
 test "many cases"
-  where "a" { x = 1; want = 2 }
-  where "b" { x = 2; want = 4 }
-  where "c" { x = 3; want = 6 }
-  where "d" { x = 4; want = 8 }
-  where "e" { x = 5; want = 10 }
+  where "a" [x = 1,want = 2]
+  where "b" [x = 2,want = 4]
+  where "c" [x = 3,want = 6]
+  where "d" [x = 4,want = 8]
+  where "e" [x = 5,want = 10]
 {
   assert_eq(multiply(x, 2), want)
 }
@@ -99,9 +99,9 @@ test "many cases"
 // ── Edge: table case with override ──
 
 test "case override"
-  where "double" { negate(x) => x * 2; input = 5; want = 10 }
-  where "triple" { negate(x) => x * 3; input = 5; want = 15 }
-  where "original" { input = 5; want = -5 }
+  where "double" [negate(x) => x * 2,input = 5,want = 10]
+  where "triple" [negate(x) => x * 3,input = 5,want = 15]
+  where "original" [input = 5,want = -5]
 {
   assert_eq(negate(input), want)
 }
@@ -137,8 +137,8 @@ test "nested override"
 // ── Edge: table with no shared bindings ──
 
 test "independent cases"
-  where "ints" { a = 1; b = 2; want = 3 }
-  where "strings" { a = 10; b = 20; want = 30 }
+  where "ints" [a = 1,b = 2,want = 3]
+  where "strings" [a = 10,b = 20,want = 30]
 {
   assert_eq(a + b, want)
 }
@@ -173,9 +173,9 @@ test "option binding"
 // ── Edge: deeply nested table cases ──
 
 test "math operations"
-  where "add 1+1" { op = (a, b) => a + b; a = 1; b = 1; want = 2 }
-  where "mul 3*4" { op = (a, b) => a * b; a = 3; b = 4; want = 12 }
-  where "sub 10-3" { op = (a, b) => a - b; a = 10; b = 3; want = 7 }
+  where "add 1+1" [op = (a, b) => a + b, a = 1, b = 1, want = 2]
+  where "mul 3*4" [op = (a, b) => a * b, a = 3, b = 4, want = 12]
+  where "sub 10-3" [op = (a, b) => a - b, a = 10, b = 3, want = 7]
 {
   assert_eq(op(a, b), want)
 }

--- a/spec/lang/test_where_test.almd
+++ b/spec/lang/test_where_test.almd
@@ -1,0 +1,62 @@
+// Phase 1: test where — value binding + table-driven tests
+
+fn parse_age(s: String) -> Result[Int, String] =
+  match int.parse(s) {
+    ok(n) => if n >= 0 then ok(n) else err("negative"),
+    err(_) => err("invalid"),
+  }
+
+fn add(a: Int, b: Int) -> Int = a + b
+
+// ── Value binding ──
+
+test "parse age with where"
+  where input = "20"
+  where want = 20
+{
+  assert_eq(parse_age(input) ?? -1, want)
+}
+
+test "add with where"
+  where a = 3
+  where b = 7
+{
+  assert_eq(add(a, b), 10)
+}
+
+// ── Table-driven ──
+
+test "parse age table"
+  where "valid" {
+    input = "20"
+    want = 20
+  }
+  where "zero" {
+    input = "0"
+    want = 0
+  }
+  where "large" {
+    input = "999"
+    want = 999
+  }
+{
+  assert_eq(parse_age(input) ?? -1, want)
+}
+
+test "add table"
+  where "positive" { a = 1; b = 2; want = 3 }
+  where "zero" { a = 0; b = 0; want = 0 }
+  where "negative" { a = -5; b = 3; want = -2 }
+{
+  assert_eq(add(a, b), want)
+}
+
+// ── Mixed: top-level where + cases ──
+
+test "string ops"
+  where prefix = "hello"
+  where "world" { suffix = " world"; want = "hello world" }
+  where "almide" { suffix = " almide"; want = "hello almide" }
+{
+  assert_eq(prefix + suffix, want)
+}

--- a/spec/lang/test_where_test.almd
+++ b/spec/lang/test_where_test.almd
@@ -26,27 +26,19 @@ test "add with where"
 
 // ── Table-driven ──
 
-test "parse age table"
-  where "valid" {
-    input = "20"
-    want = 20
-  }
-  where "zero" {
-    input = "0"
-    want = 0
-  }
-  where "large" {
-    input = "999"
-    want = 999
-  }
+test "parse age table" where [
+  "valid" [input = "20", want = 20],
+  "zero"  [input = "0", want = 0],
+  "large" [input = "999", want = 999],
+]
 {
   assert_eq(parse_age(input) ?? -1, want)
 }
 
 test "add table"
-  where "positive" { a = 1; b = 2; want = 3 }
-  where "zero" { a = 0; b = 0; want = 0 }
-  where "negative" { a = -5; b = 3; want = -2 }
+  where "positive" [a = 1,b = 2,want = 3]
+  where "zero" [a = 0,b = 0,want = 0]
+  where "negative" [a = -5,b = 3,want = -2]
 {
   assert_eq(add(a, b), want)
 }
@@ -55,8 +47,8 @@ test "add table"
 
 test "string ops"
   where prefix = "hello"
-  where "world" { suffix = " world"; want = "hello world" }
-  where "almide" { suffix = " almide"; want = "hello almide" }
+  where "world" [suffix = " world",want = "hello world"]
+  where "almide" [suffix = " almide",want = "hello almide"]
 {
   assert_eq(prefix + suffix, want)
 }
@@ -84,8 +76,8 @@ test "override with call response"
 }
 
 test "call response table"
-  where "times 10" { double(x) => x * 10; input = 5; want = 50 }
-  where "times 100" { double(x) => x * 100; input = 5; want = 500 }
+  where "times 10" [double(x) => x * 10,input = 5,want = 50]
+  where "times 100" [double(x) => x * 100,input = 5,want = 500]
 {
   assert_eq(double(input), want)
 }

--- a/spec/lang/test_where_test.almd
+++ b/spec/lang/test_where_test.almd
@@ -1,4 +1,4 @@
-// Phase 1: test where — value binding + table-driven tests
+// Phase 1+2: test where — value binding, table-driven, reference override, call response
 
 fn parse_age(s: String) -> Result[Int, String] =
   match int.parse(s) {
@@ -59,4 +59,33 @@ test "string ops"
   where "almide" { suffix = " almide"; want = "hello almide" }
 {
   assert_eq(prefix + suffix, want)
+}
+
+// ── Phase 2: reference override + call response ──
+
+fn greet(name: String) -> String = "Hello, ${name}!"
+
+fn get_greeting() -> String = greet("World")
+
+test "override function"
+  where greet = (name) => "Hi, ${name}!"
+{
+  // greet is overridden, but get_greeting calls the original
+  // Direct call uses override:
+  assert_eq(greet("Alice"), "Hi, Alice!")
+}
+
+fn double(x: Int) -> Int = x * 2
+
+test "override with call response"
+  where double(x) => x * 10
+{
+  assert_eq(double(3), 30)
+}
+
+test "call response table"
+  where "times 10" { double(x) => x * 10; input = 5; want = 50 }
+  where "times 100" { double(x) => x * 100; input = 5; want = 500 }
+{
+  assert_eq(double(input), want)
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -216,42 +216,47 @@ fn inject_dep_natives_rec(code: &mut String, source_root: Option<&std::path::Pat
     if !toml_path.exists() { return Ok(()); }
     let proj = crate::project::parse_toml(&toml_path).map_err(|e| format!("parse almide.toml: {}", e))?;
     for dep in &proj.dependencies {
-        let dep_dir = if let Some(ref p) = dep.path {
-            std::path::PathBuf::from(p)
-        } else if let Ok(d) = crate::project_fetch::fetch_dep(dep) {
-            d
-        } else { continue };
+        let dep_dir = resolve_dep_dir(dep);
+        let Some(dep_dir) = dep_dir else { continue };
         let key = dep_dir.to_string_lossy().to_string();
         if visited.contains(&key) { continue; }
         visited.insert(key);
         inject_native_modules(code, Some(&dep_dir), src_dir)?;
-        // Propagate native-deps from dependency's almide.toml into Cargo.toml
-        let dep_toml = dep_dir.join("almide.toml");
-        if dep_toml.exists() {
-            if let Ok(dep_proj) = crate::project::parse_toml(&dep_toml) {
-                let cargo_path = project_dir.join("Cargo.toml");
-                let mut cargo = std::fs::read_to_string(&cargo_path).unwrap_or_default();
-                for nd in &dep_proj.native_deps {
-                    if cargo.contains(&nd.name) { continue; }
-                    let line = if nd.spec.starts_with('{') {
-                        format!("{} = {}\n", nd.name, nd.spec)
-                    } else {
-                        format!("{} = \"{}\"\n", nd.name, nd.spec)
-                    };
-                    if let Some(pos) = cargo.find("[dependencies]") {
-                        let insert = cargo[pos..].find('\n').map(|i| pos + i + 1).unwrap_or(cargo.len());
-                        cargo.insert_str(insert, &line);
-                    } else {
-                        cargo.push_str(&format!("\n[dependencies]\n{}", line));
-                    }
-                }
-                let _ = std::fs::write(&cargo_path, &cargo);
-            }
-        }
-        // Recurse into transitive dependencies
+        propagate_native_deps(&dep_dir, project_dir);
         inject_dep_natives_rec(code, Some(&dep_dir), src_dir, project_dir, visited)?;
     }
     Ok(())
+}
+
+fn resolve_dep_dir(dep: &crate::project::Dependency) -> Option<std::path::PathBuf> {
+    if let Some(ref p) = dep.path { Some(std::path::PathBuf::from(p)) }
+    else { crate::project_fetch::fetch_dep(dep).ok() }
+}
+
+fn propagate_native_deps(dep_dir: &std::path::Path, project_dir: &std::path::Path) {
+    let dep_toml = dep_dir.join("almide.toml");
+    let dep_proj = match dep_toml.exists().then(|| crate::project::parse_toml(&dep_toml).ok()).flatten() {
+        Some(p) => p, None => return,
+    };
+    if dep_proj.native_deps.is_empty() { return; }
+    let cargo_path = project_dir.join("Cargo.toml");
+    let mut cargo = std::fs::read_to_string(&cargo_path).unwrap_or_default();
+    for nd in &dep_proj.native_deps {
+        if cargo.contains(&nd.name) { continue; }
+        append_cargo_dep(&mut cargo, &nd.name, &nd.spec);
+    }
+    let _ = std::fs::write(&cargo_path, &cargo);
+}
+
+fn append_cargo_dep(cargo: &mut String, name: &str, spec: &str) {
+    let line = if spec.starts_with('{') { format!("{} = {}\n", name, spec) }
+        else { format!("{} = \"{}\"\n", name, spec) };
+    if let Some(pos) = cargo.find("[dependencies]") {
+        let insert = cargo[pos..].find('\n').map(|i| pos + i + 1).unwrap_or(cargo.len());
+        cargo.insert_str(insert, &line);
+    } else {
+        cargo.push_str(&format!("\n[dependencies]\n{}", line));
+    }
 }
 
 /// Build generated Rust code as a cdylib shared library (.dylib/.so).


### PR DESCRIPTION
## Summary

Full `test where` implementation — value binding, table-driven tests, reference override, call response, file/module scoped environments.

### test where syntax
```almide
test "parse age" where [
  "valid" [input = "20", want = 20],
  "empty" [input = "", want = -1],
]
{ assert_eq(parse_age(input) ?? -1, want) }

test "override" where double(x) => x * 10
{ assert_eq(double(3), 30) }

local test where { logger = silent }
```

### Features
- `where x = expr` — value binding
- `where fn(args) => expr` — call response (generates lambda, rewrites call sites)
- `where fn = replacement` — reference override
- `where [...]` — table-driven tests with `[]` case syntax
- `local test where { ... }` — file-scoped test environment
- `mod test where { ... }` — module-scoped test environment
- Scope priority: inline > local > mod
- TypeVar erase for generic function override
- WASM: lambda param types inferred from body usage (BinOp, etc.)
- Zero POSTCONDITION violations

### Compiler improvements
- `infer_var_type_from_body` in ConcretizeTypes + LambdaTypeResolve
- `erase_typevars` for generic fn signatures
- Codopsy: 14 issues in new code (all structural/threshold)

### Tests
- 239 test files pass (Rust)
- WASM validates clean
- 14 test_where_test + 28 monkey tests