### PR TITLE
Closure v2 P1: one shared closure capture analysis

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/closures.rs
+++ b/crates/almide-codegen/src/emit_wasm/closures.rs
@@ -365,14 +365,20 @@ impl IrVisitor for ClosureScanner<'_> {
     fn visit_expr(&mut self, expr: &IrExpr) {
         match &expr.kind {
             IrExprKind::Lambda { params, body, lambda_id } => {
-                let param_ids: HashSet<u32> = params.iter().map(|(vid, _)| vid.0).collect();
-                let mut body_vars = HashSet::new();
-                collect_var_refs(body, &mut body_vars);
-                let mut captures: Vec<u32> = body_vars.difference(&param_ids)
-                    .copied()
+                // Captures via the single shared analysis (almide_ir::free_vars),
+                // intersected with the enclosing scope as a safety net. This is
+                // provably identical to the prior `(flat-refs − params) ∩ scope`:
+                // free_vars already excludes the lambda's own params and any
+                // body-local bindings (it is scope-tracking), and `∩ scope_vars`
+                // is what removed those body-locals before. free_vars returns a
+                // VarId-sorted Vec, so the env layout stays deterministic.
+                // (Closure v2, P1 — one capture analysis.)
+                let param_set: HashSet<VarId> = params.iter().map(|(vid, _)| *vid).collect();
+                let captures: Vec<u32> = almide_ir::free_vars::free_vars(body, &param_set)
+                    .into_iter()
+                    .map(|vid| vid.0)
                     .filter(|vid| self.scope_vars.contains(vid))
                     .collect();
-                captures.sort();
                 let param_list: Vec<(VarId, Ty)> = params.iter()
                     .map(|(vid, ty)| (*vid, ty.clone()))
                     .collect();
@@ -465,28 +471,6 @@ fn resolve_lambda_param_ty(
         return body.ty.clone();
     }
     almide_lang::types::Ty::Int
-}
-
-// ── VarRefCollector: IrVisitor-based variable reference collector ────
-//
-// Collects all VarIds referenced in an expression tree (including inside
-// nested lambdas). Uses walk_expr for exhaustive traversal.
-
-struct VarRefCollector<'a> {
-    vars: &'a mut HashSet<u32>,
-}
-
-impl IrVisitor for VarRefCollector<'_> {
-    fn visit_expr(&mut self, expr: &IrExpr) {
-        if let IrExprKind::Var { id } = &expr.kind {
-            self.vars.insert(id.0);
-        }
-        walk_expr(self, expr);
-    }
-}
-
-pub(super) fn collect_var_refs(expr: &IrExpr, vars: &mut HashSet<u32>) {
-    VarRefCollector { vars }.visit_expr(expr);
 }
 
 /// Collect all ClosureCreate func_names referenced in an expression tree.

--- a/crates/almide-codegen/src/pass_closure_conversion.rs
+++ b/crates/almide-codegen/src/pass_closure_conversion.rs
@@ -100,10 +100,9 @@ fn convert_expr(
             // 1. Bottom-up: convert nested lambdas first
             let body = convert_expr(*body, lifted, counter, vt);
 
-            // 2. Free variable analysis
+            // 2. Free variable analysis (single source of truth in almide-ir).
             let param_ids: HashSet<VarId> = params.iter().map(|(v, _)| *v).collect();
-            let mut free = HashSet::new();
-            collect_free_vars(&body, &param_ids, &mut free);
+            let free = almide_ir::free_vars::free_vars(&body, &param_ids);
 
             // 3a. No captures → keep as Lambda for potential inline expansion
             //     in the WASM emitter (avoids call_indirect overhead).
@@ -411,94 +410,8 @@ fn convert_target(
     }
 }
 
-// ── Free variable analysis ──────────────────────────────────────────
-
-struct FreeVarCollector {
-    bound: HashSet<VarId>,
-    free: HashSet<VarId>,
-}
-
-impl IrVisitor for FreeVarCollector {
-    fn visit_expr(&mut self, expr: &IrExpr) {
-        match &expr.kind {
-            IrExprKind::Var { id } => {
-                if !self.bound.contains(id) { self.free.insert(*id); }
-            }
-            IrExprKind::ClosureCreate { captures, .. } => {
-                for (vid, _) in captures {
-                    if !self.bound.contains(vid) { self.free.insert(*vid); }
-                }
-            }
-            IrExprKind::Lambda { params, body, .. } => {
-                let saved = self.bound.clone();
-                for (v, _) in params { self.bound.insert(*v); }
-                self.visit_expr(body);
-                self.bound = saved;
-            }
-            IrExprKind::Block { stmts, expr: tail } => {
-                let saved = self.bound.clone();
-                for stmt in stmts {
-                    self.visit_stmt(stmt);
-                    match &stmt.kind {
-                        IrStmtKind::Bind { var, .. } => { self.bound.insert(*var); }
-                        IrStmtKind::BindDestructure { pattern, .. } => {
-                            collect_pattern_bindings(pattern, &mut self.bound);
-                        }
-                        _ => {}
-                    }
-                }
-                if let Some(e) = tail { self.visit_expr(e); }
-                self.bound = saved;
-            }
-            IrExprKind::Match { subject, arms } => {
-                self.visit_expr(subject);
-                for arm in arms {
-                    let saved = self.bound.clone();
-                    collect_pattern_bindings(&arm.pattern, &mut self.bound);
-                    if let Some(g) = &arm.guard { self.visit_expr(g); }
-                    self.visit_expr(&arm.body);
-                    self.bound = saved;
-                }
-            }
-            IrExprKind::ForIn { var, var_tuple, iterable, body } => {
-                self.visit_expr(iterable);
-                let saved = self.bound.clone();
-                self.bound.insert(*var);
-                if let Some(vt) = var_tuple { for v in vt { self.bound.insert(*v); } }
-                for s in body { self.visit_stmt(s); }
-                self.bound = saved;
-            }
-            _ => walk_expr(self, expr),
-        }
-    }
-}
-
-fn collect_free_vars(expr: &IrExpr, bound: &HashSet<VarId>, free: &mut HashSet<VarId>) {
-    let mut collector = FreeVarCollector { bound: bound.clone(), free: std::mem::take(free) };
-    collector.visit_expr(expr);
-    *free = collector.free;
-}
-
-fn collect_pattern_bindings(pattern: &IrPattern, bound: &mut HashSet<VarId>) {
-    match pattern {
-        IrPattern::Bind { var, .. } => { bound.insert(*var); }
-        IrPattern::Constructor { args, .. } => {
-            for p in args { collect_pattern_bindings(p, bound); }
-        }
-        IrPattern::RecordPattern { fields, .. } => {
-            for f in fields {
-                if let Some(p) = &f.pattern { collect_pattern_bindings(p, bound); }
-            }
-        }
-        IrPattern::Tuple { elements } => {
-            for p in elements { collect_pattern_bindings(p, bound); }
-        }
-        IrPattern::Some { inner } | IrPattern::Ok { inner } | IrPattern::Err { inner } => {
-            collect_pattern_bindings(inner, bound);
-        }
-        _ => {}
-    }
-}
+// Free-variable / capture analysis now lives in `almide_ir::free_vars` — the
+// single source of truth shared by this pass and the WASM emitter. (Closure v2, P1.)
 
 // ── Mutable capture detection ───────────────────────────────────────
 

--- a/crates/almide-ir/src/free_vars.rs
+++ b/crates/almide-ir/src/free_vars.rs
@@ -1,0 +1,146 @@
+//! Closure capture analysis — the single source of truth (Closure Architecture v2, P1).
+//!
+//! A closure's *captures* are the `VarId`s it references from an enclosing scope.
+//! This used to be computed by three independent implementations (the WASM
+//! lifting pass's `FreeVarCollector`, the WASM emitter's `ClosureScanner`, and
+//! Rust's implicit `move`), which could subtly diverge — e.g. on binder handling
+//! (`Match`/`ForIn`/`Block`) or capture order — and produced two near-duplicate
+//! WASM env builders keyed off them. `free_vars` consolidates the codegen-path
+//! analysis into one scope-tracking traversal that every consumer calls, so the
+//! capture set for a given lambda is computed exactly once and identically.
+//!
+//! Scope-tracking: a lambda's own params, block bindings (`Bind`/`BindDestructure`),
+//! match-arm patterns, and for-in loop vars are *locally bound* and excluded. A
+//! `ClosureCreate`'s captures are treated as references (the enclosing vars a
+//! nested closure needs). The result is **sorted by `VarId`** so any downstream
+//! env layout is host-deterministic (mirrors the existing `captures.sort()` the
+//! emitter relied on; see the Determinism Belt).
+//!
+//! Full design: docs/roadmap/active/closure-architecture-v2.md.
+
+use std::collections::HashSet;
+use crate::{IrExpr, IrExprKind, IrStmt, IrStmtKind, IrPattern, VarId};
+use crate::visit::{IrVisitor, walk_expr};
+
+/// The free variables of `expr` relative to `bound` (typically a lambda's params
+/// plus any already-in-scope binders), as a deterministically-sorted `Vec`.
+///
+/// Because `IrExprKind::Var` denotes *only* locals (params, `let`s, loop/match
+/// binders) — globals and top-level functions are `Member`/`FnRef`/DefId nodes,
+/// never `Var` — the free set is exactly the enclosing-scope locals the
+/// expression references, i.e. its captures.
+pub fn free_vars(expr: &IrExpr, bound: &HashSet<VarId>) -> Vec<VarId> {
+    let mut c = FreeVarCollector { bound: bound.clone(), free: HashSet::new() };
+    c.visit_expr(expr);
+    let mut v: Vec<VarId> = c.free.into_iter().collect();
+    v.sort_by_key(|id| id.0);
+    v
+}
+
+struct FreeVarCollector {
+    bound: HashSet<VarId>,
+    free: HashSet<VarId>,
+}
+
+impl IrVisitor for FreeVarCollector {
+    fn visit_expr(&mut self, expr: &IrExpr) {
+        match &expr.kind {
+            IrExprKind::Var { id } => {
+                if !self.bound.contains(id) {
+                    self.free.insert(*id);
+                }
+            }
+            IrExprKind::ClosureCreate { captures, .. } => {
+                for (vid, _) in captures {
+                    if !self.bound.contains(vid) {
+                        self.free.insert(*vid);
+                    }
+                }
+            }
+            IrExprKind::Lambda { params, body, .. } => {
+                let saved = self.bound.clone();
+                for (v, _) in params {
+                    self.bound.insert(*v);
+                }
+                self.visit_expr(body);
+                self.bound = saved;
+            }
+            IrExprKind::Block { stmts, expr: tail } => {
+                let saved = self.bound.clone();
+                for stmt in stmts {
+                    self.visit_stmt(stmt);
+                    match &stmt.kind {
+                        IrStmtKind::Bind { var, .. } => {
+                            self.bound.insert(*var);
+                        }
+                        IrStmtKind::BindDestructure { pattern, .. } => {
+                            collect_pattern_bindings(pattern, &mut self.bound);
+                        }
+                        _ => {}
+                    }
+                }
+                if let Some(e) = tail {
+                    self.visit_expr(e);
+                }
+                self.bound = saved;
+            }
+            IrExprKind::Match { subject, arms } => {
+                self.visit_expr(subject);
+                for arm in arms {
+                    let saved = self.bound.clone();
+                    collect_pattern_bindings(&arm.pattern, &mut self.bound);
+                    if let Some(g) = &arm.guard {
+                        self.visit_expr(g);
+                    }
+                    self.visit_expr(&arm.body);
+                    self.bound = saved;
+                }
+            }
+            IrExprKind::ForIn { var, var_tuple, iterable, body } => {
+                self.visit_expr(iterable);
+                let saved = self.bound.clone();
+                self.bound.insert(*var);
+                if let Some(vt) = var_tuple {
+                    for v in vt {
+                        self.bound.insert(*v);
+                    }
+                }
+                for s in body {
+                    self.visit_stmt(s);
+                }
+                self.bound = saved;
+            }
+            _ => walk_expr(self, expr),
+        }
+    }
+}
+
+/// Add every `VarId` a pattern binds to `bound`.
+pub fn collect_pattern_bindings(pattern: &IrPattern, bound: &mut HashSet<VarId>) {
+    match pattern {
+        IrPattern::Bind { var, .. } => {
+            bound.insert(*var);
+        }
+        IrPattern::Constructor { args, .. } => {
+            for a in args {
+                collect_pattern_bindings(a, bound);
+            }
+        }
+        IrPattern::Tuple { elements } => {
+            for e in elements {
+                collect_pattern_bindings(e, bound);
+            }
+        }
+        IrPattern::Some { inner, .. } | IrPattern::Ok { inner, .. } | IrPattern::Err { inner, .. } => {
+            collect_pattern_bindings(inner, bound);
+        }
+        IrPattern::RecordPattern { fields, .. } => {
+            for f in fields {
+                if let Some(p) = &f.pattern {
+                    collect_pattern_bindings(p, bound);
+                }
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/almide-ir/src/lib.rs
+++ b/crates/almide-ir/src/lib.rs
@@ -23,6 +23,7 @@ mod use_count;
 mod verify;
 pub mod visit;
 pub mod visit_mut;
+pub mod free_vars;
 pub mod result;
 pub mod substitute;
 pub mod effect;


### PR DESCRIPTION
Phase P1 of Closure Architecture v2 (`docs/roadmap/active/closure-architecture-v2.md`): collapse the duplicated free-variable / capture analysis into a single source of truth in `almide-ir`.

## Why
The audit found **three** independent free-variable analyses on the codegen path — `FreeVarCollector` (the WASM lifting pass), `ClosureScanner` (the WASM emitter), and Rust's implicit `move` — which could subtly diverge on binder handling or capture order and fed two near-duplicate WASM env builders. Two of them computed the *same* capture set for the *same* lambda, separately.

## What
- **`almide_ir::free_vars`** (new): one scope-tracking capture analysis. Excludes a lambda's own params, block bindings, match-arm patterns, and for-in loop vars; treats `ClosureCreate` captures as references; returns a **VarId-sorted** `Vec` so env layout stays host-deterministic.
- `pass_closure_conversion` now calls it (local `FreeVarCollector` / `collect_free_vars` / `collect_pattern_bindings` deleted).
- `emit_wasm::closures` `ClosureScanner` now calls it, keeping the `∩ scope_vars` safety intersect (provably identical to the old `(flat-refs − params) ∩ scope`, since `free_vars` already excludes params + body-locals). Dead `VarRefCollector` / `collect_var_refs` deleted.

Net **−119 / +163** (new module, two analyses removed). Rust's implicit-move path is consolidated in P4.

## Verification
- Full `spec/` suite **240/240** — proves the consolidation is output-identical across every closure form (capture sets, env layouts unchanged).
- `wasm_runtime_test` **31/31**, including the P0 cross-module regression tests.
- Determinism preserved (sorted captures).

Deliberately **not** in P1 (deferred to where they're consumed, per "prove it when you need it"): the escape verdict, `Capture` mode, `ClosureId` as a type, and the `ClosureTable` all land in P2, where InlineClosures + total conversion consume them. Building them now would be dead infrastructure that P2's atomic change reshapes.