### PR TITLE
Build speed: parallel test loop + precompiled runtime rlib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Almide spec tests (Rust target)
         run: |
           ALMIDE=/tmp/almide-bin/almide
-          $ALMIDE test spec/
+          $ALMIDE test spec/ --target rust
 
       - name: Almide examples tests
         run: |
@@ -248,7 +248,7 @@ jobs:
         shell: bash
         run: |
           ALMIDE=${{ matrix.binary }}
-          $ALMIDE test spec/
+          $ALMIDE test spec/ --target rust
 
   # ═══════════════════════════════════════════════
   # Post-merge — trigger playground deploy

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -148,11 +148,15 @@ impl<'a> Verified<'a> {
 
 pub fn codegen_with(program: &mut IrProgram, target: Target, options: &CodegenOptions) -> CodegenOutput {
     let config = target::configure(target);
+    let prof = std::env::var_os("ALMIDE_PROFILE").is_some();
+    let pt = std::time::Instant::now();
 
     // Layer 2: Run Nanopass pipeline (semantic rewrites — takes ownership, returns modified)
     let owned = std::mem::take(program);
     let transformed = config.pipeline.run(owned, target);
     *program = transformed;
+    if prof { eprintln!("[prof:codegen] pipeline={:.3}s", pt.elapsed().as_secs_f64()); }
+    let et = std::time::Instant::now();
 
     // Layer 3: Target-specific emit
     match target {
@@ -160,7 +164,9 @@ pub fn codegen_with(program: &mut IrProgram, target: Target, options: &CodegenOp
             // AlmidePerceusBelt: Verified::verify() runs Lean 4-certified
             // RC balance check. Only verified programs can reach WASM emit.
             let verified = Verified::verify(program);
-            CodegenOutput::Binary(emit_wasm::emit_verified(verified))
+            let out = emit_wasm::emit_verified(verified);
+            if prof { eprintln!("[prof:codegen] wasm_emit={:.3}s", et.elapsed().as_secs_f64()); }
+            CodegenOutput::Binary(out)
         }
         Target::Wgsl => CodegenOutput::Source(emit_wgsl::emit(program)),
         _ => CodegenOutput::Source(emit_source(program, target, &config, options)),

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -83,6 +83,28 @@ pub struct CodegenOptions {
     pub repr_c: bool,
 }
 
+/// Marker the Rust emitter inserts between the inlined runtime preamble and the
+/// user code. The rlib fast path splits generated source here: everything before
+/// is the runtime (provided instead by the precompiled `almide_rt` rlib), and
+/// everything after — the user code — is wrapped into a slim main that links it.
+pub const RT_BOUNDARY_MARKER: &str = "//__ALMIDE_RT_BOUNDARY__";
+
+/// Rebuild full generated Rust source into a slim main that links the `almide_rt`
+/// rlib instead of inlining the runtime. Splits on [`RT_BOUNDARY_MARKER`]: the
+/// user code (after the marker) is prefixed with the crate attrs, std imports, and
+/// `extern crate almide_rt`. Returns `None` if the marker is absent (e.g. the
+/// source predates this emitter or isn't a Rust target) so callers fall back.
+pub fn slim_main_with_external_runtime(full_rs: &str) -> Option<String> {
+    let idx = full_rs.find(RT_BOUNDARY_MARKER)?;
+    let user_code = full_rs[idx + RT_BOUNDARY_MARKER.len()..].trim_start_matches('\n');
+    let mut out = String::new();
+    out.push_str("#![allow(unused_parens, unused_variables, dead_code, unused_imports, unused_mut, unused_must_use)]\n\n");
+    out.push_str("use std::collections::HashMap;\nuse std::collections::HashSet;\n");
+    out.push_str("#[macro_use] extern crate almide_rt;\nuse almide_rt::*;\n\n");
+    out.push_str(user_code);
+    Some(out)
+}
+
 /// Strip `mod tests { ... }` blocks from runtime source (avoid conflicts with user tests)
 fn strip_test_blocks(src: &str) -> String {
     let mut out = String::new();
@@ -174,6 +196,178 @@ pub fn codegen_with(program: &mut IrProgram, target: Target, options: &CodegenOp
 }
 
 
+/// The fixed runtime prelude: AlmideConcat trait + impls, the almide_eq!/almide_ne!
+/// macros, and the RcCow<T> COW value type with its impls.
+///
+/// `for_crate` toggles between two emission modes:
+/// - `false` (inline): private items, plain `macro_rules!` — one self-contained main.rs.
+/// - `true` (rlib): `pub` items + `#[macro_export]` so a slim user main can link this
+///   as the `almide_rt` crate (`use almide_rt::*` + `#[macro_use] extern crate`).
+fn rust_runtime_prelude(for_crate: bool) -> String {
+    let vis = if for_crate { "pub " } else { "" };
+    let macro_attr = if for_crate { "#[macro_export]\n" } else { "" };
+    let mut s = String::new();
+    s.push_str(&format!("{vis}trait AlmideConcat<Rhs> {{ type Output; fn concat(self, rhs: Rhs) -> Self::Output; }}\n"));
+    s.push_str("impl AlmideConcat<String> for String { type Output = String; #[inline(always)] fn concat(self, rhs: String) -> String { format!(\"{}{}\", self, rhs) } }\n");
+    s.push_str("impl AlmideConcat<&str> for String { type Output = String; #[inline(always)] fn concat(self, rhs: &str) -> String { format!(\"{}{}\", self, rhs) } }\n");
+    s.push_str("impl AlmideConcat<String> for &str { type Output = String; #[inline(always)] fn concat(self, rhs: String) -> String { format!(\"{}{}\", self, rhs) } }\n");
+    s.push_str("impl AlmideConcat<&str> for &str { type Output = String; #[inline(always)] fn concat(self, rhs: &str) -> String { format!(\"{}{}\", self, rhs) } }\n");
+    s.push_str("impl<T: Clone> AlmideConcat<Vec<T>> for Vec<T> { type Output = Vec<T>; #[inline(always)] fn concat(self, rhs: Vec<T>) -> Vec<T> { let mut r = self; r.extend(rhs); r } }\n");
+    s.push_str(&format!("{macro_attr}macro_rules! almide_eq {{ ($a:expr, $b:expr) => {{ ($a) == ($b) }}; }}\n"));
+    s.push_str(&format!("{macro_attr}macro_rules! almide_ne {{ ($a:expr, $b:expr) => {{ ($a) != ($b) }}; }}\n"));
+    // RcCow<T>: COW value type. Clone = Rc::clone (O(1)), mutation = Rc::make_mut (COW).
+    // Inspired by Swift's value type semantics.
+    s.push_str(&format!("{vis}struct RcCow<T>({vis}std::rc::Rc<T>);\n"));
+    s.push_str("impl<T: std::fmt::Debug> std::fmt::Debug for RcCow<T> { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.0.fmt(f) } }\n");
+    s.push_str("impl<T: Clone> Clone for RcCow<T> { fn clone(&self) -> Self { RcCow(std::rc::Rc::clone(&self.0)) } }\n");
+    s.push_str("impl<T: PartialEq> PartialEq for RcCow<T> { fn eq(&self, other: &Self) -> bool { *self.0 == *other.0 } }\n");
+    s.push_str("impl<T: PartialEq> PartialEq<T> for RcCow<T> { fn eq(&self, other: &T) -> bool { *self.0 == *other } }\n");
+    s.push_str("impl PartialEq<&str> for RcCow<String> { fn eq(&self, other: &&str) -> bool { self.0.as_str() == *other } }\n");
+    s.push_str("impl<T> std::ops::Deref for RcCow<T> { type Target = T; fn deref(&self) -> &T { &self.0 } }\n");
+    s.push_str("impl<T: Clone> std::ops::DerefMut for RcCow<T> { fn deref_mut(&mut self) -> &mut T { std::rc::Rc::make_mut(&mut self.0) } }\n");
+    s.push_str(&format!("impl<T> RcCow<T> {{ {vis}fn new(v: T) -> Self {{ RcCow(std::rc::Rc::new(v)) }} {vis}fn make_mut(&mut self) -> &mut T where T: Clone {{ std::rc::Rc::make_mut(&mut self.0) }} {vis}fn into_inner(self) -> T where T: Clone {{ std::rc::Rc::try_unwrap(self.0).unwrap_or_else(|rc| (*rc).clone()) }} }}\n"));
+    s.push_str("impl<T> From<T> for RcCow<T> { fn from(v: T) -> Self { RcCow::new(v) } }\n");
+    s.push_str("impl<T: std::fmt::Display> std::fmt::Display for RcCow<T> { fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { self.0.fmt(f) } }\n");
+    s.push_str("impl<T: std::hash::Hash> std::hash::Hash for RcCow<T> { fn hash<H: std::hash::Hasher>(&self, state: &mut H) { self.0.hash(state) } }\n");
+    // Blanket AlmideConcat: RcCow<T> + Rhs and RcCow<T> + Val<U> — 2 impls cover all combos.
+    s.push_str("impl<T: Clone, Rhs> AlmideConcat<Rhs> for RcCow<T> where T: AlmideConcat<Rhs> { type Output = RcCow<<T as AlmideConcat<Rhs>>::Output>; #[inline(always)] fn concat(self, rhs: Rhs) -> Self::Output { RcCow::new((*self).clone().concat(rhs)) } }\n");
+    s
+}
+
+/// Resolve inter-module runtime dependencies into `needed` (auto-extracted from
+/// source by build.rs — no manual whitelist). Fixpoint over RUNTIME_DEPS.
+fn resolve_runtime_deps(needed: &mut std::collections::HashSet<&str>) {
+    let mut added = true;
+    while added {
+        added = false;
+        for (module, deps) in crate::generated::rust_runtime::RUNTIME_DEPS {
+            if needed.contains(module) {
+                for dep in *deps {
+                    if needed.insert(dep) { added = true; }
+                }
+            }
+        }
+    }
+}
+
+/// Collect the runtime module bodies for the `needed` set: hoist top-level `use`
+/// to the front, deduplicate, and skip struct definitions the walker already
+/// emitted (present in `user_code`) to avoid E0428. Returns the assembled block.
+fn rust_runtime_modules(needed: &std::collections::HashSet<&str>, user_code: &str) -> String {
+    let mut use_set = std::collections::HashSet::new();
+    let mut use_lines = Vec::new();
+    let mut body_lines = Vec::new();
+    for (name, source) in crate::generated::rust_runtime::RUST_RUNTIME_MODULES {
+        if needed.contains(name) {
+            let stripped = strip_test_blocks(source);
+            let lines: Vec<&str> = stripped.lines().collect();
+            let mut i = 0;
+            while i < lines.len() {
+                let line = lines[i];
+                let trimmed = line.trim();
+                // Top-level use: not indented and starts with "use "
+                if !line.starts_with(' ') && !line.starts_with('\t')
+                    && trimmed.starts_with("use ") && trimmed.ends_with(';')
+                {
+                    if use_set.insert(trimmed.to_string()) {
+                        use_lines.push(trimmed.to_string());
+                    }
+                    i += 1;
+                    continue;
+                }
+                // Detect struct definitions: #[derive(...)] followed by pub struct Name
+                // Skip the block if user_code already contains that struct (walker emitted it).
+                if trimmed.starts_with("#[derive(") {
+                    if let Some(next) = lines.get(i + 1) {
+                        if let Some(struct_name) = next.trim().strip_prefix("pub struct ")
+                            .and_then(|s| s.split_whitespace().next())
+                            .map(|s| s.trim_end_matches('{').trim())
+                        {
+                            let needle = format!("struct {}", struct_name);
+                            if user_code.contains(&needle) {
+                                // Skip derive + struct + fields + closing brace
+                                i += 1; // skip #[derive]
+                                let mut depth = 0u32;
+                                while i < lines.len() {
+                                    if lines[i].contains('{') { depth += 1; }
+                                    if lines[i].contains('}') {
+                                        depth = depth.saturating_sub(1);
+                                        if depth == 0 { i += 1; break; }
+                                    }
+                                    i += 1;
+                                }
+                                continue;
+                            }
+                        }
+                    }
+                }
+                body_lines.push(line.to_string());
+                i += 1;
+            }
+            body_lines.push(String::new());
+        }
+    }
+    // Remove single-item `use a::b::X;` when a group `use a::b::{..., X, ...};` exists
+    let use_lines: Vec<String> = use_lines.into_iter().filter(|line| {
+        // Parse: use path::Item;
+        if let Some(rest) = line.strip_prefix("use ").and_then(|s| s.strip_suffix(';')) {
+            if !rest.contains('{') {
+                if let Some(pos) = rest.rfind("::") {
+                    let prefix = &rest[..pos];
+                    let item = &rest[pos + 2..];
+                    // Check if any group import covers this item
+                    let dominated = use_set.iter().any(|other| {
+                        if let Some(orest) = other.strip_prefix("use ").and_then(|s| s.strip_suffix(';')) {
+                            if let Some(opos) = orest.find("::{") {
+                                let oprefix = &orest[..opos];
+                                if oprefix == prefix {
+                                    let items_str = &orest[opos + 3..orest.len() - 1]; // strip ::{ and }
+                                    return items_str.split(',').any(|i| i.trim() == item);
+                                }
+                            }
+                        }
+                        false
+                    });
+                    if dominated { return false; }
+                }
+            }
+        }
+        true
+    }).collect();
+    let mut out = String::new();
+    for u in &use_lines { out.push_str(u); out.push('\n'); }
+    for line in &body_lines { out.push_str(line); out.push('\n'); }
+    out
+}
+
+/// Runtime modules that cannot live in the bare-rustc `almide_rt` rlib: `http`
+/// needs rustls, `zlib` needs flate2, and `sse` calls into `http` for its
+/// streaming transport. Programs using these stay on the cargo path; the rlib
+/// fast path only covers std-only programs (a link error otherwise falls back).
+pub const NON_STD_RUNTIME_MODULES: &[&str] = &["http", "zlib", "sse"];
+
+/// Emit the full `almide_rt` runtime crate source: the prelude (pub items +
+/// exported macros) plus every std-only runtime module. Built once into an
+/// `.rlib` and linked by slim user mains (see `CodegenOptions::external_runtime`).
+///
+/// Deterministic — depends only on the embedded runtime sources and the compiler
+/// version, so callers can cache the resulting rlib keyed by a hash of this output.
+pub fn emit_runtime_crate() -> String {
+    let mut out = String::new();
+    out.push_str("#![allow(unused_parens, unused_variables, dead_code, unused_imports, unused_mut, unused_must_use, non_snake_case)]\n\n");
+    out.push_str("use std::collections::HashMap;\nuse std::collections::HashSet;\n\n");
+    out.push_str(&rust_runtime_prelude(true));
+    // Every std-only runtime module (exclude external-dep modules).
+    let mut needed: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for (name, _) in crate::generated::rust_runtime::RUST_RUNTIME_MODULES {
+        if !NON_STD_RUNTIME_MODULES.contains(name) {
+            needed.insert(*name);
+        }
+    }
+    out.push_str(&rust_runtime_modules(&needed, ""));
+    out
+}
+
 /// Emit source code for text targets (Rust, TypeScript, JavaScript).
 fn emit_source(program: &mut IrProgram, target: Target, config: &target::TargetConfig, options: &CodegenOptions) -> String {
     // Template-driven rendering (walker reads annotations, never checks types)
@@ -190,135 +384,21 @@ fn emit_source(program: &mut IrProgram, target: Target, config: &target::TargetC
         Target::Rust => {
             output.push_str("#![allow(unused_parens, unused_variables, dead_code, unused_imports, unused_mut, unused_must_use)]\n\n");
             output.push_str("use std::collections::HashMap;\nuse std::collections::HashSet;\n\n");
-            output.push_str("trait AlmideConcat<Rhs> { type Output; fn concat(self, rhs: Rhs) -> Self::Output; }\n");
-            output.push_str("impl AlmideConcat<String> for String { type Output = String; #[inline(always)] fn concat(self, rhs: String) -> String { format!(\"{}{}\", self, rhs) } }\n");
-            output.push_str("impl AlmideConcat<&str> for String { type Output = String; #[inline(always)] fn concat(self, rhs: &str) -> String { format!(\"{}{}\", self, rhs) } }\n");
-            output.push_str("impl AlmideConcat<String> for &str { type Output = String; #[inline(always)] fn concat(self, rhs: String) -> String { format!(\"{}{}\", self, rhs) } }\n");
-            output.push_str("impl AlmideConcat<&str> for &str { type Output = String; #[inline(always)] fn concat(self, rhs: &str) -> String { format!(\"{}{}\", self, rhs) } }\n");
-            output.push_str("impl<T: Clone> AlmideConcat<Vec<T>> for Vec<T> { type Output = Vec<T>; #[inline(always)] fn concat(self, rhs: Vec<T>) -> Vec<T> { let mut r = self; r.extend(rhs); r } }\n");
-            output.push_str("macro_rules! almide_eq { ($a:expr, $b:expr) => { ($a) == ($b) }; }\n");
-            output.push_str("macro_rules! almide_ne { ($a:expr, $b:expr) => { ($a) != ($b) }; }\n");
-            // RcCow<T>: COW value type. Clone = Rc::clone (O(1)), mutation = Rc::make_mut (COW).
-            // Inspired by Swift's value type semantics.
-            output.push_str("struct RcCow<T>(std::rc::Rc<T>);\n");
-            output.push_str("impl<T: std::fmt::Debug> std::fmt::Debug for RcCow<T> { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.0.fmt(f) } }\n");
-            output.push_str("impl<T: Clone> Clone for RcCow<T> { fn clone(&self) -> Self { RcCow(std::rc::Rc::clone(&self.0)) } }\n");
-            output.push_str("impl<T: PartialEq> PartialEq for RcCow<T> { fn eq(&self, other: &Self) -> bool { *self.0 == *other.0 } }\n");
-            output.push_str("impl<T: PartialEq> PartialEq<T> for RcCow<T> { fn eq(&self, other: &T) -> bool { *self.0 == *other } }\n");
-            output.push_str("impl PartialEq<&str> for RcCow<String> { fn eq(&self, other: &&str) -> bool { self.0.as_str() == *other } }\n");
-            output.push_str("impl<T> std::ops::Deref for RcCow<T> { type Target = T; fn deref(&self) -> &T { &self.0 } }\n");
-            output.push_str("impl<T: Clone> std::ops::DerefMut for RcCow<T> { fn deref_mut(&mut self) -> &mut T { std::rc::Rc::make_mut(&mut self.0) } }\n");
-            output.push_str("impl<T> RcCow<T> { fn new(v: T) -> Self { RcCow(std::rc::Rc::new(v)) } fn make_mut(&mut self) -> &mut T where T: Clone { std::rc::Rc::make_mut(&mut self.0) } fn into_inner(self) -> T where T: Clone { std::rc::Rc::try_unwrap(self.0).unwrap_or_else(|rc| (*rc).clone()) } }\n");
-            output.push_str("impl<T> From<T> for RcCow<T> { fn from(v: T) -> Self { RcCow::new(v) } }\n");
-            output.push_str("impl<T: std::fmt::Display> std::fmt::Display for RcCow<T> { fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { self.0.fmt(f) } }\n");
-            output.push_str("impl<T: std::hash::Hash> std::hash::Hash for RcCow<T> { fn hash<H: std::hash::Hasher>(&self, state: &mut H) { self.0.hash(state) } }\n");
-            // Blanket AlmideConcat: RcCow<T> + Rhs and RcCow<T> + Val<U> — 2 impls cover all combos.
-            output.push_str("impl<T: Clone, Rhs> AlmideConcat<Rhs> for RcCow<T> where T: AlmideConcat<Rhs> { type Output = RcCow<<T as AlmideConcat<Rhs>>::Output>; #[inline(always)] fn concat(self, rhs: Rhs) -> Self::Output { RcCow::new((*self).clone().concat(rhs)) } }\n");
-            // Include runtime modules referenced in the IR.
-            // The IrProgram tracks which stdlib modules are used across
-            // all functions and transitive dependencies — no text search.
+            output.push_str(&rust_runtime_prelude(false));
+            // Include runtime modules referenced in the IR. The IrProgram tracks
+            // which stdlib modules are used across all functions and transitive
+            // dependencies — no text search.
             let mut needed: std::collections::HashSet<&str> = std::collections::HashSet::new();
             for m in &program.used_stdlib_modules {
                 needed.insert(m.as_str());
             }
-            // Resolve inter-module runtime dependencies (auto-extracted
-            // from source by build.rs — no manual whitelist).
-            let mut added = true;
-            while added {
-                added = false;
-                for (module, deps) in crate::generated::rust_runtime::RUNTIME_DEPS {
-                    if needed.contains(module) {
-                        for dep in *deps {
-                            if needed.insert(dep) { added = true; }
-                        }
-                    }
-                }
-            }
-            // Collect runtime modules, hoist top-level `use` to front and deduplicate.
-            // Struct definitions in runtime sources that the walker already emitted
-            // (from stdlib/*.almd type declarations) are skipped to avoid E0428.
-            let mut use_set = std::collections::HashSet::new();
-            let mut use_lines = Vec::new();
-            let mut body_lines = Vec::new();
-            for (name, source) in crate::generated::rust_runtime::RUST_RUNTIME_MODULES {
-                if needed.contains(name) {
-                    let stripped = strip_test_blocks(source);
-                    let lines: Vec<&str> = stripped.lines().collect();
-                    let mut i = 0;
-                    while i < lines.len() {
-                        let line = lines[i];
-                        let trimmed = line.trim();
-                        // Top-level use: not indented and starts with "use "
-                        if !line.starts_with(' ') && !line.starts_with('\t')
-                            && trimmed.starts_with("use ") && trimmed.ends_with(';')
-                        {
-                            if use_set.insert(trimmed.to_string()) {
-                                use_lines.push(trimmed.to_string());
-                            }
-                            i += 1;
-                            continue;
-                        }
-                        // Detect struct definitions: #[derive(...)] followed by pub struct Name
-                        // Skip the block if user_code already contains that struct (walker emitted it).
-                        if trimmed.starts_with("#[derive(") {
-                            if let Some(next) = lines.get(i + 1) {
-                                if let Some(struct_name) = next.trim().strip_prefix("pub struct ")
-                                    .and_then(|s| s.split_whitespace().next())
-                                    .map(|s| s.trim_end_matches('{').trim())
-                                {
-                                    let needle = format!("struct {}", struct_name);
-                                    if user_code.contains(&needle) {
-                                        // Skip derive + struct + fields + closing brace
-                                        i += 1; // skip #[derive]
-                                        let mut depth = 0u32;
-                                        while i < lines.len() {
-                                            if lines[i].contains('{') { depth += 1; }
-                                            if lines[i].contains('}') {
-                                                depth = depth.saturating_sub(1);
-                                                if depth == 0 { i += 1; break; }
-                                            }
-                                            i += 1;
-                                        }
-                                        continue;
-                                    }
-                                }
-                            }
-                        }
-                        body_lines.push(line.to_string());
-                        i += 1;
-                    }
-                    body_lines.push(String::new());
-                }
-            }
-            // Remove single-item `use a::b::X;` when a group `use a::b::{..., X, ...};` exists
-            let use_lines: Vec<String> = use_lines.into_iter().filter(|line| {
-                // Parse: use path::Item;
-                if let Some(rest) = line.strip_prefix("use ").and_then(|s| s.strip_suffix(';')) {
-                    if !rest.contains('{') {
-                        if let Some(pos) = rest.rfind("::") {
-                            let prefix = &rest[..pos];
-                            let item = &rest[pos + 2..];
-                            // Check if any group import covers this item
-                            let dominated = use_set.iter().any(|other| {
-                                if let Some(orest) = other.strip_prefix("use ").and_then(|s| s.strip_suffix(';')) {
-                                    if let Some(opos) = orest.find("::{") {
-                                        let oprefix = &orest[..opos];
-                                        if oprefix == prefix {
-                                            let items_str = &orest[opos + 3..orest.len() - 1]; // strip ::{ and }
-                                            return items_str.split(',').any(|i| i.trim() == item);
-                                        }
-                                    }
-                                }
-                                false
-                            });
-                            if dominated { return false; }
-                        }
-                    }
-                }
-                true
-            }).collect();
-            for u in &use_lines { output.push_str(u); output.push('\n'); }
-            for line in &body_lines { output.push_str(line); output.push('\n'); }
+            resolve_runtime_deps(&mut needed);
+            output.push_str(&rust_runtime_modules(&needed, &user_code));
+            // Boundary marker: everything above is the inlined runtime preamble,
+            // everything below is user code. The rlib fast path (see CLI) splits
+            // here to swap the preamble for `extern crate almide_rt`.
+            output.push_str(RT_BOUNDARY_MARKER);
+            output.push('\n');
         }
         _ => {}
     }

--- a/crates/almide-codegen/src/pass.rs
+++ b/crates/almide-codegen/src/pass.rs
@@ -246,6 +246,13 @@ impl Pipeline {
         // `ALMIDE_VERIFY_IR` used to gate this — removed in S2 flip
         // (v0.14.7-phase3.2); `expr.ty` is now trustworthy by contract.
         let hard_fail = cfg!(debug_assertions);
+        // The inter-pass IR verifier + postcondition checks walk the entire
+        // (merged) program after EVERY pass. That's a developer safety net —
+        // it catches compiler bugs but does nothing for a correct build. In
+        // release it can't even fail hard, yet it dominates codegen time
+        // (~1.2s/file: 20 passes × verify(user + all merged stdlib functions)).
+        // Run it only in debug (cargo test / CI) or when explicitly requested.
+        let verify_ir = hard_fail || std::env::var_os("ALMIDE_VERIFY_IR").is_some();
 
         for pass in &self.passes {
             // Skip passes not relevant to this target
@@ -266,7 +273,12 @@ impl Pipeline {
             }
 
             let pass_name = pass.name();
+            let _pass_t = std::time::Instant::now();
             let result = pass.run(program, target);
+            if std::env::var_os("ALMIDE_PROFILE").is_some() {
+                let dt = _pass_t.elapsed().as_secs_f64();
+                if dt > 0.01 { eprintln!("[prof:pass] {:30} {:.3}s", pass_name, dt); }
+            }
             program = result.program;
 
             // IR dump (opt-in via ALMIDE_DUMP_IR=all or ALMIDE_DUMP_IR=pass1,pass2)
@@ -283,27 +295,29 @@ impl Pipeline {
                 eprintln!("── end {} ──\n", pass_name);
             }
 
-            // Inter-pass IR verification — always on.
-            let errors = almide_ir::verify_program(&program);
-            if !errors.is_empty() {
-                eprintln!("[IR CHECK] {} error(s) after pass '{}':", errors.len(), pass_name);
-                for e in &errors {
-                    eprintln!("  {}", e);
+            // Inter-pass IR verification (debug / opt-in only — see verify_ir).
+            if verify_ir {
+                let errors = almide_ir::verify_program(&program);
+                if !errors.is_empty() {
+                    eprintln!("[IR CHECK] {} error(s) after pass '{}':", errors.len(), pass_name);
+                    for e in &errors {
+                        eprintln!("  {}", e);
+                    }
+                    if hard_fail {
+                        panic!("IR verification failed after pass '{}'", pass_name);
+                    }
                 }
-                if hard_fail {
-                    panic!("IR verification failed after pass '{}'", pass_name);
-                }
-            }
 
-            // Postcondition verification — always on.
-            let postconds = pass.postconditions();
-            if !postconds.is_empty() {
-                let violations = verify_postconditions(pass_name, &program, &postconds);
-                for v in &violations {
-                    eprintln!("[POSTCONDITION VIOLATION] {}", v);
-                }
-                if !violations.is_empty() && hard_fail {
-                    panic!("Postcondition violation after pass '{}'", pass_name);
+                // Postcondition verification.
+                let postconds = pass.postconditions();
+                if !postconds.is_empty() {
+                    let violations = verify_postconditions(pass_name, &program, &postconds);
+                    for v in &violations {
+                        eprintln!("[POSTCONDITION VIOLATION] {}", v);
+                    }
+                    if !violations.is_empty() && hard_fail {
+                        panic!("Postcondition violation after pass '{}'", pass_name);
+                    }
                 }
             }
 

--- a/docs/roadmap/active/build-speed-runtime-rlib.md
+++ b/docs/roadmap/active/build-speed-runtime-rlib.md
@@ -1,0 +1,54 @@
+<!-- description: Native build-speed — precompiled almide_rt runtime rlib, and recovering the shipping-build inlining gap with #[inline] -->
+# Build Speed: Runtime rlib + Hot-Fn Inlining
+
+> Goal: Go-like build speed. The dev/test/run loop and shipping builds should not pay to recompile the runtime every time.
+
+## Status
+
+**Shipped (branch `build-speed-parallel-rustc`):** the `almide_rt` runtime is
+compiled once into an `.rlib` (`codegen::emit_runtime_crate()`), cached under
+`$TMPDIR/almide-rtlib-<hash>` keyed by runtime-source + rustc-version + opt-level.
+Per-file/per-build rustc emits a slim main (`#[macro_use] extern crate almide_rt;
+use almide_rt::*;` + user code, split on `RT_BOUNDARY_MARKER`) and links the rlib
+with `--extern almide_rt=<rlib>`. Falls back to the inline/cargo path on any
+failure; `ALMIDE_NO_RTLIB=1` disables it.
+
+Wired into:
+- **Test path** (`cargo_build_test_with_native`): rlib at opt1 + slim main at **opt0** (tests don't need optimized user code) → **2.45x/file**, spec/lang 116 files **2.26x wall / 3.1x CPU**.
+- **Run/build path** (`cargo_build_generated_with_native`): rlib + slim main at the binary's opt-level (1 debug, 3 release). Shipping `--release` builds **~20x** (27–33s → 1–2s), output verified identical.
+
+Excluded: `http`/`zlib`/`sse` (non-std deps) stay on the cargo path.
+
+## The remaining gap (this roadmap item): shipping-build inlining
+
+Because the runtime is a separate crate compiled **without LTO**, non-generic,
+non-`#[inline]` runtime fns are **not inlined across the crate boundary**. On a
+string/list-heavy hot loop (measured: 200k-row CSV through `csv-to-json`) the
+shipped binary runs **~10% slower** than the monolithic build (typical programs:
+2–5%). Generic runtime fns (most `list`/`map`/`option`/`result` ops) and the
+existing `#[inline(always)]` helpers are unaffected — they inline cross-crate
+already.
+
+Rejected alternative — **ThinLTO**: recovers the inlining but re-optimizes the
+runtime's bitcode at link time, erasing the build-speed win (≈ monolithic build
+time). Measured: no compile win, so not worth it.
+
+### Plan: `#[inline]` the hot non-generic runtime fns
+
+Mark the small set of hot, non-generic runtime fns — primarily `string.*`
+(`trim`, `split`, `lines`, `concat`, `len`, slicing) and any frequently-called
+scalar helpers — with `#[inline]` in `runtime/rs/src/*.rs`. With their MIR
+exposed in the rlib, rustc inlines them across the crate boundary even without
+LTO, recovering the lost performance while keeping the ~20x build win and the
+"separate runtime crate, no LTO" model. This mirrors Go's "small functions are
+auto-inlined" stance.
+
+Steps:
+1. Profile a runtime-heavy workload (e.g. the 200k-CSV `csv-to-json` benchmark) to identify which runtime fns dominate the rlib-vs-monolithic gap.
+2. Add `#[inline]` to those fns (prefer targeted `#[inline]` over blanket `#[inline(always)]` to avoid bloating caller compile time).
+3. Re-measure: confirm shipping runtime regression → ~0% while build stays ~20x.
+4. Guard against over-inlining: watch that the slim-main compile time doesn't creep back up (more inline candidates = more work for the final rustc).
+
+### Open follow-ups
+- Wire the rlib into `almide build` for projects with **native deps** (currently cargo-only) — would need the rlib passed through cargo as a path dependency or `RUSTFLAGS --extern`.
+- Consider shipping a prebuilt rlib with the compiler release so the first build in a fresh environment skips the one-time rlib compile.

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -385,6 +385,128 @@ pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
     }
 }
 
+/// Default `almide test`: run each file on the fast rustc-free WASM path; for
+/// any file the WASM path can't pass (emitter gap, wasm:skip, or a trap), fall
+/// back to the native rustc path, which is authoritative. The common case (most
+/// tests pass on WASM) is ~9x faster; the native fallback preserves correctness.
+pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
+    let test_files: Vec<String> = if !file.is_empty() {
+        let path = std::path::Path::new(file);
+        if path.is_dir() {
+            let mut files = collect_test_files(path);
+            files.sort();
+            if files.is_empty() {
+                eprintln!("No .almd files with test blocks found in {}", file);
+                std::process::exit(1);
+            }
+            files
+        } else {
+            vec![file.to_string()]
+        }
+    } else {
+        let mut files = Vec::new();
+        for dir in &["spec", "exercises"] {
+            let path = std::path::Path::new(dir);
+            if path.exists() { files.extend(collect_test_files(path)); }
+        }
+        if files.is_empty() { files = collect_test_files(std::path::Path::new(".")); }
+        files.sort();
+        if files.is_empty() {
+            eprintln!("No .almd files with test blocks found.");
+            std::process::exit(1);
+        }
+        files
+    };
+
+    let cpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4);
+    let tmp_dir = std::sync::Arc::new(std::env::temp_dir().join("almide-wasm-test"));
+    std::fs::create_dir_all(&*tmp_dir).ok();
+
+    // Phase 1: WASM (fast, rustc-free), parallel.
+    let wasm_outcomes: Vec<WasmTestOutcome> = {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
+        for _ in 0..cpus { let _ = sem_tx.send(()); }
+        let sem_tx = std::sync::Arc::new(sem_tx);
+        let sem_rx = std::sync::Arc::new(std::sync::Mutex::new(sem_rx));
+        let mut handles = Vec::new();
+        for tf in test_files.clone() {
+            let tx = tx.clone();
+            let td = tmp_dir.clone();
+            let sr = sem_rx.clone();
+            let st = sem_tx.clone();
+            handles.push(std::thread::spawn(move || {
+                let _ = sr.lock().unwrap().recv();
+                let o = compile_and_run_wasm_test(&tf, &td);
+                let _ = st.send(());
+                let _ = tx.send(o);
+            }));
+        }
+        drop(tx);
+        let v: Vec<_> = rx.iter().collect();
+        for h in handles { let _ = h.join(); }
+        v
+    };
+
+    let mut wasm_pass = 0usize;
+    let mut fallback: Vec<String> = Vec::new();
+    for o in wasm_outcomes {
+        match o {
+            WasmTestOutcome::Pass { .. } => wasm_pass += 1,
+            WasmTestOutcome::Fail { file, .. } | WasmTestOutcome::Skip { file, .. } => fallback.push(file),
+        }
+    }
+
+    // Phase 2: native rustc fallback (authoritative) for everything the WASM
+    // path didn't pass, parallel with per-file scratch dirs.
+    let mut program_args: Vec<String> = Vec::new();
+    if let Some(f) = run_filter { program_args.push(f.to_string()); }
+    let program_args = std::sync::Arc::new(program_args);
+
+    let native_results: Vec<(String, i32)> = {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
+        for _ in 0..cpus { let _ = sem_tx.send(()); }
+        let sem_tx = std::sync::Arc::new(sem_tx);
+        let sem_rx = std::sync::Arc::new(std::sync::Mutex::new(sem_rx));
+        let mut handles = Vec::new();
+        for tf in fallback.clone() {
+            let tx = tx.clone();
+            let args = program_args.clone();
+            let sr = sem_rx.clone();
+            let st = sem_tx.clone();
+            handles.push(std::thread::spawn(move || {
+                let _ = sr.lock().unwrap().recv();
+                let worker_dir = std::env::temp_dir()
+                    .join("almide-test")
+                    .join(tf.replace('/', "_").replace('.', "_"));
+                let code = match super::run::compile_to_binary(&tf, no_check, true, false, Some(&worker_dir)) {
+                    Ok(bin) => super::run::run_binary(&bin, &args),
+                    Err(e) => { eprintln!("Compile error for {}:\n{}", tf, e); 1 }
+                };
+                let _ = st.send(());
+                let _ = tx.send((tf, code));
+            }));
+        }
+        drop(tx);
+        let mut v: Vec<(String, i32)> = rx.iter().collect();
+        for h in handles { let _ = h.join(); }
+        v.sort_by(|a, b| a.0.cmp(&b.0));
+        v
+    };
+
+    let mut failed = 0;
+    for (file, code) in &native_results {
+        if *code != 0 { eprintln!("FAILED: {}", file); failed += 1; }
+    }
+    eprintln!("\n{} via WASM, {} via native fallback, {} failed (of {} files)",
+        wasm_pass, fallback.len().saturating_sub(failed), failed, test_files.len());
+    if failed > 0 {
+        std::process::exit(1);
+    }
+    eprintln!("All {} test file(s) passed", test_files.len());
+}
+
 pub fn cmd_test_ts(file: &str, _run_filter: Option<&str>) {
     use crate::{parse_file, canonicalize, check, diagnostic, resolve, project, project_fetch};
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -170,9 +170,129 @@ pub fn cmd_test(file: &str, no_check: bool, run_filter: Option<&str>) {
     eprintln!("\nAll {} test file(s) passed", test_files.len());
 }
 
-pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
-    use crate::{parse_file, canonicalize, check, diagnostic, resolve, project, project_fetch};
+enum WasmTestOutcome {
+    Pass { file: String, count: usize, bytes: usize },
+    Fail { file: String, detail: String },
+    Skip { file: String, reason: String },
+}
 
+/// Compile one `.almd` file to WASM and run it under wasmtime. Pure per-file
+/// work (no shared mutable state) so it runs in parallel — the WASM path takes
+/// no rustc/cargo, so there's no global build lock to serialize on.
+fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> WasmTestOutcome {
+    use crate::{parse_file, canonicalize, check, diagnostic, resolve, project, project_fetch};
+    let skip = |reason: String| WasmTestOutcome::Skip { file: test_file.to_string(), reason };
+
+    let wasm_name = test_file.replace('/', "_").replace('.', "_") + ".wasm";
+    let wasm_path = tmp_dir.join(&wasm_name);
+
+    let (mut program, source_text, _parse_errors) = parse_file(test_file);
+    if source_text.lines().take(3).any(|line| line.contains("// wasm:skip")) {
+        return skip("wasm:skip".to_string());
+    }
+
+    let dep_paths: Vec<(project::PkgId, std::path::PathBuf)> =
+        if std::path::Path::new("almide.toml").exists() {
+            if let Ok(proj) = project::parse_toml(std::path::Path::new("almide.toml")) {
+                project_fetch::fetch_all_deps(&proj)
+                    .unwrap_or_else(|_| vec![])
+                    .into_iter()
+                    .map(|fd| (fd.pkg_id, fd.source_dir))
+                    .collect()
+            } else { vec![] }
+        } else { vec![] };
+
+    let mut resolved = match resolve::resolve_imports_with_deps(test_file, &program, &dep_paths) {
+        Ok(r) => r,
+        Err(e) => return skip(format!("resolve: {}", e)),
+    };
+
+    let canon = canonicalize::canonicalize_program(
+        &program,
+        resolved.modules.iter().map(|(n, p, _, s)| (n.as_str(), p, *s)),
+    );
+    let mut checker = check::Checker::from_env(canon.env);
+    checker.set_source(test_file, &source_text);
+    checker.diagnostics = canon.diagnostics;
+    let diagnostics = checker.infer_program(&mut program);
+    if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
+        return skip("type errors".to_string());
+    }
+
+    for (name, _, pkg_id, _) in &resolved.modules {
+        if let Some(pid) = pkg_id.as_ref() {
+            let base = pid.mod_name();
+            let v = if let Some(suffix) = name.strip_prefix(&pid.name) { format!("{}{}", base, suffix) } else { base };
+            checker.env.module_versioned_names.insert(almide::intern::sym(name), almide::intern::sym(&v));
+        }
+    }
+    let mut ir_program = almide::lower::lower_program(&program, &checker.env, &checker.type_map);
+    for (name, mod_prog, pkg_id, _) in &mut resolved.modules {
+        if almide::stdlib::is_stdlib_module(name) && !almide::stdlib::is_bundled_module(name) { continue; }
+        let saved_self = checker.env.self_module_name;
+        if let Some(pid) = pkg_id.as_ref() {
+            checker.env.self_module_name = Some(almide::intern::sym(&pid.name));
+        }
+        checker.infer_module(mod_prog, name);
+        let versioned = pkg_id.as_ref().map(|pid| {
+            let base = pid.mod_name();
+            if let Some(suffix) = name.strip_prefix(&pid.name) { format!("{}{}", base, suffix) } else { base }
+        });
+        if let Some(ref v) = versioned {
+            checker.env.module_versioned_names.insert(almide::intern::sym(name), almide::intern::sym(v));
+        }
+        let self_name = checker.env.self_module_name.map(|s| s.to_string());
+        let import_table_name = self_name.as_deref().unwrap_or(name);
+        let (mod_table, _) = almide::import_table::build_import_table(mod_prog, Some(import_table_name), &checker.env.user_modules);
+        let saved_table = std::mem::replace(&mut checker.env.import_table, mod_table);
+        let mod_ir_module = almide::lower::lower_module(name, mod_prog, &checker.env, &checker.type_map, versioned);
+        checker.env.import_table = saved_table;
+        checker.env.self_module_name = saved_self;
+        ir_program.modules.push(mod_ir_module);
+    }
+    almide::ir_link::ir_link(&mut ir_program);
+    almide::optimize::optimize_program(&mut ir_program);
+    almide::mono::monomorphize(&mut ir_program);
+    let bytes = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        match almide::codegen::codegen(&mut ir_program, almide::codegen::pass::Target::Wasm) {
+            almide::codegen::CodegenOutput::Binary(b) => b,
+            almide::codegen::CodegenOutput::Source(_) => unreachable!(),
+        }
+    }));
+    let bytes = match bytes {
+        Ok(b) => b,
+        Err(_) => return skip("WASM codegen panic".to_string()),
+    };
+    if let Err(e) = std::fs::write(&wasm_path, &bytes) {
+        return skip(format!("write: {}", e));
+    }
+
+    let output = std::process::Command::new("wasmtime")
+        .arg("--dir=/")
+        .arg(wasm_path.to_str().unwrap())
+        .output();
+    match output {
+        Ok(result) => {
+            let stdout = String::from_utf8_lossy(&result.stdout);
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            if result.status.success() {
+                WasmTestOutcome::Pass { file: test_file.to_string(), count: stdout.matches("ok\n").count(), bytes: bytes.len() }
+            } else {
+                let mut last_test = String::new();
+                for line in stdout.lines() {
+                    if line.starts_with("test: ") { last_test = line.to_string(); }
+                }
+                let mut detail = String::new();
+                if !last_test.is_empty() { detail.push_str(&format!("  trapped at: {}\n", last_test)); }
+                for line in stderr.lines().take(2) { detail.push_str(&format!("  {}\n", line)); }
+                WasmTestOutcome::Fail { file: test_file.to_string(), detail }
+            }
+        }
+        Err(e) => skip(format!("wasmtime: {}", e)),
+    }
+}
+
+pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
     let test_files: Vec<String> = if !file.is_empty() {
         let path = std::path::Path::new(file);
         if path.is_dir() {
@@ -199,153 +319,54 @@ pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
     let tmp_dir = std::env::temp_dir().join("almide-wasm-test");
     std::fs::create_dir_all(&tmp_dir).ok();
 
+    // Parallel: each file's compile+run is independent and rustc/cargo-free,
+    // so there's no global build lock to serialize on (unlike the native path).
+    let cpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4);
+    let tmp_dir = std::sync::Arc::new(tmp_dir);
+    let (tx, rx) = std::sync::mpsc::channel();
+    let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
+    for _ in 0..cpus { let _ = sem_tx.send(()); }
+    let sem_tx = std::sync::Arc::new(sem_tx);
+    let sem_rx = std::sync::Arc::new(std::sync::Mutex::new(sem_rx));
+    let mut handles = Vec::new();
+    for test_file in test_files.clone() {
+        let tx = tx.clone();
+        let tmp_dir = tmp_dir.clone();
+        let sem_rx = sem_rx.clone();
+        let sem_tx = sem_tx.clone();
+        handles.push(std::thread::spawn(move || {
+            let _ = sem_rx.lock().unwrap().recv();
+            let outcome = compile_and_run_wasm_test(&test_file, &tmp_dir);
+            let _ = sem_tx.send(());
+            let _ = tx.send(outcome);
+        }));
+    }
+    drop(tx);
+    let mut outcomes: Vec<WasmTestOutcome> = rx.iter().collect();
+    for h in handles { let _ = h.join(); }
+    let file_of = |o: &WasmTestOutcome| match o {
+        WasmTestOutcome::Pass { file, .. }
+        | WasmTestOutcome::Fail { file, .. }
+        | WasmTestOutcome::Skip { file, .. } => file.clone(),
+    };
+    outcomes.sort_by(|a, b| file_of(a).cmp(&file_of(b)));
+
     let mut failed = 0;
     let mut passed = 0;
     let mut skipped = 0;
-
-    for test_file in &test_files {
-        // Build WASM binary
-        let wasm_name = test_file.replace('/', "_").replace('.', "_") + ".wasm";
-        let wasm_path = tmp_dir.join(&wasm_name);
-
-        let (mut program, source_text, _parse_errors) = parse_file(test_file);
-
-        // Skip files marked with // wasm:skip
-        if source_text.lines().take(3).any(|line| line.contains("// wasm:skip")) {
-            skipped += 1;
-            continue;
-        }
-
-        // Resolve dependencies
-        let dep_paths: Vec<(project::PkgId, std::path::PathBuf)> =
-            if std::path::Path::new("almide.toml").exists() {
-                if let Ok(proj) = project::parse_toml(std::path::Path::new("almide.toml")) {
-                    project_fetch::fetch_all_deps(&proj)
-                        .unwrap_or_else(|e| { eprintln!("{}", e); vec![] })
-                        .into_iter()
-                        .map(|fd| (fd.pkg_id, fd.source_dir))
-                        .collect()
-                } else { vec![] }
-            } else { vec![] };
-
-        let mut resolved = match resolve::resolve_imports_with_deps(test_file, &program, &dep_paths) {
-            Ok(r) => r,
-            Err(e) => {
-                eprintln!("SKIP {} (resolve: {})", test_file, e);
-                skipped += 1;
-                continue;
+    for o in &outcomes {
+        match o {
+            WasmTestOutcome::Pass { file, count, bytes } => {
+                eprintln!("{}: {} tests passed ({} bytes)", file, count, bytes);
+                passed += 1;
             }
-        };
-
-        let canon = canonicalize::canonicalize_program(
-            &program,
-            resolved.modules.iter().map(|(n, p, _, s)| (n.as_str(), p, *s)),
-        );
-        let mut checker = check::Checker::from_env(canon.env);
-        checker.set_source(test_file, &source_text);
-        checker.diagnostics = canon.diagnostics;
-        let diagnostics = checker.infer_program(&mut program);
-        if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
-            eprintln!("SKIP {} (type errors)", test_file);
-            skipped += 1;
-            continue;
-        }
-
-        for (name, _, pkg_id, _) in &resolved.modules {
-            if let Some(pid) = pkg_id.as_ref() {
-                let base = pid.mod_name();
-                let v = if let Some(suffix) = name.strip_prefix(&pid.name) { format!("{}{}", base, suffix) } else { base };
-                checker.env.module_versioned_names.insert(almide::intern::sym(name), almide::intern::sym(&v));
+            WasmTestOutcome::Fail { file, detail } => {
+                eprintln!("FAIL {}", file);
+                eprint!("{}", detail);
+                failed += 1;
             }
-        }
-        let mut ir_program = almide::lower::lower_program(&program, &checker.env, &checker.type_map);
-        for (name, mod_prog, pkg_id, _) in &mut resolved.modules {
-            if almide::stdlib::is_stdlib_module(name) && !almide::stdlib::is_bundled_module(name) { continue; }
-            let saved_self = checker.env.self_module_name;
-            if let Some(pid) = pkg_id.as_ref() {
-                checker.env.self_module_name = Some(almide::intern::sym(&pid.name));
-            }
-            checker.infer_module(mod_prog, name);
-            let versioned = pkg_id.as_ref().map(|pid| {
-                let base = pid.mod_name();
-                if let Some(suffix) = name.strip_prefix(&pid.name) { format!("{}{}", base, suffix) } else { base }
-            });
-            if let Some(ref v) = versioned {
-                checker.env.module_versioned_names.insert(almide::intern::sym(name), almide::intern::sym(v));
-            }
-            let self_name = checker.env.self_module_name.map(|s| s.to_string());
-            let import_table_name = self_name.as_deref().unwrap_or(name);
-            let (mod_table, _) = almide::import_table::build_import_table(mod_prog, Some(import_table_name), &checker.env.user_modules);
-            let saved_table = std::mem::replace(&mut checker.env.import_table, mod_table);
-            let mod_ir_module = almide::lower::lower_module(name, mod_prog, &checker.env, &checker.type_map, versioned);
-            checker.env.import_table = saved_table;
-            checker.env.self_module_name = saved_self;
-            ir_program.modules.push(mod_ir_module);
-        }
-        almide::ir_link::ir_link(&mut ir_program);
-        almide::optimize::optimize_program(&mut ir_program);
-        almide::mono::monomorphize(&mut ir_program);
-        let bytes = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            match almide::codegen::codegen(&mut ir_program, almide::codegen::pass::Target::Wasm) {
-                almide::codegen::CodegenOutput::Binary(b) => b,
-                almide::codegen::CodegenOutput::Source(_) => unreachable!(),
-            }
-        }));
-        let bytes = match bytes {
-            Ok(b) => b,
-            Err(_) => {
-                eprintln!("SKIP {} (WASM codegen panic)", test_file);
-                skipped += 1;
-                continue;
-            }
-        };
-
-        if let Err(e) = std::fs::write(&wasm_path, &bytes) {
-            eprintln!("SKIP {} (write: {})", test_file, e);
-            skipped += 1;
-            continue;
-        }
-
-        // Run with wasmtime (preopened root dir for full filesystem access)
-        let output = std::process::Command::new("wasmtime")
-            .arg("--dir=/")
-            .arg(wasm_path.to_str().unwrap())
-            .output();
-
-        match output {
-            Ok(result) => {
-                let stdout = String::from_utf8_lossy(&result.stdout);
-                let stderr = String::from_utf8_lossy(&result.stderr);
-
-                if result.status.success() {
-                    // Count tests from output
-                    let test_count = stdout.matches("ok\n").count();
-                    eprintln!("{}: {} tests passed ({} bytes)", test_file, test_count, bytes.len());
-                    passed += 1;
-                } else {
-                    // Find which test failed (last "test: NAME" before trap)
-                    let lines: Vec<&str> = stdout.lines().collect();
-                    let mut last_test = "";
-                    for line in &lines {
-                        if line.starts_with("test: ") {
-                            last_test = line;
-                        }
-                    }
-                    eprintln!("FAIL {}", test_file);
-                    if !last_test.is_empty() {
-                        eprintln!("  trapped at: {}", last_test);
-                    }
-                    if !stderr.is_empty() {
-                        // Show just the trap message, not the full stack trace
-                        for line in stderr.lines().take(2) {
-                            eprintln!("  {}", line);
-                        }
-                    }
-                    failed += 1;
-                }
-            }
-            Err(e) => {
-                eprintln!("SKIP {} (wasmtime: {})", test_file, e);
+            WasmTestOutcome::Skip { file, reason } => {
+                eprintln!("SKIP {} ({})", file, reason);
                 skipped += 1;
             }
         }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -104,7 +104,12 @@ pub fn cmd_test(file: &str, no_check: bool, run_filter: Option<&str>) {
             let sem_tx = sem_tx.clone();
             handles.push(std::thread::spawn(move || {
                 let _ = sem_rx.lock().unwrap().recv();
-                let result = super::run::compile_to_binary(&test_file, no_check, true, false);
+                // Per-file scratch dir so cold rustc builds parallelize instead
+                // of serializing on the shared dir's BUILD_LOCK.
+                let worker_dir = std::env::temp_dir()
+                    .join("almide-test")
+                    .join(test_file.replace('/', "_").replace('.', "_"));
+                let result = super::run::compile_to_binary(&test_file, no_check, true, false, Some(&worker_dir));
                 let _ = sem_tx.send(());
                 let _ = tx.send((test_file, result));
             }));

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -182,11 +182,14 @@ enum WasmTestOutcome {
 fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> WasmTestOutcome {
     use crate::{parse_file, canonicalize, check, diagnostic, resolve, project, project_fetch};
     let skip = |reason: String| WasmTestOutcome::Skip { file: test_file.to_string(), reason };
+    let prof = std::env::var_os("ALMIDE_PROFILE").is_some();
+    let mut marks: Vec<(&str, std::time::Instant)> = vec![("start", std::time::Instant::now())];
 
     let wasm_name = test_file.replace('/', "_").replace('.', "_") + ".wasm";
     let wasm_path = tmp_dir.join(&wasm_name);
 
     let (mut program, source_text, _parse_errors) = parse_file(test_file);
+    if prof { marks.push(("parse", std::time::Instant::now())); }
     if source_text.lines().take(3).any(|line| line.contains("// wasm:skip")) {
         return skip("wasm:skip".to_string());
     }
@@ -206,6 +209,7 @@ fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> Wasm
         Ok(r) => r,
         Err(e) => return skip(format!("resolve: {}", e)),
     };
+    if prof { marks.push(("resolve", std::time::Instant::now())); }
 
     let canon = canonicalize::canonicalize_program(
         &program,
@@ -218,6 +222,7 @@ fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> Wasm
     if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
         return skip("type errors".to_string());
     }
+    if prof { marks.push(("check_user", std::time::Instant::now())); }
 
     for (name, _, pkg_id, _) in &resolved.modules {
         if let Some(pid) = pkg_id.as_ref() {
@@ -250,9 +255,11 @@ fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> Wasm
         checker.env.self_module_name = saved_self;
         ir_program.modules.push(mod_ir_module);
     }
+    if prof { marks.push(("lower_modules", std::time::Instant::now())); }
     almide::ir_link::ir_link(&mut ir_program);
     almide::optimize::optimize_program(&mut ir_program);
     almide::mono::monomorphize(&mut ir_program);
+    if prof { marks.push(("opt_mono", std::time::Instant::now())); }
     let bytes = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         match almide::codegen::codegen(&mut ir_program, almide::codegen::pass::Target::Wasm) {
             almide::codegen::CodegenOutput::Binary(b) => b,
@@ -263,6 +270,15 @@ fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> Wasm
         Ok(b) => b,
         Err(_) => return skip("WASM codegen panic".to_string()),
     };
+    if prof {
+        marks.push(("codegen", std::time::Instant::now()));
+        let total = marks.last().unwrap().1.duration_since(marks[0].1).as_secs_f64();
+        let mut line = format!("[prof] {} total={:.3}s", test_file, total);
+        for w in marks.windows(2) {
+            line.push_str(&format!(" | {}={:.3}", w[1].0, w[1].1.duration_since(w[0].1).as_secs_f64()));
+        }
+        eprintln!("{}", line);
+    }
     if let Err(e) = std::fs::write(&wasm_path, &bytes) {
         return skip(format!("write: {}", e));
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -423,6 +423,37 @@ fn cargo_build_test_with_native(
     if uses_zlib {
         all_deps.push(crate::project::NativeDep { name: "flate2".into(), spec: "1".into() });
     }
+
+    // Fast path: the generated test crate is dependency-free (the runtime is
+    // inlined as source). `cargo test --no-run` serializes concurrent builds on
+    // cargo's global `~/.cargo/.package-cache` lock — even across separate
+    // project dirs — so a parallel test run is effectively sequential. A bare
+    // `rustc --test` has no such lock, so per-file builds run truly in parallel.
+    if !uses_http && !uses_zlib && native_deps.is_empty() && source_root.is_none() {
+        let mut final_code = rs_code.to_string();
+        if !final_code.contains("fn main(") && !final_code.contains("fn almide_main(") {
+            final_code.push_str("\nfn main() {}\n");
+        }
+        let rs_path = project_dir.join("almide_test_main.rs");
+        std::fs::write(&rs_path, &final_code)
+            .map_err(|e| format!("failed to write {}: {}", rs_path.display(), e))?;
+        let bin_path = project_dir.join("almide_test_bin");
+        let output = std::process::Command::new(crate::find_rustc())
+            .arg(&rs_path)
+            .arg("--test")
+            .arg("-o").arg(&bin_path)
+            .arg("--edition").arg("2021")
+            .arg("-C").arg("opt-level=1")
+            .arg("-C").arg("overflow-checks=no")
+            .arg("-A").arg("warnings")
+            .output()
+            .map_err(|e| format!("failed to run rustc: {}", e))?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).to_string());
+        }
+        return Ok(bin_path);
+    }
+
     let cargo_toml = build_cargo_toml(base_toml, &all_deps);
     let src_dir = project_dir.join("src");
     std::fs::create_dir_all(&src_dir).map_err(|e| format!("failed to create {}: {}", src_dir.display(), e))?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,7 +19,7 @@ pub use build::cmd_build;
 pub use compile::cmd_compile;
 pub use emit::cmd_emit;
 pub use check::{cmd_check, cmd_check_json, cmd_check_effects};
-pub use commands::{cmd_init, cmd_test, cmd_test_json, cmd_test_wasm, cmd_test_ts, cmd_fmt, cmd_clean};
+pub use commands::{cmd_init, cmd_test, cmd_test_fast, cmd_test_json, cmd_test_wasm, cmd_test_ts, cmd_fmt, cmd_clean};
 pub use install::cmd_install;
 pub use selfupdate::cmd_self_update;
 pub use ide::{cmd_ide_outline, cmd_ide_doc, cmd_ide_stdlib_snapshot};

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -410,6 +410,65 @@ fn cargo_build_test(rs_code: &str, project_dir: &std::path::Path) -> Result<std:
     cargo_build_test_with_native(rs_code, project_dir, &[], None)
 }
 
+/// Path to the precompiled `almide_rt` runtime rlib, built once per process.
+///
+/// The runtime (string/list/map/... ops, RcCow, AlmideConcat, the equality
+/// macros) is identical across every compiled file, yet the inline-source model
+/// makes rustc recompile all ~2000 lines of it for each one (~2.2s/file). The
+/// rlib model — Rust's own — compiles it once into an `.rlib`; per-file rustc
+/// then just links it (~0.4s/file).
+///
+/// Keyed by a hash of the runtime source + rustc version + opt flags, so a
+/// compiler upgrade or a runtime edit transparently rebuilds. Cross-process
+/// builders serialize on a per-dir advisory lock; a warm cache is a stat.
+fn ensure_runtime_rlib() -> Result<std::path::PathBuf, String> {
+    static CACHED: std::sync::OnceLock<Result<std::path::PathBuf, String>> = std::sync::OnceLock::new();
+    CACHED.get_or_init(build_runtime_rlib).clone()
+}
+
+fn build_runtime_rlib() -> Result<std::path::PathBuf, String> {
+    let src = crate::codegen::emit_runtime_crate();
+    let rustc = crate::find_rustc();
+    let rustc_ver = std::process::Command::new(&rustc)
+        .arg("--version")
+        .output()
+        .ok()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    // opt/edition flags here MUST match the per-file rustc invocation below.
+    let key = format!("{:016x}", hash64(format!("{src}|{rustc_ver}|opt1|ed2021").as_bytes()));
+    let dir = std::env::temp_dir().join(format!("almide-rtlib-{key}"));
+    let rlib = dir.join("libalmide_rt.rlib");
+    if rlib.exists() {
+        return Ok(rlib);
+    }
+    std::fs::create_dir_all(&dir).map_err(|e| format!("rtlib dir: {e}"))?;
+    let _lock = run::BuildDirLock::acquire(&dir)?;
+    if rlib.exists() {
+        return Ok(rlib); // another builder won the race while we waited
+    }
+    let src_path = dir.join("almide_rt.rs");
+    std::fs::write(&src_path, &src).map_err(|e| format!("rtlib src: {e}"))?;
+    let output = std::process::Command::new(&rustc)
+        .arg(&src_path)
+        .arg("--crate-type").arg("lib")
+        .arg("--crate-name").arg("almide_rt")
+        .arg("--edition").arg("2021")
+        .arg("-C").arg("opt-level=1")
+        .arg("-C").arg("overflow-checks=no")
+        .arg("-A").arg("warnings")
+        .arg("--out-dir").arg(&dir)
+        .output()
+        .map_err(|e| format!("rtlib rustc: {e}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).to_string());
+    }
+    if !rlib.exists() {
+        return Err("rtlib build produced no .rlib".to_string());
+    }
+    Ok(rlib)
+}
+
 fn cargo_build_test_with_native(
     rs_code: &str,
     project_dir: &std::path::Path,
@@ -430,6 +489,50 @@ fn cargo_build_test_with_native(
     // project dirs — so a parallel test run is effectively sequential. A bare
     // `rustc --test` has no such lock, so per-file builds run truly in parallel.
     if !uses_http && !uses_zlib && native_deps.is_empty() && source_root.is_none() {
+        let bin_path = project_dir.join("almide_test_bin");
+
+        // rlib fast path: link the precompiled runtime instead of recompiling
+        // its ~2000 lines per file (~2.2s → ~0.4s). Any failure (e.g. a runtime
+        // vs. user type collision that only manifests cross-crate) falls through
+        // to the inline path below, so this never regresses correctness — at
+        // worst a file pays one extra rustc. Opt out with ALMIDE_NO_RTLIB=1.
+        if std::env::var_os("ALMIDE_NO_RTLIB").is_none() {
+            if let (Ok(rlib), Some(mut slim)) = (
+                ensure_runtime_rlib(),
+                crate::codegen::slim_main_with_external_runtime(rs_code),
+            ) {
+                if !slim.contains("fn main(") && !slim.contains("fn almide_main(") {
+                    slim.push_str("\nfn main() {}\n");
+                }
+                let rlib_dir = rlib.parent().unwrap_or_else(|| std::path::Path::new("."));
+                let rs_path = project_dir.join("almide_test_main.rs");
+                if std::fs::write(&rs_path, &slim).is_ok() {
+                    // opt-level=0 for the slim main: the runtime (the part that
+                    // benefits from optimization) is already compiled into the
+                    // rlib at opt-level=1, and test user code is short-lived, so
+                    // optimizing it just burns compile time. opt0 + rlib is ~2.7x
+                    // over the inline opt1 path; opt1 + rlib only ~1.6x.
+                    let output = std::process::Command::new(crate::find_rustc())
+                        .arg(&rs_path)
+                        .arg("--test")
+                        .arg("-o").arg(&bin_path)
+                        .arg("--edition").arg("2021")
+                        .arg("-C").arg("opt-level=0")
+                        .arg("-C").arg("overflow-checks=no")
+                        .arg("--extern").arg(format!("almide_rt={}", rlib.display()))
+                        .arg("-L").arg(rlib_dir)
+                        .arg("-A").arg("warnings")
+                        .output();
+                    if let Ok(output) = output {
+                        if output.status.success() {
+                            return Ok(bin_path);
+                        }
+                        // else: fall through to the self-contained inline build
+                    }
+                }
+            }
+        }
+
         let mut final_code = rs_code.to_string();
         if !final_code.contains("fn main(") && !final_code.contains("fn almide_main(") {
             final_code.push_str("\nfn main() {}\n");
@@ -437,7 +540,6 @@ fn cargo_build_test_with_native(
         let rs_path = project_dir.join("almide_test_main.rs");
         std::fs::write(&rs_path, &final_code)
             .map_err(|e| format!("failed to write {}: {}", rs_path.display(), e))?;
-        let bin_path = project_dir.join("almide_test_bin");
         let output = std::process::Command::new(crate::find_rustc())
             .arg(&rs_path)
             .arg("--test")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -327,6 +327,56 @@ fn cargo_build_generated_with_native(
     let uses_matrix = rs_code.contains("almide_rt_matrix_");
     let uses_http = rs_code.contains("almide_rt_http_") || rs_code.contains("use rustls");
     let uses_zlib = rs_code.contains("almide_rt_zlib_") || rs_code.contains("use flate2");
+
+    // rlib fast path (dep-free): link the precompiled runtime instead of
+    // recompiling its ~2000 lines per build. The runtime is compiled at the same
+    // opt-level as the binary (3 for `--release`, 1 for debug/`almide run`), so
+    // it is fully optimized; only its compilation is amortized. Net: shipping
+    // builds drop from ~27-33s to ~1-2s (~20x).
+    //
+    // Tradeoff: because the runtime is a separate crate (no LTO), non-generic
+    // non-#[inline] runtime fns (e.g. string.trim/split) aren't inlined across
+    // the crate boundary, costing up to ~10% runtime on string/list-heavy hot
+    // loops (typically 2-5%). ThinLTO would recover it but erases the build win
+    // (it re-optimizes the runtime at link time). The planned fix is #[inline] on
+    // the hot runtime fns — see docs/roadmap. ALMIDE_NO_RTLIB=1 forces the
+    // monolithic cargo build (full cross-crate inlining) when a shipped binary
+    // must squeeze out that last few percent. Any rustc failure also falls
+    // through to the cargo path below, so correctness never regresses.
+    if std::env::var_os("ALMIDE_NO_RTLIB").is_none()
+        && !uses_matrix && !uses_http && !uses_zlib
+        && native_deps.is_empty() && source_root.is_none()
+    {
+        let opt_level = if release { "3" } else { "1" };
+        if let (Ok(rlib), Some(mut slim)) = (
+            ensure_runtime_rlib(opt_level),
+            crate::codegen::slim_main_with_external_runtime(rs_code),
+        ) {
+            if !slim.contains("fn main(") && !slim.contains("fn almide_main(") {
+                slim.push_str("\nfn main() {}\n");
+            }
+            let rlib_dir = rlib.parent().unwrap_or_else(|| std::path::Path::new("."));
+            let rs_path = project_dir.join("almide_gen_main.rs");
+            let bin_path = project_dir.join(if cfg!(windows) { "almide-out.exe" } else { "almide-out" });
+            if std::fs::write(&rs_path, &slim).is_ok() {
+                let mut cmd = std::process::Command::new(crate::find_rustc());
+                cmd.arg(&rs_path)
+                    .arg("-o").arg(&bin_path)
+                    .arg("--edition").arg("2021")
+                    .arg("-C").arg(format!("opt-level={opt_level}"))
+                    .arg("--extern").arg(format!("almide_rt={}", rlib.display()))
+                    .arg("-L").arg(rlib_dir)
+                    .arg("-A").arg("warnings");
+                if let Ok(output) = cmd.output() {
+                    if output.status.success() {
+                        return Ok(bin_path);
+                    }
+                    // else: fall through to the self-contained cargo build
+                }
+            }
+        }
+    }
+
     let src_dir = project_dir.join("src");
     std::fs::create_dir_all(&src_dir).map_err(|e| format!("failed to create {}: {}", src_dir.display(), e))?;
 
@@ -418,15 +468,30 @@ fn cargo_build_test(rs_code: &str, project_dir: &std::path::Path) -> Result<std:
 /// rlib model — Rust's own — compiles it once into an `.rlib`; per-file rustc
 /// then just links it (~0.4s/file).
 ///
-/// Keyed by a hash of the runtime source + rustc version + opt flags, so a
+/// Keyed by a hash of the runtime source + rustc version + opt profile, so a
 /// compiler upgrade or a runtime edit transparently rebuilds. Cross-process
 /// builders serialize on a per-dir advisory lock; a warm cache is a stat.
-fn ensure_runtime_rlib() -> Result<std::path::PathBuf, String> {
-    static CACHED: std::sync::OnceLock<Result<std::path::PathBuf, String>> = std::sync::OnceLock::new();
-    CACHED.get_or_init(build_runtime_rlib).clone()
+///
+/// `opt_level` selects the optimization the runtime is compiled at: "1" for
+/// tests/debug (where runtime speed is irrelevant), "3" for release shipping
+/// (so the linked runtime keeps full optimization). Each level is cached
+/// separately and built at most once per process.
+fn ensure_runtime_rlib(opt_level: &str) -> Result<std::path::PathBuf, String> {
+    use std::sync::{Mutex, OnceLock};
+    static CACHE: OnceLock<Mutex<std::collections::HashMap<String, Result<std::path::PathBuf, String>>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+    {
+        let guard = cache.lock().unwrap();
+        if let Some(r) = guard.get(opt_level) {
+            return r.clone();
+        }
+    }
+    let result = build_runtime_rlib(opt_level);
+    cache.lock().unwrap().insert(opt_level.to_string(), result.clone());
+    result
 }
 
-fn build_runtime_rlib() -> Result<std::path::PathBuf, String> {
+fn build_runtime_rlib(opt_level: &str) -> Result<std::path::PathBuf, String> {
     let src = crate::codegen::emit_runtime_crate();
     let rustc = crate::find_rustc();
     let rustc_ver = std::process::Command::new(&rustc)
@@ -435,8 +500,8 @@ fn build_runtime_rlib() -> Result<std::path::PathBuf, String> {
         .ok()
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
         .unwrap_or_default();
-    // opt/edition flags here MUST match the per-file rustc invocation below.
-    let key = format!("{:016x}", hash64(format!("{src}|{rustc_ver}|opt1|ed2021").as_bytes()));
+    // The profile string here MUST match the per-file rustc invocation that links it.
+    let key = format!("{:016x}", hash64(format!("{src}|{rustc_ver}|opt{opt_level}|ed2021").as_bytes()));
     let dir = std::env::temp_dir().join(format!("almide-rtlib-{key}"));
     let rlib = dir.join("libalmide_rt.rlib");
     if rlib.exists() {
@@ -454,7 +519,7 @@ fn build_runtime_rlib() -> Result<std::path::PathBuf, String> {
         .arg("--crate-type").arg("lib")
         .arg("--crate-name").arg("almide_rt")
         .arg("--edition").arg("2021")
-        .arg("-C").arg("opt-level=1")
+        .arg("-C").arg(format!("opt-level={opt_level}"))
         .arg("-C").arg("overflow-checks=no")
         .arg("-A").arg("warnings")
         .arg("--out-dir").arg(&dir)
@@ -498,7 +563,7 @@ fn cargo_build_test_with_native(
         // worst a file pays one extra rustc. Opt out with ALMIDE_NO_RTLIB=1.
         if std::env::var_os("ALMIDE_NO_RTLIB").is_none() {
             if let (Ok(rlib), Some(mut slim)) = (
-                ensure_runtime_rlib(),
+                ensure_runtime_rlib("1"),
                 crate::codegen::slim_main_with_external_runtime(rs_code),
             ) {
                 if !slim.contains("fn main(") && !slim.contains("fn almide_main(") {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -61,14 +61,15 @@ impl BuildDirLock {
 
 /// Compile an .almd file to a native binary, returning the path to the executable.
 /// Uses incremental caching: if the generated Rust code hasn't changed, skips cargo build.
-pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: bool) -> Result<std::path::PathBuf, String> {
+pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: bool, project_dir_override: Option<&std::path::Path>) -> Result<std::path::PathBuf, String> {
     let rs_code = try_compile(file, no_check).map_err(|_| "compile failed".to_string())?;
 
-    // Default shared scratch dir. Tests set `ALMIDE_RUN_PROJECT_DIR` to a
-    // unique path so parallel `cargo test --all` can't race on the shared
-    // `src/main.rs` / `target/debug/` inside it.
-    let project_dir = std::env::var_os("ALMIDE_RUN_PROJECT_DIR")
-        .map(std::path::PathBuf::from)
+    // Scratch dir. A per-call `project_dir_override` (one dir per test file)
+    // gives each parallel worker its own `src/main.rs`, so cold rustc builds
+    // run truly in parallel instead of serializing on the shared dir's
+    // `BUILD_LOCK`. Otherwise: `ALMIDE_RUN_PROJECT_DIR`, else a shared default.
+    let project_dir = project_dir_override.map(std::path::PathBuf::from)
+        .or_else(|| std::env::var_os("ALMIDE_RUN_PROJECT_DIR").map(std::path::PathBuf::from))
         .unwrap_or_else(|| std::env::temp_dir().join("almide-run"));
     std::fs::create_dir_all(&project_dir)
         .map_err(|e| format!("Failed to create temp directory: {}", e))?;
@@ -120,7 +121,10 @@ pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: b
     // concurrent build could overwrite the generated binary between our build
     // and our copy-out.
     static BUILD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    let _guard = BUILD_LOCK.lock().unwrap();
+    // A unique per-call dir has its own src/main.rs, so the global mutex (which
+    // only exists to serialize the shared default dir) isn't needed — the
+    // per-dir flock still guards a separate process reusing the same dir.
+    let _guard = project_dir_override.is_none().then(|| BUILD_LOCK.lock().unwrap());
     let _flock = BuildDirLock::acquire(&project_dir)?;
 
     // Re-check the cache under the lock: another process/thread may have built
@@ -140,8 +144,17 @@ pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: b
 
     match result {
         Ok(built_path) => {
-            // Copy built binary to per-file cached path
-            let _ = std::fs::copy(&built_path, &bin_path);
+            // Copy built binary to per-file cached path. The bare-rustc fast
+            // path doesn't create a cargo `target/<profile>/` dir, so ensure
+            // bin_path's parent exists, and surface a copy failure instead of
+            // silently leaving bin_path missing (→ "Failed to execute" at run).
+            if let Some(parent) = bin_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            if let Err(e) = std::fs::copy(&built_path, &bin_path) {
+                return Err(format!("failed to stage built binary {} -> {}: {}",
+                    built_path.display(), bin_path.display(), e));
+            }
             let _ = std::fs::create_dir_all(&cache);
             let _ = std::fs::write(&hash_file, &code_hash);
             Ok(bin_path)
@@ -161,7 +174,7 @@ pub fn run_binary(bin: &std::path::Path, program_args: &[String]) -> i32 {
 }
 
 pub fn cmd_run_inner(file: &str, program_args: &[String], no_check: bool, test_mode: bool, release: bool) -> i32 {
-    match compile_to_binary(file, no_check, test_mode, release) {
+    match compile_to_binary(file, no_check, test_mode, release, None) {
         Ok(bin) => run_binary(&bin, program_args),
         Err(e) => {
             eprintln!("Compile error:\n{}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -627,8 +627,12 @@ fn dispatch(cli: Cli) {
                 cli::cmd_test_ts(file_str, run.as_deref());
             } else if json {
                 cli::cmd_test_json(file_str, run.as_deref());
-            } else {
+            } else if matches!(target.as_deref(), Some("rust" | "native")) {
+                // Explicit pure-native run (e.g. CI's "Test Rust" job).
                 cli::cmd_test(file_str, no_check, run.as_deref());
+            } else {
+                // Default: fast rustc-free WASM path, native fallback for gaps.
+                cli::cmd_test_fast(file_str, no_check, run.as_deref());
             }
         }
         Commands::Check { file, deny_warnings, json, explain, effects } => {

--- a/tests/snapshots/codegen_snapshot_test__effect_fn.snap
+++ b/tests/snapshots/codegen_snapshot_test__effect_fn.snap
@@ -102,6 +102,7 @@ pub fn almide_rt_int_from_uint16(n: u16) -> i64 { n as i64 }
 pub fn almide_rt_int_from_uint32(n: u32) -> i64 { n as i64 }
 pub fn almide_rt_int_from_uint64(n: u64) -> i64 { n as i64 }
 
+//__ALMIDE_RT_BOUNDARY__
 pub fn parse_int(s: &str) -> Result<i64, String> {
     Ok((almide_rt_int_parse(&*s))?)
 }

--- a/tests/snapshots/codegen_snapshot_test__list_filter.snap
+++ b/tests/snapshots/codegen_snapshot_test__list_filter.snap
@@ -226,6 +226,7 @@ pub fn almide_rt_list_binary_search(xs: &[i64], target: i64) -> Option<i64> {
     xs.binary_search(&target).ok().map(|i| i as i64)
 }
 
+//__ALMIDE_RT_BOUNDARY__
 pub fn positives(xs: Vec<i64>) -> Vec<i64> {
     almide_rt_list_filter(xs, move |x| (x > 0i64))
 }

--- a/tests/snapshots/codegen_snapshot_test__list_map.snap
+++ b/tests/snapshots/codegen_snapshot_test__list_map.snap
@@ -226,6 +226,7 @@ pub fn almide_rt_list_binary_search(xs: &[i64], target: i64) -> Option<i64> {
     xs.binary_search(&target).ok().map(|i| i as i64)
 }
 
+//__ALMIDE_RT_BOUNDARY__
 pub fn doubles(xs: Vec<i64>) -> Vec<i64> {
     almide_rt_list_map(xs, move |x| (x * 2i64))
 }

--- a/tests/snapshots/codegen_snapshot_test__pipe_chain.snap
+++ b/tests/snapshots/codegen_snapshot_test__pipe_chain.snap
@@ -226,6 +226,7 @@ pub fn almide_rt_list_binary_search(xs: &[i64], target: i64) -> Option<i64> {
     xs.binary_search(&target).ok().map(|i| i as i64)
 }
 
+//__ALMIDE_RT_BOUNDARY__
 pub fn process(xs: Vec<i64>) -> i64 {
     almide_rt_list_fold(almide_rt_list_filter(xs, move |x| (x > 0i64)), 0i64, move |acc, x| (acc + (x * 2i64)))
 }

--- a/tests/snapshots/codegen_snapshot_test__string_interp.snap
+++ b/tests/snapshots/codegen_snapshot_test__string_interp.snap
@@ -102,6 +102,7 @@ pub fn almide_rt_int_from_uint16(n: u16) -> i64 { n as i64 }
 pub fn almide_rt_int_from_uint32(n: u32) -> i64 { n as i64 }
 pub fn almide_rt_int_from_uint64(n: u64) -> i64 { n as i64 }
 
+//__ALMIDE_RT_BOUNDARY__
 pub fn describe(name: String, age: i64) -> String {
     format!("{} is {} years old", name, almide_rt_int_to_string(age))
 }


### PR DESCRIPTION
Go-like build speed for the dev/test/run loop and shipping builds. Seven commits, each a self-contained step.

## What changed

**Test loop (WASM-first + parallel)**
- `almide test` defaults to the rustc-free WASM path with native fallback; the WASM path is parallelized.
- Native path parallelized via per-file scratch dirs + a bare-rustc fast path (no cargo lock serialization).

**The big release lever**
- Gated the inter-pass IR verifier to debug/`ALMIDE_VERIFY_IR` — it was running after every nanopass over the full program in release (pure debug safety net). This is the dominant per-file codegen cost in debug; off in release.

**Precompiled runtime rlib**
- The `almide_rt` runtime (RcCow, AlmideConcat, eq macros, all std-only runtime modules) is compiled once into an `.rlib` (`codegen::emit_runtime_crate()`), cached by runtime-source + rustc-version + opt-level.
- Per-file/per-build rustc emits a slim main (`#[macro_use] extern crate almide_rt; use almide_rt::*;` + user code, split on `RT_BOUNDARY_MARKER`) and links the rlib.
- Wired into the test path (rlib opt1 + user code opt0) and the run/build path (opt-level matches the binary).
- `http`/`zlib`/`sse` (non-std deps) stay on the cargo path. Any failure falls back to the inline/cargo build; `ALMIDE_NO_RTLIB=1` disables it. Correctness never regresses.

## Measured (release binary)

| Path | Before | After | Speedup |
|---|---|---|---|
| Test, per file | 3.85s | 1.58s | 2.45x |
| `spec/lang` 116 files (CPU) | 141s | 45s | 3.1x |
| `almide build --release` (examples) | 27–33s | 1–2s | ~20x |

## Shipping-build tradeoff (chosen: speed-first, reversible)

The release rlib path runs no LTO, so non-generic non-`#[inline]` runtime fns (e.g. `string.trim/split`) aren't inlined across the crate boundary → up to ~10% slower shipped binary on string/list-heavy hot loops (typically 2–5%; measured on a 200k-row CSV). ThinLTO recovers it but erases the build win (re-optimizes the runtime at link time), so it's rejected. `ALMIDE_NO_RTLIB=1` forces the monolithic full-optimization build. The planned fix — `#[inline]` on the hot runtime fns to recover perf while keeping the ~20x — is documented in `docs/roadmap/active/build-speed-runtime-rlib.md`.

## Verification (local, release binary)

- `almide test spec/ --target rust`: **240/240 pass** (via rlib)
- `almide test examples/`: 11/11 pass
- `cargo test`: green (codegen snapshots updated for the boundary marker — diff is only the marker line)
- Shipping output verified byte-identical to the monolithic build