### PR TITLE
Close five cross-target closure codegen gaps from the adversarial sweep

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string.rs
@@ -467,6 +467,39 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(s1);
                 self.scratch.free_i32(s);
             }
+            // ── In-place mutators (Unit-returning, write back into the var) ──
+            // These mirror `list.push` / `list.clear`: the receiver is mutated
+            // and (for push) the possibly-reallocated pointer is written back
+            // into the var/cell via `emit_mutator_writeback`. They leave nothing
+            // on the stack (the call is in Unit context). See
+            // `is_inplace_mutator` in pass_closure_conversion.rs for the source
+            // of truth on which calls mutate `args[0]`.
+            "push" | "push_char" => {
+                // push(mut s, suffix) → Unit. `__string_append` appends suffix
+                // to s in place when s has spare capacity, else grows 2x and
+                // returns a new pointer — exactly the semantics native
+                // `s.push_str(suffix)` needs. push_char takes a 1-char String,
+                // so it is identical. Both args are `String` (i32 ptr).
+                let new_ptr = self.scratch.alloc_i32();
+                self.emit_expr(&args[0]);
+                self.emit_expr(&args[1]);
+                wasm!(self.func, {
+                    call(self.emitter.rt.string_append);
+                    local_set(new_ptr);
+                });
+                // Write the (possibly reallocated) string ptr back into the
+                // local / global / mutable-capture cell.
+                self.emit_mutator_writeback(&args[0], new_ptr);
+                self.scratch.free_i32(new_ptr);
+            }
+            "clear" => {
+                // clear(mut s) → Unit. Sets the length header to 0 in place.
+                // Capacity and buffer are kept (matches `String::clear`), so no
+                // writeback is needed — the pointer is unchanged. Mirrors
+                // `list.clear`.
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { i32_const(0); i32_store(0); });
+            }
             _ => return false,
         }
         true

--- a/crates/almide-codegen/src/walker/helpers.rs
+++ b/crates/almide-codegen/src/walker/helpers.rs
@@ -64,6 +64,27 @@ pub fn erase_named_typevars(ty: Ty) -> Ty {
     }
 }
 
+/// Replace every Fn type (at any depth) with Ty::Unknown (rendered as `_`).
+///
+/// Rust forbids `impl Trait` in the type of a variable binding (E0562), so a
+/// `let`/`var` whose type *contains* a closure type — e.g. a tuple element
+/// `(impl Fn() -> () + Clone, i64)`, a map value `HashMap<String, impl Fn..>`,
+/// or a record field — cannot be written literally. Erasing the Fn subtree to
+/// `_` lets Rust infer the concrete (unnameable) closure type from the RHS,
+/// while preserving the surrounding container shape (`(_, i64)`,
+/// `HashMap<String, _>`). The closure value itself is emitted unchanged and is
+/// `Clone` (captures are `Rc`/`Copy` clones), so later `g.clone()()` call sites
+/// keep working.
+///
+/// A top-level Fn is already mapped to `Ty::Unknown` by the binding code before
+/// this runs, so this only rewrites Fn types nested inside containers.
+pub fn erase_fn_types(ty: Ty) -> Ty {
+    match &ty {
+        Ty::Fn { .. } => Ty::Unknown,
+        _ => ty.map_children(&|child| erase_fn_types(child.clone())),
+    }
+}
+
 /// Indent each non-empty line by the given number of spaces.
 pub fn indent_lines(s: &str, spaces: usize) -> String {
     let prefix = " ".repeat(spaces);

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -7,7 +7,7 @@ use almide_lang::types::{Ty, TypeConstructorId};
 use super::RenderContext;
 use super::types::render_type;
 use super::expressions::render_expr;
-use super::helpers::{template_or, terminate_stmt, ty_has_named_typevar, erase_named_typevars};
+use super::helpers::{template_or, terminate_stmt, ty_has_named_typevar, erase_named_typevars, erase_fn_types};
 
 /// Check if an expression references a specific variable (any depth).
 pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
@@ -81,34 +81,63 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             } else {
                 ty
             };
+            // Erase Fn types nested inside containers (tuple element, map value,
+            // record field, ...). Rust forbids `impl Trait` in a binding type
+            // (E0562), so `(impl Fn() -> () + Clone, i64)` is illegal; rewrite the
+            // Fn subtree to `_` (-> `(_, i64)`) and let Rust infer the concrete
+            // closure type from the RHS. A top-level Fn was already turned into
+            // Ty::Unknown above, so this only touches the nested-container case.
+            let fn_erased_owned;
+            let ty = if matches!(ty, Ty::Tuple(_) | Ty::Applied(..) | Ty::Named(_, _) | Ty::Record { .. } | Ty::OpenRecord { .. })
+                && ty.any_child_recursive(&|t| matches!(t, Ty::Fn { .. }))
+            {
+                fn_erased_owned = erase_fn_types(ty.clone());
+                &fn_erased_owned
+            } else {
+                ty
+            };
             let type_s = render_type(ctx, ty);
             // When binding a lambda to a Fn-typed variable (e.g. type alias Handler = (String) -> String),
             // the let type is erased to `_` but the lambda params have no type annotations either,
             // causing Rust type inference failure. Render lambda params with explicit types in this case.
+            let annotate_lambda = |params: &[(VarId, Ty)], body: &IrExpr| -> String {
+                let params_str = params.iter()
+                    .map(|(id, pty)| {
+                        let name = ctx.var_name(*id).to_string();
+                        if matches!(pty, Ty::Unknown) {
+                            name
+                        } else {
+                            format!("{}: {}", name, super::types::render_type(ctx, pty))
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let body_str = render_expr(ctx, body);
+                ctx.templates.render_with("lambda_single", None, &[], &[("params", params_str.as_str()), ("body", body_str.as_str())])
+                    .unwrap_or_else(|| format!("move |{}| {}", params_str, body_str))
+            };
+            let has_typed = |params: &[(VarId, Ty)]| params.iter().any(|(_, t)| !matches!(t, Ty::Unknown));
             let value_s = if matches!(ty, Ty::Unknown) {
-                if let IrExprKind::Lambda { params, body, .. } = &value.kind {
-                    let has_typed_params = params.iter().any(|(_, t)| !matches!(t, Ty::Unknown));
-                    if has_typed_params {
-                        let params_str = params.iter()
-                            .map(|(id, pty)| {
-                                let name = ctx.var_name(*id).to_string();
-                                if matches!(pty, Ty::Unknown) {
-                                    name
-                                } else {
-                                    let ty_str = super::types::render_type(ctx, pty);
-                                    format!("{}: {}", name, ty_str)
-                                }
-                            })
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        let body_str = render_expr(ctx, body);
-                        ctx.templates.render_with("lambda_single", None, &[], &[("params", params_str.as_str()), ("body", body_str.as_str())])
-                            .unwrap_or_else(|| format!("move |{}| {}", params_str, body_str))
-                    } else {
-                        render_expr(ctx, value)
+                match &value.kind {
+                    IrExprKind::Lambda { params, body, .. } if has_typed(params) => annotate_lambda(params, body),
+                    // Capture-clone-wrapped closure: a shared-mut-capturing raw closure
+                    // lowers to `{ let __cap = x.clone(); move |k| … }`. The wrapping
+                    // block hides the lambda from the bare-Lambda case above, so a typed
+                    // param rendered `move |k|` with no type → E0282. Annotate the tail
+                    // lambda's params, keeping the capture prologue. HOF-arg lambdas
+                    // never reach here (render_iter_chain splices them inline), so this
+                    // is safe. (Closure v2 P6.)
+                    IrExprKind::Block { stmts, expr: Some(tail) }
+                        if matches!(&tail.kind, IrExprKind::Lambda { params, .. } if has_typed(params)) =>
+                    {
+                        if let IrExprKind::Lambda { params, body, .. } = &tail.kind {
+                            let stmts_s = stmts.iter().map(|s| render_stmt(ctx, s)).collect::<Vec<_>>().join("\n");
+                            format!("{{\n{}\n{}\n}}", stmts_s, annotate_lambda(params, body))
+                        } else {
+                            render_expr(ctx, value)
+                        }
                     }
-                } else {
-                    render_expr(ctx, value)
+                    _ => render_expr(ctx, value),
                 }
             } else {
                 render_expr(ctx, value)

--- a/crates/almide-syntax/src/parser/helpers.rs
+++ b/crates/almide-syntax/src/parser/helpers.rs
@@ -47,6 +47,7 @@ impl Parser {
         if self.current().token_type != TokenType::LBracket { return false; }
         let mut depth = 0;
         let mut i = 0;
+        let mut has_typename = false;
         loop {
             let tok = match self.peek_at(i) {
                 Some(t) => t,
@@ -57,9 +58,18 @@ impl Parser {
                 TokenType::RBracket => {
                     depth -= 1;
                     if depth == 0 {
-                        return self.peek_at(i + 1).map(|t| t.token_type == TokenType::LParen).unwrap_or(false);
+                        // `<expr>[...]( ` is a *type-args* call (e.g. `parse[Int](s)`)
+                        // ONLY when the brackets actually name a type. Otherwise the
+                        // brackets are a value INDEX and the parens a call on the
+                        // indexed element: `fs[0]()` is `(fs[0])()`, not `fs::<0>()`.
+                        // Without the TypeName gate, `[0]` (an int index) was misread
+                        // as a const-generic type argument, so calling a closure out
+                        // of a list (`fs[0]()`) emitted an invalid bare-name call.
+                        return has_typename
+                            && self.peek_at(i + 1).map(|t| t.token_type == TokenType::LParen).unwrap_or(false);
                     }
                 }
+                TokenType::TypeName => has_typename = true,
                 TokenType::EOF => return false,
                 _ => {}
             }

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -801,6 +801,80 @@ fn wasm_bytes_mutable_capture_through_closure() {
 }
 
 #[test]
+fn wasm_string_push_clear_in_place() {
+    // string.push / string.clear had NO WASM dispatch arm — they ICE'd the emitter
+    // (native worked). They are `mut s`/in-place mutators in is_inplace_mutator, so
+    // a captured String mutated through a closure also relied on this. push appends
+    // (via __string_append, write-back like list.push), clear sets len 0. 2 pushes
+    // of "ab" -> len 4. Cross-target = 4.
+    assert_cross_target_effect_main(
+        "effect fn main() -> Unit = {\n\
+         \x20 var s: String = \"\"\n\
+         \x20 let f = () => { string.push(s, \"ab\") }\n\
+         \x20 f()\n\
+         \x20 f()\n\
+         \x20 println(int.to_string(string.len(s)))\n\
+         }\n",
+    );
+}
+
+#[test]
+fn wasm_closure_stored_in_tuple() {
+    // A capture-mutating closure stored in a tuple, destructured into a `let`, and
+    // called. Rust typed the binding `(impl Fn(), i64)` → E0562 (impl Trait in a
+    // binding type). The let-type's nested Fn subtree is now erased to `_` so Rust
+    // infers the concrete closure type. 2 calls -> len 2. Cross-target = 2.
+    assert_cross_target_effect_main(
+        "effect fn main() -> Unit = {\n\
+         \x20 var acc: List[Int] = []\n\
+         \x20 let pair = (() => { list.push(acc, 1) }, 0)\n\
+         \x20 let (g, _) = pair\n\
+         \x20 g()\n\
+         \x20 g()\n\
+         \x20 println(int.to_string(list.len(acc)))\n\
+         }\n",
+    );
+}
+
+#[test]
+fn wasm_call_closure_through_list_index() {
+    // `fs[0]()` — calling a closure indexed out of a list. The parser read `[0](` as
+    // a const-generic type-args call (`fs::<0>()`), emitting an invalid bare-name
+    // call (native E0425 / wasm trap). `[...]( ` is now a type-args call only when
+    // the brackets name a type; an int index makes it `(fs[0])()`. 2 calls -> len 2.
+    assert_cross_target_effect_main(
+        "effect fn main() -> Unit = {\n\
+         \x20 var acc: List[Int] = []\n\
+         \x20 let fs = [() => { list.push(acc, 1) }]\n\
+         \x20 fs[0]()\n\
+         \x20 fs[0]()\n\
+         \x20 println(int.to_string(list.len(acc)))\n\
+         }\n",
+    );
+}
+
+#[test]
+fn wasm_typed_param_closure_capturing_mutable() {
+    // A closure with a TYPED param `(k: String) => …` that captures a mutated var
+    // (so it stays a raw, capture-clone-wrapped closure) dropped the param type in
+    // Rust codegen → `move |k| …` → E0282. The bind site now annotates the tail
+    // lambda's params through the capture-clone block. Word-count -> 3,2,2.
+    assert_cross_target_effect_main(
+        "effect fn main() -> Unit = {\n\
+         \x20 var m: Map[String, Int] = map.new()\n\
+         \x20 let bump = (k: String) => {\n\
+         \x20   let cur: Int = map.get_or(m, k, 0)\n\
+         \x20   map.insert(m, k, cur + 1)\n\
+         \x20 }\n\
+         \x20 for w in [\"a\", \"b\", \"a\", \"a\", \"b\"] { bump(w) }\n\
+         \x20 println(int.to_string(map.get_or(m, \"a\", -1)))\n\
+         \x20 println(int.to_string(map.get_or(m, \"b\", -1)))\n\
+         \x20 println(int.to_string(map.len(m)))\n\
+         }\n",
+    );
+}
+
+#[test]
 fn wasm_reassign_concat_capture_through_closure() {
     // A non-Copy `var` GROWN by reassignment-concat through a closure
     // (`xs = xs + [list.len(xs)]`, reading its own length each step) must behave


### PR DESCRIPTION
A fresh adversarial cross-target (native vs wasm) differential sweep over non-Copy mutable captures surfaced a new batch of closure/codegen divergences. This PR closes five of them; three deeper ones are root-caused and tracked for follow-up (below).

## Fixed (cross-target verified, no regression)
- **WASM string mutators** — `string.push` / `string.clear` had no WASM dispatch arm and ICE'd the emitter (native worked). They are in-place mutators in `is_inplace_mutator`, so a captured String mutated through a closure relied on them too. Added the WASM emit (push via `__string_append` + write-back like `list.push`; clear sets len 0).
- **Closure stored in a tuple** — `let (g, _) = (() => {…}, 0)` typed the binding `(impl Fn(), i64)` → `E0562` (impl Trait in a binding type). The let-type's nested `Fn` subtree is now erased to `_` so rustc infers the concrete closure type.
- **Calling a closure indexed out of a list** — `fs[0]()` was parsed as a const-generic type-args call (`fs::<0>()`), emitting an invalid bare-name call (native `E0425` / wasm trap). `[...]( ` is now a type-args call only when the brackets name a type; an int index makes it `(fs[0])()`.
- **Typed param on a capture-clone-wrapped closure** — `(k: String) => {…}` capturing a mutated var stays a raw, capture-clone-wrapped closure; the param type was dropped (`move |k|`) → `E0282`. The bind site now annotates the tail lambda's params through the capture-clone block. (HOF-arg lambdas are unaffected — they're spliced inline by `render_iter_chain`.)

## Verification
spec 240/240 (cross-target), cargo test 784/0, +5 cross-target regression tests. The parser change is regression-clean (type-args calls like `parse[Int](s)` still work).

## Deeper divergences root-caused, NOT in this PR (follow-up)
- **Closure as a uniform value in a Map / anonymous record** (`Map[K, () -> Unit]`, `{ run: () => … }`) → native `E0308`/`E0277`. Needs the `RcWrap`/`type_fn_field` (`Rc<dyn Fn>`) boxing — today applied only to `List[Fn]` literal bindings — generalized to map values, record fields, and `get_or` defaults. A `type`-declared record already works.
- **IndexAssign of a non-Copy element through a closure** (`xs: List[String]; () => { xs[0] = xs[0] + "!" }`) → wasm traps in the Perceus drop of the old element; the cell-deref and drop-of-old-element aren't coordinated.