### PR TITLE
Migrate MatchSubject pass to IrMutVisitor (traversal-totality tier-1 pilot)

### DIFF
--- a/crates/almide-codegen/src/pass_match_subject.rs
+++ b/crates/almide-codegen/src/pass_match_subject.rs
@@ -7,8 +7,14 @@
 //!
 //! This pass inserts `Borrow { as_str: true }` or `Call { Method "as_deref" }` IR nodes
 //! on match subjects, so the walker never needs to check types.
+//!
+//! Traversal goes through the canonical `IrMutVisitor`/`walk_expr_mut` (exhaustive,
+//! wildcard-free) rather than a hand-rolled `match expr.kind { …; _ => {} }`, so a
+//! `Match` nested under any wrapper or future node kind is always reached — no
+//! silent subtree drop (see docs/roadmap/active/codegen-traversal-totality.md).
 
 use almide_ir::*;
+use almide_ir::visit_mut::{IrMutVisitor, walk_expr_mut};
 use almide_lang::types::{Ty, TypeConstructorId};
 use super::pass::{NanoPass, PassResult, Target};
 
@@ -23,114 +29,36 @@ impl NanoPass for MatchSubjectPass {
     }
 
     fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
+        let mut v = MatchSubjectVisitor;
         for func in &mut program.functions {
-            rewrite_expr(&mut func.body);
+            v.visit_expr_mut(&mut func.body);
         }
         for tl in &mut program.top_lets {
-            rewrite_expr(&mut tl.value);
+            v.visit_expr_mut(&mut tl.value);
         }
         for module in &mut program.modules {
             for func in &mut module.functions {
-                rewrite_expr(&mut func.body);
+                v.visit_expr_mut(&mut func.body);
             }
             for tl in &mut module.top_lets {
-                rewrite_expr(&mut tl.value);
+                v.visit_expr_mut(&mut tl.value);
             }
         }
         PassResult { program, changed: true }
     }
 }
 
-fn rewrite_expr(expr: &mut IrExpr) {
-    // Recurse into children first (bottom-up)
-    match &mut expr.kind {
-        IrExprKind::BinOp { left, right, .. } => { rewrite_expr(left); rewrite_expr(right); }
-        IrExprKind::UnOp { operand, .. } => rewrite_expr(operand),
-        IrExprKind::If { cond, then, else_ } => { rewrite_expr(cond); rewrite_expr(then); rewrite_expr(else_); }
-        IrExprKind::Block { stmts, expr } => {
-            for s in stmts { rewrite_stmt(s); }
-            if let Some(e) = expr { rewrite_expr(e); }
-        }
-        IrExprKind::Call { target, args, .. } => {
-            match target {
-                CallTarget::Method { object, .. } | CallTarget::Computed { callee: object } => rewrite_expr(object),
-                _ => {}
-            }
-            for a in args { rewrite_expr(a); }
-        }
-        IrExprKind::RuntimeCall { args, .. } | IrExprKind::TailCall { args, .. } => {
-            // Recurse into args so match subjects inside lambda bodies
-            // passed to intrinsic calls (e.g. `list.fold` → `RuntimeCall`)
-            // still get their `c: String` subject wrapped with `as_str()`.
-            for a in args { rewrite_expr(a); }
-        }
-        IrExprKind::InlineRust { args, .. } => {
-            for (_, a) in args { rewrite_expr(a); }
-        }
-        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
-        | IrExprKind::Fan { exprs: elements } => {
-            for e in elements { rewrite_expr(e); }
-        }
-        IrExprKind::Record { fields, .. } => { for (_, v) in fields { rewrite_expr(v); } }
-        IrExprKind::SpreadRecord { base, fields } => {
-            rewrite_expr(base);
-            for (_, v) in fields { rewrite_expr(v); }
-        }
-        IrExprKind::MapLiteral { entries } => { for (k, v) in entries { rewrite_expr(k); rewrite_expr(v); } }
-        IrExprKind::Range { start, end, .. } => { rewrite_expr(start); rewrite_expr(end); }
-        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. }
-        | IrExprKind::OptionalChain { expr: object, .. } => rewrite_expr(object),
-        IrExprKind::IndexAccess { object, index } => { rewrite_expr(object); rewrite_expr(index); }
-        IrExprKind::MapAccess { object, key } => { rewrite_expr(object); rewrite_expr(key); }
-        IrExprKind::Lambda { body, .. } => rewrite_expr(body),
-        IrExprKind::StringInterp { parts } => {
-            for p in parts { if let IrStringPart::Expr { expr } = p { rewrite_expr(expr); } }
-        }
-        IrExprKind::ForIn { iterable, body, .. } => {
-            rewrite_expr(iterable);
-            for s in body { rewrite_stmt(s); }
-        }
-        IrExprKind::While { cond, body } => {
-            rewrite_expr(cond);
-            for s in body { rewrite_stmt(s); }
-        }
-        IrExprKind::ResultOk { expr: e } | IrExprKind::ResultErr { expr: e }
-        | IrExprKind::OptionSome { expr: e } | IrExprKind::Try { expr: e }
-        | IrExprKind::Unwrap { expr: e } | IrExprKind::ToOption { expr: e }
-        | IrExprKind::Await { expr: e } | IrExprKind::Clone { expr: e }
-        | IrExprKind::Deref { expr: e } | IrExprKind::Borrow { expr: e, .. }
-        | IrExprKind::BoxNew { expr: e } | IrExprKind::ToVec { expr: e } => rewrite_expr(e),
-        IrExprKind::UnwrapOr { expr: e, fallback: f } => { rewrite_expr(e); rewrite_expr(f); }
-        IrExprKind::RustMacro { args, .. } => { for a in args { rewrite_expr(a); } }
-        // Match — handled below after recursion
-        IrExprKind::Match { subject, arms } => {
-            rewrite_expr(subject);
-            for arm in arms {
-                if let Some(g) = &mut arm.guard { rewrite_expr(g); }
-                rewrite_expr(&mut arm.body);
-            }
-        }
-        _ => {}
-    }
+/// Post-order rewrite: descend into every child first via the exhaustive
+/// `walk_expr_mut`, then — once a `Match`'s subject and arms are themselves
+/// rewritten — insert its `.as_str()`/`.as_deref()` ownership transform.
+struct MatchSubjectVisitor;
 
-    // Transform match subjects after children are rewritten
-    if let IrExprKind::Match { subject, arms } = &mut expr.kind {
-        transform_match_subject(subject, arms);
-    }
-}
-
-fn rewrite_stmt(stmt: &mut IrStmt) {
-    match &mut stmt.kind {
-        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
-        | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => rewrite_expr(value),
-        IrStmtKind::IndexAssign { index, value, .. } => { rewrite_expr(index); rewrite_expr(value); }
-        IrStmtKind::MapInsert { key, value, .. } => { rewrite_expr(key); rewrite_expr(value); }
-        IrStmtKind::ListSwap { a, b, .. } => { rewrite_expr(a); rewrite_expr(b); }
-        IrStmtKind::ListReverse { end, .. } | IrStmtKind::ListRotateLeft { end, .. } => { rewrite_expr(end); }
-        IrStmtKind::ListCopySlice { len, .. } => { rewrite_expr(len); }
-        IrStmtKind::Guard { cond, else_ } => { rewrite_expr(cond); rewrite_expr(else_); }
-        IrStmtKind::Expr { expr } => rewrite_expr(expr),
-        IrStmtKind::Comment { .. } | IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. } => {}
+impl IrMutVisitor for MatchSubjectVisitor {
+    fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
+        walk_expr_mut(self, expr);
+        if let IrExprKind::Match { subject, arms } = &mut expr.kind {
+            transform_match_subject(subject, arms);
+        }
     }
 }
 

--- a/tests/traversal_totality_lint.rs
+++ b/tests/traversal_totality_lint.rs
@@ -42,7 +42,6 @@ const LEGACY_DEBT: &[&str] = &[
     "crates/almide-codegen/src/pass_licm.rs",
     "crates/almide-codegen/src/pass_list_pattern.rs",
     "crates/almide-codegen/src/pass_match_lowering.rs",
-    "crates/almide-codegen/src/pass_match_subject.rs",
     "crates/almide-codegen/src/pass_matrix_shape_spec.rs",
     "crates/almide-codegen/src/pass_mut_param_lowering.rs",
     "crates/almide-codegen/src/pass_peephole.rs",


### PR DESCRIPTION
First migration off the `LEGACY_DEBT` ratchet from #348 — the pilot that proves the recipe: replace a hand-rolled `match expr.kind { …; _ => {} }` recursion with the canonical `IrMutVisitor`/`walk_expr_mut`.

## Change

`MatchSubjectPass` (inserts `.as_str()` / `.as_deref()` on `String` / `Option<String>` match subjects) recursed via a hand-rolled `rewrite_expr`/`rewrite_stmt` ending in `_ => {}` — so a `Match` nested inside any un-listed wrapper or future node kind would be skipped, its subject never transformed. It is a context-free, post-order rewrite, so it maps directly onto a visitor:

```rust
impl IrMutVisitor for MatchSubjectVisitor {
    fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
        walk_expr_mut(self, expr);                 // descend every child (exhaustive)
        if let IrExprKind::Match { subject, arms } = &mut expr.kind {
            transform_match_subject(subject, arms); // then transform (post-order, unchanged)
        }
    }
}
```

`rewrite_expr` + `rewrite_stmt` are deleted (subsumed by `walk_expr_mut`/`walk_stmt_mut`); `transform_match_subject` is unchanged. The file is removed from `LEGACY_DEBT` (27 → 26); the lint now guards it against regression.

## Verification (pure refactor — output unchanged)

- `.as_str()` inserted for `match s { "yes" => … }`; `.as_deref()` for `match o { Some("hit") => … }`; both run correctly native + WASM.
- `codegen_snapshot_test` (incl. `match_option`, `match_variant`) unchanged; `cargo test` green; `almide test` (stdlib + lang) green.
- Traversal lint green with `pass_match_subject` delisted.

## Next

The context-threading and HIGH-tier passes (`pass_capture_clone`, `pass_clone`, `pass_borrow_inference`, `pass_stdlib_lowering`, `pass_perceus`, …) follow the same recipe but maintain a binder/scope/count stack across `visit_*_mut` (the `free_vars.rs` pattern, mutable). Per `docs/roadmap/active/codegen-traversal-totality.md`.