### PR TITLE
Closure-repr convergence hygiene: drop dead templates, supersede stale wasm milestone doc

### DIFF
--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -255,12 +255,6 @@ template = "HashMap<{key}, {value}>"
 [type_set]
 template = "std::collections::HashSet<{inner}>"
 
-[type_fn]
-template = "impl Fn({params}) -> {return} + Clone"
-
-[type_fn_boxed]
-template = "Box<dyn Fn({params}) -> {return}>"
-
 # Fn type for struct fields: uses Rc for cloneability
 [type_fn_field]
 template = "std::rc::Rc<dyn Fn({params}) -> {return}>"

--- a/crates/almide-codegen/src/walker/helpers.rs
+++ b/crates/almide-codegen/src/walker/helpers.rs
@@ -127,24 +127,6 @@ pub fn render_type_rc_fn(ctx: &RenderContext, ty: &Ty) -> String {
     render_type_field_fn(ctx, ty)
 }
 
-/// Render a Fn type as Box<dyn Fn(...) -> T> (for nested impl Trait in Rust)
-pub fn render_type_boxed_fn(ctx: &RenderContext, ty: &Ty) -> String {
-    match ty {
-        Ty::Fn { params, ret } => {
-            let params_str = params.iter().map(|p| super::types::render_type(ctx, p)).collect::<Vec<_>>().join(", ");
-            let ret_str = if matches!(ret.as_ref(), Ty::Fn { .. }) {
-                render_type_boxed_fn(ctx, ret)
-            } else {
-                super::types::render_type(ctx, ret)
-            };
-            ctx.templates.render_with("type_fn_boxed", None, &[], &[("params", params_str.as_str()), ("return", ret_str.as_str())])
-                .unwrap_or_else(|| ctx.templates.render_with("type_fn", None, &[], &[("params", params_str.as_str()), ("return", ret_str.as_str())])
-                    .unwrap_or_else(|| "BoxFn".into()))
-        }
-        _ => super::types::render_type(ctx, ty),
-    }
-}
-
 /// Render a `fan.*` thread-thunk's boxed trait-object type:
 /// `Box<dyn Fn(params) -> ret + {bounds}>` (`bounds` = `"Send + Sync"`).
 ///

--- a/docs/roadmap/active/wasm-remaining-15.md
+++ b/docs/roadmap/active/wasm-remaining-15.md
@@ -1,6 +1,8 @@
 # WASM Remaining 15 Skips — Fix Roadmap
 
-> Current: 225/240 pass, 0 fail, 15 skip
+> **SUPERSEDED (2026-06-04)** — the "225/240" below is a historical milestone snapshot, NOT current state. On origin/develop the full `spec/` suite is green on both targets: 241/241 files native, 233/233 wasm-eligible (8 intentional `wasm:skip`), 2807 test cases all passing. Do not cite "225/240" as a current regression — see `docs/roadmap/active/determinism-belt.md` and the closure-repr convergence (uniform `Rc<dyn Fn>`, PR #345, on develop's first-parent mainline).
+>
+> Historical: 225/240 pass, 0 fail, 15 skip
 
 ## Skip Categories
 


### PR DESCRIPTION
Follow-up hygiene from confirming the closure representation is already converged on develop (uniform `Rc<dyn Fn>`, PR #345, on develop's first-parent mainline — verified: all closure spec files green both targets, the `closure_boxed_to_hof` E0277/E0308 divergence is fixed, `git branch -a --no-merged origin/develop` over closure branches is empty).

## Changes

- **Remove dead closure-repr templates + renderer.** `render_type_boxed_fn` (walker/helpers.rs) had no caller but its own self-recursion, and was the sole consumer of the `type_fn` (`impl Fn + Clone`) and `type_fn_boxed` (`Box<dyn Fn>`) templates. With the uniform `Rc<dyn Fn>` repr, every `Ty::Fn` position routes through `render_type_field_fn` → `Rc<dyn Fn>`; the `impl Fn`/`Box<dyn Fn>` renderers are dead. Removing them prevents the repr from accidentally regressing to a mixed `impl-Fn`/`Box`/`Rc` surface (the exact class that caused the old E0277/E0308). The live `render_type_box_fn` (fan thread thunks, `Box<dyn Fn + Send + Sync>`) is unaffected.
- **Mark the stale "225/240" milestone superseded.** `docs/roadmap/active/wasm-remaining-15.md` froze a historical "Current: 225/240 pass" snapshot that reads as a current regression. develop is 241/241 spec files green on both targets (2807 cases). Annotated as superseded to stop the stale figure being re-cited.

## Verification

- `spec/stdlib` 99 native / 93 wasm, `spec/lang` 115 native — green (confirms the removed templates were truly dead: no render-time panic).
- `cargo test --test codegen_snapshot_test` — 13 passed (generated code unchanged).