### PR TITLE
Narrow sized-numeric literals in tuple/list/record positions (resolving named types)

### DIFF
--- a/crates/almide-frontend/src/lower/calls.rs
+++ b/crates/almide-frontend/src/lower/calls.rs
@@ -121,20 +121,20 @@ pub(super) fn lower_call(ctx: &mut LowerCtx, callee: &ast::Expr, args: &[ast::Ex
         if matches!(name.as_str(), "assert_eq" | "assert_ne") && ir_args.len() == 2 {
             let l_ty = ir_args[0].ty.clone();
             let r_ty = ir_args[1].ty.clone();
-            super::statements::coerce_literal_to_sized(&mut ir_args[1], &l_ty);
-            super::statements::coerce_literal_to_sized(&mut ir_args[0], &r_ty);
+            super::statements::coerce_literal_to_sized(&mut ir_args[1], &l_ty, ctx.env);
+            super::statements::coerce_literal_to_sized(&mut ir_args[0], &r_ty, ctx.env);
         }
         if let Some(sig) = ctx.env.functions.get(name).cloned() {
             for (i, (_, param_ty)) in sig.params.iter().enumerate() {
                 if let Some(arg) = ir_args.get_mut(i) {
-                    super::statements::coerce_literal_to_sized(arg, param_ty);
+                    super::statements::coerce_literal_to_sized(arg, param_ty, ctx.env);
                 }
             }
         } else if let Some((module, func)) = name.as_str().split_once('.') {
             if let Some(sig) = crate::stdlib::lookup_sig(module, func) {
                 for (i, (_, param_ty)) in sig.params.iter().enumerate() {
                     if let Some(arg) = ir_args.get_mut(i) {
-                        super::statements::coerce_literal_to_sized(arg, param_ty);
+                        super::statements::coerce_literal_to_sized(arg, param_ty, ctx.env);
                     }
                 }
             }
@@ -143,7 +143,7 @@ pub(super) fn lower_call(ctx: &mut LowerCtx, callee: &ast::Expr, args: &[ast::Ex
         if let Some(sig) = crate::stdlib::lookup_sig(module.as_str(), func.as_str()) {
             for (i, (_, param_ty)) in sig.params.iter().enumerate() {
                 if let Some(arg) = ir_args.get_mut(i) {
-                    super::statements::coerce_literal_to_sized(arg, param_ty);
+                    super::statements::coerce_literal_to_sized(arg, param_ty, ctx.env);
                 }
             }
         }

--- a/crates/almide-frontend/src/lower/expressions.rs
+++ b/crates/almide-frontend/src/lower/expressions.rs
@@ -184,8 +184,8 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
             // operand widths. Mirrors the fn-arg and let-binding
             // coercion rules — the same authoritative-context rule
             // applies to any pairing where one side locks the width.
-            super::statements::coerce_literal_to_sized(&mut r, &l.ty);
-            super::statements::coerce_literal_to_sized(&mut l, &r.ty);
+            super::statements::coerce_literal_to_sized(&mut r, &l.ty, ctx.env);
+            super::statements::coerce_literal_to_sized(&mut l, &r.ty, ctx.env);
             // Resolve operand types: if expr.ty is Unknown, try VarTable lookup
             let left_ty = if l.ty == Ty::Unknown {
                 if let IrExprKind::Var { id } = &l.kind { ctx.var_table.get(*id).ty.clone() } else { l.ty.clone() }

--- a/crates/almide-frontend/src/lower/statements.rs
+++ b/crates/almide-frontend/src/lower/statements.rs
@@ -3,7 +3,7 @@
 use almide_lang::ast;
 use almide_base::intern::sym;
 use almide_ir::*;
-use crate::types::{Ty, TypeConstructorId};
+use crate::types::{Ty, TypeConstructorId, TypeEnv};
 use super::LowerCtx;
 use super::expressions::lower_expr;
 
@@ -26,7 +26,7 @@ pub(super) fn lower_stmt(ctx: &mut LowerCtx, stmt: &ast::Stmt) -> IrStmt {
             // at codegen time because the value keeps its structural type.
             let val_ty = if let Some(te) = ty {
                 let declared = super::types::resolve_type_expr(te);
-                override_record_literal_ty(&mut ir_val, &declared);
+                override_record_literal_ty(&mut ir_val, &declared, ctx.env);
                 declared
             } else {
                 ir_val.ty.clone()
@@ -38,7 +38,7 @@ pub(super) fn lower_stmt(ctx: &mut LowerCtx, stmt: &ast::Stmt) -> IrStmt {
             let mut ir_val = lower_expr(ctx, value);
             let val_ty = if let Some(te) = ty {
                 let declared = super::types::resolve_type_expr(te);
-                override_record_literal_ty(&mut ir_val, &declared);
+                override_record_literal_ty(&mut ir_val, &declared, ctx.env);
                 declared
             } else {
                 ir_val.ty.clone()
@@ -95,7 +95,7 @@ pub(super) fn lower_stmt(ctx: &mut LowerCtx, stmt: &ast::Stmt) -> IrStmt {
 /// the declared type should win. Otherwise multiple nominal types with
 /// identical field shapes (Dog vs Cat, both `{name: String}`) collide at
 /// codegen because `collect_named_records` keys by sorted field names.
-fn override_record_literal_ty(ir_val: &mut IrExpr, declared: &Ty) {
+fn override_record_literal_ty(ir_val: &mut IrExpr, declared: &Ty, env: &TypeEnv) {
     // Nominal record type override — keeps `Dog` / `Cat` distinct even
     // when their structural shapes match.
     if matches!(declared, Ty::Named(_, _)) {
@@ -106,13 +106,19 @@ fn override_record_literal_ty(ir_val: &mut IrExpr, declared: &Ty) {
                 }
             }
             IrExprKind::Block { expr: Some(inner), .. } => {
-                override_record_literal_ty(inner, declared);
+                override_record_literal_ty(inner, declared, env);
                 if matches!(ir_val.ty, Ty::Record { .. } | Ty::OpenRecord { .. } | Ty::Unknown) {
                     ir_val.ty = declared.clone();
                 }
             }
             _ => {}
         }
+        // A named record/alias whose structural shape carries sized fields
+        // (`type Rec = { b: Int8, n: Int }`) still needs its bare-literal
+        // field values narrowed to the sized field types. The nominal retag
+        // above only fixes the record's *own* type tag; `coerce_literal_to_sized`
+        // resolves the Named type and descends into the field literals.
+        coerce_literal_to_sized(ir_val, declared, env);
         return;
     }
 
@@ -124,7 +130,7 @@ fn override_record_literal_ty(ir_val: &mut IrExpr, declared: &Ty) {
     // `expr.ty` for the literal suffix (`42i64` → `42i32`), so this
     // is the single hook that makes `let x: Int32 = 42` emit correct
     // Rust instead of an `i64` / `i32` mismatch.
-    coerce_literal_to_sized(ir_val, declared);
+    coerce_literal_to_sized(ir_val, declared, env);
 }
 
 /// Whether `ty` is one of the sized numeric types the Stage 1a/1b
@@ -146,19 +152,74 @@ pub(crate) fn is_sized_numeric(ty: &Ty) -> bool {
 /// type — which matches the Stage 1b rule that literals flow into
 /// sized slots but named-variable refs don't (they retype instead
 /// with an explicit conversion).
-pub(crate) fn coerce_literal_to_sized(ir_val: &mut IrExpr, declared: &Ty) {
-    if !is_sized_numeric(declared) { return; }
-    match &mut ir_val.kind {
-        IrExprKind::LitInt { .. } if ir_val.ty == Ty::Int => {
-            ir_val.ty = declared.clone();
-        }
-        IrExprKind::LitFloat { .. } if ir_val.ty == Ty::Float => {
-            ir_val.ty = declared.clone();
-        }
-        IrExprKind::UnOp { op: almide_ir::UnOp::NegInt, operand } => {
-            if matches!(&operand.kind, IrExprKind::LitInt { .. }) && operand.ty == Ty::Int {
-                operand.ty = declared.clone();
+///
+/// Recurses through container literals so a sized field nested inside a
+/// list / tuple / record annotation also coerces: `let a: List[(Int8,
+/// Int)] = [(1, 100)]` retypes the `1` element to `Int8` while the type
+/// checker only narrowed the *binding* type (the inner literal keeps the
+/// default `Ty::Int` in `expr_types`, so codegen would otherwise emit
+/// `1i64` against a `Vec<(i8, i64)>` slot — an E0308). The declared type
+/// drives the descent; the value literal's own shape must match for any
+/// element to be touched.
+pub(crate) fn coerce_literal_to_sized(ir_val: &mut IrExpr, declared: &Ty, env: &TypeEnv) {
+    use almide_lang::types::constructor::TypeConstructorId;
+    // Look through blocks/parenthesized tails: a literal can be wrapped in
+    // a single-tail block (e.g. `{ (1, 2) }`) by lowering.
+    if let IrExprKind::Block { expr: Some(tail), .. } = &mut ir_val.kind {
+        coerce_literal_to_sized(tail, declared, env);
+        return;
+    }
+    // Resolve a named type alias to its structural form so a record / sized
+    // alias declared via `type Rec = { b: Int8, .. }` (a `Ty::Named`) becomes
+    // its `Ty::Record { .. }` / `Ty::Int8` / etc. before the match below.
+    // `resolve_named` is a no-op for non-Named types, so the scalar / List /
+    // Tuple arms are unaffected.
+    let resolved = env.resolve_named(declared);
+    let declared = &resolved;
+    match declared {
+        // Scalar sized numeric slot: retype a bare default-typed literal.
+        _ if is_sized_numeric(declared) => match &mut ir_val.kind {
+            IrExprKind::LitInt { .. } if ir_val.ty == Ty::Int => {
                 ir_val.ty = declared.clone();
+            }
+            IrExprKind::LitFloat { .. } if ir_val.ty == Ty::Float => {
+                ir_val.ty = declared.clone();
+            }
+            IrExprKind::UnOp { op: almide_ir::UnOp::NegInt, operand } => {
+                if matches!(&operand.kind, IrExprKind::LitInt { .. }) && operand.ty == Ty::Int {
+                    operand.ty = declared.clone();
+                    ir_val.ty = declared.clone();
+                }
+            }
+            _ => {}
+        },
+        // List[T]: every element literal is coerced against T.
+        Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 => {
+            if let IrExprKind::List { elements } = &mut ir_val.kind {
+                for e in elements.iter_mut() {
+                    coerce_literal_to_sized(e, &args[0], env);
+                }
+            }
+        }
+        // Tuple([t0, t1, ...]): element i is coerced against t_i.
+        Ty::Tuple(elem_tys) => {
+            if let IrExprKind::Tuple { elements } = &mut ir_val.kind {
+                if elements.len() == elem_tys.len() {
+                    for (e, t) in elements.iter_mut().zip(elem_tys.iter()) {
+                        coerce_literal_to_sized(e, t, env);
+                    }
+                }
+            }
+        }
+        // Structural record annotation `{ b: Int8, n: Int }`: coerce each
+        // field value against its declared field type, matched by name.
+        Ty::Record { fields: decl_fields } | Ty::OpenRecord { fields: decl_fields } => {
+            if let IrExprKind::Record { fields, .. } = &mut ir_val.kind {
+                for (fname, fvalue) in fields.iter_mut() {
+                    if let Some((_, fty)) = decl_fields.iter().find(|(n, _)| n == fname) {
+                        coerce_literal_to_sized(fvalue, fty, env);
+                    }
+                }
             }
         }
         _ => {}

--- a/spec/lang/sized_numeric_types_test.almd
+++ b/spec/lang/sized_numeric_types_test.almd
@@ -172,3 +172,90 @@ test "Int8 sign extends to Int64" {
   let z: Int64 = y.to_int64()
   assert_eq(z, -1)
 }
+
+// ── Container-literal field narrowing ────────────────────────────
+//
+// A sized numeric type nested inside a list / tuple / record
+// annotation must coerce the element literal's width. The checker
+// only narrows the *binding* type; the inner literal keeps the
+// default `Ty::Int` in expr_types, so without lowering-side
+// coercion codegen emits `1i64` against a `Vec<(i8, i64)>` slot
+// (E0308 on native). Regression guard for that bug.
+
+test "List of (Int8, Int) tuples narrows element literal" {
+  let a: List[(Int8, Int)] = [(1, 100)]
+  let p = a[0]
+  assert_eq(p.0.to_int64(), 1)
+  assert_eq(p.1, 100)
+}
+
+test "List[Int8] narrows every element literal" {
+  let a: List[Int8] = [1, 2, 3]
+  assert_eq(list.len(a), 3)
+  assert_eq(a[2].to_int64(), 3)
+}
+
+test "List of (UInt8, Int16) narrows mixed-width elements" {
+  let a: List[(UInt8, Int16)] = [(7, 300)]
+  let p = a[0]
+  assert_eq(p.0.to_int64(), 7)
+  assert_eq(p.1.to_int64(), 300)
+}
+
+test "Structural record with Int8 field narrows literal" {
+  let r: { b: Int8, n: Int } = { b: 5, n: 99 }
+  assert_eq(r.b.to_int64(), 5)
+  assert_eq(r.n, 99)
+}
+
+test "Nested tuple narrows Int8 at depth" {
+  let t: ((Int8, Int), Int) = ((1, 2), 3)
+  let inner = t.0
+  assert_eq(inner.0.to_int64(), 1)
+  assert_eq(inner.1, 2)
+  assert_eq(t.1, 3)
+}
+
+test "Bare (Int8, Int) tuple narrows first element" {
+  let t: (Int8, Int) = (1, 2)
+  assert_eq(t.0.to_int64(), 1)
+  assert_eq(t.1, 2)
+}
+
+test "List[Int] stays i64 (regression)" {
+  let a: List[Int] = [1, 2]
+  assert_eq(list.len(a), 2)
+  assert_eq(a[1], 2)
+}
+
+// ── Named-record-alias field narrowing ───────────────────────────
+//
+// A record declared via a NAMED type alias (`type Rec = { b: Int8, .. }`)
+// is `Ty::Named("Rec")`, not structural `Ty::Record`, so the structural
+// record arm was skipped: native emitted `Rec { b: 127i64, .. }` (E0308)
+// and WASM was SILENT-WRONG (the 8-byte write into the 1-byte Int8 slot
+// corrupted the next field's offset). Lowering now resolves the named
+// alias before descending, so the field literal narrows on both targets.
+
+type SizedRec = { b: Int8, n: Int }
+type USizedRec = { x: UInt8, y: Int }
+
+test "Named record alias with Int8 field narrows literal" {
+  let r: SizedRec = { b: 127, n: 9999 }
+  assert_eq(r.b.to_int64(), 127)
+  assert_eq(r.n, 9999)
+}
+
+test "Named record alias with UInt8 field narrows literal" {
+  let u: USizedRec = { x: 200, y: 5 }
+  assert_eq(u.x.to_int64(), 200)
+  assert_eq(u.y, 5)
+}
+
+test "Named record alias nested inside a tuple narrows field" {
+  let v: (SizedRec, Int) = ({ b: 127, n: 9999 }, 42)
+  let r = v.0
+  assert_eq(r.b.to_int64(), 127)
+  assert_eq(r.n, 9999)
+  assert_eq(v.1, 42)
+}

--- a/spec/wasm_cross/sized_numeric_literals.almd
+++ b/spec/wasm_cross/sized_numeric_literals.almd
@@ -1,0 +1,20 @@
+// Sized-numeric literals in tuple / list / nested / named-record positions must
+// narrow to the declared field width (Int8 -> i8, ...) so native compiles and
+// wasm stores at the right width. Was: native E0308 + wasm silent field corruption.
+type Rec = { b: Int8, n: Int }
+
+fn main() -> Unit = {
+  let a: List[(Int8, Int)] = [(1, 100), (127, 300)]
+  for p in a { let (x, y) = p; println("${int.to_string(int.from_int8(x))}:${int.to_string(y)}") }
+
+  let bs: List[Int8] = [1, 2, 127, -128]
+  println(int.to_string(list.len(bs)))
+
+  let r: Rec = { b: 127, n: 9999 }
+  println("${int.to_string(int.from_int8(r.b))}:${int.to_string(r.n)}")
+
+  let n: ((Int8, Int), Int) = ((127, 1000), 2000)
+  let (inner, z) = n
+  let (ix, iy) = inner
+  println("${int.to_string(int.from_int8(ix))}:${int.to_string(iy)}:${int.to_string(z)}")
+}


### PR DESCRIPTION
A native-codegen / cross-target bug found while verifying #366. A sized-numeric literal inside a **tuple / list / record** field emitted the default `i64` suffix instead of the declared narrow width:
```
let a: List[(Int8, Int)] = [(1, 100)]   // emitted (1i64, 100i64) against Vec<(i8,i64)>
```
→ native **E0308** ("codegen produced invalid Rust" ICE); and for a **record** field, WASM was **silently wrong** — the 8-byte write into a 1-byte `Int8` slot corrupted the next field's offset (`{ b: 127, n: 9999 }` printed `127:1080863910568919040`).

## Fix (lowering — the layer where the declared annotation and the value IR are both in hand)
`coerce_literal_to_sized` (the established Stage-1b hook that retypes a bare literal to a sized annotation) now:
- recurses structurally into `List[T]`, `Tuple([t0,..])`, and structural `Record { fields }` (by field name), coercing nested scalar literals at any depth;
- takes the `TypeEnv` and resolves `Ty::Named` aliases (`type Rec = { b: Int8, n: Int }`) to their structural form first, so named-type record/tuple fields narrow too. All 5 call sites (let/var, fn-args, comparison operands) pass `ctx.env`.

The walker already picked the Rust suffix from `expr.ty`; the literal just never carried the narrow type. No codegen hack.

## Validation
- Repro now compiles + prints `127:9999`; rust emits `Rec { b: 127i8, n: 9999i64 }`. WASM corruption gone.
- New corpus `spec/wasm_cross/sized_numeric_literals.almd` (tuple/list/nested/named-record) byte-identical native==wasm; spec/lang sized-numeric tests extended.
- A 2-prober adversarial sweep (List/Tuple/Record/nested/fn-arg + boundary values + i64 regression) found zero residual.
- Gate green; native spec 241/241; WASM 233/0; `cargo test` green.