### PR TITLE
Merge develop to main: build-speed overhaul + WASM engine v2 progress

### DIFF
--- a/.github/workflows/ci-feature.yml
+++ b/.github/workflows/ci-feature.yml
@@ -44,10 +44,10 @@ jobs:
         run: cargo build --release
 
       - name: Cargo tests
-        # --test-threads=1: fix_test spawns `almide run` as a sub-process
-        # and relies on cargo's incremental build cache; parallel runs
-        # hit the known race and flake. Matches ci.yml.
-        run: cargo test -- --test-threads=1
+        # Parallel-safe on Unix: the shared build scratch dir is serialized
+        # across processes by an advisory flock (src/cli/run.rs BuildDirLock).
+        # This runner is ubuntu, so the lock applies. Matches ci.yml.
+        run: cargo test
 
       - name: Run exercises (Rust target)
         continue-on-error: true  # TODO: re-enable after stdlib reconnection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,11 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Cargo tests
-        # --test-threads=1: fix_test spawns `almide run` as a sub-process
-        # that shares `.almide/cache` and `/tmp/almide-run` across threads,
-        # racing on cached binaries. Fix tracked in
-        # docs/roadmap/active/cargo-test-cache-race.md; single-thread run
-        # is the temporary workaround until per-test cache dirs land.
-        run: cargo test -- --test-threads=1
+        # Parallel-safe: the shared build scratch dir (/tmp/almide-run,
+        # /tmp/almide-build) is serialized across processes by an advisory
+        # flock (see src/cli/run.rs BuildDirLock). Unix only — this runner
+        # is ubuntu, so the lock applies.
+        run: cargo test
 
       - name: Almide spec tests (Rust target)
         run: |
@@ -204,7 +203,9 @@ jobs:
         if: runner.os != 'Windows'
         run: curl https://wasmtime.dev/install.sh -sSf | bash && echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
 
-      # --test-threads=1: see note on the primary Test Rust job.
+      # Keep --test-threads=1 here: this matrix includes windows-latest,
+      # where the build-scratch flock is a no-op (#[cfg(unix)]), so parallel
+      # `almide` subprocesses could still race the shared scratch dir.
       - run: cargo test -- --test-threads=1
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Almide spec tests (Rust target)
         run: |
           ALMIDE=/tmp/almide-bin/almide
-          $ALMIDE test spec/
+          $ALMIDE test spec/ --target rust
 
       - name: Almide examples tests
         run: |
@@ -248,7 +248,7 @@ jobs:
         shell: bash
         run: |
           ALMIDE=${{ matrix.binary }}
-          $ALMIDE test spec/
+          $ALMIDE test spec/ --target rust
 
   # ═══════════════════════════════════════════════
   # Post-merge — trigger playground deploy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.23.11"
+version = "0.23.10"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.23.10"
+version = "0.23.11"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.23.10"
+version = "0.23.11"
 dependencies = [
  "almide-base",
  "almide-codegen",
@@ -35,6 +35,7 @@ dependencies = [
  "clap",
  "insta",
  "lasso",
+ "libc",
  "lsp-server",
  "lsp-types",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,12 @@ wasm-encoder = "0.225"
 lasso = { version = "0.7", features = ["multi-threaded"] }
 lsp-server = "0.7"
 lsp-types = "0.97"
+# Advisory cross-process file lock (flock) for the shared build scratch
+# dirs: serializes concurrent `almide run`/`build` invocations that share
+# /tmp/almide-run's single src/main.rs + target/. Already present in the
+# dependency tree transitively; used only under cfg(unix).
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 
 [dev-dependencies]

--- a/crates/almide-codegen/src/emit_wasm/engine/emit.rs
+++ b/crates/almide-codegen/src/emit_wasm/engine/emit.rs
@@ -123,8 +123,8 @@ pub fn emit_op(op: &Op, f: &mut Function, reg: &LayoutRegistry) {
         Op::Return => { f.instruction(&Return); }
         Op::Unreachable => { f.instruction(&Unreachable); }
 
-        Op::Call(idx) => { f.instruction(&Call(*idx)); }
-        Op::CallIndirect { sig } => {
+        Op::Call { idx, .. } => { f.instruction(&Call(*idx)); }
+        Op::CallIndirect { sig, .. } => {
             f.instruction(&CallIndirect { type_index: *sig, table_index: 0 });
         }
 

--- a/crates/almide-codegen/src/emit_wasm/engine/ir.rs
+++ b/crates/almide-codegen/src/emit_wasm/engine/ir.rs
@@ -188,8 +188,8 @@ pub enum Op {
     Unreachable,
 
     // ── Calls ──
-    Call(FuncIdx),
-    CallIndirect { sig: SigIdx },
+    Call { idx: FuncIdx, pops: u8, pushes: u8 },
+    CallIndirect { sig: SigIdx, pops: u8, pushes: u8 },
 
     // ── Memory ──
     MemoryCopy,
@@ -201,6 +201,218 @@ pub enum Op {
     Seq(Vec<Op>),
 }
 
+// ── Stack-effect verification ─────────────────────────────────────────
+
+/// Stack effect: how many values an op consumes and produces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StackEffect {
+    /// Normal op: pops N values, pushes M values.
+    Normal { pops: u8, pushes: u8 },
+    /// Divergent: unreachable after this (br, return, unreachable).
+    Divergent,
+    /// Compound: must verify children recursively (Block, Loop, If, Seq).
+    Compound,
+}
+
+impl Op {
+    /// Returns the stack effect of this op.
+    pub fn stack_effect(&self) -> StackEffect {
+        use StackEffect::*;
+        match self {
+            // ── Stack: push 1 ──
+            Op::LocalGet(_) | Op::GlobalGet(_) | Op::Const(_) | Op::MemorySize
+                => Normal { pops: 0, pushes: 1 },
+
+            // ── Stack: pop 1 ──
+            Op::LocalSet(_) | Op::GlobalSet(_) | Op::Drop
+                => Normal { pops: 1, pushes: 0 },
+
+            // ── Stack: pop 1, push 1 ──
+            Op::LocalTee(_) | Op::UnOp(_) | Op::Load(_) | Op::MemoryGrow
+                => Normal { pops: 1, pushes: 1 },
+
+            // ── Memory: pop 2, push 0 ──
+            Op::Store(_) | Op::FieldStore { .. }
+                => Normal { pops: 2, pushes: 0 },
+
+            // ── Arithmetic: pop 2, push 1 ──
+            Op::BinOp(_)
+                => Normal { pops: 2, pushes: 1 },
+
+            // ── Layout-safe memory: pop 1 (base), push 1 (value/addr) ──
+            Op::FieldLoad { .. } | Op::DynFieldAddr { .. }
+                => Normal { pops: 1, pushes: 1 },
+
+            // ── ElemAddr: pop 2 (base + index), push 1 (addr) ──
+            Op::ElemAddr { .. }
+                => Normal { pops: 2, pushes: 1 },
+
+            // ── Iteration: no net stack effect (uses locals) ──
+            Op::ListForEach { .. } | Op::MapForEach { .. }
+                => Compound,
+
+            // ── Abstract allocation: pop 1 (size), push 1 (ptr) ──
+            Op::Alloc => Normal { pops: 1, pushes: 1 },
+            Op::AllocCollection { .. } => Normal { pops: 0, pushes: 1 },
+
+            // ── Perceus RC: pop 1 (ptr) ──
+            Op::RcInc => Normal { pops: 1, pushes: 0 },
+            Op::RcDec { .. } => Normal { pops: 1, pushes: 0 },
+            Op::CowCheck { .. } => Compound,
+
+            // ── String ops ──
+            Op::StringConcat => Normal { pops: 2, pushes: 1 },
+            Op::StringInterp { parts } => {
+                let expr_count = parts.iter()
+                    .filter(|p| matches!(p, StringPart::Expr(_)))
+                    .count() as u8;
+                Normal { pops: expr_count, pushes: 1 }
+            }
+
+            // ── Deep equality: pop 2, push 1 (i32 bool) ──
+            Op::DeepEq { .. } => Normal { pops: 2, pushes: 1 },
+
+            // ── Control flow ──
+            Op::Block(_) | Op::Loop(_) | Op::Seq(_) => Compound,
+            Op::If { .. } => Compound,   // pops 1 (cond) + body effect
+            Op::IfVoid { .. } => Compound, // pops 1 (cond)
+            Op::BrIf(_) => Normal { pops: 1, pushes: 0 },
+            Op::Br(_) | Op::Return | Op::Unreachable => Divergent,
+
+            // ── Calls ──
+            Op::Call { pops, pushes, .. } | Op::CallIndirect { pops, pushes, .. }
+                => Normal { pops: *pops, pushes: *pushes },
+
+            // ── Memory bulk ──
+            Op::MemoryCopy => Normal { pops: 3, pushes: 0 },
+        }
+    }
+}
+
+/// Verify stack balance of a WasmIR function.
+///
+/// Returns Ok(()) if every block and the function body have correct
+/// stack balance. Returns Err with diagnostic on first violation.
+pub fn verify_func_stack(func: &WasmFunc) -> Result<(), String> {
+    let expected = func.results.len() as i32;
+    verify_ops(&func.body, expected, &func.name)
+}
+
+fn verify_ops(ops: &[Op], expected_net: i32, ctx: &str) -> Result<(), String> {
+    let mut depth: i32 = 0;
+
+    for (i, op) in ops.iter().enumerate() {
+        match op.stack_effect() {
+            StackEffect::Normal { pops, pushes } => {
+                depth -= pops as i32;
+                if depth < 0 {
+                    return Err(format!(
+                        "[StackVerify] {}: stack underflow at op #{} ({:?}), depth={}",
+                        ctx, i, op_name(op), depth,
+                    ));
+                }
+                depth += pushes as i32;
+            }
+            StackEffect::Divergent => {
+                // After divergent op, remaining ops in this sequence are unreachable.
+                // Stack balance is satisfied (divergent code can't violate it).
+                return Ok(());
+            }
+            StackEffect::Compound => {
+                verify_compound(op, &mut depth, ctx, i)?;
+            }
+        }
+    }
+
+    if depth != expected_net {
+        return Err(format!(
+            "[StackVerify] {}: stack imbalance — expected net {}, got {}",
+            ctx, expected_net, depth,
+        ));
+    }
+    Ok(())
+}
+
+fn verify_compound(op: &Op, depth: &mut i32, ctx: &str, idx: usize) -> Result<(), String> {
+    match op {
+        Op::Block(body) | Op::Loop(body) | Op::Seq(body) => {
+            // Block/Loop/Seq: body must have net 0 effect (no result type in current usage)
+            verify_ops(body, 0, ctx)?;
+        }
+        Op::If { then, else_ } => {
+            // Pops condition (i32)
+            *depth -= 1;
+            if *depth < 0 {
+                return Err(format!(
+                    "[StackVerify] {}: stack underflow at If condition, op #{}", ctx, idx,
+                ));
+            }
+            // Both branches must produce exactly 1 value (i32 result type)
+            verify_ops(then, 1, ctx)?;
+            verify_ops(else_, 1, ctx)?;
+            *depth += 1; // result
+        }
+        Op::IfVoid { then, else_ } => {
+            *depth -= 1;
+            if *depth < 0 {
+                return Err(format!(
+                    "[StackVerify] {}: stack underflow at IfVoid condition, op #{}", ctx, idx,
+                ));
+            }
+            verify_ops(then, 0, ctx)?;
+            if !else_.is_empty() {
+                verify_ops(else_, 0, ctx)?;
+            }
+        }
+        Op::ListForEach { body, .. } => {
+            // Body runs per element, must have net 0 effect
+            verify_ops(body, 0, ctx)?;
+        }
+        Op::MapForEach { body, .. } => {
+            verify_ops(body, 0, ctx)?;
+        }
+        Op::CowCheck { clone_body, .. } => {
+            // COW check: ptr on stack, if rc>1 run clone_body which must push 1 (new ptr)
+            // Net effect on outer stack: pop 1 (ptr), push 1 (ptr or clone)
+            *depth -= 1;
+            if *depth < 0 {
+                return Err(format!(
+                    "[StackVerify] {}: stack underflow at CowCheck, op #{}", ctx, idx,
+                ));
+            }
+            verify_ops(clone_body, 1, ctx)?;
+            *depth += 1;
+        }
+        _ => {} // non-compound ops handled by caller
+    }
+    Ok(())
+}
+
+fn op_name(op: &Op) -> &'static str {
+    match op {
+        Op::LocalGet(_) => "LocalGet", Op::LocalSet(_) => "LocalSet",
+        Op::LocalTee(_) => "LocalTee", Op::GlobalGet(_) => "GlobalGet",
+        Op::GlobalSet(_) => "GlobalSet", Op::Const(_) => "Const",
+        Op::Drop => "Drop", Op::BinOp(_) => "BinOp", Op::UnOp(_) => "UnOp",
+        Op::FieldLoad { .. } => "FieldLoad", Op::FieldStore { .. } => "FieldStore",
+        Op::ElemAddr { .. } => "ElemAddr", Op::Load(_) => "Load", Op::Store(_) => "Store",
+        Op::DynFieldAddr { .. } => "DynFieldAddr",
+        Op::ListForEach { .. } => "ListForEach", Op::MapForEach { .. } => "MapForEach",
+        Op::Alloc => "Alloc", Op::AllocCollection { .. } => "AllocCollection",
+        Op::RcInc => "RcInc", Op::RcDec { .. } => "RcDec",
+        Op::CowCheck { .. } => "CowCheck",
+        Op::StringConcat => "StringConcat", Op::StringInterp { .. } => "StringInterp",
+        Op::DeepEq { .. } => "DeepEq",
+        Op::Block(_) => "Block", Op::Loop(_) => "Loop",
+        Op::If { .. } => "If", Op::IfVoid { .. } => "IfVoid",
+        Op::Br(_) => "Br", Op::BrIf(_) => "BrIf",
+        Op::Return => "Return", Op::Unreachable => "Unreachable",
+        Op::Call { .. } => "Call", Op::CallIndirect { .. } => "CallIndirect",
+        Op::MemoryCopy => "MemoryCopy", Op::MemorySize => "MemorySize",
+        Op::MemoryGrow => "MemoryGrow", Op::Seq(_) => "Seq",
+    }
+}
+
 /// A compiled WASM function in WasmIR form.
 #[derive(Debug, Clone)]
 pub struct WasmFunc {
@@ -209,4 +421,118 @@ pub struct WasmFunc {
     pub results: Vec<WasmTy>,
     pub locals: Vec<WasmTy>,
     pub body: Vec<Op>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn void_func(body: Vec<Op>) -> WasmFunc {
+        WasmFunc { name: "test".into(), params: vec![], results: vec![], locals: vec![WasmTy::I32; 4], body }
+    }
+
+    fn i32_func(body: Vec<Op>) -> WasmFunc {
+        WasmFunc { name: "test".into(), params: vec![], results: vec![WasmTy::I32], locals: vec![WasmTy::I32; 4], body }
+    }
+
+    #[test]
+    fn empty_void_function_is_valid() {
+        assert!(verify_func_stack(&void_func(vec![])).is_ok());
+    }
+
+    #[test]
+    fn const_return_is_valid() {
+        let f = i32_func(vec![Op::Const(Const::I32(42))]);
+        assert!(verify_func_stack(&f).is_ok());
+    }
+
+    #[test]
+    fn missing_return_value_detected() {
+        let f = i32_func(vec![]); // needs 1 value but body is empty
+        assert!(verify_func_stack(&f).is_err());
+    }
+
+    #[test]
+    fn leftover_value_detected() {
+        let f = void_func(vec![Op::Const(Const::I32(1))]); // void fn but pushes 1
+        assert!(verify_func_stack(&f).is_err());
+    }
+
+    #[test]
+    fn stack_underflow_detected() {
+        let f = void_func(vec![Op::Drop]); // nothing to drop
+        assert!(verify_func_stack(&f).is_err());
+    }
+
+    #[test]
+    fn binop_balance() {
+        // Push 2, binop produces 1, total net = 1
+        let f = i32_func(vec![
+            Op::Const(Const::I32(1)),
+            Op::Const(Const::I32(2)),
+            Op::BinOp(BinOp::I32Add),
+        ]);
+        assert!(verify_func_stack(&f).is_ok());
+    }
+
+    #[test]
+    fn local_get_set_balance() {
+        let f = void_func(vec![
+            Op::Const(Const::I32(1)),
+            Op::LocalSet(0),
+        ]);
+        assert!(verify_func_stack(&f).is_ok());
+    }
+
+    #[test]
+    fn if_void_balance() {
+        let f = void_func(vec![
+            Op::Const(Const::I32(1)), // condition
+            Op::IfVoid { then: vec![], else_: vec![] },
+        ]);
+        assert!(verify_func_stack(&f).is_ok());
+    }
+
+    #[test]
+    fn if_result_balance() {
+        let f = i32_func(vec![
+            Op::Const(Const::I32(1)), // condition
+            Op::If {
+                then: vec![Op::Const(Const::I32(10))],
+                else_: vec![Op::Const(Const::I32(20))],
+            },
+        ]);
+        assert!(verify_func_stack(&f).is_ok());
+    }
+
+    #[test]
+    fn call_with_correct_effects() {
+        // Call pops 2, pushes 1 → net -1
+        let f = i32_func(vec![
+            Op::Const(Const::I32(1)),
+            Op::Const(Const::I32(2)),
+            Op::Call { idx: 0, pops: 2, pushes: 1 },
+        ]);
+        assert!(verify_func_stack(&f).is_ok());
+    }
+
+    #[test]
+    fn divergent_return_ok() {
+        // After Return, stack state doesn't matter
+        let f = void_func(vec![
+            Op::Return,
+        ]);
+        assert!(verify_func_stack(&f).is_ok());
+    }
+
+    #[test]
+    fn seq_flattened() {
+        let f = void_func(vec![
+            Op::Seq(vec![
+                Op::Const(Const::I32(1)),
+                Op::Drop,
+            ]),
+        ]);
+        assert!(verify_func_stack(&f).is_ok());
+    }
 }

--- a/crates/almide-codegen/src/emit_wasm/engine/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/engine/mod.rs
@@ -27,3 +27,4 @@ pub mod builder;
 
 pub use layout::LayoutRegistry;
 pub use builder::WasmBuilder;
+pub use ir::verify_func_stack;

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -148,11 +148,15 @@ impl<'a> Verified<'a> {
 
 pub fn codegen_with(program: &mut IrProgram, target: Target, options: &CodegenOptions) -> CodegenOutput {
     let config = target::configure(target);
+    let prof = std::env::var_os("ALMIDE_PROFILE").is_some();
+    let pt = std::time::Instant::now();
 
     // Layer 2: Run Nanopass pipeline (semantic rewrites — takes ownership, returns modified)
     let owned = std::mem::take(program);
     let transformed = config.pipeline.run(owned, target);
     *program = transformed;
+    if prof { eprintln!("[prof:codegen] pipeline={:.3}s", pt.elapsed().as_secs_f64()); }
+    let et = std::time::Instant::now();
 
     // Layer 3: Target-specific emit
     match target {
@@ -160,7 +164,9 @@ pub fn codegen_with(program: &mut IrProgram, target: Target, options: &CodegenOp
             // AlmidePerceusBelt: Verified::verify() runs Lean 4-certified
             // RC balance check. Only verified programs can reach WASM emit.
             let verified = Verified::verify(program);
-            CodegenOutput::Binary(emit_wasm::emit_verified(verified))
+            let out = emit_wasm::emit_verified(verified);
+            if prof { eprintln!("[prof:codegen] wasm_emit={:.3}s", et.elapsed().as_secs_f64()); }
+            CodegenOutput::Binary(out)
         }
         Target::Wgsl => CodegenOutput::Source(emit_wgsl::emit(program)),
         _ => CodegenOutput::Source(emit_source(program, target, &config, options)),

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -83,6 +83,28 @@ pub struct CodegenOptions {
     pub repr_c: bool,
 }
 
+/// Marker the Rust emitter inserts between the inlined runtime preamble and the
+/// user code. The rlib fast path splits generated source here: everything before
+/// is the runtime (provided instead by the precompiled `almide_rt` rlib), and
+/// everything after — the user code — is wrapped into a slim main that links it.
+pub const RT_BOUNDARY_MARKER: &str = "//__ALMIDE_RT_BOUNDARY__";
+
+/// Rebuild full generated Rust source into a slim main that links the `almide_rt`
+/// rlib instead of inlining the runtime. Splits on [`RT_BOUNDARY_MARKER`]: the
+/// user code (after the marker) is prefixed with the crate attrs, std imports, and
+/// `extern crate almide_rt`. Returns `None` if the marker is absent (e.g. the
+/// source predates this emitter or isn't a Rust target) so callers fall back.
+pub fn slim_main_with_external_runtime(full_rs: &str) -> Option<String> {
+    let idx = full_rs.find(RT_BOUNDARY_MARKER)?;
+    let user_code = full_rs[idx + RT_BOUNDARY_MARKER.len()..].trim_start_matches('\n');
+    let mut out = String::new();
+    out.push_str("#![allow(unused_parens, unused_variables, dead_code, unused_imports, unused_mut, unused_must_use)]\n\n");
+    out.push_str("use std::collections::HashMap;\nuse std::collections::HashSet;\n");
+    out.push_str("#[macro_use] extern crate almide_rt;\nuse almide_rt::*;\n\n");
+    out.push_str(user_code);
+    Some(out)
+}
+
 /// Strip `mod tests { ... }` blocks from runtime source (avoid conflicts with user tests)
 fn strip_test_blocks(src: &str) -> String {
     let mut out = String::new();
@@ -174,6 +196,178 @@ pub fn codegen_with(program: &mut IrProgram, target: Target, options: &CodegenOp
 }
 
 
+/// The fixed runtime prelude: AlmideConcat trait + impls, the almide_eq!/almide_ne!
+/// macros, and the RcCow<T> COW value type with its impls.
+///
+/// `for_crate` toggles between two emission modes:
+/// - `false` (inline): private items, plain `macro_rules!` — one self-contained main.rs.
+/// - `true` (rlib): `pub` items + `#[macro_export]` so a slim user main can link this
+///   as the `almide_rt` crate (`use almide_rt::*` + `#[macro_use] extern crate`).
+fn rust_runtime_prelude(for_crate: bool) -> String {
+    let vis = if for_crate { "pub " } else { "" };
+    let macro_attr = if for_crate { "#[macro_export]\n" } else { "" };
+    let mut s = String::new();
+    s.push_str(&format!("{vis}trait AlmideConcat<Rhs> {{ type Output; fn concat(self, rhs: Rhs) -> Self::Output; }}\n"));
+    s.push_str("impl AlmideConcat<String> for String { type Output = String; #[inline(always)] fn concat(self, rhs: String) -> String { format!(\"{}{}\", self, rhs) } }\n");
+    s.push_str("impl AlmideConcat<&str> for String { type Output = String; #[inline(always)] fn concat(self, rhs: &str) -> String { format!(\"{}{}\", self, rhs) } }\n");
+    s.push_str("impl AlmideConcat<String> for &str { type Output = String; #[inline(always)] fn concat(self, rhs: String) -> String { format!(\"{}{}\", self, rhs) } }\n");
+    s.push_str("impl AlmideConcat<&str> for &str { type Output = String; #[inline(always)] fn concat(self, rhs: &str) -> String { format!(\"{}{}\", self, rhs) } }\n");
+    s.push_str("impl<T: Clone> AlmideConcat<Vec<T>> for Vec<T> { type Output = Vec<T>; #[inline(always)] fn concat(self, rhs: Vec<T>) -> Vec<T> { let mut r = self; r.extend(rhs); r } }\n");
+    s.push_str(&format!("{macro_attr}macro_rules! almide_eq {{ ($a:expr, $b:expr) => {{ ($a) == ($b) }}; }}\n"));
+    s.push_str(&format!("{macro_attr}macro_rules! almide_ne {{ ($a:expr, $b:expr) => {{ ($a) != ($b) }}; }}\n"));
+    // RcCow<T>: COW value type. Clone = Rc::clone (O(1)), mutation = Rc::make_mut (COW).
+    // Inspired by Swift's value type semantics.
+    s.push_str(&format!("{vis}struct RcCow<T>({vis}std::rc::Rc<T>);\n"));
+    s.push_str("impl<T: std::fmt::Debug> std::fmt::Debug for RcCow<T> { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.0.fmt(f) } }\n");
+    s.push_str("impl<T: Clone> Clone for RcCow<T> { fn clone(&self) -> Self { RcCow(std::rc::Rc::clone(&self.0)) } }\n");
+    s.push_str("impl<T: PartialEq> PartialEq for RcCow<T> { fn eq(&self, other: &Self) -> bool { *self.0 == *other.0 } }\n");
+    s.push_str("impl<T: PartialEq> PartialEq<T> for RcCow<T> { fn eq(&self, other: &T) -> bool { *self.0 == *other } }\n");
+    s.push_str("impl PartialEq<&str> for RcCow<String> { fn eq(&self, other: &&str) -> bool { self.0.as_str() == *other } }\n");
+    s.push_str("impl<T> std::ops::Deref for RcCow<T> { type Target = T; fn deref(&self) -> &T { &self.0 } }\n");
+    s.push_str("impl<T: Clone> std::ops::DerefMut for RcCow<T> { fn deref_mut(&mut self) -> &mut T { std::rc::Rc::make_mut(&mut self.0) } }\n");
+    s.push_str(&format!("impl<T> RcCow<T> {{ {vis}fn new(v: T) -> Self {{ RcCow(std::rc::Rc::new(v)) }} {vis}fn make_mut(&mut self) -> &mut T where T: Clone {{ std::rc::Rc::make_mut(&mut self.0) }} {vis}fn into_inner(self) -> T where T: Clone {{ std::rc::Rc::try_unwrap(self.0).unwrap_or_else(|rc| (*rc).clone()) }} }}\n"));
+    s.push_str("impl<T> From<T> for RcCow<T> { fn from(v: T) -> Self { RcCow::new(v) } }\n");
+    s.push_str("impl<T: std::fmt::Display> std::fmt::Display for RcCow<T> { fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { self.0.fmt(f) } }\n");
+    s.push_str("impl<T: std::hash::Hash> std::hash::Hash for RcCow<T> { fn hash<H: std::hash::Hasher>(&self, state: &mut H) { self.0.hash(state) } }\n");
+    // Blanket AlmideConcat: RcCow<T> + Rhs and RcCow<T> + Val<U> — 2 impls cover all combos.
+    s.push_str("impl<T: Clone, Rhs> AlmideConcat<Rhs> for RcCow<T> where T: AlmideConcat<Rhs> { type Output = RcCow<<T as AlmideConcat<Rhs>>::Output>; #[inline(always)] fn concat(self, rhs: Rhs) -> Self::Output { RcCow::new((*self).clone().concat(rhs)) } }\n");
+    s
+}
+
+/// Resolve inter-module runtime dependencies into `needed` (auto-extracted from
+/// source by build.rs — no manual whitelist). Fixpoint over RUNTIME_DEPS.
+fn resolve_runtime_deps(needed: &mut std::collections::HashSet<&str>) {
+    let mut added = true;
+    while added {
+        added = false;
+        for (module, deps) in crate::generated::rust_runtime::RUNTIME_DEPS {
+            if needed.contains(module) {
+                for dep in *deps {
+                    if needed.insert(dep) { added = true; }
+                }
+            }
+        }
+    }
+}
+
+/// Collect the runtime module bodies for the `needed` set: hoist top-level `use`
+/// to the front, deduplicate, and skip struct definitions the walker already
+/// emitted (present in `user_code`) to avoid E0428. Returns the assembled block.
+fn rust_runtime_modules(needed: &std::collections::HashSet<&str>, user_code: &str) -> String {
+    let mut use_set = std::collections::HashSet::new();
+    let mut use_lines = Vec::new();
+    let mut body_lines = Vec::new();
+    for (name, source) in crate::generated::rust_runtime::RUST_RUNTIME_MODULES {
+        if needed.contains(name) {
+            let stripped = strip_test_blocks(source);
+            let lines: Vec<&str> = stripped.lines().collect();
+            let mut i = 0;
+            while i < lines.len() {
+                let line = lines[i];
+                let trimmed = line.trim();
+                // Top-level use: not indented and starts with "use "
+                if !line.starts_with(' ') && !line.starts_with('\t')
+                    && trimmed.starts_with("use ") && trimmed.ends_with(';')
+                {
+                    if use_set.insert(trimmed.to_string()) {
+                        use_lines.push(trimmed.to_string());
+                    }
+                    i += 1;
+                    continue;
+                }
+                // Detect struct definitions: #[derive(...)] followed by pub struct Name
+                // Skip the block if user_code already contains that struct (walker emitted it).
+                if trimmed.starts_with("#[derive(") {
+                    if let Some(next) = lines.get(i + 1) {
+                        if let Some(struct_name) = next.trim().strip_prefix("pub struct ")
+                            .and_then(|s| s.split_whitespace().next())
+                            .map(|s| s.trim_end_matches('{').trim())
+                        {
+                            let needle = format!("struct {}", struct_name);
+                            if user_code.contains(&needle) {
+                                // Skip derive + struct + fields + closing brace
+                                i += 1; // skip #[derive]
+                                let mut depth = 0u32;
+                                while i < lines.len() {
+                                    if lines[i].contains('{') { depth += 1; }
+                                    if lines[i].contains('}') {
+                                        depth = depth.saturating_sub(1);
+                                        if depth == 0 { i += 1; break; }
+                                    }
+                                    i += 1;
+                                }
+                                continue;
+                            }
+                        }
+                    }
+                }
+                body_lines.push(line.to_string());
+                i += 1;
+            }
+            body_lines.push(String::new());
+        }
+    }
+    // Remove single-item `use a::b::X;` when a group `use a::b::{..., X, ...};` exists
+    let use_lines: Vec<String> = use_lines.into_iter().filter(|line| {
+        // Parse: use path::Item;
+        if let Some(rest) = line.strip_prefix("use ").and_then(|s| s.strip_suffix(';')) {
+            if !rest.contains('{') {
+                if let Some(pos) = rest.rfind("::") {
+                    let prefix = &rest[..pos];
+                    let item = &rest[pos + 2..];
+                    // Check if any group import covers this item
+                    let dominated = use_set.iter().any(|other| {
+                        if let Some(orest) = other.strip_prefix("use ").and_then(|s| s.strip_suffix(';')) {
+                            if let Some(opos) = orest.find("::{") {
+                                let oprefix = &orest[..opos];
+                                if oprefix == prefix {
+                                    let items_str = &orest[opos + 3..orest.len() - 1]; // strip ::{ and }
+                                    return items_str.split(',').any(|i| i.trim() == item);
+                                }
+                            }
+                        }
+                        false
+                    });
+                    if dominated { return false; }
+                }
+            }
+        }
+        true
+    }).collect();
+    let mut out = String::new();
+    for u in &use_lines { out.push_str(u); out.push('\n'); }
+    for line in &body_lines { out.push_str(line); out.push('\n'); }
+    out
+}
+
+/// Runtime modules that cannot live in the bare-rustc `almide_rt` rlib: `http`
+/// needs rustls, `zlib` needs flate2, and `sse` calls into `http` for its
+/// streaming transport. Programs using these stay on the cargo path; the rlib
+/// fast path only covers std-only programs (a link error otherwise falls back).
+pub const NON_STD_RUNTIME_MODULES: &[&str] = &["http", "zlib", "sse"];
+
+/// Emit the full `almide_rt` runtime crate source: the prelude (pub items +
+/// exported macros) plus every std-only runtime module. Built once into an
+/// `.rlib` and linked by slim user mains (see `CodegenOptions::external_runtime`).
+///
+/// Deterministic — depends only on the embedded runtime sources and the compiler
+/// version, so callers can cache the resulting rlib keyed by a hash of this output.
+pub fn emit_runtime_crate() -> String {
+    let mut out = String::new();
+    out.push_str("#![allow(unused_parens, unused_variables, dead_code, unused_imports, unused_mut, unused_must_use, non_snake_case)]\n\n");
+    out.push_str("use std::collections::HashMap;\nuse std::collections::HashSet;\n\n");
+    out.push_str(&rust_runtime_prelude(true));
+    // Every std-only runtime module (exclude external-dep modules).
+    let mut needed: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for (name, _) in crate::generated::rust_runtime::RUST_RUNTIME_MODULES {
+        if !NON_STD_RUNTIME_MODULES.contains(name) {
+            needed.insert(*name);
+        }
+    }
+    out.push_str(&rust_runtime_modules(&needed, ""));
+    out
+}
+
 /// Emit source code for text targets (Rust, TypeScript, JavaScript).
 fn emit_source(program: &mut IrProgram, target: Target, config: &target::TargetConfig, options: &CodegenOptions) -> String {
     // Template-driven rendering (walker reads annotations, never checks types)
@@ -190,135 +384,21 @@ fn emit_source(program: &mut IrProgram, target: Target, config: &target::TargetC
         Target::Rust => {
             output.push_str("#![allow(unused_parens, unused_variables, dead_code, unused_imports, unused_mut, unused_must_use)]\n\n");
             output.push_str("use std::collections::HashMap;\nuse std::collections::HashSet;\n\n");
-            output.push_str("trait AlmideConcat<Rhs> { type Output; fn concat(self, rhs: Rhs) -> Self::Output; }\n");
-            output.push_str("impl AlmideConcat<String> for String { type Output = String; #[inline(always)] fn concat(self, rhs: String) -> String { format!(\"{}{}\", self, rhs) } }\n");
-            output.push_str("impl AlmideConcat<&str> for String { type Output = String; #[inline(always)] fn concat(self, rhs: &str) -> String { format!(\"{}{}\", self, rhs) } }\n");
-            output.push_str("impl AlmideConcat<String> for &str { type Output = String; #[inline(always)] fn concat(self, rhs: String) -> String { format!(\"{}{}\", self, rhs) } }\n");
-            output.push_str("impl AlmideConcat<&str> for &str { type Output = String; #[inline(always)] fn concat(self, rhs: &str) -> String { format!(\"{}{}\", self, rhs) } }\n");
-            output.push_str("impl<T: Clone> AlmideConcat<Vec<T>> for Vec<T> { type Output = Vec<T>; #[inline(always)] fn concat(self, rhs: Vec<T>) -> Vec<T> { let mut r = self; r.extend(rhs); r } }\n");
-            output.push_str("macro_rules! almide_eq { ($a:expr, $b:expr) => { ($a) == ($b) }; }\n");
-            output.push_str("macro_rules! almide_ne { ($a:expr, $b:expr) => { ($a) != ($b) }; }\n");
-            // RcCow<T>: COW value type. Clone = Rc::clone (O(1)), mutation = Rc::make_mut (COW).
-            // Inspired by Swift's value type semantics.
-            output.push_str("struct RcCow<T>(std::rc::Rc<T>);\n");
-            output.push_str("impl<T: std::fmt::Debug> std::fmt::Debug for RcCow<T> { fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { self.0.fmt(f) } }\n");
-            output.push_str("impl<T: Clone> Clone for RcCow<T> { fn clone(&self) -> Self { RcCow(std::rc::Rc::clone(&self.0)) } }\n");
-            output.push_str("impl<T: PartialEq> PartialEq for RcCow<T> { fn eq(&self, other: &Self) -> bool { *self.0 == *other.0 } }\n");
-            output.push_str("impl<T: PartialEq> PartialEq<T> for RcCow<T> { fn eq(&self, other: &T) -> bool { *self.0 == *other } }\n");
-            output.push_str("impl PartialEq<&str> for RcCow<String> { fn eq(&self, other: &&str) -> bool { self.0.as_str() == *other } }\n");
-            output.push_str("impl<T> std::ops::Deref for RcCow<T> { type Target = T; fn deref(&self) -> &T { &self.0 } }\n");
-            output.push_str("impl<T: Clone> std::ops::DerefMut for RcCow<T> { fn deref_mut(&mut self) -> &mut T { std::rc::Rc::make_mut(&mut self.0) } }\n");
-            output.push_str("impl<T> RcCow<T> { fn new(v: T) -> Self { RcCow(std::rc::Rc::new(v)) } fn make_mut(&mut self) -> &mut T where T: Clone { std::rc::Rc::make_mut(&mut self.0) } fn into_inner(self) -> T where T: Clone { std::rc::Rc::try_unwrap(self.0).unwrap_or_else(|rc| (*rc).clone()) } }\n");
-            output.push_str("impl<T> From<T> for RcCow<T> { fn from(v: T) -> Self { RcCow::new(v) } }\n");
-            output.push_str("impl<T: std::fmt::Display> std::fmt::Display for RcCow<T> { fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result { self.0.fmt(f) } }\n");
-            output.push_str("impl<T: std::hash::Hash> std::hash::Hash for RcCow<T> { fn hash<H: std::hash::Hasher>(&self, state: &mut H) { self.0.hash(state) } }\n");
-            // Blanket AlmideConcat: RcCow<T> + Rhs and RcCow<T> + Val<U> — 2 impls cover all combos.
-            output.push_str("impl<T: Clone, Rhs> AlmideConcat<Rhs> for RcCow<T> where T: AlmideConcat<Rhs> { type Output = RcCow<<T as AlmideConcat<Rhs>>::Output>; #[inline(always)] fn concat(self, rhs: Rhs) -> Self::Output { RcCow::new((*self).clone().concat(rhs)) } }\n");
-            // Include runtime modules referenced in the IR.
-            // The IrProgram tracks which stdlib modules are used across
-            // all functions and transitive dependencies — no text search.
+            output.push_str(&rust_runtime_prelude(false));
+            // Include runtime modules referenced in the IR. The IrProgram tracks
+            // which stdlib modules are used across all functions and transitive
+            // dependencies — no text search.
             let mut needed: std::collections::HashSet<&str> = std::collections::HashSet::new();
             for m in &program.used_stdlib_modules {
                 needed.insert(m.as_str());
             }
-            // Resolve inter-module runtime dependencies (auto-extracted
-            // from source by build.rs — no manual whitelist).
-            let mut added = true;
-            while added {
-                added = false;
-                for (module, deps) in crate::generated::rust_runtime::RUNTIME_DEPS {
-                    if needed.contains(module) {
-                        for dep in *deps {
-                            if needed.insert(dep) { added = true; }
-                        }
-                    }
-                }
-            }
-            // Collect runtime modules, hoist top-level `use` to front and deduplicate.
-            // Struct definitions in runtime sources that the walker already emitted
-            // (from stdlib/*.almd type declarations) are skipped to avoid E0428.
-            let mut use_set = std::collections::HashSet::new();
-            let mut use_lines = Vec::new();
-            let mut body_lines = Vec::new();
-            for (name, source) in crate::generated::rust_runtime::RUST_RUNTIME_MODULES {
-                if needed.contains(name) {
-                    let stripped = strip_test_blocks(source);
-                    let lines: Vec<&str> = stripped.lines().collect();
-                    let mut i = 0;
-                    while i < lines.len() {
-                        let line = lines[i];
-                        let trimmed = line.trim();
-                        // Top-level use: not indented and starts with "use "
-                        if !line.starts_with(' ') && !line.starts_with('\t')
-                            && trimmed.starts_with("use ") && trimmed.ends_with(';')
-                        {
-                            if use_set.insert(trimmed.to_string()) {
-                                use_lines.push(trimmed.to_string());
-                            }
-                            i += 1;
-                            continue;
-                        }
-                        // Detect struct definitions: #[derive(...)] followed by pub struct Name
-                        // Skip the block if user_code already contains that struct (walker emitted it).
-                        if trimmed.starts_with("#[derive(") {
-                            if let Some(next) = lines.get(i + 1) {
-                                if let Some(struct_name) = next.trim().strip_prefix("pub struct ")
-                                    .and_then(|s| s.split_whitespace().next())
-                                    .map(|s| s.trim_end_matches('{').trim())
-                                {
-                                    let needle = format!("struct {}", struct_name);
-                                    if user_code.contains(&needle) {
-                                        // Skip derive + struct + fields + closing brace
-                                        i += 1; // skip #[derive]
-                                        let mut depth = 0u32;
-                                        while i < lines.len() {
-                                            if lines[i].contains('{') { depth += 1; }
-                                            if lines[i].contains('}') {
-                                                depth = depth.saturating_sub(1);
-                                                if depth == 0 { i += 1; break; }
-                                            }
-                                            i += 1;
-                                        }
-                                        continue;
-                                    }
-                                }
-                            }
-                        }
-                        body_lines.push(line.to_string());
-                        i += 1;
-                    }
-                    body_lines.push(String::new());
-                }
-            }
-            // Remove single-item `use a::b::X;` when a group `use a::b::{..., X, ...};` exists
-            let use_lines: Vec<String> = use_lines.into_iter().filter(|line| {
-                // Parse: use path::Item;
-                if let Some(rest) = line.strip_prefix("use ").and_then(|s| s.strip_suffix(';')) {
-                    if !rest.contains('{') {
-                        if let Some(pos) = rest.rfind("::") {
-                            let prefix = &rest[..pos];
-                            let item = &rest[pos + 2..];
-                            // Check if any group import covers this item
-                            let dominated = use_set.iter().any(|other| {
-                                if let Some(orest) = other.strip_prefix("use ").and_then(|s| s.strip_suffix(';')) {
-                                    if let Some(opos) = orest.find("::{") {
-                                        let oprefix = &orest[..opos];
-                                        if oprefix == prefix {
-                                            let items_str = &orest[opos + 3..orest.len() - 1]; // strip ::{ and }
-                                            return items_str.split(',').any(|i| i.trim() == item);
-                                        }
-                                    }
-                                }
-                                false
-                            });
-                            if dominated { return false; }
-                        }
-                    }
-                }
-                true
-            }).collect();
-            for u in &use_lines { output.push_str(u); output.push('\n'); }
-            for line in &body_lines { output.push_str(line); output.push('\n'); }
+            resolve_runtime_deps(&mut needed);
+            output.push_str(&rust_runtime_modules(&needed, &user_code));
+            // Boundary marker: everything above is the inlined runtime preamble,
+            // everything below is user code. The rlib fast path (see CLI) splits
+            // here to swap the preamble for `extern crate almide_rt`.
+            output.push_str(RT_BOUNDARY_MARKER);
+            output.push('\n');
         }
         _ => {}
     }

--- a/crates/almide-codegen/src/pass.rs
+++ b/crates/almide-codegen/src/pass.rs
@@ -246,6 +246,13 @@ impl Pipeline {
         // `ALMIDE_VERIFY_IR` used to gate this — removed in S2 flip
         // (v0.14.7-phase3.2); `expr.ty` is now trustworthy by contract.
         let hard_fail = cfg!(debug_assertions);
+        // The inter-pass IR verifier + postcondition checks walk the entire
+        // (merged) program after EVERY pass. That's a developer safety net —
+        // it catches compiler bugs but does nothing for a correct build. In
+        // release it can't even fail hard, yet it dominates codegen time
+        // (~1.2s/file: 20 passes × verify(user + all merged stdlib functions)).
+        // Run it only in debug (cargo test / CI) or when explicitly requested.
+        let verify_ir = hard_fail || std::env::var_os("ALMIDE_VERIFY_IR").is_some();
 
         for pass in &self.passes {
             // Skip passes not relevant to this target
@@ -266,7 +273,12 @@ impl Pipeline {
             }
 
             let pass_name = pass.name();
+            let _pass_t = std::time::Instant::now();
             let result = pass.run(program, target);
+            if std::env::var_os("ALMIDE_PROFILE").is_some() {
+                let dt = _pass_t.elapsed().as_secs_f64();
+                if dt > 0.01 { eprintln!("[prof:pass] {:30} {:.3}s", pass_name, dt); }
+            }
             program = result.program;
 
             // IR dump (opt-in via ALMIDE_DUMP_IR=all or ALMIDE_DUMP_IR=pass1,pass2)
@@ -283,27 +295,29 @@ impl Pipeline {
                 eprintln!("── end {} ──\n", pass_name);
             }
 
-            // Inter-pass IR verification — always on.
-            let errors = almide_ir::verify_program(&program);
-            if !errors.is_empty() {
-                eprintln!("[IR CHECK] {} error(s) after pass '{}':", errors.len(), pass_name);
-                for e in &errors {
-                    eprintln!("  {}", e);
+            // Inter-pass IR verification (debug / opt-in only — see verify_ir).
+            if verify_ir {
+                let errors = almide_ir::verify_program(&program);
+                if !errors.is_empty() {
+                    eprintln!("[IR CHECK] {} error(s) after pass '{}':", errors.len(), pass_name);
+                    for e in &errors {
+                        eprintln!("  {}", e);
+                    }
+                    if hard_fail {
+                        panic!("IR verification failed after pass '{}'", pass_name);
+                    }
                 }
-                if hard_fail {
-                    panic!("IR verification failed after pass '{}'", pass_name);
-                }
-            }
 
-            // Postcondition verification — always on.
-            let postconds = pass.postconditions();
-            if !postconds.is_empty() {
-                let violations = verify_postconditions(pass_name, &program, &postconds);
-                for v in &violations {
-                    eprintln!("[POSTCONDITION VIOLATION] {}", v);
-                }
-                if !violations.is_empty() && hard_fail {
-                    panic!("Postcondition violation after pass '{}'", pass_name);
+                // Postcondition verification.
+                let postconds = pass.postconditions();
+                if !postconds.is_empty() {
+                    let violations = verify_postconditions(pass_name, &program, &postconds);
+                    for v in &violations {
+                        eprintln!("[POSTCONDITION VIOLATION] {}", v);
+                    }
+                    if !violations.is_empty() && hard_fail {
+                        panic!("Postcondition violation after pass '{}'", pass_name);
+                    }
                 }
             }
 

--- a/crates/almide-codegen/src/pass_anf.rs
+++ b/crates/almide-codegen/src/pass_anf.rs
@@ -13,23 +13,50 @@
 //! IS a VDecl, closing the gap between the proof and the implementation.
 
 use almide_ir::*;
+use almide_ir::visit::{IrVisitor, walk_expr};
 use almide_lang::types::Ty;
-use super::pass::{NanoPass, PassResult, Target};
+use super::pass::{NanoPass, Postcondition, PassResult, Target};
 
 fn is_heap_type(ty: &Ty) -> bool {
     matches!(ty, Ty::String | Ty::Applied(_, _) | Ty::Record { .. } | Ty::Unknown | Ty::Fn { .. })
 }
 
 /// Does this expression produce a new heap allocation that should be lifted?
+///
+/// Inverted logic: any heap-typed expression that is NOT a simple value
+/// reference needs lifting. This way new IrExprKind variants are lifted
+/// by default (safe), rather than silently leaking (unsafe).
 fn needs_lift(expr: &IrExpr) -> bool {
     if !is_heap_type(&expr.ty) { return false; }
-    matches!(&expr.kind,
-        IrExprKind::Call { .. }
-        | IrExprKind::RuntimeCall { .. }
-        | IrExprKind::BinOp { .. }
-        | IrExprKind::If { .. }
-        | IrExprKind::Match { .. }
-        | IrExprKind::Block { .. }
+    // Expressions that don't produce NEW heap allocations never need lifting.
+    // Two categories:
+    //   1. Simple values: literals, variable references
+    //   2. Read operations: field/index access borrows from parent object,
+    //      whose lifetime Perceus already tracks
+    !matches!(&expr.kind,
+        // Category 1: simple values / references
+        IrExprKind::Var { .. }
+        | IrExprKind::EnvLoad { .. }
+        | IrExprKind::FnRef { .. }
+        | IrExprKind::LitInt { .. }
+        | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitBool { .. }
+        | IrExprKind::LitStr { .. }
+        | IrExprKind::Unit
+        | IrExprKind::OptionNone
+        | IrExprKind::EmptyMap
+        | IrExprKind::Hole
+        | IrExprKind::Todo { .. }
+        | IrExprKind::Break
+        | IrExprKind::Continue
+        // Category 2: read operations (borrow from parent, no new alloc)
+        | IrExprKind::Member { .. }
+        | IrExprKind::TupleIndex { .. }
+        | IrExprKind::IndexAccess { .. }
+        | IrExprKind::MapAccess { .. }
+        | IrExprKind::UnOp { .. }
+        | IrExprKind::Deref { .. }
+        | IrExprKind::Borrow { .. }
     )
 }
 
@@ -120,6 +147,59 @@ fn anf_expr(expr: &mut IrExpr, var_table: &mut VarTable, counter: &mut u32) {
             }
         }
         IrExprKind::Lambda { body, .. } => { anf_expr(body, var_table, counter); }
+
+        // Compound expressions with sub-expressions: recurse into children
+        IrExprKind::List { elements } | IrExprKind::Tuple { elements } | IrExprKind::Fan { exprs: elements } => {
+            for elem in elements.iter_mut() { anf_expr(elem, var_table, counter); }
+        }
+        IrExprKind::Record { fields, .. } => {
+            for (_, val) in fields.iter_mut() { anf_expr(val, var_table, counter); }
+        }
+        IrExprKind::SpreadRecord { base, fields } => {
+            anf_expr(base, var_table, counter);
+            for (_, val) in fields.iter_mut() { anf_expr(val, var_table, counter); }
+        }
+        IrExprKind::MapLiteral { entries } => {
+            for (k, v) in entries.iter_mut() {
+                anf_expr(k, var_table, counter);
+                anf_expr(v, var_table, counter);
+            }
+        }
+        IrExprKind::StringInterp { parts } => {
+            for part in parts.iter_mut() {
+                if let IrStringPart::Expr { expr: e } = part { anf_expr(e, var_table, counter); }
+            }
+        }
+        IrExprKind::OptionSome { expr: inner }
+        | IrExprKind::ResultOk { expr: inner }
+        | IrExprKind::ResultErr { expr: inner }
+        | IrExprKind::Unwrap { expr: inner }
+        | IrExprKind::Try { expr: inner }
+        | IrExprKind::ToOption { expr: inner }
+        | IrExprKind::Clone { expr: inner }
+        | IrExprKind::Deref { expr: inner }
+        | IrExprKind::ToVec { expr: inner }
+        | IrExprKind::BoxNew { expr: inner } => {
+            anf_expr(inner, var_table, counter);
+        }
+        IrExprKind::UnwrapOr { expr: inner, fallback } => {
+            anf_expr(inner, var_table, counter);
+            anf_expr(fallback, var_table, counter);
+        }
+        IrExprKind::Range { start, end, .. } => {
+            anf_expr(start, var_table, counter);
+            anf_expr(end, var_table, counter);
+        }
+        IrExprKind::Member { object, .. }
+        | IrExprKind::TupleIndex { object, .. }
+        | IrExprKind::OptionalChain { expr: object, .. } => {
+            anf_expr(object, var_table, counter);
+        }
+        IrExprKind::IndexAccess { object, index } | IrExprKind::MapAccess { object, key: index } => {
+            anf_expr(object, var_table, counter);
+            anf_expr(index, var_table, counter);
+        }
+
         _ => {
             // For Call, RuntimeCall, BinOp: lift heap sub-args
             anf_lift_children(expr, var_table, counter);
@@ -176,6 +256,10 @@ impl NanoPass for AnfPass {
     fn name(&self) -> &str { "ANF" }
     fn targets(&self) -> Option<Vec<Target>> { Some(vec![Target::Wasm]) }
 
+    fn postconditions(&self) -> Vec<Postcondition> {
+        vec![Postcondition::Custom(verify_anf_args_lifted)]
+    }
+
     fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
         let mut counter = 0u32;
         for func in &mut program.functions {
@@ -189,4 +273,89 @@ impl NanoPass for AnfPass {
         }
         PassResult { program, changed: counter > 0 }
     }
+}
+
+// ── Postcondition: verify all heap-typed args are Var after ANF ──────
+
+fn expr_kind_name(kind: &IrExprKind) -> &'static str {
+    match kind {
+        IrExprKind::Var { .. } => "Var",
+        IrExprKind::LitInt { .. } => "LitInt",
+        IrExprKind::LitFloat { .. } => "LitFloat",
+        IrExprKind::LitBool { .. } => "LitBool",
+        IrExprKind::LitStr { .. } => "LitStr",
+        IrExprKind::Unit => "Unit",
+        IrExprKind::Call { .. } => "Call",
+        IrExprKind::RuntimeCall { .. } => "RuntimeCall",
+        IrExprKind::BinOp { .. } => "BinOp",
+        IrExprKind::UnOp { .. } => "UnOp",
+        IrExprKind::If { .. } => "If",
+        IrExprKind::Match { .. } => "Match",
+        IrExprKind::Block { .. } => "Block",
+        IrExprKind::Lambda { .. } => "Lambda",
+        IrExprKind::List { .. } => "List",
+        IrExprKind::Tuple { .. } => "Tuple",
+        IrExprKind::Record { .. } => "Record",
+        IrExprKind::MapLiteral { .. } => "MapLiteral",
+        IrExprKind::StringInterp { .. } => "StringInterp",
+        IrExprKind::ClosureCreate { .. } => "ClosureCreate",
+        IrExprKind::EnvLoad { .. } => "EnvLoad",
+        IrExprKind::Member { .. } => "Member",
+        IrExprKind::IndexAccess { .. } => "IndexAccess",
+        IrExprKind::OptionSome { .. } => "OptionSome",
+        IrExprKind::ResultOk { .. } => "ResultOk",
+        IrExprKind::ResultErr { .. } => "ResultErr",
+        IrExprKind::Fan { .. } => "Fan",
+        IrExprKind::ForIn { .. } => "ForIn",
+        IrExprKind::While { .. } => "While",
+        IrExprKind::Range { .. } => "Range",
+        _ => "Other",
+    }
+}
+
+fn verify_anf_args_lifted(program: &IrProgram) -> Vec<String> {
+    let mut violations = Vec::new();
+    struct Checker<'a> { violations: &'a mut Vec<String>, func_name: String }
+
+    impl<'a> IrVisitor for Checker<'a> {
+        fn visit_expr(&mut self, expr: &IrExpr) {
+            match &expr.kind {
+                IrExprKind::Call { args, .. } | IrExprKind::RuntimeCall { args, .. } => {
+                    for arg in args {
+                        if needs_lift(arg) {
+                            self.violations.push(format!(
+                                "[ANF] in {}: heap-typed call arg not lifted — kind={}, ty={:?}",
+                                self.func_name, expr_kind_name(&arg.kind), arg.ty,
+                            ));
+                        }
+                    }
+                }
+                IrExprKind::BinOp { left, right, .. } => {
+                    for arg in [left.as_ref(), right.as_ref()] {
+                        if needs_lift(arg) {
+                            self.violations.push(format!(
+                                "[ANF] in {}: heap-typed binop operand not lifted — kind={}, ty={:?}",
+                                self.func_name, expr_kind_name(&arg.kind), arg.ty,
+                            ));
+                        }
+                    }
+                }
+                _ => {}
+            }
+            walk_expr(self, expr);
+        }
+    }
+
+    for func in &program.functions {
+        if func.is_test { continue; }
+        let mut checker = Checker { violations: &mut violations, func_name: func.name.as_str().to_string() };
+        checker.visit_expr(&func.body);
+    }
+    for module in &program.modules {
+        for func in &module.functions {
+            let mut checker = Checker { violations: &mut violations, func_name: func.name.as_str().to_string() };
+            checker.visit_expr(&func.body);
+        }
+    }
+    violations
 }

--- a/crates/almide-codegen/src/pass_anf.rs
+++ b/crates/almide-codegen/src/pass_anf.rs
@@ -57,6 +57,13 @@ fn needs_lift(expr: &IrExpr) -> bool {
         | IrExprKind::UnOp { .. }
         | IrExprKind::Deref { .. }
         | IrExprKind::Borrow { .. }
+        // Lambdas / closures must NOT be lifted: they must stay in
+        // argument position so the WASM closure-table pre-scan and
+        // HOF emission can see them. (Regression guard for 5cae928d:
+        // deny-list inversion swept in Fn-typed exprs that were never
+        // lifted by the prior allow-list.)
+        | IrExprKind::Lambda { .. }
+        | IrExprKind::ClosureCreate { .. }
     )
 }
 

--- a/crates/almide-codegen/src/pass_closure_conversion.rs
+++ b/crates/almide-codegen/src/pass_closure_conversion.rs
@@ -17,7 +17,7 @@ use almide_ir::*;
 use almide_ir::visit::{IrVisitor, walk_expr, walk_stmt};
 use almide_lang::types::Ty;
 use almide_base::intern::sym;
-use super::pass::{NanoPass, PassResult, Target};
+use super::pass::{NanoPass, Postcondition, PassResult, Target};
 
 #[derive(Debug)]
 pub struct ClosureConversionPass;
@@ -30,6 +30,10 @@ impl NanoPass for ClosureConversionPass {
     }
 
     fn depends_on(&self) -> Vec<&'static str> { vec!["LambdaTypeResolve"] }
+
+    fn postconditions(&self) -> Vec<Postcondition> {
+        vec![Postcondition::Custom(verify_env_load_indices)]
+    }
 
     fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
         let mut program_lifted = Vec::new();
@@ -578,4 +582,67 @@ impl<'a> IrMutVisitor for VarIdRewriter<'a> {
 fn rewrite_var_ids(expr: &mut IrExpr, mappings: &[(VarId, VarId, Ty)]) {
     let mut rewriter = VarIdRewriter { mappings };
     rewriter.visit_expr_mut(expr);
+}
+
+// ── Postcondition: verify EnvLoad indices are within bounds ──────────
+
+fn verify_env_load_indices(program: &IrProgram) -> Vec<String> {
+    let mut violations = Vec::new();
+
+    let check_funcs = |funcs: &[IrFunction], violations: &mut Vec<String>| {
+        for func in funcs {
+            // Lifted closures have __env as first param and ClosureCreate captures
+            // tell us the env size. But we can also verify structurally: collect
+            // the max EnvLoad index in each function and ensure it's consistent
+            // with the number of __cap_N bindings in the prologue.
+            let cap_count = count_cap_bindings(&func.body);
+            if cap_count == 0 { continue; }
+
+            let max_index = max_env_load_index(&func.body);
+            if let Some(max_idx) = max_index {
+                if max_idx >= cap_count as u32 {
+                    violations.push(format!(
+                        "[ClosureConversion] in {}: EnvLoad index {} >= cap_count {} (offset would be {})",
+                        func.name.as_str(), max_idx, cap_count, max_idx * 8,
+                    ));
+                }
+            }
+        }
+    };
+
+    check_funcs(&program.functions, &mut violations);
+    for module in &program.modules {
+        check_funcs(&module.functions, &mut violations);
+    }
+    violations
+}
+
+fn count_cap_bindings(expr: &IrExpr) -> usize {
+    // Count __cap_N let bindings in the top-level block prologue
+    if let IrExprKind::Block { stmts, .. } = &expr.kind {
+        stmts.iter().filter(|s| {
+            if let IrStmtKind::Bind { value, .. } = &s.kind {
+                matches!(&value.kind, IrExprKind::EnvLoad { .. })
+            } else {
+                false
+            }
+        }).count()
+    } else {
+        0
+    }
+}
+
+fn max_env_load_index(expr: &IrExpr) -> Option<u32> {
+    struct MaxIdx(Option<u32>);
+    impl IrVisitor for MaxIdx {
+        fn visit_expr(&mut self, expr: &IrExpr) {
+            if let IrExprKind::EnvLoad { index, .. } = &expr.kind {
+                self.0 = Some(self.0.map_or(*index, |m| m.max(*index)));
+            }
+            walk_expr(self, expr);
+        }
+    }
+    let mut finder = MaxIdx(None);
+    finder.visit_expr(expr);
+    finder.0
 }

--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -1019,6 +1019,36 @@ fn resolve_node_ty(expr: &IrExpr, vt: &VarTable, symbols: &SymbolTable) -> Optio
         IrExprKind::LitBool { .. } => Some(Ty::Bool),
         IrExprKind::LitStr { .. } => Some(Ty::String),
         IrExprKind::Unit => Some(Ty::Unit),
+        // StringInterp always produces String
+        IrExprKind::StringInterp { .. } => Some(Ty::String),
+        // Clone preserves the inner type
+        IrExprKind::Clone { expr } => {
+            if !expr.ty.has_unresolved_deep() { Some(expr.ty.clone()) } else { None }
+        }
+        // Range produces List[Int]
+        IrExprKind::Range { .. } => Some(Ty::Applied(
+            almide_lang::types::constructor::TypeConstructorId::List, vec![Ty::Int],
+        )),
+        // MapAccess: Map[K,V] → Option[V]
+        IrExprKind::MapAccess { object, .. } => {
+            let obj_ty = effective_ty(object, vt);
+            if let Ty::Applied(_, args) = &obj_ty {
+                args.get(1).cloned()
+                    .filter(|t| !t.has_unresolved_deep())
+                    .map(|v| Ty::Applied(
+                        almide_lang::types::constructor::TypeConstructorId::Option, vec![v],
+                    ))
+            } else { None }
+        }
+        // ResultOk wraps in Result[T, E]
+        IrExprKind::ResultOk { expr } => {
+            if !expr.ty.has_unresolved_deep() {
+                Some(Ty::Applied(
+                    almide_lang::types::constructor::TypeConstructorId::Result,
+                    vec![expr.ty.clone(), Ty::String],
+                ))
+            } else { None }
+        }
         IrExprKind::Call { target, args, .. } => resolve_call_ret_ty(target, args, vt, symbols),
         IrExprKind::RuntimeCall { symbol, args } => {
             // Post-IntrinsicLowering, the `Call { target: Module }` node

--- a/crates/almide-codegen/src/perceus_verified.rs
+++ b/crates/almide-codegen/src/perceus_verified.rs
@@ -238,6 +238,11 @@ mod proptest_lean_rust {
         prop_oneof![
             Just(Ty::String),
             Just(Ty::Unknown),
+            Just(Ty::Applied(
+                almide_lang::types::constructor::TypeConstructorId::List, vec![Ty::Int],
+            )),
+            Just(Ty::Record { fields: vec![(almide_base::intern::sym("x"), Ty::Int)] }),
+            Just(Ty::Fn { params: vec![Ty::Int], ret: Box::new(Ty::Int) }),
         ]
     }
 
@@ -260,16 +265,36 @@ mod proptest_lean_rust {
 
     fn arb_stmt() -> impl Strategy<Value = IrStmt> {
         prop_oneof![
+            // RcInc
             arb_var_id().prop_map(|v| IrStmt {
                 kind: IrStmtKind::RcInc { var: v }, span: None,
             }),
+            // RcDec
             arb_var_id().prop_map(|v| IrStmt {
                 kind: IrStmtKind::RcDec { var: v }, span: None,
             }),
+            // Bind (immutable)
             (arb_var_id(), arb_ty()).prop_map(|(v, ty)| IrStmt {
                 kind: IrStmtKind::Bind {
                     var: v, ty: ty.clone(),
                     mutability: almide_ir::Mutability::Let,
+                    value: dummy_expr(ty),
+                },
+                span: None,
+            }),
+            // Bind (mutable)
+            (arb_var_id(), arb_heap_ty()).prop_map(|(v, ty)| IrStmt {
+                kind: IrStmtKind::Bind {
+                    var: v, ty: ty.clone(),
+                    mutability: almide_ir::Mutability::Var,
+                    value: dummy_expr(ty),
+                },
+                span: None,
+            }),
+            // Assign (mutable reassignment)
+            (arb_var_id(), arb_heap_ty()).prop_map(|(v, ty)| IrStmt {
+                kind: IrStmtKind::Assign {
+                    var: v,
                     value: dummy_expr(ty),
                 },
                 span: None,
@@ -511,6 +536,77 @@ mod proptest_lean_rust {
             shuffled.reverse();
             prop_assert_eq!(count_decs(&stmts, var), count_decs(&shuffled, var));
             prop_assert_eq!(count_incs(&stmts, var), count_incs(&shuffled, var));
+        }
+    }
+
+    // ── Assign does not change Inc/Dec counts ──
+    // Assign is a value overwrite, not an Inc/Dec operation.
+    proptest! {
+        #[test]
+        fn assign_does_not_affect_counts(stmts in arb_stmts(), var in arb_var_id(), ty in arb_heap_ty()) {
+            let decs_before = count_decs(&stmts, var);
+            let incs_before = count_incs(&stmts, var);
+            let mut with_assign = stmts;
+            with_assign.push(IrStmt {
+                kind: IrStmtKind::Assign { var, value: dummy_expr(ty) },
+                span: None,
+            });
+            prop_assert_eq!(count_decs(&with_assign, var), decs_before);
+            prop_assert_eq!(count_incs(&with_assign, var), incs_before);
+        }
+    }
+
+    // ── Applied/Record/Fn types are heap ──
+    proptest! {
+        #[test]
+        fn applied_record_fn_are_heap(ty in arb_heap_ty()) {
+            prop_assert!(is_heap_type(&ty), "{:?} must be heap", ty);
+        }
+    }
+
+    // ── Mutable var: Bind(var) + Assign(var) + 2*Dec = 2 decs ──
+    // Models: allocate, reassign, free both old and new values.
+    proptest! {
+        #[test]
+        fn mutable_reassign_two_decs(var in arb_var_id()) {
+            let stmts = vec![
+                IrStmt {
+                    kind: IrStmtKind::Bind {
+                        var, ty: Ty::String,
+                        mutability: almide_ir::Mutability::Var,
+                        value: dummy_expr(Ty::String),
+                    },
+                    span: None,
+                },
+                IrStmt { kind: IrStmtKind::RcDec { var }, span: None },
+                IrStmt {
+                    kind: IrStmtKind::Assign { var, value: dummy_expr(Ty::String) },
+                    span: None,
+                },
+                IrStmt { kind: IrStmtKind::RcDec { var }, span: None },
+            ];
+            prop_assert_eq!(count_decs(&stmts, var), 2);
+            prop_assert_eq!(count_incs(&stmts, var), 0);
+        }
+
+        #[test]
+        fn mutable_triple_reassign(var in arb_var_id()) {
+            let stmts = vec![
+                IrStmt {
+                    kind: IrStmtKind::Bind {
+                        var, ty: Ty::String,
+                        mutability: almide_ir::Mutability::Var,
+                        value: dummy_expr(Ty::String),
+                    },
+                    span: None,
+                },
+                IrStmt { kind: IrStmtKind::RcDec { var }, span: None },
+                IrStmt { kind: IrStmtKind::Assign { var, value: dummy_expr(Ty::String) }, span: None },
+                IrStmt { kind: IrStmtKind::RcDec { var }, span: None },
+                IrStmt { kind: IrStmtKind::Assign { var, value: dummy_expr(Ty::String) }, span: None },
+                IrStmt { kind: IrStmtKind::RcDec { var }, span: None },
+            ];
+            prop_assert_eq!(count_decs(&stmts, var), 3, "3 allocations need 3 decs");
         }
     }
 

--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -1124,23 +1124,60 @@ impl Checker {
                 let resolved = resolve_ty(ty, &self.uf);
                 let elem_ty = match &resolved {
                     Ty::Applied(TypeConstructorId::List, args) if !args.is_empty() => args[0].clone(),
+                    // Subject is still an unresolved inference var (e.g. a
+                    // lambda param not yet linked to its call site). Matching
+                    // `[..]` asserts it is a List, so pin its structure to
+                    // List[?elem] — otherwise the element pattern var
+                    // dead-ends at Unknown and leaks to the IR.
+                    Ty::TypeVar(_) => {
+                        let elem_v = self.fresh_var();
+                        self.unify_infer(&resolved, &Ty::list(elem_v.clone()));
+                        elem_v
+                    }
                     _ => Ty::Unknown,
                 };
                 for e in elements { self.bind_pattern(e, &elem_ty); }
             }
             ast::Pattern::Some { inner } => {
                 let resolved = resolve_ty(ty, &self.uf);
-                let it = match &resolved { Ty::Applied(TypeConstructorId::Option, args) if args.len() == 1 => args[0].clone(), _ => Ty::Unknown };
+                let it = match &resolved {
+                    Ty::Applied(TypeConstructorId::Option, args) if args.len() == 1 => args[0].clone(),
+                    // See List arm: pin an unresolved subject to Option[?inner].
+                    Ty::TypeVar(_) => {
+                        let inner_v = self.fresh_var();
+                        self.unify_infer(&resolved, &Ty::option(inner_v.clone()));
+                        inner_v
+                    }
+                    _ => Ty::Unknown,
+                };
                 self.bind_pattern(inner, &it);
             }
             ast::Pattern::Ok { inner } => {
                 let resolved = resolve_ty(ty, &self.uf);
-                let it = match &resolved { Ty::Applied(TypeConstructorId::Result, args) if args.len() == 2 => args[0].clone(), _ => Ty::Unknown };
+                let it = match &resolved {
+                    Ty::Applied(TypeConstructorId::Result, args) if args.len() == 2 => args[0].clone(),
+                    Ty::TypeVar(_) => {
+                        let ok_v = self.fresh_var();
+                        let err_v = self.fresh_var();
+                        self.unify_infer(&resolved, &Ty::result(ok_v.clone(), err_v));
+                        ok_v
+                    }
+                    _ => Ty::Unknown,
+                };
                 self.bind_pattern(inner, &it);
             }
             ast::Pattern::Err { inner } => {
                 let resolved = resolve_ty(ty, &self.uf);
-                let it = match &resolved { Ty::Applied(TypeConstructorId::Result, args) if args.len() == 2 => args[1].clone(), _ => Ty::Unknown };
+                let it = match &resolved {
+                    Ty::Applied(TypeConstructorId::Result, args) if args.len() == 2 => args[1].clone(),
+                    Ty::TypeVar(_) => {
+                        let ok_v = self.fresh_var();
+                        let err_v = self.fresh_var();
+                        self.unify_infer(&resolved, &Ty::result(ok_v, err_v.clone()));
+                        err_v
+                    }
+                    _ => Ty::Unknown,
+                };
                 self.bind_pattern(inner, &it);
             }
             ast::Pattern::None | ast::Pattern::Literal { .. } => {}

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -31,7 +31,7 @@ mod exhaustiveness;
 use almide_lang::ast;
 use almide_base::diagnostic::Diagnostic;
 use crate::import_table::{ImportTable, build_import_table};
-use almide_base::intern::sym;
+use almide_base::intern::{Sym, sym};
 use crate::types::{Ty, TypeEnv};
 use types::{TyVarId, Constraint, FixHint, UnionFind, resolve_ty};
 

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -599,12 +599,19 @@ impl Checker {
             ast::TestWhere::Bind { name, value } => {
                 let mut val = value.clone();
                 let ty = self.infer_expr(&mut val);
+                // A `where greet = (name) => ...` binding shadows an existing
+                // top-level function. Unify the inferred lambda type with that
+                // function's signature so the lambda's parameter type variables
+                // get pinned — otherwise they stay unbound and leak into the IR
+                // as Unknown, tripping the ConcretizeTypes postcondition.
+                self.unify_where_override_with_fn_sig(&[*name], &ty);
                 let resolved = resolve_ty(&ty, &self.uf);
                 self.env.define_var(name.as_str(), resolved);
             }
             ast::TestWhere::Override { path, value } => {
                 let mut v = value.clone();
                 let ty = self.infer_expr(&mut v);
+                self.unify_where_override_with_fn_sig(path, &ty);
                 let resolved = resolve_ty(&ty, &self.uf);
                 let override_name = format!("__where_{}", path.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("_"));
                 self.env.define_var(&override_name, resolved);
@@ -635,6 +642,37 @@ impl Checker {
                 for b in bindings { self.infer_test_where_inner(b); }
             }
         }
+    }
+
+    /// Unify a `where`-clause override value's inferred type with the
+    /// shadowed top-level function's signature, pinning the override
+    /// lambda's parameter type variables. `path` is the overridden
+    /// function's name path (`["greet"]` or `["http", "get"]`); `value_ty`
+    /// is the inferred type of the override expression.
+    ///
+    /// Without this, an override like `where greet = (name) => ...` leaves
+    /// `name`'s type variable unbound — it resolves to Unknown and leaks
+    /// into the IR, tripping the ConcretizeTypes postcondition (and falling
+    /// back to a wrong WASM ValType for non-i32 params).
+    ///
+    /// No-op when the path names no known function or the signature is
+    /// generic: unifying a lambda's `?N` param with a named TypeVar would
+    /// resolve it to `A`, which is itself unresolved at codegen time.
+    fn unify_where_override_with_fn_sig(&mut self, path: &[Sym], value_ty: &Ty) {
+        let name = if path.len() == 1 {
+            path[0]
+        } else {
+            sym(&path.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("."))
+        };
+        let Some(sig) = self.env.functions.get(&name) else { return };
+        let sig_ty = Ty::Fn {
+            params: sig.params.iter().map(|(_, t)| t.clone()).collect(),
+            ret: Box::new(sig.ret.clone()),
+        };
+        let mut typevars = Vec::new();
+        TypeEnv::collect_typevars(&sig_ty, &mut typevars);
+        if !typevars.is_empty() { return; }
+        self.unify_infer(&sig_ty, value_ty);
     }
 }
 

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -792,61 +792,23 @@ fn rewrite_calls_in_expr(expr: &mut ast::Expr, path: &[Sym], override_name: &str
 }
 
 fn lower_where_bind(ctx: &mut LowerCtx, bind_name: &Sym, value: &ast::Expr) -> IrStmt {
-    let mut ir_val = lower_expr(ctx, value);
-    // Patch lambda params from checker's inferred Fn type
-    patch_lambda_params_from_checker(ctx, &mut ir_val, bind_name);
+    // The checker pins this binding's lambda param types during inference
+    // (`unify_where_override_with_fn_sig` in check/mod.rs), so `lower_expr`
+    // reads correct types straight from the TypeMap — no lowering-side patch.
+    let ir_val = lower_expr(ctx, value);
     let ty = ir_val.ty.clone();
     let var = ctx.define_var(bind_name.as_str(), ty.clone(), Mutability::Let, None);
     IrStmt { kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val }, span: None }
 }
 
-/// If ir_val is a Lambda with Unknown params, try to resolve from checker's env.
-fn patch_lambda_params_from_checker(ctx: &mut LowerCtx, ir_val: &mut IrExpr, bind_name: &Sym) {
-    let IrExprKind::Lambda { params: ir_params, body, .. } = &mut ir_val.kind else { return };
-    if !ir_params.iter().any(|(_, ty)| matches!(ty, Ty::Unknown)) { return; }
-    // Check if checker stored a Fn type for this binding
-    let fn_ty = ctx.env.lookup_var(bind_name.as_str()).cloned();
-    let Some(Ty::Fn { params: sig_tys, ret }) = fn_ty else { return };
-    for (i, (var_id, var_ty)) in ir_params.iter_mut().enumerate() {
-        if let Some(concrete) = sig_tys.get(i) {
-            if !matches!(concrete, Ty::Unknown) && !matches!(concrete, Ty::TypeVar(_)) {
-                *var_ty = concrete.clone();
-                ctx.var_table.entries[var_id.0 as usize].ty = concrete.clone();
-            }
-        }
-    }
-    if matches!(body.ty, Ty::Unknown) && !matches!(*ret, Ty::Unknown) {
-        body.ty = *ret.clone();
-    }
-    ir_val.ty = Ty::Fn { params: sig_tys, ret };
-}
-
 fn lower_where_override(ctx: &mut LowerCtx, path: &[Sym], value: &ast::Expr, stmts: &mut Vec<IrStmt>, overrides: &mut Vec<(Vec<Sym>, String)>) {
+    // Param types already resolved by the checker (see lower_where_bind).
     let override_name = where_override_name(path);
-    let mut ir_val = lower_expr(ctx, value);
-    patch_lambda_from_fn_sig(ctx, &mut ir_val, path);
+    let ir_val = lower_expr(ctx, value);
     let ty = ir_val.ty.clone();
     let var = ctx.define_var(&override_name, ty.clone(), Mutability::Let, None);
     stmts.push(IrStmt { kind: IrStmtKind::Bind { var, mutability: Mutability::Let, ty, value: ir_val }, span: None });
     overrides.push((path.to_vec(), override_name));
-}
-
-fn patch_lambda_from_fn_sig(ctx: &mut LowerCtx, ir_val: &mut IrExpr, path: &[Sym]) {
-    let IrExprKind::Lambda { params: ir_params, body, .. } = &mut ir_val.kind else { return };
-    if !ir_params.iter().any(|(_, ty)| matches!(ty, Ty::Unknown)) { return; }
-    let Some(Ty::Fn { params: sig_tys, ret }) = resolve_target_fn_type(ctx, path) else { return };
-    let erased: Vec<Ty> = sig_tys.iter().map(erase_typevars).collect();
-    for (i, (var_id, var_ty)) in ir_params.iter_mut().enumerate() {
-        if let Some(concrete) = erased.get(i) {
-            if !matches!(concrete, Ty::Unknown) {
-                *var_ty = concrete.clone();
-                ctx.var_table.entries[var_id.0 as usize].ty = concrete.clone();
-            }
-        }
-    }
-    let erased_ret = erase_typevars(&ret);
-    if matches!(body.ty, Ty::Unknown) { body.ty = erased_ret.clone(); }
-    ir_val.ty = Ty::Fn { params: erased, ret: Box::new(body.ty.clone()) };
 }
 
 fn lower_where_call_response(ctx: &mut LowerCtx, target: &[Sym], params: &[ast::Pattern], response: &ast::Expr, stmts: &mut Vec<IrStmt>, overrides: &mut Vec<(Vec<Sym>, String)>) {

--- a/crates/almide-syntax/src/lexer.rs
+++ b/crates/almide-syntax/src/lexer.rs
@@ -397,7 +397,17 @@ fn strip_heredoc_indent(raw: &str) -> String {
         .unwrap_or(0);
 
     content.iter()
-        .map(|l| if l.len() >= indent { &l[indent..] } else { "" })
+        .map(|l| {
+            // `indent` is a byte length of leading whitespace measured over the
+            // non-blank lines. A whitespace-only line (excluded from that min)
+            // may hold multi-byte Unicode whitespace such as U+3000, so clamp
+            // the cut down to a char boundary — slicing mid-codepoint panics.
+            let mut cut = indent.min(l.len());
+            while cut > 0 && !l.is_char_boundary(cut) {
+                cut -= 1;
+            }
+            &l[cut..]
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -565,4 +575,35 @@ fn lex_operator(chars: &[char], pos: usize, line: usize, col: usize) -> (Token, 
 
 fn peek(chars: &[char], pos: usize) -> Option<char> {
     chars.get(pos).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression: a heredoc whose blank line holds multi-byte Unicode whitespace
+    // (U+3000) used to panic in strip_heredoc_indent — the byte-offset dedent
+    // sliced mid-codepoint. The lexer must never crash (almide-syntax contract).
+    #[test]
+    fn heredoc_multibyte_whitespace_line_does_not_panic() {
+        let src = "let x = \"\"\"\n a\n\u{3000}\n  \"\"\"\n";
+        let tokens = Lexer::tokenize(src);
+        let s = tokens
+            .iter()
+            .find(|t| t.token_type == TokenType::String)
+            .expect("heredoc should lex to a String token");
+        // " a" dedents to "a"; the U+3000-only line is preserved (not split).
+        assert_eq!(s.value, "a\n\u{3000}");
+    }
+
+    #[test]
+    fn heredoc_ascii_dedent_still_works() {
+        let src = "let x = \"\"\"\n    one\n    two\n    \"\"\"\n";
+        let tokens = Lexer::tokenize(src);
+        let s = tokens
+            .iter()
+            .find(|t| t.token_type == TokenType::String)
+            .expect("heredoc should lex to a String token");
+        assert_eq!(s.value, "one\ntwo");
+    }
 }

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -24,7 +24,7 @@
 
 ## On Hold
 
-30 items
+29 items
 
 | Item | Description |
 |------|-------------|
@@ -54,20 +54,20 @@
 | [Shell Completions](on-hold/shell-completions.md) | almide completions subcommand for bash/zsh/fish auto-completion |
 | [Snapshot Testing](on-hold/snapshot-testing.md) | Built-in snapshot testing for output regression detection |
 | [Supervision & Actors](on-hold/supervision-and-actors.md) | Erlang-style actors, supervisors, and typed channels as stdlib modules |
-| [WASM Component Model](on-hold/wasm-component-model.md) | WebAssembly Component Model support with WIT bindings |
 | [WASM Exception Handling](on-hold/wasm-exception-handling.md) | WASM native exception handling (try_table/throw) for zero-cost effect fn error propagation |
 | [WASM HTTP Client](on-hold/wasm-http-client.md) | HTTP client support for the WASM target via WASI or host imports |
 | [Web Framework](on-hold/web-framework.md) | First-party Hono-like web framework with template and Codec integration |
 
 ## Done
 
-247 items
+248 items
 
 <details>
-<summary>Show all 247 completed items</summary>
+<summary>Show all 248 completed items</summary>
 
 | Done | Item | Description |
 |------|------|-------------|
+| 2026-05-29 | [WASM Component Model](done/wasm-component-model.md) | WebAssembly Component Model support with WIT bindings |
 | 2026-04-20 | [`almide docs-gen` — llms.txt Auto-Generation](done/llms-txt-autogen.md) | Auto-generate llms.txt from canonical sources (CHEATSHEET, diagnostics, stdlib) |
 | 2026-04-20 | [Whisper in Pure Almide](done/whisper-almide.md) | Whisper speech recognition implemented entirely in Almide |
 | 2026-04-20 | [Variant Exhaustiveness Refinement](done/variant-exhaustiveness-refinement.md) | Non-exhaustive match suggests missing arm code; unreachable arms become hard errors |

--- a/docs/roadmap/active/build-speed-runtime-rlib.md
+++ b/docs/roadmap/active/build-speed-runtime-rlib.md
@@ -1,0 +1,54 @@
+<!-- description: Native build-speed — precompiled almide_rt runtime rlib, and recovering the shipping-build inlining gap with #[inline] -->
+# Build Speed: Runtime rlib + Hot-Fn Inlining
+
+> Goal: Go-like build speed. The dev/test/run loop and shipping builds should not pay to recompile the runtime every time.
+
+## Status
+
+**Shipped (branch `build-speed-parallel-rustc`):** the `almide_rt` runtime is
+compiled once into an `.rlib` (`codegen::emit_runtime_crate()`), cached under
+`$TMPDIR/almide-rtlib-<hash>` keyed by runtime-source + rustc-version + opt-level.
+Per-file/per-build rustc emits a slim main (`#[macro_use] extern crate almide_rt;
+use almide_rt::*;` + user code, split on `RT_BOUNDARY_MARKER`) and links the rlib
+with `--extern almide_rt=<rlib>`. Falls back to the inline/cargo path on any
+failure; `ALMIDE_NO_RTLIB=1` disables it.
+
+Wired into:
+- **Test path** (`cargo_build_test_with_native`): rlib at opt1 + slim main at **opt0** (tests don't need optimized user code) → **2.45x/file**, spec/lang 116 files **2.26x wall / 3.1x CPU**.
+- **Run/build path** (`cargo_build_generated_with_native`): rlib + slim main at the binary's opt-level (1 debug, 3 release). Shipping `--release` builds **~20x** (27–33s → 1–2s), output verified identical.
+
+Excluded: `http`/`zlib`/`sse` (non-std deps) stay on the cargo path.
+
+## The remaining gap (this roadmap item): shipping-build inlining
+
+Because the runtime is a separate crate compiled **without LTO**, non-generic,
+non-`#[inline]` runtime fns are **not inlined across the crate boundary**. On a
+string/list-heavy hot loop (measured: 200k-row CSV through `csv-to-json`) the
+shipped binary runs **~10% slower** than the monolithic build (typical programs:
+2–5%). Generic runtime fns (most `list`/`map`/`option`/`result` ops) and the
+existing `#[inline(always)]` helpers are unaffected — they inline cross-crate
+already.
+
+Rejected alternative — **ThinLTO**: recovers the inlining but re-optimizes the
+runtime's bitcode at link time, erasing the build-speed win (≈ monolithic build
+time). Measured: no compile win, so not worth it.
+
+### Plan: `#[inline]` the hot non-generic runtime fns
+
+Mark the small set of hot, non-generic runtime fns — primarily `string.*`
+(`trim`, `split`, `lines`, `concat`, `len`, slicing) and any frequently-called
+scalar helpers — with `#[inline]` in `runtime/rs/src/*.rs`. With their MIR
+exposed in the rlib, rustc inlines them across the crate boundary even without
+LTO, recovering the lost performance while keeping the ~20x build win and the
+"separate runtime crate, no LTO" model. This mirrors Go's "small functions are
+auto-inlined" stance.
+
+Steps:
+1. Profile a runtime-heavy workload (e.g. the 200k-CSV `csv-to-json` benchmark) to identify which runtime fns dominate the rlib-vs-monolithic gap.
+2. Add `#[inline]` to those fns (prefer targeted `#[inline]` over blanket `#[inline(always)]` to avoid bloating caller compile time).
+3. Re-measure: confirm shipping runtime regression → ~0% while build stays ~20x.
+4. Guard against over-inlining: watch that the slim-main compile time doesn't creep back up (more inline candidates = more work for the final rustc).
+
+### Open follow-ups
+- Wire the rlib into `almide build` for projects with **native deps** (currently cargo-only) — would need the rlib passed through cargo as a path dependency or `RUSTFLAGS --extern`.
+- Consider shipping a prebuilt rlib with the compiler release so the first build in a fresh environment skips the one-time rlib compile.

--- a/docs/roadmap/active/correctness-guarantee-gaps.md
+++ b/docs/roadmap/active/correctness-guarantee-gaps.md
@@ -127,3 +127,39 @@ Quick wins first (small effort, high leverage):
 3. **4a** — ConcretizeTypes easy cases. Straightforward.
 4. **5b** — Expand Perceus proptest. Low effort, incremental.
 5. **1b-1g** — WASM emitter migration. Largest effort, tracked separately.
+
+  # 11. Status snapshot (2026-05-30) — closure / where / fold inference round
+
+  このラウンドで閉じたギャップ:
+  - **WASM closure-table regression**: ANF deny-list 反転（5cae928d）が
+    `Ty::Fn` のラムダを lift 対象に巻き込み、`pre_scan_closures` の
+    func-table 登録から漏れて `call_indirect` が未宣言 table 0 を参照
+    → 不正WASM。`needs_lift` の deny-list に Lambda/ClosureCreate を追加
+    して復元（802bb944）。
+  - **§1 (Inference↔Codegen contract) の実例 2 件を checker 側で根治**:
+    1. `test where greet = (name) => ...` の override ラムダ param が
+       Unknown 化 → checker で override 値をシャドウ元 fn シグネチャと
+       unify（88993d58 / 25a6f341）。
+    2. 未解決型変数を subject に `match` したとき `some(stack)` 等の内側
+       パターン変数が Unknown 化（fold accumulator `some([])`）→
+       `bind_pattern` で subject が `Ty::TypeVar` のとき
+       `Option/Result/List[?inner]` に unify してから束縛（e8d44dcb）。
+  - **anti-pattern 撤去**: lowering 側 `patch_lambda_params_from_checker` /
+    `patch_lambda_from_fn_sig` を削除（930bd486）。checker が source of
+    truth になり「Lowering never runs inference」原則に前進。
+    残: `lower_where_call_response` 内の同種パッチはまだ残（CallResponse の
+    checker 側 TypeMap 反映を確認後に撤去可能）。
+  - spec POSTCONDITION: 5 → 0（wasm/native とも）。
+
+  残る完全性ギャップ（このラウンドでは未着手、要・腰を据えた別アーク）:
+  - **§5 を保証に格上げ**: postcondition の release hard-fail 化。
+    現状 `hard_fail = cfg!(debug_assertions)`（pass.rs:248）。release では
+    print のみで素通り。注意: そのまま hard error 化すると、下記
+    under-constrained のような「今 warning で通っているプログラム」が
+    全て compile error になる破壊的変更。先に spec/exercises 全量で
+    影響件数を測ること。
+  - **under-constrained を明確に拒否**: `ok([])` を fold init にし err 値が
+    一度も現れないケースは err 型 `E` が原理的に未制約 → 現状
+    POSTCONDITION を踏むが warning 止まり。「曖昧なら型エラー」にするには
+    constraint solving 後の到達可能性解析（その TypeVar が本当に決まらない
+    か／後で決まるか）の線引き設計が要る。§5 の格上げと同時に行うのが筋。

--- a/docs/roadmap/active/correctness-guarantee-gaps.md
+++ b/docs/roadmap/active/correctness-guarantee-gaps.md
@@ -2,7 +2,7 @@
 
 > "well-typed source -> correct binary" chain: layers that lack mechanical/mathematical proof
 
-Status: **Active** — analysis complete, fixes tracked per-layer
+Status: **Active** — analysis complete, milestone steps defined per-layer
 
 ## Layers WITH guarantees
 
@@ -23,23 +23,31 @@ Hand-written WASM instruction emission. Hundreds of `wasm!()` macro calls whose 
 - `expressions.rs`: BinOp, Match, Record — branch stack effects are eyeballed
 - Layout offsets: `LayoutRegistry` centralizes them, but correct usage is manual
 
-**Fix path**: `wasm-engine-redesign` WasmIR (typed instruction builder that statically checks stack effects). Designed but not yet implemented.
+**Current state**: WasmBuilder + WasmIR + LayoutRegistry infrastructure exists in `emit_wasm/engine/`. Partial migration done (list_layout.rs uses WasmBuilder). Most of `expressions.rs` and `rt_*.rs` still use raw `wasm!()`.
 
 ### 2. ANF pass — heap alloc visibility unproven
 
 ANF must lift every heap intermediate to a VDecl so Perceus can track it. `needs_lift()` covers known cases but there is no proof it covers ALL cases. A miss = heap leak.
 
+**Current state**: `needs_lift()` covers Call, RuntimeCall, BinOp, If, Match, Block. **Known gaps**: Fan, List/MapLiteral/Record/Tuple literals, StringInterp, IterChain, ForIn, While, UnwrapOr, OptionalChain, Member, IndexAccess, ClosureCreate are NOT matched. No dedicated ANF test exists.
+
 ### 3. Closure conversion — env layout correctness
 
 `ClosureConversionPass` packs capture variables into an env struct and reads them via `EnvLoad` with computed offsets. Offset correctness is verified only by tests.
+
+**Current state**: Offset formula is `index * 8` with captures sorted by VarId. Emission uses type-aware loads (I32/I64/F64). Zero `debug_assert` on offset bounds or env size consistency. Test coverage: `closure_nested_capture_test.almd` + `monkey06_closures_test.almd`.
 
 ### 4. Type inference -> IR lowering fidelity
 
 Types inferred in `almide-frontend` must be faithfully reflected in IR `expr.ty`. `ConcretizeTypes` postcondition checks exist but coverage of all patterns is unproven.
 
+**Current state**: `resolve_node_ty` handles 17 variants explicitly. 24+ variants return None (MapLiteral, Record, SpreadRecord, Range, MapAccess, StringInterp, Try, UnwrapOr, ToOption, OptionalChain, Clone, Deref, Borrow, BoxNew, RcWrap, ClosureCreate, FnRef, ForIn, While, Fan, etc.). Postcondition audit (`audit_remaining_unresolved`) catches unresolved types but does not guarantee all variants were visited. Design is intentionally best-effort.
+
 ### 5. Perceus Inc/Dec insertion — Lean-to-Rust fidelity
 
 The Lean 4 theorems prove the algorithm correct, but the Rust implementation was hand-translated, not mechanically extracted. Conformance is verified by manual comparison with the Lean spec.
+
+**Current state**: Strongest of all gaps. `perceus_verified.rs` mirrors Lean proofs in Rust. proptest validates is_freed/has_dec. PerceusVerifyPass runs on every WASM build. `perceus_monkey_test.almd` has adversarial cases. Lean proofs: 23 theorems, 0 sorry.
 
 ## Risk ranking
 
@@ -49,12 +57,73 @@ The Lean 4 theorems prove the algorithm correct, but the Rust implementation was
 4. **Type lowering fidelity** — mitigated by postcondition checks
 5. **Perceus Lean conformance** — mitigated by extensive test suite
 
-## Resolution strategy
+---
 
-| Gap | Approach | Tracked in |
-|-----|----------|------------|
-| WASM emitter | WasmIR typed builder with stack-effect types | `wasm-engine-redesign` |
-| ANF coverage | Property-based test: round-trip IR and assert all heap values have VDecl | — |
-| Closure offsets | Fuzzer + offset consistency assertion in debug builds | — |
-| Type lowering | Expand ConcretizeTypes postcondition to cover all Expr variants | — |
-| Perceus conformance | Differential testing against Lean reference impl | — |
+## Milestone Steps
+
+### Gap 1: WASM emitter -> WasmIR migration
+
+Tracked in: [wasm-engine-redesign.md](wasm-engine-redesign.md)
+
+| Step | Description | Deliverable | Depends on |
+|------|-------------|-------------|------------|
+| 1a | Audit remaining raw `wasm!()` call sites | List of files/functions not yet using WasmBuilder | — |
+| 1b | Migrate `rt_string.rs` to WasmBuilder | Zero raw `wasm!()` in rt_string | — |
+| 1c | Migrate `rt_list.rs` to WasmBuilder | Zero raw `wasm!()` in rt_list | — |
+| 1d | Migrate `expressions.rs` (BinOp, Match, Record) | Zero raw `wasm!()` in expressions | — |
+| 1e | Add stack-effect type annotations to WasmIR Op enum | Each Op declares `(pops, pushes)` | 1b-1d |
+| 1f | Implement stack-effect verifier on WasmIR | Reject instruction sequences where net effect != expected | 1e |
+| 1g | Delete old raw emission paths | `wasm!()` macro removed or dead | 1f |
+
+**Gate**: after 1f, every WASM function's instruction stream is statically verified for stack balance before encoding.
+
+### Gap 2: ANF `needs_lift()` completeness
+
+| Step | Description | Deliverable | Depends on |
+|------|-------------|-------------|------------|
+| 2a | Add missing IrExprKind variants to `needs_lift()` | Fan, List, MapLiteral, Record, Tuple, StringInterp, IterChain, ForIn, While, UnwrapOr, OptionalChain, Member, IndexAccess, ClosureCreate | — |
+| 2b | Add postcondition assert: after ANF, walk all Call/RuntimeCall/BinOp args and assert each heap-typed arg is `IrExprKind::Var` | Debug-mode panic on violation | 2a |
+| 2c | Add ANF-specific spec test: nested heap expressions in every position | `spec/lang/anf_lift_test.almd` | 2a |
+
+**Gate**: after 2b, a missed case triggers a debug-mode panic instead of a silent leak.
+
+### Gap 3: Closure env offset verification
+
+| Step | Description | Deliverable | Depends on |
+|------|-------------|-------------|------------|
+| 3a | Add `debug_assert!(index < captures.len())` in EnvLoad emission | Panic on out-of-bounds index | — |
+| 3b | Add ClosureVerifyPass (postcondition on ClosureConversionPass): for each lifted fn, assert all EnvLoad indices < param env_size / 8 | Registered as postcondition | — |
+| 3c | Add closure capture fuzzer: random capture patterns (0-20 vars, mixed types, nested) | proptest in `tests/closure_env_test.rs` | 3b |
+
+**Gate**: after 3b, offset mismatch is caught at compile time (debug builds).
+
+### Gap 4: ConcretizeTypes postcondition coverage
+
+| Step | Description | Deliverable | Depends on |
+|------|-------------|-------------|------------|
+| 4a | Add trivial `resolve_node_ty` cases: StringInterp->String, Clone->expr.ty, Deref->inner, Range->List[Int] | Reduce None-returning variants from 24 to ~15 | — |
+| 4b | Add per-variant visit counter to postcondition audit | CI log shows which variants were never visited (coverage blind spots) | — |
+| 4c | Convert audit to hard error for non-whitelisted Unknown types | Unknown in non-whitelisted variant = compile error, not silent fallthrough | 4a, 4b |
+
+**Gate**: after 4c, new IR variants that produce Unknown without being whitelisted fail the build.
+
+### Gap 5: Perceus Lean->Rust conformance
+
+| Step | Description | Deliverable | Depends on |
+|------|-------------|-------------|------------|
+| 5a | Differential test: serialize IR to JSON, run both Lean `perceusTransform` and Rust `perceus_fnbody`, compare Inc/Dec positions | `tests/perceus_differential_test.rs` | — |
+| 5b | Expand proptest coverage: closure captures, mutable reassignment, nested match | Additional proptest strategies in `perceus_verified.rs` | — |
+
+**Gate**: 5a provides mechanical conformance evidence. Full extraction (Lean->Rust codegen) is a long-term aspiration, not a near-term step.
+
+---
+
+## Priority order
+
+Quick wins first (small effort, high leverage):
+
+1. **2a + 2b** — ANF needs_lift() fix + assert. Days, not weeks. Closes silent leak risk.
+2. **3a + 3b** — Closure offset asserts. Trivial to add.
+3. **4a** — ConcretizeTypes easy cases. Straightforward.
+4. **5b** — Expand Perceus proptest. Low effort, incremental.
+5. **1b-1g** — WASM emitter migration. Largest effort, tracked separately.

--- a/docs/roadmap/active/wasm-engine-redesign.md
+++ b/docs/roadmap/active/wasm-engine-redesign.md
@@ -1,326 +1,274 @@
 # Almide WASM Engine — Complete Redesign
 
-> **Status**: Design phase
-> **Motivation**: String layout migration (4→8 byte header) broke 35+ sites silently. Map Swiss Table migration broke all map closure ops. Root cause: raw WASM instruction emission with no type/layout abstraction.
-> **Goal**: Replace the 40-file hand-written assembler with a type-aware, layout-safe WASM compilation engine.
+> **Status**: Design phase — foundation (LayoutRegistry + WasmIR + WasmBuilder) exists, full recreate planned
+> **Motivation**: Hand-written WASM emission is the largest correctness gap. Also: WASM 3.0, WASI Preview 2, and Component Model all require a proper compilation pipeline, not raw instruction assembly.
+> **Goal**: Replace the 40-file hand-written assembler with a type-aware, layout-safe, stack-verified WASM compiler that outputs core modules or Component Model components.
 
 ## Problem Statement
 
-Current `emit_wasm/` is an assembler: AlmideIR → raw `wasm-encoder` instructions. Every memory access manually computes offsets:
-
-```rust
-// "load string data at index i" — 6 instructions, 3 magic numbers
-wasm!(self.func, {
-    local_get(str_ptr); i32_const(8); i32_add;
-    local_get(i); i32_add; i32_load8_u(0);
-});
-```
+Current `emit_wasm/` is an assembler: AlmideIR → raw `wasm-encoder` instructions. Every memory access manually computes offsets. Stack balance is verified by humans.
 
 **Consequences**:
 - Layout change → grep 40 files → miss sites → silent memory corruption
+- No static stack-effect verification → stack bugs at runtime
 - Swiss Table map iteration is 30+ lines of boilerplate per method
-- No way to verify layout consistency at compile time
-- Code is unreadable — intent buried in instruction soup
+- WASI Preview 1 raw imports can't interop with Component Model ecosystem
+- No WIT generation → can't participate in WASM component ecosystem
 
 ## Architecture
 
 ```
-AlmideIR (after nanopass)
+AlmideIR (after nanopass pipeline)
   ↓
-┌─────────────────────────────────┐
-│  Almide WASM Engine             │
-│                                 │
-│  LayoutRegistry                 │  ← single source of truth for memory layouts
-│  WasmIR (typed mid-level IR)    │  ← stack-machine IR with typed memory ops
-│  Lowering (AlmideIR → WasmIR)  │  ← semantic translation
-│  Optimize (WasmIR → WasmIR)    │  ← RC fusion, dead field elim, slot coloring
-│  Emit (WasmIR → wasm-encoder)  │  ← mechanical translation
-│                                 │
-└─────────────────────────────────┘
-  ↓
-WASM binary
+┌──────────────────────────────────────────────────┐
+│  Almide WASM Engine v2                           │
+│                                                  │
+│  LayoutRegistry          ← memory layout SoT     │
+│  Lowering (AlmideIR → WasmIR)                    │
+│  Stack-Effect Verifier   ← static balance proof   │
+│  Optimize (RC fusion, local coloring, peephole)   │
+│  Core Emit (WasmIR → wasm-encoder)               │
+│  Component Wrap (core → component + WIT)          │
+│  WASI Adapter (canonical ABI for system calls)    │
+│                                                  │
+└──────────────────────────────────────────────────┘
+  ↓                        ↓
+Core WASM module     Component (.wasm + WIT)
 ```
+
+### Key Design Decisions
+
+1. **Internal layout stays Almide-native** (LayoutRegistry). No canonical ABI overhead for internal data. Canonical ABI is only used at component boundaries (imports/exports).
+
+2. **Stack effects are structural, not annotated**. Each WasmIR Op declares `(pops: u8, pushes: u8)`. The verifier computes net stack effect per block/function and rejects mismatches before emission.
+
+3. **Component Model is a wrapper, not a rewrite**. The core module is compiled normally. A separate Component Wrap phase lifts it to a component by generating:
+   - WIT declarations from Almide's `pub fn` / `pub type` exports
+   - Canonical ABI adapter functions (Almide layout ↔ canonical layout)
+   - WASI Preview 2 imports via `wit-component`
+
+4. **WASI Preview 2 replaces Preview 1**. Current raw imports (`fd_write`, `clock_time_get`, etc.) are replaced with Component Model imports (`wasi:filesystem/types`, `wasi:http/outgoing-handler`, etc.).
 
 ## Core Components
 
-### 1. LayoutRegistry
+### 1. LayoutRegistry (exists)
 
-All memory layouts defined declaratively. **No hardcoded offsets anywhere else.**
+All memory layouts defined declaratively. No hardcoded offsets anywhere else.
 
-```rust
-pub struct LayoutRegistry {
-    layouts: Vec<MemLayout>,
-}
+Built-in layouts: String, List, SwissMap, Set, AllocHeader, ClosurePair, Variant, Option, Result.
 
-pub struct MemLayout {
-    pub name: &'static str,
-    pub fields: Vec<MemField>,
-}
-
-pub struct MemField {
-    pub name: &'static str,
-    pub offset: FieldOffset,  // Fixed(n) or Dynamic(expr)
-    pub ty: MemType,
-}
-
-pub enum FieldOffset {
-    Fixed(u32),
-    /// Offset depends on runtime value (e.g., map entries after tag array)
-    AfterField { field: &'static str },
-}
-
-pub enum MemType {
-    I32, I64, F32, F64, U8,
-    ByteArray,          // [u8; field.len]
-    Array(Box<MemType>), // [T; field.len]
-}
-```
-
-Definitions:
+### 2. WasmIR with Stack Effects
 
 ```rust
-registry.define("String", fields![
-    len  : I32 @ 0,
-    cap  : I32 @ 4,
-    data : ByteArray @ 8,
-]);
+pub struct WasmOp {
+    pub kind: WasmOpKind,
+    pub pops: u8,    // values consumed from stack
+    pub pushes: u8,  // values produced onto stack
+}
 
-registry.define("List", fields![
-    len  : I32 @ 0,
-    cap  : I32 @ 4,
-    data : Array(elem_type) @ 8,
-]);
+pub enum WasmOpKind {
+    // ── Typed memory access (layout-safe) ──
+    FieldLoad { layout: LayoutId, field: FieldId },   // pops: 1 (base), pushes: 1
+    FieldStore { layout: LayoutId, field: FieldId },   // pops: 2 (base, val), pushes: 0
+    FieldAddr { layout: LayoutId, field: FieldId },    // pops: 1 (base), pushes: 1 (addr)
 
-registry.define("SwissMap", fields![
-    len     : I32 @ 0,
-    cap     : I32 @ 4,
-    tags    : ByteArray @ 8,          // size = cap
-    entries : Array(entry_type) @ after("tags"),  // offset = 8 + cap
-]);
-```
-
-### 2. WasmIR
-
-Stack-machine IR that preserves Almide type information. Matches WASM's execution model but with typed operations.
-
-```rust
-pub enum WasmOp {
-    // ── Typed memory access ──
-    FieldLoad { base: Local, layout: LayoutId, field: FieldId },
-    FieldStore { base: Local, layout: LayoutId, field: FieldId },
-    ElemLoad { base: Local, layout: LayoutId, field: FieldId, index: Local, elem_ty: WasmType },
-    ElemStore { base: Local, layout: LayoutId, field: FieldId, index: Local, elem_ty: WasmType },
-
-    // ── Collection iteration ──
-    ListForEach { list: Local, elem_ty: WasmType, body: Vec<WasmOp> },
-    MapForEach { map: Local, key_ty: WasmType, val_ty: WasmType, body: Vec<WasmOp> },
+    // ── Collection iteration (single IR node) ──
+    ListForEach { body: Vec<WasmOp> },     // pops: 1 (list), pushes: 0
+    MapForEach { body: Vec<WasmOp> },      // pops: 1 (map), pushes: 0
 
     // ── Allocation ──
-    Alloc { layout: LayoutId, size_expr: SizeExpr },
-    AllocList { elem_ty: WasmType, len: Local },
-    AllocMap { key_ty: WasmType, val_ty: WasmType, cap: u32 },
+    Alloc { layout: LayoutId, size: SizeExpr },
+    AllocCollection { layout: LayoutId, len_local: Local, stride: u32 },
 
     // ── Reference counting ──
-    RcInc { ptr: Local },
-    RcDec { ptr: Local, layout: LayoutId },
-    CowCheck { ptr: Local, clone_body: Vec<WasmOp> },
+    RcInc,                                  // pops: 1 (ptr), pushes: 0
+    RcDec { layout: LayoutId },            // pops: 1 (ptr), pushes: 0
+    CowCheck { clone_body: Vec<WasmOp> },  // pops: 1 (ptr), pushes: 1 (ptr or clone)
 
-    // ── Control flow (WASM-native structured) ──
-    Block { body: Vec<WasmOp> },
+    // ── Structured control flow ──
+    Block { body: Vec<WasmOp>, result_ty: Option<ValType> },
     Loop { body: Vec<WasmOp> },
-    If { then: Vec<WasmOp>, else_: Vec<WasmOp> },
+    If { then: Vec<WasmOp>, else_: Vec<WasmOp>, result_ty: Option<ValType> },
     Br(u32),
     BrIf(u32),
     Return,
+    ReturnCall(FuncId),          // WASM 3.0 tail call
 
-    // ── Stack operations ──
+    // ── Stack primitives ──
     LocalGet(Local),
     LocalSet(Local),
+    LocalTee(Local),
     Const(WasmConst),
+    Drop,
     BinOp(WasmBinOp),
     Call(FuncId),
-    CallIndirect { sig: SigId, table_idx: Local },
+    CallIndirect { sig: SigId },
 
-    // ── String operations (first-class) ──
-    StringConcat { left: Local, right: Local },
-    StringInterp { parts: Vec<StringPart> },
+    // ── High-level ops (lowered to primitives in emit) ──
+    StringConcat,                           // pops: 2, pushes: 1
+    StringInterp { part_count: u32 },       // pops: N, pushes: 1
+    DeepEq { ty: AlmideTy },               // pops: 2, pushes: 1 (i32 bool)
 
-    // ── Comparison ──
-    DeepEq { ty: AlmideTy, left: Local, right: Local },
+    // ── Component Model canonical ABI ──
+    CanonLift { wit_func: WitFuncId },      // core → component boundary
+    CanonLower { wit_func: WitFuncId },     // component → core boundary
+    CanonStringToMemory,                    // canonical string → Almide string
+    CanonStringFromMemory,                  // Almide string → canonical string
+    CanonListToMemory { elem_ty: ValType }, // canonical list → Almide list
+    CanonListFromMemory { elem_ty: ValType },
+
+    // ── Memory ──
+    MemoryCopy { dst_mem: u32, src_mem: u32 },
+    MemoryGrow(u32),
+    MemorySize(u32),
+
+    Seq(Vec<WasmOp>),
+    Unreachable,
 }
 ```
 
-### 3. Lowering (AlmideIR → WasmIR)
-
-Each AlmideIR node maps to WasmIR ops. This is where semantic decisions happen.
+### 3. Stack-Effect Verifier
 
 ```rust
-fn lower_expr(expr: &IrExpr, ctx: &mut LowerCtx) -> Vec<WasmOp> {
-    match &expr.kind {
-        IrExprKind::StringInterp { parts } => {
-            vec![WasmOp::StringInterp {
-                parts: parts.iter().map(|p| lower_string_part(p, ctx)).collect(),
-            }]
-        }
-        IrExprKind::ForIn { var, iterable, body } if is_map(&iterable.ty) => {
-            vec![WasmOp::MapForEach {
-                map: ctx.lower_to_local(iterable),
-                key_ty: map_key_wasm_ty(&iterable.ty),
-                val_ty: map_val_wasm_ty(&iterable.ty),
-                body: lower_stmts(body, ctx),
-            }]
-        }
-        // ...
+fn verify_stack_balance(ops: &[WasmOp], expected_result: Option<ValType>) -> Result<(), StackError> {
+    let mut depth: i32 = 0;
+    for op in ops {
+        depth -= op.pops as i32;
+        if depth < 0 { return Err(StackError::Underflow { op, depth }); }
+        depth += op.pushes as i32;
     }
+    let expected = if expected_result.is_some() { 1 } else { 0 };
+    if depth != expected {
+        return Err(StackError::Imbalance { expected, actual: depth });
+    }
+    Ok(())
 }
 ```
 
-### 4. Emit (WasmIR → wasm-encoder)
+Runs recursively on every Block/If/Loop body. Nested scopes are verified independently.
 
-Mechanical translation. **This is the only place that knows raw WASM instructions.**
+### 4. Lowering (AlmideIR → WasmIR)
 
-```rust
-fn emit_op(op: &WasmOp, f: &mut Function, reg: &LayoutRegistry) {
-    match op {
-        WasmOp::FieldLoad { base, layout, field } => {
-            let offset = reg.resolve_offset(*layout, *field);
-            f.instruction(&LocalGet(*base));
-            f.instruction(&I32Load(mem_arg(offset)));
-        }
-        WasmOp::MapForEach { map, key_ty, val_ty, body } => {
-            let layout = reg.get("SwissMap");
-            // Emit Swiss Table iteration — ONCE, CORRECTLY
-            // cap, entry_base, tag check, skip empty — all here
-            emit_swiss_table_iter(f, reg, *map, *key_ty, *val_ty, body);
-        }
-        WasmOp::StringInterp { parts } => {
-            emit_string_interp(f, reg, parts);  // uses LayoutRegistry for offsets
-        }
-        // ...
-    }
-}
+Semantic translation. Each AlmideIR node maps to WasmIR ops.
+
+### 5. Core Emit (WasmIR → wasm-encoder)
+
+Mechanical translation. The **only** place that touches raw WASM instructions. Verified-correct WasmIR goes in, valid WASM bytes come out.
+
+### 6. Component Wrap
+
+Generates a Component Model component from the core module:
+
+```
+Core WASM module
+  + WIT declarations (from pub fn/type exports)
+  + Canonical ABI adapter functions
+  + WASI Preview 2 import declarations
+  = Component (.wasm)
 ```
 
-### 5. Optimization Passes (WasmIR → WasmIR)
+Uses `wit-component` crate for the heavy lifting. Almide generates:
+- **WIT from types**: `pub type User = { name: String, age: Int }` → `record user { name: string, age: s64 }`
+- **WIT from functions**: `pub fn greet(name: String) -> String` → `greet: func(name: string) -> string`
+- **Canonical ABI adapters**: Convert between Almide's internal layout and canonical ABI at export boundaries
 
-Run between lowering and emission:
+### 7. WASI Preview 2 Adapter
 
-| Pass | Effect | LLVM equivalent |
-|------|--------|-----------------|
-| **RC Fusion** | Cancel adjacent inc+dec | None (LLVM doesn't know RC) |
-| **Dead Field Elim** | Skip unused record fields in alloc | Partial (SROA) |
-| **Iterator Fusion** | Merge chained MapForEach/ListForEach | None |
-| **Const Folding** | Evaluate constant FieldLoad at compile time | Yes, but layout-unaware |
-| **Local Coloring** | Reuse WASM locals across non-overlapping lifetimes | Register allocation |
-| **Inline Expansion** | Inline small WasmIR function bodies | Yes |
-| **Peephole** | Pattern-match and simplify instruction sequences | Yes |
+Replaces raw WASI Preview 1 imports with Component Model imports:
+
+| Current (Preview 1) | New (Preview 2 via CM) |
+|---------------------|----------------------|
+| `fd_write(fd, iovs, ...)` | `wasi:cli/stdout.get-stdout` + `output-stream.write` |
+| `fd_read(fd, iovs, ...)` | `wasi:cli/stdin.get-stdin` + `input-stream.read` |
+| `path_open(...)` | `wasi:filesystem/types.open-at` |
+| `clock_time_get(...)` | `wasi:clocks/monotonic-clock.now` |
+| (none) | `wasi:http/outgoing-handler.handle` |
+
+## Implementation Phases
+
+### Phase 0: Stack-Effect Verifier
+
+Add `(pops, pushes)` to existing WasmIR Op enum. Implement verifier. Run on WasmBuilder output. This alone closes the correctness gap for the engine layer.
+
+- [ ] Add stack-effect fields to WasmIR Op
+- [ ] Implement `verify_stack_balance()` recursive checker
+- [ ] Wire into WasmBuilder — verify after each function is built
+- [ ] Gate: zero stack-effect violations on `almide test spec/ --target wasm`
+
+### Phase 1: New Lowering
+
+Replace hand-written emission with AlmideIR → WasmIR lowering.
+
+- [ ] `lower_expr()` for all IrExprKind variants
+- [ ] `lower_stmt()` for all IrStmtKind variants
+- [ ] `lower_function()` with local allocation and structured control flow
+- [ ] Core emit: WasmIR → wasm-encoder (mechanical)
+- [ ] Gate: all `spec/lang/` + `spec/stdlib/` pass through new pipeline (240/240)
+
+### Phase 2: Component Model
+
+- [ ] WIT generation from Almide pub exports (`almide build --target wasm-component`)
+- [ ] Canonical ABI adapter generation (string, list, record, variant, option, result)
+- [ ] `wit-component` integration for component wrapping
+- [ ] Gate: compiled component validates with `wasm-tools validate --features component-model`
+
+### Phase 3: WASI Preview 2
+
+- [ ] Replace fd_write/fd_read with `wasi:cli/std{in,out,err}`
+- [ ] Replace path_open/fd_seek etc. with `wasi:filesystem/types`
+- [ ] Replace clock_time_get with `wasi:clocks/monotonic-clock`
+- [ ] Add `wasi:http/outgoing-handler` for HTTP client
+- [ ] Gate: `almide run app.almd --target wasm` works on wasmtime with WASI Preview 2
+
+### Phase 4: Exception Handling (WASM 3.0 v2)
+
+Waiting for wasmtime to enable by default.
+
+- [ ] `try_table`/`throw` for effect fn `?` propagation
+- [ ] Zero-cost error path (no Result heap allocation)
+- [ ] Gate: effect fn benchmarks show measurable improvement
+
+### Phase 5: Component Model Async (WASM 3.0 v3)
+
+- [ ] `fan` → `future<T>` + `waitable-set` multiplex
+- [ ] `stream<T>` for streaming data
+- [ ] Gate: fan benchmarks work on wasmtime with WASI 0.3
 
 ## What Dies
 
-All of current `emit_wasm/`:
+All of current `emit_wasm/` (40 files, ~15K LOC):
 
-| File | Replacement |
-|------|------------|
-| `list_layout.rs` | `LayoutRegistry` definitions |
-| `calls_string.rs` | `lower_string_call()` + StringInterp/StringConcat ops |
-| `calls_map.rs` | `lower_map_call()` + MapForEach/FieldLoad ops |
-| `calls_map_closure.rs` | same — 500 lines of boilerplate → ~50 lines of lowering |
-| `calls_list*.rs` | `lower_list_call()` + ListForEach ops |
-| `runtime.rs` | Emit phase: runtime fns emitted from WasmIR |
-| `rt_string*.rs` | same |
-| `expressions.rs` | `lower_expr()` |
-| `statements.rs` | `lower_stmt()` |
-| `control.rs` | Lowering for loops/match + Block/Loop/If WasmIR ops |
-| `equality.rs` | `DeepEq` WasmIR op |
-| `scratch.rs` | Local allocator moves into emit phase |
+| Current | Replacement |
+|---------|------------|
+| `expressions.rs`, `statements.rs`, `control.rs` | `lower_expr()`, `lower_stmt()` |
+| `calls_*.rs` (12 files) | stdlib lowering rules |
+| `rt_*.rs` (6 files) | runtime as WasmIR sequences |
+| `runtime.rs`, `runtime_eq.rs` | emit phase primitives |
+| `closures.rs`, `calls_lambda.rs` | closure lowering |
+| `equality.rs`, `collections.rs` | `DeepEq` op, collection lowering |
+| `scratch.rs` | local allocator in emit phase |
+| `values.rs` | LayoutRegistry |
+| `dce.rs` | WasmIR-level DCE pass |
 
-## Implementation Plan
+Kept: `engine/` (LayoutRegistry, WasmIR, WasmBuilder, emit) — this IS the new engine.
 
-### Phase 1: Foundation (LayoutRegistry + WasmIR types)
-- [ ] `LayoutRegistry` with String, List, Map, Set, Variant, Record, Tuple, Option, Result
-- [ ] `WasmIR` enum with core ops
-- [ ] `emit_op()` for each WasmIR variant (the only wasm-encoder touchpoint)
-- [ ] Proof of concept: compile `"hello ${name}" |> println` through new pipeline
+## Existing Foundation
 
-### Phase 2: Lowering (AlmideIR → WasmIR)
-- [ ] `lower_expr()` for all IrExprKind variants
-- [ ] `lower_stmt()` for all IrStmtKind variants
-- [ ] `lower_function()` including local allocation and control flow
-- [ ] Gate: all `spec/lang/` tests pass through new pipeline
+Already implemented in `emit_wasm/engine/`:
+- **LayoutRegistry**: All layouts defined (String, List, SwissMap, Set, AllocHeader, ClosurePair, Variant, Option, Result)
+- **WasmIR**: 40+ op variants with typed memory access
+- **WasmBuilder**: Chainable API with layout-safe field access, collection iteration, RC ops
+- **Emit**: WasmIR → wasm-encoder translation
 
-### Phase 3: Stdlib & Runtime
-- [ ] String runtime (concat, interp, slice, trim, eq, cmp, etc.)
-- [ ] List runtime (push, map, filter, fold, sort, etc.)
-- [ ] Map runtime (get, set, delete, keys, values, fold, etc.)
-- [ ] Other stdlib modules
-- [ ] Gate: all `spec/stdlib/` tests pass
-
-### Phase 4: Optimization Passes
-- [ ] RC Fusion
-- [ ] Local Coloring
-- [ ] Peephole
-- [ ] Gate: all benchmarks match or beat current emit_wasm performance
-
-### Phase 5: Delete Old Code
-- [ ] Remove all `emit_wasm/*.rs` files
-- [ ] Single entry point: `wasm_engine::compile(ir_program) -> Vec<u8>`
-
-## Findings from v0.23.11 Patch Session (2026-05-27)
-
-Session fixed 18 test files (175→193/240) by patching emit_wasm directly. Key findings that inform the redesign:
-
-### 1. Stack Discipline is the Hardest Problem
-
-**The blocking CI bug**: Perceus/ANF inserts a trailing `Ret(var_ref)` in void functions. This becomes a Block tail expression that pushes a value onto the WASM stack. The IR type annotation says Unit (Perceus doesn't update it), but codegen actually emits `local.get` which pushes i32. Result: "values remaining on stack at end of block" — rejected by V8 and newer wasmtime.
-
-**Why WasmIR fixes this**: The emit phase can statically verify stack balance per block/function. Each `Op` has a known stack effect (+1, -1, 0). A void function whose ops sum to non-zero gets an automatic `Op::Drop`. No IR type annotation trust needed.
-
-### 2. Layout Offset Bugs are Systemic
-
-String layout change (4→8 byte header) broke 3 sites. Map Swiss Table migration broke 35+ sites. HTTP module had 15+ hardcoded offsets. All fixed by replacing `i32_const(4)` with `list_layout::DATA_OFFSET` — but this is still manual and fragile.
-
-**Why WasmIR fixes this**: `Op::FieldLoad { layout: STRING, field: DATA }` resolves offset via `LayoutRegistry`. Zero hardcoded offsets in lowering.
-
-### 3. rc_dec on Data Section Pointers Corrupts Memory
-
-`rc_dec(ptr)` reads `ptr-4` as refcount. Interned strings in the data section have no alloc header → memory corruption. Fixed by adding `ptr < heap_start` guard to rc_dec/rc_inc/cow_check.
-
-**Why WasmIR fixes this**: `Op::RcDec { ptr, layout }` in the emit phase can check pointer origin. Or better: the lowering phase never emits RcDec for compile-time-known interned values.
-
-### 4. wasmparser Validation+Stub Hides Bugs
-
-The old emit_wasm validated with wasmparser 0.225 and replaced broken functions with `unreachable` stubs. This silently degraded correctness. Worse: wasmparser 0.225 had false positives on valid WASM that wasm-tools 0.244 accepts. Removed entirely — codegen must produce valid WASM.
-
-**Why WasmIR fixes this**: Stack balance is verified structurally at the IR level before emission. If WasmIR is well-formed, the emitted WASM is guaranteed valid.
-
-### 5. Swiss Table Iteration is a Pattern, Not a Primitive
-
-Every map closure method (fold/each/any/all/count/find/update/map) reimplemented the Swiss Table iteration loop. Extracted `MapIter` helpers — but still 8 call sites.
-
-**Why WasmIR fixes this**: `Op::MapForEach { map, entry_stride, body }` is a single IR node. The emit phase generates the Swiss Table loop once.
-
-### 6. Perceus/ANF Transforms IR Types Unreliably
-
-Perceus changes block structure (inserts RcDec statements, Ret tail expressions) but doesn't always update `.ty` annotations. The WASM emitter can't trust `expr.ty` for stack management decisions.
-
-**Why WasmIR fixes this**: WasmIR doesn't carry type annotations — it carries stack effects. Each Op explicitly declares what it pushes/pops. No "trust the annotation" problem.
-
-### Current Blockers (require WasmEngine to fix properly)
-
-| Bug | Symptom | Root Cause |
-|-----|---------|-----------|
-| `filter \|> map` pipe | WASM stack mismatch in void function | Perceus tail expr in void block |
-| `mut` param | list.push via mut param traps | Pass-by-reference not implemented in WASM |
-| `bytes.from_list` + assert | Heap corruption in test function | Perceus drop ordering |
-| `group_by` + assert | Same as above | Same |
-| `opaque type` | ConcretizeTypes fails on Member | Upstream type checker issue |
-| `intra-module fn ref` | Wrong function table index | Closure conversion for module fns |
+23 files already migrated to LayoutRegistry. WasmBuilder used in list_layout.rs and Perceus core.
 
 ## Metrics
 
-- **Correctness**: `almide test spec/ --target wasm` — 240/240 (currently 193/240)
-- **Binary size**: ≤ current (336B hello world baseline)
-- **Performance**: ≥ current (5 wins vs Rust+LLVM baseline)
+- **Correctness**: `almide test spec/ --target wasm` — 240/240
+- **Stack safety**: zero stack-effect violations (structurally enforced)
+- **Layout safety**: zero hardcoded offsets (enforced by LayoutRegistry)
+- **Binary size**: ≤ current
+- **Performance**: ≥ current
 - **Code volume**: emit_wasm/ LOC reduced by ≥50%
-- **Layout bugs**: structurally impossible (enforced by LayoutRegistry)
-- **Stack bugs**: structurally impossible (verified at WasmIR level)
+- **Component Model**: validates with `wasm-tools validate --features component-model`
+- **WASI Preview 2**: runs on wasmtime without Preview 1 adapter

--- a/docs/roadmap/done/wasm-component-model.md
+++ b/docs/roadmap/done/wasm-component-model.md
@@ -1,4 +1,6 @@
 <!-- description: WebAssembly Component Model support with WIT bindings -->
+<!-- done: 2026-05-29 -->
+<!-- note: merged into docs/roadmap/active/wasm-engine-redesign.md Phase 2-3 -->
 # WASM Component Model
 
 WebAssembly Component Model と WIT (WebAssembly Interface Types) をサポートし、言語間の相互運用を実現する。

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -56,6 +56,11 @@ pub fn cmd_build(file: &str, output: Option<&str>, target: Option<&str>, release
         let project_dir = std::env::temp_dir().join("almide-build-cdylib");
         // Strip fn main() from the code — cdylib has no entry point
         let lib_code = rs_code.replace("fn main()", "fn __almide_unused_main()");
+        // Serialize across processes: the shared scratch dir's src + target
+        // would otherwise be corrupted by a concurrent `almide build`.
+        let _ = std::fs::create_dir_all(&project_dir);
+        let _flock = super::run::BuildDirLock::acquire(&project_dir)
+            .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
         match super::cargo_build_cdylib(&lib_code, &project_dir, &output, use_release) {
             Ok(lib_path) => {
                 eprintln!("Built {}", lib_path.display());
@@ -89,6 +94,13 @@ pub fn cmd_build(file: &str, output: Option<&str>, target: Option<&str>, release
         .unwrap_or_else(|| std::path::PathBuf::from("."));
     let has_deps = parsed.as_ref().map_or(false, |p| !p.dependencies.is_empty());
     let source_root = if !native_deps.is_empty() || has_deps { Some(toml_dir.as_path()) } else { None };
+    // Serialize across processes: the shared scratch dir's src + target would
+    // otherwise be corrupted by a concurrent `almide build`. Held through the
+    // copy-out below so the generated binary can't be overwritten between
+    // build and copy.
+    let _ = std::fs::create_dir_all(&project_dir);
+    let _flock = super::run::BuildDirLock::acquire(&project_dir)
+        .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
     match super::cargo_build_generated_with_native(&rs_code, &project_dir, use_release, native_deps, source_root) {
         Ok(bin_path) => {
             // Copy the built binary to the desired output location

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -56,11 +56,6 @@ pub fn cmd_build(file: &str, output: Option<&str>, target: Option<&str>, release
         let project_dir = std::env::temp_dir().join("almide-build-cdylib");
         // Strip fn main() from the code — cdylib has no entry point
         let lib_code = rs_code.replace("fn main()", "fn __almide_unused_main()");
-        // Serialize across processes: the shared scratch dir's src + target
-        // would otherwise be corrupted by a concurrent `almide build`.
-        let _ = std::fs::create_dir_all(&project_dir);
-        let _flock = super::run::BuildDirLock::acquire(&project_dir)
-            .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
         match super::cargo_build_cdylib(&lib_code, &project_dir, &output, use_release) {
             Ok(lib_path) => {
                 eprintln!("Built {}", lib_path.display());
@@ -94,13 +89,6 @@ pub fn cmd_build(file: &str, output: Option<&str>, target: Option<&str>, release
         .unwrap_or_else(|| std::path::PathBuf::from("."));
     let has_deps = parsed.as_ref().map_or(false, |p| !p.dependencies.is_empty());
     let source_root = if !native_deps.is_empty() || has_deps { Some(toml_dir.as_path()) } else { None };
-    // Serialize across processes: the shared scratch dir's src + target would
-    // otherwise be corrupted by a concurrent `almide build`. Held through the
-    // copy-out below so the generated binary can't be overwritten between
-    // build and copy.
-    let _ = std::fs::create_dir_all(&project_dir);
-    let _flock = super::run::BuildDirLock::acquire(&project_dir)
-        .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
     match super::cargo_build_generated_with_native(&rs_code, &project_dir, use_release, native_deps, source_root) {
         Ok(bin_path) => {
             // Copy the built binary to the desired output location

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -385,6 +385,128 @@ pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
     }
 }
 
+/// Default `almide test`: run each file on the fast rustc-free WASM path; for
+/// any file the WASM path can't pass (emitter gap, wasm:skip, or a trap), fall
+/// back to the native rustc path, which is authoritative. The common case (most
+/// tests pass on WASM) is ~9x faster; the native fallback preserves correctness.
+pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
+    let test_files: Vec<String> = if !file.is_empty() {
+        let path = std::path::Path::new(file);
+        if path.is_dir() {
+            let mut files = collect_test_files(path);
+            files.sort();
+            if files.is_empty() {
+                eprintln!("No .almd files with test blocks found in {}", file);
+                std::process::exit(1);
+            }
+            files
+        } else {
+            vec![file.to_string()]
+        }
+    } else {
+        let mut files = Vec::new();
+        for dir in &["spec", "exercises"] {
+            let path = std::path::Path::new(dir);
+            if path.exists() { files.extend(collect_test_files(path)); }
+        }
+        if files.is_empty() { files = collect_test_files(std::path::Path::new(".")); }
+        files.sort();
+        if files.is_empty() {
+            eprintln!("No .almd files with test blocks found.");
+            std::process::exit(1);
+        }
+        files
+    };
+
+    let cpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4);
+    let tmp_dir = std::sync::Arc::new(std::env::temp_dir().join("almide-wasm-test"));
+    std::fs::create_dir_all(&*tmp_dir).ok();
+
+    // Phase 1: WASM (fast, rustc-free), parallel.
+    let wasm_outcomes: Vec<WasmTestOutcome> = {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
+        for _ in 0..cpus { let _ = sem_tx.send(()); }
+        let sem_tx = std::sync::Arc::new(sem_tx);
+        let sem_rx = std::sync::Arc::new(std::sync::Mutex::new(sem_rx));
+        let mut handles = Vec::new();
+        for tf in test_files.clone() {
+            let tx = tx.clone();
+            let td = tmp_dir.clone();
+            let sr = sem_rx.clone();
+            let st = sem_tx.clone();
+            handles.push(std::thread::spawn(move || {
+                let _ = sr.lock().unwrap().recv();
+                let o = compile_and_run_wasm_test(&tf, &td);
+                let _ = st.send(());
+                let _ = tx.send(o);
+            }));
+        }
+        drop(tx);
+        let v: Vec<_> = rx.iter().collect();
+        for h in handles { let _ = h.join(); }
+        v
+    };
+
+    let mut wasm_pass = 0usize;
+    let mut fallback: Vec<String> = Vec::new();
+    for o in wasm_outcomes {
+        match o {
+            WasmTestOutcome::Pass { .. } => wasm_pass += 1,
+            WasmTestOutcome::Fail { file, .. } | WasmTestOutcome::Skip { file, .. } => fallback.push(file),
+        }
+    }
+
+    // Phase 2: native rustc fallback (authoritative) for everything the WASM
+    // path didn't pass, parallel with per-file scratch dirs.
+    let mut program_args: Vec<String> = Vec::new();
+    if let Some(f) = run_filter { program_args.push(f.to_string()); }
+    let program_args = std::sync::Arc::new(program_args);
+
+    let native_results: Vec<(String, i32)> = {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
+        for _ in 0..cpus { let _ = sem_tx.send(()); }
+        let sem_tx = std::sync::Arc::new(sem_tx);
+        let sem_rx = std::sync::Arc::new(std::sync::Mutex::new(sem_rx));
+        let mut handles = Vec::new();
+        for tf in fallback.clone() {
+            let tx = tx.clone();
+            let args = program_args.clone();
+            let sr = sem_rx.clone();
+            let st = sem_tx.clone();
+            handles.push(std::thread::spawn(move || {
+                let _ = sr.lock().unwrap().recv();
+                let worker_dir = std::env::temp_dir()
+                    .join("almide-test")
+                    .join(tf.replace('/', "_").replace('.', "_"));
+                let code = match super::run::compile_to_binary(&tf, no_check, true, false, Some(&worker_dir)) {
+                    Ok(bin) => super::run::run_binary(&bin, &args),
+                    Err(e) => { eprintln!("Compile error for {}:\n{}", tf, e); 1 }
+                };
+                let _ = st.send(());
+                let _ = tx.send((tf, code));
+            }));
+        }
+        drop(tx);
+        let mut v: Vec<(String, i32)> = rx.iter().collect();
+        for h in handles { let _ = h.join(); }
+        v.sort_by(|a, b| a.0.cmp(&b.0));
+        v
+    };
+
+    let mut failed = 0;
+    for (file, code) in &native_results {
+        if *code != 0 { eprintln!("FAILED: {}", file); failed += 1; }
+    }
+    eprintln!("\n{} via WASM, {} via native fallback, {} failed (of {} files)",
+        wasm_pass, fallback.len().saturating_sub(failed), failed, test_files.len());
+    if failed > 0 {
+        std::process::exit(1);
+    }
+    eprintln!("All {} test file(s) passed", test_files.len());
+}
+
 pub fn cmd_test_ts(file: &str, _run_filter: Option<&str>) {
     use crate::{parse_file, canonicalize, check, diagnostic, resolve, project, project_fetch};
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -170,9 +170,129 @@ pub fn cmd_test(file: &str, no_check: bool, run_filter: Option<&str>) {
     eprintln!("\nAll {} test file(s) passed", test_files.len());
 }
 
-pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
-    use crate::{parse_file, canonicalize, check, diagnostic, resolve, project, project_fetch};
+enum WasmTestOutcome {
+    Pass { file: String, count: usize, bytes: usize },
+    Fail { file: String, detail: String },
+    Skip { file: String, reason: String },
+}
 
+/// Compile one `.almd` file to WASM and run it under wasmtime. Pure per-file
+/// work (no shared mutable state) so it runs in parallel — the WASM path takes
+/// no rustc/cargo, so there's no global build lock to serialize on.
+fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> WasmTestOutcome {
+    use crate::{parse_file, canonicalize, check, diagnostic, resolve, project, project_fetch};
+    let skip = |reason: String| WasmTestOutcome::Skip { file: test_file.to_string(), reason };
+
+    let wasm_name = test_file.replace('/', "_").replace('.', "_") + ".wasm";
+    let wasm_path = tmp_dir.join(&wasm_name);
+
+    let (mut program, source_text, _parse_errors) = parse_file(test_file);
+    if source_text.lines().take(3).any(|line| line.contains("// wasm:skip")) {
+        return skip("wasm:skip".to_string());
+    }
+
+    let dep_paths: Vec<(project::PkgId, std::path::PathBuf)> =
+        if std::path::Path::new("almide.toml").exists() {
+            if let Ok(proj) = project::parse_toml(std::path::Path::new("almide.toml")) {
+                project_fetch::fetch_all_deps(&proj)
+                    .unwrap_or_else(|_| vec![])
+                    .into_iter()
+                    .map(|fd| (fd.pkg_id, fd.source_dir))
+                    .collect()
+            } else { vec![] }
+        } else { vec![] };
+
+    let mut resolved = match resolve::resolve_imports_with_deps(test_file, &program, &dep_paths) {
+        Ok(r) => r,
+        Err(e) => return skip(format!("resolve: {}", e)),
+    };
+
+    let canon = canonicalize::canonicalize_program(
+        &program,
+        resolved.modules.iter().map(|(n, p, _, s)| (n.as_str(), p, *s)),
+    );
+    let mut checker = check::Checker::from_env(canon.env);
+    checker.set_source(test_file, &source_text);
+    checker.diagnostics = canon.diagnostics;
+    let diagnostics = checker.infer_program(&mut program);
+    if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
+        return skip("type errors".to_string());
+    }
+
+    for (name, _, pkg_id, _) in &resolved.modules {
+        if let Some(pid) = pkg_id.as_ref() {
+            let base = pid.mod_name();
+            let v = if let Some(suffix) = name.strip_prefix(&pid.name) { format!("{}{}", base, suffix) } else { base };
+            checker.env.module_versioned_names.insert(almide::intern::sym(name), almide::intern::sym(&v));
+        }
+    }
+    let mut ir_program = almide::lower::lower_program(&program, &checker.env, &checker.type_map);
+    for (name, mod_prog, pkg_id, _) in &mut resolved.modules {
+        if almide::stdlib::is_stdlib_module(name) && !almide::stdlib::is_bundled_module(name) { continue; }
+        let saved_self = checker.env.self_module_name;
+        if let Some(pid) = pkg_id.as_ref() {
+            checker.env.self_module_name = Some(almide::intern::sym(&pid.name));
+        }
+        checker.infer_module(mod_prog, name);
+        let versioned = pkg_id.as_ref().map(|pid| {
+            let base = pid.mod_name();
+            if let Some(suffix) = name.strip_prefix(&pid.name) { format!("{}{}", base, suffix) } else { base }
+        });
+        if let Some(ref v) = versioned {
+            checker.env.module_versioned_names.insert(almide::intern::sym(name), almide::intern::sym(v));
+        }
+        let self_name = checker.env.self_module_name.map(|s| s.to_string());
+        let import_table_name = self_name.as_deref().unwrap_or(name);
+        let (mod_table, _) = almide::import_table::build_import_table(mod_prog, Some(import_table_name), &checker.env.user_modules);
+        let saved_table = std::mem::replace(&mut checker.env.import_table, mod_table);
+        let mod_ir_module = almide::lower::lower_module(name, mod_prog, &checker.env, &checker.type_map, versioned);
+        checker.env.import_table = saved_table;
+        checker.env.self_module_name = saved_self;
+        ir_program.modules.push(mod_ir_module);
+    }
+    almide::ir_link::ir_link(&mut ir_program);
+    almide::optimize::optimize_program(&mut ir_program);
+    almide::mono::monomorphize(&mut ir_program);
+    let bytes = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        match almide::codegen::codegen(&mut ir_program, almide::codegen::pass::Target::Wasm) {
+            almide::codegen::CodegenOutput::Binary(b) => b,
+            almide::codegen::CodegenOutput::Source(_) => unreachable!(),
+        }
+    }));
+    let bytes = match bytes {
+        Ok(b) => b,
+        Err(_) => return skip("WASM codegen panic".to_string()),
+    };
+    if let Err(e) = std::fs::write(&wasm_path, &bytes) {
+        return skip(format!("write: {}", e));
+    }
+
+    let output = std::process::Command::new("wasmtime")
+        .arg("--dir=/")
+        .arg(wasm_path.to_str().unwrap())
+        .output();
+    match output {
+        Ok(result) => {
+            let stdout = String::from_utf8_lossy(&result.stdout);
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            if result.status.success() {
+                WasmTestOutcome::Pass { file: test_file.to_string(), count: stdout.matches("ok\n").count(), bytes: bytes.len() }
+            } else {
+                let mut last_test = String::new();
+                for line in stdout.lines() {
+                    if line.starts_with("test: ") { last_test = line.to_string(); }
+                }
+                let mut detail = String::new();
+                if !last_test.is_empty() { detail.push_str(&format!("  trapped at: {}\n", last_test)); }
+                for line in stderr.lines().take(2) { detail.push_str(&format!("  {}\n", line)); }
+                WasmTestOutcome::Fail { file: test_file.to_string(), detail }
+            }
+        }
+        Err(e) => skip(format!("wasmtime: {}", e)),
+    }
+}
+
+pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
     let test_files: Vec<String> = if !file.is_empty() {
         let path = std::path::Path::new(file);
         if path.is_dir() {
@@ -199,153 +319,54 @@ pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
     let tmp_dir = std::env::temp_dir().join("almide-wasm-test");
     std::fs::create_dir_all(&tmp_dir).ok();
 
+    // Parallel: each file's compile+run is independent and rustc/cargo-free,
+    // so there's no global build lock to serialize on (unlike the native path).
+    let cpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4);
+    let tmp_dir = std::sync::Arc::new(tmp_dir);
+    let (tx, rx) = std::sync::mpsc::channel();
+    let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
+    for _ in 0..cpus { let _ = sem_tx.send(()); }
+    let sem_tx = std::sync::Arc::new(sem_tx);
+    let sem_rx = std::sync::Arc::new(std::sync::Mutex::new(sem_rx));
+    let mut handles = Vec::new();
+    for test_file in test_files.clone() {
+        let tx = tx.clone();
+        let tmp_dir = tmp_dir.clone();
+        let sem_rx = sem_rx.clone();
+        let sem_tx = sem_tx.clone();
+        handles.push(std::thread::spawn(move || {
+            let _ = sem_rx.lock().unwrap().recv();
+            let outcome = compile_and_run_wasm_test(&test_file, &tmp_dir);
+            let _ = sem_tx.send(());
+            let _ = tx.send(outcome);
+        }));
+    }
+    drop(tx);
+    let mut outcomes: Vec<WasmTestOutcome> = rx.iter().collect();
+    for h in handles { let _ = h.join(); }
+    let file_of = |o: &WasmTestOutcome| match o {
+        WasmTestOutcome::Pass { file, .. }
+        | WasmTestOutcome::Fail { file, .. }
+        | WasmTestOutcome::Skip { file, .. } => file.clone(),
+    };
+    outcomes.sort_by(|a, b| file_of(a).cmp(&file_of(b)));
+
     let mut failed = 0;
     let mut passed = 0;
     let mut skipped = 0;
-
-    for test_file in &test_files {
-        // Build WASM binary
-        let wasm_name = test_file.replace('/', "_").replace('.', "_") + ".wasm";
-        let wasm_path = tmp_dir.join(&wasm_name);
-
-        let (mut program, source_text, _parse_errors) = parse_file(test_file);
-
-        // Skip files marked with // wasm:skip
-        if source_text.lines().take(3).any(|line| line.contains("// wasm:skip")) {
-            skipped += 1;
-            continue;
-        }
-
-        // Resolve dependencies
-        let dep_paths: Vec<(project::PkgId, std::path::PathBuf)> =
-            if std::path::Path::new("almide.toml").exists() {
-                if let Ok(proj) = project::parse_toml(std::path::Path::new("almide.toml")) {
-                    project_fetch::fetch_all_deps(&proj)
-                        .unwrap_or_else(|e| { eprintln!("{}", e); vec![] })
-                        .into_iter()
-                        .map(|fd| (fd.pkg_id, fd.source_dir))
-                        .collect()
-                } else { vec![] }
-            } else { vec![] };
-
-        let mut resolved = match resolve::resolve_imports_with_deps(test_file, &program, &dep_paths) {
-            Ok(r) => r,
-            Err(e) => {
-                eprintln!("SKIP {} (resolve: {})", test_file, e);
-                skipped += 1;
-                continue;
+    for o in &outcomes {
+        match o {
+            WasmTestOutcome::Pass { file, count, bytes } => {
+                eprintln!("{}: {} tests passed ({} bytes)", file, count, bytes);
+                passed += 1;
             }
-        };
-
-        let canon = canonicalize::canonicalize_program(
-            &program,
-            resolved.modules.iter().map(|(n, p, _, s)| (n.as_str(), p, *s)),
-        );
-        let mut checker = check::Checker::from_env(canon.env);
-        checker.set_source(test_file, &source_text);
-        checker.diagnostics = canon.diagnostics;
-        let diagnostics = checker.infer_program(&mut program);
-        if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
-            eprintln!("SKIP {} (type errors)", test_file);
-            skipped += 1;
-            continue;
-        }
-
-        for (name, _, pkg_id, _) in &resolved.modules {
-            if let Some(pid) = pkg_id.as_ref() {
-                let base = pid.mod_name();
-                let v = if let Some(suffix) = name.strip_prefix(&pid.name) { format!("{}{}", base, suffix) } else { base };
-                checker.env.module_versioned_names.insert(almide::intern::sym(name), almide::intern::sym(&v));
+            WasmTestOutcome::Fail { file, detail } => {
+                eprintln!("FAIL {}", file);
+                eprint!("{}", detail);
+                failed += 1;
             }
-        }
-        let mut ir_program = almide::lower::lower_program(&program, &checker.env, &checker.type_map);
-        for (name, mod_prog, pkg_id, _) in &mut resolved.modules {
-            if almide::stdlib::is_stdlib_module(name) && !almide::stdlib::is_bundled_module(name) { continue; }
-            let saved_self = checker.env.self_module_name;
-            if let Some(pid) = pkg_id.as_ref() {
-                checker.env.self_module_name = Some(almide::intern::sym(&pid.name));
-            }
-            checker.infer_module(mod_prog, name);
-            let versioned = pkg_id.as_ref().map(|pid| {
-                let base = pid.mod_name();
-                if let Some(suffix) = name.strip_prefix(&pid.name) { format!("{}{}", base, suffix) } else { base }
-            });
-            if let Some(ref v) = versioned {
-                checker.env.module_versioned_names.insert(almide::intern::sym(name), almide::intern::sym(v));
-            }
-            let self_name = checker.env.self_module_name.map(|s| s.to_string());
-            let import_table_name = self_name.as_deref().unwrap_or(name);
-            let (mod_table, _) = almide::import_table::build_import_table(mod_prog, Some(import_table_name), &checker.env.user_modules);
-            let saved_table = std::mem::replace(&mut checker.env.import_table, mod_table);
-            let mod_ir_module = almide::lower::lower_module(name, mod_prog, &checker.env, &checker.type_map, versioned);
-            checker.env.import_table = saved_table;
-            checker.env.self_module_name = saved_self;
-            ir_program.modules.push(mod_ir_module);
-        }
-        almide::ir_link::ir_link(&mut ir_program);
-        almide::optimize::optimize_program(&mut ir_program);
-        almide::mono::monomorphize(&mut ir_program);
-        let bytes = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            match almide::codegen::codegen(&mut ir_program, almide::codegen::pass::Target::Wasm) {
-                almide::codegen::CodegenOutput::Binary(b) => b,
-                almide::codegen::CodegenOutput::Source(_) => unreachable!(),
-            }
-        }));
-        let bytes = match bytes {
-            Ok(b) => b,
-            Err(_) => {
-                eprintln!("SKIP {} (WASM codegen panic)", test_file);
-                skipped += 1;
-                continue;
-            }
-        };
-
-        if let Err(e) = std::fs::write(&wasm_path, &bytes) {
-            eprintln!("SKIP {} (write: {})", test_file, e);
-            skipped += 1;
-            continue;
-        }
-
-        // Run with wasmtime (preopened root dir for full filesystem access)
-        let output = std::process::Command::new("wasmtime")
-            .arg("--dir=/")
-            .arg(wasm_path.to_str().unwrap())
-            .output();
-
-        match output {
-            Ok(result) => {
-                let stdout = String::from_utf8_lossy(&result.stdout);
-                let stderr = String::from_utf8_lossy(&result.stderr);
-
-                if result.status.success() {
-                    // Count tests from output
-                    let test_count = stdout.matches("ok\n").count();
-                    eprintln!("{}: {} tests passed ({} bytes)", test_file, test_count, bytes.len());
-                    passed += 1;
-                } else {
-                    // Find which test failed (last "test: NAME" before trap)
-                    let lines: Vec<&str> = stdout.lines().collect();
-                    let mut last_test = "";
-                    for line in &lines {
-                        if line.starts_with("test: ") {
-                            last_test = line;
-                        }
-                    }
-                    eprintln!("FAIL {}", test_file);
-                    if !last_test.is_empty() {
-                        eprintln!("  trapped at: {}", last_test);
-                    }
-                    if !stderr.is_empty() {
-                        // Show just the trap message, not the full stack trace
-                        for line in stderr.lines().take(2) {
-                            eprintln!("  {}", line);
-                        }
-                    }
-                    failed += 1;
-                }
-            }
-            Err(e) => {
-                eprintln!("SKIP {} (wasmtime: {})", test_file, e);
+            WasmTestOutcome::Skip { file, reason } => {
+                eprintln!("SKIP {} ({})", file, reason);
                 skipped += 1;
             }
         }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -104,7 +104,12 @@ pub fn cmd_test(file: &str, no_check: bool, run_filter: Option<&str>) {
             let sem_tx = sem_tx.clone();
             handles.push(std::thread::spawn(move || {
                 let _ = sem_rx.lock().unwrap().recv();
-                let result = super::run::compile_to_binary(&test_file, no_check, true, false);
+                // Per-file scratch dir so cold rustc builds parallelize instead
+                // of serializing on the shared dir's BUILD_LOCK.
+                let worker_dir = std::env::temp_dir()
+                    .join("almide-test")
+                    .join(test_file.replace('/', "_").replace('.', "_"));
+                let result = super::run::compile_to_binary(&test_file, no_check, true, false, Some(&worker_dir));
                 let _ = sem_tx.send(());
                 let _ = tx.send((test_file, result));
             }));

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -182,11 +182,14 @@ enum WasmTestOutcome {
 fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> WasmTestOutcome {
     use crate::{parse_file, canonicalize, check, diagnostic, resolve, project, project_fetch};
     let skip = |reason: String| WasmTestOutcome::Skip { file: test_file.to_string(), reason };
+    let prof = std::env::var_os("ALMIDE_PROFILE").is_some();
+    let mut marks: Vec<(&str, std::time::Instant)> = vec![("start", std::time::Instant::now())];
 
     let wasm_name = test_file.replace('/', "_").replace('.', "_") + ".wasm";
     let wasm_path = tmp_dir.join(&wasm_name);
 
     let (mut program, source_text, _parse_errors) = parse_file(test_file);
+    if prof { marks.push(("parse", std::time::Instant::now())); }
     if source_text.lines().take(3).any(|line| line.contains("// wasm:skip")) {
         return skip("wasm:skip".to_string());
     }
@@ -206,6 +209,7 @@ fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> Wasm
         Ok(r) => r,
         Err(e) => return skip(format!("resolve: {}", e)),
     };
+    if prof { marks.push(("resolve", std::time::Instant::now())); }
 
     let canon = canonicalize::canonicalize_program(
         &program,
@@ -218,6 +222,7 @@ fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> Wasm
     if diagnostics.iter().any(|d| d.level == diagnostic::Level::Error) {
         return skip("type errors".to_string());
     }
+    if prof { marks.push(("check_user", std::time::Instant::now())); }
 
     for (name, _, pkg_id, _) in &resolved.modules {
         if let Some(pid) = pkg_id.as_ref() {
@@ -250,9 +255,11 @@ fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> Wasm
         checker.env.self_module_name = saved_self;
         ir_program.modules.push(mod_ir_module);
     }
+    if prof { marks.push(("lower_modules", std::time::Instant::now())); }
     almide::ir_link::ir_link(&mut ir_program);
     almide::optimize::optimize_program(&mut ir_program);
     almide::mono::monomorphize(&mut ir_program);
+    if prof { marks.push(("opt_mono", std::time::Instant::now())); }
     let bytes = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         match almide::codegen::codegen(&mut ir_program, almide::codegen::pass::Target::Wasm) {
             almide::codegen::CodegenOutput::Binary(b) => b,
@@ -263,6 +270,15 @@ fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> Wasm
         Ok(b) => b,
         Err(_) => return skip("WASM codegen panic".to_string()),
     };
+    if prof {
+        marks.push(("codegen", std::time::Instant::now()));
+        let total = marks.last().unwrap().1.duration_since(marks[0].1).as_secs_f64();
+        let mut line = format!("[prof] {} total={:.3}s", test_file, total);
+        for w in marks.windows(2) {
+            line.push_str(&format!(" | {}={:.3}", w[1].0, w[1].1.duration_since(w[0].1).as_secs_f64()));
+        }
+        eprintln!("{}", line);
+    }
     if let Err(e) = std::fs::write(&wasm_path, &bytes) {
         return skip(format!("write: {}", e));
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -423,6 +423,37 @@ fn cargo_build_test_with_native(
     if uses_zlib {
         all_deps.push(crate::project::NativeDep { name: "flate2".into(), spec: "1".into() });
     }
+
+    // Fast path: the generated test crate is dependency-free (the runtime is
+    // inlined as source). `cargo test --no-run` serializes concurrent builds on
+    // cargo's global `~/.cargo/.package-cache` lock — even across separate
+    // project dirs — so a parallel test run is effectively sequential. A bare
+    // `rustc --test` has no such lock, so per-file builds run truly in parallel.
+    if !uses_http && !uses_zlib && native_deps.is_empty() && source_root.is_none() {
+        let mut final_code = rs_code.to_string();
+        if !final_code.contains("fn main(") && !final_code.contains("fn almide_main(") {
+            final_code.push_str("\nfn main() {}\n");
+        }
+        let rs_path = project_dir.join("almide_test_main.rs");
+        std::fs::write(&rs_path, &final_code)
+            .map_err(|e| format!("failed to write {}: {}", rs_path.display(), e))?;
+        let bin_path = project_dir.join("almide_test_bin");
+        let output = std::process::Command::new(crate::find_rustc())
+            .arg(&rs_path)
+            .arg("--test")
+            .arg("-o").arg(&bin_path)
+            .arg("--edition").arg("2021")
+            .arg("-C").arg("opt-level=1")
+            .arg("-C").arg("overflow-checks=no")
+            .arg("-A").arg("warnings")
+            .output()
+            .map_err(|e| format!("failed to run rustc: {}", e))?;
+        if !output.status.success() {
+            return Err(String::from_utf8_lossy(&output.stderr).to_string());
+        }
+        return Ok(bin_path);
+    }
+
     let cargo_toml = build_cargo_toml(base_toml, &all_deps);
     let src_dir = project_dir.join("src");
     std::fs::create_dir_all(&src_dir).map_err(|e| format!("failed to create {}: {}", src_dir.display(), e))?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,7 +19,7 @@ pub use build::cmd_build;
 pub use compile::cmd_compile;
 pub use emit::cmd_emit;
 pub use check::{cmd_check, cmd_check_json, cmd_check_effects};
-pub use commands::{cmd_init, cmd_test, cmd_test_json, cmd_test_wasm, cmd_test_ts, cmd_fmt, cmd_clean};
+pub use commands::{cmd_init, cmd_test, cmd_test_fast, cmd_test_json, cmd_test_wasm, cmd_test_ts, cmd_fmt, cmd_clean};
 pub use install::cmd_install;
 pub use selfupdate::cmd_self_update;
 pub use ide::{cmd_ide_outline, cmd_ide_doc, cmd_ide_stdlib_snapshot};

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -410,6 +410,65 @@ fn cargo_build_test(rs_code: &str, project_dir: &std::path::Path) -> Result<std:
     cargo_build_test_with_native(rs_code, project_dir, &[], None)
 }
 
+/// Path to the precompiled `almide_rt` runtime rlib, built once per process.
+///
+/// The runtime (string/list/map/... ops, RcCow, AlmideConcat, the equality
+/// macros) is identical across every compiled file, yet the inline-source model
+/// makes rustc recompile all ~2000 lines of it for each one (~2.2s/file). The
+/// rlib model — Rust's own — compiles it once into an `.rlib`; per-file rustc
+/// then just links it (~0.4s/file).
+///
+/// Keyed by a hash of the runtime source + rustc version + opt flags, so a
+/// compiler upgrade or a runtime edit transparently rebuilds. Cross-process
+/// builders serialize on a per-dir advisory lock; a warm cache is a stat.
+fn ensure_runtime_rlib() -> Result<std::path::PathBuf, String> {
+    static CACHED: std::sync::OnceLock<Result<std::path::PathBuf, String>> = std::sync::OnceLock::new();
+    CACHED.get_or_init(build_runtime_rlib).clone()
+}
+
+fn build_runtime_rlib() -> Result<std::path::PathBuf, String> {
+    let src = crate::codegen::emit_runtime_crate();
+    let rustc = crate::find_rustc();
+    let rustc_ver = std::process::Command::new(&rustc)
+        .arg("--version")
+        .output()
+        .ok()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    // opt/edition flags here MUST match the per-file rustc invocation below.
+    let key = format!("{:016x}", hash64(format!("{src}|{rustc_ver}|opt1|ed2021").as_bytes()));
+    let dir = std::env::temp_dir().join(format!("almide-rtlib-{key}"));
+    let rlib = dir.join("libalmide_rt.rlib");
+    if rlib.exists() {
+        return Ok(rlib);
+    }
+    std::fs::create_dir_all(&dir).map_err(|e| format!("rtlib dir: {e}"))?;
+    let _lock = run::BuildDirLock::acquire(&dir)?;
+    if rlib.exists() {
+        return Ok(rlib); // another builder won the race while we waited
+    }
+    let src_path = dir.join("almide_rt.rs");
+    std::fs::write(&src_path, &src).map_err(|e| format!("rtlib src: {e}"))?;
+    let output = std::process::Command::new(&rustc)
+        .arg(&src_path)
+        .arg("--crate-type").arg("lib")
+        .arg("--crate-name").arg("almide_rt")
+        .arg("--edition").arg("2021")
+        .arg("-C").arg("opt-level=1")
+        .arg("-C").arg("overflow-checks=no")
+        .arg("-A").arg("warnings")
+        .arg("--out-dir").arg(&dir)
+        .output()
+        .map_err(|e| format!("rtlib rustc: {e}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).to_string());
+    }
+    if !rlib.exists() {
+        return Err("rtlib build produced no .rlib".to_string());
+    }
+    Ok(rlib)
+}
+
 fn cargo_build_test_with_native(
     rs_code: &str,
     project_dir: &std::path::Path,
@@ -430,6 +489,50 @@ fn cargo_build_test_with_native(
     // project dirs — so a parallel test run is effectively sequential. A bare
     // `rustc --test` has no such lock, so per-file builds run truly in parallel.
     if !uses_http && !uses_zlib && native_deps.is_empty() && source_root.is_none() {
+        let bin_path = project_dir.join("almide_test_bin");
+
+        // rlib fast path: link the precompiled runtime instead of recompiling
+        // its ~2000 lines per file (~2.2s → ~0.4s). Any failure (e.g. a runtime
+        // vs. user type collision that only manifests cross-crate) falls through
+        // to the inline path below, so this never regresses correctness — at
+        // worst a file pays one extra rustc. Opt out with ALMIDE_NO_RTLIB=1.
+        if std::env::var_os("ALMIDE_NO_RTLIB").is_none() {
+            if let (Ok(rlib), Some(mut slim)) = (
+                ensure_runtime_rlib(),
+                crate::codegen::slim_main_with_external_runtime(rs_code),
+            ) {
+                if !slim.contains("fn main(") && !slim.contains("fn almide_main(") {
+                    slim.push_str("\nfn main() {}\n");
+                }
+                let rlib_dir = rlib.parent().unwrap_or_else(|| std::path::Path::new("."));
+                let rs_path = project_dir.join("almide_test_main.rs");
+                if std::fs::write(&rs_path, &slim).is_ok() {
+                    // opt-level=0 for the slim main: the runtime (the part that
+                    // benefits from optimization) is already compiled into the
+                    // rlib at opt-level=1, and test user code is short-lived, so
+                    // optimizing it just burns compile time. opt0 + rlib is ~2.7x
+                    // over the inline opt1 path; opt1 + rlib only ~1.6x.
+                    let output = std::process::Command::new(crate::find_rustc())
+                        .arg(&rs_path)
+                        .arg("--test")
+                        .arg("-o").arg(&bin_path)
+                        .arg("--edition").arg("2021")
+                        .arg("-C").arg("opt-level=0")
+                        .arg("-C").arg("overflow-checks=no")
+                        .arg("--extern").arg(format!("almide_rt={}", rlib.display()))
+                        .arg("-L").arg(rlib_dir)
+                        .arg("-A").arg("warnings")
+                        .output();
+                    if let Ok(output) = output {
+                        if output.status.success() {
+                            return Ok(bin_path);
+                        }
+                        // else: fall through to the self-contained inline build
+                    }
+                }
+            }
+        }
+
         let mut final_code = rs_code.to_string();
         if !final_code.contains("fn main(") && !final_code.contains("fn almide_main(") {
             final_code.push_str("\nfn main() {}\n");
@@ -437,7 +540,6 @@ fn cargo_build_test_with_native(
         let rs_path = project_dir.join("almide_test_main.rs");
         std::fs::write(&rs_path, &final_code)
             .map_err(|e| format!("failed to write {}: {}", rs_path.display(), e))?;
-        let bin_path = project_dir.join("almide_test_bin");
         let output = std::process::Command::new(crate::find_rustc())
             .arg(&rs_path)
             .arg("--test")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -327,6 +327,56 @@ fn cargo_build_generated_with_native(
     let uses_matrix = rs_code.contains("almide_rt_matrix_");
     let uses_http = rs_code.contains("almide_rt_http_") || rs_code.contains("use rustls");
     let uses_zlib = rs_code.contains("almide_rt_zlib_") || rs_code.contains("use flate2");
+
+    // rlib fast path (dep-free): link the precompiled runtime instead of
+    // recompiling its ~2000 lines per build. The runtime is compiled at the same
+    // opt-level as the binary (3 for `--release`, 1 for debug/`almide run`), so
+    // it is fully optimized; only its compilation is amortized. Net: shipping
+    // builds drop from ~27-33s to ~1-2s (~20x).
+    //
+    // Tradeoff: because the runtime is a separate crate (no LTO), non-generic
+    // non-#[inline] runtime fns (e.g. string.trim/split) aren't inlined across
+    // the crate boundary, costing up to ~10% runtime on string/list-heavy hot
+    // loops (typically 2-5%). ThinLTO would recover it but erases the build win
+    // (it re-optimizes the runtime at link time). The planned fix is #[inline] on
+    // the hot runtime fns — see docs/roadmap. ALMIDE_NO_RTLIB=1 forces the
+    // monolithic cargo build (full cross-crate inlining) when a shipped binary
+    // must squeeze out that last few percent. Any rustc failure also falls
+    // through to the cargo path below, so correctness never regresses.
+    if std::env::var_os("ALMIDE_NO_RTLIB").is_none()
+        && !uses_matrix && !uses_http && !uses_zlib
+        && native_deps.is_empty() && source_root.is_none()
+    {
+        let opt_level = if release { "3" } else { "1" };
+        if let (Ok(rlib), Some(mut slim)) = (
+            ensure_runtime_rlib(opt_level),
+            crate::codegen::slim_main_with_external_runtime(rs_code),
+        ) {
+            if !slim.contains("fn main(") && !slim.contains("fn almide_main(") {
+                slim.push_str("\nfn main() {}\n");
+            }
+            let rlib_dir = rlib.parent().unwrap_or_else(|| std::path::Path::new("."));
+            let rs_path = project_dir.join("almide_gen_main.rs");
+            let bin_path = project_dir.join(if cfg!(windows) { "almide-out.exe" } else { "almide-out" });
+            if std::fs::write(&rs_path, &slim).is_ok() {
+                let mut cmd = std::process::Command::new(crate::find_rustc());
+                cmd.arg(&rs_path)
+                    .arg("-o").arg(&bin_path)
+                    .arg("--edition").arg("2021")
+                    .arg("-C").arg(format!("opt-level={opt_level}"))
+                    .arg("--extern").arg(format!("almide_rt={}", rlib.display()))
+                    .arg("-L").arg(rlib_dir)
+                    .arg("-A").arg("warnings");
+                if let Ok(output) = cmd.output() {
+                    if output.status.success() {
+                        return Ok(bin_path);
+                    }
+                    // else: fall through to the self-contained cargo build
+                }
+            }
+        }
+    }
+
     let src_dir = project_dir.join("src");
     std::fs::create_dir_all(&src_dir).map_err(|e| format!("failed to create {}: {}", src_dir.display(), e))?;
 
@@ -418,15 +468,30 @@ fn cargo_build_test(rs_code: &str, project_dir: &std::path::Path) -> Result<std:
 /// rlib model — Rust's own — compiles it once into an `.rlib`; per-file rustc
 /// then just links it (~0.4s/file).
 ///
-/// Keyed by a hash of the runtime source + rustc version + opt flags, so a
+/// Keyed by a hash of the runtime source + rustc version + opt profile, so a
 /// compiler upgrade or a runtime edit transparently rebuilds. Cross-process
 /// builders serialize on a per-dir advisory lock; a warm cache is a stat.
-fn ensure_runtime_rlib() -> Result<std::path::PathBuf, String> {
-    static CACHED: std::sync::OnceLock<Result<std::path::PathBuf, String>> = std::sync::OnceLock::new();
-    CACHED.get_or_init(build_runtime_rlib).clone()
+///
+/// `opt_level` selects the optimization the runtime is compiled at: "1" for
+/// tests/debug (where runtime speed is irrelevant), "3" for release shipping
+/// (so the linked runtime keeps full optimization). Each level is cached
+/// separately and built at most once per process.
+fn ensure_runtime_rlib(opt_level: &str) -> Result<std::path::PathBuf, String> {
+    use std::sync::{Mutex, OnceLock};
+    static CACHE: OnceLock<Mutex<std::collections::HashMap<String, Result<std::path::PathBuf, String>>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+    {
+        let guard = cache.lock().unwrap();
+        if let Some(r) = guard.get(opt_level) {
+            return r.clone();
+        }
+    }
+    let result = build_runtime_rlib(opt_level);
+    cache.lock().unwrap().insert(opt_level.to_string(), result.clone());
+    result
 }
 
-fn build_runtime_rlib() -> Result<std::path::PathBuf, String> {
+fn build_runtime_rlib(opt_level: &str) -> Result<std::path::PathBuf, String> {
     let src = crate::codegen::emit_runtime_crate();
     let rustc = crate::find_rustc();
     let rustc_ver = std::process::Command::new(&rustc)
@@ -435,8 +500,8 @@ fn build_runtime_rlib() -> Result<std::path::PathBuf, String> {
         .ok()
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
         .unwrap_or_default();
-    // opt/edition flags here MUST match the per-file rustc invocation below.
-    let key = format!("{:016x}", hash64(format!("{src}|{rustc_ver}|opt1|ed2021").as_bytes()));
+    // The profile string here MUST match the per-file rustc invocation that links it.
+    let key = format!("{:016x}", hash64(format!("{src}|{rustc_ver}|opt{opt_level}|ed2021").as_bytes()));
     let dir = std::env::temp_dir().join(format!("almide-rtlib-{key}"));
     let rlib = dir.join("libalmide_rt.rlib");
     if rlib.exists() {
@@ -454,7 +519,7 @@ fn build_runtime_rlib() -> Result<std::path::PathBuf, String> {
         .arg("--crate-type").arg("lib")
         .arg("--crate-name").arg("almide_rt")
         .arg("--edition").arg("2021")
-        .arg("-C").arg("opt-level=1")
+        .arg("-C").arg(format!("opt-level={opt_level}"))
         .arg("-C").arg("overflow-checks=no")
         .arg("-A").arg("warnings")
         .arg("--out-dir").arg(&dir)
@@ -498,7 +563,7 @@ fn cargo_build_test_with_native(
         // worst a file pays one extra rustc. Opt out with ALMIDE_NO_RTLIB=1.
         if std::env::var_os("ALMIDE_NO_RTLIB").is_none() {
             if let (Ok(rlib), Some(mut slim)) = (
-                ensure_runtime_rlib(),
+                ensure_runtime_rlib("1"),
                 crate::codegen::slim_main_with_external_runtime(rs_code),
             ) {
                 if !slim.contains("fn main(") && !slim.contains("fn almide_main(") {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -2,6 +2,63 @@ use std::process::Command;
 use crate::try_compile;
 use super::{hash64, cargo_build_generated_with_native, cargo_build_test_with_native};
 
+/// Cross-process advisory lock on a shared build scratch dir.
+///
+/// `compile_to_binary` (and `cmd_build`) write a single `src/main.rs` into
+/// a shared project dir, run `cargo build` there, then copy the result to
+/// a per-hash binary. The in-process `BUILD_LOCK` mutex serializes threads
+/// within one process, but the compiler is also invoked as separate
+/// subprocesses — e.g. `almide run a.almd` & `almide run b.almd` at once,
+/// or a parallel `cargo test` driving many `almide run`/`almide build`
+/// children. Those races corrupt the shared `main.rs`/generated binary and
+/// produce an executable built from the wrong source.
+///
+/// An advisory `flock` on a lockfile in the project dir serializes that
+/// critical section across processes too. It is crash-safe: the kernel
+/// releases the lock when the holding process exits, so an aborted build
+/// never deadlocks the next one. The shared `target/` dep cache is
+/// preserved (builds serialize but reuse compiled deps).
+///
+/// Non-unix: a no-op (those platforms keep `--test-threads=1` in CI).
+pub(crate) struct BuildDirLock {
+    #[cfg(unix)]
+    _file: std::fs::File,
+}
+
+impl BuildDirLock {
+    pub(crate) fn acquire(project_dir: &std::path::Path) -> Result<Self, String> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::io::AsRawFd;
+            let lock_path = project_dir.join(".almide-build.lock");
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(&lock_path)
+                .map_err(|e| format!("Failed to open build lock {}: {}", lock_path.display(), e))?;
+            // SAFETY: `fd` is a valid, open file descriptor owned by `file`,
+            // which outlives this call. `flock` only associates an advisory
+            // lock with the open file description; it does not mutate Rust
+            // state. The lock is released when `file` is dropped (close) or
+            // the process exits.
+            let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+            if rc != 0 {
+                return Err(format!(
+                    "Failed to acquire build lock: {}",
+                    std::io::Error::last_os_error()
+                ));
+            }
+            Ok(BuildDirLock { _file: file })
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = project_dir;
+            Ok(BuildDirLock {})
+        }
+    }
+}
+
 /// Compile an .almd file to a native binary, returning the path to the executable.
 /// Uses incremental caching: if the generated Rust code hasn't changed, skips cargo build.
 pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: bool) -> Result<std::path::PathBuf, String> {
@@ -56,9 +113,25 @@ pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: b
     let source_root = if !native_deps.is_empty() || has_deps { Some(toml_dir.as_path()) } else { None };
 
     // Serialize cargo builds: the shared project dir has a single src/main.rs
-    // that gets overwritten per compilation. Parallel writes corrupt it.
+    // and one generated binary, overwritten per compilation. Parallel writes
+    // corrupt them. `BUILD_LOCK` serializes threads in this process; the
+    // `flock` extends that across separate `almide` processes. The lock spans
+    // the whole write→build→copy window — without covering the copy, a
+    // concurrent build could overwrite the generated binary between our build
+    // and our copy-out.
     static BUILD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     let _guard = BUILD_LOCK.lock().unwrap();
+    let _flock = BuildDirLock::acquire(&project_dir)?;
+
+    // Re-check the cache under the lock: another process/thread may have built
+    // this exact binary while we waited, making a rebuild redundant.
+    if hash_file.exists()
+        && bin_path.exists()
+        && std::fs::read_to_string(&hash_file).ok().as_deref() == Some(&code_hash)
+    {
+        return Ok(bin_path);
+    }
+
     let result = if use_test_harness {
         cargo_build_test_with_native(&rs_code, &project_dir, native_deps, source_root)
     } else {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -2,52 +2,6 @@ use std::process::Command;
 use crate::try_compile;
 use super::{hash64, cargo_build_generated_with_native, cargo_build_test_with_native};
 
-/// Cross-process advisory lock on the shared build scratch dir.
-///
-/// `compile_to_binary` writes a single `src/main.rs` into the shared
-/// project dir and runs `cargo build` there, then copies the result to a
-/// per-hash binary. The in-process `BUILD_LOCK` mutex serializes threads
-/// within one process, but the compiler is also invoked as separate
-/// subprocesses (e.g. `almide run a.almd` & `almide run b.almd` at once,
-/// or a parallel `cargo test` driving many `almide run` children). Those
-/// races corrupt the shared `main.rs`/generated binary and produce an
-/// executable built from the wrong source.
-///
-/// An advisory `flock` on a lockfile in the project dir serializes that
-/// critical section across processes too. It is crash-safe: the kernel
-/// releases the lock when the holding process exits, so an aborted build
-/// never deadlocks the next one. The shared `target/` dep cache is
-/// preserved (builds serialize but reuse compiled deps).
-///
-/// Non-unix: a no-op (those platforms keep `--test-threads=1` in CI).
-pub(crate) struct BuildDirLock {
-    #[cfg(unix)]
-    _file: std::fs::File,
-}
-
-impl BuildDirLock {
-    pub(crate) fn acquire(project_dir: &std::path::Path) -> Result<Self, String> {
-        #[cfg(unix)]
-        {
-            let lock_path = project_dir.join(".almide-build.lock");
-            let file = std::fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(false)
-                .open(&lock_path)
-                .map_err(|e| format!("Failed to open build lock {}: {}", lock_path.display(), e))?;
-            rustix::fs::flock(&file, rustix::fs::FlockOperation::LockExclusive)
-                .map_err(|e| format!("Failed to acquire build lock: {}", e))?;
-            Ok(BuildDirLock { _file: file })
-        }
-        #[cfg(not(unix))]
-        {
-            let _ = project_dir;
-            Ok(BuildDirLock {})
-        }
-    }
-}
-
 /// Compile an .almd file to a native binary, returning the path to the executable.
 /// Uses incremental caching: if the generated Rust code hasn't changed, skips cargo build.
 pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: bool) -> Result<std::path::PathBuf, String> {
@@ -102,25 +56,9 @@ pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: b
     let source_root = if !native_deps.is_empty() || has_deps { Some(toml_dir.as_path()) } else { None };
 
     // Serialize cargo builds: the shared project dir has a single src/main.rs
-    // and one generated binary, overwritten per compilation. Parallel writes
-    // corrupt them. `BUILD_LOCK` serializes threads in this process; the
-    // `flock` extends that across separate `almide` processes. The lock spans
-    // the whole write→build→copy window — without covering the copy, a
-    // concurrent build could overwrite the generated binary between our build
-    // and our copy-out.
+    // that gets overwritten per compilation. Parallel writes corrupt it.
     static BUILD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     let _guard = BUILD_LOCK.lock().unwrap();
-    let _flock = BuildDirLock::acquire(&project_dir)?;
-
-    // Re-check the cache under the lock: another process/thread may have built
-    // this exact binary while we waited, making a rebuild redundant.
-    if hash_file.exists()
-        && bin_path.exists()
-        && std::fs::read_to_string(&hash_file).ok().as_deref() == Some(&code_hash)
-    {
-        return Ok(bin_path);
-    }
-
     let result = if use_test_harness {
         cargo_build_test_with_native(&rs_code, &project_dir, native_deps, source_root)
     } else {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -61,14 +61,15 @@ impl BuildDirLock {
 
 /// Compile an .almd file to a native binary, returning the path to the executable.
 /// Uses incremental caching: if the generated Rust code hasn't changed, skips cargo build.
-pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: bool) -> Result<std::path::PathBuf, String> {
+pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: bool, project_dir_override: Option<&std::path::Path>) -> Result<std::path::PathBuf, String> {
     let rs_code = try_compile(file, no_check).map_err(|_| "compile failed".to_string())?;
 
-    // Default shared scratch dir. Tests set `ALMIDE_RUN_PROJECT_DIR` to a
-    // unique path so parallel `cargo test --all` can't race on the shared
-    // `src/main.rs` / `target/debug/` inside it.
-    let project_dir = std::env::var_os("ALMIDE_RUN_PROJECT_DIR")
-        .map(std::path::PathBuf::from)
+    // Scratch dir. A per-call `project_dir_override` (one dir per test file)
+    // gives each parallel worker its own `src/main.rs`, so cold rustc builds
+    // run truly in parallel instead of serializing on the shared dir's
+    // `BUILD_LOCK`. Otherwise: `ALMIDE_RUN_PROJECT_DIR`, else a shared default.
+    let project_dir = project_dir_override.map(std::path::PathBuf::from)
+        .or_else(|| std::env::var_os("ALMIDE_RUN_PROJECT_DIR").map(std::path::PathBuf::from))
         .unwrap_or_else(|| std::env::temp_dir().join("almide-run"));
     std::fs::create_dir_all(&project_dir)
         .map_err(|e| format!("Failed to create temp directory: {}", e))?;
@@ -120,7 +121,10 @@ pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: b
     // concurrent build could overwrite the generated binary between our build
     // and our copy-out.
     static BUILD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    let _guard = BUILD_LOCK.lock().unwrap();
+    // A unique per-call dir has its own src/main.rs, so the global mutex (which
+    // only exists to serialize the shared default dir) isn't needed — the
+    // per-dir flock still guards a separate process reusing the same dir.
+    let _guard = project_dir_override.is_none().then(|| BUILD_LOCK.lock().unwrap());
     let _flock = BuildDirLock::acquire(&project_dir)?;
 
     // Re-check the cache under the lock: another process/thread may have built
@@ -140,8 +144,17 @@ pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: b
 
     match result {
         Ok(built_path) => {
-            // Copy built binary to per-file cached path
-            let _ = std::fs::copy(&built_path, &bin_path);
+            // Copy built binary to per-file cached path. The bare-rustc fast
+            // path doesn't create a cargo `target/<profile>/` dir, so ensure
+            // bin_path's parent exists, and surface a copy failure instead of
+            // silently leaving bin_path missing (→ "Failed to execute" at run).
+            if let Some(parent) = bin_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            if let Err(e) = std::fs::copy(&built_path, &bin_path) {
+                return Err(format!("failed to stage built binary {} -> {}: {}",
+                    built_path.display(), bin_path.display(), e));
+            }
             let _ = std::fs::create_dir_all(&cache);
             let _ = std::fs::write(&hash_file, &code_hash);
             Ok(bin_path)
@@ -161,7 +174,7 @@ pub fn run_binary(bin: &std::path::Path, program_args: &[String]) -> i32 {
 }
 
 pub fn cmd_run_inner(file: &str, program_args: &[String], no_check: bool, test_mode: bool, release: bool) -> i32 {
-    match compile_to_binary(file, no_check, test_mode, release) {
+    match compile_to_binary(file, no_check, test_mode, release, None) {
         Ok(bin) => run_binary(&bin, program_args),
         Err(e) => {
             eprintln!("Compile error:\n{}", e);

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -2,6 +2,52 @@ use std::process::Command;
 use crate::try_compile;
 use super::{hash64, cargo_build_generated_with_native, cargo_build_test_with_native};
 
+/// Cross-process advisory lock on the shared build scratch dir.
+///
+/// `compile_to_binary` writes a single `src/main.rs` into the shared
+/// project dir and runs `cargo build` there, then copies the result to a
+/// per-hash binary. The in-process `BUILD_LOCK` mutex serializes threads
+/// within one process, but the compiler is also invoked as separate
+/// subprocesses (e.g. `almide run a.almd` & `almide run b.almd` at once,
+/// or a parallel `cargo test` driving many `almide run` children). Those
+/// races corrupt the shared `main.rs`/generated binary and produce an
+/// executable built from the wrong source.
+///
+/// An advisory `flock` on a lockfile in the project dir serializes that
+/// critical section across processes too. It is crash-safe: the kernel
+/// releases the lock when the holding process exits, so an aborted build
+/// never deadlocks the next one. The shared `target/` dep cache is
+/// preserved (builds serialize but reuse compiled deps).
+///
+/// Non-unix: a no-op (those platforms keep `--test-threads=1` in CI).
+pub(crate) struct BuildDirLock {
+    #[cfg(unix)]
+    _file: std::fs::File,
+}
+
+impl BuildDirLock {
+    pub(crate) fn acquire(project_dir: &std::path::Path) -> Result<Self, String> {
+        #[cfg(unix)]
+        {
+            let lock_path = project_dir.join(".almide-build.lock");
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(&lock_path)
+                .map_err(|e| format!("Failed to open build lock {}: {}", lock_path.display(), e))?;
+            rustix::fs::flock(&file, rustix::fs::FlockOperation::LockExclusive)
+                .map_err(|e| format!("Failed to acquire build lock: {}", e))?;
+            Ok(BuildDirLock { _file: file })
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = project_dir;
+            Ok(BuildDirLock {})
+        }
+    }
+}
+
 /// Compile an .almd file to a native binary, returning the path to the executable.
 /// Uses incremental caching: if the generated Rust code hasn't changed, skips cargo build.
 pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: bool) -> Result<std::path::PathBuf, String> {
@@ -56,9 +102,25 @@ pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: b
     let source_root = if !native_deps.is_empty() || has_deps { Some(toml_dir.as_path()) } else { None };
 
     // Serialize cargo builds: the shared project dir has a single src/main.rs
-    // that gets overwritten per compilation. Parallel writes corrupt it.
+    // and one generated binary, overwritten per compilation. Parallel writes
+    // corrupt them. `BUILD_LOCK` serializes threads in this process; the
+    // `flock` extends that across separate `almide` processes. The lock spans
+    // the whole write→build→copy window — without covering the copy, a
+    // concurrent build could overwrite the generated binary between our build
+    // and our copy-out.
     static BUILD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     let _guard = BUILD_LOCK.lock().unwrap();
+    let _flock = BuildDirLock::acquire(&project_dir)?;
+
+    // Re-check the cache under the lock: another process/thread may have built
+    // this exact binary while we waited, making a rebuild redundant.
+    if hash_file.exists()
+        && bin_path.exists()
+        && std::fs::read_to_string(&hash_file).ok().as_deref() == Some(&code_hash)
+    {
+        return Ok(bin_path);
+    }
+
     let result = if use_test_harness {
         cargo_build_test_with_native(&rs_code, &project_dir, native_deps, source_root)
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -627,8 +627,12 @@ fn dispatch(cli: Cli) {
                 cli::cmd_test_ts(file_str, run.as_deref());
             } else if json {
                 cli::cmd_test_json(file_str, run.as_deref());
-            } else {
+            } else if matches!(target.as_deref(), Some("rust" | "native")) {
+                // Explicit pure-native run (e.g. CI's "Test Rust" job).
                 cli::cmd_test(file_str, no_check, run.as_deref());
+            } else {
+                // Default: fast rustc-free WASM path, native fallback for gaps.
+                cli::cmd_test_fast(file_str, no_check, run.as_deref());
             }
         }
         Commands::Check { file, deny_warnings, json, explain, effects } => {

--- a/tests/snapshots/codegen_snapshot_test__effect_fn.snap
+++ b/tests/snapshots/codegen_snapshot_test__effect_fn.snap
@@ -102,6 +102,7 @@ pub fn almide_rt_int_from_uint16(n: u16) -> i64 { n as i64 }
 pub fn almide_rt_int_from_uint32(n: u32) -> i64 { n as i64 }
 pub fn almide_rt_int_from_uint64(n: u64) -> i64 { n as i64 }
 
+//__ALMIDE_RT_BOUNDARY__
 pub fn parse_int(s: &str) -> Result<i64, String> {
     Ok((almide_rt_int_parse(&*s))?)
 }

--- a/tests/snapshots/codegen_snapshot_test__list_filter.snap
+++ b/tests/snapshots/codegen_snapshot_test__list_filter.snap
@@ -226,6 +226,7 @@ pub fn almide_rt_list_binary_search(xs: &[i64], target: i64) -> Option<i64> {
     xs.binary_search(&target).ok().map(|i| i as i64)
 }
 
+//__ALMIDE_RT_BOUNDARY__
 pub fn positives(xs: Vec<i64>) -> Vec<i64> {
     almide_rt_list_filter(xs, move |x| (x > 0i64))
 }

--- a/tests/snapshots/codegen_snapshot_test__list_map.snap
+++ b/tests/snapshots/codegen_snapshot_test__list_map.snap
@@ -226,6 +226,7 @@ pub fn almide_rt_list_binary_search(xs: &[i64], target: i64) -> Option<i64> {
     xs.binary_search(&target).ok().map(|i| i as i64)
 }
 
+//__ALMIDE_RT_BOUNDARY__
 pub fn doubles(xs: Vec<i64>) -> Vec<i64> {
     almide_rt_list_map(xs, move |x| (x * 2i64))
 }

--- a/tests/snapshots/codegen_snapshot_test__pipe_chain.snap
+++ b/tests/snapshots/codegen_snapshot_test__pipe_chain.snap
@@ -226,6 +226,7 @@ pub fn almide_rt_list_binary_search(xs: &[i64], target: i64) -> Option<i64> {
     xs.binary_search(&target).ok().map(|i| i as i64)
 }
 
+//__ALMIDE_RT_BOUNDARY__
 pub fn process(xs: Vec<i64>) -> i64 {
     almide_rt_list_fold(almide_rt_list_filter(xs, move |x| (x > 0i64)), 0i64, move |acc, x| (acc + (x * 2i64)))
 }

--- a/tests/snapshots/codegen_snapshot_test__string_interp.snap
+++ b/tests/snapshots/codegen_snapshot_test__string_interp.snap
@@ -102,6 +102,7 @@ pub fn almide_rt_int_from_uint16(n: u16) -> i64 { n as i64 }
 pub fn almide_rt_int_from_uint32(n: u32) -> i64 { n as i64 }
 pub fn almide_rt_int_from_uint64(n: u64) -> i64 { n as i64 }
 
+//__ALMIDE_RT_BOUNDARY__
 pub fn describe(name: String, age: i64) -> String {
     format!("{} is {} years old", name, almide_rt_int_to_string(age))
 }


### PR DESCRIPTION
Promotes the current `develop` to `main` (23 commits). Highlights:

## Build speed (Go-like dev/test/shipping loop)
- `almide test` defaults to the rustc-free WASM path (parallel) with native fallback.
- Native test path parallelized: per-file scratch dirs + bare-rustc fast path (no cargo-lock serialization).
- Inter-pass IR verifier gated to debug/`ALMIDE_VERIFY_IR` (was the dominant per-file codegen cost in release).
- **Precompiled `almide_rt` runtime rlib**: the runtime compiles once into an `.rlib`; per-file/per-build rustc links it instead of recompiling ~2000 lines. Test loop 2.3–3x, `almide build --release` ~20x. Falls back to inline/cargo on any failure; `ALMIDE_NO_RTLIB=1` opts out. Shipping tradeoff + the `#[inline]` follow-up are documented in `docs/roadmap/active/build-speed-runtime-rlib.md`.

## WASM engine v2
- Stack-effect verifier for WasmIR (Phase 0).
- ANF keeps lambdas/closures in argument position to fix a WASM closure-table regression.

## Type checker / inference
- Resolve where-binding types in the checker; drop lowering-side lambda param patching.
- Pin container-pattern subject structure when matching on an unresolved inference var.
- Roadmap notes on remaining closure/where/fold completeness gaps.

## CI / build infra
- Serialize shared build scratch dirs across processes with an advisory flock (fixes cargo-test cache race); cargo test runs parallel on Unix CI.
- Rust-target test jobs pinned to `--target rust`.

Cross-platform matrix (macOS/Windows) runs on this PR. No version bump/tag — this is a develop→main sync, not a tagged release.