### PR TITLE
Full Unicode White_Space for WASM trim / is_whitespace / parse-trim

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -184,6 +184,10 @@ pub struct StringRuntime {
     pub is_alpha: u32,
     pub is_alnum: u32,
     pub is_whitespace: u32,
+    /// `is_unicode_ws(scalar) -> i32`: 1 iff `scalar` has the Unicode White_Space
+    /// property (Rust `char::is_whitespace`). The single source of truth for all
+    /// trim / is_whitespace / parse-trim sites.
+    pub is_unicode_ws: u32,
     pub is_upper: u32,
     pub is_lower: u32,
     pub cmp: u32,
@@ -489,7 +493,7 @@ impl WasmEmitter {
                     replace_first: 0, last_index_of: 0,
                     strip_prefix: 0, strip_suffix: 0,
                     is_digit: 0, is_alpha: 0, is_alnum: 0,
-                    is_whitespace: 0, is_upper: 0, is_lower: 0,
+                    is_whitespace: 0, is_unicode_ws: 0, is_upper: 0, is_lower: 0,
                     cmp: 0,
                     char_count: 0,
                     run_length_encode: 0,

--- a/crates/almide-codegen/src/emit_wasm/rt_numeric.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_numeric.rs
@@ -265,33 +265,11 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
         i32_const(0); local_set(21);   // sticky
     });
 
-    // Trim leading ASCII whitespace: while i < end and is_ws(data[i]) { i++ }
-    wasm!(f, {
-        block_empty; loop_empty;
-          local_get(2); local_get(10); i32_ge_u; br_if(1);
-          local_get(11); local_get(2); i32_add; i32_load8_u(0); local_set(5);
-    });
-    emit_is_ascii_ws(&mut f, 5); // leaves 1 if data[i] is ws
-    wasm!(f, {
-          i32_eqz; br_if(1);            // not ws -> stop
-          local_get(2); i32_const(1); i32_add; local_set(2);
-          br(0);
-        end; end;
-    });
-
-    // Trim trailing ASCII whitespace: while end > i and is_ws(data[end-1]) { end-- }
-    wasm!(f, {
-        block_empty; loop_empty;
-          local_get(10); local_get(2); i32_le_u; br_if(1);
-          local_get(11); local_get(10); i32_add; i32_const(1); i32_sub; i32_load8_u(0); local_set(5);
-    });
-    emit_is_ascii_ws(&mut f, 5);
-    wasm!(f, {
-          i32_eqz; br_if(1);            // not ws -> stop
-          local_get(10); i32_const(1); i32_sub; local_set(10);
-          br(0);
-        end; end;
-    });
+    // Trim leading + trailing Unicode whitespace (matches native s.trim().parse),
+    // codepoint-aware via the shared __is_unicode_ws helpers. i=cursor(2),
+    // end=10, string ptr=0, scratch q=5.
+    super::rt_string::emit_trim_forward(&mut f, emitter, 2, 10);
+    super::rt_string::emit_trim_backward(&mut f, emitter, 10, 2, 5);
 
     // Empty after trim -> "cannot parse float from empty string"
     wasm!(f, {
@@ -507,25 +485,6 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
     });
 
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
-}
-
-/// Push 1 if the byte in `byte_local` is ASCII whitespace, else 0.
-/// Rust `str::trim` strips Unicode whitespace, but ASCII covers the corpus
-/// (space, \t, \n, \r, \x0b, \x0c).
-fn emit_is_ascii_ws(f: &mut Function, byte_local: u32) {
-    wasm!(f, {
-        local_get(byte_local); i32_const(32); i32_eq;   // ' '
-        local_get(byte_local); i32_const(9);  i32_eq;   // \t
-        i32_or;
-        local_get(byte_local); i32_const(10); i32_eq;   // \n
-        i32_or;
-        local_get(byte_local); i32_const(13); i32_eq;   // \r
-        i32_or;
-        local_get(byte_local); i32_const(11); i32_eq;   // \x0b
-        i32_or;
-        local_get(byte_local); i32_const(12); i32_eq;   // \x0c
-        i32_or;
-    });
 }
 
 /// Push 1 if `data[i..end]` (i in `i_local`, end in `end_local`, base in

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -102,6 +102,11 @@ pub fn register(emitter: &mut WasmEmitter) {
     // ASCII cases agree and multibyte joins the string-codepoint cluster).
     emitter.rt.string.run_length_encode = emitter.register_func("__str_rle", ty_i32_i32);
 
+    // Unicode White_Space membership: __is_unicode_ws(scalar) -> i32. The single
+    // source of truth for every trim / is_whitespace / parse-trim site. No
+    // dependency on the utf8_* helpers (it takes an already-decoded scalar).
+    emitter.rt.string.is_unicode_ws = emitter.register_func("__is_unicode_ws", ty_i32_i32);
+
     // ── Shared UTF-8 codepoint helpers ──
     // IMPORTANT: registration order here MUST match the compile() call order
     // below — function bodies are emitted to the code section in compile order
@@ -173,6 +178,7 @@ pub fn compile(emitter: &mut WasmEmitter) {
     super::rt_string_extra::compile_cmp(emitter);
     compile_char_count(emitter);
     compile_run_length_encode(emitter);
+    compile_is_unicode_ws(emitter);
     compile_utf8_width(emitter);
     compile_utf8_scalar(emitter);
     compile_utf8_byte_of_cp(emitter);
@@ -441,48 +447,125 @@ fn compile_contains(emitter: &mut WasmEmitter) {
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
+/// The Unicode `White_Space` codepoint ranges, derived AT EMIT TIME from Rust
+/// `char::is_whitespace` — so the set is exactly what native `str::trim` /
+/// `char::is_whitespace` use, and stays locked to the compiler's Unicode version
+/// (no hardcoded codepoints). Currently 10 contiguous runs over 25 codepoints:
+/// the ASCII run U+0009..=U+000D and U+0020, plus U+0085, U+00A0, U+1680,
+/// U+2000..=U+200A, U+2028..=U+2029, U+202F, U+205F, U+3000. NOTE: VT (U+000B)
+/// and FF (U+000C) ARE whitespace; ZWSP (U+200B) is NOT.
+fn whitespace_ranges() -> Vec<(u32, u32)> {
+    let mut runs: Vec<(u32, u32)> = Vec::new();
+    for cp in 0u32..=char::MAX as u32 {
+        if !char::from_u32(cp).is_some_and(|c| c.is_whitespace()) {
+            continue;
+        }
+        match runs.last_mut() {
+            Some(last) if last.1 + 1 == cp => last.1 = cp,
+            _ => runs.push((cp, cp)),
+        }
+    }
+    runs
+}
+
+#[cfg(test)]
+mod ws_tests {
+    /// The generated ranges must cover exactly Rust's White_Space set, contiguously.
+    #[test]
+    fn whitespace_ranges_match_char_is_whitespace() {
+        let runs = super::whitespace_ranges();
+        let total: u32 = runs.iter().map(|(lo, hi)| hi - lo + 1).sum();
+        assert_eq!(total, 25, "Unicode White_Space is 25 codepoints");
+        // Every codepoint in a run is whitespace; gaps between runs are not.
+        for cp in 0u32..=0x3001 {
+            let in_runs = runs.iter().any(|(lo, hi)| cp >= *lo && cp <= *hi);
+            let is_ws = char::from_u32(cp).is_some_and(|c| c.is_whitespace());
+            assert_eq!(in_runs, is_ws, "U+{cp:04X}");
+        }
+        // VT/FF are whitespace; ZWSP is not (the boundary the byte version got wrong).
+        let member = |cp: u32| runs.iter().any(|(lo, hi)| cp >= *lo && cp <= *hi);
+        assert!(member(0x0B) && member(0x0C) && member(0xA0) && member(0x3000));
+        assert!(!member(0x200B));
+    }
+}
+
+/// `__is_unicode_ws(scalar) -> i32`: 1 iff `scalar` has the Unicode White_Space
+/// property. The OR of `lo <= scalar <= hi` over the emit-time-generated ranges.
+fn compile_is_unicode_ws(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.string.is_unicode_ws];
+    let mut f = Function::new([]);
+    wasm!(f, { i32_const(0); }); // running OR accumulator
+    for (lo, hi) in whitespace_ranges() {
+        if lo == hi {
+            wasm!(f, { local_get(0); i32_const(lo as i32); i32_eq; i32_or; });
+        } else {
+            wasm!(f, {
+                local_get(0); i32_const(lo as i32); i32_ge_u;
+                local_get(0); i32_const(hi as i32); i32_le_u;
+                i32_and; i32_or;
+            });
+        }
+    }
+    wasm!(f, { end; });
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}
+
+/// Emit a forward codepoint loop that advances `pos_local` past leading
+/// White_Space, stopping at `end_local` (decode scalar → `__is_unicode_ws`,
+/// advance by `utf8_width`). The string pointer is local 0. Shared by the trim
+/// runtime fns and the leading-trim in int/float `.parse`.
+pub(super) fn emit_trim_forward(f: &mut Function, emitter: &WasmEmitter, pos_local: u32, end_local: u32) {
+    let uw = emitter.rt.string.utf8_width;
+    let us = emitter.rt.string.utf8_scalar;
+    let isws = emitter.rt.string.is_unicode_ws;
+    wasm!(f, {
+        block_empty; loop_empty;
+          local_get(pos_local); local_get(end_local); i32_ge_u; br_if(1);
+          local_get(0); local_get(pos_local); call(us); i32_wrap_i64; call(isws); i32_eqz; br_if(1);
+          local_get(0); local_get(pos_local); call(uw); local_get(pos_local); i32_add; local_set(pos_local);
+          br(0);
+        end; end;
+    });
+}
+
+/// Emit a backward codepoint loop that shrinks `end_local` past trailing
+/// White_Space, not below `floor_local` (step back over UTF-8 continuation bytes
+/// to the lead byte, decode scalar → `__is_unicode_ws`). `q_local` is scratch.
+/// The string pointer is local 0. Shared with int/float `.parse` trailing trim.
+pub(super) fn emit_trim_backward(f: &mut Function, emitter: &WasmEmitter, end_local: u32, floor_local: u32, q_local: u32) {
+    let us = emitter.rt.string.utf8_scalar;
+    let isws = emitter.rt.string.is_unicode_ws;
+    let do_ = string_data_off();
+    wasm!(f, {
+        block_empty; loop_empty;
+          local_get(end_local); local_get(floor_local); i32_le_u; br_if(1);
+          // q = end-1; step back over continuation bytes (0b10xxxxxx) to the lead byte.
+          local_get(end_local); i32_const(1); i32_sub; local_set(q_local);
+          block_empty; loop_empty;
+            local_get(0); i32_const(do_); i32_add; local_get(q_local); i32_add; i32_load8_u(0);
+            i32_const(0xC0); i32_and; i32_const(0x80); i32_ne; br_if(1);   // lead byte → stop
+            local_get(q_local); i32_eqz; br_if(1);
+            local_get(q_local); i32_const(1); i32_sub; local_set(q_local);
+            br(0);
+          end; end;
+          local_get(0); local_get(q_local); call(us); i32_wrap_i64; call(isws); i32_eqz; br_if(1);
+          local_get(q_local); local_set(end_local);
+          br(0);
+        end; end;
+    });
+}
+
 fn compile_trim(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.trim];
-    let mut f = Function::new([
-        (1, ValType::I32), (1, ValType::I32), (1, ValType::I32), (1, ValType::I32),
-    ]);
+    // locals: 1=len, 2=start, 3=end, 4=q
+    let mut f = Function::new([(4, ValType::I32)]);
     wasm!(f, {
         local_get(0); i32_load(0); local_set(1);
-        i32_const(0); local_set(2); // start
-        local_get(1); local_set(3); // end = len
+        i32_const(0); local_set(2);
+        local_get(1); local_set(3);
     });
-    // Find start (skip whitespace)
-    wasm!(f, {
-        block_empty; loop_empty;
-          local_get(2); local_get(3); i32_ge_u; br_if(1);
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(2); i32_add; i32_load8_u(0);
-          local_set(1);
-          local_get(1); i32_const(32); i32_eq;
-          local_get(1); i32_const(9); i32_eq; i32_or;
-          local_get(1); i32_const(10); i32_eq; i32_or;
-          local_get(1); i32_const(13); i32_eq; i32_or;
-          i32_eqz; br_if(1);
-          local_get(2); i32_const(1); i32_add; local_set(2);
-          br(0);
-        end; end;
-    });
-    // Find end (skip trailing whitespace)
-    wasm!(f, {
-        block_empty; loop_empty;
-          local_get(3); local_get(2); i32_le_u; br_if(1);
-          local_get(0); i32_const(string_data_off()); i32_add;
-          local_get(3); i32_const(1); i32_sub; i32_add; i32_load8_u(0);
-          local_set(1);
-          local_get(1); i32_const(32); i32_eq;
-          local_get(1); i32_const(9); i32_eq; i32_or;
-          local_get(1); i32_const(10); i32_eq; i32_or;
-          local_get(1); i32_const(13); i32_eq; i32_or;
-          i32_eqz; br_if(1);
-          local_get(3); i32_const(1); i32_sub; local_set(3);
-          br(0);
-        end; end;
-    });
-    // slice(s, start, end)
+    emit_trim_forward(&mut f, emitter, 2, 1);
+    emit_trim_backward(&mut f, emitter, 3, 2, 4);
     wasm!(f, {
         local_get(0); local_get(2); local_get(3);
         call(emitter.rt.string.slice);
@@ -835,24 +918,14 @@ fn compile_pad_end(emitter: &mut WasmEmitter) {
 
 fn compile_trim_start(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.trim_start];
-    let mut f = Function::new([(1, ValType::I32), (1, ValType::I32)]);
+    // locals: 1=len, 2=start
+    let mut f = Function::new([(2, ValType::I32)]);
     wasm!(f, {
         local_get(0); i32_load(0); local_set(1);
         i32_const(0); local_set(2);
-        block_empty; loop_empty;
-          local_get(2); local_get(1); i32_ge_u; br_if(1);
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(2); i32_add; i32_load8_u(0);
-          local_tee(1);
-          i32_const(32); i32_eq;
-          local_get(1); i32_const(9); i32_eq; i32_or;
-          local_get(1); i32_const(10); i32_eq; i32_or;
-          local_get(1); i32_const(13); i32_eq; i32_or;
-          i32_eqz; br_if(1);
-          local_get(2); i32_const(1); i32_add; local_set(2);
-          local_get(0); i32_load(0); local_set(1);
-          br(0);
-        end; end;
-        local_get(0); i32_load(0); local_set(1);
+    });
+    emit_trim_forward(&mut f, emitter, 2, 1);
+    wasm!(f, {
         local_get(0); local_get(2); local_get(1);
         call(emitter.rt.string.slice);
         end;
@@ -862,22 +935,14 @@ fn compile_trim_start(emitter: &mut WasmEmitter) {
 
 fn compile_trim_end(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.trim_end];
-    let mut f = Function::new([(1, ValType::I32), (1, ValType::I32)]);
+    // locals: 1=end, 2=q, 3=floor(=0)
+    let mut f = Function::new([(3, ValType::I32)]);
     wasm!(f, {
         local_get(0); i32_load(0); local_set(1);
-        block_empty; loop_empty;
-          local_get(1); i32_eqz; br_if(1);
-          local_get(0); i32_const(string_data_off()); i32_add;
-          local_get(1); i32_const(1); i32_sub; i32_add;
-          i32_load8_u(0); local_set(2);
-          local_get(2); i32_const(32); i32_eq;
-          local_get(2); i32_const(9); i32_eq; i32_or;
-          local_get(2); i32_const(10); i32_eq; i32_or;
-          local_get(2); i32_const(13); i32_eq; i32_or;
-          i32_eqz; br_if(1);
-          local_get(1); i32_const(1); i32_sub; local_set(1);
-          br(0);
-        end; end;
+        i32_const(0); local_set(3);
+    });
+    emit_trim_backward(&mut f, emitter, 1, 3, 2);
+    wasm!(f, {
         local_get(0); i32_const(0); local_get(1);
         call(emitter.rt.string.slice);
         end;

--- a/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
@@ -235,33 +235,30 @@ pub(super) fn compile_is_alnum(emitter: &mut WasmEmitter) {
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
-/// is_whitespace: space(32), tab(9), LF(10), CR(13). Empty string returns false.
+/// is_whitespace: every codepoint has the Unicode White_Space property (Rust
+/// `char::is_whitespace`, via `__is_unicode_ws`). Mirrors native
+/// `s.chars().all(|c| c.is_whitespace())`, so the EMPTY string is vacuously TRUE
+/// (Rust `.all()` on an empty iterator) — the old byte version wrongly returned
+/// false for "" and missed VT/FF and all non-ASCII whitespace.
 pub(super) fn compile_is_whitespace(emitter: &mut WasmEmitter) {
     let func_idx = emitter.rt.string.is_whitespace;
     let type_idx = emitter.func_type_indices[&func_idx];
-    let mut f = Function::new([(1, ValType::I32), (1, ValType::I32)]);
+    let uw = emitter.rt.string.utf8_width;
+    let us = emitter.rt.string.utf8_scalar;
+    let isws = emitter.rt.string.is_unicode_ws;
+    // locals: 1=blen, 2=i
+    let mut f = Function::new([(2, ValType::I32)]);
     wasm!(f, {
         local_get(0); i32_load(0); local_set(1);
-        local_get(1); i32_eqz;
-        if_i32; i32_const(0);
-        else_;
-          i32_const(0); local_set(2);
-          block_empty; loop_empty;
-            local_get(2); local_get(1); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(2); i32_add; i32_load8_u(0);
-            local_tee(1);
-            i32_const(32); i32_eq;
-            local_get(1); i32_const(9); i32_eq; i32_or;
-            local_get(1); i32_const(10); i32_eq; i32_or;
-            local_get(1); i32_const(13); i32_eq; i32_or;
-            i32_eqz;
-            br_if(1);
-            local_get(0); i32_load(0); local_set(1);
-            local_get(2); i32_const(1); i32_add; local_set(2);
-            br(0);
-          end; end;
-          local_get(2); local_get(0); i32_load(0); i32_eq;
-        end;
+        i32_const(0); local_set(2);
+        block_empty; loop_empty;
+          local_get(2); local_get(1); i32_ge_u; br_if(1);   // end (incl. empty) → all WS
+          local_get(0); local_get(2); call(us); i32_wrap_i64; call(isws); i32_eqz;
+          if_empty; i32_const(0); return_; end;              // a non-WS codepoint → false
+          local_get(0); local_get(2); call(uw); local_get(2); i32_add; local_set(2);
+          br(0);
+        end; end;
+        i32_const(1);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));

--- a/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
@@ -471,57 +471,18 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
         });
     };
 
-    // Emit `is_ascii_ws(byte_local)` → i32 (1 if whitespace) on the stack.
-    // Matches Rust char::is_whitespace for ASCII: {0x09..=0x0D, 0x20}.
-    let push_is_ws = |f: &mut Function, byte_local: u32| {
-        wasm!(f, {
-            // byte == 0x20
-            local_get(byte_local); i32_const(0x20); i32_eq;
-            // (byte >= 0x09) & (byte <= 0x0D)
-            local_get(byte_local); i32_const(0x09); i32_ge_u;
-            local_get(byte_local); i32_const(0x0D); i32_le_u;
-            i32_and;
-            i32_or;
-        });
-    };
-
     // len = s.len  (byte length lives at the LEN field, offset 0)
     wasm!(f, {
         local_get(0); i32_load(0); local_set(1);
     });
 
-    // ── Trim leading ASCII whitespace: i = 0; while i < len && is_ws(s[i]): i++ ──
+    // Trim leading + trailing Unicode whitespace (matches native s.trim().parse),
+    // codepoint-aware via the shared __is_unicode_ws helpers. i=cursor(2), end=3,
+    // string ptr=0, scratch q=5.
     wasm!(f, { i32_const(0); local_set(2); });
-    wasm!(f, { block_empty; loop_empty;
-        local_get(2); local_get(1); i32_ge_u; br_if(1); // i >= len → stop
-    });
-    load_byte(&mut f, 2, 5);
-    push_is_ws(&mut f, 5);
-    wasm!(f, {
-        i32_eqz; br_if(1);                              // not ws → stop
-        local_get(2); i32_const(1); i32_add; local_set(2);
-        br(0);
-        end; end;
-    });
-
-    // ── Trim trailing ASCII whitespace: end = len; while end > i && is_ws(s[end-1]): end-- ──
+    super::rt_string::emit_trim_forward(&mut f, emitter, 2, 1);
     wasm!(f, { local_get(1); local_set(3); });
-    wasm!(f, { block_empty; loop_empty;
-        local_get(3); local_get(2); i32_le_u; br_if(1); // end <= i → stop
-    });
-    // byte = s[end-1]
-    wasm!(f, {
-        local_get(0); i32_const(data_off); i32_add;
-        local_get(3); i32_add; i32_const(1); i32_sub;
-        i32_load8_u(0); local_set(5);
-    });
-    push_is_ws(&mut f, 5);
-    wasm!(f, {
-        i32_eqz; br_if(1);                              // not ws → stop
-        local_get(3); i32_const(1); i32_sub; local_set(3);
-        br(0);
-        end; end;
-    });
+    super::rt_string::emit_trim_backward(&mut f, emitter, 3, 2, 5);
 
     // ── Empty after trim → "cannot parse integer from empty string" ──
     wasm!(f, { local_get(2); local_get(3); i32_ge_u; if_empty; });

--- a/spec/wasm_cross/string_whitespace.almd
+++ b/spec/wasm_cross/string_whitespace.almd
@@ -1,0 +1,42 @@
+// Regression: WASM string.trim / trim_start / trim_end / is_whitespace and the
+// leading/trailing trim in int.parse / float.parse must match native
+// (Rust str::trim* / char::is_whitespace = the Unicode White_Space property, 25
+// codepoints). The old WASM checked only {0x09,0x0A,0x0D,0x20} (missing VT/FF and
+// every non-ASCII space), and is_whitespace("") wrongly returned false. The
+// runtime now routes all of them through __is_unicode_ws (oracle-derived from
+// char::is_whitespace). string.len is BYTE length, so this asserts on byte counts.
+effect fn main() -> Unit = {
+  let nbsp = string.from_codepoint(160)     // U+00A0
+  let thin = string.from_codepoint(8201)    // U+2009 THIN SPACE
+  let ideo = string.from_codepoint(12288)   // U+3000 IDEOGRAPHIC SPACE
+  let ensp = string.from_codepoint(8194)    // U+2002 EN SPACE
+  let nel  = string.from_codepoint(133)     // U+0085 NEL
+  let ogh  = string.from_codepoint(5760)    // U+1680 OGHAM SPACE MARK
+  let nnbsp = string.from_codepoint(8239)   // U+202F NARROW NO-BREAK SPACE
+  let mmsp = string.from_codepoint(8287)    // U+205F MEDIUM MATHEMATICAL SPACE
+  let lsep = string.from_codepoint(8232)    // U+2028 LINE SEPARATOR
+  let vt   = string.from_codepoint(11)      // U+000B (whitespace)
+  let ff   = string.from_codepoint(12)      // U+000C (whitespace)
+  let zwsp = string.from_codepoint(8203)    // U+200B (NOT whitespace)
+
+  // trim strips Unicode whitespace on both ends; interior is preserved.
+  println("[" + string.trim(nbsp + thin + "a b" + ideo + nel) + "]")        // [a b]
+  println(int.to_string(string.len(string.trim(ideo + ensp + ogh))))        // 0 (all ws)
+  println("[" + string.trim_start(nnbsp + mmsp + "x") + "]")                // [x]
+  println("[" + string.trim_end("y" + lsep + nbsp) + "]")                   // [y]
+  println("[" + string.trim(vt + ff + "z" + vt) + "]")                      // [z] (VT/FF are ws)
+  println("[" + string.trim(zwsp + "w" + zwsp) + "]")                       // [​w​] (ZWSP kept)
+  println(int.to_string(string.len(string.trim("")) + string.len(string.trim(ideo))))  // 0
+
+  // is_whitespace: all codepoints White_Space; EMPTY is vacuously TRUE.
+  println(if string.is_whitespace("") then "T" else "F")                    // T
+  println(if string.is_whitespace(nbsp + thin + vt + ff) then "T" else "F") // T
+  println(if string.is_whitespace(zwsp) then "T" else "F")                  // F
+  println(if string.is_whitespace(ideo + "x") then "T" else "F")            // F
+
+  // int.parse / float.parse trim the same Unicode whitespace before parsing.
+  println(int.to_string(int.parse(nbsp + "99" + ideo)!))                    // 99
+  println(int.to_string(int.parse(ideo + "-42" + vt)!))                     // -42
+  println(float.to_string(float.parse(thin + "3.14" + nbsp)!))             // 3.14
+  println(float.to_string(float.parse(nnbsp + "-2.5" + mmsp)!))            // -2.5
+}


### PR DESCRIPTION
## Unicode-whitespace cluster — WASM trim/is_whitespace were ASCII-only

WASM `string.trim` / `trim_start` / `trim_end` / `is_whitespace`, and the leading/trailing trim inside `int.parse` / `float.parse`, treated only `{0x09,0x0A,0x0D,0x20}` as whitespace. Native uses Rust `str::trim*()` / `char::is_whitespace` = the Unicode **White_Space** property (25 codepoints). So a string padded with a non-ASCII space (`U+00A0`, `U+2009`, `U+3000`, …) trimmed/compared/parsed differently native vs WASM.

The fix also corrects **two latent bugs** in the old byte version:
- It missed **VT (`0x0B`)** and **FF (`0x0C`)** (which Rust *does* treat as whitespace).
- `is_whitespace("")` returned **false**, but native `s.chars().all(..)` on the empty string is vacuously **true**.

### Approach — one oracle-derived source of truth
A single runtime fn `__is_unicode_ws(scalar) -> i32` whose ranges are **generated at emit time from Rust `char::is_whitespace`** (no hardcoded codepoints — version-locked to the toolchain, same as the case tables). All six sites decode codepoints with the existing `utf8_scalar`/`utf8_width` helpers and route through it; `trim_end` and the trailing parse-trim step **backward** over UTF-8 (skipping continuation bytes to the lead byte), reusing the A-case pattern. Shared `emit_trim_forward`/`emit_trim_backward` helpers replace four inconsistent ad-hoc ASCII byte-sets.

### Proof
- **Exhaustive: `is_whitespace` over all 1,112,064 scalars is byte-identical native==WASM** — exactly the 25 White_Space codepoints.
- New `spec/wasm_cross/string_whitespace.almd` corpus (NBSP/thin/ideographic/line-sep/VT/FF trims, ZWSP kept, `is_whitespace("")`, Unicode-space-padded int/float parse) — byte-identical.
- A `#[test]` asserts the generated ranges equal `char::is_whitespace` (and the VT/FF-in, ZWSP-out boundary).
- Full `cargo test --release` 0 failures; native spec 242/242; WASM 234/8skip/0.
- Adversarial-verify pass (4 agents): **0 divergences** across emoji/CJK multibyte boundaries, the backward-stepper, ~600 parse cases, and a 2000-case fuzz; near-miss chars sharing a UTF-8 prefix (`U+3000` ws `E3 80 80` vs `U+3001` `E3 80 81`) correctly distinguished.