### PR TITLE
Finish the 0.26 fixes: soft-keyword field names, dead-code/CI gates, wasm parse-error failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,24 @@ jobs:
           ALMIDE_BIN: /tmp/almide-bin/almide
         run: cargo test
 
+      - name: Generated runtime registry matches committed sources (regenerate and diff)
+        # crates/almide-codegen/src/generated/{rust_runtime,runtime_fn_modes}.rs
+        # are committed, but build.rs regenerates them from runtime/rs/src by
+        # embedding each module's source TEXT. A draft edited in runtime/rs/src
+        # but not committed can be baked into the generated file and committed on
+        # its own, silently desyncing the two (this is exactly how the #419
+        # codepoint draft leaked). Force a fresh regen (touch the generator so
+        # cargo re-runs the build script) and fail on any diff — in CI only
+        # committed sources exist, so a leaked draft cannot reproduce. Mirrors the
+        # "Contract README up to date" regenerate-and-diff gate.
+        run: |
+          touch crates/almide-codegen/buildscript/runtime_registry.rs
+          cargo build -p almide-codegen
+          git diff --exit-code -- \
+            crates/almide-codegen/src/generated/rust_runtime.rs \
+            crates/almide-codegen/src/generated/runtime_fn_modes.rs \
+            || { echo "::error::generated runtime registry is stale — a runtime/rs/src edit was not committed, or a generated file was hand-edited. Rebuild almide-codegen and commit crates/almide-codegen/src/generated/*.rs"; exit 1; }
+
       - name: Almide spec tests (Rust target)
         run: |
           ALMIDE=/tmp/almide-bin/almide

--- a/crates/almide-codegen/src/pass_borrow_inference.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference.rs
@@ -159,22 +159,15 @@ pub fn infer_borrow_signatures(program: &mut IrProgram) -> HashMap<String, Vec<P
                     if !is_borrow_ref {
                         if let Some(b) = borrows.get_mut(idx) {
                             // A heap container an intrinsic mutates in place (Unit
-                            // return) must be taken by `&mut`. `List`/`String`/`Bytes`
-                            // are already Ref-family and promote cleanly; `Map`/`Set`
-                            // are mis-seeded `Own` by `intrinsic_borrow_mode_from_type_expr`,
-                            // so promote those too — else a `mut Map` user param that
-                            // forwards `&mut m` into `map.insert` can't borrow-check
-                            // (#436, E0596). Primitives are never these generics, so
-                            // they stay `Own`.
-                            let is_owned_map_or_set = matches!(b, ParamBorrow::Own)
-                                && matches!(
-                                    params.get(idx).map(|p| &p.ty),
-                                    Some(almide_lang::ast::TypeExpr::Generic { name, .. })
-                                        if matches!(name.as_str(), "Map" | "Set")
-                                );
-                            if matches!(b, ParamBorrow::Ref | ParamBorrow::RefSlice | ParamBorrow::RefStr)
-                                || is_owned_map_or_set
-                            {
+                            // return) is taken by `&mut`. Every heap container
+                            // reaches here already Ref-family:
+                            // `intrinsic_borrow_mode_from_type_expr` seeds
+                            // `List`→RefSlice, `String`→RefStr, and
+                            // `Bytes`/`Map`/`Set`/records→Ref — so promoting the
+                            // Ref family to RefMut covers them all. Primitives are
+                            // seeded `Own` and stay `Own` (never mutated in place
+                            // through a reference).
+                            if matches!(b, ParamBorrow::Ref | ParamBorrow::RefSlice | ParamBorrow::RefStr) {
                                 *b = ParamBorrow::RefMut;
                             }
                         }

--- a/crates/almide-syntax/src/parser/expressions.rs
+++ b/crates/almide-syntax/src/parser/expressions.rs
@@ -256,7 +256,7 @@ impl Parser {
                             while self.check(TokenType::Comma) {
                                 self.advance(); self.skip_newlines();
                                 if self.check(TokenType::RBrace) { break; }
-                                let fname = self.expect_ident()?;
+                                let fname = self.expect_any_name()?;
                                 self.expect(TokenType::Colon)?;
                                 self.skip_newlines();
                                 let fval = self.parse_expr()?;

--- a/crates/almide-syntax/src/parser/helpers.rs
+++ b/crates/almide-syntax/src/parser/helpers.rs
@@ -77,7 +77,10 @@ impl Parser {
         }
     }
 
-    /// Peek past optional newlines for `{ Ident :` pattern — named record.
+    /// Peek past optional newlines for `{ <name> :` — named record. `<name>` is
+    /// any token `expect_any_name` accepts (ident, TypeName, or a soft keyword),
+    /// so a `Foo { ok: … }` first field enters the record path instead of being
+    /// mis-read as a block. Also matches `{ ...spread }` and `{ }` (all-default).
     pub(crate) fn peek_named_record(&self) -> bool {
         let mut i = 0;
         while self.peek_at(i).map(|t| &t.token_type) == Some(&TokenType::Newline) { i += 1; }
@@ -85,8 +88,8 @@ impl Parser {
             && {
                 let mut j = i + 1;
                 while self.peek_at(j).map(|t| &t.token_type) == Some(&TokenType::Newline) { j += 1; }
-                // { ident: ... } or { ...spread } or { } (empty record with all defaults)
-                (self.peek_at(j).map(|t| &t.token_type) == Some(&TokenType::Ident)
+                // { name: ... } or { ...spread } or { } (empty record with all defaults)
+                (self.peek_at(j).map_or(false, |t| Self::is_name_token(&t.token_type))
                     && self.peek_at(j + 1).map(|t| &t.token_type) == Some(&TokenType::Colon))
                 || self.peek_at(j).map(|t| &t.token_type) == Some(&TokenType::DotDotDot)
                 || self.peek_at(j).map(|t| &t.token_type) == Some(&TokenType::RBrace)
@@ -232,19 +235,39 @@ impl Parser {
         ))
     }
 
-    /// True if the current token is a word that is a keyword only in
-    /// expression/pattern position but a valid field/member NAME here — the
-    /// Result/Option value constructors and `todo`. Its lexeme (`ok`, `err`, …)
-    /// is taken as the name. Lets `{ ok: Bool }`, `r.ok`, `Ack { ok: true }` parse.
-    pub(crate) fn is_soft_keyword_name(&self) -> bool {
+    /// The soft keywords: words the lexer tokenizes as value-constructor
+    /// keywords (`ok`/`err`/`some`/`none`) or the `todo` marker, but which are
+    /// valid NAMEs in field/member position (NOT binding position — a bound
+    /// soft-keyword local could never be read, since in value position the
+    /// lexeme is the constructor again). Single source of truth for that set —
+    /// `is_soft_keyword_name`, `is_name_token`, and the `peek_named_record`
+    /// lookahead all consult it, so adding a soft keyword in one place keeps
+    /// every name position in sync.
+    pub(crate) fn is_soft_keyword_token(tt: &TokenType) -> bool {
         matches!(
-            self.current().token_type,
+            tt,
             TokenType::Ok | TokenType::Err | TokenType::Some | TokenType::None | TokenType::Todo
         )
     }
 
+    /// The token kinds accepted in "any name" position (record/struct field,
+    /// member access, field assignment, record-pattern field): a plain
+    /// identifier, a `TypeName` (a capitalized field name is permitted), or a
+    /// soft keyword. `expect_any_name` advances exactly this set and
+    /// `peek_named_record` recognizes a record by the same set, so the lookahead
+    /// can never disagree with what the field loop will go on to accept.
+    pub(crate) fn is_name_token(tt: &TokenType) -> bool {
+        matches!(tt, TokenType::Ident | TokenType::TypeName) || Self::is_soft_keyword_token(tt)
+    }
+
+    /// True if the current token is a soft keyword used here as a NAME — lets
+    /// `{ ok: Bool }`, `r.ok`, `Ack { ok: true }` parse. See `is_soft_keyword_token`.
+    pub(crate) fn is_soft_keyword_name(&self) -> bool {
+        Self::is_soft_keyword_token(&self.current().token_type)
+    }
+
     pub(crate) fn expect_any_name(&mut self) -> Result<Sym, String> {
-        if self.check(TokenType::Ident) || self.check(TokenType::TypeName) || self.is_soft_keyword_name() {
+        if Self::is_name_token(&self.current().token_type) {
             return Ok(self.advance_and_get_sym());
         }
         let tok = self.current();

--- a/crates/almide-syntax/src/parser/patterns.rs
+++ b/crates/almide-syntax/src/parser/patterns.rs
@@ -172,7 +172,7 @@ impl Parser {
                     self.skip_newlines();
                     break;
                 }
-                let field_name = self.expect_ident()?;
+                let field_name = self.expect_any_name()?;
                 if self.check(TokenType::Colon) {
                     self.advance();
                     let pattern = self.parse_pattern()?;

--- a/crates/almide-syntax/src/parser/primary.rs
+++ b/crates/almide-syntax/src/parser/primary.rs
@@ -272,7 +272,7 @@ impl Parser {
                     self.advance();
                     self.skip_newlines();
                     if self.check(TokenType::RBrace) { break; }
-                    let field_name = self.expect_ident()?;
+                    let field_name = self.expect_any_name()?;
                     self.expect(TokenType::Colon)?;
                     self.skip_newlines();
                     let field_value = self.parse_expr()?;

--- a/crates/almide-syntax/src/parser/statements.rs
+++ b/crates/almide-syntax/src/parser/statements.rs
@@ -26,10 +26,13 @@ impl Parser {
             }
         }
 
-        // obj.field = value (field assignment)
+        // obj.field = value (field assignment). The field name may be any token
+        // `expect_any_name` accepts (ident, TypeName, or a soft keyword) so
+        // `obj.ok = v` routes here, exactly as `obj.ok` reads in expression
+        // position — see parse_field_assign_stmt / parse_postfix.
         if self.check(TokenType::Ident)
             && self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::Dot)
-            && self.peek_at(2).map(|t| matches!(t.token_type, TokenType::Ident)).unwrap_or(false)
+            && self.peek_at(2).map(|t| Self::is_name_token(&t.token_type)).unwrap_or(false)
             && self.peek_at(3).map(|t| &t.token_type) == Some(&TokenType::Eq)
             && self.peek_at(4).map(|t| &t.token_type) != Some(&TokenType::Eq)
         {
@@ -58,7 +61,12 @@ impl Parser {
             return Err(format!("'let rec' is not valid in Almide at line {}:{}", tok.line, tok.col));
         }
 
-        // Record destructuring: let { a, b } = expr
+        // Record destructuring: let { a, b } = expr. This form is shorthand
+        // only — each name becomes BOTH the field label and a usable local — so
+        // it stays `expect_ident`: a soft-keyword local (`let { ok } = …`) could
+        // be bound but never read (in value position `ok` is the constructor),
+        // so accepting it would only enable a dead binding. Soft keywords are
+        // names in label/member position (`{ ok: … }`, `.ok`), not as bindings.
         if self.check(TokenType::LBrace) {
             self.advance();
             let mut names = Vec::new();
@@ -201,7 +209,7 @@ impl Parser {
         let target = sym(&self.current().value);
         self.advance(); // ident
         self.advance(); // .
-        let field = self.expect_ident()?;
+        let field = self.expect_any_name()?;
         self.expect(TokenType::Eq)?;
         self.skip_newlines();
         let value = self.parse_expr()?;

--- a/spec/lang/soft_keyword_field_test.almd
+++ b/spec/lang/soft_keyword_field_test.almd
@@ -1,0 +1,71 @@
+// soft_keyword_field_test — `ok`/`err`/`some`/`none`/`todo` are keywords only
+// in value/pattern position; everywhere a NAME is expected they are ordinary
+// field/member names. Regression for the #418 generalization, which left these
+// positions unconverted: the `peek_named_record` lookahead, the named- and
+// qualified-spread field loops, the record-pattern field, and the field-assign
+// statement (target `obj.ok = v`). Every name position now routes through the
+// single `is_name_token` predicate, so a soft keyword is accepted uniformly.
+
+type Flags = { ok: Bool, err: String, some: Int, none: Bool, todo: String }
+
+test "type decl with soft-keyword field names" {
+  let f = Flags { ok: true, err: "e", some: 1, none: false, todo: "later" };
+  assert_eq(f.ok, true);
+  assert_eq(f.err, "e");
+  assert_eq(f.some, 1);
+  assert_eq(f.none, false);
+  assert_eq(f.todo, "later")
+}
+
+test "named record with a soft-keyword FIRST field parses as a record" {
+  // peek_named_record must enter the record path on `{ ok: ...`, not read it
+  // as a block whose first statement is an `ok(...)` constructor.
+  let f = Flags { ok: false, err: "x", some: 2, none: true, todo: "t" };
+  assert_eq(f.ok, false);
+  assert_eq(f.some, 2)
+}
+
+test "anonymous record literal with soft-keyword fields" {
+  let r = { ok: true, err: "msg", some: 9 };
+  assert_eq(r.ok, true);
+  assert_eq(r.err, "msg");
+  assert_eq(r.some, 9)
+}
+
+test "named record spread updates a soft-keyword field" {
+  let base = Flags { ok: true, err: "a", some: 1, none: false, todo: "t" };
+  let next = Flags { ...base, ok: false, todo: "done" };
+  assert_eq(next.ok, false);
+  assert_eq(next.todo, "done");
+  assert_eq(next.some, 1)
+}
+
+test "anonymous spread updates a soft-keyword field" {
+  let base = { ok: true, some: 1 };
+  let next = { ...base, ok: false };
+  assert_eq(next.ok, false);
+  assert_eq(next.some, 1)
+}
+
+test "member access reads a soft-keyword field" {
+  let f = Flags { ok: true, err: "", some: 0, none: true, todo: "" };
+  let v = f.ok;
+  assert_eq(v, true)
+}
+
+test "field assignment targets a soft-keyword field" {
+  var f = Flags { ok: true, err: "", some: 0, none: false, todo: "" };
+  f.ok = false;
+  f.todo = "shipped";
+  assert_eq(f.ok, false);
+  assert_eq(f.todo, "shipped")
+}
+
+test "record pattern destructures a soft-keyword field" {
+  let f = Flags { ok: true, err: "boom", some: 7, none: false, todo: "x" };
+  let label = match f {
+    Flags { ok: o, err: e, .. } => if o then e else "no",
+    _ => "none",
+  };
+  assert_eq(label, "boom")
+}

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -188,10 +188,23 @@ fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> Wasm
     let wasm_name = test_file.replace('/', "_").replace('.', "_") + ".wasm";
     let wasm_path = tmp_dir.join(&wasm_name);
 
-    let (mut program, source_text, _parse_errors) = parse_file(test_file);
+    let (mut program, source_text, parse_errors) = parse_file(test_file);
     if prof { marks.push(("parse", std::time::Instant::now())); }
     if source_text.lines().take(3).any(|line| line.contains("// wasm:skip")) {
         return skip("wasm:skip".to_string());
+    }
+    // A parse error leaves an error-recovered (partial) AST. Compiling and
+    // running that mangled module would report a PASS, so a broken file looked
+    // green on the WASM path (only the rust path surfaced it). It is a real
+    // failure — NOT a benign skip like `// wasm:skip` — so report it as Fail:
+    // `cmd_test_wasm` then counts it failed, and `cmd_test_fast` routes it to the
+    // authoritative native fallback, which prints the full diagnostics.
+    if parse_errors.iter().any(|d| d.level == diagnostic::Level::Error) {
+        let mut detail = String::new();
+        for d in parse_errors.iter().filter(|d| d.level == diagnostic::Level::Error).take(3) {
+            detail.push_str(&format!("  parse error: {}\n", d.message));
+        }
+        return WasmTestOutcome::Fail { file: test_file.to_string(), detail };
     }
 
     let dep_paths: Vec<(project::PkgId, std::path::PathBuf)> =


### PR DESCRIPTION
A multi-agent audit of every 0.26.x fix (28 changes) classified 22 as already-ideal, 8 as deliberately-tracked interim, and **2 as genuine band-aids**. This PR closes both, plus two correctness hardenings found along the way. The big architectural ideal the audit surfaced — per-package type namespacing (bare-name type identity, #433) — is intentionally **out of scope** here and stays tracked.

### 1. Soft-keyword field names — complete the #418 generalization
`ok`/`err`/`some`/`none`/`todo` were accepted as field names in record literals and type decls (#418) but not in several other name positions. This unifies them on a single `is_name_token` predicate (one source of truth for the soft-keyword set) and applies it everywhere a field/member is named:
- the `peek_named_record` lookahead (so `Foo { ok: … }` enters the record path),
- the named- and qualified-spread field loops,
- the record-pattern field (`match f { Foo { ok: o } => … }` — previously unparseable),
- the field-assignment gate **and** read (`obj.ok = v`).

Boundary, established empirically: soft keywords are names in **label/member** position, but remain constructors in **binding** position — a `let { ok } = r` shorthand local could be bound but never read (in value position the lexeme is the constructor again), so that one stays `expect_ident`. Adds `spec/lang/soft_keyword_field_test.almd` (8 cases across every position; #418 shipped no test).

### 2. Drop a dead borrow special-case (#436)
The `is_owned_map_or_set` branch in the `@intrinsic` seeding loop is unreachable: `intrinsic_borrow_mode_from_type_expr` seeds `Map`/`Set` as `Ref` (not `Own`), so its `matches!(b, Own)` guard is always false. The load-bearing #436 fix is the `is_heap_type` += `Map`/`Set` change alone. Removes the dead branch and its factually-wrong comment.

### 3. Gate the generated runtime registry
`crates/almide-codegen/src/generated/{rust_runtime,runtime_fn_modes}.rs` embed runtime source TEXT, so a draft edited in `runtime/rs/src` but not committed can be baked into the generated file and committed on its own — silently desyncing the two (how the #419 codepoint draft leaked). Adds a regenerate-and-diff CI step mirroring the existing contract-README gate.

### 4. Fail wasm-path tests on parse errors
`compile_and_run_wasm_test` discarded parse errors and ran the error-recovered module, reporting a **false PASS** for a broken file (only the rust path surfaced it). It now reports `Fail`, so `cmd_test_wasm` counts it failed and `cmd_test_fast` routes it to the authoritative native fallback. Verified: the full 254-file spec corpus stays green on the wasm-fast path (no previously-masked breakage), while a deliberately-broken file now fails on both runners.

### Validation
`cargo test --release` green (incl. fmt round-trip and the byte-identical cross-target gate), all 254 spec files green on rust and wasm, the new test green on the rust target.