### PR TITLE
Make WASM string ops UTF-8 codepoint-aware (cluster A — byte vs codepoint)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string.rs
@@ -90,39 +90,38 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(s0);
             }
             "get" => {
-                // get(s, i) → Option[String]
-                // OOB → none(0), else → some(1-char string)
+                // get(s, i) → Option[String]. Maps to native `string.char_at`:
+                // `i` is a BYTE index; OOB → none, else snap `i` down to a char
+                // boundary and return the WHOLE codepoint starting there.
                 let s = self.scratch.alloc_i32();
-                let s1 = self.scratch.alloc_i32();
-                let s2 = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();   // byte index (snapped)
+                let cp = self.scratch.alloc_i32();  // result string ptr / some box
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s1);
-                    // bounds check
-                    local_get(s1); i32_const(0); i32_lt_s;
-                    local_get(s1); local_get(s); i32_load(0); i32_ge_u;
+                    i32_wrap_i64; local_set(i);
+                    // bounds check: i < 0 || i >= byte_len → none
+                    local_get(i); i32_const(0); i32_lt_s;
+                    local_get(i); local_get(s); i32_load(0); i32_ge_u;
                     i32_or;
                     if_i32;
                       i32_const(0); // none
                     else_;
-                      // Build 1-char string [len=1][cap=1][byte]
-                      i32_const(1); call(self.emitter.rt.string_alloc); local_set(s2);
-                      local_get(s2); i32_const(1); i32_store(0);
-                      local_get(s2); i32_const(1); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
-                      local_get(s2);
-                      local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(s1); i32_add; i32_load8_u(0);
-                      i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
-                      // Wrap in some: alloc ptr, store string ptr
-                      i32_const(4); call(self.emitter.rt.alloc); local_set(s1);
-                      local_get(s1); local_get(s2); i32_store(0);
-                      local_get(s1);
+                      // snap i down to a char boundary
+                      local_get(s); local_get(i); call(self.emitter.rt.string.utf8_snap); local_set(i);
+                      // cp = slice(s, i, i + width(s, i))
+                      local_get(s); local_get(i);
+                      local_get(i); local_get(s); local_get(i); call(self.emitter.rt.string.utf8_width); i32_add;
+                      call(self.emitter.rt.string.slice); local_set(cp);
+                      // wrap in some: alloc ptr, store string ptr
+                      i32_const(4); call(self.emitter.rt.alloc); local_set(i);
+                      local_get(i); local_get(cp); i32_store(0);
+                      local_get(i);
                     end;
                 });
-                self.scratch.free_i32(s2);
-                self.scratch.free_i32(s1);
+                self.scratch.free_i32(cp);
+                self.scratch.free_i32(i);
                 self.scratch.free_i32(s);
             }
             "repeat" => {
@@ -131,40 +130,83 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { i32_wrap_i64; call(self.emitter.rt.string.repeat); });
             }
             "slice" => {
-                // slice(s, start, end) — when `end` comes from the
-                // `end: Int = i64::MAX` default injection, wrapping to
-                // i32 produces 0xFFFFFFFF (-1) which the runtime
-                // interprets as a huge unsigned → trap. Cap `end` to
-                // the string's char length so the sentinel degrades
-                // to "to the end" without a trap.
+                // slice(s, start, end) — BYTE indices, clamped to [0, byte_len]
+                // and each SNAPPED DOWN to a char boundary so a multibyte
+                // codepoint is never split (matches native string.slice).
+                //
+                // When `end` comes from the `end: Int = i64::MAX` default
+                // injection, wrapping to i32 produces 0xFFFFFFFF (-1) which the
+                // runtime would read as a huge unsigned → trap. Clamping to the
+                // byte length degrades the sentinel to "to the end" safely.
                 let s_ptr = self.scratch.alloc_i32();
-                let end_wrapped = self.scratch.alloc_i32();
+                let start_b = self.scratch.alloc_i32();
+                let end_b = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s_ptr); });
-                wasm!(self.func, { local_get(s_ptr); });
+                // start (clamped to [0, byte_len], then snapped to a boundary)
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; });
+                wasm!(self.func, {
+                    i32_wrap_i64; local_set(start_b);
+                    // clamp negative → 0
+                    local_get(start_b); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(0); local_set(start_b); end;
+                    // clamp > byte_len → byte_len
+                    local_get(start_b); local_get(s_ptr); i32_load(0); i32_gt_u;
+                    if_empty; local_get(s_ptr); i32_load(0); local_set(start_b); end;
+                    // snap down to char boundary
+                    local_get(s_ptr); local_get(start_b);
+                    call(self.emitter.rt.string.utf8_snap); local_set(start_b);
+                });
+                // end — clamp the i64 value to [0, byte_len] BEFORE wrapping to i32, so the
+                // `end: Int = i64::MAX` default (and any end > byte_len) degrades to byte_len
+                // instead of wrapping to a bogus i32 (i64::MAX -> -1 -> clamp 0 -> empty).
                 if args.len() > 2 {
+                    let end64 = self.scratch.alloc_i64();
                     self.emit_expr(&args[2]);
                     wasm!(self.func, {
-                        i32_wrap_i64;
-                        local_set(end_wrapped);
-                        // clamp: if end > len then len else end
-                        local_get(end_wrapped);
-                        local_get(s_ptr); i32_load(0);
-                        i32_gt_u;
+                        local_set(end64);
+                        local_get(end64); i64_const(0); i64_lt_s;                 // end < 0 ?
                         if_i32;
-                            local_get(s_ptr); i32_load(0);
+                            i32_const(0);
                         else_;
-                            local_get(end_wrapped);
+                            local_get(end64);
+                            local_get(s_ptr); i32_load(0); i64_extend_i32_u;       // byte_len as i64
+                            i64_gt_s;                                             // end > byte_len ?
+                            if_i32;
+                                local_get(s_ptr); i32_load(0);                    // -> byte_len
+                            else_;
+                                local_get(end64); i32_wrap_i64;                   // fits in i32
+                            end;
                         end;
+                        local_set(end_b);
                     });
+                    self.scratch.free_i64(end64);
                 } else {
-                    wasm!(self.func, { local_get(s_ptr); i32_load(0); });
+                    wasm!(self.func, { local_get(s_ptr); i32_load(0); local_set(end_b); });
                 }
-                wasm!(self.func, { call(self.emitter.rt.string.slice); });
+                wasm!(self.func, {
+                    // clamp negative → 0
+                    local_get(end_b); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(0); local_set(end_b); end;
+                    // clamp > byte_len → byte_len
+                    local_get(end_b); local_get(s_ptr); i32_load(0); i32_gt_u;
+                    if_empty; local_get(s_ptr); i32_load(0); local_set(end_b); end;
+                    // snap down to char boundary
+                    local_get(s_ptr); local_get(end_b);
+                    call(self.emitter.rt.string.utf8_snap); local_set(end_b);
+                    // start >= end → empty string (matches native; also guards
+                    // __str_slice against an unsigned `end - start` underflow)
+                    local_get(start_b); local_get(end_b); i32_ge_u;
+                    if_i32;
+                        i32_const(0); call(self.emitter.rt.string_alloc);
+                    else_;
+                        local_get(s_ptr); local_get(start_b); local_get(end_b);
+                        call(self.emitter.rt.string.slice);
+                    end;
+                });
                 self.scratch.free_i32(s_ptr);
-                self.scratch.free_i32(end_wrapped);
+                self.scratch.free_i32(start_b);
+                self.scratch.free_i32(end_b);
             }
             "index_of" => {
                 let s64 = self.scratch.alloc_i64();
@@ -295,38 +337,101 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { call(self.emitter.rt.string.is_lower); });
             }
             "codepoint" => {
+                // codepoint(s) → Option[Int]: Unicode scalar of the FIRST
+                // codepoint (decoded from its UTF-8 bytes), none if empty.
                 let s = self.scratch.alloc_i32();
-                let s1 = self.scratch.alloc_i32();
+                let some = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(s);
                     local_get(s); i32_load(0); i32_eqz;
                     if_i32; i32_const(0);
                     else_;
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(s1);
-                      local_get(s1);
-                      local_get(s); i32_load8_u(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32); i64_extend_i32_u;
+                      i32_const(8); call(self.emitter.rt.alloc); local_set(some);
+                      local_get(some);
+                      local_get(s); i32_const(0); call(self.emitter.rt.string.utf8_scalar);
                       i64_store(0);
-                      local_get(s1);
+                      local_get(some);
                     end;
                 });
-                self.scratch.free_i32(s1);
+                self.scratch.free_i32(some);
                 self.scratch.free_i32(s);
             }
             "from_codepoint" => {
-                let s = self.scratch.alloc_i32();
-                let s1 = self.scratch.alloc_i32();
+                // from_codepoint(cp) → UTF-8 ENCODE the scalar (1-4 bytes).
+                // Invalid scalar (cp < 0, cp > 0x10FFFF, or surrogate
+                // 0xD800..=0xDFFF) → EMPTY string (matches char::from_u32).
+                let cp = self.scratch.alloc_i32();
+                let r = self.scratch.alloc_i32();   // result string ptr
+                let data = self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32;
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s);
-                    i32_const(1); call(self.emitter.rt.string_alloc); local_set(s1);
-                    local_get(s1); i32_const(1); i32_store(0);
-                    local_get(s1); i32_const(1); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
-                    local_get(s1); local_get(s); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
-                    local_get(s1);
+                    i32_wrap_i64; local_set(cp);
+                    // invalid? cp < 0 || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF)
+                    local_get(cp); i32_const(0); i32_lt_s;
+                    local_get(cp); i32_const(0x10FFFF); i32_gt_s; i32_or;
+                    local_get(cp); i32_const(0xD800); i32_ge_s;
+                    local_get(cp); i32_const(0xDFFF); i32_le_s; i32_and; i32_or;
+                    if_i32;
+                      // invalid → empty string
+                      i32_const(0); call(self.emitter.rt.string_alloc);
+                    else_;
+                      local_get(cp); i32_const(0x80); i32_lt_s;
+                      if_i32;
+                        // 1 byte
+                        i32_const(1); call(self.emitter.rt.string_alloc); local_set(r);
+                        local_get(r); local_get(cp); i32_store8(data);
+                        local_get(r);
+                      else_;
+                        local_get(cp); i32_const(0x800); i32_lt_s;
+                        if_i32;
+                          // 2 bytes
+                          i32_const(2); call(self.emitter.rt.string_alloc); local_set(r);
+                          local_get(r);
+                          i32_const(0xC0); local_get(cp); i32_const(6); i32_shr_u; i32_or;
+                          i32_store8(data);
+                          local_get(r);
+                          i32_const(0x80); local_get(cp); i32_const(0x3F); i32_and; i32_or;
+                          i32_store8(data + 1);
+                          local_get(r);
+                        else_;
+                          local_get(cp); i32_const(0x10000); i32_lt_s;
+                          if_i32;
+                            // 3 bytes
+                            i32_const(3); call(self.emitter.rt.string_alloc); local_set(r);
+                            local_get(r);
+                            i32_const(0xE0); local_get(cp); i32_const(12); i32_shr_u; i32_or;
+                            i32_store8(data);
+                            local_get(r);
+                            i32_const(0x80); local_get(cp); i32_const(6); i32_shr_u; i32_const(0x3F); i32_and; i32_or;
+                            i32_store8(data + 1);
+                            local_get(r);
+                            i32_const(0x80); local_get(cp); i32_const(0x3F); i32_and; i32_or;
+                            i32_store8(data + 2);
+                            local_get(r);
+                          else_;
+                            // 4 bytes
+                            i32_const(4); call(self.emitter.rt.string_alloc); local_set(r);
+                            local_get(r);
+                            i32_const(0xF0); local_get(cp); i32_const(18); i32_shr_u; i32_or;
+                            i32_store8(data);
+                            local_get(r);
+                            i32_const(0x80); local_get(cp); i32_const(12); i32_shr_u; i32_const(0x3F); i32_and; i32_or;
+                            i32_store8(data + 1);
+                            local_get(r);
+                            i32_const(0x80); local_get(cp); i32_const(6); i32_shr_u; i32_const(0x3F); i32_and; i32_or;
+                            i32_store8(data + 2);
+                            local_get(r);
+                            i32_const(0x80); local_get(cp); i32_const(0x3F); i32_and; i32_or;
+                            i32_store8(data + 3);
+                            local_get(r);
+                          end;
+                        end;
+                      end;
+                    end;
                 });
-                self.scratch.free_i32(s1);
-                self.scratch.free_i32(s);
+                self.scratch.free_i32(r);
+                self.scratch.free_i32(cp);
             }
             "replace_first" => {
                 self.emit_expr(&args[0]);
@@ -345,130 +450,159 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { call(self.emitter.rt.string.strip_suffix); });
             }
             "first" => {
-                // first(s) → Option[String]: get(s, 0)
+                // first(s) → Option[String]: the first whole CODEPOINT.
                 let s = self.scratch.alloc_i32();
-                let s1 = self.scratch.alloc_i32();
-                let s2 = self.scratch.alloc_i32();
+                let cp = self.scratch.alloc_i32();  // codepoint string
+                let some = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(s);
                     local_get(s); i32_load(0); i32_eqz; // empty?
                     if_i32; i32_const(0); // none
                     else_;
-                      // alloc 1-char string [len=1][cap=1][byte]
-                      i32_const(1); call(self.emitter.rt.string_alloc); local_set(s1);
-                      local_get(s1); i32_const(1); i32_store(0);
-                      local_get(s1); i32_const(1); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
-                      local_get(s1); local_get(s); i32_load8_u(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
-                      // wrap in some: alloc ptr
-                      i32_const(4); call(self.emitter.rt.alloc); local_set(s2);
-                      local_get(s2); local_get(s1); i32_store(0);
-                      local_get(s2);
+                      // cp = slice(s, 0, width(s, 0))
+                      local_get(s); i32_const(0);
+                      local_get(s); i32_const(0); call(self.emitter.rt.string.utf8_width);
+                      call(self.emitter.rt.string.slice); local_set(cp);
+                      // wrap in some
+                      i32_const(4); call(self.emitter.rt.alloc); local_set(some);
+                      local_get(some); local_get(cp); i32_store(0);
+                      local_get(some);
                     end;
                 });
-                self.scratch.free_i32(s2);
-                self.scratch.free_i32(s1);
+                self.scratch.free_i32(some);
+                self.scratch.free_i32(cp);
                 self.scratch.free_i32(s);
             }
             "last" => {
+                // last(s) → Option[String]: the last whole CODEPOINT.
                 let s = self.scratch.alloc_i32();
-                let s1 = self.scratch.alloc_i32();
-                let s2 = self.scratch.alloc_i32();
+                let start = self.scratch.alloc_i32(); // byte offset of last cp
+                let cp = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(s);
                     local_get(s); i32_load(0); i32_eqz;
                     if_i32; i32_const(0);
                     else_;
-                      i32_const(1); call(self.emitter.rt.string_alloc); local_set(s1);
-                      local_get(s1); i32_const(1); i32_store(0);
-                      local_get(s1); i32_const(1); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
-                      local_get(s1);
-                      local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(s); i32_load(0); i32_const(1); i32_sub; i32_add;
-                      i32_load8_u(0); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
-                      i32_const(4); call(self.emitter.rt.alloc); local_set(s2);
-                      local_get(s2); local_get(s1); i32_store(0);
-                      local_get(s2);
+                      // start = byte_of_cp(s, char_count(s) - 1)
+                      local_get(s);
+                      local_get(s); call(self.emitter.rt.string.char_count); i32_wrap_i64;
+                      i32_const(1); i32_sub;
+                      call(self.emitter.rt.string.utf8_byte_of_cp); local_set(start);
+                      // cp = slice(s, start, byte_len)
+                      local_get(s); local_get(start); local_get(s); i32_load(0);
+                      call(self.emitter.rt.string.slice); local_set(cp);
+                      // wrap in some
+                      i32_const(4); call(self.emitter.rt.alloc); local_set(start);
+                      local_get(start); local_get(cp); i32_store(0);
+                      local_get(start);
                     end;
                 });
-                self.scratch.free_i32(s2);
-                self.scratch.free_i32(s1);
+                self.scratch.free_i32(cp);
+                self.scratch.free_i32(start);
                 self.scratch.free_i32(s);
             }
             "take_end" => {
-                // take_end(s, n) = slice(s, max(0, len-n), len)
+                // take_end(s, n) = last n CODEPOINTS.
+                // = slice_bytes(s, byte_of_cp(s, count - n), byte_len)
+                // (n >= count → byte_of_cp(s, <=0) = 0 → whole string)
                 let s = self.scratch.alloc_i32();
-                let s1 = self.scratch.alloc_i32();
+                let n = self.scratch.alloc_i32();
+                let cp = self.scratch.alloc_i32(); // count - n
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s1);
-                    local_get(s); i32_load(0); local_get(s1); i32_sub;
-                    local_set(s1);
-                    local_get(s1); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(s1); end;
-                    local_get(s); local_get(s1); local_get(s); i32_load(0);
+                    i32_wrap_i64; local_set(n);
+                    // negative n → i32::MAX so cp = count - n underflows to <0 → start 0 →
+                    // whole string, matching native take_end (n as usize >= count → start 0).
+                    local_get(n); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(2147483647); local_set(n); end;
+                    // cp = char_count(s) - n
+                    local_get(s); call(self.emitter.rt.string.char_count); i32_wrap_i64;
+                    local_get(n); i32_sub; local_set(cp);
+                    // start_byte = byte_of_cp(s, max(0, cp))
+                    local_get(cp); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(0); local_set(cp); end;
+                    local_get(s);
+                    local_get(s); local_get(cp); call(self.emitter.rt.string.utf8_byte_of_cp);
+                    local_get(s); i32_load(0);
                     call(self.emitter.rt.string.slice);
                 });
-                self.scratch.free_i32(s1);
+                self.scratch.free_i32(cp);
+                self.scratch.free_i32(n);
                 self.scratch.free_i32(s);
             }
             "drop_end" => {
-                // drop_end(s, n) = slice(s, 0, max(0, len-n))
+                // drop_end(s, n) = all but last n CODEPOINTS.
+                // = slice_bytes(s, 0, byte_of_cp(s, count - n))
                 let s = self.scratch.alloc_i32();
-                let s1 = self.scratch.alloc_i32();
+                let n = self.scratch.alloc_i32();
+                let cp = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s1);
-                    local_get(s); i32_load(0); local_get(s1); i32_sub;
-                    local_set(s1);
-                    local_get(s1); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(s1); end;
-                    local_get(s); i32_const(0); local_get(s1);
+                    i32_wrap_i64; local_set(n);
+                    // negative n → i32::MAX so cp = count - n underflows to <0 → end 0 →
+                    // empty, matching native drop_end (n as usize >= count → end 0).
+                    local_get(n); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(2147483647); local_set(n); end;
+                    local_get(s); call(self.emitter.rt.string.char_count); i32_wrap_i64;
+                    local_get(n); i32_sub; local_set(cp); // cp = count - n
+                    local_get(cp); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(0); local_set(cp); end;
+                    local_get(s); i32_const(0);
+                    local_get(s); local_get(cp); call(self.emitter.rt.string.utf8_byte_of_cp);
                     call(self.emitter.rt.string.slice);
                 });
-                self.scratch.free_i32(s1);
+                self.scratch.free_i32(cp);
+                self.scratch.free_i32(n);
                 self.scratch.free_i32(s);
             }
             "take" => {
-                // take(s, n) = slice(s, 0, min(n, len))
+                // take(s, n) = first n CODEPOINTS = slice_bytes(s, 0, byte_of_cp(s, n)).
+                // byte_of_cp clamps n >= count → byte_len, so n>=count → whole string.
                 let s = self.scratch.alloc_i32();
-                let s1 = self.scratch.alloc_i32();
+                let n = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s1); // n
-                    // min(n, len)
-                    local_get(s1); local_get(s); i32_load(0); i32_lt_u;
-                    if_i32; local_get(s1); else_; local_get(s); i32_load(0); end;
-                    local_set(s1);
-                    local_get(s); i32_const(0); local_get(s1);
+                    i32_wrap_i64; local_set(n);
+                    // negative n → huge (i32::MAX): byte_of_cp clamps to byte_len → whole
+                    // string, matching native `take(n as usize)` (a negative i64 casts to a
+                    // huge usize). NOT clamp-to-0.
+                    local_get(n); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(2147483647); local_set(n); end;
+                    local_get(s); i32_const(0);
+                    local_get(s); local_get(n); call(self.emitter.rt.string.utf8_byte_of_cp);
                     call(self.emitter.rt.string.slice);
                 });
-                self.scratch.free_i32(s1);
+                self.scratch.free_i32(n);
                 self.scratch.free_i32(s);
             }
             "drop" => {
-                // drop(s, n) = slice(s, min(n, len), len)
+                // drop(s, n) = all but first n CODEPOINTS
+                // = slice_bytes(s, byte_of_cp(s, n), byte_len).
                 let s = self.scratch.alloc_i32();
-                let s1 = self.scratch.alloc_i32();
+                let n = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(s); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(s1);
-                    local_get(s1); local_get(s); i32_load(0); i32_lt_u;
-                    if_i32; local_get(s1); else_; local_get(s); i32_load(0); end;
-                    local_set(s1);
-                    local_get(s); local_get(s1); local_get(s); i32_load(0);
+                    i32_wrap_i64; local_set(n);
+                    // negative n → huge (i32::MAX): byte_of_cp clamps to byte_len → drop
+                    // everything (empty), matching native `drop(n as usize)`.
+                    local_get(n); i32_const(0); i32_lt_s;
+                    if_empty; i32_const(2147483647); local_set(n); end;
+                    local_get(s);
+                    local_get(s); local_get(n); call(self.emitter.rt.string.utf8_byte_of_cp);
+                    local_get(s); i32_load(0);
                     call(self.emitter.rt.string.slice);
                 });
-                self.scratch.free_i32(s1);
+                self.scratch.free_i32(n);
                 self.scratch.free_i32(s);
             }
             // ── In-place mutators (Unit-returning, write back into the var) ──

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -185,6 +185,22 @@ pub struct StringRuntime {
     pub is_lower: u32,
     pub cmp: u32,
     pub run_length_encode: u32,
+    /// UTF-8 codepoint helpers (shared by codepoint-aware string ops).
+    /// `utf8_width(s, byte_i) -> i32`: byte width (1-4) of the codepoint whose
+    /// lead byte sits at data offset `byte_i`. Stray continuation bytes and a
+    /// width that would read past the end both clamp to 1.
+    pub utf8_width: u32,
+    /// `utf8_scalar(s, byte_i) -> i64`: Unicode scalar value decoded from the
+    /// codepoint at data offset `byte_i`. Malformed sequences yield the lead
+    /// byte (width-1 fallback), never an OOB read.
+    pub utf8_scalar: u32,
+    /// `utf8_byte_of_cp(s, n) -> i32`: byte offset (within the data section) of
+    /// the start of the n-th codepoint. `n >= count` returns the byte length.
+    pub utf8_byte_of_cp: u32,
+    /// `utf8_snap(s, byte_i) -> i32`: byte_i rounded DOWN to the nearest UTF-8
+    /// char boundary (clamped to [0, byte_len]). Mirrors native `slice`'s
+    /// boundary-safe byte indexing.
+    pub utf8_snap: u32,
 }
 
 /// Indices of built-in runtime functions.
@@ -434,6 +450,10 @@ impl WasmEmitter {
                     cmp: 0,
                     char_count: 0,
                     run_length_encode: 0,
+                    utf8_width: 0,
+                    utf8_scalar: 0,
+                    utf8_byte_of_cp: 0,
+                    utf8_snap: 0,
                 },
                 value_stringify: 0,
                 json_escape_string: 0,

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -101,6 +101,23 @@ pub fn register(emitter: &mut WasmEmitter) {
     // the byte-based rest of this runtime; native is codepoint-based, so the
     // ASCII cases agree and multibyte joins the string-codepoint cluster).
     emitter.rt.string.run_length_encode = emitter.register_func("__str_rle", ty_i32_i32);
+
+    // ── Shared UTF-8 codepoint helpers ──
+    // IMPORTANT: registration order here MUST match the compile() call order
+    // below — function bodies are emitted to the code section in compile order
+    // and bound to indices in registration order. These four are registered
+    // and compiled last, after run_length_encode.
+    // utf8_width(s, byte_i) -> i32 : byte width (1-4) of the codepoint whose
+    //   lead byte is at data offset byte_i. Bounds-safe (clamped to remaining
+    //   bytes; stray continuation byte → 1).
+    emitter.rt.string.utf8_width = emitter.register_func("__utf8_width", ty_i32x2_i32);
+    // utf8_scalar(s, byte_i) -> i64 : Unicode scalar of the codepoint at byte_i.
+    emitter.rt.string.utf8_scalar = emitter.register_func("__utf8_scalar", ty_i32x2_i64);
+    // utf8_byte_of_cp(s, n) -> i32 : byte offset of the start of the n-th
+    //   codepoint (n >= count → byte length).
+    emitter.rt.string.utf8_byte_of_cp = emitter.register_func("__utf8_byte_of_cp", ty_i32x2_i32);
+    // utf8_snap(s, byte_i) -> i32 : byte_i snapped down to a char boundary.
+    emitter.rt.string.utf8_snap = emitter.register_func("__utf8_snap", ty_i32x2_i32);
 }
 
 /// Compile all string runtime function bodies.
@@ -139,6 +156,166 @@ pub fn compile(emitter: &mut WasmEmitter) {
     super::rt_string_extra::compile_cmp(emitter);
     compile_char_count(emitter);
     compile_run_length_encode(emitter);
+    compile_utf8_width(emitter);
+    compile_utf8_scalar(emitter);
+    compile_utf8_byte_of_cp(emitter);
+    compile_utf8_snap(emitter);
+}
+
+// ── Shared UTF-8 codepoint helpers ──
+//
+// UTF-8 lead-byte classification (see task spec):
+//   b0 < 0x80          → width 1 (ASCII)
+//   0x80 <= b0 < 0xC0  → continuation byte (malformed as a lead) → width 1
+//   0xC0 <= b0 < 0xE0  → width 2
+//   0xE0 <= b0 < 0xF0  → width 3
+//   b0 >= 0xF0         → width 4
+// The width is then clamped so it never runs past the byte length — a
+// truncated trailing sequence reads only the bytes that exist.
+
+/// `utf8_width(s, byte_i) -> i32`. Returns the byte width (1-4) of the codepoint
+/// whose lead byte is at data offset `byte_i`, clamped to the remaining bytes.
+fn compile_utf8_width(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.utf8_width];
+    // params: 0=s, 1=byte_i | locals: 2=blen, 3=b0, 4=width
+    let mut f = Function::new([(3, ValType::I32)]);
+    wasm!(f, {
+        local_get(0); i32_load(0); local_set(2);                 // blen = *s
+        // b0 = s[data + byte_i]
+        local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
+        i32_load8_u(0); local_set(3);
+        // width by lead-byte class
+        local_get(3); i32_const(0x80); i32_lt_u;
+        if_i32; i32_const(1);
+        else_;
+          local_get(3); i32_const(0xF0); i32_ge_u;
+          if_i32; i32_const(4);
+          else_;
+            local_get(3); i32_const(0xE0); i32_ge_u;
+            if_i32; i32_const(3);
+            else_;
+              local_get(3); i32_const(0xC0); i32_ge_u;
+              if_i32; i32_const(2);
+              else_; i32_const(1); // continuation byte as lead → 1
+              end;
+            end;
+          end;
+        end;
+        local_set(4);
+        // clamp width to remaining bytes: if byte_i + width > blen → blen - byte_i
+        local_get(1); local_get(4); i32_add; local_get(2); i32_gt_u;
+        if_i32;
+          local_get(2); local_get(1); i32_sub;
+        else_;
+          local_get(4);
+        end;
+        end;
+    });
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}
+
+/// `utf8_scalar(s, byte_i) -> i64`. Decodes the Unicode scalar at data offset
+/// `byte_i`. Combines the lead byte's low bits with `width-1` continuation
+/// bytes. A malformed/truncated sequence (width clamped to 1) yields the raw
+/// lead byte.
+fn compile_utf8_scalar(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.utf8_scalar];
+    // params: 0=s, 1=byte_i | locals: 2=width, 3=b0, 4=scalar(i64), 5=k(i32), 6=cont(i32)
+    let mut f = Function::new([
+        (1, ValType::I32), (1, ValType::I32), (1, ValType::I64),
+        (1, ValType::I32), (1, ValType::I32),
+    ]);
+    wasm!(f, {
+        local_get(0); local_get(1); call(emitter.rt.string.utf8_width); local_set(2);
+        local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
+        i32_load8_u(0); local_set(3);                            // b0
+        // width 1 → scalar = b0 (ASCII or fallback)
+        local_get(2); i32_const(1); i32_eq;
+        if_i64;
+          local_get(3); i64_extend_i32_u;
+        else_;
+          // mask lead bits: 2→0x1F, 3→0x0F, 4→0x07
+          local_get(2); i32_const(2); i32_eq;
+          if_i32; i32_const(0x1F);
+          else_;
+            local_get(2); i32_const(3); i32_eq;
+            if_i32; i32_const(0x0F); else_; i32_const(0x07); end;
+          end;
+          local_get(3); i32_and; i64_extend_i32_u; local_set(4); // scalar = b0 & mask
+          // fold in (width-1) continuation bytes
+          i32_const(1); local_set(5);                            // k = 1
+          block_empty; loop_empty;
+            local_get(5); local_get(2); i32_ge_u; br_if(1);
+            local_get(0); i32_const(string_data_off()); i32_add;
+            local_get(1); i32_add; local_get(5); i32_add;
+            i32_load8_u(0); i32_const(0x3F); i32_and; local_set(6); // cont = byte & 0x3F
+            local_get(4); i64_const(6); i64_shl;
+            local_get(6); i64_extend_i32_u; i64_or; local_set(4);   // scalar = (scalar<<6) | cont
+            local_get(5); i32_const(1); i32_add; local_set(5);
+            br(0);
+          end; end;
+          local_get(4);
+        end;
+        end;
+    });
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}
+
+/// `utf8_snap(s, byte_i) -> i32`. Rounds `byte_i` DOWN to the nearest UTF-8
+/// char boundary, clamped to `[0, byte_len]`. A boundary is any byte that is
+/// not a continuation byte (`0x80..0xC0`). Mirrors native slice's
+/// `is_char_boundary` round-down so a byte range never splits a codepoint.
+fn compile_utf8_snap(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.utf8_snap];
+    // params: 0=s, 1=byte_i | locals: 2=blen, 3=i, 4=byte
+    let mut f = Function::new([(3, ValType::I32)]);
+    wasm!(f, {
+        local_get(0); i32_load(0); local_set(2);                 // blen
+        // i = min(byte_i, blen)
+        local_get(1); local_get(2); i32_lt_u;
+        if_i32; local_get(1); else_; local_get(2); end;
+        local_set(3);
+        block_empty; loop_empty;
+          // stop at 0 or at a non-continuation byte
+          local_get(3); i32_eqz; br_if(1);
+          local_get(3); local_get(2); i32_ge_u; br_if(1);       // i == blen is a boundary
+          local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; i32_load8_u(0);
+          i32_const(0xC0); i32_and; i32_const(0x80); i32_ne; br_if(1); // not continuation → boundary
+          local_get(3); i32_const(1); i32_sub; local_set(3);
+          br(0);
+        end; end;
+        local_get(3);
+        end;
+    });
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}
+
+/// `utf8_byte_of_cp(s, n) -> i32`. Walks `n` codepoints from the start and
+/// returns the byte offset of the n-th one (or the byte length if `n` exceeds
+/// the codepoint count, so callers get a clean "to the end" boundary).
+fn compile_utf8_byte_of_cp(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.utf8_byte_of_cp];
+    // params: 0=s, 1=n | locals: 2=blen, 3=off, 4=cp
+    let mut f = Function::new([(3, ValType::I32)]);
+    wasm!(f, {
+        local_get(0); i32_load(0); local_set(2);                 // blen
+        i32_const(0); local_set(3);                              // off = 0
+        i32_const(0); local_set(4);                              // cp = 0
+        block_empty; loop_empty;
+          // stop when we've passed n codepoints or run out of bytes
+          local_get(4); local_get(1); i32_ge_s; br_if(1);
+          local_get(3); local_get(2); i32_ge_u; br_if(1);
+          // off += width(off)
+          local_get(3);
+          local_get(0); local_get(3); call(emitter.rt.string.utf8_width);
+          i32_add; local_set(3);
+          local_get(4); i32_const(1); i32_add; local_set(4);
+          br(0);
+        end; end;
+        local_get(3);
+        end;
+    });
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 /// Count UTF-8 code points in a string (pointer to `[len:i32][bytes...]`).
@@ -312,20 +489,35 @@ fn compile_slice(emitter: &mut WasmEmitter) {
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
+/// reverse(s): reverse by CODEPOINT. Each codepoint's bytes are copied in
+/// forward order, but whole codepoints are placed from the end of the output
+/// toward the start — so multibyte sequences stay valid UTF-8 (native parity).
 fn compile_reverse(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.reverse];
-    let mut f = Function::new([(1, ValType::I32), (1, ValType::I32), (1, ValType::I32)]);
+    // params: 0=s | locals: 1=blen, 2=result, 3=in_off, 4=out_off, 5=width, 6=k
+    let mut f = Function::new([(6, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
+        local_get(0); i32_load(0); local_set(1);                 // blen
         local_get(1); call(emitter.rt.string_alloc); local_set(2);
-        i32_const(0); local_set(3);
+        i32_const(0); local_set(3);                              // in_off = 0
+        local_get(1); local_set(4);                              // out_off = blen (write end-first)
         block_empty; loop_empty;
           local_get(3); local_get(1); i32_ge_u; br_if(1);
-          local_get(2); i32_const(string_data_off()); i32_add; local_get(3); i32_add;
-          local_get(0); i32_const(string_data_off()); i32_add;
-          local_get(1); i32_const(1); i32_sub; local_get(3); i32_sub; i32_add;
-          i32_load8_u(0); i32_store8(0);
-          local_get(3); i32_const(1); i32_add; local_set(3);
+          // width of codepoint at in_off
+          local_get(0); local_get(3); call(emitter.rt.string.utf8_width); local_set(5);
+          // out_off -= width (start of this codepoint in the output)
+          local_get(4); local_get(5); i32_sub; local_set(4);
+          // copy width bytes forward: out[out_off + k] = in[in_off + k]
+          i32_const(0); local_set(6);
+          block_empty; loop_empty;
+            local_get(6); local_get(5); i32_ge_u; br_if(1);
+            local_get(2); i32_const(string_data_off()); i32_add; local_get(4); i32_add; local_get(6); i32_add;
+            local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; local_get(6); i32_add;
+            i32_load8_u(0); i32_store8(0);
+            local_get(6); i32_const(1); i32_add; local_set(6);
+            br(0);
+          end; end;
+          local_get(3); local_get(5); i32_add; local_set(3);     // in_off += width
           br(0);
         end; end;
         local_get(2); end;
@@ -553,34 +745,64 @@ fn compile_count(emitter: &mut WasmEmitter) {
 
 // ── Padding / trimming ──
 
+/// Build a 1-codepoint String holding the FIRST codepoint of `pad`. Empty
+/// `pad` degenerates to a width-0 string (native uses `' '`, but pad is never
+/// empty in practice for the padding ops; an empty pad simply pads with
+/// nothing on both targets — kept consistent here).
+fn emit_pad_first_cp(emitter: &mut WasmEmitter, f: &mut Function, pad_local: u32, out_local: u32) {
+    // width of first codepoint (0 if pad empty)
+    wasm!(*f, {
+        local_get(pad_local); i32_load(0); i32_eqz;
+        if_i32;
+          i32_const(0); call(emitter.rt.string_alloc);
+        else_;
+          // unit = slice(pad, 0, width(pad, 0))
+          local_get(pad_local); i32_const(0);
+          local_get(pad_local); i32_const(0); call(emitter.rt.string.utf8_width);
+          call(emitter.rt.string.slice);
+        end;
+        local_set(out_local);
+    });
+}
+
+/// pad_start(s, width, pad): width measured in CODEPOINTS; pad unit = first
+/// codepoint of `pad`, repeated (width - char_count(s)) times, prepended.
 fn compile_pad_start(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.pad_start];
-    let mut f = Function::new([(1, ValType::I32), (1, ValType::I32), (1, ValType::I32)]);
+    // params: 0=s, 1=width, 2=pad | locals: 3=count, 4=n, 5=unit, 6=fill
+    let mut f = Function::new([(4, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(3);
+        local_get(0); call(emitter.rt.string.char_count); i32_wrap_i64; local_set(3);
         local_get(3); local_get(1); i32_ge_u;
         if_i32; local_get(0);
         else_;
-          local_get(1); local_get(3); i32_sub; local_set(4);
-          local_get(2); local_get(4); call(emitter.rt.string.repeat); local_set(5);
-          local_get(5); local_get(0); call(emitter.rt.concat_str);
+          local_get(1); local_get(3); i32_sub; local_set(4);    // n = width - count
+    });
+    emit_pad_first_cp(emitter, &mut f, 2, 5);                    // unit (local 5)
+    wasm!(f, {
+          local_get(5); local_get(4); call(emitter.rt.string.repeat); local_set(6);
+          local_get(6); local_get(0); call(emitter.rt.concat_str);
         end;
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
+/// pad_end(s, width, pad): like pad_start but appended.
 fn compile_pad_end(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.pad_end];
-    let mut f = Function::new([(1, ValType::I32), (1, ValType::I32), (1, ValType::I32)]);
+    let mut f = Function::new([(4, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(3);
+        local_get(0); call(emitter.rt.string.char_count); i32_wrap_i64; local_set(3);
         local_get(3); local_get(1); i32_ge_u;
         if_i32; local_get(0);
         else_;
           local_get(1); local_get(3); i32_sub; local_set(4);
-          local_get(2); local_get(4); call(emitter.rt.string.repeat); local_set(5);
-          local_get(0); local_get(5); call(emitter.rt.concat_str);
+    });
+    emit_pad_first_cp(emitter, &mut f, 2, 5);
+    wasm!(f, {
+          local_get(5); local_get(4); call(emitter.rt.string.repeat); local_set(6);
+          local_get(0); local_get(6); call(emitter.rt.concat_str);
         end;
         end;
     });
@@ -683,30 +905,42 @@ fn compile_case_transform(emitter: &mut WasmEmitter, type_idx: u32, lo: i32, hi:
 
 // ── Decompose ──
 
+/// chars(s): one element per CODEPOINT, each a String holding that codepoint's
+/// 1-4 UTF-8 bytes. The list length is the codepoint count (worst case = byte
+/// length, so we size the list buffer by byte length and only fill `j` slots).
 fn compile_chars(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.chars];
-    let mut f = Function::new([
-        (1, ValType::I32), (1, ValType::I32), (1, ValType::I32), (1, ValType::I32),
-    ]);
+    // params: 0=s | locals: 1=blen, 2=result, 3=in_off, 4=str, 5=width, 6=j, 7=k
+    let mut f = Function::new([(7, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
+        local_get(0); i32_load(0); local_set(1);                 // blen
+        // worst-case slots = blen (all-ASCII); fewer codepoints just leave gaps
         i32_const(list_hdr()); local_get(1); i32_const(4); i32_mul; i32_add;
         call(emitter.rt.alloc); local_set(2);
-        local_get(2); local_get(1); i32_store(0);
-        i32_const(0); local_set(3);
+        i32_const(0); local_set(3);                              // in_off = 0
+        i32_const(0); local_set(6);                              // j = 0 (codepoint index)
         block_empty; loop_empty;
           local_get(3); local_get(1); i32_ge_u; br_if(1);
-          i32_const(1); call(emitter.rt.string_alloc); local_set(4);
-          local_get(4); i32_const(1); i32_store(0);
-          local_get(4); i32_const(1); i32_store(string_cap_off() as u32, 0);
-          local_get(4);
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; i32_load8_u(0);
-          i32_store8(string_data_off() as u32);
-          local_get(2); i32_const(list_data_off()); i32_add; local_get(3); i32_const(4); i32_mul; i32_add;
+          local_get(0); local_get(3); call(emitter.rt.string.utf8_width); local_set(5);
+          // str = alloc(width); copy width bytes
+          local_get(5); call(emitter.rt.string_alloc); local_set(4);
+          i32_const(0); local_set(7);
+          block_empty; loop_empty;
+            local_get(7); local_get(5); i32_ge_u; br_if(1);
+            local_get(4); i32_const(string_data_off()); i32_add; local_get(7); i32_add;
+            local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; local_get(7); i32_add;
+            i32_load8_u(0); i32_store8(0);
+            local_get(7); i32_const(1); i32_add; local_set(7);
+            br(0);
+          end; end;
+          // result.data[j] = str
+          local_get(2); i32_const(list_data_off()); i32_add; local_get(6); i32_const(4); i32_mul; i32_add;
           local_get(4); i32_store(0);
-          local_get(3); i32_const(1); i32_add; local_set(3);
+          local_get(3); local_get(5); i32_add; local_set(3);     // in_off += width
+          local_get(6); i32_const(1); i32_add; local_set(6);     // j += 1
           br(0);
         end; end;
+        local_get(2); local_get(6); i32_store(0);                // result.len = j
         local_get(2); end;
     });
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));

--- a/docs/roadmap/active/correctness-guarantee-gaps.md
+++ b/docs/roadmap/active/correctness-guarantee-gaps.md
@@ -267,8 +267,11 @@ Quick wins first (small effort, high leverage):
   | F | 型を変えるクロージャの map.map/set.map が **trap**（indirect call 型不一致） | 2 | 中 | wasm closure dispatch |
   | G | **fan.\*** = §12。WASM は `fns[0]` のみ走る逐次スタブ、native は thread::scope。副作用集合・勝者・全失敗（panic101/trap134/propagate1）が乖離 | 6 | **契約決定が先** | `emit_wasm/calls.rs:1478-1561` + `runtime/rs/src/fan.rs` |
   | H | div/mod by zero（native panic101 vs wasm trap134）、const畳み込み div0（native コンパイルエラー）、Map の Display | 3 | 中 | wasm arith/display |
+  | A-case | to_upper/to_lower/capitalize が WASM は**ASCII のみ**（±32 byte-wise）、native は全 Unicode（é→É, ß→SS 伸長, Greek/Cyrillic）。A の敵対的検証で発見 | — | 中（要 Unicode case 表、重い）| `emit_wasm/calls_string.rs` emit_str_case_convert |
 
-  §13（termination）も §12（fan）も、この 8 クラスタの一部分。
+  §13（termination）も §12（fan）も、この 8（+A-case）クラスタの一部分。
+
+  **進捗（burndown, 2026-06-04）**: ✅ **E**（#363 マージ, OOB 境界チェック）、✅ **B-int**（#364 マージ, parse オーバーフロー/符号/trim + 4 エラー文字列）、✅ **A**（文字列コードポイント化: 4 UTF-8 ヘルパー + 全 op 変換、負 n は i32::MAX クランプ、2-arg slice の i64::MAX デフォルトは i64 クランプで修正）。残: D / C+B-float / H / F / G(fan) / A-case。
 
   **fan(G) は契約の決定が前提**（§12 の深掘り）。native/wasm のどちらも今は仕様逸脱（native race は
   Ok のみ拾う＝実質 any、wasm は fns[0] のみ）。推奨契約は **「決定論的 list-order-first」**: 両 target

--- a/spec/wasm_cross/string_codepoint.almd
+++ b/spec/wasm_cross/string_codepoint.almd
@@ -1,0 +1,44 @@
+// UTF-8 codepoint-aware string ops: native (Rust char-based) is the oracle and
+// WASM must byte-match it. Exercises chars/reverse/slice/take/drop/first/last/
+// get/codepoint/from_codepoint/pad on ASCII + multibyte input (Latin-1 accent,
+// CJK, 4-byte emoji, 3-byte currency). No @xt-allow — this must be exact.
+
+fn report(s: String) -> Unit = {
+  println("-- ${s} --")
+  println("len=${int.to_string(string.len(s))}")              // BYTE length
+  println("nchars=${int.to_string(list.length(string.chars(s)))}")
+  println("reverse=${string.reverse(s)}")
+  println("chars=${list.join(string.chars(s), "|")}")
+  println("take2=${string.take(s, 2)}")
+  println("drop2=${string.drop(s, 2)}")
+  println("take_end2=${string.take_end(s, 2)}")
+  println("drop_end2=${string.drop_end(s, 2)}")
+  println("first=${string.first(s) ?? "<none>"}")
+  println("last=${string.last(s) ?? "<none>"}")
+  println("get0=${string.get(s, 0) ?? "<none>"}")
+  println("get3=${string.get(s, 3) ?? "<none>"}")
+  println("slice14=${string.slice(s, 1, 4)}")
+  println("pad_start8=${string.pad_start(s, 8, "·")}")
+  println("pad_end8=${string.pad_end(s, 8, "·")}")
+  println("codepoint=${int.to_string(string.codepoint(s) ?? -1)}")
+}
+
+fn main() -> Unit = {
+  let samples = ["hello", "héllo", "日本語", "a😀b", "x€y日", ""]
+  for s in samples { report(s) }
+
+  // from_codepoint: valid scalars (1-4 byte encode) + invalid → empty string.
+  let cps = [104, 233, 26085, 128512, 8364, 0, 1114111, 1114112, 55296]
+  for c in cps {
+    let enc = string.from_codepoint(c)
+    // round-trip the valid ones back through codepoint for a stable check
+    let back = string.codepoint(enc) ?? -1
+    println("from_cp ${int.to_string(c)} -> [${enc}] back=${int.to_string(back)} bytes=${int.to_string(string.len(enc))}")
+  }
+
+  // Negative n: native casts `n as usize` (a negative i64 -> huge), so take/take_end
+  // return the WHOLE string and drop/drop_end return EMPTY. WASM must match.
+  for s in ["héllo", "日本語", "a😀b"] {
+    println("neg take=[${string.take(s, 0 - 2)}] drop=[${string.drop(s, 0 - 2)}] take_end=[${string.take_end(s, 0 - 2)}] drop_end=[${string.drop_end(s, 0 - 2)}]")
+  }
+}


### PR DESCRIPTION
Cluster A of the cross-target divergence burndown (roadmap §14) — the largest. WASM string ops were **byte-indexed** while native is **codepoint-indexed** (Rust `char` ops), so any multibyte input (accents, CJK, emoji) produced wrong output — `string.reverse` even produced **invalid UTF-8**.

## Fix
Added 4 shared UTF-8 wasm helpers (`utf8_width`, `utf8_scalar`, `utf8_byte_of_cp`, `utf8_snap`) and rebuilt every codepoint-sensitive op on them:
- **chars** (one element per codepoint), **reverse** (codepoint-reversal, each codepoint's bytes intact), **take/drop/take_end/drop_end** (codepoint counts), **first/last/get** (whole codepoint), **codepoint** (decode scalar), **from_codepoint** (1–4 byte UTF-8 encode; invalid/surrogate → empty), **pad_start/pad_end** (width in codepoints).
- **slice** stays byte-indexed but snaps each index *down* to a char boundary (matches native, never splits a codepoint).
- `len` left byte-based (already native==wasm).

Two issues the adversarial verifiers + full sweep caught (beyond the initial probe set):
- **negative n**: native casts `n as usize` so `take(-3)` = whole / `drop(-3)` = empty; wasm clamped neg→0. Fixed by clamping negative n → `i32::MAX` so it flows to whole/empty.
- **2-arg slice** (`slice(s, start)`): the injected `end: Int = i64::MAX` default wrapped to -1 and emptied the result. Fixed by clamping the i64 `end` to `[0, byte_len]` *before* the i32 wrap.

A new sub-cluster (**A-case**: `to_upper`/`to_lower`/`capitalize` are ASCII-only in wasm vs full-Unicode native) was surfaced by the verifiers and recorded in §14 — deferred (needs Unicode case tables).

## Validation
- New corpus `spec/wasm_cross/string_codepoint.almd` (ASCII/Latin/CJK/emoji/€, the from_codepoint encode table, and negative-n) — byte-identical native==wasm, no `@xt-allow`.
- A 5-family adversarial sweep (chars/reverse, index ops, mid-codepoint slice, codepoint encode, pad) found zero residual divergence.
- Gate green; native spec 241/241; WASM 233/0; `cargo test` green (snapshots unchanged — native runtime untouched).