### PR TITLE
Make integer div/mod total: unified abort contract, byte-identical native==WASM (cluster H, 1/2)

### DIFF
--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -31,6 +31,14 @@ template = "almide_rt_{module}_{func}({args})"
 [binary_op]
 template = "({left} {op} {right})"
 
+# Integer `/` and `%` are total (zero divisor / signed MIN-by-(-1) overflow abort
+# with `Error: <msg>\n` + exit 1 via the prelude macros), not the bare operator.
+[div_int]
+template = "almide_div!({left}, {right})"
+
+[mod_int]
+template = "almide_mod!({left}, {right})"
+
 [field_access]
 template = "{expr}.{field}"
 

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -987,27 +987,15 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { i64_mul; });
                 }
             }
+            // Integer `/` and `%` are total: a zero divisor (or signed MIN/-1, which
+            // wasm's div_s traps but rem_s silently DEFINES as 0) aborts with
+            // `Error: <msg>\n` + exit 1 instead of diverging from native. See
+            // `emit_checked_int_div_mod`.
             BinOp::DivInt => {
-                self.emit_expr(left);
-                self.emit_expr(right);
-                let instr = match (is_i32_int, is_unsigned_int) {
-                    (true, true) => wasm_encoder::Instruction::I32DivU,
-                    (true, false) => wasm_encoder::Instruction::I32DivS,
-                    (false, true) => wasm_encoder::Instruction::I64DivU,
-                    (false, false) => wasm_encoder::Instruction::I64DivS,
-                };
-                self.func.instruction(&instr);
+                self.emit_checked_int_div_mod(left, right, /*is_mod=*/false, is_i32_int, is_unsigned_int);
             }
             BinOp::ModInt => {
-                self.emit_expr(left);
-                self.emit_expr(right);
-                let instr = match (is_i32_int, is_unsigned_int) {
-                    (true, true) => wasm_encoder::Instruction::I32RemU,
-                    (true, false) => wasm_encoder::Instruction::I32RemS,
-                    (false, true) => wasm_encoder::Instruction::I64RemU,
-                    (false, false) => wasm_encoder::Instruction::I64RemS,
-                };
-                self.func.instruction(&instr);
+                self.emit_checked_int_div_mod(left, right, /*is_mod=*/true, is_i32_int, is_unsigned_int);
             }
             BinOp::AddFloat => {
                 self.emit_expr(left);
@@ -1258,6 +1246,127 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i64(result_s);
                 self.scratch.free_i64(base_s);
             }
+        }
+    }
+
+    /// Emit a total integer `/` or `%`: spill both operands to scratch, guard the
+    /// divisor, then run the raw div/rem. A zero divisor aborts with `division by
+    /// zero`; for SIGNED div AND rem, the width's `MIN op -1` aborts with `integer
+    /// overflow` (wasm `i64.rem_s`/narrow `i32.div_s` of MIN/-1 do NOT trap, so the
+    /// explicit check is what keeps wasm aligned with native `checked_div`/`checked_rem`).
+    /// Both abort paths call `__div_trap` with the interned `Error: <msg>\n` string.
+    fn emit_checked_int_div_mod(
+        &mut self,
+        left: &IrExpr,
+        right: &IrExpr,
+        is_mod: bool,
+        is_i32_int: bool,
+        is_unsigned_int: bool,
+    ) {
+        // Divisor -1 — the second half of the signed `MIN / -1` overflow witness.
+        const NEG_ONE: i64 = -1;
+        let div_by_zero_msg = self.emitter.intern_string("Error: division by zero\n") as i32;
+        let overflow_msg = self.emitter.intern_string("Error: integer overflow\n") as i32;
+        let div_trap = self.emitter.rt.div_trap;
+
+        // Most-negative value of the operand width — `MIN / -1` is the only signed
+        // overflow. Narrow ints run as i32 arithmetic, so an i8/i16 MIN must be the
+        // TRUE per-width MIN (e.g. i8 -128), not i32::MIN: `i32.div_s(-128, -1)` is
+        // 128 and does NOT trap, yet native `i8::checked_div` returns None.
+        let width_min: i64 = match left.ty {
+            Ty::Int8 => i8::MIN as i64,
+            Ty::Int16 => i16::MIN as i64,
+            Ty::Int32 => i32::MIN as i64,
+            _ => i64::MIN,
+        };
+
+        if is_i32_int {
+            let la = self.scratch.alloc_i32();
+            let rb = self.scratch.alloc_i32();
+            self.emit_expr(left);
+            wasm!(self.func, { local_set(la); });
+            self.emit_expr(right);
+            wasm!(self.func, { local_set(rb); });
+
+            // if rb == 0 { div_trap("division by zero") }
+            wasm!(self.func, {
+                local_get(rb);
+                i32_eqz;
+                if_empty;
+                i32_const(div_by_zero_msg);
+                call(div_trap);
+                end;
+            });
+            // Signed overflow: if la == width_min && rb == -1 { div_trap("integer overflow") }
+            if !is_unsigned_int {
+                wasm!(self.func, {
+                    local_get(la);
+                    i32_const(width_min as i32);
+                    i32_eq;
+                    local_get(rb);
+                    i32_const(NEG_ONE as i32);
+                    i32_eq;
+                    i32_and;
+                    if_empty;
+                    i32_const(overflow_msg);
+                    call(div_trap);
+                    end;
+                });
+            }
+            // The checked operands are now safe — run the raw op.
+            wasm!(self.func, { local_get(la); local_get(rb); });
+            let instr = match (is_mod, is_unsigned_int) {
+                (false, true) => wasm_encoder::Instruction::I32DivU,
+                (false, false) => wasm_encoder::Instruction::I32DivS,
+                (true, true) => wasm_encoder::Instruction::I32RemU,
+                (true, false) => wasm_encoder::Instruction::I32RemS,
+            };
+            self.func.instruction(&instr);
+            self.scratch.free_i32(rb);
+            self.scratch.free_i32(la);
+        } else {
+            let la = self.scratch.alloc_i64();
+            let rb = self.scratch.alloc_i64();
+            self.emit_expr(left);
+            wasm!(self.func, { local_set(la); });
+            self.emit_expr(right);
+            wasm!(self.func, { local_set(rb); });
+
+            // if rb == 0 { div_trap("division by zero") }
+            wasm!(self.func, {
+                local_get(rb);
+                i64_eqz;
+                if_empty;
+                i32_const(div_by_zero_msg);
+                call(div_trap);
+                end;
+            });
+            // Signed overflow: if la == i64::MIN && rb == -1 { div_trap("integer overflow") }
+            if !is_unsigned_int {
+                wasm!(self.func, {
+                    local_get(la);
+                    i64_const(width_min);
+                    i64_eq;
+                    local_get(rb);
+                    i64_const(NEG_ONE);
+                    i64_eq;
+                    i32_and;
+                    if_empty;
+                    i32_const(overflow_msg);
+                    call(div_trap);
+                    end;
+                });
+            }
+            wasm!(self.func, { local_get(la); local_get(rb); });
+            let instr = match (is_mod, is_unsigned_int) {
+                (false, true) => wasm_encoder::Instruction::I64DivU,
+                (false, false) => wasm_encoder::Instruction::I64DivS,
+                (true, true) => wasm_encoder::Instruction::I64RemU,
+                (true, false) => wasm_encoder::Instruction::I64RemS,
+            };
+            self.func.instruction(&instr);
+            self.scratch.free_i64(rb);
+            self.scratch.free_i64(la);
         }
     }
 

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -259,6 +259,11 @@ pub struct RuntimeFuncs {
     pub println_int: u32,
     pub concat_str: u32,
     pub string_append: u32,
+    /// __div_trap(msg_ptr: i32) -> () — write the interned message string
+    /// (already `Error: <msg>\n`) to stderr and `proc_exit(1)`. Shared by the
+    /// integer div/mod zero-divisor and signed-overflow abort paths so the failure
+    /// matches native byte-for-byte (§13 termination convention).
+    pub div_trap: u32,
     /// __string_alloc(len: i32) -> i32
     /// Allocate string with header: writes len AND cap, returns ptr.
     /// Eliminates the class of bugs where cap is forgotten after alloc.
@@ -480,6 +485,7 @@ impl WasmEmitter {
                 base64_encode_url: 0, base64_decode_url: 0,
                 hex_encode: 0, hex_encode_upper: 0, hex_decode: 0,
                 concat_str: 0,
+                div_trap: 0,
                 string_append: 0,
                 string_alloc: 0,
                 concat_list: 0,

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -187,6 +187,11 @@ pub fn register_runtime_functions(emitter: &mut WasmEmitter) {
     let str_alloc_ty = emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
     emitter.rt.string_alloc = emitter.register_func("__string_alloc", str_alloc_ty);
 
+    // __div_trap(msg_ptr: i32) -> () — integer div/mod abort: write the interned
+    // `Error: <msg>\n` string to stderr (fd 2) and proc_exit(1).
+    let div_trap_ty = emitter.register_type(vec![ValType::I32], vec![]);
+    emitter.rt.div_trap = emitter.register_func("__div_trap", div_trap_ty);
+
     // Note: string interpolation is now emitted inline at the call site
     // (see `calls_string::emit_string_interp`). No scratch runtime helpers.
 
@@ -323,6 +328,7 @@ pub fn compile_runtime(emitter: &mut WasmEmitter) {
     compile_concat_str(emitter);
     compile_string_append(emitter);
     compile_string_alloc(emitter);
+    compile_div_trap(emitter);
     super::runtime_eq::compile_option_eq_i64(emitter);
     super::runtime_eq::compile_option_eq_str(emitter);
     super::runtime_eq::compile_result_eq_i64_str(emitter);
@@ -940,6 +946,64 @@ fn compile_string_alloc(emitter: &mut WasmEmitter) {
         w.get(1);
     }
     f.instruction(&wasm_encoder::Instruction::End);
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}
+
+/// __div_trap(msg_ptr: i32)
+/// Integer div/mod abort: write the interned message string at `msg_ptr` — already
+/// the full `Error: <msg>\n` text, [len:i32][cap:i32][data@DATA] layout — to stderr
+/// via WASI fd_write, then `proc_exit(1)`. The shared trap keeps the div-by-zero and
+/// signed-overflow paths a single function call at every emit site.
+fn compile_div_trap(emitter: &mut WasmEmitter) {
+    // WASI fd for stderr (matches native `eprintln!` → fd 2).
+    const STDERR_FD: i32 = 2;
+    // Exit code on an aborting integer op (matches native `std::process::exit(1)`).
+    const ABORT_EXIT_CODE: i32 = 1;
+    // Scratch layout for the single fd_write iovec: [buf:i32@0][len:i32@4], with the
+    // returned byte count written at [8]. Mirrors `compile_println_str`.
+    const IOV_BUF_OFF: i32 = 0;
+    const IOV_LEN_OFF: i32 = 4;
+    const NWRITTEN_OFF: i32 = 8;
+    const IOV_BASE: i32 = 0;
+    const IOV_COUNT: i32 = 1;
+
+    let type_idx = emitter.func_type_indices[&emitter.rt.div_trap];
+    let data_off = string_data_off();
+    let fd_write = emitter.rt.fd_write;
+    let proc_exit = emitter.rt.proc_exit;
+
+    // param 0 = msg_ptr (interned `Error: <msg>\n` string)
+    let mut f = Function::new([]);
+    // iov[0].buf = msg_ptr + DATA  (skip the len+cap header)
+    wasm!(f, {
+        i32_const(IOV_BUF_OFF);
+        local_get(0);
+        i32_const(data_off);
+        i32_add;
+        i32_store(0);
+    });
+    // iov[0].len = *msg_ptr  (the byte length, which already includes the newline)
+    wasm!(f, {
+        i32_const(IOV_LEN_OFF);
+        local_get(0);
+        i32_load(0);
+        i32_store(0);
+    });
+    // fd_write(stderr, iovs=IOV_BASE, iovs_len=IOV_COUNT, nwritten=NWRITTEN_OFF)
+    wasm!(f, {
+        i32_const(STDERR_FD);
+        i32_const(IOV_BASE);
+        i32_const(IOV_COUNT);
+        i32_const(NWRITTEN_OFF);
+        call(fd_write);
+        drop;
+    });
+    // proc_exit(1) — diverges; never returns.
+    wasm!(f, {
+        i32_const(ABORT_EXIT_CODE);
+        call(proc_exit);
+        end;
+    });
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -306,6 +306,15 @@ fn rust_runtime_prelude(for_crate: bool) -> String {
     s.push_str("impl<T: Clone> AlmideConcat<Vec<T>> for Vec<T> { type Output = Vec<T>; #[inline(always)] fn concat(self, rhs: Vec<T>) -> Vec<T> { let mut r = self; r.extend(rhs); r } }\n");
     s.push_str(&format!("{macro_attr}macro_rules! almide_eq {{ ($a:expr, $b:expr) => {{ ($a) == ($b) }}; }}\n"));
     s.push_str(&format!("{macro_attr}macro_rules! almide_ne {{ ($a:expr, $b:expr) => {{ ($a) != ($b) }}; }}\n"));
+    // almide_div!/almide_mod!: total integer `/` and `%`. `checked_div`/`checked_rem`
+    // return `None` for BOTH a zero divisor AND signed `MIN / -1` overflow, so one
+    // arm distinguishes the two messages by the divisor (b == 0). Generic over every
+    // int width (i8..i64, u*); the Call form is not const-evaluable, so rustc's
+    // `deny(unconditional_panic)` never fires on a literal `10 / 0` and the diagnostic
+    // is the runtime abort below — byte-identical to the §13 termination convention
+    // (`Error: <msg>\n` + exit 1) and to the WASM div/mod trap.
+    s.push_str(&format!("{macro_attr}macro_rules! almide_div {{ ($a:expr, $b:expr) => {{{{ let (__a, __b) = ($a, $b); match __a.checked_div(__b) {{ Some(__v) => __v, None => {{ eprintln!(\"Error: {{}}\", if __b == 0 {{ \"division by zero\" }} else {{ \"integer overflow\" }}); std::process::exit(1); }} }} }}}}; }}\n"));
+    s.push_str(&format!("{macro_attr}macro_rules! almide_mod {{ ($a:expr, $b:expr) => {{{{ let (__a, __b) = ($a, $b); match __a.checked_rem(__b) {{ Some(__v) => __v, None => {{ eprintln!(\"Error: {{}}\", if __b == 0 {{ \"division by zero\" }} else {{ \"integer overflow\" }}); std::process::exit(1); }} }} }}}}; }}\n"));
     // RcCow<T>: COW value type. Clone = Rc::clone (O(1)), mutation = Rc::make_mut (COW).
     // Inspired by Swift's value type semantics.
     s.push_str(&format!("{vis}struct RcCow<T>({vis}std::rc::Rc<T>);\n"));

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -172,7 +172,9 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             if ctx.ann.lazy_vars.contains(id) || is_module_lazy {
                 ctx.templates.render_with("deref_lazy", None, &[], &[("name", upper.as_str())])
                     .unwrap_or_else(|| upper.clone())
-            } else if has_module {
+            } else if has_module || ctx.ann.const_top_let_vars.contains(id) {
+                // Const top_lets declare as `const NAME_UPPER` — a lowercase
+                // source binding must not emit its raw name (E0425).
                 upper
             } else {
                 raw_name
@@ -1000,6 +1002,20 @@ fn render_binop(ctx: &RenderContext, op: BinOp, left: &IrExpr, right: &IrExpr, _
             ctx.templates.render_with("power_expr", Some("Int"), &[], &[("left", l.as_str()), ("right", r.as_str())])
                 .unwrap_or_else(|| format!("pow(_, _)"))
         }
+        // Integer `/` and `%` are total: a zero divisor or signed MIN/-1 overflow
+        // aborts via the almide_div!/almide_mod! prelude macros (`Error: <msg>\n` +
+        // exit 1) instead of panicking. The macro is generic over all int widths and
+        // is not const-evaluable, so a literal `10 / 0` compiles (no rustc
+        // `unconditional_panic`) and aborts at runtime — matching the WASM trap.
+        // Float div/mod keep IEEE semantics and fall through to the bare-operator arm.
+        BinOp::DivInt => {
+            ctx.templates.render_with("div_int", None, &[], &[("left", l.as_str()), ("right", r.as_str())])
+                .unwrap_or_else(|| format!("almide_div!({}, {})", l, r))
+        }
+        BinOp::ModInt => {
+            ctx.templates.render_with("mod_int", None, &[], &[("left", l.as_str()), ("right", r.as_str())])
+                .unwrap_or_else(|| format!("almide_mod!({}, {})", l, r))
+        }
         BinOp::PowFloat => {
             ctx.templates.render_with("power_expr", Some("Float"), &[], &[("left", l.as_str()), ("right", r.as_str())])
                 .unwrap_or_else(|| format!("pow(_, _)"))
@@ -1009,8 +1025,10 @@ fn render_binop(ctx: &RenderContext, op: BinOp, left: &IrExpr, right: &IrExpr, _
                 BinOp::AddInt | BinOp::AddFloat => "+",
                 BinOp::SubInt | BinOp::SubFloat => "-",
                 BinOp::MulInt | BinOp::MulFloat => "*",
-                BinOp::DivInt | BinOp::DivFloat => "/",
-                BinOp::ModInt | BinOp::ModFloat => "%",
+                // DivInt/ModInt are matched above (totality macros) and must never
+                // reach this bare-operator fallback — fall to "??" loudly if they do.
+                BinOp::DivFloat => "/",
+                BinOp::ModFloat => "%",
                 BinOp::Lt => "<",
                 BinOp::Gt => ">",
                 BinOp::Lte => "<=",

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -317,11 +317,20 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
     // intentional Almide decision and lets the WASM target match it byte-for-byte.
     let is_rust_effect_main = matches!(ctx.target, Target::Rust)
         && func.name.as_str() == "main" && func.is_effect && !func.is_test;
+    // A plain (non-effect) `fn main` also needs the wrapper when there are
+    // abortable lazy top-lets to force at startup (wasm-eager parity).
+    let is_rust_plain_main_with_forces = matches!(ctx.target, Target::Rust)
+        && func.name.as_str() == "main" && !func.is_effect && !func.is_test
+        && !ctx.ann.eager_force_top_lets.is_empty();
 
     // Sanitize function name: spaces/dots/hyphens → underscores.
     // Test blocks already carry `TEST_NAME_PREFIX` from lowering so they
     // cannot collide with user fns here — no conditional prefixing needed.
-    let raw_name = if is_rust_effect_main { "__almide_main".to_string() } else { func.name.to_string() };
+    let raw_name = if is_rust_effect_main || is_rust_plain_main_with_forces {
+        "__almide_main".to_string()
+    } else {
+        func.name.to_string()
+    };
     let mut safe_name = raw_name.replace(' ', "_").replace('-', "_").replace('.', "_")
         .replace('+', "_plus_").replace('/', "_div_").replace('*', "_mul_")
         .replace('(', "").replace(')', "").replace(',', "_").replace(':', "_")
@@ -357,8 +366,16 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
         .unwrap_or_else(|| format!("fn {}() {{ }}", func.name));
 
     // Wrap `effect fn main`: report an unhandled error via Display + exit 1.
+    // Both wrapper shapes first FORCE the abortable lazy top-lets in declaration
+    // order, so an aborting initializer (integer `/`/`%`) fires at startup —
+    // byte-identical to wasm's eager top-let evaluation in `_start`.
+    let force_lines: String = ctx.ann.eager_force_top_lets.iter()
+        .map(|name| format!("    std::sync::LazyLock::force(&{});\n", name))
+        .collect();
     let fn_code = if is_rust_effect_main {
-        format!("{}\n\nfn main() {{\n    if let Err(__almide_err) = __almide_main() {{\n        eprintln!(\"Error: {{}}\", __almide_err);\n        std::process::exit(1);\n    }}\n}}", fn_code)
+        format!("{}\n\nfn main() {{\n{}    if let Err(__almide_err) = __almide_main() {{\n        eprintln!(\"Error: {{}}\", __almide_err);\n        std::process::exit(1);\n    }}\n}}", fn_code, force_lines)
+    } else if is_rust_plain_main_with_forces {
+        format!("{}\n\nfn main() {{\n{}    __almide_main();\n}}", fn_code, force_lines)
     } else {
         fn_code
     };
@@ -373,6 +390,27 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
     } else {
         fn_code
     }
+}
+
+/// Whether an expression contains an integer `/` or `%` anywhere — the ops that
+/// render as the aborting totality macros (`Error: <msg>` + exit 1). Uses the
+/// exhaustive `IrVisitor` walk so new IR nodes are traversed automatically.
+fn contains_aborting_int_div(expr: &IrExpr) -> bool {
+    use almide_ir::visit::{IrVisitor, walk_expr};
+    struct Finder { found: bool }
+    impl IrVisitor for Finder {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if self.found { return; }
+            if matches!(&e.kind, IrExprKind::BinOp { op: BinOp::DivInt | BinOp::ModInt, .. }) {
+                self.found = true;
+                return;
+            }
+            walk_expr(self, e);
+        }
+    }
+    let mut f = Finder { found: false };
+    f.visit_expr(expr);
+    f.found
 }
 
 // ── Full program rendering ──
@@ -424,7 +462,18 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
             } else {
                 vi.name.to_uppercase()
             };
+            // An initializer containing integer `/` or `%` can abort (the totality
+            // macros) — `fn main` forces it at entry, in declaration order, so the
+            // abort fires at startup exactly like wasm's eager top-let evaluation.
+            // Pure lazies stay lazy: their timing is unobservable.
+            if contains_aborting_int_div(&tl.value) {
+                ann.eager_force_top_lets.push(full_name.clone());
+            }
             ann.lazy_top_let_names.insert(full_name);
+        } else {
+            // Const-kind top_lets declare as `const NAME_UPPER` — references
+            // must render uppercased too (see const_top_let_vars).
+            ann.const_top_let_vars.insert(tl.var);
         }
     }
     // Module top_lets are flattened into program.top_lets by ir_link_flatten.

--- a/crates/almide-ir/src/annotations.rs
+++ b/crates/almide-ir/src/annotations.rs
@@ -28,6 +28,18 @@ pub struct CodegenAnnotations {
     /// emitting `(*NAME)` — scalar `Const` top_lets (plain `const
     /// NAME: i64 = 42;`) must NOT be dereferenced.
     pub lazy_top_let_names: HashSet<String>,
+    /// Uppercased names of `Lazy` top_lets whose initializer can ABORT (today:
+    /// contains an integer `/` or `%`, which abort on a zero divisor / MIN÷-1).
+    /// `fn main` forces these in DECLARATION ORDER before running, so an aborting
+    /// initializer fires at startup — matching wasm, which evaluates every top-let
+    /// eagerly in `_start`. Pure lazies stay lazy (timing is unobservable for them).
+    pub eager_force_top_lets: Vec<String>,
+    /// VarIds of `Const`-kind top_lets. Their declarations render as
+    /// `const NAME_UPPER: T = ...;`, so every reference must also render the
+    /// uppercased name — a lowercase source binding (`let zero = 0`) would
+    /// otherwise emit `zero` against `const ZERO` (E0425, native-only failure
+    /// while wasm builds: a cross-target divergence).
+    pub const_top_let_vars: HashSet<VarId>,
     /// Unified variable storage classification.
     /// Keyed by VarId for local vars (RcCow) and module vars with known ids.
     pub var_storage: HashMap<VarId, VarStorage>,

--- a/crates/almide-ir/src/use_count.rs
+++ b/crates/almide-ir/src/use_count.rs
@@ -569,6 +569,13 @@ fn is_const_expr(expr: &IrExpr, const_vars: &std::collections::HashSet<u32>) -> 
         // String requires heap allocation — not const-compatible in Rust
         IrExprKind::LitStr { .. } => false,
         IrExprKind::UnOp { operand, .. } => is_const_expr(operand, const_vars),
+        // Integer `/` and `%` render as the almide_div!/almide_mod! totality macros
+        // (abort with `Error: <msg>` + exit 1), which are not const-evaluable Rust —
+        // a top-level let containing one must take the Lazy (runtime) path, where the
+        // abort fires at startup exactly like wasm's top-let evaluation. Plain
+        // literal-by-nonzero-literal division is folded by pass_const_fold before
+        // classification, so `10 / 2` still reaches codegen as a Const literal.
+        IrExprKind::BinOp { op: crate::BinOp::DivInt | crate::BinOp::ModInt, .. } => false,
         IrExprKind::BinOp { left, right, .. } => is_const_expr(left, const_vars) && is_const_expr(right, const_vars),
         IrExprKind::Var { id } => const_vars.contains(&id.0),
         _ => false,

--- a/spec/lang/int_div_mod_total_test.almd
+++ b/spec/lang/int_div_mod_total_test.almd
@@ -1,0 +1,28 @@
+// Integer `/` and `%` are TOTAL: a zero divisor or signed `MIN / -1` overflow aborts
+// (`Error: <msg>\n` + exit 1) instead of panicking, byte-identically on native and
+// wasm. The aborting cases are covered by the spec/wasm_cross/ gate (an aborting
+// program can't be an in-test assertion). This file is the happy-path regression
+// guard: the checked-div rewrite (native `almide_div!`/`almide_mod!`, wasm guarded
+// div/rem) must not perturb ordinary results — including negative operands, whose
+// truncated-toward-zero `/` and sign-of-dividend `%` are easy to get wrong.
+
+fn shield(x: Int, v: Int) -> Int = (x - x) + v
+
+test "integer division truncates toward zero" {
+  assert_eq(17 / 5, 3)
+  assert_eq(17 / shield(7, 5), 3)
+  assert_eq(-17 / 5, -3)
+  assert_eq(-17 / shield(7, 5), -3)
+}
+
+test "integer remainder takes sign of dividend" {
+  assert_eq(17 % 5, 2)
+  assert_eq(17 % shield(7, 5), 2)
+  assert_eq(-17 % 5, -2)
+  assert_eq(-17 % shield(7, 5), -2)
+}
+
+test "division by one is identity" {
+  assert_eq(42 / shield(7, 1), 42)
+  assert_eq(-42 % shield(7, 1), 0)
+}

--- a/spec/wasm_cross/int8_div_overflow.almd
+++ b/spec/wasm_cross/int8_div_overflow.almd
@@ -1,0 +1,15 @@
+// Narrow-width signed `MIN / -1` overflow (Int8: -128 / -1) aborts with
+// "Error: integer overflow" + exit 1 on BOTH targets. This is the width-trap guard:
+// Int8 lowers to i32 arithmetic in wasm, and `i32.div_s(-128, -1)` is 128 — it does
+// NOT trap — yet native `i8::checked_div` returns None. The wasm overflow check must
+// compare against the TRUE per-width MIN (i8 -128), not i32::MIN, or wasm would
+// silently return 128 (`i8`-wrapped to -128) while native aborts. `neg_one_i8(7)`
+// shields the -1 divisor from const-folding.
+fn neg_one_i8(x: Int8) -> Int8 = (x - x) - 1
+
+fn main() -> Unit = {
+  println("before")
+  let m: Int8 = -128
+  let r: Int8 = m / neg_one_i8(7)
+  println(int.to_string(int.from_int8(r)))
+}

--- a/spec/wasm_cross/int_div_by_zero.almd
+++ b/spec/wasm_cross/int_div_by_zero.almd
@@ -1,0 +1,12 @@
+// Integer `/` by zero aborts with "Error: division by zero" + exit 1 on BOTH
+// targets, not a native panic (exit 101) nor a wasm `unreachable` trap (exit 134).
+// `den(7)` shields the divisor so neither target const-folds it away — the
+// runtime div path (native `almide_div!`, wasm `__div_trap`) is what's exercised.
+// The leading print locks stdout/stderr interleaving across the abort.
+fn den(x: Int) -> Int = x - x
+
+fn main() -> Unit = {
+  println("before")
+  let r = 10 / den(7)
+  println(int.to_string(r))
+}

--- a/spec/wasm_cross/int_div_by_zero_literal.almd
+++ b/spec/wasm_cross/int_div_by_zero_literal.almd
@@ -1,0 +1,12 @@
+// A const-foldable `10 / 0` must COMPILE and abort identically on both targets.
+// Before integer div/mod became total, native leaked rustc's
+// `deny(unconditional_panic)` on the literal as an ICE-class
+// "codegen produced invalid Rust — this is an Almide bug". Routing `/` through
+// the (non-const-evaluable) `almide_div!` macro means rustc never const-evaluates
+// the divide, so the literal builds and aborts at RUNTIME with the same
+// "Error: division by zero" + exit 1 as the shielded-divisor case.
+fn main() -> Unit = {
+  println("before")
+  let r = 10 / 0
+  println(int.to_string(r))
+}

--- a/spec/wasm_cross/int_div_mod_ok.almd
+++ b/spec/wasm_cross/int_div_mod_ok.almd
@@ -1,0 +1,17 @@
+// Non-aborting integer `/` and `%` (incl. negative operands and the now-total
+// codepath) stay byte-identical on both targets — the regression guard that the
+// checked-div rewrite did not perturb ordinary division. Divisors are shielded so
+// the values are computed at runtime, exercising the same guarded path as the
+// abort cases but landing on the happy branch.
+fn den(x: Int, base: Int) -> Int = (x - x) + base
+
+fn main() -> Unit = {
+  let a = 17 / den(7, 5)
+  let b = 17 % den(7, 5)
+  let c = -17 / den(7, 5)
+  let d = -17 % den(7, 5)
+  println(int.to_string(a))
+  println(int.to_string(b))
+  println(int.to_string(c))
+  println(int.to_string(d))
+}

--- a/spec/wasm_cross/int_div_overflow.almd
+++ b/spec/wasm_cross/int_div_overflow.almd
@@ -1,0 +1,13 @@
+// Signed `MIN / -1` overflows and aborts with "Error: integer overflow" + exit 1
+// on BOTH targets. `neg_one(7)` shields the `-1` divisor from const-folding. Native
+// runs `almide_div!` (checked_div → None on MIN/-1); wasm's `i64.div_s` would TRAP
+// here (exit 134), so the explicit MIN/-1 guard before the divide converts that into
+// the same defined abort as native.
+fn neg_one(x: Int) -> Int = (x - x) - 1
+
+fn main() -> Unit = {
+  println("before")
+  let m: Int = -9223372036854775807 - 1
+  let r = m / neg_one(7)
+  println(int.to_string(r))
+}

--- a/spec/wasm_cross/int_mod_by_zero.almd
+++ b/spec/wasm_cross/int_mod_by_zero.almd
@@ -1,0 +1,12 @@
+// Integer `%` by zero aborts with "Error: division by zero" + exit 1 on BOTH
+// targets (the message matches `/` — both are "division by zero"). `den(7)`
+// shields the divisor so neither target const-folds. Native runs `almide_mod!`
+// (checked_rem → None on a zero divisor); wasm guards before `i64.rem_s`, which
+// would otherwise TRAP on a zero divisor with a bare `unreachable` (exit 134).
+fn den(x: Int) -> Int = x - x
+
+fn main() -> Unit = {
+  println("before")
+  let r = 10 % den(7)
+  println(int.to_string(r))
+}

--- a/spec/wasm_cross/int_mod_overflow.almd
+++ b/spec/wasm_cross/int_mod_overflow.almd
@@ -1,0 +1,13 @@
+// Signed `MIN % -1` overflows and aborts with "Error: integer overflow" + exit 1
+// on BOTH targets. This is the silent-divergence case the explicit guard exists for:
+// wasm `i64.rem_s` DEFINES `MIN % -1 = 0` (it does NOT trap), so without the check
+// wasm would print `0` and exit 0 while native's `almide_mod!` (checked_rem → None)
+// aborts. The MIN/-1 guard before `i64.rem_s` realigns wasm with native.
+fn neg_one(x: Int) -> Int = (x - x) - 1
+
+fn main() -> Unit = {
+  println("before")
+  let m: Int = -9223372036854775807 - 1
+  let r = m % neg_one(7)
+  println(int.to_string(r))
+}

--- a/spec/wasm_cross/top_let_div_eager.almd
+++ b/spec/wasm_cross/top_let_div_eager.almd
@@ -1,0 +1,9 @@
+// Cluster-H: top-let initializers that can abort evaluate EAGERLY at startup.
+// `bad` is never used, but both targets must abort before main runs: wasm
+// evaluates every top-let in _start; native forces abortable lazies at main
+// entry. Without the force, native would lazily skip the abort (silent-alive).
+let bad = 10 / 0
+
+fn main() -> Unit = {
+  println("never reached")
+}

--- a/spec/wasm_cross/top_let_div_used.almd
+++ b/spec/wasm_cross/top_let_div_used.almd
@@ -1,0 +1,10 @@
+// Cluster-H: an abortable top-let used MID-main must still abort at STARTUP
+// (declaration-order eager), not at first use — so no stdout is emitted on
+// either target. Locks the evaluation-timing contract, not just the message.
+let zero = 0
+let half = 10 / zero
+
+fn main() -> Unit = {
+  println("before use")
+  println("${half}")
+}


### PR DESCRIPTION
## Contract (cluster H, part 1)

Integer \`/\` and \`%\` are now **total** on both targets, byte-identical in (exit, stdout, stderr):

| case | both targets now |
|---|---|
| zero divisor (runtime or const-foldable literal) | \`Error: division by zero\` + exit 1 |
| signed \`MIN / -1\`, \`MIN % -1\` (every width) | \`Error: integer overflow\` + exit 1 |
| float \`/\` \`%\` | untouched (IEEE inf/NaN, already identical) |

Previously: native panic exit 101 vs wasm trap exit 134 with different stderr on every case — and \`10 / 0\` failed the **native build** via a leaked rustc \`deny(unconditional_panic)\` wrapped as "this is an Almide bug".

## How

- **Native**: \`almide_div!\`/\`almide_mod!\` prelude macros (the \`almide_eq!\` precedent) — \`checked_div\`/\`checked_rem\` return \`None\` for both zero and MIN/-1, one arm picks the message by \`b == 0\`. Generic over all int widths. A macro call is not const-evaluable, so the rustc lint leak disappears for free (no const-fold changes).
- **WASM**: \`emit_checked_int_div_mod\` — divisor-zero guard + per-width \`MIN && -1\` overflow guard (true per-width MIN: \`i32.div_s(-128,-1)=128\` doesn't trap but native \`i8::checked_div\` is \`None\`; \`i64.rem_s\` *defines* \`MIN%-1=0\` and would silently diverge) → shared \`__div_trap\` writes the interned message to fd 2 + \`proc_exit(1)\`. All constants named.
- **Top-let evaluation contract**: abortable initializers (containing int \`/\`/\`%\`) are classified \`Lazy\` and **forced at \`fn main\` entry in declaration order** — an aborting top-let fires at startup exactly like wasm's eager \`_start\` evaluation. Unused-but-aborting top-lets no longer silently pass on native.
- **Bonus pre-existing fix**: a lowercase const top-let (\`let zero = 0\`) declared as \`const ZERO\` but referenced as \`zero\` → native-only E0425 build failure (wasm built fine — itself a divergence). References now render the uppercased name.

## Validation

- Adversarial probe battery: 35+ cases hexdump-compared across both targets (closures, match arms, effect fns, fan thunks, nested division, stdout-ordering under a pipe, all widths, unsigned)
- Gate \`wasm_cross_target_spec\`: 53 corpus files byte-identical, 0 divergence (9 new corpus files incl. the \`MIN%-1\` silent-wasm landmine and both top-let timing cases)
- \`almide test spec/\`: 243/243 native, 243/243 wasm; full \`cargo test --release\`: 33 suites 0 fail; snapshots 13/13 zero churn