### PR TITLE
fix: build -o creates output dir; don't auto-? the Result arg of result/option fns

### DIFF
--- a/crates/almide-frontend/src/lower/auto_try.rs
+++ b/crates/almide-frontend/src/lower/auto_try.rs
@@ -236,10 +236,24 @@ fn insert_try(expr: IrExpr, in_match_subject: bool) -> IrExpr {
             op,
             operand: Box::new(insert_try(*operand, false)),
         },
-        IrExprKind::Call { target, args, type_args } => IrExprKind::Call {
-            target,
-            args: args.into_iter().map(|a| insert_try(a, false)).collect(),
-            type_args,
+        IrExprKind::Call { target, args, type_args } => {
+            // `result.*` / `option.*` functions consume their FIRST argument AS a
+            // Result/Option (UFCS: `r.unwrap_or(d)` == `result.unwrap_or(r, d)`).
+            // That arg must NOT be auto-?'d, exactly like the `??` (UnwrapOr) and
+            // match-subject exceptions — otherwise `result.unwrap_or(int.parse(s), d)`
+            // becomes `result.unwrap_or((int.parse(s))?, d)`, unwrapping the Result
+            // the callee needs (E0308 at build; passes check/test). The `true` flag
+            // suppresses only the top-level wrap of that arg, like a match subject.
+            let skip_first = matches!(&target,
+                CallTarget::Module { module, .. }
+                    if module.as_str() == "result" || module.as_str() == "option");
+            IrExprKind::Call {
+                target,
+                args: args.into_iter().enumerate()
+                    .map(|(i, a)| insert_try(a, skip_first && i == 0))
+                    .collect(),
+                type_args,
+            }
         },
         IrExprKind::Lambda { params, body, lambda_id } => IrExprKind::Lambda {
             params, body, lambda_id,

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -103,7 +103,15 @@ pub fn cmd_build(file: &str, output: Option<&str>, target: Option<&str>, release
         .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
     match super::cargo_build_generated_with_native(&rs_code, &project_dir, use_release, native_deps, source_root) {
         Ok(bin_path) => {
-            // Copy the built binary to the desired output location
+            // Copy the built binary to the desired output location. Create the
+            // output's parent directory first — `-o build/app` must not fail
+            // just because `build/` doesn't exist yet (it's the natural place
+            // to put a binary, and every caller otherwise needs a manual mkdir).
+            if let Some(parent) = std::path::Path::new(&output).parent() {
+                if !parent.as_os_str().is_empty() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+            }
             if let Err(e) = std::fs::copy(&bin_path, &output) {
                 eprintln!("Failed to copy binary to {}: {}", output, e);
                 std::process::exit(1);


### PR DESCRIPTION
Two independent papercuts that surface when building real multi-file programs
(both pass `almide check` / `almide test` but break `almide build`).

## 1. `almide build -o <dir>/<bin>` doesn't create the output directory

```
$ almide build src/main.almd -o build/app
Compile error: …                 # actually compiles fine
Failed to copy binary to build/app: No such file or directory (os error 2)
```

The compile succeeds; only the final copy fails because `build/` doesn't
exist. `-o <dir>/<bin>` is the natural way to place a binary, so every caller
otherwise needs a manual `mkdir -p`. Fix: create the output's parent dir
before copying (`src/cli/build.rs`).

## 2. auto-? unwraps the Result argument of `result.*` / `option.*` functions

The auto-? pass wraps every Result-typed call in a `Try`, including a call
passed as the **first argument** to a `result.*` / `option.*` function — which
consumes it *as* a Result (UFCS: `r.unwrap_or(d)` == `result.unwrap_or(r, d)`):

```almide
effect fn main() -> Unit = {
  let cap = result.unwrap_or(int.parse(env.get("CAP") ?? ""), 512)  // lowered to (int.parse(...))?
  ...
}
```

lowered to `result.unwrap_or((int.parse(...))?, 512)` — unwrapping the very
Result the callee needs → `error[E0308]: expected Result<i64,_>, found i64`
at `almide build` (passes check/test). It also bites effect-fn call sites
(typed `Result[T,String]`) consumed by `result.unwrap_or`, e.g.
`result.unwrap_or(run_once(), seq)`.

Fix: same shape as the existing `??` (UnwrapOr) and match-subject exceptions —
suppress the top-level auto-? on the first arg of `result.*` / `option.*`
calls (`crates/almide-frontend/src/lower/auto_try.rs`).

## Verification

- Repro (both patterns + `-o build/x` into a missing dir) builds and runs.
- Spec suite green with the patch: **stdlib 100 / lang 121 / integration 27**, 0 failures.

Found while building the Fizz component repos (multi-package CLIs) on v0.25.
