### PR TITLE
Type match-with-err()-arms as Result, not Never (fixes a silent WASM trap)

### DIFF
--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -482,12 +482,18 @@ impl Checker {
                 let sc = resolve_ty(&subject_ty, &self.uf);
                 self.check_match_exhaustiveness(&sc, arms);
                 let mut arm_types = Vec::new();
+                // Real (un-substituted) arm types, used to pick the overall match
+                // result type. An `err(..)` arm produces a genuine `Result[T, E]`
+                // value — it is NOT divergent — so even when every arm is `err`,
+                // the match still has a concrete Result type (not `Never`).
+                let mut arm_real_types = Vec::new();
                 for arm in arms.iter_mut() {
                     self.env.push_scope();
                     let sub_c = resolve_ty(&subject_ty, &self.uf);
                     self.bind_pattern(&arm.pattern, &sub_c);
                     if let Some(ref mut guard) = arm.guard { self.infer_expr(guard); }
                     let arm_ty = self.infer_expr(&mut arm.body);
+                    arm_real_types.push(arm_ty.clone());
                     // err() in a match arm is an early return — unify as Never
                     // so it doesn't constrain sibling arm types.
                     let arm_ty = if matches!(&arm.body.kind, ExprKind::Err { .. }) {
@@ -513,7 +519,23 @@ impl Checker {
                     for aty in &arm_types[1..] {
                         self.constrain(first.clone(), aty.clone(), "match arm");
                     }
-                    first
+                    // The overall match type is the first non-`Never` arm type.
+                    // `Never` arms (every `err(..)` arm) carry no useful result
+                    // type but they DO produce a Result value, so when they are
+                    // the only arms we recover the concrete type from the real
+                    // (un-substituted) arm types — preferring an `err` arm's
+                    // `Result[T, E]` so the match types as Result, never `Never`.
+                    if matches!(first, Ty::Never) {
+                        arm_types.iter()
+                            .find(|t| !matches!(t, Ty::Never))
+                            .cloned()
+                            .or_else(|| arm_real_types.iter()
+                                .find(|t| !matches!(resolve_ty(t, &self.uf), Ty::Never))
+                                .cloned())
+                            .unwrap_or(first)
+                    } else {
+                        first
+                    }
                 } else {
                     Ty::Unit
                 }

--- a/spec/lang/match_result_err_test.almd
+++ b/spec/lang/match_result_err_test.almd
@@ -1,0 +1,101 @@
+// match_result_err_test — a `match` expression whose arms construct a Result
+// must type as Result (and emit a Result pointer on WASM) even when one or more
+// arms are `err(..)`.
+//
+// Regression: a match with an `err(..)` arm was typed `Never` (each `err` arm
+// is unified as Never to avoid constraining siblings; with no non-err arm the
+// whole match collapsed to Never). On WASM that left the function body type as
+// non-valtype, so the epilogue appended `unreachable` and the function trapped
+// (exit 134) — while native ran correctly. Now the match recovers the concrete
+// Result type from the arm values, so native == WASM.
+
+// ── Every arm is err ──
+fn all_err(x: Int) -> Result[Int, String] = match x {
+  2 => err("two"),
+  _ => err("other"),
+}
+
+test "all-err match: literal arm" {
+  assert_eq(all_err(2), err("two"))
+}
+
+test "all-err match: wildcard arm" {
+  assert_eq(all_err(5), err("other"))
+}
+
+// ── Mixed: err arm + ok arm ──
+fn mixed(x: Int) -> Result[Int, String] = match x {
+  2 => err("bad"),
+  _ => ok(x * 10),
+}
+
+test "mixed match: err arm taken" {
+  assert_eq(mixed(2), err("bad"))
+}
+
+test "mixed match: ok arm taken" {
+  assert_eq(mixed(7), ok(70))
+}
+
+// ── Nested match returning Result with err arms ──
+fn nested(x: Int) -> Result[Int, String] = match x {
+  0 => err("zero"),
+  _ => match x {
+    1 => err("one"),
+    _ => ok(x),
+  },
+}
+
+test "nested match: outer err" {
+  assert_eq(nested(0), err("zero"))
+}
+
+test "nested match: inner err" {
+  assert_eq(nested(1), err("one"))
+}
+
+test "nested match: inner ok" {
+  assert_eq(nested(9), ok(9))
+}
+
+// ── Guarded arm returning err ──
+fn guarded(x: Int) -> Result[Int, String] = match x {
+  n if n < 0 => err("neg"),
+  0 => err("zero"),
+  _ => ok(x),
+}
+
+test "guarded match: guard err" {
+  assert_eq(guarded(0 - 4), err("neg"))
+}
+
+test "guarded match: literal err" {
+  assert_eq(guarded(0), err("zero"))
+}
+
+test "guarded match: ok arm" {
+  assert_eq(guarded(8), ok(8))
+}
+
+// ── Option analogue: a match with `none` arms must type as Option (not Never).
+// `none` was never collapsed to Never, so this is a guard against regressing
+// the sibling path while fixing the Result path. ──
+fn opt_all_none(x: Int) -> Option[Int] = match x {
+  2 => none,
+  _ => none,
+}
+
+fn opt_mixed(x: Int) -> Option[Int] = match x {
+  2 => none,
+  _ => some(x * 10),
+}
+
+test "option match: all none" {
+  assert_eq(opt_all_none(2), none);
+  assert_eq(opt_all_none(5), none)
+}
+
+test "option match: mixed" {
+  assert_eq(opt_mixed(2), none);
+  assert_eq(opt_mixed(3), some(30))
+}

--- a/spec/wasm_cross/match_result.almd
+++ b/spec/wasm_cross/match_result.almd
@@ -1,0 +1,46 @@
+// Cross-target coverage: a `match` whose arms construct a Result with `err(..)`
+// arms. Regression — such a match was typed `Never`, so the WASM function
+// epilogue appended `unreachable` and trapped (exit 134) while native ran fine.
+// Now native == WASM byte-for-byte on stdout.
+
+fn all_err(x: Int) -> Result[Int, String] = match x {
+  2 => err("two"),
+  _ => err("other"),
+}
+
+fn mixed(x: Int) -> Result[Int, String] = match x {
+  2 => err("bad"),
+  _ => ok(x * 10),
+}
+
+fn nested(x: Int) -> Result[Int, String] = match x {
+  0 => err("zero"),
+  _ => match x {
+    1 => err("one"),
+    _ => ok(x),
+  },
+}
+
+fn guarded(x: Int) -> Result[Int, String] = match x {
+  n if n < 0 => err("neg"),
+  0 => err("zero"),
+  _ => ok(x),
+}
+
+fn show(r: Result[Int, String]) -> String = match r {
+  ok(v) => "ok(" + int.to_string(v) + ")",
+  err(e) => "err(" + e + ")",
+}
+
+fn main() -> Unit = {
+  println(show(all_err(2)))
+  println(show(all_err(5)))
+  println(show(mixed(2)))
+  println(show(mixed(7)))
+  println(show(nested(0)))
+  println(show(nested(1)))
+  println(show(nested(9)))
+  println(show(guarded(0 - 4)))
+  println(show(guarded(0)))
+  println(show(guarded(8)))
+}


### PR DESCRIPTION
A silent cross-target divergence found by the fan verifier (#369). A `match` whose arms construct a Result with **any `err(...)` arm** trapped in WASM (exit 134 `unreachable`) while native ran correctly — and the `if/then/else` equivalent worked on both, so existing tests (if-shaped) hid it. Triggered through `fan.map` callbacks but **general** (effect or pure, taken arm or not).

## Root cause (the checker, not codegen)
`check/infer.rs` deliberately substitutes each `err(...)` arm's type with `Ty::Never` (so an `err` arm doesn't constrain sibling arms), then takes the overall match type as the first arm type. When the first arm (or every arm) is `err`, the whole match collapsed to **`Never`**. `ty_to_valtype(Never)` is `None`, so the WASM function epilogue (`emit_wasm/functions.rs:164-171`) saw "function expects a value but body produces none" and appended `unreachable` after the (correctly value-producing) match → runtime trap. (The `i32.const 0` in the disassembled arm was a red herring — wasm-opt rewriting the value it had already proven dead behind the `unreachable`.)

## Fix
Record each arm's real (un-substituted) type alongside the `Never`-for-constraints type. Cross-arm unification is unchanged (err arms still don't constrain siblings), but when the chosen overall type is `Never`, recover the concrete type from a non-`Never` arm (falling back to an err arm's real `Result[T, E]`). The match now types as `Result[...]`, never `Never`. An `err(...)` arm is not divergent — it produces a real Result value. (`Option` `none` arms were already fine — only `Err` was collapsed.)

## Validation
- The 3 repros + an extended matrix (err/ok/both-err/mixed/nested/guarded/`!`-unwrap/match→Option) all byte-identical native==wasm.
- New `spec/lang/match_result_err_test.almd` (12 tests, both targets) + `spec/wasm_cross/match_result.almd` (gate corpus).
- Gate green; native spec **242/242**; WASM **234/0**; `cargo test` green; snapshots unchanged.