### PR TITLE
Determinism Belt Phase 1: purity gate + monomorphization host-determinism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,9 @@ jobs:
           $ALMIDE "$f" --target rust > /dev/null && echo "Rust emit OK"
           $ALMIDE "$f" --emit-ast    > /dev/null && echo "AST emit OK"
 
+      - name: Forbidden impurities (no raw clocks/threads in the compile path)
+        run: scripts/check-forbidden-impurities.sh
+
   # ═══════════════════════════════════════════════
   # Full CI — cross-platform (PRs to main only)
   # ═══════════════════════════════════════════════

--- a/crates/almide-base/src/lib.rs
+++ b/crates/almide-base/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod intern;
 pub mod span;
 pub mod diagnostic;
+pub mod profile;
 
 // Re-export commonly used items at crate root
 pub use intern::{Sym, sym, resolve};

--- a/crates/almide-base/src/profile.rs
+++ b/crates/almide-base/src/profile.rs
@@ -1,0 +1,49 @@
+//! The ONE sanctioned place in the compiler that may read the wall clock.
+//!
+//! `std::time::Instant::now()` PANICS on `wasm32-unknown-unknown` (time is
+//! unsupported there) — and the compiler runs on that target in the browser
+//! playground. Every other crate is forbidden (CI-enforced, see the
+//! `forbidden-impurities` check) from naming `std::time` / `Instant` /
+//! `SystemTime` directly; they must time through this shim, which is
+//! `#[cfg]`-gated to be a no-op on wasm32. This makes the "unconditional clock
+//! read crashes the in-browser compiler" bug class un-writable by construction.
+//!
+//! Determinism corollary: timing must NEVER influence emitted output — it is
+//! diagnostics only. This type only exposes elapsed seconds for `eprintln!`.
+
+/// A wall-clock timer for `ALMIDE_PROFILE` diagnostics. `start(false)` and every
+/// call on wasm32 yield `None`, so profiling silently no-ops where there is no
+/// clock — and a misuse that fed timing into codegen would have nothing to read.
+pub struct ProfileTimer {
+    #[cfg(not(target_arch = "wasm32"))]
+    start: std::time::Instant,
+}
+
+impl ProfileTimer {
+    /// Begin timing iff `enabled` and a clock exists (never on wasm32).
+    #[inline]
+    pub fn start(enabled: bool) -> Option<ProfileTimer> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            enabled.then(|| ProfileTimer { start: std::time::Instant::now() })
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = enabled;
+            None
+        }
+    }
+
+    /// Seconds since `start`. Always finite; 0.0 where there is no clock.
+    #[inline]
+    pub fn elapsed_secs(&self) -> f64 {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.start.elapsed().as_secs_f64()
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            0.0
+        }
+    }
+}

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -171,18 +171,18 @@ impl<'a> Verified<'a> {
 pub fn codegen_with(program: &mut IrProgram, target: Target, options: &CodegenOptions) -> CodegenOutput {
     let config = target::configure(target);
     let prof = std::env::var_os("ALMIDE_PROFILE").is_some();
-    // Only read the clock when profiling: `std::time::Instant::now()` PANICS on
-    // wasm32-unknown-unknown (time is unsupported there), and the compiler runs
-    // on that target in the browser playground. An unconditional now() here
-    // crashed every in-browser compile.
-    let pt = prof.then(std::time::Instant::now);
+    // Time only through the sanctioned, wasm-safe shim. Raw std::time is
+    // forbidden in this crate (it panics on wasm32-unknown-unknown, the browser
+    // playground target) — see almide_base::profile and the forbidden-impurities
+    // CI gate.
+    let pt = almide_base::profile::ProfileTimer::start(prof);
 
     // Layer 2: Run Nanopass pipeline (semantic rewrites — takes ownership, returns modified)
     let owned = std::mem::take(program);
     let transformed = config.pipeline.run(owned, target);
     *program = transformed;
-    if let Some(pt) = &pt { eprintln!("[prof:codegen] pipeline={:.3}s", pt.elapsed().as_secs_f64()); }
-    let et = prof.then(std::time::Instant::now);
+    if let Some(pt) = &pt { eprintln!("[prof:codegen] pipeline={:.3}s", pt.elapsed_secs()); }
+    let et = almide_base::profile::ProfileTimer::start(prof);
 
     // Layer 3: Target-specific emit
     match target {
@@ -191,7 +191,7 @@ pub fn codegen_with(program: &mut IrProgram, target: Target, options: &CodegenOp
             // RC balance check. Only verified programs can reach WASM emit.
             let verified = Verified::verify(program);
             let out = emit_wasm::emit_verified(verified);
-            if let Some(et) = &et { eprintln!("[prof:codegen] wasm_emit={:.3}s", et.elapsed().as_secs_f64()); }
+            if let Some(et) = &et { eprintln!("[prof:codegen] wasm_emit={:.3}s", et.elapsed_secs()); }
             CodegenOutput::Binary(out)
         }
         Target::Wgsl => CodegenOutput::Source(emit_wgsl::emit(program)),

--- a/crates/almide-codegen/src/pass.rs
+++ b/crates/almide-codegen/src/pass.rs
@@ -273,15 +273,14 @@ impl Pipeline {
             }
 
             let pass_name = pass.name();
-            // Gate the clock read: std::time::Instant::now() panics on
-            // wasm32-unknown-unknown (the browser playground target), so only
-            // read it when profiling is actually requested.
-            let _pass_t = std::env::var_os("ALMIDE_PROFILE")
-                .is_some()
-                .then(std::time::Instant::now);
+            // Time only through the wasm-safe shim (raw std::time is forbidden in
+            // this crate — it panics on the wasm32-unknown-unknown playground).
+            let _pass_t = almide_base::profile::ProfileTimer::start(
+                std::env::var_os("ALMIDE_PROFILE").is_some(),
+            );
             let result = pass.run(program, target);
             if let Some(t) = &_pass_t {
-                let dt = t.elapsed().as_secs_f64();
+                let dt = t.elapsed_secs();
                 if dt > 0.01 { eprintln!("[prof:pass] {:30} {:.3}s", pass_name, dt); }
             }
             program = result.program;

--- a/crates/almide-optimize/src/mono/mod.rs
+++ b/crates/almide-optimize/src/mono/mod.rs
@@ -21,6 +21,7 @@ mod rewrite;
 mod propagation;
 
 use std::collections::HashMap;
+use std::collections::BTreeMap;
 use almide_ir::*;
 use almide_lang::types::Ty;
 
@@ -46,7 +47,13 @@ pub fn monomorphize(program: &mut IrProgram) {
     // Fixed-point loop: transitive monomorphization (A → B → C chains)
     // Converges when no new instances are discovered. Warns if instance count
     // exceeds 1000 (possible infinite expansion).
-    let mut all_instances: HashMap<MonoKey, HashMap<String, Ty>> = HashMap::new();
+    // BTreeMap, not HashMap: `new` (below) is iterated to append specialized
+    // functions to program.functions, and a function's WASM index is its position
+    // there. HashMap iteration order is host-pointer-width AND Sym-intern-order
+    // dependent, so the wasm32 playground compiler would assign different indices
+    // than x86-64 → a divergent/trapping module. MonoKey=(String,String) is Ord,
+    // so BTreeMap iterates in content order = a pure function of the program.
+    let mut all_instances: BTreeMap<MonoKey, HashMap<String, Ty>> = BTreeMap::new();
     let mut frontier_start: Option<usize> = None; // None = first round (scan all)
 
     loop {
@@ -62,7 +69,7 @@ pub fn monomorphize(program: &mut IrProgram) {
         };
 
         // Filter to only new instances
-        let new: HashMap<MonoKey, HashMap<String, Ty>> = instances.into_iter()
+        let new: BTreeMap<MonoKey, HashMap<String, Ty>> = instances.into_iter()
             .filter(|(k, _)| !all_instances.contains_key(k))
             .collect();
         if new.is_empty() {

--- a/crates/almide-optimize/src/mono/rewrite.rs
+++ b/crates/almide-optimize/src/mono/rewrite.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::BTreeMap;
 use almide_ir::*;
 use almide_ir::visit_mut::{IrMutVisitor, walk_expr_mut, walk_stmt_mut};
 use almide_lang::types::Ty;
@@ -10,7 +11,7 @@ use super::specialization::substitute_ty;
 pub(super) fn rewrite_calls(
     program: &mut IrProgram,
     bound_fns: &HashMap<String, Vec<BoundedParam>>,
-    instances: &HashMap<MonoKey, HashMap<String, Ty>>,
+    instances: &BTreeMap<MonoKey, HashMap<String, Ty>>,
 ) {
     let fn_param_types: HashMap<String, Vec<Ty>> = program.functions.iter()
         .filter(|f| !f.is_test && bound_fns.contains_key::<str>(&f.name))
@@ -44,7 +45,7 @@ pub(super) fn rewrite_calls(
 
 struct RewriteVisitor<'a> {
     bound_fns: &'a HashMap<String, Vec<BoundedParam>>,
-    instances: &'a HashMap<MonoKey, HashMap<String, Ty>>,
+    instances: &'a BTreeMap<MonoKey, HashMap<String, Ty>>,
     fn_param_types: &'a HashMap<String, Vec<Ty>>,
     fn_generics: &'a HashMap<String, Vec<String>>,
     fn_ret_types: &'a HashMap<String, Ty>,

--- a/docs/roadmap/active/determinism-belt.md
+++ b/docs/roadmap/active/determinism-belt.md
@@ -1,0 +1,41 @@
+<!-- description: Determinism/Purity Belt — a Perceus-analog that makes the compiler deterministic & target-portable by construction -->
+# The Determinism / Purity Belt
+
+> A Perceus-analog for compiler **output determinism + target portability**. AlmidePerceusBelt makes "if it emits, RC is balanced" a theorem; this makes "if it emits, the output is a pure function of (IR, target)" enforced by construction — so a wasm32 (browser playground) compile can't crash or diverge from x86-64.
+
+## Why
+
+The compiler runs compiled to **wasm32-unknown-unknown** in the browser playground. Two bugs shipped that ALL the verifiers (stack-effect, Perceus, the spec suite) missed, both the SAME class — codegen read a non-deterministic / impure / non-portable source instead of being a pure function of `(IR, target)`:
+
+1. `std::time::Instant::now()` called unconditionally (ALMIDE_PROFILE timing) → panics on wasm32-unknown-unknown (no clock) → every in-browser compile crashed. (v0.23.13 fixed the call; the Belt makes it un-writable.)
+2. `HashMap`/`HashSet` iteration assigned WASM function/table/index/offset order; hashbrown iteration is host-pointer-width dependent (h2 = `hash >> (usize_bits-7)`) AND `Sym`-keyed maps depend on intern order (process history). → wasm32 emits a divergent/trapping module.
+
+The spec suite only runs the compiler on x86-64; the first determinism gate used wasm32-wasip1 (which HAS WASI time) and so missed bug #1. The Belt is the structural answer.
+
+## The four layers (strong inner gates carry the load; broad outer gates catch what types can't)
+
+| Layer | What | Strength | Status |
+|---|---|---|---|
+| **L1 Purity wall** | the compile-path crates can't *name* a clock/RNG/thread/atomic-counter source (grep gate `scripts/check-forbidden-impurities.sh` + planned `clippy.toml` `disallowed-methods`); timing only via `almide_base::profile::ProfileTimer` (cfg-gated, wasm-safe) | lint/deny (textual, alias-fragile — **not** the Perceus-grade type-state) | **DONE (Phase 0/1)** |
+| **L2 `DetMap`/`DetSet` prelude** | the only collections a codegen-path crate may *iterate* are content-ordered (BTreeMap-backed); plain `HashMap` survives only for lookup-only caches behind an audited `// DET-ESCAPE` | type-state | roadmap |
+| **L3 `Canonical<IrProgram>`** | a terminal `CanonicalizePass` puts functions/type-decls/variant-cases/record-fields into a content-derived **total** order; `emit` accepts only `Canonical` (sibling of `Verified`). Re-normalizes even if an upstream pass built a Vec in hash order | type-state (true Perceus spine) | roadmap |
+| **L4 Runtime tripwire** | `check-host-determinism.sh` (wasm32-wasip1) + `check-browser-determinism.sh` (wasm32-unknown-unknown via node) byte-compare the compiler's output to native | test (open-world backstop, permanent) | **DONE** |
+| L5 Lean proof | `canonicalize` is idempotent & input-order-independent | proof | optional |
+
+## Done so far (v0.23.13 + this work)
+
+- **L1**: `almide_base::profile::ProfileTimer` (the one sanctioned, wasm-safe clock); the three codegen clock sites route through it; `scripts/check-forbidden-impurities.sh` fails CI on raw `std::time|Instant|SystemTime|thread::spawn|thread_rng|fastrand|AtomicU64|fetch_add` in `crates/{almide-codegen,almide-frontend,almide-optimize,almide-ir}/src` (excluding `/generated/` `/runtime/` — those are runtime code emitted into the user's native program). Wired into the `checks` CI job.
+- **The confirmed-live data-order leak**: `record_fields`/`variant_info` → `BTreeMap`; `closures.rs`/variant-eq/name-section sorted; **`almide-optimize/src/mono/mod.rs` `all_instances`/`new` → `BTreeMap`** (specialized-function append order, → WASM function indices, was HashMap-ordered → host-width + intern-order dependent).
+- **L4**: both gates in CI; `spec/wasm_cross/` fixtures incl. `playground_default.almd` and `generics_mono.almd` (exercises monomorphization).
+
+## Deferred (honest limits)
+
+- **L1 is alias-fragile and `#[allow]`-bypassable** — it buys coverage + a CI failure, not Perceus-grade impossibility. The real spine is L3.
+- **The `Sym` interner is a latent worse-than-RandomState hazard**: `Sym: Hash` is the intern-order `Spur` id over a process-global `ThreadedRodeo`, so `HashMap<Sym,_>` iteration order depends on process history (warm/cold `bundled_sigs`, N-th compile in the long-lived playground / `almide test`). L1+L2 must forbid iterating `Sym`-keyed hash maps outright; L3 sorts by `Sym::as_str()` content. NOT yet enforced.
+- **egg's `EGG_FRESH_COUNTER` (`almide-egg-lab/src/bridge.rs`) is never reset per-compile** → `__egg_v{n}` names differ across compiles in one process. Fix: thread it through pass state / reset at pass entry. NOT yet done (egg-lab is outside the current grep scope).
+- **L3's total sort key is a correctness minefield** — a non-total key makes canonicalize unstable (re-introducing non-determinism); it must run after order-dependent passes and the key must be provably total. Real, unbudgeted design risk.
+- **No layer certifies the *artifact*** — determinism is a property of provenance, gone by the time you hold the bytes. The construction layers constrain the *process*; emitter faithfulness + the unknown N+1-th source axis are closed only empirically by L4. The runtime gate's reliance is permanent, not transitional.
+
+## Next highest-leverage step
+
+The `clippy.toml` `disallowed-methods` deny (Instant::now, SystemTime::now, thread_rng, fetch_add) + `#![deny(clippy::disallowed_methods)]` in the four crates — upgrades L1 from grep to compiler-checked for the method-call axis (cheap, no new toolchain). Then L2 `DetMap` for the `Sym`-iteration ban, then L3.

--- a/scripts/check-forbidden-impurities.sh
+++ b/scripts/check-forbidden-impurities.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Determinism/Purity Belt — construction layer, tier T1.
+#
+# The compiler runs compiled to wasm32-unknown-unknown in the browser playground,
+# where std::time / threads are unsupported (they PANIC), and where any output
+# that depends on a clock/RNG/thread-schedule is also non-deterministic. These
+# sources can NEVER legitimately reach the codegen path. Forbid them by grep so a
+# violation fails CI instead of crashing the in-browser compiler — the bug that
+# broke the playground (an unconditional std::time::Instant::now in codegen).
+#
+# Timing for ALMIDE_PROFILE must go through the one sanctioned, wasm-safe shim:
+# almide_base::profile::ProfileTimer (cfg-gated to no-op on wasm32).
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+# Crates on the in-browser compile path (parse → check → lower → mono → codegen).
+SCOPE="crates/almide-codegen/src crates/almide-frontend/src crates/almide-optimize/src crates/almide-ir/src"
+# Forbidden source tokens: clocks, threads, RNG, and never-reset atomic counters
+# (the egg fresh-var counter class) — all non-deterministic or wasm32-unsupported.
+PATTERN='std::time|Instant::now|SystemTime|thread::spawn|::spawn_blocking|thread_rng|fastrand|rand::random|AtomicU64|AtomicUsize|fetch_add'
+
+# Strip line comments before matching so doc/comments that NAME the forbidden API
+# (like this file's own references) don't trip it; ignore #[cfg(test)] modules is
+# left to reviewers (tests don't reach the wasm build).
+hits=$(grep -rnE "$PATTERN" $SCOPE 2>/dev/null \
+  | grep -vE '/generated/|/runtime/|rust_runtime\.rs|rt_datetime' \
+  | grep -vE '^\s*[^:]+:[0-9]+:\s*//' \
+  | grep -vE '//.*(forbidden|sanctioned|shim|ProfileTimer|wasm-safe|playground)' )
+
+if [ -n "$hits" ]; then
+  echo "::error::forbidden impurity in the compile path — std::time/threads panic on wasm32-unknown-unknown (the playground) and break determinism. Route timing through almide_base::profile::ProfileTimer."
+  echo "$hits"
+  exit 1
+fi
+echo "forbidden-impurities: clean (no raw clock/thread sources in the compile-path crates)"

--- a/spec/wasm_cross/generics_mono.almd
+++ b/spec/wasm_cross/generics_mono.almd
@@ -1,0 +1,17 @@
+// Host-determinism fixture: exercises monomorphization — generic fns specialized
+// for multiple concrete types. The specialized-function append order (→ WASM
+// function indices) must be host-independent (regression guard for the
+// HashMap-ordered mono append that diverged on wasm32).
+fn pair_first[A, B](p: (A, B)) -> A = p.0
+fn wrap[T](x: T) -> List[T] = [x]
+fn sum_len[T](xs: List[T]) -> Int = list.len(xs)
+
+fn main() -> Unit = {
+  let a = pair_first((1, "x"))
+  let b = pair_first(("y", 2.0))
+  let c = wrap(42)
+  let d = wrap("hi")
+  let e = wrap(3.14)
+  let n = sum_len([1, 2, 3]) + sum_len(["a", "b"]) + list.len(c) + list.len(d) + list.len(e)
+  println("first=" + int.to_string(a) + " n=" + int.to_string(n) + " " + b)
+}


### PR DESCRIPTION
A Perceus-analog "Determinism/Purity Belt" — makes the compiler deterministic & target-portable by construction, so a wasm32 (browser playground) compile can't crash or diverge from x86-64. This is Phase 1 (the buildable-today layer); full 4-layer design in `docs/roadmap/active/determinism-belt.md`.

Both playground-breaking bugs were the SAME class: codegen read a non-deterministic/impure source instead of being a pure function of (IR, target). This Belt forbids the sources by construction.

## L1 — purity wall (clock confinement + CI gate)
- `almide_base::profile::ProfileTimer`: the ONE sanctioned, wasm-safe clock (cfg-gated to no-op on wasm32-unknown-unknown, where `std::time` panics). The three codegen `Instant::now()` sites route through it.
- `scripts/check-forbidden-impurities.sh` (new `checks` CI step): fails on raw `std::time|Instant|SystemTime|thread::spawn|thread_rng|fastrand|AtomicU64|fetch_add` in the compile-path crates (codegen/frontend/optimize/ir), excluding `/generated/` `/runtime/` (runtime code emitted into the user's native program). → bug #1's class is now un-writable.

## The confirmed-live data-order leak
- **`almide-optimize/src/mono/mod.rs`**: `all_instances`/`new` `HashMap<MonoKey,_>` → `BTreeMap`. These were iterated to append specialized functions to `program.functions`, and a function's WASM index is its position there — so the append order (HashMap iteration: host-pointer-width AND Sym-intern-order dependent) made the wasm32 compiler assign different indices than x86-64. This is the leak the audit found that the per-emit-site sorts didn't cover.
- `spec/wasm_cross/generics_mono.almd`: a monomorphization fixture so the byte-compare gates (`check-host-determinism.sh` / `check-browser-determinism.sh`) exercise this path.

## Deferred (roadmap)
L2 `DetMap` prelude (forbid iterating hash maps into bytes), L3 `Canonical<IrProgram>` type-state (the true Perceus spine), `Sym`-iteration ban, egg fresh-counter reset, optional Lean proof. See the roadmap doc — incl. the honest limits (L1 is alias-fragile; the interner is a latent worse-than-RandomState hazard; no layer certifies the artifact — the runtime gate's reliance is permanent).