### PR TITLE
Migrate ConstFold + BuiltinLowering off silent catch-alls (traversal-totality batch)

### DIFF
--- a/crates/almide-codegen/src/pass_builtin_lowering.rs
+++ b/crates/almide-codegen/src/pass_builtin_lowering.rs
@@ -355,7 +355,14 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
         },
         IrExprKind::Clone { expr } => IrExprKind::Clone { expr: Box::new(rewrite_expr(*expr)) },
         IrExprKind::Deref { expr } => IrExprKind::Deref { expr: Box::new(rewrite_expr(*expr)) },
-        other => other,
+        // No builtin lowering applies to this node — recurse into its children
+        // via the exhaustive `map_children` so a lowerable call nested inside an
+        // un-listed / future kind is still reached (was a silent `other => other`
+        // drop). See docs/roadmap/active/codegen-traversal-totality.md.
+        other => {
+            return IrExpr { kind: other, ty, span, def_id: None }
+                .map_children(&mut |e| rewrite_expr(e));
+        }
     };
 
     IrExpr { kind, ty, span, def_id: None }
@@ -403,7 +410,9 @@ fn rewrite_stmts(stmts: Vec<IrStmt>) -> Vec<IrStmt> {
             IrStmtKind::BindDestructure { pattern, value } => IrStmtKind::BindDestructure {
                 pattern, value: rewrite_expr(value),
             },
-            other => other,
+            // Recurse the exprs of any other statement kind via `map_exprs`
+            // (was a silent drop of e.g. IndexAssign/MapInsert/ListSwap exprs).
+            other => return IrStmt { kind: other, span: s.span }.map_exprs(&mut |e| rewrite_expr(e)),
         };
         IrStmt { kind, span: s.span }
     }).collect()

--- a/crates/almide-codegen/src/pass_const_fold.rs
+++ b/crates/almide-codegen/src/pass_const_fold.rs
@@ -5,9 +5,14 @@
 //!
 //! Conservative — only folds when both operands are LitFloat or LitInt and
 //! the operation is trivially safe (no divide-by-zero, no overflow on Int).
+//!
+//! Traversal goes through the canonical `IrMutVisitor`/`walk_expr_mut`
+//! (exhaustive, wildcard-free) rather than a hand-rolled `match expr.kind { …;
+//! _ => {} }`, so a foldable subtree under any wrapper / future node kind is
+//! reached — no silent drop (see docs/roadmap/active/codegen-traversal-totality.md).
 
 use almide_ir::*;
-use almide_lang::types::Ty;
+use almide_ir::visit_mut::{IrMutVisitor, walk_expr_mut};
 use super::pass::{NanoPass, PassResult, Target};
 
 #[derive(Debug)]
@@ -19,89 +24,55 @@ impl NanoPass for ConstFoldPass {
     fn depends_on(&self) -> Vec<&'static str> { vec![] }
 
     fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
-        let mut changed = false;
+        let mut folder = ConstFolder { changed: false };
         for func in &mut program.functions {
-            if rewrite_expr(&mut func.body) { changed = true; }
+            folder.visit_expr_mut(&mut func.body);
         }
         for tl in &mut program.top_lets {
-            if rewrite_expr(&mut tl.value) { changed = true; }
+            folder.visit_expr_mut(&mut tl.value);
         }
         for module in &mut program.modules {
             for func in &mut module.functions {
-                if rewrite_expr(&mut func.body) { changed = true; }
+                folder.visit_expr_mut(&mut func.body);
             }
             for tl in &mut module.top_lets {
-                if rewrite_expr(&mut tl.value) { changed = true; }
+                folder.visit_expr_mut(&mut tl.value);
             }
         }
-        PassResult { program, changed }
+        PassResult { program, changed: folder.changed }
     }
 }
 
-fn rewrite_expr(expr: &mut IrExpr) -> bool {
-    let mut changed = false;
+/// Bottom-up fold: descend into every child via the exhaustive `walk_expr_mut`,
+/// then fold this node if it is a constant arithmetic op (so a parent sees its
+/// already-folded children).
+struct ConstFolder {
+    changed: bool,
+}
 
-    match &mut expr.kind {
-        IrExprKind::Block { stmts, expr: tail } => {
-            for stmt in stmts.iter_mut() { if rewrite_stmt(stmt) { changed = true; } }
-            if let Some(e) = tail { if rewrite_expr(e) { changed = true; } }
-        }
-        IrExprKind::If { cond, then, else_ } => {
-            if rewrite_expr(cond) { changed = true; }
-            if rewrite_expr(then) { changed = true; }
-            if rewrite_expr(else_) { changed = true; }
-        }
-        IrExprKind::Match { subject, arms } => {
-            if rewrite_expr(subject) { changed = true; }
-            for arm in arms {
-                if let Some(g) = &mut arm.guard { if rewrite_expr(g) { changed = true; } }
-                if rewrite_expr(&mut arm.body) { changed = true; }
+impl IrMutVisitor for ConstFolder {
+    fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
+        walk_expr_mut(self, expr);
+
+        if let IrExprKind::BinOp { op, left, right } = &expr.kind {
+            if let Some(folded) = try_fold(*op, left, right) {
+                expr.kind = folded;
+                self.changed = true;
             }
         }
-        IrExprKind::ForIn { iterable, body, .. } => {
-            if rewrite_expr(iterable) { changed = true; }
-            for stmt in body.iter_mut() { if rewrite_stmt(stmt) { changed = true; } }
+        if let IrExprKind::UnOp { op: UnOp::NegFloat, operand } = &expr.kind {
+            if let IrExprKind::LitFloat { value } = &operand.kind {
+                expr.kind = IrExprKind::LitFloat { value: -*value };
+                self.changed = true;
+            }
         }
-        IrExprKind::While { cond, body } => {
-            if rewrite_expr(cond) { changed = true; }
-            for stmt in body.iter_mut() { if rewrite_stmt(stmt) { changed = true; } }
-        }
-        IrExprKind::Lambda { body, .. } => {
-            if rewrite_expr(body) { changed = true; }
-        }
-        IrExprKind::Call { args, .. } => {
-            for a in args.iter_mut() { if rewrite_expr(a) { changed = true; } }
-        }
-        IrExprKind::BinOp { left, right, .. } => {
-            if rewrite_expr(left) { changed = true; }
-            if rewrite_expr(right) { changed = true; }
-        }
-        IrExprKind::UnOp { operand, .. } => {
-            if rewrite_expr(operand) { changed = true; }
-        }
-        _ => {}
-    }
-
-    if let IrExprKind::BinOp { op, left, right } = &expr.kind {
-        if let Some(folded) = try_fold(*op, left, right) {
-            expr.kind = folded;
-            changed = true;
+        if let IrExprKind::UnOp { op: UnOp::NegInt, operand } = &expr.kind {
+            if let IrExprKind::LitInt { value } = &operand.kind {
+                expr.kind = IrExprKind::LitInt { value: -*value };
+                self.changed = true;
+            }
         }
     }
-    if let IrExprKind::UnOp { op: UnOp::NegFloat, operand } = &expr.kind {
-        if let IrExprKind::LitFloat { value } = &operand.kind {
-            expr.kind = IrExprKind::LitFloat { value: -*value };
-            changed = true;
-        }
-    }
-    if let IrExprKind::UnOp { op: UnOp::NegInt, operand } = &expr.kind {
-        if let IrExprKind::LitInt { value } = &operand.kind {
-            expr.kind = IrExprKind::LitInt { value: -*value };
-            changed = true;
-        }
-    }
-
-    changed
 }
 
 fn try_fold(op: BinOp, left: &IrExpr, right: &IrExpr) -> Option<IrExprKind> {
@@ -161,36 +132,3 @@ fn try_fold(op: BinOp, left: &IrExpr, right: &IrExpr) -> Option<IrExprKind> {
     }
     None
 }
-
-fn rewrite_stmt(stmt: &mut IrStmt) -> bool {
-    let mut changed = false;
-    match &mut stmt.kind {
-        IrStmtKind::Bind { value, .. }
-        | IrStmtKind::BindDestructure { value, .. }
-        | IrStmtKind::Assign { value, .. }
-        | IrStmtKind::FieldAssign { value, .. } => {
-            if rewrite_expr(value) { changed = true; }
-        }
-        IrStmtKind::IndexAssign { index, value, .. } => {
-            if rewrite_expr(index) { changed = true; }
-            if rewrite_expr(value) { changed = true; }
-        }
-        IrStmtKind::MapInsert { key, value, .. } => {
-            if rewrite_expr(key) { changed = true; }
-            if rewrite_expr(value) { changed = true; }
-        }
-        IrStmtKind::Guard { cond, else_ } => {
-            if rewrite_expr(cond) { changed = true; }
-            if rewrite_expr(else_) { changed = true; }
-        }
-        IrStmtKind::Expr { expr } => {
-            if rewrite_expr(expr) { changed = true; }
-        }
-        _ => {}
-    }
-    changed
-}
-
-// Suppress unused import warning.
-#[allow(dead_code)]
-fn _ty_marker(_: Ty) {}

--- a/tests/traversal_totality_lint.rs
+++ b/tests/traversal_totality_lint.rs
@@ -30,7 +30,6 @@ const LEGACY_DEBT: &[&str] = &[
     "crates/almide-codegen/src/pass_auto_parallel.rs",
     "crates/almide-codegen/src/pass_borrow_inference.rs",
     "crates/almide-codegen/src/pass_box_deref.rs",
-    "crates/almide-codegen/src/pass_builtin_lowering.rs",
     "crates/almide-codegen/src/pass_capture_clone.rs",
     "crates/almide-codegen/src/pass_clone.rs",
     "crates/almide-codegen/src/pass_closure_conversion.rs",
@@ -177,12 +176,18 @@ fn find_violations(src: &str) -> Vec<Violation> {
         }
         let Some(close) = body_close else { continue };
 
-        // A catch-all is only a *recursion* drop when this match IS the descent.
-        // If the enclosing function delegates the rest of the walk to a canonical
-        // primitive (`walk_expr(_mut)` / `map_children` / `self.visit_*`), the
-        // match is a side-table override (binding collection, var shifting, …) and
-        // its `_ => {}` is correct — recursion happens via the delegation.
-        if enclosing_fn_delegates(src, b, open) {
+        // A silent catch-all only *drops a subtree* when this match is the
+        // descent itself. A match whose arms merely inspect/decide — a literal
+        // re-typer, a binding collector, a var-shifter whose recursion is a
+        // separate `walk_*` call *outside* the match — never recurses children,
+        // so its `_ => {}` is a legitimate "no action" default, not a drop.
+        // This match recurses iff an arm descends into a child: a known descent
+        // primitive, OR a self-call to the enclosing (recursive walker) function.
+        let body = &src[open..=close];
+        let recurses = has_descent_primitive(body)
+            || enclosing_fn_name(src, b, open)
+                .map_or(false, |name| body.contains(&format!("{}(", name)));
+        if !recurses {
             continue;
         }
 
@@ -193,26 +198,34 @@ fn find_violations(src: &str) -> Vec<Violation> {
     violations
 }
 
-/// Canonical-walk delegations: their presence in the enclosing function means
-/// the function descends via the exhaustive primitive, so a hand-written
-/// `.kind` match within it is a safe partial override, not the recursion point.
-const DELEGATIONS: &[&str] = &[
-    "walk_expr", "walk_stmt", "walk_pattern", "walk_expr_mut", "walk_stmt_mut",
-    "map_children", "map_exprs", ".visit_expr", ".visit_stmt",
-];
+/// Canonical descent primitives + the `*_expr(` / `*_stmt(` naming most
+/// hand-rolled recursive walkers use (`rewrite_expr`, `fold_expr`, `erase_expr`,
+/// …). Their presence in a match body means an arm recurses into a child.
+fn has_descent_primitive(body: &str) -> bool {
+    body.contains("walk_expr") || body.contains("walk_stmt")
+        || body.contains("map_children") || body.contains("map_exprs")
+        || body.contains(".visit_expr") || body.contains(".visit_stmt")
+        || body.contains("_expr(") || body.contains("_stmt(")
+}
 
-/// Does the function body enclosing byte `pos` call a canonical-walk primitive?
-fn enclosing_fn_delegates(src: &str, b: &[u8], pos: usize) -> bool {
-    // Find the innermost `fn …(…) … { … }` whose body brackets `pos`.
-    let mut best: Option<(usize, usize)> = None;
+/// Name of the innermost `fn …` whose body brackets byte `pos`. Used to detect a
+/// self-recursive walker (e.g. `rewrite_calls`) whose name does not match the
+/// `*_expr`/`*_stmt` convention.
+fn enclosing_fn_name(src: &str, b: &[u8], pos: usize) -> Option<String> {
+    let mut best: Option<(usize, usize, String)> = None;
     let mut search = 0;
     while let Some(rel) = src[search..].find("fn ") {
         let f = search + rel;
         search = f + 3;
-        let before_ok = f == 0 || !is_ident_byte(b[f - 1]);
-        if !before_ok { continue; }
-        // Body opens at the first `{` after the signature's `)` (skip `where`…).
-        let mut j = f + 3;
+        if !(f == 0 || !is_ident_byte(b[f - 1])) { continue; }
+        // Capture the function name (identifier right after `fn `).
+        let mut n = f + 3;
+        while n < b.len() && b[n] == b' ' { n += 1; }
+        let name_start = n;
+        while n < b.len() && is_ident_byte(b[n]) { n += 1; }
+        let name = src[name_start..n].to_string();
+        // Body opens at the first top-level `{` after the signature's `)`.
+        let mut j = n;
         let mut paren = 0i32;
         let mut seen_params = false;
         let mut body_open = None;
@@ -221,7 +234,7 @@ fn enclosing_fn_delegates(src: &str, b: &[u8], pos: usize) -> bool {
                 b'(' => { paren += 1; seen_params = true; }
                 b')' => paren -= 1,
                 b'{' if paren == 0 && seen_params => { body_open = Some(j); break; }
-                b';' if paren == 0 => break, // fn-type / trait decl, no body
+                b';' if paren == 0 => break,
                 _ => {}
             }
             j += 1;
@@ -239,18 +252,11 @@ fn enclosing_fn_delegates(src: &str, b: &[u8], pos: usize) -> bool {
             k += 1;
         }
         let Some(bc) = body_close else { continue };
-        if bo < pos && pos < bc {
-            // innermost = smallest containing range
-            if best.map_or(true, |(s, e)| bo > s || bc < e) {
-                best = Some((bo, bc));
-            }
+        if bo < pos && pos < bc && best.as_ref().map_or(true, |(s, e, _)| bo > *s || bc < *e) {
+            best = Some((bo, bc, name));
         }
     }
-    if let Some((s, e)) = best {
-        let body = &src[s..e];
-        return DELEGATIONS.iter().any(|d| body.contains(d));
-    }
-    false
+    best.map(|(_, _, name)| name)
 }
 
 fn scan_arms(src: &str, b: &[u8], open: usize, close: usize, out: &mut Vec<Violation>) {

--- a/tests/traversal_totality_lint.rs
+++ b/tests/traversal_totality_lint.rs
@@ -35,7 +35,6 @@ const LEGACY_DEBT: &[&str] = &[
     "crates/almide-codegen/src/pass_clone.rs",
     "crates/almide-codegen/src/pass_closure_conversion.rs",
     "crates/almide-codegen/src/pass_concretize_types.rs",
-    "crates/almide-codegen/src/pass_const_fold.rs",
     "crates/almide-codegen/src/pass_effect_inference.rs",
     "crates/almide-codegen/src/pass_fan_lowering.rs",
     "crates/almide-codegen/src/pass_lambda_type_resolve.rs",


### PR DESCRIPTION
Pays down two more `LEGACY_DEBT` entries from the traversal-totality ratchet (#348), and sharpens the lint that guards it. Follows #349 (MatchSubject pilot).

## Migrations

- **ConstFold** → a stateful `IrMutVisitor`. The hand-rolled `rewrite_expr`/`rewrite_stmt` (recursion ending in `_ => {}`) becomes `visit_expr_mut`: `walk_expr_mut(self, expr)` (descend every child via the exhaustive primitive) then fold this node; a `changed: bool` field preserves the pass's fix-point signal. Now folds inside `List`/`Record`/`RuntimeCall`/wrapper positions the old `_ => {}` skipped — semantics-preserving.
- **BuiltinLowering** → the **by-value recipe**: the recursion catch-all that previously read `other => other` (dropping the children of un-listed kinds — `TailCall`/`RcWrap`/`ToVec`/`BoxNew`, plus stmt exprs) now reconstructs the node and recurses via `IrExpr::map_children` / `IrStmt::map_exprs`. The explicitly-handled arms (assert/println/`Type.method` → macro) are untouched; only the silent default is fixed.

## Lint sharpened

A `match … .kind { … }` is treated as a *recursion* match — and its silent catch-all flagged — only when an arm actually descends into a child: a **descent primitive** (`walk_*`/`map_children`/`map_exprs`/`*_expr(`/`*_stmt(`/`.visit_*`) **or** a **self-call** to the enclosing recursive walker (catches `rewrite_calls`-style names). This removes false positives on *decision* matches (a literal re-typer like `coerce_macro_arg`, a binding collector like `free_vars`' inner `match &stmt.kind`) while still catching every real recursion drop. `LEGACY_DEBT` stays exact (no over-grandfathering).

## Verification (both pure refactors / surgical — behavior preserved)

- ConstFold: `1 + 2 * 3` → `7`; nanopass + snapshot tests unchanged.
- BuiltinLowering: `assert_eq!`/`println!` still emitted; programs run native; spec stdlib (99) + lang (114) green.
- Traversal lint green with both files delisted (26 → 24); positive control intact.
- `cargo test` green.

## Next

Remaining `LEGACY_DEBT` (24) per `docs/roadmap/active/codegen-traversal-totality.md`: the by-value recipe extends to `auto_parallel`; the context-threading HIGH-tier passes (`capture_clone`, `clone`, `borrow_inference`, `stdlib_lowering`, `perceus`) maintain a binder/scope/count stack across `visit_*_mut` (the `free_vars` pattern, mutable); `peephole` needs its stmt-sequence analysis kept while the expr recursion moves to `walk_expr_mut`.