### PR TITLE
Full-Unicode WASM string case ops via oracle-derived tables (cluster A-case)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls.rs
@@ -789,11 +789,11 @@ impl FuncCompiler<'_> {
                     }
                     "to_upper" | "string.to_upper" if matches!(object.ty, Ty::String) => {
                         self.emit_expr(object);
-                        self.emit_str_case_convert(true);
+                        wasm!(self.func, { call(self.emitter.rt.string.to_upper); });
                     }
                     "to_lower" | "string.to_lower" if matches!(object.ty, Ty::String) => {
                         self.emit_expr(object);
-                        self.emit_str_case_convert(false);
+                        wasm!(self.func, { call(self.emitter.rt.string.to_lower); });
                     }
                     "starts_with" | "string.starts_with" | "ends_with" | "string.ends_with" if matches!(object.ty, Ty::String) => {
                         let m = method.strip_prefix("string.").unwrap_or(method);

--- a/crates/almide-codegen/src/emit_wasm/calls_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string.rs
@@ -271,22 +271,8 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { call(self.emitter.rt.string.to_lower); });
             }
             "capitalize" => {
-                let s = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); i32_eqz;
-                    if_i32; local_get(s);
-                    else_;
-                      local_get(s); i32_const(0); i32_const(1);
-                      call(self.emitter.rt.string.slice);
-                      call(self.emitter.rt.string.to_upper);
-                      local_get(s); i32_const(1); local_get(s); i32_load(0);
-                      call(self.emitter.rt.string.slice);
-                      call(self.emitter.rt.concat_str);
-                    end;
-                });
-                self.scratch.free_i32(s);
+                wasm!(self.func, { call(self.emitter.rt.string.capitalize); });
             }
             "chars" => {
                 self.emit_expr(&args[0]);
@@ -805,118 +791,5 @@ impl FuncCompiler<'_> {
                 }
             }
         }
-    }
-
-    /// ASCII case conversion. Expects string ptr on stack. Returns new string ptr.
-    pub(super) fn emit_str_case_convert(&mut self, is_upper: bool) {
-        // String ptr is on stack. Store to scratch local.
-        let src = self.scratch.alloc_i32();
-        let dst = self.scratch.alloc_i32();
-        let s = self.scratch.alloc_i32();
-        let s1 = self.scratch.alloc_i32();
-        wasm!(self.func, {
-            local_set(src);
-            // Alloc dst with same len: [len:i32][cap:i32][data...]
-            i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32);
-            local_get(src);
-            i32_load(0);
-            i32_add;
-            call(self.emitter.rt.alloc);
-            local_set(dst);
-            // Store len in dst
-            local_get(dst);
-            local_get(src);
-            i32_load(0);
-            i32_store(0);
-            // Store cap = len in dst
-            local_get(dst);
-            local_get(src);
-            i32_load(0);
-            i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32);
-        });
-        // Loop: convert each byte
-        wasm!(self.func, {
-            i32_const(0);
-            local_set(s);
-            block_empty;
-            loop_empty;
-        });
-        let depth_guard = self.depth_push_n(2);
-        wasm!(self.func, {
-            local_get(s);
-            local_get(src);
-            i32_load(0);
-            i32_ge_u;
-            br_if(1);
-            // dst addr
-            local_get(dst);
-            i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
-            i32_add;
-            local_get(s);
-            i32_add;
-            // src byte
-            local_get(src);
-            i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
-            i32_add;
-            local_get(s);
-            i32_add;
-            i32_load8_u(0);
-            // Convert
-            local_set(s1);
-        });
-        if is_upper {
-            wasm!(self.func, {
-                local_get(s1);
-                i32_const(97);
-                i32_ge_u;
-                local_get(s1);
-                i32_const(122);
-                i32_le_u;
-                i32_and;
-                if_i32;
-                local_get(s1);
-                i32_const(32);
-                i32_sub;
-                else_;
-                local_get(s1);
-                end;
-            });
-        } else {
-            wasm!(self.func, {
-                local_get(s1);
-                i32_const(65);
-                i32_ge_u;
-                local_get(s1);
-                i32_const(90);
-                i32_le_u;
-                i32_and;
-                if_i32;
-                local_get(s1);
-                i32_const(32);
-                i32_add;
-                else_;
-                local_get(s1);
-                end;
-            });
-        }
-        wasm!(self.func, {
-            i32_store8(0);
-            local_get(s);
-            i32_const(1);
-            i32_add;
-            local_set(s);
-            br(0);
-        });
-        self.depth_pop(depth_guard);
-        wasm!(self.func, {
-            end;
-            end;
-            // Return dst
-            local_get(dst);
-        });
-        self.scratch.free_i32(s1);
-        self.scratch.free_i32(s);
-        self.scratch.free_i32(dst);
-        self.scratch.free_i32(src);
     }
 }

--- a/crates/almide-codegen/src/emit_wasm/dce.rs
+++ b/crates/almide-codegen/src/emit_wasm/dce.rs
@@ -138,7 +138,17 @@ pub fn eliminate_dead_data(emitter: &mut WasmEmitter) -> usize {
     new_data.push(emitter.data_bytes[0]);
     old_to_new.insert(data_start, data_start); // newline stays at same offset
 
-    let mut read_pos = 1usize; // skip newline
+    // Preserve the embedded Unicode case-table region verbatim. It sits at the
+    // FRONT of data_bytes (right after the newline byte) and must NOT be walked as
+    // interned-string `[len][cap][data]` entries (its raw bytes would misparse and
+    // corrupt the keep/compact loop + heap), nor shift when dead strings are
+    // compacted (the case lookup functions bake its absolute addresses). Copy it
+    // through unchanged and begin the interned-string walk after it.
+    let table_bytes = emitter.case_table_bytes;
+    if table_bytes > 0 {
+        new_data.extend_from_slice(&emitter.data_bytes[1..1 + table_bytes]);
+    }
+    let mut read_pos = 1usize + table_bytes; // skip newline + case tables
     while read_pos + 8 <= emitter.data_bytes.len() {
         let old_offset = data_start + read_pos as u32;
         let slen = u32::from_le_bytes([

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -23,6 +23,7 @@ mod runtime;
 mod runtime_eq;
 mod rt_string;
 mod rt_string_extra;
+mod rt_string_case;
 mod rt_numeric;
 mod rt_dragon;
 mod expressions;
@@ -202,6 +203,33 @@ pub struct StringRuntime {
     /// char boundary (clamped to [0, byte_len]). Mirrors native `slice`'s
     /// boundary-safe byte indexing.
     pub utf8_snap: u32,
+    // ── Full-Unicode case folding (oracle-derived tables in `rt_string_case`) ──
+    /// `__utf8_emit_scalar(dst, byte_off, scalar) -> i32`: encode `scalar` as
+    /// UTF-8 at `dst`'s data section + byte_off; returns the advanced byte_off.
+    pub utf8_emit_scalar: u32,
+    /// `__case_map_lookup(map_sel, scalar) -> i32`: binary-search the UPPER(0) /
+    /// LOWER(1) map; returns the absolute address of the `[len][bytes]` value
+    /// record, or -1 on miss (identity).
+    pub case_map_lookup: u32,
+    /// `__set_member(set_sel, scalar) -> i32`: 1 iff `scalar` is in the
+    /// CASED(0) / CASE_IGNORABLE(1) sorted key array.
+    pub set_member: u32,
+    /// `__final_sigma(s, byte_off) -> i32`: ς(U+03C2) or σ(U+03C3) for a Σ at
+    /// `byte_off`, per the Unicode Final_Sigma context rule.
+    pub final_sigma: u32,
+    /// `__str_case_map(s, is_upper) -> i32`: the unified two-pass case driver.
+    pub str_case_map: u32,
+    /// `__str_capitalize(s) -> i32`: first scalar uppercased, rest verbatim.
+    pub capitalize: u32,
+}
+
+/// Absolute linear-memory addresses + counts of the embedded case tables.
+#[derive(Clone, Copy)]
+struct CaseTableOffsets {
+    upper_keys: u32, upper_offs: u32, upper_n: u32,
+    lower_keys: u32, lower_offs: u32, lower_n: u32,
+    cased: u32, cased_n: u32,
+    ci: u32, ci_n: u32,
 }
 
 /// Indices of built-in runtime functions.
@@ -331,6 +359,14 @@ pub struct WasmEmitter {
     strings: HashMap<String, u32>,
     data_bytes: Vec<u8>,
 
+    /// Embedded Unicode case-mapping table offsets (Some only when the program
+    /// uses string case ops — see `embed_case_tables` / `program_uses_case_op`).
+    case_tables: Option<CaseTableOffsets>,
+    /// Total bytes of the case-table region at the FRONT of `data_bytes` (after
+    /// the newline byte). `eliminate_dead_data` skips this region so the table
+    /// is never misparsed as interned-string entries. 0 when no case op.
+    pub case_table_bytes: usize,
+
     // Runtime function indices
     pub rt: RuntimeFuncs,
 
@@ -418,6 +454,8 @@ impl WasmEmitter {
             strings: HashMap::new(),
             // First byte is newline at NEWLINE_OFFSET
             data_bytes: vec![0x0A],
+            case_tables: None,
+            case_table_bytes: 0,
             rt: RuntimeFuncs {
                 fd_write: 0, alloc: 0, rc_inc: 0, rc_dec: 0, cow_check: 0,
                 heap_save: 0, heap_restore: 0, heap_start_global: 0,
@@ -457,6 +495,12 @@ impl WasmEmitter {
                     utf8_scalar: 0,
                     utf8_byte_of_cp: 0,
                     utf8_snap: 0,
+                    utf8_emit_scalar: 0,
+                    case_map_lookup: 0,
+                    set_member: 0,
+                    final_sigma: 0,
+                    str_case_map: 0,
+                    capitalize: 0,
                 },
                 value_stringify: 0,
                 json_escape_string: 0,
@@ -543,6 +587,61 @@ impl WasmEmitter {
     /// Add a compiled function body.
     pub fn add_compiled(&mut self, compiled: CompiledFunc) {
         self.compiled.push(compiled);
+    }
+
+    /// Embed the oracle-derived Unicode case tables at the FRONT of `data_bytes`
+    /// (immediately after the newline byte), recording their absolute addresses.
+    ///
+    /// Placement at the front is MANDATORY: it sits at a fixed low offset that
+    /// never moves when interned string literals (appended later, during function
+    /// compilation) are compacted by `eliminate_dead_data`. Must be called once,
+    /// before any string is interned (asserted), so the baked `i32_const` offsets
+    /// in the case runtime functions stay valid for the life of the module.
+    fn embed_case_tables(&mut self) {
+        debug_assert_eq!(
+            self.data_bytes.len(), 1,
+            "case tables must be embedded before any string interning"
+        );
+        let t = rt_string_case::generate_case_tables();
+
+        fn pad4(db: &mut Vec<u8>) {
+            while db.len() % 4 != 0 { db.push(0); }
+        }
+        fn push_u32s(db: &mut Vec<u8>, arr: &[u32]) -> u32 {
+            pad4(db);
+            let base = NEWLINE_OFFSET + db.len() as u32;
+            for &x in arr { db.extend_from_slice(&x.to_le_bytes()); }
+            base
+        }
+        fn push_bytes(db: &mut Vec<u8>, bytes: &[u8]) -> u32 {
+            let base = NEWLINE_OFFSET + db.len() as u32;
+            db.extend_from_slice(bytes);
+            base
+        }
+
+        // For each map: place VALS first so its base is known, then bake the OFFS
+        // array as ABSOLUTE addresses into VALS, then the KEYS search array.
+        let db = &mut self.data_bytes;
+        let upper_vals = push_bytes(db, &t.upper.vals);
+        let upper_keys = push_u32s(db, &t.upper.keys);
+        let upper_offs_abs: Vec<u32> = t.upper.val_offsets.iter().map(|o| upper_vals + o).collect();
+        let upper_offs = push_u32s(db, &upper_offs_abs);
+
+        let lower_vals = push_bytes(db, &t.lower.vals);
+        let lower_keys = push_u32s(db, &t.lower.keys);
+        let lower_offs_abs: Vec<u32> = t.lower.val_offsets.iter().map(|o| lower_vals + o).collect();
+        let lower_offs = push_u32s(db, &lower_offs_abs);
+
+        let cased = push_u32s(db, &t.cased);
+        let ci = push_u32s(db, &t.case_ignorable);
+
+        self.case_table_bytes = self.data_bytes.len() - 1;
+        self.case_tables = Some(CaseTableOffsets {
+            upper_keys, upper_offs, upper_n: t.upper.keys.len() as u32,
+            lower_keys, lower_offs, lower_n: t.lower.keys.len() as u32,
+            cased, cased_n: t.cased.len() as u32,
+            ci, ci_n: t.case_ignorable.len() as u32,
+        });
     }
 }
 
@@ -682,6 +781,13 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
                 );
             }
         }
+    }
+
+    // Embed the Unicode case-mapping tables at the FRONT of the data section
+    // (while data_bytes is still just the newline byte) when the program uses any
+    // string case op. Gated to keep non-case-folding modules lean (~51KB tables).
+    if program_uses_case_op(program) {
+        emitter.embed_case_tables();
     }
 
     // Phase 1: Register types and function indices
@@ -1522,9 +1628,20 @@ fn assemble(emitter: &mut WasmEmitter) -> Vec<u8> {
     // The heap grows upward via `__alloc`. There is no reserved scratch
     // region — string interpolation builds results inline directly on the
     // heap (see `calls_string::emit_string_interp`).
+    // Data layout: [data bytes][8-byte alignment][heap...]. The active data
+    // segment (newline + embedded case tables + interned string literals) is
+    // written into linear memory at instantiation, so the INITIAL memory must
+    // already cover it — derive the page count from the heap start (>= data_end)
+    // rather than a fixed 2 pages. The ~51KB case tables roughly halve the
+    // literal headroom of the old fixed 128KB minimum, so a large-literal
+    // case-folding program could otherwise overrun it and fail to instantiate.
+    let data_end = NEWLINE_OFFSET + emitter.data_bytes.len() as u32;
+    let heap_start_aligned = (data_end + 7) & !7;
+    const WASM_PAGE_BYTES: u32 = 65536;
+    let min_pages = heap_start_aligned.div_ceil(WASM_PAGE_BYTES).max(2);
     let mut memory = MemorySection::new();
     memory.memory(MemoryType {
-        minimum: 2,             // 128KB initial — minimal footprint; allocator grows exponentially
+        minimum: min_pages as u64,  // covers the full data region; allocator grows from here
         maximum: Some(65536),   // 4GB max (WASM32 hard limit) — explicit so V8 doesn't apply a smaller default
         memory64: false,
         shared: false,
@@ -1534,9 +1651,6 @@ fn assemble(emitter: &mut WasmEmitter) -> Vec<u8> {
 
     // ── Global section ──
     let mut globals = GlobalSection::new();
-    // Data layout: [data bytes][8-byte alignment][heap...]
-    let data_end = NEWLINE_OFFSET + emitter.data_bytes.len() as u32;
-    let heap_start_aligned = (data_end + 7) & !7;
     // Global 0: heap pointer (memory 0)
     globals.global(
         GlobalType {
@@ -2233,6 +2347,71 @@ mod tests {
 }
 
 /// Scan IR program for filesystem module calls (fs.read_text, fs.write_text, etc.).
+/// True iff the program references `string.to_upper` / `to_lower` / `capitalize`
+/// in any form (resolved module call, unresolved method call, or runtime call).
+/// Conservative by design: matching every dispatch form the emitter handles means
+/// the pre-scan never misses a reachable case op (a miss would leave the always-
+/// compiled case lookup functions baking stale offsets — silently wrong).
+fn program_uses_case_op(program: &IrProgram) -> bool {
+    use almide_ir::{IrExprKind, CallTarget};
+    use almide_ir::visit::{IrVisitor, walk_expr, walk_stmt};
+
+    fn is_case_fn(name: &str) -> bool {
+        // Accept both the bare method name and a "string."-qualified one: the
+        // Module arm sees a bare `func`, but the unresolved Method arm (and the
+        // calls.rs UFCS fallback) can carry a dotted "string.to_upper". Missing a
+        // form would leave the case tables un-embedded while the runtime fns stay
+        // DCE-live — silently wrong, so keep this strictly broader than dispatch.
+        let name = name.strip_prefix("string.").unwrap_or(name);
+        matches!(name, "to_upper" | "to_lower" | "capitalize")
+    }
+
+    struct CaseScanner { found: bool }
+    impl IrVisitor for CaseScanner {
+        fn visit_expr(&mut self, expr: &almide_ir::IrExpr) {
+            if self.found { return; }
+            match &expr.kind {
+                IrExprKind::Call { target: CallTarget::Module { module, func, .. }, .. }
+                    if module.as_str() == "string" && is_case_fn(func.as_str()) =>
+                {
+                    self.found = true;
+                    return;
+                }
+                IrExprKind::Call { target: CallTarget::Method { method, .. }, .. }
+                    if is_case_fn(method.as_str()) =>
+                {
+                    self.found = true;
+                    return;
+                }
+                IrExprKind::RuntimeCall { symbol, .. }
+                    if matches!(
+                        symbol.as_str(),
+                        "almide_rt_string_to_upper"
+                            | "almide_rt_string_to_lower"
+                            | "almide_rt_string_capitalize"
+                    ) =>
+                {
+                    self.found = true;
+                    return;
+                }
+                _ => {}
+            }
+            walk_expr(self, expr);
+        }
+        fn visit_stmt(&mut self, stmt: &almide_ir::IrStmt) {
+            if self.found { return; }
+            walk_stmt(self, stmt);
+        }
+    }
+
+    let mut scanner = CaseScanner { found: false };
+    for func in &program.functions {
+        scanner.visit_expr(&func.body);
+        if scanner.found { return true; }
+    }
+    false
+}
+
 fn program_uses_fs(program: &IrProgram) -> bool {
     use almide_ir::{IrExprKind, IrStmtKind, CallTarget};
     use almide_ir::visit::{IrVisitor, walk_expr, walk_stmt};

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -118,6 +118,23 @@ pub fn register(emitter: &mut WasmEmitter) {
     emitter.rt.string.utf8_byte_of_cp = emitter.register_func("__utf8_byte_of_cp", ty_i32x2_i32);
     // utf8_snap(s, byte_i) -> i32 : byte_i snapped down to a char boundary.
     emitter.rt.string.utf8_snap = emitter.register_func("__utf8_snap", ty_i32x2_i32);
+
+    // ── Full-Unicode case folding ──
+    // Registered + compiled LAST, in identical order (same discipline as the
+    // utf8_* helpers and Dragon4): bodies bind to indices by registration and
+    // emit by compile order, so a mismatch produces an invalid module.
+    // __utf8_emit_scalar(dst, byte_off, scalar) -> new_byte_off
+    emitter.rt.string.utf8_emit_scalar = emitter.register_func("__utf8_emit_scalar", ty_i32x3_i32);
+    // __case_map_lookup(map_sel, scalar) -> VALS addr | -1
+    emitter.rt.string.case_map_lookup = emitter.register_func("__case_map_lookup", ty_i32x2_i32);
+    // __set_member(set_sel, scalar) -> 0/1
+    emitter.rt.string.set_member = emitter.register_func("__set_member", ty_i32x2_i32);
+    // __final_sigma(s, byte_off) -> ς|σ
+    emitter.rt.string.final_sigma = emitter.register_func("__final_sigma", ty_i32x2_i32);
+    // __str_case_map(s, is_upper) -> i32 (unified two-pass driver)
+    emitter.rt.string.str_case_map = emitter.register_func("__str_case_map", ty_i32x2_i32);
+    // __str_capitalize(s) -> i32
+    emitter.rt.string.capitalize = emitter.register_func("__str_capitalize", ty_i32_i32);
 }
 
 /// Compile all string runtime function bodies.
@@ -160,6 +177,13 @@ pub fn compile(emitter: &mut WasmEmitter) {
     compile_utf8_scalar(emitter);
     compile_utf8_byte_of_cp(emitter);
     compile_utf8_snap(emitter);
+    // Case folding — compiled LAST, in registration order.
+    compile_utf8_emit_scalar(emitter);
+    compile_case_map_lookup(emitter);
+    compile_set_member(emitter);
+    compile_final_sigma(emitter);
+    compile_str_case_map(emitter);
+    compile_str_capitalize(emitter);
 }
 
 // ── Shared UTF-8 codepoint helpers ──
@@ -862,44 +886,26 @@ fn compile_trim_end(emitter: &mut WasmEmitter) {
 }
 
 // ── Case transform ──
+//
+// Full-Unicode, byte-identical to native `str::to_uppercase()`/`to_lowercase()`.
+// `to_upper`/`to_lower` are thin wrappers over the unified `__str_case_map`
+// driver; the real work (oracle-derived table lookup, Final_Sigma scan, two-pass
+// exact-size allocation) lives in the case-folding functions at the end of this
+// file. The old ASCII-only ±32 byte loop (`compile_case_transform`) is gone.
 
 fn compile_to_upper(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.to_upper];
-    compile_case_transform(emitter, type_idx, 97, 122, -32); // a-z → A-Z
+    let map = emitter.rt.string.str_case_map;
+    let mut f = Function::new([]);
+    wasm!(f, { local_get(0); i32_const(1); call(map); end; });
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_to_lower(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.to_lower];
-    compile_case_transform(emitter, type_idx, 65, 90, 32); // A-Z → a-z
-}
-
-fn compile_case_transform(emitter: &mut WasmEmitter, type_idx: u32, lo: i32, hi: i32, delta: i32) {
-    let mut f = Function::new([
-        (1, ValType::I32), (1, ValType::I32), (1, ValType::I32), (1, ValType::I32),
-    ]);
-    wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
-        i32_const(string_hdr()); local_get(1); i32_add;
-        call(emitter.rt.alloc); local_set(2);
-        local_get(2); local_get(1); i32_store(0);
-        i32_const(0); local_set(3);
-        block_empty; loop_empty;
-          local_get(3); local_get(1); i32_ge_u; br_if(1);
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add;
-          i32_load8_u(0); local_set(4);
-          local_get(4); i32_const(lo); i32_ge_u;
-          local_get(4); i32_const(hi); i32_le_u;
-          i32_and;
-          if_empty;
-            local_get(4); i32_const(delta); i32_add; local_set(4);
-          end;
-          local_get(2); i32_const(string_data_off()); i32_add; local_get(3); i32_add;
-          local_get(4); i32_store8(0);
-          local_get(3); i32_const(1); i32_add; local_set(3);
-          br(0);
-        end; end;
-        local_get(2); end;
-    });
+    let map = emitter.rt.string.str_case_map;
+    let mut f = Function::new([]);
+    wasm!(f, { local_get(0); i32_const(0); call(map); end; });
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
@@ -1078,6 +1084,391 @@ fn compile_to_bytes(emitter: &mut WasmEmitter) {
           br(0);
         end; end;
         local_get(2); end;
+    });
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}
+
+// ── Full-Unicode case folding ──
+//
+// `to_upper`/`to_lower`/`capitalize` are byte-identical to native (Rust
+// `str::to_uppercase`/`to_lowercase` + char `to_uppercase`). The mapping tables
+// are generated at emit time in `rt_string_case` from the SAME `std`, embedded at
+// the front of the data section, and consulted here. Uppercasing is context-free;
+// lowercasing is too EXCEPT Greek capital sigma U+03A3 (Final_Sigma), resolved by
+// `__final_sigma`. See `rt_string_case` for the derivation + proofs.
+
+/// `__utf8_emit_scalar(dst, byte_off, scalar) -> new_byte_off`. Encodes `scalar`
+/// (a valid Unicode scalar, max U+10FFFF) as 1-4 UTF-8 bytes into `dst`'s data
+/// section at `byte_off`; returns the advanced byte offset.
+fn compile_utf8_emit_scalar(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.utf8_emit_scalar];
+    // params: 0=dst, 1=byte_off, 2=scalar | local: 3=addr
+    let mut f = Function::new([(1, ValType::I32)]);
+    wasm!(f, {
+        local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add; local_set(3);
+        local_get(2); i32_const(0x80); i32_lt_u;
+        if_i32;
+          local_get(3); local_get(2); i32_store8(0);
+          local_get(1); i32_const(1); i32_add;
+        else_;
+          local_get(2); i32_const(0x800); i32_lt_u;
+          if_i32;
+            local_get(3); local_get(2); i32_const(6); i32_shr_u; i32_const(0xC0); i32_or; i32_store8(0);
+            local_get(3); local_get(2); i32_const(0x3F); i32_and; i32_const(0x80); i32_or; i32_store8(1);
+            local_get(1); i32_const(2); i32_add;
+          else_;
+            local_get(2); i32_const(0x10000); i32_lt_u;
+            if_i32;
+              local_get(3); local_get(2); i32_const(12); i32_shr_u; i32_const(0xE0); i32_or; i32_store8(0);
+              local_get(3); local_get(2); i32_const(6); i32_shr_u; i32_const(0x3F); i32_and; i32_const(0x80); i32_or; i32_store8(1);
+              local_get(3); local_get(2); i32_const(0x3F); i32_and; i32_const(0x80); i32_or; i32_store8(2);
+              local_get(1); i32_const(3); i32_add;
+            else_;
+              local_get(3); local_get(2); i32_const(18); i32_shr_u; i32_const(0xF0); i32_or; i32_store8(0);
+              local_get(3); local_get(2); i32_const(12); i32_shr_u; i32_const(0x3F); i32_and; i32_const(0x80); i32_or; i32_store8(1);
+              local_get(3); local_get(2); i32_const(6); i32_shr_u; i32_const(0x3F); i32_and; i32_const(0x80); i32_or; i32_store8(2);
+              local_get(3); local_get(2); i32_const(0x3F); i32_and; i32_const(0x80); i32_or; i32_store8(3);
+              local_get(1); i32_const(4); i32_add;
+            end;
+          end;
+        end;
+        end;
+    });
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}
+
+/// `__case_map_lookup(map_sel, scalar) -> i32`. Binary-search the UPPER(0)/LOWER(1)
+/// map; returns the absolute address of the `[len:u8][utf8 bytes]` value record,
+/// or -1 on miss (caller emits the scalar unchanged). Trivial when no case op is
+/// present (then DCE-stubbed anyway).
+fn compile_case_map_lookup(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.case_map_lookup];
+    // params: 0=map_sel, 1=scalar | locals: 2=keys, 3=n, 4=offs, 5=lo, 6=hi, 7=mid, 8=k
+    let mut f = Function::new([(7, ValType::I32)]);
+    if let Some(ct) = emitter.case_tables {
+        wasm!(f, {
+            local_get(0); i32_eqz;
+            if_empty;
+              i32_const(ct.upper_keys as i32); local_set(2);
+              i32_const(ct.upper_n as i32); local_set(3);
+              i32_const(ct.upper_offs as i32); local_set(4);
+            else_;
+              i32_const(ct.lower_keys as i32); local_set(2);
+              i32_const(ct.lower_n as i32); local_set(3);
+              i32_const(ct.lower_offs as i32); local_set(4);
+            end;
+            i32_const(0); local_set(5);
+            local_get(3); local_set(6);
+            block_empty; loop_empty;
+              local_get(5); local_get(6); i32_ge_u;
+              if_empty; i32_const(-1); return_; end;
+              local_get(5); local_get(6); i32_add; i32_const(1); i32_shr_u; local_set(7);
+              local_get(2); local_get(7); i32_const(2); i32_shl; i32_add; i32_load(0); local_set(8);
+              local_get(8); local_get(1); i32_eq;
+              if_empty;
+                local_get(4); local_get(7); i32_const(2); i32_shl; i32_add; i32_load(0); return_;
+              end;
+              local_get(8); local_get(1); i32_lt_u;
+              if_empty;
+                local_get(7); i32_const(1); i32_add; local_set(5);
+              else_;
+                local_get(7); local_set(6);
+              end;
+              br(0);
+            end; end;
+            i32_const(-1);
+            end;
+        });
+    } else {
+        wasm!(f, { i32_const(-1); end; });
+    }
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}
+
+/// `__set_member(set_sel, scalar) -> i32`. 1 iff `scalar` is in the CASED(0) /
+/// CASE_IGNORABLE(1) sorted key array (binary search). Used by `__final_sigma`.
+fn compile_set_member(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.set_member];
+    // params: 0=set_sel, 1=scalar | locals: 2=base, 3=n, 4=lo, 5=hi, 6=mid, 7=k
+    let mut f = Function::new([(6, ValType::I32)]);
+    if let Some(ct) = emitter.case_tables {
+        wasm!(f, {
+            local_get(0); i32_eqz;
+            if_empty;
+              i32_const(ct.cased as i32); local_set(2);
+              i32_const(ct.cased_n as i32); local_set(3);
+            else_;
+              i32_const(ct.ci as i32); local_set(2);
+              i32_const(ct.ci_n as i32); local_set(3);
+            end;
+            i32_const(0); local_set(4);
+            local_get(3); local_set(5);
+            block_empty; loop_empty;
+              local_get(4); local_get(5); i32_ge_u;
+              if_empty; i32_const(0); return_; end;
+              local_get(4); local_get(5); i32_add; i32_const(1); i32_shr_u; local_set(6);
+              local_get(2); local_get(6); i32_const(2); i32_shl; i32_add; i32_load(0); local_set(7);
+              local_get(7); local_get(1); i32_eq;
+              if_empty; i32_const(1); return_; end;
+              local_get(7); local_get(1); i32_lt_u;
+              if_empty;
+                local_get(6); i32_const(1); i32_add; local_set(4);
+              else_;
+                local_get(6); local_set(5);
+              end;
+              br(0);
+            end; end;
+            i32_const(0);
+            end;
+        });
+    } else {
+        wasm!(f, { i32_const(0); end; });
+    }
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}
+
+/// `__final_sigma(s, byte_off) -> i32`. The Unicode `Final_Sigma` rule for a Σ at
+/// `byte_off`: ς (U+03C2) iff it is preceded by a Cased char (skipping
+/// Case_Ignorable) AND not followed by one; else σ (U+03C3).
+///
+/// Both context scans cost O(length of the adjacent Case_Ignorable run), NOT
+/// O(position): the "Before" scan steps BACKWARD over codepoints (skipping UTF-8
+/// continuation bytes) rather than re-walking from byte 0, so a Σ-dense string
+/// stays O(n) overall (a forward re-walk would be O(n²)). This mirrors Rust's
+/// reverse-iterator `Final_Sigma` scan in `str::to_lowercase`.
+fn compile_final_sigma(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.final_sigma];
+    // params: 0=s, 1=byte_off | locals: 2=blen, 3=before, 4=after, 5=p, 6=q, 7=sc, 8=done
+    let mut f = Function::new([(7, ValType::I32)]);
+    let uw = emitter.rt.string.utf8_width;
+    let us = emitter.rt.string.utf8_scalar;
+    let setm = emitter.rt.string.set_member;
+    let do_ = string_data_off();
+    wasm!(f, {
+        local_get(0); i32_load(0); local_set(2);
+        i32_const(0); local_set(3);   // before
+        i32_const(0); local_set(4);   // after
+        // Before: step BACKWARD from byte_off over codepoints, skipping
+        // Case_Ignorable; the first non-ignorable char's Cased-ness is `before`.
+        local_get(1); local_set(5);   // p = byte_off
+        i32_const(0); local_set(8);   // done
+        block_empty; loop_empty;
+          local_get(8); br_if(1);            // done → break
+          local_get(5); i32_eqz; br_if(1);   // p == 0 → break (before stays 0)
+          // q = p-1; skip UTF-8 continuation bytes (0b10xxxxxx) back to a lead byte.
+          local_get(5); i32_const(1); i32_sub; local_set(6);
+          block_empty; loop_empty;
+            local_get(6); i32_eqz; br_if(1);                   // q == 0 → stop
+            local_get(0); i32_const(do_); i32_add; local_get(6); i32_add; i32_load8_u(0);
+            i32_const(0xC0); i32_and; i32_const(0x80); i32_eq; // continuation byte?
+            i32_eqz; br_if(1);                                 // not continuation → stop (lead byte)
+            local_get(6); i32_const(1); i32_sub; local_set(6);
+            br(0);
+          end; end;
+          local_get(0); local_get(6); call(us); i32_wrap_i64; local_set(7);
+          i32_const(1); local_get(7); call(setm); i32_eqz;     // not Case_Ignorable
+          if_empty;
+            i32_const(0); local_get(7); call(setm); local_set(3);  // before = Cased(sc)
+            i32_const(1); local_set(8);
+          else_;
+            local_get(6); local_set(5);                            // p = q (keep scanning back)
+          end;
+          br(0);
+        end; end;
+        // After: first non-CI scalar at/after byte_off + width(Σ).
+        local_get(1); local_get(0); local_get(1); call(uw); i32_add; local_set(5);
+        i32_const(0); local_set(8);
+        block_empty; loop_empty;
+          local_get(5); local_get(2); i32_ge_u; br_if(1);
+          local_get(8); br_if(1);
+          local_get(0); local_get(5); call(uw); local_set(6);
+          local_get(0); local_get(5); call(us); i32_wrap_i64; local_set(7);
+          i32_const(1); local_get(7); call(setm); i32_eqz;
+          if_empty;
+            i32_const(0); local_get(7); call(setm); local_set(4);
+            i32_const(1); local_set(8);
+          end;
+          local_get(5); local_get(6); i32_add; local_set(5);
+          br(0);
+        end; end;
+        local_get(3); local_get(4); i32_eqz; i32_and;
+        if_i32; i32_const(0x03C2); else_; i32_const(0x03C3); end;
+        end;
+    });
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}
+
+/// `__str_case_map(s, is_upper) -> i32`. The unified two-pass case driver, exact
+/// for all scalars. Pass 1 sizes the output (ASCII = 1 byte; Σ-lower = 2 bytes;
+/// else table out_len or identity width); ONE allocation; pass 2 fills (ASCII
+/// fold inline, Σ via Final_Sigma, else `memory.copy` of the table/identity bytes).
+fn compile_str_case_map(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.str_case_map];
+    // params: 0=s, 1=is_upper
+    // locals: 2=blen,3=total,4=i,5=b0,6=w,7=sc,8=rec,9=out,10=woff,11=outlen,12=fold,13=msel
+    let mut f = Function::new([(12, ValType::I32)]);
+    let uw = emitter.rt.string.utf8_width;
+    let us = emitter.rt.string.utf8_scalar;
+    let lk = emitter.rt.string.case_map_lookup;
+    let fsig = emitter.rt.string.final_sigma;
+    let em = emitter.rt.string.utf8_emit_scalar;
+    let alloc = emitter.rt.alloc;
+    let do_ = string_data_off();
+    let hdr = string_hdr();
+    let capo = string_cap_off() as u32;
+    wasm!(f, {
+        local_get(0); i32_load(0); local_set(2);
+        local_get(1); i32_eqz; local_set(13);   // msel = is_upper==0 ? 1 : 0
+        // PASS 1: total output bytes
+        i32_const(0); local_set(3);
+        i32_const(0); local_set(4);
+        block_empty; loop_empty;
+          local_get(4); local_get(2); i32_ge_u; br_if(1);
+          local_get(0); i32_const(do_); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(5);
+          local_get(5); i32_const(0x80); i32_lt_u;
+          if_empty;
+            local_get(3); i32_const(1); i32_add; local_set(3);
+            local_get(4); i32_const(1); i32_add; local_set(4);
+          else_;
+            local_get(0); local_get(4); call(uw); local_set(6);
+            local_get(0); local_get(4); call(us); i32_wrap_i64; local_set(7);
+            local_get(1); i32_eqz; local_get(7); i32_const(0x03A3); i32_eq; i32_and;
+            if_empty;
+              local_get(3); i32_const(2); i32_add; local_set(3);
+            else_;
+              local_get(13); local_get(7); call(lk); local_set(8);
+              local_get(8); i32_const(-1); i32_eq;
+              if_empty;
+                local_get(3); local_get(6); i32_add; local_set(3);
+              else_;
+                local_get(3); local_get(8); i32_load8_u(0); i32_add; local_set(3);
+              end;
+            end;
+            local_get(4); local_get(6); i32_add; local_set(4);
+          end;
+          br(0);
+        end; end;
+        // ALLOC exact-size output
+        i32_const(hdr); local_get(3); i32_add; call(alloc); local_set(9);
+        local_get(9); local_get(3); i32_store(0);
+        local_get(9); local_get(3); i32_store(capo, 0);
+        // PASS 2: fill
+        i32_const(0); local_set(10);
+        i32_const(0); local_set(4);
+        block_empty; loop_empty;
+          local_get(4); local_get(2); i32_ge_u; br_if(1);
+          local_get(0); i32_const(do_); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(5);
+          local_get(5); i32_const(0x80); i32_lt_u;
+          if_empty;
+            local_get(1);
+            if_i32;
+              local_get(5); i32_const(0x61); i32_ge_u; local_get(5); i32_const(0x7A); i32_le_u; i32_and;
+              if_i32; local_get(5); i32_const(32); i32_sub; else_; local_get(5); end;
+            else_;
+              local_get(5); i32_const(0x41); i32_ge_u; local_get(5); i32_const(0x5A); i32_le_u; i32_and;
+              if_i32; local_get(5); i32_const(32); i32_add; else_; local_get(5); end;
+            end;
+            local_set(12);
+            local_get(9); i32_const(do_); i32_add; local_get(10); i32_add; local_get(12); i32_store8(0);
+            local_get(10); i32_const(1); i32_add; local_set(10);
+            local_get(4); i32_const(1); i32_add; local_set(4);
+          else_;
+            local_get(0); local_get(4); call(uw); local_set(6);
+            local_get(0); local_get(4); call(us); i32_wrap_i64; local_set(7);
+            local_get(1); i32_eqz; local_get(7); i32_const(0x03A3); i32_eq; i32_and;
+            if_empty;
+              local_get(9); local_get(10);
+              local_get(0); local_get(4); call(fsig);
+              call(em); local_set(10);
+            else_;
+              local_get(13); local_get(7); call(lk); local_set(8);
+              local_get(8); i32_const(-1); i32_eq;
+              if_empty;
+                local_get(9); i32_const(do_); i32_add; local_get(10); i32_add;
+                local_get(0); i32_const(do_); i32_add; local_get(4); i32_add;
+                local_get(6);
+                memory_copy;
+                local_get(10); local_get(6); i32_add; local_set(10);
+              else_;
+                local_get(8); i32_load8_u(0); local_set(11);
+                local_get(9); i32_const(do_); i32_add; local_get(10); i32_add;
+                local_get(8); i32_const(1); i32_add;
+                local_get(11);
+                memory_copy;
+                local_get(10); local_get(11); i32_add; local_set(10);
+              end;
+            end;
+            local_get(4); local_get(6); i32_add; local_set(4);
+          end;
+          br(0);
+        end; end;
+        local_get(9); end;
+    });
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}
+
+/// `__str_capitalize(s) -> i32`. First scalar uppercased (`char::to_uppercase` —
+/// context-free, no Σ rule), the rest of the bytes copied VERBATIM (native
+/// `string.capitalize` does not recase the tail).
+fn compile_str_capitalize(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.capitalize];
+    // params: 0=s (1 param ⇒ declared locals start at index 1; index 1 is unused).
+    // locals: 2=blen,3=w0,4=sc0,5=b0,6=rec,7=hlen,8=total,9=out,10=hb
+    let mut f = Function::new([(10, ValType::I32)]);
+    let uw = emitter.rt.string.utf8_width;
+    let us = emitter.rt.string.utf8_scalar;
+    let lk = emitter.rt.string.case_map_lookup;
+    let alloc = emitter.rt.alloc;
+    let do_ = string_data_off();
+    let hdr = string_hdr();
+    let capo = string_cap_off() as u32;
+    wasm!(f, {
+        local_get(0); i32_load(0); local_set(2);
+        local_get(2); i32_eqz; if_empty; local_get(0); return_; end;
+        local_get(0); i32_const(do_); i32_add; i32_load8_u(0); local_set(5);
+        local_get(0); i32_const(0); call(uw); local_set(3);
+        local_get(5); i32_const(0x80); i32_lt_u;
+        if_empty;
+          i32_const(1); local_set(7);
+          local_get(5); i32_const(0x61); i32_ge_u; local_get(5); i32_const(0x7A); i32_le_u; i32_and;
+          if_i32; local_get(5); i32_const(32); i32_sub; else_; local_get(5); end;
+          local_set(10);
+          i32_const(-2); local_set(6);
+        else_;
+          local_get(0); i32_const(0); call(us); i32_wrap_i64; local_set(4);
+          i32_const(0); local_get(4); call(lk); local_set(6);
+          local_get(6); i32_const(-1); i32_eq;
+          if_empty; local_get(3); local_set(7);
+          else_; local_get(6); i32_load8_u(0); local_set(7); end;
+        end;
+        local_get(7); local_get(2); i32_add; local_get(3); i32_sub; local_set(8);
+        i32_const(hdr); local_get(8); i32_add; call(alloc); local_set(9);
+        local_get(9); local_get(8); i32_store(0);
+        local_get(9); local_get(8); i32_store(capo, 0);
+        // head
+        local_get(6); i32_const(-2); i32_eq;
+        if_empty;
+          local_get(9); i32_const(do_); i32_add; local_get(10); i32_store8(0);
+        else_;
+          local_get(6); i32_const(-1); i32_eq;
+          if_empty;
+            local_get(9); i32_const(do_); i32_add;
+            local_get(0); i32_const(do_); i32_add;
+            local_get(3);
+            memory_copy;
+          else_;
+            local_get(9); i32_const(do_); i32_add;
+            local_get(6); i32_const(1); i32_add;
+            local_get(7);
+            memory_copy;
+          end;
+        end;
+        // tail (verbatim): blen - w0 bytes from s data+w0 to out data+hlen
+        local_get(9); i32_const(do_); i32_add; local_get(7); i32_add;
+        local_get(0); i32_const(do_); i32_add; local_get(3); i32_add;
+        local_get(2); local_get(3); i32_sub;
+        memory_copy;
+        local_get(9); end;
     });
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/rt_string_case.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string_case.rs
@@ -1,0 +1,284 @@
+//! Emit-time Unicode case-mapping tables for the WASM runtime.
+//!
+//! Native `string.to_upper/to_lower/capitalize` call Rust `str::to_uppercase()` /
+//! `str::to_lowercase()` (full Unicode). The WASM runtime must produce
+//! **byte-identical** output. We achieve this by GENERATING the case-mapping
+//! tables AT EMIT TIME from the SAME `char::to_uppercase()` / `char::to_lowercase()`
+//! the native runtime links — so the tables are an exact serialization of `std`
+//! and are locked to the compiler toolchain's Unicode version. No UCD files, no
+//! `build.rs`, no external crate: Rust `std` IS the oracle.
+//!
+//! The one context-sensitive scalar in all of Unicode — Greek capital sigma
+//! U+03A3, whose lowercasing depends on `Final_Sigma` (→ ς word-finally, else σ) —
+//! is resolved by a runtime scan over the `Cased` / `Case_Ignorable` property sets.
+//! Those two properties are *also* derived purely from `str::to_lowercase` (via a
+//! U+03A3 probe — see [`cased`] / [`case_ignorable`]), NEVER from
+//! `char::is_lowercase`, which mislabels modifier letters (e.g. Lm U+02B0) and
+//! would silently corrupt Final_Sigma.
+
+use std::sync::LazyLock;
+
+/// Greek capital sigma — the sole context-sensitive scalar; excluded from the
+/// lower map and resolved at runtime.
+pub const SIGMA: u32 = 0x03A3;
+/// Greek small final sigma ς (U+03C2) — Final_Sigma "word-final" result.
+pub const FINAL_SIGMA: u32 = 0x03C2;
+/// Greek small sigma σ (U+03C3) — Final_Sigma "medial" result.
+pub const MEDIAL_SIGMA: u32 = 0x03C3;
+
+/// One case-mapping direction, serialized for embedding as three parallel blobs:
+/// `keys` (binary-search array), `val_offsets` (record offset within `vals` per
+/// key), and `vals` (packed `[out_len:u8][utf8 bytes...]` records).
+pub struct CaseMap {
+    /// Sorted scalars that have a non-identity mapping.
+    pub keys: Vec<u32>,
+    /// For each key, the byte offset of its value record within `vals`.
+    pub val_offsets: Vec<u32>,
+    /// Packed value records: `[out_len:u8][utf8 bytes...]` per key.
+    pub vals: Vec<u8>,
+}
+
+/// All four oracle-derived tables.
+pub struct CaseTables {
+    /// `to_upper` map (`char::to_uppercase`), ASCII excluded (inline fast path).
+    pub upper: CaseMap,
+    /// `to_lower` map (`char::to_lowercase`), ASCII excluded AND U+03A3 excluded
+    /// (Final_Sigma resolved at runtime).
+    pub lower: CaseMap,
+    /// Sorted scalars with the Unicode `Cased` property.
+    pub cased: Vec<u32>,
+    /// Sorted scalars with the Unicode `Case_Ignorable` property.
+    pub case_ignorable: Vec<u32>,
+}
+
+fn is_surrogate(cp: u32) -> bool {
+    (0xD800..=0xDFFF).contains(&cp)
+}
+
+/// `Cased(c)`: place `c` immediately before Σ; `str::to_lowercase` maps Σ to
+/// final-sigma ς iff Σ is preceded by a `Cased` char (and followed by none).
+fn cased(c: char) -> bool {
+    format!("{}\u{03A3}", c).to_lowercase().ends_with('\u{03C2}')
+}
+
+/// `Case_Ignorable(c)`: in `"a{c}Σ"` the backward `Final_Sigma` scan skips an
+/// ignorable `c` and reaches the cased `'a'` → ς. `Cased` chars (which also yield
+/// ς, for a different reason) and `'a'` itself are excluded.
+fn case_ignorable(c: char) -> bool {
+    if c == 'a' || cased(c) {
+        return false;
+    }
+    format!("a{}\u{03A3}", c).to_lowercase().ends_with('\u{03C2}')
+}
+
+fn push_utf8(out: &mut Vec<u8>, chars: &[char]) {
+    for c in chars {
+        let mut buf = [0u8; 4];
+        out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+    }
+}
+
+fn build_map(upper: bool) -> CaseMap {
+    let mut keys = Vec::new();
+    let mut val_offsets = Vec::new();
+    let mut vals = Vec::new();
+    for cp in 0u32..=0x10FFFF {
+        if is_surrogate(cp) {
+            continue;
+        }
+        // ASCII is handled by the inline byte fast path; never in the table.
+        if cp < 0x80 {
+            continue;
+        }
+        // Σ lowercasing is context-sensitive → resolved by the runtime scan.
+        if !upper && cp == SIGMA {
+            continue;
+        }
+        let c = char::from_u32(cp).unwrap();
+        let mapped: Vec<char> = if upper {
+            c.to_uppercase().collect()
+        } else {
+            c.to_lowercase().collect()
+        };
+        if mapped.as_slice() == [c] {
+            continue; // identity mapping
+        }
+        let mut rec = Vec::new();
+        push_utf8(&mut rec, &mapped);
+        assert!(rec.len() <= u8::MAX as usize, "case map value too long: U+{cp:04X}");
+        val_offsets.push(vals.len() as u32);
+        vals.push(rec.len() as u8);
+        vals.extend_from_slice(&rec);
+        keys.push(cp);
+    }
+    CaseMap { keys, val_offsets, vals }
+}
+
+fn build_property(pred: fn(char) -> bool) -> Vec<u32> {
+    let mut v = Vec::new();
+    for cp in 0u32..=0x10FFFF {
+        if is_surrogate(cp) {
+            continue;
+        }
+        if pred(char::from_u32(cp).unwrap()) {
+            v.push(cp);
+        }
+    }
+    v
+}
+
+/// Build (once, cached) the four case tables. Pure and deterministic (~4M char
+/// ops, <100ms); the `LazyLock` keeps it to once per process, not per module.
+pub fn generate_case_tables() -> &'static CaseTables {
+    static TABLES: LazyLock<CaseTables> = LazyLock::new(|| CaseTables {
+        upper: build_map(true),
+        lower: build_map(false),
+        cased: build_property(cased),
+        case_ignorable: build_property(case_ignorable),
+    });
+    &TABLES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lookup(map: &CaseMap, scalar: u32) -> Option<&[u8]> {
+        match map.keys.binary_search(&scalar) {
+            Ok(i) => {
+                let off = map.val_offsets[i] as usize;
+                let len = map.vals[off] as usize;
+                Some(&map.vals[off + 1..off + 1 + len])
+            }
+            Err(_) => None,
+        }
+    }
+
+    fn identity_bytes(scalar: u32) -> Vec<u8> {
+        let mut buf = [0u8; 4];
+        char::from_u32(scalar)
+            .unwrap()
+            .encode_utf8(&mut buf)
+            .as_bytes()
+            .to_vec()
+    }
+
+    /// Models the runtime `to_upper` pipeline for a single scalar.
+    fn pipeline_upper(scalar: u32, t: &CaseTables) -> Vec<u8> {
+        if scalar < 0x80 {
+            let b = scalar as u8;
+            return vec![if (0x61..=0x7A).contains(&b) { b - 32 } else { b }];
+        }
+        lookup(&t.upper, scalar)
+            .map(|v| v.to_vec())
+            .unwrap_or_else(|| identity_bytes(scalar))
+    }
+
+    /// Models the runtime `to_lower` pipeline for a single *isolated* scalar
+    /// (lone Σ → σ: Before=false, Final_Sigma medial).
+    fn pipeline_lower_isolated(scalar: u32, t: &CaseTables) -> Vec<u8> {
+        if scalar < 0x80 {
+            let b = scalar as u8;
+            return vec![if (0x41..=0x5A).contains(&b) { b + 32 } else { b }];
+        }
+        if scalar == SIGMA {
+            return identity_bytes(MEDIAL_SIGMA);
+        }
+        lookup(&t.lower, scalar)
+            .map(|v| v.to_vec())
+            .unwrap_or_else(|| identity_bytes(scalar))
+    }
+
+    /// Layer 1: the emitted tables reproduce `char::to_uppercase`/`to_lowercase`
+    /// for ALL 1.1M scalars, byte-for-byte.
+    #[test]
+    fn tables_reproduce_char_methods() {
+        let t = generate_case_tables();
+        for cp in 0u32..=0x10FFFF {
+            if is_surrogate(cp) {
+                continue;
+            }
+            let c = char::from_u32(cp).unwrap();
+
+            let want_u: Vec<u8> = c.to_uppercase().collect::<String>().into_bytes();
+            let got_u = pipeline_upper(cp, t);
+            assert_eq!(got_u, want_u, "to_upper mismatch at U+{cp:04X}");
+
+            // char::to_lowercase has no context, so it equals the isolated pipeline.
+            let want_l: Vec<u8> = c.to_lowercase().collect::<String>().into_bytes();
+            let got_l = pipeline_lower_isolated(cp, t);
+            assert_eq!(got_l, want_l, "to_lower mismatch at U+{cp:04X}");
+        }
+    }
+
+    /// Models the runtime `to_lower` over a whole string using ONLY the serialized
+    /// `cased` / `case_ignorable` membership arrays — the exact data the wasm
+    /// Final_Sigma scan reads.
+    fn my_lower(chars: &[char], t: &CaseTables) -> String {
+        let is_cased = |c: char| t.cased.binary_search(&(c as u32)).is_ok();
+        let is_ci = |c: char| t.case_ignorable.binary_search(&(c as u32)).is_ok();
+        let mut out = String::new();
+        for i in 0..chars.len() {
+            let c = chars[i];
+            if c as u32 == SIGMA {
+                let before = (0..i).rev().find(|&j| !is_ci(chars[j])).map_or(false, |j| is_cased(chars[j]));
+                let after = ((i + 1)..chars.len()).find(|&j| !is_ci(chars[j])).map_or(false, |j| is_cased(chars[j]));
+                out.push(char::from_u32(if before && !after { FINAL_SIGMA } else { MEDIAL_SIGMA }).unwrap());
+            } else {
+                out.extend(c.to_lowercase());
+            }
+        }
+        out
+    }
+
+    /// Layer 1b: the serialized property sets + Final_Sigma scan reproduce
+    /// `str::to_lowercase` over an exhaustive window matrix.
+    #[test]
+    fn final_sigma_via_serialized_sets() {
+        let t = generate_case_tables();
+        // Behaviorally-distinct alphabet: cased/uncased letters, a titlecase Lt,
+        // digit, space, period, apostrophe, soft-hyphen (CI), combining (CI), two
+        // modifier letters (CI, the is_lowercase trap), and Σ itself.
+        let alpha: Vec<char> = vec![
+            'a', 'Z', 'α', 'Α', '\u{01F2}', '1', ' ', '.', '\'',
+            '\u{00AD}', '\u{0301}', '\u{02B0}', '\u{02BC}', '\u{03A3}', 'b',
+        ];
+        let mut window = Vec::new();
+        let mut count = 0usize;
+        fn rec(prefix: &mut Vec<char>, depth: usize, alpha: &[char], t: &CaseTables, count: &mut usize) {
+            if depth == 0 {
+                let s: String = prefix.iter().collect();
+                assert_eq!(my_lower(prefix, t), s.to_lowercase(), "Final_Sigma window {s:?}");
+                *count += 1;
+                return;
+            }
+            for &a in alpha {
+                prefix.push(a);
+                rec(prefix, depth - 1, alpha, t, count);
+                prefix.pop();
+            }
+        }
+        for len in 1..=4 {
+            rec(&mut window, len, &alpha, t, &mut count);
+        }
+        assert_eq!(count, 54240);
+    }
+
+    /// Sanity: counts match the independently verified design figures.
+    #[test]
+    fn table_counts() {
+        let t = generate_case_tables();
+        // ASCII a-z (26) excluded from upper, A-Z (26) from lower vs the raw 1580/1487.
+        assert_eq!(t.upper.keys.len(), 1554);
+        assert_eq!(t.lower.keys.len(), 1461);
+        assert_eq!(t.cased.len(), 4364);
+        assert_eq!(t.case_ignorable.len(), 2794);
+        // Disjoint by construction.
+        for cp in &t.cased {
+            assert!(t.case_ignorable.binary_search(cp).is_err(), "overlap at U+{cp:04X}");
+        }
+        // keys are sorted (binary search precondition).
+        assert!(t.upper.keys.windows(2).all(|w| w[0] < w[1]));
+        assert!(t.lower.keys.windows(2).all(|w| w[0] < w[1]));
+    }
+}

--- a/spec/wasm_cross/string_case_unicode.almd
+++ b/spec/wasm_cross/string_case_unicode.almd
@@ -1,0 +1,52 @@
+// Regression: WASM string.to_upper / to_lower / capitalize must produce the SAME
+// bytes as native (Rust str::to_uppercase / str::to_lowercase / first-char
+// char::to_uppercase). Previously the WASM runtime folded ONLY ASCII a-z<->A-Z
+// (±32 byte loop), so every non-ASCII case op diverged: accents, Greek, Cyrillic,
+// the length-CHANGING maps (ß -> SS), and the context-sensitive Greek sigma
+// (Final_Sigma: word-final ς vs medial σ). The runtime now embeds oracle-derived
+// Unicode case tables (crates/almide-codegen/src/emit_wasm/rt_string_case.rs) and
+// resolves Final_Sigma at runtime — byte-identical to native for ALL scalars.
+effect fn main() -> Unit = {
+  // ── ASCII (the old fast path; still correct) ──
+  println(string.to_upper("hello, world!"))   // HELLO, WORLD!
+  println(string.to_lower("HELLO, WORLD!"))   // hello, world!
+
+  // ── Latin-1 / accents (1:1 maps) ──
+  println(string.to_upper("café crème"))      // CAFÉ CRÈME
+  println(string.to_lower("CAFÉ CRÈME"))      // café crème
+  println(string.to_upper("àÉîõü"))           // ÀÉÎÕÜ
+
+  // ── Length-changing maps (output longer than input) ──
+  println(string.to_upper("straße"))          // STRASSE  (ß -> SS)
+  println(string.to_upper("ﬁle ﬄ"))          // FILE FFL (ligatures)
+  println(string.to_upper("ŉ"))               // ʼN       (U+0149 -> 2 scalars)
+
+  // ── Cyrillic ──
+  println(string.to_upper("привет, мир"))     // ПРИВЕТ, МИР
+  println(string.to_lower("ПРИВЕТ, МИР"))     // привет, мир
+
+  // ── Greek Final_Sigma (the context-sensitive case) ──
+  println(string.to_lower("Σ"))               // σ   (lone -> medial)
+  println(string.to_lower("ΟΔΟΣ"))            // οδος (word-final -> ς)
+  println(string.to_lower("ΣΟΣ"))             // σος  (start σ, end ς)
+  println(string.to_lower("ΑΣΑ"))             // ασα  (medial -> σ)
+  println(string.to_lower("ΑΣ ΒΣ"))           // ας βς (each word-final -> ς)
+  println(string.to_lower("ΣΣ"))              // σς   (first medial, second final)
+  println(string.to_upper("σοφία τέλος"))     // ΣΟΦΊΑ ΤΈΛΟΣ
+
+  // ── İ / dotted-I (U+0130 -> i + combining dot above) ──
+  println(string.to_lower("İ"))               // i̇
+
+  // ── capitalize: first scalar uppercased, REST VERBATIM (no recase, no Σ rule) ──
+  println(string.capitalize("über"))          // Über
+  println(string.capitalize("ßeta"))          // SSeta  (ß -> SS as head)
+  println(string.capitalize("σοσ"))           // Σοσ    (tail σ kept, NOT lowered to ς)
+  println(string.capitalize("ΣΟΣ"))           // ΣΟΣ
+  println(string.capitalize("hELLO"))         // HELLO  (tail not lowercased)
+  println(string.capitalize("123abc"))        // 123abc (non-cased head unchanged)
+  println(string.capitalize(""))              // (empty)
+
+  // ── Astral plane (Deseret, has case mappings) via from_codepoint ──
+  println(string.to_lower(string.from_codepoint(66560)))  // 𐐀 U+10400 -> 𐐨 U+10428
+  println(string.to_upper(string.from_codepoint(66600)))  // 𐐨 U+10428 -> 𐐀 U+10400
+}


### PR DESCRIPTION
## Cluster A-case — WASM `to_upper` / `to_lower` / `capitalize` were ASCII-only

The WASM runtime folded only `a-z`↔`A-Z` (±32 byte loop), so every non-ASCII case op diverged from native (Rust `str::to_uppercase` / `to_lowercase` / first-char `char::to_uppercase`): accents, Greek, Cyrillic, the length-**changing** maps (`ß`→`SS`), and the context-sensitive Greek sigma (Final_Sigma: word-final `ς` vs medial `σ`). Native is full-Unicode; WASM now matches it **byte-for-byte for all scalars**.

### Approach — correctness by construction
New `rt_string_case.rs` generates the case tables **at emit time from the same Rust `std`** (`char::to_uppercase` / `to_lowercase`) the native runtime links — so the tables are an exact serialization of `std`, version-locked to the toolchain, no UCD files or external crate. The one context-sensitive scalar in all of Unicode (Σ U+03A3) is resolved at runtime by `__final_sigma` over `Cased` / `Case_Ignorable` property sets that are **also derived purely from `str::to_lowercase`** (a U+03A3 probe: `"{c}Σ".to_lowercase().ends_with('ς')` ⇔ `Cased(c)`) — never from `char::is_lowercase` (which mislabels modifier letters).

- Tables embedded at the **front** of the data section; `eliminate_dead_data` preserves that region verbatim and walks interned strings after it (the table addresses are baked, must not shift).
- Unified two-pass driver `__str_case_map` (exact-size alloc, ASCII fast path); `to_upper`/`to_lower` are thin wrappers; `capitalize` = first scalar `char::to_uppercase` ++ verbatim tail.
- Embedding is gated on a reachability pre-scan, so non-case modules stay lean (hello-world WASM unchanged at 732 B; case-folding adds ~51 KB).
- Old ASCII-only paths (`compile_case_transform`, inline `emit_str_case_convert`) deleted; both dispatch routes go through the driver.

### Validation
- **Exhaustive: all 1,112,067 Unicode scalars byte-identical native==WASM** for `to_upper`/`to_lower`/`capitalize`.
- Emit-time `#[test]`: tables == `char` methods (all scalars) + Final_Sigma reproduces `str::to_lowercase` over a 54,240-window matrix.
- New cross-target corpus `spec/wasm_cross/string_case_unicode.almd` (ß→SS, ligatures, İ, all Final_Sigma contexts, capitalize, Deseret astral) — byte-identical, no `@xt-allow`.
- Full `cargo test --release` 0 failures; native spec 242/242; WASM 234 passed / 8 skipped / 0 failed.

### Hardening from an adversarial-verify pass (3 issues found + fixed)
- **Final_Sigma O(n²) → O(n)**: the "Before" scan re-walked from byte 0 per Σ (50k Σ = 44 s WASM vs 0.65 s native, larger inputs hung). Rewrote it as a backward UTF-8 walk (now 0.02 s), matching Rust's reverse-iterator scan. Output was already correct; this is a liveness/DoS fix.
- **Memory-minimum crash (also a pre-existing latent bug)**: the WASM memory `minimum` was hardcoded to 2 pages (128 KB); the tables + >~76 KB of string literals overran the initial data segment → module failed to instantiate. Now derived from `data_end`.
- **Pre-scan hardening**: `is_case_fn` now also accepts a `string.`-qualified method name so the scanner can never disagree with dispatch (silent-wrong failure mode otherwise).