### PR TITLE
Reject Set elements and Map keys that contain a function (E016)

### DIFF
--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -942,6 +942,18 @@ impl Checker {
 
     // ── Statement checking ──
 
+    /// Reject a binding whose type uses a function in a position that demands
+    /// equality/hashing: a `Set` element or a `Map` key. Closures have neither,
+    /// so such a type is meaningless — and the two targets disagree (native
+    /// rustc rejects it, WASM silently drops the inserts). Closures are fine as
+    /// `Map` *values*.
+    pub(crate) fn check_collection_element_types(&mut self, ty: &Ty) {
+        let resolved = resolve_ty(ty, &self.uf);
+        if let Some((msg, hint)) = invalid_collection_type(&resolved) {
+            self.emit(super::err(msg, hint, "collection element type").with_code("E016"));
+        }
+    }
+
     pub(crate) fn check_stmt(&mut self, stmt: &mut ast::Stmt) {
         match stmt {
             ast::Stmt::Let { name, ty, value, span } => {
@@ -966,6 +978,7 @@ impl Checker {
                 if let Some(s) = span {
                     self.env.var_decl_locs.insert(sym(name), (s.line, s.col));
                 }
+                self.check_collection_element_types(&final_ty);
                 self.env.define_var(name, final_ty);
             }
             ast::Stmt::Var { name, ty, value, span } => {
@@ -986,6 +999,7 @@ impl Checker {
                 if let Some(s) = span {
                     self.env.var_decl_locs.insert(sym(name), (s.line, s.col));
                 }
+                self.check_collection_element_types(&final_ty);
                 self.env.define_var(name, final_ty);
                 self.env.mutable_vars.insert(sym(name));
                 self.env.var_lambda_depth.insert(sym(name), self.env.lambda_depth);
@@ -1467,4 +1481,48 @@ fn if_arm_fix_hint(then: &ast::Expr, else_: &ast::Expr) -> Option<FixHint> {
         }),
         (None, None) => None,
     }
+}
+
+/// True if `ty` mentions a function type anywhere (directly or nested in a
+/// container/tuple/record). Such a type can't be hashed or compared.
+fn ty_mentions_fn(ty: &Ty) -> bool {
+    match ty {
+        Ty::Fn { .. } => true,
+        Ty::Tuple(ts) => ts.iter().any(ty_mentions_fn),
+        Ty::Record { fields } | Ty::OpenRecord { fields } => fields.iter().any(|(_, t)| ty_mentions_fn(t)),
+        Ty::Applied(_, args) | Ty::Named(_, args) => args.iter().any(ty_mentions_fn),
+        _ => false,
+    }
+}
+
+/// `Some((message, hint))` if `ty` (or a nested type) uses a function where a
+/// comparable/hashable type is required: a `Set` element or a `Map` key.
+/// Closures are allowed as `Map` values, so only the key (arg 0) is checked.
+fn invalid_collection_type(ty: &Ty) -> Option<(&'static str, &'static str)> {
+    match ty {
+        Ty::Applied(TypeConstructorId::Set, args) if args.len() == 1 && ty_mentions_fn(&args[0]) => {
+            return Some((
+                "a `Set` element type cannot contain a function — closures have no equality or hashing",
+                "Closures can't be deduplicated. Keep them in a `List`, or build the set from a comparable key.",
+            ));
+        }
+        Ty::Applied(TypeConstructorId::Map, args) if args.len() == 2 && ty_mentions_fn(&args[0]) => {
+            return Some((
+                "a `Map` key type cannot contain a function — closures have no equality or hashing",
+                "Closures are fine as `Map` values; only the key must be comparable.",
+            ));
+        }
+        _ => {}
+    }
+    let children: Vec<&Ty> = match ty {
+        Ty::Tuple(ts) => ts.iter().collect(),
+        Ty::Record { fields } | Ty::OpenRecord { fields } => fields.iter().map(|(_, t)| t).collect(),
+        Ty::Applied(_, args) | Ty::Named(_, args) => args.iter().collect(),
+        Ty::Fn { params, ret } => params.iter().chain(std::iter::once(ret.as_ref())).collect(),
+        _ => Vec::new(),
+    };
+    for c in children {
+        if let Some(e) = invalid_collection_type(c) { return Some(e); }
+    }
+    None
 }

--- a/docs/diagnostics/E016.md
+++ b/docs/diagnostics/E016.md
@@ -1,0 +1,45 @@
+# E016 — Function in a Set element or Map key
+
+A `Set` element type, or a `Map` **key** type, resolves to a type
+that contains a function (a closure). Closures have no equality and
+no hash, so they cannot be deduplicated or looked up — a `Set` or
+`Map` keyed on them is meaningless.
+
+This is a hard error on **both** targets. It used to diverge: the
+Rust target rejected it (`Eq`/`Hash` not satisfied) while the WASM
+target compiled but silently dropped every insert (a `Set[() ->
+Unit]` always reported length 0). Rejecting it at type-check keeps
+the two targets in agreement.
+
+Closures are fine as `Map` **values** — only the key is constrained.
+
+## Common case
+
+```almide
+var handlers: Set[() -> Unit] = set.new()
+set.insert(handlers, () => {})
+// error[E016]: a `Set` element type cannot contain a function
+```
+
+```almide
+var routes: Map[() -> Unit, String] = map.new()
+// error[E016]: a `Map` key type cannot contain a function
+```
+
+## Fix
+
+Keep the closures in a `List` (which has no ordering/hashing
+requirement):
+
+```almide
+var handlers: List[() -> Unit] = []
+list.push(handlers, () => {})
+```
+
+Or, if you genuinely need set/map semantics, key by a comparable
+value (a name, an id) and store the closure alongside it:
+
+```almide
+var handlers: Map[String, () -> Unit] = map.new()  // closure as VALUE — allowed
+map.insert(handlers, "on_click", () => {})
+```

--- a/llms.txt
+++ b/llms.txt
@@ -163,6 +163,7 @@ let root_i = float.to_int(root_f)    // truncating
 | E013 | Field access on non-record / missing field | Check spelling; non-records don't have method syntax (see E002) |
 | E014 | Unreachable match arm | Drop the dead arm, or tighten the earlier arm so this one is reachable |
 | E015 | Possible stdlib reimplementation (warning) | Delegate via the `try:` shim, or rename if intentionally different |
+| E016 | Function in a `Set` element or `Map` key | Keep closures in a `List`, or use a comparable key (closures are fine as `Map` values) |
 | E420 | Function visibility violation (callee is private) | Make the callee public, or add a public shim |
 
 A rustc 4-digit code (`error[E0XXX]`) leaking through always indicates

--- a/tests/checker_test.rs
+++ b/tests/checker_test.rs
@@ -1079,3 +1079,33 @@ fn strict_matrix_float_alias_interop() {
         "fn f(m: Matrix) -> Int = matrix.rows(m)\nfn g() -> Int = {\n  let m: Matrix[Float] = matrix.zeros(3, 3)\n  f(m)\n}"
     );
 }
+
+#[test]
+fn set_of_closures_rejected() {
+    // A closure has no equality/hash, so a `Set` of closures is meaningless. The
+    // two targets disagreed (native rustc E0277, WASM silently dropped inserts and
+    // printed 0), so reject it at typecheck on both. (E016)
+    let errs = errors(
+        "effect fn main() -> Unit = {\n  var s: Set[() -> Unit] = set.new()\n}"
+    );
+    assert!(errs.iter().any(|e| e.contains("Set") && e.contains("function")),
+        "should reject Set[() -> Unit], got: {:?}", errs);
+}
+
+#[test]
+fn map_with_closure_key_rejected() {
+    // Same reason for a `Map` *key*. (E016)
+    let errs = errors(
+        "effect fn main() -> Unit = {\n  var m: Map[() -> Unit, Int] = map.new()\n}"
+    );
+    assert!(errs.iter().any(|e| e.contains("Map") && e.contains("key") && e.contains("function")),
+        "should reject Map[() -> Unit, Int], got: {:?}", errs);
+}
+
+#[test]
+fn map_with_closure_value_allowed() {
+    // A closure is fine as a `Map` *value* — only the key must be comparable.
+    has_no_errors(
+        "effect fn main() -> Unit = {\n  var m: Map[String, () -> Unit] = map.new()\n  map.insert(m, \"a\", () => {})\n}"
+    );
+}

--- a/tests/diagnostics/e016-set-of-closures/broken.almd
+++ b/tests/diagnostics/e016-set-of-closures/broken.almd
@@ -1,0 +1,5 @@
+effect fn main() -> Unit = {
+  var handlers: Set[() -> Unit] = set.new()
+  set.insert(handlers, () => {})
+  println(int.to_string(set.len(handlers)))
+}

--- a/tests/diagnostics/e016-set-of-closures/fixed.almd
+++ b/tests/diagnostics/e016-set-of-closures/fixed.almd
@@ -1,0 +1,5 @@
+effect fn main() -> Unit = {
+  var handlers: List[() -> Unit] = []
+  list.push(handlers, () => {})
+  println(int.to_string(list.len(handlers)))
+}

--- a/tests/diagnostics/e016-set-of-closures/meta.toml
+++ b/tests/diagnostics/e016-set-of-closures/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E016"
+expects_error = "element type cannot contain a function"
+hint_substring = "List"


### PR DESCRIPTION
## What

The last divergence from the 3rd cross-target sweep. A closure has no equality or hash, so a `Set` of closures (or a `Map` keyed on one) is meaningless. The targets disagreed: native rustc rejected it (`Eq`/`Hash` not satisfied), while WASM compiled and **silently dropped every insert** (a `Set[() -> Unit]` always reported length 0) — the worst kind of cross-target gap, since "compiles on one target" was the one that's wrong.

Now rejected at type-check on both targets with a new diagnostic **E016**. The check walks a binding's resolved type and flags a `Set` element type, or a `Map` key type, that contains a function anywhere (directly or nested in a tuple/record/container). Closures remain valid as `Map` **values** (only the key is constrained).

## Verification
- `var s: Set[() -> Unit]` / `Map[() -> Unit, Int]` → rejected with E016 + source location + hint
- `Map[String, () -> Unit]` (closure value) and `Set[Int]` → still accepted
- 3 new checker tests + E016 fixture (broken/fixed) + `docs/diagnostics/E016.md`
- diagnostic coverage + harness tests green; `almide test spec/` and `spec/ --target rust` 240/240 (no false rejections)