### PR TITLE
Box closures in variant payloads and Fn-typed closure parameters

### DIFF
--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -315,6 +315,10 @@ template = "#[derive(Clone, Debug, PartialEq)]\npub struct {name} {{\n{fields}\n
 template = "    pub {name}: {type},"
 
 [[enum_decl]]
+when_attr = "has_fn_fields"
+template = "#[derive(Clone)]\npub enum {name} {{\n{variants}\n}}"
+
+[[enum_decl]]
 when_attr = "has_hash"
 template = "#[derive(Clone, Debug, PartialEq, Eq, Hash)]\npub enum {name} {{\n{variants}\n}}"
 

--- a/crates/almide-codegen/src/walker/declarations.rs
+++ b/crates/almide-codegen/src/walker/declarations.rs
@@ -73,7 +73,13 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                     IrVariantKind::Tuple { fields } => {
                         let is_recursive = ctx.ann.recursive_enums.contains(&*td.name);
                         let types: Vec<String> = fields.iter().map(|t| {
-                            let rendered = render_type(ctx, t);
+                            // Fn payloads use Rc<dyn Fn> (impl Fn is invalid in field
+                            // position, Box<dyn Fn> is not Clone) — same as a struct field.
+                            let rendered = if matches!(t, Ty::Fn { .. }) {
+                                render_type_field_fn(ctx, t)
+                            } else {
+                                render_type(ctx, t)
+                            };
                             if is_recursive && ty_contains_name(t, &td.name) { format!("Box<{}>", rendered) } else { rendered }
                         }).collect();
                         let fields_str = types.join(", ");
@@ -94,7 +100,11 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                     IrVariantKind::Record { fields } => {
                         let fields_str = fields.iter()
                             .map(|f| {
-                                let rendered = render_type(ctx, &f.ty);
+                                let rendered = if matches!(&f.ty, Ty::Fn { .. }) {
+                                    render_type_field_fn(ctx, &f.ty)
+                                } else {
+                                    render_type(ctx, &f.ty)
+                                };
                                 let boxed = if ctx.ann.recursive_enums.contains(&*td.name) && ty_contains_name(&f.ty, &td.name) {
                                     format!("Box<{}>", rendered)
                                 } else {
@@ -115,10 +125,22 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
             let variants_str = variants_parts.join(&sep);
             let full_name = format!("{}{}", td.name, generics_str);
             let has_hash = td.deriving.as_ref().map_or(false, |d| d.iter().any(|s| s.as_str() == "Hash"));
+            // A closure payload (Fn directly, or nested in a container) lowers to
+            // `Rc<dyn Fn>`, which is neither Debug nor PartialEq → derive Clone only.
+            let has_fn_fields = cases.iter().any(|v| match &v.kind {
+                IrVariantKind::Unit => false,
+                IrVariantKind::Tuple { fields } => fields.iter().any(ty_has_fn),
+                IrVariantKind::Record { fields } => fields.iter().any(|f| ty_has_fn(&f.ty)),
+            });
             let mut enum_attrs = decl_attrs.clone();
-            if has_hash { enum_attrs.push("has_hash"); }
+            if has_fn_fields { enum_attrs.push("has_fn_fields"); }
+            else if has_hash { enum_attrs.push("has_hash"); }
             let repr_prefix = if ctx.repr_c { "#[repr(C)]\n" } else { "" };
-            let fallback = format!("{}pub enum {} {{\n{}\n}}", repr_prefix, full_name, &variants_str);
+            let fallback = if has_fn_fields {
+                format!("#[derive(Clone)]\npub enum {} {{\n{}\n}}", full_name, &variants_str)
+            } else {
+                format!("{}pub enum {} {{\n{}\n}}", repr_prefix, full_name, &variants_str)
+            };
             ctx.templates.render_with("enum_decl", None, &enum_attrs, &[("name", full_name.as_str()), ("variants", variants_str.as_str())])
                 .unwrap_or(fallback)
         }

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -1066,7 +1066,17 @@ fn render_generic_call(ctx: &RenderContext, target: &CallTarget, args: &[IrExpr]
         }
         CallTarget::Module { .. } => unreachable!(),
     };
-    let args_str = args.iter().map(|a| render_expr_owned(ctx, a)).collect::<Vec<_>>().join(", ");
+    // Calling a closure VALUE (Computed target): a function-typed parameter of
+    // that closure is `Rc<dyn Fn>` (a closure can't take an `impl Fn` param), so
+    // box a fresh closure passed as such an argument. Named/Method calls go to
+    // real `fn`s whose `impl Fn` params accept the raw closure, so leave those.
+    let box_fn_args = matches!(target, CallTarget::Computed { .. });
+    let args_str = args.iter().map(|a| {
+        let s = render_expr_owned(ctx, a);
+        if box_fn_args && matches!(&a.ty, Ty::Fn { .. }) && !matches!(&a.kind, IrExprKind::RcWrap { .. }) {
+            format!("std::rc::Rc::new({})", s)
+        } else { s }
+    }).collect::<Vec<_>>().join(", ");
     ctx.templates.render_with("call_expr", None, &[], &[("callee", callee.as_str()), ("args", args_str.as_str())])
         .unwrap_or_else(|| format!("call(...)"))
 }
@@ -1172,6 +1182,11 @@ fn render_enum_constructor(ctx: &RenderContext, ctor_name: &str, enum_name: &str
         let is_rc_cow_var = matches!(&a.kind, IrExprKind::Var { id } if ctx.ann.is_rc_cow(id));
         let rendered = if is_rc_cow_var {
             format!("{}.into_inner()", rendered)
+        } else { rendered };
+        // A closure payload field is typed `Rc<dyn Fn>` (see the variant decl), so
+        // a fresh closure passed to the constructor must be boxed to match.
+        let rendered = if matches!(&a.ty, Ty::Fn { .. }) && !matches!(&a.kind, IrExprKind::RcWrap { .. }) {
+            format!("std::rc::Rc::new({})", rendered)
         } else { rendered };
         if needs_box {
             format!("Box::new({})", rendered)

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -106,6 +106,11 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
                         let name = ctx.var_name(*id).to_string();
                         if matches!(pty, Ty::Unknown) {
                             name
+                        } else if matches!(pty, Ty::Fn { .. }) {
+                            // A closure can't take an `impl Fn` parameter (E0562);
+                            // a function-typed param is `Rc<dyn Fn>` (callers box
+                            // the closure they pass — see render_generic_call).
+                            format!("{}: {}", name, super::helpers::render_type_field_fn(ctx, pty))
                         } else {
                             format!("{}: {}", name, super::types::render_type(ctx, pty))
                         }

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -1097,3 +1097,38 @@ fn wasm_bytes_set_at_shared_through_closure() {
          }\n",
     );
 }
+
+#[test]
+fn wasm_closure_as_variant_payload() {
+    // A closure stored as a tuple-variant payload `Run(() -> Unit)`. Native gave
+    // E0562 "impl Trait not allowed in field types" — the variant field rendered
+    // `impl Fn`. The payload type is now `Rc<dyn Fn>`, the enum derives Clone only,
+    // and the constructor boxes the closure. One Run fires, one Noop fires. len 2.
+    assert_cross_target_effect_main(
+        "type Action = Run(() -> Unit) | Noop\n\
+         effect fn main() -> Unit = {\n\
+         \x20 var acc: List[Int] = []\n\
+         \x20 let a = Run(() => { list.push(acc, 1) })\n\
+         \x20 match a { Run(f) => f(), Noop => {} }\n\
+         \x20 let b: Action = Noop\n\
+         \x20 match b { Run(f) => f(), Noop => { list.push(acc, 9) } }\n\
+         \x20 println(int.to_string(list.len(acc)))\n\
+         }\n",
+    );
+}
+
+#[test]
+fn wasm_closure_with_fn_typed_param() {
+    // A closure whose own parameter is function-typed: `(g: () -> Unit) => ...`.
+    // Native gave E0562 "impl Trait not allowed in closure parameters". The param
+    // is now `Rc<dyn Fn>` and the call site boxes the closure it passes. The inner
+    // closure runs 3 times, each adding 10 to a captured var -> p=30.
+    assert_cross_target_effect_main(
+        "effect fn main() -> Unit = {\n\
+         \x20 let run3 = (g: () -> Unit) => { g(); g(); g() }\n\
+         \x20 var p = 0\n\
+         \x20 run3(() => { p = p + 10 })\n\
+         \x20 println(\"p=\" + int.to_string(p))\n\
+         }\n",
+    );
+}


### PR DESCRIPTION
## What

Continues the closure cross-target work (#337). Two more positions where a closure value/type lands in a slot Rust can't express as bare `impl Fn`.

### Variant payloads (gap 3)
`type Action = Run(() -> Unit) | Noop; let a = Run(() => …)` failed native with E0562 "impl Trait not allowed in field types".
- variant Tuple/Record payload of `Fn` type now renders `Rc<dyn Fn>` (`render_type_field_fn`), same as a struct field
- an enum with any closure-containing payload derives `Clone` only (a new `has_fn_fields` `enum_decl` template variant), since `Rc<dyn Fn>` is neither `Debug` nor `PartialEq`
- the constructor boxes a fresh closure argument (`Rc::new`) to match the payload type

### Fn-typed closure parameters (mismatch 2)
`let run3 = (g: () -> Unit) => { g(); g(); g() }` failed native with E0562 "impl Trait not allowed in closure parameters" (a closure can't take an `impl Fn` param).
- a function-typed lambda parameter now renders `Rc<dyn Fn>` in `annotate_lambda`
- calling a closure VALUE (Computed target) boxes a fresh closure passed as such an argument; Named/Method calls to real `fn`s keep their `impl Fn` params and are left untouched

WASM already handled both (closures are lifted there); this brings the Rust target into agreement.

## Verification
- native-vs-wasm repros for both: MATCH (`Run(...)` -> 2, `run3` -> p=30)
- 2 new regression tests + full `wasm_runtime_test` 57/57
- `almide test spec/ --target rust` 240/240
- full `cargo test` green