### PR TITLE
Fix fan.map inline-lambda WASM trap: pin the callback type unconditionally

### DIFF
--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -990,6 +990,14 @@ pub fn infer_var_type_from_body(body: &IrExpr, var: VarId) -> Option<Ty> {
         IrExprKind::Match { subject, arms } =>
             infer_var_type_from_body(subject, var)
                 .or_else(|| arms.iter().find_map(|a| infer_var_type_from_body(&a.body, var))),
+        // Look through Result/Option constructors so a wrapped body like
+        // `ok(x * 10)` or `some(x * 10)` still exposes `x`'s use site. Without
+        // this, a callback whose param type the checker failed to pin would have
+        // no body-derived fallback either.
+        IrExprKind::ResultOk { expr }
+        | IrExprKind::ResultErr { expr }
+        | IrExprKind::OptionSome { expr } =>
+            infer_var_type_from_body(expr, var),
         _ => None,
     }
 }

--- a/crates/almide-frontend/src/check/static_dispatch.rs
+++ b/crates/almide-frontend/src/check/static_dispatch.rs
@@ -98,16 +98,26 @@ impl Checker {
                             Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 => args[0].clone(),
                             _ => Ty::Unknown,
                         };
-                        // Infer return type from f's return type
-                        let fn_ty = resolve_ty(&arg_tys[1], &self.uf);
-                        let result_elem = unwrap_fn_return(&fn_ty).unwrap_or_else(|| {
-                            let ret_var = self.fresh_var();
-                            self.constrain(arg_tys[1].clone(),
-                                Ty::Fn { params: vec![elem_ty], ret: Box::new(ret_var.clone()) },
-                                "fan.map callback");
-                            resolve_ty(&ret_var, &self.uf)
-                        });
-                        return Some(Ty::result(Ty::list(result_elem), Ty::String));
+                        // Pin the callback's full type — `Fn(elem_ty) -> Result[B, String]`
+                        // — UNCONDITIONALLY, mirroring the normal `list.map` rule
+                        // (check/calls.rs constrains the arg to `Fn { params: arg_tys, .. }`),
+                        // with fan.map's added contract that the callback returns a Result.
+                        // Two things hinge on this being unconditional, not a fallback:
+                        //   - Param pinning: an inline lambda whose return type resolves on
+                        //     its own — e.g. `(x) => ok(x * 10)` — would otherwise leave `x`
+                        //     a free var that resolves to Ty::Unknown in the IR. WASM closure
+                        //     registration then falls back to i32 for the param while the body
+                        //     emits i64 for `x * 10` (validator: i32 != i64).
+                        //   - Return contract: a callback returning a bare Int or an Option
+                        //     (e.g. `(x) => x * 10` / `(x) => some(...)`) is ill-typed and is
+                        //     now reported at check time, instead of silently lowering to
+                        //     invalid Rust (E0308: expected Result, found Int/Option).
+                        let result_elem = self.fresh_var();
+                        let callback_ret = Ty::result(result_elem.clone(), Ty::String);
+                        self.constrain(arg_tys[1].clone(),
+                            Ty::Fn { params: vec![elem_ty], ret: Box::new(callback_ret) },
+                            "fan.map callback");
+                        return Some(Ty::result(Ty::list(resolve_ty(&result_elem, &self.uf)), Ty::String));
                     }
                     "race" => {
                         // fan.race(thunks) -> Result[T, String] — the FIRST thunk in

--- a/spec/lang/fan_map_test.almd
+++ b/spec/lang/fan_map_test.almd
@@ -30,3 +30,39 @@ test "fan.map with capture" {
   let results = fan.map([1, 2, 3], (x) => add_offset(x, offset));
   assert_eq(results, ok([101, 102, 103]))
 }
+
+// ── Inline-lambda callbacks ──
+// These wrap the param in an `ok(...)`/`err(...)` directly in the lambda body
+// (no named effect fn). The Result wrapper hides the param's use site, so the
+// checker must still pin the callback param to the list element type. Otherwise
+// the param stays a free var -> Ty::Unknown -> WASM reads it as i32 while the
+// body emits i64 (validator: i32 != i64). All shapes are exercised here.
+
+test "fan.map inline ok lambda (i64 payload)" {
+  // The original break: `x * 10` is i64; without the param pin the wasm closure
+  // registered x as i32 and the module failed to build.
+  let results = fan.map([1, 2, 3], (x) => ok(x * 10));
+  assert_eq(results, ok([10, 20, 30]))
+}
+
+test "fan.map inline lambda capturing an outer Int" {
+  let factor = 100;
+  let results = fan.map([1, 2], (x) => ok(x * factor));
+  assert_eq(results, ok([100, 200]))
+}
+
+test "fan.map inline lambda changing the element type" {
+  let results = fan.map([7, 8], (x) => ok("n" + int.to_string(x)));
+  assert_eq(results, ok(["n7", "n8"]))
+}
+
+test "fan.map inline lambda over String elements" {
+  let results = fan.map(["a", "b"], (s) => ok(s + "!"));
+  assert_eq(results, ok(["a!", "b!"]))
+}
+
+test "fan.map inline lambda propagating element Err" {
+  let results = fan.map([1, 2, 3], (x) =>
+    if x == 2 then err("boom") else ok(x * 10));
+  assert_eq(results, err("boom"))
+}

--- a/spec/wasm_cross/fan_map_inline_err.almd
+++ b/spec/wasm_cross/fan_map_inline_err.almd
@@ -1,0 +1,11 @@
+// fan.map element-Err propagation through an INLINE lambda (vs fan_map_err.almd's
+// named `(x) => step(x)`). The first element fn that returns Err (in list order)
+// makes the whole fan.map produce that Err, which the effect-main termination
+// surfaces as "Error: <msg>" + exit 1 on BOTH targets — native via the Display
+// `fn main` wrapper, wasm via __main_runner. The inline `if ... then err(...) else
+// ok(x * 10)` body must still pin x:Int so the i64 `x * 10` path matches native.
+effect fn main() -> Unit = {
+  let mapped = fan.map([1, 2, 3], (x) =>
+    if x == 2 then err("element " + int.to_string(x) + " failed") else ok(x * 10))
+  println("unreachable: " + int.to_string(list.len(mapped)))
+}

--- a/spec/wasm_cross/fan_map_inline_lambda.almd
+++ b/spec/wasm_cross/fan_map_inline_lambda.almd
@@ -1,0 +1,36 @@
+// fan.map with an INLINE-lambda callback whose Result wrapper hides the param's
+// use site, e.g. `(x) => ok(x * 10)`. This is the shape that diverged: the named
+// callback in fan_deterministic.almd (`(x) => dbl(x)`) pins x:Int through dbl's
+// signature, but an inline `ok(x * 10)` lambda left x as a free var -> Ty::Unknown
+// in the IR. The WASM closure registration then read x as i32 while the body
+// emitted i64 for `x * 10`, so the module FAILED the validator (i32 != i64) and
+// never built. Native was fine. The fix pins the callback param to the list
+// element type unconditionally in the checker (fan.map type rule). All cases here
+// must build AND produce byte-identical output on native and wasm.
+effect fn main() -> Unit = {
+  // Bare inline ok(...) over Int — the original break (i64 payload behind a Result).
+  let tens = fan.map([1, 2, 3], (x) => ok(x * 10))
+  println("tens=" + int.to_string(list.len(tens)) + ":"
+    + int.to_string(tens[0]) + "," + int.to_string(tens[1]) + "," + int.to_string(tens[2]))
+
+  // Inline lambda that captures an outer Int.
+  let factor = 100
+  let scaled = fan.map([1, 2], (x) => ok(x * factor))
+  println("scaled=" + int.to_string(scaled[0]) + "," + int.to_string(scaled[1]))
+
+  // Inline lambda whose Result CHANGES the element type (Int -> String).
+  let named = fan.map([7, 8], (x) => ok("n" + int.to_string(x)))
+  println("named=" + named[0] + "|" + named[1])
+
+  // Inline lambda over a String list (no i64 payload — control for the type axis).
+  let banged = fan.map(["a", "b"], (s) => ok(s + "!"))
+  println("banged=" + banged[0] + "," + banged[1])
+
+  // Inline lambda with a nested closure in the body, still ok-wrapped.
+  let nested = fan.map([1, 2, 3], (x) => {
+    let bump = (y) => y + x
+    ok(bump(1000))
+  })
+  println("nested=" + int.to_string(nested[0]) + ","
+    + int.to_string(nested[1]) + "," + int.to_string(nested[2]))
+}


### PR DESCRIPTION
## The last catalogued cross-target divergence

\`fan.map([1, 2, 3], (x) => ok(x * 10))\` — an inline lambda wrapping its param in a Result/Option constructor — failed WASM validation (\`i32 != i64\` in \`__closure_0\`) while native ran fine. The named-fn shape \`(x) => dbl(x)\` worked, which is why the committed spec tests never caught it.

## Root cause (checker, not emit)

fan.map's special-cased type rule pinned the callback param to the list element type **only inside the \`unwrap_fn_return(..).unwrap_or_else(..)\` fallback**. An inline lambda whose return type resolves on its own (\`ok(x*10)\` → \`Result[Int, String]\`) skipped the fallback → \`x\` stayed a free var → \`Ty::Unknown\` in the IR → WASM closure registration defaulted the param to **i32** while the body emitted **i64** for \`x * 10\`. (Exactly the \`Unknown → i32\` silent-miscompile class the completeness roadmap's AllTypesConcrete hard-postcondition targets.)

## Fix

- **Checker**: constrain the callback **unconditionally** to \`Fn(elem_ty) -> Result[B, String]\`, mirroring how \`list.map\` is checked (which is why list.map was always immune). Bonus: a callback returning a bare Int or an Option is now a **proper E001 type error** instead of silently lowering to invalid Rust.
- **Defense in depth**: \`infer_var_type_from_body\` now looks through \`ok(..)/err(..)/some(..)\` wrappers, so the emit-side fallback ladder can see param uses inside Result/Option constructors.

## Validation

- Original repro + 11-combination probe matrix + adversarial battery (captures, mixed ok/err, String payloads, nested closures) — all build and run **byte-identical native==wasm**
- New corpus: \`spec/wasm_cross/fan_map_inline_lambda.almd\`, \`fan_map_inline_err.almd\`; \`spec/lang/fan_map_test.almd\` +5 asserts (validated on both targets)
- Suite: 244/244 native, 236+8 wasm, gate 67/67, snapshots clean