### PR TITLE
Pin CI wasmtime to v42.0.1 (the latest-release API call is rate-limited and flaky)

### DIFF
--- a/.github/workflows/ci-cross-target.yml
+++ b/.github/workflows/ci-cross-target.yml
@@ -41,7 +41,11 @@ jobs:
 
       - name: Install wasmtime
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+          # Pinned (not "latest"): the unauthenticated releases/latest API call is
+          # rate-limited per runner IP and intermittently returns an error body,
+          # yielding an empty VERSION and a garbage download (hit 2026-06-06).
+          # A pinned toolchain is also reproducible. Bump deliberately.
+          VERSION=v42.0.1
           curl -LO "https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/wasmtime-${VERSION}-x86_64-linux.tar.xz"
           tar -xf wasmtime-*.tar.xz
           sudo mv wasmtime-*/wasmtime /usr/local/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,11 @@ jobs:
         # wasm_runtime_test capture tests — without it they skip, so the
         # cross-target ratchet would not actually enforce here.
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+          # Pinned (not "latest"): the unauthenticated releases/latest API call is
+          # rate-limited per runner IP and intermittently returns an error body,
+          # yielding an empty VERSION and a garbage download (hit 2026-06-06).
+          # A pinned toolchain is also reproducible. Bump deliberately.
+          VERSION=v42.0.1
           curl -LO "https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/wasmtime-${VERSION}-x86_64-linux.tar.xz"
           tar -xf wasmtime-*.tar.xz
           sudo mv wasmtime-*/wasmtime /usr/local/bin/
@@ -123,7 +127,11 @@ jobs:
 
       - name: Install wasmtime
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+          # Pinned (not "latest"): the unauthenticated releases/latest API call is
+          # rate-limited per runner IP and intermittently returns an error body,
+          # yielding an empty VERSION and a garbage download (hit 2026-06-06).
+          # A pinned toolchain is also reproducible. Bump deliberately.
+          VERSION=v42.0.1
           curl -LO "https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/wasmtime-${VERSION}-x86_64-linux.tar.xz"
           tar -xf wasmtime-*.tar.xz
           sudo mv wasmtime-*/wasmtime /usr/local/bin/
@@ -177,7 +185,11 @@ jobs:
 
       - name: Install wasmtime
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+          # Pinned (not "latest"): the unauthenticated releases/latest API call is
+          # rate-limited per runner IP and intermittently returns an error body,
+          # yielding an empty VERSION and a garbage download (hit 2026-06-06).
+          # A pinned toolchain is also reproducible. Bump deliberately.
+          VERSION=v42.0.1
           curl -LO "https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/wasmtime-${VERSION}-x86_64-linux.tar.xz"
           tar -xf wasmtime-*.tar.xz
           sudo mv wasmtime-*/wasmtime /usr/local/bin/


### PR DESCRIPTION
The develop push run failed in 'Install wasmtime': the unauthenticated `releases/latest` API call hit GitHub's per-IP rate limit and returned an error body, so VERSION was empty and curl downloaded garbage ('This does not look like a tar archive'). All 4 install sites now pin v42.0.1 (matches the local toolchain; asset URL verified HTTP 200) — no API call, reproducible toolchain, deliberate bumps.