### PR TITLE
Render records, variants, and anonymous records as literal repr in interpolation (PR-3)

### DIFF
--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -362,7 +362,7 @@ template = "_"
 template = "_"
 
 [empty_map]
-template = "AlmideMap::new()"
+template = "AlmideMap::<{key_type}, {value_type}>::new()"
 
 [try_expr]
 template = "({inner})?"

--- a/crates/almide-codegen/rt-oracle-registry.toml
+++ b/crates/almide-codegen/rt-oracle-registry.toml
@@ -112,6 +112,14 @@ oracle = "native derived PartialEq / almide_eq! deep variant equality"
 test = "tests/wasm_runtime_test.rs::wasm_cross_target_spec"
 note = "spec/wasm_cross/deep_eq_heap.almd compares `Tagged(\"x\") == Tagged(\"y\")` (variant), list, and tuple equality byte-identically native vs wasm; records_variants.almd also exercises variant construction/eq."
 
+[[routine]]
+file = "mod.rs"
+routine = "compile_repr_funcs"
+status = "verified"
+oracle = "Generated per-type AlmideRepr impls on native (walker/declarations.rs render_repr_impl) — recursive named types repr via runtime dispatch on both targets"
+test = "tests/wasm_runtime_test.rs::wasm_cross_target_spec"
+note = "Added in PR-3 (compound repr): per-type __repr_<Type> wasm fns for RECURSIVE named types (cycle-set DFS; bodies sorted by name for host determinism); exercised by spec/wasm_cross/compound_repr_recursive_interp.almd (self/mutual recursion, generics, anon records)."
+
 # ── runtime.rs ───────────────────────────────────────────────────────
 [[routine]]
 file = "runtime.rs"

--- a/crates/almide-codegen/src/emit_wasm/calls_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string.rs
@@ -780,8 +780,10 @@ impl FuncCompiler<'_> {
                     }
                     Ty::Float => {
                         self.emit_expr(expr);
+                        // Display form: an integer-valued float drops its `.0`
+                        // (`${1.0}` → `1`), matching the native Rust `Display`.
                         wasm!(self.func, {
-                            call(self.emitter.rt.float_to_string);
+                            call(self.emitter.rt.float_display);
                         });
                     }
                     _ => {

--- a/crates/almide-codegen/src/emit_wasm/calls_string_repr.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string_repr.rs
@@ -49,11 +49,14 @@ impl FuncCompiler<'_> {
             Ty::UInt8 | Ty::UInt16 | Ty::UInt32 => {
                 wasm!(self.func, { i64_extend_i32_u; call(self.emitter.rt.int_to_string); });
             }
+            // A float inside a container uses the SAME Display form as a bare
+            // interpolated float — native `AlmideRepr for f64` is `format!("{}",
+            // self)`, so an integer-valued float drops its `.0` here too.
             Ty::Float | Ty::Float64 => {
-                wasm!(self.func, { call(self.emitter.rt.float_to_string); });
+                wasm!(self.func, { call(self.emitter.rt.float_display); });
             }
             Ty::Float32 => {
-                wasm!(self.func, { f64_promote_f32; call(self.emitter.rt.float_to_string); });
+                wasm!(self.func, { f64_promote_f32; call(self.emitter.rt.float_display); });
             }
             Ty::Bool => {
                 let t = self.emitter.intern_string("true");
@@ -88,9 +91,46 @@ impl FuncCompiler<'_> {
                 let elems = elems.clone();
                 self.emit_repr_tuple(&elems);
             }
-            // Anything else is not a backed compound (records/variants are scoped
-            // out — see `ty_needs_repr`); leave the value as-is. Unreachable in
-            // practice because the walker only routes backed shapes here.
+            // ── Recursive named record/variant → per-type repr fn ──
+            // A self/mutually-recursive named type must NOT inline-expand its type
+            // graph (infinite at compile time); it routes through its reserved
+            // `__repr_<Type>(ptr) -> str` function, so recursion is a runtime CALL
+            // that bottoms out on the finite value — exactly like native trait
+            // dispatch. Only recursive types get a reserved fn (see
+            // `register_repr_funcs`); the value pointer is already on the stack.
+            Ty::Named(name, _) if self.emitter.repr_funcs.contains_key(name.as_str()) => {
+                let f = self.emitter.repr_funcs[name.as_str()];
+                wasm!(self.func, { call(f); });
+            }
+            // ── Non-recursive named variant → inline walk ──
+            // Inlining is finite (acyclic) AND keeps the concrete `type_args` at
+            // this site, so a generic variant (`Wrapper[Int]`) reprs its payload
+            // with the resolved type — a monomorphic per-type fn could not.
+            Ty::Named(name, _) if self.emitter.variant_info.contains_key(name.as_str()) => {
+                self.emit_repr_variant(ty);
+            }
+            // ── Non-recursive named record (or opaque newtype) → inline walk ──
+            // Same rationale: acyclic, and the site's `type_args` resolve a generic
+            // record's field types (`Box[Int]` reprs its `T` value correctly).
+            Ty::Named(..) => {
+                let fields = self.extract_record_fields(ty);
+                let type_name = match ty {
+                    Ty::Named(n, _) => Some(n.to_string()),
+                    _ => None,
+                };
+                self.emit_repr_record(type_name.as_deref(), &fields);
+            }
+            // ── Anonymous records → inline literal walk (no type name) ──
+            // Structurally finite (an anon record cannot reference itself), so
+            // inline expansion is safe. Fields render in SORTED name order to
+            // match the native synthesized struct (`AlmdRec_*` field order is the
+            // sorted field-name list); see `emit_repr_record`.
+            Ty::Record { .. } | Ty::OpenRecord { .. } => {
+                let fields = self.extract_record_fields(ty);
+                self.emit_repr_record(None, &fields);
+            }
+            // Anything else has no repr (the walker only routes backed shapes
+            // here); leave the value as-is.
             _ => {}
         }
     }
@@ -339,4 +379,199 @@ impl FuncCompiler<'_> {
 
         self.scratch.free_i32(res);
     }
+
+    /// Record walk: `TypeName { f0: <repr>, f1: <repr> }`, fields at sequential
+    /// offsets (record layout `[field0][field1]...`).
+    ///
+    /// A NAMED record renders its fields in declaration order (the layout order),
+    /// `TypeName { f0: …, f1: … }`. An ANONYMOUS record has no `type_name` and
+    /// renders just `{ f0: …, … }`; its fields render in SORTED name order so the
+    /// output matches the native synthesized `AlmdRec_*` struct, whose field list
+    /// is the sorted field-name set (`collect_anon_records` sorts). The VALUE of
+    /// each field is still loaded from its real layout offset (source order), so
+    /// reordering the render does not misalign reads.
+    pub(super) fn emit_repr_record(&mut self, type_name: Option<&str>, fields: &[(String, Ty)]) {
+        let open = match type_name {
+            Some(n) => format!("{} {{ ", n),
+            None => "{ ".to_string(),
+        };
+        let open_s = self.emitter.intern_string(&open) as i32;
+        let close_s = self.emitter.intern_string(" }") as i32;
+
+        // Pair each field with its absolute layout offset (in declaration order),
+        // then choose the render order: named → declaration order; anonymous →
+        // sorted by field name (matches the native anon struct's field order).
+        let mut placed: Vec<(usize, u32)> = Vec::with_capacity(fields.len());
+        let mut offset = 0u32;
+        for (idx, (_, fty)) in fields.iter().enumerate() {
+            placed.push((idx, offset));
+            offset += values::byte_size(fty);
+        }
+        if type_name.is_none() {
+            placed.sort_by(|&(a, _), &(b, _)| fields[a].0.cmp(&fields[b].0));
+        }
+
+        let rec = self.scratch.alloc_i32();
+        let acc = self.scratch.alloc_i32();
+        let concat = self.emitter.rt.concat_str;
+
+        wasm!(self.func, {
+            local_set(rec);
+            i32_const(open_s); local_set(acc);
+        });
+        for (render_idx, &(field_idx, field_off)) in placed.iter().enumerate() {
+            let (fname, fty) = &fields[field_idx];
+            // `, f: ` (the `, ` separator before every field but the first is
+            // folded into the label so the whole prefix is one interned string).
+            let label = format!("{}{}: ", if render_idx > 0 { ", " } else { "" }, fname);
+            let label_s = self.emitter.intern_string(&label) as i32;
+            wasm!(self.func, {
+                local_get(acc); i32_const(label_s); call(concat); local_set(acc);
+                local_get(acc);
+                local_get(rec); i32_const(field_off as i32); i32_add;
+            });
+            self.emit_load_at(fty, 0);
+            self.emit_repr_value(fty);
+            wasm!(self.func, { call(concat); local_set(acc); });
+        }
+        wasm!(self.func, { local_get(acc); i32_const(close_s); call(concat); });
+
+        self.scratch.free_i32(acc);
+        self.scratch.free_i32(rec);
+    }
+
+    /// Variant walk. Layout `[tag:i32][payload...]`; the tag selects the case.
+    /// Each case renders in its constructor form, matching the native impl:
+    ///   tuple variant  → `Click(<repr>, <repr>)`
+    ///   record variant → `Scroll { dy: <repr> }`
+    ///   nullary        → `Quit`
+    /// Cases are dispatched by a chain of `if tag == k` tests (the final case is
+    /// the trailing `else`), so exactly one constructor renders.
+    pub(super) fn emit_repr_variant(&mut self, ty: &Ty) {
+        let (type_name, type_args) = match ty {
+            Ty::Named(n, args) => (n.to_string(), args.clone()),
+            _ => return,
+        };
+        let mut cases = match self.emitter.variant_info.get(type_name.as_str()) {
+            Some(c) => c.clone(),
+            None => return,
+        };
+        // Substitute the site's concrete type args into each case's payload types
+        // so a generic variant (`Wrapper[Int]`) reprs its payload with the resolved
+        // type, not the raw `T`. Generic names are collected from ALL constructors
+        // (so `Either[A,B]` indexes A,B consistently), mirroring
+        // `extract_record_fields`. With no type args, the cases are unchanged.
+        if !type_args.is_empty() {
+            // Collect generic-param names as OWNED strings first (they borrow from
+            // `cases`, which is mutated below).
+            let generic_names: Vec<String> = {
+                let mut names: Vec<&str> = Vec::new();
+                for case in &cases {
+                    for (_, fty) in &case.fields {
+                        super::expressions::collect_type_param_names(fty, &mut names);
+                    }
+                }
+                names.into_iter().map(|s| s.to_string()).collect()
+            };
+            if !generic_names.is_empty() {
+                let name_refs: Vec<&str> = generic_names.iter().map(|s| s.as_str()).collect();
+                for case in &mut cases {
+                    for (_, fty) in &mut case.fields {
+                        *fty = super::expressions::substitute_type_params(fty, &name_refs, &type_args);
+                    }
+                }
+            }
+        }
+        // Payload starts after the tag word — the same offset the constructor
+        // and match-destructure use (`variant_tag_offset`, the single source of
+        // truth). The tag itself is the leading i32 of the cell.
+        let payload_off = self.variant_tag_offset(ty);
+
+        let val = self.scratch.alloc_i32();
+        let tag = self.scratch.alloc_i32();
+        wasm!(self.func, {
+            local_set(val);
+            local_get(val); i32_load(0); local_set(tag); // tag @ cell start
+        });
+
+        let n = cases.len();
+        for (idx, case) in cases.iter().enumerate() {
+            let is_last = idx + 1 == n;
+            if !is_last {
+                // if tag == case.tag { <case> } else { …next… }
+                wasm!(self.func, {
+                    local_get(tag); i32_const(case.tag as i32); i32_eq;
+                    if_i32;
+                });
+            }
+            self.emit_repr_variant_case(val, payload_off, &case.name, &case.fields);
+            if !is_last {
+                wasm!(self.func, { else_; });
+            }
+        }
+        // Close one `end` per non-final case (the if/else chain nests N-1 deep).
+        for _ in 0..n.saturating_sub(1) {
+            wasm!(self.func, { end; });
+        }
+
+        self.scratch.free_i32(tag);
+        self.scratch.free_i32(val);
+    }
+
+    /// Render one variant case onto the stack from the value pointer in `val`.
+    /// Tuple-variant fields carry synthetic `_0, _1, …` names (see
+    /// `register_type_info`); they render positionally, `Click(a, b)`. Real
+    /// field names render as a record-variant, `Scroll { dy: v }`. No fields →
+    /// the bare constructor name.
+    fn emit_repr_variant_case(&mut self, val: u32, payload_off: u32, ctor: &str, fields: &[(String, Ty)]) {
+        if fields.is_empty() {
+            let name_s = self.emitter.intern_string(ctor) as i32;
+            wasm!(self.func, { i32_const(name_s); });
+            return;
+        }
+
+        let is_tuple = fields.iter().all(|(n, _)| is_synthetic_index_name(n));
+        let (open, close): (String, String) = if is_tuple {
+            (format!("{}(", ctor), ")".to_string())
+        } else {
+            (format!("{} {{ ", ctor), " }".to_string())
+        };
+        let open_s = self.emitter.intern_string(&open) as i32;
+        let close_s = self.emitter.intern_string(&close) as i32;
+
+        let acc = self.scratch.alloc_i32();
+        let concat = self.emitter.rt.concat_str;
+        wasm!(self.func, { i32_const(open_s); local_set(acc); });
+
+        let mut offset = payload_off;
+        for (idx, (fname, fty)) in fields.iter().enumerate() {
+            // Tuple payload: `, ` separators only. Record payload: `, f: `.
+            let label = if is_tuple {
+                if idx > 0 { ", ".to_string() } else { String::new() }
+            } else {
+                format!("{}{}: ", if idx > 0 { ", " } else { "" }, fname)
+            };
+            if !label.is_empty() {
+                let label_s = self.emitter.intern_string(&label) as i32;
+                wasm!(self.func, { local_get(acc); i32_const(label_s); call(concat); local_set(acc); });
+            }
+            wasm!(self.func, {
+                local_get(acc);
+                local_get(val); i32_const(offset as i32); i32_add;
+            });
+            self.emit_load_at(fty, 0);
+            self.emit_repr_value(fty);
+            wasm!(self.func, { call(concat); local_set(acc); });
+            offset += values::byte_size(fty);
+        }
+        wasm!(self.func, { local_get(acc); i32_const(close_s); call(concat); });
+        self.scratch.free_i32(acc);
+    }
+}
+
+/// A synthetic tuple-variant field name `_0`, `_1`, … (assigned in
+/// `register_type_info`). Such names mark a tuple-payload variant, rendered
+/// positionally; any other name marks a record-payload variant.
+fn is_synthetic_index_name(name: &str) -> bool {
+    name.strip_prefix('_').map_or(false, |rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
 }

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -28,6 +28,7 @@ mod rt_numeric;
 mod rt_dragon;
 mod rt_dec2flt;
 mod rt_repr;
+mod rt_float_display;
 mod calls_string_repr;
 mod expressions;
 mod stdlib_dispatch;
@@ -339,6 +340,11 @@ pub struct RuntimeFuncs {
     /// interpolation). Escape set mirrors `almide_rt_value_stringify` and the
     /// native `almide_repr_str`: `\\ \" \n \r \t`.
     pub repr_str: u32,
+    /// __float_display(f: f64) -> i32: the `Display`-form float text used by
+    /// string interpolation — the Dragon4 `float.to_string` output with a
+    /// trailing `.0` removed, matching the native Rust `Display` oracle
+    /// (`0.0` → `0`, `1.0` → `1`; non-integral values are unchanged).
+    pub float_display: u32,
 }
 
 /// Import descriptor for WASM import section.
@@ -439,6 +445,15 @@ pub struct WasmEmitter {
     pub mutable_captures: HashSet<u32>,
     // Deep-equality functions per variant type: type_name → func_idx
     pub eq_funcs: HashMap<String, u32>,
+    // Almide-literal repr functions per NAMED record/variant type: type_name →
+    // func_idx. A `__repr_<Type>(ptr) -> str_ptr` walks one finite value of that
+    // type back to its literal form, recursing into self/mutually-recursive type
+    // references as a CALL (terminating at runtime over the finite value) — the
+    // same shape as the native `AlmideRepr` trait dispatch. Without this, a
+    // recursive ADT (`type Tree = Leaf(Int) | Node(Tree, Tree)`) would expand its
+    // type graph forever at compile time. Reserved (sorted, host-deterministic)
+    // before compilation, mirroring `eq_funcs`.
+    pub repr_funcs: BTreeMap<String, u32>,
     // Whether the program uses filesystem operations (fs.read_text, etc.)
     pub needs_fs: bool,
 }
@@ -555,6 +570,7 @@ impl WasmEmitter {
                 dragon: rt_dragon::DragonRuntime::default(),
                 decfloat: rt_dec2flt::DecFloatRuntime::default(),
                 repr_str: 0,
+                float_display: 0,
             },
             heap_ptr_global: 0,
             free_list_global: 1,
@@ -576,6 +592,7 @@ impl WasmEmitter {
             effect_fns: HashSet::new(),
             mutable_captures: HashSet::new(),
             eq_funcs: HashMap::new(),
+            repr_funcs: BTreeMap::new(),
             user_exports: Vec::new(),
             needs_fs: false,
         }
@@ -1423,6 +1440,10 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
     // Pre-register variant deep-equality functions (must be before compilation starts)
     register_variant_eq_funcs(&mut emitter);
 
+    // Pre-register per-type Almide-literal repr functions (recursive ADTs walk via
+    // call, not inline expansion). Must reserve indices before compilation starts.
+    register_repr_funcs(&mut emitter);
+
     // Phase 2: Compile function bodies (order must match registration order)
     runtime::compile_runtime(&mut emitter);
 
@@ -1489,6 +1510,11 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
 
     // Compile variant deep-equality functions (bodies, after all user code)
     compile_variant_eq_funcs(&mut emitter, &program.var_table);
+
+    // Compile per-type repr function bodies (after eq funcs, same sorted-order
+    // index/body contract). Order relative to eq funcs matches the registration
+    // order above (eq funcs reserved first, then repr funcs).
+    compile_repr_funcs(&mut emitter, &program.var_table);
 
     // Phase 2.5: Dead Code Elimination
     let dce_count = dce::eliminate_dead_code(&mut emitter);
@@ -2158,6 +2184,196 @@ fn compile_variant_eq_funcs(emitter: &mut WasmEmitter, var_table: &almide_ir::Va
                 }
             }
 
+            compiler.func.instruction(&wasm_encoder::Instruction::End);
+            compiler.func
+        };
+
+        emitter.add_compiled(CompiledFunc::tracked(type_idx, compiled_func));
+    }
+}
+
+/// A named record/variant type is repr-backed unless it (transitively, through a
+/// container) holds a closure field — a closure has no Almide-literal form, so it
+/// never reaches compound interpolation. Mirrors the native `type_has_repr_impl`
+/// closure gate so the two targets agree on exactly which types get a repr.
+fn ty_field_has_closure(ty: &almide_lang::types::Ty) -> bool {
+    matches!(ty, almide_lang::types::Ty::Fn { .. })
+        || ty.children().into_iter().any(ty_field_has_closure)
+}
+
+/// Collect the names of named types referenced anywhere inside `ty` (directly or
+/// nested in a container / tuple / record), into `out`.
+fn collect_named_refs(ty: &almide_lang::types::Ty, out: &mut HashSet<String>) {
+    if let almide_lang::types::Ty::Named(n, _) = ty {
+        out.insert(n.to_string());
+    }
+    for child in ty.children() {
+        collect_named_refs(child, out);
+    }
+}
+
+/// The set of named record/variant types that lie on a reference CYCLE — i.e. a
+/// type that can reach itself through its fields/cases (self-recursion like
+/// `Tree = … Node(Tree, Tree)`, or mutual recursion `A → B → A`). Only these need
+/// a per-type repr function: a NON-recursive type stays on the inline walk, where
+/// the concrete `Ty::Named(_, type_args)` at the interpolation site resolves its
+/// fields' types (so a generic non-recursive type like `Box[Int]` reprs its `T`
+/// payload correctly). A recursive type's inline walk would instead expand its
+/// type graph forever at compile time, so it routes through its repr fn where the
+/// self-reference is a runtime CALL.
+fn recursive_type_names(emitter: &WasmEmitter) -> HashSet<String> {
+    // Edge set: type name → directly-referenced named types (through fields).
+    let mut edges: HashMap<String, HashSet<String>> = HashMap::new();
+    for (name, cases) in &emitter.variant_info {
+        let mut refs = HashSet::new();
+        for c in cases {
+            for (_, ft) in &c.fields { collect_named_refs(ft, &mut refs); }
+        }
+        edges.insert(name.clone(), refs);
+    }
+    let case_names: HashSet<String> = emitter.variant_info.values()
+        .flat_map(|cases| cases.iter().map(|c| c.name.clone()))
+        .collect();
+    for (name, fields) in &emitter.record_fields {
+        if name.starts_with("__anon_record_") || case_names.contains(name)
+            || emitter.variant_info.contains_key(name) { continue; }
+        let mut refs = HashSet::new();
+        for (_, ft) in fields { collect_named_refs(ft, &mut refs); }
+        edges.insert(name.clone(), refs);
+    }
+
+    // A type is recursive iff it can reach itself. Reachability via DFS over the
+    // edge set (only edges to nodes that are themselves typed are followed).
+    let mut recursive = HashSet::new();
+    for start in edges.keys() {
+        let mut stack: Vec<String> = edges[start].iter().cloned().collect();
+        let mut seen: HashSet<String> = HashSet::new();
+        while let Some(n) = stack.pop() {
+            if &n == start { recursive.insert(start.clone()); break; }
+            if !seen.insert(n.clone()) { continue; }
+            if let Some(next) = edges.get(&n) {
+                for m in next { stack.push(m.clone()); }
+            }
+        }
+    }
+    recursive
+}
+
+/// Pre-register one `__repr_<TypeName>(ptr: i32) -> i32` per repr-backed NAMED
+/// record/variant type that lies on a reference cycle. Recursion (self / mutual)
+/// becomes a CALL into the callee's repr fn, so a finite runtime value terminates
+/// exactly like the native trait dispatch — inline expansion of a recursive type
+/// graph would loop forever at compile time. NON-recursive types are walked
+/// inline (the concrete type args at the interpolation site resolve their fields).
+///
+/// Reserve indices in SORTED name order so they are a pure function of the
+/// program (the same 32-bit/64-bit host-determinism contract as
+/// `register_variant_eq_funcs`); the (also sorted) compile order must match.
+fn register_repr_funcs(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
+
+    let recursive = recursive_type_names(emitter);
+
+    // Repr-backed RECURSIVE named types: every recursive variant type, plus every
+    // recursive named record. A record case-name is also stored in `record_fields`
+    // (for field access), so restrict records to declared record types — not the
+    // synthetic `__anon_record_*` shapes (walked inline) and not the variant CASE
+    // names (a `Node` value reprs through its variant type's fn, by tag). A type
+    // with a closure field is excluded.
+    let mut names: Vec<String> = Vec::new();
+    for (name, cases) in &emitter.variant_info {
+        let has_closure = cases.iter().any(|c| c.fields.iter().any(|(_, ft)| ty_field_has_closure(ft)));
+        if recursive.contains(name) && !has_closure {
+            names.push(name.clone());
+        }
+    }
+    // Variant CASE names that are also keyed in record_fields — skip them as
+    // standalone record reprs (they are reached via the owning variant type).
+    let case_names: HashSet<String> = emitter.variant_info.values()
+        .flat_map(|cases| cases.iter().map(|c| c.name.clone()))
+        .collect();
+    for (name, fields) in &emitter.record_fields {
+        let is_anon = name.starts_with("__anon_record_");
+        let is_variant_case = case_names.contains(name);
+        let is_variant_type = emitter.variant_info.contains_key(name);
+        let has_closure = fields.iter().any(|(_, ft)| ty_field_has_closure(ft));
+        if recursive.contains(name) && !is_anon && !is_variant_case && !is_variant_type && !has_closure {
+            names.push(name.clone());
+        }
+    }
+    names.sort();
+    names.dedup();
+    for name in names {
+        let func_idx = emitter.register_func(&format!("__repr_{}", name), type_idx);
+        emitter.repr_funcs.insert(name, func_idx);
+    }
+}
+
+/// Compile each `__repr_<TypeName>` body: load the value pointer (param 0) and
+/// run the SAME structural walk the inline path uses (`emit_repr_record` /
+/// `emit_repr_variant`). Nested named-type fields recurse as a CALL because
+/// `emit_repr_value` routes a repr-backed `Ty::Named` through its repr fn (see
+/// `calls_string_repr.rs`). Body-emit order is sorted to match the (sorted)
+/// index reservation in `register_repr_funcs`.
+fn compile_repr_funcs(emitter: &mut WasmEmitter, var_table: &almide_ir::VarTable) {
+    let mut entries: Vec<(String, u32)> = emitter.repr_funcs.iter()
+        .map(|(n, &idx)| (n.clone(), idx))
+        .collect();
+    entries.sort();
+
+    for (name, _func_idx) in &entries {
+        let type_idx = emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
+
+        // One repr fn walks a SINGLE level (children recurse via call), so its
+        // scratch demand is bounded by one type's field/case count — the generous
+        // caps below mirror the eq-fn setup and never approach the inline-expansion
+        // overflow that motivated these functions.
+        let mut local_decls = Vec::new();
+        let scratch_i32_cap = 32usize;
+        let scratch_i64_cap = 8usize;
+        let scratch_f64_cap = 2usize;
+        let scratch_i32_base = 1u32; // after the single `ptr` param
+        for _ in 0..scratch_i32_cap { local_decls.push((1, ValType::I32)); }
+        let scratch_i64_base = scratch_i32_base + scratch_i32_cap as u32;
+        for _ in 0..scratch_i64_cap { local_decls.push((1, ValType::I64)); }
+        let scratch_f64_base = scratch_i64_base + scratch_i64_cap as u32;
+        for _ in 0..scratch_f64_cap { local_decls.push((1, ValType::F64)); }
+
+        let wasm_func = TrackedFunction::new(local_decls);
+        let mut scratch_alloc = scratch::ScratchAllocator::new();
+        scratch_alloc.set_bases_with_capacity(
+            scratch_i32_base, scratch_i32_cap,
+            scratch_i64_base, scratch_i64_cap,
+            scratch_f64_base, scratch_f64_cap,
+        );
+
+        // The repr emitters dispatch on the static `Ty` of the value: a variant
+        // type → `emit_repr_variant`, otherwise a record → `emit_repr_record`.
+        let is_variant = emitter.variant_info.contains_key(name.as_str());
+        let ty = almide_lang::types::Ty::Named(almide_base::intern::sym(name), Vec::new());
+
+        let compiled_func = {
+            let mut compiler = FuncCompiler {
+                emitter: &mut *emitter,
+                func: wasm_func,
+                var_map: std::collections::HashMap::new(),
+                depth: 0,
+                loop_stack: Vec::new(),
+                scratch: scratch_alloc,
+                var_table,
+                stub_ret_ty: almide_lang::types::Ty::Unit,
+                current_module_name: None,
+            };
+
+            // Push the value pointer (param 0); the walk consumes it from the
+            // stack and leaves the result string pointer (the return value).
+            wasm!(compiler.func, { local_get(0); });
+            if is_variant {
+                compiler.emit_repr_variant(&ty);
+            } else {
+                let fields = compiler.extract_record_fields(&ty);
+                compiler.emit_repr_record(Some(name.as_str()), &fields);
+            }
             compiler.func.instruction(&wasm_encoder::Instruction::End);
             compiler.func
         };

--- a/crates/almide-codegen/src/emit_wasm/rt_float_display.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_float_display.rs
@@ -1,0 +1,103 @@
+//! WASM runtime for the `Display`-style float text used in string interpolation.
+//!
+//! `float.to_string(x)` (the Dragon4 driver, `__float_to_string`) appends a `.0`
+//! to every integer-valued float so a `Float` always reads as a float — that is
+//! the stdlib contract and is byte-identical native↔WASM.
+//!
+//! Bare/contained string INTERPOLATION (`"${0.0}"`, `"${[1.0]}"`) is different:
+//! the native oracle routes a float through Rust's `Display` (`format!("{}", x)`),
+//! which renders an integer-valued float WITHOUT the trailing `.0` (`0.0` → `0`,
+//! `-0.0` → `-0`, `1.0` → `1`). Every non-integral value (`0.1`, `1.5`, the huge
+//! fixed-notation strings for `1e300` / `1e-300`) is already identical between
+//! the two formats. So `Display(x)` is exactly `to_string(x)` with a single
+//! trailing `.0` removed when (and only when) it is present.
+//!
+//! `__float_display(f) -> ptr` therefore calls the Dragon4 driver and, if the
+//! result ends in `.0`, returns a copy truncated by those two bytes; otherwise
+//! it returns the driver's string pointer unchanged. Output uses the standard
+//! `[len:i32][cap:i32][data:u8...]` string layout.
+
+use super::{CompiledFunc, WasmEmitter};
+use wasm_encoder::ValType;
+use super::TrackedFunction as Function;
+use super::rt_string::{string_data_off, string_hdr, string_cap_off};
+
+// The 2-byte `.0` suffix the Dragon4 driver adds to integer-valued floats; the
+// only difference between `float.to_string` and the `Display` form.
+const BYTE_DOT: i32 = 0x2E; // '.'
+const BYTE_ZERO: i32 = 0x30; // '0'
+const DOT_ZERO_LEN: i32 = 2;
+
+pub(super) fn register(emitter: &mut WasmEmitter) {
+    // __float_display(f: f64) -> i32 (String ptr)
+    let ty = emitter.register_type(vec![ValType::F64], vec![ValType::I32]);
+    emitter.rt.float_display = emitter.register_func("__float_display", ty);
+}
+
+/// __float_display(f) -> ptr: `__float_to_string(f)` with a trailing `.0` removed.
+pub(super) fn compile(emitter: &mut WasmEmitter) {
+    let type_idx = emitter.func_type_indices[&emitter.rt.float_display];
+    let to_string = emitter.rt.float_to_string;
+    let alloc = emitter.rt.alloc;
+    let data_off = string_data_off();
+    let hdr = string_hdr();
+    let cap_off = string_cap_off() as u32; // string header: [len@0][cap@cap_off]
+
+    // param 0 = f (the float)
+    // locals:
+    //   1 = src      (Dragon4 string ptr)
+    //   2 = len      (src byte length)
+    //   3 = out      (truncated result ptr)
+    //   4 = out_len  (len - 2)
+    //   5 = i        (copy index)
+    let mut f = Function::new([
+        (1, ValType::I32), // 1: src
+        (1, ValType::I32), // 2: len
+        (1, ValType::I32), // 3: out
+        (1, ValType::I32), // 4: out_len
+        (1, ValType::I32), // 5: i
+    ]);
+    const F: u32 = 0;
+    const SRC: u32 = 1;
+    const LEN: u32 = 2;
+    const OUT: u32 = 3;
+    const OUT_LEN: u32 = 4;
+    const I: u32 = 5;
+
+    wasm!(f, {
+        local_get(F); call(to_string); local_set(SRC);
+        local_get(SRC); i32_load(0); local_set(LEN);
+        // Keep the driver's string verbatim unless it ends in exactly `.0`:
+        //   len >= 2  &&  data[len-2] == '.'  &&  data[len-1] == '0'
+        local_get(LEN); i32_const(DOT_ZERO_LEN); i32_ge_s;
+        local_get(SRC); i32_const(data_off); i32_add;
+          local_get(LEN); i32_add; i32_const(DOT_ZERO_LEN); i32_sub;
+          i32_load8_u(0); i32_const(BYTE_DOT); i32_eq;
+        i32_and;
+        local_get(SRC); i32_const(data_off); i32_add;
+          local_get(LEN); i32_add; i32_const(1); i32_sub;
+          i32_load8_u(0); i32_const(BYTE_ZERO); i32_eq;
+        i32_and;
+        if_i32;
+          // out_len = len - 2; allocate header + out_len, copy the prefix bytes.
+          local_get(LEN); i32_const(DOT_ZERO_LEN); i32_sub; local_set(OUT_LEN);
+          local_get(OUT_LEN); i32_const(hdr); i32_add; call(alloc); local_set(OUT);
+          local_get(OUT); local_get(OUT_LEN); i32_store(0);
+          local_get(OUT); local_get(OUT_LEN); i32_store(cap_off, 0);
+          i32_const(0); local_set(I);
+          block_empty; loop_empty;
+            local_get(I); local_get(OUT_LEN); i32_ge_u; br_if(1);
+            local_get(OUT); i32_const(data_off); i32_add; local_get(I); i32_add;
+            local_get(SRC); i32_const(data_off); i32_add; local_get(I); i32_add;
+            i32_load8_u(0); i32_store8(0);
+            local_get(I); i32_const(1); i32_add; local_set(I);
+            br(0);
+          end; end;
+          local_get(OUT);
+        else_;
+          local_get(SRC);
+        end;
+        end;
+    });
+    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+}

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -304,6 +304,9 @@ pub fn register_runtime_functions(emitter: &mut WasmEmitter) {
     // Compound-repr string escape helper (registered last → compiled last so the
     // func-index order matches; see the compile-order note in `compile_runtime`).
     super::rt_repr::register(emitter);
+    // Display-form float text for string interpolation (reuses the Dragon4
+    // driver). Registered right after rt_repr so the compile order below matches.
+    super::rt_float_display::register(emitter);
 
     // Global 0: __heap_ptr (memory 0 bump allocator)
     emitter.heap_ptr_global = 0;
@@ -376,6 +379,8 @@ pub fn compile_runtime(emitter: &mut WasmEmitter) {
     // Compound-repr string escape (registered last in register_runtime, so its
     // body is emitted last to keep func-index order).
     super::rt_repr::compile(emitter);
+    // Display-form float text (registered right after rt_repr → compiled here).
+    super::rt_float_display::compile(emitter);
 }
 
 /// __alloc(size: i32) -> i32

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -378,21 +378,27 @@ fn almide_repr_prelude(vis: &str) -> String {
     for t in ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64", "bool"] {
         s.push_str(&format!("impl AlmideRepr for {t} {{ fn almide_repr(&self) -> String {{ format!(\"{{}}\", self) }} }}\n"));
     }
-    // Strings inside a container are double-quoted + escaped.
-    s.push_str("impl AlmideRepr for String { fn almide_repr(&self) -> String { almide_repr_str(self) } }\n");
+    // Strings inside a container are double-quoted + escaped. The impl TARGET of
+    // every std type below is FULLY QUALIFIED (`std::string::String`,
+    // `std::boxed::Box`, …): a user `type Box = { … }` / `type Vec = …` lowers to
+    // a `pub struct Box`/`pub struct Vec` that would otherwise SHADOW the std type
+    // at the impl site, binding this blanket impl to the user struct (E0614:
+    // `(**self)` on a non-pointer, or a method-not-found). Qualifying pins each
+    // blanket to the real std type so the user's own type keeps its generated impl.
+    s.push_str("impl AlmideRepr for std::string::String { fn almide_repr(&self) -> String { almide_repr_str(self) } }\n");
     s.push_str("impl AlmideRepr for str { fn almide_repr(&self) -> String { almide_repr_str(self) } }\n");
     // List: `[a, b, c]`, empty `[]`.
-    s.push_str("impl<T: AlmideRepr> AlmideRepr for Vec<T> { fn almide_repr(&self) -> String { let mut o = String::from(\"[\"); for (i, e) in self.iter().enumerate() { if i > 0 { o.push_str(\", \"); } o.push_str(&e.almide_repr()); } o.push(']'); o } }\n");
+    s.push_str("impl<T: AlmideRepr> AlmideRepr for std::vec::Vec<T> { fn almide_repr(&self) -> String { let mut o = String::from(\"[\"); for (i, e) in self.iter().enumerate() { if i > 0 { o.push_str(\", \"); } o.push_str(&e.almide_repr()); } o.push(']'); o } }\n");
     // Option: `some(v)` / `none`.
-    s.push_str("impl<T: AlmideRepr> AlmideRepr for Option<T> { fn almide_repr(&self) -> String { match self { Some(v) => format!(\"some({})\", v.almide_repr()), None => \"none\".to_string() } } }\n");
+    s.push_str("impl<T: AlmideRepr> AlmideRepr for std::option::Option<T> { fn almide_repr(&self) -> String { match self { Some(v) => format!(\"some({})\", v.almide_repr()), None => \"none\".to_string() } } }\n");
     // Result: `ok(v)` / `err(e)`.
-    s.push_str("impl<T: AlmideRepr, E: AlmideRepr> AlmideRepr for Result<T, E> { fn almide_repr(&self) -> String { match self { Ok(v) => format!(\"ok({})\", v.almide_repr()), Err(e) => format!(\"err({})\", e.almide_repr()) } } }\n");
+    s.push_str("impl<T: AlmideRepr, E: AlmideRepr> AlmideRepr for std::result::Result<T, E> { fn almide_repr(&self) -> String { match self { Ok(v) => format!(\"ok({})\", v.almide_repr()), Err(e) => format!(\"err({})\", e.almide_repr()) } } }\n");
     // RcCow / SharedMut transparently forward to the wrapped value.
     s.push_str("impl<T: AlmideRepr> AlmideRepr for RcCow<T> { fn almide_repr(&self) -> String { (**self).almide_repr() } }\n");
     s.push_str("impl<T: AlmideRepr + Clone> AlmideRepr for SharedMut<T> { fn almide_repr(&self) -> String { self.0.borrow().almide_repr() } }\n");
     // Reference forwarders so `almide_repr(&&x)` and slice elements compose.
     s.push_str("impl<T: AlmideRepr + ?Sized> AlmideRepr for &T { fn almide_repr(&self) -> String { (**self).almide_repr() } }\n");
-    s.push_str("impl<T: AlmideRepr + ?Sized> AlmideRepr for Box<T> { fn almide_repr(&self) -> String { (**self).almide_repr() } }\n");
+    s.push_str("impl<T: AlmideRepr + ?Sized> AlmideRepr for std::boxed::Box<T> { fn almide_repr(&self) -> String { (**self).almide_repr() } }\n");
     // Tuples: `(a, b, …)` for arities 2..=12 (the parser caps tuple width well below this).
     let names = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"];
     for arity in 2..=names.len() {

--- a/crates/almide-codegen/src/walker/declarations.rs
+++ b/crates/almide-codegen/src/walker/declarations.rs
@@ -25,7 +25,7 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
         String::new()
     };
 
-    match &td.kind {
+    let decl = match &td.kind {
         IrTypeDeclKind::Record { fields } => {
             let has_fn_fields = fields.iter().any(|f| matches!(&f.ty, Ty::Fn { .. }));
             // Matrix / Fn / transitively-blocking types prevent PartialEq derive.
@@ -157,6 +157,130 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
             let type_s = render_type(ctx, target);
             ctx.templates.render_with("type_alias", None, &[], &[("name", td.name.as_str()), ("type", type_s.as_str())])
                 .unwrap_or_else(|| format!("type {} = {};", td.name, render_type(ctx, target)))
+        }
+    };
+
+    // Emit the `AlmideRepr` impl for records/variants so a record/variant value
+    // interpolated in a string (`"${p}"`) renders to its Almide-literal form —
+    // the SAME construction-literal format `deriving Repr` produces — on BOTH
+    // targets (the WASM half walks the same layout). Closure-bearing types are
+    // skipped (a closure is not `AlmideRepr`; they never reach compound interp).
+    if let Some(impl_s) = render_repr_impl(ctx, td) {
+        format!("{decl}\n{impl_s}")
+    } else {
+        decl
+    }
+}
+
+/// Build `impl AlmideRepr for <Type>` for a record or variant type, mirroring
+/// the `auto_derive_repr` literal format:
+///   record       → `P { x: 1, y: 2 }`     (field declaration order)
+///   tuple variant→ `Click(10, 20)`
+///   record variant→`Scroll { dy: 5 }`
+///   nullary       → `Quit`
+/// Each field/payload routes through `almide_repr()`, so strings get quoted,
+/// floats use the `Display` form, and nested compounds recurse — identical to
+/// how a field renders inside any other container. Returns `None` for types
+/// that cannot back a repr (closure fields) or are not records/variants.
+/// Whether a type decl gets a generated `AlmideRepr` impl: a record or variant
+/// whose fields/payloads are all `AlmideRepr` (no closure field). The interp
+/// router (`ty_needs_repr`) and the impl emitter share this predicate so the
+/// "this Named type is repr-backed" decision is made in exactly one place.
+pub fn type_has_repr_impl(td: &IrTypeDecl) -> bool {
+    match &td.kind {
+        IrTypeDeclKind::Record { fields } => !fields.iter().any(|f| ty_has_fn(&f.ty)),
+        IrTypeDeclKind::Variant { cases, .. } => !cases.iter().any(|v| match &v.kind {
+            IrVariantKind::Unit => false,
+            IrVariantKind::Tuple { fields } => fields.iter().any(ty_has_fn),
+            IrVariantKind::Record { fields } => fields.iter().any(|f| ty_has_fn(&f.ty)),
+        }),
+        _ => false,
+    }
+}
+
+fn render_repr_impl(ctx: &RenderContext, td: &IrTypeDecl) -> Option<String> {
+    // Records/variants without a closure field back a repr; skip everything else.
+    if !type_has_repr_impl(td) { return None; }
+
+    // Generic header + target. The impl GENERICS carry every param's bounds; the
+    // impl TARGET uses BARE params. For a generic type these MUST differ:
+    //   impl<T: AlmideRepr + Clone + PartialEq> AlmideRepr for Tree<T> { … }
+    //                       ^^^^^^^^^^^^^^^^^^^ bounds belong here          ^^^ bare
+    // Reusing the decl's bounded `<T: Clone + PartialEq>` as the target emits the
+    // invalid `for Tree<T: Clone + PartialEq>` (E0229: associated-item-constraint
+    // not allowed). The param's own bound set is whatever the struct/enum decl
+    // declared (via the `generic_bound` template), plus `AlmideRepr` so the field
+    // reprs compose; rendering them through the same template keeps the impl
+    // bounds in lock-step with the type decl (Rust requires the impl to satisfy
+    // every bound the type definition declares).
+    let (impl_generics, target_args) = match td.generics.as_ref().filter(|g| !g.is_empty()) {
+        Some(generics) => {
+            let impl_bounds = generics.iter().map(|g| {
+                // The type DEFINITION declares each param via `generic_bound`
+                // (`T: Clone + PartialEq`); the impl must satisfy those same
+                // bounds, so reuse the rendered form and splice `AlmideRepr` in
+                // right after the `name:` colon → `T: AlmideRepr + Clone + …`.
+                let own = ctx.templates.render_with("generic_bound", None, &[], &[("name", g.name.as_str())])
+                    .unwrap_or_else(|| format!("{}: Clone + PartialEq", g.name));
+                match own.split_once(':') {
+                    Some((name, rest)) => format!("{}: AlmideRepr +{}", name.trim_end(), rest),
+                    None => format!("{}: AlmideRepr", g.name),
+                }
+            }).collect::<Vec<_>>().join(", ");
+            let bare = generics.iter().map(|g| g.name.to_string()).collect::<Vec<_>>().join(", ");
+            (format!("<{}>", impl_bounds), format!("<{}>", bare))
+        }
+        None => (String::new(), String::new()),
+    };
+    let full_name = format!("{}{}", td.name, target_args);
+
+    let body = match &td.kind {
+        IrTypeDeclKind::Record { fields } => {
+            // `Type { f0: {}, f1: {} }`, fields in declaration order.
+            let fmt = fields.iter().enumerate()
+                .map(|(i, f)| format!("{}{}: {{}}", if i > 0 { ", " } else { "" }, f.name))
+                .collect::<Vec<_>>().join("");
+            let args = fields.iter()
+                .map(|f| format!("self.{}.almide_repr()", f.name))
+                .collect::<Vec<_>>().join(", ");
+            format!("format!(\"{} {{{{ {} }}}}\", {})", td.name, fmt, args)
+        }
+        IrTypeDeclKind::Variant { cases, .. } => {
+            let arms = cases.iter().map(|v| render_repr_variant_arm(&td.name, v))
+                .collect::<Vec<_>>().join("\n            ");
+            format!("match self {{\n            {}\n        }}", arms)
+        }
+        _ => return None,
+    };
+
+    Some(format!(
+        "impl{} AlmideRepr for {} {{ fn almide_repr(&self) -> String {{ {} }} }}",
+        impl_generics, full_name, body
+    ))
+}
+
+/// One match arm of a variant's `AlmideRepr` impl.
+fn render_repr_variant_arm(type_name: &str, v: &IrVariantDecl) -> String {
+    match &v.kind {
+        IrVariantKind::Unit => {
+            // Nullary constructor → bare name.
+            format!("{}::{} => \"{}\".to_string(),", type_name, v.name, v.name)
+        }
+        IrVariantKind::Tuple { fields } => {
+            // `Click(10, 20)`: positional bindings v0, v1, … rendered via repr.
+            let binds = (0..fields.len()).map(|i| format!("v{}", i)).collect::<Vec<_>>().join(", ");
+            let fmt = (0..fields.len()).map(|_| "{}").collect::<Vec<_>>().join(", ");
+            let args = (0..fields.len()).map(|i| format!("v{}.almide_repr()", i)).collect::<Vec<_>>().join(", ");
+            format!("{}::{}({}) => format!(\"{}({})\", {}),", type_name, v.name, binds, v.name, fmt, args)
+        }
+        IrVariantKind::Record { fields } => {
+            // `Scroll { dy: 5 }`: named bindings, field declaration order.
+            let binds = fields.iter().map(|f| f.name.to_string()).collect::<Vec<_>>().join(", ");
+            let fmt = fields.iter().enumerate()
+                .map(|(i, f)| format!("{}{}: {{}}", if i > 0 { ", " } else { "" }, f.name))
+                .collect::<Vec<_>>().join("");
+            let args = fields.iter().map(|f| format!("{}.almide_repr()", f.name)).collect::<Vec<_>>().join(", ");
+            format!("{}::{} {{ {} }} => format!(\"{} {{{{ {} }}}}\", {}),", type_name, v.name, binds, v.name, fmt, args)
         }
     }
 }

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -636,7 +636,19 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                 .unwrap_or_else(|| format!("map([{}])", parts.join(", ")))
         }
         IrExprKind::EmptyMap => {
-            template_or(ctx, "empty_map", &[], "HashMap::new()")
+            // Render `AlmideMap::<K, V>::new()` with the key/value types from the
+            // literal's resolved type, so an annotated empty map (`[:]: Map[K,V]`)
+            // routed through `almide_repr` infers (native E0282 otherwise). When
+            // the types are unknown they erase to `_` (inference fills them from
+            // the surrounding context, as before this turbofish).
+            let (key_ty, value_ty) = match &expr.ty {
+                Ty::Applied(TypeConstructorId::Map, args) if args.len() == 2 => {
+                    (render_map_type_arg(ctx, &args[0]), render_map_type_arg(ctx, &args[1]))
+                }
+                _ => ("_".to_string(), "_".to_string()),
+            };
+            ctx.templates.render_with("empty_map", None, &[], &[("key_type", key_ty.as_str()), ("value_type", value_ty.as_str())])
+                .unwrap_or_else(|| format!("AlmideMap::<{}, {}>::new()", key_ty, value_ty))
         }
 
         // ── SpreadRecord ──
@@ -1390,22 +1402,33 @@ fn render_runtime_call(ctx: &RenderContext, symbol: &almide_base::intern::Sym, a
 /// `Bool`, `Unit`) and bare `String` keep their plain `{}` Display path so the
 /// emitted code for existing programs is byte-identical.
 ///
-/// Scope (this PR — cluster-H compound interpolation): the STRUCTURAL types that
-/// are backed by an `AlmideRepr` impl on BOTH targets — `List`, `Map`, `Set`,
-/// `Option`, `Result`, and `Tuple`, recursively composed. User-defined records
-/// and variants are deliberately left on the Display path here: to repr them we
-/// would also need the WASM record/variant field-walk emitters, and rendering
-/// them native-only would re-introduce a native↔WASM divergence (the exact bug
-/// class this work closes). They stay scoped out until both targets back them.
-fn ty_needs_repr(ty: &Ty) -> bool {
+/// Scope: the types backed by an `AlmideRepr` impl on BOTH targets, recursively
+/// composed — the structural containers (`List`, `Map`, `Set`, `Option`,
+/// `Result`, `Tuple`) plus user-defined records and variants. A record/variant
+/// is identified by name via `ctx.repr_named_types` (the set of types that got a
+/// generated `AlmideRepr` impl); an anonymous record (`Ty::Record`/`OpenRecord`)
+/// is always repr-backed. Closure-bearing types are excluded from the set, so a
+/// value with an `Fn` field stays on the Display path (it has no repr).
+/// Render a key/value type for an empty-map turbofish, erasing unresolved
+/// named typevars to `_` exactly like the empty-list `inner_type` path.
+fn render_map_type_arg(ctx: &RenderContext, ty: &Ty) -> String {
+    let ty = if ty_has_named_typevar(ty) { erase_named_typevars(ty.clone()) } else { ty.clone() };
+    render_type(ctx, &ty)
+}
+
+fn ty_needs_repr(ctx: &RenderContext, ty: &Ty) -> bool {
     use TypeConstructorId::{List, Map, Set, Option as OptionId, Result as ResultId};
     match ty {
         // Backed container constructors → repr.
         Ty::Applied(id, _) => matches!(id, List | Map | Set | OptionId | ResultId),
         // Tuples → repr.
         Ty::Tuple(..) => true,
-        // Everything else (scalars, String, Bool, Unit, records, variants,
-        // Named, Fn, Unknown, …) stays on the Display path.
+        // Anonymous records get an inline literal repr.
+        Ty::Record { .. } | Ty::OpenRecord { .. } => true,
+        // Named records/variants → repr only when a generated impl exists.
+        Ty::Named(name, _) => ctx.repr_named_types.contains(name),
+        // Everything else (scalars, String, Bool, Unit, Fn, Unknown, …) stays on
+        // the Display path.
         _ => false,
     }
 }
@@ -1434,7 +1457,7 @@ fn render_string_interp(ctx: &RenderContext, parts: &[IrStringPart]) -> String {
                 // existing programs' emitted code is byte-identical. `almide_repr`
                 // takes `&T` and has ref-forwarding impls, so `&(...)` is correct
                 // whether the part renders to an owned value or an existing borrow.
-                if ty_needs_repr(&expr.ty) {
+                if ty_needs_repr(ctx, &expr.ty) {
                     arg_parts.push(format!("almide_repr(&({}))", render_expr(ctx, expr)));
                 } else {
                     arg_parts.push(render_expr(ctx, expr));

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -56,11 +56,17 @@ pub struct RenderContext<'a> {
     /// `RefMut` param into another `RefMut` callee slot (Rust
     /// auto-reborrows).
     pub ref_mut_params: std::collections::HashSet<VarId>,
+    /// Names of user-defined record/variant types that have a generated
+    /// `AlmideRepr` impl (see `render_repr_impl`). A `Ty::Named` in a compound
+    /// interpolation part routes through `almide_repr` only when it is in this
+    /// set, so a value with the impl renders to its literal form while opaque
+    /// `Named` references (e.g. runtime newtypes) stay on the Display path.
+    pub repr_named_types: std::collections::HashSet<almide_base::intern::Sym>,
 }
 
 impl<'a> RenderContext<'a> {
     pub fn new(templates: &'a TemplateSet, var_table: &'a VarTable) -> Self {
-        Self { templates, var_table, indent: 0, target: Target::Rust, auto_unwrap: false, is_test: false, ann: CodegenAnnotations::default(), type_aliases: std::collections::HashMap::new(), generic_types: std::collections::HashSet::new(), minimal_generic_bounds: false, repr_c: false, ref_params: std::collections::HashSet::new(), ref_mut_params: std::collections::HashSet::new() }
+        Self { templates, var_table, indent: 0, target: Target::Rust, auto_unwrap: false, is_test: false, ann: CodegenAnnotations::default(), type_aliases: std::collections::HashMap::new(), generic_types: std::collections::HashSet::new(), minimal_generic_bounds: false, repr_c: false, ref_params: std::collections::HashSet::new(), ref_mut_params: std::collections::HashSet::new(), repr_named_types: std::collections::HashSet::new() }
     }
 
     pub fn with_target(mut self, target: Target) -> Self {
@@ -147,6 +153,7 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
         repr_c: ctx.repr_c,
         ref_params,
         ref_mut_params,
+        repr_named_types: ctx.repr_named_types.clone(),
     };
 
     // Dispatch-only fns (body is Hole): `@inline_rust` / `@intrinsic`
@@ -439,6 +446,17 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
             generic_types.insert(td.name);
         }
     }
+    // Record/variant types that get a generated `AlmideRepr` impl — a value of
+    // such a type interpolated in a string renders to its literal form. Gate
+    // mirrors `render_repr_impl` (closure-bearing types are excluded).
+    let mut repr_named_types = std::collections::HashSet::new();
+    for td in program.type_decls.iter()
+        .chain(program.modules.iter().flat_map(|m| m.type_decls.iter()))
+    {
+        if declarations::type_has_repr_impl(td) {
+            repr_named_types.insert(td.name);
+        }
+    }
     let mut ann = ctx.ann.clone();
     // Compute which user types cannot derive PartialEq (contain Matrix,
     // Fn, or a field whose type itself blocks equality). Must consider
@@ -620,6 +638,7 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         repr_c: ctx.repr_c,
         ref_params: std::collections::HashSet::new(),
         ref_mut_params: std::collections::HashSet::new(),
+        repr_named_types,
     };
     for td in &program.type_decls {
         if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
@@ -680,6 +699,44 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
             let repr_prefix = if ctx.repr_c { "#[repr(C)]\n" } else { "" };
             parts.push(ctx.templates.render_with("struct_decl", None, &decl_attrs, &[("name", full_name.as_str()), ("fields", fields_str.as_str())])
                 .unwrap_or_else(|| format!("{}pub struct {} {{\n{}\n}}", repr_prefix, struct_name, fields_str)));
+
+            // `AlmideRepr` impl for the anonymous struct: `"${rec}"` renders an
+            // anonymous record to `{ x: 1, y: 2 }` — NO type name, because it HAS
+            // none — byte-identically with the WASM anon-record walk. A
+            // closure-bearing anon record (`has_fn`) is not `AlmideRepr`, so it is
+            // skipped (it never reaches compound interp). Fields render in the
+            // struct's own field order, which is the SORTED field-name list (this
+            // `field_names` is the sorted key from `collect_anon_records`); the
+            // WASM walk sorts to match (see `emit_repr_record`).
+            if !has_fn {
+                let bare_generics: Vec<String> = (0..field_names.len())
+                    .map(|i| format!("T{}", i)).collect();
+                // The anon struct declares each param via `generic_bound_full`
+                // (`T: Clone + Debug + PartialEq`); the impl must satisfy those
+                // same bounds, plus `AlmideRepr` so the field reprs compose.
+                // Reuse the template so the bounds stay in lock-step with the decl.
+                let impl_bounds = bare_generics.iter()
+                    .map(|t| {
+                        let own = ctx.templates.render_with("generic_bound_full", None, &[], &[("name", t.as_str())])
+                            .unwrap_or_else(|| format!("{}: Clone + std::fmt::Debug + PartialEq", t));
+                        match own.split_once(':') {
+                            Some((name, rest)) => format!("{}: AlmideRepr +{}", name.trim_end(), rest),
+                            None => format!("{}: AlmideRepr", t),
+                        }
+                    })
+                    .collect::<Vec<_>>().join(", ");
+                let target = format!("{}<{}>", struct_name, bare_generics.join(", "));
+                let fmt = field_names.iter().enumerate()
+                    .map(|(i, name)| format!("{}{}: {{}}", if i > 0 { ", " } else { "" }, name))
+                    .collect::<Vec<_>>().join("");
+                let args = field_names.iter()
+                    .map(|name| format!("self.{}.almide_repr()", name))
+                    .collect::<Vec<_>>().join(", ");
+                parts.push(format!(
+                    "impl<{}> AlmideRepr for {} {{ fn almide_repr(&self) -> String {{ format!(\"{{{{ {} }}}}\", {}) }} }}",
+                    impl_bounds, target, fmt, args
+                ));
+            }
         }
     }
 

--- a/crates/almide-frontend/src/lower/expressions.rs
+++ b/crates/almide-frontend/src/lower/expressions.rs
@@ -568,8 +568,13 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
                 ast::StringPart::Lit { value } => IrStringPart::Lit { value: value.clone() },
                 ast::StringPart::Expr { expr } => {
                     let mut ir_expr = lower_expr(ctx, expr);
-                    // Operator protocol: dispatch to Repr convention if available
-                    if let Some(repr_fn) = ctx.find_convention_fn(&ir_expr.ty, "repr") {
+                    // Operator protocol: dispatch to an EXPLICIT user `repr` only.
+                    // An auto-derived `repr` is intentionally NOT used here — the
+                    // record/variant instead falls through to the codegen
+                    // `AlmideRepr` impl (the canonical literal form with quoted
+                    // strings), so an auto-derived and a plain record interpolate
+                    // byte-identically. An explicit `fn X.repr` still wins.
+                    if let Some(repr_fn) = ctx.find_explicit_convention_fn(&ir_expr.ty, "repr") {
                         ir_expr = ctx.mk(IrExprKind::Call {
                             target: CallTarget::Named { name: repr_fn },
                             args: vec![ir_expr], type_args: vec![],
@@ -629,7 +634,27 @@ pub(super) fn lower_expr(ctx: &mut LowerCtx, expr: &ast::Expr) -> IrExpr {
 
         // ── Misc ──
         ast::ExprKind::Paren { expr, .. } => lower_expr(ctx, expr),
-        ast::ExprKind::TypeAscription { expr, .. } => lower_expr(ctx, expr),
+        ast::ExprKind::TypeAscription { expr, ty: ascribed_te } => {
+            // The ascription pins the inner expression's type (`[]: List[Int]`).
+            // Lower the inner expr, then adopt the ascribed type when the inner
+            // came back less resolved — an empty collection literal otherwise
+            // carries an unresolved element type, which codegen renders as an
+            // uninferable `Vec::<_>::new()` (native E0282) under `almide_repr`.
+            // The annotation's own `TypeExpr` is the authoritative source: the
+            // checker's resolved type-map entry for the ascription can still be
+            // an unresolved `List[?]` when nothing outside the annotation
+            // constrained the element.
+            let mut inner = lower_expr(ctx, expr);
+            if inner.ty.has_unresolved_deep() {
+                let ascribed = resolve_type_expr(ascribed_te);
+                if !ascribed.has_unresolved_deep() {
+                    inner.ty = ascribed;
+                } else if !ty.has_unresolved_deep() {
+                    inner.ty = ty;
+                }
+            }
+            inner
+        }
         ast::ExprKind::Hole => ctx.mk(IrExprKind::Hole, ty, span),
         ast::ExprKind::Todo { message, .. } => ctx.mk(IrExprKind::Todo { message: message.clone() }, ty, span),
         ast::ExprKind::Error => ctx.mk(IrExprKind::Unit, Ty::Unknown, span),

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -43,6 +43,8 @@ pub struct LowerCtx<'a> {
     type_map: &'a TypeMap,
     fn_defaults: HashMap<Sym, Vec<Option<ast::Expr>>>,
     type_conventions: HashMap<Sym, std::collections::HashSet<Sym>>,
+    /// `Type.convention` names the user wrote explicitly (vs auto-derived).
+    explicit_convention_fns: std::collections::HashSet<Sym>,
     protocol_bounds: HashMap<Sym, Vec<Sym>>,
     lambda_id_counter: u32,
     /// Maps const param name → VarId for value parameter lowering.
@@ -62,6 +64,7 @@ impl<'a> LowerCtx<'a> {
             type_map,
             fn_defaults: HashMap::new(),
             type_conventions: HashMap::new(),
+            explicit_convention_fns: std::collections::HashSet::new(),
             protocol_bounds: HashMap::new(),
             lambda_id_counter: 0,
             const_param_vars: HashMap::new(),
@@ -74,6 +77,21 @@ impl<'a> LowerCtx<'a> {
     /// Returns the fully qualified function name if:
     /// - The function is explicitly defined in env.functions, OR
     /// - The type declares `deriving <Convention>` (auto-derive will generate the function)
+    /// A convention method the user wrote EXPLICITLY (not one auto-derive will
+    /// synthesize). String interpolation of a record/variant uses this — when no
+    /// explicit `repr` exists it falls through to the codegen `AlmideRepr` impl,
+    /// the canonical Almide-literal form (quoted strings, Display floats), so a
+    /// `deriving Repr` record and a plain record interpolate identically.
+    pub(super) fn find_explicit_convention_fn(&self, ty: &Ty, convention: &str) -> Option<Sym> {
+        if let Ty::Named(type_name, _) = ty {
+            let fn_name = sym(&format!("{}.{}", type_name, convention));
+            if self.explicit_convention_fns.contains(&fn_name) {
+                return Some(fn_name);
+            }
+        }
+        None
+    }
+
     pub(super) fn find_convention_fn(&self, ty: &Ty, convention: &str) -> Option<Sym> {
         if let Ty::Named(type_name, _) = ty {
             let fn_name = sym(&format!("{}.{}", type_name, convention));
@@ -218,6 +236,27 @@ fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &Type
             for conv in derives {
                 ctx.type_conventions.entry(*conv).or_default().insert(*name);
             }
+        }
+    }
+
+    // Collect convention methods the user wrote EXPLICITLY (a dotted `fn X.repr`
+    // or an `impl` method), as opposed to ones auto-derive will synthesize. The
+    // interpolation `repr` dispatch uses this so a `deriving Repr` record falls
+    // through to the codegen `AlmideRepr` impl (canonical literal form) while a
+    // hand-written `fn X.repr` still overrides it.
+    for decl in &prog.decls {
+        match decl {
+            ast::Decl::Fn { name, body: Some(_), .. } if name.as_str().contains('.') => {
+                ctx.explicit_convention_fns.insert(*name);
+            }
+            ast::Decl::Impl { for_, methods, .. } => {
+                for m in methods {
+                    if let ast::Decl::Fn { name, body: Some(_), .. } = m {
+                        ctx.explicit_convention_fns.insert(sym(&format!("{}.{}", for_, name)));
+                    }
+                }
+            }
+            _ => {}
         }
     }
 

--- a/crates/almide-syntax/src/parser/entry.rs
+++ b/crates/almide-syntax/src/parser/entry.rs
@@ -22,7 +22,25 @@ fn extract_doc_comment(comments: &[String]) -> Option<String> {
 
 impl Parser {
     pub fn parse_single_expr(&mut self) -> Result<crate::ast::Expr, String> {
-        self.parse_expr()
+        let expr = self.parse_expr()?;
+        // A trailing `: Type` pins the expression's type, exactly as in call-arg
+        // position. This matters for string interpolation: `"${[]: List[Int]}"`
+        // sub-parses through here, and the annotation is the only thing that
+        // gives an empty collection literal a concrete element type. (A `::`
+        // is a path separator, not the start of an ascription.)
+        if self.check(crate::lexer::TokenType::Colon)
+            && self.peek_at(1).map(|t| &t.token_type) != Some(&crate::lexer::TokenType::Colon)
+        {
+            let span = expr.span;
+            self.advance(); // skip ':'
+            let ty = self.parse_type_expr()?;
+            return Ok(crate::ast::Expr::new(
+                self.next_id(),
+                span,
+                crate::ast::ExprKind::TypeAscription { expr: Box::new(expr), ty },
+            ));
+        }
+        Ok(expr)
     }
 
     pub fn parse(&mut self) -> Result<Program, String> {

--- a/spec/lang/compound_repr_interp_test.almd
+++ b/spec/lang/compound_repr_interp_test.almd
@@ -1,7 +1,23 @@
 // compound_repr_interp_test — `"${compound}"` renders a value to its
-// Almide-literal form (List/Map/Set/Tuple/Option/Result + nesting), identical
-// on native and WASM. Records/variants are scoped out (Display path), so they
-// are not asserted here.
+// Almide-literal form, identical on native and WASM: List/Map/Set/Tuple/Option/
+// Result and nesting, plus user-defined records and variants (the same
+// construction-literal form `deriving Repr` produces) and the Display form of
+// an interpolated float.
+
+type ReprPoint = { x: Int, y: Int }
+type ReprPerson = { name: String, score: Float }
+type ReprEvent = Click(Int, Int) | Scroll { dy: Int } | Quit
+// Recursive ADTs: the repr walk recurses over the finite value (a runtime call
+// on WASM, trait dispatch on native), never an infinite compile-time expansion.
+type ReprTree = Leaf(Int) | Node(ReprTree, ReprTree)
+type ReprRNode = { val: Int, kids: List[ReprRNode] }
+// Mutual recursion (A → B → A), legal via List indirection.
+type ReprA = { bs: List[ReprB] }
+type ReprB = { as_: List[ReprA] }
+// Generic record / variant: the interpolation site's concrete type args resolve
+// each payload's repr.
+type ReprHolder[T] = { value: T, label: String }
+type ReprEither[L, R] = Left(L) | Right(R)
 
 // ── List ──
 test "repr list of ints" {
@@ -80,4 +96,113 @@ test "bare string interpolation is not quoted" {
 // ── Floats inside a container use the shortest-round-trip path ──
 test "repr floats inside list" {
   assert_eq("${[0.1, 0.2]}", "[0.1, 0.2]")
+}
+
+// ── Records: `Type { f: v, … }`, field declaration order ──
+test "repr record" {
+  assert_eq("${ReprPoint { x: 1, y: 2 }}", "ReprPoint { x: 1, y: 2 }")
+}
+
+test "repr record with string and float fields" {
+  // String field quoted + escaped; integer-valued float drops its `.0`.
+  assert_eq("${ReprPerson { name: "Ada", score: 10.0 }}", "ReprPerson { name: \"Ada\", score: 10 }")
+}
+
+test "repr record inside a list" {
+  let ps: List[ReprPoint] = [ReprPoint { x: 1, y: 2 }, ReprPoint { x: 3, y: 4 }];
+  assert_eq("${ps}", "[ReprPoint { x: 1, y: 2 }, ReprPoint { x: 3, y: 4 }]")
+}
+
+// ── Variants: constructor form ──
+test "repr tuple-payload variant" {
+  let e: ReprEvent = Click(10, 20);
+  assert_eq("${e}", "Click(10, 20)")
+}
+
+test "repr record-payload variant" {
+  let e: ReprEvent = Scroll { dy: 5 };
+  assert_eq("${e}", "Scroll { dy: 5 }")
+}
+
+test "repr nullary variant" {
+  let e: ReprEvent = Quit;
+  assert_eq("${e}", "Quit")
+}
+
+// ── Bare integral-float interpolation uses the Display form (drops `.0`) ──
+test "repr integral float drops decimal" {
+  assert_eq("${1.0}", "1")
+}
+
+test "repr negative zero float" {
+  assert_eq("${-0.0}", "-0")
+}
+
+test "repr fractional float keeps digits" {
+  assert_eq("${0.25}", "0.25")
+}
+
+// ── Inline-annotated empty collection literals ──
+test "repr annotated empty list" {
+  assert_eq("${[]: List[Int]}", "[]")
+}
+
+test "repr annotated empty map" {
+  assert_eq("${[:]: Map[String, Int]}", "[:]")
+}
+
+// ── Recursive ADTs: walk recurses over the finite value, not the type graph ──
+test "repr recursive variant leaf" {
+  let t: ReprTree = Leaf(42)
+  assert_eq("${t}", "Leaf(42)")
+}
+
+test "repr recursive variant nested" {
+  let t: ReprTree = Node(Node(Leaf(1), Leaf(2)), Leaf(3))
+  assert_eq("${t}", "Node(Node(Leaf(1), Leaf(2)), Leaf(3))")
+}
+
+test "repr recursive record" {
+  let n: ReprRNode = { val: 1, kids: [{ val: 2, kids: [] }] }
+  assert_eq("${n}", "ReprRNode { val: 1, kids: [ReprRNode { val: 2, kids: [] }] }")
+}
+
+test "repr mutually recursive records" {
+  let a: ReprA = { bs: [] }
+  let b: ReprB = { as_: [a] }
+  let top: ReprA = { bs: [b] }
+  assert_eq("${top}", "ReprA { bs: [ReprB { as_: [ReprA { bs: [] }] }] }")
+}
+
+// ── Generic record / variant: site type args resolve each payload's repr ──
+test "repr generic record int payload" {
+  let h: ReprHolder[Int] = { value: 42, label: "answer" }
+  assert_eq("${h}", "ReprHolder { value: 42, label: \"answer\" }")
+}
+
+test "repr generic record string payload" {
+  let h: ReprHolder[String] = { value: "hi", label: "g" }
+  assert_eq("${h}", "ReprHolder { value: \"hi\", label: \"g\" }")
+}
+
+test "repr generic variant left and right" {
+  let l: ReprEither[Int, String] = Left(5)
+  assert_eq("${l}", "Left(5)")
+  let r: ReprEither[Int, String] = Right("x")
+  assert_eq("${r}", "Right(\"x\")")
+}
+
+// ── Anonymous records: NO type name, fields in SORTED name order ──
+// Field names are unique to this test so the literal cannot unify with a named
+// record of the same shape (which would render WITH that type's name).
+test "repr anonymous record" {
+  let r = { ax: 1, ay: 2 }
+  assert_eq("${r}", "{ ax: 1, ay: 2 }")
+}
+
+test "repr anonymous record sorts fields by name" {
+  // Source order zebra, apple, mango → sorted render apple, mango, zebra;
+  // values stay bound to their names (apple=2, mango=3, zebra=1).
+  let r = { zebra: 1, apple: 2, mango: 3 }
+  assert_eq("${r}", "{ apple: 2, mango: 3, zebra: 1 }")
 }

--- a/spec/wasm_cross/compound_repr_records_interp.almd
+++ b/spec/wasm_cross/compound_repr_records_interp.almd
@@ -1,0 +1,68 @@
+// Cluster-H completion: record / variant / integral-float string interpolation.
+//
+// `"${value}"` renders a record or variant back to its Almide-literal form — the
+// same construction-literal format `deriving Repr` produces — byte-identically
+// on native and WASM, recursively composing with the container machinery
+// (PR #379). This file is the cross-target gate for:
+//   • records (multi-field, string + float fields, nested, in containers)
+//   • variants (tuple payload, record payload, nullary, in containers)
+//   • integer-valued floats in interpolation (Display form drops the `.0`)
+//   • inline-annotated empty collection literals
+//
+// The container shapes themselves are gated by compound_repr_interp.almd; here
+// the new surface is records, variants, and the bare-float Display form.
+
+type Point = { x: Int, y: Int }
+type Person = { name: String, age: Int, score: Float }
+type Line = { start: Point, end: Point }
+type Event = Click(Int, Int) | Scroll { dy: Int } | Quit
+type Shape = Circle(Float) | Rect(Int, Int) | Label { text: String, at: Point }
+
+fn main() -> Unit = {
+  // ── Records: `Type { f: v, … }`, field declaration order ──
+  println("point=${Point { x: 1, y: 2 }}")
+  // String fields are quoted + escaped; float fields use the Display form.
+  println("person=${Person { name: "Ada \"A\"", age: 36, score: 9.5 }}")
+  // An integer-valued float field drops its `.0` (`10.0` → `10`).
+  println("person_int=${Person { name: "Bob", age: 40, score: 10.0 }}")
+  // Nested record (record field inside a record).
+  println("line=${Line { start: Point { x: 1, y: 2 }, end: Point { x: 3, y: 4 } }}")
+  // Record inside a list / option / map.
+  let pts: List[Point] = [Point { x: 1, y: 2 }, Point { x: 5, y: 6 }]
+  println("points=${pts}")
+  let op: Option[Point] = some(Point { x: 7, y: 8 })
+  println("opt_rec=${op}")
+  let pm: Map[String, Point] = ["o": Point { x: 0, y: 0 }]
+  println("rec_map=${pm}")
+
+  // ── Variants: constructor form ──
+  println("click=${Click(10, 20)}")       // tuple payload
+  println("scroll=${Scroll { dy: 5 }}")    // record payload
+  println("quit=${Quit}")                  // nullary
+  // Variant with a float payload (Display form, integral drops `.0`).
+  println("circle=${Circle(2.0)}")
+  println("circle_f=${Circle(2.5)}")
+  // Variant inside a list / map (value).
+  let shapes: List[Shape] =
+    [Circle(1.0), Rect(2, 3), Label { text: "box", at: Point { x: 0, y: 0 } }]
+  println("shapes=${shapes}")
+  let sm: Map[String, Shape] = ["a": Circle(3.0), "b": Rect(4, 5)]
+  println("shape_map=${sm}")
+
+  // ── Bare integral-float interpolation: Display form (oracle = native `{}`) ──
+  println("zero=${0.0}")
+  println("neg_zero=${-0.0}")
+  println("one=${1.0}")
+  println("big=${1e300}")
+  println("frac=${0.25}")
+  // Floats inside a container inherit the same Display form.
+  println("float_list=${[0.0, 1.0, 0.5]}")
+  let ft: (Float, Float) = (2.0, 3.5)
+  println("float_tuple=${ft}")
+
+  // ── Inline-annotated empty collection literals ──
+  println("empty_list=${[]: List[Int]}")
+  println("empty_map=${[:]: Map[String, Int]}")
+  println("empty_set=${set.from_list([]): Set[Int]}")
+  println("empty_nested=${[]: List[List[Int]]}")
+}

--- a/spec/wasm_cross/compound_repr_recursive_interp.almd
+++ b/spec/wasm_cross/compound_repr_recursive_interp.almd
@@ -1,0 +1,76 @@
+// Cross-target gate for the recursive / generic / anonymous repr surface.
+//
+// `"${value}"` renders a value back to its Almide-literal form byte-identically
+// on native and WASM. This file covers the shapes the inline type-driven walk
+// CANNOT handle on WASM and that route through per-type repr functions, plus the
+// generic and anonymous record shapes whose field types/orders must converge:
+//
+//   • Self-recursive ADTs (`Tree = Leaf(Int) | Node(Tree, Tree)`) — the WASM
+//     walk recurses via a CALL into `__repr_Tree` (terminating on the finite
+//     value), not an infinite compile-time type-graph expansion.
+//   • Self-recursive records (`Node = { val, kids: List[Node] }`).
+//   • Mutually-recursive records (`A → B → A`).
+//   • Generic records / variants (`Holder[Int]`, `Either[Int, String]`) — the
+//     concrete type args at the interpolation site resolve each payload's repr.
+//   • Anonymous records (`{ x: 1, y: 2 }`) — NO type name; fields render in
+//     SORTED name order on BOTH targets (the native synthesized `AlmdRec_*`
+//     struct stores fields sorted; the WASM walk sorts to match).
+
+type Tree = Leaf(Int) | Node(Tree, Tree)
+type RNode = { val: Int, kids: List[RNode] }
+type A = { b: List[B] }
+type B = { a: List[A] }
+type Holder[T] = { value: T, label: String }
+type Either[L, R] = Left(L) | Right(R)
+
+fn main() -> Unit = {
+  // ── Self-recursive variant ADT ──
+  let leaf: Tree = Leaf(42)
+  println("leaf=${leaf}")
+  let tree: Tree = Node(Node(Leaf(1), Leaf(2)), Leaf(3))
+  println("tree=${tree}")
+  // Recursive ADT inside containers.
+  let forest: List[Tree] = [Leaf(7), Node(Leaf(8), Leaf(9))]
+  println("forest=${forest}")
+  let opt_tree: Option[Tree] = some(Node(Leaf(4), Leaf(5)))
+  println("opt_tree=${opt_tree}")
+
+  // ── Self-recursive record (List indirection makes it native-legal) ──
+  let rleaf: RNode = { val: 1, kids: [] }
+  println("rleaf=${rleaf}")
+  let rtree: RNode = { val: 1, kids: [{ val: 2, kids: [] }, { val: 3, kids: [] }] }
+  println("rtree=${rtree}")
+
+  // ── Mutual recursion (A references B references A) ──
+  let ma: A = { b: [] }
+  let mb: B = { a: [ma] }
+  let top: A = { b: [mb] }
+  println("mutual=${top}")
+
+  // ── Generic record: the site's concrete type args resolve the `T` payload ──
+  let bi: Holder[Int] = { value: 42, label: "answer" }
+  println("box_int=${bi}")
+  let bs: Holder[String] = { value: "hi", label: "greet" }
+  println("box_str=${bs}")
+  let bl: Holder[List[Int]] = { value: [1, 2, 3], label: "nums" }
+  println("box_list=${bl}")
+
+  // ── Generic variant: each constructor's payload resolves to the site type ──
+  let el: Either[Int, String] = Left(5)
+  println("either_left=${el}")
+  let er: Either[Int, String] = Right("x")
+  println("either_right=${er}")
+  let es: List[Either[Int, String]] = [Left(1), Right("y")]
+  println("either_list=${es}")
+
+  // ── Anonymous records: no type name, fields in SORTED name order ──
+  let anon = { x: 1, y: 2 }
+  println("anon=${anon}")
+  // Source order is zebra, apple, mango → sorted render is apple, mango, zebra
+  // (values stay bound to their names: apple=2, mango=3, zebra=1).
+  let anon_unsorted = { zebra: 1, apple: 2, mango: 3 }
+  println("anon_sorted=${anon_unsorted}")
+  // Anonymous record nested in a list.
+  let anon_list = [{ x: 1, y: 2 }, { x: 3, y: 4 }]
+  println("anon_list=${anon_list}")
+}


### PR DESCRIPTION
## What (completes the compound-repr contract from #379)

\`"${value}"\` now renders **records, variants, and anonymous records** back to their Almide-literal form, byte-identical native==WASM, recursively composing with the #379 machinery:

| type | renders as |
|---|---|
| Record | \`P { x: 1, y: 2 }\` (matches the existing \`deriving Repr\` format — one format, shared machinery) |
| Variant | \`Click(10, 20)\` / \`Scroll { dy: 5 }\` / \`Quit\` |
| Anonymous record | \`{ apple: 2, zebra: 1 }\` (no type name; fields sorted by name on both targets) |
| **Recursive ADTs** | per-type \`__repr_<T>\` wasm functions (runtime dispatch like native's trait), self+mutual recursion both work — 1000-node trees verified |
| Generic records/variants | \`Holder[Int]\`, \`Either[L,R]\` etc. via type-arg substitution |

Plus two pre-existing interpolation divergences fixed:
- **Bare integral floats**: \`${0.0}\` was native \`0\` vs wasm \`0.0\` — wasm interp now routes through a \`__float_display\` wrapper of the same Dragon4 driver (strips the one trailing \`.0\`); \`float.to_string\` unchanged
- **\`${[]: List[Int]}\`**: the interp sub-parser dropped trailing type ascriptions → native E0282; now parsed + adopted

## The remediation round (3 verifiers failed the first attempt; all fixed)

1. **Recursive ADTs panicked the wasm compiler** (inline walk followed the cyclic *type* graph) → per-type functions with a DFS cycle-set, bodies sorted by name (host-determinism contract)
2. **Anonymous records diverged** (native had no impls for synthesized structs; field-order differed) → impls at the synthesis site + name-sorted rendering on both targets
3. **7 native spec regressions** in the generated impls (generic bounds leaked into impl targets E0229; anon fields E0599; user \`Box[T]\` shadowing the blanket impl E0614 → all prelude blanket impls now std-qualified) — all 7 files re-verified passing

## Validation

- Adversarial reverify PASS: deep recursion (1000 nodes, both targets), mutual A↔B, multibyte/escape fields, generics in containers, full #379-surface regression — byte-identical throughout
- Suite PASS: 245/245 native + 245/245 wasm spec, wasm_runtime_test 67/67 (gate incl. 2 new corpus files), full cargo test 813 passed, snapshots clean
- Registry: \`compile_repr_funcs\` registered verified (the #382 gate caught it)

## Known residuals (documented, queued)

- Recursive **generic** types (\`Tree[T]\` self-referencing) would misrender the \`T\` payload on wasm (no panic; generics erased in the monomorphic per-type fn) — no spec exercises it; queued
- Pre-existing: user type named \`Box\` + recursive enum needing Box indirection collides on native (independent of this PR)