### PR TITLE
Closure v2 P0: fix cross-module closure resolution + design RFC

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/closures.rs
+++ b/crates/almide-codegen/src/emit_wasm/closures.rs
@@ -27,6 +27,19 @@ pub(super) fn pre_scan_closures(program: &IrProgram, emitter: &mut WasmEmitter) 
         let scope_vars: HashSet<u32> = func.params.iter().map(|p| p.var.0).collect();
         scan_closures(&func.body, scope_vars, &mut mutable_vars, &mut lambda_exprs, &mut fn_ref_set);
     }
+    // Module functions also carry raw Lambdas (e.g. a submodule combinator
+    // factory returning a non-capturing lambda). They are NOT flattened into
+    // program.functions on the WASM path, so without this scan they get no
+    // LambdaInfo / table slot, and a call site resolves to the wrong function
+    // (or none) — the cross-module closure bug. Order: functions then modules,
+    // IDENTICAL to compile_lambda_bodies so the positional index aligns.
+    // (Closure v2, P0.)
+    for module in &program.modules {
+        for func in &module.functions {
+            let scope_vars: HashSet<u32> = func.params.iter().map(|p| p.var.0).collect();
+            scan_closures(&func.body, scope_vars, &mut mutable_vars, &mut lambda_exprs, &mut fn_ref_set);
+        }
+    }
     // BFS: scan lambda bodies for nested lambdas (repeat until no new lambdas found)
     let mut scan_start = 0;
     loop {
@@ -154,6 +167,15 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
     for func in &program.functions {
         let scope_vars: HashSet<u32> = func.params.iter().map(|p| p.var.0).collect();
         scan_closures(&func.body, scope_vars, &mut mutable_vars, &mut lambda_exprs, &mut fn_ref_set);
+    }
+    // Module functions, IDENTICAL order to pre_scan_closures (functions then
+    // modules) so emitter.lambdas[i] lines up with the pre-scan registration.
+    // (Closure v2, P0.)
+    for module in &program.modules {
+        for func in &module.functions {
+            let scope_vars: HashSet<u32> = func.params.iter().map(|p| p.var.0).collect();
+            scan_closures(&func.body, scope_vars, &mut mutable_vars, &mut lambda_exprs, &mut fn_ref_set);
+        }
     }
     // BFS: scan lambda bodies for nested lambdas
     let mut scan_start = 0;

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -49,6 +49,7 @@ pub mod pass_peephole;
 pub mod pass_anf;
 pub mod pass_stack_balance;
 pub mod pass_perceus;
+pub mod pass_globalize_closure_ids;
 pub mod pass_canonicalize;
 pub mod perceus_verified;
 pub mod pass_egg_saturation;

--- a/crates/almide-codegen/src/pass_globalize_closure_ids.rs
+++ b/crates/almide-codegen/src/pass_globalize_closure_ids.rs
@@ -1,0 +1,81 @@
+//! GlobalizeClosureIdsPass — Closure Architecture v2, phase P0 (WASM-only).
+//!
+//! `lambda_id` (the field on `IrExprKind::Lambda`) is the key the WASM emitter
+//! uses to correlate a raw-Lambda creation site with its pre-scanned
+//! `LambdaInfo` (table slot + capture layout): see `emit_lambda_closure`, which
+//! takes the FIRST `info.lambda_id == Some(lid)` match. But the frontend assigns
+//! `lambda_id` with a counter that **resets to 0 in every module**
+//! (`LowerCtx::new`), so a module's lambda and the main program's lambda routinely
+//! share id 0. The first-match then resolves a module closure to the WRONG
+//! function.
+//!
+//! Verified failure (the JSON-parser-class bug): with
+//! `pub fn neg() -> (Int)->Int = (n) => 0 - n` in a submodule and
+//! `fn add() -> (Int)->Int = (n) => n + 1000` in main, `lib.neg()(5)` returns
+//! `1005` (main's `add` body) on WASM instead of `-5` — and a variant with no main
+//! lambda emits invalid WASM ("unknown table 0: table index out of bounds").
+//!
+//! This pass re-stamps every `Lambda` node across functions + modules + top-lets
+//! with a program-unique, total id, so the emitter's correlation is exact. It is
+//! the perf-neutral half of the redesign: it does NOT change which lambdas stay
+//! raw, the inline fast path, or the table layout (slots are assigned by the
+//! emitter in scan order, independent of these ids). It runs late — after
+//! `ClosureConversionPass` has turned capturing lambdas into `ClosureCreate`
+//! (which resolve by globally-unique name and need no id) — so it only re-stamps
+//! the residual raw lambdas the emitter still matches by id.
+//!
+//! Full design: docs/roadmap/active/closure-architecture-v2.md.
+
+use almide_ir::*;
+use almide_ir::visit_mut::{IrMutVisitor, walk_expr_mut, walk_stmt_mut};
+use super::pass::{NanoPass, PassResult, Target};
+
+#[derive(Debug)]
+pub struct GlobalizeClosureIdsPass;
+
+struct Restamp {
+    next: u32,
+}
+
+impl IrMutVisitor for Restamp {
+    fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
+        if let IrExprKind::Lambda { lambda_id, .. } = &mut expr.kind {
+            *lambda_id = Some(self.next);
+            self.next += 1;
+        }
+        walk_expr_mut(self, expr);
+    }
+    fn visit_stmt_mut(&mut self, stmt: &mut IrStmt) {
+        walk_stmt_mut(self, stmt);
+    }
+}
+
+impl NanoPass for GlobalizeClosureIdsPass {
+    fn name(&self) -> &str { "GlobalizeClosureIds" }
+    // WASM-only: lambda_id is purely a WASM-emit correlation key; the Rust target
+    // ignores it and emits native closures.
+    fn targets(&self) -> Option<Vec<Target>> { Some(vec![Target::Wasm]) }
+    fn depends_on(&self) -> Vec<&'static str> { vec![] }
+
+    fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
+        // One deterministic traversal over the whole linked program. Order is
+        // irrelevant to emitted bytes (ids are a correlation key, not emitted);
+        // only program-wide UNIQUENESS matters.
+        let mut r = Restamp { next: 0 };
+        for func in &mut program.functions {
+            r.visit_expr_mut(&mut func.body);
+        }
+        for tl in &mut program.top_lets {
+            r.visit_expr_mut(&mut tl.value);
+        }
+        for module in &mut program.modules {
+            for func in &mut module.functions {
+                r.visit_expr_mut(&mut func.body);
+            }
+            for tl in &mut module.top_lets {
+                r.visit_expr_mut(&mut tl.value);
+            }
+        }
+        PassResult { program, changed: true }
+    }
+}

--- a/crates/almide-codegen/src/target.rs
+++ b/crates/almide-codegen/src/target.rs
@@ -30,6 +30,7 @@ use super::pass_anf::AnfPass;
 use super::pass_stack_balance::StackBalancePass;
 use super::pass_perceus::{PerceusPass, PerceusOptPass, PerceusVerifyPass};
 use super::pass_canonicalize::CanonicalizePass;
+use super::pass_globalize_closure_ids::GlobalizeClosureIdsPass;
 use super::pass_egg_saturation::EggSaturationPass;
 use super::pass_matrix_shape_spec::MatrixShapeSpecPass;
 use super::pass_const_fold::ConstFoldPass;
@@ -221,6 +222,11 @@ fn build_pipeline(target: Target) -> Pipeline {
         // TailCallMark: mark tail-position calls for WASM return_call emission.
         // Must run after all passes that may create or transform calls.
         .add(TailCallMarkPass)
+        // GlobalizeClosureIds: re-stamp every residual raw Lambda with a
+        // program-unique lambda_id so the emitter's id-keyed lambda↔LambdaInfo
+        // correlation is exact across modules. Runs late (after any pass that
+        // could clone a lambda) and before Canonicalize. (Closure v2, P0.)
+        .add(GlobalizeClosureIdsPass)
         // Canonicalize: terminal pass. Sort functions into content-derived order
         // so the emitted module is host-deterministic by construction. MUST be
         // last — `Canonical::certify` asserts its postcondition at the emit gate,

--- a/docs/roadmap/active/closure-architecture-v2.md
+++ b/docs/roadmap/active/closure-architecture-v2.md
@@ -1,0 +1,204 @@
+<!-- description: Closure Architecture v2 — one identity, one capture-set, lifting is lowering; separates closure REPRESENTATION from the inlining OPTIMIZATION -->
+# Closure Architecture v2
+
+> **One identity, one capture-set, lifting is lowering.** A closure is a single
+> canonical value with a program-unique identity and an explicit, once-computed
+> capture set; *inlining* is a separate, escape-proven rewrite — never a
+> representational shortcut. This is the closure analogue of how `Verified` /
+> `Canonical` gate emit: correctness by construction, not by guessing.
+
+## Why
+
+Today a single source lambda `(x) => f(x)` is represented up to **five** different
+ways depending on use-site syntax, capture analysis, mutability, and target:
+
+1. an inline iterator-adapter callback (`IterStep`/`IterCollector`, Rust);
+2. a surviving raw `IrExprKind::Lambda` value;
+3. a lifted `__closure_N` function + `ClosureCreate` + `EnvLoad` triple (WASM, immutable captures);
+4. a heap-cell mutable-capture raw `Lambda` (WASM);
+5. an eta-expanded wrapper / `FnRef` (named functions).
+
+Captures are **not** stored on the `Lambda` node; they are re-derived by **three**
+independent free-variable analyses (`FreeVarCollector` in closure conversion,
+`ClosureScanner` in `emit_wasm`, and Rust's implicit `move`), feeding **two**
+near-duplicate WASM env builders (`emit_lambda_closure` vs `emit_closure_create`).
+`Ty::Fn { params, ret }` is the *only* callable type — it carries no closure /
+capture / calling-convention tag, so every operational distinction lives
+implicitly in *which node kind* and *which pipeline branch* was chosen.
+
+The conceptual-integrity defect: **there is no canonical "function value."** The
+representation is *guessed* from the lambda's shape (`free.is_empty()` ⟹ "this
+will be inlined at a HOF call site"), a property the pass cannot actually see.
+
+### The verified bug this produces
+
+`ClosureConversionPass` keeps non-capturing lambdas raw (`pass_closure_conversion.rs`
+`free.is_empty()` branch). Raw lambdas are correlated to their pre-scanned
+`LambdaInfo` at emit by `lambda_id` — but `lambda_id` **resets to 0 per module**
+(`LowerCtx::new`) and module lambdas are **never registered** (the WASM pre-scan
+only walks `program.functions`). Result, reproduced on 0.23.14 with an 8-line
+two-module program:
+
+```almide
+// src/lib.almd
+pub fn neg() -> (Int) -> Int = (n) => 0 - n
+// main.almd
+import self.lib
+fn apply(f: (Int) -> Int, x: Int) -> Int = f(x)
+fn add() -> (Int) -> Int = (n) => n + 1000
+effect fn main() -> Unit = {
+  println(int.to_string(apply(add(), 5)))     // 1005  (correct on both)
+  println(int.to_string(apply(lib.neg(), 5))) // want -5; WASM printed 1005
+}
+```
+
+`lib.neg()(5)` returns `1005` (main's `add` body) on WASM — a silent wrong result.
+A variant with no main-program lambda emits invalid WASM
+(`unknown table 0: table index out of bounds`). Native is correct because the
+Rust target uses native closures and never runs the WASM id-matching path.
+
+## The principle: separate three conflated concerns
+
+| Concern | Today (broken) | v2 |
+|---|---|---|
+| **Identity** — *which* closure | per-module `lambda_id`, collides across modules | program-unique `ClosureId` |
+| **Capture set** — *what* it closes over | re-derived by 3 analyses, can diverge | one shared analysis, attached to the node, with explicit `mode` + precise `Ty` |
+| **Representation** — *how* it is laid out & called | guessed from capture-emptiness → 5 shapes | the `Lambda` value node is canonical through the shared pipeline; *lifting* is a target lowering; *inlining* is the proven absence of lifting |
+
+The inversion: **today the representation is guessed from the lambda's shape;
+in v2 it is proven from the use** (escape analysis decides per call-site), while
+identity and captures are computed once and shared by all targets.
+
+## The boundary: shared semantic core vs target lowering
+
+The redesign's single most important decision (a uniform *lifted* `Closure{code,env}`
+node is the wrong altitude — it is a WASM lowering form; pushing it through Rust
+forces a backwards reconstruction of native closures that defeats `rustc`, and
+WGSL cannot represent it at all):
+
+**SHARED (in `almide-ir`, computed once over functions *and* modules, before the
+pipeline splits):**
+
+- `ClosureId(u32)` — program-unique identity, replaces `lambda_id: Option<u32>`.
+- The capture set, attached to the node:
+  `Lambda { params, body, id: ClosureId, captures: Vec<Capture>, escape: EscapeVerdict }`,
+  `Capture { var, ty: Ty /* Almide owned type */, mode: ByVal | ByMutCell }`.
+  Non-capturing ⟹ `captures: []`. No `free.is_empty()` bypass.
+- A program-wide `ClosureTable` keyed by `ClosureId` (functions + modules).
+- One shared free-var + escape analysis fills all of the above.
+
+`Lambda` (carrying id + captures + escape) **stays the canonical closure VALUE
+form through the entire shared pipeline.** There is no shared lifted
+`Closure{code,env}` node.
+
+**TARGET LOWERING (each reads the shared capture-set + escape verdict):**
+
+- **Rust** — never lifts. Emits native `move |params| body`, driving
+  `CaptureClonePass` deterministically from `captures` (delete the
+  `needs_clone_type` allowlist). `ParamBorrow` materialization (`to_vec`/`to_owned`)
+  is a Rust-representation derivation. Escape-required stored forms → `Rc<dyn Fn>`.
+  Lets `rustc` optimize.
+- **WASM** — a WASM-only `ClosureLowering` pass lifts **only the closures that
+  survive `InlineClosures`** (the escaping ones) to `__closure_N` + a `Ty::EnvPtr`
+  env + `EnvLoad`, registered in the `ClosureTable` → func-table **by name**
+  (order-independent, module-safe). One env builder; one `valtype_and_load(ty, mode)`
+  helper centralizing ValType selection, mut-cell-as-i32, and narrow-int
+  sign-extension. `call_indirect` type index comes from the lifted fn's registered
+  `closure_type_idx` via `ClosureId` — **one source of truth**.
+- **WGSL** — a *closure-free* target. `InlineClosures` runs unconditionally inside
+  `@gpu` bodies; any residual escaping closure → a hard compile error. (This
+  validates the thesis from the other side: WGSL is where "inline or error" is
+  forced rather than optional.)
+
+The elegant payoff: **shared = identity + capture-set + escape-verdict; lifting,
+sign-extension, `to_vec`/`to_owned`, `Rc<dyn Fn>`, `call_indirect`, and
+"inline-or-error" are all per-target derivations of that one shared truth.**
+Neither backend is contorted.
+
+## InlineClosures: "prove the use"
+
+A recognizer pass that runs **before** lifting. A closure may be inlined iff a
+**two-sided** proof holds:
+
+- **(a) the use site**: the closure is *anonymous* (not the RHS of any `Bind`),
+  *single-use*, and does not escape its scope; **and**
+- **(b) the sink**: the callee is on a curated allowlist of *consume-only*
+  combinators carrying `@fn_arg_consumed(idx)` in `stdlib/defs`, verified once
+  against the runtime impl — so the closure cannot escape *through* the call (a
+  `fold` whose reducer captures the fn into the accumulator would otherwise
+  escape it).
+
+When both hold, rewrite `Call(combinator, [.., literal-closure])` → an
+`InlinedHOF` node (WASM: spliced body, no alloc / no `call_indirect`; Rust:
+`IterChain` adapter). Egg fusion composes `InlinedHOF`s. **A bound closure is
+never inlined** ⟹ "computed once" is literally true. The WASM emitter's fast path
+keys on `InlinedHOF`, not on raw-`Lambda` shape.
+
+## The hard correctness pieces (designed in, not glossed)
+
+- **Recursion.** Self / mutual-recursive *local* closures cannot capture
+  themselves into their own env (a cycle / a not-yet-allocated value). A pre-pass
+  computes SCCs over `let`-bound lambda groups; self/sibling references are
+  rewritten to the `ClosureId` code symbol and the lifted fn's own `__env` param
+  is threaded into the recursive call (the standard "recursive closures pass their
+  own env"). Postcondition: no `env` captures the closure being constructed.
+- **Mutable capture is a *lifetime* bug, not a representation bug.** `ByMutCell`
+  is necessary but insufficient alone (the current code silently stores `0` into
+  the env when the captured local is out of `var_map`). Fix: a `CellAlloc` node at
+  the variable's *binding* site; redirect **every** read/write of that var — in
+  the enclosing function too, not just the lifted body — to `CellRead`/`CellWrite`;
+  the cell (`Ty::Cell(T)`, a 1-slot heap record) is RC-tracked so Perceus keeps it
+  alive across the closure's escape. Delete the zero-store fallback → a
+  postcondition error.
+- **Perceus RC through env.** Today capture-inc fires only when `ClosureCreate` is
+  a `VDecl` value — so a closure created as a call-arg or tail (exactly the verified
+  bug's shape) gets **no** inc → under-count. Fix: bind inc/dec to the **Closure
+  node** in *every* syntactic position (decl value, call arg, tail, list element);
+  inc each heap env capture where the value is materialized, dec each on the
+  Closure's own drop. `Ty::EnvPtr` is heap **and** borrowed-not-owned; EnvLoad-bound
+  captures are structural borrows (no inc/dec). This gives the L5 Lean proof a clean
+  handle — `inc_count(cap) == dec_count(cap)` over every path because both ends bind
+  to one node — **closing the "Perceus → binary" proof chain.**
+- **Type identity, one source of truth.** `Ty::EnvPtr` is a *real sealed scalar
+  variant* (not a `Ty::String` alias — else Perceus `RcDec`s the env block and
+  corrupts the heap); `ty_to_valtype = I32` today, target-parametrized for a future
+  GC backend (`(ref $env)` + `call_ref`). `call_indirect` type comes from
+  `closure_type_idx` via `ClosureId`, not re-derived from `callee.ty` per site (the
+  structural `register_type` dedup is a latent second collision — the no-main
+  "table OOB" variant). **Keep one `Ty::Fn`** — bifurcating the callable type
+  metastasizes through unification and every `Type[Fn]` container; the convention
+  lives on the node, enforced by "every callable value is a Closure after
+  conversion; sites always emit the closure ABI, never sniff `.ty`."
+
+## Phasing (every boundary perf-neutral AND invariant-satisfiable)
+
+The red-team's rule: **totality is atomic with its dependents.** "Zero raw Lambda
+after conversion" is *unsatisfiable* while egg fusion (runs before conversion,
+re-emits raw lambdas) and the WASM inline fast path (`is_inline_lambda` matches
+raw `Lambda`) still need raw lambdas. Never split that across releases.
+
+| Phase | Content | Property |
+|---|---|---|
+| **P0** | program-unique closure identity (`GlobalizeClosureIdsPass`) + register module lambdas in the WASM scan | **fixes the verified bug, perf-neutral** (fast path untouched). 8-line repro as a native==wasm regression test |
+| **P1** | shared core: `ClosureId` + one free-var/escape analysis over functions+modules; attach `captures`/`escape` to the node; `ClosureTable` | representation unchanged; Rust/WASM *read* the shared set; assert old analyses agree |
+| **P2** | `InlineClosures` (`InlinedHOF`) + **atomic totality**: move egg onto identified closures; rewrite the 3 WASM fast-paths to key on `InlinedHOF`; total WASM `ClosureLowering` over survivors; delete the `lambda_id`/`param_id`/counter resolver + one env builder; `Ty::EnvPtr`; `EnvLoad` via `emit_load_at`; `closure_type_idx` via `ClosureId` | "zero raw Lambda" finally satisfiable; the `unreachable`s become postcondition errors |
+| **P3** | `ByMutCell` (`CellAlloc`/`CellRead`/`CellWrite`) + SCC recursion + Perceus-RC-through-env | the three correctness blockers, verified at `PerceusVerify` |
+| **P4** | Rust reads the shared capture set fully; retire `needs_clone_type` + the third (implicit-move) analysis | one analysis, both targets |
+| **P5** | Lean: certify `inc == dec` over env | the proof chain closes |
+
+## Honest limits
+
+- **P0 is a targeted fix, not the redesign.** It makes `lambda_id` program-unique
+  and registers module lambdas; the `free.is_empty()` representational bypass and
+  the parallel raw-Lambda emit path remain until P2. It does not improve
+  mutable-capture lifetime (P3) or the duplicate analyses (P1/P4).
+- **The escape allowlist (`@fn_arg_consumed`) is hand-curated and verified once
+  against each runtime impl** — a maintenance obligation, not an inferred property.
+  A wrong annotation can inline an escaping closure; treat it as a trusted base.
+- **GC migration is localized but not free**: `Ty::EnvPtr` and the Closure layout
+  are target-parametrized, so a `gc` backend swaps `emit_wasm` + `ty_to_valtype`
+  only — but `call_ref`/typed-funcref bring their own type-identity model to design.
+- **L3 determinism interaction**: `GlobalizeClosureIdsPass` runs before
+  `CanonicalizePass` and mutates only `lambda_id` (not function order), so the
+  `Canonical` certificate is unaffected; closure table slots are assigned in scan
+  order, independent of these ids, so emitted bytes stay host-deterministic.

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -508,3 +508,115 @@ fn wasm_cross_target_spec() {
         );
     }
 }
+
+// ── Closure Architecture v2, P0: cross-module closure identity ──
+// A submodule function returning a non-capturing lambda, applied across the
+// module boundary. Before P0 the WASM emitter correlated a raw Lambda to its
+// LambdaInfo by `lambda_id`, which resets to 0 per module — so a module lambda
+// collided with a main-program lambda of the same id, AND module lambdas were
+// never registered in the WASM closure pre-scan. `lib.neg()(5)` then returned
+// main's `add` body on WASM (native `1005 / -5`, WASM `1005 / 1005`), and a
+// no-main-lambda variant emitted invalid WASM ("table index out of bounds").
+// GlobalizeClosureIdsPass (program-unique ids) + scanning module functions in
+// the pre-scan fix both. These must run on WASM and match the native result.
+
+/// Write a multi-file project into a tempdir and assert its `main.almd`
+/// produces identical stdout on the Rust and WASM targets.
+fn assert_cross_target_project(files: &[(&str, &str)]) {
+    let bin = almide_bin();
+    if Command::new(&bin).arg("--version").output().is_err() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    for (rel, content) in files {
+        let p = dir.path().join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, content).unwrap();
+    }
+
+    // Native: compile + run from inside the project dir (so almide.toml resolves).
+    let r = Command::new(&bin)
+        .current_dir(dir.path())
+        .args(["run", "main.almd"])
+        .output()
+        .expect("native run");
+    assert!(
+        r.status.success(),
+        "native compile/run failed:\n{}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    let rust_out = String::from_utf8_lossy(&r.stdout).trim().to_string();
+
+    // WASM: build, then run with wasmtime (skip the run if wasmtime is absent —
+    // the native arm and the build still gate, and the byte gate covers wasm32).
+    let b = Command::new(&bin)
+        .current_dir(dir.path())
+        .args(["build", "main.almd", "--target", "wasm", "-o", "out.wasm"])
+        .output()
+        .expect("wasm build");
+    assert!(
+        b.status.success(),
+        "wasm build failed:\n{}",
+        String::from_utf8_lossy(&b.stderr)
+    );
+    let w = match Command::new("wasmtime")
+        .current_dir(dir.path())
+        .arg("--dir=/")
+        .arg("out.wasm")
+        .output()
+    {
+        Ok(o) if o.status.code() != Some(127) => o,
+        _ => return, // wasmtime unavailable
+    };
+    assert!(
+        w.status.success(),
+        "wasm execution failed (invalid module?):\n{}",
+        String::from_utf8_lossy(&w.stderr)
+    );
+    let wasm_out = String::from_utf8_lossy(&w.stdout).trim().to_string();
+
+    assert_eq!(
+        rust_out, wasm_out,
+        "\ncross-module closure mismatch!\nRust: {:?}\nWASM: {:?}",
+        rust_out, wasm_out
+    );
+}
+
+const CROSS_PKG_TOML: &str = "[package]\nname = \"clostest\"\nversion = \"0.1.0\"\n\n[targets]\nwasm = true\n";
+const CROSS_PKG_LIB: &str = "pub fn neg() -> (Int) -> Int = (n) => 0 - n\n";
+
+#[test]
+fn wasm_cross_module_returned_non_capturing_lambda() {
+    assert_cross_target_project(&[
+        ("almide.toml", CROSS_PKG_TOML),
+        ("src/lib.almd", CROSS_PKG_LIB),
+        (
+            "main.almd",
+            "import self.lib\n\
+             fn apply(f: (Int) -> Int, x: Int) -> Int = f(x)\n\
+             fn add() -> (Int) -> Int = (n) => n + 1000\n\
+             fn main() -> Unit = {\n\
+             \x20 println(int.to_string(apply(add(), 5)))\n\
+             \x20 println(int.to_string(apply(lib.neg(), 5)))\n\
+             }\n",
+        ),
+    ]);
+}
+
+#[test]
+fn wasm_cross_module_lambda_without_local_decoy() {
+    // No main-program lambda for the module lambda to mis-resolve to: before P0
+    // this emitted invalid WASM ("unknown table 0: table index out of bounds").
+    assert_cross_target_project(&[
+        ("almide.toml", CROSS_PKG_TOML),
+        ("src/lib.almd", CROSS_PKG_LIB),
+        (
+            "main.almd",
+            "import self.lib\n\
+             fn apply(f: (Int) -> Int, x: Int) -> Int = f(x)\n\
+             fn main() -> Unit = {\n\
+             \x20 println(int.to_string(apply(lib.neg(), 5)))\n\
+             }\n",
+        ),
+    ]);
+}


### PR DESCRIPTION
Phase P0 of the Closure Architecture v2 redesign (full design: `docs/roadmap/active/closure-architecture-v2.md`). A perf-neutral fix for a **verified, silent wrong-result bug** on the WASM target, decoupled from the larger representational change so it ships immediately.

## The bug (reproduced on 0.23.14)
A submodule function returning a non-capturing lambda, applied across the module boundary, resolved to the **wrong function** on WASM:

```almide
// src/lib.almd
pub fn neg() -> (Int) -> Int = (n) => 0 - n
// main.almd
import self.lib
fn apply(f: (Int) -> Int, x: Int) -> Int = f(x)
fn add() -> (Int) -> Int = (n) => n + 1000
fn main() -> Unit = {
  println(int.to_string(apply(add(), 5)))      // 1005 (both)
  println(int.to_string(apply(lib.neg(), 5)))  // native -5;  WASM printed 1005
}
```

`lib.neg()(5)` returned `1005` (main's `add` body) on WASM; a no-main-lambda variant emitted invalid WASM (`unknown table 0: table index out of bounds`). Native was always correct (it uses native closures, not the WASM id-matching path).

## Root cause (two compounding defects)
The WASM emitter correlates a raw `Lambda` creation site to its pre-scanned `LambdaInfo` by `lambda_id` (`emit_lambda_closure` takes the first `lambda_id == Some(lid)` match), but:
1. `lambda_id` **resets to 0 per module** (`LowerCtx::new`) — so `lib.neg`'s lambda (id 0) collides with `main.add`'s lambda (id 0), and the first-match resolves to the wrong one.
2. Module lambdas are **never registered** — `pre_scan_closures`/`compile_lambda_bodies` only walk `program.functions`, never `program.modules`.

## The fix (perf-neutral)
- **`GlobalizeClosureIdsPass`** (new, WASM-only, terminal-area): re-stamps every residual raw `Lambda` across functions + modules + top-lets with a program-unique `lambda_id`, so the emitter's correlation is exact. It does not change which lambdas stay raw, the inline fast path, or the table layout (slots are assigned in scan order, independent of these ids).
- **Scan `program.modules`** in `pre_scan_closures` and `compile_lambda_bodies` (identical order in both, so the positional index aligns), so module lambdas get a `LambdaInfo` + table slot + compiled body.

## Verification
- Both verified failure modes fixed: `lib.neg()(5)` → `-5` on WASM; the no-main variant runs and prints `-5`.
- Two regression tests in `tests/wasm_runtime_test.rs` (multi-module, native==wasm).
- Full `spec/` suite **240/240**; `wasm_runtime_test` 31/31; `nanopass`/`ir` tests green.
- Determinism preserved: the pass mutates only `lambda_id` (not function order), so the `Canonical` certificate is unaffected and emitted bytes stay host-deterministic.

P0 is a targeted fix, not the redesign — the `free.is_empty()` representational bypass, the duplicate analyses, and the mutable-capture lifetime gap remain for P1–P5 (see the RFC).