### PR TITLE
Reference interpreter for the typed IR + three-way differential harness (Stage 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "almide-interp"
+version = "0.1.0"
+dependencies = [
+ "almide-base",
+ "almide-frontend",
+ "almide-ir",
+ "almide-lang",
+ "almide-optimize",
+ "tempfile",
+]
+
+[[package]]
 name = "almide-ir"
 version = "0.12.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/almide-base", "crates/almide-syntax", "crates/almide-types", "crates/almide-lang", "crates/almide-ir", "crates/almide-dialect", "crates/almide-codegen", "crates/almide-optimize", "crates/almide-frontend", "crates/almide-tools", "crates/almide-egg-lab"]
+members = [".", "crates/almide-base", "crates/almide-syntax", "crates/almide-types", "crates/almide-lang", "crates/almide-ir", "crates/almide-dialect", "crates/almide-codegen", "crates/almide-optimize", "crates/almide-frontend", "crates/almide-interp", "crates/almide-tools", "crates/almide-egg-lab"]
 resolver = "3"
 exclude = ["research/benchmark/stdlib/rust_wasm_compare", "tools/wasmgen-harness", "tools/wasmgen-harness-uu"]
 

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -27,8 +27,15 @@ almide-ir             Typed IR, VarTable, visitors
 almide-frontend       Type checker, constraint solver, AST→IR lowering
 almide-optimize       Monomorphization, DCE, constant propagation
 almide-codegen        Nanopass pipeline, TOML templates, walker, WASM emit
+almide-interp         Pre-codegen IR tree-walker — 3rd cross-target oracle / executable spec
 almide-tools          Formatter, module interface, language server
 ```
+
+`almide-interp` is a *sibling consumer* of the linked IR, not part of the
+compile pipeline: it runs the IR at the cut point **after** `lower → optimize →
+mono → ir_link` but **before** any of `almide-codegen`'s target-lowering passes,
+so it shares no codegen pass with either backend. See
+[almide-interp/CLAUDE.md](./almide-interp/CLAUDE.md).
 
 ## Core Design Principles
 
@@ -47,6 +54,6 @@ almide-tools          Formatter, module interface, language server
 ## When Adding a New Feature
 
 - **New syntax** → almide-syntax (parser) → almide-frontend (checker + lowering) → almide-codegen (passes + templates)
-- **New stdlib function** → `stdlib/defs/<module>.toml` + `runtime/rs/<module>.rs` + WASM runtime in `emit_wasm/rt_*.rs`
+- **New stdlib function** → `stdlib/defs/<module>.toml` + `runtime/rs/<module>.rs` + WASM runtime in `emit_wasm/rt_*.rs`. To keep the 3-way oracle covering it (instead of skipping it), also add the glue to almide-interp's bridge — it is hand-maintained, NOT auto-generated. See [almide-interp/CLAUDE.md](./almide-interp/CLAUDE.md#coverage-model--does-a-new-stdlib-fn-get-covered-automatically).
 - **New type** → almide-types (Ty variant) → almide-frontend (inference rules) → almide-ir (IR nodes) → almide-codegen (emission)
 - **New codegen target** → almide-codegen (pass pipeline + TOML template + target entry)

--- a/crates/almide-interp/CLAUDE.md
+++ b/crates/almide-interp/CLAUDE.md
@@ -1,0 +1,44 @@
+# almide-interp
+
+A tree-walking interpreter over the **pre-codegen** `IrProgram` — the third leg of the cross-target oracle and an executable spec.
+
+## Why it exists
+
+The cross-target gate (`spec/wasm_cross/*.almd`, enforced by `tests/wasm_runtime_test.rs::wasm_cross_target_spec`) compares the **native** and **WASM** backends and requires byte-identical `(stdout, stderr, exit)`. That 2-way vote is structurally blind to a *both-wrong-the-same-way* bug: if codegen and the WASM emitter share a lowering pass that is wrong, both agree and the gate stays green while the behaviour is wrong.
+
+This crate adds a third, independent judge. It evaluates the IR at the cut point **after** `lower → optimize → mono → ir_link` but **before** any of `almide-codegen`'s target-lowering passes (`ClosureConversion` / `Perceus` / `StdlibLowering` / `IterChain` / …). So it shares *none* of codegen's target passes with either backend. The ~22 codegen-inserted `IrExprKind` variants are unreachable here and `eval.rs` asserts them `unreachable!` to guard the boundary.
+
+`tests/interp_cross_target_test.rs::interp_cross_target_spec` is the 3-way harness:
+- `interp == native == wasm` → corroborated by a spec that cannot share a codegen bug.
+- `native != wasm` → a backend split **owned by the 2-way `@xt-allow` gate**; this harness only logs which backend the interp sides with (tie-break diagnostic), it does NOT fail.
+- `native == wasm` but interp dissents → **LOUD failure** (`BOTH-BACKENDS-WRONG` banner). Diagnose: fix the interpreter, or you just found a both-backends bug the 2-way gate is blind to.
+
+## Module map
+
+- `value.rs` — the dynamic `Value` model + the two display modes (`display_bare` = `println`/Display, `almide_repr` = compound/container form). Both replicate `almide_repr_prelude` (`crates/almide-codegen/src/lib.rs`) so they are byte-identical to native.
+- `env.rs` — `VarId`-keyed, `Rc`-shared frames. Reproduces native `RcCow` capture semantics.
+- `eval.rs` — the tree-walker for every eval-able IR node, fuel accounting, the pattern engine (incl. list patterns, which survive past the cut point), and record-repr nominal-name recovery.
+- `dispatch.rs` — `Call` routing (`Named` / `Module` / `Method` / `Computed`), the variant-ctor registry, and the **HOF allowlist** (`is_hof`).
+- `hofs.rs` — the in-interp HOFs (map/filter/fold/…) and the interp-native container ops, plus the in-place-mutation guard.
+- `bridge.rs` — the scalar/string/math `(module, func)` bridge.
+
+## Coverage model — does a NEW stdlib fn get covered automatically?
+
+**No. A new stdlib fn needs manual glue here, or it becomes an honest skip.** Dispatch is three hand-maintained surfaces keyed by `(module, func)`:
+
+1. `dispatch.rs::is_hof` — the closure-taking combinators (the allowlist).
+2. `hofs.rs::eval_container_op` — non-HOF structural container ops.
+3. `bridge.rs::dispatch` — scalar `int`/`float`/`string`/`math`/`bool` fns.
+
+Anything not matched by one of these falls through to `Flow::Unsupported(...)`, which the 3-way gate records as a **data-driven, reasoned skip** (printed with its concrete reason; there is no hardcoded skip-list). So a new stdlib fn does not break the oracle — it silently shrinks its coverage until someone adds the glue. Widening this bridge surface (the partial json/regex/fan/map-constructor/bytes/string surface) is the highest-leverage follow-up: each added fn converts a skip into a real third vote.
+
+When you add a stdlib fn and want the oracle to cover it: add the arm to the right surface above, mirroring the native runtime fn's behaviour exactly (the Rust-std behaviour IS the oracle for the scalar fns). Do NOT path-depend on `almide_rt` for this — that crate pulls in rustls/webpki (network/TLS) and effectful surface the interp does not need.
+
+## Rules
+
+- **The interp must MATCH the backends, not "be correct" in the abstract.** Where the backends share a quirk (e.g. anonymous-record fields render in sorted order; `${float}` uses plain `{}` Display with no `.0`; the `0.30000000000000004` shortest-roundtrip), the interp replicates the quirk. A divergence here is a third vote, and a wrong third vote is worse than a skip.
+- **A wrong vote is worse than an honest skip.** When the interp cannot faithfully model something (in-place `mut`-receiver container ops whose binding is unreachable by-value; platform-libm transcendentals that diverge from the backends' vendored musl-libm in the last ULP; non-deterministic `fan.*`), return `Flow::Unsupported` with a reason — never guess.
+- **Stay at the pre-codegen cut point.** Codegen-inserted IR nodes (`Clone`, `Borrow`, `IterChain`, `ClosureCreate`, `RuntimeCall`, …) are `unreachable!` by construction. If one becomes reachable, the cut point moved — fix the boundary, don't silently handle it.
+- **Skips are data-driven and loud.** Every skip is the interpreter's own `RunStatus::Unsupported`/`FuelExhausted`, logged with its reason. Never add a hardcoded skip-list to the harness.
+- **Fuel is mandatory.** Every eval step burns one unit (`DEFAULT_FUEL`); deep recursion is bounded by `MAX_DEPTH`. An adversarial loop must terminate as `FuelExhausted`, never hang.
+- **Display contracts are derived from codegen, with a cite.** When you touch `value.rs` display, point at the exact `almide-codegen` / `runtime/rs` line you are mirroring (as the existing comments do).

--- a/crates/almide-interp/Cargo.toml
+++ b/crates/almide-interp/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "almide-interp"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Almide IR tree-walking interpreter — the executable spec / third cross-target oracle"
+
+[dependencies]
+almide-base = { path = "../almide-base" }
+almide-lang = { path = "../almide-lang" }
+almide-ir = { path = "../almide-ir" }
+almide-frontend = { path = "../almide-frontend" }
+almide-optimize = { path = "../almide-optimize" }
+
+[dev-dependencies]
+# The test battery lowers .almd source to IR through the same public frontend
+# functions the driver uses, then interprets. No fixtures, all inline.
+#
+# `interp_cross_target_test.rs` additionally drives the native and WASM backends
+# as subprocesses (the `almide` binary built into the workspace target dir) to
+# run the 3-way oracle over `spec/wasm_cross/*.almd`, so it needs a scratch dir.
+tempfile = "3"

--- a/crates/almide-interp/src/bridge.rs
+++ b/crates/almide-interp/src/bridge.rs
@@ -1,0 +1,291 @@
+//! Scalar / string / math native bridge.
+//!
+//! The monomorphic, concrete-typed runtime surface (`int.*`, `float.*`,
+//! `string.*`, `math.*`) is dispatched here by `(module, func)` name. Each glue
+//! reproduces the native runtime fn's behavior directly over `Value` — the
+//! runtime fns are mostly one-liners over Rust std, so the bridge stays small
+//! and stays byte-identical to native (the std behavior IS the oracle).
+//!
+//! Deliberately NOT taking a path dependency on the `almide_rt` crate in this
+//! phase: that crate pulls in rustls/webpki (network/TLS), bloating the build
+//! and importing effectful surface the interp does not need. The pure scalar
+//! fns are reproduced inline. Wiring `almide_rt` as a path dep to cover the
+//! full ~200-fn surface is the documented next-phase expansion.
+//!
+//! Returns `None` when `(module, func)` is not a bridged scalar fn (the caller
+//! then tries an almide-bodied stdlib fn or reports `Unsupported`).
+
+use crate::value::{float_to_string, Value};
+use crate::Flow;
+
+/// Dispatch a scalar/string/math `(module, func)` with evaluated args.
+pub(crate) fn dispatch(module: &str, func: &str, args: &[Value]) -> Option<Flow> {
+    match module {
+        "int" => int_fn(func, args),
+        "float" => float_fn(func, args),
+        "string" => string_fn(func, args),
+        "math" => math_fn(func, args),
+        "bool" => bool_fn(func, args),
+        _ => None,
+    }
+}
+
+// ── helpers to pull typed args ──────────────────────────────────
+
+fn as_int(v: Option<&Value>) -> Option<i64> {
+    match v {
+        Some(Value::Int(n)) => Some(*n),
+        _ => None,
+    }
+}
+fn as_float(v: Option<&Value>) -> Option<f64> {
+    match v {
+        Some(Value::Float(f)) => Some(*f),
+        _ => None,
+    }
+}
+fn as_str(v: Option<&Value>) -> Option<&str> {
+    match v {
+        Some(Value::Str(s)) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+fn abort_args(module: &str, func: &str) -> Flow {
+    Flow::Abort(format!("internal: bad args to {}.{}", module, func))
+}
+
+// ── int ─────────────────────────────────────────────────────────
+
+fn int_fn(func: &str, args: &[Value]) -> Option<Flow> {
+    let f = match func {
+        "to_string" => {
+            let n = as_int(args.first())?;
+            Flow::val(Value::str(n.to_string()))
+        }
+        "to_float" => {
+            let n = as_int(args.first())?;
+            Flow::val(Value::Float(n as f64))
+        }
+        "abs" => Flow::val(Value::Int(as_int(args.first())?.abs())),
+        "min" => Flow::val(Value::Int(as_int(args.first())?.min(as_int(args.get(1))?))),
+        "max" => Flow::val(Value::Int(as_int(args.first())?.max(as_int(args.get(1))?))),
+        "clamp" => {
+            let n = as_int(args.first())?;
+            let lo = as_int(args.get(1))?;
+            let hi = as_int(args.get(2))?;
+            Flow::val(Value::Int(n.clamp(lo, hi)))
+        }
+        "to_hex" => Flow::val(Value::str(format!("{:x}", as_int(args.first())?))),
+        "parse" | "from_string" => {
+            let s = as_str(args.first())?;
+            // Returns Result[Int, String] — matches almide_rt_int_parse.
+            match s.trim().parse::<i64>() {
+                Ok(n) => Flow::val(Value::Result(Ok(Box::new(Value::Int(n))))),
+                Err(e) => Flow::val(Value::Result(Err(Box::new(Value::str(e.to_string()))))),
+            }
+        }
+        // Bitwise.
+        "band" => Flow::val(Value::Int(as_int(args.first())? & as_int(args.get(1))?)),
+        "bor" => Flow::val(Value::Int(as_int(args.first())? | as_int(args.get(1))?)),
+        "bxor" => Flow::val(Value::Int(as_int(args.first())? ^ as_int(args.get(1))?)),
+        "bnot" => Flow::val(Value::Int(!as_int(args.first())?)),
+        "bshl" => Flow::val(Value::Int(as_int(args.first())? << as_int(args.get(1))?)),
+        "bshr" => Flow::val(Value::Int(as_int(args.first())? >> as_int(args.get(1))?)),
+        _ => return None,
+    };
+    Some(f)
+}
+
+// ── float ───────────────────────────────────────────────────────
+
+fn float_fn(func: &str, args: &[Value]) -> Option<Flow> {
+    let f = match func {
+        // The `.0`-suffixed form — the ONLY display path that uses it.
+        "to_string" => Flow::val(Value::str(float_to_string(as_float(args.first())?))),
+        "to_int" => Flow::val(Value::Int(as_float(args.first())? as i64)),
+        "from_int" => Flow::val(Value::Float(as_int(args.first())? as f64)),
+        "abs" => Flow::val(Value::Float(as_float(args.first())?.abs())),
+        "ceil" => Flow::val(Value::Float(as_float(args.first())?.ceil())),
+        "floor" => Flow::val(Value::Float(as_float(args.first())?.floor())),
+        "round" => Flow::val(Value::Float(as_float(args.first())?.round())),
+        "sqrt" => Flow::val(Value::Float(as_float(args.first())?.sqrt())),
+        "min" => Flow::val(Value::Float(as_float(args.first())?.min(as_float(args.get(1))?))),
+        "max" => Flow::val(Value::Float(as_float(args.first())?.max(as_float(args.get(1))?))),
+        "sign" => Flow::val(Value::Float(as_float(args.first())?.signum())),
+        "is_nan" => Flow::val(Value::Bool(as_float(args.first())?.is_nan())),
+        "is_infinite" => Flow::val(Value::Bool(as_float(args.first())?.is_infinite())),
+        "to_fixed" => {
+            let n = as_float(args.first())?;
+            let d = as_int(args.get(1))?;
+            Flow::val(Value::str(format!("{:.1$}", n, d as usize)))
+        }
+        "parse" => {
+            let s = as_str(args.first())?;
+            match s.trim().parse::<f64>() {
+                Ok(n) => Flow::val(Value::Result(Ok(Box::new(Value::Float(n))))),
+                Err(e) => Flow::val(Value::Result(Err(Box::new(Value::str(e.to_string()))))),
+            }
+        }
+        _ => return None,
+    };
+    Some(f)
+}
+
+// ── math ────────────────────────────────────────────────────────
+
+fn math_fn(func: &str, args: &[Value]) -> Option<Flow> {
+    // TRANSCENDENTALS DIVERGE FROM THE ORACLE. Both backends deliberately route
+    // `math.sin/cos/tan/exp/log*/pow` (and float `**`) through a VENDORED
+    // musl-libm (`runtime/rs/src/libm.rs`, mirrored by `emit_wasm/rt_libm.rs`)
+    // rather than the platform `f64::sin/…`, because the system libm's last-ULP
+    // result is platform-specific and provides no stable oracle (the StrictMath
+    // / fdlibm decision). Rust `std`'s `f64::sin` calls that same platform libm,
+    // so if the interp used it here it would diverge from the native==wasm
+    // consensus in the last ULP (e.g. `0.799441007199113` vs
+    // `0.7994410071991129`) and cast a WRONG third vote into the cross-target
+    // oracle. The interp does not vendor the libm (it would couple this lean
+    // crate to `almide_rt`'s heavyweight TLS deps and risk silent drift from the
+    // oracle), so it honestly reports `Unsupported` for the platform-libm
+    // transcendentals; the 3-way gate logs a reasoned skip.
+    //
+    // SAFE here: `sqrt` is IEEE-754 correctly-rounded (identical on every libm /
+    // platform), `abs` is exact, and `pi` / `e` are constants — all match the
+    // backends bit-for-bit.
+    if matches!(
+        func,
+        "sin" | "cos" | "tan" | "asin" | "acos" | "atan" | "atan2"
+            | "sinh" | "cosh" | "tanh"
+            | "exp" | "exp2" | "expm1"
+            | "ln" | "log" | "log2" | "log10" | "log1p"
+            | "pow" | "fpow" | "powf" | "cbrt" | "hypot"
+    ) {
+        return Some(Flow::Unsupported(format!(
+            "transcendental `math.{func}` (backends use vendored musl-libm; \
+             interp's platform libm diverges in the last ULP — no oracle match)"
+        )));
+    }
+    let f = match func {
+        "pi" => Flow::val(Value::Float(std::f64::consts::PI)),
+        "e" => Flow::val(Value::Float(std::f64::consts::E)),
+        "sqrt" => Flow::val(Value::Float(as_float(args.first())?.sqrt())),
+        "abs" => Flow::val(Value::Float(as_float(args.first())?.abs())),
+        _ => return None,
+    };
+    Some(f)
+}
+
+// ── bool ────────────────────────────────────────────────────────
+
+fn bool_fn(func: &str, args: &[Value]) -> Option<Flow> {
+    let f = match func {
+        "to_string" => match args.first() {
+            Some(Value::Bool(b)) => Flow::val(Value::str(b.to_string())),
+            _ => abort_args("bool", "to_string"),
+        },
+        _ => return None,
+    };
+    Some(f)
+}
+
+// ── string ──────────────────────────────────────────────────────
+
+fn string_fn(func: &str, args: &[Value]) -> Option<Flow> {
+    let f = match func {
+        "len" | "length" => Flow::val(Value::Int(as_str(args.first())?.len() as i64)),
+        "char_count" => Flow::val(Value::Int(as_str(args.first())?.chars().count() as i64)),
+        "is_empty" => Flow::val(Value::Bool(as_str(args.first())?.is_empty())),
+        "to_upper" => Flow::val(Value::str(as_str(args.first())?.to_uppercase())),
+        "to_lower" => Flow::val(Value::str(as_str(args.first())?.to_lowercase())),
+        "trim" => Flow::val(Value::str(as_str(args.first())?.trim().to_string())),
+        "trim_start" => Flow::val(Value::str(as_str(args.first())?.trim_start().to_string())),
+        "trim_end" => Flow::val(Value::str(as_str(args.first())?.trim_end().to_string())),
+        "reverse" => Flow::val(Value::str(
+            as_str(args.first())?.chars().rev().collect::<String>(),
+        )),
+        "contains" => Flow::val(Value::Bool(
+            as_str(args.first())?.contains(as_str(args.get(1))?),
+        )),
+        "starts_with" => Flow::val(Value::Bool(
+            as_str(args.first())?.starts_with(as_str(args.get(1))?),
+        )),
+        "ends_with" => Flow::val(Value::Bool(
+            as_str(args.first())?.ends_with(as_str(args.get(1))?),
+        )),
+        "replace" => Flow::val(Value::str(
+            as_str(args.first())?
+                .replace(as_str(args.get(1))?, as_str(args.get(2))?),
+        )),
+        "repeat" => Flow::val(Value::str(
+            as_str(args.first())?.repeat(as_int(args.get(1))? as usize),
+        )),
+        "count" => Flow::val(Value::Int(
+            as_str(args.first())?.matches(as_str(args.get(1))?).count() as i64,
+        )),
+        // index_of returns Option[Int] of the BYTE offset (matches the runtime:
+        // both targets return byte offsets, confirmed in memory).
+        "index_of" => Flow::val(Value::Option(
+            as_str(args.first())?
+                .find(as_str(args.get(1))?)
+                .map(|i| Box::new(Value::Int(i as i64))),
+        )),
+        "last_index_of" => Flow::val(Value::Option(
+            as_str(args.first())?
+                .rfind(as_str(args.get(1))?)
+                .map(|i| Box::new(Value::Int(i as i64))),
+        )),
+        "split" => {
+            let s = as_str(args.first())?;
+            let sep = as_str(args.get(1))?;
+            Flow::val(Value::list(
+                s.split(sep).map(|p| Value::str(p.to_string())).collect(),
+            ))
+        }
+        "lines" => Flow::val(Value::list(
+            as_str(args.first())?
+                .lines()
+                .map(|l| Value::str(l.to_string()))
+                .collect(),
+        )),
+        "chars" => Flow::val(Value::list(
+            as_str(args.first())?
+                .chars()
+                .map(|c| Value::str(c.to_string()))
+                .collect(),
+        )),
+        "join" => {
+            // join(parts: List[String], sep: String)
+            let parts = match args.first() {
+                Some(Value::List(xs)) => xs,
+                _ => return Some(abort_args("string", "join")),
+            };
+            let sep = as_str(args.get(1))?;
+            let strs: Vec<String> = parts
+                .iter()
+                .map(|v| match v {
+                    Value::Str(s) => (**s).clone(),
+                    other => other.display_bare(),
+                })
+                .collect();
+            Flow::val(Value::str(strs.join(sep)))
+        }
+        "capitalize" => {
+            let s = as_str(args.first())?;
+            let mut c = s.chars();
+            let out = match c.next() {
+                Some(first) => format!("{}{}", first.to_uppercase(), c.as_str()),
+                None => String::new(),
+            };
+            Flow::val(Value::str(out))
+        }
+        "to_int" => {
+            let s = as_str(args.first())?;
+            match s.trim().parse::<i64>() {
+                Ok(n) => Flow::val(Value::Result(Ok(Box::new(Value::Int(n))))),
+                Err(e) => Flow::val(Value::Result(Err(Box::new(Value::str(e.to_string()))))),
+            }
+        }
+        _ => return None,
+    };
+    Some(f)
+}

--- a/crates/almide-interp/src/dispatch.rs
+++ b/crates/almide-interp/src/dispatch.rs
@@ -1,0 +1,383 @@
+//! Call dispatch: the hub where `Call` nodes are routed.
+//!
+//! Taxonomy (from the IR `CallTarget` plus empirical IR inspection):
+//!   - `Named`:   builtins (println/print/assert_eq/…), variant constructors,
+//!                or user/stdlib free functions.
+//!   - `Module`:  `(module, func)` — three outcomes:
+//!                  (i)   an in-interp HOF (closure-taking combinator),
+//!                  (ii)  a scalar/string native bridge fn, or
+//!                  (iii) an almide-bodied stdlib fn lowered into the program.
+//!   - `Method`:  residual UFCS — evaluate object, dispatch as `(module,func)`.
+//!   - `Computed`: evaluate callee to a `Closure`, apply.
+
+use std::rc::Rc;
+
+use almide_base::intern::Sym;
+use almide_ir::{CallTarget, IrExpr};
+
+use crate::env::Scope;
+use crate::value::{Closure, Value, VariantPayload};
+use crate::{Flow, Interpreter};
+
+macro_rules! val {
+    ($flow:expr) => {
+        match $flow {
+            Flow::Value(v) => v,
+            other => return other,
+        }
+    };
+}
+
+impl<'a> Interpreter<'a> {
+    pub(crate) fn eval_call(
+        &mut self,
+        target: &CallTarget,
+        args: &[IrExpr],
+        scope: &Scope,
+    ) -> Flow {
+        match target {
+            CallTarget::Named { name } => self.eval_named_call(*name, args, scope),
+            CallTarget::Module { module, func, .. } => {
+                self.eval_module_call(*module, *func, args, scope)
+            }
+            CallTarget::Method { object, method } => {
+                // Residual UFCS: evaluate the receiver, prepend as first arg,
+                // and dispatch as a module call inferred from the receiver
+                // kind. Post-lower this is rare; treat the method name as the
+                // func and the receiver's kind as the module.
+                let recv = val!(self.eval_expr(object, scope));
+                let module = infer_module_for(&recv);
+                let mut evaled = vec![recv];
+                for a in args {
+                    evaled.push(val!(self.eval_expr(a, scope)));
+                }
+                self.dispatch_module_resolved(module, *method, evaled)
+            }
+            CallTarget::Computed { callee } => {
+                let f = val!(self.eval_expr(callee, scope));
+                let mut evaled = Vec::with_capacity(args.len());
+                for a in args {
+                    evaled.push(val!(self.eval_expr(a, scope)));
+                }
+                match f {
+                    Value::Closure(clo) => self.apply_closure(&clo, evaled),
+                    other => Flow::Abort(format!(
+                        "internal: call of non-closure {}",
+                        other.type_name()
+                    )),
+                }
+            }
+        }
+    }
+
+    // ── Named calls ─────────────────────────────────────────────
+
+    fn eval_named_call(&mut self, name: Sym, args: &[IrExpr], scope: &Scope) -> Flow {
+        let n = name.as_str();
+
+        // 1. Builtins.
+        match n {
+            "println" | "print" => {
+                let mut evaled = Vec::with_capacity(args.len());
+                for a in args {
+                    evaled.push(val!(self.eval_expr(a, scope)));
+                }
+                let line = match evaled.first() {
+                    Some(v) => v.display_bare(),
+                    None => String::new(),
+                };
+                self.stdout.push_str(&line);
+                if n == "println" {
+                    self.stdout.push('\n');
+                }
+                return Flow::val(Value::Unit);
+            }
+            "eprintln" | "eprint" => {
+                let mut evaled = Vec::with_capacity(args.len());
+                for a in args {
+                    evaled.push(val!(self.eval_expr(a, scope)));
+                }
+                let line = evaled.first().map(|v| v.display_bare()).unwrap_or_default();
+                self.stderr.push_str(&line);
+                if n == "eprintln" {
+                    self.stderr.push('\n');
+                }
+                return Flow::val(Value::Unit);
+            }
+            "assert" => {
+                let v = val!(self.eval_expr(&args[0], scope));
+                return match v {
+                    Value::Bool(true) => Flow::val(Value::Unit),
+                    Value::Bool(false) => Flow::Abort("assertion failed".into()),
+                    other => Flow::Abort(format!(
+                        "internal: assert on {}",
+                        other.type_name()
+                    )),
+                };
+            }
+            "assert_eq" | "assert_ne" => {
+                let a = val!(self.eval_expr(&args[0], scope));
+                let b = val!(self.eval_expr(&args[1], scope));
+                let eq = a == b;
+                let ok = if n == "assert_eq" { eq } else { !eq };
+                return if ok {
+                    Flow::val(Value::Unit)
+                } else {
+                    // Mirror the native assert macro's panic message shape.
+                    Flow::Abort(format!(
+                        "assertion failed: {} {} {}",
+                        a.almide_repr(),
+                        if n == "assert_eq" { "==" } else { "!=" },
+                        b.almide_repr()
+                    ))
+                };
+            }
+            "panic" => {
+                let msg = match args.first() {
+                    Some(a) => val!(self.eval_expr(a, scope)).display_bare(),
+                    None => "explicit panic".to_string(),
+                };
+                return Flow::Abort(msg);
+            }
+            _ => {}
+        }
+
+        // 2. Variant constructor (Unit / Tuple). Record-variant ctors arrive
+        //    as `Record` nodes, handled in eval. Look up in the registry.
+        if let Some((ty_name, kind)) = self.variant_ctor(name) {
+            return match kind {
+                CtorKind::Unit => Flow::val(Value::Variant {
+                    ty: Some(ty_name),
+                    ctor: name,
+                    payload: VariantPayload::Unit,
+                }),
+                CtorKind::Tuple => {
+                    let mut evaled = Vec::with_capacity(args.len());
+                    for a in args {
+                        evaled.push(val!(self.eval_expr(a, scope)));
+                    }
+                    Flow::val(Value::Variant {
+                        ty: Some(ty_name),
+                        ctor: name,
+                        payload: VariantPayload::Tuple(evaled),
+                    })
+                }
+                CtorKind::Record => {
+                    // Should not arrive as a Named call, but handle defensively.
+                    Flow::Unsupported(format!("record-variant ctor call {}", n))
+                }
+            };
+        }
+
+        // 3. A user / stdlib free function lowered into the program.
+        if let Some(func) = self.fns.get(&name).copied() {
+            let mut evaled = Vec::with_capacity(args.len());
+            for a in args {
+                evaled.push(val!(self.eval_expr(a, scope)));
+            }
+            let root = self.root_scope();
+            return self.call_function(func, evaled, &root);
+        }
+
+        Flow::Unsupported(format!("named call `{}`", n))
+    }
+
+    // ── Module calls ────────────────────────────────────────────
+
+    fn eval_module_call(
+        &mut self,
+        module: Sym,
+        func: Sym,
+        args: &[IrExpr],
+        scope: &Scope,
+    ) -> Flow {
+        // First: is this an in-interp HOF? Those take closure ARGUMENTS and
+        // must be evaluated specially (an interp closure cannot become the
+        // `Rc<dyn Fn>` a generic runtime HOF demands).
+        if crate::dispatch::is_hof(module.as_str(), func.as_str()) {
+            return self.eval_hof(module, func, args, scope);
+        }
+
+        // Otherwise evaluate all args eagerly, then dispatch.
+        let mut evaled = Vec::with_capacity(args.len());
+        for a in args {
+            evaled.push(val!(self.eval_expr(a, scope)));
+        }
+        self.dispatch_module_resolved(module, func, evaled)
+    }
+
+    /// Dispatch a `(module, func)` whose args are already evaluated. Tiers:
+    /// interp-native container ops → scalar/string bridge → almide-bodied
+    /// stdlib fn → unsupported.
+    pub(crate) fn dispatch_module_resolved(
+        &mut self,
+        module: Sym,
+        func: Sym,
+        args: Vec<Value>,
+    ) -> Flow {
+        // Interp-native container ops (non-HOF: structural transforms).
+        if let Some(result) = self.eval_container_op(module.as_str(), func.as_str(), &args) {
+            return result;
+        }
+
+        // Scalar / string / math native bridge (intrinsic-symbol surface).
+        if let Some(result) = crate::bridge::dispatch(module.as_str(), func.as_str(), &args) {
+            return result;
+        }
+
+        // An almide-bodied stdlib fn lowered into the program (pre-ir_link it
+        // lives under program.modules; some helpers are top-level fns).
+        if let Some(func_def) = self.module_fns.get(&(module, func)).copied() {
+            // Only interpret if it has a real (non-Hole) body.
+            if !matches!(func_def.body.kind, almide_ir::IrExprKind::Hole) {
+                let root = self.root_scope();
+                return self.call_function(func_def, args, &root);
+            }
+        }
+        // A top-level fn named exactly `func` (some stdlib helpers flatten).
+        if let Some(func_def) = self.fns.get(&func).copied() {
+            if !matches!(func_def.body.kind, almide_ir::IrExprKind::Hole) {
+                let root = self.root_scope();
+                return self.call_function(func_def, args, &root);
+            }
+        }
+
+        Flow::Unsupported(format!("{}.{}", module, func))
+    }
+
+    // ── FnRef ───────────────────────────────────────────────────
+
+    /// A named function used as a value (`list.map(xs, double)`). We synthesize
+    /// a closure value: there is no IR lambda, so we model it by a thin wrapper
+    /// closure whose application re-dispatches to the named fn. Because the
+    /// HOFs apply closures via `apply_closure`, we instead store the resolved
+    /// IrFunction and special-case it — but `Closure` holds an IR body, so the
+    /// simplest faithful model is to look up the fn and build a forwarding
+    /// closure is not possible without an IR body. We therefore resolve a
+    /// top-level fn into a closure over its own body + params.
+    pub(crate) fn fn_ref_value(&mut self, name: Sym, _scope: &Scope) -> Flow {
+        if let Some(func) = self.fns.get(&name).copied() {
+            let params = func.params.iter().map(|p| p.var).collect();
+            let clo = Closure {
+                params,
+                body: Rc::new(func.body.clone()),
+                // Top-level fn closes only over top-level lets, modeled by the
+                // root scope.
+                captured: self.root_scope(),
+            };
+            return Flow::val(Value::Closure(Rc::new(clo)));
+        }
+        Flow::Unsupported(format!("fn-ref `{}`", name))
+    }
+
+    /// The shared global scope (top-level lets), the base every top-level fn
+    /// call parents off. Seeded once by `run_main` / `ensure_globals`, so a
+    /// global referenced from a nested call resolves correctly. Cheap to clone
+    /// (Rc-shared).
+    pub(crate) fn root_scope(&self) -> Scope {
+        self.globals.clone()
+    }
+}
+
+// ── Constructor registry ────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+pub(crate) enum CtorKind {
+    Unit,
+    Tuple,
+    Record,
+}
+
+impl<'a> Interpreter<'a> {
+    /// Look up a variant constructor by name in the program's type decls.
+    /// Returns `(type_name, ctor_kind)`.
+    pub(crate) fn variant_ctor(&self, name: Sym) -> Option<(Sym, CtorKind)> {
+        use almide_ir::{IrTypeDeclKind, IrVariantKind};
+        for td in &self.program.type_decls {
+            if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
+                for case in cases {
+                    if case.name == name {
+                        let kind = match case.kind {
+                            IrVariantKind::Unit => CtorKind::Unit,
+                            IrVariantKind::Tuple { .. } => CtorKind::Tuple,
+                            IrVariantKind::Record { .. } => CtorKind::Record,
+                        };
+                        return Some((td.name, kind));
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Infer the dispatch module for a residual UFCS `Method` receiver.
+fn infer_module_for(v: &Value) -> Sym {
+    let m = match v {
+        Value::Str(_) => "string",
+        Value::Int(_) => "int",
+        Value::Float(_) => "float",
+        Value::List(_) | Value::Range { .. } => "list",
+        Value::Map(_) => "map",
+        Value::Set(_) => "set",
+        Value::Option(_) => "option",
+        Value::Result(_) => "result",
+        _ => "value",
+    };
+    almide_base::intern::sym(m)
+}
+
+// ── HOF registry ────────────────────────────────────────────────
+
+/// Is `(module, func)` an in-interp higher-order function (takes a closure
+/// argument)? Mirrors the runtime `Rc<dyn Fn>`-taking surface. The list is the
+/// design's verified ~45 HOFs.
+pub(crate) fn is_hof(module: &str, func: &str) -> bool {
+    matches!(
+        (module, func),
+        ("list", "map")
+            | ("list", "filter")
+            | ("list", "find")
+            | ("list", "any")
+            | ("list", "all")
+            | ("list", "count")
+            | ("list", "flat_map")
+            | ("list", "filter_map")
+            | ("list", "fold")
+            | ("list", "reduce")
+            | ("list", "sort_by")
+            | ("list", "take_while")
+            | ("list", "drop_while")
+            | ("list", "partition")
+            | ("list", "group_by")
+            | ("list", "find_index")
+            | ("list", "update")
+            | ("list", "scan")
+            | ("list", "zip_with")
+            | ("list", "unique_by")
+            | ("list", "each")
+            | ("map", "map")
+            | ("map", "filter")
+            | ("map", "fold")
+            | ("map", "any")
+            | ("map", "all")
+            | ("map", "count")
+            | ("map", "find")
+            | ("map", "update")
+            | ("set", "filter")
+            | ("set", "map")
+            | ("set", "fold")
+            | ("set", "any")
+            | ("set", "all")
+            | ("option", "map")
+            | ("option", "flat_map")
+            | ("option", "unwrap_or_else")
+            | ("option", "filter")
+            | ("option", "or_else")
+            | ("result", "map")
+            | ("result", "map_err")
+            | ("result", "flat_map")
+            | ("result", "unwrap_or_else")
+            | ("bytes", "map_each")
+    )
+}

--- a/crates/almide-interp/src/env.rs
+++ b/crates/almide-interp/src/env.rs
@@ -1,0 +1,82 @@
+//! Variable environment.
+//!
+//! Variables are keyed by `VarId` (the IR's shadow-free identifier), so the
+//! environment is a flat `VarId -> Value` map per scope. Scopes are reference
+//! counted and shared so a closure can cheaply snapshot the environment it
+//! captures: cloning a `Scope` clones an `Rc`, and writes go through a
+//! `RefCell`. This reproduces native `RcCow` capture semantics — a captured
+//! variable observed *after* the closure was created reflects the value at
+//! capture time (we snapshot the frame chain by Rc).
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use almide_ir::VarId;
+
+use crate::value::Value;
+
+/// A single lexical frame: `VarId -> Value`, chained to its parent.
+#[derive(Clone)]
+pub struct Scope {
+    inner: Rc<ScopeInner>,
+}
+
+struct ScopeInner {
+    vars: RefCell<HashMap<VarId, Value>>,
+    parent: Option<Scope>,
+}
+
+impl Scope {
+    /// A fresh root scope with no parent.
+    pub fn root() -> Scope {
+        Scope {
+            inner: Rc::new(ScopeInner {
+                vars: RefCell::new(HashMap::new()),
+                parent: None,
+            }),
+        }
+    }
+
+    /// Push a new child frame on top of `self`. Lookups fall through to the
+    /// parent chain; binds land in the new frame.
+    pub fn child(&self) -> Scope {
+        Scope {
+            inner: Rc::new(ScopeInner {
+                vars: RefCell::new(HashMap::new()),
+                parent: Some(self.clone()),
+            }),
+        }
+    }
+
+    /// Bind (or rebind) a variable in *this* frame.
+    pub fn bind(&self, id: VarId, value: Value) {
+        self.inner.vars.borrow_mut().insert(id, value);
+    }
+
+    /// Look up a variable, walking the parent chain.
+    pub fn get(&self, id: VarId) -> Option<Value> {
+        if let Some(v) = self.inner.vars.borrow().get(&id) {
+            return Some(v.clone());
+        }
+        match &self.inner.parent {
+            Some(p) => p.get(id),
+            None => None,
+        }
+    }
+
+    /// Assign to an existing variable, walking the parent chain to find the
+    /// frame that owns it. Returns `true` if the variable was found and
+    /// updated, `false` if it was never bound (a should-not-happen on
+    /// well-formed IR, which the evaluator turns into an ICE-style abort).
+    pub fn assign(&self, id: VarId, value: Value) -> bool {
+        if self.inner.vars.borrow().contains_key(&id) {
+            self.inner.vars.borrow_mut().insert(id, value);
+            return true;
+        }
+        match &self.inner.parent {
+            Some(p) => p.assign(id, value),
+            None => false,
+        }
+    }
+}

--- a/crates/almide-interp/src/eval.rs
+++ b/crates/almide-interp/src/eval.rs
@@ -1,0 +1,1067 @@
+//! The tree-walking evaluator: `IrExpr` / `IrStmt` / `IrPattern` → `Value`.
+//!
+//! Every eval step burns one unit of fuel. Codegen-inserted node kinds (Clone,
+//! Borrow, IterChain, ClosureCreate, …) are unreachable at the pre-codegen cut
+//! point and panic with an explanatory message to document the boundary.
+
+use std::rc::Rc;
+
+use almide_base::intern::Sym;
+use almide_ir::{
+    BinOp, IrExpr, IrExprKind, IrMatchArm, IrPattern, IrStmt, IrStmtKind, IrStringPart, UnOp,
+    VarId,
+};
+use almide_lang::types::Ty;
+
+use crate::env::Scope;
+use crate::value::{Closure, Value, VariantPayload};
+use crate::{Flow, Interpreter};
+
+/// Helper: short-circuit a `Flow` that is not a plain value out of an
+/// expression evaluator. Returns the inner `Value`, or propagates the signal.
+macro_rules! val {
+    ($flow:expr) => {
+        match $flow {
+            Flow::Value(v) => v,
+            other => return other,
+        }
+    };
+}
+
+impl<'a> Interpreter<'a> {
+    pub(crate) fn eval_expr(&mut self, expr: &IrExpr, scope: &Scope) -> Flow {
+        if let Err(f) = self.step() {
+            return f;
+        }
+        match &expr.kind {
+            // ── Literals ──
+            IrExprKind::LitInt { value } => Flow::val(Value::Int(*value)),
+            IrExprKind::LitFloat { value } => Flow::val(Value::Float(*value)),
+            IrExprKind::LitStr { value } => Flow::val(Value::str(value.clone())),
+            IrExprKind::LitBool { value } => Flow::val(Value::Bool(*value)),
+            IrExprKind::Unit => Flow::val(Value::Unit),
+
+            // ── Variables ──
+            IrExprKind::Var { id } => match scope.get(*id) {
+                Some(v) => Flow::val(v),
+                None => Flow::Abort(format!(
+                    "internal: unbound variable {:?} ({})",
+                    id,
+                    self.var_name(*id)
+                )),
+            },
+            // A named function used as a value: wrap it as a closure-like value
+            // by capturing its name; application looks it up. We model it as a
+            // closure whose body re-dispatches to the named fn.
+            IrExprKind::FnRef { name } => self.fn_ref_value(*name, scope),
+
+            // ── Operators ──
+            IrExprKind::BinOp { op, left, right } => self.eval_binop(*op, left, right, scope),
+            IrExprKind::UnOp { op, operand } => {
+                let v = val!(self.eval_expr(operand, scope));
+                self.eval_unop(*op, v)
+            }
+
+            // ── Control flow ──
+            IrExprKind::If { cond, then, else_ } => {
+                let c = val!(self.eval_expr(cond, scope));
+                match c {
+                    Value::Bool(true) => self.eval_expr(then, scope),
+                    Value::Bool(false) => self.eval_expr(else_, scope),
+                    other => Flow::Abort(format!(
+                        "internal: if-condition is {} not Bool",
+                        other.type_name()
+                    )),
+                }
+            }
+            IrExprKind::Match { subject, arms } => self.eval_match(subject, arms, scope),
+            IrExprKind::Block { stmts, expr } => self.eval_block(stmts, expr.as_deref(), scope),
+            // Fan block: evaluate each expr SEQUENTIALLY in source order — the
+            // deterministic mode both backends collapse to (WASM has no threads;
+            // native's `fan_effect`/`fan_expr` join in handle order). Both
+            // backends materialize the results as a TUPLE, not a list:
+            //   - native walker `render_fan` joins as `(j0, j1, ...)` for >1 expr,
+            //     and a bare `j0` for exactly one expr;
+            //   - WASM `emit_wasm/expressions.rs::Fan` builds a tuple (`>1`) or
+            //     emits the single value bare (`==1`).
+            // Each Result-typed spawn body auto-unwraps with `?` semantics at the
+            // join (`handle.join().unwrap()?`): on Ok the inner value is taken, on
+            // Err the enclosing fn short-circuits. At THIS pre-codegen cut point
+            // the auto-`?` is still an explicit `Try`/`Unwrap` node wrapping each
+            // Result-typed fan expr (the `strip_fan_auto_try` codegen pass that
+            // removes it runs post-cut), so evaluating the expr already performs
+            // the unwrap and propagates an `Err` as `Flow::Return` — exactly the
+            // backends' join-point `?`. We therefore just evaluate and collect.
+            IrExprKind::Fan { exprs } => {
+                let mut out = Vec::with_capacity(exprs.len());
+                for e in exprs {
+                    out.push(val!(self.eval_expr(e, scope)));
+                }
+                // Single-expr fan is the bare value (no 1-tuple), matching both
+                // backends; multi-expr is a tuple.
+                if out.len() == 1 {
+                    Flow::val(out.into_iter().next().unwrap())
+                } else {
+                    Flow::val(Value::tuple(out))
+                }
+            }
+
+            // ── Loops ──
+            IrExprKind::ForIn { var, var_tuple, iterable, body } => {
+                self.eval_for_in(*var, var_tuple.as_deref(), iterable, body, scope)
+            }
+            IrExprKind::While { cond, body } => self.eval_while(cond, body, scope),
+            IrExprKind::Break => Flow::Break,
+            IrExprKind::Continue => Flow::Continue,
+
+            // ── Calls ──
+            IrExprKind::Call { target, args, .. } => self.eval_call(target, args, scope),
+            // TailCall is codegen-inserted (TailCallMarkPass, post-cut) but we
+            // treat it == Call defensively.
+            IrExprKind::TailCall { target, args } => self.eval_call(target, args, scope),
+
+            // ── Collections ──
+            IrExprKind::List { elements } => {
+                let mut out = Vec::with_capacity(elements.len());
+                for e in elements {
+                    out.push(val!(self.eval_expr(e, scope)));
+                }
+                Flow::val(Value::list(out))
+            }
+            IrExprKind::Tuple { elements } => {
+                let mut out = Vec::with_capacity(elements.len());
+                for e in elements {
+                    out.push(val!(self.eval_expr(e, scope)));
+                }
+                Flow::val(Value::tuple(out))
+            }
+            IrExprKind::MapLiteral { entries } => {
+                let mut out: Vec<(Value, Value)> = Vec::with_capacity(entries.len());
+                for (k, v) in entries {
+                    let kv = val!(self.eval_expr(k, scope));
+                    let vv = val!(self.eval_expr(v, scope));
+                    map_insert(&mut out, kv, vv);
+                }
+                Flow::val(Value::Map(Rc::new(out)))
+            }
+            IrExprKind::EmptyMap => Flow::val(Value::Map(Rc::new(Vec::new()))),
+            IrExprKind::Record { name, fields } => {
+                let mut out = Vec::with_capacity(fields.len());
+                for (k, v) in fields {
+                    out.push((*k, val!(self.eval_expr(v, scope))));
+                }
+                // A record-shaped node whose `name` is a registered
+                // record-variant constructor builds a `Variant` (so it
+                // equality- / pattern-matches as a variant). A plain record
+                // type stays a `Record`. Empirically (probe /tmp/repr_probe),
+                // both display identically as `Name { f: v }`.
+                if let Some(n) = name {
+                    if let Some((ty_name, crate::dispatch::CtorKind::Record)) =
+                        self.variant_ctor(*n)
+                    {
+                        return Flow::val(Value::Variant {
+                            ty: Some(ty_name),
+                            ctor: *n,
+                            payload: VariantPayload::Record(out),
+                        });
+                    }
+                }
+                // Recover the displayed shape exactly as the codegen walker does
+                // (walker/expressions.rs:511-530, walker/types.rs:111). A record
+                // LITERAL carries no inline `name` when its nominal type comes
+                // from an annotation/inference — the name must be recovered from
+                // the expression's type. Three cases, in the walker's order:
+                //   1. `expr.ty == Ty::Named(n, _)`  → the nominal name `n`,
+                //      fields in literal (declaration) order.
+                //   2. `expr.ty == Ty::Record/OpenRecord` whose field-name set
+                //      matches a registered NAMED record type (e.g. a nested
+                //      list element `[{ val: 2, kids: [] }]` whose element type
+                //      was inferred structurally) → that type's name, fields
+                //      reordered to the type's DECLARATION order.
+                //   3. A genuinely ANONYMOUS record → no name; the native
+                //      synthesized struct stores fields in SORTED name order, so
+                //      sort here to match the backends' repr.
+                let resolved_name;
+                if let Some(n) = name {
+                    resolved_name = Some(*n);
+                } else {
+                    match &expr.ty {
+                        Ty::Named(n, _) => resolved_name = Some(*n),
+                        Ty::Record { .. } | Ty::OpenRecord { .. } => {
+                            let mut key: Vec<Sym> = out.iter().map(|(k, _)| *k).collect();
+                            key.sort();
+                            if let Some((ty_name, decl_order)) =
+                                self.named_records.get(&key).cloned()
+                            {
+                                // Case 2: reorder fields to declaration order.
+                                let mut reordered = Vec::with_capacity(out.len());
+                                for field in &decl_order {
+                                    if let Some(pos) = out.iter().position(|(k, _)| k == field) {
+                                        reordered.push(out.swap_remove(pos));
+                                    }
+                                }
+                                reordered.extend(out.drain(..));
+                                out = reordered;
+                                resolved_name = Some(ty_name);
+                            } else {
+                                // Case 3: true anonymous record → sorted fields.
+                                out.sort_by(|a, b| a.0.cmp(&b.0));
+                                resolved_name = None;
+                            }
+                        }
+                        _ => resolved_name = None,
+                    }
+                }
+                Flow::val(Value::Record { name: resolved_name, fields: Rc::new(out) })
+            }
+            IrExprKind::SpreadRecord { base, fields } => {
+                let base_v = val!(self.eval_expr(base, scope));
+                let (name, mut merged) = match base_v {
+                    Value::Record { name, fields } => (name, (*fields).clone()),
+                    other => {
+                        return Flow::Abort(format!(
+                            "internal: spread base is {} not Record",
+                            other.type_name()
+                        ))
+                    }
+                };
+                for (k, v) in fields {
+                    let vv = val!(self.eval_expr(v, scope));
+                    if let Some(slot) = merged.iter_mut().find(|(fk, _)| fk == k) {
+                        slot.1 = vv;
+                    } else {
+                        merged.push((*k, vv));
+                    }
+                }
+                Flow::val(Value::Record { name, fields: Rc::new(merged) })
+            }
+            IrExprKind::Range { start, end, inclusive } => {
+                let s = val!(self.eval_expr(start, scope));
+                let e = val!(self.eval_expr(end, scope));
+                match (s, e) {
+                    (Value::Int(s), Value::Int(e)) => {
+                        Flow::val(Value::Range { start: s, end: e, inclusive: *inclusive })
+                    }
+                    _ => Flow::Abort("internal: range bounds must be Int".into()),
+                }
+            }
+
+            // ── Access ──
+            IrExprKind::Member { object, field } => {
+                let o = val!(self.eval_expr(object, scope));
+                self.eval_member(o, *field)
+            }
+            IrExprKind::TupleIndex { object, index } => {
+                let o = val!(self.eval_expr(object, scope));
+                match o {
+                    Value::Tuple(items) | Value::List(items) => match items.get(*index) {
+                        Some(v) => Flow::val(v.clone()),
+                        None => Flow::Abort("index out of bounds".into()),
+                    },
+                    other => Flow::Abort(format!(
+                        "internal: tuple-index on {} ",
+                        other.type_name()
+                    )),
+                }
+            }
+            IrExprKind::IndexAccess { object, index } => {
+                let o = val!(self.eval_expr(object, scope));
+                let i = val!(self.eval_expr(index, scope));
+                self.eval_index(o, i)
+            }
+            IrExprKind::MapAccess { object, key } => {
+                let o = val!(self.eval_expr(object, scope));
+                let k = val!(self.eval_expr(key, scope));
+                match o {
+                    Value::Map(entries) => {
+                        let found = entries.iter().find(|(ek, _)| ek == &k);
+                        Flow::val(Value::Option(found.map(|(_, v)| Box::new(v.clone()))))
+                    }
+                    other => Flow::Abort(format!(
+                        "internal: map-access on {}",
+                        other.type_name()
+                    )),
+                }
+            }
+
+            // ── Functions ──
+            IrExprKind::Lambda { params, body, .. } => {
+                let clo = Closure {
+                    params: params.iter().map(|(v, _)| *v).collect(),
+                    body: Rc::new((**body).clone()),
+                    captured: scope.clone(),
+                };
+                Flow::val(Value::Closure(Rc::new(clo)))
+            }
+
+            // ── Strings ──
+            IrExprKind::StringInterp { parts } => self.eval_string_interp(parts, scope),
+
+            // ── Result / Option ──
+            IrExprKind::ResultOk { expr } => {
+                let v = val!(self.eval_expr(expr, scope));
+                Flow::val(Value::Result(Ok(Box::new(v))))
+            }
+            IrExprKind::ResultErr { expr } => {
+                let v = val!(self.eval_expr(expr, scope));
+                Flow::val(Value::Result(Err(Box::new(v))))
+            }
+            IrExprKind::OptionSome { expr } => {
+                let v = val!(self.eval_expr(expr, scope));
+                Flow::val(Value::Option(Some(Box::new(v))))
+            }
+            IrExprKind::OptionNone => Flow::val(Value::Option(None)),
+            // `?` / `!` — short-circuit the enclosing fn on Err/None.
+            IrExprKind::Try { expr } | IrExprKind::Unwrap { expr } => {
+                let v = val!(self.eval_expr(expr, scope));
+                match v {
+                    Value::Result(Ok(inner)) => Flow::val(*inner),
+                    Value::Result(Err(e)) => Flow::Return(Value::Result(Err(e))),
+                    Value::Option(Some(inner)) => Flow::val(*inner),
+                    Value::Option(None) => Flow::Return(Value::Option(None)),
+                    other => Flow::val(other),
+                }
+            }
+            // `??` — unwrap with a fallback value.
+            IrExprKind::UnwrapOr { expr, fallback } => {
+                let v = val!(self.eval_expr(expr, scope));
+                match v {
+                    Value::Option(Some(inner)) => Flow::val(*inner),
+                    Value::Option(None) => self.eval_expr(fallback, scope),
+                    Value::Result(Ok(inner)) => Flow::val(*inner),
+                    Value::Result(Err(_)) => self.eval_expr(fallback, scope),
+                    other => Flow::val(other),
+                }
+            }
+            // `?` Result→Option (identity for Option).
+            IrExprKind::ToOption { expr } => {
+                let v = val!(self.eval_expr(expr, scope));
+                match v {
+                    Value::Result(Ok(inner)) => Flow::val(Value::Option(Some(inner))),
+                    Value::Result(Err(_)) => Flow::val(Value::Option(None)),
+                    opt @ Value::Option(_) => Flow::val(opt),
+                    other => Flow::val(other),
+                }
+            }
+            // `?.field` — optional chaining.
+            IrExprKind::OptionalChain { expr, field } => {
+                let v = val!(self.eval_expr(expr, scope));
+                match v {
+                    Value::Option(None) => Flow::val(Value::Option(None)),
+                    Value::Option(Some(inner)) => match self.eval_member(*inner, *field) {
+                        Flow::Value(m) => Flow::val(Value::Option(Some(Box::new(m)))),
+                        other => other,
+                    },
+                    other => match self.eval_member(other, *field) {
+                        Flow::Value(m) => Flow::val(Value::Option(Some(Box::new(m)))),
+                        other => other,
+                    },
+                }
+            }
+            // The interp is synchronous: await is identity over the value.
+            IrExprKind::Await { expr } => self.eval_expr(expr, scope),
+
+            // ── Misc ──
+            IrExprKind::Hole => Flow::Abort(
+                "internal: evaluated a Hole (intrinsic-stub body reached as an expr)".into(),
+            ),
+            IrExprKind::Todo { message } => Flow::Abort(message.clone()),
+
+            // ── Codegen-inserted: UNREACHABLE at the pre-codegen cut point ──
+            IrExprKind::RuntimeCall { .. } => unreachable!(
+                "RuntimeCall is codegen-inserted (IntrinsicLowering); interp runs pre-codegen"
+            ),
+            IrExprKind::Clone { .. } => {
+                unreachable!("Clone is codegen-inserted (CloneInsertion); interp runs pre-codegen")
+            }
+            IrExprKind::Deref { .. } => {
+                unreachable!("Deref is codegen-inserted (BoxDeref); interp runs pre-codegen")
+            }
+            IrExprKind::Borrow { .. } => unreachable!(
+                "Borrow is codegen-inserted (BorrowInsertion); interp runs pre-codegen"
+            ),
+            IrExprKind::BoxNew { .. } => {
+                unreachable!("BoxNew is codegen-inserted (BoxDeref); interp runs pre-codegen")
+            }
+            IrExprKind::RcWrap { .. } => unreachable!(
+                "RcWrap is codegen-inserted (ClosureConversion); interp runs pre-codegen"
+            ),
+            IrExprKind::RustMacro { .. } => unreachable!(
+                "RustMacro is codegen-inserted (BuiltinLowering); interp runs pre-codegen"
+            ),
+            IrExprKind::ToVec { .. } => {
+                unreachable!("ToVec is codegen-inserted; interp runs pre-codegen")
+            }
+            IrExprKind::RenderedCall { .. } => unreachable!(
+                "RenderedCall is codegen-inserted (StdlibLowering); interp runs pre-codegen"
+            ),
+            IrExprKind::InlineRust { .. } => unreachable!(
+                "InlineRust is codegen-inserted (StdlibLowering); interp runs pre-codegen"
+            ),
+            IrExprKind::ClosureCreate { .. } => unreachable!(
+                "ClosureCreate is codegen-inserted (ClosureConversion); interp runs pre-codegen"
+            ),
+            IrExprKind::EnvLoad { .. } => unreachable!(
+                "EnvLoad is codegen-inserted (ClosureConversion); interp runs pre-codegen"
+            ),
+            IrExprKind::IterChain { .. } => unreachable!(
+                "IterChain is codegen-inserted (StdlibLowering); interp runs pre-codegen"
+            ),
+        }
+    }
+
+    // ── Member / index access ──────────────────────────────────
+
+    fn eval_member(&mut self, object: Value, field: Sym) -> Flow {
+        match object {
+            Value::Record { fields, .. } => {
+                match fields.iter().find(|(k, _)| *k == field) {
+                    Some((_, v)) => Flow::val(v.clone()),
+                    None => Flow::Abort(format!("internal: no field `{}` on record", field)),
+                }
+            }
+            Value::Variant { payload: VariantPayload::Record(fields), .. } => {
+                match fields.iter().find(|(k, _)| *k == field) {
+                    Some((_, v)) => Flow::val(v.clone()),
+                    None => Flow::Abort(format!("internal: no field `{}` on variant", field)),
+                }
+            }
+            other => Flow::Abort(format!(
+                "internal: member access `.{}` on {}",
+                field,
+                other.type_name()
+            )),
+        }
+    }
+
+    fn eval_index(&mut self, object: Value, index: Value) -> Flow {
+        let i = match index {
+            Value::Int(i) => i,
+            other => {
+                return Flow::Abort(format!(
+                    "internal: list index is {} not Int",
+                    other.type_name()
+                ))
+            }
+        };
+        match object {
+            Value::List(xs) => {
+                if i < 0 || (i as usize) >= xs.len() {
+                    // Matches the codegen OOB contract: abort + exit 1.
+                    Flow::Abort("index out of bounds".into())
+                } else {
+                    Flow::val(xs[i as usize].clone())
+                }
+            }
+            Value::Str(s) => {
+                // String indexing returns the byte? Almide indexes strings via
+                // string.* fns; a bare index on a String is unusual. Treat as
+                // unsupported to avoid a wrong third vote.
+                let _ = s;
+                Flow::Unsupported("string index access".into())
+            }
+            other => Flow::Abort(format!(
+                "internal: index access on {}",
+                other.type_name()
+            )),
+        }
+    }
+
+    // ── String interpolation ───────────────────────────────────
+
+    fn eval_string_interp(&mut self, parts: &[IrStringPart], scope: &Scope) -> Flow {
+        let mut out = String::new();
+        for part in parts {
+            match part {
+                IrStringPart::Lit { value } => out.push_str(value),
+                IrStringPart::Expr { expr } => {
+                    let v = val!(self.eval_expr(expr, scope));
+                    // A bare top-level String stays raw; everything else routes
+                    // through the bare-display path (which for compounds is
+                    // `almide_repr`, for scalars is plain Display).
+                    out.push_str(&v.display_bare());
+                }
+            }
+        }
+        Flow::val(Value::str(out))
+    }
+
+    // ── Blocks ──────────────────────────────────────────────────
+
+    fn eval_block(
+        &mut self,
+        stmts: &[IrStmt],
+        tail: Option<&IrExpr>,
+        scope: &Scope,
+    ) -> Flow {
+        // A block introduces a new lexical frame.
+        let frame = scope.child();
+        for stmt in stmts {
+            if let Err(f) = self.exec_stmt(stmt, &frame) {
+                return f;
+            }
+        }
+        match tail {
+            Some(e) => self.eval_expr(e, &frame),
+            None => Flow::val(Value::Unit),
+        }
+    }
+
+    // ── Loops ───────────────────────────────────────────────────
+
+    fn eval_for_in(
+        &mut self,
+        var: VarId,
+        var_tuple: Option<&[VarId]>,
+        iterable: &IrExpr,
+        body: &[IrStmt],
+        scope: &Scope,
+    ) -> Flow {
+        let iter_v = val!(self.eval_expr(iterable, scope));
+        let items = match iter_v.as_iter_items() {
+            Some(items) => items,
+            None => {
+                return Flow::Abort(format!(
+                    "internal: for-in over non-iterable {}",
+                    iter_v.type_name()
+                ))
+            }
+        };
+        for item in items {
+            if let Err(f) = self.step() {
+                return f;
+            }
+            let frame = scope.child();
+            // Destructure tuple binding `for (a, b) in ...`.
+            if let Some(vars) = var_tuple {
+                match &item {
+                    Value::Tuple(elems) if elems.len() == vars.len() => {
+                        for (vid, ev) in vars.iter().zip(elems.iter()) {
+                            frame.bind(*vid, ev.clone());
+                        }
+                    }
+                    _ => {
+                        return Flow::Abort(
+                            "internal: for-in tuple destructure shape mismatch".into(),
+                        )
+                    }
+                }
+            } else {
+                frame.bind(var, item);
+            }
+            for stmt in body {
+                match self.exec_stmt(stmt, &frame) {
+                    Ok(()) => {}
+                    Err(Flow::Break) => return Flow::val(Value::Unit),
+                    Err(Flow::Continue) => break,
+                    Err(other) => return other,
+                }
+            }
+        }
+        Flow::val(Value::Unit)
+    }
+
+    fn eval_while(&mut self, cond: &IrExpr, body: &[IrStmt], scope: &Scope) -> Flow {
+        loop {
+            if let Err(f) = self.step() {
+                return f;
+            }
+            let c = val!(self.eval_expr(cond, scope));
+            match c {
+                Value::Bool(true) => {}
+                Value::Bool(false) => return Flow::val(Value::Unit),
+                other => {
+                    return Flow::Abort(format!(
+                        "internal: while-condition is {} not Bool",
+                        other.type_name()
+                    ))
+                }
+            }
+            let frame = scope.child();
+            let mut broke = false;
+            for stmt in body {
+                match self.exec_stmt(stmt, &frame) {
+                    Ok(()) => {}
+                    Err(Flow::Break) => {
+                        broke = true;
+                        break;
+                    }
+                    Err(Flow::Continue) => break,
+                    Err(other) => return other,
+                }
+            }
+            if broke {
+                return Flow::val(Value::Unit);
+            }
+        }
+    }
+
+    // ── Statements ──────────────────────────────────────────────
+
+    fn exec_stmt(&mut self, stmt: &IrStmt, scope: &Scope) -> Result<(), Flow> {
+        if let Err(f) = self.step() {
+            return Err(f);
+        }
+        match &stmt.kind {
+            IrStmtKind::Bind { var, value, .. } => {
+                let v = match self.eval_expr(value, scope) {
+                    Flow::Value(v) => v,
+                    other => return Err(other),
+                };
+                scope.bind(*var, v);
+                Ok(())
+            }
+            IrStmtKind::BindDestructure { pattern, value } => {
+                let v = match self.eval_expr(value, scope) {
+                    Flow::Value(v) => v,
+                    other => return Err(other),
+                };
+                let mut binds = Vec::new();
+                if self.try_match(pattern, &v, &mut binds) {
+                    for (id, val) in binds {
+                        scope.bind(id, val);
+                    }
+                    Ok(())
+                } else {
+                    Err(Flow::Abort("internal: irrefutable destructure failed".into()))
+                }
+            }
+            IrStmtKind::Assign { var, value } => {
+                let v = match self.eval_expr(value, scope) {
+                    Flow::Value(v) => v,
+                    other => return Err(other),
+                };
+                if !scope.assign(*var, v) {
+                    return Err(Flow::Abort(format!(
+                        "internal: assign to unbound variable {:?}",
+                        var
+                    )));
+                }
+                Ok(())
+            }
+            IrStmtKind::IndexAssign { target, index, value } => {
+                let iv = match self.eval_expr(index, scope) {
+                    Flow::Value(v) => v,
+                    other => return Err(other),
+                };
+                let vv = match self.eval_expr(value, scope) {
+                    Flow::Value(v) => v,
+                    other => return Err(other),
+                };
+                let cur = scope.get(*target).ok_or_else(|| {
+                    Flow::Abort("internal: index-assign to unbound list".into())
+                })?;
+                match (cur, iv) {
+                    (Value::List(xs), Value::Int(i)) => {
+                        if i < 0 || (i as usize) >= xs.len() {
+                            return Err(Flow::Abort("index out of bounds".into()));
+                        }
+                        let mut new = (*xs).clone();
+                        new[i as usize] = vv;
+                        scope.assign(*target, Value::list(new));
+                        Ok(())
+                    }
+                    _ => Err(Flow::Abort("internal: malformed index-assign".into())),
+                }
+            }
+            IrStmtKind::MapInsert { target, key, value } => {
+                let kv = match self.eval_expr(key, scope) {
+                    Flow::Value(v) => v,
+                    other => return Err(other),
+                };
+                let vv = match self.eval_expr(value, scope) {
+                    Flow::Value(v) => v,
+                    other => return Err(other),
+                };
+                let cur = scope.get(*target).ok_or_else(|| {
+                    Flow::Abort("internal: map-insert to unbound map".into())
+                })?;
+                match cur {
+                    Value::Map(entries) => {
+                        let mut new = (*entries).clone();
+                        map_insert(&mut new, kv, vv);
+                        scope.assign(*target, Value::Map(Rc::new(new)));
+                        Ok(())
+                    }
+                    _ => Err(Flow::Abort("internal: map-insert on non-Map".into())),
+                }
+            }
+            IrStmtKind::FieldAssign { target, field, value } => {
+                let vv = match self.eval_expr(value, scope) {
+                    Flow::Value(v) => v,
+                    other => return Err(other),
+                };
+                let cur = scope.get(*target).ok_or_else(|| {
+                    Flow::Abort("internal: field-assign to unbound record".into())
+                })?;
+                match cur {
+                    Value::Record { name, fields } => {
+                        let mut new = (*fields).clone();
+                        if let Some(slot) = new.iter_mut().find(|(k, _)| k == field) {
+                            slot.1 = vv;
+                        } else {
+                            new.push((*field, vv));
+                        }
+                        scope.assign(*target, Value::Record { name, fields: Rc::new(new) });
+                        Ok(())
+                    }
+                    _ => Err(Flow::Abort("internal: field-assign on non-Record".into())),
+                }
+            }
+            IrStmtKind::Guard { cond, else_ } => {
+                let c = match self.eval_expr(cond, scope) {
+                    Flow::Value(v) => v,
+                    other => return Err(other),
+                };
+                match c {
+                    Value::Bool(true) => Ok(()),
+                    Value::Bool(false) => {
+                        // The else branch is an early-return expression.
+                        match self.eval_expr(else_, scope) {
+                            Flow::Value(v) => Err(Flow::Return(v)),
+                            other => Err(other),
+                        }
+                    }
+                    other => Err(Flow::Abort(format!(
+                        "internal: guard condition is {} not Bool",
+                        other.type_name()
+                    ))),
+                }
+            }
+            IrStmtKind::Expr { expr } => {
+                match self.eval_expr(expr, scope) {
+                    Flow::Value(_) => Ok(()),
+                    other => Err(other),
+                }
+            }
+            IrStmtKind::Comment { .. } => Ok(()),
+
+            // ── Codegen-inserted statement kinds ──
+            // RcInc/RcDec are pure refcount bookkeeping (Perceus, post-cut) —
+            // semantic no-ops for values. Degrade to no-op (belt-and-braces) so
+            // a future post-Perceus run doesn't panic.
+            IrStmtKind::RcInc { .. } | IrStmtKind::RcDec { .. } => Ok(()),
+            IrStmtKind::ListSwap { .. }
+            | IrStmtKind::ListReverse { .. }
+            | IrStmtKind::ListRotateLeft { .. }
+            | IrStmtKind::ListCopySlice { .. } => unreachable!(
+                "list peephole stmt is codegen-inserted (PeepholePass); interp runs pre-codegen"
+            ),
+        }
+    }
+
+    // ── Match ───────────────────────────────────────────────────
+
+    fn eval_match(&mut self, subject: &IrExpr, arms: &[IrMatchArm], scope: &Scope) -> Flow {
+        let subj = val!(self.eval_expr(subject, scope));
+        for arm in arms {
+            let mut binds = Vec::new();
+            if self.try_match(&arm.pattern, &subj, &mut binds) {
+                let frame = scope.child();
+                for (id, v) in &binds {
+                    frame.bind(*id, v.clone());
+                }
+                // Evaluate the guard (if any) in the arm's frame.
+                if let Some(guard) = &arm.guard {
+                    match self.eval_expr(guard, &frame) {
+                        Flow::Value(Value::Bool(true)) => {}
+                        Flow::Value(Value::Bool(false)) => continue,
+                        Flow::Value(other) => {
+                            return Flow::Abort(format!(
+                                "internal: match guard is {} not Bool",
+                                other.type_name()
+                            ))
+                        }
+                        other => return other,
+                    }
+                }
+                return self.eval_expr(&arm.body, &frame);
+            }
+        }
+        Flow::Abort("internal: non-exhaustive match (no arm matched)".into())
+    }
+
+    /// Attempt to match `value` against `pattern`, accumulating bindings.
+    /// Returns `true` on success (bindings valid only then). Implements the
+    /// IR-level pattern engine directly — including `List` patterns, since
+    /// `ListPatternLoweringPass` runs post-cut so list patterns are still
+    /// present.
+    fn try_match(
+        &mut self,
+        pattern: &IrPattern,
+        value: &Value,
+        binds: &mut Vec<(VarId, Value)>,
+    ) -> bool {
+        match pattern {
+            IrPattern::Wildcard => true,
+            IrPattern::Bind { var, .. } => {
+                binds.push((*var, value.clone()));
+                true
+            }
+            IrPattern::Literal { expr } => {
+                // Evaluate the literal in an empty scope (literals are closed).
+                let scope = Scope::root();
+                match self.eval_expr(expr, &scope) {
+                    Flow::Value(lit) => &lit == value,
+                    _ => false,
+                }
+            }
+            IrPattern::Tuple { elements } => match value {
+                Value::Tuple(items) if items.len() == elements.len() => elements
+                    .iter()
+                    .zip(items.iter())
+                    .all(|(p, v)| self.try_match(p, v, binds)),
+                _ => false,
+            },
+            IrPattern::List { elements } => match value.as_iter_items() {
+                Some(items) if items.len() == elements.len() => elements
+                    .iter()
+                    .zip(items.iter())
+                    .all(|(p, v)| self.try_match(p, v, binds)),
+                _ => false,
+            },
+            IrPattern::Some { inner } => match value {
+                Value::Option(Some(v)) => self.try_match(inner, v, binds),
+                _ => false,
+            },
+            IrPattern::None => matches!(value, Value::Option(None)),
+            IrPattern::Ok { inner } => match value {
+                Value::Result(Ok(v)) => self.try_match(inner, v, binds),
+                _ => false,
+            },
+            IrPattern::Err { inner } => match value {
+                Value::Result(Err(v)) => self.try_match(inner, v, binds),
+                _ => false,
+            },
+            IrPattern::Constructor { name, args } => match value {
+                Value::Variant { ctor, payload, .. } if ctor.as_str() == name => match payload {
+                    VariantPayload::Unit => args.is_empty(),
+                    VariantPayload::Tuple(items) if items.len() == args.len() => args
+                        .iter()
+                        .zip(items.iter())
+                        .all(|(p, v)| self.try_match(p, v, binds)),
+                    _ => false,
+                },
+                _ => false,
+            },
+            IrPattern::RecordPattern { name, fields, rest } => {
+                let (obj_name, obj_fields): (Option<Sym>, &Vec<(Sym, Value)>) = match value {
+                    Value::Record { name, fields } => (*name, fields),
+                    Value::Variant { ctor, payload: VariantPayload::Record(fields), .. } => {
+                        (Some(*ctor), fields)
+                    }
+                    _ => return false,
+                };
+                // Name must match when the pattern names a constructor.
+                if !name.is_empty() {
+                    match obj_name {
+                        Some(n) if n.as_str() == name => {}
+                        _ => return false,
+                    }
+                }
+                if !rest && fields.len() != obj_fields.len() {
+                    return false;
+                }
+                for fp in fields {
+                    let fname = fp.name.as_str();
+                    let fv = match obj_fields.iter().find(|(k, _)| k.as_str() == fname) {
+                        Some((_, v)) => v,
+                        None => return false,
+                    };
+                    match &fp.pattern {
+                        // Shorthand `{ x, y }` lowers to explicit `Bind`
+                        // sub-patterns (verified via IR dump), so binding is
+                        // handled here uniformly.
+                        Some(sub) => {
+                            if !self.try_match(sub, fv, binds) {
+                                return false;
+                            }
+                        }
+                        // A field with no sub-pattern is a structural-only
+                        // match (the field must exist, but binds nothing).
+                        None => {}
+                    }
+                }
+                true
+            }
+        }
+    }
+
+    // ── Operators ───────────────────────────────────────────────
+
+    fn eval_binop(&mut self, op: BinOp, left: &IrExpr, right: &IrExpr, scope: &Scope) -> Flow {
+        // Short-circuit logical operators evaluate the right side lazily.
+        match op {
+            BinOp::And => {
+                let l = val!(self.eval_expr(left, scope));
+                return match l {
+                    Value::Bool(false) => Flow::val(Value::Bool(false)),
+                    Value::Bool(true) => self.eval_expr(right, scope),
+                    other => Flow::Abort(format!(
+                        "internal: `and` on {}",
+                        other.type_name()
+                    )),
+                };
+            }
+            BinOp::Or => {
+                let l = val!(self.eval_expr(left, scope));
+                return match l {
+                    Value::Bool(true) => Flow::val(Value::Bool(true)),
+                    Value::Bool(false) => self.eval_expr(right, scope),
+                    other => Flow::Abort(format!("internal: `or` on {}", other.type_name())),
+                };
+            }
+            _ => {}
+        }
+
+        let l = val!(self.eval_expr(left, scope));
+        let r = val!(self.eval_expr(right, scope));
+        self.apply_binop(op, l, r)
+    }
+
+    pub(crate) fn apply_binop(&mut self, op: BinOp, l: Value, r: Value) -> Flow {
+        use BinOp::*;
+        match op {
+            // Integer arithmetic. Native release emits bare `+`/`-`/`*` which
+            // WRAP (no panic) — replicate with wrapping ops.
+            AddInt => int2(l, r, |a, b| Flow::val(Value::Int(a.wrapping_add(b)))),
+            SubInt => int2(l, r, |a, b| Flow::val(Value::Int(a.wrapping_sub(b)))),
+            MulInt => int2(l, r, |a, b| Flow::val(Value::Int(a.wrapping_mul(b)))),
+            // Total div / mod: `almide_div!` / `almide_mod!` semantics —
+            // checked_div/checked_rem, None → abort with the exact native msg.
+            DivInt => int2(l, r, |a, b| match a.checked_div(b) {
+                Some(v) => Flow::val(Value::Int(v)),
+                None => Flow::Abort(div_msg(b)),
+            }),
+            ModInt => int2(l, r, |a, b| match a.checked_rem(b) {
+                Some(v) => Flow::val(Value::Int(v)),
+                None => Flow::Abort(div_msg(b)),
+            }),
+            // base.pow(exp as u32), wrapping in release; negative exp is a
+            // type error upstream.
+            PowInt => int2(l, r, |a, b| Flow::val(Value::Int(a.wrapping_pow(b as u32)))),
+
+            AddFloat => float2(l, r, |a, b| a + b),
+            SubFloat => float2(l, r, |a, b| a - b),
+            MulFloat => float2(l, r, |a, b| a * b),
+            DivFloat => float2(l, r, |a, b| a / b),
+            ModFloat => float2(l, r, |a, b| a % b),
+            PowFloat => float2(l, r, |a, b| a.powf(b)),
+
+            ConcatStr => match (l, r) {
+                (Value::Str(a), Value::Str(b)) => {
+                    Flow::val(Value::str(format!("{}{}", a, b)))
+                }
+                (a, b) => Flow::Abort(format!(
+                    "internal: string concat on {} and {}",
+                    a.type_name(),
+                    b.type_name()
+                )),
+            },
+            ConcatList => match (l, r) {
+                (Value::List(a), Value::List(b)) => {
+                    let mut v = (*a).clone();
+                    v.extend((*b).clone());
+                    Flow::val(Value::list(v))
+                }
+                (a, b) => Flow::Abort(format!(
+                    "internal: list concat on {} and {}",
+                    a.type_name(),
+                    b.type_name()
+                )),
+            },
+
+            Eq => Flow::val(Value::Bool(l == r)),
+            Neq => Flow::val(Value::Bool(l != r)),
+            Lt | Gt | Lte | Gte => match l.partial_cmp_val(&r) {
+                Some(ord) => {
+                    let res = match op {
+                        Lt => ord == std::cmp::Ordering::Less,
+                        Gt => ord == std::cmp::Ordering::Greater,
+                        Lte => ord != std::cmp::Ordering::Greater,
+                        Gte => ord != std::cmp::Ordering::Less,
+                        _ => unreachable!(),
+                    };
+                    Flow::val(Value::Bool(res))
+                }
+                None => Flow::Abort(format!(
+                    "internal: ordering {} vs {}",
+                    l.type_name(),
+                    r.type_name()
+                )),
+            },
+
+            And | Or => unreachable!("short-circuited above"),
+
+            // Matrix ops would dispatch to the runtime matrix bridge; not yet
+            // implemented in this phase.
+            MulMatrix | AddMatrix | SubMatrix | ScaleMatrix => {
+                Flow::Unsupported("matrix arithmetic".into())
+            }
+        }
+    }
+
+    fn eval_unop(&mut self, op: UnOp, v: Value) -> Flow {
+        match (op, v) {
+            (UnOp::NegInt, Value::Int(n)) => Flow::val(Value::Int(n.wrapping_neg())),
+            (UnOp::NegFloat, Value::Float(f)) => Flow::val(Value::Float(-f)),
+            (UnOp::Not, Value::Bool(b)) => Flow::val(Value::Bool(!b)),
+            (op, v) => Flow::Abort(format!(
+                "internal: unop {:?} on {}",
+                op,
+                v.type_name()
+            )),
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────
+
+    fn var_name(&self, id: VarId) -> String {
+        if (id.0 as usize) < self.program.var_table.len() {
+            self.program.var_table.get(id).name.to_string()
+        } else {
+            format!("v{}", id.0)
+        }
+    }
+}
+
+/// Insert / overwrite a key in an insertion-ordered map entry vec, matching the
+/// compact-ordered-dict: existing key updates in place; new key appends.
+pub(crate) fn map_insert(entries: &mut Vec<(Value, Value)>, key: Value, value: Value) {
+    if let Some(slot) = entries.iter_mut().find(|(k, _)| k == &key) {
+        slot.1 = value;
+    } else {
+        entries.push((key, value));
+    }
+}
+
+fn int2(l: Value, r: Value, f: impl FnOnce(i64, i64) -> Flow) -> Flow {
+    match (l, r) {
+        (Value::Int(a), Value::Int(b)) => f(a, b),
+        (a, b) => Flow::Abort(format!(
+            "internal: int op on {} and {}",
+            a.type_name(),
+            b.type_name()
+        )),
+    }
+}
+
+fn float2(l: Value, r: Value, f: impl FnOnce(f64, f64) -> f64) -> Flow {
+    match (l, r) {
+        (Value::Float(a), Value::Float(b)) => Flow::val(Value::Float(f(a, b))),
+        (a, b) => Flow::Abort(format!(
+            "internal: float op on {} and {}",
+            a.type_name(),
+            b.type_name()
+        )),
+    }
+}
+
+/// The exact native abort message for a failing checked int div/mod.
+fn div_msg(divisor: i64) -> String {
+    if divisor == 0 {
+        "division by zero".to_string()
+    } else {
+        "integer overflow".to_string()
+    }
+}

--- a/crates/almide-interp/src/hofs.rs
+++ b/crates/almide-interp/src/hofs.rs
@@ -1,0 +1,905 @@
+//! In-interp higher-order functions and interp-native container ops.
+//!
+//! The HOFs (map/filter/fold/…) MUST be interpreted natively: an interp
+//! `Closure` cannot be coerced into the `Rc<dyn Fn>` a generic runtime HOF
+//! demands. Each iterates the receiver and calls `apply_closure` per element.
+//!
+//! The container ops (non-HOF list/map/set/option/result transforms) are also
+//! interp-native because they are generic — the runtime versions monomorphize
+//! and cannot take a dynamic `Value`. They reproduce the same structural
+//! transforms.
+
+use std::rc::Rc;
+
+use almide_base::intern::Sym;
+use almide_ir::IrExpr;
+
+use crate::env::Scope;
+use crate::value::Value;
+use crate::{Flow, Interpreter};
+
+macro_rules! val {
+    ($flow:expr) => {
+        match $flow {
+            Flow::Value(v) => v,
+            other => return other,
+        }
+    };
+}
+
+impl<'a> Interpreter<'a> {
+    /// Evaluate a higher-order `(module, func)` call. The closure argument is
+    /// applied per element via `apply_closure`.
+    pub(crate) fn eval_hof(
+        &mut self,
+        module: Sym,
+        func: Sym,
+        args: &[IrExpr],
+        scope: &Scope,
+    ) -> Flow {
+        let m = module.as_str();
+        let f = func.as_str();
+
+        // Evaluate all args (the receiver + the closure[s]) eagerly.
+        let mut evaled = Vec::with_capacity(args.len());
+        for a in args {
+            evaled.push(val!(self.eval_expr(a, scope)));
+        }
+
+        match (m, f) {
+            // ── list HOFs ──
+            ("list", "map") => self.hof_map(&evaled),
+            ("list", "filter") => self.hof_filter(&evaled, true),
+            ("list", "find") => self.hof_find(&evaled),
+            ("list", "find_index") => self.hof_find_index(&evaled),
+            ("list", "any") => self.hof_any_all(&evaled, true),
+            ("list", "all") => self.hof_any_all(&evaled, false),
+            ("list", "count") => self.hof_count(&evaled),
+            ("list", "flat_map") => self.hof_flat_map(&evaled),
+            ("list", "filter_map") => self.hof_filter_map(&evaled),
+            ("list", "fold") => self.hof_fold(&evaled),
+            ("list", "reduce") => self.hof_reduce(&evaled),
+            ("list", "take_while") => self.hof_take_drop_while(&evaled, true),
+            ("list", "drop_while") => self.hof_take_drop_while(&evaled, false),
+            ("list", "partition") => self.hof_partition(&evaled),
+            ("list", "sort_by") => self.hof_sort_by(&evaled),
+            ("list", "each") => self.hof_each(&evaled),
+            ("list", "zip_with") => self.hof_zip_with(&evaled),
+
+            // ── option HOFs ──
+            ("option", "map") => self.hof_option_map(&evaled),
+            ("option", "flat_map") => self.hof_option_flat_map(&evaled),
+            ("option", "filter") => self.hof_option_filter(&evaled),
+            ("option", "unwrap_or_else") => self.hof_option_unwrap_or_else(&evaled),
+            ("option", "or_else") => self.hof_option_or_else(&evaled),
+
+            // ── result HOFs ──
+            ("result", "map") => self.hof_result_map(&evaled, false),
+            ("result", "map_err") => self.hof_result_map(&evaled, true),
+            ("result", "flat_map") => self.hof_result_flat_map(&evaled),
+            ("result", "unwrap_or_else") => self.hof_result_unwrap_or_else(&evaled),
+
+            // ── set HOFs (operate on the ordered backing vec) ──
+            ("set", "map") => self.hof_set_map(&evaled),
+            ("set", "filter") => self.hof_set_filter(&evaled),
+            ("set", "any") => self.hof_any_all(&evaled, true),
+            ("set", "all") => self.hof_any_all(&evaled, false),
+            ("set", "fold") => self.hof_fold(&evaled),
+
+            _ => Flow::Unsupported(format!("HOF {}.{}", m, f)),
+        }
+    }
+
+    // ── list HOFs ──────────────────────────────────────────────
+
+    fn recv_items(args: &[Value]) -> Result<Vec<Value>, Flow> {
+        match args.first().and_then(|v| v.as_iter_items()) {
+            Some(items) => Ok(items),
+            None => Err(Flow::Abort("internal: HOF receiver not iterable".into())),
+        }
+    }
+
+    fn recv_closure(args: &[Value], idx: usize) -> Result<Rc<crate::Closure>, Flow> {
+        match args.get(idx) {
+            Some(Value::Closure(c)) => Ok(c.clone()),
+            _ => Err(Flow::Abort(format!(
+                "internal: HOF arg {} not a closure",
+                idx
+            ))),
+        }
+    }
+
+    fn hof_map(&mut self, args: &[Value]) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        let mut out = Vec::with_capacity(items.len());
+        for item in items {
+            out.push(val!(self.apply_closure(&clo, vec![item])));
+        }
+        Flow::val(Value::list(out))
+    }
+
+    fn hof_filter(&mut self, args: &[Value], keep_true: bool) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        let mut out = Vec::new();
+        for item in items {
+            let keep = val!(self.apply_closure(&clo, vec![item.clone()]));
+            if matches!(keep, Value::Bool(b) if b == keep_true) {
+                out.push(item);
+            }
+        }
+        Flow::val(Value::list(out))
+    }
+
+    fn hof_find(&mut self, args: &[Value]) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        for item in items {
+            let hit = val!(self.apply_closure(&clo, vec![item.clone()]));
+            if matches!(hit, Value::Bool(true)) {
+                return Flow::val(Value::Option(Some(Box::new(item))));
+            }
+        }
+        Flow::val(Value::Option(None))
+    }
+
+    fn hof_find_index(&mut self, args: &[Value]) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        for (i, item) in items.into_iter().enumerate() {
+            let hit = val!(self.apply_closure(&clo, vec![item]));
+            if matches!(hit, Value::Bool(true)) {
+                return Flow::val(Value::Option(Some(Box::new(Value::Int(i as i64)))));
+            }
+        }
+        Flow::val(Value::Option(None))
+    }
+
+    fn hof_any_all(&mut self, args: &[Value], is_any: bool) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        for item in items {
+            let r = val!(self.apply_closure(&clo, vec![item]));
+            let b = matches!(r, Value::Bool(true));
+            if is_any && b {
+                return Flow::val(Value::Bool(true));
+            }
+            if !is_any && !b {
+                return Flow::val(Value::Bool(false));
+            }
+        }
+        Flow::val(Value::Bool(!is_any))
+    }
+
+    fn hof_count(&mut self, args: &[Value]) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        let mut n = 0i64;
+        for item in items {
+            let r = val!(self.apply_closure(&clo, vec![item]));
+            if matches!(r, Value::Bool(true)) {
+                n += 1;
+            }
+        }
+        Flow::val(Value::Int(n))
+    }
+
+    fn hof_flat_map(&mut self, args: &[Value]) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        let mut out = Vec::new();
+        for item in items {
+            let r = val!(self.apply_closure(&clo, vec![item]));
+            match r.as_iter_items() {
+                Some(sub) => out.extend(sub),
+                None => {
+                    return Flow::Abort("internal: flat_map closure did not return a list".into())
+                }
+            }
+        }
+        Flow::val(Value::list(out))
+    }
+
+    fn hof_filter_map(&mut self, args: &[Value]) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        let mut out = Vec::new();
+        for item in items {
+            let r = val!(self.apply_closure(&clo, vec![item]));
+            if let Value::Option(Some(v)) = r {
+                out.push(*v);
+            }
+        }
+        Flow::val(Value::list(out))
+    }
+
+    fn hof_fold(&mut self, args: &[Value]) -> Flow {
+        // fold(receiver, init, (acc, x) => ...)
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let mut acc = match args.get(1) {
+            Some(v) => v.clone(),
+            None => return Flow::Abort("internal: fold missing init".into()),
+        };
+        let clo = match Self::recv_closure(args, 2) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        for item in items {
+            acc = val!(self.apply_closure(&clo, vec![acc, item]));
+        }
+        Flow::val(acc)
+    }
+
+    fn hof_reduce(&mut self, args: &[Value]) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        let mut iter = items.into_iter();
+        let mut acc = match iter.next() {
+            Some(v) => v,
+            None => return Flow::val(Value::Option(None)),
+        };
+        for item in iter {
+            acc = val!(self.apply_closure(&clo, vec![acc, item]));
+        }
+        Flow::val(Value::Option(Some(Box::new(acc))))
+    }
+
+    fn hof_take_drop_while(&mut self, args: &[Value], take: bool) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        let mut split = items.len();
+        for (i, item) in items.iter().enumerate() {
+            let r = val!(self.apply_closure(&clo, vec![item.clone()]));
+            if !matches!(r, Value::Bool(true)) {
+                split = i;
+                break;
+            }
+        }
+        let out: Vec<Value> = if take {
+            items[..split].to_vec()
+        } else {
+            items[split..].to_vec()
+        };
+        Flow::val(Value::list(out))
+    }
+
+    fn hof_partition(&mut self, args: &[Value]) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        let (mut yes, mut no) = (Vec::new(), Vec::new());
+        for item in items {
+            let r = val!(self.apply_closure(&clo, vec![item.clone()]));
+            if matches!(r, Value::Bool(true)) {
+                yes.push(item);
+            } else {
+                no.push(item);
+            }
+        }
+        Flow::val(Value::tuple(vec![Value::list(yes), Value::list(no)]))
+    }
+
+    fn hof_sort_by(&mut self, args: &[Value]) -> Flow {
+        // `sort_by[A, B](xs: List[A], f: (A) -> B) -> List[A]` is KEY-EXTRACTION,
+        // NOT a comparator. The native runtime is the oracle:
+        //   runtime/rs/src/list.rs:
+        //     xs.sort_by_key(|x| f(x.clone()))   (B: Ord)
+        // i.e. apply the 1-arg closure to each element to get its sort key, then
+        // STABLY sort the elements by their keys' natural `Ord`. The WASM backend
+        // (emit_wasm/calls_list_closure.rs `sort_by`) reproduces this with a
+        // stable bubble sort that swaps only on key[j] > key[j+1] (strict — equal
+        // keys never swap → stable). Both verified byte-identical on Int / String
+        // keys, ties preserved in input order (probe /tmp/sorti.almd).
+        //
+        // Key ordering: native `B: Ord` means the only key types a *compilable*
+        // program can use are Ord types — Int, String, Bool (and Ord-composites).
+        // A Float key is a hard compile error in BOTH backends (`f64: !Ord`,
+        // verified: the type checker rejects `sort_by(xs, (x: Float) => x)` with
+        // an `Ord` bound failure), so a Float-key sort_by never reaches a runnable
+        // program and therefore never reaches this interpreter on the 3-way
+        // oracle. `Value::partial_cmp_val` still orders floats sensibly (and falls
+        // back to "Equal → no swap", preserving stability) so a defensive path
+        // never panics, but it casts no third vote a backend could disagree with.
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        // Compute each element's key once (a single application per element,
+        // matching native's `sort_by_key`, which does NOT re-call the key fn on
+        // every comparison).
+        let mut keyed: Vec<(Value, Value)> = Vec::with_capacity(items.len());
+        for item in items {
+            let key = val!(self.apply_closure(&clo, vec![item.clone()]));
+            keyed.push((key, item));
+        }
+        // Stable sort by key. `slice::sort_by` is stable (mirrors native
+        // `sort_by_key`); compare keys with the same total order the backends'
+        // `Ord` keys use (`Value::partial_cmp_val`: Int/Bool/String → natural
+        // `cmp`). Incomparable keys (only the can't-actually-compile Float case)
+        // collapse to `Equal`, which under a stable sort leaves input order — no
+        // panic, no spurious vote.
+        keyed.sort_by(|(ka, _), (kb, _)| {
+            ka.partial_cmp_val(kb).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        Flow::val(Value::list(keyed.into_iter().map(|(_, item)| item).collect()))
+    }
+
+    fn hof_each(&mut self, args: &[Value]) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        for item in items {
+            val!(self.apply_closure(&clo, vec![item]));
+        }
+        Flow::val(Value::Unit)
+    }
+
+    fn hof_zip_with(&mut self, args: &[Value]) -> Flow {
+        let a = match args.first().and_then(|v| v.as_iter_items()) {
+            Some(i) => i,
+            None => return Flow::Abort("internal: zip_with arg 0 not iterable".into()),
+        };
+        let b = match args.get(1).and_then(|v| v.as_iter_items()) {
+            Some(i) => i,
+            None => return Flow::Abort("internal: zip_with arg 1 not iterable".into()),
+        };
+        let clo = match Self::recv_closure(args, 2) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        let mut out = Vec::new();
+        for (x, y) in a.into_iter().zip(b.into_iter()) {
+            out.push(val!(self.apply_closure(&clo, vec![x, y])));
+        }
+        Flow::val(Value::list(out))
+    }
+
+    // ── option HOFs ────────────────────────────────────────────
+
+    fn hof_option_map(&mut self, args: &[Value]) -> Flow {
+        match args.first() {
+            Some(Value::Option(Some(v))) => {
+                let clo = match Self::recv_closure(args, 1) {
+                    Ok(c) => c,
+                    Err(f) => return f,
+                };
+                let r = val!(self.apply_closure(&clo, vec![(**v).clone()]));
+                Flow::val(Value::Option(Some(Box::new(r))))
+            }
+            Some(Value::Option(None)) => Flow::val(Value::Option(None)),
+            _ => Flow::Abort("internal: option.map on non-Option".into()),
+        }
+    }
+
+    fn hof_option_flat_map(&mut self, args: &[Value]) -> Flow {
+        match args.first() {
+            Some(Value::Option(Some(v))) => {
+                let clo = match Self::recv_closure(args, 1) {
+                    Ok(c) => c,
+                    Err(f) => return f,
+                };
+                self.apply_closure(&clo, vec![(**v).clone()])
+            }
+            Some(Value::Option(None)) => Flow::val(Value::Option(None)),
+            _ => Flow::Abort("internal: option.flat_map on non-Option".into()),
+        }
+    }
+
+    fn hof_option_filter(&mut self, args: &[Value]) -> Flow {
+        match args.first() {
+            Some(Value::Option(Some(v))) => {
+                let clo = match Self::recv_closure(args, 1) {
+                    Ok(c) => c,
+                    Err(f) => return f,
+                };
+                let keep = val!(self.apply_closure(&clo, vec![(**v).clone()]));
+                if matches!(keep, Value::Bool(true)) {
+                    Flow::val(Value::Option(Some(v.clone())))
+                } else {
+                    Flow::val(Value::Option(None))
+                }
+            }
+            Some(Value::Option(None)) => Flow::val(Value::Option(None)),
+            _ => Flow::Abort("internal: option.filter on non-Option".into()),
+        }
+    }
+
+    fn hof_option_unwrap_or_else(&mut self, args: &[Value]) -> Flow {
+        match args.first() {
+            Some(Value::Option(Some(v))) => Flow::val((**v).clone()),
+            Some(Value::Option(None)) => {
+                let clo = match Self::recv_closure(args, 1) {
+                    Ok(c) => c,
+                    Err(f) => return f,
+                };
+                self.apply_closure(&clo, vec![])
+            }
+            _ => Flow::Abort("internal: option.unwrap_or_else on non-Option".into()),
+        }
+    }
+
+    fn hof_option_or_else(&mut self, args: &[Value]) -> Flow {
+        match args.first() {
+            Some(opt @ Value::Option(Some(_))) => Flow::val(opt.clone()),
+            Some(Value::Option(None)) => {
+                let clo = match Self::recv_closure(args, 1) {
+                    Ok(c) => c,
+                    Err(f) => return f,
+                };
+                self.apply_closure(&clo, vec![])
+            }
+            _ => Flow::Abort("internal: option.or_else on non-Option".into()),
+        }
+    }
+
+    // ── result HOFs ────────────────────────────────────────────
+
+    fn hof_result_map(&mut self, args: &[Value], map_err: bool) -> Flow {
+        match args.first() {
+            Some(Value::Result(res)) => {
+                let clo = match Self::recv_closure(args, 1) {
+                    Ok(c) => c,
+                    Err(f) => return f,
+                };
+                match (res, map_err) {
+                    (Ok(v), false) => {
+                        let r = val!(self.apply_closure(&clo, vec![(**v).clone()]));
+                        Flow::val(Value::Result(Ok(Box::new(r))))
+                    }
+                    (Err(e), true) => {
+                        let r = val!(self.apply_closure(&clo, vec![(**e).clone()]));
+                        Flow::val(Value::Result(Err(Box::new(r))))
+                    }
+                    (other, _) => Flow::val(Value::Result(other.clone())),
+                }
+            }
+            _ => Flow::Abort("internal: result.map on non-Result".into()),
+        }
+    }
+
+    fn hof_result_flat_map(&mut self, args: &[Value]) -> Flow {
+        match args.first() {
+            Some(Value::Result(Ok(v))) => {
+                let clo = match Self::recv_closure(args, 1) {
+                    Ok(c) => c,
+                    Err(f) => return f,
+                };
+                self.apply_closure(&clo, vec![(**v).clone()])
+            }
+            Some(Value::Result(Err(e))) => {
+                Flow::val(Value::Result(Err(e.clone())))
+            }
+            _ => Flow::Abort("internal: result.flat_map on non-Result".into()),
+        }
+    }
+
+    fn hof_result_unwrap_or_else(&mut self, args: &[Value]) -> Flow {
+        match args.first() {
+            Some(Value::Result(Ok(v))) => Flow::val((**v).clone()),
+            Some(Value::Result(Err(e))) => {
+                let clo = match Self::recv_closure(args, 1) {
+                    Ok(c) => c,
+                    Err(f) => return f,
+                };
+                self.apply_closure(&clo, vec![(**e).clone()])
+            }
+            _ => Flow::Abort("internal: result.unwrap_or_else on non-Result".into()),
+        }
+    }
+
+    // ── set HOFs ───────────────────────────────────────────────
+
+    fn hof_set_map(&mut self, args: &[Value]) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        let mut out: Vec<Value> = Vec::new();
+        for item in items {
+            let r = val!(self.apply_closure(&clo, vec![item]));
+            if !out.contains(&r) {
+                out.push(r);
+            }
+        }
+        Flow::val(Value::Set(Rc::new(out)))
+    }
+
+    fn hof_set_filter(&mut self, args: &[Value]) -> Flow {
+        let items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let clo = match Self::recv_closure(args, 1) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        let mut out = Vec::new();
+        for item in items {
+            let keep = val!(self.apply_closure(&clo, vec![item.clone()]));
+            if matches!(keep, Value::Bool(true)) {
+                out.push(item);
+            }
+        }
+        Flow::val(Value::Set(Rc::new(out)))
+    }
+}
+
+// ── Interp-native container ops (non-HOF structural transforms) ──
+
+impl<'a> Interpreter<'a> {
+    /// Handle a non-HOF `(module, func)` container op. Returns `None` if this
+    /// op is not interp-native (the caller falls through to the bridge / an
+    /// almide-bodied fn).
+    pub(crate) fn eval_container_op(
+        &mut self,
+        module: &str,
+        func: &str,
+        args: &[Value],
+    ) -> Option<Flow> {
+        // In-place container MUTATION cannot be faithfully modeled here: the
+        // dispatch path evaluates every arg by VALUE before reaching us, so the
+        // `var` binding identity of the receiver is already lost. These stdlib
+        // ops have a `mut` receiver and (mostly) return Unit — the program reads
+        // the EFFECT on the variable, not a returned value (e.g.
+        // `for i in 0..100 { list.push(xs, ..) }` then indexes `xs`). Modeling
+        // them functionally (returning a fresh container that the caller drops)
+        // is silently WRONG and would emit a misleading third vote into the
+        // cross-target oracle — strictly worse than an honest skip. So we report
+        // `Unsupported`, which the 3-way gate logs as a reasoned skip. (The
+        // FUNCTIONAL siblings that return a new container — `list.set`,
+        // `list.insert`, `map.set`, `set.insert` — are NOT here and stay
+        // supported.) Index-assign (`xs[i] = v`) keeps its binding and IS
+        // modeled correctly via `IrStmtKind::IndexAssign`.
+        if is_inplace_mutating_op(module, func) {
+            return Some(Flow::Unsupported(format!(
+                "in-place container mutation `{module}.{func}` (mut receiver; \
+                 interp args are by-value so the binding cannot be written back)"
+            )));
+        }
+        match (module, func) {
+            // ── list ──
+            ("list", "len") | ("list", "length") => Some(match args.first() {
+                Some(v) => match v.as_iter_items() {
+                    Some(items) => Flow::val(Value::Int(items.len() as i64)),
+                    None => Flow::Abort("internal: list.len on non-list".into()),
+                },
+                None => Flow::Abort("internal: list.len no arg".into()),
+            }),
+            ("list", "is_empty") => Some(match args.first().and_then(|v| v.as_iter_items()) {
+                Some(items) => Flow::val(Value::Bool(items.is_empty())),
+                None => Flow::Abort("internal: list.is_empty on non-list".into()),
+            }),
+            ("list", "reverse") => Some(match args.first().and_then(|v| v.as_iter_items()) {
+                Some(mut items) => {
+                    items.reverse();
+                    Flow::val(Value::list(items))
+                }
+                None => Flow::Abort("internal: list.reverse on non-list".into()),
+            }),
+            ("list", "first") | ("list", "head") => Some(
+                match args.first().and_then(|v| v.as_iter_items()) {
+                    Some(items) => Flow::val(Value::Option(
+                        items.first().cloned().map(Box::new),
+                    )),
+                    None => Flow::Abort("internal: list.first on non-list".into()),
+                },
+            ),
+            ("list", "last") => Some(match args.first().and_then(|v| v.as_iter_items()) {
+                Some(items) => Flow::val(Value::Option(items.last().cloned().map(Box::new))),
+                None => Flow::Abort("internal: list.last on non-list".into()),
+            }),
+            ("list", "get") => Some(self.list_get(args)),
+            ("list", "contains") => Some(match (args.first().and_then(|v| v.as_iter_items()), args.get(1)) {
+                (Some(items), Some(x)) => Flow::val(Value::Bool(items.contains(x))),
+                _ => Flow::Abort("internal: list.contains bad args".into()),
+            }),
+            // `list.append` is the FUNCTIONAL append (returns a new list); the
+            // mutating `list.push` is intercepted by the in-place-mutation guard
+            // above and never reaches here.
+            ("list", "append") => Some(match (args.first().and_then(|v| v.as_iter_items()), args.get(1)) {
+                (Some(mut items), Some(x)) => {
+                    items.push(x.clone());
+                    Flow::val(Value::list(items))
+                }
+                _ => Flow::Abort("internal: list.append bad args".into()),
+            }),
+            ("list", "concat") => Some(match (args.first().and_then(|v| v.as_iter_items()), args.get(1).and_then(|v| v.as_iter_items())) {
+                (Some(mut a), Some(b)) => {
+                    a.extend(b);
+                    Flow::val(Value::list(a))
+                }
+                _ => Flow::Abort("internal: list.concat bad args".into()),
+            }),
+            ("list", "sum") => Some(self.list_sum(args)),
+            ("list", "join") => Some(self.list_join(args)),
+            ("list", "sort") => Some(self.list_sort(args)),
+            ("list", "enumerate") => Some(match args.first().and_then(|v| v.as_iter_items()) {
+                Some(items) => Flow::val(Value::list(
+                    items
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, v)| Value::tuple(vec![Value::Int(i as i64), v]))
+                        .collect(),
+                )),
+                None => Flow::Abort("internal: list.enumerate on non-list".into()),
+            }),
+
+            // ── map ──
+            ("map", "len") | ("map", "size") => Some(match args.first() {
+                Some(Value::Map(e)) => Flow::val(Value::Int(e.len() as i64)),
+                _ => Flow::Abort("internal: map.len on non-map".into()),
+            }),
+            ("map", "get") => Some(match (args.first(), args.get(1)) {
+                (Some(Value::Map(e)), Some(k)) => Flow::val(Value::Option(
+                    e.iter().find(|(ek, _)| ek == k).map(|(_, v)| Box::new(v.clone())),
+                )),
+                _ => Flow::Abort("internal: map.get bad args".into()),
+            }),
+            ("map", "contains_key") | ("map", "has") => Some(match (args.first(), args.get(1)) {
+                (Some(Value::Map(e)), Some(k)) => {
+                    Flow::val(Value::Bool(e.iter().any(|(ek, _)| ek == k)))
+                }
+                _ => Flow::Abort("internal: map.contains_key bad args".into()),
+            }),
+            // `map.set` is FUNCTIONAL (`-> Map`, returns a new map); the
+            // mutating `map.insert` (`mut m, .. -> Unit`) is intercepted by the
+            // in-place-mutation guard above.
+            ("map", "set") => Some(match (args.first(), args.get(1), args.get(2)) {
+                (Some(Value::Map(e)), Some(k), Some(v)) => {
+                    let mut new = (**e).clone();
+                    crate::eval::map_insert(&mut new, k.clone(), v.clone());
+                    Flow::val(Value::Map(Rc::new(new)))
+                }
+                _ => Flow::Abort("internal: map.set bad args".into()),
+            }),
+            ("map", "keys") => Some(match args.first() {
+                Some(Value::Map(e)) => {
+                    Flow::val(Value::list(e.iter().map(|(k, _)| k.clone()).collect()))
+                }
+                _ => Flow::Abort("internal: map.keys on non-map".into()),
+            }),
+            ("map", "values") => Some(match args.first() {
+                Some(Value::Map(e)) => {
+                    Flow::val(Value::list(e.iter().map(|(_, v)| v.clone()).collect()))
+                }
+                _ => Flow::Abort("internal: map.values on non-map".into()),
+            }),
+
+            // ── set ──
+            ("set", "len") | ("set", "size") => Some(match args.first() {
+                Some(Value::Set(e)) => Flow::val(Value::Int(e.len() as i64)),
+                _ => Flow::Abort("internal: set.len on non-set".into()),
+            }),
+            ("set", "contains") | ("set", "has") => Some(match (args.first(), args.get(1)) {
+                (Some(Value::Set(e)), Some(x)) => Flow::val(Value::Bool(e.contains(x))),
+                _ => Flow::Abort("internal: set.contains bad args".into()),
+            }),
+            ("set", "insert") | ("set", "add") => Some(match (args.first(), args.get(1)) {
+                (Some(Value::Set(e)), Some(x)) => {
+                    let mut new = (**e).clone();
+                    if !new.contains(x) {
+                        new.push(x.clone());
+                    }
+                    Flow::val(Value::Set(Rc::new(new)))
+                }
+                _ => Flow::Abort("internal: set.insert bad args".into()),
+            }),
+            ("set", "to_list") => Some(match args.first() {
+                Some(Value::Set(e)) => Flow::val(Value::list((**e).clone())),
+                _ => Flow::Abort("internal: set.to_list on non-set".into()),
+            }),
+
+            // ── option ──
+            ("option", "is_some") => Some(match args.first() {
+                Some(Value::Option(o)) => Flow::val(Value::Bool(o.is_some())),
+                _ => Flow::Abort("internal: option.is_some on non-option".into()),
+            }),
+            ("option", "is_none") => Some(match args.first() {
+                Some(Value::Option(o)) => Flow::val(Value::Bool(o.is_none())),
+                _ => Flow::Abort("internal: option.is_none on non-option".into()),
+            }),
+            ("option", "unwrap_or") => Some(match (args.first(), args.get(1)) {
+                (Some(Value::Option(Some(v))), _) => Flow::val((**v).clone()),
+                (Some(Value::Option(None)), Some(d)) => Flow::val(d.clone()),
+                _ => Flow::Abort("internal: option.unwrap_or bad args".into()),
+            }),
+
+            // ── result ──
+            ("result", "is_ok") => Some(match args.first() {
+                Some(Value::Result(r)) => Flow::val(Value::Bool(r.is_ok())),
+                _ => Flow::Abort("internal: result.is_ok on non-result".into()),
+            }),
+            ("result", "is_err") => Some(match args.first() {
+                Some(Value::Result(r)) => Flow::val(Value::Bool(r.is_err())),
+                _ => Flow::Abort("internal: result.is_err on non-result".into()),
+            }),
+            ("result", "unwrap_or") => Some(match (args.first(), args.get(1)) {
+                (Some(Value::Result(Ok(v))), _) => Flow::val((**v).clone()),
+                (Some(Value::Result(Err(_))), Some(d)) => Flow::val(d.clone()),
+                _ => Flow::Abort("internal: result.unwrap_or bad args".into()),
+            }),
+
+            _ => None,
+        }
+    }
+
+    fn list_get(&mut self, args: &[Value]) -> Flow {
+        match (args.first().and_then(|v| v.as_iter_items()), args.get(1)) {
+            (Some(items), Some(Value::Int(i))) => {
+                let i = *i;
+                if i < 0 || (i as usize) >= items.len() {
+                    Flow::val(Value::Option(None))
+                } else {
+                    Flow::val(Value::Option(Some(Box::new(items[i as usize].clone()))))
+                }
+            }
+            _ => Flow::Abort("internal: list.get bad args".into()),
+        }
+    }
+
+    fn list_sum(&mut self, args: &[Value]) -> Flow {
+        match args.first().and_then(|v| v.as_iter_items()) {
+            Some(items) => {
+                // Int sum or Float sum depending on element kind.
+                if items.iter().all(|v| matches!(v, Value::Int(_))) {
+                    let s: i64 = items
+                        .iter()
+                        .map(|v| if let Value::Int(n) = v { *n } else { 0 })
+                        .fold(0i64, |a, b| a.wrapping_add(b));
+                    Flow::val(Value::Int(s))
+                } else {
+                    let s: f64 = items
+                        .iter()
+                        .map(|v| match v {
+                            Value::Float(f) => *f,
+                            Value::Int(n) => *n as f64,
+                            _ => 0.0,
+                        })
+                        .sum();
+                    Flow::val(Value::Float(s))
+                }
+            }
+            None => Flow::Abort("internal: list.sum on non-list".into()),
+        }
+    }
+
+    fn list_join(&mut self, args: &[Value]) -> Flow {
+        match (args.first().and_then(|v| v.as_iter_items()), args.get(1)) {
+            (Some(items), Some(Value::Str(sep))) => {
+                let parts: Vec<String> = items.iter().map(|v| v.display_bare()).collect();
+                Flow::val(Value::str(parts.join(sep.as_str())))
+            }
+            _ => Flow::Abort("internal: list.join bad args".into()),
+        }
+    }
+
+    fn list_sort(&mut self, args: &[Value]) -> Flow {
+        match args.first().and_then(|v| v.as_iter_items()) {
+            Some(mut items) => {
+                let mut ok = true;
+                items.sort_by(|a, b| {
+                    a.partial_cmp_val(b).unwrap_or_else(|| {
+                        ok = false;
+                        std::cmp::Ordering::Equal
+                    })
+                });
+                if ok {
+                    Flow::val(Value::list(items))
+                } else {
+                    Flow::Abort("internal: list.sort on non-comparable elements".into())
+                }
+            }
+            None => Flow::Abort("internal: list.sort on non-list".into()),
+        }
+    }
+}
+
+/// The stdlib container ops with a `mut` receiver — they mutate the receiver
+/// IN PLACE and the program observes the effect on the bound `var`, not a
+/// returned value. The interp cannot model these (args arrive by value, so the
+/// binding is unreachable from the dispatch point); it reports `Unsupported`
+/// for them so the 3-way oracle records an honest skip instead of a wrong vote.
+///
+/// Source of truth: the `mut`-receiver Unit/Option-returning functions in
+/// `stdlib/{list,map,string,bytes}.almd`. The FUNCTIONAL siblings (`list.set`,
+/// `list.insert`, `map.set`, `set.insert` — all `-> NewContainer`) are NOT
+/// listed and remain fully supported.
+fn is_inplace_mutating_op(module: &str, func: &str) -> bool {
+    matches!(
+        (module, func),
+        ("list", "push")
+            | ("list", "pop")
+            | ("list", "clear")
+            | ("map", "insert")
+            | ("map", "delete")
+            | ("map", "clear")
+            | ("string", "push")
+            | ("string", "clear")
+            | ("bytes", "push")
+            | ("bytes", "set_at")
+            | ("bytes", "copy_within")
+    )
+}
+

--- a/crates/almide-interp/src/lib.rs
+++ b/crates/almide-interp/src/lib.rs
@@ -1,0 +1,444 @@
+//! Almide IR tree-walking interpreter.
+//!
+//! Runs an `IrProgram` at the *pre-codegen* cut point — after
+//! `lower_program → optimize_program → monomorphize → ir_link`, but before any
+//! of `almide-codegen`'s target-lowering passes. At that point the IR is still
+//! a faithful, target-agnostic spec: sugar is desugared, generics are
+//! monomorphized, modules are flat, yet none of `ClosureConversion` /
+//! `Perceus` / `StdlibLowering` / `IterChain` / … have run. The ~22 codegen-
+//! inserted `IrExprKind` variants therefore CANNOT reach this interpreter; the
+//! evaluator asserts them unreachable to document (and guard) the boundary.
+//!
+//! The interpreter is the third leg of the cross-target oracle: a fast,
+//! in-process executable spec that can break ties between the native and WASM
+//! backends and detect a both-wrong-the-same-way divergence the 2-way vote is
+//! structurally blind to.
+//!
+//! Scope of THIS module set: the evaluator for every eval-able IR node, the
+//! runtime/std dispatch bridge, the in-interp HOFs, fuel, and the total-op /
+//! abort semantics. The 3-way harness is wired in a later phase.
+
+mod bridge;
+mod dispatch;
+mod env;
+mod eval;
+mod hofs;
+mod value;
+
+pub use value::{Closure, Value, VariantPayload};
+
+use std::cell::Cell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use almide_base::intern::Sym;
+use almide_ir::{IrFunction, IrProgram};
+
+/// The observable result of an interpreter run — the SAME 3-tuple shape as the
+/// existing `run_native_capture` / `run_wasm_capture` harness helpers, plus a
+/// classification so the gate can tell a real divergence from "the interp can't
+/// run this fixture yet".
+#[derive(Debug, Clone)]
+pub struct RunOutcome {
+    pub status: RunStatus,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl RunOutcome {
+    /// The process-style exit code the harness compares (0 = clean, 1 = abort).
+    pub fn exit_code(&self) -> i32 {
+        match self.status {
+            RunStatus::Ok => 0,
+            RunStatus::Aborted => 1,
+            // Distinguished markers: the gate excludes these from the 3-way
+            // assert rather than emitting a bogus third vote.
+            RunStatus::Unsupported(_) => -2,
+            RunStatus::FuelExhausted => -3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RunStatus {
+    /// Program completed; `main` returned normally.
+    Ok,
+    /// Program aborted with a runtime error (div-by-zero, OOB, unhandled
+    /// error reaching `main`, panic, failed assert). `stderr` carries the
+    /// `Error: <msg>` line and `exit_code()` is 1 — matching both backends.
+    Aborted,
+    /// A capability the interpreter does not implement (a non-deterministic or
+    /// out-of-scope intrinsic). NOT a bug — the gate skips this fixture.
+    Unsupported(String),
+    /// The fuel / recursion-depth budget was exhausted. NOT a hang or panic —
+    /// a clean distinguished outcome for the future fuzz oracle.
+    FuelExhausted,
+}
+
+/// The interpreter over a fully-linked `IrProgram`.
+pub struct Interpreter<'a> {
+    pub(crate) program: &'a IrProgram,
+    /// Top-level functions indexed by name for O(1) call dispatch. Holds
+    /// user fns, monomorphized specializations, and any almide-bodied stdlib
+    /// fns that were lowered into the program.
+    pub(crate) fns: HashMap<Sym, &'a IrFunction>,
+    /// `(module, func)` -> almide-bodied stdlib IrFunction, when present.
+    /// Populated from `program.modules` (pre-`ir_link`) and from any function
+    /// whose name encodes a module path. Used by tier-(i) dispatch.
+    pub(crate) module_fns: HashMap<(Sym, Sym), &'a IrFunction>,
+    /// Named record types keyed by their SORTED field-name set, mapping to
+    /// `(type name, declaration-order field names)`. Lets the repr recover the
+    /// nominal name + declaration order for a record LITERAL whose inferred type
+    /// is structural (`Ty::Record`) rather than `Ty::Named` — e.g. nested list
+    /// elements `[{ val: 2, kids: [] }]` whose element type was inferred
+    /// structurally. This mirrors the codegen walker's
+    /// `ctx.ann.named_records.get(&sorted_names)` lookup
+    /// (walker/expressions.rs:520) so `${value}` renders `RNode { .. }` (decl
+    /// order), not the anonymous `{ .. }` (sorted) the structural type would
+    /// otherwise imply. A field-name set shared by two record types is
+    /// ambiguous and intentionally NOT indexed (the structural type is then
+    /// treated as a true anonymous record).
+    pub(crate) named_records: HashMap<Vec<Sym>, (Sym, Vec<Sym>)>,
+    /// The global scope holding evaluated top-level lets. Every top-level fn
+    /// call and `FnRef` closure parents off this so globals are visible from
+    /// nested calls (not just from `main`'s body). Seeded once, lazily.
+    pub(crate) globals: env::Scope,
+    pub(crate) globals_ready: Cell<bool>,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+    /// Decremented per eval step; 0 → `FuelExhausted`.
+    pub(crate) fuel: Cell<u64>,
+    /// Current call-stack depth, bounded to avoid a native stack overflow on
+    /// adversarial deep recursion.
+    pub(crate) depth: Cell<u32>,
+}
+
+/// Default fuel budget — high enough for any real corpus program, low enough to
+/// bound an adversarial loop. Roughly 100M eval steps.
+pub const DEFAULT_FUEL: u64 = 100_000_000;
+/// Recursion-depth ceiling (interp call frames, not Rust frames per se). This is
+/// a *semantic* fuel-like bound on call nesting: a clean `FuelExhausted` once a
+/// program nests calls this deep, never a native stack overflow. The native
+/// stack is decoupled from this number by running the evaluator on a dedicated
+/// [`INTERP_STACK_SIZE`]-byte thread (see [`Interpreter::run_main`]) so the
+/// guard is host-stack-independent.
+///
+/// Sizing (empirically measured — `crates/almide-interp/examples/depth_probe*`):
+/// a worst-case interp call frame costs ~48 KiB of native stack in an
+/// unoptimized (cargo-test `debug`) build — the `eval_expr → eval_call →
+/// call_function → eval_expr …` chain is not inlined. So `MAX_DEPTH` frames need
+/// `MAX_DEPTH × 48 KiB` of stack. With `INTERP_STACK_SIZE = 256 MiB`:
+///   256 MiB / 48 KiB ≈ 5460 frames fit; MAX_DEPTH = 4000 leaves a ~1.37×
+///   safety factor (4000 × 48 KiB ≈ 187 MiB < 256 MiB). Both bounds verified by
+///   the probe: 4000 frames survive a 192 MiB stack, 5500 survive 256 MiB.
+pub const MAX_DEPTH: u32 = 4_000;
+
+/// Dedicated-thread stack size for the evaluator. Decouples [`MAX_DEPTH`] from
+/// the caller's thread stack so the recursion bound is host-independent: a
+/// program that exhausts [`MAX_DEPTH`] reports a clean `FuelExhausted` whether it
+/// runs on a 2 MiB cargo-test worker thread, an 8 MiB main thread, or anywhere
+/// else. 256 MiB is *reserved* address space, not committed memory — thread
+/// stacks are demand-paged, so only the pages actually touched by the deepest
+/// recursion a given run reaches are ever backed by RAM. Sized for `MAX_DEPTH`
+/// debug-build frames with margin (see the `MAX_DEPTH` sizing note).
+pub const INTERP_STACK_SIZE: usize = 256 * 1024 * 1024;
+
+/// Internal control-flow signal threaded out of `eval`. A `Value` result is the
+/// normal case; the others unwind to the nearest handler (loop / function).
+pub(crate) enum Flow {
+    /// Normal completion with a value.
+    Value(Value),
+    /// `break` — unwinds to the enclosing loop.
+    Break,
+    /// `continue` — unwinds to the enclosing loop.
+    Continue,
+    /// A function-level early return (the value of a `?`/`!` short-circuit, a
+    /// `Guard` else, or an explicit return-position). Carries the value the
+    /// function should yield.
+    Return(Value),
+    /// A runtime abort (`Error: <msg>` → stderr, exit 1). Propagates straight
+    /// to the top.
+    Abort(String),
+    /// Out of fuel / too deep. Propagates straight to the top.
+    Fuel,
+    /// An out-of-scope capability. Propagates straight to the top.
+    Unsupported(String),
+}
+
+impl Flow {
+    pub(crate) fn val(v: Value) -> Flow {
+        Flow::Value(v)
+    }
+}
+
+impl<'a> Interpreter<'a> {
+    pub fn new(program: &'a IrProgram) -> Self {
+        let mut fns = HashMap::new();
+        for f in &program.functions {
+            fns.insert(f.name, f);
+        }
+        let mut module_fns = HashMap::new();
+        for m in &program.modules {
+            for f in &m.functions {
+                module_fns.insert((m.name, f.name), f);
+            }
+        }
+
+        // Index named record types by their sorted field-name set. A set shared
+        // by two distinct record types is ambiguous → drop it (sentinel-marked),
+        // so the repr falls back to anonymous-record rendering rather than
+        // guessing a name.
+        let mut named_records: HashMap<Vec<Sym>, (Sym, Vec<Sym>)> = HashMap::new();
+        let mut ambiguous: std::collections::HashSet<Vec<Sym>> = std::collections::HashSet::new();
+        let record_decls = program.type_decls.iter().chain(
+            program.modules.iter().flat_map(|m| m.type_decls.iter()),
+        );
+        for decl in record_decls {
+            if let almide_ir::IrTypeDeclKind::Record { fields } = &decl.kind {
+                let decl_order: Vec<Sym> = fields.iter().map(|f| f.name).collect();
+                let mut key = decl_order.clone();
+                key.sort();
+                if ambiguous.contains(&key) {
+                    continue;
+                }
+                if let Some(prev) = named_records.get(&key) {
+                    // Two record types with identical field-name sets: ambiguous.
+                    if prev.0 != decl.name {
+                        named_records.remove(&key);
+                        ambiguous.insert(key);
+                    }
+                } else {
+                    named_records.insert(key, (decl.name, decl_order));
+                }
+            }
+        }
+
+        Interpreter {
+            program,
+            fns,
+            module_fns,
+            named_records,
+            globals: env::Scope::root(),
+            globals_ready: Cell::new(false),
+            stdout: String::new(),
+            stderr: String::new(),
+            fuel: Cell::new(DEFAULT_FUEL),
+            depth: Cell::new(0),
+        }
+    }
+
+    /// Override the fuel budget (for tests / the fuzz oracle).
+    pub fn with_fuel(mut self, fuel: u64) -> Self {
+        self.fuel = Cell::new(fuel);
+        self
+    }
+
+    /// Run the program's `main` entry point and return the observable outcome.
+    ///
+    /// The evaluation runs on a dedicated [`INTERP_STACK_SIZE`]-byte thread so
+    /// the [`MAX_DEPTH`] recursion bound is decoupled from the *caller's* thread
+    /// stack: a deeply-recursive program reports a clean `FuelExhausted` instead
+    /// of a native stack overflow whether it is driven from a 2 MiB cargo-test
+    /// worker, the 8 MiB main thread, or any other host stack. Only the
+    /// `Send + Sync` `&IrProgram` crosses into the thread and the `Send`
+    /// `RunOutcome` crosses back — the `Rc`/`Cell` evaluator state never leaves
+    /// it. A `std::thread::scope` borrows the program in place (no `'static`
+    /// requirement) and joins before returning, so the borrow is sound.
+    ///
+    /// The fuel budget is captured *before* spawning (the `Interpreter` itself is
+    /// not `Send`); the worker rebuilds a fresh interpreter over the same program
+    /// inside the big-stack thread — `Interpreter::new` only indexes the program,
+    /// so this is cheap and observationally identical.
+    pub fn run_main(self) -> RunOutcome {
+        let program: &'a IrProgram = self.program;
+        let fuel = self.fuel.get();
+        std::thread::scope(|scope| {
+            std::thread::Builder::new()
+                .name("almide-interp".to_string())
+                // The whole point: a big, KNOWN stack so MAX_DEPTH — not the
+                // host thread's stack — is the binding recursion bound.
+                .stack_size(INTERP_STACK_SIZE)
+                .spawn_scoped(scope, move || {
+                    Interpreter::new(program).with_fuel(fuel).run_main_on_stack()
+                })
+                .expect("failed to spawn almide-interp worker thread")
+                .join()
+                // A panic inside the evaluator is a genuine interpreter bug, not
+                // an out-of-scope skip — re-raise it so it is never swallowed.
+                .unwrap_or_else(|panic| std::panic::resume_unwind(panic))
+        })
+    }
+
+    /// The actual `main`-driving logic. Runs on the big-stack worker thread
+    /// spawned by [`run_main`](Self::run_main). Never call this directly off the
+    /// dedicated thread — it carries the deep recursion that [`run_main`]'s stack
+    /// is sized for.
+    fn run_main_on_stack(mut self) -> RunOutcome {
+        let main = match self.fns.get(&almide_base::intern::sym("main")) {
+            Some(f) => *f,
+            None => {
+                // No entry point: a program of pure definitions. Treat as a
+                // clean no-op run (matches `almide run` on a fn-only file,
+                // which also produces no output).
+                return RunOutcome {
+                    status: RunStatus::Ok,
+                    stdout: self.stdout,
+                    stderr: self.stderr,
+                };
+            }
+        };
+
+        // Seed top-level lets into the shared global scope before main runs.
+        if let Err(flow) = self.ensure_globals() {
+            return self.outcome_from_flow(flow);
+        }
+        let root = self.globals.clone();
+
+        match self.call_function(main, Vec::new(), &root) {
+            // A `main` body whose value is an unhandled `Err`/`None` terminates
+            // the program with `Error: <inner>` + exit 1 (the unhandled-main-
+            // error termination contract). An `Ok`/`Some`/other value is a
+            // clean exit. `call_function` already collapses a body-level
+            // `Return` into `Value`.
+            Flow::Value(v) => match unhandled_main_error(&v) {
+                Some(msg) => self.outcome_from_flow(Flow::Abort(msg)),
+                None => RunOutcome {
+                    status: RunStatus::Ok,
+                    stdout: self.stdout,
+                    stderr: self.stderr,
+                },
+            },
+            other => self.outcome_from_flow(other),
+        }
+    }
+
+    /// Evaluate top-level lets into the shared `globals` scope exactly once.
+    /// Idempotent: a second call is a no-op (so nested calls that trigger it do
+    /// not re-run any effectful top-let).
+    pub(crate) fn ensure_globals(&mut self) -> Result<(), Flow> {
+        if self.globals_ready.get() {
+            return Ok(());
+        }
+        // Mark ready up front so a top-let that calls a fn (which itself wants
+        // globals) does not recurse into re-seeding.
+        self.globals_ready.set(true);
+        let globals = self.globals.clone();
+        let lets: Vec<_> = self.program.top_lets.iter().collect();
+        for tl in lets {
+            match self.eval_expr(&tl.value, &globals) {
+                Flow::Value(v) => globals.bind(tl.var, v),
+                other => return Err(other),
+            }
+        }
+        Ok(())
+    }
+
+    fn outcome_from_flow(&self, flow: Flow) -> RunOutcome {
+        match flow {
+            Flow::Value(_) | Flow::Return(_) | Flow::Break | Flow::Continue => RunOutcome {
+                status: RunStatus::Ok,
+                stdout: self.stdout.clone(),
+                stderr: self.stderr.clone(),
+            },
+            Flow::Abort(msg) => {
+                let mut stderr = self.stderr.clone();
+                // The unhandled-error / abort termination contract: a single
+                // `Error: <msg>` line on stderr, exit 1 (matches both backends'
+                // main-error termination).
+                stderr.push_str(&format!("Error: {}\n", msg));
+                RunOutcome {
+                    status: RunStatus::Aborted,
+                    stdout: self.stdout.clone(),
+                    stderr,
+                }
+            }
+            Flow::Fuel => RunOutcome {
+                status: RunStatus::FuelExhausted,
+                stdout: self.stdout.clone(),
+                stderr: self.stderr.clone(),
+            },
+            Flow::Unsupported(what) => RunOutcome {
+                status: RunStatus::Unsupported(what),
+                stdout: self.stdout.clone(),
+                stderr: self.stderr.clone(),
+            },
+        }
+    }
+
+    /// Burn one unit of fuel; returns `Err(Flow::Fuel)` when exhausted.
+    pub(crate) fn step(&self) -> Result<(), Flow> {
+        let f = self.fuel.get();
+        if f == 0 {
+            return Err(Flow::Fuel);
+        }
+        self.fuel.set(f - 1);
+        Ok(())
+    }
+
+    /// Bind a function's params and evaluate its body in a fresh frame parented
+    /// at the program root scope (`base`). Top-level fns do not close over the
+    /// caller's locals — only over top-level lets — so `base` is the root.
+    pub(crate) fn call_function(
+        &mut self,
+        func: &'a IrFunction,
+        args: Vec<Value>,
+        base: &env::Scope,
+    ) -> Flow {
+        let d = self.depth.get();
+        if d >= MAX_DEPTH {
+            return Flow::Fuel;
+        }
+        self.depth.set(d + 1);
+
+        let frame = base.child();
+        for (param, arg) in func.params.iter().zip(args.into_iter()) {
+            frame.bind(param.var, arg);
+        }
+        let result = match self.eval_expr(&func.body, &frame) {
+            // A function-body `Return` resolves to the returned value here.
+            Flow::Return(v) => Flow::Value(v),
+            other => other,
+        };
+        self.depth.set(d);
+        result
+    }
+
+    /// Apply a closure value to arguments. Used by the in-interp HOFs and by
+    /// `Computed` call targets.
+    pub(crate) fn apply_closure(&mut self, clo: &Rc<Closure>, args: Vec<Value>) -> Flow {
+        let d = self.depth.get();
+        if d >= MAX_DEPTH {
+            return Flow::Fuel;
+        }
+        self.depth.set(d + 1);
+
+        let frame = clo.captured.child();
+        for (param, arg) in clo.params.iter().zip(args.into_iter()) {
+            frame.bind(*param, arg);
+        }
+        let result = match self.eval_expr(&clo.body, &frame) {
+            Flow::Return(v) => Flow::Value(v),
+            other => other,
+        };
+        self.depth.set(d);
+        result
+    }
+}
+
+/// If `main`'s result value is an unhandled error, return the message that the
+/// program should terminate with (`Error: <msg>`). An `Err(e)` yields `e`
+/// displayed bare (a String error prints raw, matching native
+/// `Error: invalid digit found in string`); a `None` yields a generic message.
+/// Any other value (incl. `Ok`/`Some`/`Unit`) is a clean exit (`None`).
+fn unhandled_main_error(v: &Value) -> Option<String> {
+    match v {
+        Value::Result(Err(e)) => Some(e.display_bare()),
+        Value::Option(None) => Some("called `Option::unwrap()` on a `None` value".to_string()),
+        _ => None,
+    }
+}
+
+/// Convenience: build an interpreter for `program` and run `main`.
+pub fn interpret(program: &IrProgram) -> RunOutcome {
+    Interpreter::new(program).run_main()
+}

--- a/crates/almide-interp/src/value.rs
+++ b/crates/almide-interp/src/value.rs
@@ -1,0 +1,362 @@
+//! The interpreter value model.
+//!
+//! `Value` is the dynamic runtime representation the tree-walker manipulates.
+//! Heap kinds share interior state via `Rc` so closure-capture and `Assign`
+//! stay cheap — observationally matching native `RcCow` semantics.
+//!
+//! Two display modes, both derived from inspecting codegen so they are
+//! byte-identical to the native runtime:
+//!   - [`Value::display_bare`]  — the `println` / Display form.
+//!   - [`Value::almide_repr`]   — the compound / container form, replicating
+//!     `almide_repr_prelude` (crates/almide-codegen/src/lib.rs) exactly.
+
+use std::rc::Rc;
+use almide_base::intern::Sym;
+
+/// A closure value: a lambda body plus the environment it captured.
+#[derive(Clone)]
+pub struct Closure {
+    /// Parameter VarIds in declaration order.
+    pub params: Vec<almide_ir::VarId>,
+    /// The lambda body to evaluate on application.
+    pub body: Rc<almide_ir::IrExpr>,
+    /// Captured environment snapshot (one frame holding all free vars).
+    pub captured: crate::env::Scope,
+}
+
+impl std::fmt::Debug for Closure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<closure/{}>", self.params.len())
+    }
+}
+
+/// The payload carried by an algebraic-data-type constructor value.
+#[derive(Debug, Clone, PartialEq)]
+pub enum VariantPayload {
+    Unit,
+    Tuple(Vec<Value>),
+    Record(Vec<(Sym, Value)>),
+}
+
+#[derive(Debug, Clone)]
+pub enum Value {
+    Unit,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Str(Rc<String>),
+    List(Rc<Vec<Value>>),
+    Tuple(Rc<Vec<Value>>),
+    /// Insertion-ordered dense entries — matches the WASM compact-ordered-dict
+    /// and the native `AlmideMap`. Equality is order-sensitive exactly where
+    /// native is (i.e. it is structural over the ordered entry vec).
+    Map(Rc<Vec<(Value, Value)>>),
+    /// Insertion-ordered, dedup-on-insert.
+    Set(Rc<Vec<Value>>),
+    Record {
+        name: Option<Sym>,
+        fields: Rc<Vec<(Sym, Value)>>,
+    },
+    Variant {
+        ty: Option<Sym>,
+        ctor: Sym,
+        payload: VariantPayload,
+    },
+    Option(Option<Box<Value>>),
+    Result(Result<Box<Value>, Box<Value>>),
+    Closure(Rc<Closure>),
+    /// A lazy integer range; materialized to a `List` by iteration / list ops.
+    Range { start: i64, end: i64, inclusive: bool },
+}
+
+impl Value {
+    pub fn str(s: impl Into<String>) -> Value {
+        Value::Str(Rc::new(s.into()))
+    }
+    pub fn list(items: Vec<Value>) -> Value {
+        Value::List(Rc::new(items))
+    }
+    pub fn tuple(items: Vec<Value>) -> Value {
+        Value::Tuple(Rc::new(items))
+    }
+
+    /// Materialize a `Range` (or pass through a `List`) to a concrete element
+    /// vector for iteration / container ops. Returns `None` for non-iterables.
+    pub fn as_iter_items(&self) -> Option<Vec<Value>> {
+        match self {
+            Value::List(xs) => Some((**xs).clone()),
+            Value::Set(xs) => Some((**xs).clone()),
+            Value::Range { start, end, inclusive } => {
+                let mut out = Vec::new();
+                let mut i = *start;
+                let last = if *inclusive { *end } else { *end - 1 };
+                while i <= last {
+                    out.push(Value::Int(i));
+                    i += 1;
+                }
+                Some(out)
+            }
+            // Map iterates as (k, v) tuples (matches native `for (k,v) in m`).
+            Value::Map(entries) => Some(
+                entries
+                    .iter()
+                    .map(|(k, v)| Value::tuple(vec![k.clone(), v.clone()]))
+                    .collect(),
+            ),
+            _ => None,
+        }
+    }
+
+    /// A human label for the value's kind — used only in error messages.
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Value::Unit => "Unit",
+            Value::Bool(_) => "Bool",
+            Value::Int(_) => "Int",
+            Value::Float(_) => "Float",
+            Value::Str(_) => "String",
+            Value::List(_) => "List",
+            Value::Tuple(_) => "Tuple",
+            Value::Map(_) => "Map",
+            Value::Set(_) => "Set",
+            Value::Record { .. } => "Record",
+            Value::Variant { .. } => "Variant",
+            Value::Option(_) => "Option",
+            Value::Result(_) => "Result",
+            Value::Closure(_) => "Closure",
+            Value::Range { .. } => "Range",
+        }
+    }
+}
+
+// ── Equality ────────────────────────────────────────────────────
+//
+// Mirrors `almide_eq!` (= `==`) which on the runtime types is a derived
+// structural `PartialEq`. Closures are never equatable (matches native: a
+// closure value has no PartialEq) — comparing them yields `false`.
+
+impl PartialEq for Value {
+    fn eq(&self, other: &Value) -> bool {
+        use Value::*;
+        match (self, other) {
+            (Unit, Unit) => true,
+            (Bool(a), Bool(b)) => a == b,
+            (Int(a), Int(b)) => a == b,
+            // f64 PartialEq: NaN != NaN, matching Rust `==` semantics that
+            // codegen lowers `almide_eq!` to.
+            (Float(a), Float(b)) => a == b,
+            (Str(a), Str(b)) => a == b,
+            (List(a), List(b)) => a == b,
+            (Tuple(a), Tuple(b)) => a == b,
+            (Map(a), Map(b)) => a == b,
+            (Set(a), Set(b)) => a == b,
+            (
+                Record { name: n1, fields: f1 },
+                Record { name: n2, fields: f2 },
+            ) => n1 == n2 && f1 == f2,
+            (
+                Variant { ty: t1, ctor: c1, payload: p1 },
+                Variant { ty: t2, ctor: c2, payload: p2 },
+            ) => t1 == t2 && c1 == c2 && p1 == p2,
+            (Option(a), Option(b)) => a == b,
+            (Result(a), Result(b)) => a == b,
+            (
+                Range { start: s1, end: e1, inclusive: i1 },
+                Range { start: s2, end: e2, inclusive: i2 },
+            ) => s1 == s2 && e1 == e2 && i1 == i2,
+            // A materialized range compares equal to the equivalent list.
+            (Range { .. }, List(_)) | (List(_), Range { .. }) => {
+                self.as_iter_items() == other.as_iter_items()
+            }
+            (Closure(_), Closure(_)) => false,
+            _ => false,
+        }
+    }
+}
+
+// ── Ordering (for <, >, <=, >= and sort) ────────────────────────
+
+impl Value {
+    /// Total-ish ordering over comparable kinds. Returns `None` when the two
+    /// values are of different/incomparable kinds (the caller turns that into
+    /// a runtime abort, matching the type-checker's guarantee that codegen
+    /// only ever compares same-typed operands).
+    pub fn partial_cmp_val(&self, other: &Value) -> Option<std::cmp::Ordering> {
+        use Value::*;
+        match (self, other) {
+            (Int(a), Int(b)) => Some(a.cmp(b)),
+            (Float(a), Float(b)) => a.partial_cmp(b),
+            (Str(a), Str(b)) => Some(a.cmp(b)),
+            (Bool(a), Bool(b)) => Some(a.cmp(b)),
+            (Unit, Unit) => Some(std::cmp::Ordering::Equal),
+            (List(a), List(b)) => Self::cmp_seq(a, b),
+            (Tuple(a), Tuple(b)) => Self::cmp_seq(a, b),
+            _ => None,
+        }
+    }
+
+    fn cmp_seq(a: &[Value], b: &[Value]) -> Option<std::cmp::Ordering> {
+        for (x, y) in a.iter().zip(b.iter()) {
+            match x.partial_cmp_val(y)? {
+                std::cmp::Ordering::Equal => continue,
+                ord => return Some(ord),
+            }
+        }
+        Some(a.len().cmp(&b.len()))
+    }
+}
+
+// ── Display: the bare `println` / Display form ──────────────────
+
+impl Value {
+    /// The bare top-level Display form (what `println(x)` / a bare `${x}`
+    /// produces). Strings render raw (no quotes); compound values render via
+    /// `almide_repr`. This is the `almide_rt_value_stringify` / Display
+    /// contract.
+    pub fn display_bare(&self) -> String {
+        match self {
+            Value::Str(s) => (**s).clone(),
+            Value::Int(n) => n.to_string(),
+            // EMPIRICAL (probe /tmp/float_probe.almd on almide 0.24.0): a bare
+            // `${f}` of a Float renders via Rust `{}` Display (`3`, not `3.0`),
+            // NOT via `almide_rt_float_to_string`. The `.0`-suffixed form is
+            // produced ONLY by an explicit `float.to_string(f)` call. So both
+            // the bare and the repr float paths use plain `{}`.
+            Value::Float(f) => format!("{}", f),
+            Value::Bool(b) => b.to_string(),
+            Value::Unit => "()".to_string(),
+            // Compound / container values use the repr form even at top level.
+            _ => self.almide_repr(),
+        }
+    }
+
+    /// The compound / container form, byte-identical to `almide_repr_prelude`
+    /// (crates/almide-codegen/src/lib.rs:370). Used for compound string-interp
+    /// parts and for any value nested inside a container.
+    pub fn almide_repr(&self) -> String {
+        match self {
+            Value::Unit => "()".to_string(),
+            Value::Bool(b) => b.to_string(),
+            Value::Int(n) => n.to_string(),
+            // Prelude: `impl AlmideRepr for f64 { format!("{}", self) }` — plain
+            // Display, NO `.0` suffix (verified: `[3, 1.5]`, `some(3)`).
+            Value::Float(f) => format!("{}", f),
+            // A string inside a container is double-quoted + escaped with the
+            // exact set `\\ \" \n \r \t`.
+            Value::Str(s) => repr_str(s),
+            Value::List(xs) => repr_seq("[", "]", xs),
+            // A range renders as its materialized list.
+            Value::Range { .. } => {
+                let items = self.as_iter_items().unwrap_or_default();
+                repr_seq("[", "]", &items)
+            }
+            Value::Tuple(xs) => repr_seq("(", ")", xs),
+            Value::Set(xs) => repr_seq("[", "]", xs),
+            Value::Map(entries) => {
+                // Map: `["k": v]` insertion order (runtime/rs/src/map.rs:74),
+                // empty map `[:]`.
+                if entries.is_empty() {
+                    return "[:]".to_string();
+                }
+                let mut o = String::from("[");
+                for (i, (k, v)) in entries.iter().enumerate() {
+                    if i > 0 {
+                        o.push_str(", ");
+                    }
+                    o.push_str(&k.almide_repr());
+                    o.push_str(": ");
+                    o.push_str(&v.almide_repr());
+                }
+                o.push(']');
+                o
+            }
+            Value::Option(opt) => match opt {
+                Some(v) => format!("some({})", v.almide_repr()),
+                None => "none".to_string(),
+            },
+            Value::Result(res) => match res {
+                Ok(v) => format!("ok({})", v.almide_repr()),
+                Err(e) => format!("err({})", e.almide_repr()),
+            },
+            Value::Record { name, fields } => repr_record(*name, fields),
+            Value::Variant { ctor, payload, .. } => match payload {
+                VariantPayload::Unit => ctor.to_string(),
+                VariantPayload::Tuple(items) => {
+                    let inner = items
+                        .iter()
+                        .map(|v| v.almide_repr())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    format!("{}({})", ctor, inner)
+                }
+                VariantPayload::Record(fs) => {
+                    repr_record(Some(*ctor), fs)
+                }
+            },
+            Value::Closure(_) => "<closure>".to_string(),
+        }
+    }
+}
+
+/// `[a, b]` / `(a, b)` — comma-joined `almide_repr` of each element, empty
+/// container renders as just the delimiters.
+fn repr_seq(open: &str, close: &str, xs: &[Value]) -> String {
+    let mut o = String::from(open);
+    for (i, e) in xs.iter().enumerate() {
+        if i > 0 {
+            o.push_str(", ");
+        }
+        o.push_str(&e.almide_repr());
+    }
+    o.push_str(close);
+    o
+}
+
+/// `Name { f: v, g: w }` in field-declaration order; anonymous records omit
+/// the leading name (`{ f: v }`). Matches walker/declarations.rs.
+fn repr_record(name: Option<Sym>, fields: &[(Sym, Value)]) -> String {
+    let mut o = String::new();
+    if let Some(n) = name {
+        o.push_str(n.as_str());
+        o.push(' ');
+    }
+    o.push('{');
+    for (i, (k, v)) in fields.iter().enumerate() {
+        o.push_str(if i == 0 { " " } else { ", " });
+        o.push_str(k.as_str());
+        o.push_str(": ");
+        o.push_str(&v.almide_repr());
+    }
+    o.push_str(" }");
+    o
+}
+
+/// Escape a string for container context — the exact replacement chain from
+/// `almide_repr_str` (crates/almide-codegen/src/lib.rs:376).
+fn repr_str(sv: &str) -> String {
+    let escaped = sv
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t");
+    format!("\"{}\"", escaped)
+}
+
+/// Replicates `almide_rt_float_to_string` (runtime/rs/src/float.rs:3) exactly:
+/// Rust `{}` Display, with a `.0` suffix appended for whole-number floats so
+/// `3.0` does not print as `3`.
+///
+/// IMPORTANT: this is the formatter for an *explicit* `float.to_string(f)`
+/// call ONLY. Display / `almide_repr` of a Float use plain `{}` (no `.0`) —
+/// see [`Value::display_bare`] / [`Value::almide_repr`]. The known native↔WASM
+/// float divergence (`0.30000000000000004` vs `0.3`) lives in the underlying
+/// `{}` Display, so the interp inherits native's shortest-roundtrip here.
+pub fn float_to_string(n: f64) -> String {
+    let s = format!("{}", n);
+    if n.fract() == 0.0 && !s.contains('.') && !s.contains("inf") && !s.contains("NaN") {
+        format!("{}.0", s)
+    } else {
+        s
+    }
+}

--- a/crates/almide-interp/tests/eval_test.rs
+++ b/crates/almide-interp/tests/eval_test.rs
@@ -1,0 +1,789 @@
+//! Library-level evaluator battery.
+//!
+//! Each test lowers `.almd` source to a linked `IrProgram` through the SAME
+//! public frontend / optimize functions the driver uses — at the pre-codegen
+//! cut point (`lower_program → optimize_program → monomorphize → ir_link`) —
+//! then interprets `main` and asserts on the observable `(exit, stdout,
+//! stderr)`.
+//!
+//! Stdlib bodies are NOT loaded (the lightweight `canonicalize(..,
+//! iter::empty())` recipe), so stdlib calls resolve to `Module` targets and are
+//! served by the interp's bridge / native HOFs — exactly the dispatch the
+//! production cut point exercises.
+
+use almide_frontend::canonicalize;
+use almide_frontend::check::Checker;
+use almide_frontend::ir_link;
+use almide_frontend::lower::lower_program;
+use almide_interp::{Interpreter, RunStatus};
+use almide_lang::lexer::Lexer;
+use almide_lang::parser::Parser;
+use almide_optimize::{mono, optimize};
+
+/// Lower source to a linked `IrProgram` at the interpreter's cut point.
+fn lower(src: &str) -> almide_ir::IrProgram {
+    let tokens = Lexer::tokenize(src);
+    let mut parser = Parser::new(tokens);
+    let mut prog = parser.parse().expect("parse failed");
+    assert!(parser.errors.is_empty(), "parse errors: {:?}", parser.errors);
+
+    let canon = canonicalize::canonicalize_program(&prog, std::iter::empty());
+    let mut checker = Checker::from_env(canon.env);
+    let diags = checker.infer_program(&mut prog);
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.level == almide_frontend::diagnostic::Level::Error)
+        .collect();
+    assert!(errors.is_empty(), "type errors: {:#?}", errors);
+
+    let mut ir = lower_program(&prog, &checker.env, &checker.type_map);
+    optimize::optimize_program(&mut ir);
+    mono::monomorphize(&mut ir);
+    ir_link::ir_link(&mut ir);
+    ir
+}
+
+/// Run `main` and return `(exit, stdout, stderr)`.
+fn run(src: &str) -> (i32, String, String) {
+    let ir = lower(src);
+    let out = Interpreter::new(&ir).run_main();
+    (out.exit_code(), out.stdout, out.stderr)
+}
+
+/// Convenience: assert a clean run with the given stdout.
+fn expect_out(src: &str, expected_stdout: &str) {
+    let (exit, stdout, stderr) = run(src);
+    assert_eq!(
+        exit, 0,
+        "expected clean exit; stderr=<{}> stdout=<{}>",
+        stderr, stdout
+    );
+    assert_eq!(stdout, expected_stdout, "stdout mismatch (stderr=<{}>)", stderr);
+}
+
+/// Wrap a list of statements in a `main` that prints `expr`.
+fn main_print(body: &str) -> String {
+    format!("fn main() -> Unit = {{\n{}\n}}", body)
+}
+
+// ── Literals ────────────────────────────────────────────────────
+
+#[test]
+fn lit_int_and_string() {
+    expect_out(&main_print(r#"  println("${42}")"#), "42\n");
+    expect_out(&main_print(r#"  println("hi")"#), "hi\n");
+}
+
+#[test]
+fn lit_bool_and_unit() {
+    expect_out(&main_print(r#"  println("${true}")"#), "true\n");
+    expect_out(&main_print(r#"  println("${false}")"#), "false\n");
+}
+
+#[test]
+fn lit_float_display_is_plain() {
+    // EMPIRICAL: `${3.0}` renders `3` (plain Display), not `3.0`.
+    expect_out(&main_print(r#"  println("${3.0}")"#), "3\n");
+    expect_out(&main_print(r#"  println("${1.5}")"#), "1.5\n");
+}
+
+// ── Arithmetic ──────────────────────────────────────────────────
+
+#[test]
+fn int_arithmetic() {
+    expect_out(&main_print(r#"  println("${1 + 2 * 3}")"#), "7\n");
+    expect_out(&main_print(r#"  println("${10 - 4}")"#), "6\n");
+    expect_out(&main_print(r#"  println("${20 / 5}")"#), "4\n");
+    expect_out(&main_print(r#"  println("${17 % 5}")"#), "2\n");
+}
+
+#[test]
+fn int_div_by_zero_aborts() {
+    let (exit, _stdout, stderr) = run(&main_print(
+        "  let z = 0\n  println(\"${10 / z}\")",
+    ));
+    assert_eq!(exit, 1, "div-by-zero must abort with exit 1");
+    assert!(
+        stderr.contains("division by zero"),
+        "stderr should carry the native message, got <{}>",
+        stderr
+    );
+}
+
+#[test]
+fn int_mod_by_zero_aborts() {
+    let (exit, _stdout, stderr) = run(&main_print(
+        "  let z = 0\n  println(\"${10 % z}\")",
+    ));
+    assert_eq!(exit, 1);
+    assert!(stderr.contains("division by zero"), "got <{}>", stderr);
+}
+
+#[test]
+fn float_arithmetic_inheritance() {
+    // The known float divergence lives in `{}` Display; the interp inherits
+    // native's shortest-roundtrip.
+    expect_out(&main_print(r#"  println("${0.1 + 0.2}")"#), "0.30000000000000004\n");
+}
+
+#[test]
+fn unary_negation_and_not() {
+    expect_out(&main_print(r#"  println("${-5}")"#), "-5\n");
+    expect_out(&main_print(r#"  let b = true
+  println("${not b}")"#), "false\n");
+}
+
+// ── Strings ─────────────────────────────────────────────────────
+
+#[test]
+fn string_concat_and_bridge() {
+    expect_out(&main_print(r#"  println("a" + "b")"#), "ab\n");
+    expect_out(&main_print(r#"  println(string.trim("  hi  "))"#), "hi\n");
+    expect_out(&main_print(r#"  println(string.to_upper("abc"))"#), "ABC\n");
+    expect_out(&main_print(r#"  println("${string.len("hello")}")"#), "5\n");
+}
+
+#[test]
+fn string_interp_compound_repr() {
+    // The load-bearing display contract for this branch: a List/Map/Tuple/etc.
+    // in a string-interp part renders via `almide_repr`.
+    expect_out(&main_print(r#"  let xs = [1, 2, 3]
+  println("${xs}")"#), "[1, 2, 3]\n");
+    expect_out(&main_print(r#"  let t = (1, "two", true)
+  println("${t}")"#), "(1, \"two\", true)\n");
+    expect_out(&main_print(r#"  let o = some(5)
+  println("${o}")"#), "some(5)\n");
+    expect_out(&main_print(r#"  let n: Option[Int] = none
+  println("${n}")"#), "none\n");
+    expect_out(&main_print(r#"  let nested = [[1], [2, 3]]
+  println("${nested}")"#), "[[1], [2, 3]]\n");
+}
+
+#[test]
+fn string_interp_string_in_container_is_quoted() {
+    // A bare String stays raw; a String inside a container is quoted+escaped.
+    expect_out(&main_print(r#"  let s = "hi"
+  println("${s}")"#), "hi\n");
+    expect_out(&main_print(r#"  let xs = ["a", "b"]
+  println("${xs}")"#), "[\"a\", \"b\"]\n");
+}
+
+// ── Lists / Maps / Sets ─────────────────────────────────────────
+
+#[test]
+fn list_ops() {
+    expect_out(&main_print(r#"  let xs = [1, 2, 3]
+  println("${list.len(xs)}")"#), "3\n");
+    expect_out(&main_print(r#"  let xs = [3, 1, 2]
+  println("${list.sort(xs)}")"#), "[1, 2, 3]\n");
+    expect_out(&main_print(r#"  let xs = [1, 2, 3]
+  println("${list.reverse(xs)}")"#), "[3, 2, 1]\n");
+    expect_out(&main_print(r#"  let xs = [1, 2, 3]
+  println("${list.sum(xs)}")"#), "6\n");
+}
+
+#[test]
+fn list_index_oob_aborts() {
+    let (exit, _o, stderr) = run(&main_print(
+        "  let xs = [1, 2]\n  println(\"${xs[5]}\")",
+    ));
+    assert_eq!(exit, 1, "OOB index must abort");
+    assert!(stderr.contains("index out of bounds"), "got <{}>", stderr);
+}
+
+#[test]
+fn map_literal_and_access() {
+    expect_out(&main_print(r#"  let m = ["a": 1, "b": 2]
+  println("${m}")"#), "[\"a\": 1, \"b\": 2]\n");
+    expect_out(&main_print(r#"  let m: Map[String, Int] = [:]
+  println("${m}")"#), "[:]\n");
+}
+
+#[test]
+fn map_insertion_order_preserved() {
+    expect_out(&main_print(r#"  let m = ["z": 1, "a": 2, "m": 3]
+  println("${m}")"#), "[\"z\": 1, \"a\": 2, \"m\": 3]\n");
+}
+
+// ── Records / Variants ──────────────────────────────────────────
+
+#[test]
+fn record_construct_and_display() {
+    let src = r#"
+type Point = { x: Int, y: Int }
+fn main() -> Unit = {
+  let p = Point { x: 1, y: 2 }
+  println("${p}")
+}"#;
+    expect_out(src, "Point { x: 1, y: 2 }\n");
+}
+
+#[test]
+fn record_field_access() {
+    let src = r#"
+type Point = { x: Int, y: Int }
+fn main() -> Unit = {
+  let p = Point { x: 10, y: 20 }
+  println("${p.x}")
+  println("${p.y}")
+}"#;
+    expect_out(src, "10\n20\n");
+}
+
+#[test]
+fn variant_construct_and_display() {
+    let src = r#"
+type Shape =
+  | Circle(Int)
+  | Named { label: String }
+  | Dot
+fn main() -> Unit = {
+  let c = Circle(3)
+  let nm = Named { label: "hi" }
+  let d = Dot
+  println("${c}")
+  println("${nm}")
+  println("${d}")
+}"#;
+    expect_out(src, "Circle(3)\nNamed { label: \"hi\" }\nDot\n");
+}
+
+#[test]
+fn variant_pattern_match() {
+    let src = r#"
+type Shape =
+  | Circle(Int)
+  | Dot
+fn area(s: Shape) -> Int =
+  match s {
+    Circle(r) => r * r,
+    Dot => 0,
+  }
+fn main() -> Unit = {
+  println("${area(Circle(4))}")
+  println("${area(Dot)}")
+}"#;
+    expect_out(src, "16\n0\n");
+}
+
+#[test]
+fn record_pattern_destructure() {
+    // Shorthand `{ x, y }` binds each field via lowered Bind sub-patterns.
+    let src = r#"
+type P = { x: Int, y: Int }
+fn f(p: P) -> Int =
+  match p {
+    P { x, y } => x + y,
+  }
+fn main() -> Unit = {
+  println("${f(P { x: 3, y: 4 })}")
+}"#;
+    expect_out(src, "7\n");
+}
+
+#[test]
+fn list_pattern_match() {
+    // List patterns survive to the interp (ListPatternLowering is post-cut),
+    // so the interp matches them itself.
+    let src = r#"
+fn describe(xs: List[Int]) -> String =
+  match xs {
+    [] => "empty",
+    [a] => "one ${a}",
+    [a, b] => "two ${a} ${b}",
+    _ => "many",
+  }
+fn main() -> Unit = {
+  let e: List[Int] = []
+  println(describe(e))
+  println(describe([9]))
+  println(describe([1, 2]))
+  println(describe([1, 2, 3]))
+}"#;
+    expect_out(src, "empty\none 9\ntwo 1 2\nmany\n");
+}
+
+// ── Closures: capture + HOF ─────────────────────────────────────
+
+#[test]
+fn closure_capture() {
+    let src = r#"
+fn main() -> Unit = {
+  let base = 10
+  let add = (x: Int) => x + base
+  println("${add(5)}")
+}"#;
+    expect_out(src, "15\n");
+}
+
+#[test]
+fn hof_list_map() {
+    let src = r#"
+fn main() -> Unit = {
+  let xs = [1, 2, 3]
+  let ys = xs |> list.map((n) => n + 1)
+  println("${ys}")
+}"#;
+    expect_out(src, "[2, 3, 4]\n");
+}
+
+#[test]
+fn hof_list_filter_and_fold() {
+    let src = r#"
+fn main() -> Unit = {
+  let xs = [1, 2, 3, 4, 5]
+  let evens = xs |> list.filter((n) => n % 2 == 0)
+  println("${evens}")
+  let total = list.fold(xs, 0, (acc, n) => acc + n)
+  println("${total}")
+}"#;
+    expect_out(src, "[2, 4]\n15\n");
+}
+
+#[test]
+fn hof_find_and_any_all() {
+    let src = r#"
+fn main() -> Unit = {
+  let xs = [1, 2, 3]
+  println("${list.find(xs, (n) => n > 1)}")
+  println("${list.any(xs, (n) => n > 2)}")
+  println("${list.all(xs, (n) => n > 0)}")
+}"#;
+    expect_out(src, "some(2)\ntrue\ntrue\n");
+}
+
+#[test]
+fn hof_capturing_closure_in_map() {
+    let src = r#"
+fn main() -> Unit = {
+  let factor = 3
+  let xs = [1, 2, 3]
+  let scaled = xs |> list.map((n) => n * factor)
+  println("${scaled}")
+}"#;
+    expect_out(src, "[3, 6, 9]\n");
+}
+
+// ── Match ───────────────────────────────────────────────────────
+
+#[test]
+fn match_literal_and_wildcard() {
+    let src = r#"
+fn classify(n: Int) -> String =
+  match n {
+    0 => "zero",
+    1 => "one",
+    _ => "many",
+  }
+fn main() -> Unit = {
+  println(classify(0))
+  println(classify(1))
+  println(classify(99))
+}"#;
+    expect_out(src, "zero\none\nmany\n");
+}
+
+#[test]
+fn match_option_and_guard() {
+    let src = r#"
+fn describe(o: Option[Int]) -> String =
+  match o {
+    some(n) if n > 10 => "big",
+    some(n) => "small",
+    none => "nothing",
+  }
+fn main() -> Unit = {
+  println(describe(some(50)))
+  println(describe(some(5)))
+  println(describe(none))
+}"#;
+    expect_out(src, "big\nsmall\nnothing\n");
+}
+
+#[test]
+fn match_tuple_destructure() {
+    let src = r#"
+fn main() -> Unit = {
+  let p = (1, 2)
+  let r = match p {
+    (0, _) => "x-zero",
+    (a, b) => "${a}-${b}",
+  }
+  println(r)
+}"#;
+    expect_out(src, "1-2\n");
+}
+
+// ── Recursion ───────────────────────────────────────────────────
+
+#[test]
+fn recursion_factorial() {
+    let src = r#"
+fn fact(n: Int) -> Int =
+  if n <= 1 then 1 else n * fact(n - 1)
+fn main() -> Unit = {
+  println("${fact(5)}")
+}"#;
+    expect_out(src, "120\n");
+}
+
+#[test]
+fn recursion_fib() {
+    let src = r#"
+fn fib(n: Int) -> Int =
+  if n < 2 then n else fib(n - 1) + fib(n - 2)
+fn main() -> Unit = {
+  println("${fib(10)}")
+}"#;
+    expect_out(src, "55\n");
+}
+
+// ── for / while ─────────────────────────────────────────────────
+
+#[test]
+fn for_in_range_accumulate() {
+    let src = r#"
+fn main() -> Unit = {
+  var sum = 0
+  for i in [1, 2, 3, 4] {
+    sum = sum + i
+  }
+  println("${sum}")
+}"#;
+    expect_out(src, "10\n");
+}
+
+#[test]
+fn for_in_range_exclusive_and_inclusive() {
+    // `1..5` is exclusive (sum 1+2+3+4 = 10); `1..=3` materializes to
+    // [1, 2, 3] when displayed.
+    let src = r#"
+fn main() -> Unit = {
+  var sum = 0
+  for i in 1..5 {
+    sum = sum + i
+  }
+  println("${sum}")
+  let r = 1..=3
+  println("${r}")
+}"#;
+    expect_out(src, "10\n[1, 2, 3]\n");
+}
+
+#[test]
+fn while_loop() {
+    let src = r#"
+fn main() -> Unit = {
+  var i = 0
+  var acc = 0
+  while i < 5 {
+    acc = acc + i
+    i = i + 1
+  }
+  println("${acc}")
+}"#;
+    expect_out(src, "10\n");
+}
+
+#[test]
+fn for_in_break_continue() {
+    let src = r#"
+fn main() -> Unit = {
+  var sum = 0
+  for i in [1, 2, 3, 4, 5, 6] {
+    if i == 5 then { break } else { () }
+    if i % 2 == 0 then { continue } else { () }
+    sum = sum + i
+  }
+  println("${sum}")
+}"#;
+    // odds below 5: 1 + 3 = 4
+    expect_out(src, "4\n");
+}
+
+// ── Result / Option propagation ─────────────────────────────────
+
+#[test]
+fn option_unwrap_or() {
+    let src = r#"
+fn main() -> Unit = {
+  let a: Option[Int] = some(7)
+  let b: Option[Int] = none
+  println("${a ?? 0}")
+  println("${b ?? 99}")
+}"#;
+    expect_out(src, "7\n99\n");
+}
+
+#[test]
+fn unwrap_ok_continues_in_effect_main() {
+    // `!` (Unwrap) on an Ok value continues; the program prints normally.
+    let src = r#"
+effect fn main() -> Unit = {
+  let x = int.parse("41")!
+  println("${x + 1}")
+}"#;
+    expect_out(src, "42\n");
+}
+
+#[test]
+fn unwrap_err_aborts_with_inner_error() {
+    // `!` (Unwrap) on an Err short-circuits; reaching `main` unhandled, the
+    // program terminates with `Error: <inner>` and exit 1 — the
+    // unhandled-main-error termination contract.
+    let src = r#"
+effect fn main() -> Unit = {
+  let x = int.parse("nope")!
+  println("${x}")
+}"#;
+    let (exit, stdout, stderr) = run(src);
+    assert_eq!(exit, 1, "stdout=<{}> stderr=<{}>", stdout, stderr);
+    assert!(stderr.starts_with("Error:"), "got <{}>", stderr);
+    assert!(stdout.is_empty(), "no output should precede the abort, got <{}>", stdout);
+}
+
+// ── Fuel ────────────────────────────────────────────────────────
+
+#[test]
+fn fuel_exhaustion_is_clean() {
+    // An unbounded loop must terminate as FuelExhausted, not hang/panic.
+    let src = r#"
+fn main() -> Unit = {
+  var i = 0
+  while true {
+    i = i + 1
+  }
+}"#;
+    let ir = lower(src);
+    let out = Interpreter::new(&ir).with_fuel(10_000).run_main();
+    assert_eq!(out.status, RunStatus::FuelExhausted);
+}
+
+// ── Unhandled abort termination contract ────────────────────────
+
+#[test]
+fn panic_terminates_with_error_line() {
+    let src = r#"
+fn main() -> Unit = {
+  panic("kaboom")
+}"#;
+    let (exit, _o, stderr) = run(src);
+    assert_eq!(exit, 1);
+    assert!(stderr.contains("Error: kaboom"), "got <{}>", stderr);
+}
+
+#[test]
+fn assert_eq_pass_and_fail() {
+    expect_out(&main_print(r#"  assert_eq(1 + 1, 2)
+  println("ok")"#), "ok\n");
+
+    let (exit, _o, stderr) = run(&main_print("  assert_eq(1, 2)"));
+    assert_eq!(exit, 1);
+    assert!(stderr.contains("Error:"), "got <{}>", stderr);
+}
+
+// ── Spread record ───────────────────────────────────────────────
+
+#[test]
+fn spread_record_override() {
+    let src = r#"
+type Cfg = { a: Int, b: Int, c: Int }
+fn main() -> Unit = {
+  let base = Cfg { a: 1, b: 2, c: 3 }
+  let updated = { ...base, b: 20 }
+  println("${updated}")
+}"#;
+    expect_out(src, "Cfg { a: 1, b: 20, c: 3 }\n");
+}
+
+// ── Top-level let visibility (known gap probe) ──────────────────
+
+#[test]
+fn top_level_let_referenced_from_fn() {
+    let src = r#"
+let BASE: Int = 100
+fn bump(x: Int) -> Int = x + BASE
+fn main() -> Unit = {
+  println("${bump(5)}")
+}"#;
+    // Documents current behavior. If top-lets aren't threaded into nested-call
+    // scopes this will surface as an unbound-variable abort.
+    let (exit, stdout, stderr) = run(src);
+    eprintln!("exit={} stdout=<{}> stderr=<{}>", exit, stdout, stderr);
+    assert_eq!(exit, 0, "top-let not visible from fn: stderr=<{}>", stderr);
+    assert_eq!(stdout, "105\n");
+}
+
+// ── list.sort_by is KEY-EXTRACTION, not a comparator ─────────────
+//
+// The stdlib contract is `sort_by[A, B](xs, f: (A) -> B)`: `f` extracts a sort
+// KEY from each element and the list is STABLY sorted by the keys' natural
+// ordering (native `xs.sort_by_key(|x| f(x.clone()))`, `B: Ord`). These assert
+// the interp matches that — and the byte-identical native/wasm output probed in
+// /tmp/sort{i,f}.almd.
+
+#[test]
+fn sort_by_int_key_is_stable() {
+    // Int key with ties: stability must preserve input order among equal keys
+    // (native sort_by_key + wasm strict-`>` bubble sort both keep (3,"a") before
+    // (3,"c") and (1,"b") before (1,"d")).
+    let src = r#"
+fn main() -> Unit = {
+  let xs = [(3, "a"), (1, "b"), (3, "c"), (1, "d"), (2, "e")]
+  let sorted = list.sort_by(xs, (p) => p.0)
+  println("${sorted}")
+}"#;
+    expect_out(src, r#"[(1, "b"), (1, "d"), (2, "e"), (3, "a"), (3, "c")]
+"#);
+}
+
+#[test]
+fn sort_by_negative_int_key() {
+    // Negative keys order by signed `i64::cmp` (not unsigned), matching native.
+    let src = r#"
+fn main() -> Unit = {
+  let ns = [3, -1, 0, -5, 2]
+  println("${list.sort_by(ns, (n) => n)}")
+}"#;
+    expect_out(src, "[-5, -1, 0, 2, 3]\n");
+}
+
+#[test]
+fn sort_by_string_key() {
+    // String key: lexicographic `str::cmp`, stable on duplicates. Matches the
+    // native/wasm probe (["apple","apple","banana","cherry"]).
+    let src = r#"
+fn main() -> Unit = {
+  let ws = ["banana", "apple", "cherry", "apple"]
+  let sorted = list.sort_by(ws, (w) => w)
+  println("${sorted}")
+}"#;
+    expect_out(src, r#"["apple", "apple", "banana", "cherry"]
+"#);
+}
+
+#[test]
+fn sort_by_derived_string_len_key() {
+    // The canonical spec example (spec/lang/function_test.almd): sort by a
+    // DERIVED Int key (string length), stable on equal lengths.
+    let src = r#"
+fn main() -> Unit = {
+  let xs = ["bb", "a", "ccc", "dd"]
+  let sorted = list.sort_by(xs, (s) => string.len(s))
+  println("${sorted}")
+}"#;
+    // lengths 1, 2, 2, 3 → "a", then "bb"/"dd" (input order on the len-2 tie),
+    // then "ccc".
+    expect_out(src, r#"["a", "bb", "dd", "ccc"]
+"#);
+}
+
+#[test]
+fn sort_by_float_derived_key_is_stable() {
+    // A *Float key* is a compile error in both backends (`f64: !Ord`), so it can
+    // never reach the interp on a runnable program. But a key DERIVED to an Ord
+    // type FROM float elements is fine and common: here we sort float pairs by an
+    // Int key. This exercises the key-extraction path over Float-bearing elements
+    // and confirms ordering + stability without ever needing a Float key.
+    let src = r#"
+fn main() -> Unit = {
+  let pts = [(2, 3.5), (1, 9.9), (2, 1.1), (1, 0.0)]
+  let sorted = list.sort_by(pts, (p) => p.0)
+  println("${sorted}")
+}"#;
+    // Int key 1,1,2,2; ties keep input order → (1,9.9),(1,0.0),(2,3.5),(2,1.1).
+    expect_out(src, "[(1, 9.9), (1, 0), (2, 3.5), (2, 1.1)]\n");
+}
+
+#[test]
+fn sort_by_empty_list() {
+    let src = r#"
+fn main() -> Unit = {
+  let xs: List[Int] = []
+  println("${list.sort_by(xs, (n) => n)}")
+}"#;
+    expect_out(src, "[]\n");
+}
+
+// ── fan block materializes a TUPLE (both backends), not a list ───
+//
+// `fan { a; b; c }` (the block form) lowers to `IrExprKind::Fan` and BOTH
+// backends materialize a tuple of the (auto-`?`-unwrapped) results: native
+// `(j0, j1, j2)`, wasm a packed tuple. A single-expr fan is the bare value (no
+// 1-tuple). Probed byte-identical native/wasm in /tmp/fan{1,2}.almd.
+
+#[test]
+fn fan_block_yields_tuple_destructurable() {
+    let src = r#"
+effect fn double(x: Int) -> Int = x * 2
+effect fn main() -> Unit = {
+  let r = fan {
+    double(1)
+    double(2)
+    double(3)
+  }
+  let (a, b, c) = r
+  println("${a} ${b} ${c}")
+  println("${r}")
+}"#;
+    // Destructure proves it is a 3-tuple; the repr line proves the display form
+    // `(2, 4, 6)` (a list would render `[2, 4, 6]`).
+    expect_out(src, "2 4 6\n(2, 4, 6)\n");
+}
+
+#[test]
+fn fan_block_single_expr_is_bare_value() {
+    // Exactly one expr: the result is the bare value, NOT a 1-tuple — matching
+    // both backends' single-expr fan path.
+    let src = r#"
+effect fn double(x: Int) -> Int = x * 2
+effect fn main() -> Unit = {
+  let r = fan {
+    double(5)
+  }
+  println("${r}")
+}"#;
+    expect_out(src, "10\n");
+}
+
+// ── Recursion depth bound is HOST-STACK-INDEPENDENT ──────────────
+
+#[test]
+fn deep_recursion_hits_depth_guard_cleanly() {
+    // `sum_to(5000)` nests 5000 interp call frames — past MAX_DEPTH (4000). The
+    // evaluator runs on a dedicated big-stack thread, so this terminates as a
+    // CLEAN `FuelExhausted` (the depth guard) rather than overflowing the native
+    // stack of the default cargo-test worker thread (~2 MiB) and aborting the
+    // whole process. This test is itself driven from that default-stack worker,
+    // so it is the real regression scenario.
+    let src = r#"
+fn sum_to(n: Int) -> Int =
+  if n <= 0 then 0 else n + sum_to(n - 1)
+fn main() -> Unit = {
+  println("${sum_to(5000)}")
+}"#;
+    let ir = lower(src);
+    let out = Interpreter::new(&ir).run_main();
+    assert_eq!(
+        out.status,
+        RunStatus::FuelExhausted,
+        "deep recursion must trip the depth guard cleanly, not overflow; got {:?}",
+        out.status
+    );
+}
+
+#[test]
+fn moderate_recursion_completes_under_depth_guard() {
+    // A recursion depth WELL under MAX_DEPTH must complete normally on the
+    // big-stack worker — proving the guard does not fire early and the dedicated
+    // thread carries the depth a 2 MiB host stack could not (sum_to(3000) blows
+    // a 2 MiB native stack but is fine on the interp's worker).
+    let src = r#"
+fn sum_to(n: Int) -> Int =
+  if n <= 0 then 0 else n + sum_to(n - 1)
+fn main() -> Unit = {
+  println("${sum_to(3000)}")
+}"#;
+    // 3000 * 3001 / 2 = 4_501_500
+    expect_out(src, "4501500\n");
+}

--- a/crates/almide-interp/tests/interp_cross_target_test.rs
+++ b/crates/almide-interp/tests/interp_cross_target_test.rs
@@ -1,0 +1,390 @@
+//! The 3-way cross-target oracle.
+//!
+//! `spec/wasm_cross/*.almd` is the cross-target observable-equivalence corpus:
+//! every program must produce a byte-identical `(stdout, stderr, exit)` on the
+//! native (Rust) and WASM backends. That 2-way vote — gated by
+//! `tests/wasm_runtime_test.rs::wasm_cross_target_spec` — is structurally blind
+//! to a *both-wrong-the-same-way* bug: if codegen and the WASM emitter share a
+//! lowering pass that is wrong, both agree and the gate stays green while the
+//! observed behaviour is wrong.
+//!
+//! This test adds the interpreter as a third, independent judge. The interp
+//! runs the IR at the pre-codegen cut point (`lower → optimize → mono →
+//! ir_link`), so it shares *none* of `almide-codegen`'s target-lowering passes
+//! with either backend. When all three agree, the result is corroborated by an
+//! executable spec that cannot share a codegen bug with the backends. When the
+//! interp disagrees with a native==wasm consensus, exactly one of two things is
+//! true and the test says which:
+//!
+//!   (a) the interpreter is wrong  → fix the interpreter, or
+//!   (b) the interpreter is right  → we just found a both-backends-wrong bug
+//!       that the 2-way gate is blind to. This is the entire point of the
+//!       third judge, so it is REPORTED LOUDLY (the test fails with a
+//!       `BOTH-BACKENDS-WRONG` banner).
+//!
+//! Skips are data-driven, never silent. A fixture is skipped only when the
+//! interpreter itself reports it cannot run that program — either it fails to
+//! lower at the interp's lightweight cut point (no stdlib bodies / unresolved
+//! `import json|regex|…`), or evaluation reaches an out-of-interp-scope
+//! capability (`RunStatus::Unsupported`) or the fuel budget
+//! (`RunStatus::FuelExhausted`). Every skip is logged with its concrete reason
+//! and the skip count is printed; there is no hardcoded skip-list to drift out
+//! of date.
+//!
+//! Requires the workspace `almide` binary (built `--release`) for the native /
+//! WASM legs and `wasmtime` for the WASM run. If either is absent the test
+//! self-skips cleanly (matching the existing wasm_runtime harness behaviour),
+//! so it never spuriously fails a machine without the toolchain.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use almide_frontend::canonicalize;
+use almide_frontend::check::Checker;
+use almide_frontend::ir_link;
+use almide_frontend::lower::lower_program;
+use almide_interp::{Interpreter, RunStatus};
+use almide_lang::lexer::Lexer;
+use almide_lang::parser::Parser;
+use almide_optimize::{mono, optimize};
+
+// ── Toolchain location (mirrors tests/wasm_runtime_test.rs::almide_bin) ──
+
+/// Path to the `almide` binary used for the native + WASM legs.
+/// Order: `ALMIDE_BIN` env → workspace `target/release/almide` → `almide` on PATH.
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    // CARGO_MANIFEST_DIR here is crates/almide-interp; the workspace target dir
+    // is two levels up.
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn spec_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../spec/wasm_cross")
+}
+
+// ── Leg 1: native backend (compile to a binary, then run it) ──
+// Identical shape to wasm_runtime_test.rs::run_native_capture: build to a binary
+// FIRST (compiler diagnostics discarded), then run it, so the captured stderr is
+// the PROGRAM's runtime stderr — not the compiler's warnings — matching the wasm
+// path (build then wasmtime). `almide run` would mix compile-time warnings into
+// stderr and spuriously diverge.
+fn run_native_capture(source: &str) -> (i32, String, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let src_path = dir.path().join("test.almd");
+    let bin_path = dir.path().join("test_native_bin");
+    std::fs::write(&src_path, source).unwrap();
+    let build = Command::new(almide_bin())
+        // ISOLATE the native build scratch dir. `almide build` (native) compiles
+        // generated Rust inside `std::env::temp_dir().join("almide-build")` — a
+        // SHARED dir guarded only by a cross-process flock held through
+        // build+copy. When other test processes (e.g. the 2-way
+        // `wasm_cross_target_spec` gate) run `almide build` in parallel, the
+        // shared `src/main.rs`+`target/` can get cross-contaminated and a fixture
+        // spuriously fails to compile with another fixture's types (observed:
+        // `inff64`, `Box<Tree>` leaking across fixtures). Pointing `TMPDIR` at a
+        // unique per-invocation dir gives this build its own scratch, removing
+        // the race so the third judge is deterministic.
+        .env("TMPDIR", dir.path())
+        .args(["build", src_path.to_str().unwrap(), "-o", bin_path.to_str().unwrap()])
+        .output()
+        .expect("failed to build native");
+    if !build.status.success() {
+        return (
+            build.status.code().unwrap_or(-1),
+            String::new(),
+            String::from_utf8_lossy(&build.stderr).trim().to_string(),
+        );
+    }
+    let out = Command::new(&bin_path).output().expect("failed to run native binary");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        String::from_utf8_lossy(&out.stderr).trim().to_string(),
+    )
+}
+
+// ── Leg 2: WASM backend (compile to wasm, run via wasmtime) ──
+// `None` if wasmtime is unavailable (the whole gate then self-skips). Mirrors
+// wasm_runtime_test.rs::run_wasm_capture.
+fn run_wasm_capture(source: &str) -> Option<(i32, String, String)> {
+    let dir = tempfile::tempdir().unwrap();
+    let src_path = dir.path().join("test.almd");
+    let wasm_path = dir.path().join("test.wasm");
+    std::fs::write(&src_path, source).unwrap();
+    let build = Command::new(almide_bin())
+        // Isolate scratch (see run_native_capture). The wasm path uses bare
+        // rustc into the output dir, but pinning TMPDIR keeps any incidental
+        // temp use off the shared dir too.
+        .env("TMPDIR", dir.path())
+        .args(["build", src_path.to_str().unwrap(), "--target", "wasm", "-o", wasm_path.to_str().unwrap()])
+        .output()
+        .expect("failed to build wasm");
+    assert!(
+        build.status.success(),
+        "wasm build failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    match Command::new("wasmtime")
+        .arg("--dir=/")
+        .arg(wasm_path.to_str().unwrap())
+        .output()
+    {
+        Ok(o) if o.status.code() != Some(127) => Some((
+            o.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&o.stdout).trim().to_string(),
+            String::from_utf8_lossy(&o.stderr).trim().to_string(),
+        )),
+        _ => None,
+    }
+}
+
+// ── Leg 3: the interpreter (in-process, no codegen) ──
+
+/// The interp leg's outcome. Either an observable `(exit, stdout, stderr)`
+/// 3-tuple to vote with, or a `Skip(reason)` meaning the interpreter cannot run
+/// this fixture — NOT a divergence.
+enum InterpLeg {
+    Ran(i32, String, String),
+    Skip(String),
+}
+
+/// Lower `source` to a linked `IrProgram` at the interpreter's cut point
+/// (`lower → optimize → mono → ir_link`) with NO stdlib bodies loaded — the same
+/// lightweight `canonicalize(.., iter::empty())` recipe the interp's eval_test
+/// uses. Returns `Err(reason)` (rather than panicking) when the program does not
+/// parse / typecheck at this cut point, so the harness can record it as a clean,
+/// reasoned skip (e.g. `import json` is unresolved without the json module
+/// source). All of parse / check / lower run under `catch_unwind` so an internal
+/// `assert`/`unwrap` in the frontend on an out-of-scope construct degrades to a
+/// skip instead of crashing the whole gate.
+fn lower_for_interp(source: &str) -> Result<almide_ir::IrProgram, String> {
+    let src = source.to_string();
+    let result = std::panic::catch_unwind(move || {
+        let tokens = Lexer::tokenize(&src);
+        let mut parser = Parser::new(tokens);
+        let mut prog = match parser.parse() {
+            Ok(p) => p,
+            Err(e) => return Err(format!("parse error: {:?}", e)),
+        };
+        if !parser.errors.is_empty() {
+            return Err(format!("parse errors: {:?}", parser.errors));
+        }
+
+        let canon = canonicalize::canonicalize_program(&prog, std::iter::empty());
+        let mut checker = Checker::from_env(canon.env);
+        let diags = checker.infer_program(&mut prog);
+        let errors: Vec<_> = diags
+            .iter()
+            .filter(|d| d.level == almide_frontend::diagnostic::Level::Error)
+            .map(|d| d.message.clone())
+            .collect();
+        if !errors.is_empty() {
+            // The common case: an `import json|regex|…` fixture whose module
+            // source is not loaded by the empty-stdlib recipe. A reasoned skip,
+            // not a divergence.
+            return Err(format!("type errors at interp cut point: {:?}", errors));
+        }
+
+        let mut ir = lower_program(&prog, &checker.env, &checker.type_map);
+        optimize::optimize_program(&mut ir);
+        mono::monomorphize(&mut ir);
+        ir_link::ir_link(&mut ir);
+        Ok(ir)
+    });
+    match result {
+        Ok(r) => r,
+        Err(_) => Err("interp lowering panicked (out-of-scope construct)".to_string()),
+    }
+}
+
+/// Run the fixture through the interpreter. Maps the interpreter's own
+/// self-reported scope limits to a `Skip`; everything else is a real third vote.
+/// stdout/stderr are `.trim()`-ed to match the native/wasm legs' comparison.
+fn run_interp_capture(source: &str) -> InterpLeg {
+    let ir = match lower_for_interp(source) {
+        Ok(ir) => ir,
+        Err(reason) => return InterpLeg::Skip(reason),
+    };
+    // The interpreter is single-shot per program; catch a defensive panic so an
+    // evaluator bug surfaces as a loud skip rather than poisoning the gate.
+    let outcome = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        Interpreter::new(&ir).run_main()
+    })) {
+        Ok(o) => o,
+        Err(_) => return InterpLeg::Skip("interp evaluation panicked".to_string()),
+    };
+    match &outcome.status {
+        RunStatus::Ok | RunStatus::Aborted => InterpLeg::Ran(
+            outcome.exit_code(),
+            outcome.stdout.trim().to_string(),
+            outcome.stderr.trim().to_string(),
+        ),
+        RunStatus::Unsupported(what) => {
+            InterpLeg::Skip(format!("out-of-interp-scope capability: {what}"))
+        }
+        RunStatus::FuelExhausted => {
+            InterpLeg::Skip("interp fuel/recursion budget exhausted".to_string())
+        }
+    }
+}
+
+// ── The 3-way gate ──
+
+#[test]
+fn interp_cross_target_spec() {
+    // Self-skip on a toolchain without the binary or wasmtime (CI without
+    // `make install`, or a machine lacking wasmtime) — same posture as the
+    // existing wasm cross gate. The interp leg alone is meaningless without the
+    // two backend legs to judge against.
+    let bin = almide_bin();
+    if Command::new(&bin).arg("--version").output().is_err() {
+        eprintln!("interp_cross_target_spec: almide binary unavailable — skipping");
+        return;
+    }
+    if Command::new("wasmtime").arg("--version").output().is_err() {
+        eprintln!("interp_cross_target_spec: wasmtime unavailable — skipping");
+        return;
+    }
+
+    let dir = spec_dir();
+    if !dir.exists() {
+        eprintln!("interp_cross_target_spec: {} missing — skipping", dir.display());
+        return;
+    }
+
+    let mut entries: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map(|x| x == "almd").unwrap_or(false))
+        .collect();
+    entries.sort_by_key(|e| e.path());
+    if entries.is_empty() {
+        eprintln!("interp_cross_target_spec: corpus empty — skipping");
+        return;
+    }
+
+    let total = entries.len();
+    let mut agreed = 0usize; // interp == native == wasm
+    let mut skipped: Vec<(String, String)> = Vec::new(); // (fixture, reason)
+    // interp disagrees with a native==wasm consensus → a both-backends-wrong
+    // suspect (or an interp bug). The headline of this whole test.
+    let mut both_backends_wrong: Vec<String> = Vec::new();
+    // native != wasm: a 2-way divergence already owned by wasm_runtime_test's
+    // gate. We do NOT fail here (that would double-report and fight the
+    // @xt-allow ratchet); instead the interp casts a tie-breaking vote and we
+    // log which backend it corroborates, as a diagnostic aid for that gate.
+    let mut backend_split: Vec<String> = Vec::new();
+
+    for entry in &entries {
+        let path = entry.path();
+        let name = path.file_stem().unwrap().to_str().unwrap().to_string();
+        let source = std::fs::read_to_string(&path).unwrap();
+
+        let interp = run_interp_capture(&source);
+        let (ic, iout, ierr) = match interp {
+            InterpLeg::Ran(c, o, e) => (c, o, e),
+            InterpLeg::Skip(reason) => {
+                skipped.push((name, reason));
+                continue;
+            }
+        };
+
+        let (nc, nout, nerr) = run_native_capture(&source);
+        let wasm = match std::panic::catch_unwind(|| run_wasm_capture(&source)) {
+            Ok(Some(w)) => w,
+            Ok(None) => {
+                // wasmtime vanished mid-run; abandon the gate cleanly rather
+                // than half-reporting.
+                eprintln!("interp_cross_target_spec: wasmtime unavailable mid-run — skipping");
+                return;
+            }
+            Err(_) => {
+                // A WASM build/run panic is a backend bug, not an interp skip.
+                // Surface it as a backend split (native is the reference) so it
+                // is never swallowed.
+                backend_split.push(format!(
+                    "{name}: WASM build/run panicked; interp={ic}/{iout:?} native={nc}/{nout:?}"
+                ));
+                continue;
+            }
+        };
+        let (wc, wout, werr) = wasm;
+
+        let native_wasm_agree = nc == wc && nout == wout && nerr == werr;
+        let interp_matches_native = ic == nc && iout == nout && ierr == nerr;
+
+        if native_wasm_agree {
+            if interp_matches_native {
+                agreed += 1;
+            } else {
+                // The load-bearing case. Native and WASM agree, the interp — an
+                // independent spec sharing no codegen pass with them — disagrees.
+                // Either both backends are wrong the same way, or the interp is.
+                both_backends_wrong.push(format!(
+                    "{name}:\n  interp:  exit={ic} stdout={iout:?} stderr={ierr:?}\n  \
+                     native:  exit={nc} stdout={nout:?} stderr={nerr:?}\n  \
+                     wasm:    exit={wc} stdout={wout:?} stderr={werr:?}\n  \
+                     → native==wasm consensus, interp dissents. Diagnose: is the \
+                     interpreter wrong (fix it) or is this a BOTH-BACKENDS-WRONG bug?"
+                ));
+            }
+        } else {
+            // native != wasm: owned by wasm_runtime_test's @xt-allow gate. The
+            // interp breaks the tie; we report which backend it sides with.
+            let sides_with = if interp_matches_native {
+                "native"
+            } else if ic == wc && iout == wout && ierr == werr {
+                "wasm"
+            } else {
+                "neither"
+            };
+            backend_split.push(format!(
+                "{name}: native!=wasm (owned by wasm_cross gate); interp sides with {sides_with}\n  \
+                 interp:  exit={ic} stdout={iout:?} stderr={ierr:?}\n  \
+                 native:  exit={nc} stdout={nout:?} stderr={nerr:?}\n  \
+                 wasm:    exit={wc} stdout={wout:?} stderr={werr:?}"
+            ));
+        }
+    }
+
+    // ── Honest, loud reporting ──
+    eprintln!(
+        "\ninterp_cross_target_spec (3-way oracle): {total} fixtures | \
+         {agreed} interp==native==wasm | {} skipped | {} backend-split | {} interp-dissent",
+        skipped.len(),
+        backend_split.len(),
+        both_backends_wrong.len()
+    );
+    eprintln!("\n  Skips (interpreter self-reported out-of-scope — never silent):");
+    for (n, r) in &skipped {
+        eprintln!("    - {n}: {r}");
+    }
+    if !backend_split.is_empty() {
+        eprintln!("\n  Backend splits (native!=wasm; owned by wasm_cross gate, interp tie-break logged):");
+        for s in &backend_split {
+            eprintln!("    ~ {s}");
+        }
+    }
+
+    if !both_backends_wrong.is_empty() {
+        panic!(
+            "\n\n========================================================================\n\
+             BOTH-BACKENDS-WRONG SUSPECT(S): the interpreter (an independent spec\n\
+             sharing no codegen pass with either backend) dissents from a\n\
+             native==wasm consensus on {} fixture(s). The 2-way gate is blind to\n\
+             this. For EACH: decide is the interpreter wrong (fix it) or did we\n\
+             just find a bug both backends share (report + fix the backends)?\n\
+             ========================================================================\n\n{}\n",
+            both_backends_wrong.len(),
+            both_backends_wrong.join("\n\n")
+        );
+    }
+}


### PR DESCRIPTION
## What — the third judge

A new crate \`crates/almide-interp\`: a tree-walking **reference interpreter** over the typed IR at the pre-codegen cut point. It turns the 2-way native↔wasm vote into a **judged 3-way comparison** — when backends disagree, the interpreter localizes which one diverged; when they agree, it can catch both-wrong-the-same-way.

- Value model + evaluator for the full pure IR surface: total int arithmetic (div/mod abort with the exact native message + exit 1), floats (shortest-roundtrip via native semantics), collections (insertion order), records/variants, closures + ~25 in-interp HOFs, match incl. list patterns, \`??\`/\`!\`, compound interpolation **byte-identical to the literal-repr contract**
- Pure scalar bridge reproduces the runtime one-liners over Rust std (no \`almide_rt\` path-dep — it would drag rustls into the build); effects and unbridged modules report a clean \`Unsupported\`, never a wrong vote
- Robustness: fuel bound + a dedicated 256 MiB evaluator thread (measured ~48 KiB/frame; \`sum_to(1_000_000)\` returns clean \`FuelExhausted\` from a 2 MiB test thread)
- **Harness**: all spec/wasm_cross fixtures 3-way — **78 fixtures: 33 interp==native==wasm, 45 honest logged skips, 0 backend-splits, 0 interp-dissent**

## The verify loop caught 3 interpreter bugs before shipping

(a misjudging judge is worse than none): \`sort_by\` modeled as comparator instead of **key-extraction** (stability proven 3-way with duplicate keys), fan-block list instead of **tuple** (auto-\`?\` Err propagation verified 3-way), depth guard not protecting small host stacks. All fixed; eval_test 53/53.

## Validation

Both verdicts PASS; full ladder green; the 2-way gate untouched (78 equal / 0 divergence).