### PR TITLE
Skip the process.exec test when the almide binary is absent

### DIFF
--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -687,6 +687,9 @@ fn rust_process_exec_forwards_bound_list() {
     // compiled fine, which made it sneaky. `process.*` is native-only, so this is a
     // Rust-target build+run test: `run_rust` compiles via `almide run` and panics if
     // the build fails, then we assert the output.
+    // Skip when the `almide` binary isn't available (e.g. the CI Test Rust job runs
+    // `cargo test` without building it) — same guard the cross-target tests use.
+    if std::process::Command::new(almide_bin()).arg("--version").output().is_err() { return; }
     let out = run_rust(
         "import process\n\
          effect fn run(cmd: String, a: List[String]) -> String =\n\


### PR DESCRIPTION
`rust_process_exec_forwards_bound_list` called `run_rust` directly without the binary-availability guard the other cross-target tests use, so it panicked (`failed to run almide: NotFound`) in the CI Test Rust job, which runs `cargo test` without building the `almide` binary. This reddened develop right after #332 merged.

Add the same `almide_bin() --version` skip guard the cross-target helpers already use. Test-only; no behavior change. (The test still runs locally where the binary exists.)

Follow-up worth doing separately: have the CI Test Rust job build/expose the binary so these binary-dependent tests actually run in CI instead of skipping.