### PR TITLE
Fix the 2 remaining native↔WASM closure sweep divergences

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
@@ -680,9 +680,12 @@ impl FuncCompiler<'_> {
                 });
                 if key_is_i64 { wasm!(self.func, { i64_load(0); local_set(cur_key); }); }
                 else { wasm!(self.func, { i32_load(0); local_set(cur_key); }); }
-                // Hash key → h1 (probe index) + h2 (tag)
-                if key_is_i64 { wasm!(self.func, { local_get(cur_key); i32_wrap_i64; }); }
-                else { wasm!(self.func, { local_get(cur_key); }); }
+                // Hash key → h1 (probe index) + h2 (tag). Push the RAW key (i64 for
+                // an Int key, ptr for String); `emit_hash_key` consumes the key's
+                // natural type and does its OWN i32 reduction. Pre-wrapping an Int
+                // key to i32 here fed `emit_hash_key`'s `local.tee` (an i64 temp) an
+                // i32 → "local.set's value type must be correct" (invalid module).
+                wasm!(self.func, { local_get(cur_key); });
                 self.emit_hash_key(&key_ty);
                 self.emit_h1_h2(cap_local, probe_idx, h2);
                 // Probe for existing key or empty slot

--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -45,25 +45,29 @@ impl Checker {
                     self.check_constructor_args(name, &case, &arg_tys);
                     // Instantiate parent type's generics with fresh inference vars
                     let generic_args = self.instantiate_type_generics(type_name.as_str());
-                    // Unify constructor payload types with arg types to resolve generic vars.
-                    // e.g., Leaf(1) where Leaf(T) → unify T=?fresh with Int → ?fresh=Int
-                    if !generic_args.is_empty() {
-                        if let Some(ty_def) = self.env.types.get(&sym(type_name.as_str())).cloned() {
+                    // Unify each constructor arg with its payload type. For a GENERIC
+                    // variant this resolves the parent's vars (Leaf(1) → T=Int); for
+                    // ANY variant it also propagates a CONCRETE payload type — e.g. a
+                    // function payload `Tick((Unit) -> Int)` — into a lambda arg's
+                    // otherwise-unconstrained params. Without it a closure payload's
+                    // unused param stays unresolved and the WASM closure signature
+                    // mismatched the call site (an indirect-call trap). Was gated on
+                    // `!generic_args.is_empty()`, so non-generic variants were skipped.
+                    let subst: std::collections::HashMap<almide_base::intern::Sym, Ty> = if !generic_args.is_empty() {
+                        self.env.types.get(&sym(type_name.as_str())).cloned().map(|ty_def| {
                             let mut type_var_names = Vec::new();
                             crate::types::TypeEnv::collect_typevars(&ty_def, &mut type_var_names);
-                            // Build substitution map: named TypeVar name → fresh inference var
-                            let subst: std::collections::HashMap<almide_base::intern::Sym, Ty> = type_var_names.iter()
-                                .zip(generic_args.iter())
+                            type_var_names.iter().zip(generic_args.iter())
                                 .map(|(tv, fresh)| (*tv, fresh.clone()))
-                                .collect();
-                            // Get expected payload types for this case
-                            if let crate::types::VariantPayload::Tuple(expected) = &case.payload {
-                                for (aty, ety) in arg_tys.iter().zip(expected.iter()) {
-                                    // Substitute named TypeVars with fresh inference vars, then unify
-                                    let substituted = subst_ty(ety, &subst);
-                                    self.unify_infer(aty, &substituted);
-                                }
-                            }
+                                .collect()
+                        }).unwrap_or_default()
+                    } else {
+                        std::collections::HashMap::new()
+                    };
+                    if let crate::types::VariantPayload::Tuple(expected) = &case.payload {
+                        for (aty, ety) in arg_tys.iter().zip(expected.iter()) {
+                            let substituted = subst_ty(ety, &subst);
+                            self.unify_infer(aty, &substituted);
                         }
                     }
                     Ty::Named(type_name, generic_args)


### PR DESCRIPTION
A fresh adversarial native-vs-WASM closure sweep on the merged `develop` (run because the fan audit showed the WASM-only spec tests mask bugs) surfaced 2 divergences — 4 of 6 sweep categories were perfectly clean, these were the last 2. Both fixed here. native==wasm, spec 240/240, full `cargo test` green.

## BUG B — Int-keyed `list.group_by` → invalid WASM module
`list.group_by(xs, (n) => n % 3)` read via `g[2]` / `map.get_or(g, 2, [])` built a module wasmtime refused ("local.set's value type must be correct" / "expected i64, found i32"). `group_by` pre-wrapped the Int key with `i32.wrap_i64` before `emit_hash_key`, but `emit_hash_key(Int)` expects the **raw i64 key** and reduces it internally (its `local.tee` is an i64 temp). Push the raw key; drop the pre-wrap. Plain Int-keyed maps were already fine (no pre-wrap) — only `group_by` had it.

## BUG A — Unit-param closure as a variant payload → WASM indirect-call trap
`type Event = Tick((Unit) -> Int) | Reset`; `Tick((u) => 1)` then `match e { Tick(f) => f(()) }` trapped on WASM (`indirect call type mismatch`), native r=111. Root: the closure's unused param `u` stayed `Unknown`, so WASM compiled the closure as `(i32 env, i32 u) -> i64` while the call site (typed from the payload) skipped the `Unit` param → `(i32 env) -> i64`. The arg-vs-payload unification was gated on the parent type being generic, so a non-generic variant (`Event`) never unified `(?u) -> Int` with `(Unit) -> Int`. Always unify (empty substitution for a non-generic variant) so `u` resolves to `Unit`.