### PR TITLE
Fix host-arch WASM codegen divergence (playground unreachable trap) + determinism gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,50 @@ jobs:
           $ALMIDE test spec/ --target wasm
 
   # ═══════════════════════════════════════════════
+  # WASM host-arch codegen determinism
+  #
+  # The compiler runs as wasm32 in the browser playground but as 64-bit in the
+  # test suite. A codegen path whose output depends on host pointer width or
+  # HashMap iteration order emits a different — but stack-/RC-valid — module on
+  # 32-bit, which can trap (`RuntimeError: unreachable`). The stack/Perceus
+  # verifiers check one module's well-formedness, not reproducibility across
+  # hosts. This gate compiles each fixture with the compiler built BOTH natively
+  # and to wasm32-wasip1 and asserts byte-identical output.
+  # ═══════════════════════════════════════════════
+
+  wasm-host-determinism:
+    name: WASM host-arch determinism
+    if: github.server_url == 'https://github.com'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          targets: wasm32-wasip1
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            tools/wasmgen-harness/target
+          key: wasmgen-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('crates/almide-codegen/src/emit_wasm/**') }}
+          restore-keys: wasmgen-${{ env.RUST_TOOLCHAIN }}-
+
+      - name: Install wasmtime
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+          curl -LO "https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/wasmtime-${VERSION}-x86_64-linux.tar.xz"
+          tar -xf wasmtime-*.tar.xz
+          sudo mv wasmtime-*/wasmtime /usr/local/bin/
+          wasmtime --version
+
+      - name: Host-arch codegen determinism (wasm32 vs native, byte-identical)
+        run: scripts/check-host-determinism.sh
+
+  # ═══════════════════════════════════════════════
   # Lean Proofs (AlmidePerceusBelt)
   # ═══════════════════════════════════════════════
 
@@ -256,7 +300,9 @@ jobs:
 
   trigger-playground:
     name: Trigger Playground Deploy
-    needs: [test-rust, checks]
+    # Gate the deploy on host-arch determinism: the playground runs the compiler
+    # as wasm32, so a 32/64-bit codegen divergence must block deploy, not ship.
+    needs: [test-rust, checks, wasm-host-determinism]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = [".", "crates/almide-base", "crates/almide-syntax", "crates/almide-types", "crates/almide-lang", "crates/almide-ir", "crates/almide-dialect", "crates/almide-codegen", "crates/almide-optimize", "crates/almide-frontend", "crates/almide-tools", "crates/almide-egg-lab"]
 resolver = "3"
-exclude = ["research/benchmark/stdlib/rust_wasm_compare"]
+exclude = ["research/benchmark/stdlib/rust_wasm_compare", "tools/wasmgen-harness"]
 
 [package]
 name = "almide"

--- a/crates/almide-codegen/src/emit_wasm/closures.rs
+++ b/crates/almide-codegen/src/emit_wasm/closures.rs
@@ -116,15 +116,23 @@ pub(super) fn pre_scan_closures(program: &IrProgram, emitter: &mut WasmEmitter) 
     // function table. After ClosureConversion, Lambda nodes become ClosureCreate
     // nodes referencing lifted __closure_N functions. These functions must be in
     // the table so call_indirect can dispatch them.
-    let mut closure_create_names: HashSet<String> = HashSet::new();
+    let mut closure_create_set: HashSet<String> = HashSet::new();
     for func in &program.functions {
-        collect_closure_creates(&func.body, &mut closure_create_names);
+        collect_closure_creates(&func.body, &mut closure_create_set);
     }
     for module in &program.modules {
         for func in &module.functions {
-            collect_closure_creates(&func.body, &mut closure_create_names);
+            collect_closure_creates(&func.body, &mut closure_create_set);
         }
     }
+    // Sort before assigning function-table slots: HashSet iteration order is
+    // host-dependent (hash seed + usize-width bucket layout), which made the
+    // compiler emit different `call_indirect` table indices when run on a
+    // 32-bit host (wasm32, the browser playground) vs a 64-bit host — a valid
+    // but divergent module that traps with `unreachable`. Sorting makes the
+    // table layout a pure function of the program (mirrors fn_ref_names.sort()).
+    let mut closure_create_names: Vec<String> = closure_create_set.into_iter().collect();
+    closure_create_names.sort();
     for name in &closure_create_names {
         if let Some(&func_idx) = emitter.func_map.get(name.as_str()) {
             if !emitter.func_to_table_idx.contains_key(&func_idx) {

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -65,8 +65,8 @@ use std::collections::HashMap;
 use wasm_encoder::{
     CodeSection, DataSection, ElementSection, Elements, ExportSection,
     Function, FunctionSection, GlobalSection, GlobalType, ImportSection,
-    MemorySection, MemoryType, Module, RefType, TableSection, TableType,
-    TypeSection, ValType,
+    MemorySection, MemoryType, Module, NameMap, NameSection, RefType, TableSection,
+    TableType, TypeSection, ValType,
 };
 
 use almide_ir::IrProgram;
@@ -1557,6 +1557,25 @@ fn assemble(emitter: &mut WasmEmitter) -> Vec<u8> {
     }
     module.section(&data);
 
+    // ── Custom `name` section ──
+    // Attribute functions by name so a trap (e.g. a `RuntimeError: unreachable`
+    // surfaced in the browser playground) points at a named function instead of
+    // an anonymous `wasm-function[N]`. Built from func_map sorted by index, so it
+    // is host-deterministic (same as the rest of the module).
+    let mut fn_index_names: Vec<(u32, &str)> =
+        emitter.func_map.iter().map(|(name, &idx)| (idx, name.as_str())).collect();
+    fn_index_names.sort_by_key(|(idx, _)| *idx);
+    fn_index_names.dedup_by_key(|(idx, _)| *idx);
+    if !fn_index_names.is_empty() {
+        let mut fn_names = NameMap::new();
+        for (idx, name) in &fn_index_names {
+            fn_names.append(*idx, name);
+        }
+        let mut names = NameSection::new();
+        names.functions(&fn_names);
+        module.section(&names);
+    }
+
     module.finish()
 }
 
@@ -1690,8 +1709,15 @@ fn register_variant_eq_funcs(emitter: &mut WasmEmitter) {
         vec![ValType::I32, ValType::I32],
         vec![ValType::I32],
     );
-    // Collect variant names that need deep eq (have pointer fields)
-    let names: Vec<String> = emitter.variant_info.iter()
+    // Collect variant names that need deep eq (have pointer fields).
+    // Sort: variant_info is a HashMap, and its iteration order (host-dependent —
+    // hash seed + usize bucket layout) here determines the func indices these
+    // __eq_* functions reserve. Unsorted, a 32-bit host (wasm32) reserves them
+    // in a different order than a 64-bit host, shifting every later function's
+    // index and producing a divergent, trapping module. Sorting makes index
+    // reservation a pure function of the program, and must match the (also
+    // sorted) compile order in compile_variant_eq_funcs.
+    let mut names: Vec<String> = emitter.variant_info.iter()
         .filter(|(_, cases)| {
             cases.iter().any(|c| c.fields.iter().any(|(_, ft)| {
                 !matches!(ft, almide_lang::types::Ty::Int | almide_lang::types::Ty::Float | almide_lang::types::Ty::Bool | almide_lang::types::Ty::Unit)
@@ -1699,6 +1725,7 @@ fn register_variant_eq_funcs(emitter: &mut WasmEmitter) {
         })
         .map(|(name, _)| name.clone())
         .collect();
+    names.sort();
     for name in names {
         let func_idx = emitter.register_func(&format!("__eq_{}", name), type_idx);
         emitter.eq_funcs.insert(name, func_idx);
@@ -1708,10 +1735,16 @@ fn register_variant_eq_funcs(emitter: &mut WasmEmitter) {
 /// Compile variant deep-equality function bodies.
 /// Each function: (a: i32, b: i32) -> i32 — compares tag then dispatches to per-case field comparison.
 fn compile_variant_eq_funcs(emitter: &mut WasmEmitter, var_table: &almide_ir::VarTable) {
-    // Collect eq_funcs entries (name → func_idx) and corresponding cases
-    let eq_entries: Vec<(String, u32)> = emitter.eq_funcs.iter()
+    // Collect eq_funcs entries (name → func_idx) and corresponding cases.
+    // Sort by name so body-emission order matches the (sorted) index-reservation
+    // order in register_variant_eq_funcs. add_compiled pushes bodies positionally
+    // (function index = num_imports + push position), so the two orders MUST
+    // agree, and both must be host-independent — otherwise a 32-bit host places
+    // __eq_Foo's body at __eq_Bar's index and the module traps.
+    let mut eq_entries: Vec<(String, u32)> = emitter.eq_funcs.iter()
         .map(|(n, &idx)| (n.clone(), idx))
         .collect();
+    eq_entries.sort();
 
     for (name, _func_idx) in &eq_entries {
         let cases = match emitter.variant_info.get(name.as_str()) {

--- a/scripts/check-host-determinism.sh
+++ b/scripts/check-host-determinism.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Host-architecture WASM codegen determinism gate.
+#
+# The compiler runs as wasm32 in the browser playground but as x86-64/aarch64 in
+# the test suite. A codegen path whose output depends on host pointer width
+# (usize) or HashMap iteration order produces a DIFFERENT — but individually
+# stack-/RC-valid — WASM module on a 32-bit host, which can trap at runtime
+# (`RuntimeError: unreachable`). The stack-effect verifier and Perceus belt check
+# a single module's well-formedness, not reproducibility ACROSS hosts, so they
+# are blind to this class. This gate closes that gap: it compiles each fixture
+# with the compiler built BOTH natively and to wasm32-wasip1, and asserts the
+# emitted WASM is byte-identical.
+#
+# Usage: scripts/check-host-determinism.sh [fixture-dir]   (default: spec/wasm_cross)
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+FIXTURE_DIR="${1:-spec/wasm_cross}"
+HARNESS="tools/wasmgen-harness"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+WASMTIME="$(command -v wasmtime || echo "$HOME/.wasmtime/bin/wasmtime")"
+[ -x "$WASMTIME" ] || { echo "::error::wasmtime not found"; exit 2; }
+
+echo "==> Building harness (native)"
+cargo build --release --manifest-path "$HARNESS/Cargo.toml" -q || { echo "::error::native harness build failed"; exit 2; }
+echo "==> Building harness (wasm32-wasip1)"
+cargo build --release --target wasm32-wasip1 --manifest-path "$HARNESS/Cargo.toml" -q || { echo "::error::wasm32 harness build failed"; exit 2; }
+
+NATIVE_BIN="$HARNESS/target/release/wasmgen-harness"
+WASM_BIN="$HARNESS/target/wasm32-wasip1/release/wasmgen-harness.wasm"
+
+fail=0; n=0
+for fix in "$FIXTURE_DIR"/*.almd; do
+  [ -e "$fix" ] || continue
+  name="$(basename "$fix")"
+  cp "$fix" "$WORK/in.almd"
+  # x86-64/aarch64 host
+  "$NATIVE_BIN" "$WORK/in.almd" "$WORK/native.wasm" 2>/dev/null || { echo "FAIL  $name (native harness errored)"; fail=1; continue; }
+  # wasm32 host (compiler running as 32-bit, under wasmtime)
+  "$WASMTIME" run --dir "$WORK::/w" "$WASM_BIN" /w/in.almd /w/wasm32.wasm >/dev/null 2>&1 || { echo "FAIL  $name (wasm32 harness errored)"; fail=1; continue; }
+  if cmp -s "$WORK/native.wasm" "$WORK/wasm32.wasm"; then
+    echo "ok    $name ($(wc -c < "$WORK/native.wasm" | tr -d ' ') bytes, identical)"
+  else
+    echo "FAIL  $name — host-arch codegen DIVERGENCE (native $(wc -c < "$WORK/native.wasm" | tr -d ' ')B vs wasm32 $(wc -c < "$WORK/wasm32.wasm" | tr -d ' ')B)"
+    fail=1
+  fi
+  n=$((n+1))
+done
+
+echo "----"
+if [ "$fail" -ne 0 ]; then
+  echo "::error::host-architecture codegen determinism FAILED — the compiler emits different WASM on 32-bit vs 64-bit hosts (the playground runs wasm32). See crates/almide-codegen/src/emit_wasm: sort any HashMap/HashSet whose iteration order reaches emitted bytes."
+  exit 1
+fi
+echo "host-architecture codegen determinism: $n/$n fixtures byte-identical across x86-64 and wasm32"

--- a/spec/wasm_cross/closures_and_variants.almd
+++ b/spec/wasm_cross/closures_and_variants.almd
@@ -1,0 +1,30 @@
+// Host-determinism fixture: exercises lifted closures (map/filter/fold) and
+// multiple variants with deep-eq — the two codegen sites whose iteration order
+// was host-dependent. Regression guard for the 32/64-bit codegen divergence.
+
+type Tree =
+  | Leaf(Int)
+  | Node(Int, Int)
+  | Empty
+
+fn label(t: Tree) -> String = match t {
+  Leaf(n)    => "leaf:" + int.to_string(n),
+  Node(a, b) => "node:" + int.to_string(a) + "," + int.to_string(b),
+  Empty      => "empty",
+}
+
+fn main() -> Unit = {
+  let nodes = [Leaf(1), Node(2, 3), Empty, Leaf(4), Node(5, 6)]
+  let sum = nodes
+    |> list.filter((t) => match t { Empty => false, _ => true })
+    |> list.map((t) => label(t))
+    |> list.enumerate
+    |> list.map((e) => {
+        let (i, s) = e
+        "${int.to_string(i)}: ${s}"
+      })
+    |> list.join("\n")
+  println(sum)
+  let total = [1, 2, 3, 4, 5] |> list.fold(0, (acc, x) => acc + x * x)
+  println("sumsq=" + int.to_string(total))
+}

--- a/spec/wasm_cross/playground_default.almd
+++ b/spec/wasm_cross/playground_default.almd
@@ -1,0 +1,67 @@
+// Mini Markdown → HTML — ADT + pattern match + pipes + string interp
+
+type Block =
+  | Heading(Int, String)
+  | Bullet(String)
+  | Para(String)
+  | Blank
+
+fn parse_line(line: String) -> Block =
+  if string.starts_with(line, "### ") then Heading(3, string.drop(line, 4))
+  else if string.starts_with(line, "## ") then Heading(2, string.drop(line, 3))
+  else if string.starts_with(line, "# ") then Heading(1, string.drop(line, 2))
+  else if string.starts_with(line, "- ") then Bullet(string.drop(line, 2))
+  else if string.is_empty(string.trim(line)) then Blank
+  else Para(line)
+
+fn bold(s: String) -> String =
+  string.split(s, "**") |> list.enumerate |> list.map((e) => {
+    let (i, chunk) = e
+    if i % 2 == 1 then "<strong>${chunk}</strong>" else chunk
+  }) |> list.join("")
+
+fn render(block: Block) -> String =
+  match block {
+    Heading(n, text) => {
+      let tag = "h" + int.to_string(n)
+      "<${tag}>${bold(text)}</${tag}>"
+    }
+    Bullet(text) => "<li>${bold(text)}</li>"
+    Para(text)   => "<p>${bold(text)}</p>"
+    Blank        => ""
+  }
+
+fn wrap_lists(blocks: List[Block]) -> List[String] = {
+  let result = blocks |> list.fold({ out: [], in_ul: false }, (st, b) => {
+    let is_bullet = match b { Bullet(_) => true, _ => false }
+    let opened =
+      if is_bullet and not st.in_ul then st.out + ["<ul>"]
+      else if not is_bullet and st.in_ul then st.out + ["</ul>"]
+      else st.out
+    { out: opened + [render(b)], in_ul: is_bullet }
+  })
+  if result.in_ul then result.out + ["</ul>"] else result.out
+}
+
+fn main() -> Unit = {
+  let md = """
+# Almide Playground
+
+A **tiny** Markdown to HTML converter in ~50 lines.
+
+## Features
+
+- ADT with **variants**
+- Pattern matching
+- Pipe-based list ops
+
+It's **compact** and **expressive**.
+"""
+  md
+    |> string.lines
+    |> list.map(parse_line)
+    |> wrap_lists
+    |> list.filter((s) => not string.is_empty(s))
+    |> list.join("\n")
+    |> println
+}

--- a/tools/wasmgen-harness/Cargo.toml
+++ b/tools/wasmgen-harness/Cargo.toml
@@ -1,0 +1,25 @@
+# Host-architecture codegen determinism harness (NOT a workspace member — see
+# the root Cargo.toml `exclude`). Compiles one .almd source to WASM bytes using
+# the exact pipeline the browser playground uses (parse → check → lower → mono →
+# codegen(Target::Wasm)). Built BOTH natively and to wasm32-wasip1 by
+# scripts/check-host-determinism.sh; the two outputs must be byte-identical.
+#
+# Empty [workspace] makes this its own workspace root so the parent workspace
+# ignores it (it path-deps the parent's `almide` crate without being a member).
+[workspace]
+
+[package]
+name = "wasmgen-harness"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "wasmgen-harness"
+path = "src/main.rs"
+
+[dependencies]
+almide = { path = "../.." }
+
+[profile.release]
+opt-level = 2

--- a/tools/wasmgen-harness/src/main.rs
+++ b/tools/wasmgen-harness/src/main.rs
@@ -1,0 +1,27 @@
+//! Emit WASM bytes for one `.almd` file via the playground's exact pipeline.
+//! Usage: wasmgen-harness <input.almd> <output.wasm>
+//!
+//! Run natively and on wasm32-wasip1; the two outputs must match byte-for-byte
+//! (host-architecture codegen determinism). See scripts/check-host-determinism.sh.
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let inp = args.get(1).expect("usage: wasmgen-harness <in.almd> <out.wasm>");
+    let outp = args.get(2).expect("usage: wasmgen-harness <in.almd> <out.wasm>");
+    let source = std::fs::read_to_string(inp).expect("read input");
+
+    let tokens = almide::lexer::Lexer::tokenize(&source);
+    let mut parser = almide::parser::Parser::new(tokens);
+    let mut program = parser.parse().expect("parse failed");
+    let canon = almide::canonicalize::canonicalize_program(&program, std::iter::empty());
+    let mut checker = almide::check::Checker::from_env(canon.env);
+    checker.diagnostics = canon.diagnostics;
+    let _ = checker.infer_program(&mut program);
+    let mut ir = almide::lower::lower_program(&program, &checker.env, &checker.type_map);
+    almide::mono::monomorphize(&mut ir);
+    match almide::codegen::codegen(&mut ir, almide::codegen::pass::Target::Wasm) {
+        almide::codegen::CodegenOutput::Binary(bytes) => {
+            std::fs::write(outp, &bytes).expect("write output");
+        }
+        almide::codegen::CodegenOutput::Source(_) => panic!("expected WASM binary output"),
+    }
+}


### PR DESCRIPTION
## The bug

The playground runs the **compiler compiled to wasm32** (auto-redeployed from `main`). v0.23.12's default example (a Markdown→HTML converter using `list.map/fold/filter`) trapped with `RuntimeError: unreachable`. The same compiler on x86-64 produced correct, deterministic WASM — so this was a **host-architecture-dependent codegen bug**.

Root cause: `emit_wasm` assigned WASM function-table slots (lifted closures) and `__eq_*` indices in **`HashMap`/`HashSet` iteration order**. `std`'s SipHash mixes `usize` into its state, so a 32-bit host (wasm32) iterates differently than a 64-bit host → divergent `call_indirect` table indices → closure dispatch traps. The stack-effect verifier and Perceus belt validate one module's well-formedness, not reproducibility across hosts, so they were blind to it.

## The fix (`672726bb`)

Sort before assigning indices (mirrors the existing `fn_ref_names.sort()`):
- `closures.rs`: `closure_create_names` (the trigger).
- `mod.rs`: `register_variant_eq_funcs` / `compile_variant_eq_funcs` (same class, multi-variant programs).

Verified: the fixed compiler emits **byte-identical** WASM on x86-64 and wasm32. Also emits a WASM **name section** (sorted by index → host-deterministic) so a trap shows the function name instead of `wasm-function[N]`.

## The completeness gate (`374182a6`) — the durable win

`scripts/check-host-determinism.sh` builds a tiny harness (`tools/wasmgen-harness`, replicates the playground's `compile_to_wasm`) **both natively and to wasm32-wasip1**, compiles each `spec/wasm_cross/*.almd` with both, and asserts **byte-identical** output. New CI job `wasm-host-determinism`; `trigger-playground` now `needs` it (a divergence blocks deploy). Local run: **13/13 fixtures byte-identical**.

Invariant going forward: compiler output must be byte-identical across host architecture. Rule for new emit_wasm code: never let HashMap/HashSet iteration order reach emitted bytes.

## Verification
- 13/13 host-determinism fixtures byte-identical (x86-64 vs wasm32), incl. the exact broken `playground_default.almd`.
- `almide run`/`build` of the Markdown converter: correct output.
- spec WASM suite: 232/240 (unchanged; 8 pre-existing skips).