### PR TITLE
Render nested returned closures as Rc<dyn Fn> with a trait-object cast

### DIFF
--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -465,7 +465,7 @@ template = "{{\n{body}\n}}"
 template = "{expr}"
 
 [box_wrap]
-template = "Box::new({inner})"
+template = "std::rc::Rc::new({inner})"
 
 [fan_expr]
 template = "std::thread::scope(|__s| {{ {spawns} {join_expr} }})"

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -535,10 +535,15 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                     format!("(*{}).clone()", ctx.var_name(*id))
                 } else { render_expr(ctx, body) }
             } else { render_expr(ctx, body) };
-            // Nested lambda: wrap in Box for languages that need it (template returns identity in TS)
+            // Nested (curried) lambda: box the returned closure as `Rc<dyn Fn>`
+            // with an explicit cast, so `Rc<concrete-closure>` coerces to the
+            // trait object the outer closure's return type demands (E0271 without
+            // the cast). `Rc` (not `Box`) because the result is cloned at calls.
             if matches!(&body.kind, IrExprKind::Lambda { .. }) {
-                body_str = ctx.templates.render_with("box_wrap", None, &[], &[("inner", body_str.as_str())])
-                    .unwrap_or(body_str);
+                let wrapped = ctx.templates.render_with("box_wrap", None, &[], &[("inner", body_str.as_str())])
+                    .unwrap_or_else(|| format!("std::rc::Rc::new({})", body_str));
+                let cast = super::helpers::render_type_rc_fn(ctx, &body.ty);
+                body_str = format!("{} as {}", wrapped, cast);
             }
             ctx.templates.render_with("lambda_single", None, &[], &[("params", params_str.as_str()), ("body", body_str.as_str())])
                 .unwrap_or_else(|| format!("|_| {{ }}"))

--- a/crates/almide-codegen/src/walker/helpers.rs
+++ b/crates/almide-codegen/src/walker/helpers.rs
@@ -120,19 +120,11 @@ pub fn render_body_content(ctx: &RenderContext, expr: &almide_ir::IrExpr) -> Str
 
 /// Render a Fn type as Rc<dyn Fn(...) -> T> (for Fn types inside collections — cloneable)
 pub fn render_type_rc_fn(ctx: &RenderContext, ty: &Ty) -> String {
-    match ty {
-        Ty::Fn { params, ret } => {
-            let params_str = params.iter().map(|p| super::types::render_type(ctx, p)).collect::<Vec<_>>().join(", ");
-            let ret_str = if matches!(ret.as_ref(), Ty::Fn { .. }) {
-                render_type_boxed_fn(ctx, ret)
-            } else {
-                super::types::render_type(ctx, ret)
-            };
-            ctx.templates.render_with("type_fn_field", None, &[], &[("params", params_str.as_str()), ("return", ret_str.as_str())])
-                .unwrap_or_else(|| format!("std::rc::Rc<dyn Fn({}) -> {}>", params_str, ret_str))
-        }
-        _ => super::types::render_type(ctx, ty),
-    }
+    // A boxed closure VALUE (RcWrap) uses the same all-`Rc<dyn Fn>` rendering as a
+    // field: a nested returned closure must be `Rc<dyn Fn>` (Clone), not
+    // `Box<dyn Fn>` — a closure-returning-closure result is cloned at call sites,
+    // and `Box<dyn Fn>` is not `Clone` (E0599).
+    render_type_field_fn(ctx, ty)
 }
 
 /// Render a Fn type as Box<dyn Fn(...) -> T> (for nested impl Trait in Rust)

--- a/crates/almide-codegen/src/walker/types.rs
+++ b/crates/almide-codegen/src/walker/types.rs
@@ -2,7 +2,7 @@
 
 use almide_lang::types::{Ty, TypeConstructorId};
 use super::RenderContext;
-use super::helpers::{template_or, render_type_boxed_fn, render_type_rc_fn, ty_has_named_typevar};
+use super::helpers::{template_or, render_type_rc_fn};
 
 pub fn render_type(ctx: &RenderContext, ty: &Ty) -> String {
     match ty {
@@ -139,9 +139,11 @@ pub fn render_type(ctx: &RenderContext, ty: &Ty) -> String {
         }
         Ty::Fn { params, ret } => {
             let params_str = params.iter().map(|p| render_type(ctx, p)).collect::<Vec<_>>().join(", ");
-            // Nested Fn return may need boxing (Rust: Box<dyn Fn>; TS: identity)
+            // A nested returned closure is `Rc<dyn Fn>` (Clone — it is cloned at
+            // call sites), matching the `Rc::new` the value side emits for a
+            // curried lambda. `Box<dyn Fn>` is not Clone (E0599/E0271).
             let ret_str = if matches!(ret.as_ref(), Ty::Fn { .. }) {
-                render_type_boxed_fn(ctx, ret)
+                render_type_rc_fn(ctx, ret)
             } else {
                 render_type(ctx, ret)
             };

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -1223,3 +1223,22 @@ fn wasm_record_field_list_of_closures() {
          }\n",
     );
 }
+
+#[test]
+fn wasm_closure_returning_closure_in_list() {
+    // Curried closures (`(Int) -> (Int) -> Int`) stored in a list: calling one
+    // yields an inner closure, which is then called. The inner returned closure
+    // rendered `Box<dyn Fn>` (not Clone → E0599 when cloned at the call site), and
+    // its value lacked the trait-object cast (E0271). Nested returned closures are
+    // now `Rc<dyn Fn>` with an explicit cast on both the type and the value sides.
+    // make_add(10)(5) = 15; make_mul(3)(4) = 12.
+    assert_cross_target_effect_main(
+        "effect fn main() -> Unit = {\n\
+         \x20 let factories: List[(Int) -> (Int) -> Int] = [(n) => (x) => x + n, (n) => (x) => x * n]\n\
+         \x20 let make_add = factories[0]\n\
+         \x20 let make_mul = factories[1]\n\
+         \x20 println(int.to_string((make_add(10))(5)))\n\
+         \x20 println(int.to_string((make_mul(3))(4)))\n\
+         }\n",
+    );
+}


### PR DESCRIPTION
## What

A clean cross-target sweep found that a closure which **returns a closure** (`(Int) -> (Int) -> Int`, e.g. a list of curry factories) failed on the native target while WASM ran correctly. The inner returned closure was rendered `Box<dyn Fn>` — not `Clone`, so cloning it at a call site gave rustc E0599 — and its value lacked the trait-object cast, so `Rc<concrete-closure>` would not coerce to `Rc<dyn Fn>` (E0271).

Nested returned closures are now `Rc<dyn Fn>` consistently:
- `render_type_rc_fn` (RcWrap rendering) and `render_type` (function return position) render a nested `Fn` return as `Rc<dyn Fn>` (Clone), not `Box<dyn Fn>`
- the `box_wrap` template emits `Rc::new(...)`, and the lambda renderer appends an explicit `as Rc<dyn Fn(..) -> ..>` cast so `Rc<concrete>` coerces to the trait object the outer closure's return type demands

## Verification
- closure-returning-closure repro: native == wasm (`103,209,15,23`)
- 1 new cross-target regression test; full `cargo test` green
- `almide test spec/` and `spec/ --target rust` 240/240 (curried-closure shapes unaffected; `cr_simple`/`cr_list`/fold regressions still pass)

## Remaining (tracked)
One clean-sweep root cause left: `??`/match-arm closure-type erasure (E0308 cluster), where a fallback/branch produces a closure that isn't erased to the trait object.