### PR TITLE
Fix heredoc dedent panic on multi-byte Unicode whitespace

### DIFF
--- a/crates/almide-syntax/src/lexer.rs
+++ b/crates/almide-syntax/src/lexer.rs
@@ -397,7 +397,17 @@ fn strip_heredoc_indent(raw: &str) -> String {
         .unwrap_or(0);
 
     content.iter()
-        .map(|l| if l.len() >= indent { &l[indent..] } else { "" })
+        .map(|l| {
+            // `indent` is a byte length of leading whitespace measured over the
+            // non-blank lines. A whitespace-only line (excluded from that min)
+            // may hold multi-byte Unicode whitespace such as U+3000, so clamp
+            // the cut down to a char boundary — slicing mid-codepoint panics.
+            let mut cut = indent.min(l.len());
+            while cut > 0 && !l.is_char_boundary(cut) {
+                cut -= 1;
+            }
+            &l[cut..]
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -565,4 +575,35 @@ fn lex_operator(chars: &[char], pos: usize, line: usize, col: usize) -> (Token, 
 
 fn peek(chars: &[char], pos: usize) -> Option<char> {
     chars.get(pos).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression: a heredoc whose blank line holds multi-byte Unicode whitespace
+    // (U+3000) used to panic in strip_heredoc_indent — the byte-offset dedent
+    // sliced mid-codepoint. The lexer must never crash (almide-syntax contract).
+    #[test]
+    fn heredoc_multibyte_whitespace_line_does_not_panic() {
+        let src = "let x = \"\"\"\n a\n\u{3000}\n  \"\"\"\n";
+        let tokens = Lexer::tokenize(src);
+        let s = tokens
+            .iter()
+            .find(|t| t.token_type == TokenType::String)
+            .expect("heredoc should lex to a String token");
+        // " a" dedents to "a"; the U+3000-only line is preserved (not split).
+        assert_eq!(s.value, "a\n\u{3000}");
+    }
+
+    #[test]
+    fn heredoc_ascii_dedent_still_works() {
+        let src = "let x = \"\"\"\n    one\n    two\n    \"\"\"\n";
+        let tokens = Lexer::tokenize(src);
+        let s = tokens
+            .iter()
+            .find(|t| t.token_type == TokenType::String)
+            .expect("heredoc should lex to a String token");
+        assert_eq!(s.value, "one\ntwo");
+    }
 }


### PR DESCRIPTION
The cross-platform CI for #317 (develop→main) caught a pre-existing lexer panic via the `fuzz_parser_arbitrary` proptest — unrelated to the build-speed work, latent since the heredoc lexer landed (20596f91, March).

`strip_heredoc_indent` computes the common indent as a **byte** length and slices every content line at `&l[indent..]`. A whitespace-only line excluded from the indent min may contain multi-byte Unicode whitespace (e.g. U+3000), so the byte offset can land mid-codepoint → `byte index N is not a char boundary` panic. Violates the almide-syntax "parser must never crash" contract.

Fix: clamp the cut down to a char boundary before slicing. ASCII dedent is unchanged.

Repro (now clean): a heredoc with a `U+3000`-only line.

Tests: two unit tests in `lexer.rs` — the multi-byte regression and an ASCII-dedent sanity check. `cargo test -p almide-syntax` green; release `almide check` on the repro reports no errors instead of panicking.