### PR TITLE
Box nested closures in struct/record/variant field types as Rc<dyn Fn>

### DIFF
--- a/crates/almide-codegen/src/walker/declarations.rs
+++ b/crates/almide-codegen/src/walker/declarations.rs
@@ -34,13 +34,11 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
             let has_non_eq_fields = fields.iter().any(|f| ty_blocks_eq_with(&f.ty, &ctx.ann.eq_blocked_types));
             let fields_str = fields.iter()
                 .map(|f| {
-                    // Fn-typed struct fields: use Rc<dyn Fn> for cloneability
-                    // (impl Fn is invalid in struct position, Box<dyn Fn> is not Clone)
-                    let type_s = if matches!(&f.ty, Ty::Fn { .. }) {
-                        render_type_field_fn(ctx, &f.ty)
-                    } else {
-                        render_type(ctx, &f.ty)
-                    };
+                    // Closure-bearing struct fields use Rc<dyn Fn> (impl Fn is
+                    // invalid in struct position, Box<dyn Fn> is not Clone) — also
+                    // when the closure is nested in a List/Map/Tuple field. Fn-free
+                    // field types fall through to the normal renderer.
+                    let type_s = render_type_field_fn(ctx, &f.ty);
                     ctx.templates.render_with("struct_field", None, &[], &[("name", f.name.as_str()), ("type", type_s.as_str())])
                         .unwrap_or_else(|| format!("    pub {}: {},", f.name, render_type(ctx, &f.ty)))
                 })
@@ -73,13 +71,9 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                     IrVariantKind::Tuple { fields } => {
                         let is_recursive = ctx.ann.recursive_enums.contains(&*td.name);
                         let types: Vec<String> = fields.iter().map(|t| {
-                            // Fn payloads use Rc<dyn Fn> (impl Fn is invalid in field
-                            // position, Box<dyn Fn> is not Clone) — same as a struct field.
-                            let rendered = if matches!(t, Ty::Fn { .. }) {
-                                render_type_field_fn(ctx, t)
-                            } else {
-                                render_type(ctx, t)
-                            };
+                            // Closure payloads (direct or nested in a container) use
+                            // Rc<dyn Fn> — same as a struct field.
+                            let rendered = render_type_field_fn(ctx, t);
                             if is_recursive && ty_contains_name(t, &td.name) { format!("Box<{}>", rendered) } else { rendered }
                         }).collect();
                         let fields_str = types.join(", ");
@@ -100,11 +94,7 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                     IrVariantKind::Record { fields } => {
                         let fields_str = fields.iter()
                             .map(|f| {
-                                let rendered = if matches!(&f.ty, Ty::Fn { .. }) {
-                                    render_type_field_fn(ctx, &f.ty)
-                                } else {
-                                    render_type(ctx, &f.ty)
-                                };
+                                let rendered = render_type_field_fn(ctx, &f.ty);
                                 let boxed = if ctx.ann.recursive_enums.contains(&*td.name) && ty_contains_name(&f.ty, &td.name) {
                                     format!("Box<{}>", rendered)
                                 } else {

--- a/crates/almide-codegen/src/walker/helpers.rs
+++ b/crates/almide-codegen/src/walker/helpers.rs
@@ -153,19 +153,62 @@ pub fn render_type_boxed_fn(ctx: &RenderContext, ty: &Ty) -> String {
     }
 }
 
-/// Render a Fn type as Rc<dyn Fn(...) -> T> for struct fields (cloneable, no impl Trait)
+/// True if `ty` mentions a function type anywhere (directly or nested).
+pub(super) fn ty_mentions_fn(ty: &Ty) -> bool {
+    match ty {
+        Ty::Fn { .. } => true,
+        Ty::Tuple(ts) => ts.iter().any(ty_mentions_fn),
+        Ty::Record { fields } | Ty::OpenRecord { fields } => fields.iter().any(|(_, t)| ty_mentions_fn(t)),
+        Ty::Applied(_, args) | Ty::Named(_, args) => args.iter().any(ty_mentions_fn),
+        _ => false,
+    }
+}
+
+/// Render a type for a STORAGE position (struct/record field, variant payload),
+/// rendering every `Fn` — directly or nested inside a `List`/`Map`/`Tuple`/
+/// `Option`/`Result` — as `Rc<dyn Fn(...) -> T>` rather than `impl Fn` (which is
+/// illegal in field types, E0562) or `Box<dyn Fn>` (not `Clone`). Fn-free
+/// subtrees fall through to the normal `render_type`.
 pub fn render_type_field_fn(ctx: &RenderContext, ty: &Ty) -> String {
+    use almide_lang::types::constructor::TypeConstructorId as TCI;
+    // Fast path: no closure anywhere → render normally.
+    if !ty_mentions_fn(ty) {
+        return super::types::render_type(ctx, ty);
+    }
+    let rf = |t: &Ty| render_type_field_fn(ctx, t);
+    let tmpl = |name: &str, kv: &[(&str, &str)], fb: String| {
+        ctx.templates.render_with(name, None, &[], kv).unwrap_or(fb)
+    };
     match ty {
         Ty::Fn { params, ret } => {
-            let params_str = params.iter().map(|p| super::types::render_type(ctx, p)).collect::<Vec<_>>().join(", ");
-            let ret_str = if matches!(ret.as_ref(), Ty::Fn { .. }) {
-                render_type_field_fn(ctx, ret)
-            } else {
-                super::types::render_type(ctx, ret)
-            };
-            ctx.templates.render_with("type_fn_field", None, &[], &[("params", params_str.as_str()), ("return", ret_str.as_str())])
-                .unwrap_or_else(|| format!("std::rc::Rc<dyn Fn({}) -> {}>", params_str, ret_str))
+            let params_str = params.iter().map(&rf).collect::<Vec<_>>().join(", ");
+            let ret_str = rf(ret);
+            tmpl("type_fn_field", &[("params", params_str.as_str()), ("return", ret_str.as_str())],
+                format!("std::rc::Rc<dyn Fn({}) -> {}>", params_str, ret_str))
         }
+        Ty::Tuple(elems) => {
+            let parts = elems.iter().map(&rf).collect::<Vec<_>>().join(", ");
+            tmpl("type_tuple", &[("elements", parts.as_str())], format!("({})", parts))
+        }
+        Ty::Applied(TCI::List, args) if args.len() == 1 => {
+            let inner = rf(&args[0]);
+            tmpl("type_list", &[("inner", inner.as_str())], format!("Vec<{}>", inner))
+        }
+        Ty::Applied(TCI::Map, args) if args.len() == 2 => {
+            let (k, v) = (rf(&args[0]), rf(&args[1]));
+            tmpl("type_map", &[("key", k.as_str()), ("value", v.as_str())], format!("HashMap<{}, {}>", k, v))
+        }
+        Ty::Applied(TCI::Option, args) if args.len() == 1 => {
+            let inner = rf(&args[0]);
+            tmpl("type_option", &[("inner", inner.as_str())], format!("Option<{}>", inner))
+        }
+        Ty::Applied(TCI::Result, args) if args.len() == 2 => {
+            let (ok, err) = (rf(&args[0]), rf(&args[1]));
+            tmpl("type_result", &[("ok", ok.as_str()), ("err", err.as_str())], format!("Result<{}, {}>", ok, err))
+        }
+        // Set[Fn] is rejected at typecheck (E016); render conservatively if reached.
+        // Other Fn-containing shapes (e.g. a user generic over a closure) are rare —
+        // fall back to render_type, which at least keeps the container correct.
         _ => super::types::render_type(ctx, ty),
     }
 }

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -1191,3 +1191,35 @@ fn wasm_closure_called_as_hof_lambda_param() {
          }\n",
     );
 }
+
+#[test]
+fn wasm_variant_payload_parametered_closure() {
+    // A variant whose payload is a closure with a non-Unit signature
+    // (`Thunk((Int) -> Int)`). The variant field rendered `impl Fn(i64) -> i64`
+    // (E0562 in field types) for the parametered closure; it now renders
+    // `Rc<dyn Fn>`. Thunk((x) => x*x), matched and called with 9 -> 81.
+    assert_cross_target_effect_main(
+        "type Node = Leaf(Int) | Thunk((Int) -> Int)\n\
+         effect fn main() -> Unit = {\n\
+         \x20 let n = Thunk((x) => x * x)\n\
+         \x20 let r = match n { Leaf(v) => v, Thunk(f) => f(9) }\n\
+         \x20 println(int.to_string(r))\n\
+         }\n",
+    );
+}
+
+#[test]
+fn wasm_record_field_list_of_closures() {
+    // A struct/record field whose type CONTAINS a closure nested in a container
+    // (`stages: List[(Int) -> Int]`). The field type rendered `Vec<impl Fn>`
+    // (E0562: impl Trait in field types); `render_type_field_fn` now recurses
+    // into List/Map/Tuple, boxing every Fn to `Rc<dyn Fn>`. stages[1] = (x)=>x*3;
+    // (stages[1])(10) = 30; len 3.
+    assert_cross_target_effect_main(
+        "effect fn main() -> Unit = {\n\
+         \x20 let r = { stages: [(x) => x + 2, (x) => x * 3], extra: 0 }\n\
+         \x20 println(int.to_string((r.stages[1])(10)))\n\
+         \x20 println(int.to_string(list.len(r.stages)))\n\
+         }\n",
+    );
+}


### PR DESCRIPTION
## What

A clean cross-target sweep (verified against current `develop`) found that closures with **non-`Unit` signatures** stored in a field type still leaked `impl Trait` on the native target. `render_type_field_fn` only boxed a *directly* `Fn`-typed field; a closure nested in a container (`stages: List[(Int) -> Int]`, `Map[_, (Int)->Int]`, `(Int, (Int)->Int)`, a curried `(Int) -> (Int) -> Int`) rendered `Vec<impl Fn>` etc. — illegal in a struct/variant field (rustc E0562) — while WASM compiled and ran correctly.

`render_type_field_fn` now recurses into `List`/`Map`/`Option`/`Result`/`Tuple`/`Fn`, rendering every `Fn` position as `Rc<dyn Fn>` (Fn-free subtrees fall through to the normal renderer). It is applied to all field-type positions: typed-record struct fields and both tuple- and record-variant payloads.

## Covers (clean-sweep, current `develop`)
- record/struct field of `List[(Int)->Int]` (case4) → now `calc,68,result=68,30` on both targets
- variant payloads with parametered/nested closures: `Thunk((Int)->Int)`, `Apply{op: (Int)->Int}`, `Pair(Int, (Int)->Int)` → all match cross-target

## Verification
- native == wasm for the record-field and variant-payload repros
- 2 new cross-target regression tests; full `cargo test` green
- `almide test spec/` and `spec/ --target rust` 240/240

## Remaining (tracked, follow-up)
Two clean-sweep root causes are not in this PR: closure-returning-closure stored + called (`Box<dyn Fn>` is not `Clone`, E0599) and `??`/match-arm closure-type erasure (E0308).