### PR TITLE
Type WASM map.map/set.map by the closure return type (cluster F — type-changing closures)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -176,6 +176,41 @@ impl FuncCompiler<'_> {
         None
     }
 
+    /// Resolve the concrete return *type* of a closure argument as a `Ty`.
+    ///
+    /// Unlike `resolve_closure_ret_valtype` (which collapses to a coarse
+    /// `ValType`), this keeps the source-level `Ty` so callers can size the
+    /// result *and* pick the right load/store width and `call_indirect`
+    /// signature. Resolution order mirrors `emit_list_map`:
+    ///   1. `Ty::Fn.ret`            (post-inference, usually concrete)
+    ///   2. Lambda body's own `.ty` (pre-closure-conversion)
+    ///   3. lifted closure's registered WASM return ValType → placeholder `Ty`
+    /// Falls back to `fallback` when every source is unresolved.
+    pub(super) fn resolve_closure_ret_ty(&self, fn_expr: &IrExpr, fallback: &Ty) -> Ty {
+        let mut ret = fallback.clone();
+        if let Ty::Fn { ret: r, .. } = &fn_expr.ty {
+            if !r.is_unresolved() {
+                ret = (**r).clone();
+            }
+        }
+        if ret.is_unresolved() {
+            if let almide_ir::IrExprKind::Lambda { body, .. } = &fn_expr.kind {
+                if !body.ty.is_unresolved() {
+                    ret = body.ty.clone();
+                }
+            }
+        }
+        // Final reconciliation with the lifted closure's actual WASM signature,
+        // same as emit_list_map: if the registered ret valtype disagrees with
+        // the `Ty` we derived (e.g. inference left it Unknown→i32 but the
+        // closure really returns i64), trust the registered ABI width.
+        let ret_vt = values::ty_to_valtype(&ret);
+        match self.resolve_closure_ret_valtype(fn_expr) {
+            Some(actual) if Some(actual) != ret_vt => values::vt_to_placeholder_ty(actual),
+            _ => ret,
+        }
+    }
+
     /// Resolve the concrete type of the first non-env parameter of a closure
     /// argument. Like `resolve_closure_ret_valtype` but for the input side.
     /// Used to size the `param_ty`/`in_elem_ty` in `emit_list_map` etc. when

--- a/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
@@ -244,29 +244,67 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(m);
             }
             "map" => {
-                // map(m, f) → Map[K, B]: copy Swiss Table, transform each occupied value
+                // map(m, f) → Map[K, B]: rebuild the COD table transforming each
+                // value via f. The closure's return type B can differ from the
+                // source value type V — so the *new* value valtype/width follows
+                // B, the call_indirect signature is (V)->B, and the rebuilt table
+                // uses the new entry stride es_new = ks + vs_new. Keys, tags, and
+                // the hash index are value-width-independent, so they are copied
+                // verbatim (insertion order + lookups preserved). When B == V this
+                // degenerates to the old same-width copy-and-transform.
+                use super::engine::layout::map as lm;
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let val_ty = self.map_val_ty(&args[0].ty);
+                // Closure return type (the NEW value type). Fall back to the
+                // source value type when inference left it unresolved.
+                let new_val_ty = self.resolve_closure_ret_ty(&args[1], &val_ty);
+                let vs_new = values::byte_size(&new_val_ty);
+                let es_old = ks + vs;
+                let es_new = ks + vs_new;
                 let closure = self.scratch.alloc_i32();
-                let it = self.map_iter_begin(&args[0], ks + vs);
+                let it = self.map_iter_begin(&args[0], es_old);
                 self.emit_expr(&args[1]);
                 wasm!(self.func, { local_set(closure); });
-                let new_map = self.map_copy_full(&it);
-                let new_eb = self.map_copy_entry_base(new_map, &it);
+                // Allocate a fresh table at the new entry stride, then copy the
+                // value-width-independent prefix (header + tags + index) verbatim
+                // from the source so len/cap/tags/index match exactly.
+                let new_map = self.scratch.alloc_i32();
+                self.emit_dict_alloc(new_map, it.cap, es_new);
+                // prefix_size = header + cap*(tag(1) + INDEX_SLOT_SIZE)
+                let hdr = self.emitter.layout_reg.header_size(super::engine::layout::SWISS_MAP) as i32;
+                let tag_plus_index = 1 + lm::INDEX_SLOT_SIZE as i32;
+                wasm!(self.func, {
+                    local_get(new_map);
+                    local_get(it.map);
+                    i32_const(hdr);
+                    local_get(it.cap); i32_const(tag_plus_index); i32_mul; i32_add;
+                    memory_copy;
+                });
+                let new_eb = self.scratch.alloc_i32();
+                self.emit_dict_entries_base(new_map, it.cap);
+                wasm!(self.func, { local_set(new_eb); });
                 self.map_iter_loop_head(&it);
-                // dst = new_eb + i*entry + ks (val addr in copy)
+                // Copy the key bytes (unchanged) from source entry i into dst entry i.
                 wasm!(self.func, {
                     local_get(new_eb);
-                    local_get(it.i); i32_const((ks + vs) as i32); i32_mul; i32_add;
+                    local_get(it.i); i32_const(es_new as i32); i32_mul; i32_add;
+                    local_get(it.eb);
+                    local_get(it.i); i32_const(es_old as i32); i32_mul; i32_add;
+                    i32_const(ks as i32); memory_copy;
+                });
+                // dst = new_eb + i*es_new + ks (new val addr in the rebuilt table)
+                wasm!(self.func, {
+                    local_get(new_eb);
+                    local_get(it.i); i32_const(es_new as i32); i32_mul; i32_add;
                     i32_const(ks as i32); i32_add;
                 });
-                // f(env, old_val) → new_val
+                // f(env, old_val) → new_val, then store at the new value width.
                 wasm!(self.func, { local_get(closure); i32_load(4); });
                 self.map_iter_val_addr(&it, ks);
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, { local_get(closure); i32_load(0); });
-                self.emit_closure_call(&val_ty, &val_ty);
-                self.emit_store_at(&val_ty, 0);
+                self.emit_closure_call(&val_ty, &new_val_ty);
+                self.emit_store_at(&new_val_ty, 0);
                 self.map_iter_loop_tail(&it);
                 wasm!(self.func, { local_get(new_map); });
                 self.scratch.free_i32(new_eb);
@@ -522,35 +560,5 @@ impl FuncCompiler<'_> {
         self.scratch.free_i32(it.len);
         self.scratch.free_i32(it.cap);
         self.scratch.free_i32(it.map);
-    }
-
-    /// Allocate a full byte-copy of a COD map (header + tags + index + dense
-    /// entries). Safe for `map`, which transforms values in place: keys, tags,
-    /// and index pointers are unchanged, so the copied index stays valid.
-    pub(super) fn map_copy_full(&mut self, it: &MapIter) -> u32 {
-        use super::engine::layout::{SWISS_MAP, map as lm};
-        let map_hdr = self.emitter.layout_reg.header_size(SWISS_MAP) as i32;
-        let per_slot = 1 + lm::INDEX_SLOT_SIZE as i32 + it.entry_size as i32;
-        let total = self.scratch.alloc_i32();
-        let new_map = self.scratch.alloc_i32();
-        wasm!(self.func, {
-            // total = header + cap*(tag(1) + INDEX_SLOT_SIZE + entry_size)
-            i32_const(map_hdr);
-            local_get(it.cap); i32_const(per_slot); i32_mul; i32_add;
-            local_tee(total);
-            call(self.emitter.rt.alloc); local_set(new_map);
-            local_get(new_map); local_get(it.map); local_get(total);
-            memory_copy;
-        });
-        self.scratch.free_i32(total);
-        new_map
-    }
-
-    /// Compute the dense entries base of a copied map.
-    pub(super) fn map_copy_entry_base(&mut self, new_map: u32, it: &MapIter) -> u32 {
-        let new_eb = self.scratch.alloc_i32();
-        self.emit_dict_entries_base(new_map, it.cap);
-        wasm!(self.func, { local_set(new_eb); });
-        new_eb
     }
 }

--- a/crates/almide-codegen/src/emit_wasm/calls_set.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_set.rs
@@ -772,10 +772,16 @@ impl FuncCompiler<'_> {
                 // set.map = list.map + dedup
                 // 1. Emit list.map (result on stack)
                 self.emit_list_closure_call("map", args);
-                // 2. Dedup the result using set.from_list logic (insert-if-not-exists)
-                // The map result type is the closure return type = element type of the new set
-                // For simplicity: use from_list which already deduplicates
-                let result_elem_ty = self.set_elem_ty(&args[0].ty); // same elem type for now
+                // 2. Dedup the result (insert-if-not-exists). The mapped list's
+                // element type is the CLOSURE RETURN type — which can differ from
+                // the source set's element type for a type-changing map (e.g.
+                // Set[String] with String->Int). The dedup must load/compare/copy
+                // and stride at that NEW element width, not the source's; using
+                // the source type here loaded/stored the wrong number of bytes
+                // (native "1,2,3" vs wasm "1"). Fall back to the source element
+                // type only when the closure return is left unresolved.
+                let src_elem_ty = self.set_elem_ty(&args[0].ty);
+                let result_elem_ty = self.resolve_closure_ret_ty(&args[1], &src_elem_ty);
                 let es = values::byte_size(&result_elem_ty) as i32;
                 let mapped = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();

--- a/spec/wasm_cross/map_set_typechange.almd
+++ b/spec/wasm_cross/map_set_typechange.almd
@@ -1,0 +1,90 @@
+// Cross-target gate for TYPE-CHANGING map.map and set.map closures.
+//
+// Native is the oracle: applying a closure whose return type differs from the
+// collection's value/element type yields a collection of the NEW type
+// (Map[K,V] with (V)->B => Map[K,B]; Set[A] with (A)->B => Set[B]). The WASM
+// emitter previously kept the SOURCE value/element width — wrong call_indirect
+// signature (trap) for map.map, wrong load/store width (truncated dedup) for
+// set.map. This program exercises every width transition (i64<->i32 pointer,
+// f64, tuple) on both String and Int keys and must be byte-identical wasm==native.
+//
+// NO @xt-allow: this is a fixed invariant, not a tracked divergence.
+
+fn show_map_si(m: Map[String, Int]) -> String =
+  map.entries(m)
+    |> list.map((e) => { let (k, v) = e; k + "=" + int.to_string(v) })
+    |> list.join(",")
+
+fn show_map_ss(m: Map[String, String]) -> String =
+  map.entries(m)
+    |> list.map((e) => { let (k, v) = e; k + "=" + v })
+    |> list.join(",")
+
+fn show_map_sf(m: Map[String, Float]) -> String =
+  map.entries(m)
+    |> list.map((e) => { let (k, v) = e; k + "=" + float.to_string(v) })
+    |> list.join(",")
+
+fn show_map_ii(m: Map[Int, Int]) -> String =
+  map.entries(m)
+    |> list.map((e) => { let (k, v) = e; int.to_string(k) + "=" + int.to_string(v) })
+    |> list.join(",")
+
+fn main() -> Unit = {
+  // ── map.map: value TYPE CHANGES (String key) ──
+  let ms = map.from_list([("a", "xx"), ("bb", "yyy"), ("ccc", "z")])
+  // String -> Int (i32 ptr -> i64): widen
+  println(show_map_si(map.map(ms, (v) => string.len(v))))
+
+  let mi = map.from_list([("a", 1), ("b", 22), ("c", 333)])
+  // Int -> String (i64 -> i32 ptr): narrow
+  println(show_map_ss(map.map(mi, (v) => int.to_string(v) + "!")))
+  // Int -> Float (i64 -> f64): same width, different valtype
+  println(show_map_sf(map.map(mi, (v) => int.to_float(v) / 2.0)))
+
+  // map.map: value -> tuple (i64 -> i32 ptr)
+  let mt = map.map(mi, (v) => (v, v * v))
+  let tparts = map.entries(mt)
+    |> list.map((e) => { let (k, p) = e; let (x, y) = p; k + "=" + int.to_string(x) + ":" + int.to_string(y) })
+    |> list.join(",")
+  println(tparts)
+
+  // ── map.map with Int KEYS (ks = 8) — key bytes preserved across rewrite ──
+  let mik = map.from_list([(1, "xx"), (2, "yyy"), (3, "z")])
+  println(show_map_ii(map.map(mik, (v) => string.len(v))))
+
+  // ── map.map regression: same value type still works ──
+  let mr = map.from_list([("a", 1), ("b", 2), ("c", 3)])
+  println(show_map_si(map.map(mr, (v) => v * 10)))
+
+  // ── set.map: element TYPE CHANGES ──
+  // String -> Int via string.len; "bb"/"dd" both => 2, dedup keeps one
+  let ss = set.from_list(["a", "bb", "ccc", "dd"])
+  let s_si = set.map(ss, (x) => string.len(x))
+    |> set.to_list
+    |> list.map((v) => int.to_string(v))
+    |> list.join(",")
+  println(s_si)
+
+  // Int -> String
+  let si = set.from_list([1, 2, 3])
+  let s_is = set.map(si, (x) => "n" + int.to_string(x))
+    |> set.to_list
+    |> list.join(",")
+  println(s_is)
+
+  // Int -> Bool: 4 elements collapse to {false, true}
+  let sb = set.from_list([1, 2, 3, 4])
+  let s_ib = set.map(sb, (x) => x % 2 == 0)
+    |> set.to_list
+    |> list.map((b) => if b then "T" else "F")
+    |> list.join(",")
+  println(s_ib)
+
+  // set.map regression: same element type still works
+  let s_ii = set.map(si, (x) => x * 10)
+    |> set.to_list
+    |> list.map((v) => int.to_string(v))
+    |> list.join(",")
+  println(s_ii)
+}


### PR DESCRIPTION
Cluster F of the cross-target divergence burndown (roadmap §14). When a `map.map` / `set.map` closure **changes the value/element type** (e.g. `String → Int` via `string.len`), WASM trapped with `indirect call type mismatch` (exit 134) while native produced the mapped collection.

## Root cause
- `map.map` (`emit_wasm/calls_map_closure.rs`) byte-copied the source COD table at the **source** value stride and called the closure via `call_indirect` typed `(V) → V`. When the return type `B ≠ V`, the type index didn't match the closure's real `(V) → B` function type → trap; the store width was also wrong.
- `set.map` (`calls_set.rs`) ran the dedup pass at `set_elem_ty(source)` (= `V`), reading/writing the wrong byte width when `B ≠ V`.

## Fix (WASM-only; native untouched)
New `resolve_closure_ret_ty` helper derives the closure's concrete return `Ty` (`Ty::Fn.ret` → lambda body `.ty` → the lifted closure's registered WASM return valtype). `map.map` rebuilds a **fresh** COD table at the new value stride (memcpy the value-width-independent header+tags+index prefix to preserve insertion order & hash index, then per entry: memcpy key + closure-call typed `(V) → B` + store at `B`'s width). `set.map` dedups at the resolved result type. Degenerates to the old path when `B == V`.

## Validation
- New corpus `spec/wasm_cross/map_set_typechange.almd` — byte-identical native==wasm.
- 2-prober adversarial sweep (map.map & set.map: String↔Int, Int↔Float, Int→Bool, Int→tuple, Int→List, same-type regression) — zero divergence. (Composite *result elements/keys* now also work via the structural eq/hash from #366, merged in.)
- Gate green; native spec 241/241; WASM 233/0; `cargo test` green.