### PR TITLE
Resolve HOF-lambda-param closure call result type; gate WASM build on IR verify

### DIFF
--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -1093,6 +1093,17 @@ fn resolve_call_ret_ty(
                 }
             }
         }
+        // Calling a closure VALUE (`f(x)` where `f` is a Fn-typed var/expr — e.g.
+        // a HOF lambda parameter): the call's type is the callee's RETURN type, not
+        // its whole Fn type. Without this the node keeps the `fn(..) -> T` type and
+        // a later `acc + f(x)` trips the IR verifier (AddInt on a function value).
+        CallTarget::Computed { callee } => {
+            if let Ty::Fn { ret, .. } = &callee.ty {
+                if !ret.has_unresolved_deep() {
+                    return Some((**ret).clone());
+                }
+            }
+        }
         _ => {}
     }
 

--- a/crates/almide-frontend/src/lower/calls.rs
+++ b/crates/almide-frontend/src/lower/calls.rs
@@ -149,6 +149,19 @@ pub(super) fn lower_call(ctx: &mut LowerCtx, callee: &ast::Expr, args: &[ast::Ex
         }
     }
 
+    // A call to a closure VALUE (Computed target) has, by definition, the
+    // callee's RETURN type — even when the inferred `ty` came back as the whole
+    // `Fn` type (which happens for a HOF lambda parameter whose concrete type is
+    // only fixed by the enclosing call's unification, after the body was checked).
+    // Leaving the node typed `fn(..) -> T` makes a later `acc + f(x)` trip the IR
+    // verifier (AddInt on a function value).
+    let ty = match &target {
+        CallTarget::Computed { callee } => match &callee.ty {
+            Ty::Fn { ret, .. } if !ret.has_unresolved_deep() => (**ret).clone(),
+            _ => ty,
+        },
+        _ => ty,
+    };
     ctx.mk(IrExprKind::Call { target, args: ir_args, type_args: ta }, ty, span)
 }
 

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -249,6 +249,19 @@ fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool) {
     // Monomorphize
     almide::mono::monomorphize(&mut ir_program);
 
+    // Verify IR integrity — gate the WASM emit on the same check the native
+    // path (main.rs) enforces. Without this an invalid IR (e.g. an unresolved
+    // closure-call result type) is emitted as a structurally-broken module that
+    // `almide build` reports as success (rc 0) but wasmtime refuses to load.
+    let verify_errors = almide::ir::verify_program(&ir_program);
+    if !verify_errors.is_empty() {
+        for e in &verify_errors {
+            eprintln!("internal compiler error: {}", e);
+        }
+        eprintln!("{} IR verification error(s) — no WASM emitted", verify_errors.len());
+        std::process::exit(1);
+    }
+
     // Codegen (nanopass pipeline + WASM binary emit)
     let bytes = match almide::codegen::codegen(&mut ir_program, almide::codegen::pass::Target::Wasm) {
         almide::codegen::CodegenOutput::Binary(b) => b,

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -1171,3 +1171,23 @@ fn wasm_global_name_collides_with_stdlib_param() {
          }\n",
     );
 }
+
+#[test]
+fn wasm_closure_called_as_hof_lambda_param() {
+    // A closure that arrives as a higher-order-function lambda PARAMETER, called
+    // inside the lambda body: `list.fold(fns, 0, (acc, f) => acc + f(100))`. The
+    // call `f(100)` kept the type `fn(Int) -> Int` instead of its return `Int`
+    // (the param's concrete type is only fixed by the enclosing fold's
+    // unification, after the body was checked), so `acc + f(100)` tripped the IR
+    // verifier — a native ICE, and a structurally-broken WASM module. A Computed
+    // call's result type is now the callee's Fn return. fns = [+1, *2, -3];
+    // fns[0](10) = 11; fold over f(100) = 101 + 200 + 97 = 398.
+    assert_cross_target_effect_main(
+        "effect fn main() -> Unit = {\n\
+         \x20 let fns: List[(Int) -> Int] = [(x) => x + 1, (x) => x * 2, (x) => x - 3]\n\
+         \x20 println(int.to_string(fns[0](10)))\n\
+         \x20 let total = list.fold(fns, 0, (acc, f) => acc + f(100))\n\
+         \x20 println(int.to_string(total))\n\
+         }\n",
+    );
+}


### PR DESCRIPTION
## What

A 4th adversarial sweep (run against a stale 0.23.11 binary — most of its 40 "divergences" were already fixed on current) nonetheless surfaced two genuine bugs on current `develop`, both about closures with non-`Unit` signatures.

### Closure call result type for a HOF lambda parameter
`list.fold(fns, 0, (acc, f) => acc + f(100))` where `fns: List[(Int) -> Int]`: the call `f(100)` kept the type `fn(Int) -> Int` instead of its return `Int`, so `acc + f(100)` tripped the IR verifier — a native ICE ("AddInt expects Int operands, got Int and fn(Int) -> Int"), and a structurally-broken WASM module. A closure *local var* called directly (`let f = …; f(5)`) resolved fine; only a HOF lambda *parameter* missed it (its concrete type is only fixed by the enclosing call's unification, after the lambda body was already checked).

Fix: in `lower_call`, a `Computed` (closure-value) call's result type is, by definition, the callee's `Fn` return type — so override the inferred node type with `callee.ret`. Added the same resolution to `ConcretizeTypes::resolve_call_ret_ty` as defense for codegen-introduced computed calls.

### WASM build gate on IR verify
`almide build --target wasm` printed IR-verify + wasm-validator errors yet emitted an invalid module and exited rc 0; wasmtime then refused to load it. The native path gates the same `verify_program` failure (no artifact, rc 1). `cmd_build_wasm_direct` now runs the same gate before codegen, so an invalid IR fails fast instead of shipping a broken module under a success exit code.

## Note on the 4th sweep
The sweep's other findings (E0562 `impl Trait` leakage, copy-cell write-back loss) reproduced **only** on the stale PATH binary (0.23.11). On current `develop` they already work: `((Int)->Int, (Int)->String)` tuple, `Map[String,(Int)->Int]`, variant/return parametered closures, and `Int`/`Float`/`Bool` cell captures all compile and run correctly cross-target. The PATH binary has been refreshed; a clean re-sweep will follow.

## Verification
- fold cases native == wasm (`11,398` / `301`); 1 new cross-target regression test
- full `cargo test` green; `almide test spec/` and `spec/ --target rust` 240/240
- WASM gate fires on no spec file (no false positives)