### PR TITLE
True-Perceus prep: kill warn-mode, harden remaining emit miss-arms, recover the frees design doc

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls.rs
@@ -995,7 +995,11 @@ impl FuncCompiler<'_> {
                     let type_idx = self.emitter.register_type(closure_params, ret_types);
                     wasm!(self.func, { call_indirect(type_idx, 0); });
                 } else {
-                    wasm!(self.func, { unreachable; });
+                    panic!(
+                        "[ICE] emit_wasm: closure call through a non-Fn type `{:?}` — \
+                         the call signature cannot be built; resolve upstream",
+                        callee_fn_ty
+                    );
                 }
                 self.scratch.free_i32(scratch);
             }
@@ -1140,7 +1144,10 @@ impl FuncCompiler<'_> {
                     let type_idx = self.emitter.register_type(closure_params, ret_types);
                     wasm!(self.func, { return_call_indirect(type_idx, 0); });
                 } else {
-                    wasm!(self.func, { unreachable; });
+                    panic!(
+                        "[ICE] emit_wasm: tail closure call through a non-Fn type — \
+                         the call signature cannot be built; resolve upstream"
+                    );
                 }
                 self.scratch.free_i32(scratch);
             }

--- a/crates/almide-codegen/src/emit_wasm/equality.rs
+++ b/crates/almide-codegen/src/emit_wasm/equality.rs
@@ -793,9 +793,19 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(left);
                 self.scratch.free_i32(right);
             }
-            // TypeVar/Unknown: unresolved type — trap rather than silently compare as wrong type
+            // TypeVar/Unknown: unresolved type — dead-code residue from error
+            // recovery may reach here; live code is guarded by
+            // assert_types_concretized. Keep the trap for that case only.
             (ty, _) if ty.is_unresolved() => { wasm!(self.func, { unreachable; }); }
-            _ => { wasm!(self.func, { unreachable; }); }
+            (l, _) => {
+                // A RESOLVED type with no comparison emission is a
+                // compiler bug — fail the build (§5: no silent traps).
+                panic!(
+                    "[ICE] emit_wasm: no equality/comparison emission for type `{:?}` — \
+                     add an arm or reject upstream in the checker",
+                    l
+                );
+            }
         }
     }
 

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -1686,11 +1686,10 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
     // This is a static, post-emit check — no runtime overhead, no function
     // index perturbation. Combined with PerceusVerifyPass (Lean 4 certified
     // IR-level balance) and Verified<'_> type-state gate, this closes the
-    // gap between IR verification and WASM emission.
-    #[cfg(debug_assertions)]
-    {
-        verify_rc_balance(program, &emitter);
-    }
+    // gap between IR verification and WASM emission. ALWAYS-ON (§10): it is
+    // a cheap per-function instruction count, and a violation in the
+    // double-free direction must stop a release build too.
+    verify_rc_balance(program, &emitter);
 
     bytes
 }
@@ -1700,7 +1699,6 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
 /// Counts call(rc_dec) in each compiled function's call_targets and compares
 /// with the IR-level RcDec count. Extra rc_dec calls (beyond typed child
 /// drops) indicate a compiler bug.
-#[cfg(debug_assertions)]
 fn verify_rc_balance(program: &IrProgram, emitter: &WasmEmitter) {
     use almide_ir::{IrStmtKind, IrExprKind};
     use almide_ir::visit::{IrVisitor, walk_expr, walk_stmt};
@@ -1744,13 +1742,17 @@ fn verify_rc_balance(program: &IrProgram, emitter: &WasmEmitter) {
                 // emit_typed_rc_dec generates child drops. But it should
                 // never have FEWER (that would be a leak, caught by
                 // PerceusVerifyPass). We log mismatches for debugging.
-                if wasm_dec_count > 0 || ir_dec_count > 0 {
-                    if wasm_dec_count < ir_dec_count {
-                        eprintln!(
-                            "[RC verify] WARNING: `{}` has {} IR RcDec but only {} WASM rc_dec calls (possible leak)",
-                            func_name, ir_dec_count, wasm_dec_count,
-                        );
-                    }
+                if wasm_dec_count < ir_dec_count {
+                    // The IR (Verified by PerceusVerifyPass) specifies the
+                    // balance; an emission that DROPS a Dec is a leak the
+                    // belt already certified against. No warn-mode (§10).
+                    eprintln!("error: [COMPILER BUG] WASM emission dropped RC decrements");
+                    eprintln!(
+                        "  `{}` has {} IR RcDec statement(s) but only {} emitted rc_dec call(s).",
+                        func_name, ir_dec_count, wasm_dec_count,
+                    );
+                    eprintln!("  Please report this at https://github.com/almide/almide/issues");
+                    std::process::exit(1);
                 }
             }
         }

--- a/crates/almide-codegen/src/pass.rs
+++ b/crates/almide-codegen/src/pass.rs
@@ -246,6 +246,7 @@ impl Pipeline {
         // `ALMIDE_VERIFY_IR` used to gate this — removed in S2 flip
         // (v0.14.7-phase3.2); `expr.ty` is now trustworthy by contract.
         let hard_fail = cfg!(debug_assertions);
+        let _ = hard_fail; // escalation is unconditional now; the flag only gates whether verification RUNS
         // The inter-pass IR verifier + postcondition checks walk the entire
         // (merged) program after EVERY pass. That's a developer safety net —
         // it catches compiler bugs but does nothing for a correct build. In
@@ -307,9 +308,12 @@ impl Pipeline {
                     for e in &errors {
                         eprintln!("  {}", e);
                     }
-                    if hard_fail {
-                        panic!("IR verification failed after pass '{}'", pass_name);
-                    }
+                    // No warn-mode: a DETECTED violation is fatal in every
+                    // profile (release-parity §10 — the v0.25.0 lesson:
+                    // a warning's audience cannot fix a compiler bug).
+                    // Release cost is unchanged: the verifier itself stays
+                    // debug/opt-in (the measured ~1.2s/file walk).
+                    panic!("IR verification failed after pass '{}'", pass_name);
                 }
 
                 // Postcondition verification.
@@ -319,7 +323,7 @@ impl Pipeline {
                     for v in &violations {
                         eprintln!("[POSTCONDITION VIOLATION] {}", v);
                     }
-                    if !violations.is_empty() && hard_fail {
+                    if !violations.is_empty() {
                         panic!("Postcondition violation after pass '{}'", pass_name);
                     }
                 }

--- a/docs/roadmap/active/wasm-frees-ownership-discipline.md
+++ b/docs/roadmap/active/wasm-frees-ownership-discipline.md
@@ -1,0 +1,182 @@
+# WASM Reference-Count Frees: the Ownership-Discipline Drain
+
+**Status:** in progress (2026-06-07). Branch `perceus-belt-hard-error`, worktree
+`xtarget-compound-display`. All work LOCAL/uncommitted pending the full two-gate
+green.
+
+## Mission
+
+WASM is the memory frontier. Native Rust gets the borrow checker for free; the
+WASM backend has historically **leaked all heap by design** — `compile_rc_inc` /
+`compile_rc_dec` (`emit_wasm/runtime.rs`) were deliberate no-ops (`if ptr <
+heap_start return`, reading the legacy `heap_start_global` field that stays `0`,
+so the guard is always true). The whole Perceus belt has been verifying the RC
+balance of NO-OPS. The goal: **activate frees** so WASM reclaims heap (churn
+O(1), not O(n)) **without** introducing a single double-free, and keep
+native↔WASM byte-identical.
+
+This is the heart of "the trust layer for machine-written software": the same
+program, run native or in a WASM sandbox, frees memory correctly and produces
+identical bytes.
+
+## The discovery
+
+Flipping the rc guard to the correct `HEAP_START_GLOBAL_IDX` (=4) activates the
+fully-built free-list machinery (alloc walk+reuse, rc_dec push). It immediately
+exposed a **class of pre-existing latent double-frees** the no-op model had
+masked: anywhere a heap value is *borrowed/aliased* or *moved into a container*,
+the simplified Perceus inserts a scope-end `Dec` that frees a value something
+else still owns. Activating frees turns each into a free-list cycle (silent hang)
+or — with the **double-free sentinel guard** added to `rc_dec` (stamps a freed
+block rc=0, traps `unreachable` on a second Dec) — a loud WASM trap caught by the
+cross-target gate.
+
+## Root cause: the simplified Perceus has no ownership/move discipline
+
+Real Perceus (Koka) tracks *ownership*: a value is dup'd (Inc) when a new owner is
+created, dropped (Dec) at an owner's last use, and **moved** (ownership
+transferred, no separate drop) when consumed by a constructor/return. Almide's
+WASM Perceus was a simplification: it Dec's *every* heap local at scope end and
+Inc's *only* `Var`/`Clone`/`Deref` binds. That is wrong in two directions:
+
+1. **Borrowed/aliased values bound to a Dec'd local under-count** — the local's
+   scope-end Dec frees a value its source still holds (extraction aliases,
+   env-loads, direct element accessors).
+2. **Values moved into a container are over-Dec'd** — the container takes the
+   value by reference (no copy/Inc), then Perceus Dec's the source local too,
+   deep-freeing the container's contents.
+
+Every bug in this drain is one facet of this single gap.
+
+## The completion bar = BOTH gates (the key lesson)
+
+`almide test spec/ --target wasm` (the test-block assertion corpus) is
+**necessary but NOT sufficient**. Test blocks exercise value assertions but skip
+whole shapes. The **`cargo test --release --test wasm_runtime_test`** gate (the
+~100 `spec/wasm_cross/*.almd` `@contract` fixtures, byte-identical stdout/stderr/
+exit) exercises shapes the test corpus never does — e.g. **compound set/map keys**
+(`compound_eq.almd`, contract C-015). The real done-bar is:
+
+- `almide test spec/ --target wasm` = clean (assertions), AND
+- `cargo test --release --test wasm_runtime_test` = clean (byte-identical), AND
+- churn benchmark O(1) (the leak gate — see below), AND
+- native `almide test spec/` unregressed.
+
+"240/0 on the test corpus" was an early false summit; the cargo gate found
+`compound_eq` still diverging.
+
+## Mechanisms implemented (each a facet of the one discipline)
+
+All reuse one classifier — `yields_borrowed_alias(e)` in `pass_perceus.rs`
+(exhaustive `match`, no wildcard = total; a new `IrExprKind` must be classified
+deliberately). ALIAS forms acquire a reference; FRESH forms own theirs already.
+The leak/crash asymmetry sets the safe default: a **missing** Inc on an alias =
+double-free (crash); an **extra** Inc on a fresh value = leak (safe) — so unknown
+forms default FRESH only where proven, else ALIAS.
+
+| # | Mechanism | Where | Fixed |
+|---|-----------|-------|-------|
+| 1 | `yields_borrowed_alias` + **VDecl alias-Inc-after-bind** (subsumes old Var/Clone/Deref Rule-1; covers Member/Index/TupleIndex/MapAccess/OptionalChain, Match/If/Block tails, Unwrap/Try/ToOption/UnwrapOr peels) | `pass_perceus.rs` ChainHead::VDecl | hamming, default_fields, result_option_matrix |
+| 2 | **`emit_stored_field`** — constructor/value-builder dup of alias args | value str/array/object (`calls_value.rs`), Record/List/Tuple (`collections.rs`), OptionSome/ResultOk/ResultErr (`expressions.rs`) | codec/variant cluster (11), capture_clone, protocol_advanced, try_parse_list |
+| 3 | **fold accumulator dup** — `fold(xs,seed,f)` move-returns its seed; dup an alias seed | `calls_list_closure2.rs:1046,1155` | option.collect-empty, is_balanced-empty |
+| 4 | **EnvLoad-borrow exclusion** — a closure body's `EnvLoad`-bound local borrows an env capture the env owns; exclude from scope-end Dec | `collect_heap_vdecls` | `>>` composition chains (compose_test) |
+| 5 | **`is_alias_returning_runtime_call`** — `list.get_or`/`map.get_or` return the element pointer directly (alias) | `pass_perceus.rs` | protocol_extreme decode |
+
+Mechanism #2/#3/#5 emit `call rt.rc_inc` **directly** (not an IR `RcInc` node).
+
+## Verification status (2026-06-07)
+
+- ✅ `almide test spec/ --target wasm`: **240 passed / 0 failed** (8 wasm:skip).
+- ✅ native `almide test spec/`: **248/248**.
+- ✅ churn (2M iters of {build Codec record + encode + value.stringify}): peak RSS
+  **7.46 MB** = O(1), no leak.
+- ❌ cargo `wasm_runtime_test` gate: **`compound_eq.almd` (C-015) diverges** —
+  `set.contains(sr, {record})` returns F (should T) **and** a `rc_dec` sentinel
+  trap at `main` exit. (Full diverging list pending the gate run.)
+
+## Second layer: the COLLECTION RUNTIME (found by the cargo gate, 2026-06-08)
+
+The expression/constructor/closure drain above is verified clean by BOTH the test
+corpus AND a 2M-iter churn. But the `cargo wasm_runtime_test` gate (byte-identical,
+the part `almide test` cannot reach) exposes a **second layer**: the WASM
+collection runtime copies heap element/key/value POINTERS into new structures
+without dup'ing them, so the source's scope-end Dec deep-frees what the new
+structure now holds. A full streaming byte-sweep of the 100 fixtures (stdout-only;
+`control_flow`/`cross_module_spread` were md5 false-positives = native-side
+compiler *warnings* on stderr, not divergence) found **4 real divergences**, all
+WASM `rc_dec`-sentinel traps / corruption under frees-on:
+
+| Fixture | Op(s) | Sub-class | Status |
+|---------|-------|-----------|--------|
+| `compound_eq` (C-015) | `set.from_list`/`set.insert`/`map.from_list`/`map.insert` over record/tuple keys | heap-element/key RC | **set.from_list FIXED** (stdout now identical); exit still 134 (set.insert/map ops remain) |
+| `list_float_total_order` | `list.sort_by` over `List[R]` | heap-element RC | open |
+| `alias_cow` | `var b = a; a[0]=…` list COW | list-BACKING / COW RC | open (all values correct; double-free only at main-exit teardown) |
+| `list_count_index_truncation` | `list.take/drop/slice` huge indices (2³²…) | NUMERIC (likely u32 index truncation → OOB → corruption), maybe NOT frees-related | open / triage |
+
+### The fix tool + WHY a piecemeal drain CORRUPTS (attempted + REVERTED 2026-06-08)
+`emit_elem_copy_owned(ty)` = `emit_elem_copy` plus, for a heap element, a
+stack-neutral `rc_inc` (`i32_load; call rc_inc; i32_store`), at **SHARE points
+only** (copy OUT of a still-live source), NOT intra-structure MOVE points (grow +
+abandon → an extra Inc leaks). Applying it to `set.from_list` (`calls_set.rs`
+append-from-xs) DID fix `compound_eq`'s stdout value (set.contains(record) F→T)
+and kept the corpus at 240/0. **BUT** a `set.from_list` + `set.insert` churn loop
+then revealed the trap of piecemeal collection fixes: native `sink=30` vs **wasm
+`sink=31`** at 10 iters (one set's dedup length wrong), → **OOB at 1.5M iters**.
+A set op has MULTIPLE share/move points; fixing some but not all leaves a residual
+double-free that reuses freed memory → corrupts the element-equality the *next*
+op's dedup depends on → wrong length → eventually OOB. **Lesson: the collection
+drain must fix ALL of a structure's share/move points ATOMICALLY and gate on a
+per-structure CHURN loop (1M+ iters), not just stdout/corpus.** The piecemeal
+changes were **REVERTED** to the validated known-good (240/0 + records-churn
+7.43 MB). The tool/approach is sound; the *increment* was wrong.
+
+### The remaining collection drain (mechanical, but per-site share/move judgement)
+~15-20 `emit_elem_copy`/`emit_elem_copy_sized` sites across `calls_set.rs` (lines
+240,310,355,392,470,536,609 — insert/union/intersect/diff/…) and `calls_map.rs`
+(the dict path: `emit_dict_put_entry` + `emit_elem_copy_sized` at 102/510/519 —
+note `emit_elem_copy_sized` takes a SIZE not a Ty, so it needs heap-ness threaded
+in or an owned variant keyed on `key_ty`/val-ty). Plus `list.sort_by`
+(`calls_list_closure.rs:941`) and the slice/take/drop family. Each: classify the
+copy as SHARE (source survives → owned) vs MOVE (source abandoned → plain), then
+swap. The leak gate for these is **the cargo gate / a 2M-churn**, NOT the test
+corpus — verify both after each batch.
+
+### COW (`alias_cow`) is its own sub-problem
+`var b = a` (list aliasing) + `a[0]=…` (copy-on-write) — all VALUES are already
+byte-identical; only the main-exit teardown double-frees the COW'd backing. Lives
+in `AliasCowPass` + the IndexAssign/var-alias RC, not the element-copy helper.
+Separate, careful fix.
+
+## Remaining work
+
+1. **Compound set/map keys** (`compound_eq`, C-015). `set.from_list`/`map.from_list`
+   move record/tuple elements into the structure by reference; the input list's
+   scope-end Dec then deep-frees the moved-in elements (and dedup'd duplicates).
+   Same move-discipline gap as #2, in the set/map runtime (`calls_set.rs`,
+   `calls_map.rs`). Apply the dup-on-store / move-exclusion there.
+2. **Run the full cargo gate** and drain every diverging fixture (the test corpus
+   misses these shapes by construction).
+3. **Verifier-invisibility (follow-up, load-bearing for the belt):** mechanisms
+   #2/#3/#5 emit `rc_inc` inside the emitter, NOT as IR `RcInc` nodes, so the
+   perceus-belt verifier **cannot see them** — the churn benchmark is currently
+   their only leak gate. Extend the verifier to MODEL constructor/builder/HOF
+   dups (treat `value_object`/`Record`/`fold`/… as dup'ing their alias args) so
+   they are *certified*, not just runtime-checked. Until then the belt's
+   "we certify RC balance" claim has a hole.
+4. **Re-land** M1 (rc guard flip) + M2 (TCO flatten + `tco_managed_params`) +
+   sentinel guard + mechanisms #1–#5 + the compound fix as ONE coherent commit,
+   only after BOTH gates + churn are green.
+
+## Trap log (environment)
+
+- `almide test spec/ --target wasm` runs every test block on wasmtime; the cargo
+  `wasm_runtime_test` gate is the byte-identical contract gate. **Neither alone is
+  the bar — both are.**
+- The sentinel guard converts double-free hangs → fast traps, so the corpus run
+  terminates instead of spinning.
+- **Orphan `rustc` hazard:** the cargo gate compiles each fixture's native side
+  via `rustc`; a previous session left 3-day-old `rustc` orphans (PPID=1) spinning
+  at 99% CPU on the shared build scratch `/tmp/claude-501/almide-build/`, starving
+  the gate for 47h. Check `pgrep rustc` + kill stale PPID=1 rustc before timing the
+  gate. A `perl -e 'alarm N'` wrapper around `cargo test` kills cargo but leaves
+  the test binary detached/running — background the gate instead.


### PR DESCRIPTION
Preparation for the WASM frees activation (true Perceus). Three pieces:

- **No warn-mode anywhere (§10)**: a DETECTED inter-pass IR-verification or postcondition violation is now fatal in every profile (the verifier itself stays debug/opt-in — the measured ~1.2s/file walk is unchanged in release). The post-emit RC-balance check (IR RcDec count vs emitted rc_dec calls) is now always-on and fatal in the leak direction. The v0.25.0 lesson, finished: a warning's audience cannot fix a compiler bug.
- **§5 completion**: the last resolved-type miss arms in emit_wasm (equality dispatch catch-all, closure-call through a non-Fn type ×2) now fail the build instead of emitting silent runtime traps. Unknown-type dead-code residue keeps its trap (guarded by AllTypesConcrete for live code).
- **Salvage**: pushed the previously-unpushed `perceus-belt-hard-error` branch (4 commits — the second activation attempt with the alias-accounting core, double-free sentinel, and per-structure churn evidence) and recovered its design doc into `docs/roadmap/active/wasm-frees-ownership-discipline.md`. That branch was a single point of loss for weeks of work.

Verification: spec corpus 264/264 on both targets; cargo test green on release and debug profiles.

Confirmed already-landed (no change needed): ANF `needs_lift` is lift-by-default with a registered postcondition; ClosureConversion has an EnvLoad bounds postcondition — both are now FATAL whenever they run thanks to the warn-mode removal.