### PR TITLE
Migrate CloneInsertion + StdlibLowering to traversal-total primitives

### DIFF
--- a/crates/almide-codegen/src/pass_clone.rs
+++ b/crates/almide-codegen/src/pass_clone.rs
@@ -87,116 +87,25 @@ fn compute_syntactic_counts_module(module: &IrModule) -> HashMap<VarId, u32> {
     counts
 }
 
-fn count_syntactic(expr: &IrExpr, counts: &mut HashMap<VarId, u32>) {
-    match &expr.kind {
-        IrExprKind::Var { id } => { *counts.entry(*id).or_insert(0) += 1; }
-        IrExprKind::BinOp { left, right, .. } => {
-            count_syntactic(left, counts); count_syntactic(right, counts);
+/// Counts every syntactic `Var` use by riding the exhaustive `IrVisitor` walk —
+/// so no node kind (incl. `IterChain`/`RcWrap`/`TailCall`, present here because
+/// StreamFusion/TCO run before this pass) can silently drop a subtree and
+/// under-count a var, which would desync the `remaining` last-use tracking.
+struct SyntacticCounter<'a> {
+    counts: &'a mut HashMap<VarId, u32>,
+}
+
+impl IrVisitor for SyntacticCounter<'_> {
+    fn visit_expr(&mut self, expr: &IrExpr) {
+        if let IrExprKind::Var { id } = &expr.kind {
+            *self.counts.entry(*id).or_insert(0) += 1;
         }
-        IrExprKind::UnOp { operand, .. } => count_syntactic(operand, counts),
-        IrExprKind::If { cond, then, else_ } => {
-            count_syntactic(cond, counts); count_syntactic(then, counts); count_syntactic(else_, counts);
-        }
-        IrExprKind::Match { subject, arms } => {
-            count_syntactic(subject, counts);
-            for arm in arms {
-                if let Some(g) = &arm.guard { count_syntactic(g, counts); }
-                count_syntactic(&arm.body, counts);
-            }
-        }
-        IrExprKind::Block { stmts, expr } => {
-            for s in stmts { count_syntactic_stmt(s, counts); }
-            if let Some(e) = expr { count_syntactic(e, counts); }
-        }
-        IrExprKind::Call { target, args, .. } => {
-            match target {
-                CallTarget::Method { object, .. } => count_syntactic(object, counts),
-                CallTarget::Computed { callee } => count_syntactic(callee, counts),
-                _ => {}
-            }
-            for a in args { count_syntactic(a, counts); }
-        }
-        IrExprKind::RuntimeCall { args, .. } => {
-            for a in args { count_syntactic(a, counts); }
-        }
-        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
-        | IrExprKind::Fan { exprs: elements } => {
-            for e in elements { count_syntactic(e, counts); }
-        }
-        IrExprKind::Record { fields, .. } => {
-            for (_, e) in fields { count_syntactic(e, counts); }
-        }
-        IrExprKind::SpreadRecord { base, fields } => {
-            count_syntactic(base, counts);
-            for (_, e) in fields { count_syntactic(e, counts); }
-        }
-        IrExprKind::MapLiteral { entries } => {
-            for (k, v) in entries { count_syntactic(k, counts); count_syntactic(v, counts); }
-        }
-        IrExprKind::Range { start, end, .. } => {
-            count_syntactic(start, counts); count_syntactic(end, counts);
-        }
-        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. }
-        | IrExprKind::OptionalChain { expr: object, .. } => count_syntactic(object, counts),
-        IrExprKind::IndexAccess { object, index } => {
-            count_syntactic(object, counts); count_syntactic(index, counts);
-        }
-        IrExprKind::MapAccess { object, key } => {
-            count_syntactic(object, counts); count_syntactic(key, counts);
-        }
-        IrExprKind::ForIn { iterable, body, .. } => {
-            count_syntactic(iterable, counts);
-            for s in body { count_syntactic_stmt(s, counts); }
-        }
-        IrExprKind::While { cond, body } => {
-            count_syntactic(cond, counts);
-            for s in body { count_syntactic_stmt(s, counts); }
-        }
-        IrExprKind::Lambda { body, .. } => count_syntactic(body, counts),
-        IrExprKind::StringInterp { parts } => {
-            for p in parts { if let IrStringPart::Expr { expr } = p { count_syntactic(expr, counts); } }
-        }
-        IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
-        | IrExprKind::OptionSome { expr } | IrExprKind::Try { expr }
-        | IrExprKind::Unwrap { expr } | IrExprKind::ToOption { expr }
-        | IrExprKind::Await { expr }
-        | IrExprKind::Clone { expr } | IrExprKind::Deref { expr }
-        | IrExprKind::Borrow { expr, .. } | IrExprKind::BoxNew { expr }
-        | IrExprKind::ToVec { expr } => count_syntactic(expr, counts),
-        IrExprKind::UnwrapOr { expr, fallback } => {
-            count_syntactic(expr, counts); count_syntactic(fallback, counts);
-        }
-        IrExprKind::RustMacro { args, .. } => {
-            for a in args { count_syntactic(a, counts); }
-        }
-        _ => {}
+        walk_expr(self, expr); // exhaustive recursion into all children
     }
 }
 
-fn count_syntactic_stmt(stmt: &IrStmt, counts: &mut HashMap<VarId, u32>) {
-    match &stmt.kind {
-        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
-        | IrStmtKind::Assign { value, .. } => count_syntactic(value, counts),
-        IrStmtKind::IndexAssign { index, value, .. } => {
-            count_syntactic(index, counts); count_syntactic(value, counts);
-        }
-        IrStmtKind::MapInsert { key, value, .. } => {
-            count_syntactic(key, counts); count_syntactic(value, counts);
-        }
-        IrStmtKind::FieldAssign { value, .. } => count_syntactic(value, counts),
-        IrStmtKind::ListSwap { a, b, .. } => {
-            count_syntactic(a, counts); count_syntactic(b, counts);
-        }
-        IrStmtKind::ListReverse { end, .. } | IrStmtKind::ListRotateLeft { end, .. } => {
-            count_syntactic(end, counts);
-        }
-        IrStmtKind::ListCopySlice { len, .. } => count_syntactic(len, counts),
-        IrStmtKind::Expr { expr } => count_syntactic(expr, counts),
-        IrStmtKind::Guard { cond, else_ } => {
-            count_syntactic(cond, counts); count_syntactic(else_, counts);
-        }
-        IrStmtKind::Comment { .. } | IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. } => {}
-    }
+fn count_syntactic(expr: &IrExpr, counts: &mut HashMap<VarId, u32>) {
+    SyntacticCounter { counts }.visit_expr(expr);
 }
 
 // ── Clone ID classification ────────────────────────────────────────
@@ -534,7 +443,15 @@ fn insert_clones_live(
         IrExprKind::RustMacro { name, args } => IrExprKind::RustMacro {
             name, args: args.into_iter().map(|a| insert_clones_live(a, always, eligible, remaining, in_loop)).collect(),
         },
-        other => other,
+        // Default: recurse into every child through the exhaustive `map_children`
+        // chokepoint, so no un-listed node kind (`IterChain`/`RcWrap`/`TailCall`/
+        // future variants) silently drops its subtree — that was the DIV2-sibling
+        // (clone insertion blind to closures fused inside a chain). Leaf kinds have
+        // no children and pass through unchanged.
+        other => {
+            let e = IrExpr { kind: other, ty: ty.clone(), span, def_id: None };
+            return e.map_children(&mut |child| insert_clones_live(child, always, eligible, remaining, in_loop));
+        }
     };
 
     IrExpr { kind, ty, span, def_id: None }
@@ -569,7 +486,12 @@ fn insert_clone_stmts_live(
             IrStmtKind::MapInsert { target, key, value } => IrStmtKind::MapInsert {
                 target, key: insert_clones_live(key, always, eligible, remaining, in_loop), value: insert_clones_live(value, always, eligible, remaining, in_loop),
             },
-            other => other,
+            // Default: recurse every expr child via the exhaustive `map_exprs`
+            // chokepoint so no un-listed stmt kind (`ListSwap`/`ListReverse`/… —
+            // which `count_syntactic` already counts) drops its expr subtree.
+            other => IrStmt { kind: other, span: s.span }
+                .map_exprs(&mut |e| insert_clones_live(e, always, eligible, remaining, in_loop))
+                .kind,
         };
         IrStmt { kind, span: s.span }
     }).collect()

--- a/crates/almide-codegen/src/pass_stdlib_lowering.rs
+++ b/crates/almide-codegen/src/pass_stdlib_lowering.rs
@@ -652,7 +652,12 @@ fn rewrite_expr(expr: IrExpr) -> IrExpr {
             symbol,
             args: args.into_iter().map(|a| rewrite_expr(a)).collect(),
         },
-        other => other,
+        // Default: recurse every child via the exhaustive map_children chokepoint
+        // so no un-listed node kind silently drops its subtree.
+        other => {
+            let e = IrExpr { kind: other, ty: ty.clone(), span, def_id: None };
+            return e.map_children(&mut |c| rewrite_expr(c));
+        }
     };
 
     IrExpr { kind, ty, span, def_id: None }
@@ -713,7 +718,10 @@ fn rewrite_stmts(stmts: Vec<IrStmt>) -> Vec<IrStmt> {
             IrStmtKind::MapInsert { target, key, value } => IrStmtKind::MapInsert {
                 target, key: rewrite_expr(key), value: rewrite_expr(value),
             },
-            other => other,
+            // Default: recurse every expr child via the exhaustive map_exprs chokepoint.
+            other => IrStmt { kind: other, span: s.span }
+                .map_exprs(&mut |e| rewrite_expr(e))
+                .kind,
         };
         IrStmt { kind, span: s.span }
     }).collect()
@@ -1254,119 +1262,45 @@ fn count_lambda_body_uses(expr: &IrExpr, targets: &HashSet<VarId>) -> HashMap<Va
 }
 
 fn count_lbu_expr(expr: &IrExpr, targets: &HashSet<VarId>, counts: &mut HashMap<VarId, u32>, in_multi: bool) {
-    match &expr.kind {
-        IrExprKind::Var { id } if targets.contains(id) => {
-            *counts.entry(*id).or_insert(0) += if in_multi { 2 } else { 1 };
-        }
-        IrExprKind::Block { stmts, expr } => {
-            for s in stmts { count_lbu_stmt(s, targets, counts, in_multi); }
-            if let Some(e) = expr { count_lbu_expr(e, targets, counts, in_multi); }
-        }
-        IrExprKind::If { cond, then, else_ } => {
-            count_lbu_expr(cond, targets, counts, in_multi);
-            count_lbu_expr(then, targets, counts, in_multi);
-            count_lbu_expr(else_, targets, counts, in_multi);
-        }
-        IrExprKind::Match { subject, arms } => {
-            count_lbu_expr(subject, targets, counts, in_multi);
-            for arm in arms {
-                if let Some(g) = &arm.guard { count_lbu_expr(g, targets, counts, in_multi); }
-                count_lbu_expr(&arm.body, targets, counts, in_multi);
-            }
-        }
-        IrExprKind::ForIn { iterable, body, .. } => {
-            count_lbu_expr(iterable, targets, counts, in_multi);
-            for s in body { count_lbu_stmt(s, targets, counts, true); }
-        }
-        IrExprKind::While { cond, body } => {
-            count_lbu_expr(cond, targets, counts, true);
-            for s in body { count_lbu_stmt(s, targets, counts, true); }
-        }
-        IrExprKind::Lambda { body, .. } => {
-            count_lbu_expr(body, targets, counts, true);
-        }
-        IrExprKind::Call { target, args, .. } => {
-            match target {
-                CallTarget::Method { object, .. } => count_lbu_expr(object, targets, counts, in_multi),
-                CallTarget::Computed { callee } => count_lbu_expr(callee, targets, counts, in_multi),
-                _ => {}
-            }
-            for a in args { count_lbu_expr(a, targets, counts, in_multi); }
-        }
-        IrExprKind::BinOp { left, right, .. } => {
-            count_lbu_expr(left, targets, counts, in_multi);
-            count_lbu_expr(right, targets, counts, in_multi);
-        }
-        IrExprKind::UnOp { operand, .. } => count_lbu_expr(operand, targets, counts, in_multi),
-        IrExprKind::List { elements } | IrExprKind::Tuple { elements }
-        | IrExprKind::Fan { exprs: elements } => {
-            for e in elements { count_lbu_expr(e, targets, counts, in_multi); }
-        }
-        IrExprKind::Record { fields, .. } => {
-            for (_, e) in fields { count_lbu_expr(e, targets, counts, in_multi); }
-        }
-        IrExprKind::SpreadRecord { base, fields } => {
-            count_lbu_expr(base, targets, counts, in_multi);
-            for (_, e) in fields { count_lbu_expr(e, targets, counts, in_multi); }
-        }
-        IrExprKind::Member { object, .. } | IrExprKind::TupleIndex { object, .. }
-        | IrExprKind::OptionalChain { expr: object, .. } => count_lbu_expr(object, targets, counts, in_multi),
-        IrExprKind::IndexAccess { object, index } | IrExprKind::MapAccess { object, key: index } => {
-            count_lbu_expr(object, targets, counts, in_multi);
-            count_lbu_expr(index, targets, counts, in_multi);
-        }
-        IrExprKind::Range { start, end, .. } => {
-            count_lbu_expr(start, targets, counts, in_multi);
-            count_lbu_expr(end, targets, counts, in_multi);
-        }
-        IrExprKind::StringInterp { parts } => {
-            for p in parts { if let IrStringPart::Expr { expr } = p { count_lbu_expr(expr, targets, counts, in_multi); } }
-        }
-        IrExprKind::MapLiteral { entries } => {
-            for (k, v) in entries { count_lbu_expr(k, targets, counts, in_multi); count_lbu_expr(v, targets, counts, in_multi); }
-        }
-        IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
-        | IrExprKind::OptionSome { expr } | IrExprKind::Try { expr }
-        | IrExprKind::Unwrap { expr } | IrExprKind::ToOption { expr }
-        | IrExprKind::Clone { expr } | IrExprKind::Deref { expr }
-        | IrExprKind::Borrow { expr, .. } | IrExprKind::BoxNew { expr }
-        | IrExprKind::ToVec { expr } | IrExprKind::Await { expr } => {
-            count_lbu_expr(expr, targets, counts, in_multi);
-        }
-        IrExprKind::UnwrapOr { expr, fallback } => {
-            count_lbu_expr(expr, targets, counts, in_multi);
-            count_lbu_expr(fallback, targets, counts, in_multi);
-        }
-        IrExprKind::RustMacro { args, .. } => {
-            for a in args { count_lbu_expr(a, targets, counts, in_multi); }
-        }
-        _ => {}
-    }
+    LbuCounter { targets, counts, in_multi }.visit_expr(expr);
 }
 
-fn count_lbu_stmt(stmt: &IrStmt, targets: &HashSet<VarId>, counts: &mut HashMap<VarId, u32>, in_multi: bool) {
-    match &stmt.kind {
-        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
-        | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => {
-            count_lbu_expr(value, targets, counts, in_multi);
+/// Counts target-var uses by riding the exhaustive `IrVisitor` walk, so no node
+/// kind (incl. IterChain/RcWrap/TailCall) drops a subtree and under-counts — which
+/// would let a captured var move when it must clone. A use inside a loop or nested
+/// lambda counts double (conservative: forces a clone).
+struct LbuCounter<'a> {
+    targets: &'a HashSet<VarId>,
+    counts: &'a mut HashMap<VarId, u32>,
+    in_multi: bool,
+}
+
+impl IrVisitor for LbuCounter<'_> {
+    fn visit_expr(&mut self, expr: &IrExpr) {
+        match &expr.kind {
+            IrExprKind::Var { id } if self.targets.contains(id) => {
+                *self.counts.entry(*id).or_insert(0) += if self.in_multi { 2 } else { 1 };
+            }
+            // Multi-execution contexts: their bodies run per-iteration/per-call,
+            // so a use inside counts double.
+            IrExprKind::ForIn { iterable, body, .. } => {
+                self.visit_expr(iterable);
+                let saved = std::mem::replace(&mut self.in_multi, true);
+                for s in body { self.visit_stmt(s); }
+                self.in_multi = saved;
+            }
+            IrExprKind::While { cond, body } => {
+                let saved = std::mem::replace(&mut self.in_multi, true);
+                self.visit_expr(cond);
+                for s in body { self.visit_stmt(s); }
+                self.in_multi = saved;
+            }
+            IrExprKind::Lambda { body, .. } => {
+                let saved = std::mem::replace(&mut self.in_multi, true);
+                self.visit_expr(body);
+                self.in_multi = saved;
+            }
+            _ => walk_expr(self, expr), // default: recurse all children at current in_multi
         }
-        IrStmtKind::IndexAssign { index, value, .. } | IrStmtKind::MapInsert { key: index, value, .. } => {
-            count_lbu_expr(index, targets, counts, in_multi);
-            count_lbu_expr(value, targets, counts, in_multi);
-        }
-        IrStmtKind::Expr { expr } => count_lbu_expr(expr, targets, counts, in_multi),
-        IrStmtKind::Guard { cond, else_ } => {
-            count_lbu_expr(cond, targets, counts, in_multi);
-            count_lbu_expr(else_, targets, counts, in_multi);
-        }
-        IrStmtKind::ListSwap { a, b, .. } => {
-            count_lbu_expr(a, targets, counts, in_multi);
-            count_lbu_expr(b, targets, counts, in_multi);
-        }
-        IrStmtKind::ListReverse { end, .. } | IrStmtKind::ListRotateLeft { end, .. } => {
-            count_lbu_expr(end, targets, counts, in_multi);
-        }
-        IrStmtKind::ListCopySlice { len, .. } => count_lbu_expr(len, targets, counts, in_multi),
-        IrStmtKind::Comment { .. } | IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. } => {}
     }
 }

--- a/tests/traversal_totality_lint.rs
+++ b/tests/traversal_totality_lint.rs
@@ -47,7 +47,6 @@ const LEGACY_DEBT: &[&str] = &[
     "crates/almide-codegen/src/pass_result_propagation.rs",
     "crates/almide-codegen/src/pass_rust_lowering.rs",
     "crates/almide-codegen/src/pass_shadow_resolve.rs",
-    "crates/almide-codegen/src/pass_stdlib_lowering.rs",
     "crates/almide-codegen/src/pass_tco.rs",
 ];
 
@@ -183,15 +182,28 @@ fn find_violations(src: &str) -> Vec<Violation> {
         // This match recurses iff an arm descends into a child: a known descent
         // primitive, OR a self-call to the enclosing (recursive walker) function.
         let body = &src[open..=close];
+        let enclosing = enclosing_fn(src, b, open);
         let recurses = has_descent_primitive(body)
-            || enclosing_fn_name(src, b, open)
-                .map_or(false, |name| body.contains(&format!("{}(", name)));
+            || enclosing.as_ref().map_or(false, |(name, _)| body.contains(&format!("{}(", name)));
         if !recurses {
             continue;
         }
 
+        // Deferral: an empty `_ => {}` is NOT a drop when the enclosing fn recurses
+        // the SAME scrutinee via an external `<var>.map_children`/`map_exprs` after
+        // the match — the "decide special cases, recurse the default outside" pattern
+        // (e.g. `match &expr.kind { Special => …; _ => {} } expr.map_children(…)`).
+        // The external primitive is exhaustive, so the default IS handled.
+        let defers = match (scrutinee_var(scrutinee), enclosing.as_ref()) {
+            (Some(v), Some((_, fn_close))) => {
+                let tail = &src[close.min(*fn_close)..*fn_close];
+                tail.contains(&format!("{v}.map_children(")) || tail.contains(&format!("{v}.map_exprs("))
+            }
+            _ => false,
+        };
+
         // Within (open, close), find catch-all arms at arm-level (depth == 1).
-        scan_arms(src, b, open, close, &mut violations);
+        scan_arms(src, b, open, close, defers, &mut violations);
     }
 
     violations
@@ -207,10 +219,11 @@ fn has_descent_primitive(body: &str) -> bool {
         || body.contains("_expr(") || body.contains("_stmt(")
 }
 
-/// Name of the innermost `fn …` whose body brackets byte `pos`. Used to detect a
-/// self-recursive walker (e.g. `rewrite_calls`) whose name does not match the
-/// `*_expr`/`*_stmt` convention.
-fn enclosing_fn_name(src: &str, b: &[u8], pos: usize) -> Option<String> {
+/// Name and body-close byte of the innermost `fn …` whose body brackets `pos`.
+/// The name detects a self-recursive walker (e.g. `rewrite_calls`) whose name
+/// doesn't match the `*_expr`/`*_stmt` convention; the close bounds the tail in
+/// which an external `map_children`/`map_exprs` deferral may live.
+fn enclosing_fn(src: &str, b: &[u8], pos: usize) -> Option<(String, usize)> {
     let mut best: Option<(usize, usize, String)> = None;
     let mut search = 0;
     while let Some(rel) = src[search..].find("fn ") {
@@ -255,10 +268,10 @@ fn enclosing_fn_name(src: &str, b: &[u8], pos: usize) -> Option<String> {
             best = Some((bo, bc, name));
         }
     }
-    best.map(|(_, _, name)| name)
+    best.map(|(_, bc, name)| (name, bc))
 }
 
-fn scan_arms(src: &str, b: &[u8], open: usize, close: usize, out: &mut Vec<Violation>) {
+fn scan_arms(src: &str, b: &[u8], open: usize, close: usize, defers: bool, out: &mut Vec<Violation>) {
     // Walk the body; an arm pattern begins at arm-level (depth 1) right after the
     // body `{`, or after a top-level `,`/`}` of a previous arm. We detect a `=>`
     // at depth 1 and inspect the preceding pattern + following body.
@@ -278,8 +291,15 @@ fn scan_arms(src: &str, b: &[u8], open: usize, close: usize, out: &mut Vec<Viola
                 let (body, next) = read_arm_body(b, src, body_start, close);
                 if let Some(binder) = catchall_binder(&pat) {
                     if let Some(reason) = silent_body(&body, binder.as_deref()) {
-                        let line = src[..arm_pat_start].bytes().filter(|&c| c == b'\n').count() + 1;
-                        out.push(Violation { line, arm: format!("{} => {}  [{}]", pat, body.trim(), reason) });
+                        // An empty `_ => {}` that defers to an external map_children/
+                        // map_exprs on the scrutinee is not a drop. (A non-empty drop —
+                        // `other => other` / `_ => x.kind` — produces the match value
+                        // itself, so it can never defer; always flag it.)
+                        let deferral = reason == "empty" && defers;
+                        if !deferral {
+                            let line = src[..arm_pat_start].bytes().filter(|&c| c == b'\n').count() + 1;
+                            out.push(Violation { line, arm: format!("{} => {}  [{}]", pat, body.trim(), reason) });
+                        }
                     }
                 }
                 i = next;
@@ -335,6 +355,17 @@ fn read_arm_body(b: &[u8], src: &str, start: usize, close: usize) -> (String, us
 
 fn is_ident_byte(c: u8) -> bool {
     c == b'_' || c.is_ascii_alphanumeric()
+}
+
+/// The scrutinee variable of a `match … .kind` — the identifier immediately
+/// before `.kind` (`expr` from `&expr.kind`, `self` from `self.kind`). None for
+/// non-trivial scrutinees like `foo().kind` (no `<var>.map_children` deferral).
+fn scrutinee_var(scrutinee: &str) -> Option<String> {
+    let head = scrutinee.trim().split(".kind").next()?;
+    let ident: String = head.chars().rev()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect::<String>().chars().rev().collect();
+    if ident.is_empty() { None } else { Some(ident) }
 }
 
 /// If `pat` is a catch-all (`_` or a single bare binder), return Some(binder

--- a/tests/traversal_totality_lint.rs
+++ b/tests/traversal_totality_lint.rs
@@ -31,7 +31,6 @@ const LEGACY_DEBT: &[&str] = &[
     "crates/almide-codegen/src/pass_borrow_inference.rs",
     "crates/almide-codegen/src/pass_box_deref.rs",
     "crates/almide-codegen/src/pass_capture_clone.rs",
-    "crates/almide-codegen/src/pass_clone.rs",
     "crates/almide-codegen/src/pass_closure_conversion.rs",
     "crates/almide-codegen/src/pass_concretize_types.rs",
     "crates/almide-codegen/src/pass_effect_inference.rs",


### PR DESCRIPTION
**Phase 2** of [`codegen-traversal-totality`](docs/roadmap/active/codegen-traversal-totality.md) — the first two HIGH-tier pass migrations, plus a lint precision fix that unblocks them. (Phase 0 `fold.rs` + Phase 1 the lint already landed.)

## Lint precision: recognize the `map_children` deferral
An empty `_ => {}` is **not** a drop when the enclosing fn recurses the same scrutinee via an external `<var>.map_children`/`map_exprs` *after* the match — the "decide special cases, recurse the default outside" pattern:
```rust
match &expr.kind { Special => { …; return … } _ => {} }
expr.map_children(&mut …)   // ← exhaustive: the default IS handled
```
The lint previously false-flagged this whenever the match body had self-calls. A non-empty drop (`other => other` / `_ => x.kind`) produces the match value itself and can never defer — still always flagged.

## CloneInsertion (`pass_clone`)
`count_syntactic`'s `_ => {}`, `insert_clones_live`'s `other => other`, and `insert_clone_stmts_live`'s `other => other` each skipped `IterChain`/`RcWrap`/`TailCall` children (present here — StreamFusion/TCO run before this Rust pass): clone insertion blind to closures fused inside a chain (the DIV2-sibling). Now `count_syntactic` rides `IrVisitor`, `insert_clones_live` delegates to `IrExpr::map_children`, the stmt walker to `IrStmt::map_exprs`.

## StdlibLowering (`pass_stdlib_lowering`)
Its already-total walkers (`resolve_unresolved_ufcs`, `prefix_intra_module_calls`) were only grandfathered because of the lint false positive above. The three genuine drops now migrate: `rewrite_expr` → `map_children`, `rewrite_stmts` → `map_exprs`, and `count_lbu_expr` → an `IrVisitor` (threading the `in_multi` loop/lambda doubling in the struct; `count_lbu_stmt` is subsumed by `walk_stmt` and deleted). The count is a clone-vs-move threshold, so the now-total recursion only over-counts inside previously-dropped nodes — conservative (forces a clone).

Both files removed from the lint's `LEGACY_DEBT` (23 → 21).

**Verified** (each pass): lint green, full `cargo test` green, native compile+run + `native == wasm` sweep over `spec/wasm_cross` clean (25/25). Adds three reusable migration recipes (in-place→`IrMutVisitor`, by-value→`map_children`, read-only→`IrVisitor`).