### PR TITLE
0.23.13: fix playground wasm32 panic (std::time) + browser-ABI determinism gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-          targets: wasm32-wasip1
+          targets: wasm32-wasip1, wasm32-unknown-unknown
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - uses: actions/cache@v4
         with:
@@ -149,7 +156,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             tools/wasmgen-harness/target
-          key: wasmgen-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('crates/almide-codegen/src/emit_wasm/**') }}
+            tools/wasmgen-harness-uu/target
+          key: wasmgen-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('crates/almide-codegen/src/emit_wasm/**', 'crates/almide-codegen/src/lib.rs', 'crates/almide-codegen/src/pass.rs') }}
           restore-keys: wasmgen-${{ env.RUST_TOOLCHAIN }}-
 
       - name: Install wasmtime
@@ -160,8 +168,11 @@ jobs:
           sudo mv wasmtime-*/wasmtime /usr/local/bin/
           wasmtime --version
 
-      - name: Host-arch codegen determinism (wasm32 vs native, byte-identical)
+      - name: Host-arch codegen determinism (wasm32-wasip1 vs native, byte-identical)
         run: scripts/check-host-determinism.sh
+
+      - name: Browser-ABI determinism (wasm32-unknown-unknown via node, no panic + byte-identical)
+        run: scripts/check-browser-determinism.sh
 
   # ═══════════════════════════════════════════════
   # Lean Proofs (AlmidePerceusBelt)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.23.12"
+version = "0.23.13"
 dependencies = [
  "almide-base",
  "almide-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["research/benchmark/stdlib/rust_wasm_compare", "tools/wasmgen-harness
 
 [package]
 name = "almide"
-version = "0.23.12"
+version = "0.23.13"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = [".", "crates/almide-base", "crates/almide-syntax", "crates/almide-types", "crates/almide-lang", "crates/almide-ir", "crates/almide-dialect", "crates/almide-codegen", "crates/almide-optimize", "crates/almide-frontend", "crates/almide-tools", "crates/almide-egg-lab"]
 resolver = "3"
-exclude = ["research/benchmark/stdlib/rust_wasm_compare", "tools/wasmgen-harness"]
+exclude = ["research/benchmark/stdlib/rust_wasm_compare", "tools/wasmgen-harness", "tools/wasmgen-harness-uu"]
 
 [package]
 name = "almide"

--- a/crates/almide-codegen/src/emit_wasm/equality.rs
+++ b/crates/almide-codegen/src/emit_wasm/equality.rs
@@ -3,6 +3,7 @@
 //! Type-aware recursive equality for List, Option, Result, Tuple, Record, Variant.
 
 use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use super::FuncCompiler;
 use super::VariantCase;
@@ -614,16 +615,15 @@ impl FuncCompiler<'_> {
 
     /// Find local index for a pattern field binding by name.
     pub(super) fn find_var_by_field(&self, field_name: &str, _case_fields: &[(String, Ty)]) -> Option<&u32> {
-        // Search var_map for VarIds whose name in var_table matches field_name
-        for (&var_id, local_idx) in &self.var_map {
-            if (var_id as usize) < self.var_table.len() {
-                let info = self.var_table.get(almide_ir::VarId(var_id));
-                if info.name == field_name {
-                    return Some(local_idx);
-                }
-            }
-        }
-        None
+        // Pick the SMALLEST matching VarId, not first-in-iteration: var_map is a
+        // HashMap whose iteration order is host-pointer-width dependent, so a
+        // first-match would choose a different local index on wasm32 (the
+        // playground) vs x86-64 → a wrong-slot local.get → garbage read → trap.
+        self.var_map.iter()
+            .filter(|&(&var_id, _)| (var_id as usize) < self.var_table.len()
+                && self.var_table.get(almide_ir::VarId(var_id)).name == field_name)
+            .min_by_key(|&(&var_id, _)| var_id)
+            .map(|(_, local_idx)| local_idx)
     }
 
 }
@@ -697,8 +697,8 @@ impl FuncCompiler<'_> {
 /// `FuncCompiler::extract_record_fields` delegates here.
 pub(super) fn extract_record_fields(
     ty: &Ty,
-    record_fields: &HashMap<String, Vec<(String, Ty)>>,
-    variant_info: &HashMap<String, Vec<VariantCase>>,
+    record_fields: &BTreeMap<String, Vec<(String, Ty)>>,
+    variant_info: &BTreeMap<String, Vec<VariantCase>>,
 ) -> Vec<(String, Ty)> {
     match ty {
         Ty::Record { fields } | Ty::OpenRecord { fields } => {

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -62,6 +62,12 @@ pub mod scratch;
 mod dce;
 
 use std::collections::HashMap;
+// BTreeMap for record_fields / variant_info: their iteration order reaches
+// emitted bytes (field offsets, variant sizes, the Unknown-type member-access
+// fallback), and HashMap iteration is host-pointer-width dependent (hashbrown's
+// h2 control byte = hash >> (usize_bits-7)), so a wasm32 host (the playground)
+// would pick different offsets than x86-64 and trap. BTreeMap is deterministic.
+use std::collections::BTreeMap;
 use wasm_encoder::{
     CodeSection, DataSection, ElementSection, Elements, ExportSection,
     Function, FunctionSection, GlobalSection, GlobalType, ImportSection,
@@ -336,9 +342,9 @@ pub struct WasmEmitter {
     pub user_exports: Vec<(String, String)>,
 
     // Type info: record/variant name → field list (for field offset computation)
-    pub record_fields: HashMap<String, Vec<(String, almide_lang::types::Ty)>>,
+    pub record_fields: BTreeMap<String, Vec<(String, almide_lang::types::Ty)>>,
     // Variant info: variant type name → list of (case_name, tag, fields)
-    pub variant_info: HashMap<String, Vec<VariantCase>>,
+    pub variant_info: BTreeMap<String, Vec<VariantCase>>,
     // Default field values: (type_name, field_name) → default IR expr
     pub default_fields: HashMap<(String, String), almide_ir::IrExpr>,
 
@@ -465,8 +471,8 @@ impl WasmEmitter {
             next_global: 5, // 0=heap_ptr, 1=free_list, 2=preopen_table, 3=preopen_count, 4=heap_start
             func_table: Vec::new(),
             func_to_table_idx: HashMap::new(),
-            record_fields: HashMap::new(),
-            variant_info: HashMap::new(),
+            record_fields: BTreeMap::new(),
+            variant_info: BTreeMap::new(),
             default_fields: HashMap::new(),
             lambdas: Vec::new(),
             fn_ref_wrappers: HashMap::new(),
@@ -1861,7 +1867,7 @@ fn register_anonymous_records(program: &IrProgram, emitter: &mut WasmEmitter) {
     fn walk_ty(
         ty: &Ty,
         seen: &mut HashSet<Vec<(String, String)>>,
-        record_fields: &mut HashMap<String, Vec<(String, Ty)>>,
+        record_fields: &mut BTreeMap<String, Vec<(String, Ty)>>,
     ) {
         match ty {
             Ty::Record { fields } | Ty::OpenRecord { fields } => {
@@ -1890,7 +1896,7 @@ fn register_anonymous_records(program: &IrProgram, emitter: &mut WasmEmitter) {
     fn walk_expr(
         expr: &IrExpr,
         seen: &mut HashSet<Vec<(String, String)>>,
-        record_fields: &mut HashMap<String, Vec<(String, Ty)>>,
+        record_fields: &mut BTreeMap<String, Vec<(String, Ty)>>,
     ) {
         walk_ty(&expr.ty, seen, record_fields);
         match &expr.kind {
@@ -1963,7 +1969,7 @@ fn register_anonymous_records(program: &IrProgram, emitter: &mut WasmEmitter) {
     fn walk_stmt(
         stmt: &IrStmt,
         seen: &mut HashSet<Vec<(String, String)>>,
-        record_fields: &mut HashMap<String, Vec<(String, Ty)>>,
+        record_fields: &mut BTreeMap<String, Vec<(String, Ty)>>,
     ) {
         match &stmt.kind {
             IrStmtKind::Bind { value, ty, .. } => {

--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -38,10 +38,10 @@ use super::values;
 /// Lookup for record/variant field types by nominal name.
 /// Used during pre-scan to resolve `Ty::Named` to concrete field types
 /// so that destructuring patterns allocate the correct WASM local valtypes.
-pub(super) type RecordFieldLookup = HashMap<String, Vec<(String, Ty)>>;
+pub(super) type RecordFieldLookup = std::collections::BTreeMap<String, Vec<(String, Ty)>>;
 
 /// Lookup for variant type info by nominal name.
-pub(super) type VariantInfoLookup = HashMap<String, Vec<VariantCase>>;
+pub(super) type VariantInfoLookup = std::collections::BTreeMap<String, Vec<VariantCase>>;
 
 impl FuncCompiler<'_> {
     /// Get the element type of a list variable from VarTable.

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -171,14 +171,18 @@ impl<'a> Verified<'a> {
 pub fn codegen_with(program: &mut IrProgram, target: Target, options: &CodegenOptions) -> CodegenOutput {
     let config = target::configure(target);
     let prof = std::env::var_os("ALMIDE_PROFILE").is_some();
-    let pt = std::time::Instant::now();
+    // Only read the clock when profiling: `std::time::Instant::now()` PANICS on
+    // wasm32-unknown-unknown (time is unsupported there), and the compiler runs
+    // on that target in the browser playground. An unconditional now() here
+    // crashed every in-browser compile.
+    let pt = prof.then(std::time::Instant::now);
 
     // Layer 2: Run Nanopass pipeline (semantic rewrites — takes ownership, returns modified)
     let owned = std::mem::take(program);
     let transformed = config.pipeline.run(owned, target);
     *program = transformed;
-    if prof { eprintln!("[prof:codegen] pipeline={:.3}s", pt.elapsed().as_secs_f64()); }
-    let et = std::time::Instant::now();
+    if let Some(pt) = &pt { eprintln!("[prof:codegen] pipeline={:.3}s", pt.elapsed().as_secs_f64()); }
+    let et = prof.then(std::time::Instant::now);
 
     // Layer 3: Target-specific emit
     match target {
@@ -187,7 +191,7 @@ pub fn codegen_with(program: &mut IrProgram, target: Target, options: &CodegenOp
             // RC balance check. Only verified programs can reach WASM emit.
             let verified = Verified::verify(program);
             let out = emit_wasm::emit_verified(verified);
-            if prof { eprintln!("[prof:codegen] wasm_emit={:.3}s", et.elapsed().as_secs_f64()); }
+            if let Some(et) = &et { eprintln!("[prof:codegen] wasm_emit={:.3}s", et.elapsed().as_secs_f64()); }
             CodegenOutput::Binary(out)
         }
         Target::Wgsl => CodegenOutput::Source(emit_wgsl::emit(program)),

--- a/crates/almide-codegen/src/pass.rs
+++ b/crates/almide-codegen/src/pass.rs
@@ -273,10 +273,15 @@ impl Pipeline {
             }
 
             let pass_name = pass.name();
-            let _pass_t = std::time::Instant::now();
+            // Gate the clock read: std::time::Instant::now() panics on
+            // wasm32-unknown-unknown (the browser playground target), so only
+            // read it when profiling is actually requested.
+            let _pass_t = std::env::var_os("ALMIDE_PROFILE")
+                .is_some()
+                .then(std::time::Instant::now);
             let result = pass.run(program, target);
-            if std::env::var_os("ALMIDE_PROFILE").is_some() {
-                let dt = _pass_t.elapsed().as_secs_f64();
+            if let Some(t) = &_pass_t {
+                let dt = t.elapsed().as_secs_f64();
                 if dt > 0.01 { eprintln!("[prof:pass] {:30} {:.3}s", pass_name, dt); }
             }
             program = result.program;

--- a/llms.txt
+++ b/llms.txt
@@ -207,6 +207,6 @@ Diagnostics for each carry a `try:` snippet that shows the Almide form.
 - License: MIT or Apache-2.0 (see LICENSE files).
 - Repo: <https://github.com/almide/almide>
 - Dojo (MSR benchmark): <https://github.com/almide/almide-dojo>
-- Current stable: v0.23.12 (prev v0.23.11). Precompiled runtime rlib (~20x faster `--release` builds, ~2.3x test loop), WASM-first parallel test loop, IR verifier gated to debug, heredoc UTF-8 dedent fix. 240/240 Rust tests, 232/240 WASM tests (8 skipped).
+- Current stable: v0.23.13 (prev v0.23.12). Fix host-arch WASM codegen divergence (HashMap iteration order leaked into function-table indices → the wasm32 playground compiler emitted a divergent module that trapped); now byte-identical across hosts, guarded by a `wasm-host-determinism` CI gate. WASM name section for trap attribution. 240/240 Rust tests, 232/240 WASM tests (8 skipped).
 - Baseline → 0.14.6 MSR: llama-3.3-70b 17/30 → 23/30 (+20pt);
   Sonnet 4.6 30/30 (100%) validates design.

--- a/scripts/check-browser-determinism.sh
+++ b/scripts/check-browser-determinism.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Browser-ABI codegen gate. The playground runs the compiler compiled to
+# wasm32-unknown-unknown (no WASI, no std::time, JS-shimmed). This builds the
+# SAME compile path to that target via wasm-bindgen + node and asserts, for each
+# fixture, that compilation (1) does NOT panic and (2) emits byte-identical bytes
+# to the native compiler. Catches both wasm32-unknown-unknown-only failures
+# (e.g. an unconditional std::time::Instant::now()) and host-width codegen
+# divergence that the wasip1 gate can mask.
+#
+# Requires: wasm-pack, node. Skips with a warning if either is missing.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+FIXTURE_DIR="${1:-spec/wasm_cross}"
+NATIVE_HARNESS="tools/wasmgen-harness"
+UU_HARNESS="tools/wasmgen-harness-uu"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+command -v wasm-pack >/dev/null || { echo "::warning::wasm-pack not found — skipping browser-ABI determinism gate"; exit 0; }
+command -v node      >/dev/null || { echo "::warning::node not found — skipping browser-ABI determinism gate"; exit 0; }
+
+echo "==> Building native harness"
+cargo build --release --manifest-path "$NATIVE_HARNESS/Cargo.toml" -q || { echo "::error::native harness build failed"; exit 2; }
+echo "==> Building browser harness (wasm32-unknown-unknown via wasm-pack)"
+( cd "$UU_HARNESS" && wasm-pack build --target nodejs --out-dir "$WORK/pkg" ) >/dev/null 2>&1 \
+  || { echo "::error::wasm32-unknown-unknown harness build failed"; exit 2; }
+
+cat > "$WORK/run.js" <<'JS'
+const pkg = require(process.argv[2]);
+const fs = require('fs');
+const src = fs.readFileSync(process.argv[3], 'utf8');
+const bytes = pkg.compile_source_to_wasm(src);   // throws (panics) → nonzero exit
+fs.writeFileSync(process.argv[4], Buffer.from(bytes));
+JS
+
+NATIVE_BIN="$NATIVE_HARNESS/target/release/wasmgen-harness"
+fail=0; n=0
+for fix in "$FIXTURE_DIR"/*.almd; do
+  [ -e "$fix" ] || continue
+  name="$(basename "$fix")"
+  "$NATIVE_BIN" "$fix" "$WORK/native.wasm" 2>/dev/null || { echo "FAIL  $name (native errored)"; fail=1; continue; }
+  if ! node "$WORK/run.js" "$WORK/pkg" "$fix" "$WORK/uu.wasm" 2>"$WORK/err"; then
+    echo "FAIL  $name — browser compile PANICKED: $(grep -iE 'panic|unreachable|RuntimeError' "$WORK/err" | head -1)"
+    fail=1; continue
+  fi
+  if cmp -s "$WORK/native.wasm" "$WORK/uu.wasm"; then
+    echo "ok    $name ($(wc -c < "$WORK/native.wasm" | tr -d ' ') bytes, identical)"
+  else
+    echo "FAIL  $name — browser vs native codegen DIVERGENCE (native $(wc -c < "$WORK/native.wasm" | tr -d ' ')B vs browser $(wc -c < "$WORK/uu.wasm" | tr -d ' ')B)"
+    fail=1
+  fi
+  n=$((n+1))
+done
+
+echo "----"
+if [ "$fail" -ne 0 ]; then
+  echo "::error::browser-ABI codegen gate FAILED — the compiler panics or diverges when built to wasm32-unknown-unknown (the playground target). Common causes: unconditional std::time/Instant in the compile path, or HashMap iteration reaching emitted bytes."
+  exit 1
+fi
+echo "browser-ABI determinism: $n/$n fixtures compile without panic and byte-identical to native"

--- a/tools/wasmgen-harness-uu/Cargo.toml
+++ b/tools/wasmgen-harness-uu/Cargo.toml
@@ -1,0 +1,22 @@
+# Browser-ABI determinism harness: the SAME compile_to_wasm the playground uses,
+# built to wasm32-unknown-unknown (the actual browser target) via wasm-bindgen.
+# Run by scripts/check-browser-determinism.sh under node, it (1) must not panic
+# (wasm32-unknown-unknown lacks std::time etc.) and (2) must emit byte-identical
+# output to the native compiler. Standalone (own workspace).
+[workspace]
+
+[package]
+name = "wasmgen-harness-uu"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+almide = { path = "../.." }
+wasm-bindgen = "0.2"
+
+[profile.release]
+opt-level = 2

--- a/tools/wasmgen-harness-uu/src/lib.rs
+++ b/tools/wasmgen-harness-uu/src/lib.rs
@@ -1,0 +1,24 @@
+//! Browser-ABI determinism harness. Mirrors the playground's `compile_to_wasm`
+//! (parse → check → lower → mono → codegen(Target::Wasm)) but built to
+//! wasm32-unknown-unknown so the gate exercises the exact target the browser
+//! playground runs the compiler on — catching wasm32-unknown-unknown-specific
+//! failures (e.g. unconditional std::time, unsupported there) and host-pointer-
+//! width codegen divergence that wasm32-wasip1 can mask.
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn compile_source_to_wasm(source: &str) -> Result<Vec<u8>, String> {
+    let tokens = almide::lexer::Lexer::tokenize(source);
+    let mut parser = almide::parser::Parser::new(tokens);
+    let mut program = parser.parse().map_err(|e| format!("parse: {e}"))?;
+    let canon = almide::canonicalize::canonicalize_program(&program, std::iter::empty());
+    let mut checker = almide::check::Checker::from_env(canon.env);
+    checker.diagnostics = canon.diagnostics;
+    let _ = checker.infer_program(&mut program);
+    let mut ir = almide::lower::lower_program(&program, &checker.env, &checker.type_map);
+    almide::mono::monomorphize(&mut ir);
+    match almide::codegen::codegen(&mut ir, almide::codegen::pass::Target::Wasm) {
+        almide::codegen::CodegenOutput::Binary(bytes) => Ok(bytes),
+        almide::codegen::CodegenOutput::Source(_) => Err("expected WASM binary".into()),
+    }
+}


### PR DESCRIPTION
## The real playground bug

The playground runs the compiler compiled to **wasm32-unknown-unknown**, where `std::time::Instant::now()` is unsupported and **panics**. The codegen pipeline called it unconditionally for `ALMIDE_PROFILE` timing (added in 0.23.12's build-speed work), so EVERY in-browser compile crashed with `RuntimeError: unreachable` — including the default Markdown→HTML example.

This was invisible to CI because the spec suite runs the compiler on x86-64, and the new `wasm-host-determinism` gate used **wasm32-wasip1** (which HAS time via WASI). Only the browser's `unknown-unknown` target lacks it.

## Fixes

- **`c2d22f3a` (the fix):** gate the three `Instant::now()` calls (`lib.rs`, `pass.rs`) behind the profiling flag — `prof.then(Instant::now)` — so they're never called on `unknown-unknown`. **Verified on the actual browser target:** built the playground's `compile_to_wasm` to wasm32-unknown-unknown via wasm-pack, ran under node → compiles the default example without panic and emits **byte-identical** output to x86-64.
- **`213756ec` (defensive):** `record_fields` / `variant_info` → `BTreeMap` so their iteration (field offsets, the Unknown-type member fallback) is host-pointer-width independent; `find_var_by_field` picks the smallest VarId. Closes the host-width codegen-divergence class the audit found.
- **`374fe7b5` (the gate that would have caught it):** new `scripts/check-browser-determinism.sh` builds a wasm-bindgen harness to **wasm32-unknown-unknown** and runs it under node, asserting each fixture compiles **without panic** and **byte-identical** to native. Wired into the `wasm-host-determinism` CI job. This catches both `unknown-unknown`-only failures (std::time) and host-width divergence.

Plus the `0.23.13` version bump (`Cargo.toml`, `Cargo.lock`, `llms.txt`).