### PR TITLE
Empty the traversal-totality LEGACY_DEBT: the final 12 passes go total-by-construction

### DIFF
--- a/crates/almide-codegen/src/pass_anf.rs
+++ b/crates/almide-codegen/src/pass_anf.rs
@@ -117,7 +117,20 @@ fn anf_expr(expr: &mut IrExpr, var_table: &mut VarTable, counter: &mut u32) {
                         anf_expr(cond, var_table, counter);
                         anf_expr(else_, var_table, counter);
                     }
-                    _ => {}
+                    // Explicit-preserve: statement kinds carrying no heap
+                    // sub-expression to ANF-lift (or only simple var/key refs).
+                    // Listed so a new IrStmtKind is a compile error, not a drop.
+                    IrStmtKind::BindDestructure { .. }
+                    | IrStmtKind::IndexAssign { .. }
+                    | IrStmtKind::MapInsert { .. }
+                    | IrStmtKind::FieldAssign { .. }
+                    | IrStmtKind::Comment { .. }
+                    | IrStmtKind::RcInc { .. }
+                    | IrStmtKind::RcDec { .. }
+                    | IrStmtKind::ListSwap { .. }
+                    | IrStmtKind::ListReverse { .. }
+                    | IrStmtKind::ListRotateLeft { .. }
+                    | IrStmtKind::ListCopySlice { .. } => {}
                 }
             }
             if let Some(t) = tail { anf_expr(t, var_table, counter); }
@@ -138,7 +151,19 @@ fn anf_expr(expr: &mut IrExpr, var_table: &mut VarTable, counter: &mut u32) {
                     IrStmtKind::Bind { value, .. } | IrStmtKind::Assign { value, .. } =>
                         anf_expr(value, var_table, counter),
                     IrStmtKind::Expr { expr } => anf_expr(expr, var_table, counter),
-                    _ => {}
+                    // Explicit-preserve: no heap sub-expression to ANF-lift.
+                    IrStmtKind::Guard { .. }
+                    | IrStmtKind::BindDestructure { .. }
+                    | IrStmtKind::IndexAssign { .. }
+                    | IrStmtKind::MapInsert { .. }
+                    | IrStmtKind::FieldAssign { .. }
+                    | IrStmtKind::Comment { .. }
+                    | IrStmtKind::RcInc { .. }
+                    | IrStmtKind::RcDec { .. }
+                    | IrStmtKind::ListSwap { .. }
+                    | IrStmtKind::ListReverse { .. }
+                    | IrStmtKind::ListRotateLeft { .. }
+                    | IrStmtKind::ListCopySlice { .. } => {}
                 }
             }
         }
@@ -149,7 +174,19 @@ fn anf_expr(expr: &mut IrExpr, var_table: &mut VarTable, counter: &mut u32) {
                     IrStmtKind::Bind { value, .. } | IrStmtKind::Assign { value, .. } =>
                         anf_expr(value, var_table, counter),
                     IrStmtKind::Expr { expr } => anf_expr(expr, var_table, counter),
-                    _ => {}
+                    // Explicit-preserve: no heap sub-expression to ANF-lift.
+                    IrStmtKind::Guard { .. }
+                    | IrStmtKind::BindDestructure { .. }
+                    | IrStmtKind::IndexAssign { .. }
+                    | IrStmtKind::MapInsert { .. }
+                    | IrStmtKind::FieldAssign { .. }
+                    | IrStmtKind::Comment { .. }
+                    | IrStmtKind::RcInc { .. }
+                    | IrStmtKind::RcDec { .. }
+                    | IrStmtKind::ListSwap { .. }
+                    | IrStmtKind::ListReverse { .. }
+                    | IrStmtKind::ListRotateLeft { .. }
+                    | IrStmtKind::ListCopySlice { .. } => {}
                 }
             }
         }
@@ -250,7 +287,65 @@ fn anf_lift_children(expr: &mut IrExpr, var_table: &mut VarTable, counter: &mut 
                 });
             }
         }
-        _ => {}
+        // Explicit-preserve: this helper only lifts the children of Call /
+        // RuntimeCall / BinOp (the kinds that route here from `anf_expr`'s
+        // catch-all). Every other kind has no arg-position heap child to lift
+        // — but they are listed so a new IrExprKind is a compile error here,
+        // not a silently un-lifted (leaking) node.
+        IrExprKind::LitInt { .. }
+        | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. }
+        | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit
+        | IrExprKind::Var { .. }
+        | IrExprKind::FnRef { .. }
+        | IrExprKind::UnOp { .. }
+        | IrExprKind::If { .. }
+        | IrExprKind::Match { .. }
+        | IrExprKind::Block { .. }
+        | IrExprKind::Fan { .. }
+        | IrExprKind::ForIn { .. }
+        | IrExprKind::While { .. }
+        | IrExprKind::Break
+        | IrExprKind::Continue
+        | IrExprKind::TailCall { .. }
+        | IrExprKind::List { .. }
+        | IrExprKind::MapLiteral { .. }
+        | IrExprKind::EmptyMap
+        | IrExprKind::Record { .. }
+        | IrExprKind::SpreadRecord { .. }
+        | IrExprKind::Tuple { .. }
+        | IrExprKind::Range { .. }
+        | IrExprKind::Member { .. }
+        | IrExprKind::TupleIndex { .. }
+        | IrExprKind::IndexAccess { .. }
+        | IrExprKind::MapAccess { .. }
+        | IrExprKind::Lambda { .. }
+        | IrExprKind::StringInterp { .. }
+        | IrExprKind::ResultOk { .. }
+        | IrExprKind::ResultErr { .. }
+        | IrExprKind::OptionSome { .. }
+        | IrExprKind::OptionNone
+        | IrExprKind::Try { .. }
+        | IrExprKind::Unwrap { .. }
+        | IrExprKind::UnwrapOr { .. }
+        | IrExprKind::ToOption { .. }
+        | IrExprKind::OptionalChain { .. }
+        | IrExprKind::Await { .. }
+        | IrExprKind::Clone { .. }
+        | IrExprKind::Deref { .. }
+        | IrExprKind::Borrow { .. }
+        | IrExprKind::BoxNew { .. }
+        | IrExprKind::RcWrap { .. }
+        | IrExprKind::RustMacro { .. }
+        | IrExprKind::ToVec { .. }
+        | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. }
+        | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. }
+        | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole
+        | IrExprKind::Todo { .. } => {}
     }
 
     *expr = wrap_with_lets(owned, lifted);
@@ -326,28 +421,28 @@ fn verify_anf_args_lifted(program: &IrProgram) -> Vec<String> {
 
     impl<'a> IrVisitor for Checker<'a> {
         fn visit_expr(&mut self, expr: &IrExpr) {
-            match &expr.kind {
-                IrExprKind::Call { args, .. } | IrExprKind::RuntimeCall { args, .. } => {
-                    for arg in args {
-                        if needs_lift(arg) {
-                            self.violations.push(format!(
-                                "[ANF] in {}: heap-typed call arg not lifted — kind={}, ty={:?}",
-                                self.func_name, expr_kind_name(&arg.kind), arg.ty,
-                            ));
-                        }
+            // Decision-only: inspect Call/RuntimeCall args and BinOp operands for
+            // un-lifted heap exprs. Recursion into children is the external
+            // `walk_expr` below — so this uses `if let` (no catch-all that could
+            // drop a subtree; every node is still walked exhaustively).
+            if let IrExprKind::Call { args, .. } | IrExprKind::RuntimeCall { args, .. } = &expr.kind {
+                for arg in args {
+                    if needs_lift(arg) {
+                        self.violations.push(format!(
+                            "[ANF] in {}: heap-typed call arg not lifted — kind={}, ty={:?}",
+                            self.func_name, expr_kind_name(&arg.kind), arg.ty,
+                        ));
                     }
                 }
-                IrExprKind::BinOp { left, right, .. } => {
-                    for arg in [left.as_ref(), right.as_ref()] {
-                        if needs_lift(arg) {
-                            self.violations.push(format!(
-                                "[ANF] in {}: heap-typed binop operand not lifted — kind={}, ty={:?}",
-                                self.func_name, expr_kind_name(&arg.kind), arg.ty,
-                            ));
-                        }
+            } else if let IrExprKind::BinOp { left, right, .. } = &expr.kind {
+                for arg in [left.as_ref(), right.as_ref()] {
+                    if needs_lift(arg) {
+                        self.violations.push(format!(
+                            "[ANF] in {}: heap-typed binop operand not lifted — kind={}, ty={:?}",
+                            self.func_name, expr_kind_name(&arg.kind), arg.ty,
+                        ));
                     }
                 }
-                _ => {}
             }
             walk_expr(self, expr);
         }

--- a/crates/almide-codegen/src/pass_borrow_inference.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference.rs
@@ -680,7 +680,23 @@ fn check_needs_ownership(expr: &IrExpr, var: VarId, needs: &mut bool) {
             }
             for arg in args { check_needs_ownership(arg, var, needs); }
         }
-        _ => {}
+        // Leaves and nodes that carry no borrowable child use of `var` in this
+        // analysis. Explicit-preserve (not recurse-more): borrow inference is
+        // sensitive to which refs are seen, so every un-handled variant is
+        // listed with the original `=> {}` behaviour, total-by-construction.
+        // `Var { id }` where `id != var` (the `id == var` case is the guarded
+        // arm at the top — a bare self-reference whose ownership is decided by
+        // its enclosing context, e.g. Block tail / arg position).
+        IrExprKind::Var { .. }
+        | IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::FnRef { .. }
+        | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::TailCall { .. } | IrExprKind::EmptyMap
+        | IrExprKind::OptionNone | IrExprKind::RcWrap { .. }
+        | IrExprKind::RenderedCall { .. } | IrExprKind::InlineRust { .. }
+        | IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => {}
     }
 }
 
@@ -700,7 +716,11 @@ fn check_needs_ownership_stmt(stmt: &IrStmt, var: VarId, needs: &mut bool) {
             check_needs_ownership(cond, var, needs);
             check_needs_ownership(else_, var, needs);
         }
-        _ => {}
+        // Explicit-preserve: stmt kinds with no ownership-relevant child expr
+        // (or only VarId operands). Same `=> {}` behaviour as before.
+        IrStmtKind::Comment { .. } | IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. }
+        | IrStmtKind::ListSwap { .. } | IrStmtKind::ListReverse { .. }
+        | IrStmtKind::ListRotateLeft { .. } | IrStmtKind::ListCopySlice { .. } => {}
     }
 }
 
@@ -796,7 +816,24 @@ fn check_needs_refmut(expr: &IrExpr, var: VarId, needs: &mut bool) {
         IrExprKind::ResultOk { expr } | IrExprKind::ResultErr { expr }
         | IrExprKind::OptionSome { expr } => check_needs_refmut(expr, var, needs),
         IrExprKind::Lambda { body, .. } => check_needs_refmut(body, var, needs),
-        _ => {}
+        // Explicit-preserve: nodes whose children cannot forward `var` into a
+        // RefMut callee slot for the purposes of this analysis. Listed
+        // explicitly with the original `=> {}` behaviour (total-by-construction).
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::FnRef { .. } | IrExprKind::Fan { .. }
+        | IrExprKind::Break | IrExprKind::Continue | IrExprKind::TailCall { .. }
+        | IrExprKind::List { .. } | IrExprKind::MapLiteral { .. } | IrExprKind::EmptyMap
+        | IrExprKind::Record { .. } | IrExprKind::SpreadRecord { .. }
+        | IrExprKind::Tuple { .. } | IrExprKind::Range { .. }
+        | IrExprKind::Member { .. } | IrExprKind::TupleIndex { .. }
+        | IrExprKind::IndexAccess { .. } | IrExprKind::MapAccess { .. }
+        | IrExprKind::StringInterp { .. } | IrExprKind::OptionNone
+        | IrExprKind::OptionalChain { .. } | IrExprKind::RcWrap { .. }
+        | IrExprKind::RustMacro { .. } | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. } | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => {}
     }
 }
 
@@ -816,7 +853,11 @@ fn check_needs_refmut_stmt(stmt: &IrStmt, var: VarId, needs: &mut bool) {
             check_needs_refmut(cond, var, needs);
             check_needs_refmut(else_, var, needs);
         }
-        _ => {}
+        // Explicit-preserve: stmt kinds with no RefMut-relevant child expr.
+        // Same `=> {}` behaviour as before.
+        IrStmtKind::Comment { .. } | IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. }
+        | IrStmtKind::ListSwap { .. } | IrStmtKind::ListReverse { .. }
+        | IrStmtKind::ListRotateLeft { .. } | IrStmtKind::ListCopySlice { .. } => {}
     }
 }
 
@@ -1148,7 +1189,18 @@ fn rewrite_calls(expr: IrExpr, sigs: &HashMap<String, Vec<ParamBorrow>>, mod_sco
             } else { args };
             IrExprKind::RuntimeCall { symbol, args }
         }
-        other => other,
+        // Explicit-preserve: leaves + nodes this call-rewriter intentionally
+        // does NOT descend into (TailCall / RcWrap / InlineRust args are left
+        // untouched, matching the original `other => other`). Listed explicitly
+        // so a new IrExprKind variant is a compile error here.
+        kind @ (IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+            | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+            | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+            | IrExprKind::Break | IrExprKind::Continue | IrExprKind::TailCall { .. }
+            | IrExprKind::EmptyMap | IrExprKind::OptionNone | IrExprKind::RcWrap { .. }
+            | IrExprKind::RenderedCall { .. } | IrExprKind::InlineRust { .. }
+            | IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. }
+            | IrExprKind::Hole | IrExprKind::Todo { .. }) => kind,
     };
 
     IrExpr { kind, ty, span, def_id: None }
@@ -1167,7 +1219,13 @@ fn rewrite_calls_stmt(stmt: IrStmt, sigs: &HashMap<String, Vec<ParamBorrow>>, mo
         IrStmtKind::BindDestructure { pattern, value } => IrStmtKind::BindDestructure {
             pattern, value: rewrite_calls(value, sigs, mod_scope),
         },
-        other => other,
+        // Explicit-preserve: stmt kinds this rewriter does NOT descend into,
+        // matching the original `other => other` (zero behaviour change).
+        kind @ (IrStmtKind::IndexAssign { .. } | IrStmtKind::MapInsert { .. }
+            | IrStmtKind::FieldAssign { .. } | IrStmtKind::Comment { .. }
+            | IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. }
+            | IrStmtKind::ListSwap { .. } | IrStmtKind::ListReverse { .. }
+            | IrStmtKind::ListRotateLeft { .. } | IrStmtKind::ListCopySlice { .. }) => kind,
     };
     IrStmt { kind, span: stmt.span }
 }
@@ -1296,7 +1354,30 @@ fn hoist_expr(expr: IrExpr, vt: &mut VarTable) -> IrExpr {
         IrExprKind::UnwrapOr { expr, fallback } => IrExprKind::UnwrapOr {
             expr: Box::new(hoist_expr(*expr, vt)), fallback: Box::new(hoist_expr(*fallback, vt)),
         },
-        other => other,
+        // Explicit-preserve: nodes this hoist pass does NOT descend into. The
+        // &mut-conflict hoist only fires at Call / RuntimeCall sites and the
+        // compound forms above; everything else is returned unchanged, exactly
+        // as the original `other => other` did (zero behaviour change).
+        kind @ (IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+            | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+            | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+            | IrExprKind::Fan { .. } | IrExprKind::Break | IrExprKind::Continue
+            | IrExprKind::TailCall { .. } | IrExprKind::List { .. }
+            | IrExprKind::MapLiteral { .. } | IrExprKind::EmptyMap
+            | IrExprKind::Record { .. } | IrExprKind::SpreadRecord { .. }
+            | IrExprKind::Tuple { .. } | IrExprKind::Range { .. }
+            | IrExprKind::Member { .. } | IrExprKind::TupleIndex { .. }
+            | IrExprKind::IndexAccess { .. } | IrExprKind::MapAccess { .. }
+            | IrExprKind::StringInterp { .. } | IrExprKind::OptionNone
+            | IrExprKind::ToOption { .. } | IrExprKind::OptionalChain { .. }
+            | IrExprKind::Await { .. } | IrExprKind::Clone { .. }
+            | IrExprKind::Deref { .. } | IrExprKind::Borrow { .. }
+            | IrExprKind::BoxNew { .. } | IrExprKind::RcWrap { .. }
+            | IrExprKind::RustMacro { .. } | IrExprKind::ToVec { .. }
+            | IrExprKind::RenderedCall { .. } | IrExprKind::InlineRust { .. }
+            | IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. }
+            | IrExprKind::IterChain { .. } | IrExprKind::Hole
+            | IrExprKind::Todo { .. }) => kind,
     };
 
     IrExpr { kind, ty, span, def_id: None }
@@ -1361,7 +1442,12 @@ fn hoist_stmt(stmt: IrStmt, vt: &mut VarTable) -> IrStmt {
         IrStmtKind::FieldAssign { target, field, value } => IrStmtKind::FieldAssign {
             target, field, value: hoist_expr(value, vt),
         },
-        other => other,
+        // Explicit-preserve: stmt kinds with no hoistable child expr, matching
+        // the original `other => other` (zero behaviour change).
+        kind @ (IrStmtKind::Comment { .. } | IrStmtKind::RcInc { .. }
+            | IrStmtKind::RcDec { .. } | IrStmtKind::ListSwap { .. }
+            | IrStmtKind::ListReverse { .. } | IrStmtKind::ListRotateLeft { .. }
+            | IrStmtKind::ListCopySlice { .. }) => kind,
     };
     IrStmt { kind, span: stmt.span }
 }

--- a/crates/almide-codegen/src/pass_capture_clone.rs
+++ b/crates/almide-codegen/src/pass_capture_clone.rs
@@ -354,7 +354,27 @@ fn transform_expr(expr: &mut IrExpr, vt: &mut VarTable, scope_vars: &HashSet<Var
                 }
             }
         }
-        _ => {}
+        IrExprKind::TailCall { target, args } => {
+            match target {
+                CallTarget::Method { object, .. } => { if transform_expr(object, vt, scope_vars) { changed = true; } }
+                CallTarget::Computed { callee } => { if transform_expr(callee, vt, scope_vars) { changed = true; } }
+                CallTarget::Named { .. } | CallTarget::Module { .. } => {}
+            }
+            for a in args { if transform_expr(a, vt, scope_vars) { changed = true; } }
+        }
+        IrExprKind::RcWrap { expr: e, .. } => { if transform_expr(e, vt, scope_vars) { changed = true; } }
+        IrExprKind::InlineRust { args, .. } => {
+            for (_, a) in args { if transform_expr(a, vt, scope_vars) { changed = true; } }
+        }
+        // True leaves (no child `IrExpr`). Listed explicitly so a new
+        // child-bearing IrExprKind is a compile error here, not a silently
+        // dropped subtree (the native↔WASM capture-divergence class).
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. } | IrExprKind::LitStr { .. }
+        | IrExprKind::LitBool { .. } | IrExprKind::Unit | IrExprKind::Var { .. }
+        | IrExprKind::FnRef { .. } | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::EmptyMap | IrExprKind::OptionNone | IrExprKind::RenderedCall { .. }
+        | IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => {}
     }
 
     // Now check: is this expr itself a Lambda with captured vars that need cloning?
@@ -617,7 +637,26 @@ fn replace_vars(expr: &mut IrExpr, renames: &std::collections::HashMap<VarId, Va
                 }
             }
         }
-        _ => {}
+        IrExprKind::TailCall { target, args } => {
+            match target {
+                CallTarget::Method { object, .. } => replace_vars(object, renames),
+                CallTarget::Computed { callee } => replace_vars(callee, renames),
+                CallTarget::Named { .. } | CallTarget::Module { .. } => {}
+            }
+            for a in args { replace_vars(a, renames); }
+        }
+        IrExprKind::RcWrap { expr: e, .. } => replace_vars(e, renames),
+        IrExprKind::InlineRust { args, .. } => {
+            for (_, a) in args { replace_vars(a, renames); }
+        }
+        // True leaves (no child `IrExpr`); `Var` is renamed above. Listed
+        // explicitly so a new child-bearing IrExprKind is a compile error.
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. } | IrExprKind::LitStr { .. }
+        | IrExprKind::LitBool { .. } | IrExprKind::Unit | IrExprKind::FnRef { .. }
+        | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::EmptyMap | IrExprKind::OptionNone | IrExprKind::RenderedCall { .. }
+        | IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => {}
     }
 }
 

--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -290,7 +290,30 @@ fn erase_type_aliases(program: &mut IrProgram, aliases: &HashMap<String, Ty>) {
             IrExprKind::ResultOk { expr: e } | IrExprKind::ResultErr { expr: e }
             | IrExprKind::OptionSome { expr: e } | IrExprKind::Try { expr: e }
             | IrExprKind::Unwrap { expr: e } | IrExprKind::Clone { expr: e } => erase_expr(e, aliases),
-            _ => {}
+            // Explicit-preserve (total-by-construction). The head of this
+            // fn already ran `erase_ty(&mut expr.ty, ..)` for this node;
+            // these variants intentionally do not descend further (exactly
+            // the old `_ => {}` behaviour). Listing every remaining kind
+            // makes a future IrExprKind variant a compile error here so a
+            // new node carrying an aliasable subtree cannot be silently
+            // skipped.
+            IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+            | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+            | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+            | IrExprKind::Fan { .. } | IrExprKind::Break | IrExprKind::Continue
+            | IrExprKind::MapLiteral { .. } | IrExprKind::EmptyMap
+            | IrExprKind::SpreadRecord { .. } | IrExprKind::Range { .. }
+            | IrExprKind::TupleIndex { .. } | IrExprKind::MapAccess { .. }
+            | IrExprKind::StringInterp { .. } | IrExprKind::OptionNone
+            | IrExprKind::UnwrapOr { .. } | IrExprKind::ToOption { .. }
+            | IrExprKind::OptionalChain { .. } | IrExprKind::Await { .. }
+            | IrExprKind::Deref { .. } | IrExprKind::Borrow { .. }
+            | IrExprKind::BoxNew { .. } | IrExprKind::RcWrap { .. }
+            | IrExprKind::RustMacro { .. } | IrExprKind::ToVec { .. }
+            | IrExprKind::RenderedCall { .. } | IrExprKind::InlineRust { .. }
+            | IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. }
+            | IrExprKind::IterChain { .. } | IrExprKind::Hole
+            | IrExprKind::Todo { .. } => {}
         }
     }
 
@@ -306,7 +329,20 @@ fn erase_type_aliases(program: &mut IrProgram, aliases: &HashMap<String, Ty>) {
                 erase_expr(value, aliases);
                 erase_pattern(pattern, aliases);
             }
-            _ => {}
+            // Explicit-preserve (total-by-construction). These statement
+            // kinds carry no `Ty::Named` slot or aliasable subtree that
+            // alias-erasure needs to touch (the assignable expressions
+            // inside IndexAssign/MapInsert/FieldAssign/Guard contain only
+            // values whose own types are erased when their enclosing
+            // expression is visited). Zero behaviour change vs the old
+            // `_ => {}`; listing every kind makes a new IrStmtKind a
+            // compile error here.
+            IrStmtKind::IndexAssign { .. } | IrStmtKind::MapInsert { .. }
+            | IrStmtKind::FieldAssign { .. } | IrStmtKind::Guard { .. }
+            | IrStmtKind::Comment { .. } | IrStmtKind::RcInc { .. }
+            | IrStmtKind::RcDec { .. } | IrStmtKind::ListSwap { .. }
+            | IrStmtKind::ListReverse { .. } | IrStmtKind::ListRotateLeft { .. }
+            | IrStmtKind::ListCopySlice { .. } => {}
         }
     }
 
@@ -547,7 +583,49 @@ fn propagate_ty_down(expr: &mut IrExpr, expected: &Ty) {
                 propagate_ty_down(&mut arm.body, expected);
             }
         }
-        _ => {}
+        // Explicit-preserve (total-by-construction). The guarded arms above
+        // handle the wrapper/branch shapes whose `expr.kind` and `expected`
+        // line up; every other (kind, expected) pairing — including a
+        // wrapper kind whose `expected` shape did NOT match its guard —
+        // falls here and is a no-op, exactly as the old `_ => {}`. The merge
+        // of `expr.ty` with `expected` already happened above, so there is
+        // nothing further to push down. Wildcarding only the `expected`
+        // slot keeps the fall-through identical while making the first
+        // tuple element exhaustive: a new IrExprKind variant is a compile
+        // error here. `If`/`Match` are NOT re-listed: their arms above are
+        // unguarded, so they already cover every `expected` and re-listing
+        // them would be an unreachable pattern.
+        (IrExprKind::OptionSome { .. }, _)
+        | (IrExprKind::ResultOk { .. }, _)
+        | (IrExprKind::ResultErr { .. }, _)
+        | (IrExprKind::List { .. }, _)
+        | (IrExprKind::Tuple { .. }, _)
+        | (IrExprKind::Block { .. }, _)
+        | (IrExprKind::LitInt { .. }, _) | (IrExprKind::LitFloat { .. }, _)
+        | (IrExprKind::LitStr { .. }, _) | (IrExprKind::LitBool { .. }, _)
+        | (IrExprKind::Unit, _) | (IrExprKind::Var { .. }, _)
+        | (IrExprKind::FnRef { .. }, _) | (IrExprKind::BinOp { .. }, _)
+        | (IrExprKind::UnOp { .. }, _) | (IrExprKind::Fan { .. }, _)
+        | (IrExprKind::ForIn { .. }, _) | (IrExprKind::While { .. }, _)
+        | (IrExprKind::Break, _) | (IrExprKind::Continue, _)
+        | (IrExprKind::Call { .. }, _) | (IrExprKind::TailCall { .. }, _)
+        | (IrExprKind::RuntimeCall { .. }, _)
+        | (IrExprKind::MapLiteral { .. }, _) | (IrExprKind::EmptyMap, _)
+        | (IrExprKind::Record { .. }, _) | (IrExprKind::SpreadRecord { .. }, _)
+        | (IrExprKind::Range { .. }, _) | (IrExprKind::Member { .. }, _)
+        | (IrExprKind::TupleIndex { .. }, _) | (IrExprKind::IndexAccess { .. }, _)
+        | (IrExprKind::MapAccess { .. }, _) | (IrExprKind::Lambda { .. }, _)
+        | (IrExprKind::StringInterp { .. }, _) | (IrExprKind::OptionNone, _)
+        | (IrExprKind::Try { .. }, _) | (IrExprKind::Unwrap { .. }, _)
+        | (IrExprKind::UnwrapOr { .. }, _) | (IrExprKind::ToOption { .. }, _)
+        | (IrExprKind::OptionalChain { .. }, _) | (IrExprKind::Await { .. }, _)
+        | (IrExprKind::Clone { .. }, _) | (IrExprKind::Deref { .. }, _)
+        | (IrExprKind::Borrow { .. }, _) | (IrExprKind::BoxNew { .. }, _)
+        | (IrExprKind::RcWrap { .. }, _) | (IrExprKind::RustMacro { .. }, _)
+        | (IrExprKind::ToVec { .. }, _) | (IrExprKind::RenderedCall { .. }, _)
+        | (IrExprKind::InlineRust { .. }, _) | (IrExprKind::ClosureCreate { .. }, _)
+        | (IrExprKind::EnvLoad { .. }, _) | (IrExprKind::IterChain { .. }, _)
+        | (IrExprKind::Hole, _) | (IrExprKind::Todo { .. }, _) => {}
     }
 }
 

--- a/crates/almide-codegen/src/pass_effect_inference.rs
+++ b/crates/almide-codegen/src/pass_effect_inference.rs
@@ -132,203 +132,57 @@ impl NanoPass for EffectInferencePass {
 
 /// Collect direct effects from stdlib calls in an expression.
 fn collect_direct_effects(expr: &IrExpr) -> HashSet<Effect> {
-    let mut effects = HashSet::new();
-    collect_effects_inner(expr, &mut effects);
-    effects
+    let mut collector = EffectCollector { effects: HashSet::new() };
+    collector.visit_expr(expr);
+    collector.effects
 }
 
-fn collect_effects_inner(expr: &IrExpr, effects: &mut HashSet<Effect>) {
-    match &expr.kind {
-        // Module call: list.map, fs.read_text, etc.
-        IrExprKind::Call { target: CallTarget::Module { module, .. }, args, .. } => {
-            if let Some(effect) = module_to_effect(module) {
-                effects.insert(effect);
-            }
-            // Check for math.random specifically
-            if module == "math" {
-                // math module functions that use randomness
-                // (detected by function name in args or specific math functions)
-            }
-            for arg in args {
-                collect_effects_inner(arg, effects);
-            }
-        }
-
-        // Named call: almide_rt_fs_read_text, etc.
-        IrExprKind::Call { target: CallTarget::Named { name }, args, .. } => {
-            if let Some(effect) = runtime_name_to_effect(name) {
-                effects.insert(effect);
-            }
-            for arg in args {
-                collect_effects_inner(arg, effects);
-            }
-        }
-
-        // Pre-resolved runtime call (from @intrinsic). Symbol follows
-        // the same `almide_rt_<m>_<f>` mangling as Named, so reuse
-        // `runtime_name_to_effect`.
-        IrExprKind::RuntimeCall { symbol, args } => {
-            if let Some(effect) = runtime_name_to_effect(symbol) {
-                effects.insert(effect);
-            }
-            for arg in args {
-                collect_effects_inner(arg, effects);
-            }
-        }
-
-        // Fan expressions
-        IrExprKind::Fan { exprs } => {
-            effects.insert(Effect::Fan);
-            for e in exprs {
-                collect_effects_inner(e, effects);
-            }
-        }
-
-        // Recurse into all other expression kinds
-        IrExprKind::Call { args, target, .. } => {
-            if let CallTarget::Method { object, .. } = target {
-                collect_effects_inner(object, effects);
-            }
-            if let CallTarget::Computed { callee } = target {
-                collect_effects_inner(callee, effects);
-            }
-            for arg in args {
-                collect_effects_inner(arg, effects);
-            }
-        }
-
-        IrExprKind::Block { stmts, expr } => {
-            for stmt in stmts {
-                collect_effects_from_stmt(stmt, effects);
-            }
-            if let Some(e) = expr {
-                collect_effects_inner(e, effects);
-            }
-        }
-
-        IrExprKind::If { cond, then, else_ } => {
-            collect_effects_inner(cond, effects);
-            collect_effects_inner(then, effects);
-            collect_effects_inner(else_, effects);
-        }
-
-        IrExprKind::Match { subject, arms } => {
-            collect_effects_inner(subject, effects);
-            for arm in arms {
-                if let Some(g) = &arm.guard {
-                    collect_effects_inner(g, effects);
-                }
-                collect_effects_inner(&arm.body, effects);
-            }
-        }
-
-        IrExprKind::Lambda { body, .. } => {
-            collect_effects_inner(body, effects);
-        }
-
-        IrExprKind::ForIn { iterable, body, .. } => {
-            collect_effects_inner(iterable, effects);
-            for stmt in body {
-                collect_effects_from_stmt(stmt, effects);
-            }
-        }
-
-        IrExprKind::While { cond, body } => {
-            collect_effects_inner(cond, effects);
-            for stmt in body {
-                collect_effects_from_stmt(stmt, effects);
-            }
-        }
-
-        IrExprKind::BinOp { left, right, .. } => {
-            collect_effects_inner(left, effects);
-            collect_effects_inner(right, effects);
-        }
-
-        IrExprKind::UnOp { operand, .. } => {
-            collect_effects_inner(operand, effects);
-        }
-
-        IrExprKind::List { elements } | IrExprKind::Tuple { elements } => {
-            for e in elements {
-                collect_effects_inner(e, effects);
-            }
-        }
-
-        IrExprKind::Record { fields, .. } => {
-            for (_, v) in fields {
-                collect_effects_inner(v, effects);
-            }
-        }
-
-        IrExprKind::SpreadRecord { base, fields } => {
-            collect_effects_inner(base, effects);
-            for (_, v) in fields {
-                collect_effects_inner(v, effects);
-            }
-        }
-
-        IrExprKind::OptionSome { expr } | IrExprKind::ResultOk { expr }
-        | IrExprKind::ResultErr { expr } | IrExprKind::Try { expr }
-        | IrExprKind::Unwrap { expr } | IrExprKind::ToOption { expr }
-        | IrExprKind::Member { object: expr, .. } | IrExprKind::OptionalChain { expr, .. }
-        | IrExprKind::Borrow { expr, .. }
-        | IrExprKind::ToVec { expr } | IrExprKind::Clone { expr }
-        | IrExprKind::Deref { expr } => {
-            collect_effects_inner(expr, effects);
-        }
-        IrExprKind::UnwrapOr { expr, fallback } => {
-            collect_effects_inner(expr, effects);
-            collect_effects_inner(fallback, effects);
-        }
-
-        IrExprKind::StringInterp { parts } => {
-            for part in parts {
-                if let IrStringPart::Expr { expr } = part {
-                    collect_effects_inner(expr, effects);
-                }
-            }
-        }
-
-        IrExprKind::MapLiteral { entries } => {
-            for (k, v) in entries {
-                collect_effects_inner(k, effects);
-                collect_effects_inner(v, effects);
-            }
-        }
-
-        IrExprKind::Range { start, end, .. } => {
-            collect_effects_inner(start, effects);
-            collect_effects_inner(end, effects);
-        }
-
-        IrExprKind::IndexAccess { object, index } => {
-            collect_effects_inner(object, effects);
-            collect_effects_inner(index, effects);
-        }
-
-        IrExprKind::MapAccess { object, key } => {
-            collect_effects_inner(object, effects);
-            collect_effects_inner(key, effects);
-        }
-
-        // Leaf nodes — no effects
-        _ => {}
-    }
+/// Traversal-total effect collector. Classifies the effect-bearing nodes
+/// (module/named/runtime calls, fan) and delegates *all* descent — into those
+/// nodes' children and into every other node — to `walk_expr`/`walk_stmt`.
+/// A new `IrExprKind`/`IrStmtKind` variant is automatically traversed, and a
+/// forgotten one is a compile error in the almide-ir walk primitive, not a
+/// silently-dropped subtree here.
+struct EffectCollector {
+    effects: HashSet<Effect>,
 }
 
-fn collect_effects_from_stmt(stmt: &IrStmt, effects: &mut HashSet<Effect>) {
-    match &stmt.kind {
-        IrStmtKind::Bind { value, .. } => collect_effects_inner(value, effects),
-        IrStmtKind::Assign { value, .. } => collect_effects_inner(value, effects),
-        IrStmtKind::Expr { expr } => collect_effects_inner(expr, effects),
-        IrStmtKind::Guard { cond, else_ } => {
-            collect_effects_inner(cond, effects);
-            collect_effects_inner(else_, effects);
+impl IrVisitor for EffectCollector {
+    fn visit_expr(&mut self, expr: &IrExpr) {
+        match &expr.kind {
+            // Module call: list.map, fs.read_text, etc.
+            IrExprKind::Call { target: CallTarget::Module { module, .. }, .. } => {
+                if let Some(effect) = module_to_effect(module) {
+                    self.effects.insert(effect);
+                }
+            }
+
+            // Named call: almide_rt_fs_read_text, etc.
+            IrExprKind::Call { target: CallTarget::Named { name }, .. } => {
+                if let Some(effect) = runtime_name_to_effect(name) {
+                    self.effects.insert(effect);
+                }
+            }
+
+            // Pre-resolved runtime call (from @intrinsic). Symbol follows
+            // the same `almide_rt_<m>_<f>` mangling as Named, so reuse
+            // `runtime_name_to_effect`.
+            IrExprKind::RuntimeCall { symbol, .. } => {
+                if let Some(effect) = runtime_name_to_effect(symbol) {
+                    self.effects.insert(effect);
+                }
+            }
+
+            // Fan expressions.
+            IrExprKind::Fan { .. } => {
+                self.effects.insert(Effect::Fan);
+            }
+
+            _ => {}
         }
-        IrStmtKind::BindDestructure { value, .. } => collect_effects_inner(value, effects),
-        IrStmtKind::FieldAssign { value, .. } => collect_effects_inner(value, effects),
-        _ => {}
+        // Exhaustive descent into all children (covers the non-classified
+        // nodes, and the children of the classified ones above).
+        walk_expr(self, expr);
     }
 }
 
@@ -337,88 +191,52 @@ fn build_call_graph(program: &IrProgram) -> HashMap<String, HashSet<String>> {
     let mut graph: HashMap<String, HashSet<String>> = HashMap::new();
 
     for func in &program.functions {
-        let mut callees = HashSet::new();
-        collect_callees(&func.body, &mut callees);
-        graph.insert(func.name.to_string(), callees);
+        graph.insert(func.name.to_string(), collect_callees(&func.body));
     }
 
     for module in &program.modules {
         for func in &module.functions {
-            let mut callees = HashSet::new();
-            collect_callees(&func.body, &mut callees);
             let qualified = format!("{}.{}", module.name, func.name);
-            graph.insert(qualified, callees);
+            graph.insert(qualified, collect_callees(&func.body));
         }
     }
 
     graph
 }
 
-fn collect_callees(expr: &IrExpr, callees: &mut HashSet<String>) {
-    match &expr.kind {
-        IrExprKind::Call { target: CallTarget::Named { name }, args, .. } => {
-            // Skip runtime functions — they're stdlib, not user functions
-            if !name.starts_with("almide_rt_") {
-                callees.insert(name.to_string());
-            }
-            for arg in args {
-                collect_callees(arg, callees);
-            }
-        }
-        IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. } => {
-            callees.insert(format!("{}.{}", module, func));
-            for arg in args {
-                collect_callees(arg, callees);
-            }
-        }
-        IrExprKind::Block { stmts, expr } => {
-            for stmt in stmts {
-                match &stmt.kind {
-                    IrStmtKind::Bind { value, .. } | IrStmtKind::Assign { value, .. } => collect_callees(value, callees),
-                    IrStmtKind::Expr { expr } => collect_callees(expr, callees),
-                    IrStmtKind::Guard { cond, else_ } => {
-                        collect_callees(cond, callees);
-                        collect_callees(else_, callees);
-                    }
-                    IrStmtKind::BindDestructure { value, .. } => collect_callees(value, callees),
-                    _ => {}
+fn collect_callees(expr: &IrExpr) -> HashSet<String> {
+    let mut collector = CalleeCollector { callees: HashSet::new() };
+    collector.visit_expr(expr);
+    collector.callees
+}
+
+/// Traversal-total callee collector. Records the user-function call targets
+/// (named non-runtime calls + module calls) and delegates *all* descent to
+/// `walk_expr`/`walk_stmt`. A new node kind is automatically traversed, and a
+/// forgotten one is a compile error in the almide-ir walk primitive, not a
+/// silently-dropped subtree here.
+struct CalleeCollector {
+    callees: HashSet<String>,
+}
+
+impl IrVisitor for CalleeCollector {
+    fn visit_expr(&mut self, expr: &IrExpr) {
+        match &expr.kind {
+            IrExprKind::Call { target: CallTarget::Named { name }, .. }
+            | IrExprKind::TailCall { target: CallTarget::Named { name }, .. } => {
+                // Skip runtime functions — they're stdlib, not user functions.
+                if !name.starts_with("almide_rt_") {
+                    self.callees.insert(name.to_string());
                 }
             }
-            if let Some(e) = expr { collect_callees(e, callees); }
-        }
-        IrExprKind::If { cond, then, else_ } => {
-            collect_callees(cond, callees);
-            collect_callees(then, callees);
-            collect_callees(else_, callees);
-        }
-        IrExprKind::Lambda { body, .. } => collect_callees(body, callees),
-        IrExprKind::Match { subject, arms } => {
-            collect_callees(subject, callees);
-            for arm in arms {
-                if let Some(g) = &arm.guard { collect_callees(g, callees); }
-                collect_callees(&arm.body, callees);
+            IrExprKind::Call { target: CallTarget::Module { module, func, .. }, .. }
+            | IrExprKind::TailCall { target: CallTarget::Module { module, func, .. }, .. } => {
+                self.callees.insert(format!("{}.{}", module, func));
             }
+            _ => {}
         }
-        IrExprKind::ForIn { iterable, body, .. } => {
-            collect_callees(iterable, callees);
-            for stmt in body {
-                match &stmt.kind {
-                    IrStmtKind::Bind { value, .. } | IrStmtKind::Assign { value, .. } => collect_callees(value, callees),
-                    IrStmtKind::Expr { expr } => collect_callees(expr, callees),
-                    _ => {}
-                }
-            }
-        }
-        IrExprKind::Call { target, args, .. } => {
-            if let CallTarget::Method { object, .. } = target { collect_callees(object, callees); }
-            if let CallTarget::Computed { callee } = target { collect_callees(callee, callees); }
-            for arg in args { collect_callees(arg, callees); }
-        }
-        IrExprKind::BinOp { left, right, .. } => {
-            collect_callees(left, callees);
-            collect_callees(right, callees);
-        }
-        _ => {}
+        // Exhaustive descent into all children.
+        walk_expr(self, expr);
     }
 }
 

--- a/crates/almide-codegen/src/pass_lambda_type_resolve.rs
+++ b/crates/almide-codegen/src/pass_lambda_type_resolve.rs
@@ -13,7 +13,7 @@
 //! reachable from a typed list-callback call are `!is_unresolved_structural()`.
 
 use almide_ir::*;
-use almide_ir::visit::{IrVisitor, walk_expr, walk_stmt};
+use almide_ir::visit::{IrVisitor, walk_expr};
 use almide_lang::types::Ty;
 use super::pass::{NanoPass, PassResult, Postcondition, Target};
 
@@ -218,7 +218,38 @@ fn resolve_expr(expr: &mut IrExpr, vt: &mut VarTable) {
         IrExprKind::MapAccess { object, key } => {
             resolve_expr(object, vt); resolve_expr(key, vt);
         }
-        _ => {}
+        // Leaf / non-type-bearing kinds: nothing to descend into for the
+        // top-down type propagation. Listed explicitly so a new IrExprKind
+        // is a compile error here, never a silently-dropped subtree.
+        IrExprKind::LitInt { .. }
+        | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. }
+        | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit
+        | IrExprKind::Var { .. }
+        | IrExprKind::FnRef { .. }
+        | IrExprKind::Fan { .. }
+        | IrExprKind::Break
+        | IrExprKind::Continue
+        | IrExprKind::TailCall { .. }
+        | IrExprKind::EmptyMap
+        | IrExprKind::OptionNone
+        | IrExprKind::Unwrap { .. }
+        | IrExprKind::UnwrapOr { .. }
+        | IrExprKind::ToOption { .. }
+        | IrExprKind::OptionalChain { .. }
+        | IrExprKind::Borrow { .. }
+        | IrExprKind::BoxNew { .. }
+        | IrExprKind::RcWrap { .. }
+        | IrExprKind::RustMacro { .. }
+        | IrExprKind::ToVec { .. }
+        | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. }
+        | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. }
+        | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole
+        | IrExprKind::Todo { .. } => {}
     }
 
     // Post-visit: sync expr.ty from VarTable for Var nodes,
@@ -297,7 +328,17 @@ fn resolve_stmt(stmt: &mut IrStmt, vt: &mut VarTable) {
         IrStmtKind::Guard { cond, else_ } => {
             resolve_expr(cond, vt); resolve_expr(else_, vt);
         }
-        _ => {}
+        // Statements with no type to propagate into (or whose IrExpr
+        // children — ListSwap/ListReverse/ListRotateLeft/ListCopySlice
+        // operands — the original catch-all intentionally left untouched).
+        // Listed explicitly so a new IrStmtKind is a compile error here.
+        IrStmtKind::Comment { .. }
+        | IrStmtKind::ListCopySlice { .. }
+        | IrStmtKind::ListReverse { .. }
+        | IrStmtKind::ListRotateLeft { .. }
+        | IrStmtKind::ListSwap { .. }
+        | IrStmtKind::RcDec { .. }
+        | IrStmtKind::RcInc { .. } => {}
     }
 }
 
@@ -703,54 +744,6 @@ fn resolve_via_tuple_index(expr: &IrExpr, params: &[(VarId, Ty)]) -> Option<Ty> 
         }
     }
     None
-}
-
-/// Infer a lambda parameter's type by scanning the body for operations
-/// that constrain it (e.g., `p + 1.0` → p is Float).
-pub(crate) fn infer_param_ty_from_body(body: &IrExpr, target: VarId) -> Option<Ty> {
-    fn walk(expr: &IrExpr, target: VarId) -> Option<Ty> {
-        match &expr.kind {
-            IrExprKind::BinOp { left, right, .. } => {
-                if let IrExprKind::Var { id } = &left.kind {
-                    if *id == target && !right.ty.is_unresolved_structural() {
-                        return Some(right.ty.clone());
-                    }
-                }
-                if let IrExprKind::Var { id } = &right.kind {
-                    if *id == target && !left.ty.is_unresolved_structural() {
-                        return Some(left.ty.clone());
-                    }
-                }
-                walk(left, target).or_else(|| walk(right, target))
-            }
-            IrExprKind::If { cond, then, else_ } => {
-                walk(cond, target).or_else(|| walk(then, target)).or_else(|| walk(else_, target))
-            }
-            IrExprKind::Block { stmts, expr: tail } => {
-                for s in stmts { if let Some(t) = walk_stmt(s, target) { return Some(t); } }
-                tail.as_ref().and_then(|e| walk(e, target))
-            }
-            IrExprKind::Match { subject, arms } => {
-                walk(subject, target).or_else(|| {
-                    arms.iter().find_map(|arm| walk(&arm.body, target))
-                })
-            }
-            IrExprKind::Call { args, .. } => {
-                args.iter().find_map(|a| walk(a, target))
-            }
-            _ => None,
-        }
-    }
-    fn walk_stmt(stmt: &IrStmt, target: VarId) -> Option<Ty> {
-        match &stmt.kind {
-            IrStmtKind::Bind { value, .. } => walk(value, target),
-            IrStmtKind::BindDestructure { value, .. } => walk(value, target),
-            IrStmtKind::Assign { value, .. } => walk(value, target),
-            IrStmtKind::Expr { expr } => walk(expr, target),
-            _ => None,
-        }
-    }
-    walk(body, target)
 }
 
 /// Compute the return type of a stdlib list Call node from the

--- a/crates/almide-codegen/src/pass_licm.rs
+++ b/crates/almide-codegen/src/pass_licm.rs
@@ -129,7 +129,34 @@ fn hoist_loops(expr: &mut IrExpr, vt: &mut VarTable, pure_fns: &HashSet<Sym>, mm
             if hoist_loops(cond, vt, pure_fns, mm) { changed = true; }
             for s in body { if hoist_loops_stmt(s, vt, pure_fns, mm) { changed = true; } }
         }
-        _ => {}
+        // Explicit-preserve: hoisting is selective — these node kinds are
+        // not descended for loop discovery here. Listing every remaining
+        // variant makes a new IrExprKind a compile error, not a silent drop.
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+        | IrExprKind::BinOp { .. } | IrExprKind::UnOp { .. }
+        | IrExprKind::Fan { .. } | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::Call { .. } | IrExprKind::TailCall { .. }
+        | IrExprKind::RuntimeCall { .. } | IrExprKind::List { .. }
+        | IrExprKind::MapLiteral { .. } | IrExprKind::EmptyMap
+        | IrExprKind::Record { .. } | IrExprKind::SpreadRecord { .. }
+        | IrExprKind::Tuple { .. } | IrExprKind::Range { .. }
+        | IrExprKind::Member { .. } | IrExprKind::TupleIndex { .. }
+        | IrExprKind::IndexAccess { .. } | IrExprKind::MapAccess { .. }
+        | IrExprKind::StringInterp { .. } | IrExprKind::ResultOk { .. }
+        | IrExprKind::ResultErr { .. } | IrExprKind::OptionSome { .. }
+        | IrExprKind::OptionNone | IrExprKind::Try { .. }
+        | IrExprKind::Unwrap { .. } | IrExprKind::UnwrapOr { .. }
+        | IrExprKind::ToOption { .. } | IrExprKind::OptionalChain { .. }
+        | IrExprKind::Await { .. } | IrExprKind::Clone { .. }
+        | IrExprKind::Deref { .. } | IrExprKind::Borrow { .. }
+        | IrExprKind::BoxNew { .. } | IrExprKind::RcWrap { .. }
+        | IrExprKind::RustMacro { .. } | IrExprKind::ToVec { .. }
+        | IrExprKind::RenderedCall { .. } | IrExprKind::InlineRust { .. }
+        | IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. }
+        | IrExprKind::IterChain { .. } | IrExprKind::Hole
+        | IrExprKind::Todo { .. } => {}
     }
     changed
 }
@@ -185,7 +212,36 @@ fn try_hoist_from_loop(expr: &mut IrExpr, vt: &mut VarTable, pure_fns: &HashSet<
                 extract_invariants_from_stmt(stmt, &loop_defined, vt, &mut hoisted, pure_fns, mm);
             }
         }
-        _ => {}
+        // Explicit-preserve: only loop heads (ForIn/While) drive hoisting
+        // here; every other node kind yields no hoisted bindings. Listing
+        // each variant turns a new IrExprKind into a compile error.
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+        | IrExprKind::BinOp { .. } | IrExprKind::UnOp { .. }
+        | IrExprKind::If { .. } | IrExprKind::Match { .. }
+        | IrExprKind::Block { .. } | IrExprKind::Fan { .. }
+        | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::Call { .. } | IrExprKind::TailCall { .. }
+        | IrExprKind::RuntimeCall { .. } | IrExprKind::List { .. }
+        | IrExprKind::MapLiteral { .. } | IrExprKind::EmptyMap
+        | IrExprKind::Record { .. } | IrExprKind::SpreadRecord { .. }
+        | IrExprKind::Tuple { .. } | IrExprKind::Range { .. }
+        | IrExprKind::Member { .. } | IrExprKind::TupleIndex { .. }
+        | IrExprKind::IndexAccess { .. } | IrExprKind::MapAccess { .. }
+        | IrExprKind::Lambda { .. } | IrExprKind::StringInterp { .. }
+        | IrExprKind::ResultOk { .. } | IrExprKind::ResultErr { .. }
+        | IrExprKind::OptionSome { .. } | IrExprKind::OptionNone
+        | IrExprKind::Try { .. } | IrExprKind::Unwrap { .. }
+        | IrExprKind::UnwrapOr { .. } | IrExprKind::ToOption { .. }
+        | IrExprKind::OptionalChain { .. } | IrExprKind::Await { .. }
+        | IrExprKind::Clone { .. } | IrExprKind::Deref { .. }
+        | IrExprKind::Borrow { .. } | IrExprKind::BoxNew { .. }
+        | IrExprKind::RcWrap { .. } | IrExprKind::RustMacro { .. }
+        | IrExprKind::ToVec { .. } | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. } | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => {}
     }
 
     hoisted
@@ -262,7 +318,13 @@ fn collect_pattern_defined_vars(pat: &IrPattern, defined: &mut HashSet<VarId>) {
                 if let Some(p) = &f.pattern { collect_pattern_defined_vars(p, defined); }
             }
         }
-        _ => {}
+        // Explicit-preserve (zero behavior change): these patterns bind no
+        // vars that the current analysis tracks. NOTE: `List` does bind vars
+        // inside `elements` and was already dropped by the prior `_ => {}` —
+        // preserving that exact behavior here, but now a NEW IrPattern variant
+        // is a compile error instead of a silent miss. See residual risk.
+        IrPattern::Wildcard | IrPattern::Literal { .. }
+        | IrPattern::None | IrPattern::List { .. } => {}
     }
 }
 
@@ -313,7 +375,35 @@ fn collect_defined_vars_expr(expr: &IrExpr, defined: &mut HashSet<VarId>, mm: &M
                 }
             }
         }
-        _ => {}
+        // Explicit-preserve: only the scopes/loops/mutating-Module-calls above
+        // define variables relevant to LICM. Every other node (including Call
+        // with a non-Module target) defines nothing. Listing each variant
+        // turns a new IrExprKind into a compile error instead of a silent miss.
+        IrExprKind::Call { .. } | IrExprKind::TailCall { .. }
+        | IrExprKind::RuntimeCall { .. }
+        | IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+        | IrExprKind::BinOp { .. } | IrExprKind::UnOp { .. }
+        | IrExprKind::Fan { .. } | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::List { .. } | IrExprKind::MapLiteral { .. }
+        | IrExprKind::EmptyMap | IrExprKind::Record { .. }
+        | IrExprKind::SpreadRecord { .. } | IrExprKind::Tuple { .. }
+        | IrExprKind::Range { .. } | IrExprKind::Member { .. }
+        | IrExprKind::TupleIndex { .. } | IrExprKind::IndexAccess { .. }
+        | IrExprKind::MapAccess { .. } | IrExprKind::StringInterp { .. }
+        | IrExprKind::ResultOk { .. } | IrExprKind::ResultErr { .. }
+        | IrExprKind::OptionSome { .. } | IrExprKind::OptionNone
+        | IrExprKind::Try { .. } | IrExprKind::Unwrap { .. }
+        | IrExprKind::UnwrapOr { .. } | IrExprKind::ToOption { .. }
+        | IrExprKind::OptionalChain { .. } | IrExprKind::Await { .. }
+        | IrExprKind::Clone { .. } | IrExprKind::Deref { .. }
+        | IrExprKind::Borrow { .. } | IrExprKind::BoxNew { .. }
+        | IrExprKind::RcWrap { .. } | IrExprKind::RustMacro { .. }
+        | IrExprKind::ToVec { .. } | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. } | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => {}
     }
 }
 
@@ -349,7 +439,16 @@ fn extract_invariants_from_stmt(
             // the hoisted binding's type (Result<(),_>) incompatible with
             // non-effect function return type (()).
         }
-        _ => {}
+        // Explicit-preserve: only Bind / Expr / Assign / Guard values are
+        // examined for invariant sub-expressions. The remaining statement
+        // kinds carry no hoistable RHS in this analysis. Listing each one
+        // makes a new IrStmtKind a compile error, not a silent skip.
+        IrStmtKind::BindDestructure { .. } | IrStmtKind::FieldAssign { .. }
+        | IrStmtKind::IndexAssign { .. } | IrStmtKind::MapInsert { .. }
+        | IrStmtKind::ListSwap { .. } | IrStmtKind::ListReverse { .. }
+        | IrStmtKind::ListRotateLeft { .. } | IrStmtKind::ListCopySlice { .. }
+        | IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. }
+        | IrStmtKind::Comment { .. } => {}
     }
 }
 
@@ -397,7 +496,7 @@ fn try_hoist_expr(
             match target {
                 CallTarget::Method { object, .. } => try_hoist_expr(object, loop_defined, vt, hoisted, pure_fns, mm),
                 CallTarget::Computed { callee } => try_hoist_expr(callee, loop_defined, vt, hoisted, pure_fns, mm),
-                _ => {}
+                other @ (CallTarget::Named { .. } | CallTarget::Module { .. }) => { let _ = other; }
             }
             for arg in args {
                 try_hoist_expr(arg, loop_defined, vt, hoisted, pure_fns, mm);
@@ -483,7 +582,30 @@ fn try_hoist_expr(
                 extract_invariants_from_stmt(stmt, &nested_defined, vt, hoisted, pure_fns, mm);
             }
         }
-        _ => {}
+        // Explicit-preserve: the whole-expression hoist check above already
+        // decided these nodes are not worth recursing into for sub-part
+        // hoisting (they are leaves, control flow with their own scoping, or
+        // wrappers handled by the whole-expr path). Listing every remaining
+        // variant turns a new IrExprKind into a compile error, not a silent
+        // dropped subtree.
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+        | IrExprKind::Match { .. } | IrExprKind::Block { .. }
+        | IrExprKind::Fan { .. } | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::TailCall { .. } | IrExprKind::MapLiteral { .. }
+        | IrExprKind::EmptyMap | IrExprKind::SpreadRecord { .. }
+        | IrExprKind::TupleIndex { .. } | IrExprKind::Lambda { .. }
+        | IrExprKind::OptionNone | IrExprKind::Try { .. }
+        | IrExprKind::Unwrap { .. } | IrExprKind::UnwrapOr { .. }
+        | IrExprKind::ToOption { .. } | IrExprKind::Await { .. }
+        | IrExprKind::Clone { .. } | IrExprKind::Deref { .. }
+        | IrExprKind::Borrow { .. } | IrExprKind::BoxNew { .. }
+        | IrExprKind::RcWrap { .. } | IrExprKind::RustMacro { .. }
+        | IrExprKind::ToVec { .. } | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. } | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => {}
     }
 }
 
@@ -518,7 +640,36 @@ fn has_assignment(expr: &IrExpr) -> bool {
         }
         IrExprKind::If { cond, then, else_ } => has_assignment(cond) || has_assignment(then) || has_assignment(else_),
         IrExprKind::Match { subject, arms } => has_assignment(subject) || arms.iter().any(|a| has_assignment(&a.body)),
-        _ => false,
+        // Explicit-preserve: only Block/If/Match are scanned for nested
+        // assignments here; an Assign reachable through any other node kind
+        // would not be hoistable for other reasons (impurity / control flow).
+        // Listing each variant makes a new IrExprKind a compile error.
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+        | IrExprKind::BinOp { .. } | IrExprKind::UnOp { .. }
+        | IrExprKind::Fan { .. } | IrExprKind::ForIn { .. }
+        | IrExprKind::While { .. } | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::Call { .. } | IrExprKind::TailCall { .. }
+        | IrExprKind::RuntimeCall { .. } | IrExprKind::List { .. }
+        | IrExprKind::MapLiteral { .. } | IrExprKind::EmptyMap
+        | IrExprKind::Record { .. } | IrExprKind::SpreadRecord { .. }
+        | IrExprKind::Tuple { .. } | IrExprKind::Range { .. }
+        | IrExprKind::Member { .. } | IrExprKind::TupleIndex { .. }
+        | IrExprKind::IndexAccess { .. } | IrExprKind::MapAccess { .. }
+        | IrExprKind::Lambda { .. } | IrExprKind::StringInterp { .. }
+        | IrExprKind::ResultOk { .. } | IrExprKind::ResultErr { .. }
+        | IrExprKind::OptionSome { .. } | IrExprKind::OptionNone
+        | IrExprKind::Try { .. } | IrExprKind::Unwrap { .. }
+        | IrExprKind::UnwrapOr { .. } | IrExprKind::ToOption { .. }
+        | IrExprKind::OptionalChain { .. } | IrExprKind::Await { .. }
+        | IrExprKind::Clone { .. } | IrExprKind::Deref { .. }
+        | IrExprKind::Borrow { .. } | IrExprKind::BoxNew { .. }
+        | IrExprKind::RcWrap { .. } | IrExprKind::RustMacro { .. }
+        | IrExprKind::ToVec { .. } | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. } | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => false,
     }
 }
 
@@ -527,7 +678,14 @@ fn has_assignment_stmt(stmt: &IrStmt) -> bool {
         IrStmtKind::Assign { .. } | IrStmtKind::FieldAssign { .. } | IrStmtKind::IndexAssign { .. } => true,
         IrStmtKind::Expr { expr } => has_assignment(expr),
         IrStmtKind::Bind { value, .. } => has_assignment(value),
-        _ => false,
+        // Explicit-preserve: remaining statement kinds carry no nested
+        // expression that could hide a hoistable assignment here. Listing
+        // each one makes a new IrStmtKind a compile error.
+        IrStmtKind::BindDestructure { .. } | IrStmtKind::MapInsert { .. }
+        | IrStmtKind::ListSwap { .. } | IrStmtKind::ListReverse { .. }
+        | IrStmtKind::ListRotateLeft { .. } | IrStmtKind::ListCopySlice { .. }
+        | IrStmtKind::Guard { .. } | IrStmtKind::RcInc { .. }
+        | IrStmtKind::RcDec { .. } | IrStmtKind::Comment { .. } => false,
     }
 }
 
@@ -545,7 +703,7 @@ fn has_control_flow(expr: &IrExpr) -> bool {
             let target_cf = match target {
                 CallTarget::Method { object, .. } => has_control_flow(object),
                 CallTarget::Computed { callee } => has_control_flow(callee),
-                _ => false,
+                CallTarget::Named { .. } | CallTarget::Module { .. } => false,
             };
             target_cf || args.iter().any(|a| has_control_flow(a))
         }
@@ -572,7 +730,28 @@ fn has_control_flow(expr: &IrExpr) -> bool {
         IrExprKind::UnwrapOr { expr: e, fallback: f } => {
             has_control_flow(e) || has_control_flow(f)
         }
-        _ => false,
+        // Explicit-preserve: these node kinds are treated as control-flow-free
+        // for hoisting (Match/Lambda are conservatively reported as false here
+        // because their bodies have their own scoping). Preserving the prior
+        // `false` for every remaining variant makes a new IrExprKind a compile
+        // error, not a silent miss.
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+        | IrExprKind::Match { .. } | IrExprKind::Fan { .. }
+        | IrExprKind::TailCall { .. } | IrExprKind::MapLiteral { .. }
+        | IrExprKind::EmptyMap | IrExprKind::Record { .. }
+        | IrExprKind::SpreadRecord { .. } | IrExprKind::Range { .. }
+        | IrExprKind::Member { .. } | IrExprKind::TupleIndex { .. }
+        | IrExprKind::IndexAccess { .. } | IrExprKind::MapAccess { .. }
+        | IrExprKind::Lambda { .. } | IrExprKind::StringInterp { .. }
+        | IrExprKind::OptionNone | IrExprKind::Await { .. }
+        | IrExprKind::Borrow { .. } | IrExprKind::BoxNew { .. }
+        | IrExprKind::RcWrap { .. } | IrExprKind::RustMacro { .. }
+        | IrExprKind::ToVec { .. } | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. } | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => false,
     }
 }
 
@@ -582,7 +761,14 @@ fn has_control_flow_stmt(stmt: &IrStmt) -> bool {
         | IrStmtKind::FieldAssign { value, .. } => has_control_flow(value),
         IrStmtKind::Expr { expr } => has_control_flow(expr),
         IrStmtKind::Guard { cond, else_ } => has_control_flow(cond) || has_control_flow(else_),
-        _ => false,
+        // Explicit-preserve: remaining statement kinds carry no expression
+        // whose control flow would block hoisting here. Listing each one makes
+        // a new IrStmtKind a compile error.
+        IrStmtKind::BindDestructure { .. } | IrStmtKind::IndexAssign { .. }
+        | IrStmtKind::MapInsert { .. } | IrStmtKind::ListSwap { .. }
+        | IrStmtKind::ListReverse { .. } | IrStmtKind::ListRotateLeft { .. }
+        | IrStmtKind::ListCopySlice { .. } | IrStmtKind::RcInc { .. }
+        | IrStmtKind::RcDec { .. } | IrStmtKind::Comment { .. } => false,
     }
 }
 
@@ -628,7 +814,8 @@ fn is_pure(expr: &IrExpr, pure_fns: &HashSet<Sym>) -> bool {
                     pure_fns.contains(&key)
                 }
                 CallTarget::Named { name } => pure_fns.contains(name),
-                _ => false,
+                // Method/Computed dispatch can hide effects → conservatively impure.
+                CallTarget::Method { .. } | CallTarget::Computed { .. } => false,
             };
             call_pure && args.iter().all(|a| is_pure(a, pure_fns))
         }
@@ -662,12 +849,22 @@ fn is_pure(expr: &IrExpr, pure_fns: &HashSet<Sym>) -> bool {
         IrExprKind::StringInterp { parts } => {
             parts.iter().all(|p| match p {
                 IrStringPart::Expr { expr } => is_pure(expr, pure_fns),
-                _ => true,
+                lit @ IrStringPart::Lit { .. } => { let _ = lit; true }
             })
         }
 
-        // Everything else: conservatively impure
-        _ => false,
+        // Everything else: conservatively impure. Listed explicitly so a new
+        // IrExprKind is a compile error here, not a silently-impure default.
+        IrExprKind::If { .. } | IrExprKind::Match { .. }
+        | IrExprKind::Block { .. } | IrExprKind::Fan { .. }
+        | IrExprKind::ForIn { .. } | IrExprKind::While { .. }
+        | IrExprKind::TailCall { .. } | IrExprKind::RuntimeCall { .. }
+        | IrExprKind::Lambda { .. } | IrExprKind::Try { .. }
+        | IrExprKind::Unwrap { .. } | IrExprKind::ToOption { .. }
+        | IrExprKind::OptionalChain { .. } | IrExprKind::Await { .. }
+        | IrExprKind::RcWrap { .. } | IrExprKind::InlineRust { .. }
+        | IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. }
+        | IrExprKind::IterChain { .. } | IrExprKind::Todo { .. } => false,
     }
 }
 
@@ -680,7 +877,7 @@ fn refs_are_outside_loop(expr: &IrExpr, loop_defined: &HashSet<VarId>) -> bool {
             let target_ok = match target {
                 CallTarget::Method { object, .. } => refs_are_outside_loop(object, loop_defined),
                 CallTarget::Computed { callee } => refs_are_outside_loop(callee, loop_defined),
-                _ => true,
+                CallTarget::Named { .. } | CallTarget::Module { .. } => true,
             };
             target_ok && args.iter().all(|a| refs_are_outside_loop(a, loop_defined))
         }
@@ -730,7 +927,7 @@ fn refs_are_outside_loop(expr: &IrExpr, loop_defined: &HashSet<VarId>) -> bool {
         IrExprKind::StringInterp { parts } => {
             parts.iter().all(|p| match p {
                 IrStringPart::Expr { expr } => refs_are_outside_loop(expr, loop_defined),
-                _ => true,
+                lit @ IrStringPart::Lit { .. } => { let _ = lit; true }
             })
         }
         IrExprKind::MapLiteral { entries } => {
@@ -759,8 +956,21 @@ fn refs_are_outside_loop(expr: &IrExpr, loop_defined: &HashSet<VarId>) -> bool {
                         && refs_are_outside_loop(&a.body, loop_defined)
                 })
         }
-        // Leaf nodes (LitInt, LitFloat, LitStr, LitBool, Unit, OptionNone, etc.)
-        _ => true,
+        // Leaf nodes and nodes whose inner refs aren't tracked here: treated as
+        // "all refs outside loop" (true). Listed explicitly so a new IrExprKind
+        // is a compile error, not a silent always-true default.
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::FnRef { .. } | IrExprKind::Fan { .. }
+        | IrExprKind::ForIn { .. } | IrExprKind::While { .. }
+        | IrExprKind::Break | IrExprKind::Continue | IrExprKind::TailCall { .. }
+        | IrExprKind::RuntimeCall { .. } | IrExprKind::EmptyMap
+        | IrExprKind::OptionNone | IrExprKind::Await { .. }
+        | IrExprKind::RcWrap { .. } | IrExprKind::RustMacro { .. }
+        | IrExprKind::RenderedCall { .. } | IrExprKind::InlineRust { .. }
+        | IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. }
+        | IrExprKind::IterChain { .. } | IrExprKind::Hole
+        | IrExprKind::Todo { .. } => true,
     }
 }
 
@@ -861,7 +1071,8 @@ fn expr_is_pure_with(expr: &IrExpr, pure_fns: &HashSet<Sym>) -> bool {
                     pure_fns.contains(&key)
                 }
                 CallTarget::Named { name } => pure_fns.contains(name),
-                _ => false,
+                // Method/Computed dispatch can hide effects → conservatively impure.
+                CallTarget::Method { .. } | CallTarget::Computed { .. } => false,
             };
             call_pure && args.iter().all(|a| expr_is_pure_with(a, pure_fns))
         }
@@ -899,11 +1110,22 @@ fn expr_is_pure_with(expr: &IrExpr, pure_fns: &HashSet<Sym>) -> bool {
         IrExprKind::StringInterp { parts } => {
             parts.iter().all(|p| match p {
                 IrStringPart::Expr { expr } => expr_is_pure_with(expr, pure_fns),
-                _ => true,
+                lit @ IrStringPart::Lit { .. } => { let _ = lit; true }
             })
         }
-        // ForIn, While, Fan, Await, etc. — conservatively impure
-        _ => false,
+        // ForIn, While, Fan, Await, etc. — conservatively impure. Listed
+        // explicitly so a new IrExprKind is a compile error here, not a
+        // silently-impure default.
+        IrExprKind::Fan { .. } | IrExprKind::ForIn { .. }
+        | IrExprKind::While { .. } | IrExprKind::TailCall { .. }
+        | IrExprKind::RuntimeCall { .. } | IrExprKind::MapLiteral { .. }
+        | IrExprKind::SpreadRecord { .. } | IrExprKind::MapAccess { .. }
+        | IrExprKind::Try { .. } | IrExprKind::Unwrap { .. }
+        | IrExprKind::ToOption { .. } | IrExprKind::OptionalChain { .. }
+        | IrExprKind::Await { .. } | IrExprKind::RcWrap { .. }
+        | IrExprKind::InlineRust { .. } | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::IterChain { .. }
+        | IrExprKind::Todo { .. } => false,
     }
 }
 

--- a/crates/almide-codegen/src/pass_matrix_shape_spec.rs
+++ b/crates/almide-codegen/src/pass_matrix_shape_spec.rs
@@ -215,7 +215,58 @@ fn rewrite_expr(expr: &mut IrExpr, shapes: &mut HashMap<VarId, Shape>) -> bool {
         IrExprKind::Record { fields, .. } => {
             for (_, e) in fields { if rewrite_expr(e, shapes) { changed = true; } }
         }
-        _ => {}
+        // Explicit-preserve: every other node kind is left untouched by this
+        // shape-specialization pass. Listing them all (instead of `_ => {}`)
+        // makes the descent total-by-construction — a new IrExprKind variant
+        // becomes a compile error here, forcing a deliberate traversal choice
+        // rather than silently dropping the subtree.
+        IrExprKind::LitInt { .. }
+        | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. }
+        | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit
+        | IrExprKind::Var { .. }
+        | IrExprKind::FnRef { .. }
+        | IrExprKind::Fan { .. }
+        | IrExprKind::ForIn { .. }
+        | IrExprKind::While { .. }
+        | IrExprKind::Break
+        | IrExprKind::Continue
+        | IrExprKind::TailCall { .. }
+        | IrExprKind::RuntimeCall { .. }
+        | IrExprKind::MapLiteral { .. }
+        | IrExprKind::EmptyMap
+        | IrExprKind::SpreadRecord { .. }
+        | IrExprKind::Range { .. }
+        | IrExprKind::Member { .. }
+        | IrExprKind::TupleIndex { .. }
+        | IrExprKind::IndexAccess { .. }
+        | IrExprKind::MapAccess { .. }
+        | IrExprKind::StringInterp { .. }
+        | IrExprKind::ResultOk { .. }
+        | IrExprKind::ResultErr { .. }
+        | IrExprKind::OptionSome { .. }
+        | IrExprKind::OptionNone
+        | IrExprKind::Try { .. }
+        | IrExprKind::Unwrap { .. }
+        | IrExprKind::UnwrapOr { .. }
+        | IrExprKind::ToOption { .. }
+        | IrExprKind::OptionalChain { .. }
+        | IrExprKind::Await { .. }
+        | IrExprKind::Clone { .. }
+        | IrExprKind::Deref { .. }
+        | IrExprKind::Borrow { .. }
+        | IrExprKind::BoxNew { .. }
+        | IrExprKind::RcWrap { .. }
+        | IrExprKind::RustMacro { .. }
+        | IrExprKind::ToVec { .. }
+        | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. }
+        | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. }
+        | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole
+        | IrExprKind::Todo { .. } => {}
     }
 
     // Now look at self: is it a small matmul we can unroll?
@@ -267,7 +318,24 @@ fn rewrite_stmt(stmt: &mut IrStmt, shapes: &mut HashMap<VarId, Shape>) -> bool {
         IrStmtKind::Expr { expr } => {
             if rewrite_expr(expr, shapes) { changed = true; }
         }
-        _ => {}
+        // Explicit-preserve: the shape-specialization pass only descends into
+        // bind/assign/expr statements (the only ones that introduce or carry a
+        // matmul-bearing expression whose shape table we track). All other
+        // statement kinds are left untouched. Listing them (instead of `_ => {}`)
+        // makes the descent total-by-construction — a new IrStmtKind variant is
+        // a compile error here, not a silent subtree drop.
+        IrStmtKind::BindDestructure { .. }
+        | IrStmtKind::IndexAssign { .. }
+        | IrStmtKind::MapInsert { .. }
+        | IrStmtKind::FieldAssign { .. }
+        | IrStmtKind::Guard { .. }
+        | IrStmtKind::Comment { .. }
+        | IrStmtKind::RcInc { .. }
+        | IrStmtKind::RcDec { .. }
+        | IrStmtKind::ListSwap { .. }
+        | IrStmtKind::ListReverse { .. }
+        | IrStmtKind::ListRotateLeft { .. }
+        | IrStmtKind::ListCopySlice { .. } => {}
     }
     changed
 }

--- a/crates/almide-codegen/src/pass_mut_param_lowering.rs
+++ b/crates/almide-codegen/src/pass_mut_param_lowering.rs
@@ -138,7 +138,16 @@ fn rewrite_calls(expr: &mut IrExpr, mut_fns: &std::collections::HashMap<String, 
                     IrStmtKind::Bind { value, .. } => rewrite_calls(value, mut_fns),
                     IrStmtKind::Assign { value, .. } => rewrite_calls(value, mut_fns),
                     IrStmtKind::Expr { expr } => rewrite_calls(expr, mut_fns),
-                    _ => {}
+                    // Explicit-preserve: mutation lowering only rewrites call sites
+                    // reachable through the statement kinds above. The remaining
+                    // kinds are listed so a new IrStmtKind is a compile error here,
+                    // not a silently-dropped subtree.
+                    IrStmtKind::BindDestructure { .. } | IrStmtKind::IndexAssign { .. }
+                    | IrStmtKind::MapInsert { .. } | IrStmtKind::FieldAssign { .. }
+                    | IrStmtKind::Guard { .. } | IrStmtKind::Comment { .. }
+                    | IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. }
+                    | IrStmtKind::ListSwap { .. } | IrStmtKind::ListReverse { .. }
+                    | IrStmtKind::ListRotateLeft { .. } | IrStmtKind::ListCopySlice { .. } => {}
                 }
                 i += 1;
             }
@@ -160,7 +169,13 @@ fn rewrite_calls(expr: &mut IrExpr, mut_fns: &std::collections::HashMap<String, 
                     IrStmtKind::Bind { value, .. } => rewrite_calls(value, mut_fns),
                     IrStmtKind::Assign { value, .. } => rewrite_calls(value, mut_fns),
                     IrStmtKind::Expr { expr } => rewrite_calls(expr, mut_fns),
-                    _ => {}
+                    // Explicit-preserve (see Block above).
+                    IrStmtKind::BindDestructure { .. } | IrStmtKind::IndexAssign { .. }
+                    | IrStmtKind::MapInsert { .. } | IrStmtKind::FieldAssign { .. }
+                    | IrStmtKind::Guard { .. } | IrStmtKind::Comment { .. }
+                    | IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. }
+                    | IrStmtKind::ListSwap { .. } | IrStmtKind::ListReverse { .. }
+                    | IrStmtKind::ListRotateLeft { .. } | IrStmtKind::ListCopySlice { .. } => {}
                 }
             }
         }
@@ -171,10 +186,45 @@ fn rewrite_calls(expr: &mut IrExpr, mut_fns: &std::collections::HashMap<String, 
                     IrStmtKind::Bind { value, .. } => rewrite_calls(value, mut_fns),
                     IrStmtKind::Assign { value, .. } => rewrite_calls(value, mut_fns),
                     IrStmtKind::Expr { expr } => rewrite_calls(expr, mut_fns),
-                    _ => {}
+                    // Explicit-preserve (see Block above).
+                    IrStmtKind::BindDestructure { .. } | IrStmtKind::IndexAssign { .. }
+                    | IrStmtKind::MapInsert { .. } | IrStmtKind::FieldAssign { .. }
+                    | IrStmtKind::Guard { .. } | IrStmtKind::Comment { .. }
+                    | IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. }
+                    | IrStmtKind::ListSwap { .. } | IrStmtKind::ListReverse { .. }
+                    | IrStmtKind::ListRotateLeft { .. } | IrStmtKind::ListCopySlice { .. } => {}
                 }
             }
         }
-        _ => {}
+        // Explicit-preserve: this pass walks the structural-control nodes above
+        // to reach mutating call sites; the remaining expression kinds either
+        // contain no statement-level call sites to rewrite or are leaves. Listing
+        // every kind makes a new IrExprKind a compile error rather than a silently
+        // un-rewritten (native↔WASM divergent) subtree.
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+        | IrExprKind::BinOp { .. } | IrExprKind::UnOp { .. }
+        | IrExprKind::Fan { .. } | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::Call { .. } | IrExprKind::TailCall { .. }
+        | IrExprKind::RuntimeCall { .. } | IrExprKind::List { .. }
+        | IrExprKind::MapLiteral { .. } | IrExprKind::EmptyMap
+        | IrExprKind::Record { .. } | IrExprKind::SpreadRecord { .. }
+        | IrExprKind::Tuple { .. } | IrExprKind::Range { .. }
+        | IrExprKind::Member { .. } | IrExprKind::TupleIndex { .. }
+        | IrExprKind::IndexAccess { .. } | IrExprKind::MapAccess { .. }
+        | IrExprKind::Lambda { .. } | IrExprKind::StringInterp { .. }
+        | IrExprKind::ResultOk { .. } | IrExprKind::ResultErr { .. }
+        | IrExprKind::OptionSome { .. } | IrExprKind::OptionNone
+        | IrExprKind::Try { .. } | IrExprKind::Unwrap { .. }
+        | IrExprKind::UnwrapOr { .. } | IrExprKind::ToOption { .. }
+        | IrExprKind::OptionalChain { .. } | IrExprKind::Await { .. }
+        | IrExprKind::Clone { .. } | IrExprKind::Deref { .. }
+        | IrExprKind::Borrow { .. } | IrExprKind::BoxNew { .. }
+        | IrExprKind::RcWrap { .. } | IrExprKind::RustMacro { .. }
+        | IrExprKind::ToVec { .. } | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. } | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => {}
     }
 }

--- a/crates/almide-codegen/src/pass_peephole.rs
+++ b/crates/almide-codegen/src/pass_peephole.rs
@@ -5,6 +5,7 @@
 //! Runs AFTER CloneInsertionPass so it sees the final ownership structure.
 
 use almide_ir::*;
+use almide_ir::visit_mut::{IrMutVisitor, walk_expr_mut};
 use super::pass::{NanoPass, PassResult, Target};
 
 #[derive(Debug)]
@@ -16,72 +17,70 @@ impl NanoPass for PeepholePass {
     fn depends_on(&self) -> Vec<&'static str> { vec![] }
 
     fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
-        let mut changed = false;
+        let mut v = Peephole { changed: false };
         for func in &mut program.functions {
-            if rewrite_expr(&mut func.body) { changed = true; }
+            v.visit_expr_mut(&mut func.body);
         }
         for tl in &mut program.top_lets {
-            if rewrite_expr(&mut tl.value) { changed = true; }
+            v.visit_expr_mut(&mut tl.value);
         }
         for module in &mut program.modules {
             for func in &mut module.functions {
-                if rewrite_expr(&mut func.body) { changed = true; }
+                v.visit_expr_mut(&mut func.body);
             }
             for tl in &mut module.top_lets {
-                if rewrite_expr(&mut tl.value) { changed = true; }
+                v.visit_expr_mut(&mut tl.value);
             }
         }
-        PassResult { program, changed }
+        PassResult { program, changed: v.changed }
     }
 }
 
-fn rewrite_expr(expr: &mut IrExpr) -> bool {
-    let mut changed = false;
-    match &mut expr.kind {
-        IrExprKind::Block { stmts, expr: tail } => {
-            if rewrite_stmts(stmts) { changed = true; }
-            if let Some(e) = tail { if rewrite_expr(e) { changed = true; } }
-        }
-        IrExprKind::If { cond, then, else_ } => {
-            if rewrite_expr(cond) { changed = true; }
-            if rewrite_expr(then) { changed = true; }
-            if rewrite_expr(else_) { changed = true; }
-        }
-        IrExprKind::Match { subject, arms } => {
-            if rewrite_expr(subject) { changed = true; }
-            for arm in arms {
-                if let Some(g) = &mut arm.guard { if rewrite_expr(g) { changed = true; } }
-                if rewrite_expr(&mut arm.body) { changed = true; }
-            }
-        }
-        IrExprKind::ForIn { iterable, body, .. } => {
-            if rewrite_expr(iterable) { changed = true; }
-            if rewrite_stmts(body) { changed = true; }
-        }
-        IrExprKind::While { cond, body } => {
-            if rewrite_expr(cond) { changed = true; }
-            if rewrite_stmts(body) { changed = true; }
-        }
-        IrExprKind::Lambda { body, .. } => {
-            if rewrite_expr(body) { changed = true; }
-        }
-        IrExprKind::BinOp { left, right, .. } => {
-            if rewrite_expr(left) { changed = true; }
-            if rewrite_expr(right) { changed = true; }
-        }
-        IrExprKind::UnOp { operand, .. } => {
-            if rewrite_expr(operand) { changed = true; }
-        }
-        IrExprKind::UnwrapOr { expr: inner, fallback } => {
-            if rewrite_expr(inner) { changed = true; }
-            if rewrite_expr(fallback) { changed = true; }
-        }
-        IrExprKind::Call { args, .. } | IrExprKind::RuntimeCall { args, .. } => {
-            for a in args { if rewrite_expr(a) { changed = true; } }
-        }
-        _ => {}
-    }
+/// Post-order peephole rewriter.
+///
+/// Child recursion goes through the canonical, wildcard-free `walk_expr_mut`, so
+/// the per-expression fusion/copy-loop rewrites are reached inside *every* node
+/// kind (Record fields, `Try`/`Clone` wrappers, map literals, …). A partial
+/// hand-rolled `match … { _ => {} }` would silently skip the unlisted kinds and
+/// drop their subtrees — the native↔WASM divergence class.
+///
+/// The only kinds handled explicitly are those carrying a `Vec<IrStmt>`
+/// (`Block` / `ForIn` / `While`): they route their statement vector through
+/// `rewrite_stmts` so the cross-statement sequence detectors (vec-init / swap /
+/// reverse / rotate idioms) keep running. Those arms early-return from the match
+/// (no `walk_expr_mut`) so the statement bodies are visited exactly once.
+struct Peephole {
+    changed: bool,
+}
 
+impl IrMutVisitor for Peephole {
+    fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
+        match &mut expr.kind {
+            IrExprKind::Block { stmts, expr: tail } => {
+                self.rewrite_stmts(stmts);
+                if let Some(e) = tail { self.visit_expr_mut(e); }
+            }
+            IrExprKind::ForIn { iterable, body, .. } => {
+                self.visit_expr_mut(iterable);
+                self.rewrite_stmts(body);
+            }
+            IrExprKind::While { cond, body } => {
+                self.visit_expr_mut(cond);
+                self.rewrite_stmts(body);
+            }
+            // Every other kind: exhaustive child recursion via the IR visitor —
+            // any future variant is traversed automatically.
+            _ => walk_expr_mut(self, expr),
+        }
+
+        self.local_rewrite(expr);
+    }
+}
+
+impl Peephole {
+    /// Apply the single-expression peephole rewrites to `expr` after its children
+    /// have already been rewritten (post-order). Sets `self.changed` on a hit.
+    fn local_rewrite(&mut self, expr: &mut IrExpr) {
     // ── Fusion: unwrap_or(map.get(m, k), default) → map.get_or(m, k, default) ──
     // Eliminates heap allocation for Option return in the common ?? pattern.
     if let IrExprKind::UnwrapOr { expr: inner, fallback } = &expr.kind {
@@ -104,7 +103,8 @@ fn rewrite_expr(expr: &mut IrExpr) -> bool {
                     span: expr.span,
                     def_id: None,
                 };
-                return true;
+                self.changed = true;
+                return;
             }
         }
         // Also handle RuntimeCall form (post-IntrinsicLowering)
@@ -128,7 +128,8 @@ fn rewrite_expr(expr: &mut IrExpr) -> bool {
                     span: expr.span,
                     def_id: None,
                 };
-                return true;
+                self.changed = true;
+                return;
             }
         }
     }
@@ -138,92 +139,93 @@ fn rewrite_expr(expr: &mut IrExpr) -> bool {
         if var_tuple.is_none() && body.len() == 1 {
             if let Some(copy) = try_detect_copy_loop(*var, iterable, &body[0]) {
                 *expr = copy;
-                return true;
+                self.changed = true;
             }
         }
     }
-
-    changed
-}
-
-fn rewrite_stmts(stmts: &mut Vec<IrStmt>) -> bool {
-    // First recurse into sub-exprs of each stmt
-    let mut changed = false;
-    for stmt in stmts.iter_mut() {
-        match &mut stmt.kind {
-            IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
-            | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => {
-                if rewrite_expr(value) { changed = true; }
-            }
-            IrStmtKind::IndexAssign { index, value, .. } => {
-                if rewrite_expr(index) { changed = true; }
-                if rewrite_expr(value) { changed = true; }
-            }
-            IrStmtKind::MapInsert { key, value, .. } => {
-                if rewrite_expr(key) { changed = true; }
-                if rewrite_expr(value) { changed = true; }
-            }
-            IrStmtKind::Guard { cond, else_ } => {
-                if rewrite_expr(cond) { changed = true; }
-                if rewrite_expr(else_) { changed = true; }
-            }
-            IrStmtKind::Expr { expr } => {
-                if rewrite_expr(expr) { changed = true; }
-            }
-            IrStmtKind::ListSwap { a, b, .. } => {
-                if rewrite_expr(a) { changed = true; }
-                if rewrite_expr(b) { changed = true; }
-            }
-            IrStmtKind::ListReverse { end, .. } | IrStmtKind::ListRotateLeft { end, .. } => {
-                if rewrite_expr(end) { changed = true; }
-            }
-            IrStmtKind::ListCopySlice { len, .. } => {
-                if rewrite_expr(len) { changed = true; }
-            }
-            _ => {}
-        }
     }
 
-    // Multi-stmt peephole: work on indices, collect results
-    let orig = std::mem::take(stmts);
-    let mut result = Vec::with_capacity(orig.len());
-    let len = orig.len();
-    // Convert to indexable slice, consume via into_iter at the end
-    let slice = &orig;
-    let mut i = 0;
-    while i < len {
-        // 3-stmt patterns
-        if i + 2 < len {
-            if let Some(s) = try_detect_vec_init(&slice[i], &slice[i + 1], &slice[i + 2]) {
-                result.push(s); i += 3; changed = true; continue;
-            }
-            if let Some(s) = try_detect_reverse_block(&slice[i], &slice[i + 1], &slice[i + 2]) {
-                result.push(s); i += 3; changed = true; continue;
-            }
-            if let Some(s) = try_detect_rotate(&slice[i], &slice[i + 1], &slice[i + 2]) {
-                result.push(s); i += 3; changed = true; continue;
-            }
-            if let Some(s) = try_detect_swap(&slice[i], &slice[i + 1], &slice[i + 2]) {
-                result.push(s); i += 3; changed = true; continue;
+    /// Cross-statement sequence analysis. Recurses each statement's sub-exprs
+    /// through `visit_expr_mut` (so the per-expr rewrites still fire inside
+    /// statements), then collapses the recognized multi-statement idioms.
+    fn rewrite_stmts(&mut self, stmts: &mut Vec<IrStmt>) {
+        // First recurse into sub-exprs of each stmt
+        for stmt in stmts.iter_mut() {
+            match &mut stmt.kind {
+                IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. }
+                | IrStmtKind::Assign { value, .. } | IrStmtKind::FieldAssign { value, .. } => {
+                    self.visit_expr_mut(value);
+                }
+                IrStmtKind::IndexAssign { index, value, .. } => {
+                    self.visit_expr_mut(index);
+                    self.visit_expr_mut(value);
+                }
+                IrStmtKind::MapInsert { key, value, .. } => {
+                    self.visit_expr_mut(key);
+                    self.visit_expr_mut(value);
+                }
+                IrStmtKind::Guard { cond, else_ } => {
+                    self.visit_expr_mut(cond);
+                    self.visit_expr_mut(else_);
+                }
+                IrStmtKind::Expr { expr } => {
+                    self.visit_expr_mut(expr);
+                }
+                IrStmtKind::ListSwap { a, b, .. } => {
+                    self.visit_expr_mut(a);
+                    self.visit_expr_mut(b);
+                }
+                IrStmtKind::ListReverse { end, .. } | IrStmtKind::ListRotateLeft { end, .. } => {
+                    self.visit_expr_mut(end);
+                }
+                IrStmtKind::ListCopySlice { len, .. } => {
+                    self.visit_expr_mut(len);
+                }
+                // No recursable sub-exprs (Comment / RcInc / RcDec).
+                IrStmtKind::Comment { .. } | IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. } => {}
             }
         }
 
-        // Self-assignment elimination
-        if let IrStmtKind::Assign { var, value } = &slice[i].kind {
-            let is_self = match &value.kind {
-                IrExprKind::Var { id } => id == var,
-                IrExprKind::Clone { expr } => matches!(&expr.kind, IrExprKind::Var { id } if id == var),
-                _ => false,
-            };
-            if is_self { i += 1; changed = true; continue; }
+        // Multi-stmt peephole: work on indices, collect results
+        let orig = std::mem::take(stmts);
+        let mut result = Vec::with_capacity(orig.len());
+        let len = orig.len();
+        // Convert to indexable slice, consume via into_iter at the end
+        let slice = &orig;
+        let mut i = 0;
+        while i < len {
+            // 3-stmt patterns
+            if i + 2 < len {
+                if let Some(s) = try_detect_vec_init(&slice[i], &slice[i + 1], &slice[i + 2]) {
+                    result.push(s); i += 3; self.changed = true; continue;
+                }
+                if let Some(s) = try_detect_reverse_block(&slice[i], &slice[i + 1], &slice[i + 2]) {
+                    result.push(s); i += 3; self.changed = true; continue;
+                }
+                if let Some(s) = try_detect_rotate(&slice[i], &slice[i + 1], &slice[i + 2]) {
+                    result.push(s); i += 3; self.changed = true; continue;
+                }
+                if let Some(s) = try_detect_swap(&slice[i], &slice[i + 1], &slice[i + 2]) {
+                    result.push(s); i += 3; self.changed = true; continue;
+                }
+            }
+
+            // Self-assignment elimination
+            if let IrStmtKind::Assign { var, value } = &slice[i].kind {
+                let is_self = match &value.kind {
+                    IrExprKind::Var { id } => id == var,
+                    IrExprKind::Clone { expr } => matches!(&expr.kind, IrExprKind::Var { id } if id == var),
+                    _ => false,
+                };
+                if is_self { i += 1; self.changed = true; continue; }
+            }
+
+            result.push(orig[i].clone());
+            i += 1;
         }
 
-        result.push(orig[i].clone());
-        i += 1;
+        *stmts = result;
     }
-
-    *stmts = result;
-    changed
 }
 
 // ── Pattern detectors ──────────────────────────────────────────

--- a/crates/almide-codegen/src/pass_rust_lowering.rs
+++ b/crates/almide-codegen/src/pass_rust_lowering.rs
@@ -414,7 +414,25 @@ fn rewrite_stmts_in_expr(expr: &mut IrExpr, vt: &mut VarTable, shared: &HashSet<
         IrExprKind::RuntimeCall { args, .. } => {
             for a in args.iter_mut() { if rewrite_stmts_in_expr(a, vt, shared) { changed = true; } }
         }
-        _ => {}
+        // No nested statements to rewrite — listed explicitly so a new
+        // statement-bearing IrExprKind is a compile error, not a silent miss.
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. } | IrExprKind::LitStr { .. }
+        | IrExprKind::LitBool { .. } | IrExprKind::Unit | IrExprKind::Var { .. }
+        | IrExprKind::FnRef { .. } | IrExprKind::BinOp { .. } | IrExprKind::UnOp { .. }
+        | IrExprKind::Fan { .. } | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::Call { .. } | IrExprKind::TailCall { .. } | IrExprKind::List { .. }
+        | IrExprKind::MapLiteral { .. } | IrExprKind::EmptyMap | IrExprKind::Record { .. }
+        | IrExprKind::SpreadRecord { .. } | IrExprKind::Tuple { .. } | IrExprKind::Range { .. }
+        | IrExprKind::Member { .. } | IrExprKind::TupleIndex { .. } | IrExprKind::IndexAccess { .. }
+        | IrExprKind::MapAccess { .. } | IrExprKind::StringInterp { .. } | IrExprKind::ResultOk { .. }
+        | IrExprKind::ResultErr { .. } | IrExprKind::OptionSome { .. } | IrExprKind::OptionNone
+        | IrExprKind::Try { .. } | IrExprKind::Unwrap { .. } | IrExprKind::UnwrapOr { .. }
+        | IrExprKind::ToOption { .. } | IrExprKind::OptionalChain { .. } | IrExprKind::Await { .. }
+        | IrExprKind::Clone { .. } | IrExprKind::Deref { .. } | IrExprKind::Borrow { .. }
+        | IrExprKind::BoxNew { .. } | IrExprKind::RcWrap { .. } | IrExprKind::RustMacro { .. }
+        | IrExprKind::ToVec { .. } | IrExprKind::RenderedCall { .. } | IrExprKind::InlineRust { .. }
+        | IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. } | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => {}
     }
     changed
 }
@@ -452,7 +470,11 @@ fn rewrite_stmts_in_stmt(stmt: &mut IrStmt, vt: &mut VarTable, shared: &HashSet<
         IrStmtKind::Expr { expr } => {
             if rewrite_stmts_in_expr(expr, vt, shared) { *changed = true; }
         }
-        _ => {}
+        // No statement value to descend — listed explicitly so a new
+        // expr-bearing IrStmtKind is a compile error, not a silent miss.
+        IrStmtKind::Comment { .. } | IrStmtKind::RcDec { .. } | IrStmtKind::RcInc { .. }
+        | IrStmtKind::ListCopySlice { .. } | IrStmtKind::ListReverse { .. }
+        | IrStmtKind::ListRotateLeft { .. } | IrStmtKind::ListSwap { .. } => {}
     }
 }
 

--- a/crates/almide-codegen/src/pass_tco.rs
+++ b/crates/almide-codegen/src/pass_tco.rs
@@ -307,12 +307,57 @@ fn substitute_var(expr: &mut IrExpr, from: VarId, to: VarId) {
                 match &mut s.kind {
                     IrStmtKind::Bind { value, .. } | IrStmtKind::Assign { value, .. } => substitute_var(value, from, to),
                     IrStmtKind::Expr { expr } => substitute_var(expr, from, to),
-                    _ => {}
+                    // Explicit-preserve: substitute_var only descends into the
+                    // statement forms produced by the binary-rec rewrite
+                    // (Bind / Assign / Expr). Other statement kinds are never
+                    // traversed here — no-op, total-by-construction.
+                    IrStmtKind::BindDestructure { .. }
+                    | IrStmtKind::IndexAssign { .. }
+                    | IrStmtKind::MapInsert { .. }
+                    | IrStmtKind::FieldAssign { .. }
+                    | IrStmtKind::Guard { .. }
+                    | IrStmtKind::Comment { .. }
+                    | IrStmtKind::RcInc { .. }
+                    | IrStmtKind::RcDec { .. }
+                    | IrStmtKind::ListSwap { .. }
+                    | IrStmtKind::ListReverse { .. }
+                    | IrStmtKind::ListRotateLeft { .. }
+                    | IrStmtKind::ListCopySlice { .. } => {}
                 }
             }
             if let Some(e) = expr { substitute_var(e, from, to); }
         }
-        _ => {}
+        // Explicit-preserve: substitute_var performs a surgical single-VarId
+        // replacement over only the forms the binary-rec rewrite constructs.
+        // Recursing more would risk double-processing. Leaves and every other
+        // variant are no-ops — total-by-construction.
+        IrExprKind::Var { .. }
+        | IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::FnRef { .. }
+        | IrExprKind::Match { .. } | IrExprKind::Fan { .. }
+        | IrExprKind::ForIn { .. } | IrExprKind::While { .. }
+        | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::TailCall { .. } | IrExprKind::RuntimeCall { .. }
+        | IrExprKind::List { .. } | IrExprKind::MapLiteral { .. }
+        | IrExprKind::EmptyMap | IrExprKind::Record { .. }
+        | IrExprKind::SpreadRecord { .. } | IrExprKind::Tuple { .. }
+        | IrExprKind::Range { .. } | IrExprKind::Member { .. }
+        | IrExprKind::TupleIndex { .. } | IrExprKind::IndexAccess { .. }
+        | IrExprKind::MapAccess { .. } | IrExprKind::Lambda { .. }
+        | IrExprKind::StringInterp { .. }
+        | IrExprKind::ResultOk { .. } | IrExprKind::ResultErr { .. }
+        | IrExprKind::OptionSome { .. } | IrExprKind::OptionNone
+        | IrExprKind::Try { .. } | IrExprKind::Unwrap { .. }
+        | IrExprKind::UnwrapOr { .. } | IrExprKind::ToOption { .. }
+        | IrExprKind::OptionalChain { .. } | IrExprKind::Await { .. }
+        | IrExprKind::Clone { .. } | IrExprKind::Deref { .. }
+        | IrExprKind::Borrow { .. } | IrExprKind::BoxNew { .. }
+        | IrExprKind::RcWrap { .. } | IrExprKind::RustMacro { .. }
+        | IrExprKind::ToVec { .. } | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. } | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => {}
     }
 }
 
@@ -438,8 +483,38 @@ fn all_self_calls_in_tail_pos(expr: &IrExpr, fn_name: &str) -> (bool, bool) {
             (has, all)
         }
 
-        // Anything else: scan for non-tail self-calls
-        _ => scan_non_tail(expr, fn_name),
+        // Anything else: scan for non-tail self-calls.
+        // Explicit-preserve: every remaining variant (including a Call that is
+        // NOT a self-call, which falls through the guarded arm above) delegates
+        // to scan_non_tail — same RHS the catch-all had, total-by-construction.
+        IrExprKind::Call { .. }
+        | IrExprKind::TailCall { .. } | IrExprKind::RuntimeCall { .. }
+        | IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+        | IrExprKind::BinOp { .. } | IrExprKind::UnOp { .. }
+        | IrExprKind::Fan { .. } | IrExprKind::ForIn { .. }
+        | IrExprKind::While { .. } | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::List { .. } | IrExprKind::MapLiteral { .. }
+        | IrExprKind::EmptyMap | IrExprKind::Record { .. }
+        | IrExprKind::SpreadRecord { .. } | IrExprKind::Tuple { .. }
+        | IrExprKind::Range { .. } | IrExprKind::Member { .. }
+        | IrExprKind::TupleIndex { .. } | IrExprKind::IndexAccess { .. }
+        | IrExprKind::MapAccess { .. } | IrExprKind::Lambda { .. }
+        | IrExprKind::StringInterp { .. }
+        | IrExprKind::ResultOk { .. } | IrExprKind::ResultErr { .. }
+        | IrExprKind::OptionSome { .. } | IrExprKind::OptionNone
+        | IrExprKind::Try { .. } | IrExprKind::Unwrap { .. }
+        | IrExprKind::UnwrapOr { .. } | IrExprKind::ToOption { .. }
+        | IrExprKind::OptionalChain { .. } | IrExprKind::Await { .. }
+        | IrExprKind::Clone { .. } | IrExprKind::Deref { .. }
+        | IrExprKind::Borrow { .. } | IrExprKind::BoxNew { .. }
+        | IrExprKind::RcWrap { .. } | IrExprKind::RustMacro { .. }
+        | IrExprKind::ToVec { .. } | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. } | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. }
+            => scan_non_tail(expr, fn_name),
     }
 }
 
@@ -566,8 +641,19 @@ fn scan_non_tail(expr: &IrExpr, fn_name: &str) -> (bool, bool) {
         IrExprKind::RustMacro { args, .. } => {
             any_has_self_call(args.iter(), fn_name)
         }
-        // Leaf nodes: no self-calls
-        _ => (false, true),
+        // Leaf nodes (and codegen-internal nodes that never carry a TCO-relevant
+        // self-call): no self-calls. Explicit-preserve — same RHS the catch-all
+        // had, total-by-construction so a new IrExprKind is a compile error here.
+        IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+        | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::OptionNone | IrExprKind::EmptyMap
+        | IrExprKind::TailCall { .. } | IrExprKind::RuntimeCall { .. }
+        | IrExprKind::RcWrap { .. } | IrExprKind::RenderedCall { .. }
+        | IrExprKind::InlineRust { .. } | IrExprKind::ClosureCreate { .. }
+        | IrExprKind::EnvLoad { .. } | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => (false, true),
     }
 }
 
@@ -850,8 +936,43 @@ fn rewrite_tail_expr(
             }
         }
 
-        // Base case: assign result and break
-        _ => {
+        // Base case: assign result and break.
+        // Explicit-preserve: every remaining variant — including a Call that is
+        // NOT a self-call, a ResultOk in a non-effect fn, and a Block with no
+        // trailing expr (all of which fall through the guarded/partial arms
+        // above) — is a base case emitted via emit_base_case. Same RHS the
+        // catch-all had, total-by-construction.
+        //
+        // These patterns bind nothing (`{ .. }` / unit variants), so `expr`
+        // is not partially moved and remains usable whole — exactly as `_` was.
+        IrExprKind::Call { .. } | IrExprKind::ResultOk { .. }
+        | IrExprKind::Block { .. }
+        | IrExprKind::TailCall { .. } | IrExprKind::RuntimeCall { .. }
+        | IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
+        | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }
+        | IrExprKind::BinOp { .. } | IrExprKind::UnOp { .. }
+        | IrExprKind::Fan { .. } | IrExprKind::ForIn { .. }
+        | IrExprKind::While { .. } | IrExprKind::Break | IrExprKind::Continue
+        | IrExprKind::List { .. } | IrExprKind::MapLiteral { .. }
+        | IrExprKind::EmptyMap | IrExprKind::Record { .. }
+        | IrExprKind::SpreadRecord { .. } | IrExprKind::Tuple { .. }
+        | IrExprKind::Range { .. } | IrExprKind::Member { .. }
+        | IrExprKind::TupleIndex { .. } | IrExprKind::IndexAccess { .. }
+        | IrExprKind::MapAccess { .. } | IrExprKind::Lambda { .. }
+        | IrExprKind::StringInterp { .. }
+        | IrExprKind::ResultErr { .. } | IrExprKind::OptionSome { .. }
+        | IrExprKind::OptionNone | IrExprKind::Try { .. }
+        | IrExprKind::Unwrap { .. } | IrExprKind::UnwrapOr { .. }
+        | IrExprKind::ToOption { .. } | IrExprKind::OptionalChain { .. }
+        | IrExprKind::Await { .. } | IrExprKind::Clone { .. }
+        | IrExprKind::Deref { .. } | IrExprKind::Borrow { .. }
+        | IrExprKind::BoxNew { .. } | IrExprKind::RcWrap { .. }
+        | IrExprKind::RustMacro { .. } | IrExprKind::ToVec { .. }
+        | IrExprKind::RenderedCall { .. } | IrExprKind::InlineRust { .. }
+        | IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. }
+        | IrExprKind::IterChain { .. }
+        | IrExprKind::Hole | IrExprKind::Todo { .. } => {
             emit_base_case(expr, result_var)
         }
     }

--- a/tests/traversal_totality_lint.rs
+++ b/tests/traversal_totality_lint.rs
@@ -26,18 +26,6 @@ use std::path::{Path, PathBuf};
 /// Each must be migrated to a canonical primitive (`IrMutVisitor`/`map_children`)
 /// or have its catch-all made loud/delegating; then delete it from this list.
 const LEGACY_DEBT: &[&str] = &[
-    "crates/almide-codegen/src/pass_anf.rs",
-    "crates/almide-codegen/src/pass_borrow_inference.rs",
-    "crates/almide-codegen/src/pass_capture_clone.rs",
-    "crates/almide-codegen/src/pass_concretize_types.rs",
-    "crates/almide-codegen/src/pass_effect_inference.rs",
-    "crates/almide-codegen/src/pass_lambda_type_resolve.rs",
-    "crates/almide-codegen/src/pass_licm.rs",
-    "crates/almide-codegen/src/pass_matrix_shape_spec.rs",
-    "crates/almide-codegen/src/pass_mut_param_lowering.rs",
-    "crates/almide-codegen/src/pass_peephole.rs",
-    "crates/almide-codegen/src/pass_rust_lowering.rs",
-    "crates/almide-codegen/src/pass_tco.rs",
 ];
 
 fn repo_root() -> PathBuf {


### PR DESCRIPTION
The last batch of the traversal-totality drain (after #356/#357/#358/#359/#360). All 12 remaining passes become total-by-construction — a forgotten/new IR node kind is now a **compile error**, never a silent `_ => {}` / `other => other` that drops a subtree (the native↔WASM divergence class). **LEGACY_DEBT 12 → 0** — the ratchet is fully drained; every codegen pass is now machine-checked for traversal completeness.

## How
Classified all 12 with a parallel agent workflow, then migrated each (compile-verified) with the established recipes:
- **explicit-preserve** (zero behavior change, exhaustive variant lists) for the selective passes where recurse-more is unsafe/unneeded: `borrow_inference`, `licm`, `mut_param_lowering`, `matrix_shape_spec`, `rust_lowering`, `tco`, plus the stmt-loops in `anf`/`concretize_types`/`lambda_type_resolve`.
- **`IrVisitor` / recurse-more** (monotone-safe) for the read-only collectors: `effect_inference` (now also sees `TailCall` targets — closes a real call-graph hole, since TCO runs before it), `anf`'s checker.
- **dead-code deletion**: `lambda_type_resolve::infer_param_ty_from_body`.

### Real latent bug fixed — `capture_clone`
`transform_expr` and `replace_vars` (the DIV2-origin capture analysis, #347) silently dropped `TailCall` / `RcWrap` / `InlineRust` children via `_ => {}`. A non-Copy capture nested in one of those — e.g. a lambda inside an `InlineRust` arg — was never pre-cloned, so a later use would fail to compile (E0382). Latent today (those kinds are mostly born after this pass runs), but now closed and lint-locked: the leaves are listed explicitly so a new child-bearing kind is a compile error.

## Validation
- `cargo test` — 0 failures (incl. the traversal-totality lint, now guarding all passes).
- Native spec sweep — **all 241 files passed**.
- WASM spec sweep — **233 passed, 0 failed** (8 skipped).