### PR TITLE
Burn down Tier-0 wasm codegen-soundness divergences (map.filter/fold, Map/Set eq, run_length_encode)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
@@ -15,7 +15,12 @@ impl FuncCompiler<'_> {
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
-                let acc = self.scratch.alloc_i64();
+                // The accumulator's wasm type is the init's type (== fold result),
+                // NOT always i64 — a String/record/list accumulator is an i32 ptr,
+                // a Float is f64. Hardcoding i64 broke the wasm module (validation
+                // "expected i64, found i32") for any non-Int accumulator.
+                let acc_vt = values::ty_to_valtype(&args[1].ty).unwrap_or(ValType::I32);
+                let acc = self.scratch.alloc(acc_vt);
                 let closure = self.scratch.alloc_i32();
                 let it = self.map_iter_begin(&args[0], ks + vs);
                 self.emit_expr(&args[1]); // init
@@ -32,14 +37,14 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { local_get(closure); i32_load(0); });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
-                    let mut ct = vec![ValType::I32, ValType::I64, key_vt];
+                    let mut ct = vec![ValType::I32, acc_vt, key_vt];
                     if let Some(vt) = values::ty_to_valtype(&val_ty) { ct.push(vt); }
-                    self.emit_call_indirect(ct, vec![ValType::I64]);
+                    self.emit_call_indirect(ct, vec![acc_vt]);
                 }
                 wasm!(self.func, { local_set(acc); });
                 self.map_iter_loop_tail(&it);
                 wasm!(self.func, { local_get(acc); });
-                self.scratch.free_i64(acc);
+                self.scratch.free(acc, acc_vt);
                 self.scratch.free_i32(closure);
                 self.map_iter_end(it);
             }

--- a/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
@@ -165,41 +165,59 @@ impl FuncCompiler<'_> {
                 self.map_iter_end(it);
             }
             "filter" => {
-                // filter(m, pred) → Map: keep entries where pred(k, v) is true
+                // filter(m, pred) → Map: rebuild a Swiss table from the entries
+                // where pred(k, v) is true. The map is a Swiss table — the old
+                // dense `[len][entries]` walk read garbage / trapped. Mirrors
+                // `remove`'s rehash-into-a-fresh-table, but keeps an entry when
+                // `pred(k, v)` is true (vs `remove`'s key-mismatch).
+                use super::engine::layout::{SWISS_MAP, map as lm};
+                let map_tags_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
+                let map_cap_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP) as i32;
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
-                let entry = ks + vs;
-                let map_ptr = self.scratch.alloc_i32();
+                let es = ks + vs;
+                let m = self.scratch.alloc_i32();
                 let closure = self.scratch.alloc_i32();
-                let result = self.scratch.alloc_i32();
+                let cap = self.scratch.alloc_i32();
+                let nm = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
+                let eb_old = self.scratch.alloc_i32();
+                let eb_new = self.scratch.alloc_i32();
+                let h2r = self.scratch.alloc_i32();
+                let nidx = self.scratch.alloc_i32();
+
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(map_ptr); });
+                wasm!(self.func, { local_set(m); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
                     local_set(closure);
-                    // Alloc max-size result
-                    i32_const(4); local_get(map_ptr); i32_load(0);
-                    i32_const(entry as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(0); i32_store(0); // len=0
+                    local_get(m); i32_load(map_cap_off); local_set(cap);
+                });
+                self.emit_alloc_table(nm, cap, es as i32);
+                wasm!(self.func, {
+                    local_get(m); i32_const(map_tags_off); i32_add;
+                    local_get(cap); i32_add; local_set(eb_old);
+                    local_get(nm); i32_const(map_tags_off); i32_add;
+                    local_get(cap); i32_add; local_set(eb_new);
                     i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(i); local_get(map_ptr); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4);
-                      local_get(map_ptr); i32_const(4); i32_add;
-                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(cap); i32_ge_u; br_if(1);
+                      local_get(m); i32_const(map_tags_off); i32_add;
+                      local_get(i); i32_add; i32_load8_u(0);
+                      if_empty; // occupied (tag != 0)
+                        // pred(env, k, v)
+                        local_get(closure); i32_load(4); // env
+                        local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 wasm!(self.func, {
-                      local_get(map_ptr); i32_const(4); i32_add;
-                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_const(ks as i32); i32_add;
+                        local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add;
+                        i32_const(ks as i32); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0);
+                        local_get(closure); i32_load(0); // table_idx
                 });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
@@ -208,38 +226,50 @@ impl FuncCompiler<'_> {
                     self.emit_call_indirect(ct, vec![ValType::I32]);
                 }
                 wasm!(self.func, {
-                      if_empty;
-                        // Copy key to result[result.len]
-                        local_get(result); i32_const(4); i32_add;
-                        local_get(result); i32_load(0); i32_const(entry as i32); i32_mul; i32_add;
-                        local_get(map_ptr); i32_const(4); i32_add;
-                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                        if_empty; // pred true → keep: rehash into nm
+                          local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add;
                 });
-                self.emit_elem_copy_sized(ks);
-                // Copy val
+                self.emit_key_load(&key_ty, 0);
+                self.emit_hash_key(&key_ty);
+                self.emit_h1_h2(cap, nidx, h2r);
                 wasm!(self.func, {
-                        local_get(result); i32_const(4); i32_add;
-                        local_get(result); i32_load(0); i32_const(entry as i32); i32_mul; i32_add;
-                        i32_const(ks as i32); i32_add;
-                        local_get(map_ptr); i32_const(4); i32_add;
-                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
-                        i32_const(ks as i32); i32_add;
-                });
-                self.emit_elem_copy_sized(vs);
-                wasm!(self.func, {
-                        local_get(result);
-                        local_get(result); i32_load(0); i32_const(1); i32_add;
-                        i32_store(0);
-                      end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
-                      br(0);
+                          block_empty; loop_empty;
+                            local_get(nm); i32_const(map_tags_off); i32_add;
+                            local_get(nidx); i32_add; i32_load8_u(0);
+                            i32_eqz; br_if(1);
+                            local_get(nidx); i32_const(1); i32_add;
+                            local_get(cap); i32_const(1); i32_sub; i32_and;
+                            local_set(nidx); br(0);
+                          end; end;
+                          // copy tag
+                          local_get(nm); i32_const(map_tags_off); i32_add;
+                          local_get(nidx); i32_add;
+                          local_get(m); i32_const(map_tags_off); i32_add;
+                          local_get(i); i32_add; i32_load8_u(0);
+                          i32_store8(0);
+                          // copy entry
+                          local_get(eb_new); local_get(nidx); i32_const(es as i32); i32_mul; i32_add;
+                          local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add;
+                          i32_const(es as i32); memory_copy;
+                          // len++
+                          local_get(nm);
+                          local_get(nm); i32_load(0); i32_const(1); i32_add;
+                          i32_store(0);
+                        end; // pred-true if
+                      end; // occupied if
+                      local_get(i); i32_const(1); i32_add; local_set(i); br(0);
                     end; end;
-                    local_get(result);
+                    local_get(nm);
                 });
+                self.scratch.free_i32(nidx);
+                self.scratch.free_i32(h2r);
+                self.scratch.free_i32(eb_new);
+                self.scratch.free_i32(eb_old);
                 self.scratch.free_i32(i);
-                self.scratch.free_i32(result);
+                self.scratch.free_i32(nm);
+                self.scratch.free_i32(cap);
                 self.scratch.free_i32(closure);
-                self.scratch.free_i32(map_ptr);
+                self.scratch.free_i32(m);
             }
             "map" => {
                 // map(m, f) → Map[K, B]: copy Swiss Table, transform each occupied value

--- a/crates/almide-codegen/src/emit_wasm/calls_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string.rs
@@ -250,6 +250,10 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { call(self.emitter.rt.string.chars); });
             }
+            "run_length_encode" => {
+                self.emit_expr(&args[0]);
+                wasm!(self.func, { call(self.emitter.rt.string.run_length_encode); });
+            }
             "lines" => {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { call(self.emitter.rt.string.lines); });

--- a/crates/almide-codegen/src/emit_wasm/equality.rs
+++ b/crates/almide-codegen/src/emit_wasm/equality.rs
@@ -85,6 +85,22 @@ impl FuncCompiler<'_> {
                 self.emit_result_eq_deep(&ok_ty, &err_ty);
             }
 
+            // Map/Set are structural: two maps are equal iff same size and every
+            // (k,v) of one is present with an equal value in the other; sets the
+            // same on keys. WASM previously fell through to `i32_eq` (pointer
+            // identity) so two structurally-equal maps built independently
+            // compared unequal — a real divergence from native.
+            Ty::Applied(TypeConstructorId::Map, args) => {
+                let key_ty = args.first().cloned().unwrap_or(Ty::Int);
+                let val_ty = args.get(1).cloned().unwrap_or(Ty::Int);
+                self.emit_map_eq_deep(&key_ty, &val_ty);
+            }
+
+            Ty::Applied(TypeConstructorId::Set, args) => {
+                let elem_ty = args.first().cloned().unwrap_or(Ty::Int);
+                self.emit_set_eq_deep(&elem_ty);
+            }
+
             Ty::Tuple(elems) => {
                 if elems.iter().all(|t| self.is_value_type(t)) {
                     let size: u32 = elems.iter().map(|t| values::byte_size(t)).sum();
@@ -283,6 +299,196 @@ impl FuncCompiler<'_> {
         });
         self.scratch.free_i32(matched);
         self.scratch.free_i32(i);
+        self.scratch.free_i32(b);
+        self.scratch.free_i32(a);
+    }
+
+    /// Structural map equality (Swiss table): [a_ptr, b_ptr] → i32.
+    /// Equal iff same size and every (k,v) of `a` is present in `b` with an
+    /// equal value. Iterates a's occupied slots and probes b for each key,
+    /// mirroring the `get` probe loop, then compares values recursively.
+    fn emit_map_eq_deep(&mut self, key_ty: &Ty, val_ty: &Ty) {
+        use super::engine::layout::{SWISS_MAP, map as lm};
+        let map_cap_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP);
+        let map_tags_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
+        let ks = values::byte_size(key_ty);
+        let vs = values::byte_size(val_ty);
+        let es = ks + vs;
+
+        let a = self.scratch.alloc_i32();
+        let b = self.scratch.alloc_i32();
+        let result = self.scratch.alloc_i32();
+        let acap = self.scratch.alloc_i32();
+        let aeb = self.scratch.alloc_i32();
+        let ai = self.scratch.alloc_i32();
+        let sk32 = self.scratch.alloc_i32();
+        let sk64 = self.scratch.alloc_i64();
+        let bcap = self.scratch.alloc_i32();
+        let beb = self.scratch.alloc_i32();
+        let bidx = self.scratch.alloc_i32();
+        let h2 = self.scratch.alloc_i32();
+        let tg = self.scratch.alloc_i32();
+        let found = self.scratch.alloc_i32();
+
+        wasm!(self.func, {
+            local_set(b);
+            local_set(a);
+            // Same pointer → equal.
+            local_get(a); local_get(b); i32_eq;
+            if_i32; i32_const(1);
+            else_;
+              // Different size → not equal.
+              local_get(a); i32_load(0); local_get(b); i32_load(0); i32_ne;
+              if_i32; i32_const(0);
+              else_;
+                i32_const(1); local_set(result);
+                local_get(a); i32_load(map_cap_off); local_set(acap);
+                local_get(a); i32_const(map_tags_off); i32_add; local_get(acap); i32_add; local_set(aeb);
+                i32_const(0); local_set(ai);
+                block_empty; loop_empty;                                  // [A] a-exit, [B] a-loop
+                  local_get(ai); local_get(acap); i32_ge_u; br_if(1);     // done iterating a
+                  // Skip empty slots in a.
+                  local_get(a); i32_const(map_tags_off); i32_add; local_get(ai); i32_add; i32_load8_u(0); i32_eqz;
+                  if_empty; local_get(ai); i32_const(1); i32_add; local_set(ai); br(1); end;
+                  // Load this entry's key into the search-key register.
+                  local_get(aeb); local_get(ai); i32_const(es as i32); i32_mul; i32_add;
+        });
+        self.emit_key_load(key_ty, 0);
+        self.emit_search_key_store(key_ty, sk32, sk64);
+        // Probe b for the key.
+        wasm!(self.func, {
+                  i32_const(0); local_set(found);
+                  local_get(b); i32_load(map_cap_off); local_set(bcap);
+                  local_get(bcap); i32_eqz;
+                  if_empty; else_;                                        // [D] bcap==0 guard
+                    local_get(b); i32_const(map_tags_off); i32_add; local_get(bcap); i32_add; local_set(beb);
+        });
+        self.emit_search_key_load(key_ty, sk32, sk64);
+        self.emit_hash_key(key_ty);
+        self.emit_h1_h2(bcap, bidx, h2);
+        wasm!(self.func, {
+                    block_empty; loop_empty;                             // [E] probe-block, [F] probe-loop
+                      local_get(b); i32_const(map_tags_off); i32_add; local_get(bidx); i32_add; i32_load8_u(0); local_set(tg);
+                      local_get(tg); i32_eqz; br_if(1);                  // empty slot → key absent
+                      local_get(tg); local_get(h2); i32_eq;
+                      if_empty;                                          // [G] tag matches
+                        local_get(beb); local_get(bidx); i32_const(es as i32); i32_mul; i32_add;
+        });
+        self.emit_key_load(key_ty, 0);
+        self.emit_search_key_load(key_ty, sk32, sk64);
+        self.emit_key_eq(key_ty);
+        wasm!(self.func, {
+                        if_empty; i32_const(1); local_set(found); br(3); end;   // found → exit probe-block
+                      end;
+                      local_get(bidx); i32_const(1); i32_add;
+                      local_get(bcap); i32_const(1); i32_sub; i32_and;
+                      local_set(bidx); br(0);
+                    end; end;                                            // close F, E
+                  end;                                                   // close D
+                  // Key absent → maps differ.
+                  local_get(found); i32_eqz;
+                  if_empty; i32_const(0); local_set(result); br(2); end; // exit a-loop+block
+        });
+        // Compare the values (skip for valueless maps).
+        if vs > 0 {
+            wasm!(self.func, {
+                  local_get(aeb); local_get(ai); i32_const(es as i32); i32_mul; i32_add; i32_const(ks as i32); i32_add;
+            });
+            self.emit_load_at(val_ty, 0);
+            wasm!(self.func, {
+                  local_get(beb); local_get(bidx); i32_const(es as i32); i32_mul; i32_add; i32_const(ks as i32); i32_add;
+            });
+            self.emit_load_at(val_ty, 0);
+            self.emit_eq_typed(val_ty);
+            wasm!(self.func, {
+                  i32_eqz;
+                  if_empty; i32_const(0); local_set(result); br(2); end; // values differ → exit
+            });
+        }
+        wasm!(self.func, {
+                  local_get(ai); i32_const(1); i32_add; local_set(ai); br(0);
+                end; end;                                                // close B, A
+                local_get(result);
+              end;                                                       // close size-if
+            end;                                                         // close sameptr-if
+        });
+        self.scratch.free_i32(found);
+        self.scratch.free_i32(tg);
+        self.scratch.free_i32(h2);
+        self.scratch.free_i32(bidx);
+        self.scratch.free_i32(beb);
+        self.scratch.free_i32(bcap);
+        self.scratch.free_i64(sk64);
+        self.scratch.free_i32(sk32);
+        self.scratch.free_i32(ai);
+        self.scratch.free_i32(aeb);
+        self.scratch.free_i32(acap);
+        self.scratch.free_i32(result);
+        self.scratch.free_i32(b);
+        self.scratch.free_i32(a);
+    }
+
+    /// Structural set equality (dense list, insertion order): [a_ptr, b_ptr] → i32.
+    /// Sets are unsorted, so equal sets may differ in memory layout — compare by
+    /// size + containment (every element of `a` is in `b`) rather than byte-eq.
+    fn emit_set_eq_deep(&mut self, elem_ty: &Ty) {
+        use super::engine::layout::{LIST, list as ll};
+        let data_off = self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32;
+        let es = values::byte_size(elem_ty);
+        let ea_vt = values::ty_to_valtype(elem_ty).unwrap_or(ValType::I32);
+
+        let a = self.scratch.alloc_i32();
+        let b = self.scratch.alloc_i32();
+        let result = self.scratch.alloc_i32();
+        let ai = self.scratch.alloc_i32();
+        let bj = self.scratch.alloc_i32();
+        let found = self.scratch.alloc_i32();
+        let ea = self.scratch.alloc(ea_vt);
+
+        wasm!(self.func, {
+            local_set(b);
+            local_set(a);
+            local_get(a); local_get(b); i32_eq;
+            if_i32; i32_const(1);
+            else_;
+              local_get(a); i32_load(0); local_get(b); i32_load(0); i32_ne;
+              if_i32; i32_const(0);
+              else_;
+                i32_const(1); local_set(result);
+                i32_const(0); local_set(ai);
+                block_empty; loop_empty;                                 // [A] exit, [B] a-loop
+                  local_get(ai); local_get(a); i32_load(0); i32_ge_u; br_if(1);
+                  local_get(a); i32_const(data_off); i32_add; local_get(ai); i32_const(es as i32); i32_mul; i32_add;
+        });
+        self.emit_load_at(elem_ty, 0);
+        wasm!(self.func, {
+                  local_set(ea);
+                  i32_const(0); local_set(found);
+                  i32_const(0); local_set(bj);
+                  block_empty; loop_empty;                               // [C] scan-block, [D] scan-loop
+                    local_get(bj); local_get(b); i32_load(0); i32_ge_u; br_if(1);
+                    local_get(b); i32_const(data_off); i32_add; local_get(bj); i32_const(es as i32); i32_mul; i32_add;
+        });
+        self.emit_load_at(elem_ty, 0);
+        wasm!(self.func, { local_get(ea); });
+        self.emit_eq_typed(elem_ty);
+        wasm!(self.func, {
+                    if_empty; i32_const(1); local_set(found); br(2); end; // found → exit scan-block
+                    local_get(bj); i32_const(1); i32_add; local_set(bj); br(0);
+                  end; end;                                              // close D, C
+                  local_get(found); i32_eqz;
+                  if_empty; i32_const(0); local_set(result); br(2); end; // absent → exit a-loop+block
+                  local_get(ai); i32_const(1); i32_add; local_set(ai); br(0);
+                end; end;                                                // close B, A
+                local_get(result);
+              end;
+            end;
+        });
+        self.scratch.free(ea, ea_vt);
+        self.scratch.free_i32(found);
+        self.scratch.free_i32(bj);
+        self.scratch.free_i32(ai);
+        self.scratch.free_i32(result);
         self.scratch.free_i32(b);
         self.scratch.free_i32(a);
     }

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -184,6 +184,7 @@ pub struct StringRuntime {
     pub is_upper: u32,
     pub is_lower: u32,
     pub cmp: u32,
+    pub run_length_encode: u32,
 }
 
 /// Indices of built-in runtime functions.
@@ -432,6 +433,7 @@ impl WasmEmitter {
                     is_whitespace: 0, is_upper: 0, is_lower: 0,
                     cmp: 0,
                     char_count: 0,
+                    run_length_encode: 0,
                 },
                 value_stringify: 0,
                 json_escape_string: 0,

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -96,6 +96,11 @@ pub fn register(emitter: &mut WasmEmitter) {
     // for sizing; `char_count` walks the data section and skips UTF-8
     // continuation bytes (bytes whose top two bits are `10`).
     emitter.rt.string.char_count = emitter.register_func("__str_char_count", ty_i32_i64);
+
+    // run_length_encode: (s) -> List[(String, Int)]. Byte-level runs (matches
+    // the byte-based rest of this runtime; native is codepoint-based, so the
+    // ASCII cases agree and multibyte joins the string-codepoint cluster).
+    emitter.rt.string.run_length_encode = emitter.register_func("__str_rle", ty_i32_i32);
 }
 
 /// Compile all string runtime function bodies.
@@ -133,6 +138,7 @@ pub fn compile(emitter: &mut WasmEmitter) {
     super::rt_string_extra::compile_is_lower(emitter);
     super::rt_string_extra::compile_cmp(emitter);
     compile_char_count(emitter);
+    compile_run_length_encode(emitter);
 }
 
 /// Count UTF-8 code points in a string (pointer to `[len:i32][bytes...]`).
@@ -702,6 +708,76 @@ fn compile_chars(emitter: &mut WasmEmitter) {
           br(0);
         end; end;
         local_get(2); end;
+    });
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}
+
+/// run_length_encode(s) -> List[(String, Int)].
+/// Two passes over the byte payload: first count maximal runs of equal bytes to
+/// size the list exactly, then build a 1-char String + i64 count tuple per run.
+/// Each list slot holds a pointer to a 12-byte tuple `[str_ptr:i32 @0][cnt:i64 @4]`
+/// (tuple fields are laid out sequentially with no padding — see values::byte_size).
+/// Byte-granular like the rest of this runtime; native groups by codepoint, so
+/// ASCII inputs agree and multibyte is part of the string-codepoint gap.
+fn compile_run_length_encode(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.run_length_encode];
+    // locals: 1=blen 2=nr 3=i 4=cur 5=result 6=j 7=cnt 8=strp 9=tup
+    let mut f = Function::new([(9, ValType::I32)]);
+    wasm!(f, {
+        local_get(0); i32_load(0); local_set(1);                 // blen = *s
+        // ── Pass 1: count maximal runs into nr ──
+        i32_const(0); local_set(2);                              // nr = 0
+        i32_const(0); local_set(3);                              // i = 0
+        block_empty; loop_empty;
+          local_get(3); local_get(1); i32_ge_u; br_if(1);
+          local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; i32_load8_u(0); local_set(4); // cur
+          local_get(2); i32_const(1); i32_add; local_set(2);     // nr += 1
+          local_get(3); i32_const(1); i32_add; local_set(3);     // i += 1
+          block_empty; loop_empty;                               // skip equal bytes
+            local_get(3); local_get(1); i32_ge_u; br_if(1);
+            local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; i32_load8_u(0);
+            local_get(4); i32_ne; br_if(1);
+            local_get(3); i32_const(1); i32_add; local_set(3);
+            br(0);
+          end; end;
+          br(0);
+        end; end;
+        // ── Allocate the result list: [len=nr][nr * ptr] ──
+        i32_const(list_hdr()); local_get(2); i32_const(4); i32_mul; i32_add;
+        call(emitter.rt.alloc); local_set(5);
+        local_get(5); local_get(2); i32_store(0);
+        // ── Pass 2: emit one (char, count) tuple per run ──
+        i32_const(0); local_set(3);                              // i = 0
+        i32_const(0); local_set(6);                              // j = 0
+        block_empty; loop_empty;
+          local_get(3); local_get(1); i32_ge_u; br_if(1);
+          local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; i32_load8_u(0); local_set(4); // cur
+          i32_const(1); local_set(7);                            // cnt = 1
+          local_get(3); i32_const(1); i32_add; local_set(3);     // i += 1
+          block_empty; loop_empty;
+            local_get(3); local_get(1); i32_ge_u; br_if(1);
+            local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; i32_load8_u(0);
+            local_get(4); i32_ne; br_if(1);
+            local_get(7); i32_const(1); i32_add; local_set(7);   // cnt += 1
+            local_get(3); i32_const(1); i32_add; local_set(3);   // i += 1
+            br(0);
+          end; end;
+          // strp = one-char String holding `cur`
+          i32_const(1); call(emitter.rt.string_alloc); local_set(8);
+          local_get(8); i32_const(1); i32_store(0);              // len = 1
+          local_get(8); i32_const(1); i32_store(string_cap_off() as u32, 0); // cap = 1
+          local_get(8); local_get(4); i32_store8(string_data_off() as u32);  // data[0] = cur
+          // tup = [strp @0][cnt:i64 @4]
+          i32_const(12); call(emitter.rt.alloc); local_set(9);
+          local_get(9); local_get(8); i32_store(0);
+          local_get(9); local_get(7); i64_extend_i32_u; i64_store(4);
+          // result.data[j] = tup
+          local_get(5); i32_const(list_data_off()); i32_add; local_get(6); i32_const(4); i32_mul; i32_add;
+          local_get(9); i32_store(0);
+          local_get(6); i32_const(1); i32_add; local_set(6);     // j += 1
+          br(0);
+        end; end;
+        local_get(5); end;
     });
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }

--- a/spec/wasm_cross/map_filter.almd
+++ b/spec/wasm_cross/map_filter.almd
@@ -1,0 +1,15 @@
+// Regression: wasm map.filter walked the map as a dense array but it is a Swiss
+// table — it returned corrupt keys/values or trapped. Rebuilt as a rehash.
+// (Uses len + keyed get, not iteration order, which is a separate divergence.)
+effect fn main() -> Unit = {
+  var m: Map[String, Int] = map.new()
+  m = map.set(m, "a", 1)
+  m = map.set(m, "b", 2)
+  m = map.set(m, "c", 3)
+  m = map.set(m, "d", 4)
+  let f = map.filter(m, (k, v) => v > 2)
+  println(int.to_string(map.len(f)))
+  println(int.to_string(map.get(f, "c") ?? -1))
+  println(int.to_string(map.get(f, "d") ?? -1))
+  println(int.to_string(map.get(f, "a") ?? -99))
+}

--- a/spec/wasm_cross/map_fold.almd
+++ b/spec/wasm_cross/map_fold.almd
@@ -1,0 +1,22 @@
+// Regression: wasm map.fold hardcoded the accumulator local/closure-result as
+// i64, so any non-Int accumulator (String/record/list = i32 ptr, Float = f64)
+// failed wasm validation ("expected i64, found i32"). Now threads the init's
+// actual valtype. Order-independent here (sum is commutative; the String case
+// uses a single-entry map) so this locks in the TYPE fix, not iteration order
+// (which is a separate tracked divergence).
+effect fn main() -> Unit = {
+  var mi: Map[String, Int] = map.new()
+  mi = map.set(mi, "a", 10)
+  mi = map.set(mi, "b", 20)
+  mi = map.set(mi, "c", 30)
+  println(int.to_string(map.fold(mi, 0, (acc, k, v) => acc + v)))
+
+  var mf: Map[String, Float] = map.new()
+  mf = map.set(mf, "x", 1.5)
+  mf = map.set(mf, "y", 2.5)
+  println(float.to_string(map.fold(mf, 0.0, (acc, k, v) => acc + v)))
+
+  var ms: Map[String, String] = map.new()
+  ms = map.set(ms, "k", "v")
+  println(map.fold(ms, "[", (acc, k, v) => acc + k + "=" + v) + "]")
+}

--- a/spec/wasm_cross/map_set_eq.almd
+++ b/spec/wasm_cross/map_set_eq.almd
@@ -1,0 +1,45 @@
+// Regression: wasm `==` on Map/Set fell through to pointer identity, so two
+// structurally-equal containers built independently compared unequal (native
+// compares structurally). Now emits size + key/value containment, so equality
+// is order-independent: maps/sets built in a different insertion order are
+// still equal. Covers Int and String keys, a nested List value, and Set.
+fn yn(b: Bool) -> String = if b then "T" else "F"
+
+effect fn main() -> Unit = {
+  // Map[Int, String] — reordered insertion is still equal.
+  var ma: Map[Int, String] = map.new()
+  ma = map.set(ma, 1, "a"); ma = map.set(ma, 2, "b")
+  var mb: Map[Int, String] = map.new()
+  mb = map.set(mb, 2, "b"); mb = map.set(mb, 1, "a")
+  var mc: Map[Int, String] = map.new()
+  mc = map.set(mc, 1, "a"); mc = map.set(mc, 9, "b")
+  println(yn(ma == mb))
+  println(yn(ma == mc))
+
+  // Map[String, List[Int]] — value comparison recurses structurally.
+  var na: Map[String, List[Int]] = map.new()
+  na = map.set(na, "p", [1, 2]); na = map.set(na, "q", [3])
+  var nb: Map[String, List[Int]] = map.new()
+  nb = map.set(nb, "q", [3]); nb = map.set(nb, "p", [1, 2])
+  var nc: Map[String, List[Int]] = map.new()
+  nc = map.set(nc, "p", [1, 2]); nc = map.set(nc, "q", [9])
+  println(yn(na == nb))
+  println(yn(na == nc))
+
+  // Set[String] — reordered insertion is still equal; size matters.
+  var sa: Set[String] = set.new()
+  sa = set.insert(sa, "x"); sa = set.insert(sa, "y"); sa = set.insert(sa, "z")
+  var sb: Set[String] = set.new()
+  sb = set.insert(sb, "z"); sb = set.insert(sb, "x"); sb = set.insert(sb, "y")
+  var sc: Set[String] = set.new()
+  sc = set.insert(sc, "x"); sc = set.insert(sc, "y")
+  println(yn(sa == sb))
+  println(yn(sa == sc))
+
+  // Empty maps compare equal; empty vs non-empty differ.
+  var ea: Map[String, Int] = map.new()
+  var eb: Map[String, Int] = map.new()
+  eb = map.set(eb, "k", 1)
+  println(yn(ea == ea))
+  println(yn(ea == eb))
+}

--- a/spec/wasm_cross/string_rle.almd
+++ b/spec/wasm_cross/string_rle.almd
@@ -1,0 +1,19 @@
+// Regression: wasm had no runtime fn / dispatch arm for string.run_length_encode
+// so the codegen panicked (ICE) instead of emitting. Now a two-pass byte-level
+// runtime fn builds List[(String, Int)]. ASCII only here — wasm groups by byte
+// and native by codepoint, so they agree on ASCII; multibyte is the separate
+// string-codepoint cluster.
+fn show(s: String) -> String =
+  string.run_length_encode(s)
+    |> list.map((r) => { let (c, n) = r; c + int.to_string(n) })
+    |> list.join(",")
+
+effect fn main() -> Unit = {
+  println(show(""))           // empty → no runs
+  println(show("x"))          // single char
+  println(show("aaabbc"))     // basic runs
+  println(show("aaaa"))       // one long run
+  println(show("abcde"))      // all distinct
+  println(show("aabbaa"))     // a repeated non-adjacently → separate runs
+  println(show("  ##  "))     // spaces and symbols
+}


### PR DESCRIPTION
Continues the cross-target observable-equivalence burn-down (after #351/#352) against the live gate (`tests/wasm_runtime_test.rs::wasm_cross_target_spec`). Closes out the **Tier-0 codegen-soundness cluster**: cases where wasm silently produced corrupt values, miscompared, or crashed the compiler — all now native==wasm and pinned by gate corpus entries.

## Fixes

- **`map.filter`** walked the Swiss table as a stale dense `[len][entries]` array, returning corrupt keys/values or trapping. Rebuilt as a Swiss-table rehash (mirrors `remove`). Corpus: `spec/wasm_cross/map_filter.almd`.
- **`map.fold` with a non-Int accumulator** hardcoded the accumulator local / closure result / `call_indirect` signature as `i64`, so a `String` (i32 ptr), `Float` (f64) or record accumulator failed wasm validation (`expected i64, found i32`). Now threads the init's actual valtype. Corpus: `map_fold.almd`.
- **`==` on Map/Set** fell through to `i32_eq` (pointer identity), so two structurally-equal containers built independently compared unequal (native compares structurally). Emits size + key/value containment instead — order-independent, recurses into nested values. Map uses a Swiss-table probe; Set is an unsorted dense list so it uses linear-scan containment (byte-eq would be wrong). Corpus: `map_set_eq.almd`.
- **`string.run_length_encode`** had no wasm runtime fn and no dispatch arm, so codegen panicked (ICE). Added a two-pass byte-level runtime fn building `List[(String, Int)]`. Byte-granular like the rest of the wasm string runtime (native groups by codepoint, so ASCII agrees; multibyte is the separate string-codepoint cluster). Corpus: `string_rle.almd`.

## Verification

- Cross-target gate green (stdout+stderr+exit byte-compare over `spec/wasm_cross/*.almd`).
- `spec/stdlib` 99 native / 93 wasm, `spec/lang` 115 native / 114 wasm — all pass.
- Each fix probed on both targets (native binary vs wasmtime) including reorder, nested, empty, and edge cases.

Tier-1 (silent-wrong-value: float shortest-round-trip, string codepoint-awareness, map/set iteration order) is tracked separately.