### PR TITLE
True Perceus: real WASM reference-count frees behind ALMIDE_WASM_FREES, full quadruple bar green

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls.rs
@@ -326,11 +326,15 @@ impl FuncCompiler<'_> {
                                     i32_const(tag as i32);
                                     i32_store(0);
                                 });
-                                // Write args
+                                // Write args — through the stored-field
+                                // contract (fresh values move, alias values
+                                // dup), the same rule emit_record uses; a
+                                // bare emit_expr stored a payload the source
+                                // binding still owned and later Dec'd.
                                 let mut offset = 4u32;
                                 for arg in args {
                                     wasm!(self.func, { local_get(scratch); });
-                                    self.emit_expr(arg);
+                                    self.emit_stored_field(arg);
                                     self.emit_store_at(&arg.ty, offset);
                                     offset += values::byte_size(&arg.ty);
                                 }

--- a/crates/almide-codegen/src/emit_wasm/calls_list.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list.rs
@@ -104,7 +104,7 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -152,7 +152,7 @@ impl FuncCompiler<'_> {
                       local_get(start); local_get(i); i32_add;
                       i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -216,7 +216,7 @@ impl FuncCompiler<'_> {
                       local_get(start); local_get(len); i32_add;
                       i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(len); i32_const(1); i32_add; local_set(len);
                       br(0);
@@ -258,7 +258,7 @@ impl FuncCompiler<'_> {
                       i32_const(elem_size as i32); i32_mul; i32_add;
                 });
                 // Copy elem_size bytes
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -323,7 +323,7 @@ impl FuncCompiler<'_> {
                       local_get(result);
                       local_get(xs); i32_const(list_data_off); i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, { local_get(result); end; });
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(xs);
@@ -346,7 +346,7 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_load(0); i32_const(1); i32_sub;
                       i32_const(elem_size as i32); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, { local_get(result); end; });
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(xs);
@@ -466,7 +466,7 @@ impl FuncCompiler<'_> {
                         local_get(inner); i32_const(list_data_off); i32_add;
                         local_get(j); i32_const(elem_size as i32); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(j); i32_const(1); i32_add; local_set(j);
                         br(0);
@@ -555,6 +555,13 @@ impl FuncCompiler<'_> {
                       i32_const(es); call(self.emitter.rt.alloc); local_set(out);
                       local_get(out); local_get(best);
                 });
+                // SHARE: the winner pointer aliases an element of a list the
+                // caller still owns; the some() box must own its own ref —
+                // a freed-then-reused winner is how a list's len became a
+                // free-list next pointer (the repr-loop wall-clock hang).
+                if crate::pass_perceus::is_heap_type(&elem_ty) {
+                    wasm!(self.func, { call(self.emitter.rt.rc_inc); });
+                }
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
                       local_get(out);
@@ -608,7 +615,7 @@ impl FuncCompiler<'_> {
                         local_get(xs); i32_const(list_data_off); i32_add;
                         local_get(src_i); i32_const(elem_size as i32); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(dst_i); i32_const(1); i32_add; local_set(dst_i);
                         // Insert sep if not last
@@ -618,6 +625,11 @@ impl FuncCompiler<'_> {
                           local_get(dst_i); i32_const(elem_size as i32); i32_mul; i32_add;
                           local_get(sep);
                 });
+                // SHARE: the sep value's source survives; every stored slot
+                // needs its own reference.
+                if crate::pass_perceus::is_heap_type(&elem_ty) {
+                    wasm!(self.func, { call(self.emitter.rt.rc_inc); });
+                }
                 self.emit_elem_store(&elem_ty);
                 wasm!(self.func, {
                           local_get(dst_i); i32_const(1); i32_add; local_set(dst_i);
@@ -679,14 +691,14 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(i); i32_const(a_size as i32); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&a_ty);
+                self.emit_elem_copy_owned(&a_ty);
                 // Copy b: tuple[a_size] = ys[i]
                 wasm!(self.func, {
                       local_get(tup); i32_const(a_size as i32); i32_add;
                       local_get(ys); i32_const(list_data_off); i32_add;
                       local_get(i); i32_const(b_size as i32); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&b_ty);
+                self.emit_elem_copy_owned(&b_ty);
                 wasm!(self.func, {
                       // result[i] = tuple_ptr
                       local_get(dst); i32_const(list_data_off); i32_add;
@@ -727,8 +739,9 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { local_set(idx); });
                 // Evaluate `val` EAGERLY (native passes it by value before the
                 // call), then store conditionally — so a side-effecting value
-                // expr runs whether or not the index is in bounds.
-                self.emit_expr(&args[2]);
+                // expr runs whether or not the index is in bounds. Stored-field
+                // contract: an alias value gets its own reference.
+                self.emit_stored_field(&args[2]);
                 wasm!(self.func, {
                     local_set(val);
                     // Alloc copy
@@ -744,7 +757,7 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -752,6 +765,17 @@ impl FuncCompiler<'_> {
                     // Overwrite dst[idx] with val — only when in bounds.
                     local_get(in_bounds);
                     if_empty;
+                });
+                // Release the owned copy of the element being replaced (it
+                // received +1 in the copy loop above and loses this slot).
+                if crate::pass_perceus::is_heap_type(&elem_ty) {
+                    wasm!(self.func, {
+                      local_get(dst); i32_const(list_data_off); i32_add;
+                      local_get(idx); i32_const(es); i32_mul; i32_add;
+                      i32_load(0); call(self.emitter.rt.rc_dec);
+                    });
+                }
+                wasm!(self.func, {
                       local_get(dst); i32_const(list_data_off); i32_add;
                       local_get(idx); i32_const(es); i32_mul; i32_add;
                       local_get(val);
@@ -798,18 +822,18 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                 });
-                // Insert val at idx
+                // Insert val at idx (stored-field: alias values dup)
                 wasm!(self.func, {
                     local_get(dst); i32_const(list_data_off); i32_add;
                     local_get(idx); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_expr(&args[2]);
+                self.emit_stored_field(&args[2]);
                 self.emit_elem_store(&elem_ty);
                 // Copy [idx..old_len)
                 wasm!(self.func, {
@@ -821,7 +845,7 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -869,7 +893,7 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -885,15 +909,18 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
                     local_get(dst);
                     else_;
-                    // i >= len → return the list unchanged
-                    local_get(xs);
+                    // i >= len → return the list unchanged. SHARE: the result
+                    // is a SECOND reference to xs (native returns a clone) —
+                    // without the inc the result temp's Dec freed xs's live
+                    // backing (list_count_index_truncation silent corruption).
+                    local_get(xs); call(self.emitter.rt.rc_inc);
                     end;
                 });
                 self.scratch.free_i32(i);
@@ -958,6 +985,12 @@ impl FuncCompiler<'_> {
                     i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0); // load elem
+                // SHARE: the some-box holds a second reference to the element
+                // (the bind-level alias-Inc covers the LOCAL the caller binds;
+                // this covers the BOX, whose typed dec releases it).
+                if crate::pass_perceus::is_heap_type(&elem_ty) {
+                    wasm!(self.func, { call(self.emitter.rt.rc_inc); });
+                }
                 self.emit_store_at(&elem_ty, 0); // store at dst
                 wasm!(self.func, {
                     local_get(result); // return ptr
@@ -1093,8 +1126,10 @@ impl FuncCompiler<'_> {
                 let new_ptr = self.scratch.alloc_i32();
                 let val_scratch = self.scratch.alloc(vt);
 
-                // Evaluate value first (before reading xs, in case of side effects)
-                self.emit_expr(&args[1]);
+                // Evaluate value first (before reading xs, in case of side
+                // effects); stored-field contract — an alias value pushed
+                // into the list needs its own reference.
+                self.emit_stored_field(&args[1]);
                 wasm!(self.func, { local_set(val_scratch); });
 
                 // Read xs pointer, len, cap

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
@@ -353,6 +353,15 @@ impl FuncCompiler<'_> {
                       local_get(i); i32_const(es); i32_mul; i32_add;
                       local_get(val);
                 });
+                // The result owns n references to the SAME element block —
+                // without one inc per stored slot, a deep Dec of the result
+                // decs that single block n times (sentinel trap; surfaced via
+                // the for+concat-push → list.repeat rewrite). A fresh-arg
+                // call leaks exactly one count (no owner for the original
+                // ref) — the safe direction.
+                if crate::pass_perceus::is_heap_type(&elem_ty) {
+                    wasm!(self.func, { call(self.emitter.rt.rc_inc); });
+                }
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
@@ -53,7 +53,7 @@ impl FuncCompiler<'_> {
                         local_get(xs); i32_const(list_data_off); i32_add;
                         local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(tmp); local_set(result); br(2);
                       end;
@@ -251,7 +251,7 @@ impl FuncCompiler<'_> {
                       local_get(start); local_get(i); i32_add;
                       i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -300,7 +300,7 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -653,7 +653,7 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(k); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(k); i32_const(1); i32_add; local_set(k);
                       br(0);
@@ -773,7 +773,7 @@ impl FuncCompiler<'_> {
                         local_get(j); i32_add;
                         i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(j); i32_const(1); i32_add; local_set(j);
                         br(0);
@@ -852,7 +852,7 @@ impl FuncCompiler<'_> {
                         local_get(i); local_get(j); i32_add;
                         i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(j); i32_const(1); i32_add; local_set(j);
                         br(0);

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
@@ -892,7 +892,7 @@ impl FuncCompiler<'_> {
                       local_get(dst); i32_const(list_data_off); i32_add;
                       local_get(xs); i32_const(list_data_off); i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty); // SHARE: copy from borrowed xs into fresh dst
                 wasm!(self.func, {
                       i32_const(1); local_set(out_count); // out_count = 1
                       i32_const(1); local_set(i); // i = 1
@@ -921,7 +921,7 @@ impl FuncCompiler<'_> {
                           local_get(xs); i32_const(list_data_off); i32_add;
                           local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty); // SHARE: copy from borrowed xs into fresh dst
                 wasm!(self.func, {
                           local_get(out_count); i32_const(1); i32_add; local_set(out_count);
                         end;
@@ -1013,7 +1013,10 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                // SHARE: copy the borrowed source elements into the fresh sorted
+                // result — dup so the result owns them (the in-place swaps below just
+                // rearrange these owned references; the source's Dec is balanced).
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
@@ -79,7 +79,7 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(copy_i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
                       br(0);
@@ -143,7 +143,7 @@ impl FuncCompiler<'_> {
                       local_get(start); local_get(copy_i); i32_add;
                       i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
                       br(0);
@@ -242,7 +242,7 @@ impl FuncCompiler<'_> {
                         local_get(xs); i32_const(list_data_off); i32_add;
                         local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(true_cnt); i32_const(1); i32_add; local_set(true_cnt);
                         i32_const(0);
@@ -252,7 +252,7 @@ impl FuncCompiler<'_> {
                         local_get(xs); i32_const(list_data_off); i32_add;
                         local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(false_cnt); i32_const(1); i32_add; local_set(false_cnt);
                         i32_const(0);
@@ -315,7 +315,7 @@ impl FuncCompiler<'_> {
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(copy_i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
                       br(0);
@@ -326,6 +326,21 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_get(in_bounds);
                     if_empty;
+                });
+                // Release the owned copy of the element being replaced (it
+                // received +1 in the copy loop and loses this slot). The
+                // closure still reads it first — dec AFTER the call would be
+                // ideal, but the call's argument is the same pointer and a
+                // rc>1 dec never frees; at rc==1 the closure-arg read happens
+                // before any reuse since nothing allocates in between.
+                if crate::pass_perceus::is_heap_type(&elem_ty) {
+                    wasm!(self.func, {
+                        local_get(dst); i32_const(list_data_off); i32_add;
+                        local_get(idx); i32_const(es); i32_mul; i32_add;
+                        i32_load(0); call(self.emitter.rt.rc_dec);
+                    });
+                }
+                wasm!(self.func, {
                     local_get(dst); i32_const(list_data_off); i32_add;
                     local_get(idx); i32_const(es); i32_mul; i32_add;
                     // Call f(dst[idx])
@@ -596,7 +611,7 @@ impl FuncCompiler<'_> {
                         local_get(xs); i32_const(list_data_off); i32_add;
                         local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(seen_keys);
                         local_get(out_count); i32_const(ks); i32_mul; i32_add;
@@ -974,8 +989,26 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     end; end;
                     local_get(dst); local_get(out_count); i32_store(0);
-                    local_get(dst);
                 });
+                // SHARE dup: kept elements are second references into the
+                // surviving source list. Walk dst[0..out_count] once —
+                // per-store incs would over-count rejected slots.
+                if crate::pass_perceus::is_heap_type(&elem_ty) {
+                    let wi = self.scratch.alloc_i32();
+                    wasm!(self.func, {
+                        i32_const(0); local_set(wi);
+                        block_empty; loop_empty;
+                            local_get(wi); local_get(out_count); i32_ge_u; br_if(1);
+                            local_get(dst); i32_const(list_data_off); i32_add;
+                            local_get(wi); i32_const(elem_size as i32); i32_mul; i32_add;
+                            i32_load(0); call(self.emitter.rt.rc_inc); drop;
+                            local_get(wi); i32_const(1); i32_add; local_set(wi);
+                            br(0);
+                        end; end;
+                    });
+                    self.scratch.free_i32(wi);
+                }
+                wasm!(self.func, { local_get(dst); });
                 if let Some((pl, pvt)) = filter_param_local {
                     self.scratch.free(pl, pvt);
                 }

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
@@ -1543,6 +1543,16 @@ impl FuncCompiler<'_> {
     /// True for: single-use variables (use_count == 1) OR temporary expressions
     /// (Call results, RuntimeCall results) that are not bound to any variable.
     fn is_single_use_var(&self, expr: &IrExpr) -> bool {
+        // Under real frees (ALMIDE_WASM_FREES=1) the IR-level Perceus pass is
+        // the ONLY owner of ownership decisions: it Decs every heap VDecl at
+        // scope end, so an emitter-level in-place reuse or raw rc_dec here
+        // would create a SECOND owner of the same block — the double-free the
+        // sentinel now catches at teardown (caught by the byte gate on
+        // wasm_list_map). The reuse this disables is a micro-optimization;
+        // block recycling still happens through the free list. Re-enabling it
+        // as an IR-level move (visible to the verifier) is the tracked
+        // follow-up in wasm-frees-ownership-discipline.md.
+        if super::runtime::wasm_frees_enabled() { return false; }
         match &expr.kind {
             IrExprKind::Var { id } => self.var_table.get(*id).use_count == 1,
             // Temporary expression results: consumed exactly here, never aliased

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
@@ -1043,7 +1043,10 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { local_set(list_ptr); });
                     let source_elem_ty = self.resolve_list_elem(source_expr, None);
                     let source_elem_size = values::byte_size(&source_elem_ty);
-                    self.emit_expr(&args[1]);
+                    // See the non-fused path: dup an alias accumulator seed so the
+                    // fold loop owns its reference and the caller's Dec of the seed
+                    // local cannot double-free the (empty-list) returned result.
+                    self.emit_stored_field(&args[1]);
                     wasm!(self.func, { local_set(acc); });
                     // Pointer-based iteration: ptr and end instead of idx
                     let ptr = self.scratch.alloc_i32();
@@ -1152,7 +1155,11 @@ impl FuncCompiler<'_> {
                 let end_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(list_ptr); });
-                self.emit_expr(&args[1]);
+                // The accumulator is MOVE-STORED into the fold loop and returned
+                // as the result (unchanged when the list is empty). Dup an alias
+                // seed so the loop owns its own reference and the caller's
+                // scope-end Dec of the seed local does not double-free the result.
+                self.emit_stored_field(&args[1]);
                 wasm!(self.func, { local_set(acc); });
                 if !is_inline_lambda {
                     self.emit_expr(&args[2]);

--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -42,6 +42,18 @@ enum SortKind {
 }
 
 impl SortKind {
+    /// Whether the sorted elements are heap POINTERS the result list must
+    /// own (drives the post-build dup walk under real frees).
+    fn elems_are_heap(&self) -> bool {
+        match self {
+            SortKind::Int | SortKind::Float => false,
+            SortKind::String | SortKind::ListString => true,
+            SortKind::Ord(t) => crate::pass_perceus::is_heap_type(t),
+        }
+    }
+}
+
+impl SortKind {
     fn elem_size(&self) -> u32 {
         match self {
             SortKind::Int | SortKind::Float => 8,
@@ -770,6 +782,35 @@ impl FuncCompiler<'_> {
             local_get(dst);
         });
 
+        // 3.5 SHARE dup: every element pointer was copied from the SOURCE
+        // list exactly once across the four dst-build paths (len<2 memcpy,
+        // ascending memcpy, descending copy, merge-initial memcpy; the merge
+        // passes only permute within dst) and the source survives with its
+        // own deep Dec — one inc per element, or sorting a List[List[..]]
+        // frees the inner lists the result shares (list_total_order hang).
+        if kind.elems_are_heap() {
+            let di = self.scratch.alloc_i32();
+            let dl = self.scratch.alloc_i32();
+            let data_off = self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32;
+            wasm!(self.func, {
+                local_set(di); // borrow di as the result holder briefly
+                local_get(di); i32_load(0); local_set(dl);
+                local_get(di); local_set(dst);
+                i32_const(0); local_set(di);
+                block_empty; loop_empty;
+                    local_get(di); local_get(dl); i32_ge_u; br_if(1);
+                    local_get(dst); i32_const(data_off); i32_add;
+                    local_get(di); i32_const(4); i32_mul; i32_add;
+                    i32_load(0); call(self.emitter.rt.rc_inc); drop;
+                    local_get(di); i32_const(1); i32_add; local_set(di);
+                    br(0);
+                end; end;
+                local_get(dst);
+            });
+            self.scratch.free_i32(dl);
+            self.scratch.free_i32(di);
+        }
+
         // 4. Free scratch.
         self.scratch.free_i32(scan_done);
         self.scratch.free_i32(k);
@@ -979,6 +1020,10 @@ impl FuncCompiler<'_> {
             i32_add;
         });
         self.emit_load_at(&elem_ty, 0);
+        // SHARE: the fresh tuple holds a second reference to the element.
+        if crate::pass_perceus::is_heap_type(&elem_ty) {
+            wasm!(self.func, { call(self.emitter.rt.rc_inc); });
+        }
         self.emit_store_at(&elem_ty, 8); // store at tuple offset 8
 
         wasm!(self.func, {

--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -387,6 +387,30 @@ impl FuncCompiler<'_> {
         }
     }
 
+    /// Copy one element from [stack: dst_addr, src_addr], taking a NEW owning
+    /// reference to it (the SHARE case). Use this when the destination structure
+    /// will outlive a *still-live* source that retains its own reference to the
+    /// element (e.g. a collection op copying out of a borrowed argument): without
+    /// the extra reference, the source's scope-end `Dec` would deep-free the value
+    /// the destination now holds.
+    ///
+    /// For heap elements (the i32 pointer branch) this is `emit_elem_copy` plus a
+    /// stack-neutral `rc_inc` inserted between the load and the store — `rc_inc`
+    /// returns its pointer unchanged, and its `heap_start` guard makes it a runtime
+    /// no-op on data-section pointers and scalar i32 (Bool), so the i32 branch can
+    /// increment unconditionally. Int/Float (i64/f64) are scalars and copy exactly
+    /// as `emit_elem_copy` does.
+    ///
+    /// NOT for intra-structure MOVES (grow-and-abandon, where the source buffer is
+    /// discarded): incrementing there would leak one reference per grow.
+    pub(super) fn emit_elem_copy_owned(&mut self, ty: &Ty) {
+        match values::ty_to_valtype(ty) {
+            Some(ValType::I64) => { wasm!(self.func, { i64_load(0); i64_store(0); }); }
+            Some(ValType::F64) => { wasm!(self.func, { f64_load(0); f64_store(0); }); }
+            _ => { wasm!(self.func, { i32_load(0); call(self.emitter.rt.rc_inc); i32_store(0); }); }
+        }
+    }
+
     /// Store one element: [stack: dst_addr, value].
     pub(super) fn emit_elem_store(&mut self, ty: &Ty) {
         match values::ty_to_valtype(ty) {
@@ -857,7 +881,10 @@ impl FuncCompiler<'_> {
                 local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
                 local_get(i); i32_const(es); i32_mul; i32_add;
         });
-        self.emit_elem_copy(&elem_ty);
+        // SHARE: a unique element copied from the borrowed source list into the fresh
+        // result — dup it so the result owns its reference (else the source's
+        // scope-end Dec deep-frees the element the result now holds).
+        self.emit_elem_copy_owned(&elem_ty);
         wasm!(self.func, {
                 local_get(dst);
                 local_get(dst); i32_load(0); i32_const(1); i32_add;

--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -407,7 +407,16 @@ impl FuncCompiler<'_> {
         match values::ty_to_valtype(ty) {
             Some(ValType::I64) => { wasm!(self.func, { i64_load(0); i64_store(0); }); }
             Some(ValType::F64) => { wasm!(self.func, { f64_load(0); f64_store(0); }); }
-            _ => { wasm!(self.func, { i32_load(0); call(self.emitter.rt.rc_inc); i32_store(0); }); }
+            // The inc is gated on HEAP-ness, not on "rides in i32": Int32/
+            // UInt32/Float32 are 4-byte SCALARS whose values can exceed
+            // heap_start — an unconditional rc_inc would write +1 into a
+            // fake header at an arbitrary address (live landmine under
+            // frees). Bool's data-section guard was masking this for the
+            // other 4-byte scalars only by luck of small values.
+            _ if crate::pass_perceus::is_heap_type(ty) => {
+                wasm!(self.func, { i32_load(0); call(self.emitter.rt.rc_inc); i32_store(0); });
+            }
+            _ => { wasm!(self.func, { i32_load(0); i32_store(0); }); }
         }
     }
 

--- a/crates/almide-codegen/src/emit_wasm/calls_map.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map.rs
@@ -320,7 +320,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { local_set(ib); });
                 self.emit_dict_entries_base(nm, cap);
                 wasm!(self.func, { local_set(eb); });
-                self.emit_dict_put_entry(nm, cap, ib, eb, tmp, es, ks, vs, &key_ty);
+                self.emit_dict_put_entry(nm, cap, ib, eb, tmp, es, ks, vs, &key_ty, &val_ty);
                 wasm!(self.func, { local_get(nm); });
 
                 self.scratch.free_i32(eb);
@@ -372,7 +372,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { local_set(ib); });
                 self.emit_dict_entries_base(m, cap);
                 wasm!(self.func, { local_set(eb); });
-                self.emit_dict_put_entry(m, cap, ib, eb, tmp, es, ks, vs, &key_ty);
+                self.emit_dict_put_entry(m, cap, ib, eb, tmp, es, ks, vs, &key_ty, &val_ty);
                 // Grow if the load factor is exceeded (only a new key can trip it).
                 wasm!(self.func, {
                     local_get(m); i32_load(0); i32_const(lm::LOAD_DEN as i32); i32_mul;
@@ -589,7 +589,8 @@ impl FuncCompiler<'_> {
                       local_get(j); local_get(len_b); i32_ge_u; br_if(1);
                       local_get(eb_b); local_get(j); i32_const(es as i32); i32_mul; i32_add; local_set(src);
                 });
-                self.emit_dict_put_entry(result, r_cap, ib, eb, src, es, ks, vs, &key_ty);
+                let val_ty = self.map_val_ty(&args[0].ty);
+                self.emit_dict_put_entry(result, r_cap, ib, eb, src, es, ks, vs, &key_ty, &val_ty);
                 wasm!(self.func, {
                       local_get(j); i32_const(1); i32_add; local_set(j); br(0);
                     end; end;
@@ -613,11 +614,12 @@ impl FuncCompiler<'_> {
                 // Build a COD from a List[(K,V)]: size for plen, then put each pair in
                 // order (duplicate keys → last value wins, position kept).
                 let pair_ty = self.resolve_list_elem(&args[0], None);
-                let (ks, vs, key_ty) = if let Ty::Tuple(elems) = &pair_ty {
+                let (ks, vs, key_ty, val_ty) = if let Ty::Tuple(elems) = &pair_ty {
                     (elems.first().map(|t| values::byte_size(t)).unwrap_or(4),
                      elems.get(1).map(|t| values::byte_size(t)).unwrap_or(4),
-                     elems.first().cloned().unwrap_or(Ty::String))
-                } else { (4u32, 4u32, Ty::String) };
+                     elems.first().cloned().unwrap_or(Ty::String),
+                     elems.get(1).cloned().unwrap_or(Ty::Int))
+                } else { (4u32, 4u32, Ty::String, Ty::Int) };
                 let es = ks + vs;
                 let pairs = self.scratch.alloc_i32();
                 let plen = self.scratch.alloc_i32();
@@ -647,7 +649,7 @@ impl FuncCompiler<'_> {
                       local_get(i); i32_const(4); i32_mul; i32_add;
                       i32_load(0); local_set(tp); // tp = pairs.data[i] = (K,V) tuple ptr
                 });
-                self.emit_dict_put_entry(result, cap, ib, eb, tp, es, ks, vs, &key_ty);
+                self.emit_dict_put_entry(result, cap, ib, eb, tp, es, ks, vs, &key_ty, &val_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i); br(0);
                     end; end;
@@ -1139,7 +1141,7 @@ impl FuncCompiler<'_> {
     /// existing → overwrite its value in place (dense position kept); new → append
     /// at entries[len], write tags[slot]=h2, index[slot]=len+1, bump len. Assumes
     /// the caller has reserved capacity (no grow). `ib`/`eb` are the index/entries bases.
-    pub(super) fn emit_dict_put_entry(&mut self, map: u32, cap: u32, ib: u32, eb: u32, src: u32, es: u32, ks: u32, vs: u32, key_ty: &Ty) {
+    pub(super) fn emit_dict_put_entry(&mut self, map: u32, cap: u32, ib: u32, eb: u32, src: u32, es: u32, ks: u32, vs: u32, key_ty: &Ty, val_ty: &Ty) {
         use super::engine::layout::{SWISS_MAP, map as lm};
         let tags_off = self.emitter.layout_reg.fixed_offset(SWISS_MAP, lm::TAGS) as i32;
         let idx = self.scratch.alloc_i32();
@@ -1181,12 +1183,33 @@ impl FuncCompiler<'_> {
               local_get(map); local_get(ei); i32_const(1); i32_add; i32_store(0); // map.len = ei+1
               local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
               local_get(src); i32_const(ks as i32); memory_copy;   // copy key bytes
+        });
+        // SHARE: a NEW heap key was just copied (by reference) from the borrowed
+        // source — dup it so the dict owns its own reference, else the source's
+        // scope-end Dec deep-frees the key the dict now holds (double-free). Only on
+        // the new-key path (an existing key keeps the reference it already owns).
+        if Self::is_heap_type(key_ty) {
+            wasm!(self.func, {
+              local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
+              i32_load(0); call(self.emitter.rt.rc_inc); drop;
+            });
+        }
+        wasm!(self.func, {
             end;
             // Copy value bytes into entries[ei]+ks (both new and existing).
             local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add; i32_const(ks as i32); i32_add;
             local_get(src); i32_const(ks as i32); i32_add;
             i32_const(vs as i32); memory_copy;
         });
+        // SHARE: the heap value was copied (by reference) from the borrowed source —
+        // dup it for the same reason. (Overwriting an existing heap value leaks the
+        // old one — a separate, non-crashing gap, not a double-free.)
+        if Self::is_heap_type(val_ty) {
+            wasm!(self.func, {
+              local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add; i32_const(ks as i32); i32_add;
+              i32_load(0); call(self.emitter.rt.rc_inc); drop;
+            });
+        }
         self.scratch.free_i32(ei);
         self.scratch.free_i32(tg);
         self.scratch.free_i32(h2);

--- a/crates/almide-codegen/src/emit_wasm/calls_map.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map.rs
@@ -99,7 +99,7 @@ impl FuncCompiler<'_> {
                           local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
                           i32_const(ks as i32); i32_add;
                 });
-                self.emit_elem_copy_sized(vs);
+                self.emit_elem_copy_sized(vs, false);
                 wasm!(self.func, {
                           local_get(vc); local_set(result); br(3);
                         end;
@@ -315,7 +315,7 @@ impl FuncCompiler<'_> {
                 });
                 self.emit_dict_fit_cap(n, cap);
                 self.emit_dict_alloc(nm, cap, es);
-                self.emit_dict_recap(m, old_cap, nm, cap, es, &key_ty);
+                self.emit_dict_recap(m, old_cap, nm, cap, es, &key_ty, Some((&key_ty, &val_ty)));
                 self.emit_dict_index_base(nm, cap);
                 wasm!(self.func, { local_set(ib); });
                 self.emit_dict_entries_base(nm, cap);
@@ -442,6 +442,27 @@ impl FuncCompiler<'_> {
                       if_empty;  // key != search key → keep (append densely)
                         local_get(eb_new); local_get(ne); i32_const(es as i32); i32_mul; i32_add;
                         local_get(entry); i32_const(es as i32); memory_copy;
+                });
+                // SHARE dup: the source dict survives `remove` and owns the
+                // kept entries — the survivor copy needs its own references.
+                {
+                    let kh = crate::pass_perceus::is_heap_type(&key_ty);
+                    let vh = crate::pass_perceus::is_heap_type(&self.map_val_ty(&args[0].ty));
+                    if kh {
+                        wasm!(self.func, {
+                        local_get(eb_new); local_get(ne); i32_const(es as i32); i32_mul; i32_add;
+                        i32_load(0); call(self.emitter.rt.rc_inc); drop;
+                        });
+                    }
+                    if vh {
+                        wasm!(self.func, {
+                        local_get(eb_new); local_get(ne); i32_const(es as i32); i32_mul; i32_add;
+                        i32_const(ks as i32); i32_add;
+                        i32_load(0); call(self.emitter.rt.rc_inc); drop;
+                        });
+                    }
+                }
+                wasm!(self.func, {
                         local_get(ne); i32_const(1); i32_add; local_set(ne);
                       end;
                       local_get(i); i32_const(1); i32_add; local_set(i); br(0);
@@ -507,7 +528,9 @@ impl FuncCompiler<'_> {
                             local_get(i); i32_const(ks as i32); i32_mul; i32_add;
                             local_get(eb); local_get(i); i32_const(es as i32); i32_mul; i32_add;
                         });
-                        self.emit_elem_copy_sized(ks);
+                        // SHARE: the dict survives and owns these keys.
+                        let dup = crate::pass_perceus::is_heap_type(&self.map_key_ty(&args[0].ty));
+                        self.emit_elem_copy_sized(ks, dup);
                     }
                     "values" => {
                         wasm!(self.func, {
@@ -516,7 +539,8 @@ impl FuncCompiler<'_> {
                             local_get(eb); local_get(i); i32_const(es as i32); i32_mul; i32_add;
                             i32_const(ks as i32); i32_add;
                         });
-                        self.emit_elem_copy_sized(vs);
+                        let dup = crate::pass_perceus::is_heap_type(&self.map_val_ty(&args[0].ty));
+                        self.emit_elem_copy_sized(vs, dup);
                     }
                     _ => {
                         wasm!(self.func, {
@@ -549,6 +573,7 @@ impl FuncCompiler<'_> {
                 // value is overwritten by b; b-only keys append after a's entries.
                 let (ks, vs) = self.map_kv_sizes(&args[0].ty);
                 let key_ty = self.map_key_ty(&args[0].ty);
+                let val_ty = self.map_val_ty(&args[0].ty);
                 let es = ks + vs;
                 let ma = self.scratch.alloc_i32();
                 let mb = self.scratch.alloc_i32();
@@ -576,7 +601,7 @@ impl FuncCompiler<'_> {
                 });
                 self.emit_dict_fit_cap(n, r_cap);
                 self.emit_dict_alloc(result, r_cap, es);
-                self.emit_dict_recap(ma, cap_a, result, r_cap, es, &key_ty);
+                self.emit_dict_recap(ma, cap_a, result, r_cap, es, &key_ty, Some((&key_ty, &val_ty)));
                 self.emit_dict_index_base(result, r_cap);
                 wasm!(self.func, { local_set(ib); });
                 self.emit_dict_entries_base(result, r_cap);
@@ -895,6 +920,10 @@ impl FuncCompiler<'_> {
 
     // ── Map type helpers ──
 
+    pub(super) fn map_kv_sizes_from(&self, k: &Ty, v: &Ty) -> (u32, u32) {
+        (values::byte_size(k), values::byte_size(v))
+    }
+
     pub(super) fn map_kv_sizes(&self, ty: &Ty) -> (u32, u32) {
         if let Ty::Applied(_, args) = ty {
             (args.first().map(|t| values::byte_size(t)).unwrap_or(4),
@@ -988,9 +1017,14 @@ impl FuncCompiler<'_> {
     pub(super) fn key_valtype(key_ty: &Ty) -> ValType {
         match key_ty { Ty::Int => ValType::I64, _ => ValType::I32 }
     }
-    pub(super) fn emit_elem_copy_sized(&mut self, size: u32) {
+    pub(super) fn emit_elem_copy_sized(&mut self, size: u32, dup: bool) {
+        // `dup` = the 4-byte slot is a HEAP POINTER being SHARED (source
+        // survives) — the copy must own its own reference. Callers decide
+        // via is_heap_type on the actual K/V Ty; size alone cannot (Int32/
+        // Bool are 4-byte scalars).
         match size {
             8 => { wasm!(self.func, { i64_load(0); i64_store(0); }); }
+            4 if dup => { wasm!(self.func, { i32_load(0); call(self.emitter.rt.rc_inc); i32_store(0); }); }
             4 => { wasm!(self.func, { i32_load(0); i32_store(0); }); }
             _ => { wasm!(self.func, { i32_load(0); i32_store(0); }); }
         }
@@ -1109,7 +1143,7 @@ impl FuncCompiler<'_> {
     /// Copy `src`'s dense entries (src.len of them) into the freshly-alloced `dst`
     /// table, set dst.len = src.len, and rebuild dst's index. `dst` must already
     /// be `emit_dict_alloc`-ed at `dst_cap` (entries stride `es`, tags+index zeroed).
-    pub(super) fn emit_dict_recap(&mut self, src: u32, src_cap: u32, dst: u32, dst_cap: u32, es: u32, key_ty: &Ty) {
+    pub(super) fn emit_dict_recap(&mut self, src: u32, src_cap: u32, dst: u32, dst_cap: u32, es: u32, key_ty: &Ty, dup: Option<(&Ty, &Ty)>) {
         let len = self.scratch.alloc_i32();
         wasm!(self.func, { local_get(src); i32_load(0); local_set(len); });
         self.emit_dict_entries_base(dst, dst_cap); // memory_copy dest
@@ -1118,6 +1152,45 @@ impl FuncCompiler<'_> {
             local_get(len); i32_const(es as i32); i32_mul; memory_copy;
             local_get(dst); local_get(len); i32_store(0); // dst.len = src.len
         });
+        // SHARE vs MOVE: `dup = Some((K, V))` when the SOURCE dict survives
+        // (map.set / map.merge build a sibling) — every copied heap key/val
+        // pointer needs its own reference. `None` for grow (the old table is
+        // abandoned undecremented: a MOVE; dup would leak per grow).
+        if let Some((k_ty, v_ty)) = dup {
+            let kh = crate::pass_perceus::is_heap_type(k_ty);
+            let vh = crate::pass_perceus::is_heap_type(v_ty);
+            if kh || vh {
+                let (ks, _) = self.map_kv_sizes_from(k_ty, v_ty);
+                let di = self.scratch.alloc_i32();
+                let de = self.scratch.alloc_i32();
+                self.emit_dict_entries_base(dst, dst_cap);
+                wasm!(self.func, { local_set(de); i32_const(0); local_set(di); });
+                wasm!(self.func, {
+                    block_empty; loop_empty;
+                        local_get(di); local_get(len); i32_ge_u; br_if(1);
+                });
+                if kh {
+                    wasm!(self.func, {
+                        local_get(de); local_get(di); i32_const(es as i32); i32_mul; i32_add;
+                        i32_load(0); call(self.emitter.rt.rc_inc); drop;
+                    });
+                }
+                if vh {
+                    wasm!(self.func, {
+                        local_get(de); local_get(di); i32_const(es as i32); i32_mul; i32_add;
+                        i32_const(ks as i32); i32_add;
+                        i32_load(0); call(self.emitter.rt.rc_inc); drop;
+                    });
+                }
+                wasm!(self.func, {
+                        local_get(di); i32_const(1); i32_add; local_set(di);
+                        br(0);
+                    end; end;
+                });
+                self.scratch.free_i32(de);
+                self.scratch.free_i32(di);
+            }
+        }
         self.emit_dict_rebuild_index(dst, dst_cap, es, key_ty);
         self.scratch.free_i32(len);
     }
@@ -1130,7 +1203,7 @@ impl FuncCompiler<'_> {
         let nm = self.scratch.alloc_i32();
         wasm!(self.func, { local_get(cap); i32_const(lm::GROWTH_SHIFT as i32); i32_shl; local_set(nc); });
         self.emit_dict_alloc(nm, nc, es);
-        self.emit_dict_recap(map, cap, nm, nc, es, key_ty);
+        self.emit_dict_recap(map, cap, nm, nc, es, key_ty, None);
         wasm!(self.func, { local_get(nm); local_set(map); local_get(nc); local_set(cap); });
         self.scratch.free_i32(nm);
         self.scratch.free_i32(nc);

--- a/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
@@ -292,6 +292,14 @@ impl FuncCompiler<'_> {
                     local_get(it.i); i32_const(es_old as i32); i32_mul; i32_add;
                     i32_const(ks as i32); memory_copy;
                 });
+                // SHARE: the source dict survives and owns these keys.
+                if crate::pass_perceus::is_heap_type(&self.map_key_ty(&args[0].ty)) {
+                    wasm!(self.func, {
+                        local_get(new_eb);
+                        local_get(it.i); i32_const(es_new as i32); i32_mul; i32_add;
+                        i32_load(0); call(self.emitter.rt.rc_inc); drop;
+                    });
+                }
                 // dst = new_eb + i*es_new + ks (new val addr in the rebuilt table)
                 wasm!(self.func, {
                     local_get(new_eb);
@@ -434,9 +442,10 @@ impl FuncCompiler<'_> {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
                     end; end;
-                    // If not found, return the original map unchanged.
+                    // If not found, return the original map unchanged —
+                    // SHARE: the result is a SECOND reference to the input.
                     local_get(found_idx); i32_const(0); i32_lt_s;
-                    if_i32; local_get(map_ptr);
+                    if_i32; local_get(map_ptr); call(self.emitter.rt.rc_inc);
                     else_;
                       // Byte-copy the whole COD table: header + cap*per_slot.
                       i32_const(map_hdr);
@@ -446,6 +455,46 @@ impl FuncCompiler<'_> {
                       local_get(new_map); local_get(map_ptr); local_get(total_size);
                       memory_copy;
                 });
+                // SHARE dup over the copied table: the source survives and
+                // owns every entry; the copy needs its own references. The
+                // updated slot's OLD value ref is released below before the
+                // closure result overwrites it.
+                {
+                    let kh = crate::pass_perceus::is_heap_type(&key_ty);
+                    let vh = crate::pass_perceus::is_heap_type(&val_ty);
+                    if kh || vh {
+                        let di = self.scratch.alloc_i32();
+                        let de = self.scratch.alloc_i32();
+                        let dlen = self.scratch.alloc_i32();
+                        wasm!(self.func, { local_get(new_map); i32_load(0); local_set(dlen); });
+                        self.emit_dict_entries_base(new_map, cap);
+                        wasm!(self.func, { local_set(de); i32_const(0); local_set(di);
+                            block_empty; loop_empty;
+                                local_get(di); local_get(dlen); i32_ge_u; br_if(1);
+                        });
+                        if kh {
+                            wasm!(self.func, {
+                                local_get(de); local_get(di); i32_const(entry as i32); i32_mul; i32_add;
+                                i32_load(0); call(self.emitter.rt.rc_inc); drop;
+                            });
+                        }
+                        if vh {
+                            wasm!(self.func, {
+                                local_get(de); local_get(di); i32_const(entry as i32); i32_mul; i32_add;
+                                i32_const(ks as i32); i32_add;
+                                i32_load(0); call(self.emitter.rt.rc_inc); drop;
+                            });
+                        }
+                        wasm!(self.func, {
+                                local_get(di); i32_const(1); i32_add; local_set(di);
+                                br(0);
+                            end; end;
+                        });
+                        self.scratch.free_i32(dlen);
+                        self.scratch.free_i32(de);
+                        self.scratch.free_i32(di);
+                    }
+                }
                 // valaddr = dense entries base(new_map, cap) + found_idx*entry + ks
                 self.emit_dict_entries_base(new_map, cap);
                 wasm!(self.func, {
@@ -456,9 +505,21 @@ impl FuncCompiler<'_> {
                       local_get(valaddr);              // load old val from same addr
                 });
                 self.emit_load_at(&val_ty, 0);
+                // Capture the OLD value before the overwrite so its dup'd
+                // reference (from the table walk above) can be released after
+                // the closure result replaces it.
+                let old_val = if crate::pass_perceus::is_heap_type(&val_ty) {
+                    let ov = self.scratch.alloc_i32();
+                    wasm!(self.func, { local_tee(ov); });
+                    Some(ov)
+                } else { None };
                 wasm!(self.func, { local_get(closure); i32_load(0); }); // table_idx
                 self.emit_closure_call(&val_ty, &val_ty);
                 self.emit_store_at(&val_ty, 0);
+                if let Some(ov) = old_val {
+                    wasm!(self.func, { local_get(ov); call(self.emitter.rt.rc_dec); });
+                    self.scratch.free_i32(ov);
+                }
                 wasm!(self.func, {
                       local_get(new_map);
                     end;

--- a/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
@@ -225,7 +225,7 @@ impl FuncCompiler<'_> {
                     self.emit_call_indirect(ct, vec![ValType::I32]);
                 }
                 wasm!(self.func, { if_empty; }); // pred true → keep
-                self.emit_dict_put_entry(nm, cap, ib, eb_new, entry, es, ks, vs, &key_ty);
+                self.emit_dict_put_entry(nm, cap, ib, eb_new, entry, es, ks, vs, &key_ty, &val_ty);
                 wasm!(self.func, {
                       end; // pred-true if
                       local_get(i); i32_const(1); i32_add; local_set(i); br(0);

--- a/crates/almide-codegen/src/emit_wasm/calls_set.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_set.rs
@@ -86,6 +86,8 @@ impl FuncCompiler<'_> {
                           local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(s3); i32_const(es); i32_mul; i32_add;
                 });
+                // MOVE: from_list grows its OWN accumulator buffer and abandons the
+                // old one — the element references just relocate, no new owner.
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
                           local_get(s3); i32_const(1); i32_add; local_set(s3);
@@ -97,8 +99,13 @@ impl FuncCompiler<'_> {
                         local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(s1); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
+                        // Free the abandoned old accumulator backing: its elements
+                        // were MOVE-copied into s2, so a PLAIN rc_dec reclaims just
+                        // this buffer (not the relocated elements). Without it every
+                        // grow leaks its previous buffer (O(n) churn per from_list).
+                        local_get(s); call(self.emitter.rt.rc_dec);
                         local_get(s2); local_set(s);
                       end;
                       local_get(s1); i32_const(1); i32_add; local_set(s1);
@@ -220,7 +227,10 @@ impl FuncCompiler<'_> {
                       br(0);
                     end; end;
                     local_get(s2);
-                    if_i32; local_get(s);
+                    // SHARE: dedup hit → the result IS the borrowed input set. Dup it
+                    // so the caller's scope-end Dec of both the input and the result
+                    // don't double-free the single heap set they now share.
+                    if_i32; local_get(s); call(self.emitter.rt.rc_inc);
                     else_;
                       i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(s); i32_load(0); i32_const(1); i32_add;
                       i32_const(es); i32_mul; i32_add;
@@ -234,7 +244,7 @@ impl FuncCompiler<'_> {
                         local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(s2); i32_const(1); i32_add; local_set(s2);
                         br(0);
@@ -243,6 +253,13 @@ impl FuncCompiler<'_> {
                       local_get(s); i32_load(0); i32_const(es); i32_mul; i32_add;
                       local_get(val);
                 });
+                // SHARE: `val` (args[1]) is a borrowed element; the new set takes a
+                // new reference to it, so dup before storing (heap i32 only — rc_inc
+                // no-ops on scalars). This runs only on the not-found branch, so a
+                // deduplicated (already-present) element is never over-incremented.
+                if vt == ValType::I32 {
+                    wasm!(self.func, { call(self.emitter.rt.rc_inc); });
+                }
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, { local_get(s1); end; });
                 self.scratch.free(val, vt);
@@ -281,7 +298,9 @@ impl FuncCompiler<'_> {
                       br(0);
                     end; end;
                     local_get(s1); i32_const(0); i32_lt_s;
-                    if_i32; local_get(s); // not found
+                    // SHARE: element absent → the result IS the borrowed input set;
+                    // dup so input and result don't double-free the shared heap set.
+                    if_i32; local_get(s); call(self.emitter.rt.rc_inc); // not found
                     else_;
                       // Store original set ptr
                       local_get(s); local_set(orig);
@@ -304,7 +323,7 @@ impl FuncCompiler<'_> {
                           local_get(orig); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(s3); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                           local_get(s); i32_const(1); i32_add; local_set(s);
                         end;
@@ -349,7 +368,7 @@ impl FuncCompiler<'_> {
                       local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -386,7 +405,7 @@ impl FuncCompiler<'_> {
                         local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(i); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(out_count); i32_const(1); i32_add; local_set(out_count);
                       end;
@@ -404,8 +423,11 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(a);
             }
             "to_list" => {
-                // Set has same layout as List — just return the ptr
+                // Set has same layout as List — return the ptr, but as a NEW owner:
+                // the resulting List and the source Set share one heap object, so dup
+                // its refcount (else both their scope-end Decs double-free it).
                 self.emit_expr(&args[0]);
+                wasm!(self.func, { call(self.emitter.rt.rc_inc); });
             }
             "intersection" => {
                 // intersection(a, b) → Set[A]: elements in both a and b.
@@ -464,7 +486,7 @@ impl FuncCompiler<'_> {
                         local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(s1); i32_const(1); i32_add; local_set(s1);
                       end;
@@ -530,7 +552,7 @@ impl FuncCompiler<'_> {
                         local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(s1); i32_const(1); i32_add; local_set(s1);
                       end;
@@ -603,7 +625,7 @@ impl FuncCompiler<'_> {
                         local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(s1); i32_const(1); i32_add; local_set(s1);
                       end;
@@ -641,7 +663,7 @@ impl FuncCompiler<'_> {
                         local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(s2); i32_const(es); i32_mul; i32_add;
                 });
-                self.emit_elem_copy(&elem_ty);
+                self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
                         local_get(s1); i32_const(1); i32_add; local_set(s1);
                       end;
@@ -844,6 +866,9 @@ impl FuncCompiler<'_> {
                 });
                 self.emit_elem_copy(&result_elem_ty);
                 wasm!(self.func, {
+                        // Free the abandoned old dedup accumulator (elements MOVE-copied
+                        // into j); plain rc_dec reclaims just this buffer.
+                        local_get(result); call(self.emitter.rt.rc_dec);
                         local_get(j); local_set(result);
                       end;
                       local_get(i); i32_const(1); i32_add; local_set(i);

--- a/crates/almide-codegen/src/emit_wasm/calls_value.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_value.rs
@@ -75,7 +75,7 @@ impl FuncCompiler<'_> {
                 // value.str(s: String) -> Value: alloc [tag=4][str_ptr]
                 let val = self.scratch.alloc_i32();
                 let ptr = self.scratch.alloc_i32();
-                self.emit_expr(&args[0]);
+                self.emit_stored_field(&args[0]);
                 wasm!(self.func, {
                     local_set(val);
                     i32_const(8); call(self.emitter.rt.alloc); local_set(ptr);
@@ -90,7 +90,7 @@ impl FuncCompiler<'_> {
                 // value.array(xs: List[Value]) -> Value: alloc [tag=5][list_ptr]
                 let val = self.scratch.alloc_i32();
                 let ptr = self.scratch.alloc_i32();
-                self.emit_expr(&args[0]);
+                self.emit_stored_field(&args[0]);
                 wasm!(self.func, {
                     local_set(val);
                     i32_const(8); call(self.emitter.rt.alloc); local_set(ptr);
@@ -105,7 +105,7 @@ impl FuncCompiler<'_> {
                 // value.object(pairs: List[(String, Value)]) -> Value: alloc [tag=6][list_ptr]
                 let val = self.scratch.alloc_i32();
                 let ptr = self.scratch.alloc_i32();
-                self.emit_expr(&args[0]);
+                self.emit_stored_field(&args[0]);
                 wasm!(self.func, {
                     local_set(val);
                     i32_const(8); call(self.emitter.rt.alloc); local_set(ptr);

--- a/crates/almide-codegen/src/emit_wasm/calls_value.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_value.rs
@@ -341,10 +341,12 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { call(self.emitter.rt.json_get_path); });
             }
             "set_path" => {
-                // json.set_path(j, path, value) → Result[Value, String]
+                // json.set_path(j, path, value) → Result[Value, String].
+                // new_val is MOVE-stored into the rebuilt tree — stored-field
+                // contract so an alias argument carries its own reference.
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                self.emit_expr(&args[2]);
+                self.emit_stored_field(&args[2]);
                 wasm!(self.func, { call(self.emitter.rt.json_set_path); });
             }
             "remove_path" => {
@@ -397,9 +399,13 @@ impl FuncCompiler<'_> {
                 local_get(key);
                 call(self.emitter.rt.string.eq);
                 if_empty;
-                  // Found: some(value) — alloc Option box with value ptr
+                  // Found: some(value) — alloc Option box with value ptr.
+                  // SHARE: the boxed pointer is an interior reference into a
+                  // Value tree the caller still owns — dup it.
                   i32_const(4); call(self.emitter.rt.alloc); local_set(result);
-                  local_get(result); local_get(pair_ptr); i32_load(4); i32_store(0);
+                  local_get(result);
+                  local_get(pair_ptr); i32_load(4); call(self.emitter.rt.rc_inc);
+                  i32_store(0);
                   br(2);
                 end;
                 local_get(i); i32_const(1); i32_add; local_set(i);
@@ -430,10 +436,21 @@ impl FuncCompiler<'_> {
             local_set(v);
             local_get(v); i32_load(0); i32_const(expected_tag); i32_eq;
             if_i32;
-              // Correct tag: return ok(payload at offset 4)
+              // Correct tag: return ok(payload at offset 4). The STRING
+              // payload is an interior pointer into the surviving Value —
+              // dup it (scalar tags copy by value).
               i32_const(8); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(0); i32_store(0); // ok
-              local_get(result); local_get(v); i32_load(4); i32_store(4);
+              local_get(result);
+              local_get(v); i32_load(4);
+        });
+        if expected_tag == 4 || expected_tag == 5 {
+            // tags 4 (string) and 5 (array) carry POINTER payloads; bool
+            // shares the 4-byte size but is a scalar — key on the TAG.
+            wasm!(self.func, { call(self.emitter.rt.rc_inc); });
+        }
+        wasm!(self.func, {
+              i32_store(4);
               local_get(result);
             else_;
               // Wrong tag: return err("expected <type>")
@@ -555,9 +572,14 @@ impl FuncCompiler<'_> {
               local_get(option_box);
               local_get(found_val);
         });
-        // Copy payload from Value offset 4 to option box offset 0
+        // Copy payload from Value offset 4 to option box offset 0.
+        // get_string/get_array box an INTERIOR POINTER into the surviving
+        // Value tree → dup (SHARE). get_int/get_float are 8-byte scalars;
+        // get_bool is a 4-byte scalar — key on the FUNC, not the size.
+        let payload_is_ptr = matches!(func, "get_string" | "get_array");
         match payload_size {
             8 => { wasm!(self.func, { i64_load(4); i64_store(0); }); }
+            _ if payload_is_ptr => { wasm!(self.func, { i32_load(4); call(self.emitter.rt.rc_inc); i32_store(0); }); }
             _ => { wasm!(self.func, { i32_load(4); i32_store(0); }); }
         }
         wasm!(self.func, {

--- a/crates/almide-codegen/src/emit_wasm/collections.rs
+++ b/crates/almide-codegen/src/emit_wasm/collections.rs
@@ -89,7 +89,7 @@ impl FuncCompiler<'_> {
             for (field_name, field_ty) in &type_fields {
                 if let Some(expr) = explicit_map.get(field_name.as_str()) {
                     wasm!(self.func, { local_get(scratch); });
-                    self.emit_expr(expr);
+                    self.emit_stored_field(expr);
                     let store_ty = if expr.ty.is_unresolved() {
                         field_ty
                     } else {
@@ -124,7 +124,7 @@ impl FuncCompiler<'_> {
             for (_, field_expr) in fields {
                 let field_size = values::byte_size(&field_expr.ty);
                 wasm!(self.func, { local_get(scratch); });
-                self.emit_expr(field_expr);
+                self.emit_stored_field(field_expr);
                 self.emit_store_at(&field_expr.ty, offset);
                 offset += field_size;
             }
@@ -265,7 +265,7 @@ impl FuncCompiler<'_> {
         for (i, elem) in elements.iter().enumerate() {
             let offset = 8 + (i as u32) * elem_size;
             wasm!(self.func, { local_get(scratch); });
-            self.emit_expr(elem);
+            self.emit_stored_field(elem);
             self.emit_store_at(&elem.ty, offset);
         }
 
@@ -368,7 +368,7 @@ impl FuncCompiler<'_> {
             };
             let size = values::byte_size(&elem_ty);
             wasm!(self.func, { local_get(scratch); });
-            self.emit_expr(elem);
+            self.emit_stored_field(elem);
             self.emit_store_at(&elem_ty, offset);
             offset += size;
         }

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -18,6 +18,25 @@ pub(super) enum CmpKind {
 }
 
 impl FuncCompiler<'_> {
+    /// Emit `expr` as a value that is about to be MOVE-STORED into a constructor
+    /// or value-builder (a record field, list/tuple element, Option/Result
+    /// payload, or a `value.str/array/object` box). These builders take the raw
+    /// pointer by reference without copying, so if `expr` yields a borrowed heap
+    /// ALIAS — a field of a borrowed param (`self.name`), an extracted element,
+    /// or a local that owns it elsewhere — the container must acquire its OWN
+    /// reference. Otherwise freeing the container later double-frees a value its
+    /// source still holds. `__rc_inc` is stack-neutral (ptr → ptr) and a runtime
+    /// no-op on data-section constants; gating on `yields_borrowed_alias` keeps
+    /// us from leaking fresh heap values (an extra ref no owner ever releases).
+    pub(super) fn emit_stored_field(&mut self, expr: &IrExpr) {
+        self.emit_expr(expr);
+        if crate::pass_perceus::is_heap_type(&expr.ty)
+            && crate::pass_perceus::yields_borrowed_alias(expr)
+        {
+            wasm!(self.func, { call(self.emitter.rt.rc_inc); });
+        }
+    }
+
     /// Emit WASM instructions for an IR expression.
     /// Leaves the result value on the WASM stack (nothing for Unit).
     pub fn emit_expr(&mut self, expr: &IrExpr) {
@@ -480,6 +499,7 @@ impl FuncCompiler<'_> {
                     let vs = if let Some((_, v)) = entries.first() { values::byte_size(&v.ty) } else { 4 };
                     let es = ks + vs;
                     let key_ty = if let Some((k, _)) = entries.first() { k.ty.clone() } else { Ty::String };
+                    let val_ty = if let Some((_, v)) = entries.first() { v.ty.clone() } else { Ty::Int };
                     let mut cap = super::engine::layout::map::INITIAL_CAP;
                     while cap < n * 2 { cap *= 2; }
 
@@ -503,7 +523,7 @@ impl FuncCompiler<'_> {
                         wasm!(self.func, { local_get(tmp); i32_const(ks as i32); i32_add; });
                         self.emit_expr(val);
                         self.emit_store_at(&val.ty, 0);
-                        self.emit_dict_put_entry(map, cap_local, ib, eb, tmp, es, ks, vs, &key_ty);
+                        self.emit_dict_put_entry(map, cap_local, ib, eb, tmp, es, ks, vs, &key_ty, &val_ty);
                     }
                     wasm!(self.func, { local_get(map); });
                     self.scratch.free_i32(tmp);
@@ -532,7 +552,7 @@ impl FuncCompiler<'_> {
                     local_set(scratch);
                     local_get(scratch);
                 });
-                self.emit_expr(inner);
+                self.emit_stored_field(inner);
                 self.emit_store_at(&inner_ty, 0);
                 wasm!(self.func, { local_get(scratch); });
                 self.scratch.free_i32(scratch);
@@ -561,7 +581,7 @@ impl FuncCompiler<'_> {
                 });
                 if values::ty_to_valtype(&inner_ty).is_some() {
                     wasm!(self.func, { local_get(scratch); });
-                    self.emit_expr(inner);
+                    self.emit_stored_field(inner);
                     self.emit_store_at(&inner_ty, 4);
                 } else {
                     // Unit or zero-sized: still emit for side effects
@@ -588,7 +608,7 @@ impl FuncCompiler<'_> {
                 });
                 if values::ty_to_valtype(&inner_ty).is_some() {
                     wasm!(self.func, { local_get(scratch); });
-                    self.emit_expr(inner);
+                    self.emit_stored_field(inner);
                     self.emit_store_at(&inner_ty, 4);
                 } else {
                     // Unit or zero-sized: still emit for side effects

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -1178,6 +1178,50 @@ impl FuncCompiler<'_> {
                     i32_const(elem_size as i32);
                     call(self.emitter.rt.concat_list);
                 });
+                // SHARE dup: __concat_list bulk-copies BOTH inputs' element
+                // pointers into the fresh result while both inputs survive
+                // and keep their own scope-end (deep) Decs — without one inc
+                // per copied element, `xs = xs + [r]` frees the elements the
+                // new spine shares (cross_module_spread trap). rc_inc no-ops
+                // on data-section constants. Unresolved elem Ty falls through
+                // un-dup'd — unreachable for live code post-AllTypesConcrete.
+                let extract_elem_ty = |ty: &Ty| -> Option<Ty> {
+                    if let Ty::Applied(_, args) = ty {
+                        args.first().filter(|t| !t.is_unresolved()).cloned()
+                    } else { None }
+                };
+                let var_elem_ty = |expr: &IrExpr| -> Option<Ty> {
+                    if let almide_ir::IrExprKind::Var { id } = &expr.kind {
+                        extract_elem_ty(&self.var_table.get(*id).ty)
+                    } else { None }
+                };
+                let elem_ty = extract_elem_ty(&left.ty)
+                    .or_else(|| extract_elem_ty(&right.ty))
+                    .or_else(|| var_elem_ty(left))
+                    .or_else(|| var_elem_ty(right));
+                if elem_ty.map_or(false, |t| crate::pass_perceus::is_heap_type(&t)) {
+                    let res = self.scratch.alloc_i32();
+                    let idx = self.scratch.alloc_i32();
+                    let len = self.scratch.alloc_i32();
+                    let data_off = super::rt_string::list_data_off();
+                    wasm!(self.func, {
+                        local_set(res);
+                        local_get(res); i32_load(0); local_set(len);
+                        i32_const(0); local_set(idx);
+                        block_empty; loop_empty;
+                            local_get(idx); local_get(len); i32_ge_u; br_if(1);
+                            local_get(res); i32_const(data_off); i32_add;
+                            local_get(idx); i32_const(4); i32_mul; i32_add;
+                            i32_load(0); call(self.emitter.rt.rc_inc); drop;
+                            local_get(idx); i32_const(1); i32_add; local_set(idx);
+                            br(0);
+                        end; end;
+                        local_get(res);
+                    });
+                    self.scratch.free_i32(len);
+                    self.scratch.free_i32(idx);
+                    self.scratch.free_i32(res);
+                }
             }
 
             // ── Matrix operations (WASM stub — not yet optimized) ──

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -945,6 +945,15 @@ fn compile_join(emitter: &mut WasmEmitter) {
         else_;
           // result = list[0]
           local_get(0); i32_const(list_data_off()); i32_add; i32_load(0); local_set(4);
+          // Singleton SHARE dup: for len==1 the loop never runs and the
+          // ELEMENT POINTER itself is returned — an alias into a list the
+          // caller still owns and will deep-Dec. Inc it (no-op for
+          // data-section strings; len>=2 results are fresh via concat, an
+          // unconditional inc would leak elem0 once per join).
+          local_get(2); i32_const(1); i32_eq;
+          if_empty;
+            local_get(4); call(emitter.rt.rc_inc); drop;
+          end;
           i32_const(1); local_set(3); // i=1
           block_empty; loop_empty;
             local_get(3); local_get(2); i32_ge_u; br_if(1);

--- a/crates/almide-codegen/src/emit_wasm/rt_value.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_value.rs
@@ -1135,9 +1135,10 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
     wasm!(f, {
         local_get(2); i32_eqz;
         if_empty;
-          // Empty path → return some(value): alloc option box
+          // Empty path → return some(value): alloc option box.
+          // SHARE: the box holds a second reference to the input tree.
           i32_const(4); call(alloc); local_set(13);
-          local_get(13); local_get(0); i32_store(0);
+          local_get(13); local_get(0); call(emitter.rt.rc_inc); i32_store(0);
           local_get(13);
           return_;
         end;
@@ -1232,9 +1233,10 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
     });
 
     // --- Return some(cur_val): alloc Option box ---
+    // SHARE: cur_val is an interior pointer into the surviving input tree.
     wasm!(f, {
         i32_const(4); call(alloc); local_set(13);
-        local_get(13); local_get(8); i32_store(0);
+        local_get(13); local_get(8); call(emitter.rt.rc_inc); i32_store(0);
         local_get(13);
         end;
     });
@@ -1482,17 +1484,19 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
                 local_get(7); i32_load(8);
                 call(str_eq);
                 if_empty;
-                  // Replace value
+                  // Replace value — the kept KEY string is shared from the
+                  // old pair the source tree still owns: dup.
                   i32_const(8); call(alloc); local_set(17);
-                  local_get(17); local_get(13); i32_load(0); i32_store(0);
+                  local_get(17); local_get(13); i32_load(0); call(emitter.rt.rc_inc); i32_store(0);
                   local_get(17); local_get(9); i32_store(4);
                   local_get(15); i32_const(list_data_off()); i32_add;
                   local_get(12); i32_const(4); i32_mul; i32_add;
                   local_get(17); i32_store(0);
                 else_;
+                  // Unchanged pair: shared between old and new object — dup.
                   local_get(15); i32_const(list_data_off()); i32_add;
                   local_get(12); i32_const(4); i32_mul; i32_add;
-                  local_get(13); i32_store(0);
+                  local_get(13); call(emitter.rt.rc_inc); i32_store(0);
                 end;
                 local_get(12); i32_const(1); i32_add; local_set(12);
                 br(0);
@@ -1501,7 +1505,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
               local_get(18); local_get(11); i32_gt_u;
               if_empty;
                 i32_const(8); call(alloc); local_set(17);
-                local_get(17); local_get(7); i32_load(8); i32_store(0);
+                local_get(17); local_get(7); i32_load(8); call(emitter.rt.rc_inc); i32_store(0);
                 local_get(17); local_get(9); i32_store(4);
                 local_get(15); i32_const(list_data_off()); i32_add;
                 local_get(11); i32_const(4); i32_mul; i32_add;
@@ -1518,7 +1522,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
               i32_const(list_hdr() + 4); call(alloc); local_set(15); // pairs list: 1 slot
               local_get(15); i32_const(1); i32_store(0);
               i32_const(VALUE_BOX_SIZE); call(alloc); local_set(17); // pair [key][val]
-              local_get(17); local_get(7); i32_load(8); i32_store(0);
+              local_get(17); local_get(7); i32_load(8); call(emitter.rt.rc_inc); i32_store(0);
               local_get(17); local_get(9); i32_store(4);
               local_get(15); i32_const(list_data_off()); i32_add; local_get(17); i32_store(0);
               i32_const(VALUE_BOX_SIZE); call(alloc); local_set(9);
@@ -1538,7 +1542,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
             // Non-array → no-op: cur_built = orig_val.
             local_get(14); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
             if_empty;
-              local_get(14); local_set(9);
+              local_get(14); call(emitter.rt.rc_inc); local_set(9);
             else_;
               local_get(14); i32_load(4); local_set(10); // old list
               local_get(10); i32_load(0); local_set(11); // len
@@ -1551,7 +1555,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
               local_get(18); local_get(11); i32_ge_s;
               i32_or;
               if_empty;
-                local_get(14); local_set(9);
+                local_get(14); call(emitter.rt.rc_inc); local_set(9);
               else_;
                 // Clone list replacing at idx
                 i32_const(list_hdr()); local_get(11); i32_const(4); i32_mul; i32_add;
@@ -1565,9 +1569,10 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
                   local_get(12); local_get(18); i32_eq;
                   if_i32; local_get(9);
                   else_;
+                    // Unchanged element: shared between old and new array — dup.
                     local_get(10); i32_const(list_data_off()); i32_add;
                     local_get(12); i32_const(4); i32_mul; i32_add;
-                    i32_load(0);
+                    i32_load(0); call(emitter.rt.rc_inc);
                   end;
                   i32_store(0);
                   local_get(12); i32_const(1); i32_add; local_set(12);
@@ -1668,7 +1673,7 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
           local_get(7); i32_const(1); i32_eq;
           if_empty;
             local_get(8); i32_load(0); i32_const(6); i32_ne;
-            if_empty; local_get(0); return_; end;
+            if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end;
             local_get(8); i32_load(4); local_set(9);
             local_get(9); i32_load(0); local_set(10);
             i32_const(0); local_set(11);
@@ -1691,7 +1696,7 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
               br(0);
             end; end;
             local_get(13); i32_eqz;
-            if_empty; local_get(0); return_; end;
+            if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end;
           end;
     });
 
@@ -1700,7 +1705,7 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
           local_get(7); i32_const(2); i32_eq;
           if_empty;
             local_get(8); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
-            if_empty; local_get(0); return_; end; // non-array → no-op (orig)
+            if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end; // non-array → no-op (orig)
             local_get(8); i32_load(4); local_set(9);
             local_get(9); i32_load(0); local_set(10);
             local_get(6); i32_load(8); local_set(17);
@@ -1710,7 +1715,7 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
             local_get(17); i32_const(0); i32_lt_s;
             local_get(17); local_get(10); i32_ge_s;
             i32_or;
-            if_empty; local_get(0); return_; end; // OOB → no-op (orig)
+            if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end; // OOB → no-op (orig)
             local_get(14); local_get(5); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
             local_get(9); i32_const(list_data_off()); i32_add;
             local_get(17); i32_const(4); i32_mul; i32_add;
@@ -1739,7 +1744,7 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
         local_get(7); i32_const(1); i32_eq;
         if_empty;
           local_get(8); i32_load(0); i32_const(6); i32_ne;
-          if_empty; local_get(0); return_; end;
+          if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end;
           local_get(8); i32_load(4); local_set(9);
           local_get(9); i32_load(0); local_set(10);
           // Alloc new list (worst case same size)
@@ -1757,9 +1762,10 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
             call(str_eq);
             i32_eqz;
             if_empty;
+              // Surviving pair: shared with the source object — dup.
               local_get(15); i32_const(list_data_off()); i32_add;
               local_get(18); i32_const(4); i32_mul; i32_add;
-              local_get(12); i32_store(0);
+              local_get(12); call(emitter.rt.rc_inc); i32_store(0);
               local_get(18); i32_const(1); i32_add; local_set(18);
             end;
             local_get(11); i32_const(1); i32_add; local_set(11);
@@ -1777,7 +1783,7 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
         local_get(7); i32_const(2); i32_eq;
         if_empty;
           local_get(8); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
-          if_empty; local_get(0); return_; end; // non-array → no-op (orig)
+          if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end; // non-array → no-op (orig)
           local_get(8); i32_load(4); local_set(9);
           local_get(9); i32_load(0); local_set(10);
           local_get(6); i32_load(8); local_set(17);
@@ -1787,7 +1793,7 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
           local_get(17); i32_const(0); i32_lt_s;
           local_get(17); local_get(10); i32_ge_s;
           i32_or;
-          if_empty; local_get(0); return_; end; // OOB → no-op (orig)
+          if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end; // OOB → no-op (orig)
           // Alloc new list (len - 1)
           local_get(10); i32_const(1); i32_sub; local_set(13);
           i32_const(list_hdr()); local_get(13); i32_const(4); i32_mul; i32_add;
@@ -1848,15 +1854,15 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
               call(str_eq);
               if_empty;
                 i32_const(8); call(alloc); local_set(13);
-                local_get(13); local_get(12); i32_load(0); i32_store(0);
+                local_get(13); local_get(12); i32_load(0); call(emitter.rt.rc_inc); i32_store(0);
                 local_get(13); local_get(16); i32_store(4);
                 local_get(15); i32_const(list_data_off()); i32_add;
                 local_get(11); i32_const(4); i32_mul; i32_add;
-                local_get(13); i32_store(0);
+                local_get(13); call(emitter.rt.rc_inc); i32_store(0);
               else_;
                 local_get(15); i32_const(list_data_off()); i32_add;
                 local_get(11); i32_const(4); i32_mul; i32_add;
-                local_get(12); i32_store(0);
+                local_get(12); call(emitter.rt.rc_inc); i32_store(0);
               end;
               local_get(11); i32_const(1); i32_add; local_set(11);
               br(0);
@@ -1895,9 +1901,10 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
                 local_get(11); local_get(17); i32_eq;
                 if_i32; local_get(16);
                 else_;
+                  // Unchanged element: shared between old and new array — dup.
                   local_get(9); i32_const(list_data_off()); i32_add;
                   local_get(11); i32_const(4); i32_mul; i32_add;
-                  i32_load(0);
+                  i32_load(0); call(emitter.rt.rc_inc);
                 end;
                 i32_store(0);
                 local_get(11); i32_const(1); i32_add; local_set(11);

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -451,9 +451,15 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
         w.i32c(0).set(5);                       // steps = 0
         w.block(|w| { w.loop_(|w| {
             w.get(4).eqz().br_if(1);            // cur == null → bump
-            // steps++; steps > heap_ptr >> 3 → cycle → trap
+            // steps++; steps > cap → cycle → trap. The cap is ABSOLUTE:
+            // a heap-derived bound (heap_ptr >> 3) lets a multi-hundred-MB
+            // heap walk tens of millions of steps PER ALLOC before tripping —
+            // a corrupted cycle then spins the host at 100% CPU for hours
+            // instead of trapping (observed killing the dev machine). No sane
+            // free list approaches a million nodes in this runtime.
+            const FREE_LIST_WALK_CAP: i32 = 1 << 20;
             w.get(5).i32c(1).add().tee(5);
-            w.gget(heap_ptr).i32c(3).shr_u();
+            w.i32c(FREE_LIST_WALK_CAP);
             w.gt_u();
             w.if_void(|w| { w.unreachable_(); }, |_| {});
             // cur + hdr + cur.size must lie within the bump frontier,

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -462,11 +462,13 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
             w.i32c(FREE_LIST_WALK_CAP);
             w.gt_u();
             w.if_void(|w| { w.unreachable_(); }, |_| {});
-            // cur + hdr + cur.size must lie within the bump frontier,
-            // else the header is garbage → trap at the poisoner.
-            w.get(4).i32c(hdr).add().get(4).emit_load(size_off, size_ty).add();
-            w.gget(heap_ptr).gt_u();
-            w.if_void(|w| { w.unreachable_(); }, |_| {});
+            // NOTE: a size-sanity bound (cur+hdr+size <= heap_ptr) was tried
+            // here and removed: it false-positived on legitimate freed nodes
+            // (first churn loop), and the corruption classes it aimed at are
+            // covered by the step cap above (cycles), the rc==0 sentinel in
+            // rc_dec (double-free), and the rc==0 trap in rc_inc
+            // (resurrection). Host-clobbered headers (the fs scratch class)
+            // are addressed by construction via pinned allocations.
             w.get(4).emit_load(size_off, size_ty); // cur.size
             w.get(0).ge_u();                     // >= request_size?
             w.if_void(|w| {

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -576,16 +576,29 @@ fn compile_rc_inc(emitter: &mut WasmEmitter) {
     let rc_ty = emitter.layout_reg.field(ALLOC_HEADER, alloc::RC).ty;
     let heap_start = HEAP_START_GLOBAL_IDX;
 
-    let mut f = Function::new([]);
+    let heap_ptr = emitter.heap_ptr_global;
+    let mut f = Function::new([(1, ValType::I32)]); // local 1: $rc
     {
         let w = &mut WasmBuilder::new(&mut f, &emitter.layout_reg);
         // Data-section constants have no header: pass through.
         w.get(0).gget(heap_start).lt_u();
         w.if_void(|w| { w.get(0).ret(); }, |_| {});
-        // *(ptr - rc_neg) += 1
+        // Dead-zone guard: after __heap_restore moved the frontier DOWN, a
+        // stale pointer at/above heap_ptr has no live header — touching it
+        // would corrupt whatever gets bump-allocated there next. Skip (the
+        // leak direction is the safe one).
+        w.get(0).gget(heap_ptr).ge_u();
+        w.if_void(|w| { w.get(0).ret(); }, |_| {});
+        // Resurrection tripwire: Inc of a FREED block (rc==0 sentinel) is
+        // always a compiler bug — without this trap it silently revives a
+        // block already on the free list and the next alloc hands out live
+        // memory (observed as silent value corruption, not a crash).
+        w.get(0).i32c(rc_neg).sub().emit_load(0, rc_ty).tee(1);
+        w.eqz();
+        w.if_void(|w| { w.unreachable_(); }, |_| {});
+        // *(ptr - rc_neg) = rc + 1
         w.get(0).i32c(rc_neg).sub();
-        w.get(0).i32c(rc_neg).sub().emit_load(0, rc_ty);
-        w.i32c(1).add();
+        w.get(1).i32c(1).add();
         w.emit_store(0, rc_ty);
         w.get(0); // return ptr
     }
@@ -616,11 +629,17 @@ fn compile_rc_dec(emitter: &mut WasmEmitter) {
     let hdr = emitter.layout_reg.header_size(ALLOC_HEADER) as i32;
     let heap_start = HEAP_START_GLOBAL_IDX;
     let free_list = emitter.free_list_global;
+    let heap_ptr_g = emitter.heap_ptr_global;
 
     let mut f = Function::new([(1, ValType::I32)]); // local 1: $rc
     {
         let w = &mut WasmBuilder::new(&mut f, &emitter.layout_reg);
         w.get(0).gget(heap_start).lt_u();
+        w.if_void(|w| { w.ret(); }, |_| {});
+        // Dead-zone guard (see compile_rc_inc): a stale pointer at/above the
+        // restored bump frontier has no header — freeing it would re-poison
+        // the just-reset free list. Skip = bounded leak.
+        w.get(0).gget(heap_ptr_g).ge_u();
         w.if_void(|w| { w.ret(); }, |_| {});
         // rc = *(ptr - rc_neg)
         w.get(0).i32c(rc_neg).sub().emit_load(0, rc_ty).tee(1);
@@ -715,6 +734,13 @@ fn compile_heap_restore(emitter: &mut WasmEmitter) {
     wasm!(f, {
         local_get(0);
         global_set(emitter.heap_ptr_global);
+        // Forget the free list wholesale: nodes above the restored frontier
+        // are dead (the walk's size-sanity tripwire traps on them); nodes
+        // below are merely un-remembered — optimization loss, never
+        // corruption. Unconditional: a no-op while frees are off, so the
+        // emitted bytes stay env-independent here.
+        i32_const(0);
+        global_set(emitter.free_list_global);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -427,19 +427,40 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
     let free_list = emitter.free_list_global;
     let heap_ptr = emitter.heap_ptr_global;
 
-    // locals: 0=request_size, 1=ptr, 2=grow_pages, 3=prev, 4=cur
+    // locals: 0=request_size, 1=ptr, 2=grow_pages, 3=prev, 4=cur, 5=steps
     let mut f = Function::new([
         (1, ValType::I32), (1, ValType::I32),
         (1, ValType::I32), (1, ValType::I32),
+        (1, ValType::I32),
     ]);
     {
         let w = &mut WasmBuilder::new(&mut f, &emitter.layout_reg);
 
         // --- Free list walk ---
+        // The walk carries two tripwires (free when the list is empty, i.e.
+        // whenever frees are off): a STEP BOUND that traps on a cycle (a
+        // double-free that slipped past the rc sentinel pushes a block twice
+        // and links the list to itself — without the bound this loop spins
+        // forever, the hang that forced the first activation revert), and a
+        // SIZE SANITY check that traps when a node's header was clobbered
+        // (e.g. a host-written buffer freed and overwritten — the fs scratch
+        // poison class). No free list can have more nodes than 8-byte blocks
+        // in the heap, so heap_ptr >> 3 bounds any acyclic walk.
         w.i32c(0).set(3);                       // prev = null
         w.gget(free_list).set(4);               // cur = free_list_head
+        w.i32c(0).set(5);                       // steps = 0
         w.block(|w| { w.loop_(|w| {
             w.get(4).eqz().br_if(1);            // cur == null → bump
+            // steps++; steps > heap_ptr >> 3 → cycle → trap
+            w.get(5).i32c(1).add().tee(5);
+            w.gget(heap_ptr).i32c(3).shr_u();
+            w.gt_u();
+            w.if_void(|w| { w.unreachable_(); }, |_| {});
+            // cur + hdr + cur.size must lie within the bump frontier,
+            // else the header is garbage → trap at the poisoner.
+            w.get(4).i32c(hdr).add().get(4).emit_load(size_off, size_ty).add();
+            w.gget(heap_ptr).gt_u();
+            w.if_void(|w| { w.unreachable_(); }, |_| {});
             w.get(4).emit_load(size_off, size_ty); // cur.size
             w.get(0).ge_u();                     // >= request_size?
             w.if_void(|w| {
@@ -508,38 +529,114 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
+/// Whether this emission activates real reference-count frees
+/// (`ALMIDE_WASM_FREES=1`). Env-conditional emission is DECLARED behavior:
+/// the host-determinism gates pin the environment, and the same env must
+/// always produce identical bytes. Unset/`0` keeps the bump-and-leak model
+/// (today's default); `1` emits the real rc bodies below — the true-Perceus
+/// activation flag, flipped to default-on once the quadruple bar is green
+/// (native corpus + wasm corpus + byte gate + churn; see
+/// docs/roadmap/active/wasm-frees-ownership-discipline.md).
+pub(super) fn wasm_frees_enabled() -> bool {
+    std::env::var_os("ALMIDE_WASM_FREES").is_some_and(|v| v != "0")
+}
+
 fn compile_rc_inc(emitter: &mut WasmEmitter) {
-    use super::engine::WasmBuilder;
+    use super::engine::{WasmBuilder, layout::*};
     let type_idx = emitter.func_type_indices[&emitter.rt.rc_inc];
 
-    // True no-op: return the pointer untouched. The WASM runtime is a
-    // bump-allocate-and-leak model (see HEAP_START_GLOBAL_IDX note): the old
-    // header-guard `ptr < global0(heap_ptr)` already returned early for every
-    // VALID heap pointer, so the increment below it could only ever execute on
-    // a GARBAGE pointer (e.g. a mis-shaped drop reading past a box, #470) —
-    // and then it WROTE +1 into not-yet-allocated heap or trapped OOB.
-    // Touching memory here is pure downside until real frees land.
+    if !wasm_frees_enabled() {
+        // Bump-and-leak model (default): true no-op, return the pointer
+        // untouched. The old header-guard `ptr < global0(heap_ptr)` returned
+        // early for every VALID heap pointer, so an increment here could only
+        // ever execute on a GARBAGE pointer (#470) — touching memory is pure
+        // downside while frees are off.
+        let mut f = Function::new([]);
+        {
+            let w = &mut WasmBuilder::new(&mut f, &emitter.layout_reg);
+            w.get(0);
+        }
+        f.instruction(&wasm_encoder::Instruction::End);
+        emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+        return;
+    }
+
+    // ALMIDE_WASM_FREES=1: real reference counting. The guard uses the
+    // IMMUTABLE heap_start low bound (HEAP_START_GLOBAL_IDX) — the legacy
+    // `emitter.rt.heap_start_global` field is still 0 (= the moving heap_ptr)
+    // at compile_runtime time, which is exactly what baked the old body into
+    // a no-op for years.
+    let rc_neg = emitter.layout_reg.alloc_header_neg_offset(alloc::RC) as i32;
+    let rc_ty = emitter.layout_reg.field(ALLOC_HEADER, alloc::RC).ty;
+    let heap_start = HEAP_START_GLOBAL_IDX;
+
     let mut f = Function::new([]);
     {
         let w = &mut WasmBuilder::new(&mut f, &emitter.layout_reg);
-        w.get(0);
+        // Data-section constants have no header: pass through.
+        w.get(0).gget(heap_start).lt_u();
+        w.if_void(|w| { w.get(0).ret(); }, |_| {});
+        // *(ptr - rc_neg) += 1
+        w.get(0).i32c(rc_neg).sub();
+        w.get(0).i32c(rc_neg).sub().emit_load(0, rc_ty);
+        w.i32c(1).add();
+        w.emit_store(0, rc_ty);
+        w.get(0); // return ptr
     }
     f.instruction(&wasm_encoder::Instruction::End);
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
 
 fn compile_rc_dec(emitter: &mut WasmEmitter) {
+    use super::engine::{WasmBuilder, layout::*};
     let type_idx = emitter.func_type_indices[&emitter.rt.rc_dec];
 
-    // True no-op (see compile_rc_inc). The old body's decrement/free-list push
-    // was unreachable for valid heap pointers (header guard) — it only ever
-    // ran on GARBAGE pointers, where it either trapped OOB ([ptr-4] past
-    // memory) or silently PUSHED the garbage block onto the free list,
-    // poisoning the next __alloc free-list walk (#470's second trap site).
-    // When real frees are activated, restore the decrement/push together with
-    // the heap_start guard fix and the Perceus aliasing prerequisites (see the
-    // wasm-frees roadmap).
-    let mut f = Function::new([]);
+    if !wasm_frees_enabled() {
+        // Bump-and-leak model (default): true no-op (see compile_rc_inc).
+        let mut f = Function::new([]);
+        f.instruction(&wasm_encoder::Instruction::End);
+        emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+        return;
+    }
+
+    // ALMIDE_WASM_FREES=1: real decrement + free-list push, with the
+    // DOUBLE-FREE SENTINEL: a freed block is stamped rc=0; a Dec that sees
+    // rc==0 traps `unreachable` LOUDLY instead of pushing the block onto the
+    // free list a second time — a second push forms a cycle that spins
+    // __alloc's walk forever (the silent hang that forced the first revert).
+    // __alloc restores rc=1 on reuse, so the sentinel only marks dead blocks.
+    let rc_neg = emitter.layout_reg.alloc_header_neg_offset(alloc::RC) as i32;
+    let rc_ty = emitter.layout_reg.field(ALLOC_HEADER, alloc::RC).ty;
+    let hdr = emitter.layout_reg.header_size(ALLOC_HEADER) as i32;
+    let heap_start = HEAP_START_GLOBAL_IDX;
+    let free_list = emitter.free_list_global;
+
+    let mut f = Function::new([(1, ValType::I32)]); // local 1: $rc
+    {
+        let w = &mut WasmBuilder::new(&mut f, &emitter.layout_reg);
+        w.get(0).gget(heap_start).lt_u();
+        w.if_void(|w| { w.ret(); }, |_| {});
+        // rc = *(ptr - rc_neg)
+        w.get(0).i32c(rc_neg).sub().emit_load(0, rc_ty).tee(1);
+        w.i32c(1).gt_u();
+        w.if_void(|w| {
+            // rc > 1: decrement
+            w.get(0).i32c(rc_neg).sub();
+            w.get(1).i32c(1).sub();
+            w.emit_store(0, rc_ty);
+        }, |w| {
+            // rc <= 1: about to free. Sentinel: rc==0 = already freed → trap.
+            w.get(1).eqz();
+            w.if_void(|w| { w.unreachable_(); }, |_| {});
+            // Push to free list for reuse (next ptr lives at data[0]).
+            w.get(0).gget(free_list).emit_store(0, MemType::I32);
+            w.get(0).i32c(hdr).sub().gset(free_list);
+            // Stamp rc=0 (the sentinel).
+            w.get(0).i32c(rc_neg).sub();
+            w.i32c(0);
+            w.emit_store(0, rc_ty);
+        });
+    }
     f.instruction(&wasm_encoder::Instruction::End);
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -709,7 +709,10 @@ impl FuncCompiler<'_> {
     }
 
     pub(super) fn is_heap_type(ty: &Ty) -> bool {
-        matches!(ty, Ty::String | Ty::Applied(_, _) | Ty::Record { .. } | Ty::Unknown)
+        // `Ty::Named` (declared nominal record/variant) is a heap pointer — include
+        // it so a record FIELD that is itself a declared type is recursively dec'd
+        // by `emit_typed_rc_dec`. Mirrors pass_perceus::is_heap_type.
+        matches!(ty, Ty::String | Ty::Applied(_, _) | Ty::Record { .. } | Ty::Named(..) | Ty::Unknown)
     }
 
     /// Perceus Rule 3: type-specialized rc_dec.
@@ -718,6 +721,26 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_typed_rc_dec(&mut self, ty: &Ty, local_idx: u32) {
         use almide_lang::types::TypeConstructorId;
         use super::engine::{WasmBuilder, layout::*};
+
+        // A declared nominal record/variant (`type P = {...}`) is `Ty::Named`;
+        // resolve it to its structural fields so the child-recursion below frees its
+        // heap fields. Without this, Named hits the `_ => false` (childless) arm and
+        // its String / nested-heap fields leak. An opaque alias with no registered
+        // fields (`type H = String`) resolves to none and falls through to a plain
+        // dec of the aliased heap block, which is correct.
+        if let Ty::Named(..) = ty {
+            let fields = self.extract_record_fields(ty);
+            if !fields.is_empty() {
+                let rec = Ty::Record {
+                    fields: fields.into_iter()
+                        .map(|(n, t)| (almide_base::intern::sym(n.as_str()), t))
+                        .collect(),
+                };
+                self.emit_typed_rc_dec(&rec, local_idx);
+                return;
+            }
+        }
+
         let rc_dec_fn = self.emitter.rt.rc_dec;
         let rc_neg = self.emitter.layout_reg.alloc_header_neg_offset(alloc::RC);
 
@@ -725,7 +748,8 @@ impl FuncCompiler<'_> {
         wasm!(self.func, { local_get(local_idx); if_empty; });
 
         let has_children = match ty {
-            Ty::Applied(TypeConstructorId::List, args) =>
+            Ty::Applied(TypeConstructorId::List, args)
+            | Ty::Applied(TypeConstructorId::Set, args) =>
                 args.first().map_or(false, |t| Self::is_heap_type(t)),
             Ty::Applied(TypeConstructorId::Option, args) =>
                 args.first().map_or(false, |t| Self::is_heap_type(t)),
@@ -735,6 +759,8 @@ impl FuncCompiler<'_> {
                 args.iter().any(|t| Self::is_heap_type(t)),
             Ty::Record { fields } =>
                 fields.iter().any(|(_, t)| Self::is_heap_type(t)),
+            Ty::Tuple(tys) =>
+                tys.iter().any(|t| Self::is_heap_type(t)),
             Ty::Fn { .. } => true,
             _ => false,
         };
@@ -749,8 +775,10 @@ impl FuncCompiler<'_> {
             }
 
             match ty {
-                // ── List[HeapType]: iterate elements, rc_dec each ──
-                Ty::Applied(TypeConstructorId::List, args) => {
+                // ── List/Set[HeapType]: iterate elements, rc_dec each. Set has the
+                // identical [len][elem0..] layout, so the List element-walk applies ──
+                Ty::Applied(TypeConstructorId::List, args)
+                | Ty::Applied(TypeConstructorId::Set, args) => {
                     let elem_size = super::values::byte_size(&args[0]);
                     let elem = self.scratch.alloc_i32();
                     let idx = self.scratch.alloc_i32();
@@ -817,6 +845,21 @@ impl FuncCompiler<'_> {
                             );
                         }
                         offset += super::values::byte_size(field_ty);
+                    }
+                }
+                // ── Tuple: dec each heap-typed element (positional, no name sort) ──
+                Ty::Tuple(tys) => {
+                    let mut offset = 0u32;
+                    for elem_ty in tys {
+                        if Self::is_heap_type(elem_ty) {
+                            let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
+                            w.get(local_idx).emit_load(offset, MemType::I32);
+                            w.if_void(
+                                |w| { w.get(local_idx).emit_load(offset, MemType::I32).call(rc_dec_fn); },
+                                |_| {},
+                            );
+                        }
+                        offset += super::values::byte_size(elem_ty);
                     }
                 }
                 // ── Map[K, V]: Swiss Table iteration, dec live entries ──

--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -831,11 +831,16 @@ impl FuncCompiler<'_> {
                     }
                 }
                 // ── Record: dec each heap-typed field ──
+                // Fields are walked in GIVEN (declaration) order — the same
+                // order construction (emit_record), member access
+                // (field_offset), and spread use. The original name-sorted
+                // walk computed WRONG offsets whenever alphabetical order
+                // diverged from declaration order with mixed field sizes,
+                // assembling fake pointers out of neighboring bytes
+                // (sized_int_record_fields trap) or silently leaking.
                 Ty::Record { fields } => {
-                    let mut sorted: Vec<_> = fields.iter().collect();
-                    sorted.sort_by(|a, b| a.0.cmp(&b.0));
                     let mut offset = 0u32;
-                    for (_, field_ty) in &sorted {
+                    for (_, field_ty) in fields {
                         if Self::is_heap_type(field_ty) {
                             let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
                             w.get(local_idx).emit_load(offset, MemType::I32);

--- a/crates/almide-codegen/src/pass_perceus.rs
+++ b/crates/almide-codegen/src/pass_perceus.rs
@@ -679,7 +679,14 @@ pub(crate) fn is_heap_type(ty: &Ty) -> bool {
 /// access. Only the DIRECT-element accessors belong here; the Option-returning
 /// lookups surface their alias through a `match` arm instead (see the call site).
 fn is_alias_returning_runtime_call(symbol: &str) -> bool {
-    matches!(symbol, "almide_rt_list_get_or" | "almide_rt_map_get_or")
+    matches!(symbol,
+        "almide_rt_list_get_or" | "almide_rt_map_get_or"
+        // unwrap_or peels the payload pointer straight out of the box —
+        // identical to the IR UnwrapOr node classified below. Missing these
+        // freed the JSON root while a live alias pointed at it, then a later
+        // rc_inc RESURRECTED the freed block (silent corruption, json_gltf).
+        | "almide_rt_result_unwrap_or" | "almide_rt_option_unwrap_or"
+    )
 }
 
 pub(crate) fn yields_borrowed_alias(e: &IrExpr) -> bool {
@@ -739,6 +746,41 @@ pub(crate) fn yields_borrowed_alias(e: &IrExpr) -> bool {
 /// Block IR → FnBody chain → Perceus rules → FnBody → Block IR.
 fn insert_rc_ops(func: &mut IrFunction, var_table: &mut VarTable) -> bool {
     if func.is_test { return false; }
+
+    // Mechanism #6 — RETURN-ALIAS DUP: a function whose tail yields a
+    // borrowed alias (a param, a pattern-bound payload, a member load …)
+    // hands its caller a pointer the caller will own and Dec, while the
+    // aliased source keeps its own owner and Dec. The callee must return
+    // OWNED: bind the tail, Inc it, return the binding. Call results are
+    // (correctly) classified FRESH at bind sites, so this is the only place
+    // the missing +1 can be inserted. Mixed fresh/alias match arms take the
+    // Inc on whichever value is produced — a fresh arm then leaks one count
+    // (the safe direction). Data-section constants make the Inc a no-op.
+    if is_heap_type(&func.ret_ty) && yields_borrowed_alias(&func.body) {
+        let ret_ty = func.ret_ty.clone();
+        let dup_var = var_table.alloc(
+            almide_base::intern::sym("__ret_dup"),
+            ret_ty.clone(),
+            Mutability::Let,
+            None,
+        );
+        let body = std::mem::replace(&mut func.body, IrExpr {
+            kind: IrExprKind::Unit, ty: Ty::Unit, span: None, def_id: None,
+        });
+        let span = body.span;
+        func.body = IrExpr {
+            kind: IrExprKind::Block {
+                stmts: vec![
+                    IrStmt { kind: IrStmtKind::Bind { var: dup_var, mutability: Mutability::Let, ty: ret_ty.clone(), value: body }, span },
+                    IrStmt { kind: IrStmtKind::RcInc { var: dup_var }, span: None },
+                ],
+                expr: Some(Box::new(IrExpr { kind: IrExprKind::Var { id: dup_var }, ty: ret_ty, span: None, def_id: None })),
+            },
+            ty: func.ret_ty.clone(),
+            span,
+            def_id: None,
+        };
+    }
 
     // Apply Perceus recursively to the entire function body
     perceus_expr(&mut func.body, var_table);

--- a/crates/almide-codegen/src/pass_perceus.rs
+++ b/crates/almide-codegen/src/pass_perceus.rs
@@ -237,7 +237,34 @@ fn perceus_fnbody(fb: FnBody, var_table: &mut VarTable) -> FnBody {
                 // `let var = expr; rc_inc(var); <rest>` — the Inc lives in the
                 // VDecl body so it stays at the bind's chain level (verifier-
                 // counted) and runs once per loop iteration for in-loop binds.
-                let body = if alias_inc {
+                //
+                // ORDERING HAZARD: when `expr` is a BLOCK, its trailing temp
+                // Decs run while the block evaluates — BEFORE an after-VDecl
+                // Inc. If the tail aliases a temp's interior (unwrap_or of a
+                // parse temp), the temp's typed dec frees the payload first
+                // and the late Inc RESURRECTS a freed block (json_gltf trap).
+                // For a Block whose tail is a Var bound inside it, hoist the
+                // Inc INTO the block, right after that bind — before any Dec.
+                let mut expr = expr;
+                let mut inner_inc_done = false;
+                if alias_inc {
+                    if let IrExprKind::Block { stmts, expr: Some(tail) } = &mut expr.kind {
+                        if let IrExprKind::Var { id: tail_id } = &tail.kind {
+                            let tail_id = *tail_id;
+                            let bind_pos = stmts.iter().rposition(|st| matches!(
+                                &st.kind, IrStmtKind::Bind { var: bv, .. } if *bv == tail_id
+                            ));
+                            if let Some(pos) = bind_pos {
+                                stmts.insert(pos + 1, IrStmt {
+                                    kind: IrStmtKind::RcInc { var: tail_id },
+                                    span: None,
+                                });
+                                inner_inc_done = true;
+                            }
+                        }
+                    }
+                }
+                let body = if alias_inc && !inner_inc_done {
                     FnBody::Inc { var, body: Box::new(result) }
                 } else {
                     result

--- a/crates/almide-codegen/src/pass_perceus.rs
+++ b/crates/almide-codegen/src/pass_perceus.rs
@@ -218,27 +218,31 @@ fn perceus_fnbody(fb: FnBody, var_table: &mut VarTable) -> FnBody {
             ChainHead::VDecl { var, ty, mutability, mut expr } => {
                 // Recurse into the expression (handles nested blocks)
                 perceus_expr(&mut expr, var_table);
-                // Rule 1: RcInc for heap alias
-                let needs_inc = is_heap_type(&ty) && matches!(&expr.kind,
-                    IrExprKind::Var { .. } | IrExprKind::Clone { .. } | IrExprKind::Deref { .. });
-                let inc_var = if needs_inc {
-                    match &expr.kind {
-                        IrExprKind::Var { id } => Some(*id),
-                        IrExprKind::Clone { expr: e } | IrExprKind::Deref { expr: e } =>
-                            if let IrExprKind::Var { id } = &e.kind { Some(*id) } else { None },
-                        _ => None,
-                    }
-                } else { None };
-                // Rule 5: RcInc for closure captures
+                // Rule 1 (unified): a heap local bound to a BORROWED ALIAS must
+                // acquire its own reference, or its scope-end Dec under-counts and
+                // double-frees the value the alias points into. Inc the BOUND var
+                // AFTER the bind: it is then loop-body-local (balances the per-
+                // iteration scope-end Dec) and works for aliases produced through
+                // match/if/block tails, where no pre-existing source var exists to
+                // Inc beforehand. `yields_borrowed_alias` subsumes the former
+                // Var/Clone/Deref allow-list — Inc-after on the bound var is
+                // equivalent to Inc-before on the source they alias.
+                let alias_inc = is_heap_type(&ty) && yields_borrowed_alias(&expr);
+                // Rule 5: RcInc for closure captures (captured vars exist BEFORE
+                // the bind, so these Incs wrap around the VDecl).
                 let capture_incs: Vec<VarId> = if let IrExprKind::ClosureCreate { captures, .. } = &expr.kind {
                     captures.iter().filter(|(_, ty)| is_heap_type(ty)).map(|(v, _)| *v).collect()
                 } else { vec![] };
 
-                let mut node = FnBody::VDecl { var, ty, mutability, expr, body: Box::new(result) };
-                // Wrap with Inc nodes
-                if let Some(id) = inc_var {
-                    node = FnBody::Inc { var: id, body: Box::new(node) };
-                }
+                // `let var = expr; rc_inc(var); <rest>` — the Inc lives in the
+                // VDecl body so it stays at the bind's chain level (verifier-
+                // counted) and runs once per loop iteration for in-loop binds.
+                let body = if alias_inc {
+                    FnBody::Inc { var, body: Box::new(result) }
+                } else {
+                    result
+                };
+                let mut node = FnBody::VDecl { var, ty, mutability, expr, body: Box::new(body) };
                 for cap in capture_incs.into_iter().rev() {
                     node = FnBody::Inc { var: cap, body: Box::new(node) };
                 }
@@ -280,8 +284,15 @@ fn collect_heap_vdecls(fb: &FnBody, vars: &mut Vec<VarId>) {
     let mut cur = fb;
     loop {
         match cur {
-            FnBody::VDecl { var, ty, body, .. } => {
-                if is_heap_type(ty) { vars.push(*var); }
+            FnBody::VDecl { var, ty, expr, body, .. } => {
+                // An `EnvLoad`-bound local BORROWS the closure environment's
+                // captured value — the env owns it (Rule-5 Inc'd it at capture).
+                // A scope-end Dec here would free a value the env still holds, so
+                // the next call or the env teardown double-frees it. Exclude such
+                // borrow locals from the scope-end Dec (they own no reference).
+                if is_heap_type(ty) && !matches!(expr.kind, IrExprKind::EnvLoad { .. }) {
+                    vars.push(*var);
+                }
                 cur = body;
             }
             FnBody::Assign { body, .. } | FnBody::Inc { body, .. }
@@ -629,9 +640,100 @@ fn scan_env_loads(expr: &IrExpr, vars: &mut HashSet<VarId>) {
     }
 }
 
-fn is_heap_type(ty: &Ty) -> bool {
-    matches!(ty, Ty::String | Ty::Applied(_, _) | Ty::Record { .. } | Ty::Unknown | Ty::Fn { .. })
+pub(crate) fn is_heap_type(ty: &Ty) -> bool {
+    // `Ty::Named` is a DECLARED nominal record/variant (`type P = {...}`); its
+    // runtime repr is a heap pointer (emit's `ty_to_valtype`/`byte_size` already
+    // treat it as i32/4-byte). It must be classified heap so its locals get a
+    // scope-end Dec and its alias-binds get an Inc — without this every declared
+    // record/variant local leaks (anonymous `Ty::Record` was handled, the nominal
+    // `Ty::Named` was not). An opaque alias to a heap type (`type H = String`) is
+    // also a heap pointer; an alias to a scalar never reaches codegen as `Named`.
+    matches!(ty, Ty::String | Ty::Applied(_, _) | Ty::Record { .. } | Ty::Named(..) | Ty::Unknown | Ty::Fn { .. })
 }
+
+/// Does `e`, bound to a heap local, yield a BORROWED ALIAS of an existing owned
+/// heap value — as opposed to a freshly-owned allocation?
+///
+/// This is the exhaustive FRESH-vs-ALIAS classification at the heart of correct
+/// reference counting. A local bound to an alias shares a refcount it does not
+/// own; without an Inc at bind, its scope-end Dec under-counts and double-frees
+/// the value the alias points into (still owned by its container/source). So an
+/// alias-bound heap local must acquire its own reference (Inc-after-bind), while
+/// a fresh-bound one already owns its single reference and must NOT be Inc'd
+/// (that would leak). Returning/moving the alias out is also correct under this
+/// rule: the Inc gives the escaping value its own reference, which the consumer's
+/// Dec then balances.
+///
+/// The two directions are asymmetric in cost: a missing Inc on an alias =
+/// double-free (a crash/hang), an extra Inc on a fresh value = a leak. The
+/// classification is therefore total (no wildcard arm — a newly added
+/// `IrExprKind` must be classified deliberately, not silently defaulted).
+/// Tail-yielding forms (`match`/`if`/block) recurse into their tails: a value
+/// flows out through the tail, so an alias in ANY tail makes the whole
+/// expression able to yield an alias. `match` with a literal/data-constant
+/// fallback arm stays correct because Inc/Dec are runtime no-ops on data-section
+/// constants (`ptr < heap_start`).
+/// Runtime calls that return a BORROWED ALIAS of an element of a heap container
+/// argument (the stored pointer, no copy) — so a local or container that takes
+/// the result must acquire its own reference, exactly like a `Member`/`Index`
+/// access. Only the DIRECT-element accessors belong here; the Option-returning
+/// lookups surface their alias through a `match` arm instead (see the call site).
+fn is_alias_returning_runtime_call(symbol: &str) -> bool {
+    matches!(symbol, "almide_rt_list_get_or" | "almide_rt_map_get_or")
+}
+
+pub(crate) fn yields_borrowed_alias(e: &IrExpr) -> bool {
+    use IrExprKind::*;
+    match &e.kind {
+        // ── Definite aliases: borrow an existing owned reference ──
+        Var { .. } | Clone { .. } | Deref { .. }
+        | Member { .. } | TupleIndex { .. } | IndexAccess { .. }
+        | MapAccess { .. } | OptionalChain { .. } => true,
+
+        // ── Wrapper peels: extract the payload OUT of a Result/Option box ──
+        // `r?`/`r!`/`o ?? d` surface the wrapped heap value, which the box owns;
+        // a local bound to it shares the box's reference and must acquire its own
+        // (else its scope-end Dec frees a value the box — or the container the box
+        // borrowed from, e.g. `value.get(v, k)?` aliasing a field of `v` — still
+        // holds). This holds whether the box is fresh or itself an alias, so the
+        // peel is an alias unconditionally (for a heap payload; scalars are gated
+        // out by `is_heap_type`). `UnwrapOr`'s fallback rides the same Inc — a
+        // data-constant fallback makes it a runtime no-op, a fresh-heap fallback
+        // leaks (the safe direction).
+        Unwrap { .. } | ToOption { .. } | Try { .. } | UnwrapOr { .. } => true,
+
+        // ── Direct element/value accessors: borrow an element of a container ──
+        // `list.get_or`/`map.get_or` return the stored element POINTER directly
+        // (no copy), so the result aliases the container exactly like a Member or
+        // IndexAccess. The Option-returning lookups (`list.get`/`first`/`last`/
+        // `find`, `map.get`) surface their aliased payload through a `match` arm
+        // `Var`, already covered by the tail recursion below — so they are not
+        // listed here (dup'ing their fresh Option box would not help the payload).
+        RuntimeCall { symbol, .. } => is_alias_returning_runtime_call(symbol.as_str()),
+
+        // ── Tail-yielding forms: alias iff any tail can alias ──
+        Match { arms, .. } => arms.iter().any(|a| yields_borrowed_alias(&a.body)),
+        If { then, else_, .. } =>
+            yields_borrowed_alias(then) || yields_borrowed_alias(else_),
+        Block { expr: Some(tail), .. } => yields_borrowed_alias(tail),
+        Block { expr: None, .. } => false,
+
+        // ── Definite fresh allocations: the binding owns a new reference ──
+        LitInt { .. } | LitFloat { .. } | LitBool { .. } | LitStr { .. } | Unit
+        | OptionNone | Hole | Todo { .. }
+        | List { .. } | Record { .. } | MapLiteral { .. } | EmptyMap | Tuple { .. }
+        | StringInterp { .. } | SpreadRecord { .. }
+        | Call { .. } | RenderedCall { .. } | RustMacro { .. }
+        | InlineRust { .. } | TailCall { .. }
+        | ResultOk { .. } | ResultErr { .. } | OptionSome { .. }
+        | ClosureCreate { .. } | Lambda { .. } | FnRef { .. }
+        | BinOp { .. } | UnOp { .. } | Range { .. } | ToVec { .. } | IterChain { .. }
+        | Fan { .. } | Await { .. }
+        | RcWrap { .. } | BoxNew { .. } | Borrow { .. } | EnvLoad { .. }
+        | Break { .. } | Continue { .. } | While { .. } | ForIn { .. } => false,
+    }
+}
+
 
 /// Insert RC operations into a function body using FnBody conversion.
 /// Block IR → FnBody chain → Perceus rules → FnBody → Block IR.

--- a/crates/almide-codegen/src/perceus_verified.rs
+++ b/crates/almide-codegen/src/perceus_verified.rs
@@ -22,7 +22,9 @@ use almide_lang::types::Ty;
 /// Lean-certified: Ty.isHeap
 /// Corresponds to: `def Ty.isHeap : Ty → Bool`
 pub fn is_heap_type(ty: &Ty) -> bool {
-    matches!(ty, Ty::String | Ty::Applied(_, _) | Ty::Record { .. }
+    // Keep in sync with pass_perceus::is_heap_type — `Ty::Named` (declared nominal
+    // record/variant) is a heap pointer, so the verifier accounts for its Inc/Dec.
+    matches!(ty, Ty::String | Ty::Applied(_, _) | Ty::Record { .. } | Ty::Named(..)
         | Ty::Unknown | Ty::Fn { .. })
 }
 

--- a/docs/roadmap/active/wasm-frees-ownership-discipline.md
+++ b/docs/roadmap/active/wasm-frees-ownership-discipline.md
@@ -180,3 +180,34 @@ Separate, careful fix.
   the gate for 47h. Check `pgrep rustc` + kill stale PPID=1 rustc before timing the
   gate. A `perl -e 'alarm N'` wrapper around `cargo test` kills cargo but leaves
   the test binary detached/running — background the gate instead.
+
+
+## 2026-06-10/11 — third campaign: FULL DRAIN under the flag
+
+Branch `true-perceus`. The activation is now env-gated (`ALMIDE_WASM_FREES=1`
+at emit) with the **entire quadruple bar green under the flag**:
+native corpus 264/264 · wasm corpus (flag off) 264/264 · wasm corpus
+(flag ON) 264/264 · cargo byte gate (flag ON) 67/67 · 2M-iteration record
+churn correct + flat RSS (13.3 MB ≈ leak-mode baseline).
+
+All 14 frees-ON divergences drained (mechanism → fix):
+- record typed-drop glue sorted fields BY NAME vs declaration-order layout → de-sorted (2 lines)
+- heap_restore now resets the free list; rc_inc/rc_dec gained dead-zone guards (ptr ≥ heap_ptr)
+- double-free sentinel (rc=0 stamp → second dec traps) + rc_inc resurrection trap + absolute walk cap (1M steps)
+- string.join len==1 returned the element pointer raw → gated inc
+- tuple-payload variant ctor stores → emit_stored_field
+- mechanism #6: return-alias dup in insert_rc_ops (callee-side owned returns); unwrap_or runtime calls classified alias
+- **ordering fix**: a VDecl alias-Inc on a Block value now hoists INSIDE the block (after the tail bind, before temp decs) — the late Inc was resurrecting payloads freed by the temp's typed dec
+- emitter-level ownership retired under frees (is_single_use_var → false): in-place list reuse / raw rc_dec double-owned blocks vs IR decs
+- list family: 15 emit_elem_copy→owned + min/max + get-box + remove_at OOB inc + set/insert/push stored-field + sort post-build dup walk + filter post-loop dup + enumerate + update replaced-release; list.repeat per-slot inc (the for+concat-push → repeat rewrite exposed it)
+- concat: call-site SHARE dup walk over the fresh result's elements
+- map family: emit_elem_copy_sized(size, dup) + dict_recap dup Option<(K,V)> (set/merge=Some, grow=None) + remove survivor dup + update full-table dup with old-value capture-release and not-found input inc + map.map key inc
+- json/Value: value_get / get_typed(get_string|get_array) / as_type(tag 4|5) interior-pointer incs; set_path kept-key / unchanged-pair / path-key / no-op cur_built / unchanged-elem incs; remove_path 7 no-op alias returns + survivor sites; set_path new_val via stored-field
+- emit_elem_copy_owned gated on is_heap_type (Int32/UInt32/Float32 4-byte-scalar landmine defused)
+- free-list size-sanity bound removed (false-positived on legit freed nodes; cap+sentinel+resurrection traps cover the classes)
+
+REMAINING before default-ON: Stage C (TCO loop reclamation — M2 re-land; loops
+currently leak per iteration, bounded), committed churn fixture family
+(per-structure 1M+ gates), Stage D PIN (fs scratch by-construction) + C-042
+unlock, flag-ON full bar ×3 consecutive, then default flip + C-041 revision +
+new reclamation contract + perf suite (Stage G).


### PR DESCRIPTION
The WASM target has leaked all heap by design (rc_inc/rc_dec true no-ops). This PR makes real reference counting + free-list reclamation WORK — behind an emit-time flag, `ALMIDE_WASM_FREES=1`, so default behavior is byte-identical to today — and drains every divergence the activation exposed. The previous two attempts both died on the same reef (un-accounted aliases → double-frees → free-list cycles → silent hangs); this one lands with the **entire quadruple bar green under the flag**:

| gate | result |
|---|---|
| native corpus | 264/264 |
| wasm corpus, flag off | 264/264 |
| **wasm corpus, flag ON** | **264/264** (the run that used to hang the machine) |
| **cross-target byte gate, flag ON** | **67/67** |
| 2M-iteration record churn | correct value, flat RSS (≈ leak-mode baseline) |

## The tripwire belt (hang → deterministic trap)

- **Double-free sentinel**: freed blocks are stamped `rc=0`; a second Dec traps loudly instead of pushing the block twice (the cycle that used to spin `__alloc` forever).
- **Resurrection trap**: `rc_inc` of an `rc==0` block traps — an Inc of a freed block is always a compiler bug and used to silently revive memory the allocator had already handed out.
- **Absolute free-list walk cap** (1M steps): a corrupted cycle traps in milliseconds instead of burning CPU for hours (a heap-proportional bound let a 400 MB heap spin ~50M steps per alloc — observed taking down the dev machine).
- Dead-zone guards in rc_inc/rc_dec (`ptr >= heap_ptr` after a `heap_restore`) and a free-list reset in `heap_restore` (arena semantics).

## The ownership drain (14/14 divergences fixed)

Salvaged and landed the previously-unpushed second-attempt core (`yields_borrowed_alias` total fresh-vs-alias classifier, constructor dup-on-store), then drained everything the gates surfaced, SHARE vs MOVE judged per site:

- **Record drop glue sorted fields by NAME** while every other consumer uses declaration order — wrong offsets assembled fake pointers out of neighboring bytes (trap) or silently leaked. Two-line fix.
- **Ordering bug** behind the json cluster: a binding's alias-Inc ran AFTER the bound block's temp Decs — the temp's typed dec freed the payload, then the late Inc resurrected it. Alias-Incs on Block values now hoist inside the block, after the tail bind and before any Dec.
- **Mechanism #6 — return-alias dup**: a function whose tail yields a borrowed alias (`fn ostr(o) = match o { some(s) => s, … }`) now returns OWNED (+1 before return); call results stay fresh-classified.
- **Emitter-level ownership retired under frees**: the in-place list reuse / single-use raw `rc_dec` in the map/filter pipeline double-owned blocks against the IR pass's scope Decs. Under the flag, the IR pass is the only ownership authority.
- Per-structure runtime drains: list family (15 owned element copies, sort/filter post-build dup walks, min/max/get/remove_at/repeat/enumerate/intersperse, replaced-slot releases), map family (`emit_elem_copy_sized(size, dup)`, sibling-recap dup walk with grow exempted as MOVE, remove survivors, update full-table dup + old-value release), json/Value (interior-pointer boxing incs across get/get_typed/as_type and the get/set/remove_path no-op alias returns + share copies), `string.join` singleton, concat result dup walk, tuple-payload ctor stored-fields.
- `emit_elem_copy_owned` now keys on `is_heap_type`, defusing the Int32/UInt32/Float32 4-byte-scalar landmine (an unconditional inc corrupted fake headers for values ≥ heap_start).

## Not in this PR (tracked in docs/roadmap/active/wasm-frees-ownership-discipline.md)

TCO loop reclamation (M2 re-land — loops currently leak per iteration, bounded), the committed churn fixture family, fs scratch pinning (fs is green under the gate invocation today), the default-ON flip with its contract-ledger updates, and the perf suite run.