### PR TITLE
Bump version to 0.23.12 and refresh README/docs metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.23.11"
+version = "0.23.12"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["research/benchmark/stdlib/rust_wasm_compare"]
 
 [package]
 name = "almide"
-version = "0.23.11"
+version = "0.23.12"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -193,11 +193,11 @@ Almide emits WASM bytecode directly (no LLVM, no Cranelift). Each binary is self
 
 | Program | Size |
 |---------|-----:|
-| Hello World | **441 B** |
-| FizzBuzz | **705 B** |
-| Fibonacci (recursive) | **664 B** |
-| Closure + call_indirect | **748 B** |
-| Variant (match + float) | **1,271 B** |
+| Hello World | **467 B** |
+| FizzBuzz | **809 B** |
+| Fibonacci (recursive) | **682 B** |
+| Closure + call_indirect | **812 B** |
+| Variant (match + float) | **1,105 B** |
 
 These are raw `almide build --target wasm` output — no post-processing. `wasm-opt -O3` saves only 1–5 more bytes because the compiler's built-in dead code and dead data elimination already strips everything unused.
 
@@ -220,7 +220,7 @@ Almide compiles to Rust, which then compiles to native machine code. No runtime,
 | Targets | Rust (native), WASM (direct emit) |
 | Codegen | v3 — Nanopass + TOML templates, fully target-agnostic walker |
 | Stdlib | 834 functions across 39 modules |
-| Tests | 239 test files pass (Rust), 235 pass (WASM) |
+| Tests | 240 test files pass (Rust), 232 pass (WASM) |
 | MSR | 23/25 exercises pass (Sonnet 4.6, WASM, max 3 attempts) |
 | MiniGit Bench | 41/41 tests pass, 100% success rate ([ai-coding-lang-bench](https://github.com/mame/ai-coding-lang-bench)) |
 | Artifacts | `.almdi` module interface files via `almide compile` |
@@ -274,7 +274,7 @@ Browser-based compiler and runner. The Almide compiler runs as WASM — no serve
 - [docs/GRAMMAR.md](./docs/GRAMMAR.md) — EBNF grammar + stdlib reference
 - [docs/CHEATSHEET.md](./docs/CHEATSHEET.md) — Quick reference for AI code generation
 - [docs/DESIGN.md](./docs/DESIGN.md) — Design philosophy and trade-offs
-- [docs/STDLIB-SPEC.md](./docs/STDLIB-SPEC.md) — Standard library specification (381 functions)
+- [docs/stdlib/](./docs/stdlib/) — Standard library reference, per module (834 functions across 39 modules)
 - [docs/roadmap/](./docs/roadmap/README.md) — Language evolution plans
 
 ## Contributing

--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -73,7 +73,7 @@ Import required: json, math, random, datetime, regex, fs, http, log, testing,
                  error, crypto, uuid, set, value
 ```
 
-See [STDLIB-SPEC.md](./STDLIB-SPEC.md) for the complete stdlib function reference (381 functions across 22 modules).
+See [stdlib/](./stdlib/) for the complete stdlib function reference (834 functions across 39 modules).
 
 ## Notes
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1071,7 +1071,7 @@ The `is_` prefix convention is used for predicates in the stdlib: `string.is_emp
 
 ## 18. Standard Library
 
-381 native functions across 22 native modules, plus 10 bundled modules (pure Almide). Runtime implementation: 100%.
+834 functions across 39 modules, defined in pure Almide (`stdlib/*.almd`). Runtime implementation: 100%.
 
 ### 18.1 Auto-Imported Modules
 

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.23.11 (prev v0.23.10). WASM engine foundation (WasmBuilder + LayoutRegistry + WasmIR), Lean 4 verified Perceus RC, StackBalancePass, Mono ICE fix, 237/240 WASM tests.
+- Current stable: v0.23.12 (prev v0.23.11). Precompiled runtime rlib (~20x faster `--release` builds, ~2.3x test loop), WASM-first parallel test loop, IR verifier gated to debug, heredoc UTF-8 dedent fix. 240/240 Rust tests, 232/240 WASM tests (8 skipped).
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.


### PR DESCRIPTION
Version bump to **0.23.12** plus a pass to bring the quantitative claims in README/docs into line with the current codebase (verified by a parallel measure-and-adversarially-audit sweep).

## Version
- `Cargo.toml` 0.23.11 → 0.23.12 (+ Cargo.lock).
- `llms.txt` "Current stable" line → v0.23.12 (prev v0.23.11), describing this cycle's build-speed work + heredoc fix; WASM test count 237/240 → 232/240.

## Metrics corrected to ground truth
| Claim | Was | Now | How verified |
|---|---|---|---|
| Tests (README:223) | 239 Rust / 235 WASM | **240 Rust / 232 WASM** | ran `almide test spec/ --target rust\|wasm`; audited (the "239" was a parallel-stdout merge artifact) |
| Stdlib doc link (README:277) | `docs/STDLIB-SPEC.md` (381 functions) — **dead link** | `docs/stdlib/` (834 functions across 39 modules) | counted module-level `fn`/`effect fn` across `stdlib/*.almd` (757+77=834), audited |
| Stdlib ref (GRAMMAR:76) | 381 / 22, dead STDLIB-SPEC link | 834 / 39, `stdlib/` link | same |
| Stdlib (SPEC:1074) | "381 native fns / 22 native modules + 10 bundled" (pre-migration) | "834 functions across 39 modules, pure Almide" | same |
| WASM binary sizes (README:196-200) | 441/705/664/748/1271 B | **467/809/682/812/1105 B** | rebuilt each canonical program with `almide build --target wasm`, `wc -c` |

## Left unchanged (not re-verifiable here)
- MSR scorecard + MiniGit bench (external: almide-dojo, ai-coding-lang-bench).
- Native Performance table (minigit CLI — external program, not in this repo).
- The 834/39 headline (README:92,222) was already correct.

`almide docs-gen --check` passes with 0.23.12 (version + diagnostic refs + registry bijection).