### PR TITLE
Closure v2 P2b/A: value lambdas become closures; inline-combinator args stay raw

### DIFF
--- a/crates/almide-codegen/src/pass_closure_conversion.rs
+++ b/crates/almide-codegen/src/pass_closure_conversion.rs
@@ -86,6 +86,62 @@ impl NanoPass for ClosureConversionPass {
 
 // ── Bottom-up Lambda → ClosureCreate conversion ─────────────────────
 
+/// Arg index of an inline-eligible list-combinator's lambda for the `Module`
+/// call form (e.g. egg's fused output), or None.
+fn module_inline_lambda_arg(target: &CallTarget) -> Option<usize> {
+    if let CallTarget::Module { module, func, .. } = target {
+        if module.as_str() == "list" {
+            return list_combinator_inline_arg(func.as_str());
+        }
+    }
+    None
+}
+
+/// Same, for the usual post-IntrinsicLowering `RuntimeCall` form
+/// (`almide_rt_list_<method>`). These are the only combinators the WASM emitter
+/// inline-splices (map/filter at arg 1, fold at arg 2); leaving exactly their
+/// lambda args raw keeps the fast path AND inline-context Perceus RC. A missed
+/// form only costs a perf regression (the arg becomes a ClosureCreate that
+/// dispatches via call_indirect), never correctness.
+fn runtime_inline_lambda_arg(symbol: &almide_base::intern::Sym) -> Option<usize> {
+    match symbol.as_str() {
+        "almide_rt_list_map" | "almide_rt_list_filter" => Some(1),
+        "almide_rt_list_fold" => Some(2),
+        _ => None,
+    }
+}
+
+fn list_combinator_inline_arg(func: &str) -> Option<usize> {
+    match func {
+        "map" | "filter" => Some(1),
+        "fold" => Some(2),
+        _ => None,
+    }
+}
+
+/// Convert nested closures inside a (potential) inline lambda's body, but keep
+/// the lambda itself RAW so the emitter can splice it. Non-lambda args fall back
+/// to normal conversion.
+fn keep_lambda_raw(
+    expr: IrExpr,
+    lifted: &mut Vec<IrFunction>,
+    counter: &mut u32,
+    vt: &mut VarTable,
+) -> IrExpr {
+    let IrExpr { kind, ty, span, def_id } = expr;
+    match kind {
+        IrExprKind::Lambda { params, body, lambda_id } => IrExpr {
+            kind: IrExprKind::Lambda {
+                params,
+                body: Box::new(convert_expr(*body, lifted, counter, vt)),
+                lambda_id,
+            },
+            ty, span, def_id,
+        },
+        other => convert_expr(IrExpr { kind: other, ty, span, def_id }, lifted, counter, vt),
+    }
+}
+
 fn convert_expr(
     expr: IrExpr,
     lifted: &mut Vec<IrFunction>,
@@ -104,17 +160,16 @@ fn convert_expr(
             let param_ids: HashSet<VarId> = params.iter().map(|(v, _)| *v).collect();
             let free = almide_ir::free_vars::free_vars(&body, &param_ids);
 
-            // 3a. No captures → keep as Lambda for potential inline expansion
-            //     in the WASM emitter (avoids call_indirect overhead).
-            if free.is_empty() {
-                return IrExpr {
-                    kind: IrExprKind::Lambda { params, body: Box::new(body), lambda_id },
-                    ty, span, def_id: None,
-                };
-            }
+            // A value-position lambda is always lifted to a ClosureCreate with a
+            // stable, globally-unique function name — even with NO captures (the
+            // emitter builds [table_idx, 0]). Inline-combinator args never reach
+            // here: they were kept raw at the Call/RuntimeCall site above. So we no
+            // longer leave capture-free *value* lambdas raw (that was the source of
+            // the fragile lambda_id-matched value path). (Closure v2, P2b/A.)
 
-            // 3b. Skip conversion for mutable captures (WASM emitter handles
-            //     those via heap cells in the Lambda-based path)
+            // Mutable captures stay raw: the emitter boxes them as heap cells in the
+            // Lambda path, and a lifted env doesn't yet thread the cell correctly
+            // (a P3 concern). So a mutate-captured lambda keeps the raw representation.
             if free.iter().any(|vid| body_assigns_to(&body, *vid)) {
                 return IrExpr {
                     kind: IrExprKind::Lambda { params, body: Box::new(body), lambda_id },
@@ -237,15 +292,31 @@ fn convert_expr(
             stmts: stmts.into_iter().map(|s| convert_stmt(s, lifted, counter, vt)).collect(),
             expr: tail.map(|e| Box::new(convert_expr(*e, lifted, counter, vt))),
         },
-        IrExprKind::Call { target, args, type_args } => IrExprKind::Call {
-            target: convert_target(target, lifted, counter, vt),
-            args: args.into_iter().map(|a| convert_expr(a, lifted, counter, vt)).collect(),
-            type_args,
-        },
-        IrExprKind::RuntimeCall { symbol, args } => IrExprKind::RuntimeCall {
-            symbol,
-            args: args.into_iter().map(|a| convert_expr(a, lifted, counter, vt)).collect(),
-        },
+        IrExprKind::Call { target, args, type_args } => {
+            // An inline-eligible list-combinator's lambda arg stays RAW so the WASM
+            // emitter splices it (no alloc / no call_indirect) and Perceus processes
+            // its body in the INLINE context — lifting it and re-inlining would
+            // corrupt RC. Every OTHER lambda becomes a ClosureCreate value.
+            // (Closure v2, P2b/A.)
+            let inline_idx = module_inline_lambda_arg(&target);
+            let args = args.into_iter().enumerate()
+                .map(|(i, a)| {
+                    if Some(i) == inline_idx { keep_lambda_raw(a, lifted, counter, vt) }
+                    else { convert_expr(a, lifted, counter, vt) }
+                })
+                .collect();
+            IrExprKind::Call { target: convert_target(target, lifted, counter, vt), args, type_args }
+        }
+        IrExprKind::RuntimeCall { symbol, args } => {
+            let inline_idx = runtime_inline_lambda_arg(&symbol);
+            let args = args.into_iter().enumerate()
+                .map(|(i, a)| {
+                    if Some(i) == inline_idx { keep_lambda_raw(a, lifted, counter, vt) }
+                    else { convert_expr(a, lifted, counter, vt) }
+                })
+                .collect();
+            IrExprKind::RuntimeCall { symbol, args }
+        }
         IrExprKind::If { cond, then, else_ } => IrExprKind::If {
             cond: Box::new(convert_expr(*cond, lifted, counter, vt)),
             then: Box::new(convert_expr(*then, lifted, counter, vt)),

--- a/tests/nanopass_test.rs
+++ b/tests/nanopass_test.rs
@@ -636,10 +636,15 @@ mod closure_conversion {
         let program = mk_program(vec![func], vt);
         let result = run_pass(&ClosureConversionPass, program, Target::Wasm);
 
-        // Capture-free lambdas stay as Lambda (not lifted) for inline expansion
-        // in the WASM emitter — only lambdas with captures get lifted.
-        assert_eq!(result.functions.len(), 1,
-            "Capture-free lambda should NOT be lifted, got {} functions", result.functions.len());
+        // A value-position lambda (here `let f = (x) => x + 1`, called via a
+        // Computed callee — not an inline-combinator arg) is lifted to a stable
+        // ClosureCreate even when capture-free. Only inline-combinator lambda args
+        // stay raw now. So the program gains a lifted `__closure_*` function.
+        // (Closure v2, P2b/A — representation is use-based, not capture-based.)
+        assert_eq!(result.functions.len(), 2,
+            "Capture-free VALUE lambda should be lifted to a closure, got {} functions", result.functions.len());
+        assert!(result.functions.iter().any(|f| f.name.as_str().starts_with("__closure_")),
+            "expected a lifted __closure_* function");
     }
 }
 


### PR DESCRIPTION
Closure Architecture v2, the first robust step of P2b (`docs/roadmap/active/closure-architecture-v2.md`). Replaces the **capture-based guess** that decided a lambda's representation with a **use-based** rule, while preserving the WASM inline fast path and its RC correctness.

## What changed
`ClosureConversionPass` previously kept a lambda raw iff it had **no captures** (`free.is_empty()`) — conflating "no captures" with "will be inlined". Now:
- An **inline-eligible list-combinator's lambda arg** (`list.map`/`filter` at arg 1, `list.fold` at arg 2 — the only combinators the WASM emitter inline-splices) is kept **raw** at the `Call`/`RuntimeCall` site, so the emitter splices it with no alloc / no `call_indirect`.
- **Every other lambda** — returned, stored, `let`-bound, passed to a user HOF — is lifted to a `ClosureCreate` with a stable, globally-unique function name (resolved by name, not by the fragile `lambda_id` match).
- **Mutable-capture lambdas stay raw** (the emitter boxes them as heap cells); converting them needs lifted-env cell threading, deferred to P3.

## Why this shape (the RC constraint that picked it)
Lifting an inline lambda and then re-inlining its body would corrupt Perceus RC: a lifted function's body is RC-processed in **function context**, but an inline splice needs **inline context** — they differ for heap-bodied lambdas (e.g. `xs |> list.map((x) => [x])`). Keeping inline args raw is therefore not just a perf choice but an RC-correctness one. The combinator form at this pass is uniformly `RuntimeCall{symbol: "almide_rt_list_<method>"}` (verified by instrumentation); a missed form only costs a perf regression (the arg becomes a `ClosureCreate` dispatched via `call_indirect`), never correctness.

## Wins
- **Bug class fixed structurally**: a value-position lambda (e.g. a submodule combinator factory `pub fn neg() -> (Int)->Int = (n) => 0 - n`) now gets a stable `ClosureCreate` name instead of relying on `lambda_id` matching.
- **Perf**: a *capturing* combinator lambda (`xs |> list.map((x) => x + k)`) was previously a `ClosureCreate` → `call_indirect`; it now stays raw → **inline-spliced** (no alloc, no indirect call).
- Narrows the fragile value-lambda resolver to just the mutable-capture-value case (its full deletion lands with P3's cell handling).

## Verification
- Full `spec/` suite **240/240** — proves the expanded inline set (capturing combinator lambdas now inline) and the value-lambda→ClosureCreate change are correct across every closure form.
- `wasm_runtime_test` **31/31** (incl. the P0 cross-module regression: `lib.neg()(5)` → `-5` on WASM, now via `ClosureCreate`).
- repro + fused `map∘map∘filter` + fold programs match native on WASM.

Next (P3): mutable captures via `CellAlloc` + RC-through-env, which then unblocks deleting the value-lambda resolver entirely.