### PR TITLE
v0.23.1: Fix dep native injection in almide test/run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "almide"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.23.0 (prev v0.22.2). test where: unified test context syntax — value binding, table-driven `where [...]`, reference override, call response `where fn(x) => expr`, `local test where`, `mod test where`. WASM lambda param type inference from body usage. TypeVar erase for generic fn override.
+- Current stable: v0.23.1 (prev v0.23.0). Fix: almide test/run injects dep natives when dependencies exist (not just native-deps).
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -52,7 +52,8 @@ pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: b
     let toml_dir = toml_path.parent()
         .map(|p| if p.as_os_str().is_empty() { std::path::PathBuf::from(".") } else { p.to_path_buf() })
         .unwrap_or_else(|| std::path::PathBuf::from("."));
-    let source_root = if native_deps.is_empty() { None } else { Some(toml_dir.as_path()) };
+    let has_deps = parsed.as_ref().map_or(false, |p| !p.dependencies.is_empty());
+    let source_root = if !native_deps.is_empty() || has_deps { Some(toml_dir.as_path()) } else { None };
 
     let result = if use_test_harness {
         cargo_build_test_with_native(&rs_code, &project_dir, native_deps, source_root)


### PR DESCRIPTION
## Fix

`almide test` and `almide run` skipped `inject_dep_natives` when the project had dependencies but no `[native-deps]`. This caused `@inline_rust` packages (sha1, aes) to fail with missing `mod sha1_native` errors when testing downstream projects like mc-bot-cli.

Same fix already applied to `almide build` in v0.22.1.

## Test plan
- [x] 239 compiler tests pass
- [x] mc-bot-cli: 40 tests pass (including transitive sha1/aes native)