### PR TITLE
Hoist payload-nested string literal patterns into equality guards on native (C-036)

### DIFF
--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -36,6 +36,7 @@ pub mod pass_fan_lowering;
 pub mod pass_list_pattern;
 pub mod pass_match_lowering;
 pub mod pass_match_subject;
+pub mod pass_pattern_literal_guard;
 pub mod pass_result_erasure;
 pub mod pass_result_propagation;
 pub mod pass_intrinsic_lowering;

--- a/crates/almide-codegen/src/pass_match_subject.rs
+++ b/crates/almide-codegen/src/pass_match_subject.rs
@@ -2,11 +2,15 @@
 //!
 //! Target: Rust only.
 //!
-//! Rust's `match` on `String` requires `.as_str()` to match against `&str` literals.
-//! `Option<String>` requires `.as_deref()` to match `Some("literal")` patterns.
+//! Rust's `match` on `String` requires `&*s` (`.as_str()`) to match a top-level
+//! `&str` literal pattern: `match &*s { "good" => .. }`. This pass inserts the
+//! `Borrow { as_str: true }` IR node on such subjects so the walker never checks
+//! types.
 //!
-//! This pass inserts `Borrow { as_str: true }` or `Call { Method "as_deref" }` IR nodes
-//! on match subjects, so the walker never needs to check types.
+//! String literals nested INSIDE a payload (`some("x")`, `ok("x")`, `Word("x")`)
+//! cannot be reconciled by a subject deref — they are hoisted into `==` guards by
+//! `PatternLiteralGuardPass`, which runs earlier. This pass therefore only ever
+//! handles the top-level-String-subject case.
 //!
 //! Traversal goes through the canonical `IrMutVisitor`/`walk_expr_mut` (exhaustive,
 //! wildcard-free) rather than a hand-rolled `match expr.kind { …; _ => {} }`, so a
@@ -15,7 +19,7 @@
 
 use almide_ir::*;
 use almide_ir::visit_mut::{IrMutVisitor, walk_expr_mut};
-use almide_lang::types::{Ty, TypeConstructorId};
+use almide_lang::types::Ty;
 use super::pass::{NanoPass, PassResult, Target};
 
 #[derive(Debug)]
@@ -82,36 +86,13 @@ fn transform_match_subject(subject: &mut Box<IrExpr>, arms: &[IrMatchArm]) {
         }
     }
 
-    // Option<String> subject with Some("literal") patterns → wrap with method call .as_deref()
-    // Also trigger when inner type is Unknown/TypeVar — if patterns contain string literals,
-    // the subject is Option<String> even if not fully resolved at this point.
-    if let Ty::Applied(TypeConstructorId::Option, args) = &subject.ty {
-        let inner_is_string = args.len() == 1 && matches!(&args[0], Ty::String | Ty::Unknown | Ty::TypeVar(_));
-        if inner_is_string {
-            let has_some_str_pat = arms.iter().any(|a| {
-                if let IrPattern::Some { inner } = &a.pattern {
-                    matches!(inner.as_ref(), IrPattern::Literal { expr } if matches!(&expr.kind, IrExprKind::LitStr { .. }))
-                } else { false }
-            });
-            if has_some_str_pat {
-                let inner = std::mem::replace(
-                    subject.as_mut(),
-                    IrExpr { kind: IrExprKind::Unit, ty: Ty::Unit, span: None, def_id: None },
-                );
-                let deref_ty = Ty::Applied(TypeConstructorId::Option, vec![Ty::String]);
-                **subject = IrExpr {
-                    kind: IrExprKind::Call {
-                        target: CallTarget::Method {
-                            object: Box::new(inner),
-                            method: "as_deref".into(),
-                        },
-                        args: vec![],
-                        type_args: vec![],
-                    },
-                    ty: deref_ty,
-                    span: subject.span, def_id: None,
-                };
-            }
-        }
-    }
+    // A `Some("literal")` payload was previously reconciled here by wrapping the
+    // subject in `.as_deref()` (Option<String> -> Option<&str>). That path is now
+    // owned by `PatternLiteralGuardPass`, which runs FIRST and rewrites EVERY
+    // payload-nested string literal — `Some("x")` included — into `Some(__s) if
+    // __s == "x"`. So by the time MatchSubject runs, no `Some(Literal)` survives
+    // and a single mechanism handles string-literal payloads at any depth (see
+    // contract C-036). The top-level `String` subject above keeps its `&*s` deref:
+    // there is no payload to bind, and `match &*s { "good" => .. }` is the
+    // idiomatic Rust form.
 }

--- a/crates/almide-codegen/src/pass_pattern_literal_guard.rs
+++ b/crates/almide-codegen/src/pass_pattern_literal_guard.rs
@@ -1,0 +1,191 @@
+//! PatternLiteralGuard Nanopass: hoist payload-nested string literals into guards.
+//!
+//! Target: Rust only.
+//!
+//! A string literal that is the WHOLE match subject reconciles `&str`-vs-`String`
+//! by deref-ing the subject (`match &*s { "good" => .. }`, handled by
+//! `MatchSubjectPass`). But a string literal nested INSIDE a constructor payload —
+//! `ok("good")`, `err("bad")`, `Word("hi")`, `Pair("a", _)`, `some(some("x"))` —
+//! has no subject to deref: rustc sees a `&str` pattern against a `String` field
+//! and rejects with E0308. (`some("x")` on `Option<String>` was the one payload
+//! case `MatchSubjectPass` special-cased via `.as_deref()`; this pass subsumes it
+//! so there is ONE way a string literal matches a String, at any depth.)
+//!
+//! The fix mirrors what the wasm emitter already does (contract C-036): match the
+//! container tag structurally, then compare the inner value by `==`. Here we
+//! rewrite each payload-nested `Literal { LitStr }` into a fresh `Bind` and AND an
+//! equality condition (`__lit_N == "good"`) onto the arm's guard. A literal arm
+//! therefore still REFINES (guard-false falls through to later arms, exactly like
+//! the wasm tag+value check), so arm order and reachability are byte-identical
+//! native == wasm.
+//!
+//! Only String literals are hoisted: Int/Bool/Float literals are valid Rust
+//! patterns in payload position (`ok(0)`, `some(5)`, `Flag(true)`) and need no
+//! reconciliation. A top-level `Literal` arm (the whole pattern) is likewise left
+//! for `MatchSubjectPass` — this pass only descends INTO containers.
+//!
+//! Traversal goes through the canonical `IrMutVisitor`/`walk_expr_mut`, so a
+//! `Match` nested under any wrapper node is always reached (no silent subtree
+//! drop — see docs/roadmap/active/codegen-traversal-totality.md).
+
+use almide_ir::*;
+use almide_ir::visit_mut::{IrMutVisitor, walk_expr_mut};
+use almide_lang::types::Ty;
+use super::pass::{NanoPass, PassResult, Target};
+
+#[derive(Debug)]
+pub struct PatternLiteralGuardPass;
+
+impl NanoPass for PatternLiteralGuardPass {
+    fn name(&self) -> &str { "PatternLiteralGuard" }
+
+    fn targets(&self) -> Option<Vec<Target>> {
+        Some(vec![Target::Rust])
+    }
+
+    fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
+        let IrProgram { functions, top_lets, modules, var_table, .. } = &mut program;
+        let mut v = LiteralGuardVisitor { var_table, counter: 0 };
+        for func in functions.iter_mut() {
+            v.visit_expr_mut(&mut func.body);
+        }
+        for tl in top_lets.iter_mut() {
+            v.visit_expr_mut(&mut tl.value);
+        }
+        for module in modules.iter_mut() {
+            for func in module.functions.iter_mut() {
+                v.visit_expr_mut(&mut func.body);
+            }
+            for tl in module.top_lets.iter_mut() {
+                v.visit_expr_mut(&mut tl.value);
+            }
+        }
+        PassResult { program, changed: true }
+    }
+}
+
+struct LiteralGuardVisitor<'a> {
+    var_table: &'a mut VarTable,
+    counter: u32,
+}
+
+impl IrMutVisitor for LiteralGuardVisitor<'_> {
+    fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
+        // Post-order: rewrite nested matches in subjects/bodies/guards first.
+        walk_expr_mut(self, expr);
+        if let IrExprKind::Match { arms, .. } = &mut expr.kind {
+            for arm in arms.iter_mut() {
+                self.rewrite_arm(arm);
+            }
+        }
+    }
+}
+
+impl LiteralGuardVisitor<'_> {
+    /// Hoist every payload-nested string literal in `arm.pattern` into a fresh
+    /// binding + an equality condition, then fold all conditions (and any
+    /// pre-existing guard) into the arm's guard.
+    fn rewrite_arm(&mut self, arm: &mut IrMatchArm) {
+        let mut conds: Vec<IrExpr> = Vec::new();
+        // The arm pattern itself (depth 0) is NOT a payload position: a top-level
+        // `Literal` string is handled by MatchSubjectPass. Descend into its
+        // children only.
+        descend_children(&mut arm.pattern, &mut |child| {
+            self.hoist_str_literals(child, &mut conds);
+        });
+
+        if conds.is_empty() {
+            return;
+        }
+
+        // Fold conditions left-to-right with `&&`, then AND the original guard
+        // FIRST so an existing user guard short-circuits before the synthetic
+        // literal checks (preserves evaluation-order intent and matches the wasm
+        // tag→value→guard sequencing).
+        let mut acc = if let Some(g) = arm.guard.take() {
+            let mut it = conds.into_iter();
+            let first = it.next().expect("conds is non-empty");
+            let combined = it.fold(first, and_expr);
+            and_expr(g, combined)
+        } else {
+            let mut it = conds.into_iter();
+            let first = it.next().expect("conds is non-empty");
+            it.fold(first, and_expr)
+        };
+        // Normalize the accumulator type (defensive; and_expr already sets Bool).
+        acc.ty = Ty::Bool;
+        arm.guard = Some(acc);
+    }
+
+    /// If `pat` is a `Literal { LitStr }`, replace it with a fresh `Bind` and push
+    /// `Var == literal` onto `conds`. Otherwise recurse into its children. Int /
+    /// Bool / Float literals are left intact (valid Rust payload patterns).
+    fn hoist_str_literals(&mut self, pat: &mut IrPattern, conds: &mut Vec<IrExpr>) {
+        if let IrPattern::Literal { expr } = pat {
+            if matches!(&expr.kind, IrExprKind::LitStr { .. }) {
+                // A string literal pattern equals a `String` payload, so the
+                // bound var and the comparison both have type String.
+                let lit = std::mem::replace(expr, IrExpr::default());
+                let name = almide_base::intern::sym(&format!("__lit_guard_{}", self.counter));
+                self.counter += 1;
+                let var = self.var_table.alloc(name, Ty::String, Mutability::Let, None);
+                *pat = IrPattern::Bind { var, ty: Ty::String };
+                conds.push(eq_expr(
+                    IrExpr { kind: IrExprKind::Var { id: var }, ty: Ty::String, span: None, def_id: None },
+                    lit,
+                ));
+                return;
+            }
+        }
+        descend_children(pat, &mut |child| self.hoist_str_literals(child, conds));
+    }
+}
+
+/// Apply `f` to each immediate sub-pattern of `pat`. Total over `IrPattern` —
+/// a new container variant must be added here (mirrors `render_pattern`).
+fn descend_children(pat: &mut IrPattern, f: &mut dyn FnMut(&mut IrPattern)) {
+    match pat {
+        IrPattern::Some { inner } | IrPattern::Ok { inner } | IrPattern::Err { inner } => f(inner),
+        IrPattern::Constructor { args, .. } => args.iter_mut().for_each(|a| f(a)),
+        IrPattern::Tuple { elements } | IrPattern::List { elements } => {
+            elements.iter_mut().for_each(|e| f(e))
+        }
+        IrPattern::RecordPattern { fields, .. } => {
+            for fp in fields.iter_mut() {
+                if let Some(p) = fp.pattern.as_mut() {
+                    f(p);
+                }
+            }
+        }
+        IrPattern::Wildcard
+        | IrPattern::Bind { .. }
+        | IrPattern::Literal { .. }
+        | IrPattern::None => {}
+    }
+}
+
+fn eq_expr(left: IrExpr, right: IrExpr) -> IrExpr {
+    IrExpr {
+        kind: IrExprKind::BinOp {
+            op: BinOp::Eq,
+            left: Box::new(left),
+            right: Box::new(right),
+        },
+        ty: Ty::Bool,
+        span: None,
+        def_id: None,
+    }
+}
+
+fn and_expr(left: IrExpr, right: IrExpr) -> IrExpr {
+    IrExpr {
+        kind: IrExprKind::BinOp {
+            op: BinOp::And,
+            left: Box::new(left),
+            right: Box::new(right),
+        },
+        ty: Ty::Bool,
+        span: None,
+        def_id: None,
+    }
+}

--- a/crates/almide-codegen/src/target.rs
+++ b/crates/almide-codegen/src/target.rs
@@ -22,6 +22,7 @@ use super::pass_intrinsic_lowering::IntrinsicLoweringPass;
 use super::pass_normalize_runtime_calls::NormalizeRuntimeCallsPass;
 use super::pass_stdlib_lowering::StdlibLoweringPass;
 use super::pass_match_subject::MatchSubjectPass;
+use super::pass_pattern_literal_guard::PatternLiteralGuardPass;
 use super::pass_effect_inference::EffectInferencePass;
 use super::pass_tco::TailCallOptPass;
 use super::pass_licm::LICMPass;
@@ -96,6 +97,12 @@ fn build_pipeline(target: Target) -> Pipeline {
                 // about pre-rewrite information.
                 .add(LambdaTypeResolvePass)
                 .add(ConcretizeTypesPass)
+                // Hoist payload-nested string literals (`ok("x")`, `Word("hi")`)
+                // into Bind + `==` guards BEFORE MatchSubject so the as_deref /
+                // &* subject deref only ever sees top-level / already-handled
+                // literals — one reconciliation path per literal. Runs after
+                // ConcretizeTypes so the literal/payload type is resolved.
+                .add(PatternLiteralGuardPass)
                 // Verify all user-module calls resolve to known IrFunctions.
                 .add(ResolveCallsPass)
                 // BoxDeref: insert Deref IR nodes for Box'd pattern vars (before CloneInsertion)

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -63,7 +63,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-033 | [Value semantics for aliased mutables (copy-on-write)](C-033-cow-truth-table.md) | 0.24.0 | active | fixture | 1 |
 | C-034 | Out-of-range list ops clamp / no-op gracefully (no OOB heap access) | 0.24.0 | active | fixture | 6 |
 | C-035 | Effect-main errors terminate uniformly: Error: <msg> + exit 1 | 0.24.0 | active | fixture | 3 |
-| C-036 | Records, variants, and pattern matching are byte-identical | 0.24.0 | active | fixture | 5 |
+| C-036 | Records, variants, and pattern matching are byte-identical | 0.24.0 | active | fixture | 6 |
 | C-037 | bytes.read_f16_le decodes IEEE-754 half floats identically | 0.24.0 | active | fixture | 1 |
 | C-038 | Sized-integer literals narrow to the declared field width | 0.24.0 | active | fixture | 2 |
 | C-039 | Type-changing map.map / set.map yield a collection of the new type | 0.24.0 | active | fixture | 2 |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -474,7 +474,7 @@ evidence  = [
 [[contract]]
 id        = "C-036"
 title     = "Records, variants, and pattern matching are byte-identical"
-statement = "Record construction/field-access, variant construction (tuple/record/nullary payloads), and `match` over them — including matches whose arms construct a Result with `err(..)`, and a LITERAL nested inside a container constructor (`some(\"x\")`, `some(5)`, `ok(0)`, `err(404)`) — produce byte-identical results native == wasm. The inner-literal equality is now emitted on wasm (previously `some(\"x\")` matched ANY `some(_)` because only the non-null tag was checked, silently breaking every string/int-dispatching match). A match typed `Never` no longer appends a wasm `unreachable` epilogue (trap exit 134) while native runs fine."
+statement = "Record construction/field-access, variant construction (tuple/record/nullary payloads), and `match` over them — including matches whose arms construct a Result with `err(..)`, and a LITERAL nested inside a container constructor (`some(\"x\")`, `some(5)`, `ok(0)`, `err(404)`) — produce byte-identical results native == wasm. The inner-literal equality is emitted on BOTH targets: wasm structurally checks the tag then ANDs in a value compare (previously `some(\"x\")` matched ANY `some(_)` because only the non-null tag was checked); native hoists a payload-nested STRING literal into a `Bind` + `==` guard (`Ok(__s) if __s == \"good\"`) — previously `ok(\"good\")` emitted `Ok(\"good\")` against a `Result<String,String>` value and FAILED TO BUILD (rustc E0308 &str vs String), so these programs could not run cross-target at all. The hoist is the single mechanism for a string literal in any payload position at any depth (`ok(\"x\")`, `err(\"x\")`, `Word(\"x\")`, `KV(\"k\", n)`, `Pair(1, \"one\")`, `ok(some(\"x\")))`, `(\"a\", 1)`, and literal+guard combos); a literal arm refines, later binding arms stay reachable, byte-identical to the wasm tag→value→guard order. Int/Bool/Float payload literals remain bare Rust patterns. A match typed `Never` no longer appends a wasm `unreachable` epilogue (trap exit 134) while native runs fine."
 since     = "0.24.0"
 status    = "active"
 evidence  = [
@@ -483,6 +483,7 @@ evidence  = [
   { path = "spec/wasm_cross/closures_and_variants.almd", class = "fixture" },
   { path = "spec/wasm_cross/playground_default.almd", class = "fixture" },
   { path = "spec/wasm_cross/match_container_literal.almd", class = "fixture" },
+  { path = "spec/wasm_cross/match_payload_string_literal.almd", class = "fixture" },
 ]
 
 [[contract]]

--- a/spec/wasm_cross/match_container_literal.almd
+++ b/spec/wasm_cross/match_container_literal.almd
@@ -23,9 +23,9 @@ fn ci(c: Option[Int]) -> String = match c {
   none    => "N",
 }
 
-// Int literals in Ok / Err (native compiles Result-int-literal patterns; the
-// Result-STRING-literal pattern is a separate native walker limitation and is
-// intentionally not exercised here).
+// Int literals in Ok / Err. The Result-STRING-literal pattern (`ok("good")`)
+// that used to fail to build natively is now fixed and exercised in its own
+// fixture, match_payload_string_literal.almd.
 fn ck(r: Result[Int, Int]) -> String = match r {
   ok(0)    => "ZERO",
   ok(_)    => "OK",

--- a/spec/wasm_cross/match_payload_string_literal.almd
+++ b/spec/wasm_cross/match_payload_string_literal.almd
@@ -1,0 +1,83 @@
+// @contract: C-036
+// The NATIVE half of the inner-literal container-pattern promise. The wasm side
+// (match_container_literal.almd) already compared payload-nested literals via the
+// shared type-directed `==`; native FAILED TO BUILD for any String literal in a
+// payload position (`ok("good")` emitted `Ok("good")` where the value is
+// `Result<String, String>` — &str vs String, rustc E0308), so these programs
+// could not be exercised cross-target at all.
+//
+// Native now hoists every payload-nested string literal into a `Bind` + `==`
+// guard (`Ok(__s) if __s == "good"`), the same refinement the wasm tag+value
+// check performs: a literal arm refines, later binding arms stay reachable, and
+// arm order / fall-through is byte-identical native == wasm. Int / Bool / Float
+// literals stay bare Rust patterns (already legal in payload position).
+
+// ── Result[String, _] — the headline broken case ──────────────────
+fn classify(r: Result[String, String]) -> String = match r {
+  ok("good")  => "GOOD",
+  ok(_)       => "OK",
+  err("bad")  => "BAD",
+  err(_)      => "ERR",
+}
+
+// ── User variant, single String payload ───────────────────────────
+type Tok = Word(String) | Num(Int)
+fn tok(t: Tok) -> String = match t {
+  Word("hi") => "HI",
+  Word(_)    => "W",
+  Num(7)     => "SEVEN",
+  Num(_)     => "N",
+}
+
+// ── User variant, multiple fields, one is a String literal ────────
+type Ev = KV(String, Int) | Tag(String)
+fn ev(e: Ev) -> String = match e {
+  KV("count", n) => "C" + int.to_string(n),
+  KV(_, n)       => "K" + int.to_string(n),
+  Tag("hot")     => "HOT",
+  Tag(_)         => "T",
+}
+
+// ── Mixed int + string literal payloads in the same constructor ───
+type Rec = Pair(Int, String)
+fn rec(r: Rec) -> String = match r {
+  Pair(1, "one") => "1ONE",
+  Pair(1, _)     => "1X",
+  Pair(_, "one") => "XONE",
+  Pair(_, _)     => "XX",
+}
+
+// ── Nested: ok(some("x")) — literal two levels deep ───────────────
+fn nested(r: Result[Option[String], String]) -> String = match r {
+  ok(some("hi")) => "OKHI",
+  ok(some(_))    => "OKS",
+  ok(none)       => "OKN",
+  err(_)         => "E",
+}
+
+// ── Tuple subject with a String literal element ───────────────────
+fn tup(t: (String, Int)) -> String = match t {
+  ("a", 1) => "A1",
+  ("a", _) => "AX",
+  (_, _)   => "XX",
+}
+
+// ── A guard combined with a literal payload (guard ANDs in) ───────
+type W2 = Word2(String, Int)
+fn guarded(w: W2) -> String = match w {
+  Word2("hi", n) if n > 3 => "HIBIG",
+  Word2("hi", _)          => "HISMALL",
+  Word2(_, _)             => "OTHER",
+}
+
+fn main() -> Unit = {
+  println("result=" + classify(ok("good")) + "/" + classify(ok("x"))
+                    + "/" + classify(err("bad")) + "/" + classify(err("y")))
+  println("tok=" + tok(Word("hi")) + "/" + tok(Word("yo")) + "/" + tok(Num(7)) + "/" + tok(Num(2)))
+  println("ev=" + ev(KV("count", 5)) + "/" + ev(KV("other", 9)) + "/" + ev(Tag("hot")) + "/" + ev(Tag("cold")))
+  println("rec=" + rec(Pair(1, "one")) + "/" + rec(Pair(1, "z")) + "/" + rec(Pair(2, "one")) + "/" + rec(Pair(2, "z")))
+  println("nested=" + nested(ok(some("hi"))) + "/" + nested(ok(some("yo")))
+                    + "/" + nested(ok(none)) + "/" + nested(err("e")))
+  println("tup=" + tup(("a", 1)) + "/" + tup(("a", 2)) + "/" + tup(("b", 1)))
+  println("guard=" + guarded(Word2("hi", 5)) + "/" + guarded(Word2("hi", 1)) + "/" + guarded(Word2("yo", 9)))
+}


### PR DESCRIPTION
The native half of the constructor-pattern literal class — the wasm half landed in #401 under C-036. Before this, `ok("good")`/`err("bad")` on `Result[String,_]` and user-variant patterns like `Word("hi")` FAILED to compile natively (rustc E0308 &str vs String), so the cross-target gate could not even run these programs.

## Mechanism

New Rust-only nanopass **`PatternLiteralGuardPass`**: hoists every payload-nested string-literal pattern into a fresh binding + an `==` guard reusing the existing `almide_eq!` machinery —

```rust
Ok("good") => ...            // E0308: &str vs String
Ok(__lit_guard_0) if almide_eq!(__lit_guard_0, "good".to_string()) => ...  // emitted instead
```

- Same refinement semantics as the wasm emitter's tag→value→guard chain (#401): a literal arm refines, guard-false falls through, later binding arms stay reachable — byte-identical both targets
- Runs after `ConcretizeTypesPass`, before `MatchSubjectPass`; walker stays target-agnostic (no `if target` anywhere)
- Made `MatchSubjectPass`'s old `some("x")` → `.as_deref()` special case provably dead and removed it — **one mechanism for string-literal matching at any depth**
- Int/Bool/Float literals stay bare patterns (already legal Rust)
- Total `descend_children` over `IrPattern` (no wildcard) — passes the traversal-totality lint

## Contract ledger

**Extended C-036** (no new ID): the promise is identical to the wasm half already under C-036. New fixture `match_payload_string_literal.almd` — Result-String, single/multi-field variants, int+string mixed payloads, nested `ok(some("x"))`, tuple subjects, literal+guard combos. Evidence 5→6, links bidirectional, README regenerated.

## Verification

- Implement → 2 independent adversarial verifiers, **both PASS** — one swept a 22-repro pattern lattice via the real build+wasmtime path
- E014 interaction verified correct: duplicate-literal and binding-before-literal arms rejected identically on both targets at the frontend; literal-then-binding compiles and refines
- Full ladder: wasm_runtime 67/67 · snapshots 13/13 · codegen lib 100/100 · interp 3-way · spec 247/247 · contracts 53 (92/92 fixtures) · registry 134/134 grandfathered 0

## Follow-up queued (verifier discovery, pre-existing, out of scope)

`B(("k", n))` — tuple nested inside a constructor payload — diverges on wasm with or WITHOUT literals (isolated to the tuple-in-ctor destructure itself, not this pass). Next drain queue.