### PR TITLE
Make 4 by-value codegen passes traversal-total (LEGACY_DEBT 16 → 12)

### DIFF
--- a/crates/almide-codegen/src/pass_auto_parallel.rs
+++ b/crates/almide-codegen/src/pass_auto_parallel.rs
@@ -412,7 +412,7 @@ fn rewrite_expr(
                     CallTarget::Method { object: Box::new(rewrite_expr(*object, effect_fns, mutable_vars)), method },
                 CallTarget::Computed { callee } =>
                     CallTarget::Computed { callee: Box::new(rewrite_expr(*callee, effect_fns, mutable_vars)) },
-                other => other,
+                other @ (CallTarget::Named { .. } | CallTarget::Module { .. }) => other,
             };
             IrExprKind::Call { target, args, type_args }
         }
@@ -497,7 +497,7 @@ fn rewrite_expr(
         IrExprKind::StringInterp { parts } => IrExprKind::StringInterp {
             parts: parts.into_iter().map(|p| match p {
                 IrStringPart::Expr { expr } => IrStringPart::Expr { expr: rewrite_expr(expr, effect_fns, mutable_vars) },
-                other => other,
+                lit @ IrStringPart::Lit { .. } => lit,
             }).collect(),
         },
         IrExprKind::Try { expr } => IrExprKind::Try { expr: Box::new(rewrite_expr(*expr, effect_fns, mutable_vars)) },
@@ -530,7 +530,9 @@ fn rewrite_expr(
             template,
             args: args.into_iter().map(|(n, a)| (n, rewrite_expr(a, effect_fns, mutable_vars))).collect(),
         },
-        other => other,
+        // Any other kind: recurse into every child (total by construction).
+        other => return IrExpr { kind: other, ty, span, def_id: None }
+            .map_children(&mut |e| rewrite_expr(e, effect_fns, mutable_vars)),
     };
 
     IrExpr { kind, ty, span, def_id: None }
@@ -576,7 +578,8 @@ fn rewrite_stmts(
                 target, field,
                 value: rewrite_expr(value, effect_fns, mutable_vars),
             },
-            other => other,
+            other => return IrStmt { kind: other, span: s.span }
+                .map_exprs(&mut |e| rewrite_expr(e, effect_fns, mutable_vars)),
         };
         IrStmt { kind, span: s.span }
     }).collect()

--- a/crates/almide-codegen/src/pass_box_deref.rs
+++ b/crates/almide-codegen/src/pass_box_deref.rs
@@ -220,7 +220,7 @@ fn insert_derefs(expr: IrExpr, deref_ids: &HashSet<VarId>) -> IrExpr {
                 CallTarget::Computed { callee } => CallTarget::Computed {
                     callee: Box::new(insert_derefs(*callee, deref_ids)),
                 },
-                other => other,
+                other @ (CallTarget::Named { .. } | CallTarget::Module { .. }) => other,
             };
             IrExprKind::Call { target, args, type_args }
         }
@@ -268,7 +268,7 @@ fn insert_derefs(expr: IrExpr, deref_ids: &HashSet<VarId>) -> IrExpr {
         IrExprKind::StringInterp { parts } => IrExprKind::StringInterp {
             parts: parts.into_iter().map(|p| match p {
                 IrStringPart::Expr { expr } => IrStringPart::Expr { expr: insert_derefs(expr, deref_ids) },
-                other => other,
+                lit @ IrStringPart::Lit { .. } => lit,
             }).collect(),
         },
         IrExprKind::Unwrap { expr } => IrExprKind::Unwrap { expr: Box::new(insert_derefs(*expr, deref_ids)) },
@@ -303,7 +303,9 @@ fn insert_derefs(expr: IrExpr, deref_ids: &HashSet<VarId>) -> IrExpr {
             cond: Box::new(insert_derefs(*cond, deref_ids)),
             body: insert_deref_stmts(body, deref_ids),
         },
-        other => other,
+        // Any other kind: recurse into every child (total by construction).
+        other => return IrExpr { kind: other, ty, span, def_id: None }
+            .map_children(&mut |e| insert_derefs(e, deref_ids)),
     };
 
     IrExpr { kind, ty, span, def_id: None }
@@ -320,71 +322,47 @@ fn insert_deref_stmts(stmts: Vec<IrStmt>, deref_ids: &HashSet<VarId>) -> Vec<IrS
             IrStmtKind::Guard { cond, else_ } => IrStmtKind::Guard {
                 cond: insert_derefs(cond, deref_ids), else_: insert_derefs(else_, deref_ids),
             },
-            other => other,
+            other => return IrStmt { kind: other, span: s.span }
+                .map_exprs(&mut |e| insert_derefs(e, deref_ids)),
         };
         IrStmt { kind, span: s.span }
     }).collect()
 }
 
 fn collect_from_expr(expr: &IrExpr, recursive_enums: &HashSet<String>, type_decls: &[IrTypeDecl], name_to_var: &std::collections::HashMap<String, Vec<VarId>>, deref_vars: &mut HashSet<VarId>) {
-    match &expr.kind {
-        IrExprKind::Match { subject, arms } => {
-            // Check if subject type is a recursive enum
+    DerefCollector { recursive_enums, type_decls, name_to_var, deref_vars }.visit_expr(expr);
+}
+
+/// Walks every expression collecting Box'd recursive-enum bindings that need a
+/// Deref. Riding the exhaustive `IrVisitor` means a recursive-enum Match nested
+/// inside any node kind (list/tuple/record/…) is found too — matching the now-total
+/// `insert_derefs` side. Collecting an extra deref var is rustc-checked, never silent.
+struct DerefCollector<'a> {
+    recursive_enums: &'a HashSet<String>,
+    type_decls: &'a [IrTypeDecl],
+    name_to_var: &'a std::collections::HashMap<String, Vec<VarId>>,
+    deref_vars: &'a mut HashSet<VarId>,
+}
+
+impl IrVisitor for DerefCollector<'_> {
+    fn visit_expr(&mut self, expr: &IrExpr) {
+        if let IrExprKind::Match { subject, arms } = &expr.kind {
+            // A recursive-enum match binds Box'd fields — collect their deref vars.
             let enum_name = match &subject.ty {
                 Ty::Named(n, _) => Some(n.clone()),
                 Ty::Variant { name, .. } => Some(name.clone()),
                 _ => None,
             };
-
             if let Some(ref ename) = enum_name {
-                if recursive_enums.contains(ename.as_str()) {
-                    // Find the type decl to know which fields are recursive
-                    let td = type_decls.iter().find(|td| *ename == td.name);
+                if self.recursive_enums.contains(ename.as_str()) {
+                    let td = self.type_decls.iter().find(|td| *ename == td.name);
                     for arm in arms {
-                        collect_deref_from_pattern(&arm.pattern, ename, td, name_to_var, deref_vars);
-                        collect_from_expr(&arm.body, recursive_enums, type_decls, name_to_var, deref_vars);
+                        collect_deref_from_pattern(&arm.pattern, ename, td, self.name_to_var, self.deref_vars);
                     }
-                } else {
-                    for arm in arms {
-                        collect_from_expr(&arm.body, recursive_enums, type_decls, name_to_var, deref_vars);
-                    }
-                }
-            } else {
-                for arm in arms {
-                    collect_from_expr(&arm.body, recursive_enums, type_decls, name_to_var, deref_vars);
                 }
             }
-            collect_from_expr(subject, recursive_enums, type_decls, name_to_var, deref_vars);
         }
-        IrExprKind::Block { stmts, expr: e } => {
-            for s in stmts { collect_from_stmt(s, recursive_enums, type_decls, name_to_var, deref_vars); }
-            if let Some(e) = e { collect_from_expr(e, recursive_enums, type_decls, name_to_var, deref_vars); }
-        }
-        IrExprKind::If { cond, then, else_ } => {
-            collect_from_expr(cond, recursive_enums, type_decls, name_to_var, deref_vars);
-            collect_from_expr(then, recursive_enums, type_decls, name_to_var, deref_vars);
-            collect_from_expr(else_, recursive_enums, type_decls, name_to_var, deref_vars);
-        }
-        IrExprKind::Call { args, .. }
-        | IrExprKind::RuntimeCall { args, .. } => {
-            for a in args { collect_from_expr(a, recursive_enums, type_decls, name_to_var, deref_vars); }
-        }
-        IrExprKind::BinOp { left, right, .. } => {
-            collect_from_expr(left, recursive_enums, type_decls, name_to_var, deref_vars);
-            collect_from_expr(right, recursive_enums, type_decls, name_to_var, deref_vars);
-        }
-        IrExprKind::Lambda { body, .. } => collect_from_expr(body, recursive_enums, type_decls, name_to_var, deref_vars),
-        _ => {}
-    }
-}
-
-fn collect_from_stmt(stmt: &IrStmt, recursive_enums: &HashSet<String>, type_decls: &[IrTypeDecl], name_to_var: &std::collections::HashMap<String, Vec<VarId>>, deref_vars: &mut HashSet<VarId>) {
-    match &stmt.kind {
-        IrStmtKind::Bind { value, .. } | IrStmtKind::Assign { value, .. } => {
-            collect_from_expr(value, recursive_enums, type_decls, name_to_var, deref_vars);
-        }
-        IrStmtKind::Expr { expr } => collect_from_expr(expr, recursive_enums, type_decls, name_to_var, deref_vars),
-        _ => {}
+        walk_expr(self, expr); // recurse subject, arm bodies, and every other kind
     }
 }
 

--- a/crates/almide-codegen/src/pass_closure_conversion.rs
+++ b/crates/almide-codegen/src/pass_closure_conversion.rs
@@ -418,7 +418,7 @@ fn convert_expr(
         IrExprKind::StringInterp { parts } => IrExprKind::StringInterp {
             parts: parts.into_iter().map(|p| match p {
                 IrStringPart::Expr { expr } => IrStringPart::Expr { expr: convert_expr(expr, lifted, counter, vt, shared) },
-                other => other,
+                lit @ IrStringPart::Lit { .. } => lit,
             }).collect(),
         },
         IrExprKind::ResultOk { expr } => IrExprKind::ResultOk { expr: Box::new(convert_expr(*expr, lifted, counter, vt, shared)) },
@@ -446,8 +446,10 @@ fn convert_expr(
             name, args: args.into_iter().map(|a| convert_expr(a, lifted, counter, vt, shared)).collect(),
         },
 
-        // Leaf nodes — no conversion needed
-        other => other,
+        // Any other kind: recurse into every child so a Lambda nested in a
+        // not-yet-listed node is still lifted (total by construction).
+        other => return IrExpr { kind: other, ty, span, def_id: None }
+            .map_children(&mut |e| convert_expr(e, lifted, counter, vt, shared)),
     };
 
     IrExpr { kind, ty, span, def_id: None }
@@ -490,7 +492,8 @@ fn convert_stmt(
         IrStmtKind::Expr { expr } => IrStmtKind::Expr {
             expr: convert_expr(expr, lifted, counter, vt, shared),
         },
-        other => other,
+        other => return IrStmt { kind: other, span: stmt.span }
+            .map_exprs(&mut |e| convert_expr(e, lifted, counter, vt, shared)),
     };
     IrStmt { kind, span: stmt.span }
 }
@@ -509,7 +512,7 @@ fn convert_target(
         CallTarget::Computed { callee } => CallTarget::Computed {
             callee: Box::new(convert_expr(*callee, lifted, counter, vt, shared)),
         },
-        other => other,
+        other @ (CallTarget::Named { .. } | CallTarget::Module { .. }) => other,
     }
 }
 

--- a/crates/almide-codegen/src/pass_result_erasure.rs
+++ b/crates/almide-codegen/src/pass_result_erasure.rs
@@ -109,7 +109,7 @@ fn erase_expr(expr: IrExpr) -> IrExpr {
                 CallTarget::Computed { callee } => CallTarget::Computed {
                     callee: Box::new(erase_expr(*callee)),
                 },
-                other => other,
+                other @ (CallTarget::Named { .. } | CallTarget::Module { .. }) => other,
             };
             IrExprKind::Call { target, args, type_args }
         }
@@ -166,7 +166,7 @@ fn erase_expr(expr: IrExpr) -> IrExpr {
         IrExprKind::StringInterp { parts } => IrExprKind::StringInterp {
             parts: parts.into_iter().map(|p| match p {
                 IrStringPart::Expr { expr } => IrStringPart::Expr { expr: erase_expr(expr) },
-                other => other,
+                lit @ IrStringPart::Lit { .. } => lit,
             }).collect(),
         },
         IrExprKind::Tuple { elements } => IrExprKind::Tuple {
@@ -198,7 +198,9 @@ fn erase_expr(expr: IrExpr) -> IrExpr {
         IrExprKind::RustMacro { name, args } => IrExprKind::RustMacro {
             name, args: args.into_iter().map(erase_expr).collect(),
         },
-        other => other,
+        // Any other kind: recurse into every child (total by construction).
+        other => return IrExpr { kind: other, ty, span, def_id: None }
+            .map_children(&mut erase_expr),
     };
 
     IrExpr { kind, ty, span, def_id: None }
@@ -218,7 +220,7 @@ fn erase_stmts(stmts: Vec<IrStmt>) -> Vec<IrStmt> {
             IrStmtKind::BindDestructure { pattern, value } => IrStmtKind::BindDestructure {
                 pattern, value: erase_expr(value),
             },
-            other => other,
+            other => return IrStmt { kind: other, span: s.span }.map_exprs(&mut erase_expr),
         };
         IrStmt { kind, span: s.span }
     }).collect()

--- a/tests/traversal_totality_lint.rs
+++ b/tests/traversal_totality_lint.rs
@@ -27,11 +27,8 @@ use std::path::{Path, PathBuf};
 /// or have its catch-all made loud/delegating; then delete it from this list.
 const LEGACY_DEBT: &[&str] = &[
     "crates/almide-codegen/src/pass_anf.rs",
-    "crates/almide-codegen/src/pass_auto_parallel.rs",
     "crates/almide-codegen/src/pass_borrow_inference.rs",
-    "crates/almide-codegen/src/pass_box_deref.rs",
     "crates/almide-codegen/src/pass_capture_clone.rs",
-    "crates/almide-codegen/src/pass_closure_conversion.rs",
     "crates/almide-codegen/src/pass_concretize_types.rs",
     "crates/almide-codegen/src/pass_effect_inference.rs",
     "crates/almide-codegen/src/pass_lambda_type_resolve.rs",
@@ -39,7 +36,6 @@ const LEGACY_DEBT: &[&str] = &[
     "crates/almide-codegen/src/pass_matrix_shape_spec.rs",
     "crates/almide-codegen/src/pass_mut_param_lowering.rs",
     "crates/almide-codegen/src/pass_peephole.rs",
-    "crates/almide-codegen/src/pass_result_erasure.rs",
     "crates/almide-codegen/src/pass_rust_lowering.rs",
     "crates/almide-codegen/src/pass_tco.rs",
 ];


### PR DESCRIPTION
Continues draining the traversal-totality `LEGACY_DEBT` ratchet (after #356/#357/#358/#359). Each pass becomes total-by-construction — a forgotten node-kind is a compile error, never a silent native↔WASM divergence — and graduates from the grandfather list.

- **`BoxDeref`, `ResultErasure`, `AutoParallel`** — the by-value rewriters' `other => other` leaf defaults now recurse through `IrExpr::map_children` / `IrStmt::map_exprs`; their `CallTarget` and `StringInterp` sub-matches list leaf variants (`Named`/`Module`, `Lit`) explicitly.
- **`BoxDeref` collector** — `collect_from_expr`/`collect_from_stmt`'s `_ => {}` replaced by a `DerefCollector` riding `IrVisitor`, so a recursive-enum `Match` nested in any node kind is found too (matching the now-total `insert_derefs`). A missed deref is rustc-checked, never silent.
- **`ClosureConversion`** (WASM-only) — `convert_expr`/`convert_stmt`/`convert_target` defaults recurse via `map_children`/`map_exprs`, so a `Lambda` nested in a not-yet-listed kind is still lifted. `Lambda` stays explicitly handled (lifted to `ClosureCreate`); `ClosureCreate` is a `map_children` leaf, so no double-conversion.

Recurse-more only rewrites/finds *more* (equivalence-preserving / rustc-checked) — no silent direction.

## Validation
- `cargo test` — 0 failures (incl. the traversal-totality lint).
- Native spec sweep — **all 241 files passed**.
- WASM spec sweep — **233 passed, 0 failed** (8 skipped).