### PR TITLE
chore(ci): automate dependency updates with Dependabot (cargo + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Dependabot keeps dependencies current by opening PRs automatically.
+# Updates are intentionally ungrouped: one PR per dependency, so each lands
+# as its own reviewable change. See kpi/README.md for the velocity rationale.
+version: 2
+updates:
+  # Rust crates across the Cargo workspace
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "rust"
+
+  # GitHub Actions used by the CI / release workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
## Purpose
Automate dependency updates with Dependabot so routine maintenance accumulates as legitimate commits (lever ① "automation" of the commit-velocity goal in `kpi/`).

## Changes
Adds `.github/dependabot.yml`:
- **cargo** (`/` workspace): weekly (Monday), PR limit 10, prefix `chore(deps)`
- **github-actions** (`/`): weekly (Monday), PR limit 5, prefix `chore(ci)`

## Design decisions
- **Intentionally ungrouped** (one PR per dependency) so each update lands as its own reviewable, CI-gated commit. Grouping is more conservative but collapses commits, which works against the velocity goal.
- Weekly schedule: total commit count is bounded by how often dependencies release, so a higher check frequency would not increase it.

## Follow-ups after merge
- Create labels `dependencies` / `rust` / `ci` if they don't exist (Dependabot applies them).
- Optionally enable auto-merge (e.g. `gh pr merge --auto`) for green Dependabot PRs.