### PR TITLE
Drain A: full-Unicode string predicates + empty-pattern count/last_index_of (7 divergences)

### DIFF
--- a/crates/almide-codegen/rt-oracle-registry.toml
+++ b/crates/almide-codegen/rt-oracle-registry.toml
@@ -586,9 +586,10 @@ note = "No cross-target fixture calls string.replace_first yet. Drain: add it to
 [[routine]]
 file = "rt_string_extra.rs"
 routine = "compile_last_index_of"
-status = "grandfathered"
+status = "verified"
 oracle = "runtime/rs/src/string.rs::almide_rt_string_last_index_of (str::rfind — BYTE offset)"
-note = "No cross-target fixture calls string.last_index_of. Drain: add to string_ops.almd."
+test = "tests/wasm_runtime_test.rs::wasm_cross_target_spec"
+note = "Fixed 2026-06-05 (drain PR-A): empty pattern now Some(byte_len) matching str::rfind; corpus locks empty/ASCII/multibyte/astral subjects"
 
 [[routine]]
 file = "rt_string_extra.rs"
@@ -621,16 +622,18 @@ note = "No cross-target fixture for string.is_digit."
 [[routine]]
 file = "rt_string_extra.rs"
 routine = "compile_is_alpha"
-status = "grandfathered"
+status = "verified"
 oracle = "runtime/rs/src/string.rs::almide_rt_string_is_alpha (char::is_alphabetic — Unicode!)"
-note = "CONFIRMED DIVERGENT 2026-06-05: is_alpha(α)/is_alpha(漢) = native true, wasm false (ASCII-only). Fix = oracle-derived Alphabetic range table (the case-table Σ-probe pattern). Drain HIGH priority."
+test = "crates/almide-codegen/src/emit_wasm/rt_unicode_tables.rs::alphabetic_table_matches_char_method"
+note = "Fixed 2026-06-05 (drain PR-A): codepoint walk + oracle-derived Alphabetic range table; Σ-probe lock over all scalars + spec/wasm_cross/string_predicates.almd (byte-identical via tests/wasm_runtime_test.rs::wasm_cross_target_spec)"
 
 [[routine]]
 file = "rt_string_extra.rs"
 routine = "compile_is_alnum"
-status = "grandfathered"
+status = "verified"
 oracle = "runtime/rs/src/string.rs::almide_rt_string_is_alphanumeric (Unicode)"
-note = "Same Unicode-vs-ASCII risk as is_alpha; no fixture."
+test = "crates/almide-codegen/src/emit_wasm/rt_unicode_tables.rs::alphanumeric_table_matches_char_method"
+note = "Fixed 2026-06-05 (drain PR-A): codepoint walk + Alphanumeric range table; Σ-probe lock + spec/wasm_cross/string_predicates.almd (byte-identical via tests/wasm_runtime_test.rs::wasm_cross_target_spec)"
 
 [[routine]]
 file = "rt_string_extra.rs"
@@ -642,23 +645,42 @@ note = "The is_unicode_ws RANGES are Σ-probe-verified, but the string.is_whites
 [[routine]]
 file = "rt_string_extra.rs"
 routine = "compile_is_upper"
-status = "grandfathered"
+status = "verified"
 oracle = "runtime/rs/src/string.rs::almide_rt_string_is_upper (Unicode case query)"
-note = "No fixture; Unicode-vs-ASCII risk."
+test = "crates/almide-codegen/src/emit_wasm/rt_unicode_tables.rs::uppercase_table_matches_char_method"
+note = "Fixed 2026-06-05 (drain PR-A): any-alpha guard + Uppercase property table (was vacuous-true on multibyte/no-letter strings); Σ-probe lock + spec/wasm_cross/string_predicates.almd (byte-identical via tests/wasm_runtime_test.rs::wasm_cross_target_spec)"
 
 [[routine]]
 file = "rt_string_extra.rs"
 routine = "compile_is_lower"
-status = "grandfathered"
+status = "verified"
 oracle = "runtime/rs/src/string.rs::almide_rt_string_is_lower (Unicode case query)"
-note = "No fixture; Unicode-vs-ASCII risk."
+test = "crates/almide-codegen/src/emit_wasm/rt_unicode_tables.rs::lowercase_table_matches_char_method"
+note = "Fixed 2026-06-05 (drain PR-A): any-alpha guard + Lowercase property table; Σ-probe lock + spec/wasm_cross/string_predicates.almd (byte-identical via tests/wasm_runtime_test.rs::wasm_cross_target_spec)"
 
 [[routine]]
 file = "rt_string_extra.rs"
 routine = "compile_case_predicate"
-status = "grandfathered"
+status = "verified"
 oracle = "Rust char case predicate helper (is_uppercase/is_lowercase)"
-note = "Helper behind is_upper/is_lower; no fixture."
+test = "crates/almide-codegen/src/emit_wasm/rt_unicode_tables.rs::uppercase_table_matches_char_method"
+note = "Shared is_upper/is_lower body (any_alpha + all_ok walk over Alphabetic + case property tables); verified through both predicate Σ-probes + spec/wasm_cross/string_predicates.almd (byte-identical via tests/wasm_runtime_test.rs::wasm_cross_target_spec)"
+
+[[routine]]
+file = "rt_string_extra.rs"
+routine = "compile_all_codepoints_predicate"
+status = "verified"
+oracle = "Shared is_alpha/is_alnum body: !s.is_empty() && s.chars().all(|c| property(c)) (runtime/rs/src/string.rs:32,34 shape)"
+test = "crates/almide-codegen/src/emit_wasm/rt_unicode_tables.rs::alphabetic_table_matches_char_method"
+note = "Added in drain PR-A; codepoint walk via existing utf8_scalar/utf8_width; verified through the is_alpha/is_alnum Σ-probes + spec/wasm_cross/string_predicates.almd"
+
+[[routine]]
+file = "rt_string_extra.rs"
+routine = "compile_prop_membership"
+status = "verified"
+oracle = "Binary search over an RLE [lo,hi] range table derived at emit time from char::is_* (std is the source)"
+test = "crates/almide-codegen/src/emit_wasm/rt_unicode_tables.rs::alphabetic_table_matches_char_method"
+note = "Added in drain PR-A; the 4 Σ-probe locks exercise the search against every scalar 0..=0x10FFFF for each table"
 
 [[routine]]
 file = "rt_string_extra.rs"

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -24,6 +24,7 @@ mod runtime_eq;
 mod rt_string;
 mod rt_string_extra;
 mod rt_string_case;
+mod rt_unicode_tables;
 mod rt_numeric;
 mod rt_dragon;
 mod rt_dec2flt;
@@ -215,6 +216,24 @@ pub struct StringRuntime {
     /// char boundary (clamped to [0, byte_len]). Mirrors native `slice`'s
     /// boundary-safe byte indexing.
     pub utf8_snap: u32,
+    // ── Oracle-derived Unicode property membership (in `rt_unicode_tables`) ──
+    /// `(scalar: i32) -> i32` (0/1): binary-search the embedded property range
+    /// table for `is_alphabetic` / `is_alphanumeric` / `is_uppercase` /
+    /// `is_lowercase`. These make the WASM string predicates full-Unicode and
+    /// byte-identical to native's `char` methods. Each searches the table at the
+    /// matching `prop_*_table` offset below.
+    pub prop_alpha: u32,
+    pub prop_alnum: u32,
+    pub prop_upper: u32,
+    pub prop_lower: u32,
+    /// Data-section offsets of the embedded `[len][cap][data]` range-table blobs
+    /// (interned via `intern_bytes`, so dead-data elimination may relocate or
+    /// drop them). The membership helpers above emit the BARE offset as their
+    /// only data `i32.const` so a relocation stays correct.
+    pub prop_alpha_table: u32,
+    pub prop_alnum_table: u32,
+    pub prop_upper_table: u32,
+    pub prop_lower_table: u32,
     // ── Full-Unicode case folding (oracle-derived tables in `rt_string_case`) ──
     /// `__utf8_emit_scalar(dst, byte_off, scalar) -> i32`: encode `scalar` as
     /// UTF-8 at `dst`'s data section + byte_off; returns the advanced byte_off.
@@ -519,6 +538,9 @@ impl WasmEmitter {
                     utf8_scalar: 0,
                     utf8_byte_of_cp: 0,
                     utf8_snap: 0,
+                    prop_alpha: 0, prop_alnum: 0, prop_upper: 0, prop_lower: 0,
+                    prop_alpha_table: 0, prop_alnum_table: 0,
+                    prop_upper_table: 0, prop_lower_table: 0,
                     utf8_emit_scalar: 0,
                     case_map_lookup: 0,
                     set_member: 0,

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -126,6 +126,23 @@ pub fn register(emitter: &mut WasmEmitter) {
     // utf8_snap(s, byte_i) -> i32 : byte_i snapped down to a char boundary.
     emitter.rt.string.utf8_snap = emitter.register_func("__utf8_snap", ty_i32x2_i32);
 
+    // ── Unicode property membership (oracle-derived range tables) ──
+    // (scalar) -> i32 (0/1): binary-search the embedded property range table.
+    // Registered + compiled here (in order), AFTER the utf8_* helpers and BEFORE
+    // the case-folding group — same registration==compile discipline as those.
+    emitter.rt.string.prop_alpha = emitter.register_func("__str_prop_alpha", ty_i32_i32);
+    emitter.rt.string.prop_alnum = emitter.register_func("__str_prop_alnum", ty_i32_i32);
+    emitter.rt.string.prop_upper = emitter.register_func("__str_prop_upper", ty_i32_i32);
+    emitter.rt.string.prop_lower = emitter.register_func("__str_prop_lower", ty_i32_i32);
+    // Intern the range tables now so the helper bodies can reference their
+    // offsets as constants (and the dead-data eliminator keeps a table iff a
+    // live predicate references its offset).
+    use super::rt_unicode_tables::{intern_table, UnicodeProp};
+    emitter.rt.string.prop_alpha_table = intern_table(emitter, UnicodeProp::Alphabetic);
+    emitter.rt.string.prop_alnum_table = intern_table(emitter, UnicodeProp::Alphanumeric);
+    emitter.rt.string.prop_upper_table = intern_table(emitter, UnicodeProp::Uppercase);
+    emitter.rt.string.prop_lower_table = intern_table(emitter, UnicodeProp::Lowercase);
+
     // ── Full-Unicode case folding ──
     // Registered + compiled LAST, in identical order (same discipline as the
     // utf8_* helpers and Dragon4): bodies bind to indices by registration and
@@ -186,6 +203,9 @@ pub fn compile(emitter: &mut WasmEmitter) {
     compile_utf8_scalar(emitter);
     compile_utf8_byte_of_cp(emitter);
     compile_utf8_snap(emitter);
+    // Unicode property membership helpers — compiled here in registration order
+    // (alpha, alnum, upper, lower), between the utf8_* helpers and case folding.
+    super::rt_string_extra::compile_prop_membership(emitter);
     // Case folding — compiled LAST, in registration order.
     compile_utf8_emit_scalar(emitter);
     compile_case_map_lookup(emitter);
@@ -886,7 +906,9 @@ fn compile_count(emitter: &mut WasmEmitter) {
         i32_const(0); local_set(4); // pos
         local_get(1); i32_load(0); local_set(5); // sub_len
         local_get(5); i32_eqz;
-        if_i64; i64_const(0);
+        // Empty pattern: native `s.matches("").count()` == s.chars().count() + 1
+        // (one empty match at every char boundary, including the end).
+        if_i64; local_get(0); call(emitter.rt.string.char_count); i64_const(1); i64_add;
         else_;
           block_empty; loop_empty;
             local_get(0); local_get(4); local_get(0); i32_load(0);

--- a/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
@@ -47,7 +47,9 @@ pub(super) fn compile_last_index_of(emitter: &mut WasmEmitter) {
         local_get(1); i32_load(0); local_set(3);
         i64_const(-1); local_set(7);
         local_get(3); i32_eqz;
-        if_i64; i64_const(0);
+        // Empty pattern: native `s.rfind("")` == Some(s.len()) — the BYTE length
+        // (local 2). The Some sentinel is any non-negative i64; None is -1.
+        if_i64; local_get(2); i64_extend_i32_u;
         else_;
           i32_const(0); local_set(4);
           block_empty; loop_empty;
@@ -167,68 +169,125 @@ pub(super) fn compile_is_digit(emitter: &mut WasmEmitter) {
     compile_byte_predicate_range(emitter, emitter.rt.string.is_digit, 48, 57);
 }
 
-/// is_alpha: all bytes in [A-Z] or [a-z]
-/// Empty string returns false.
-pub(super) fn compile_is_alpha(emitter: &mut WasmEmitter) {
-    let func_idx = emitter.rt.string.is_alpha;
-    let type_idx = emitter.func_type_indices[&func_idx];
-    let mut f = Function::new([(1, ValType::I32), (1, ValType::I32)]);
-    wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
-        local_get(1); i32_eqz;
-        if_i32; i32_const(0);
-        else_;
-          i32_const(0); local_set(2);
-          block_empty; loop_empty;
-            local_get(2); local_get(1); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(2); i32_add; i32_load8_u(0);
-            local_tee(1);
-            // (65..90) or (97..122)
-            i32_const(65); i32_ge_u;
-            local_get(1); i32_const(90); i32_le_u; i32_and;
-            local_get(1); i32_const(97); i32_ge_u;
-            local_get(1); i32_const(122); i32_le_u; i32_and;
-            i32_or;
-            i32_eqz;
-            br_if(1);
-            local_get(0); i32_load(0); local_set(1);
-            local_get(2); i32_const(1); i32_add; local_set(2);
-            br(0);
-          end; end;
-          local_get(2); local_get(0); i32_load(0); i32_eq;
-        end;
-        end;
-    });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+// ── Unicode-aware codepoint predicates ──
+//
+// Native Almide derives `is_alpha`/`is_alphanumeric`/`is_upper`/`is_lower` from
+// Rust's full-Unicode `char` methods. The WASM versions below walk CODEPOINTS
+// (not bytes), decode each scalar with the shared `utf8_scalar`/`utf8_width`
+// helpers (same path `is_whitespace` uses), and binary-search the oracle-derived
+// property range tables (see rt_unicode_tables.rs). This makes native and WASM
+// equivalent by construction over the whole scalar space.
+
+/// Emit one `(scalar: i32) -> i32` binary-search membership helper per property,
+/// in registration order (alpha, alnum, upper, lower). Each searches the range
+/// table interned at `table_off`; the table is a sorted array of inclusive
+/// `[lo, hi]` little-endian u32 pairs, prefixed by the standard
+/// `[len:i32][cap:i32]` interned-blob header. `len` (= the byte length) gives the
+/// pair count via `len >> 3`, so no hardcoded range count is baked in.
+pub(super) fn compile_prop_membership(emitter: &mut WasmEmitter) {
+    use super::rt_unicode_tables::RANGE_ENTRY_BYTES;
+    let entries = [
+        (emitter.rt.string.prop_alpha, emitter.rt.string.prop_alpha_table),
+        (emitter.rt.string.prop_alnum, emitter.rt.string.prop_alnum_table),
+        (emitter.rt.string.prop_upper, emitter.rt.string.prop_upper_table),
+        (emitter.rt.string.prop_lower, emitter.rt.string.prop_lower_table),
+    ];
+    // log2(RANGE_ENTRY_BYTES): a pair is 8 bytes, so pair_index = byte_off >> 3.
+    let entry_shift = RANGE_ENTRY_BYTES.trailing_zeros() as i32;
+    // Offset of `hi` within an entry (it follows the 4-byte `lo`), and the data
+    // offset that skips the interned blob's `[len][cap]` header to the pairs.
+    let hi_off = (RANGE_ENTRY_BYTES / 2) as i32;
+    let data_off = string_data_off();
+    for (func_idx, table_off) in entries {
+        let type_idx = emitter.func_type_indices[&func_idx];
+        // params: 0 = scalar
+        // locals: 1 = lo (pair index), 2 = hi (pair index, exclusive),
+        //         3 = mid, 4 = mid_ptr (base ptr of mid entry),
+        //         5 = range_lo, 6 = data_base (pointer to first pair)
+        let mut f = Function::new([(6, ValType::I32)]);
+        // IMPORTANT (DCE landmine): only the BARE `table_off` may appear as an
+        // i32.const — the dead-data eliminator relocates the table and patches
+        // any const equal to a known string offset. `table_off + data_off` would
+        // NOT be recognized, so `data_off` is added at RUNTIME below.
+        wasm!(f, {
+            // data_base = table_off + data_off (pointer to the first [lo,hi] pair)
+            i32_const(table_off as i32); i32_const(data_off); i32_add; local_set(6);
+            // lo = 0; hi = pair_count = table_len >> entry_shift
+            i32_const(0); local_set(1);
+            i32_const(table_off as i32); i32_load(0); i32_const(entry_shift); i32_shr_u; local_set(2);
+            block_empty; loop_empty;
+              // while lo < hi
+              local_get(1); local_get(2); i32_ge_u; br_if(1);
+              // mid = (lo + hi) / 2
+              local_get(1); local_get(2); i32_add; i32_const(1); i32_shr_u; local_set(3);
+              // mid_ptr = data_base + mid * RANGE_ENTRY_BYTES
+              local_get(6);
+              local_get(3); i32_const(RANGE_ENTRY_BYTES as i32); i32_mul; i32_add; local_set(4);
+              // range_lo = *mid_ptr
+              local_get(4); i32_load(0); local_set(5);
+              // if scalar < range_lo → search left (hi = mid)
+              local_get(0); local_get(5); i32_lt_u;
+              if_empty;
+                local_get(3); local_set(2);
+              else_;
+                // if scalar <= range_hi → hit
+                local_get(0); local_get(4); i32_load(hi_off); i32_le_u;
+                if_empty;
+                  i32_const(1); return_;
+                else_;
+                  // scalar > range_hi → search right (lo = mid + 1)
+                  local_get(3); i32_const(1); i32_add; local_set(1);
+                end;
+              end;
+              br(0);
+            end; end;
+            i32_const(0); // not found
+            end;
+        });
+        emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    }
 }
 
-/// is_alnum: alpha or digit. Empty string returns false.
+/// is_alpha: non-empty AND every codepoint is alphabetic (full Unicode).
+/// Native: `!s.is_empty() && s.chars().all(|c| c.is_alphabetic())`.
+pub(super) fn compile_is_alpha(emitter: &mut WasmEmitter) {
+    compile_all_codepoints_predicate(emitter, emitter.rt.string.is_alpha, emitter.rt.string.prop_alpha);
+}
+
+/// is_alnum: non-empty AND every codepoint is alphanumeric (full Unicode).
+/// Native: `!s.is_empty() && s.chars().all(|c| c.is_alphanumeric())`.
 pub(super) fn compile_is_alnum(emitter: &mut WasmEmitter) {
-    let func_idx = emitter.rt.string.is_alnum;
+    compile_all_codepoints_predicate(emitter, emitter.rt.string.is_alnum, emitter.rt.string.prop_alnum);
+}
+
+/// Shared body for `is_alpha`/`is_alnum`: empty → false (NOT vacuously true —
+/// native guards with `!s.is_empty()`), else every decoded scalar must satisfy
+/// the given property membership helper. Walks codepoints via the shared
+/// `utf8_scalar`/`utf8_width` helpers, exactly like `is_whitespace`.
+fn compile_all_codepoints_predicate(emitter: &mut WasmEmitter, func_idx: u32, prop_idx: u32) {
     let type_idx = emitter.func_type_indices[&func_idx];
-    let mut f = Function::new([(1, ValType::I32), (1, ValType::I32)]);
+    let uw = emitter.rt.string.utf8_width;
+    let us = emitter.rt.string.utf8_scalar;
+    const S: u32 = 0;     // param: string ptr
+    const BLEN: u32 = 1;  // byte length
+    const I: u32 = 2;     // byte index
+    let mut f = Function::new([(2, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
-        local_get(1); i32_eqz;
-        if_i32; i32_const(0);
+        local_get(S); i32_load(0); local_set(BLEN);
+        local_get(BLEN); i32_eqz;
+        if_i32; i32_const(0);                                   // empty → false
         else_;
-          i32_const(0); local_set(2);
+          i32_const(0); local_set(I);
           block_empty; loop_empty;
-            local_get(2); local_get(1); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(2); i32_add; i32_load8_u(0);
-            local_tee(1);
-            i32_const(65); i32_ge_u; local_get(1); i32_const(90); i32_le_u; i32_and;
-            local_get(1); i32_const(97); i32_ge_u; local_get(1); i32_const(122); i32_le_u; i32_and;
-            i32_or;
-            local_get(1); i32_const(48); i32_ge_u; local_get(1); i32_const(57); i32_le_u; i32_and;
-            i32_or;
-            i32_eqz;
-            br_if(1);
-            local_get(0); i32_load(0); local_set(1);
-            local_get(2); i32_const(1); i32_add; local_set(2);
+            local_get(I); local_get(BLEN); i32_ge_u; br_if(1);  // walked all → true
+            // scalar = utf8_scalar(s, i); fail if not a member
+            local_get(S); local_get(I); call(us); i32_wrap_i64; call(prop_idx); i32_eqz;
+            if_empty; i32_const(0); return_; end;
+            // i += utf8_width(s, i)
+            local_get(S); local_get(I); call(uw); local_get(I); i32_add; local_set(I);
             br(0);
           end; end;
-          local_get(2); local_get(0); i32_load(0); i32_eq;
+          i32_const(1);
         end;
         end;
     });
@@ -266,44 +325,65 @@ pub(super) fn compile_is_whitespace(emitter: &mut WasmEmitter) {
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
-/// is_upper: all alpha chars in [A-Z], non-alpha chars allowed, empty=false
+/// is_upper: non-empty, has >=1 alphabetic codepoint, and every alphabetic
+/// codepoint is uppercase. Native:
+/// `!s.is_empty() && s.chars().any(is_alphabetic)
+///   && s.chars().all(|c| !c.is_alphabetic() || c.is_uppercase())`.
 pub(super) fn compile_is_upper(emitter: &mut WasmEmitter) {
-    compile_case_predicate(emitter, emitter.rt.string.is_upper, 65, 90);
+    compile_case_predicate(emitter, emitter.rt.string.is_upper, emitter.rt.string.prop_upper);
 }
 
-/// is_lower: all alpha chars in [a-z], non-alpha chars allowed, empty=false
+/// is_lower: mirror of is_upper against the lowercase property.
 pub(super) fn compile_is_lower(emitter: &mut WasmEmitter) {
-    compile_case_predicate(emitter, emitter.rt.string.is_lower, 97, 122);
+    compile_case_predicate(emitter, emitter.rt.string.is_lower, emitter.rt.string.prop_lower);
 }
 
-fn compile_case_predicate(emitter: &mut WasmEmitter, func_idx: u32, lo: i32, hi: i32) {
+/// Shared body for `is_upper`/`is_lower`. Walks codepoints (via the shared
+/// `utf8_scalar`/`utf8_width` helpers) tracking two flags that mirror the native
+/// `any`/`all` expression exactly:
+///   any_alpha  — set when an alphabetic codepoint is seen
+///   all_ok     — cleared when an alphabetic codepoint lacks the case property
+/// Result = `any_alpha && all_ok` (empty string short-circuits to false). The
+/// `any_alpha` guard is what fixes the old vacuous-true bugs: "123" and any
+/// caseless multibyte string now return false, and no string is both.
+fn compile_case_predicate(emitter: &mut WasmEmitter, func_idx: u32, case_prop_idx: u32) {
     let type_idx = emitter.func_type_indices[&func_idx];
-    let mut f = Function::new([(1, ValType::I32), (1, ValType::I32)]);
+    let uw = emitter.rt.string.utf8_width;
+    let us = emitter.rt.string.utf8_scalar;
+    let prop_alpha = emitter.rt.string.prop_alpha;
+    const S: u32 = 0;        // param: string ptr
+    const BLEN: u32 = 1;     // byte length
+    const I: u32 = 2;        // byte index
+    const SCALAR: u32 = 3;   // decoded scalar
+    const ANY_ALPHA: u32 = 4;
+    const ALL_OK: u32 = 5;
+    let mut f = Function::new([(5, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
-        local_get(1); i32_eqz;
-        if_i32; i32_const(0); // empty → false
+        local_get(S); i32_load(0); local_set(BLEN);
+        local_get(BLEN); i32_eqz;
+        if_i32; i32_const(0);                                   // empty → false
         else_;
-          i32_const(0); local_set(2);
+          i32_const(0); local_set(I);
+          i32_const(0); local_set(ANY_ALPHA);                   // any_alpha = false
+          i32_const(1); local_set(ALL_OK);                      // all_ok = true
           block_empty; loop_empty;
-            local_get(2); local_get(1); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(2); i32_add; i32_load8_u(0);
-            local_tee(1);
-            // in_range = (lo..hi)
-            i32_const(lo); i32_ge_u; local_get(1); i32_const(hi); i32_le_u; i32_and;
-            // is_alpha
-            local_get(1); i32_const(65); i32_ge_u; local_get(1); i32_const(90); i32_le_u; i32_and;
-            local_get(1); i32_const(97); i32_ge_u; local_get(1); i32_const(122); i32_le_u; i32_and;
-            i32_or;
-            i32_eqz; // not_alpha
-            i32_or; // in_range OR not_alpha
-            i32_eqz;
-            br_if(1);
-            local_get(0); i32_load(0); local_set(1);
-            local_get(2); i32_const(1); i32_add; local_set(2);
+            local_get(I); local_get(BLEN); i32_ge_u; br_if(1);
+            local_get(S); local_get(I); call(us); i32_wrap_i64; local_set(SCALAR);
+            // if is_alphabetic(scalar)
+            local_get(SCALAR); call(prop_alpha);
+            if_empty;
+              i32_const(1); local_set(ANY_ALPHA);               // any_alpha = true
+              // if NOT case_prop(scalar) → all_ok = false
+              local_get(SCALAR); call(case_prop_idx); i32_eqz;
+              if_empty;
+                i32_const(0); local_set(ALL_OK);
+              end;
+            end;
+            // i += utf8_width(s, i)
+            local_get(S); local_get(I); call(uw); local_get(I); i32_add; local_set(I);
             br(0);
           end; end;
-          local_get(2); local_get(0); i32_load(0); i32_eq;
+          local_get(ANY_ALPHA); local_get(ALL_OK); i32_and;
         end;
         end;
     });

--- a/crates/almide-codegen/src/emit_wasm/rt_unicode_tables.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_unicode_tables.rs
@@ -1,0 +1,176 @@
+//! Oracle-derived Unicode property range tables for WASM string predicates.
+//!
+//! Native Almide implements `string.is_alpha`/`is_alphanumeric`/`is_upper`/
+//! `is_lower` via Rust's `char::is_alphabetic` / `is_alphanumeric` /
+//! `is_uppercase` / `is_lowercase`, which are full-Unicode. The WASM target
+//! historically byte-looped over the ASCII ranges only, so every non-ASCII
+//! scalar diverged from native.
+//!
+//! To close the gap WITHOUT shipping a UCD parser, we derive the property sets
+//! directly from the `char` methods AT COMPILE TIME: iterate every scalar in
+//! `0..=0x10FFFF`, ask the oracle method, and run-length compress the answers
+//! into sorted inclusive `[lo, hi]` codepoint ranges. The ranges are embedded
+//! in the WASM data section and binary-searched at runtime per decoded scalar.
+//!
+//! This is the same oracle-probe strategy already proven for the case tables
+//! (`rt_string_case`) and the whitespace ranges (`whitespace_ranges` in
+//! `rt_string`): the `char` standard library is the single source of truth, so
+//! native and WASM are correct-by-construction equivalent, and the `#[test]`
+//! Σ-probe (see tests at the bottom) re-derives the answer and asserts
+//! byte-for-byte agreement over the entire scalar space — a regression lock.
+//!
+//! Unlike the case tables (front-embedded at a fixed offset, always live), these
+//! tables go through `intern_bytes` so the dead-data eliminator can drop any
+//! table no live predicate references. The membership helper therefore emits the
+//! BARE interned offset as its only data `i32.const`; the `[len][cap]` header
+//! skip and per-entry stride are added at RUNTIME so a DCE relocation of the
+//! offset stays correct (see `compile_prop_membership`).
+
+use std::sync::LazyLock;
+
+/// Highest Unicode scalar value (inclusive). Surrogates `0xD800..=0xDFFF` are
+/// not scalar values; `char::from_u32` returns `None` for them and they are
+/// simply skipped during derivation (they never appear in valid UTF-8).
+const MAX_SCALAR: u32 = 0x10FFFF;
+
+/// Each embedded range entry is two little-endian `u32`s: `[lo, hi]` inclusive.
+pub const RANGE_ENTRY_BYTES: usize = 8;
+
+/// Which `char` property a table encodes. The variant order is irrelevant; the
+/// derivation reads the property method, nothing else.
+#[derive(Clone, Copy)]
+pub enum UnicodeProp {
+    Alphabetic,
+    Alphanumeric,
+    Uppercase,
+    Lowercase,
+}
+
+impl UnicodeProp {
+    fn holds(self, c: char) -> bool {
+        match self {
+            UnicodeProp::Alphabetic => c.is_alphabetic(),
+            UnicodeProp::Alphanumeric => c.is_alphanumeric(),
+            UnicodeProp::Uppercase => c.is_uppercase(),
+            UnicodeProp::Lowercase => c.is_lowercase(),
+        }
+    }
+
+    /// Stable interning key for the table's data-section blob. Prefixed with a
+    /// NUL so it can never collide with an interned source string literal (whose
+    /// key is its exact textual content).
+    fn intern_key(self) -> &'static str {
+        match self {
+            UnicodeProp::Alphabetic => "\u{0}unicode:alphabetic",
+            UnicodeProp::Alphanumeric => "\u{0}unicode:alphanumeric",
+            UnicodeProp::Uppercase => "\u{0}unicode:uppercase",
+            UnicodeProp::Lowercase => "\u{0}unicode:lowercase",
+        }
+    }
+}
+
+/// Run-length compress the scalars satisfying `prop` into sorted inclusive
+/// `[lo, hi]` ranges, serialized as little-endian `u32` pairs.
+fn derive_table_bytes(prop: UnicodeProp) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    let mut run_start: Option<u32> = None;
+    let mut prev = 0u32;
+    for cp in 0..=MAX_SCALAR {
+        let holds = char::from_u32(cp).map_or(false, |c| prop.holds(c));
+        match (holds, run_start) {
+            (true, None) => run_start = Some(cp),
+            (false, Some(start)) => {
+                bytes.extend_from_slice(&start.to_le_bytes());
+                bytes.extend_from_slice(&prev.to_le_bytes());
+                run_start = None;
+            }
+            _ => {}
+        }
+        if holds {
+            prev = cp;
+        }
+    }
+    if let Some(start) = run_start {
+        bytes.extend_from_slice(&start.to_le_bytes());
+        bytes.extend_from_slice(&MAX_SCALAR.to_le_bytes());
+    }
+    bytes
+}
+
+/// Derivation is non-trivial (a 1.1M-scalar scan); cache per property so the
+/// emitter and the Σ-probe tests share one pass instead of re-deriving.
+fn cached_table_bytes(prop: UnicodeProp) -> &'static [u8] {
+    static ALPHABETIC: LazyLock<Vec<u8>> = LazyLock::new(|| derive_table_bytes(UnicodeProp::Alphabetic));
+    static ALPHANUMERIC: LazyLock<Vec<u8>> = LazyLock::new(|| derive_table_bytes(UnicodeProp::Alphanumeric));
+    static UPPERCASE: LazyLock<Vec<u8>> = LazyLock::new(|| derive_table_bytes(UnicodeProp::Uppercase));
+    static LOWERCASE: LazyLock<Vec<u8>> = LazyLock::new(|| derive_table_bytes(UnicodeProp::Lowercase));
+    match prop {
+        UnicodeProp::Alphabetic => &ALPHABETIC,
+        UnicodeProp::Alphanumeric => &ALPHANUMERIC,
+        UnicodeProp::Uppercase => &UPPERCASE,
+        UnicodeProp::Lowercase => &LOWERCASE,
+    }
+}
+
+/// Intern a property's range table into the data section, returning the memory
+/// offset of its `[len][cap][data]` blob. Deduplicated by the property's key,
+/// so repeated calls (one per predicate that needs the table) share one copy.
+pub(super) fn intern_table(emitter: &mut super::WasmEmitter, prop: UnicodeProp) -> u32 {
+    let bytes = cached_table_bytes(prop);
+    emitter.intern_bytes(prop.intern_key(), bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Re-decode a serialized range table back into a membership closure and
+    /// assert it agrees with the oracle `char` method over EVERY scalar. This is
+    /// the Σ-probe regression lock: if a future toolchain shifts a Unicode
+    /// property, this fails loudly instead of silently diverging from native.
+    fn assert_table_matches(prop: UnicodeProp) {
+        let bytes = cached_table_bytes(prop);
+        // Decode ranges.
+        let ranges: Vec<(u32, u32)> = bytes
+            .chunks_exact(RANGE_ENTRY_BYTES)
+            .map(|c| {
+                let lo = u32::from_le_bytes([c[0], c[1], c[2], c[3]]);
+                let hi = u32::from_le_bytes([c[4], c[5], c[6], c[7]]);
+                (lo, hi)
+            })
+            .collect();
+        // Ranges must be sorted and non-overlapping (binary search precondition).
+        for w in ranges.windows(2) {
+            assert!(w[0].1 < w[1].0, "ranges out of order/overlap: {:?} then {:?}", w[0], w[1]);
+        }
+        let member = |cp: u32| ranges.binary_search_by(|&(lo, hi)| {
+            if cp < lo { std::cmp::Ordering::Greater }
+            else if cp > hi { std::cmp::Ordering::Less }
+            else { std::cmp::Ordering::Equal }
+        }).is_ok();
+        for cp in 0..=MAX_SCALAR {
+            let oracle = char::from_u32(cp).map_or(false, |c| prop.holds(c));
+            assert_eq!(member(cp), oracle, "scalar U+{cp:04X} table != char method");
+        }
+    }
+
+    #[test]
+    fn alphabetic_table_matches_char_method() {
+        assert_table_matches(UnicodeProp::Alphabetic);
+    }
+
+    #[test]
+    fn alphanumeric_table_matches_char_method() {
+        assert_table_matches(UnicodeProp::Alphanumeric);
+    }
+
+    #[test]
+    fn uppercase_table_matches_char_method() {
+        assert_table_matches(UnicodeProp::Uppercase);
+    }
+
+    #[test]
+    fn lowercase_table_matches_char_method() {
+        assert_table_matches(UnicodeProp::Lowercase);
+    }
+}

--- a/crates/almide-codegen/src/emit_wasm/strings.rs
+++ b/crates/almide-codegen/src/emit_wasm/strings.rs
@@ -27,6 +27,31 @@ impl WasmEmitter {
         offset
     }
 
+    /// Intern a raw byte blob into the data section, returning its memory offset.
+    ///
+    /// Used for static lookup tables (e.g. Unicode property range tables) whose
+    /// bytes are NOT valid UTF-8 and so cannot go through `intern_string`. The
+    /// blob is framed identically to an interned string — `[len:i32 LE][cap:i32
+    /// LE][data:u8...]` — so the dead-data eliminator (`dce::eliminate_dead_data`)
+    /// parses it as one entry and keeps it iff a live function references its
+    /// offset via `i32.const`. No padding is inserted between entries (the DCE
+    /// walk steps by `8 + len` and would desync otherwise); WASM permits the
+    /// resulting unaligned loads. `key` must be unique and disjoint from any
+    /// source string literal (callers prefix a NUL) so the two interning tables
+    /// never collide on the offset map.
+    pub fn intern_bytes(&mut self, key: &str, bytes: &[u8]) -> u32 {
+        if let Some(&offset) = self.strings.get(key) {
+            return offset;
+        }
+        let offset = super::NEWLINE_OFFSET + self.data_bytes.len() as u32;
+        let len = bytes.len() as u32;
+        self.data_bytes.extend_from_slice(&len.to_le_bytes());
+        self.data_bytes.extend_from_slice(&len.to_le_bytes()); // cap = len
+        self.data_bytes.extend_from_slice(bytes);
+        self.strings.insert(key.to_string(), offset);
+        offset
+    }
+
     /// Memory offset of the heap start (after all data).
     pub fn heap_start(&self) -> u32 {
         // Align to 8 bytes for clean allocation

--- a/spec/stdlib/string_unicode_predicates_test.almd
+++ b/spec/stdlib/string_unicode_predicates_test.almd
@@ -1,0 +1,111 @@
+// Unicode-aware string predicate tests.
+//
+// These pin the full-Unicode semantics of is_alpha/is_alphanumeric/is_upper/
+// is_lower and the empty-pattern behaviour of count/last_index_of. They run on
+// BOTH native (Rust char methods) and WASM (oracle-derived range tables) and
+// must agree — the values below are the native oracle.
+
+// ── is_alpha (full Unicode) ──
+
+test "is_alpha ascii" {
+  assert(string.is_alpha("abcXYZ"));
+  assert(not string.is_alpha("ab1"));
+  assert(not string.is_alpha(""))
+}
+
+test "is_alpha unicode letters" {
+  assert(string.is_alpha("αβγ"));      // Greek
+  assert(string.is_alpha("ягд"));      // Cyrillic
+  assert(string.is_alpha("日本"));      // CJK
+  assert(string.is_alpha("ＡＢＣ"));    // fullwidth
+  assert(string.is_alpha("ǅ"));        // titlecase
+  assert(string.is_alpha("ʰ"));        // modifier letter
+  assert(string.is_alpha("ß"))         // eszett
+}
+
+test "is_alpha excludes numeric categories" {
+  assert(not string.is_alpha("٣"));    // Arabic-Indic digit (Nd)
+  assert(not string.is_alpha("²"));    // superscript (No)
+  assert(not string.is_alpha("½"))     // fraction (No)
+}
+
+test "is_alpha roman numerals are alphabetic" {
+  assert(string.is_alpha("Ⅴ"));        // Nl is alphabetic
+  assert(string.is_alpha("ⅴ"))
+}
+
+// ── is_alphanumeric (full Unicode) ──
+
+test "is_alphanumeric unicode" {
+  assert(string.is_alphanumeric("abc123"));
+  assert(string.is_alphanumeric("αβ٣"));   // letter + Arabic-Indic digit
+  assert(string.is_alphanumeric("²½"));    // No category counts as alnum
+  assert(string.is_alphanumeric("５"));     // fullwidth digit
+  assert(not string.is_alphanumeric("A.B"));
+  assert(not string.is_alphanumeric(""))
+}
+
+// ── is_upper / is_lower (any-alpha guard + per-codepoint case) ──
+
+test "is_upper requires an alphabetic char" {
+  assert(not string.is_upper("123"));   // no alpha → false (was vacuously true)
+  assert(not string.is_upper(""));
+  assert(string.is_upper("ABC"));
+  assert(string.is_upper("A.B"))        // alpha present, non-alpha ignored
+}
+
+test "is_upper unicode" {
+  assert(string.is_upper("ΑΒΓ"));       // Greek upper
+  assert(string.is_upper("Σ"));
+  assert(string.is_upper("ＡＢＣ"));     // fullwidth upper
+  assert(string.is_upper("Ⅴ"));         // roman numeral upper
+  assert(not string.is_upper("αβγ"));
+  assert(not string.is_upper("ǅ"));     // titlecase is neither upper nor lower
+  assert(not string.is_upper("日本"))   // caseless → no alpha-is-upper, but
+}                                        // 日本 has alpha that is not upper → false
+
+test "is_lower requires an alphabetic char" {
+  assert(not string.is_lower("123"));
+  assert(not string.is_lower(""));
+  assert(string.is_lower("abc"));
+  assert(string.is_lower("a.b"))
+}
+
+test "is_lower unicode" {
+  assert(string.is_lower("αβγ"));
+  assert(string.is_lower("σ"));
+  assert(string.is_lower("ａｂｃ"));     // fullwidth lower
+  assert(string.is_lower("ⅴ"));         // roman numeral lower
+  assert(string.is_lower("ʰ"));         // modifier letter is lowercase
+  assert(string.is_lower("ß"));
+  assert(not string.is_lower("ABC"));
+  assert(not string.is_lower("ǅ"))
+}
+
+test "multibyte string is not simultaneously upper and lower" {
+  // The old WASM byte-loop reported BOTH true for any multibyte string.
+  assert(not (string.is_upper("日本") and string.is_lower("日本")));
+  assert(not (string.is_upper("αΒ") and string.is_lower("αΒ")))
+}
+
+// ── count / last_index_of with empty pattern ──
+
+test "count with empty pattern is char count plus one" {
+  assert_eq(string.count("", ""), 1);
+  assert_eq(string.count("abc", ""), 4);
+  assert_eq(string.count("日本", ""), 3);     // 2 codepoints + 1
+  assert_eq(string.count("a日b", ""), 4)      // 3 codepoints + 1
+}
+
+test "last_index_of with empty pattern is byte length" {
+  assert_eq(string.last_index_of("", ""), some(0));
+  assert_eq(string.last_index_of("abc", ""), some(3));
+  assert_eq(string.last_index_of("日本", ""), some(6));   // 6 bytes
+  assert_eq(string.last_index_of("a日b", ""), some(5))    // 5 bytes
+}
+
+test "count and last_index_of unaffected for non-empty pattern" {
+  assert_eq(string.count("ababab", "ab"), 3);
+  assert_eq(string.last_index_of("ababab", "ab"), some(4));
+  assert_eq(string.last_index_of("abc", "z"), none)
+}

--- a/spec/wasm_cross/string_empty_pattern.almd
+++ b/spec/wasm_cross/string_empty_pattern.almd
@@ -1,0 +1,30 @@
+// Cross-target probe for count / last_index_of with the EMPTY pattern.
+//
+// Native semantics (verified against the Rust runtime):
+//   "s".matches("").count() == s.chars().count() + 1   (CODEPOINT count + 1)
+//   "s".rfind("")           == Some(s.len())            (BYTE length)
+// The WASM runtime previously short-circuited empty patterns to 0; this matrix
+// pins the corrected behaviour byte-for-byte across native and WASM, including
+// multibyte subjects where codepoint-count and byte-length differ.
+
+fn opt(x: Option[Int]) -> String = match x {
+  Some(v) => int.to_string(v),
+  None => "none",
+}
+
+fn main() -> Unit = {
+  // count with empty pattern == char count + 1
+  println("count empty/empty=" + int.to_string(string.count("", "")))
+  println("count ascii/empty=" + int.to_string(string.count("abc", "")))
+  println("count cjk/empty=" + int.to_string(string.count("日本", "")))      // 2 chars
+  println("count mixed/empty=" + int.to_string(string.count("a日b", "")))    // 3 chars
+  // last_index_of with empty pattern == Some(byte length)
+  println("lio empty/empty=" + opt(string.last_index_of("", "")))
+  println("lio ascii/empty=" + opt(string.last_index_of("abc", "")))         // Some(3)
+  println("lio cjk/empty=" + opt(string.last_index_of("日本", "")))          // Some(6 bytes)
+  println("lio mixed/empty=" + opt(string.last_index_of("a日b", "")))        // Some(5 bytes)
+  // non-empty pattern behaviour is unchanged (regression guard)
+  println("count ab=" + int.to_string(string.count("ababab", "ab")))
+  println("lio ab=" + opt(string.last_index_of("ababab", "ab")))
+  println("lio miss=" + opt(string.last_index_of("abc", "z")))
+}

--- a/spec/wasm_cross/string_predicates.almd
+++ b/spec/wasm_cross/string_predicates.almd
@@ -1,0 +1,56 @@
+// Cross-target probe matrix for the Unicode-aware string predicates.
+//
+// Native derives is_alpha/is_alphanumeric/is_upper/is_lower from Rust's
+// full-Unicode char methods; the WASM target uses oracle-derived range tables
+// (rt_unicode_tables.rs) walked per codepoint. This matrix exercises every
+// interesting Unicode category so the cross-target diff gate proves native and
+// WASM agree byte-for-byte. Each row prints the 4 predicate results for a
+// carefully chosen scalar class.
+
+fn b(x: Bool) -> String = if x then "T" else "F"
+
+fn row(label: String, s: String) -> Unit =
+  println(label + ": alpha=" + b(string.is_alpha(s))
+    + " alnum=" + b(string.is_alphanumeric(s))
+    + " upper=" + b(string.is_upper(s))
+    + " lower=" + b(string.is_lower(s)))
+
+fn main() -> Unit = {
+  // ASCII
+  row("ascii_upper", "ABC")
+  row("ascii_lower", "abc")
+  row("ascii_digit", "123")
+  row("ascii_alnum", "Ab1")
+  row("ascii_punct", "A.B")     // has an alpha, '.' is non-alpha
+  row("ascii_dotonly", "...")   // no alpha at all
+  // Greek (cased, plus the Σ/σ pair)
+  row("greek_lower", "αβγ")
+  row("greek_upper", "ΑΒΓ")
+  row("greek_sigma_up", "Σ")
+  row("greek_sigma_lo", "σ")
+  // Cyrillic
+  row("cyrillic", "ягд")
+  // CJK (alphabetic but caseless)
+  row("cjk", "日本")
+  row("cjk_with_digit", "日2")
+  // Arabic-Indic digits (Nd: alnum but not alpha)
+  row("arabic_indic", "٣٤٥")
+  // Fullwidth Latin (cased)
+  row("fullwidth_up", "ＡＢＣ")
+  row("fullwidth_lo", "ａｂｃ")
+  // Numeric-but-not-alpha categories
+  row("superscript", "²")       // No
+  row("fraction", "½")          // No
+  // Roman numerals (Nl: alphabetic AND cased)
+  row("roman_up", "Ⅴ")
+  row("roman_lo", "ⅴ")
+  row("no_only", "²½")          // alnum, not alpha, no case
+  // Titlecase + modifier + eszett edge cases
+  row("titlecase", "ǅ")         // alpha, neither upper nor lower
+  row("modifier", "ʰ")          // Lm: alpha, lowercase
+  row("eszett", "ß")            // alpha, lowercase
+  // Mixed / boundary
+  row("digit_letter", "a1")     // not all alpha; alpha 'a' is lower
+  row("mixed_case_uni", "Ａa")  // fullwidth-upper + ascii-lower
+  row("empty", "")
+}


### PR DESCRIPTION
## What (drain PR-A — first chip of the grandfathered-sweep burndown)

Fixes 7 sweep-confirmed cross-target divergences. Native runtime unchanged (oracle).

| divergence | was (wasm) | now |
|---|---|---|
| \`is_alpha("α"/"漢"/"Ⅴ"/"ǅ")\` | false (ASCII byte loop) | true — codepoint walk + **Alphabetic range table derived at emit time from \`char::is_alphabetic\`** |
| \`is_alphanumeric("٣"/"５"/"½")\` | false | true — Alphanumeric table |
| \`is_upper("123")\` / \`is_lower("!@#")\` | **true** (missing any-alpha guard) | false — native's \`!empty && any(alpha) && all(!alpha \|\| case)\` shape exactly |
| \`is_upper("α") && is_lower("α")\` | **both true** (logically impossible) | disagree correctly — Uppercase/Lowercase property tables |
| \`count(s, "")\` | 0 | \`char_count + 1\` (= \`str::matches("").count()\`) |
| \`last_index_of(s, "")\` | 0 | \`Some(byte_len)\` (= \`str::rfind("")\`) |

## How

- 4 property tables RLE-derived at emit time from \`char::is_*\` (no UCD, version-locked to the std native links) — the proven #373/#375 Σ-probe pattern; **4 \`#[test]\` locks assert table == char method over every scalar 0..=0x10FFFF** (0.05s, LazyLock-cached)
- Reuses the existing \`utf8_scalar\`/\`utf8_width\` decode helpers — no new decoder; predicate loops are shape-identical to the #375 \`is_whitespace\` path
- Tables ride the interned-data DCE path via a new \`intern_bytes\` (measured: no-predicate program carries **zero** table bytes; single-predicate carries only its table)
- **Registry**: 6 entries flipped grandfathered → verified (citations to the Σ-probes + corpus), 2 new routines registered verified — the #382 gate enforced both. **Drain progress: grandfathered 48 → 42.**

## Validation

- Adversarial verifier (PASS): full Unicode-category battery (Lu/Ll/Lt/Lm/Lo/Mn/Nd/Nl/No/P/S/Z incl. titlecase ǅ, modifier ʰ, astral 𝕬, decomposed é), all 7 old divergences re-probed individually — byte-identical
- Quality verifier (PASS): magic-number sweep, infra-reuse confirmation, DCE measurements, Σ-probe runtime
- Suite: 245/245 native + 245/245 wasm spec, gate 58→60 corpus files byte-identical, snapshots clean