### PR TITLE
Codegen traversal totality: close the fold.rs hole + lint silent IR-recursion catch-alls

### DIFF
--- a/crates/almide-ir/src/fold.rs
+++ b/crates/almide-ir/src/fold.rs
@@ -6,125 +6,45 @@ use super::*;
 /// e.g. LitInt(1) + LitInt(2) → LitInt(3)
 pub fn constant_fold(program: &mut IrProgram) {
     for f in &mut program.functions {
-        fold_expr(&mut f.body);
+        fold_in_place(&mut f.body);
     }
     for tl in &mut program.top_lets {
-        fold_expr(&mut tl.value);
+        fold_in_place(&mut tl.value);
     }
 }
 
-fn fold_expr(expr: &mut IrExpr) {
-    // Recurse first (bottom-up)
-    match &mut expr.kind {
-        IrExprKind::BinOp { left, right, .. } => {
-            fold_expr(left);
-            fold_expr(right);
-        }
-        IrExprKind::UnOp { operand, .. } => fold_expr(operand),
-        IrExprKind::Block { stmts, expr: tail } => {
-            for s in stmts { fold_stmt(s); }
-            if let Some(t) = tail { fold_expr(t); }
-        }
+/// Constant-fold `slot` in place. `fold_expr` is by-value so its recursion can
+/// go through `IrExpr::map_children`; this swaps a placeholder in to take
+/// ownership and writes the folded result back.
+fn fold_in_place(slot: &mut IrExpr) {
+    let placeholder = IrExpr { kind: IrExprKind::Unit, ty: slot.ty.clone(), span: None, def_id: None };
+    let taken = std::mem::replace(slot, placeholder);
+    *slot = fold_expr(taken);
+}
 
-        IrExprKind::If { cond, then, else_ } => {
-            fold_expr(cond);
-            fold_expr(then);
-            fold_expr(else_);
-        }
-        IrExprKind::Call { args, .. } => {
-            for a in args { fold_expr(a); }
-        }
-        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
-        | IrExprKind::Fan { exprs: elements } => {
-            for e in elements { fold_expr(e); }
-        }
-        IrExprKind::Lambda { body, .. } => fold_expr(body),
-        IrExprKind::Match { subject, arms } => {
-            fold_expr(subject);
-            for a in arms {
-                if let Some(g) = &mut a.guard { fold_expr(g); }
-                fold_expr(&mut a.body);
-            }
-        }
-        IrExprKind::ForIn { iterable, body, .. } => {
-            fold_expr(iterable);
-            for s in body { fold_stmt(s); }
-        }
-        IrExprKind::While { cond, body } => {
-            fold_expr(cond);
-            for s in body { fold_stmt(s); }
-        }
-        IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
-        | IrExprKind::OptionSome { expr } | IrExprKind::Try { expr }
-        | IrExprKind::Await { expr }
-        | IrExprKind::Unwrap { expr } | IrExprKind::ToOption { expr }
-        | IrExprKind::Clone { expr } | IrExprKind::Deref { expr }
-        | IrExprKind::Borrow { expr, .. } | IrExprKind::BoxNew { expr }
-        | IrExprKind::RcWrap { expr, .. }
-        | IrExprKind::ToVec { expr } => fold_expr(expr),
-        IrExprKind::UnwrapOr { expr: e, fallback: f } => {
-            fold_expr(e);
-            fold_expr(f);
-        }
-        IrExprKind::OptionalChain { expr: object, .. } => fold_expr(object),
-        IrExprKind::RustMacro { args, .. } => {
-            for a in args { fold_expr(a); }
-        }
-        IrExprKind::InlineRust { args, .. } => {
-            for (_, a) in args { fold_expr(a); }
-        }
-        IrExprKind::IterChain { source, steps, collector, .. } => {
-            fold_expr(source);
-            for step in steps {
-                match step {
-                    super::IterStep::Map { lambda } | super::IterStep::Filter { lambda }
-                    | super::IterStep::FlatMap { lambda } | super::IterStep::FilterMap { lambda } => {
-                        fold_expr(lambda);
-                    }
-                }
-            }
-            match collector {
-                super::IterCollector::Collect => {}
-                super::IterCollector::Fold { init, lambda } => { fold_expr(init); fold_expr(lambda); }
-                super::IterCollector::Any { lambda } | super::IterCollector::All { lambda }
-                | super::IterCollector::Find { lambda } | super::IterCollector::Count { lambda } => {
-                    fold_expr(lambda);
-                }
-            }
-        }
-        IrExprKind::Record { fields, .. } => {
-            for (_, v) in fields { fold_expr(v); }
-        }
-        IrExprKind::SpreadRecord { base, fields } => {
-            fold_expr(base);
-            for (_, v) in fields { fold_expr(v); }
-        }
-        IrExprKind::Range { start, end, .. } => {
-            fold_expr(start);
-            fold_expr(end);
-        }
-        IrExprKind::IndexAccess { object, index } => {
-            fold_expr(object);
-            fold_expr(index);
-        }
-        IrExprKind::MapAccess { object, key } => {
-            fold_expr(object);
-            fold_expr(key);
-        }
-        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. } => fold_expr(object),
-        IrExprKind::MapLiteral { entries } => {
-            for (k, v) in entries { fold_expr(k); fold_expr(v); }
-        }
-        IrExprKind::StringInterp { parts } => {
-            for p in parts {
-                if let IrStringPart::Expr { expr: e } = p { fold_expr(e); }
-            }
-        }
-        _ => {}
+/// Bottom-up constant fold.
+///
+/// Recursion goes through `IrExpr::map_children` — the single wildcard-free
+/// traversal primitive (it lists every `IrExprKind`, so adding a variant is a
+/// compile error there). A hand-rolled `match expr.kind { …; _ => {} }` here
+/// would silently drop the children of any un-listed or future node kind — the
+/// exact failure class behind the native↔WASM capture divergences (DIV2). See
+/// docs/roadmap/active/codegen-traversal-totality.md.
+fn fold_expr(mut expr: IrExpr) -> IrExpr {
+    // 1. Fold every child first, so parents see already-folded literals.
+    expr = expr.map_children(&mut |e| fold_expr(e));
+    // 2. Fold this node if it has now become a constant operation.
+    if let Some(kind) = try_fold(&expr) {
+        expr.kind = kind;
     }
+    expr
+}
 
-    // Now try to fold this node
-    let folded = match &expr.kind {
+/// The node-level fold decision: the replacement kind, or `None` when no fold
+/// applies. This is a *value* match — its `_ => None` is a legitimate "nothing
+/// to fold" default, not a recursion drop.
+fn try_fold(expr: &IrExpr) -> Option<IrExprKind> {
+    match &expr.kind {
         IrExprKind::BinOp { op, left, right } => {
             match (&left.kind, &right.kind) {
                 (IrExprKind::LitInt { value: a }, IrExprKind::LitInt { value: b }) => {
@@ -171,40 +91,5 @@ fn fold_expr(expr: &mut IrExpr) {
             }
         }
         _ => None,
-    };
-
-    if let Some(kind) = folded {
-        expr.kind = kind;
-    }
-}
-
-fn fold_stmt(stmt: &mut IrStmt) {
-    match &mut stmt.kind {
-        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
-        | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => fold_expr(value),
-        IrStmtKind::IndexAssign { index, value, .. } => {
-            fold_expr(index);
-            fold_expr(value);
-        }
-        IrStmtKind::MapInsert { key, value, .. } => {
-            fold_expr(key);
-            fold_expr(value);
-        }
-        IrStmtKind::Guard { cond, else_ } => {
-            fold_expr(cond);
-            fold_expr(else_);
-        }
-        IrStmtKind::ListSwap { a, b, .. } => {
-            fold_expr(a);
-            fold_expr(b);
-        }
-        IrStmtKind::ListReverse { end, .. } | IrStmtKind::ListRotateLeft { end, .. } => {
-            fold_expr(end);
-        }
-        IrStmtKind::ListCopySlice { len, .. } => {
-            fold_expr(len);
-        }
-        IrStmtKind::Expr { expr } => fold_expr(expr),
-        IrStmtKind::Comment { .. } | IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. } => {}
     }
 }

--- a/docs/roadmap/active/codegen-traversal-totality.md
+++ b/docs/roadmap/active/codegen-traversal-totality.md
@@ -1,0 +1,113 @@
+# Codegen traversal totality
+
+**Goal:** make "a pass forgot to recurse into a node kind" a **compile error or a CI failure**, never
+a silent native↔WASM divergence. This converts the largest remaining *asymptotic* divergence class
+("keep sweeping, keep finding") into a *static* guarantee by construction.
+
+## How we got here
+
+`DIV2` (PR #347): `xs |> group_by(..)` then `map.keys(g) |> map(k => …get(g,k)…)` then `map.values(g)`
+failed to build natively (E0382, borrow of moved `g`); WASM ran fine. Root cause was **not** about
+maps or ownership — it was that `CaptureClonePass::transform_expr` hand-rolled
+`match &expr.kind { …; _ => {} }` and the `_ => {}` **silently dropped the `Borrow`-wrapped subtree**
+(`list.join(&list.map(keys, k => …g…), …)`), so the closure nested under `&(…)` was invisible to
+capture analysis and its captured `g` was never pre-cloned.
+
+The fix added the missing wrapper arms. But an audit of all 37 codegen passes shows **this is a class,
+not an incident**: ~24 passes hand-roll a `match expr.kind` recursion ending in a non-recursing
+`_ => {}` / `other => other`, each a latent divergence waiting for the right nesting. The asymptotic
+sweep keeps finding them one at a time. We want to close the class.
+
+## The key insight
+
+Every native-only divergence we have fixed is the same shape: **native asks rustc to re-derive what
+the IR already knows, and the emission under-specifies it** — OR (this class) **a pass under-traverses
+the IR and silently skips a subtree**. Both are "the pass relied on something instead of carrying the
+fact / visiting the node." The static cure is to make the carry/visit *total by construction*.
+
+For traversal specifically: a pass should `match expr.kind` **only for the nodes it transforms**, and
+**delegate all other recursion to a single, compile-enforced-exhaustive primitive** — never to a
+hand-rolled `_ => {}`.
+
+## The good news: the infrastructure already exists
+
+| Primitive | File | Mutable | Exhaustive (no `_=>`) | Recurses every wrapper child |
+|-----------|------|---------|----------------------|------------------------------|
+| `IrExpr::map_children` | `almide-ir/src/lib.rs` | by-value | **yes** (documented chokepoint) | yes |
+| `IrMutVisitor` / `walk_expr_mut` | `almide-ir/src/visit_mut.rs` | in-place | **yes** | yes |
+| `IrVisitor` / `walk_expr` | `almide-ir/src/visit.rs` | read-only | **yes** | yes |
+| `substitute_var_in_expr` | `almide-ir/src/substitute.rs` | by-value | yes | yes |
+| `fold_expr` | `almide-ir/src/fold.rs` | by-value | **NO — `_ => {}` at L123** | yes (today) |
+
+`IrExpr::map_children` is the gold standard: its doc already says *"All variants are listed explicitly
+(no wildcard) so that adding a new `IrExprKind` causes a compile error here — forcing the author to
+decide how its children should be traversed."* `free_vars.rs` is the exemplar consumer for a
+**context-threading** analysis: it overrides only the binder nodes (`Lambda`/`Block`/`Match`/`ForIn`)
+to push/pop a `bound` set and falls through to `walk_expr` for everything else — so it can never drop
+a subtree. `pass_concretize_types` and `pass_result_propagation`'s `resolve_err_types` already use
+`IrMutVisitor` correctly and are safe.
+
+So we are **~80% there**. The work is to (a) close the one infra hole (`fold.rs`), (b) migrate the
+hand-rolling passes onto these primitives, and (c) lock it with a lint so it can't regress.
+
+## Plan
+
+### Phase 0 — infra (small, pure-safety)
+- Delete `fold_expr`'s `_ => {}`; reimplement its recursion on `IrExpr::map_children` (or make the
+  match exhaustive). No behavior change today; makes variant-addition a compile error.
+
+### Phase 1 — enforcement lint (anti-regression, the "static" lock)
+
+**The enemy is *silence*, not the wildcard.** DIV2 was `_ => {}` — a catch-all that *does nothing* and
+silently drops the subtree. A wildcard is fine; a *silent no-op* wildcard is the bug. There are three
+catch-all forms; only one is banned:
+
+| Form | Example | Verdict |
+|------|---------|---------|
+| **Delegate** (correct default recursion) | `_ => walk_expr_mut(self, e)` | ✅ closes the DIV2 class by construction |
+| **Loud provisional** (Swift `Never` model) | `_ => unreachable!("…")` / `_ => todo!()` / `panic!` | ✅ traps *at codegen time* on the offending program — surfaces the gap, never ships a divergence. Lets a pass be written incrementally. |
+| **Silent no-op** | `_ => {}` / `_ => e` (returns unrecursed) | ❌ the only banned form — drops a subtree silently |
+
+This mirrors the *language's own* `hole`/`todo`: a provisional body typechecks (its type unifies with
+context) and renders to `todo!()` (`Never` in Rust — traps loudly if reached). The compiler-internal
+walks should obey the same discipline: a not-yet-handled node kind must be *loud* (`unreachable!`) or
+*correctly recursed* (`walk_*`), never *silent*.
+
+- Add a CI test (`tests/traversal_lint.rs` or a build-script check) that scans
+  `crates/almide-codegen/src/pass_*.rs` and `crates/almide-ir/src/*.rs` for the banned form: a `match`
+  on an `IrExprKind` value whose catch-all body is a **silent no-op** (empty `{}`, or returns the node
+  without recursing) — while **allowing** catch-alls that delegate to a `walk_*` primitive or diverge
+  (`unreachable!`/`todo!`/`panic!`/a `Never`-typed expr). Allow-list the canonical primitives
+  themselves. A new silently-dropping walker fails CI; a loud provisional one passes.
+- This is what makes the guarantee *static* rather than *snapshot-in-time* — and keeps incremental /
+  provisional passes writable (the Swift-`Never` escape hatch), in line with Almide's
+  modification-survival-rate mission.
+
+### Phase 2 — migrate the mutating rewriters (prioritized by audit risk)
+Each migration is **behavior-subtle** (some catch-alls were intentional non-recursion). Every pass
+gets a differential check after migration: `native == wasm` on a spec sweep + the existing suite.
+
+| Tier | Passes | Notes from audit |
+|------|--------|------------------|
+| **HIGH** | `pass_clone` (CloneInsertion) | omits `IterChain`/`RcWrap` — **a live DIV2-sibling**: clone insertion blind to fused chains. Fix first; it is the other half of DIV2. |
+| | `pass_borrow_inference` | 5 hand-rolled walkers, several dropping catch-alls; central to native borrow modes. |
+| | `pass_stdlib_lowering` | `rewrite_expr` `other => other` over ~36 variants; "the DIV2 risk is here." |
+| | `pass_perceus` | WASM RC; every helper hand-rolled, omits ~all wrappers. |
+| **MED** | `anf`, `box_deref`, `capture_clone`, `fan_lowering`, `lambda_type_resolve`, `list_pattern`, `match_subject`, `mut_param_lowering`, `peephole`, `result_propagation` (lift path), `rust_lowering` (idx path), `tco` | each drops some wrapper/collection subtree. `capture_clone` is already partially fixed (#347) but should move to the `IrMutVisitor`+binder-stack pattern so it can't drift again. |
+| **LOW / analyses** | `auto_parallel`, `builtin_lowering`, `closure_conversion`, `const_fold`, `effect_inference`, `licm`, `match_lowering`, `matrix_shape_spec` | mostly broad coverage or read-only. **`effect_inference` omitting `IterChain` is a real latent bug** (effects inside a fused chain mis-classified) — verify. Read-only analyses migrate to `IrVisitor`. |
+| **DEAD** | `pass_shadow_resolve` | `targets() == None`; never runs. Leave or delete. |
+
+### Phase 3 — differential CI gate (shared with closure-cross-target work)
+A well-typed-IR generator + `native` vs `wasm` execution assertion in CI (extending the Perceus
+proptest + byte-identical determinism gate) catches any residual traversal/codegen divergence over a
+bounded input space — "static" in the continuous-machine-checked sense, the backstop behind the lint.
+
+## Sequencing
+
+Phases 0+1 are low-risk and high-leverage — they install the guarantee. Phase 2 is the bulk and is
+behavior-subtle; it should land as **several reviewed PRs by tier**, each differential-checked, not
+one mega-diff. Phase 3 is shared infrastructure with `closure-cross-target-completeness.md`.
+
+**First PR proposal:** Phase 0 (`fold.rs`) + Phase 1 (lint) + the HIGH-tier `pass_clone` migration
+(the proven DIV2-sibling). This proves the pattern end-to-end and closes a known live bug, while the
+lint prevents new ones.

--- a/tests/traversal_totality_lint.rs
+++ b/tests/traversal_totality_lint.rs
@@ -1,0 +1,423 @@
+//! Traversal-totality lint — Phase 1 of `docs/roadmap/active/codegen-traversal-totality.md`.
+//!
+//! Bans the one failure class behind the native↔WASM capture divergences (DIV2):
+//! a `match` over an `IrExprKind` (`… .kind { … }`) whose **catch-all** arm
+//! *silently drops the subtree* — `_ => {}` (does nothing) or `other => other`
+//! (returns the node unrecursed). Such an arm skips the children of every
+//! un-listed / future node kind, so a closure/var nested inside one is invisible
+//! to the pass and native codegen diverges from WASM.
+//!
+//! The enemy is *silence*, not the wildcard. A catch-all is fine when it:
+//!   - **delegates** to the exhaustive primitive (`walk_expr(_mut)`, `map_children`), or
+//!   - **diverges loudly** (`unreachable!`/`todo!`/`panic!`/`unimplemented!` — the
+//!     Swift-`Never` provisional), or
+//!   - returns a *value* (`_ => None`, `_ => false`) in a decision match (not recursion).
+//!
+//! Only `_ => {}` / `binder => binder` / `_ => <scrutinee>.kind` are banned.
+//!
+//! Ratchet: `LEGACY_DEBT` grandfathers files still carrying the pattern. Migrate
+//! them per the roadmap and REMOVE the entry — never add one. A clean file that
+//! regresses, or any new file with the pattern, fails this test.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Files whose hand-rolled IR traversal still contains silent catch-alls.
+/// Each must be migrated to a canonical primitive (`IrMutVisitor`/`map_children`)
+/// or have its catch-all made loud/delegating; then delete it from this list.
+const LEGACY_DEBT: &[&str] = &[
+    "crates/almide-codegen/src/pass_anf.rs",
+    "crates/almide-codegen/src/pass_auto_parallel.rs",
+    "crates/almide-codegen/src/pass_borrow_inference.rs",
+    "crates/almide-codegen/src/pass_box_deref.rs",
+    "crates/almide-codegen/src/pass_builtin_lowering.rs",
+    "crates/almide-codegen/src/pass_capture_clone.rs",
+    "crates/almide-codegen/src/pass_clone.rs",
+    "crates/almide-codegen/src/pass_closure_conversion.rs",
+    "crates/almide-codegen/src/pass_concretize_types.rs",
+    "crates/almide-codegen/src/pass_const_fold.rs",
+    "crates/almide-codegen/src/pass_effect_inference.rs",
+    "crates/almide-codegen/src/pass_fan_lowering.rs",
+    "crates/almide-codegen/src/pass_lambda_type_resolve.rs",
+    "crates/almide-codegen/src/pass_licm.rs",
+    "crates/almide-codegen/src/pass_list_pattern.rs",
+    "crates/almide-codegen/src/pass_match_lowering.rs",
+    "crates/almide-codegen/src/pass_match_subject.rs",
+    "crates/almide-codegen/src/pass_matrix_shape_spec.rs",
+    "crates/almide-codegen/src/pass_mut_param_lowering.rs",
+    "crates/almide-codegen/src/pass_peephole.rs",
+    "crates/almide-codegen/src/pass_perceus.rs",
+    "crates/almide-codegen/src/pass_result_erasure.rs",
+    "crates/almide-codegen/src/pass_result_propagation.rs",
+    "crates/almide-codegen/src/pass_rust_lowering.rs",
+    "crates/almide-codegen/src/pass_shadow_resolve.rs",
+    "crates/almide-codegen/src/pass_stdlib_lowering.rs",
+    "crates/almide-codegen/src/pass_tco.rs",
+];
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR is the crate root (the repo root for this workspace member).
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// The set of source files whose IR traversal we govern: every codegen pass plus
+/// the almide-ir traversal primitives.
+fn governed_files(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let pass_dir = root.join("crates/almide-codegen/src");
+    if let Ok(entries) = std::fs::read_dir(&pass_dir) {
+        for e in entries.flatten() {
+            let p = e.path();
+            if let Some(name) = p.file_name().and_then(|n| n.to_str()) {
+                if name.starts_with("pass_") && name.ends_with(".rs") {
+                    out.push(p);
+                }
+            }
+        }
+    }
+    for f in ["fold.rs", "visit.rs", "visit_mut.rs", "substitute.rs", "free_vars.rs"] {
+        out.push(root.join("crates/almide-ir/src").join(f));
+    }
+    out.sort();
+    out
+}
+
+/// Replace `//`-comments, `/* */`-comments and string-literal contents with
+/// spaces (newlines preserved) so the scanner never trips on doc examples.
+fn blank_comments_and_strings(src: &str) -> String {
+    let b = src.as_bytes();
+    let mut out = vec![b' '; b.len()];
+    // Preserve newlines for line numbering.
+    for (i, &c) in b.iter().enumerate() {
+        if c == b'\n' { out[i] = b'\n'; }
+    }
+    let mut i = 0;
+    while i < b.len() {
+        let c = b[i];
+        if c == b'/' && i + 1 < b.len() && b[i + 1] == b'/' {
+            while i < b.len() && b[i] != b'\n' { i += 1; }
+        } else if c == b'/' && i + 1 < b.len() && b[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < b.len() && !(b[i] == b'*' && b[i + 1] == b'/') { i += 1; }
+            i += 2;
+        } else if c == b'"' {
+            i += 1;
+            while i < b.len() && b[i] != b'"' {
+                if b[i] == b'\\' { i += 1; }
+                i += 1;
+            }
+            i += 1;
+        } else if c == b'\'' {
+            // char literal or lifetime; only treat as literal when it closes quickly
+            if i + 2 < b.len() && b[i + 1] != b'\\' && b[i + 2] == b'\'' {
+                i += 3;
+            } else if i + 3 < b.len() && b[i + 1] == b'\\' {
+                i += 4;
+            } else {
+                out[i] = c; // lifetime tick — keep
+                i += 1;
+            }
+        } else {
+            out[i] = c;
+            i += 1;
+        }
+    }
+    String::from_utf8(out).unwrap()
+}
+
+#[derive(Debug)]
+struct Violation {
+    line: usize,
+    arm: String,
+}
+
+/// Scan `src` (already comment/string-blanked) for silent catch-alls inside
+/// `match … .kind { … }` blocks.
+fn find_violations(src: &str) -> Vec<Violation> {
+    let b = src.as_bytes();
+    let mut violations = Vec::new();
+
+    // Find every `match` keyword (word-boundary).
+    let mut search = 0;
+    while let Some(rel) = src[search..].find("match") {
+        let m = search + rel;
+        search = m + 5;
+        // word boundary before/after
+        let before_ok = m == 0 || !is_ident_byte(b[m - 1]);
+        let after_ok = m + 5 >= b.len() || !is_ident_byte(b[m + 5]);
+        if !(before_ok && after_ok) { continue; }
+
+        // Scrutinee runs from after `match` to the body-opening `{`.
+        let mut j = m + 5;
+        let mut depth_paren = 0i32; // (), [], <> we ignore; only stop at top-level `{`
+        let body_open;
+        loop {
+            if j >= b.len() { body_open = None; break; }
+            match b[j] {
+                b'(' | b'[' => depth_paren += 1,
+                b')' | b']' => depth_paren -= 1,
+                b'{' if depth_paren == 0 => { body_open = Some(j); break; }
+                _ => {}
+            }
+            j += 1;
+        }
+        let Some(open) = body_open else { continue };
+        let scrutinee = &src[m + 5..open];
+        if !scrutinee.contains(".kind") { continue; }
+
+        // Find the matching `}` for the match body.
+        let mut depth = 0i32;
+        let mut k = open;
+        let mut body_close = None;
+        while k < b.len() {
+            match b[k] {
+                b'{' => depth += 1,
+                b'}' => { depth -= 1; if depth == 0 { body_close = Some(k); break; } }
+                _ => {}
+            }
+            k += 1;
+        }
+        let Some(close) = body_close else { continue };
+
+        // A catch-all is only a *recursion* drop when this match IS the descent.
+        // If the enclosing function delegates the rest of the walk to a canonical
+        // primitive (`walk_expr(_mut)` / `map_children` / `self.visit_*`), the
+        // match is a side-table override (binding collection, var shifting, …) and
+        // its `_ => {}` is correct — recursion happens via the delegation.
+        if enclosing_fn_delegates(src, b, open) {
+            continue;
+        }
+
+        // Within (open, close), find catch-all arms at arm-level (depth == 1).
+        scan_arms(src, b, open, close, &mut violations);
+    }
+
+    violations
+}
+
+/// Canonical-walk delegations: their presence in the enclosing function means
+/// the function descends via the exhaustive primitive, so a hand-written
+/// `.kind` match within it is a safe partial override, not the recursion point.
+const DELEGATIONS: &[&str] = &[
+    "walk_expr", "walk_stmt", "walk_pattern", "walk_expr_mut", "walk_stmt_mut",
+    "map_children", "map_exprs", ".visit_expr", ".visit_stmt",
+];
+
+/// Does the function body enclosing byte `pos` call a canonical-walk primitive?
+fn enclosing_fn_delegates(src: &str, b: &[u8], pos: usize) -> bool {
+    // Find the innermost `fn …(…) … { … }` whose body brackets `pos`.
+    let mut best: Option<(usize, usize)> = None;
+    let mut search = 0;
+    while let Some(rel) = src[search..].find("fn ") {
+        let f = search + rel;
+        search = f + 3;
+        let before_ok = f == 0 || !is_ident_byte(b[f - 1]);
+        if !before_ok { continue; }
+        // Body opens at the first `{` after the signature's `)` (skip `where`…).
+        let mut j = f + 3;
+        let mut paren = 0i32;
+        let mut seen_params = false;
+        let mut body_open = None;
+        while j < b.len() {
+            match b[j] {
+                b'(' => { paren += 1; seen_params = true; }
+                b')' => paren -= 1,
+                b'{' if paren == 0 && seen_params => { body_open = Some(j); break; }
+                b';' if paren == 0 => break, // fn-type / trait decl, no body
+                _ => {}
+            }
+            j += 1;
+        }
+        let Some(bo) = body_open else { continue };
+        let mut depth = 0i32;
+        let mut k = bo;
+        let mut body_close = None;
+        while k < b.len() {
+            match b[k] {
+                b'{' => depth += 1,
+                b'}' => { depth -= 1; if depth == 0 { body_close = Some(k); break; } }
+                _ => {}
+            }
+            k += 1;
+        }
+        let Some(bc) = body_close else { continue };
+        if bo < pos && pos < bc {
+            // innermost = smallest containing range
+            if best.map_or(true, |(s, e)| bo > s || bc < e) {
+                best = Some((bo, bc));
+            }
+        }
+    }
+    if let Some((s, e)) = best {
+        let body = &src[s..e];
+        return DELEGATIONS.iter().any(|d| body.contains(d));
+    }
+    false
+}
+
+fn scan_arms(src: &str, b: &[u8], open: usize, close: usize, out: &mut Vec<Violation>) {
+    // Walk the body; an arm pattern begins at arm-level (depth 1) right after the
+    // body `{`, or after a top-level `,`/`}` of a previous arm. We detect a `=>`
+    // at depth 1 and inspect the preceding pattern + following body.
+    let mut depth = 0i32;
+    let mut i = open;
+    let mut arm_pat_start = open + 1;
+    while i < close {
+        match b[i] {
+            b'{' | b'(' | b'[' => depth += 1,
+            b'}' | b')' | b']' => depth -= 1,
+            b'=' if depth == 1 && i + 1 < close && b[i + 1] == b'>' => {
+                let pat = src[arm_pat_start..i].trim().to_string();
+                // Body: from after `=>` to the arm terminator at depth 1
+                // (a top-level `,`, or the next arm — approximated by the next
+                // depth-1 `,`; a block body ends at its `}` then a `,`).
+                let body_start = i + 2;
+                let (body, next) = read_arm_body(b, src, body_start, close);
+                if let Some(binder) = catchall_binder(&pat) {
+                    if let Some(reason) = silent_body(&body, binder.as_deref()) {
+                        let line = src[..arm_pat_start].bytes().filter(|&c| c == b'\n').count() + 1;
+                        out.push(Violation { line, arm: format!("{} => {}  [{}]", pat, body.trim(), reason) });
+                    }
+                }
+                i = next;
+                arm_pat_start = next;
+                continue;
+            }
+            _ => {}
+        }
+        i += 1;
+        if depth == 1 && (b[i.saturating_sub(1)] == b',' ) {
+            arm_pat_start = i;
+        }
+    }
+}
+
+/// Read an arm body starting at `start`; returns (body_text, index_after_body).
+fn read_arm_body(b: &[u8], src: &str, start: usize, close: usize) -> (String, usize) {
+    let mut i = start;
+    while i < close && (b[i] == b' ' || b[i] == b'\n' || b[i] == b'\t') { i += 1; }
+    if i < close && b[i] == b'{' {
+        // block body — consume to matching `}`
+        let mut depth = 0i32;
+        let bstart = i;
+        while i < close {
+            match b[i] {
+                b'{' => depth += 1,
+                b'}' => { depth -= 1; if depth == 0 { i += 1; break; } }
+                _ => {}
+            }
+            i += 1;
+        }
+        let mut j = i;
+        if j < close && b[j] == b',' { j += 1; }
+        (src[bstart..i].to_string(), j)
+    } else {
+        // expression body — to next depth-0 `,`
+        let estart = i;
+        let mut depth = 0i32;
+        while i < close {
+            match b[i] {
+                b'{' | b'(' | b'[' => depth += 1,
+                b'}' | b')' | b']' => depth -= 1,
+                b',' if depth == 0 => break,
+                _ => {}
+            }
+            i += 1;
+        }
+        let body = src[estart..i].to_string();
+        if i < close && b[i] == b',' { i += 1; }
+        (body, i)
+    }
+}
+
+fn is_ident_byte(c: u8) -> bool {
+    c == b'_' || c.is_ascii_alphanumeric()
+}
+
+/// If `pat` is a catch-all (`_` or a single bare binder), return Some(binder
+/// name or None for `_`). Variant patterns (`Foo`, `Foo(..)`, `A | B`) return None.
+fn catchall_binder(pat: &str) -> Option<Option<String>> {
+    let p = pat.trim();
+    if p == "_" { return Some(None); }
+    // bare lowercase identifier, no `::`, `(`, `{`, `|`, `@`, `.`
+    if !p.is_empty()
+        && p.chars().next().map_or(false, |c| c.is_ascii_lowercase() || c == '_')
+        && p.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return Some(Some(p.to_string()));
+    }
+    None
+}
+
+/// Returns Some(reason) if `body` is a silent recursion-drop.
+fn silent_body(body: &str, binder: Option<&str>) -> Option<&'static str> {
+    let t = body.trim().trim_end_matches(',').trim();
+    if t == "{}" || t == "{ }" { return Some("empty"); }
+    if let Some(name) = binder {
+        if t == name { return Some("returns-binding-unrecursed"); }
+    }
+    // `_ => expr.kind` / `self.kind` (returns scrutinee unmodified)
+    if t.ends_with(".kind")
+        && t.split(['.', ' ']).next().map_or(false, |h| !h.is_empty())
+        && !t.contains('(')
+    {
+        return Some("returns-scrutinee-kind");
+    }
+    None
+}
+
+#[test]
+fn no_silent_catchalls_in_ir_traversal() {
+    let root = repo_root();
+    let files = governed_files(&root);
+    assert!(!files.is_empty(), "no governed files found under {}", root.display());
+
+    let mut offenders: BTreeMap<String, Vec<Violation>> = BTreeMap::new();
+    let mut seen_legacy_clean: Vec<String> = Vec::new();
+
+    for path in &files {
+        let rel = path
+            .strip_prefix(&root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        let src = std::fs::read_to_string(path).unwrap_or_default();
+        let blanked = blank_comments_and_strings(&src);
+        let v = find_violations(&blanked);
+        let is_legacy = LEGACY_DEBT.contains(&rel.as_str());
+        if !v.is_empty() && !is_legacy {
+            offenders.insert(rel, v);
+        } else if v.is_empty() && is_legacy {
+            seen_legacy_clean.push(rel);
+        }
+    }
+
+    let mut msg = String::new();
+    if !offenders.is_empty() {
+        msg.push_str(
+            "\nSilent catch-all(s) found in IR-recursion match(es). A `_ => {}` / \
+             `other => other` over `expr.kind` drops the children of un-handled node \
+             kinds — the native↔WASM divergence class (DIV2).\n\
+             Fix: delegate the default arm to the exhaustive primitive \
+             (`walk_expr_mut(self, e)` / `e.map_children(..)`), or make it loud \
+             (`unreachable!(..)` / `todo!()`), or list the variants explicitly.\n\
+             See docs/roadmap/active/codegen-traversal-totality.md.\n\n",
+        );
+        for (file, vs) in &offenders {
+            for v in vs {
+                msg.push_str(&format!("  {}:{}  {}\n", file, v.line, v.arm));
+            }
+        }
+    }
+    if !seen_legacy_clean.is_empty() {
+        msg.push_str(
+            "\nThe following files are listed in LEGACY_DEBT but are now CLEAN — \
+             remove them from the list so a regression is caught:\n",
+        );
+        for f in &seen_legacy_clean {
+            msg.push_str(&format!("  {}\n", f));
+        }
+    }
+
+    assert!(offenders.is_empty() && seen_legacy_clean.is_empty(), "{}", msg);
+}


### PR DESCRIPTION
Phase 0 + Phase 1 of `docs/roadmap/active/codegen-traversal-totality.md` — converting the largest *asymptotic* divergence class ("keep sweeping, keep finding") into a *static* guarantee.

## Why

DIV2 (#347) was `CaptureClonePass` hand-rolling `match &expr.kind { …; _ => {} }`, whose `_ => {}` silently dropped a `Borrow`-wrapped subtree, so a nested closure's captured map was never cloned → native E0382 while WASM ran fine. A 7-agent audit found this is a **class, not an incident**: ~27 of 37 passes hand-roll a `match expr.kind` recursion ending in a silent catch-all (`_ => {}` / `other => other`), each a latent native↔WASM divergence. The infra to fix it already exists (`IrExpr::map_children` is wildcard-free; `IrMutVisitor`); only `fold.rs` had a hole.

## What

**Phase 0 — close the one infra hole.** `constant_fold` is rewritten on `IrExpr::map_children` (the wildcard-free traversal primitive), replacing a hand-rolled recursion that ended in `_ => {}`. Adding a new `IrExprKind` is now a compile error at the primitive instead of a silent drop; as a bonus it now folds inside `RuntimeCall`/`TailCall` args it previously skipped. `fold_stmt` is subsumed by `IrStmt::map_exprs`.

**Phase 1 — the static lock (anti-regression lint).** `tests/traversal_totality_lint.rs` fails CI when a `match … .kind { … }` has a **silent** catch-all — `_ => {}` (does nothing) or `other => other` (returns the node unrecursed). The enemy is *silence*, not the wildcard:
- **delegating** catch-alls (`walk_expr_mut(self, e)` / `e.map_children(..)`) are allowed — the enclosing-function check clears safe `IrMutVisitor` overrides (e.g. `free_vars`, `unify_var_tables`) whose recursion is delegated;
- **loud** catch-alls (`unreachable!`/`todo!`/`panic!` — the Swift-`Never` provisional) are allowed;
- **value** matches (`_ => None`) are not recursion and are ignored.

A `LEGACY_DEBT` ratchet grandfathers the 27 current hand-rolled passes (migrate per the roadmap and remove each entry; a cleaned file that regresses, or any new file with the pattern, fails). The audit also surfaced one un-tracked real recursion-drop — `pass_result_erasure`'s `other => other` — now listed.

## Verification

- Lint positive control: both banned forms are detected (`pass_const_fold` `_ => {}`, `pass_result_erasure` `other => other`) when un-grandfathered; delegating/value matches are correctly cleared.
- `cargo test` green; `almide test` (stdlib + lang) green; `fold.rs` folding behavior preserved (snapshots unchanged).

## Not in scope (follow-up PRs, by audit tier)

Migrating the 27 `LEGACY_DEBT` passes off hand-rolled traversal onto `IrMutVisitor`/`map_children` — behavior-subtle, lands per tier with differential checks. Note: the audit confirmed the flagged "live candidates" (`pass_clone`/`effect_inference` IterChain blind spots) are **not** currently reachable — they run before `IterChain` is created at `StdlibLowering`. The lint + migration make reachability irrelevant.