### PR TITLE
Fix two native-only closure sweep divergences (Result-E turbofish, capture-clone wrapper recursion)

### DIFF
--- a/crates/almide-codegen/src/pass_capture_clone.rs
+++ b/crates/almide-codegen/src/pass_capture_clone.rs
@@ -287,8 +287,20 @@ fn transform_expr(expr: &mut IrExpr, vt: &mut VarTable, scope_vars: &HashSet<Var
         IrExprKind::OptionSome { expr: e } | IrExprKind::ResultOk { expr: e }
         | IrExprKind::ResultErr { expr: e } | IrExprKind::Try { expr: e }
         | IrExprKind::Unwrap { expr: e } | IrExprKind::ToOption { expr: e }
-        | IrExprKind::Clone { expr: e } | IrExprKind::Deref { expr: e } => {
+        | IrExprKind::Clone { expr: e } | IrExprKind::Deref { expr: e }
+        // Single-expr wrappers introduced by earlier passes (BorrowInsertion,
+        // BoxDeref, ToVec materialisation, async). A lambda nested inside one of
+        // these — e.g. `list.join(&list.map(keys, k => …g…), …)` wraps the inner
+        // `map` in `Borrow` — was invisible to the capture-clone walk, so its
+        // captured non-Copy vars never got the pre-clone wrap and a later use of
+        // the var failed to compile (E0382). `replace_vars` already descends these,
+        // so the walk and the rename now agree.
+        | IrExprKind::Borrow { expr: e, .. } | IrExprKind::BoxNew { expr: e }
+        | IrExprKind::ToVec { expr: e } | IrExprKind::Await { expr: e } => {
             if transform_expr(e, vt, scope_vars) { changed = true; }
+        }
+        IrExprKind::RustMacro { args, .. } => {
+            for a in args { if transform_expr(a, vt, scope_vars) { changed = true; } }
         }
         IrExprKind::UnwrapOr { expr: e, fallback: f } => {
             if transform_expr(e, vt, scope_vars) { changed = true; }
@@ -311,6 +323,36 @@ fn transform_expr(expr: &mut IrExpr, vt: &mut VarTable, scope_vars: &HashSet<Var
         IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. }
         | IrExprKind::OptionalChain { expr: object, .. } => {
             if transform_expr(object, vt, scope_vars) { changed = true; }
+        }
+        // A fused iterator chain (produced by stream fusion) hides its step and
+        // collector lambdas from the generic recursion above. Without descending
+        // here, a `move` step closure that captures a non-Copy outer var (e.g. a
+        // map used inside `keys |> map(k => …get(g,k)…)`) never gets the pre-clone
+        // wrap, so the chain moves the var and a later use of it fails to compile
+        // (E0382). Recurse into the source and every embedded lambda. `replace_vars`
+        // already mirrors this shape, so a wrapped lambda's `__cap` renames carry
+        // through correctly.
+        IrExprKind::IterChain { source, steps, collector, .. } => {
+            if transform_expr(source, vt, scope_vars) { changed = true; }
+            for step in steps.iter_mut() {
+                match step {
+                    IterStep::Map { lambda } | IterStep::Filter { lambda }
+                    | IterStep::FlatMap { lambda } | IterStep::FilterMap { lambda } => {
+                        if transform_expr(lambda, vt, scope_vars) { changed = true; }
+                    }
+                }
+            }
+            match collector {
+                IterCollector::Collect => {}
+                IterCollector::Fold { init, lambda } => {
+                    if transform_expr(init, vt, scope_vars) { changed = true; }
+                    if transform_expr(lambda, vt, scope_vars) { changed = true; }
+                }
+                IterCollector::Any { lambda } | IterCollector::All { lambda }
+                | IterCollector::Find { lambda } | IterCollector::Count { lambda } => {
+                    if transform_expr(lambda, vt, scope_vars) { changed = true; }
+                }
+            }
         }
         _ => {}
     }

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -549,8 +549,20 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
         }
         IrExprKind::ResultOk { expr: inner } => {
             let inner_s = render_expr_owned(ctx, inner);
-            ctx.templates.render_with("ok_expr", None, &[], &[("inner", inner_s.as_str())])
-                .unwrap_or_else(|| format!("Ok({})", inner_s))
+            // A bare `Ok(x)` is `Result<TyOf(x), _>` — the error type stays open
+            // for rustc to infer from context. That fails (E0282) when the
+            // surrounding call leaves E unconstrained, e.g.
+            // `result.unwrap_or(ok(10), -1)`: `unwrap_or<T, E>` names E only in its
+            // `Result<T, E>` parameter, so nothing pins it. The checker already
+            // resolved the full Result type (`expr.ty`), so emit a turbofish that
+            // carries it — defaulting a still-unconstrained error to String
+            // (Almide's conventional error type; mirrors the render_type fix).
+            if let Some((ok_s, err_s)) = result_turbofish_args(ctx, &expr.ty) {
+                format!("Ok::<{}, {}>({})", ok_s, err_s, inner_s)
+            } else {
+                ctx.templates.render_with("ok_expr", None, &[], &[("inner", inner_s.as_str())])
+                    .unwrap_or_else(|| format!("Ok({})", inner_s))
+            }
         }
         IrExprKind::ResultErr { expr: inner } => {
             let inner_str = render_expr(ctx, inner);
@@ -1200,6 +1212,26 @@ fn render_method_call_full(ctx: &RenderContext, object: &IrExpr, method: &str, a
 }
 
 /// Render an enum constructor call with optional Box wrapping for recursive types.
+/// For a `Result<Ok, Err>` type, render the `(ok, err)` turbofish arguments used
+/// to pin a `Ok(..)` / `Err(..)` constructor's phantom type parameters. The error
+/// type defaults to `String` when still unresolved (`Unknown` or an inference
+/// typevar), exactly as the `render_type` Result arm does for type positions
+/// (dv_13). Returns `None` for a non-Result type, leaving the bare constructor.
+fn result_turbofish_args(ctx: &RenderContext, ty: &Ty) -> Option<(String, String)> {
+    match ty {
+        Ty::Applied(TypeConstructorId::Result, args) if args.len() == 2 => {
+            let ok_s = render_type(ctx, &args[0]);
+            let err_s = match &args[1] {
+                Ty::Unknown => "String".to_string(),
+                Ty::TypeVar(n) if n.starts_with('?') => "String".to_string(),
+                _ => render_type(ctx, &args[1]),
+            };
+            Some((ok_s, err_s))
+        }
+        _ => None,
+    }
+}
+
 fn render_enum_constructor(ctx: &RenderContext, ctor_name: &str, enum_name: &str, args: &[IrExpr]) -> String {
     let boxed_args: Vec<String> = args.iter().enumerate().map(|(i, a)| {
         let rendered = render_expr(ctx, a);

--- a/tests/codegen_v3_compare.rs
+++ b/tests/codegen_v3_compare.rs
@@ -190,10 +190,12 @@ fn test_walker_result_divergence() {
         span: None, def_id: None,
     };
 
-    // Rust: Ok(data)
+    // Rust: a turbofish carries the checker-resolved Result type so rustc never
+    // re-infers the phantom error param (which fails as E0282 when the surrounding
+    // call leaves it unconstrained, e.g. `result.unwrap_or(ok(..), default)`).
     let rust_templates = template::rust_templates();
     let rust_ctx = RenderContext::new(&rust_templates, &var_table);
-    assert_eq!(walker::render_expr(&rust_ctx, &ok_expr), "Ok(data)");
+    assert_eq!(walker::render_expr(&rust_ctx, &ok_expr), "Ok::<String, String>(data)");
 
 }
 

--- a/tests/snapshots/codegen_snapshot_test__effect_fn.snap
+++ b/tests/snapshots/codegen_snapshot_test__effect_fn.snap
@@ -104,5 +104,5 @@ pub fn almide_rt_int_from_uint64(n: u64) -> i64 { n as i64 }
 
 //__ALMIDE_RT_BOUNDARY__
 pub fn parse_int(s: &str) -> Result<i64, String> {
-    Ok((almide_rt_int_parse(&*s))?)
+    Ok::<i64, String>((almide_rt_int_parse(&*s))?)
 }


### PR DESCRIPTION
The final adversarial closure sweep (53 programs, 6 categories) left **2 native-fail / WASM-ok divergences** in the `combinator-mix` category — both pre-existing native-codegen gaps, not regressions. The other 5 categories (46 programs) were clean, confirming the uniform `Rc<dyn Fn>` closure repr is solid. This PR closes both.

## DIV1 — unconstrained Result error type (E0282)

`result.unwrap_or(ok(10), -1)` failed to build: `unwrap_or<T, E>` names `E` only in its `Result<T, E>` parameter, so nothing pins it. The checker already resolves the full Result type, but a bare `Ok(x)` doesn't carry it to rustc, leaving the phantom `E` uninferrable.

**Fix:** emit `Ok::<ok, err>(x)` — a turbofish carrying the resolved type — for every `ResultOk`, defaulting a still-unconstrained error to `String` (mirrors the existing `render_type` Result-arm default). Completes the same Result-E family the dv_13 type-position fix started; the constructor position was the one it didn't cover.

## DIV2 — group_by Map moved into a borrowed closure (E0382)

`xs |> group_by(...)` then `map.keys(g) |> map(k => …get(g,k)…)` then `map.values(g)` failed: the `keys` closure moved `g`, so the later `map.values(g)` saw a moved value.

**Root cause:** `CaptureClone::transform_expr` did not recurse into `Borrow` (and `ToVec`/`BoxNew`/`Await`/`RustMacro`/`IterChain`) wrapper nodes. `list.join(&list.map(keys, k => …g…), …)` wraps the inner `map` in `Borrow`, so the closure was invisible to capture analysis and its captured non-Copy `g` was never pre-cloned. `replace_vars` (the rename half) already descended these nodes — the walk and the rename simply disagreed.

**Fix:** add the missing wrapper arms to `transform_expr`, matching `replace_vars`. This closes the whole class of "closure nested under a borrow / fused chain doesn't clone its captures", not just this repro.

## Verification

- Both repros: native == WASM (DIV1 `v=10`, DIV2 values `2,2`).
- Turbofish stress: generic `ok(x)`, custom-error `ok`/`err`, list payloads — all native == WASM.
- `almide test`: stdlib 99 + lang 114 files pass.
- `cargo test`: green (effect-fn snapshot updated for the new `Ok::<i64, String>` auto-wrap).