### PR TITLE
Switch the wasm Map to an insertion-ordered compact-ordered-dict

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_http.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_http.rs
@@ -286,43 +286,38 @@ impl FuncCompiler<'_> {
                     call(self.emitter.rt.alloc); local_set(hdr_list);
                     local_get(hdr_list); local_get(len); i32_store(0);
                 });
-                // Swiss Table iteration: scan occupied slots
+                // Dense COD walk: emit entries[0..len] in insertion order (output index == i).
+                let (ks, vs) = self.map_kv_sizes(&args[2].ty);
+                let es = ks + vs;
+                let list_data_off = self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32;
                 let map_cap = self.scratch.alloc_i32();
                 let map_eb = self.scratch.alloc_i32();
-                let j = self.scratch.alloc_i32(); // output index
                 wasm!(self.func, {
                     local_get(hdr_map); i32_load(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::CAP)); local_set(map_cap);
-                    local_get(hdr_map); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(map_cap); i32_add; local_set(map_eb);
+                });
+                self.emit_dict_entries_base(hdr_map, map_cap);
+                wasm!(self.func, {
+                    local_set(map_eb);
                     i32_const(0); local_set(i);
-                    i32_const(0); local_set(j);
                     block_empty; loop_empty;
-                      local_get(i); local_get(map_cap); i32_ge_u; br_if(1);
-                      local_get(hdr_map); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                      local_get(i); i32_add; i32_load8_u(0); i32_eqz;
-                      if_empty;
-                        local_get(i); i32_const(1); i32_add; local_set(i); br(1);
-                      end;
-                      // Build tuple (key, val) from occupied entry
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(tuple);
-                      // entry = map_eb + i * 8 (entry_size = key(4) + val(4) = 8)
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      // tuple = copy of entries[i] (key@0, val@ks — es bytes contiguous)
+                      i32_const(es as i32); call(self.emitter.rt.alloc); local_set(tuple);
                       local_get(tuple);
-                      local_get(map_eb); local_get(i); i32_const(8); i32_mul; i32_add;
-                      i32_load(0); i32_store(0); // key
-                      local_get(tuple);
-                      local_get(map_eb); local_get(i); i32_const(8); i32_mul; i32_add;
-                      i32_load(4); i32_store(4); // val
-                      // hdr_list[j] = tuple
-                      local_get(hdr_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(j); i32_const(4); i32_mul; i32_add;
+                      local_get(map_eb); local_get(i); i32_const(es as i32); i32_mul; i32_add;
+                      i32_const(es as i32); memory_copy;
+                      // hdr_list[i] = tuple
+                      local_get(hdr_list); i32_const(list_data_off); i32_add;
+                      local_get(i); i32_const(4); i32_mul; i32_add;
                       local_get(tuple); i32_store(0);
-                      local_get(j); i32_const(1); i32_add; local_set(j);
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                     local_get(s); local_get(hdr_list); i32_store(12);
                     local_get(s);
                 });
+                self.scratch.free_i32(map_eb);
+                self.scratch.free_i32(map_cap);
                 self.scratch.free_i32(tuple);
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(len);

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
@@ -652,23 +652,28 @@ impl FuncCompiler<'_> {
                     end; end;
                 });
 
-                // Phase 2: Build Swiss Table map
-                // Allocate Swiss Table with cap = next_pow2(max(len*2, 16))
+                // Phase 2: Build the compact-ordered-dict map.
+                // cap = next_pow2(max(len*2, INITIAL_CAP)) — always > distinct keys, so no grow.
                 let cap_local = self.scratch.alloc_i32();
-                let eb = self.scratch.alloc_i32(); // entries base
+                let ib = self.scratch.alloc_i32(); // index base
+                let eb = self.scratch.alloc_i32(); // dense entries base
+                let cand_ei = self.scratch.alloc_i32(); // candidate dense entry index during probe
                 let h2 = self.scratch.alloc_i32();
                 let probe_idx = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    // cap = next power of 2 >= max(len * 2, 16)
-                    i32_const(16); local_set(cap_local);
+                    // cap = next power of 2 >= max(len * 2, INITIAL_CAP)
+                    i32_const(lm::INITIAL_CAP as i32); local_set(cap_local);
                     block_empty; loop_empty;
                       local_get(cap_local); local_get(len); i32_const(2); i32_mul; i32_ge_u; br_if(1);
                       local_get(cap_local); i32_const(1); i32_shl; local_set(cap_local);
                       br(0);
                     end; end;
                 });
-                self.emit_alloc_table(map_ptr, cap_local, entry_size as i32);
-                self.emit_swiss_setup(map_ptr, j, eb); // j reused as cap_check, eb = entries base
+                self.emit_dict_alloc(map_ptr, cap_local, entry_size as u32);
+                self.emit_dict_index_base(map_ptr, cap_local);
+                wasm!(self.func, { local_set(ib); });
+                self.emit_dict_entries_base(map_ptr, cap_local);
+                wasm!(self.func, { local_set(eb); });
                 wasm!(self.func, {
                     i32_const(0); local_set(map_len);
                     i32_const(0); local_set(i);
@@ -703,8 +708,10 @@ impl FuncCompiler<'_> {
                         end;
                         local_get(j); local_get(h2); i32_eq;
                         if_empty;
-                          // Tag matches: compare key
-                          local_get(eb); local_get(probe_idx); i32_const(entry_size); i32_mul; i32_add;
+                          // Tag matches: deref index[probe_idx]-1 → dense entry, compare key
+                          local_get(ib); local_get(probe_idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
+                          i32_load(0); i32_const(1); i32_sub; local_set(cand_ei);
+                          local_get(eb); local_get(cand_ei); i32_const(entry_size); i32_mul; i32_add;
                 });
                 if key_is_i64 { wasm!(self.func, { i64_load(0); local_get(cur_key); i64_eq; }); }
                 else {
@@ -713,7 +720,7 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                           if_empty;
-                            local_get(probe_idx); local_set(found_idx);
+                            local_get(cand_ei); local_set(found_idx);
                             br(3);
                           end;
                         end;
@@ -755,14 +762,17 @@ impl FuncCompiler<'_> {
                         i32_const(ks); i32_add;
                         local_get(new_list); i32_store(0);
                       else_;
-                        // === Not found: insert new entry ===
+                        // === Not found: append a new dense entry at map_len ===
                 });
-                // Write tag (h2) at probe_idx
+                // Write tag (h2) at the probe slot
                 wasm!(self.func, { local_get(h2); });
                 self.emit_swiss_tag_store(map_ptr, probe_idx);
                 wasm!(self.func, {
-                        // Write key
-                        local_get(eb); local_get(probe_idx); i32_const(entry_size); i32_mul; i32_add;
+                        // index[probe_idx] = map_len + 1 (1-based pointer into dense entries)
+                        local_get(ib); local_get(probe_idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
+                        local_get(map_len); i32_const(1); i32_add; i32_store(0);
+                        // Write key at dense entries[map_len]
+                        local_get(eb); local_get(map_len); i32_const(entry_size); i32_mul; i32_add;
                         local_get(cur_key);
                 });
                 if key_is_i64 { wasm!(self.func, { i64_store(0); }); }
@@ -779,8 +789,8 @@ impl FuncCompiler<'_> {
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        // Write list ptr in entry
-                        local_get(eb); local_get(probe_idx); i32_const(entry_size); i32_mul; i32_add;
+                        // Write list ptr at dense entries[map_len] + ks
+                        local_get(eb); local_get(map_len); i32_const(entry_size); i32_mul; i32_add;
                         i32_const(ks); i32_add;
                         local_get(new_list); i32_store(0);
                         local_get(map_len); i32_const(1); i32_add; local_set(map_len);
@@ -793,7 +803,9 @@ impl FuncCompiler<'_> {
                 });
                 self.scratch.free_i32(probe_idx);
                 self.scratch.free_i32(h2);
+                self.scratch.free_i32(cand_ei);
                 self.scratch.free_i32(eb);
+                self.scratch.free_i32(ib);
                 self.scratch.free_i32(cap_local);
 
                 if key_is_i64 { self.scratch.free_i64(cur_key); } else { self.scratch.free_i32(cur_key); }

--- a/crates/almide-codegen/src/emit_wasm/calls_map.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map.rs
@@ -746,19 +746,14 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(s);
             }
             Ty::Bool => {} // identity hash: 0 or 1, already i32
-            Ty::Named(_, _) | Ty::Record { .. } => {
-                // Hash record fields: FNV-1a over field bytes
-                let fields = if let Ty::Record { fields } = key_ty {
-                    fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect::<Vec<_>>()
-                } else if let Ty::Named(name, _) = key_ty {
-                    self.emitter.record_fields.get(name.as_str()).cloned().unwrap_or_default()
-                } else if let Some(fs) = self.emitter.record_fields.get("") {
-                    fs.clone()
-                } else {
-                    vec![]
-                };
-                if fields.is_empty() {
-                    // No fields known: identity hash
+            Ty::Named(_, _) | Ty::Record { .. } | Ty::Variant { .. } => {
+                // Records and variants are heap structs; FNV-1a over their content
+                // bytes (dereferencing the pointer). For variants this is the tag —
+                // hashing the POINTER would be identity-on-allocation and break value
+                // equality, since each constructor call allocates a fresh struct.
+                let size = self.key_content_size(key_ty);
+                if size == 0 {
+                    // No known content layout: identity hash (the key value itself).
                 } else {
                     let ptr = self.scratch.alloc_i32();
                     let h = self.scratch.alloc_i32();
@@ -766,20 +761,14 @@ impl FuncCompiler<'_> {
                         local_set(ptr);
                         i32_const(0x811C9DC5u32 as i32); local_set(h);
                     });
-                    let mut offset = 0u32;
-                    for (_, fty) in &fields {
-                        let fsize = super::values::byte_size(fty);
-                        // Hash each byte of the field
-                        for b in 0..fsize {
-                            wasm!(self.func, {
-                                local_get(h);
-                                local_get(ptr); i32_load8_u(offset + b);
-                                i32_xor;
-                                i32_const(0x01000193u32 as i32); i32_mul;
-                                local_set(h);
-                            });
-                        }
-                        offset += fsize;
+                    for b in 0..size {
+                        wasm!(self.func, {
+                            local_get(h);
+                            local_get(ptr); i32_load8_u(b);
+                            i32_xor;
+                            i32_const(0x01000193u32 as i32); i32_mul;
+                            local_set(h);
+                        });
                     }
                     wasm!(self.func, { local_get(h); });
                     self.scratch.free_i32(h);
@@ -820,11 +809,45 @@ impl FuncCompiler<'_> {
         match key_ty {
             Ty::Int => { wasm!(self.func, { i64_eq; }); }
             Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
-            Ty::Named(_, _) | Ty::Record { .. } => {
-                let size = super::values::byte_size(key_ty);
-                wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
+            Ty::Named(_, _) | Ty::Record { .. } | Ty::Variant { .. } => {
+                // Compare the dereferenced content (matching emit_hash_key's coverage so
+                // hash and equality stay consistent): full record bytes, or a variant's
+                // tag. byte_size(record/variant) is only the pointer size (4), so the old
+                // mem_eq(4) compared just the first 4 content bytes. When the layout is
+                // unknown, fall back to pointer identity (matching the identity hash).
+                let size = self.key_content_size(key_ty);
+                if size == 0 {
+                    wasm!(self.func, { i32_eq; });
+                } else {
+                    wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
+                }
             }
             _ => { wasm!(self.func, { i32_eq; }); }
+        }
+    }
+    /// Resolve a record/Named key's fields (name, type), or empty if the layout is
+    /// unknown. Single source of truth for hashing AND equality so they can't drift.
+    fn record_key_fields(&self, key_ty: &Ty) -> Vec<(String, Ty)> {
+        if let Ty::Record { fields } = key_ty {
+            fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect::<Vec<_>>()
+        } else if let Ty::Named(name, _) = key_ty {
+            self.emitter.record_fields.get(name.as_str()).cloned().unwrap_or_default()
+        } else if let Some(fs) = self.emitter.record_fields.get("") {
+            fs.clone()
+        } else {
+            vec![]
+        }
+    }
+    /// Byte count of a heap key's content for hashing/equality (0 if unknown).
+    /// Variants hash/compare their TAG only: each constructor allocates a fresh
+    /// struct (so the pointer is not stable) and the payload padding to the
+    /// variant's max size is uninitialized (so comparing it is non-deterministic);
+    /// the tag uniquely identifies a nullary case. Records use their full field size.
+    fn key_content_size(&self, key_ty: &Ty) -> u32 {
+        match key_ty {
+            Ty::Variant { .. } => 4,
+            Ty::Named(name, _) if self.emitter.variant_info.contains_key(name.as_str()) => 4,
+            _ => self.record_key_fields(key_ty).iter().map(|(_, t)| super::values::byte_size(t)).sum(),
         }
     }
     pub(super) fn emit_search_key_store(&mut self, key_ty: &Ty, s32: u32, s64: u32) {

--- a/crates/almide-codegen/src/emit_wasm/calls_map.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map.rs
@@ -1124,4 +1124,63 @@ impl FuncCompiler<'_> {
             _ => { wasm!(self.func, { i32_load(0); i32_store(0); }); }
         }
     }
+
+    // ── Compact-ordered-dict addressing — every offset by name, zero magic numbers.
+    // Layout (SWISS_MAP id, header_size=8):
+    //   [len@0][cap@4][tags:u8[cap]@8][index:i32[cap]@8+cap][entries:(K,V)[cap]@8+cap+cap*INDEX_SLOT_SIZE]
+    // tags = h2 fast-reject (0=empty); index 1-based (slot v → entries[v-1], 0=empty);
+    // entries dense, insertion order [0..len], stride es=ks+vs, key@0 val@ks.
+
+    /// Push the INDEX region base `map + header + cap` (slots start after the tags).
+    pub(super) fn emit_dict_index_base(&mut self, map: u32, cap: u32) {
+        let hdr = self.emitter.layout_reg.header_size(super::engine::layout::SWISS_MAP) as i32;
+        wasm!(self.func, { local_get(map); i32_const(hdr); i32_add; local_get(cap); i32_add; });
+    }
+
+    /// Push the dense ENTRIES base `map + header + cap + cap*INDEX_SLOT_SIZE`.
+    pub(super) fn emit_dict_entries_base(&mut self, map: u32, cap: u32) {
+        use super::engine::layout::{SWISS_MAP, map as lm};
+        let hdr = self.emitter.layout_reg.header_size(SWISS_MAP) as i32;
+        wasm!(self.func, {
+            local_get(map); i32_const(hdr); i32_add;
+            local_get(cap); i32_add;
+            local_get(cap); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
+        });
+    }
+
+    /// Allocate + zero-init a COD table of `cap` slots (entry stride `es`) into `out`.
+    /// total = header + cap*(tag(1) + INDEX_SLOT_SIZE + es); len=0; cap=cap; tags+index zeroed
+    /// (the allocator reuses a free list, so it does NOT return zeroed memory).
+    pub(super) fn emit_dict_alloc(&mut self, out: u32, cap: u32, es: u32) {
+        use super::engine::layout::{SWISS_MAP, map as lm};
+        let hdr = self.emitter.layout_reg.header_size(SWISS_MAP) as i32;
+        let cap_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP);
+        let per_slot = 1 + lm::INDEX_SLOT_SIZE as i32 + es as i32;
+        let tag_plus_index = 1 + lm::INDEX_SLOT_SIZE as i32;
+        wasm!(self.func, {
+            i32_const(hdr); local_get(cap); i32_const(per_slot); i32_mul; i32_add;
+            call(self.emitter.rt.alloc); local_set(out);
+            local_get(out); i32_const(0); i32_store(0);             // len = 0
+            local_get(out); local_get(cap); i32_store(cap_off, 0);  // cap
+            // zero tags+index: memory_fill(out+header, 0, cap*(1+INDEX_SLOT_SIZE))
+            local_get(out); i32_const(hdr); i32_add;
+            i32_const(0);
+            local_get(cap); i32_const(tag_plus_index); i32_mul;
+            memory_fill(0);
+        });
+    }
+
+    /// Push a closure pair's env pointer (field load via the CLOSURE_PAIR layout).
+    pub(super) fn emit_closure_env(&mut self, closure: u32) {
+        use super::engine::layout::{CLOSURE_PAIR, closure as lc};
+        let off = self.emitter.layout_reg.fixed_offset(CLOSURE_PAIR, lc::ENV_PTR);
+        wasm!(self.func, { local_get(closure); i32_load(off); });
+    }
+
+    /// Push a closure pair's function-table index.
+    pub(super) fn emit_closure_table_idx(&mut self, closure: u32) {
+        use super::engine::layout::{CLOSURE_PAIR, closure as lc};
+        let off = self.emitter.layout_reg.fixed_offset(CLOSURE_PAIR, lc::TABLE_IDX);
+        wasm!(self.func, { local_get(closure); i32_load(off); });
+    }
 }

--- a/crates/almide-codegen/src/emit_wasm/calls_map.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map.rs
@@ -8,20 +8,18 @@
 
 use super::FuncCompiler;
 use super::values;
-use super::list_layout; // MAP_INITIAL_CAP, MAP_TAG_EMPTY
 use almide_ir::IrExpr;
 use almide_lang::types::Ty;
 use wasm_encoder::ValType;
 
 impl FuncCompiler<'_> {
     pub(super) fn emit_map_call(&mut self, method: &str, args: &[IrExpr]) -> bool {
-        use super::engine::layout::{SWISS_MAP, LIST, STRING, map as lm, list as ll, string as ls};
+        use super::engine::layout::{SWISS_MAP, LIST, map as lm, list as ll};
         let map_cap_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP);
         let map_tags_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
         let map_hdr = self.emitter.layout_reg.header_size(SWISS_MAP) as i32;
         let list_data_off = self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32;
         let list_hdr = self.emitter.layout_reg.header_size(LIST) as i32;
-        let str_data_off = self.emitter.layout_reg.fixed_offset(STRING, ls::DATA) as i32;
         match method {
             "new" => {
                 // Empty map: header only, cap=0
@@ -44,19 +42,22 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { i32_load(0); i32_eqz; });
             }
             "get" => {
+                // Probe the hash INDEX, then read the dense entry it points at.
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
-                let es = ks + vs; // entry_size (no tag)
+                let es = ks + vs;
                 let m = self.scratch.alloc_i32();
                 let sk32 = self.scratch.alloc_i32();
                 let sk64 = self.scratch.alloc_i64();
                 let cap = self.scratch.alloc_i32();
-                let idx = self.scratch.alloc_i32();
-                let eb = self.scratch.alloc_i32(); // entries_base
+                let idx = self.scratch.alloc_i32();   // probe slot
+                let ib = self.scratch.alloc_i32();    // index base
+                let eb = self.scratch.alloc_i32();    // entries base
+                let ei = self.scratch.alloc_i32();    // dense entry index
                 let h2 = self.scratch.alloc_i32();
-                let tg = self.scratch.alloc_i32(); // tag
+                let tg = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();
-                let vc = self.scratch.alloc_i32(); // val_copy
+                let vc = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(m); });
@@ -68,25 +69,25 @@ impl FuncCompiler<'_> {
                     local_get(m); i32_load(map_cap_off); local_set(cap);
                     local_get(cap); i32_eqz;
                     if_empty; else_;
-                    // entries_base = m + 8 + cap
-                    local_get(m); i32_const(map_tags_off); i32_add;
-                    local_get(cap); i32_add; local_set(eb);
                 });
-                // Hash → h2 + idx
+                self.emit_dict_index_base(m, cap);
+                wasm!(self.func, { local_set(ib); });
+                self.emit_dict_entries_base(m, cap);
+                wasm!(self.func, { local_set(eb); });
                 self.emit_search_key_load(&key_ty, sk32, sk64);
                 self.emit_hash_key(&key_ty);
                 self.emit_h1_h2(cap, idx, h2);
-                // Probe
                 wasm!(self.func, {
                     block_empty; loop_empty;
-                      // tag = mem[m + 8 + idx] (1 byte)
                       local_get(m); i32_const(map_tags_off); i32_add;
                       local_get(idx); i32_add; i32_load8_u(0); local_set(tg);
-                      local_get(tg); i32_eqz; br_if(1); // empty
+                      local_get(tg); i32_eqz; br_if(1); // empty slot → absent
                       local_get(tg); local_get(h2); i32_eq;
                       if_empty;
-                        // entry = eb + idx * es
-                        local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
+                        // ei = index[idx] - 1 ; entry = eb + ei*es (key @0)
+                        local_get(ib); local_get(idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
+                        i32_load(0); i32_const(1); i32_sub; local_set(ei);
+                        local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 self.emit_search_key_load(&key_ty, sk32, sk64);
@@ -95,7 +96,7 @@ impl FuncCompiler<'_> {
                         if_empty;
                           i32_const(vs as i32); call(self.emitter.rt.alloc); local_set(vc);
                           local_get(vc);
-                          local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
+                          local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
                           i32_const(ks as i32); i32_add;
                 });
                 self.emit_elem_copy_sized(vs);
@@ -114,7 +115,9 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(tg);
                 self.scratch.free_i32(h2);
+                self.scratch.free_i32(ei);
                 self.scratch.free_i32(eb);
+                self.scratch.free_i32(ib);
                 self.scratch.free_i32(idx);
                 self.scratch.free_i32(cap);
                 self.scratch.free_i64(sk64);
@@ -132,7 +135,9 @@ impl FuncCompiler<'_> {
                 let sk64 = self.scratch.alloc_i64();
                 let cap = self.scratch.alloc_i32();
                 let idx = self.scratch.alloc_i32();
+                let ib = self.scratch.alloc_i32();
                 let eb = self.scratch.alloc_i32();
+                let ei = self.scratch.alloc_i32();
                 let h2 = self.scratch.alloc_i32();
                 let tg = self.scratch.alloc_i32();
                 let found = self.scratch.alloc_i32();
@@ -146,9 +151,11 @@ impl FuncCompiler<'_> {
                     local_get(m); i32_load(map_cap_off); local_set(cap);
                     local_get(cap); i32_eqz;
                     if_empty; else_;
-                    local_get(m); i32_const(map_tags_off); i32_add;
-                    local_get(cap); i32_add; local_set(eb);
                 });
+                self.emit_dict_index_base(m, cap);
+                wasm!(self.func, { local_set(ib); });
+                self.emit_dict_entries_base(m, cap);
+                wasm!(self.func, { local_set(eb); });
                 self.emit_search_key_load(&key_ty, sk32, sk64);
                 self.emit_hash_key(&key_ty);
                 self.emit_h1_h2(cap, idx, h2);
@@ -159,7 +166,9 @@ impl FuncCompiler<'_> {
                       local_get(tg); i32_eqz; br_if(1);
                       local_get(tg); local_get(h2); i32_eq;
                       if_empty;
-                        local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
+                        local_get(ib); local_get(idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
+                        i32_load(0); i32_const(1); i32_sub; local_set(ei);
+                        local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 self.emit_search_key_load(&key_ty, sk32, sk64);
@@ -182,7 +191,7 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[2]);
                 wasm!(self.func, { else_; });
                 wasm!(self.func, {
-                    local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
+                    local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
                     i32_const(ks as i32); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
@@ -191,7 +200,9 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(found);
                 self.scratch.free_i32(tg);
                 self.scratch.free_i32(h2);
+                self.scratch.free_i32(ei);
                 self.scratch.free_i32(eb);
+                self.scratch.free_i32(ib);
                 self.scratch.free_i32(idx);
                 self.scratch.free_i32(cap);
                 self.scratch.free_i64(sk64);
@@ -207,7 +218,9 @@ impl FuncCompiler<'_> {
                 let sk64 = self.scratch.alloc_i64();
                 let cap = self.scratch.alloc_i32();
                 let idx = self.scratch.alloc_i32();
+                let ib = self.scratch.alloc_i32();
                 let eb = self.scratch.alloc_i32();
+                let ei = self.scratch.alloc_i32();
                 let h2 = self.scratch.alloc_i32();
                 let tg = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();
@@ -221,9 +234,11 @@ impl FuncCompiler<'_> {
                     local_get(m); i32_load(map_cap_off); local_set(cap);
                     local_get(cap); i32_eqz;
                     if_empty; else_;
-                    local_get(m); i32_const(map_tags_off); i32_add;
-                    local_get(cap); i32_add; local_set(eb);
                 });
+                self.emit_dict_index_base(m, cap);
+                wasm!(self.func, { local_set(ib); });
+                self.emit_dict_entries_base(m, cap);
+                wasm!(self.func, { local_set(eb); });
                 self.emit_search_key_load(&key_ty, sk32, sk64);
                 self.emit_hash_key(&key_ty);
                 self.emit_h1_h2(cap, idx, h2);
@@ -234,7 +249,9 @@ impl FuncCompiler<'_> {
                       local_get(tg); i32_eqz; br_if(1);
                       local_get(tg); local_get(h2); i32_eq;
                       if_empty;
-                        local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
+                        local_get(ib); local_get(idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
+                        i32_load(0); i32_const(1); i32_sub; local_set(ei);
+                        local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 self.emit_search_key_load(&key_ty, sk32, sk64);
@@ -252,7 +269,9 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(tg);
                 self.scratch.free_i32(h2);
+                self.scratch.free_i32(ei);
                 self.scratch.free_i32(eb);
+                self.scratch.free_i32(ib);
                 self.scratch.free_i32(idx);
                 self.scratch.free_i32(cap);
                 self.scratch.free_i64(sk64);
@@ -260,225 +279,122 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(m);
             }
             "set" => {
-                // Immutable: copy table, then insert into copy
+                // Immutable COD insert: fresh table sized for old_len+1, copy the old
+                // entries + rebuild index, then probe-and-place the (key,val) — overwrite
+                // in place (position kept) or append densely (insertion order).
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let es = ks + vs;
                 let vt = values::ty_to_valtype(&val_ty).unwrap_or(ValType::I32);
                 let m = self.scratch.alloc_i32();
-                let sk32 = self.scratch.alloc_i32();
-                let sk64 = self.scratch.alloc_i64();
-                let sv = self.scratch.alloc(vt);
+                let tmp = self.scratch.alloc_i32();
+                let old_cap = self.scratch.alloc_i32();
+                let n = self.scratch.alloc_i32();
                 let cap = self.scratch.alloc_i32();
-                let nm = self.scratch.alloc_i32(); // new_map
-                let idx = self.scratch.alloc_i32();
+                let nm = self.scratch.alloc_i32();
+                let ib = self.scratch.alloc_i32();
                 let eb = self.scratch.alloc_i32();
-                let h2 = self.scratch.alloc_i32();
-                let tg = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(m); });
+                // Materialize the (key,val) into a temp entry buffer (key@0, val@ks).
+                wasm!(self.func, { i32_const(es as i32); call(self.emitter.rt.alloc); local_set(tmp); local_get(tmp); });
                 self.emit_expr(&args[1]);
-                self.emit_search_key_store(&key_ty, sk32, sk64);
+                self.emit_key_store(&key_ty, 0);
+                wasm!(self.func, { local_get(tmp); i32_const(ks as i32); i32_add; });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { local_set(sv); });
-
-                // Copy table (or create initial if cap==0)
-                wasm!(self.func, {
-                    local_get(m); i32_load(map_cap_off); local_set(cap);
-                    local_get(cap); i32_eqz;
-                    if_empty; i32_const(list_layout::MAP_INITIAL_CAP); local_set(cap); end;
-                });
-                self.emit_alloc_table(nm, cap, es as i32);
-                wasm!(self.func, {
-                    // Copy old data if exists
-                    local_get(m); i32_load(map_cap_off);
-                    if_empty;
-                      local_get(nm); i32_const(map_tags_off); i32_add;
-                      local_get(m); i32_const(map_tags_off); i32_add;
-                      local_get(m); i32_load(map_cap_off);
-                      local_tee(idx); // reuse idx as old_cap temp
-                      local_get(idx); i32_const(es as i32); i32_mul; i32_add; // tags + entries
-                      memory_copy;
-                      local_get(nm); local_get(m); i32_load(0); i32_store(0); // copy len
-                    end;
-                    local_get(nm); i32_const(map_tags_off); i32_add;
-                    local_get(cap); i32_add; local_set(eb);
-                });
-                // Insert into copy
-                self.emit_search_key_load(&key_ty, sk32, sk64);
-                self.emit_hash_key(&key_ty);
-                self.emit_h1_h2(cap, idx, h2);
-                wasm!(self.func, {
-                    block_empty; loop_empty;
-                      local_get(nm); i32_const(map_tags_off); i32_add;
-                      local_get(idx); i32_add; i32_load8_u(0); local_set(tg);
-                      local_get(tg); i32_eqz; br_if(1);
-                      local_get(tg); local_get(h2); i32_eq;
-                      if_empty;
-                        local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
-                });
-                self.emit_key_load(&key_ty, 0);
-                self.emit_search_key_load(&key_ty, sk32, sk64);
-                self.emit_key_eq(&key_ty);
-                wasm!(self.func, {
-                        br_if(2);
-                      end;
-                      local_get(idx); i32_const(1); i32_add;
-                      local_get(cap); i32_const(1); i32_sub; i32_and;
-                      local_set(idx); br(0);
-                    end; end;
-                    // Store val
-                    local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
-                    i32_const(ks as i32); i32_add;
-                    local_get(sv);
-                });
                 match vt {
                     ValType::I64 => { wasm!(self.func, { i64_store(0); }); }
                     ValType::F64 => { wasm!(self.func, { f64_store(0); }); }
                     _ => { wasm!(self.func, { i32_store(0); }); }
                 }
-                // If new entry
                 wasm!(self.func, {
-                    local_get(tg); i32_eqz;
-                    if_empty;
-                      // Store tag (h2) as 1 byte
-                      local_get(nm); i32_const(map_tags_off); i32_add;
-                      local_get(idx); i32_add; local_get(h2); i32_store8(0);
-                      // Store key
-                      local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
+                    local_get(m); i32_load(map_cap_off); local_set(old_cap);
+                    local_get(m); i32_load(0); i32_const(1); i32_add; local_set(n);
                 });
-                self.emit_search_key_load(&key_ty, sk32, sk64);
-                self.emit_key_store(&key_ty, 0);
-                wasm!(self.func, {
-                      local_get(nm);
-                      local_get(nm); i32_load(0); i32_const(1); i32_add;
-                      i32_store(0);
-                    end;
-                    local_get(nm);
-                });
-                self.scratch.free_i32(tg);
-                self.scratch.free_i32(h2);
+                self.emit_dict_fit_cap(n, cap);
+                self.emit_dict_alloc(nm, cap, es);
+                self.emit_dict_recap(m, old_cap, nm, cap, es, &key_ty);
+                self.emit_dict_index_base(nm, cap);
+                wasm!(self.func, { local_set(ib); });
+                self.emit_dict_entries_base(nm, cap);
+                wasm!(self.func, { local_set(eb); });
+                self.emit_dict_put_entry(nm, cap, ib, eb, tmp, es, ks, vs, &key_ty);
+                wasm!(self.func, { local_get(nm); });
+
                 self.scratch.free_i32(eb);
-                self.scratch.free_i32(idx);
+                self.scratch.free_i32(ib);
                 self.scratch.free_i32(nm);
                 self.scratch.free_i32(cap);
-                self.scratch.free(sv, vt);
-                self.scratch.free_i64(sk64);
-                self.scratch.free_i32(sk32);
+                self.scratch.free_i32(n);
+                self.scratch.free_i32(old_cap);
+                self.scratch.free_i32(tmp);
                 self.scratch.free_i32(m);
             }
             "insert" => {
+                // Mutable in-place COD insert: ensure allocated, probe-and-place the
+                // (key,val), then grow (rehash into 4× table) if the load factor trips.
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let es = ks + vs;
                 let vt = values::ty_to_valtype(&val_ty).unwrap_or(ValType::I32);
                 let m = self.scratch.alloc_i32();
-                let sk32 = self.scratch.alloc_i32();
-                let sk64 = self.scratch.alloc_i64();
-                let sv = self.scratch.alloc(vt);
+                let tmp = self.scratch.alloc_i32();
                 let cap = self.scratch.alloc_i32();
-                let idx = self.scratch.alloc_i32();
+                let ib = self.scratch.alloc_i32();
                 let eb = self.scratch.alloc_i32();
-                let h2 = self.scratch.alloc_i32();
-                let tg = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(m); });
+                // Materialize the (key,val) into a temp entry buffer (key@0, val@ks).
+                wasm!(self.func, { i32_const(es as i32); call(self.emitter.rt.alloc); local_set(tmp); local_get(tmp); });
                 self.emit_expr(&args[1]);
-                self.emit_search_key_store(&key_ty, sk32, sk64);
+                self.emit_key_store(&key_ty, 0);
+                wasm!(self.func, { local_get(tmp); i32_const(ks as i32); i32_add; });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { local_set(sv); });
-
-                wasm!(self.func, {
-                    local_get(m); i32_load(map_cap_off); local_set(cap);
-                    local_get(cap); i32_eqz;
-                    if_empty;
-                      i32_const(list_layout::MAP_INITIAL_CAP); local_set(cap);
-                });
-                self.emit_alloc_table(m, cap, es as i32);
-                wasm!(self.func, { end; });
-                // entries_base
-                wasm!(self.func, {
-                    local_get(m); i32_const(map_tags_off); i32_add;
-                    local_get(cap); i32_add; local_set(eb);
-                });
-
-                // Hash → h2 + idx
-                self.emit_search_key_load(&key_ty, sk32, sk64);
-                self.emit_hash_key(&key_ty);
-                self.emit_h1_h2(cap, idx, h2);
-                // Probe
-                wasm!(self.func, {
-                    block_empty; loop_empty;
-                      local_get(m); i32_const(map_tags_off); i32_add;
-                      local_get(idx); i32_add; i32_load8_u(0); local_set(tg);
-                      local_get(tg); i32_eqz; br_if(1);
-                      local_get(tg); local_get(h2); i32_eq;
-                      if_empty;
-                        local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
-                });
-                self.emit_key_load(&key_ty, 0);
-                self.emit_search_key_load(&key_ty, sk32, sk64);
-                self.emit_key_eq(&key_ty);
-                wasm!(self.func, {
-                        br_if(2);
-                      end;
-                      local_get(idx); i32_const(1); i32_add;
-                      local_get(cap); i32_const(1); i32_sub; i32_and;
-                      local_set(idx); br(0);
-                    end; end;
-                    // Store value
-                    local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
-                    i32_const(ks as i32); i32_add;
-                    local_get(sv);
-                });
                 match vt {
                     ValType::I64 => { wasm!(self.func, { i64_store(0); }); }
                     ValType::F64 => { wasm!(self.func, { f64_store(0); }); }
                     _ => { wasm!(self.func, { i32_store(0); }); }
                 }
-                // If new entry
+                // Ensure allocated (cap==0 → fresh INITIAL_CAP table into m).
                 wasm!(self.func, {
-                    local_get(tg); i32_eqz;
+                    local_get(m); i32_load(map_cap_off); local_set(cap);
+                    local_get(cap); i32_eqz;
                     if_empty;
-                      local_get(m); i32_const(map_tags_off); i32_add;
-                      local_get(idx); i32_add; local_get(h2); i32_store8(0);
-                      local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
+                      i32_const(lm::INITIAL_CAP as i32); local_set(cap);
                 });
-                self.emit_search_key_load(&key_ty, sk32, sk64);
-                self.emit_key_store(&key_ty, 0);
+                self.emit_dict_alloc(m, cap, es);
+                wasm!(self.func, { end; });
+                self.emit_dict_index_base(m, cap);
+                wasm!(self.func, { local_set(ib); });
+                self.emit_dict_entries_base(m, cap);
+                wasm!(self.func, { local_set(eb); });
+                self.emit_dict_put_entry(m, cap, ib, eb, tmp, es, ks, vs, &key_ty);
+                // Grow if the load factor is exceeded (only a new key can trip it).
                 wasm!(self.func, {
-                      local_get(m);
-                      local_get(m); i32_load(0); i32_const(1); i32_add;
-                      i32_store(0);
-                      // Resize check
-                      local_get(m); i32_load(0); i32_const(4); i32_mul;
-                      local_get(cap); i32_const(3); i32_mul;
-                      i32_gt_u;
-                      if_empty;
+                    local_get(m); i32_load(0); i32_const(lm::LOAD_DEN as i32); i32_mul;
+                    local_get(cap); i32_const(lm::LOAD_NUM as i32); i32_mul;
+                    i32_gt_u;
+                    if_empty;
                 });
-                self.emit_map_resize(&key_ty, ks, vs, m, cap);
-                wasm!(self.func, {
-                      end;
-                    end;
-                });
+                self.emit_dict_grow(m, cap, es, &key_ty);
+                wasm!(self.func, { end; });
                 // Write back the (possibly reallocated) map ptr — into the cell for a
                 // mutable capture, else into the local/global. See emit_mutator_writeback.
                 self.emit_mutator_writeback(&args[0], m);
-                self.scratch.free_i32(tg);
-                self.scratch.free_i32(h2);
                 self.scratch.free_i32(eb);
-                self.scratch.free_i32(idx);
+                self.scratch.free_i32(ib);
                 self.scratch.free_i32(cap);
-                self.scratch.free(sv, vt);
-                self.scratch.free_i64(sk64);
-                self.scratch.free_i32(sk32);
+                self.scratch.free_i32(tmp);
                 self.scratch.free_i32(m);
             }
             "remove" | "delete" => {
+                // Dense COD rebuild excluding the matching key: walk the old entries in
+                // insertion order, copy every survivor densely (order preserved), then
+                // rebuild the index over the survivors.
                 let is_delete = method == "delete";
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
@@ -486,76 +402,53 @@ impl FuncCompiler<'_> {
                 let m = self.scratch.alloc_i32();
                 let sk32 = self.scratch.alloc_i32();
                 let sk64 = self.scratch.alloc_i64();
-                let cap = self.scratch.alloc_i32();
+                let cap_old = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let new_cap = self.scratch.alloc_i32();
                 let nm = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
+                let ne = self.scratch.alloc_i32();
                 let eb_old = self.scratch.alloc_i32();
                 let eb_new = self.scratch.alloc_i32();
-                let h2r = self.scratch.alloc_i32();
-                let nidx = self.scratch.alloc_i32();
+                let entry = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(m); });
                 self.emit_expr(&args[1]);
                 self.emit_search_key_store(&key_ty, sk32, sk64);
                 wasm!(self.func, {
-                    local_get(m); i32_load(map_cap_off); local_set(cap);
+                    local_get(m); i32_load(map_cap_off); local_set(cap_old);
+                    local_get(m); i32_load(0); local_set(len);
                 });
-                self.emit_alloc_table(nm, cap, es as i32);
+                self.emit_dict_fit_cap(len, new_cap);
+                self.emit_dict_alloc(nm, new_cap, es);
+                self.emit_dict_entries_base(m, cap_old);
+                wasm!(self.func, { local_set(eb_old); });
+                self.emit_dict_entries_base(nm, new_cap);
                 wasm!(self.func, {
-                    local_get(m); i32_const(map_tags_off); i32_add;
-                    local_get(cap); i32_add; local_set(eb_old);
-                    local_get(nm); i32_const(map_tags_off); i32_add;
-                    local_get(cap); i32_add; local_set(eb_new);
+                    local_set(eb_new);
+                    i32_const(0); local_set(ne);
                     i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(i); local_get(cap); i32_ge_u; br_if(1);
-                      local_get(m); i32_const(map_tags_off); i32_add;
-                      local_get(i); i32_add; i32_load8_u(0);
-                      if_empty; // occupied
-                        // Compare key
-                        local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add; local_set(entry);
+                      local_get(entry);
                 });
                 self.emit_key_load(&key_ty, 0);
                 self.emit_search_key_load(&key_ty, sk32, sk64);
                 self.emit_key_eq(&key_ty);
                 wasm!(self.func, {
-                        i32_eqz;
-                        if_empty;
-                          // Rehash into new_map
-                          local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add;
-                });
-                self.emit_key_load(&key_ty, 0);
-                self.emit_hash_key(&key_ty);
-                self.emit_h1_h2(cap, nidx, h2r);
-                wasm!(self.func, {
-                          block_empty; loop_empty;
-                            local_get(nm); i32_const(map_tags_off); i32_add;
-                            local_get(nidx); i32_add; i32_load8_u(0);
-                            i32_eqz; br_if(1);
-                            local_get(nidx); i32_const(1); i32_add;
-                            local_get(cap); i32_const(1); i32_sub; i32_and;
-                            local_set(nidx); br(0);
-                          end; end;
-                          // Copy tag
-                          local_get(nm); i32_const(map_tags_off); i32_add;
-                          local_get(nidx); i32_add;
-                          local_get(m); i32_const(map_tags_off); i32_add;
-                          local_get(i); i32_add; i32_load8_u(0);
-                          i32_store8(0);
-                          // Copy entry
-                          local_get(eb_new); local_get(nidx); i32_const(es as i32); i32_mul; i32_add;
-                          local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add;
-                          i32_const(es as i32); memory_copy;
-                          // len++
-                          local_get(nm);
-                          local_get(nm); i32_load(0); i32_const(1); i32_add;
-                          i32_store(0);
-                        end;
+                      i32_eqz;
+                      if_empty;  // key != search key → keep (append densely)
+                        local_get(eb_new); local_get(ne); i32_const(es as i32); i32_mul; i32_add;
+                        local_get(entry); i32_const(es as i32); memory_copy;
+                        local_get(ne); i32_const(1); i32_add; local_set(ne);
                       end;
                       local_get(i); i32_const(1); i32_add; local_set(i); br(0);
                     end; end;
+                    local_get(nm); local_get(ne); i32_store(0); // nm.len = survivor count
                 });
+                self.emit_dict_rebuild_index(nm, new_cap, es, &key_ty);
                 if is_delete {
                     // delete: in-place, write the rebuilt map back to its binding.
                     self.emit_mutator_writeback(&args[0], nm);
@@ -563,18 +456,21 @@ impl FuncCompiler<'_> {
                     // remove: returns the rebuilt map as the expression value.
                     wasm!(self.func, { local_get(nm); });
                 }
-                self.scratch.free_i32(nidx);
-                self.scratch.free_i32(h2r);
+                self.scratch.free_i32(entry);
                 self.scratch.free_i32(eb_new);
                 self.scratch.free_i32(eb_old);
+                self.scratch.free_i32(ne);
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(nm);
-                self.scratch.free_i32(cap);
+                self.scratch.free_i32(new_cap);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(cap_old);
                 self.scratch.free_i64(sk64);
                 self.scratch.free_i32(sk32);
                 self.scratch.free_i32(m);
             }
             "keys" | "values" | "entries" => {
+                // Dense walk of entries[0..len] = insertion order. No tag scan.
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let es = ks + vs;
                 let m = self.scratch.alloc_i32();
@@ -582,36 +478,33 @@ impl FuncCompiler<'_> {
                 let cap = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
-                let j = self.scratch.alloc_i32();
                 let eb = self.scratch.alloc_i32();
                 let elem_size = match method {
-                    "keys" => ks, "values" => vs, _ => 4, // entries: ptr
+                    "keys" => ks, "values" => vs, _ => 4, // entries: tuple ptr
                 };
-                let tp = self.scratch.alloc_i32(); // tuple_ptr for entries
+                let tp = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(m);
                     local_get(m); i32_load(0); local_set(len);
                     local_get(m); i32_load(map_cap_off); local_set(cap);
-                    local_get(m); i32_const(map_tags_off); i32_add;
-                    local_get(cap); i32_add; local_set(eb);
+                });
+                self.emit_dict_entries_base(m, cap);
+                wasm!(self.func, {
+                    local_set(eb);
                     i32_const(list_hdr); local_get(len); i32_const(elem_size as i32); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); local_get(len); i32_store(0);
                     i32_const(0); local_set(i);
-                    i32_const(0); local_set(j);
                     block_empty; loop_empty;
-                      local_get(i); local_get(cap); i32_ge_u; br_if(1);
-                      local_get(m); i32_const(map_tags_off); i32_add;
-                      local_get(i); i32_add; i32_load8_u(0);
-                      if_empty;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
                 });
                 match method {
                     "keys" => {
                         wasm!(self.func, {
                             local_get(result); i32_const(list_data_off); i32_add;
-                            local_get(j); i32_const(ks as i32); i32_mul; i32_add;
+                            local_get(i); i32_const(ks as i32); i32_mul; i32_add;
                             local_get(eb); local_get(i); i32_const(es as i32); i32_mul; i32_add;
                         });
                         self.emit_elem_copy_sized(ks);
@@ -619,35 +512,31 @@ impl FuncCompiler<'_> {
                     "values" => {
                         wasm!(self.func, {
                             local_get(result); i32_const(list_data_off); i32_add;
-                            local_get(j); i32_const(vs as i32); i32_mul; i32_add;
+                            local_get(i); i32_const(vs as i32); i32_mul; i32_add;
                             local_get(eb); local_get(i); i32_const(es as i32); i32_mul; i32_add;
                             i32_const(ks as i32); i32_add;
                         });
                         self.emit_elem_copy_sized(vs);
                     }
                     _ => {
-                        // entries: alloc tuple, copy key+val
                         wasm!(self.func, {
                             i32_const(es as i32); call(self.emitter.rt.alloc); local_set(tp);
                             local_get(tp);
                             local_get(eb); local_get(i); i32_const(es as i32); i32_mul; i32_add;
                             i32_const(es as i32); memory_copy;
                             local_get(result); i32_const(list_data_off); i32_add;
-                            local_get(j); i32_const(4); i32_mul; i32_add;
+                            local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
                             local_get(tp); i32_store(0);
                         });
                     }
                 }
                 wasm!(self.func, {
-                        local_get(j); i32_const(1); i32_add; local_set(j);
-                      end;
                       local_get(i); i32_const(1); i32_add; local_set(i); br(0);
                     end; end;
                     local_get(result);
                 });
                 self.scratch.free_i32(tp);
                 self.scratch.free_i32(eb);
-                self.scratch.free_i32(j);
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(cap);
@@ -655,7 +544,9 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(m);
             }
             "merge" => {
-                // Copy a, then insert each b entry
+                // Copy a (entries + index) into a table sized for a.len + b.len, then
+                // put each b entry in insertion order: a-keys keep their position and
+                // value is overwritten by b; b-only keys append after a's entries.
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let es = ks + vs;
@@ -663,14 +554,15 @@ impl FuncCompiler<'_> {
                 let mb = self.scratch.alloc_i32();
                 let cap_a = self.scratch.alloc_i32();
                 let cap_b = self.scratch.alloc_i32();
-                let result = self.scratch.alloc_i32();
-                let i = self.scratch.alloc_i32();
-                let eb_b = self.scratch.alloc_i32();
-                let eb_r = self.scratch.alloc_i32();
+                let len_b = self.scratch.alloc_i32();
+                let n = self.scratch.alloc_i32();
                 let r_cap = self.scratch.alloc_i32();
-                let ri = self.scratch.alloc_i32();
-                let h2r = self.scratch.alloc_i32();
-                let tg = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let ib = self.scratch.alloc_i32();
+                let eb = self.scratch.alloc_i32();
+                let eb_b = self.scratch.alloc_i32();
+                let j = self.scratch.alloc_i32();
+                let src = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(ma); });
@@ -679,95 +571,47 @@ impl FuncCompiler<'_> {
                     local_set(mb);
                     local_get(ma); i32_load(map_cap_off); local_set(cap_a);
                     local_get(mb); i32_load(map_cap_off); local_set(cap_b);
-                    // If a is empty, just copy b and return
-                    local_get(cap_a); i32_eqz;
-                    if_empty;
-                      i32_const(map_hdr);
-                      local_get(cap_b); local_get(cap_b); i32_const(es as i32); i32_mul; i32_add; i32_add;
-                      local_tee(ri);
-                      call(self.emitter.rt.alloc); local_set(result);
-                      local_get(result); local_get(mb); local_get(ri); memory_copy;
-                      local_get(result); return_;
-                    end;
-                    // Copy a's table
-                    i32_const(map_hdr);
-                    local_get(cap_a); local_get(cap_a); i32_const(es as i32); i32_mul; i32_add; i32_add;
-                    local_tee(ri); // temp total
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); local_get(ma); local_get(ri); memory_copy;
-                    local_get(cap_a); local_set(r_cap);
-                    local_get(mb); i32_const(map_tags_off); i32_add;
-                    local_get(cap_b); i32_add; local_set(eb_b);
-                    local_get(result); i32_const(map_tags_off); i32_add;
-                    local_get(r_cap); i32_add; local_set(eb_r);
-                    // Insert each b entry
-                    i32_const(0); local_set(i);
+                    local_get(mb); i32_load(0); local_set(len_b);
+                    local_get(ma); i32_load(0); local_get(len_b); i32_add; local_set(n);
+                });
+                self.emit_dict_fit_cap(n, r_cap);
+                self.emit_dict_alloc(result, r_cap, es);
+                self.emit_dict_recap(ma, cap_a, result, r_cap, es, &key_ty);
+                self.emit_dict_index_base(result, r_cap);
+                wasm!(self.func, { local_set(ib); });
+                self.emit_dict_entries_base(result, r_cap);
+                wasm!(self.func, { local_set(eb); });
+                self.emit_dict_entries_base(mb, cap_b);
+                wasm!(self.func, {
+                    local_set(eb_b);
+                    i32_const(0); local_set(j);
                     block_empty; loop_empty;
-                      local_get(i); local_get(cap_b); i32_ge_u; br_if(1);
-                      local_get(mb); i32_const(map_tags_off); i32_add;
-                      local_get(i); i32_add; i32_load8_u(0);
-                      if_empty;
-                        local_get(eb_b); local_get(i); i32_const(es as i32); i32_mul; i32_add;
+                      local_get(j); local_get(len_b); i32_ge_u; br_if(1);
+                      local_get(eb_b); local_get(j); i32_const(es as i32); i32_mul; i32_add; local_set(src);
                 });
-                self.emit_key_load(&key_ty, 0);
-                self.emit_hash_key(&key_ty);
-                self.emit_h1_h2(r_cap, ri, h2r);
+                self.emit_dict_put_entry(result, r_cap, ib, eb, src, es, ks, vs, &key_ty);
                 wasm!(self.func, {
-                        block_empty; loop_empty;
-                          local_get(result); i32_const(map_tags_off); i32_add;
-                          local_get(ri); i32_add; i32_load8_u(0); local_set(tg);
-                          local_get(tg); i32_eqz; br_if(1);
-                          local_get(tg); local_get(h2r); i32_eq;
-                          if_empty;
-                            local_get(eb_r); local_get(ri); i32_const(es as i32); i32_mul; i32_add;
-                });
-                self.emit_key_load(&key_ty, 0);
-                wasm!(self.func, {
-                            local_get(eb_b); local_get(i); i32_const(es as i32); i32_mul; i32_add;
-                });
-                self.emit_key_load(&key_ty, 0);
-                self.emit_key_eq(&key_ty);
-                wasm!(self.func, {
-                            br_if(2);
-                          end;
-                          local_get(ri); i32_const(1); i32_add;
-                          local_get(r_cap); i32_const(1); i32_sub; i32_and;
-                          local_set(ri); br(0);
-                        end; end;
-                        // Copy tag + entry
-                        local_get(result); i32_const(map_tags_off); i32_add;
-                        local_get(ri); i32_add;
-                        local_get(mb); i32_const(map_tags_off); i32_add;
-                        local_get(i); i32_add; i32_load8_u(0);
-                        i32_store8(0);
-                        local_get(eb_r); local_get(ri); i32_const(es as i32); i32_mul; i32_add;
-                        local_get(eb_b); local_get(i); i32_const(es as i32); i32_mul; i32_add;
-                        i32_const(es as i32); memory_copy;
-                        local_get(tg); i32_eqz;
-                        if_empty;
-                          local_get(result);
-                          local_get(result); i32_load(0); i32_const(1); i32_add;
-                          i32_store(0);
-                        end;
-                      end;
-                      local_get(i); i32_const(1); i32_add; local_set(i); br(0);
+                      local_get(j); i32_const(1); i32_add; local_set(j); br(0);
                     end; end;
                     local_get(result);
                 });
-                self.scratch.free_i32(tg);
-                self.scratch.free_i32(h2r);
-                self.scratch.free_i32(ri);
-                self.scratch.free_i32(r_cap);
-                self.scratch.free_i32(eb_r);
+                self.scratch.free_i32(src);
+                self.scratch.free_i32(j);
                 self.scratch.free_i32(eb_b);
-                self.scratch.free_i32(i);
+                self.scratch.free_i32(eb);
+                self.scratch.free_i32(ib);
                 self.scratch.free_i32(result);
+                self.scratch.free_i32(r_cap);
+                self.scratch.free_i32(n);
+                self.scratch.free_i32(len_b);
                 self.scratch.free_i32(cap_b);
                 self.scratch.free_i32(cap_a);
                 self.scratch.free_i32(mb);
                 self.scratch.free_i32(ma);
             }
             "from_list" => {
+                // Build a COD from a List[(K,V)]: size for plen, then put each pair in
+                // order (duplicate keys → last value wins, position kept).
                 let pair_ty = self.resolve_list_elem(&args[0], None);
                 let (ks, vs, key_ty) = if let Ty::Tuple(elems) = &pair_ty {
                     (elems.first().map(|t| values::byte_size(t)).unwrap_or(4),
@@ -779,80 +623,40 @@ impl FuncCompiler<'_> {
                 let plen = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();
                 let cap = self.scratch.alloc_i32();
+                let ib = self.scratch.alloc_i32();
+                let eb = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 let tp = self.scratch.alloc_i32();
-                let eb = self.scratch.alloc_i32();
-                let idx = self.scratch.alloc_i32();
-                let h2 = self.scratch.alloc_i32();
-                let tg = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(pairs);
                     local_get(pairs); i32_load(0); local_set(plen);
-                    i32_const(list_layout::MAP_INITIAL_CAP); local_set(cap);
-                    block_empty; loop_empty;
-                      local_get(cap); local_get(plen); i32_const(1); i32_shl; i32_ge_u; br_if(1);
-                      local_get(cap); i32_const(1); i32_shl; local_set(cap); br(0);
-                    end; end;
                 });
-                self.emit_alloc_table(result, cap, es as i32);
+                self.emit_dict_fit_cap(plen, cap);
+                self.emit_dict_alloc(result, cap, es);
+                self.emit_dict_index_base(result, cap);
+                wasm!(self.func, { local_set(ib); });
+                self.emit_dict_entries_base(result, cap);
                 wasm!(self.func, {
-                    local_get(result); i32_const(map_tags_off); i32_add;
-                    local_get(cap); i32_add; local_set(eb);
+                    local_set(eb);
                     i32_const(0); local_set(i);
                     block_empty; loop_empty;
                       local_get(i); local_get(plen); i32_ge_u; br_if(1);
                       local_get(pairs); i32_const(list_data_off); i32_add;
                       local_get(i); i32_const(4); i32_mul; i32_add;
-                      i32_load(0); local_set(tp);
-                      local_get(tp);
+                      i32_load(0); local_set(tp); // tp = pairs.data[i] = (K,V) tuple ptr
                 });
-                self.emit_key_load(&key_ty, 0);
-                self.emit_hash_key(&key_ty);
-                self.emit_h1_h2(cap, idx, h2);
+                self.emit_dict_put_entry(result, cap, ib, eb, tp, es, ks, vs, &key_ty);
                 wasm!(self.func, {
-                      // Probe for slot
-                      block_empty; loop_empty;
-                        local_get(result); i32_const(map_tags_off); i32_add;
-                        local_get(idx); i32_add; i32_load8_u(0); local_set(tg);
-                        local_get(tg); i32_eqz; br_if(1);
-                        local_get(tg); local_get(h2); i32_eq;
-                        if_empty;
-                          local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
-                });
-                self.emit_key_load(&key_ty, 0);
-                wasm!(self.func, { local_get(tp); });
-                self.emit_key_load(&key_ty, 0);
-                self.emit_key_eq(&key_ty);
-                wasm!(self.func, {
-                          br_if(2);
-                        end;
-                        local_get(idx); i32_const(1); i32_add;
-                        local_get(cap); i32_const(1); i32_sub; i32_and;
-                        local_set(idx); br(0);
-                      end; end;
-                      // Store tag + entry
-                      local_get(result); i32_const(map_tags_off); i32_add;
-                      local_get(idx); i32_add; local_get(h2); i32_store8(0);
-                      local_get(eb); local_get(idx); i32_const(es as i32); i32_mul; i32_add;
-                      local_get(tp); i32_const(es as i32); memory_copy;
-                      local_get(tg); i32_eqz;
-                      if_empty;
-                        local_get(result);
-                        local_get(result); i32_load(0); i32_const(1); i32_add;
-                        i32_store(0);
-                      end;
                       local_get(i); i32_const(1); i32_add; local_set(i); br(0);
                     end; end;
                     local_get(result);
                 });
-                self.scratch.free_i32(tg);
-                self.scratch.free_i32(h2);
-                self.scratch.free_i32(idx);
-                self.scratch.free_i32(eb);
                 self.scratch.free_i32(tp);
                 self.scratch.free_i32(i);
+                self.scratch.free_i32(eb);
+                self.scratch.free_i32(ib);
                 self.scratch.free_i32(cap);
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(plen);
@@ -878,37 +682,18 @@ impl FuncCompiler<'_> {
         true
     }
 
-    // ── Swiss Table helpers ──
-
-    /// Allocate a new table: [len=0][cap][tags:cap bytes][entries:cap*es bytes]
-    pub(super) fn emit_alloc_table(&mut self, out: u32, cap: u32, es: i32) {
-        use super::engine::layout::{SWISS_MAP, map as lm};
-        let map_hdr = self.emitter.layout_reg.header_size(SWISS_MAP) as i32;
-        let map_cap_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP);
-        let map_tags_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
-        wasm!(self.func, {
-            i32_const(map_hdr);
-            local_get(cap); i32_add;
-            local_get(cap); i32_const(es); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(out);
-            local_get(out); i32_const(0); i32_store(0); // len = 0
-            local_get(out); local_get(cap); i32_store(map_cap_off);
-            local_get(out); i32_const(map_tags_off); i32_add;
-            i32_const(0);
-            local_get(cap);
-            memory_fill(0);
-        });
-    }
+    // ── Compact-ordered-dict hash helpers ──
 
     /// Split hash on stack into h1 (bucket index) → idx_local and h2 (tag) → h2_local.
     pub(super) fn emit_h1_h2(&mut self, cap: u32, idx_local: u32, h2_local: u32) {
+        use super::engine::layout::map as lm;
         let ht = self.scratch.alloc_i32();
         wasm!(self.func, {
             local_tee(ht);
             local_get(cap); i32_const(1); i32_sub; i32_and;
             local_set(idx_local);
             local_get(ht);
-            i32_const(25); i32_shr_u; i32_const(0x7F); i32_and;
+            i32_const(lm::H2_SHIFT as i32); i32_shr_u; i32_const(lm::H2_MASK as i32); i32_and;
             local_tee(h2_local);
             i32_eqz;
             if_empty; i32_const(1); local_set(h2_local); end; // avoid 0 (empty)
@@ -1003,72 +788,6 @@ impl FuncCompiler<'_> {
             }
             _ => {} // other pointers: identity hash
         }
-    }
-
-    /// Resize: double cap, rehash all entries into new table.
-    fn emit_map_resize(&mut self, key_ty: &Ty, ks: u32, vs: u32, m: u32, cap: u32) {
-        use super::engine::layout::{SWISS_MAP, map as lm};
-        let map_tags_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
-        let es = (ks + vs) as i32;
-        let nc = self.scratch.alloc_i32(); // new_cap
-        let nm = self.scratch.alloc_i32(); // new_map
-        let ri = self.scratch.alloc_i32();
-        let eb_old = self.scratch.alloc_i32();
-        let eb_new = self.scratch.alloc_i32();
-        let ni = self.scratch.alloc_i32();
-        let h2r = self.scratch.alloc_i32();
-
-        wasm!(self.func, {
-            local_get(cap); i32_const(2); i32_shl; local_set(nc); // 4x growth
-        });
-        self.emit_alloc_table(nm, nc, es);
-        wasm!(self.func, {
-            local_get(nm); local_get(m); i32_load(0); i32_store(0); // copy len
-            local_get(m); i32_const(map_tags_off); i32_add;
-            local_get(cap); i32_add; local_set(eb_old);
-            local_get(nm); i32_const(map_tags_off); i32_add;
-            local_get(nc); i32_add; local_set(eb_new);
-            i32_const(0); local_set(ri);
-            block_empty; loop_empty;
-              local_get(ri); local_get(cap); i32_ge_u; br_if(1);
-              local_get(m); i32_const(map_tags_off); i32_add;
-              local_get(ri); i32_add; i32_load8_u(0);
-              if_empty;
-                // Hash key from old entry
-                local_get(eb_old); local_get(ri); i32_const(es); i32_mul; i32_add;
-        });
-        self.emit_key_load(key_ty, 0);
-        self.emit_hash_key(key_ty);
-        self.emit_h1_h2(nc, ni, h2r);
-        wasm!(self.func, {
-                // Probe new table for empty
-                block_empty; loop_empty;
-                  local_get(nm); i32_const(map_tags_off); i32_add;
-                  local_get(ni); i32_add; i32_load8_u(0);
-                  i32_eqz; br_if(1);
-                  local_get(ni); i32_const(1); i32_add;
-                  local_get(nc); i32_const(1); i32_sub; i32_and;
-                  local_set(ni); br(0);
-                end; end;
-                // Copy tag (recomputed h2)
-                local_get(nm); i32_const(map_tags_off); i32_add;
-                local_get(ni); i32_add; local_get(h2r); i32_store8(0);
-                // Copy entry
-                local_get(eb_new); local_get(ni); i32_const(es); i32_mul; i32_add;
-                local_get(eb_old); local_get(ri); i32_const(es); i32_mul; i32_add;
-                i32_const(es); memory_copy;
-              end;
-              local_get(ri); i32_const(1); i32_add; local_set(ri); br(0);
-            end; end;
-            local_get(nm); local_set(m);
-        });
-        self.scratch.free_i32(h2r);
-        self.scratch.free_i32(ni);
-        self.scratch.free_i32(eb_new);
-        self.scratch.free_i32(eb_old);
-        self.scratch.free_i32(ri);
-        self.scratch.free_i32(nm);
-        self.scratch.free_i32(nc);
     }
 
     // ── Map type helpers ──
@@ -1168,6 +887,160 @@ impl FuncCompiler<'_> {
             local_get(cap); i32_const(tag_plus_index); i32_mul;
             memory_fill(0);
         });
+    }
+
+    /// Grow `cap_out` (a local) to the smallest pow2 ≥ INITIAL_CAP that keeps
+    /// `n` entries under the load factor: n*LOAD_DEN ≤ cap*LOAD_NUM.
+    pub(super) fn emit_dict_fit_cap(&mut self, n: u32, cap_out: u32) {
+        use super::engine::layout::map as lm;
+        wasm!(self.func, {
+            i32_const(lm::INITIAL_CAP as i32); local_set(cap_out);
+            block_empty; loop_empty;
+              local_get(n); i32_const(lm::LOAD_DEN as i32); i32_mul;
+              local_get(cap_out); i32_const(lm::LOAD_NUM as i32); i32_mul;
+              i32_le_u; br_if(1);
+              local_get(cap_out); i32_const(1); i32_shl; local_set(cap_out);
+              br(0);
+            end; end;
+        });
+    }
+
+    /// Rebuild the hash index (tags + index slots) of a COD table whose dense
+    /// entries[0..len] are already populated and whose tags+index are zeroed.
+    /// For each dense entry i: hash its key, probe for an empty slot, write
+    /// tags[slot]=h2 and index[slot]=i+1 (1-based pointer back to the entry).
+    pub(super) fn emit_dict_rebuild_index(&mut self, map: u32, cap: u32, es: u32, key_ty: &Ty) {
+        use super::engine::layout::{SWISS_MAP, map as lm};
+        let tags_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
+        let len = self.scratch.alloc_i32();
+        let i = self.scratch.alloc_i32();
+        let eb = self.scratch.alloc_i32();
+        let ib = self.scratch.alloc_i32();
+        let idx = self.scratch.alloc_i32();
+        let h2 = self.scratch.alloc_i32();
+        wasm!(self.func, { local_get(map); i32_load(0); local_set(len); });
+        self.emit_dict_index_base(map, cap);
+        wasm!(self.func, { local_set(ib); });
+        self.emit_dict_entries_base(map, cap);
+        wasm!(self.func, {
+            local_set(eb);
+            i32_const(0); local_set(i);
+            block_empty; loop_empty;
+              local_get(i); local_get(len); i32_ge_u; br_if(1);
+              local_get(eb); local_get(i); i32_const(es as i32); i32_mul; i32_add;
+        });
+        self.emit_key_load(key_ty, 0);
+        self.emit_hash_key(key_ty);
+        self.emit_h1_h2(cap, idx, h2);
+        wasm!(self.func, {
+              block_empty; loop_empty;
+                local_get(map); i32_const(tags_off); i32_add;
+                local_get(idx); i32_add; i32_load8_u(0); i32_eqz; br_if(1);
+                local_get(idx); i32_const(1); i32_add;
+                local_get(cap); i32_const(1); i32_sub; i32_and; local_set(idx); br(0);
+              end; end;
+              local_get(map); i32_const(tags_off); i32_add; local_get(idx); i32_add;
+              local_get(h2); i32_store8(0);
+              local_get(ib); local_get(idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
+              local_get(i); i32_const(1); i32_add; i32_store(0);
+              local_get(i); i32_const(1); i32_add; local_set(i); br(0);
+            end; end;
+        });
+        self.scratch.free_i32(h2);
+        self.scratch.free_i32(idx);
+        self.scratch.free_i32(ib);
+        self.scratch.free_i32(eb);
+        self.scratch.free_i32(i);
+        self.scratch.free_i32(len);
+    }
+
+    /// Copy `src`'s dense entries (src.len of them) into the freshly-alloced `dst`
+    /// table, set dst.len = src.len, and rebuild dst's index. `dst` must already
+    /// be `emit_dict_alloc`-ed at `dst_cap` (entries stride `es`, tags+index zeroed).
+    pub(super) fn emit_dict_recap(&mut self, src: u32, src_cap: u32, dst: u32, dst_cap: u32, es: u32, key_ty: &Ty) {
+        let len = self.scratch.alloc_i32();
+        wasm!(self.func, { local_get(src); i32_load(0); local_set(len); });
+        self.emit_dict_entries_base(dst, dst_cap); // memory_copy dest
+        self.emit_dict_entries_base(src, src_cap); // memory_copy src
+        wasm!(self.func, {
+            local_get(len); i32_const(es as i32); i32_mul; memory_copy;
+            local_get(dst); local_get(len); i32_store(0); // dst.len = src.len
+        });
+        self.emit_dict_rebuild_index(dst, dst_cap, es, key_ty);
+        self.scratch.free_i32(len);
+    }
+
+    /// Grow a COD table in place: quadruple `cap`, recap into the bigger table,
+    /// and update the `map`/`cap` locals to point at the new table.
+    pub(super) fn emit_dict_grow(&mut self, map: u32, cap: u32, es: u32, key_ty: &Ty) {
+        use super::engine::layout::map as lm;
+        let nc = self.scratch.alloc_i32();
+        let nm = self.scratch.alloc_i32();
+        wasm!(self.func, { local_get(cap); i32_const(lm::GROWTH_SHIFT as i32); i32_shl; local_set(nc); });
+        self.emit_dict_alloc(nm, nc, es);
+        self.emit_dict_recap(map, cap, nm, nc, es, key_ty);
+        wasm!(self.func, { local_get(nm); local_set(map); local_get(nc); local_set(cap); });
+        self.scratch.free_i32(nm);
+        self.scratch.free_i32(nc);
+    }
+
+    /// The single COD insertion workhorse. `src` points to a contiguous `(key,val)`
+    /// entry (key@0, val@ks, total `es` bytes). Probe `map`'s index for the key:
+    /// existing → overwrite its value in place (dense position kept); new → append
+    /// at entries[len], write tags[slot]=h2, index[slot]=len+1, bump len. Assumes
+    /// the caller has reserved capacity (no grow). `ib`/`eb` are the index/entries bases.
+    pub(super) fn emit_dict_put_entry(&mut self, map: u32, cap: u32, ib: u32, eb: u32, src: u32, es: u32, ks: u32, vs: u32, key_ty: &Ty) {
+        use super::engine::layout::{SWISS_MAP, map as lm};
+        let tags_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
+        let idx = self.scratch.alloc_i32();
+        let h2 = self.scratch.alloc_i32();
+        let tg = self.scratch.alloc_i32();
+        let ei = self.scratch.alloc_i32();
+        wasm!(self.func, { local_get(src); });
+        self.emit_key_load(key_ty, 0);
+        self.emit_hash_key(key_ty);
+        self.emit_h1_h2(cap, idx, h2);
+        wasm!(self.func, {
+            block_empty; loop_empty;
+              local_get(map); i32_const(tags_off); i32_add; local_get(idx); i32_add; i32_load8_u(0); local_set(tg);
+              local_get(tg); i32_eqz; br_if(1);              // empty slot → new key
+              local_get(tg); local_get(h2); i32_eq;
+              if_empty;
+                local_get(ib); local_get(idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
+                i32_load(0); i32_const(1); i32_sub; local_set(ei);   // ei = index[idx]-1
+                local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
+        });
+        self.emit_key_load(key_ty, 0);          // existing entry key
+        wasm!(self.func, { local_get(src); });
+        self.emit_key_load(key_ty, 0);          // src key
+        self.emit_key_eq(key_ty);
+        wasm!(self.func, {
+                br_if(2);                        // equal → existing, ei set, exit probe
+              end;
+              local_get(idx); i32_const(1); i32_add;
+              local_get(cap); i32_const(1); i32_sub; i32_and; local_set(idx); br(0);
+            end; end;
+            // New key (tg==0): append at dense entries[len].
+            local_get(tg); i32_eqz;
+            if_empty;
+              local_get(map); i32_load(0); local_set(ei);          // ei = len
+              local_get(map); i32_const(tags_off); i32_add; local_get(idx); i32_add;
+              local_get(h2); i32_store8(0);                        // tags[idx] = h2
+              local_get(ib); local_get(idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
+              local_get(ei); i32_const(1); i32_add; i32_store(0);  // index[idx] = ei+1
+              local_get(map); local_get(ei); i32_const(1); i32_add; i32_store(0); // map.len = ei+1
+              local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
+              local_get(src); i32_const(ks as i32); memory_copy;   // copy key bytes
+            end;
+            // Copy value bytes into entries[ei]+ks (both new and existing).
+            local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add; i32_const(ks as i32); i32_add;
+            local_get(src); i32_const(ks as i32); i32_add;
+            i32_const(vs as i32); memory_copy;
+        });
+        self.scratch.free_i32(ei);
+        self.scratch.free_i32(tg);
+        self.scratch.free_i32(h2);
+        self.scratch.free_i32(idx);
     }
 
     /// Push a closure pair's env pointer (field load via the CLOSURE_PAIR layout).

--- a/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
@@ -5,7 +5,6 @@
 use super::FuncCompiler;
 use super::values;
 use almide_ir::IrExpr;
-use almide_lang::types::Ty;
 use wasm_encoder::ValType;
 
 impl FuncCompiler<'_> {
@@ -170,14 +169,12 @@ impl FuncCompiler<'_> {
                 self.map_iter_end(it);
             }
             "filter" => {
-                // filter(m, pred) → Map: rebuild a Swiss table from the entries
-                // where pred(k, v) is true. The map is a Swiss table — the old
-                // dense `[len][entries]` walk read garbage / trapped. Mirrors
-                // `remove`'s rehash-into-a-fresh-table, but keeps an entry when
-                // `pred(k, v)` is true (vs `remove`'s key-mismatch).
+                // filter(m, pred) → Map: dense-walk the source entries[0..len] in
+                // insertion order; for each entry where pred(k, v) is true, append it
+                // to a fresh COD table (source keys are unique, so put_entry always
+                // appends — order preserved). Dest cap = source cap (filter never grows).
                 use super::engine::layout::{SWISS_MAP, map as lm};
-                let map_tags_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
-                let map_cap_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP) as i32;
+                let map_cap_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP);
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
@@ -185,12 +182,13 @@ impl FuncCompiler<'_> {
                 let m = self.scratch.alloc_i32();
                 let closure = self.scratch.alloc_i32();
                 let cap = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
                 let nm = self.scratch.alloc_i32();
-                let i = self.scratch.alloc_i32();
+                let ib = self.scratch.alloc_i32();
                 let eb_old = self.scratch.alloc_i32();
                 let eb_new = self.scratch.alloc_i32();
-                let h2r = self.scratch.alloc_i32();
-                let nidx = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let entry = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(m); });
@@ -198,80 +196,49 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_set(closure);
                     local_get(m); i32_load(map_cap_off); local_set(cap);
+                    local_get(m); i32_load(0); local_set(len);
                 });
-                self.emit_alloc_table(nm, cap, es as i32);
+                self.emit_dict_alloc(nm, cap, es);
+                self.emit_dict_index_base(nm, cap);
+                wasm!(self.func, { local_set(ib); });
+                self.emit_dict_entries_base(nm, cap);
+                wasm!(self.func, { local_set(eb_new); });
+                self.emit_dict_entries_base(m, cap);
                 wasm!(self.func, {
-                    local_get(m); i32_const(map_tags_off); i32_add;
-                    local_get(cap); i32_add; local_set(eb_old);
-                    local_get(nm); i32_const(map_tags_off); i32_add;
-                    local_get(cap); i32_add; local_set(eb_new);
+                    local_set(eb_old);
                     i32_const(0); local_set(i);
                     block_empty; loop_empty;
-                      local_get(i); local_get(cap); i32_ge_u; br_if(1);
-                      local_get(m); i32_const(map_tags_off); i32_add;
-                      local_get(i); i32_add; i32_load8_u(0);
-                      if_empty; // occupied (tag != 0)
-                        // pred(env, k, v)
-                        local_get(closure); i32_load(4); // env
-                        local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add; local_set(entry);
+                      // pred(env, k, v)
+                      local_get(closure); i32_load(4); // env
+                      local_get(entry);
                 });
                 self.emit_key_load(&key_ty, 0);
-                wasm!(self.func, {
-                        local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add;
-                        i32_const(ks as i32); i32_add;
-                });
+                wasm!(self.func, { local_get(entry); i32_const(ks as i32); i32_add; });
                 self.emit_load_at(&val_ty, 0);
-                wasm!(self.func, {
-                        local_get(closure); i32_load(0); // table_idx
-                });
+                wasm!(self.func, { local_get(closure); i32_load(0); }); // table_idx
                 {
                     let key_vt = Self::key_valtype(&key_ty);
                     let mut ct = vec![ValType::I32, key_vt];
                     if let Some(vt) = values::ty_to_valtype(&val_ty) { ct.push(vt); }
                     self.emit_call_indirect(ct, vec![ValType::I32]);
                 }
+                wasm!(self.func, { if_empty; }); // pred true → keep
+                self.emit_dict_put_entry(nm, cap, ib, eb_new, entry, es, ks, vs, &key_ty);
                 wasm!(self.func, {
-                        if_empty; // pred true → keep: rehash into nm
-                          local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add;
-                });
-                self.emit_key_load(&key_ty, 0);
-                self.emit_hash_key(&key_ty);
-                self.emit_h1_h2(cap, nidx, h2r);
-                wasm!(self.func, {
-                          block_empty; loop_empty;
-                            local_get(nm); i32_const(map_tags_off); i32_add;
-                            local_get(nidx); i32_add; i32_load8_u(0);
-                            i32_eqz; br_if(1);
-                            local_get(nidx); i32_const(1); i32_add;
-                            local_get(cap); i32_const(1); i32_sub; i32_and;
-                            local_set(nidx); br(0);
-                          end; end;
-                          // copy tag
-                          local_get(nm); i32_const(map_tags_off); i32_add;
-                          local_get(nidx); i32_add;
-                          local_get(m); i32_const(map_tags_off); i32_add;
-                          local_get(i); i32_add; i32_load8_u(0);
-                          i32_store8(0);
-                          // copy entry
-                          local_get(eb_new); local_get(nidx); i32_const(es as i32); i32_mul; i32_add;
-                          local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add;
-                          i32_const(es as i32); memory_copy;
-                          // len++
-                          local_get(nm);
-                          local_get(nm); i32_load(0); i32_const(1); i32_add;
-                          i32_store(0);
-                        end; // pred-true if
-                      end; // occupied if
+                      end; // pred-true if
                       local_get(i); i32_const(1); i32_add; local_set(i); br(0);
                     end; end;
                     local_get(nm);
                 });
-                self.scratch.free_i32(nidx);
-                self.scratch.free_i32(h2r);
+                self.scratch.free_i32(entry);
+                self.scratch.free_i32(i);
                 self.scratch.free_i32(eb_new);
                 self.scratch.free_i32(eb_old);
-                self.scratch.free_i32(i);
+                self.scratch.free_i32(ib);
                 self.scratch.free_i32(nm);
+                self.scratch.free_i32(len);
                 self.scratch.free_i32(cap);
                 self.scratch.free_i32(closure);
                 self.scratch.free_i32(m);
@@ -308,10 +275,10 @@ impl FuncCompiler<'_> {
                 self.map_iter_end(it);
             }
             "find" => {
-                // find(m, pred) → Option[(K, V)]
+                // find(m, pred) → Option[(K, V)]: dense-walk entries[0..len] in
+                // insertion order; return the first (k, v) where pred(k, v) is true.
                 use super::engine::layout::{SWISS_MAP, map as lm};
-                let MAP_TAGS_OFFSET = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
-                let MAP_CAP_OFFSET = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP);
+                let map_cap_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP);
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
@@ -319,41 +286,35 @@ impl FuncCompiler<'_> {
                 let map_ptr = self.scratch.alloc_i32();
                 let closure = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
                 let cap = self.scratch.alloc_i32();
                 let eb = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();
                 let tuple_ptr = self.scratch.alloc_i32();
+                let ent = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(map_ptr); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
                     local_set(closure);
-                    local_get(map_ptr); i32_load(MAP_CAP_OFFSET as u32); local_set(cap);
-                    local_get(map_ptr); i32_const(MAP_TAGS_OFFSET); i32_add;
-                    local_get(cap); i32_add; local_set(eb);
+                    local_get(map_ptr); i32_load(0); local_set(len);
+                    local_get(map_ptr); i32_load(map_cap_off); local_set(cap);
+                });
+                self.emit_dict_entries_base(map_ptr, cap);
+                wasm!(self.func, {
+                    local_set(eb);
                     i32_const(0); local_set(i);
                     i32_const(0); local_set(result); // none
                     block_empty; loop_empty;
-                      local_get(i); local_get(cap); i32_ge_u; br_if(1);
-                      local_get(map_ptr); i32_const(MAP_TAGS_OFFSET); i32_add;
-                      local_get(i); i32_add; i32_load8_u(0); i32_eqz;
-                      if_empty;
-                        local_get(i); i32_const(1); i32_add; local_set(i); br(1);
-                      end;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(eb); local_get(i); i32_const(entry as i32); i32_mul; i32_add; local_set(ent);
                       local_get(closure); i32_load(4);
-                      local_get(eb);
-                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(ent);
                 });
                 self.emit_key_load(&key_ty, 0);
-                wasm!(self.func, {
-                      local_get(eb);
-                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_const(ks as i32); i32_add;
-                });
+                wasm!(self.func, { local_get(ent); i32_const(ks as i32); i32_add; });
                 self.emit_load_at(&val_ty, 0);
-                wasm!(self.func, {
-                      local_get(closure); i32_load(0);
-                });
+                wasm!(self.func, { local_get(closure); i32_load(0); });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
                     let mut ct = vec![ValType::I32, key_vt];
@@ -362,24 +323,9 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                       if_empty;
-                        // Alloc tuple (key, val) and wrap in Option
+                        // Alloc the (key, val) tuple (one contiguous block) and wrap in Some.
                         i32_const(entry as i32); call(self.emitter.rt.alloc); local_set(tuple_ptr);
-                        // Copy key
-                        local_get(tuple_ptr);
-                        local_get(eb);
-                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
-                });
-                self.emit_elem_copy_sized(ks);
-                // Copy val
-                wasm!(self.func, {
-                        local_get(tuple_ptr); i32_const(ks as i32); i32_add;
-                        local_get(eb);
-                        local_get(i); i32_const(entry as i32); i32_mul; i32_add;
-                        i32_const(ks as i32); i32_add;
-                });
-                self.emit_elem_copy_sized(vs);
-                wasm!(self.func, {
-                        // Wrap in some
+                        local_get(tuple_ptr); local_get(ent); i32_const(entry as i32); memory_copy;
                         i32_const(4); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); local_get(tuple_ptr); i32_store(0);
                         br(2); // break out of loop
@@ -389,128 +335,106 @@ impl FuncCompiler<'_> {
                     end; end;
                     local_get(result); // result (none=0 or some ptr)
                 });
+                self.scratch.free_i32(ent);
                 self.scratch.free_i32(tuple_ptr);
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(eb);
                 self.scratch.free_i32(cap);
+                self.scratch.free_i32(len);
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(closure);
                 self.scratch.free_i32(map_ptr);
             }
             "update" => {
-                // update(m, key, f) → Map: apply f to value at key
-                // Swiss Table: memcpy entire map, then find+modify value in the copy.
+                // update(m, key, f) → Map: byte-copy the whole COD table (keys/tags/
+                // index unchanged), dense-scan for the key (found_idx = dense entry
+                // index), then apply f to the value at that dense position in the copy.
                 use super::engine::layout::{SWISS_MAP, map as lm};
-                let MAP_TAGS_OFFSET = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
-                let MAP_CAP_OFFSET = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP);
-                let MAP_HEADER_SIZE = self.emitter.layout_reg.header_size(SWISS_MAP) as i32;
+                let map_cap_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP);
+                let map_hdr = self.emitter.layout_reg.header_size(SWISS_MAP) as i32;
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
                 let entry = ks + vs;
+                let per_slot = 1 + lm::INDEX_SLOT_SIZE as i32 + entry as i32;
                 let map_ptr = self.scratch.alloc_i32();
                 let closure = self.scratch.alloc_i32();
-                let search_key_i64 = self.scratch.alloc_i64();
-                let search_key_i32 = self.scratch.alloc_i32();
+                let sk32 = self.scratch.alloc_i32();
+                let sk64 = self.scratch.alloc_i64();
                 let i = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
                 let cap = self.scratch.alloc_i32();
                 let eb = self.scratch.alloc_i32();
                 let found_idx = self.scratch.alloc_i32();
                 let new_map = self.scratch.alloc_i32();
                 let total_size = self.scratch.alloc_i32();
+                let valaddr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(map_ptr); });
-                // Store search key
                 self.emit_expr(&args[1]); // key
-                match &key_ty {
-                    Ty::Int => {
-                        wasm!(self.func, { local_set(search_key_i64); });
-                    }
-                    _ => {
-                        wasm!(self.func, { local_set(search_key_i32); });
-                    }
-                }
+                self.emit_search_key_store(&key_ty, sk32, sk64);
                 self.emit_expr(&args[2]); // closure f
                 wasm!(self.func, {
                     local_set(closure);
-                    local_get(map_ptr); i32_load(MAP_CAP_OFFSET as u32); local_set(cap);
-                    local_get(map_ptr); i32_const(MAP_TAGS_OFFSET); i32_add;
-                    local_get(cap); i32_add; local_set(eb);
-                    // Find key index by scanning occupied slots
+                    local_get(map_ptr); i32_load(0); local_set(len);
+                    local_get(map_ptr); i32_load(map_cap_off); local_set(cap);
+                });
+                self.emit_dict_entries_base(map_ptr, cap);
+                wasm!(self.func, {
+                    local_set(eb);
                     i32_const(0); local_set(i);
                     i32_const(-1); local_set(found_idx);
                     block_empty; loop_empty;
-                      local_get(i); local_get(cap); i32_ge_u; br_if(1);
-                      // Skip empty slots
-                      local_get(map_ptr); i32_const(MAP_TAGS_OFFSET); i32_add;
-                      local_get(i); i32_add; i32_load8_u(0); i32_eqz;
-                      if_empty;
-                        local_get(i); i32_const(1); i32_add; local_set(i); br(1);
-                      end;
-                      local_get(eb);
-                      local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(eb); local_get(i); i32_const(entry as i32); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
-                match &key_ty {
-                    Ty::Int => {
-                        wasm!(self.func, { local_get(search_key_i64); });
-                    }
-                    _ => {
-                        wasm!(self.func, { local_get(search_key_i32); });
-                    }
-                }
+                self.emit_search_key_load(&key_ty, sk32, sk64);
                 self.emit_key_eq(&key_ty);
                 wasm!(self.func, {
                       if_empty; local_get(i); local_set(found_idx); br(2); end; // found → break
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    // If not found, return original
+                    // If not found, return the original map unchanged.
                     local_get(found_idx); i32_const(0); i32_lt_s;
                     if_i32; local_get(map_ptr);
                     else_;
-                      // Copy entire Swiss Table: header + tags + entries
-                      // total_size = MAP_HEADER_SIZE + cap + cap * entry
-                      i32_const(MAP_HEADER_SIZE);
-                      local_get(cap); i32_add;
-                      local_get(cap); i32_const(entry as i32); i32_mul; i32_add;
+                      // Byte-copy the whole COD table: header + cap*per_slot.
+                      i32_const(map_hdr);
+                      local_get(cap); i32_const(per_slot); i32_mul; i32_add;
                       local_tee(total_size);
                       call(self.emitter.rt.alloc); local_set(new_map);
-                      // memcpy entire map
                       local_get(new_map); local_get(map_ptr); local_get(total_size);
                       memory_copy;
-                      // Compute entry base in new map
-                      // new_eb = new_map + MAP_TAGS_OFFSET + cap
-                      // Apply f to value at found_idx
-                      local_get(new_map); i32_const(MAP_TAGS_OFFSET); i32_add;
-                      local_get(cap); i32_add;
+                });
+                // valaddr = dense entries base(new_map, cap) + found_idx*entry + ks
+                self.emit_dict_entries_base(new_map, cap);
+                wasm!(self.func, {
                       local_get(found_idx); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_const(ks as i32); i32_add; // dst val addr on stack
+                      i32_const(ks as i32); i32_add; local_set(valaddr);
+                      local_get(valaddr);              // dst val addr
                       local_get(closure); i32_load(4); // env
-                      // Load old val from same addr
-                      local_get(new_map); i32_const(MAP_TAGS_OFFSET); i32_add;
-                      local_get(cap); i32_add;
-                      local_get(found_idx); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_const(ks as i32); i32_add;
+                      local_get(valaddr);              // load old val from same addr
                 });
                 self.emit_load_at(&val_ty, 0);
-                wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
-                });
+                wasm!(self.func, { local_get(closure); i32_load(0); }); // table_idx
                 self.emit_closure_call(&val_ty, &val_ty);
                 self.emit_store_at(&val_ty, 0);
                 wasm!(self.func, {
                       local_get(new_map);
                     end;
                 });
+                self.scratch.free_i32(valaddr);
                 self.scratch.free_i32(total_size);
                 self.scratch.free_i32(new_map);
                 self.scratch.free_i32(found_idx);
                 self.scratch.free_i32(eb);
                 self.scratch.free_i32(cap);
+                self.scratch.free_i32(len);
                 self.scratch.free_i32(i);
-                self.scratch.free_i32(search_key_i32);
-                self.scratch.free_i64(search_key_i64);
+                self.scratch.free_i32(sk32);
+                self.scratch.free_i64(sk64);
                 self.scratch.free_i32(closure);
                 self.scratch.free_i32(map_ptr);
             }
@@ -522,53 +446,46 @@ impl FuncCompiler<'_> {
     // (filter method is handled via map.set insertion — see calls_map.rs)
 }
 
-// ── Swiss Table iteration helpers ──
+// ── Compact-ordered-dict iteration helpers ──
 
-/// Scratch locals for iterating a Swiss Table map.
+/// Scratch locals for iterating a compact-ordered-dict map in insertion order.
 pub(super) struct MapIter {
     pub map: u32,       // map pointer
-    pub cap: u32,       // capacity (number of slots)
-    pub eb: u32,        // entry base (pointer to first entry, after tags)
-    pub i: u32,         // slot index (0..cap)
+    pub cap: u32,       // capacity (slot count) — needed only to derive the entries base
+    pub len: u32,       // entry count (dense walk bound)
+    pub eb: u32,        // dense entries base (map + header + cap + cap*INDEX_SLOT_SIZE)
+    pub i: u32,         // dense entry index (0..len)
     pub entry_size: u32, // key_size + val_size
 }
 
 impl FuncCompiler<'_> {
-    /// Allocate scratch locals and emit Swiss Table setup:
-    /// cap = map[CAP_OFFSET], eb = map + TAGS_OFFSET + cap, i = 0.
+    /// Allocate scratch locals and emit COD setup: len = map[0], cap = map[CAP],
+    /// eb = dense entries base, i = 0. Iteration walks the dense entries[0..len].
     pub(super) fn map_iter_begin(&mut self, map_expr: &IrExpr, entry_size: u32) -> MapIter {
         use super::engine::layout::{SWISS_MAP, map as lm};
-                let MAP_TAGS_OFFSET = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
-                let MAP_CAP_OFFSET = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP);
+        let map_cap_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP);
         let map = self.scratch.alloc_i32();
         let cap = self.scratch.alloc_i32();
+        let len = self.scratch.alloc_i32();
         let eb = self.scratch.alloc_i32();
         let i = self.scratch.alloc_i32();
         self.emit_expr(map_expr);
         wasm!(self.func, {
             local_set(map);
-            local_get(map); i32_load(MAP_CAP_OFFSET as u32); local_set(cap);
-            local_get(map); i32_const(MAP_TAGS_OFFSET); i32_add;
-            local_get(cap); i32_add; local_set(eb);
-            i32_const(0); local_set(i);
+            local_get(map); i32_load(0); local_set(len);
+            local_get(map); i32_load(map_cap_off); local_set(cap);
         });
-        MapIter { map, cap, eb, i, entry_size }
+        self.emit_dict_entries_base(map, cap);
+        wasm!(self.func, { local_set(eb); i32_const(0); local_set(i); });
+        MapIter { map, cap, len, eb, i, entry_size }
     }
 
-    /// Emit loop header: block/loop, break if i >= cap, skip empty tag.
-    /// After this, the current slot is guaranteed occupied.
+    /// Emit loop header: block/loop, break if i >= len. Dense entries are all
+    /// occupied (no tag scan), so the current entry is always valid.
     pub(super) fn map_iter_loop_head(&mut self, it: &MapIter) {
-        use super::engine::layout::{SWISS_MAP, map as lm};
-        let MAP_TAGS_OFFSET = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
         wasm!(self.func, {
             block_empty; loop_empty;
-              local_get(it.i); local_get(it.cap); i32_ge_u; br_if(1);
-              // tag check: skip empty
-              local_get(it.map); i32_const(MAP_TAGS_OFFSET); i32_add;
-              local_get(it.i); i32_add; i32_load8_u(0); i32_eqz;
-              if_empty;
-                local_get(it.i); i32_const(1); i32_add; local_set(it.i); br(1);
-              end;
+              local_get(it.i); local_get(it.len); i32_ge_u; br_if(1);
         });
     }
 
@@ -602,23 +519,24 @@ impl FuncCompiler<'_> {
     pub(super) fn map_iter_end(&mut self, it: MapIter) {
         self.scratch.free_i32(it.i);
         self.scratch.free_i32(it.eb);
+        self.scratch.free_i32(it.len);
         self.scratch.free_i32(it.cap);
         self.scratch.free_i32(it.map);
     }
 
-    /// Allocate a full copy of a Swiss Table map (header + tags + entries).
-    /// Returns scratch local holding the new map pointer.
+    /// Allocate a full byte-copy of a COD map (header + tags + index + dense
+    /// entries). Safe for `map`, which transforms values in place: keys, tags,
+    /// and index pointers are unchanged, so the copied index stays valid.
     pub(super) fn map_copy_full(&mut self, it: &MapIter) -> u32 {
         use super::engine::layout::{SWISS_MAP, map as lm};
-        let MAP_TAGS_OFFSET = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
-        let MAP_HEADER_SIZE = self.emitter.layout_reg.header_size(SWISS_MAP) as i32;
+        let map_hdr = self.emitter.layout_reg.header_size(SWISS_MAP) as i32;
+        let per_slot = 1 + lm::INDEX_SLOT_SIZE as i32 + it.entry_size as i32;
         let total = self.scratch.alloc_i32();
         let new_map = self.scratch.alloc_i32();
         wasm!(self.func, {
-            // total = HEADER + cap + cap * entry_size
-            i32_const(MAP_HEADER_SIZE);
-            local_get(it.cap); i32_add;
-            local_get(it.cap); i32_const(it.entry_size as i32); i32_mul; i32_add;
+            // total = header + cap*(tag(1) + INDEX_SLOT_SIZE + entry_size)
+            i32_const(map_hdr);
+            local_get(it.cap); i32_const(per_slot); i32_mul; i32_add;
             local_tee(total);
             call(self.emitter.rt.alloc); local_set(new_map);
             local_get(new_map); local_get(it.map); local_get(total);
@@ -628,15 +546,11 @@ impl FuncCompiler<'_> {
         new_map
     }
 
-    /// Compute entry base for a copied map: new_map + TAGS_OFFSET + cap.
+    /// Compute the dense entries base of a copied map.
     pub(super) fn map_copy_entry_base(&mut self, new_map: u32, it: &MapIter) -> u32 {
-        use super::engine::layout::{SWISS_MAP, map as lm};
-        let MAP_TAGS_OFFSET = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
         let new_eb = self.scratch.alloc_i32();
-        wasm!(self.func, {
-            local_get(new_map); i32_const(MAP_TAGS_OFFSET); i32_add;
-            local_get(it.cap); i32_add; local_set(new_eb);
-        });
+        self.emit_dict_entries_base(new_map, it.cap);
+        wasm!(self.func, { local_set(new_eb); });
         new_eb
     }
 }

--- a/crates/almide-codegen/src/emit_wasm/control.rs
+++ b/crates/almide-codegen/src/emit_wasm/control.rs
@@ -164,9 +164,9 @@ impl FuncCompiler<'_> {
         self.scratch.free_i32(list_scratch);
     }
 
-    /// Emit for-in over a Map (Swiss Table).
-    /// Layout: [len:i32][cap:i32][tags: cap bytes][entries: cap × (key+val)]
-    /// Iterates slot 0..cap, skips empty tags (tag==0).
+    /// Emit for-in over a Map (compact-ordered-dict).
+    /// Layout: [len:i32][cap:i32][tags: cap bytes][index: cap×4][entries: cap × (key+val)]
+    /// Walks the dense entries[0..len] in insertion order (no tag scan).
     fn emit_for_in_map(&mut self, var: almide_ir::VarId, var_tuple: Option<&[almide_ir::VarId]>, iterable: &IrExpr, body: &[IrStmt]) {
 
         let (key_ty, val_ty, key_size, val_size) = if let Ty::Applied(_, args) = &iterable.ty {
@@ -179,23 +179,22 @@ impl FuncCompiler<'_> {
             (Ty::String, Ty::Int, 4u32, 4u32)
         };
         let entry_size = key_size + val_size;
+        let map_cap_off = self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::CAP);
 
         let m = self.scratch.alloc_i32();      // map ptr
-        let cap = self.scratch.alloc_i32();     // capacity
-        let eb = self.scratch.alloc_i32();      // entry base (ptr to first entry)
-        let idx = self.scratch.alloc_i32();     // slot index (0..cap)
+        let cap = self.scratch.alloc_i32();     // capacity (to derive the entries base)
+        let len = self.scratch.alloc_i32();     // entry count (dense walk bound)
+        let eb = self.scratch.alloc_i32();      // dense entries base
+        let idx = self.scratch.alloc_i32();     // dense entry index (0..len)
 
         self.emit_expr(iterable);
         wasm!(self.func, {
             local_set(m);
-            // cap = m[self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::CAP) as i32]
-            local_get(m); i32_load(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::CAP) as i32 as u32); local_set(cap);
-            // entry_base = m + self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32 + cap
-            local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-            local_get(cap); i32_add; local_set(eb);
-            // idx = 0
-            i32_const(0); local_set(idx);
+            local_get(m); i32_load(0); local_set(len);
+            local_get(m); i32_load(map_cap_off); local_set(cap);
         });
+        self.emit_dict_entries_base(m, cap);
+        wasm!(self.func, { local_set(eb); i32_const(0); local_set(idx); });
 
         // block $break { loop $loop { ... } }
         wasm!(self.func, { block_empty; });
@@ -203,25 +202,13 @@ impl FuncCompiler<'_> {
         wasm!(self.func, { loop_empty; });
         let loop_guard = self.depth_push();
 
-        // Break if idx >= cap
+        // Break if idx >= len (dense entries are all occupied — no tag skip)
         wasm!(self.func, {
-            local_get(idx); local_get(cap); i32_ge_u;
+            local_get(idx); local_get(len); i32_ge_u;
             br_if(self.depth - break_guard.saved() - 1);
         });
 
-        // Check tag: if tag[idx] == 0 (empty), skip to next slot
-        wasm!(self.func, {
-            local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-            local_get(idx); i32_add; i32_load8_u(0);
-            i32_eqz;
-            if_empty;
-                // Skip: idx++; br $loop
-                local_get(idx); i32_const(1); i32_add; local_set(idx);
-                br(self.depth - loop_guard.saved());
-            end;
-        });
-
-        // Occupied slot: load key/value into tuple vars
+        // Dense entry: load key/value into tuple vars
         if let Some(tuple_vars) = var_tuple {
             // Load key
             if let Some(&k_local) = tuple_vars.first().and_then(|tv| self.var_map.get(&tv.0)) {
@@ -268,6 +255,7 @@ impl FuncCompiler<'_> {
 
         self.scratch.free_i32(idx);
         self.scratch.free_i32(eb);
+        self.scratch.free_i32(len);
         self.scratch.free_i32(cap);
         self.scratch.free_i32(m);
     }

--- a/crates/almide-codegen/src/emit_wasm/engine/builder.rs
+++ b/crates/almide-codegen/src/emit_wasm/engine/builder.rs
@@ -131,27 +131,31 @@ impl<'a> WasmBuilder<'a> {
         }); });
     }
 
-    /// Iterate occupied Swiss Table entries.
+    /// Iterate the dense entries of a compact-ordered-dict map in insertion order.
+    /// `cap_l` is a scratch local (used transiently for the capacity, then the len
+    /// bound). Walks `entries[0..len]` — every dense entry is occupied (no tag scan).
     pub fn map_foreach(
         &mut self, map: u32, entry: u32, cap_l: u32, eb: u32, idx: u32,
         entry_stride: u32, body: impl FnOnce(&mut Self),
     ) {
+        let len_off = self.reg.fixed_offset(SWISS_MAP, map::LEN);
+        let len_ty = self.reg.field(SWISS_MAP, map::LEN).ty;
         let cap_off = self.reg.fixed_offset(SWISS_MAP, map::CAP);
         let cap_ty = self.reg.field(SWISS_MAP, map::CAP).ty;
         let tags_off = self.reg.fixed_offset(SWISS_MAP, map::TAGS);
-        let tag_ty = self.reg.field(SWISS_MAP, map::TAGS).ty;
 
+        // Dense entries base = map + header + cap + cap*INDEX_SLOT_SIZE (after tags + index).
         self.get(map).emit_load(cap_off, cap_ty).set(cap_l);
-        self.get(map).i32c(tags_off as i32).add().get(cap_l).add().set(eb);
+        self.get(map).i32c(tags_off as i32).add()
+            .get(cap_l).add()
+            .get(cap_l).i32c(map::INDEX_SLOT_SIZE as i32).mul().add()
+            .set(eb);
+        // Reuse cap_l to hold the len bound (cap only needed for the base above).
+        self.get(map).emit_load(len_off, len_ty).set(cap_l);
         self.i32c(0).set(idx);
 
         self.block(|w| { w.loop_(|w| {
             w.get(idx).get(cap_l).ge_u().br_if(1);
-
-            // skip empty tag
-            w.get(map).i32c(tags_off as i32).add().get(idx).add();
-            w.emit_load(0, tag_ty).eqz();
-            w.if_void(|w| { w.get(idx).i32c(1).add().set(idx).br(1); }, |_| {});
 
             w.get(eb).get(idx).i32c(entry_stride as i32).mul().add().set(entry);
 

--- a/crates/almide-codegen/src/emit_wasm/engine/emit.rs
+++ b/crates/almide-codegen/src/emit_wasm/engine/emit.rs
@@ -252,14 +252,17 @@ fn emit_map_foreach(
 ) {
     use wasm_encoder::Instruction::*;
     use super::layout;
+    // Compact-ordered-dict: walk dense entries[0..len] in insertion order.
+    let len_off = reg.fixed_offset(layout::SWISS_MAP, layout::map::LEN);
+    let len_align = reg.field(layout::SWISS_MAP, layout::map::LEN).ty.align_exp();
     let cap_off = reg.fixed_offset(layout::SWISS_MAP, layout::map::CAP);
     let cap_align = reg.field(layout::SWISS_MAP, layout::map::CAP).ty.align_exp();
     let tags_off = reg.fixed_offset(layout::SWISS_MAP, layout::map::TAGS);
-    let tag_align = reg.field(layout::SWISS_MAP, layout::map::TAGS).ty.align_exp();
     let cap_l = entry + 1;
     let eb_l = entry + 2;
     let idx = entry + 3;
 
+    // Dense entries base = map + header + cap + cap*INDEX_SLOT_SIZE (after tags + index).
     f.instruction(&LocalGet(map));
     f.instruction(&I32Load(ma(cap_off, cap_align)));
     f.instruction(&LocalSet(cap_l));
@@ -268,7 +271,15 @@ fn emit_map_foreach(
     f.instruction(&I32Add);
     f.instruction(&LocalGet(cap_l));
     f.instruction(&I32Add);
+    f.instruction(&LocalGet(cap_l));
+    f.instruction(&I32Const(layout::map::INDEX_SLOT_SIZE as i32));
+    f.instruction(&I32Mul);
+    f.instruction(&I32Add);
     f.instruction(&LocalSet(eb_l));
+    // Reuse cap_l to hold the len bound (cap only needed for the base above).
+    f.instruction(&LocalGet(map));
+    f.instruction(&I32Load(ma(len_off, len_align)));
+    f.instruction(&LocalSet(cap_l));
     f.instruction(&I32Const(0));
     f.instruction(&LocalSet(idx));
     f.instruction(&Block(wasm_encoder::BlockType::Empty));
@@ -277,20 +288,6 @@ fn emit_map_foreach(
     f.instruction(&LocalGet(cap_l));
     f.instruction(&I32GeU);
     f.instruction(&BrIf(1));
-    f.instruction(&LocalGet(map));
-    f.instruction(&I32Const(tags_off as i32));
-    f.instruction(&I32Add);
-    f.instruction(&LocalGet(idx));
-    f.instruction(&I32Add);
-    f.instruction(&I32Load8U(ma(0, tag_align)));
-    f.instruction(&I32Eqz);
-    f.instruction(&If(wasm_encoder::BlockType::Empty));
-    f.instruction(&LocalGet(idx));
-    f.instruction(&I32Const(1));
-    f.instruction(&I32Add);
-    f.instruction(&LocalSet(idx));
-    f.instruction(&Br(1));
-    f.instruction(&End);
     f.instruction(&LocalGet(eb_l));
     f.instruction(&LocalGet(idx));
     f.instruction(&I32Const(stride as i32));

--- a/crates/almide-codegen/src/emit_wasm/engine/layout.rs
+++ b/crates/almide-codegen/src/emit_wasm/engine/layout.rs
@@ -105,13 +105,39 @@ pub mod list {
     pub const DATA: FieldId = FieldId(2);
 }
 
-// Well-known field IDs for SwissMap.
+// Well-known field IDs + compact-ordered-dict tuning for the Map.
+//
+// The Map is a compact-ordered-dict (Python-dict / indexmap style): a hash INDEX
+// over a DENSE insertion-ordered entries array. Heap layout:
+//   [len:i32 @0][cap:i32 @4][tags:u8[cap] @8][index:i32[cap] @8+cap][entries:(K,V)[cap] @8+cap+cap*INDEX_SLOT_SIZE]
+// `LEN`/`CAP` are fixed-offset; the three array regions are cap-relative and are
+// addressed through the centralized `dict_*` helpers (never inline byte math) so
+// there is no layout magic number at any call site.
 pub mod map {
     use super::FieldId;
     pub const LEN: FieldId = FieldId(0);
     pub const CAP: FieldId = FieldId(1);
+    /// h2 fast-reject tag array, `cap` bytes @ header (0 = empty slot).
     pub const TAGS: FieldId = FieldId(2);
+    /// Dense `(key,val)` entries in INSERTION ORDER, `entries[0..len]`. (Field id
+    /// is nominal — its actual base is `8 + cap + cap*INDEX_SLOT_SIZE`, computed by
+    /// the `dict_*` helpers, not by `fixed_offset`.)
     pub const ENTRIES: FieldId = FieldId(3);
+
+    /// Bytes per INDEX slot (a 1-based `i32` pointer into the dense entries).
+    pub const INDEX_SLOT_SIZE: u32 = 4;
+    /// INDEX slot value meaning "empty" (entries are 1-based: slot `v` → `entries[v-1]`).
+    pub const EMPTY_INDEX: i32 = 0;
+    /// Initial capacity (always a power of two).
+    pub const INITIAL_CAP: u32 = 16;
+    /// Growth on overflow: `new_cap = cap << GROWTH_SHIFT` (4×).
+    pub const GROWTH_SHIFT: u32 = 2;
+    /// Load factor: grow when `len * LOAD_NUM > cap * LOAD_DEN` (75%).
+    pub const LOAD_NUM: u32 = 3;
+    pub const LOAD_DEN: u32 = 4;
+    /// Hash split: `h2` tag = `(hash >> H2_SHIFT) & H2_MASK`, coerced to ≥ 1.
+    pub const H2_SHIFT: u32 = 25;
+    pub const H2_MASK: u32 = 0x7F;
 }
 
 // Well-known field IDs for alloc header.

--- a/crates/almide-codegen/src/emit_wasm/equality.rs
+++ b/crates/almide-codegen/src/emit_wasm/equality.rs
@@ -303,10 +303,10 @@ impl FuncCompiler<'_> {
         self.scratch.free_i32(a);
     }
 
-    /// Structural map equality (Swiss table): [a_ptr, b_ptr] → i32.
+    /// Structural map equality (compact-ordered-dict): [a_ptr, b_ptr] → i32.
     /// Equal iff same size and every (k,v) of `a` is present in `b` with an
-    /// equal value. Iterates a's occupied slots and probes b for each key,
-    /// mirroring the `get` probe loop, then compares values recursively.
+    /// equal value. Walks a's dense entries in insertion order and probes b's
+    /// COD index for each key, then compares values recursively.
     fn emit_map_eq_deep(&mut self, key_ty: &Ty, val_ty: &Ty) {
         use super::engine::layout::{SWISS_MAP, map as lm};
         let map_cap_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::CAP);
@@ -319,13 +319,16 @@ impl FuncCompiler<'_> {
         let b = self.scratch.alloc_i32();
         let result = self.scratch.alloc_i32();
         let acap = self.scratch.alloc_i32();
+        let alen = self.scratch.alloc_i32();
         let aeb = self.scratch.alloc_i32();
         let ai = self.scratch.alloc_i32();
         let sk32 = self.scratch.alloc_i32();
         let sk64 = self.scratch.alloc_i64();
         let bcap = self.scratch.alloc_i32();
+        let bib = self.scratch.alloc_i32();
         let beb = self.scratch.alloc_i32();
         let bidx = self.scratch.alloc_i32();
+        let bei = self.scratch.alloc_i32();
         let h2 = self.scratch.alloc_i32();
         let tg = self.scratch.alloc_i32();
         let found = self.scratch.alloc_i32();
@@ -342,15 +345,16 @@ impl FuncCompiler<'_> {
               if_i32; i32_const(0);
               else_;
                 i32_const(1); local_set(result);
+                local_get(a); i32_load(0); local_set(alen);
                 local_get(a); i32_load(map_cap_off); local_set(acap);
-                local_get(a); i32_const(map_tags_off); i32_add; local_get(acap); i32_add; local_set(aeb);
+        });
+        self.emit_dict_entries_base(a, acap);
+        wasm!(self.func, {
+                local_set(aeb);
                 i32_const(0); local_set(ai);
                 block_empty; loop_empty;                                  // [A] a-exit, [B] a-loop
-                  local_get(ai); local_get(acap); i32_ge_u; br_if(1);     // done iterating a
-                  // Skip empty slots in a.
-                  local_get(a); i32_const(map_tags_off); i32_add; local_get(ai); i32_add; i32_load8_u(0); i32_eqz;
-                  if_empty; local_get(ai); i32_const(1); i32_add; local_set(ai); br(1); end;
-                  // Load this entry's key into the search-key register.
+                  local_get(ai); local_get(alen); i32_ge_u; br_if(1);     // done iterating a (dense)
+                  // Load this dense entry's key into the search-key register.
                   local_get(aeb); local_get(ai); i32_const(es as i32); i32_mul; i32_add;
         });
         self.emit_key_load(key_ty, 0);
@@ -361,8 +365,11 @@ impl FuncCompiler<'_> {
                   local_get(b); i32_load(map_cap_off); local_set(bcap);
                   local_get(bcap); i32_eqz;
                   if_empty; else_;                                        // [D] bcap==0 guard
-                    local_get(b); i32_const(map_tags_off); i32_add; local_get(bcap); i32_add; local_set(beb);
         });
+        self.emit_dict_index_base(b, bcap);
+        wasm!(self.func, { local_set(bib); });
+        self.emit_dict_entries_base(b, bcap);
+        wasm!(self.func, { local_set(beb); });
         self.emit_search_key_load(key_ty, sk32, sk64);
         self.emit_hash_key(key_ty);
         self.emit_h1_h2(bcap, bidx, h2);
@@ -372,7 +379,10 @@ impl FuncCompiler<'_> {
                       local_get(tg); i32_eqz; br_if(1);                  // empty slot → key absent
                       local_get(tg); local_get(h2); i32_eq;
                       if_empty;                                          // [G] tag matches
-                        local_get(beb); local_get(bidx); i32_const(es as i32); i32_mul; i32_add;
+                        // bei = index[bidx] - 1 (1-based pointer into dense entries)
+                        local_get(bib); local_get(bidx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
+                        i32_load(0); i32_const(1); i32_sub; local_set(bei);
+                        local_get(beb); local_get(bei); i32_const(es as i32); i32_mul; i32_add;
         });
         self.emit_key_load(key_ty, 0);
         self.emit_search_key_load(key_ty, sk32, sk64);
@@ -396,7 +406,7 @@ impl FuncCompiler<'_> {
             });
             self.emit_load_at(val_ty, 0);
             wasm!(self.func, {
-                  local_get(beb); local_get(bidx); i32_const(es as i32); i32_mul; i32_add; i32_const(ks as i32); i32_add;
+                  local_get(beb); local_get(bei); i32_const(es as i32); i32_mul; i32_add; i32_const(ks as i32); i32_add;
             });
             self.emit_load_at(val_ty, 0);
             self.emit_eq_typed(val_ty);
@@ -415,13 +425,16 @@ impl FuncCompiler<'_> {
         self.scratch.free_i32(found);
         self.scratch.free_i32(tg);
         self.scratch.free_i32(h2);
+        self.scratch.free_i32(bei);
         self.scratch.free_i32(bidx);
         self.scratch.free_i32(beb);
+        self.scratch.free_i32(bib);
         self.scratch.free_i32(bcap);
         self.scratch.free_i64(sk64);
         self.scratch.free_i32(sk32);
         self.scratch.free_i32(ai);
         self.scratch.free_i32(aeb);
+        self.scratch.free_i32(alen);
         self.scratch.free_i32(acap);
         self.scratch.free_i32(result);
         self.scratch.free_i32(b);

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -455,89 +455,43 @@ impl FuncCompiler<'_> {
                     });
                     self.scratch.free_i32(scratch);
                 } else {
+                    // COD construction: alloc a table sized for n, then put each
+                    // (key, val) via the shared probe-and-place helper (duplicate
+                    // literal keys → last value wins, dense insertion order kept).
                     let ks = if let Some((k, _)) = entries.first() { values::byte_size(&k.ty) } else { 4 };
                     let vs = if let Some((_, v)) = entries.first() { values::byte_size(&v.ty) } else { 4 };
-                    let entry_size = ks + vs; // no tag per entry
+                    let es = ks + vs;
                     let key_ty = if let Some((k, _)) = entries.first() { k.ty.clone() } else { Ty::String };
-                    let mut cap = 16u32;
+                    let mut cap = super::engine::layout::map::INITIAL_CAP;
                     while cap < n * 2 { cap *= 2; }
-                    // Swiss Table: [header][tags: cap bytes][entries: cap * entry_size]
-                    let total = self.emitter.layout_reg.header_size(super::engine::layout::SWISS_MAP) as i32 as u32 + cap + cap * entry_size;
 
                     let map = self.scratch.alloc_i32();
-                    let idx = self.scratch.alloc_i32();
-                    let eb = self.scratch.alloc_i32(); // entries_base
-                    let h2_lit = self.scratch.alloc_i32();
-                    wasm!(self.func, {
-                        i32_const(total as i32);
-                        call(self.emitter.rt.alloc);
-                        local_set(map);
-                        local_get(map); i32_const(n as i32); i32_store(0);
-                        local_get(map); i32_const(cap as i32); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::CAP));
-                        // entries_base = map + 8 + cap
-                        local_get(map); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                        i32_const(cap as i32); i32_add; local_set(eb);
-                    });
+                    let cap_local = self.scratch.alloc_i32();
+                    let ib = self.scratch.alloc_i32();
+                    let eb = self.scratch.alloc_i32();
+                    let tmp = self.scratch.alloc_i32();
+                    wasm!(self.func, { i32_const(cap as i32); local_set(cap_local); });
+                    self.emit_dict_alloc(map, cap_local, es);
+                    self.emit_dict_index_base(map, cap_local);
+                    wasm!(self.func, { local_set(ib); });
+                    self.emit_dict_entries_base(map, cap_local);
+                    wasm!(self.func, { local_set(eb); });
 
                     for (key, val) in entries {
+                        // Materialize the (key, val) into a temp entry buffer.
+                        wasm!(self.func, { i32_const(es as i32); call(self.emitter.rt.alloc); local_set(tmp); local_get(tmp); });
                         self.emit_expr(key);
-                        let sk = if matches!(key_ty, Ty::Int) {
-                            let sk = self.scratch.alloc_i64();
-                            wasm!(self.func, { local_tee(sk); });
-                            sk
-                        } else {
-                            let sk = self.scratch.alloc_i32();
-                            wasm!(self.func, { local_tee(sk); });
-                            sk
-                        };
-                        self.emit_hash_key(&key_ty);
-                        // Split into h1 + h2
-                        let ht = self.scratch.alloc_i32();
-                        wasm!(self.func, {
-                            local_tee(ht);
-                            i32_const(cap as i32 - 1); i32_and; local_set(idx);
-                            local_get(ht);
-                            i32_const(25); i32_shr_u; i32_const(0x7F); i32_and;
-                            local_tee(h2_lit);
-                            i32_eqz;
-                            if_empty; i32_const(1); local_set(h2_lit); end;
-                        });
-                        self.scratch.free_i32(ht);
-                        // Probe for empty tag
-                        wasm!(self.func, {
-                            block_empty; loop_empty;
-                              local_get(map); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                              local_get(idx); i32_add; i32_load8_u(0);
-                              i32_eqz; br_if(1);
-                              local_get(idx); i32_const(1); i32_add;
-                              i32_const(cap as i32 - 1); i32_and;
-                              local_set(idx); br(0);
-                            end; end;
-                            // Store tag (1 byte)
-                            local_get(map); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                            local_get(idx); i32_add; local_get(h2_lit); i32_store8(0);
-                            // Store key at entries_base + idx * entry_size
-                            local_get(eb); local_get(idx); i32_const(entry_size as i32); i32_mul; i32_add;
-                        });
-                        if matches!(key_ty, Ty::Int) {
-                            wasm!(self.func, { local_get(sk); i64_store(0); });
-                            self.scratch.free_i64(sk);
-                        } else {
-                            wasm!(self.func, { local_get(sk); i32_store(0); });
-                            self.scratch.free_i32(sk);
-                        }
-                        // Store value at entries_base + idx * entry_size + ks
-                        wasm!(self.func, {
-                            local_get(eb); local_get(idx); i32_const(entry_size as i32); i32_mul; i32_add;
-                            i32_const(ks as i32); i32_add;
-                        });
+                        self.emit_key_store(&key_ty, 0);
+                        wasm!(self.func, { local_get(tmp); i32_const(ks as i32); i32_add; });
                         self.emit_expr(val);
                         self.emit_store_at(&val.ty, 0);
+                        self.emit_dict_put_entry(map, cap_local, ib, eb, tmp, es, ks, vs, &key_ty);
                     }
                     wasm!(self.func, { local_get(map); });
-                    self.scratch.free_i32(h2_lit);
+                    self.scratch.free_i32(tmp);
                     self.scratch.free_i32(eb);
-                    self.scratch.free_i32(idx);
+                    self.scratch.free_i32(ib);
+                    self.scratch.free_i32(cap_local);
                     self.scratch.free_i32(map);
                 }
             }

--- a/crates/almide-codegen/src/emit_wasm/list_layout.rs
+++ b/crates/almide-codegen/src/emit_wasm/list_layout.rs
@@ -70,18 +70,9 @@ impl FuncCompiler<'_> {
         w.get(list_local).field_load(LIST, list::LEN);
     }
 
-    // ── Swiss Table helpers ──
+    // ── Compact-ordered-dict tag helpers (the tags array is unchanged from the old layout) ──
 
-    /// Swiss Table setup: load cap, compute entries_base. Stack: `[]`
-    /// Sets `cap_local = map[CAP]`, `eb_local = map + TAGS_OFFSET + cap`.
-    pub fn emit_swiss_setup(&mut self, map: u32, cap_local: u32, eb_local: u32) {
-        use super::engine::{WasmBuilder, layout::{SWISS_MAP, map as m}};
-        let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-        w.get(map).field_load(SWISS_MAP, m::CAP).set(cap_local);
-        w.get(map).field_addr(SWISS_MAP, m::TAGS).get(cap_local).add().set(eb_local);
-    }
-
-    /// Load Swiss Table tag at index. Stack: `[] → [tag:i32]`
+    /// Load the COD tag byte at slot index. Stack: `[] → [tag:i32]`
     pub fn emit_swiss_tag_load(&mut self, map: u32, idx: u32) {
         use super::engine::{WasmBuilder, layout::{SWISS_MAP, map as m, MemType}};
         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);

--- a/docs/roadmap/active/map-data-structure-roadmap.md
+++ b/docs/roadmap/active/map-data-structure-roadmap.md
@@ -20,15 +20,20 @@ Shipped so far:
   ORDER** — native stays `Vec` (see ② on why no native hash index).
 - **wasm `Set`**: dense `[len][cap][data…]` list (insertion order).
 
-**PENDING (next focused session): wasm `Map` → compact-ordered-dict (②).** It is STILL a
-Swiss Table (hash-bucket iteration = the one remaining map cross-target divergence). Per
-② below: keep dense `(key,val)` entries (insertion order, iterate `0..len`) + add a
-separate hash INDEX region for O(1) lookup; centralized `dict_*` helpers + a layout
-abstraction put every offset behind a name (the magic-number cure). ~23 ops
-(`calls_map.rs` + `calls_map_closure.rs`) + 6 map-iterating external sites (`control.rs`
-for-in, `statements.rs` GC-drop, `expressions.rs` literal, `equality.rs` eq,
-`calls_list_closure2.rs` group_by, `calls_http.rs` headers) switch together (big-bang).
-Full plan: workflow `wf_1a3614dd`, memory `project_wasm_compact_ordered_dict`.
+**SHIPPED: wasm `Map` → compact-ordered-dict (②).** Branch `xtarget-wasm-map-order`
+(layout consts `709b6764`, helpers `715acc1e`, op switch `89a5833e`). Dense `(key,val)`
+entries (insertion order, iterate `0..len`) + a separate hash INDEX region (tags + 1-based
+slot pointers) for O(1) lookup; centralized `emit_dict_*` helpers + named `layout::map`
+consts put every offset behind a name (the magic-number cure). All map-layout sites
+switched together (`calls_map.rs` + `calls_map_closure.rs` + `control.rs` for-in,
+`expressions.rs` literal, `equality.rs` eq, `calls_list_closure2.rs` group_by,
+`calls_http.rs` headers). `calls_value.rs` was confirmed NOT a map (its `=8` offsets are
+`List[(String,Value)]` object payloads). Verified byte-identical native==wasm across the
+full spec suite + all `spec/wasm_cross/*.almd`; new `map_insertion_order.almd` locks the
+order guarantee into the gate (the prior corpus only checked order-independent counts).
+The dead Swiss helpers (`emit_map_resize`/`emit_alloc_table`/`emit_swiss_setup`) are gone;
+`set` now grows by load factor (fixing a >16-entry overflow). Full notes: memory
+`project_wasm_compact_ordered_dict`.
 
 > ⚠️ The earlier **seq-in-entry** attempt — a wrong hack that changed the entry *stride*
 > and so forced touching every hand-coded stride site → magic-number proliferation, 6

--- a/docs/roadmap/active/map-data-structure-roadmap.md
+++ b/docs/roadmap/active/map-data-structure-roadmap.md
@@ -1,0 +1,93 @@
+# Map / Set data-structure roadmap
+
+How `Map[K,V]` (and `Set[T]`) are represented, and where they should go.
+
+## Decision
+
+**`Map` is an O(1) insertion-ordered hash map — a compact-ordered-dict (②).** It is the
+standard "correct" map (Python dict / `indexmap`), and "do the better structure since
+both options are the same big-bang rewrite anyway." `Set` stays a dense list (its
+`PartialEq`, possibly-`Float` elements don't want a hash index). Both iterate in
+**insertion order**; cross-target equivalence (native iteration == wasm) is the hard
+invariant, enforced by the gate.
+
+Shipped so far:
+- **native** `Set` + `Map` (`runtime/rs/src/{set,map}.rs`, PR #354): `Vec<T>` /
+  `Vec<(K,V)>`, first-seen insertion order, `insert` updates value in place (keeping
+  position) / appends new, `remove` preserves survivor order, order-independent
+  equality. Key/elem bound is `PartialEq` (not `Eq + Hash`), so `Set[Float]` and maps
+  over non-`Hash` keys work. **This is the cross-target reference oracle for iteration
+  ORDER** — native stays `Vec` (see ② on why no native hash index).
+- **wasm `Set`**: dense `[len][cap][data…]` list (insertion order).
+
+**PENDING (next focused session): wasm `Map` → compact-ordered-dict (②).** It is STILL a
+Swiss Table (hash-bucket iteration = the one remaining map cross-target divergence). Per
+② below: keep dense `(key,val)` entries (insertion order, iterate `0..len`) + add a
+separate hash INDEX region for O(1) lookup; centralized `dict_*` helpers + a layout
+abstraction put every offset behind a name (the magic-number cure). ~23 ops
+(`calls_map.rs` + `calls_map_closure.rs`) + 6 map-iterating external sites (`control.rs`
+for-in, `statements.rs` GC-drop, `expressions.rs` literal, `equality.rs` eq,
+`calls_list_closure2.rs` group_by, `calls_http.rs` headers) switch together (big-bang).
+Full plan: workflow `wf_1a3614dd`, memory `project_wasm_compact_ordered_dict`.
+
+> ⚠️ The earlier **seq-in-entry** attempt — a wrong hack that changed the entry *stride*
+> and so forced touching every hand-coded stride site → magic-number proliferation, 6
+> corruption traps — was abandoned. The proper COD does NOT change the entry stride:
+> entries stay dense at `ks+vs`; the INDEX is a *separate* region.
+
+### Rejected alternative — ① plain dense list (O(n))
+
+A dense `Vec`-like map (linear-scan lookup), mirroring the wasm Set + native Vec exactly:
+simplest, lowest per-op risk, zero magic numbers. Rejected because it makes `Map` secretly
+O(n) — a footgun for mutable/read-heavy code — and a hash map *should* be O(1). (The
+persistent clone-on-write model makes *building* O(n²) regardless, muting ②'s O(1) win,
+which is the only reason ① was ever tempting.)
+
+## ② Compact-ordered-dict — the chosen Map structure
+
+The "correct hash map" — Python 3.7+ `dict`, Ruby `Hash`, Rust `indexmap`: a hash
+**INDEX** over a **DENSE insertion-ordered entries** array. O(1) lookup, iteration
+still insertion order (walk the dense entries).
+
+- wasm: TAGS (h2 fast-reject) + INDEX (1-based pointer into dense entries) + DENSE
+  ENTRIES. Lookup probes the index; iterate walks the dense entries. Entries never
+  move on grow (only the index rehashes). Full design + the centralized
+  `dict_*`/`layout::map::{INDEX_SLOT_SIZE,EMPTY_INDEX,INITIAL_CAP,GROWTH_SHIFT,LOAD_NUM,LOAD_DEN,H2_SHIFT,H2_MASK}`
+  constants already scaffolded (see workflow `wf_1a3614dd`, memory
+  `project_wasm_compact_ordered_dict`).
+- native: a dense `Vec<(K,V)>` + a hash index. The std `HashMap<K,usize>` index
+  forces `K: Eq+Hash` — which **rejects `Map[Float]` and `Map[record-without-derive-Hash]`**
+  and so would diverge from wasm (which hashes any key by raw bytes). To keep
+  cross-target parity under ②, EITHER adopt the universal **"map keys must be
+  hashable+eq"** contract on both targets (clean, but re-restricts today's `PartialEq`
+  relaxation), OR give native a custom **byte-hashing** index that matches wasm's hash
+  (more code, supports any key — the truly-equivalent option).
+
+**Why chosen:** "keys must be hashable" is the universal standard (every serious language
+requires it) and O(n) maps are a footgun — so ② is the right *map* design, and since both
+② and ① are the same big-bang rewrite, the better structure wins. **Caveat (accepted):**
+under the persistent clone-on-write model the O(n²)-build dominates, so ②'s O(1) lookup
+mostly helps mutable `insert`/`delete` chains and repeated `get` on a stable map; the
+structural correctness ("a Map is O(1)") is the real reason, not a profile. The magic-number
+risk that bit the seq-in-entry hack is handled by doing ② *properly* — separate index
+region (entry stride unchanged) + centralized `dict_*` helpers, never inline byte math.
+The native side keeps `Vec` (the order oracle) until/unless a custom byte-hashing index is
+added; the std `HashMap` index is NOT adopted (its `K:Hash` bound is the regression above).
+
+## ③ HAMT — the true persistent ideal (research)
+
+The persistent-map endgame: a **hash array mapped trie** (Clojure / Scala /
+immutable.js) — O(log n) ops with **structural sharing**, so `map.set` does NOT clone
+O(n). This is the only structure that fixes the O(n²)-persistent-build that ① and ②
+share. Cost: by far the largest implementation, and making it byte-identical across the
+native (Rust) and hand-emitted-wasm runtimes is its own project (and a strong argument
+for the "one runtime" endgame — compile one Rust runtime to wasm32, or define the map in
+Almide itself). Track as the long-term persistent-collections direction.
+
+## Cross-cutting
+
+Whatever the representation, the **hard invariant is observable cross-target equivalence**
+(native iteration == wasm iteration, enforced by `tests/wasm_runtime_test.rs::wasm_cross_target_spec`).
+Any move ①→②→③ must keep every `spec/wasm_cross/map_*` case byte-identical and add no
+`@xt-allow`. Set may stay a dense list (Set[Float] needs only `PartialEq`); the index
+question is Map-specific.

--- a/spec/wasm_cross/map_insertion_order.almd
+++ b/spec/wasm_cross/map_insertion_order.almd
@@ -1,0 +1,79 @@
+// Map is a compact-ordered-dict: iteration is insertion order on BOTH targets.
+// Every line below reveals key/value ORDER (not just counts), so a regression to
+// hash-order iteration on either target would break the byte-for-byte comparison.
+
+fn show(label: String, m: Map[String, Int]) -> String = {
+  let parts = map.entries(m) |> list.map((e) => {
+    let (k, v) = e
+    "${k}=${int.to_string(v)}"
+  })
+  "${label}: [${list.join(parts, ", ")}]"
+}
+
+fn main() -> Unit = {
+  // Literal preserves insertion order (deliberately NOT alphabetical/hash order).
+  let lit = ["zebra": 1, "apple": 2, "mango": 3, "delta": 4]
+  println(show("literal", lit))
+
+  // set: new key appends; updating an existing key keeps its position.
+  let s1 = map.set(lit, "echo", 5)
+  println(show("set-new", s1))
+  println(show("set-update", map.set(s1, "apple", 20)))
+
+  // set past INITIAL_CAP forces a grow; dense order must stay 0,1,2,...,29.
+  var big: Map[String, Int] = [:]
+  for n in list.range(0, 30) {
+    big = map.set(big, "k${int.to_string(n)}", n)
+  }
+  println("grow-len: ${int.to_string(map.len(big))}")
+  println("grow-keys: [${list.join(map.keys(big), ",")}]")
+
+  // insert (mutable, in-place) preserves order across its own grow.
+  var mp: Map[String, Int] = [:]
+  for n in list.range(0, 20) {
+    map.insert(mp, "i${int.to_string(n)}", n)
+  }
+  println("insert-keys: [${list.join(map.keys(mp), ",")}]")
+
+  // remove preserves the survivors' order.
+  println(show("remove", map.remove(s1, "mango")))
+
+  // merge: a's order first, then b-only keys; b overrides a's values in place.
+  println(show("merge", map.merge(["x": 1, "y": 2, "z": 3], ["y": 20, "w": 40])))
+
+  // from_list: insertion order, duplicate key keeps first position with last value.
+  println(show("from_list", map.from_list([("p", 1), ("q", 2), ("p", 9), ("r", 3)])))
+
+  // for-in iterates in insertion order.
+  var acc = ""
+  for (k, v) in lit { acc = acc + "${k}/" }
+  println("for-in: ${acc}")
+
+  // filter preserves order; map keeps order while transforming values.
+  println("filter-keys: [${list.join(map.keys(map.filter(big, (k, v) => v % 2 == 0)), ",")}]")
+  println(show("map", map.map(lit, (v) => v * 100)))
+
+  // find returns the first match in insertion order.
+  let fstr = match map.find(lit, (k, v) => v >= 2) {
+    some(pair) => { let (k, v) = pair; "${k}=${int.to_string(v)}" }
+    none => "none"
+  }
+  println("find: ${fstr}")
+
+  // update applies f at a key, keeping its position.
+  println(show("update", map.update(lit, "apple", (v) => v + 1000)))
+
+  // equality is order-independent: same entries inserted in a different order are equal.
+  var reordered: Map[String, Int] = [:]
+  reordered = map.set(reordered, "c", 3)
+  reordered = map.set(reordered, "a", 1)
+  reordered = map.set(reordered, "b", 2)
+  println("eq: ${if ["a": 1, "b": 2, "c": 3] == reordered then "true" else "false"}")
+  println("neq: ${if ["a": 1, "b": 2, "c": 3] == ["a": 1, "b": 99, "c": 3] then "true" else "false"}")
+
+  // group_by builds Map[B, List[A]] in first-seen key order with in-order grouped lists.
+  let grouped = list.group_by([10, 21, 32, 43, 54, 65], (x) => if x % 2 == 0 then "even" else "odd")
+  println("group-keys: [${list.join(map.keys(grouped), ",")}]")
+  let evens = map.get(grouped, "even") ?? []
+  println("group-even: [${list.join(list.map(evens, (x) => int.to_string(x)), ",")}]")
+}


### PR DESCRIPTION
Replaces the Swiss-table wasm Map with a **compact-ordered-dict** (COD): a hash index
(tags + 1-based slot pointers) over a dense, insertion-ordered entries array. Iteration
walks `entries[0..len]`, so the wasm Map now matches the native `Vec<(K,V)>` Map
**byte-for-byte across every operation** — closing the last map cross-target divergence.

## Layout (reuses `SWISS_MAP` id, header_size=8)
`[len@0][cap@4][tags:u8[cap]@8][index:i32[cap]@8+cap][entries:(K,V)[cap]@8+cap+cap*4]`
- `tags[slot]` = h2 fast-reject (0 = empty); `index[slot]` = 1-based pointer into the dense entries.
- entries are dense and insertion-ordered; lookup probes tags, then derefs `index[slot]-1`.

## Big-bang switch (a mixed Swiss/COD map corrupts at runtime)
All map-layout sites flip together: `calls_map.rs` get/get_or/contains/set/insert/remove/
merge/from_list/keys/values/entries; `calls_map_closure.rs` map_iter_*/map_copy_*/filter/
find/update; `control.rs` for-in; `equality.rs` order-independent eq (probe b via
`index[slot]-1`); `expressions.rs` MapLiteral; `calls_list_closure2.rs` group_by;
`calls_http.rs` with_headers. `calls_value.rs` was confirmed **not** a map (its `=8`
offsets address `List[(String,Value)]` object payloads) and is untouched.

## The magic-number cure
Named consts in `layout::map` + centralized `emit_dict_*` helpers — every offset behind a
name, never inline byte math. One shared `emit_dict_put_entry` probe powers
set/insert/merge/from_list/MapLiteral/filter so they can't drift. `emit_h1_h2` uses
`H2_SHIFT`/`H2_MASK` consts. Dead Swiss helpers (`emit_map_resize`/`emit_alloc_table`/
`emit_swiss_setup`) removed. **Net −181 LOC.**

Also fixes a latent bug: the old `set` never grew, so >16 entries overflowed the index and
spun the probe — `set` now grows by load factor.

## Verification (all byte-identical native==wasm)
- Full spec suite passes: stdlib 99 + lang 115 files (~206 via the wasm path).
- All 24 `spec/wasm_cross/*.almd` byte-identical.
- New `spec/wasm_cross/map_insertion_order.almd` reveals key **order** on every op — the
  prior corpus only checked order-independent counts, so it would not have caught a
  Swiss↔COD ordering regression.
- Manually corroborated cross-target: Int(i64) keys, record(mem_eq) keys, multi-grow
  (200 entries = 16→64→256), empty-map (cap=0), duplicate-key last-wins, collision stress.

Native Map stays `Vec` (the order oracle); a `HashMap<K,usize>` index is intentionally
not adopted (its `K: Eq+Hash` bound would regress `Map[Float]`/non-Hash-record keys).