### PR TITLE
Kernel-check Lean proofs in CI (lake build), not just a sorry-grep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,14 +200,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Two complementary checks — both are required for the "proven" claim:
+      # 1. grep for `sorry`: `lake build` only WARNS on sorry, so the grep is what
+      #    enforces that every theorem is actually proven, not stubbed.
+      # 2. `lake build`: kernel-checks that the proofs really compile — without it
+      #    a broken proof (or one that only ever built locally) passes CI silently.
       - name: Verify 0 sorry
         run: |
           if grep -rn '\bsorry\b' crates/almide-perceus-belt/AlmidePerceusBelt/ --include='*.lean'; then
             echo "::error::sorry found in Lean proofs — all theorems must be fully proven"
-            echo "Run 'cd crates/almide-perceus-belt && lake build' locally to verify"
             exit 1
           fi
-          echo "✓ 0 sorry in Lean proofs (kernel verification: run lake build locally)"
+          echo "✓ 0 sorry in Lean proofs"
+
+      - name: Kernel-check proofs (lake build)
+        uses: leanprover/lean-action@v1
+        with:
+          lake-package-directory: crates/almide-perceus-belt
 
   # ═══════════════════════════════════════════════
   # Checks


### PR DESCRIPTION
## What

The \`lean-proofs\` CI job only **grepped for the \`sorry\` token** and told you to "run lake build locally" — the 45 theorems (Perceus RC + closure env + heap) were never actually kernel-checked in CI. A proof that doesn't compile (or only ever built on one machine) passed silently.

Now the job does both, and both are required for the "proven" claim:

1. **\`sorry\` grep** (kept) — \`lake build\` only *warns* on \`sorry\`, so the grep is what enforces fully-proven.
2. **\`lake build\` via \`leanprover/lean-action@v1\`** (new) — kernel-checks the proofs on every PR. Toolchain pinned by \`lean-toolchain\` (v4.29.1), zero external deps, builds in seconds.

Stage 1 of the completeness roadmap (ratchet hardening), item 1.

## Validation

Local \`lake build\`: `Build completed successfully (14 jobs)` — all proofs kernel-check today, so this lands green.