### PR TITLE
Release 0.23.12: build-speed overhaul + metrics refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.23.11"
+version = "0.23.12"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["research/benchmark/stdlib/rust_wasm_compare"]
 
 [package]
 name = "almide"
-version = "0.23.11"
+version = "0.23.12"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -193,11 +193,11 @@ Almide emits WASM bytecode directly (no LLVM, no Cranelift). Each binary is self
 
 | Program | Size |
 |---------|-----:|
-| Hello World | **441 B** |
-| FizzBuzz | **705 B** |
-| Fibonacci (recursive) | **664 B** |
-| Closure + call_indirect | **748 B** |
-| Variant (match + float) | **1,271 B** |
+| Hello World | **467 B** |
+| FizzBuzz | **809 B** |
+| Fibonacci (recursive) | **682 B** |
+| Closure + call_indirect | **812 B** |
+| Variant (match + float) | **1,105 B** |
 
 These are raw `almide build --target wasm` output — no post-processing. `wasm-opt -O3` saves only 1–5 more bytes because the compiler's built-in dead code and dead data elimination already strips everything unused.
 
@@ -220,7 +220,7 @@ Almide compiles to Rust, which then compiles to native machine code. No runtime,
 | Targets | Rust (native), WASM (direct emit) |
 | Codegen | v3 — Nanopass + TOML templates, fully target-agnostic walker |
 | Stdlib | 834 functions across 39 modules |
-| Tests | 239 test files pass (Rust), 235 pass (WASM) |
+| Tests | 240 test files pass (Rust), 232 pass (WASM) |
 | MSR | 23/25 exercises pass (Sonnet 4.6, WASM, max 3 attempts) |
 | MiniGit Bench | 41/41 tests pass, 100% success rate ([ai-coding-lang-bench](https://github.com/mame/ai-coding-lang-bench)) |
 | Artifacts | `.almdi` module interface files via `almide compile` |
@@ -274,7 +274,7 @@ Browser-based compiler and runner. The Almide compiler runs as WASM — no serve
 - [docs/GRAMMAR.md](./docs/GRAMMAR.md) — EBNF grammar + stdlib reference
 - [docs/CHEATSHEET.md](./docs/CHEATSHEET.md) — Quick reference for AI code generation
 - [docs/DESIGN.md](./docs/DESIGN.md) — Design philosophy and trade-offs
-- [docs/STDLIB-SPEC.md](./docs/STDLIB-SPEC.md) — Standard library specification (381 functions)
+- [docs/stdlib/](./docs/stdlib/) — Standard library reference, per module (834 functions across 39 modules)
 - [docs/roadmap/](./docs/roadmap/README.md) — Language evolution plans
 
 ## Contributing

--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -73,7 +73,7 @@ Import required: json, math, random, datetime, regex, fs, http, log, testing,
                  error, crypto, uuid, set, value
 ```
 
-See [STDLIB-SPEC.md](./STDLIB-SPEC.md) for the complete stdlib function reference (381 functions across 22 modules).
+See [stdlib/](./stdlib/) for the complete stdlib function reference (834 functions across 39 modules).
 
 ## Notes
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1071,7 +1071,7 @@ The `is_` prefix convention is used for predicates in the stdlib: `string.is_emp
 
 ## 18. Standard Library
 
-381 native functions across 22 native modules, plus 10 bundled modules (pure Almide). Runtime implementation: 100%.
+834 functions across 39 modules, defined in pure Almide (`stdlib/*.almd`). Runtime implementation: 100%.
 
 ### 18.1 Auto-Imported Modules
 

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.23.11 (prev v0.23.10). WASM engine foundation (WasmBuilder + LayoutRegistry + WasmIR), Lean 4 verified Perceus RC, StackBalancePass, Mono ICE fix, 237/240 WASM tests.
+- Current stable: v0.23.12 (prev v0.23.11). Precompiled runtime rlib (~20x faster `--release` builds, ~2.3x test loop), WASM-first parallel test loop, IR verifier gated to debug, heredoc UTF-8 dedent fix. 240/240 Rust tests, 232/240 WASM tests (8 skipped).
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.


### PR DESCRIPTION
Promotes develop to main for the **0.23.12** release.

## Since 0.23.11
- **Build speed**: precompiled `almide_rt` runtime rlib — `almide build --release` ~20x faster (27–33s → 1–2s), test loop ~2.3x. WASM-first parallel test loop; IR verifier gated to debug. `ALMIDE_NO_RTLIB=1` opts out. Roadmap for closing the ~10% shipping-runtime gap: `docs/roadmap/active/build-speed-runtime-rlib.md`.
- **Bug fix**: heredoc dedent panic on multi-byte Unicode whitespace (UTF-8 char-boundary) — caught by cross-platform fuzz CI.
- **Docs**: version 0.23.12; README/GRAMMAR/SPEC metrics corrected to ground truth (tests 240 Rust / 232 WASM, stdlib 834/39 + fixed dead STDLIB-SPEC link, WASM binary sizes re-measured). External benchmarks (MSR, MiniGit, native minigit) left as-is.

Cross-platform matrix (macOS/Windows) runs on this PR. Tag `v0.23.12` after merge lets the release workflow build artifacts.