### PR TITLE
Make WASM compound-element equality structural (cluster D — pointer-identity)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_list.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list.rs
@@ -932,67 +932,41 @@ impl FuncCompiler<'_> {
                 // list.contains(list, elem) -> Bool (i32)
                 let elem_ty = self.resolve_list_elem(&args[0], None);
                 let elem_size = values::byte_size(&elem_ty);
+                let target_vt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32);
                 let list_ptr = self.scratch.alloc_i32();
                 let idx = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();
+                // Hold the search target in a valtype-matched register (i64 Int,
+                // f64 Float, i32 pointer for String/compound). The element load and
+                // compare below use `emit_load_at`/`emit_eq_typed(elem_ty)` so both
+                // sides agree on width and use STRUCTURAL (deep) equality — matching
+                // native `xs.contains(&x)`, not pointer identity.
+                let target = self.scratch.alloc(target_vt);
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(list_ptr); });
-                // Save target to i64 scratch or i32 scratch depending on type
-                match values::ty_to_valtype(&elem_ty) {
-                    Some(ValType::I64) => {
-                        let target = self.scratch.alloc_i64();
-                        self.emit_expr(&args[1]);
-                        wasm!(self.func, {
-                            local_set(target);
-                            i32_const(0); local_set(idx);
-                            i32_const(0); local_set(result); // result = false
-                            block_empty; loop_empty;
-                              local_get(idx); local_get(list_ptr); i32_load(0); i32_ge_u; br_if(1);
-                              local_get(list_ptr); i32_const(list_data_off); i32_add;
-                              local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
-                              i64_load(0);
-                              local_get(target); i64_eq;
-                              if_empty;
-                                i32_const(1); local_set(result); br(2);
-                              end;
-                              local_get(idx); i32_const(1); i32_add; local_set(idx);
-                              br(0);
-                            end; end;
-                            local_get(result);
-                        });
-                        self.scratch.free_i64(target);
-                    }
-                    _ => {
-                        // i32 types: String, Option, etc.
-                        let target = self.scratch.alloc_i32();
-                        self.emit_expr(&args[1]);
-                        wasm!(self.func, {
-                            local_set(target);
-                            i32_const(0); local_set(idx);
-                            i32_const(0); local_set(result);
-                            block_empty; loop_empty;
-                              local_get(idx); local_get(list_ptr); i32_load(0); i32_ge_u; br_if(1);
-                              local_get(list_ptr); i32_const(list_data_off); i32_add;
-                              local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
-                              i32_load(0);
-                              local_get(target);
-                        });
-                        match &elem_ty {
-                            Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
-                            _ => { wasm!(self.func, { i32_eq; }); }
-                        }
-                        wasm!(self.func, {
-                              if_empty;
-                                i32_const(1); local_set(result); br(2);
-                              end;
-                              local_get(idx); i32_const(1); i32_add; local_set(idx);
-                              br(0);
-                            end; end;
-                            local_get(result);
-                        });
-                        self.scratch.free_i32(target);
-                    }
-                }
+                self.emit_expr(&args[1]);
+                wasm!(self.func, {
+                    local_set(target);
+                    i32_const(0); local_set(idx);
+                    i32_const(0); local_set(result); // result = false
+                    block_empty; loop_empty;
+                      local_get(idx); local_get(list_ptr); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(list_ptr); i32_const(list_data_off); i32_add;
+                      local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
+                });
+                self.emit_load_at(&elem_ty, 0);
+                wasm!(self.func, { local_get(target); });
+                self.emit_eq_typed(&elem_ty);
+                wasm!(self.func, {
+                      if_empty;
+                        i32_const(1); local_set(result); br(2);
+                      end;
+                      local_get(idx); i32_const(1); i32_add; local_set(idx);
+                      br(0);
+                    end; end;
+                    local_get(result);
+                });
+                self.scratch.free(target, target_vt);
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(idx);
                 self.scratch.free_i32(list_ptr);

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
@@ -838,16 +838,18 @@ impl FuncCompiler<'_> {
                         // Compare xs[i] with xs[i-1]
                         local_get(xs); i32_const(list_data_off); i32_add;
                         local_get(i); i32_const(es); i32_mul; i32_add;
-                        i32_load(0);
+                });
+                self.emit_load_at(&elem_ty, 0);
+                wasm!(self.func, {
                         local_get(xs); i32_const(list_data_off); i32_add;
                         local_get(i); i32_const(1); i32_sub;
                         i32_const(es); i32_mul; i32_add;
-                        i32_load(0);
                 });
-                match &elem_ty {
-                    Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
-                    _ => { wasm!(self.func, { i32_eq; }); }
-                }
+                self.emit_load_at(&elem_ty, 0);
+                // Structural eq: collapse consecutive value-equal elements
+                // (String + compound), matching native dedup-by-`==`, not pointer
+                // identity.
+                self.emit_eq_typed(&elem_ty);
                 wasm!(self.func, {
                         i32_eqz; // not equal → include
                         if_empty;

--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -545,26 +545,23 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_list_index_of(&mut self, args: &[IrExpr]) {
         let elem_ty = self.resolve_list_elem(&args[0], None);
         let elem_size = values::byte_size(&elem_ty);
+        let search_vt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32);
         let xs_ptr = self.scratch.alloc_i32();
         let i = self.scratch.alloc_i32();
         let found_ptr = self.scratch.alloc_i32();
         let result = self.scratch.alloc_i32();
-        let search_val_i64 = self.scratch.alloc_i64();
-        let search_val_i32 = self.scratch.alloc_i32();
+        // Hold the search value in a valtype-matched register so the per-element
+        // comparison loads and compares at the correct width (i64 for Int, f64 for
+        // Float, i32 pointer for String/compound). The element load below uses
+        // `emit_load_at(elem_ty)` and the compare uses `emit_eq_typed(elem_ty)`,
+        // so both sides agree on width and on STRUCTURAL (deep) equality — matching
+        // native `position(|v| *v == x)`, not pointer identity.
+        let search_val = self.scratch.alloc(search_vt);
 
         self.emit_expr(&args[0]);
         wasm!(self.func, { local_set(xs_ptr); });
-        // Store search value
-        match values::ty_to_valtype(&elem_ty) {
-            Some(ValType::I64) => {
-                self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(search_val_i64); });
-            }
-            _ => {
-                self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(search_val_i32); });
-            }
-        }
+        self.emit_expr(&args[1]);
+        wasm!(self.func, { local_set(search_val); });
         wasm!(self.func, {
             i32_const(0); local_set(i); // i
             i32_const(0); local_set(result); // result (default: none)
@@ -572,54 +569,26 @@ impl FuncCompiler<'_> {
               local_get(i);
               local_get(xs_ptr); i32_load(0); // len
               i32_ge_u; br_if(1);
+              local_get(xs_ptr); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
+              local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
         });
-        // Compare element
-        match values::ty_to_valtype(&elem_ty) {
-            Some(ValType::I64) => {
-                wasm!(self.func, {
-                    local_get(xs_ptr); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                    local_get(i); i32_const(8); i32_mul; i32_add;
-                    i64_load(0);
-                    local_get(search_val_i64); i64_eq;
-                    if_empty;
-                      // Found: store some(i) and break
-                      i32_const(self.emitter.layout_reg.header_size(LIST) as i32); call(self.emitter.rt.alloc); local_set(found_ptr);
-                      local_get(found_ptr); local_get(i); i64_extend_i32_u; i64_store(0);
-                      local_get(found_ptr); local_set(result); br(2);
-                    end;
-                });
-            }
-            _ => {
-                wasm!(self.func, {
-                    local_get(xs_ptr); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                    local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
-                    i32_load(0);
-                    local_get(search_val_i32);
-                });
-                // String eq or i32 eq
-                if matches!(&elem_ty, Ty::String) {
-                    wasm!(self.func, { call(self.emitter.rt.string.eq); });
-                } else {
-                    wasm!(self.func, { i32_eq; });
-                }
-                wasm!(self.func, {
-                    if_empty;
-                      i32_const(self.emitter.layout_reg.header_size(LIST) as i32); call(self.emitter.rt.alloc); local_set(found_ptr);
-                      local_get(found_ptr); local_get(i); i64_extend_i32_u; i64_store(0);
-                      local_get(found_ptr); local_set(result); br(2);
-                    end;
-                });
-            }
-        }
+        self.emit_load_at(&elem_ty, 0);
+        wasm!(self.func, { local_get(search_val); });
+        self.emit_eq_typed(&elem_ty);
         wasm!(self.func, {
+              if_empty;
+                // Found: store some(i) and break
+                i32_const(self.emitter.layout_reg.header_size(LIST) as i32); call(self.emitter.rt.alloc); local_set(found_ptr);
+                local_get(found_ptr); local_get(i); i64_extend_i32_u; i64_store(0);
+                local_get(found_ptr); local_set(result); br(2);
+              end;
               local_get(i); i32_const(1); i32_add; local_set(i);
               br(0);
             end; end;
             local_get(result); // result (none if not found)
         });
 
-        self.scratch.free_i32(search_val_i32);
-        self.scratch.free_i64(search_val_i64);
+        self.scratch.free(search_val, search_vt);
         self.scratch.free_i32(result);
         self.scratch.free_i32(found_ptr);
         self.scratch.free_i32(i);
@@ -654,15 +623,16 @@ impl FuncCompiler<'_> {
                 local_get(j); local_get(dst); i32_load(0); i32_ge_u; br_if(1);
                 local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
                 local_get(i); i32_const(es); i32_mul; i32_add;
-                i32_load(0);
+        });
+        self.emit_load_at(&elem_ty, 0);
+        wasm!(self.func, {
                 local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
                 local_get(j); i32_const(es); i32_mul; i32_add;
-                i32_load(0);
         });
-        match &elem_ty {
-            Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
-            _ => { wasm!(self.func, { i32_eq; }); }
-        }
+        self.emit_load_at(&elem_ty, 0);
+        // Structural eq: collapse all value-equal elements (String + compound),
+        // matching native unique-by-`==`, not by pointer identity.
+        self.emit_eq_typed(&elem_ty);
         wasm!(self.func, {
                 if_empty; i32_const(1); local_set(found); br(2); end;
                 local_get(j); i32_const(1); i32_add; local_set(j);

--- a/crates/almide-codegen/src/emit_wasm/calls_map.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map.rs
@@ -746,36 +746,148 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(s);
             }
             Ty::Bool => {} // identity hash: 0 or 1, already i32
+            // Tuple keys, and records/Named-records whose fields include a heap
+            // POINTER (e.g. a String or nested list field), must hash by VALUE so
+            // two structurally-equal keys built from distinct allocations land in
+            // the same bucket — otherwise probing never finds the match even with
+            // a correct value-equality. Walk the fields and fold each field's
+            // value-hash recursively (`emit_hash_value`). Records with only inline
+            // value fields keep the cheaper byte-FNV path below.
+            Ty::Tuple(_) => {
+                let fields = self.key_struct_fields(key_ty).unwrap_or_default();
+                self.emit_hash_fields(&fields);
+            }
             Ty::Named(_, _) | Ty::Record { .. } | Ty::Variant { .. } => {
-                // Records and variants are heap structs; FNV-1a over their content
-                // bytes (dereferencing the pointer). For variants this is the tag —
-                // hashing the POINTER would be identity-on-allocation and break value
-                // equality, since each constructor call allocates a fresh struct.
-                let size = self.key_content_size(key_ty);
-                if size == 0 {
-                    // No known content layout: identity hash (the key value itself).
+                let struct_fields = self.key_struct_fields(key_ty);
+                let has_ptr = struct_fields.as_ref()
+                    .map(|fs| fs.iter().any(|(_, t)| !Self::ty_is_inline_value(t)))
+                    .unwrap_or(false);
+                if let (true, Some(fields)) = (has_ptr, struct_fields) {
+                    // Record/Named-record with pointer field(s): value-structural hash.
+                    self.emit_hash_fields(&fields);
                 } else {
-                    let ptr = self.scratch.alloc_i32();
-                    let h = self.scratch.alloc_i32();
-                    wasm!(self.func, {
-                        local_set(ptr);
-                        i32_const(0x811C9DC5u32 as i32); local_set(h);
-                    });
-                    for b in 0..size {
+                    // Records and variants are heap structs; FNV-1a over their content
+                    // bytes (dereferencing the pointer). For variants this is the tag —
+                    // hashing the POINTER would be identity-on-allocation and break value
+                    // equality, since each constructor call allocates a fresh struct.
+                    let size = self.key_content_size(key_ty);
+                    if size == 0 {
+                        // No known content layout: identity hash (the key value itself).
+                    } else {
+                        let ptr = self.scratch.alloc_i32();
+                        let h = self.scratch.alloc_i32();
                         wasm!(self.func, {
-                            local_get(h);
-                            local_get(ptr); i32_load8_u(b);
-                            i32_xor;
-                            i32_const(0x01000193u32 as i32); i32_mul;
-                            local_set(h);
+                            local_set(ptr);
+                            i32_const(0x811C9DC5u32 as i32); local_set(h);
                         });
+                        for b in 0..size {
+                            wasm!(self.func, {
+                                local_get(h);
+                                local_get(ptr); i32_load8_u(b);
+                                i32_xor;
+                                i32_const(0x01000193u32 as i32); i32_mul;
+                                local_set(h);
+                            });
+                        }
+                        wasm!(self.func, { local_get(h); });
+                        self.scratch.free_i32(h);
+                        self.scratch.free_i32(ptr);
                     }
-                    wasm!(self.func, { local_get(h); });
-                    self.scratch.free_i32(h);
-                    self.scratch.free_i32(ptr);
                 }
             }
             _ => {} // other pointers: identity hash
+        }
+    }
+
+    /// True if a value of `ty` is stored INLINE (no heap pointer). Strings, lists,
+    /// records, tuples, etc. are pointers; ints/floats/bools/narrow-ints are inline.
+    /// Used to decide whether a compound key needs value-structural hashing/eq.
+    fn ty_is_inline_value(ty: &Ty) -> bool {
+        matches!(ty,
+            Ty::Int | Ty::Float | Ty::Bool | Ty::Unit
+            | Ty::Int8 | Ty::Int16 | Ty::Int32 | Ty::Int64
+            | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 | Ty::UInt64
+            | Ty::Float32 | Ty::Float64)
+    }
+
+    /// Flat (name, ty) fields of a struct-like key (Tuple or Record/Named-record),
+    /// laid out sequentially in memory. None for variants and non-struct keys.
+    /// Single source of truth so hashing and equality see identical layout.
+    fn key_struct_fields(&self, key_ty: &Ty) -> Option<Vec<(String, Ty)>> {
+        match key_ty {
+            Ty::Tuple(elems) => Some(
+                elems.iter().enumerate()
+                    .map(|(i, t)| (format!("_{i}"), t.clone()))
+                    .collect()),
+            Ty::Record { fields } => Some(
+                fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect()),
+            Ty::Named(name, _) if !self.emitter.variant_info.contains_key(name.as_str()) => {
+                self.emitter.record_fields.get(name.as_str()).cloned()
+            }
+            _ => None,
+        }
+    }
+
+    /// Value-structural FNV-1a hash of a struct-like key. Consumes the struct
+    /// pointer on the stack, leaves an i32 hash. Folds each field's value-hash
+    /// (`emit_hash_value`) at its sequential offset so structurally-equal keys —
+    /// even with pointer fields like Strings — hash identically.
+    fn emit_hash_fields(&mut self, fields: &[(String, Ty)]) {
+        let ptr = self.scratch.alloc_i32();
+        let h = self.scratch.alloc_i32();
+        wasm!(self.func, {
+            local_set(ptr);
+            i32_const(0x811C9DC5u32 as i32); local_set(h);
+        });
+        let mut offset = 0u32;
+        for (_, fty) in fields {
+            // h = (h ^ field_hash) * FNV_prime
+            wasm!(self.func, {
+                local_get(ptr);
+            });
+            self.emit_load_at(fty, offset);
+            self.emit_hash_value(fty);
+            wasm!(self.func, {
+                local_get(h); i32_xor;
+                i32_const(0x01000193u32 as i32); i32_mul;
+                local_set(h);
+            });
+            offset += values::byte_size(fty);
+        }
+        wasm!(self.func, { local_get(h); });
+        self.scratch.free_i32(h);
+        self.scratch.free_i32(ptr);
+    }
+
+    /// Value-structural hash of a single value of `ty` on the stack → i32.
+    /// Mirrors `emit_eq_typed`'s notion of equality so hash and eq never disagree:
+    /// ints by value, strings by content bytes, tuples/records by their fields.
+    fn emit_hash_value(&mut self, ty: &Ty) {
+        match ty {
+            // Int: reuse the i64 mix from emit_hash_key.
+            Ty::Int | Ty::Int64 | Ty::UInt64 => self.emit_hash_key(&Ty::Int),
+            // Narrow ints ride in i32 already — fold their value directly.
+            Ty::Int8 | Ty::Int16 | Ty::Int32
+            | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 | Ty::Bool => { /* value already i32 */ }
+            // Float bits → i32 mix (reinterpret then fold high/low halves).
+            Ty::Float | Ty::Float64 => {
+                let tmp = self.scratch.alloc_i64();
+                wasm!(self.func, {
+                    i64_reinterpret_f64; local_tee(tmp);
+                    i64_const(32); i64_shr_u; local_get(tmp); i64_xor;
+                    i32_wrap_i64;
+                });
+                self.scratch.free_i64(tmp);
+            }
+            Ty::Float32 => { wasm!(self.func, { i32_reinterpret_f32; }); }
+            Ty::String | Ty::Bytes => self.emit_hash_key(&Ty::String),
+            Ty::Tuple(_) | Ty::Record { .. } | Ty::Named(_, _) | Ty::Variant { .. } => {
+                self.emit_hash_key(ty);
+            }
+            // Other heap types (List, Option, …): identity hash of the pointer.
+            // Rare as nested key fields; equality still recurses structurally, so a
+            // weaker hash only costs probe collisions, never correctness.
+            _ => {}
         }
     }
 
@@ -809,17 +921,32 @@ impl FuncCompiler<'_> {
         match key_ty {
             Ty::Int => { wasm!(self.func, { i64_eq; }); }
             Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
+            // Tuple keys, and records/Named-records with a heap POINTER field
+            // (String / nested list), need STRUCTURAL equality — `mem_eq` would
+            // compare the field's pointer bytes, not its contents, so two equal-
+            // content keys built from distinct allocations would miss. Route through
+            // the shared type-directed deep equality (matching `emit_hash_key`, which
+            // hashes these by value too, so hash and eq stay consistent).
+            Ty::Tuple(_) => { self.emit_eq_typed(key_ty); }
             Ty::Named(_, _) | Ty::Record { .. } | Ty::Variant { .. } => {
-                // Compare the dereferenced content (matching emit_hash_key's coverage so
-                // hash and equality stay consistent): full record bytes, or a variant's
-                // tag. byte_size(record/variant) is only the pointer size (4), so the old
-                // mem_eq(4) compared just the first 4 content bytes. When the layout is
-                // unknown, fall back to pointer identity (matching the identity hash).
-                let size = self.key_content_size(key_ty);
-                if size == 0 {
-                    wasm!(self.func, { i32_eq; });
+                let struct_fields = self.key_struct_fields(key_ty);
+                let has_ptr = struct_fields.as_ref()
+                    .map(|fs| fs.iter().any(|(_, t)| !Self::ty_is_inline_value(t)))
+                    .unwrap_or(false);
+                if has_ptr {
+                    self.emit_eq_typed(key_ty);
                 } else {
-                    wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
+                    // Compare the dereferenced content (matching emit_hash_key's coverage so
+                    // hash and equality stay consistent): full record bytes, or a variant's
+                    // tag. byte_size(record/variant) is only the pointer size (4), so the old
+                    // mem_eq(4) compared just the first 4 content bytes. When the layout is
+                    // unknown, fall back to pointer identity (matching the identity hash).
+                    let size = self.key_content_size(key_ty);
+                    if size == 0 {
+                        wasm!(self.func, { i32_eq; });
+                    } else {
+                        wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
+                    }
                 }
             }
             _ => { wasm!(self.func, { i32_eq; }); }

--- a/crates/almide-codegen/src/emit_wasm/calls_set.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_set.rs
@@ -174,11 +174,9 @@ impl FuncCompiler<'_> {
                               local_get(s1); i32_const(es); i32_mul; i32_add;
                               i32_load(0); local_get(s3);
                         });
-                        if matches!(&elem_ty, Ty::String) {
-                            wasm!(self.func, { call(self.emitter.rt.string.eq); });
-                        } else {
-                            wasm!(self.func, { i32_eq; });
-                        }
+                        // Structural eq: String + compound elements compare by value
+                        // (deep), matching native set containment.
+                        self.emit_eq_typed(&elem_ty);
                         wasm!(self.func, {
                               if_empty; i32_const(1); local_set(s2); br(2); end;
                               local_get(s1); i32_const(1); i32_add; local_set(s1);
@@ -865,18 +863,14 @@ impl FuncCompiler<'_> {
 
     /// Emit equality comparison for set elements.
     /// Expects two values of elem_ty on the WASM stack, leaves i32 (0 or 1).
+    ///
+    /// Delegates to the shared type-directed deep equality (`emit_eq_typed`) so
+    /// compound elements (tuples, nested lists, records) compare by STRUCTURE, not
+    /// pointer identity — matching native `Set` containment/dedup semantics. For
+    /// Int/Float/Bool/String this lowers to the same `i64_eq`/`f64_eq`/`i32_eq`/
+    /// `string.eq` it did before.
     fn emit_set_elem_eq(&mut self, elem_ty: &Ty) {
-        match values::ty_to_valtype(elem_ty) {
-            Some(ValType::I64) => { wasm!(self.func, { i64_eq; }); }
-            Some(ValType::F64) => { self.func.instruction(&wasm_encoder::Instruction::F64Eq); }
-            _ => {
-                if matches!(elem_ty, Ty::String) {
-                    wasm!(self.func, { call(self.emitter.rt.string.eq); });
-                } else {
-                    wasm!(self.func, { i32_eq; });
-                }
-            }
-        }
+        self.emit_eq_typed(elem_ty);
     }
 
     fn set_elem_ty(&self, ty: &Ty) -> Ty {

--- a/spec/wasm_cross/compound_eq.almd
+++ b/spec/wasm_cross/compound_eq.almd
@@ -1,0 +1,90 @@
+// Cross-target structural equality for COMPOUND elements (tuples, nested lists,
+// records). Native uses Rust `PartialEq` (deep) everywhere; WASM previously
+// compared compound elements by POINTER identity, so two distinct heap objects
+// with identical contents miscompared as unequal. This fixture pins the WASM
+// list/set/map element-comparison to the same type-directed deep equality `==`
+// uses, so containment / dedup / key-lookup are byte-identical on both targets.
+//
+// Covered ops: list.contains, list.index_of, list.dedup, list.unique,
+// set.from_list/insert/contains, map.from_list/insert/get/contains — over tuple,
+// nested-list, and record (incl. String-field) element/key types.
+
+type P = { name: String, age: Int }
+
+fn b(x: Bool) -> String = if x then "T" else "F"
+fn oi(o: Option[Int]) -> String =
+  if option.is_some(o) then "S" + int.to_string(o ?? -1) else "N"
+fn os(o: Option[String]) -> String =
+  if option.is_some(o) then "S" + (o ?? "?") else "N"
+fn oj(o: Option[Int]) -> String =
+  if option.is_some(o) then "S" + int.to_string(o ?? -1) else "N"
+
+fn main() -> Unit = {
+  // ── list.contains: tuple & nested-list elements ──
+  let lt: List[(Int, Int)] = [(1, 2), (3, 4)]
+  println(b(list.contains(lt, (1, 2))))   // T
+  println(b(list.contains(lt, (3, 4))))   // T
+  println(b(list.contains(lt, (5, 6))))   // F
+  let lnl: List[List[Int]] = [[1, 2], [3, 4]]
+  println(b(list.contains(lnl, [1, 2])))  // T
+  println(b(list.contains(lnl, [9, 9])))  // F
+
+  // ── list.index_of ──
+  println(oi(list.index_of(lt, (1, 2))))  // S0
+  println(oi(list.index_of(lt, (3, 4))))  // S1
+  println(oi(list.index_of(lt, (7, 8))))  // N
+  println(oi(list.index_of(lnl, [3, 4]))) // S1
+
+  // ── list.dedup (consecutive) ──
+  let dt: List[(Int, Int)] = [(1, 2), (1, 2), (3, 4), (3, 4), (1, 2)]
+  println(int.to_string(list.len(list.dedup(dt))))     // 3
+
+  // ── list.unique (all) ──
+  let ut: List[(Int, Int)] = [(1, 2), (3, 4), (1, 2), (3, 4)]
+  println(int.to_string(list.len(list.unique(ut))))    // 2
+  let unl: List[List[Int]] = [[1, 2], [3, 4], [1, 2]]
+  println(int.to_string(list.len(list.unique(unl))))   // 2
+
+  // ── Set of tuples: dedup on build, contains, insert dup vs new ──
+  let s0: Set[(Int, Int)] = set.from_list([(1, 2), (3, 4), (1, 2)])
+  println(int.to_string(set.len(s0)))                  // 2
+  println(b(set.contains(s0, (3, 4))))                 // T
+  println(b(set.contains(s0, (9, 9))))                 // F
+  let s1 = set.insert(s0, (1, 2))                      // dup
+  println(int.to_string(set.len(s1)))                  // 2
+  let s2 = set.insert(s0, (5, 6))                      // new
+  println(int.to_string(set.len(s2)))                  // 3
+
+  // ── Map with tuple keys: same-content key twice → overwrite, get ──
+  var mt: Map[(Int, Int), String] =
+    map.from_list([((1, 2), "a"), ((3, 4), "b")])
+  map.insert(mt, (1, 2), "z")
+  println(int.to_string(map.len(mt)))                  // 2
+  println(os(map.get(mt, (1, 2))))                     // Sz
+  println(os(map.get(mt, (3, 4))))                     // Sb
+  println(os(map.get(mt, (9, 9))))                     // N
+  println(b(map.contains(mt, (3, 4))))                 // T
+
+  // ── Record keys/elements with a String (pointer) field ──
+  // Each literal is a fresh allocation of identical content: value-structural
+  // hash + eq must collapse them.
+  var mr: Map[P, Int] =
+    map.from_list([({ name: "alice", age: 30 }, 1), ({ name: "bob", age: 25 }, 2)])
+  map.insert(mr, { name: "alice", age: 30 }, 99)
+  println(int.to_string(map.len(mr)))                  // 2
+  println(oj(map.get(mr, { name: "alice", age: 30 }))) // S99
+  println(oj(map.get(mr, { name: "carol", age: 9 })))  // N
+
+  let sr: Set[P] =
+    set.from_list([{ name: "x", age: 1 }, { name: "y", age: 2 }, { name: "x", age: 1 }])
+  println(int.to_string(set.len(sr)))                  // 2
+  println(b(set.contains(sr, { name: "y", age: 2 })))  // T
+
+  let lr = [{ name: "p", age: 1 }, { name: "p", age: 1 }, { name: "q", age: 2 }]
+  println(int.to_string(list.len(list.unique(lr))))    // 2
+
+  // ── Primitive-element regression: still correct ──
+  let ls = ["a", "b", "a"]
+  println(b(list.contains(ls, "b")))                   // T
+  println(int.to_string(list.len(list.unique(ls))))    // 2
+}


### PR DESCRIPTION
Cluster D of the cross-target divergence burndown (roadmap §14). WASM compared **compound** (tuple / nested-list / record) elements & keys by **pointer identity**, so two distinct heap objects with identical contents compared unequal — `list.contains([[1,2]], [1,2])` was false, `list.unique`/`dedup` never collapsed nested dupes, `Set[(Int,Int)]` and `Map` with tuple keys didn't dedup/find. Native uses structural `PartialEq`.

## Fix
**Reused the existing deep structural eq** — `emit_eq_typed` (`emit_wasm/equality.rs`), the same type-directed recursive comparison the language's `==` already uses — for every element/key comparison, replacing the hardcoded `i32_eq` (pointer) path:
- `list.contains`, `list.index_of`, `list.unique`, `list.dedup`
- all `set` ops (`emit_set_elem_eq` → `emit_eq_typed`)
- `map` key lookup (`emit_key_eq` for tuple keys + pointer-field records)

**Also made compound map-key HASHING value-structural** (`emit_hash_value`/`emit_hash_fields`) so hash and eq agree — a structurally-equal key must land in the same bucket or the probe misses even with correct eq. (Tuples + records-with-String/list-fields now value-hashed; a nested-List/Option *as a key field* still identity-hashes — costs only probe collisions, never correctness.)

## Validation
- New corpus `spec/wasm_cross/compound_eq.almd` — byte-identical native==wasm, no `@xt-allow`.
- 4-prober adversarial sweep across tuples (incl String/List/Float/Option fields, nested, mixed-width, variants), nested lists (incl differing lengths), records, with a distinct-heap-pointer literal-vs-computed cross-check proving structural (not pointer) eq — zero residual divergence.
- Gate green; native spec 241/241; WASM 233/0; `cargo test` green.

A separate, out-of-scope native codegen bug surfaced during verification (a `List[(Int8, Int)]` tuple *literal* emits `i64`-suffixed elements → E0308 on native; independent of equality) — recorded for a later fix.