### PR TITLE
Fix native codegen for keyword-named globals and name-colliding globals

### DIFF
--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -112,12 +112,15 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                 return format!("{}.get()", raw_name);
             }
             let var_info = ctx.var_table.get(*id);
-            // Emit-time prefix: module_origin → "ALMIDE_RT_{ORIGIN}_{NAME}"
+            // Emit-time prefix: module_origin → "ALMIDE_RT_{ORIGIN}_{NAME}".
+            // `upper` (the thread_local static name) is built from the RAW name via
+            // global_static_name — uppercasing the keyword-escaped `r#box` would
+            // give the invalid `R#BOX`.
             let (name, upper) = if let Some(ref origin) = var_info.module_origin {
                 let prefixed = format!("ALMIDE_RT_{}_{}", origin.to_uppercase(), raw_name.to_uppercase());
-                (prefixed.clone(), prefixed)
+                (prefixed, ctx.global_static_name(*id))
             } else {
-                (raw_name.clone(), raw_name.to_uppercase())
+                (raw_name.clone(), ctx.global_static_name(*id))
             };
             let has_module = var_info.module_origin.is_some();
             // Module-level mutable var: dispatch by storage type
@@ -1261,7 +1264,7 @@ fn render_runtime_call(ctx: &RenderContext, symbol: &almide_base::intern::Sym, a
             if let IrExprKind::Borrow { expr: inner, .. } | IrExprKind::Clone { expr: inner } = &args[0].kind {
                 if let IrExprKind::Var { id } = &inner.kind {
                     let name = ctx.var_name(*id).to_string();
-                    let upper = name.to_uppercase();
+                    let upper = ctx.global_static_name(*id);
                     match ctx.ann.get_var_storage(id, &name) {
                         VarStorage::ModuleRc => {
                             let rest_args = args[1..].iter().map(|a| render_expr(ctx, a))

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -94,6 +94,19 @@ impl<'a> RenderContext<'a> {
             name.to_string()
         }
     }
+
+    /// The thread_local static name for a global var, matching exactly what the
+    /// `render_program` top_let emission declares. Built from the RAW (un-escaped)
+    /// var name: `var_name(id)` raw-escapes Rust keywords (`box` → `r#box`), and
+    /// uppercasing that yields the invalid `R#BOX`, which mismatches the `BOX` the
+    /// declaration emits. Every read/write of a global must route through here.
+    pub(crate) fn global_static_name(&self, id: VarId) -> String {
+        let vi = self.var_table.get(id);
+        match &vi.module_origin {
+            Some(origin) => format!("ALMIDE_RT_{}_{}", origin.to_uppercase(), vi.name.to_uppercase()),
+            None => vi.name.to_uppercase(),
+        }
+    }
 }
 
 // ── Function rendering ──

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -231,7 +231,7 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             if ctx.ann.is_shared_mut(var) {
                 return format!("{}.set({});", target_s, render_expr(ctx, value));
             }
-            let upper = target_s.to_uppercase();
+            let upper = ctx.global_static_name(*var);
             let value_s = render_expr(ctx, value);
             match ctx.ann.get_var_storage(var, &target_s) {
                 VarStorage::ModuleCell => format!("{}.with(|c| c.set({}));", upper, value_s),
@@ -282,7 +282,7 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
         }
         IrStmtKind::IndexAssign { target, index, value } => {
             let target_str = ctx.var_name(*target).to_string();
-            let upper = target_str.to_uppercase();
+            let upper = ctx.global_static_name(*target);
             let idx_str = render_expr(ctx, index);
             let val_str = render_expr(ctx, value);
             let var_ty = &ctx.var_table.get(*target).ty;
@@ -301,7 +301,7 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
         }
         IrStmtKind::MapInsert { target, key, value } => {
             let target_str = ctx.var_name(*target).to_string();
-            let upper = target_str.to_uppercase();
+            let upper = ctx.global_static_name(*target);
             let key_str = render_expr(ctx, key);
             let val_str = render_expr(ctx, value);
             // Shared-mut non-Copy var (`SharedMut`, P6): insert through the cell.
@@ -317,7 +317,7 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
         }
         IrStmtKind::FieldAssign { target, field, value } => {
             let target_str = ctx.var_name(*target).to_string();
-            let upper = target_str.to_uppercase();
+            let upper = ctx.global_static_name(*target);
             let val_str = render_expr(ctx, value);
             // Shared-mut non-Copy var (`SharedMut`, P6): assign the field through the cell.
             if ctx.ann.is_shared_mut(target) {
@@ -385,7 +385,7 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
         }
         IrStmtKind::ListSwap { target, a, b } => {
             let t = ctx.var_name(*target).to_string();
-            let upper = t.to_uppercase();
+            let upper = ctx.global_static_name(*target);
             let a_s = render_expr(ctx, a);
             let b_s = render_expr(ctx, b);
             match ctx.ann.get_var_storage(target, &t) {
@@ -397,7 +397,7 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
         }
         IrStmtKind::ListReverse { target, end } => {
             let t = ctx.var_name(*target).to_string();
-            let upper = t.to_uppercase();
+            let upper = ctx.global_static_name(*target);
             let e = render_expr(ctx, end);
             match ctx.ann.get_var_storage(target, &t) {
                 VarStorage::ModuleRc => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut())[..={} as usize].reverse());", upper, e),
@@ -408,7 +408,7 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
         }
         IrStmtKind::ListRotateLeft { target, end } => {
             let t = ctx.var_name(*target).to_string();
-            let upper = t.to_uppercase();
+            let upper = ctx.global_static_name(*target);
             let e = render_expr(ctx, end);
             match ctx.ann.get_var_storage(target, &t) {
                 VarStorage::ModuleRc => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut())[..={} as usize].rotate_left(1));", upper, e),
@@ -420,12 +420,12 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
         IrStmtKind::ListCopySlice { dst, src, len } => {
             let d = ctx.var_name(*dst).to_string();
             let s = ctx.var_name(*src).to_string();
-            let upper_d = d.to_uppercase();
+            let upper_d = ctx.global_static_name(*dst);
             let n = render_expr(ctx, len);
             match ctx.ann.get_var_storage(dst, &d) {
                 VarStorage::ModuleRc => {
                     let src_read = if matches!(ctx.ann.get_var_storage(src, &s), VarStorage::ModuleRc) {
-                        format!("{}.with(|c| c.borrow().clone())", s.to_uppercase())
+                        format!("{}.with(|c| c.borrow().clone())", ctx.global_static_name(*src))
                     } else { s.clone() };
                     format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut())[..{n} as usize].copy_from_slice(&{src_read}[..{n} as usize]));", upper_d, n=n, src_read=src_read)
                 }

--- a/crates/almide-ir/src/annotations.rs
+++ b/crates/almide-ir/src/annotations.rs
@@ -63,14 +63,24 @@ pub struct CodegenAnnotations {
 
 impl CodegenAnnotations {
     /// Look up the storage mode for a variable. Checks VarId first (precise),
-    /// then falls back to uppercased name (for cross-module synthetic refs).
+    /// then falls back to uppercased name for cross-module synthetic refs only.
+    ///
+    /// A genuine global is always referenced by its real VarId (registered at
+    /// classification time), so the VarId lookup hits. The by-name fallback is a
+    /// safety net for cross-module synthetic refs, whose names are
+    /// `ALMIDE_RT_`-prefixed and therefore collision-free. It must NOT match a
+    /// bare name like `N`: a local that merely shares the name with a user global
+    /// (e.g. a stdlib fn's `n` parameter when the program has a global `n`) would
+    /// otherwise be misclassified as the global and read through its thread_local.
     pub fn get_var_storage(&self, var: &VarId, name: &str) -> VarStorage {
         if let Some(s) = self.var_storage.get(var) {
             return *s;
         }
         let upper = name.to_uppercase();
-        if let Some(s) = self.var_storage_by_name.get(&upper) {
-            return *s;
+        if upper.starts_with("ALMIDE_RT_") {
+            if let Some(s) = self.var_storage_by_name.get(&upper) {
+                return *s;
+            }
         }
         VarStorage::Local
     }

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -1132,3 +1132,42 @@ fn wasm_closure_with_fn_typed_param() {
          }\n",
     );
 }
+
+#[test]
+fn wasm_global_named_rust_keyword() {
+    // A global named `box` (a Rust reserved word). The thread_local static is
+    // declared `BOX` (raw name uppercased) but reads/writes used the keyword-
+    // escaped `r#box`, whose uppercase `R#BOX` is invalid Rust ("unknown prefix").
+    // Reads, writes, and the closure mutation now all route through the raw name.
+    assert_cross_target_effect_main(
+        "var box: List[Int] = []\n\
+         effect fn main() -> Unit = {\n\
+         \x20 let r = { run: () => { list.push(box, 42) } }\n\
+         \x20 r.run()\n\
+         \x20 r.run()\n\
+         \x20 r.run()\n\
+         \x20 println(int.to_string(list.len(box)))\n\
+         }\n",
+    );
+}
+
+#[test]
+fn wasm_global_name_collides_with_stdlib_param() {
+    // A mutable global `n: Int` collides by name with the `n` parameter of stdlib
+    // numeric helpers (e.g. `int.to_int8_checked(n)`). The storage classifier's
+    // by-name fallback misclassified that parameter as the global, so its body
+    // read `N.with(...)` (i64) where an f64 was expected -> rustc E0308. The
+    // fallback is now restricted to ALMIDE_RT_-prefixed cross-module names.
+    assert_cross_target_effect_main(
+        "var n: Int = 0\n\
+         var xs: List[Int] = []\n\
+         var s: String = \"\"\n\
+         effect fn main() -> Unit = {\n\
+         \x20 let step = () => { n = n + 1; list.push(xs, n); s = s + \"x\" }\n\
+         \x20 step(); step(); step()\n\
+         \x20 println(int.to_string(n))\n\
+         \x20 println(int.to_string(list.len(xs)))\n\
+         \x20 println(int.to_string(string.len(s)))\n\
+         }\n",
+    );
+}


### PR DESCRIPTION
## What

Two native-target (Rust) codegen bugs surfaced by the 3rd cross-target sweep, both about global vars. WASM compiled and ran both correctly; this brings the Rust target into agreement.

### Global named a Rust keyword (e.g. `var box`)
The thread_local static is declared from the RAW name uppercased (`box` → `BOX`), but reads, writes, and closure-mutation sites uppercased the keyword-escaped `var_name` (`r#box`), yielding the invalid `R#BOX` ("unknown prefix" since Rust 2021). Every global read/write now routes through one `global_static_name(id)` helper built from the raw name (matching the declaration).

### Global colliding by name with a stdlib parameter (e.g. global `n` + `int.to_int8_checked(n)`)
`get_var_storage` looked up by VarId first, then fell back to the uppercased NAME. A stdlib helper's `n` parameter (VarId not registered) fell through to the name fallback and matched a user global `n`, so the parameter was classified as the global and rendered `N.with(...)` (i64) where an f64 was expected → rustc E0308. The by-name fallback is now restricted to `ALMIDE_RT_`-prefixed cross-module names (which are collision-free); a genuine global is always found by its VarId.

## Verification
- native-vs-wasm repros for both: MATCH (`box` len -> 3; global-`n` -> 3,3,3)
- 2 new regression tests
- `almide test spec/ --target rust` 240/240
- full `cargo test` green (one unrelated pre-existing flake: `check_rejects_malformed_pin` races on the `ALMIDE_SKIP_VERSION_CHECK` env var under parallel execution; passes in isolation)