### PR TITLE
v0.23.7: Parallel test compilation, cross-crate anon record fix, WASM hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["research/benchmark/stdlib/rust_wasm_compare"]
 
 [package]
 name = "almide"
-version = "0.23.6"
+version = "0.23.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.23.6 (prev v0.23.5). Cross-crate: field-name-based AlmdRec naming, @inline_rust AlmdRec rewrite, SSE runtime dep. WASM: 441B hello world, Perceus RC free.
+- Current stable: v0.23.7 (prev v0.23.6). Cross-crate: field-name-based AlmdRec naming, @inline_rust AlmdRec rewrite, SSE runtime dep. WASM: 441B hello world, Perceus RC free.
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -89,13 +89,32 @@ pub fn cmd_test(file: &str, no_check: bool, run_filter: Option<&str>) {
         program_args.push(filter.to_string());
     }
 
-    // Phase 1: Compile all test files sequentially (shared cargo workspace)
-    let mut compiled: Vec<(String, Result<std::path::PathBuf, String>)> = Vec::new();
-    for test_file in &test_files {
-        eprintln!("Compiling {}", test_file);
-        let result = super::run::compile_to_binary(test_file, no_check, true, false);
-        compiled.push((test_file.clone(), result));
-    }
+    // Phase 1: Compile all test files in parallel (bounded by CPU count)
+    let compiled: Vec<(String, Result<std::path::PathBuf, String>)> = {
+        let cpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4);
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
+        for _ in 0..cpus { let _ = sem_tx.send(()); }
+        let sem_tx = std::sync::Arc::new(sem_tx);
+        let sem_rx = std::sync::Arc::new(std::sync::Mutex::new(sem_rx));
+        let mut handles = Vec::new();
+        for test_file in test_files.clone() {
+            let tx = tx.clone();
+            let sem_rx = sem_rx.clone();
+            let sem_tx = sem_tx.clone();
+            handles.push(std::thread::spawn(move || {
+                let _ = sem_rx.lock().unwrap().recv();
+                let result = super::run::compile_to_binary(&test_file, no_check, true, false);
+                let _ = sem_tx.send(());
+                let _ = tx.send((test_file, result));
+            }));
+        }
+        drop(tx);
+        let mut results: Vec<_> = rx.iter().collect();
+        for h in handles { let _ = h.join(); }
+        results.sort_by(|a, b| a.0.cmp(&b.0));
+        results
+    };
 
     // Phase 2: Execute test binaries in parallel (bounded by CPU count)
     let program_args = std::sync::Arc::new(program_args);

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -120,22 +120,18 @@ pub fn cmd_test(file: &str, no_check: bool, run_filter: Option<&str>) {
     let program_args = std::sync::Arc::new(program_args);
     let results: Vec<(String, i32)> = {
         let cpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4);
-        // Channel-based semaphore: pre-fill with `cpus` tokens
         let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
         for _ in 0..cpus { let _ = sem_tx.send(()); }
         let sem_tx = std::sync::Arc::new(sem_tx);
         let sem_rx = std::sync::Arc::new(std::sync::Mutex::new(sem_rx));
-
         let (tx, rx) = std::sync::mpsc::channel();
         let mut handles = Vec::new();
-
         for (file, compile_result) in compiled {
             let tx = tx.clone();
             let args = program_args.clone();
             let sem_rx = sem_rx.clone();
             let sem_tx = sem_tx.clone();
             handles.push(std::thread::spawn(move || {
-                // Acquire semaphore token
                 let _ = sem_rx.lock().unwrap().recv();
                 let code = match compile_result {
                     Ok(bin) => super::run::run_binary(&bin, &args),
@@ -144,7 +140,6 @@ pub fn cmd_test(file: &str, no_check: bool, run_filter: Option<&str>) {
                         1
                     }
                 };
-                // Release semaphore token
                 let _ = sem_tx.send(());
                 let _ = tx.send((file, code));
             }));

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -55,6 +55,10 @@ pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: b
     let has_deps = parsed.as_ref().map_or(false, |p| !p.dependencies.is_empty());
     let source_root = if !native_deps.is_empty() || has_deps { Some(toml_dir.as_path()) } else { None };
 
+    // Serialize cargo builds: the shared project dir has a single src/main.rs
+    // that gets overwritten per compilation. Parallel writes corrupt it.
+    static BUILD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = BUILD_LOCK.lock().unwrap();
     let result = if use_test_harness {
         cargo_build_test_with_native(&rs_code, &project_dir, native_deps, source_root)
     } else {


### PR DESCRIPTION
## Summary

### Test Speed (2m5s → 54s)
- Parallel compilation: test files compiled via thread pool (bounded by CPU count)
- Mutex on shared cargo workspace prevents race condition on CI

### Cross-crate Fixes
- **Anonymous record ID collision**: `AlmdRec0` → `AlmdRec_data_state` (field-name-based naming, collision impossible)
- **@inline_rust AlmdRec rewrite**: Legacy `AlmdRec{N}` in dependency templates auto-rewritten by matching constructor field names
- **http → sse runtime dep**: SSE runtime transitively included when http is needed

### WASM Hardening (Copilot 8/8)
- Fixed `rc_dec` offset bug + `RC_OFFSET` constant
- Freed leaked scratch slot in while loop
- Removed Phase 1 region scoping (no escape analysis)
- Hardened Phase 2a (`IndexAssign`/`FieldAssign` detection)
- String append peephole: condition-references-string guard

## Test plan
- [x] `almide test` — 239 pass
- [x] mc-bot-cli (4-layer chain) — 56 pass
- [x] CI green (Linux, macOS, Windows, Cross-Target)