### PR TITLE
build(deps): bump wasm-encoder to 0.244 and adapt emit_wasm to the Ieee64 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "toml",
- "wasm-encoder 0.225.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -68,8 +68,8 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
- "wasm-encoder 0.225.0",
- "wasmparser 0.244.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1216,22 +1216,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.225.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7eac0445cac73bcf09e6a97f83248d64356dccf9f2b100199769b6b42464e5"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.225.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.244.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1242,19 +1232,8 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.225.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e5456165f81e64cb9908a0fe9b9d852c2c74582aa3fe2be3c2da57f937d3ae"
-dependencies = [
- "bitflags 2.11.1",
- "indexmap",
- "semver",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1393,9 +1372,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.244.0",
+ "wasm-encoder",
  "wasm-metadata",
- "wasmparser 0.244.0",
+ "wasmparser",
  "wit-parser",
 ]
 
@@ -1414,7 +1393,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.244.0",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 semver = "1"
 toml = "1.1"
-wasm-encoder = "0.225"
+wasm-encoder = "0.244"
 lasso = { version = "0.7", features = ["multi-threaded"] }
 lsp-server = "0.7"
 lsp-types = "0.97"

--- a/crates/almide-codegen/Cargo.toml
+++ b/crates/almide-codegen/Cargo.toml
@@ -11,7 +11,7 @@ almide-lang = { path = "../almide-lang" }
 almide-ir = { path = "../almide-ir" }
 almide-egg-lab = { path = "../almide-egg-lab" }
 egg = "0.11"
-wasm-encoder = "0.225"
+wasm-encoder = "0.244"
 wasmparser = "0.244"
 toml = "1.1"
 serde_json = "1"

--- a/crates/almide-codegen/src/emit_wasm/dce.rs
+++ b/crates/almide-codegen/src/emit_wasm/dce.rs
@@ -732,7 +732,7 @@ mod tests {
     #[test]
     fn call_after_f64_const() {
         let targets = calls_in(&[
-            Instruction::F64Const(3.14159),
+            Instruction::F64Const(3.14159_f64.into()),
             Instruction::Drop,
             Instruction::Call(66),
         ]);
@@ -773,7 +773,7 @@ mod tests {
         // Numeric constants
         f.instruction(&Instruction::I32Const(999));
         f.instruction(&Instruction::I64Const(0x7FFF_FFFF_FFFF));
-        f.instruction(&Instruction::F64Const(3.14));
+        f.instruction(&Instruction::F64Const(3.14_f64.into()));
         f.instruction(&Instruction::Drop);
         f.instruction(&Instruction::Drop);
         // Local/global access
@@ -977,7 +977,7 @@ mod tests {
         tf.instruction(&Instruction::Drop);
         tf.instruction(&Instruction::I64Const(0x7FFFFFFFFFFFFFFF));
         tf.instruction(&Instruction::Drop);
-        tf.instruction(&Instruction::F64Const(f64::MAX));
+        tf.instruction(&Instruction::F64Const(f64::MAX.into()));
         tf.instruction(&Instruction::Drop);
         // Local/global
         tf.instruction(&Instruction::LocalGet(0));

--- a/crates/almide-codegen/src/emit_wasm/engine/builder.rs
+++ b/crates/almide-codegen/src/emit_wasm/engine/builder.rs
@@ -249,7 +249,7 @@ impl<'a> WasmBuilder<'a> {
     // constants
     pub fn i32c(&mut self, v: i32) -> &mut Self { self.f.instruction(&Instruction::I32Const(v)); self }
     pub fn i64c(&mut self, v: i64) -> &mut Self { self.f.instruction(&Instruction::I64Const(v)); self }
-    pub fn f64c(&mut self, v: f64) -> &mut Self { self.f.instruction(&Instruction::F64Const(v)); self }
+    pub fn f64c(&mut self, v: f64) -> &mut Self { self.f.instruction(&Instruction::F64Const(v.into())); self }
 
     // i32 ops
     pub fn add(&mut self) -> &mut Self { self.f.instruction(&Instruction::I32Add); self }

--- a/crates/almide-codegen/src/emit_wasm/engine/emit.rs
+++ b/crates/almide-codegen/src/emit_wasm/engine/emit.rs
@@ -29,8 +29,8 @@ pub fn emit_op(op: &Op, f: &mut Function, reg: &LayoutRegistry) {
         Op::Const(c) => match c {
             Const::I32(v) => { f.instruction(&I32Const(*v)); }
             Const::I64(v) => { f.instruction(&I64Const(*v)); }
-            Const::F32(v) => { f.instruction(&F32Const(*v)); }
-            Const::F64(v) => { f.instruction(&F64Const(*v)); }
+            Const::F32(v) => { f.instruction(&F32Const((*v).into())); }
+            Const::F64(v) => { f.instruction(&F64Const((*v).into())); }
         },
         Op::Drop => { f.instruction(&Drop); }
 

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -1864,7 +1864,7 @@ fn assemble(emitter: &mut WasmEmitter) -> Vec<u8> {
     for &(_, vt, bits) in &emitter.top_let_init {
         let init = match vt {
             ValType::I64 => wasm_encoder::ConstExpr::i64_const(bits),
-            ValType::F64 => wasm_encoder::ConstExpr::f64_const(f64::from_bits(bits as u64)),
+            ValType::F64 => wasm_encoder::ConstExpr::f64_const(f64::from_bits(bits as u64).into()),
             ValType::I32 => wasm_encoder::ConstExpr::i32_const(bits as i32),
             _ => wasm_encoder::ConstExpr::i32_const(0),
         };

--- a/crates/almide-codegen/src/emit_wasm/wasm_macro.rs
+++ b/crates/almide-codegen/src/emit_wasm/wasm_macro.rs
@@ -44,7 +44,7 @@ macro_rules! wasm {
         wasm!(@emit $f, $($rest)*)
     };
     (@emit $f:expr, f64_const($v:expr); $($rest:tt)*) => {
-        $f.instruction(&wasm_encoder::Instruction::F64Const($v));
+        $f.instruction(&wasm_encoder::Instruction::F64Const(($v).into()));
         wasm!(@emit $f, $($rest)*)
     };
 
@@ -571,7 +571,7 @@ macro_rules! wasm {
         $f.instruction(&wasm_encoder::Instruction::F64ConvertI64U); wasm!(@emit $f, $($rest)*)
     };
     (@emit $f:expr, f64_const($v:expr); $($rest:tt)*) => {
-        $f.instruction(&wasm_encoder::Instruction::F64Const($v)); wasm!(@emit $f, $($rest)*)
+        $f.instruction(&wasm_encoder::Instruction::F64Const(($v).into())); wasm!(@emit $f, $($rest)*)
     };
     (@emit $f:expr, memory_size($mem:expr); $($rest:tt)*) => {
         $f.instruction(&wasm_encoder::Instruction::MemorySize($mem)); wasm!(@emit $f, $($rest)*)

--- a/crates/almide-egg-lab/tests/bridge_test.rs
+++ b/crates/almide-egg-lab/tests/bridge_test.rs
@@ -114,6 +114,7 @@ fn list_call(func: &str, args: Vec<IrExpr>, result_ty: Ty) -> IrExpr {
             target: CallTarget::Module {
                 module: sym("list"),
                 func: sym(func),
+                def_id: None,
             },
             args,
             type_args: vec![],
@@ -137,6 +138,7 @@ fn matrix_call(func: &str, args: Vec<IrExpr>) -> IrExpr {
             target: CallTarget::Module {
                 module: sym("matrix"),
                 func: sym(func),
+                def_id: None,
             },
             args,
             type_args: vec![],
@@ -698,7 +700,7 @@ fn block_lets(binds: Vec<(VarId, IrExpr)>, trailing: IrExpr) -> IrExpr {
                 ty: value.ty.clone(),
                 value,
             },
-            span: None, def_id: None,
+            span: None,
         })
         .collect();
     let trailing_ty = trailing.ty.clone();


### PR DESCRIPTION
Supersedes #456 (the raw Dependabot bump), which failed CI because wasm-encoder 0.244 is a breaking API change.

## What changed
- **wasm-encoder 0.225 → 0.244** (rebased onto current `develop`, so it also carries `wasmparser = "0.244"`).
- **Adapt `emit_wasm` to the Ieee64 API**: 0.244 changed `Instruction::F32Const`/`F64Const` and `ConstExpr::f64_const` to take `Ieee32`/`Ieee64` (which `impl From<f32>/<f64>`) instead of raw floats. Wrapped the float arguments with `.into()` at the emission chokepoints (the `wasm!` macro, engine emit/builder, the global `ConstExpr` init, and the dce tests) — matching the existing `.into()` idiom already used in `expressions.rs`. Fixes 294 `E0308` errors.
- **`test(egg-lab)`: update `bridge_test.rs` fixtures for the `def_id` IR refactor** — unrelated to wasm-encoder, but `bridge_test.rs` was left out of sync with the recent `def_id` change on `develop` (CallTarget::Module/IrExpr gained `def_id`, IrStmt has none), which breaks `Test Rust` for every branch. Required to get CI green.

## Validation (local)
- `cargo check --workspace --all-targets`: 0 errors
- `cargo test -p almide-egg-lab`: 16 passed
- `cargo test -p almide-codegen` (dce): 22 passed

The `.into()` wrapping is byte-identical to the old encoding (Ieee64 stores `f64::to_bits`), so WASM output determinism is preserved.

Closes #458