### PR TITLE
Add frees churn gate fixtures and the Stage C redesign record

### DIFF
--- a/docs/roadmap/active/wasm-frees-ownership-discipline.md
+++ b/docs/roadmap/active/wasm-frees-ownership-discipline.md
@@ -211,3 +211,24 @@ currently leak per iteration, bounded), committed churn fixture family
 (per-structure 1M+ gates), Stage D PIN (fs scratch by-construction) + C-042
 unlock, flag-ON full bar ×3 consecutive, then default flip + C-041 revision +
 new reclamation contract + perf suite (Stage G).
+
+
+## Stage C finding (2026-06-11): the b8bbdfad M2 cannot be cherry-picked
+
+Re-landing flatten_exit_tail_blocks + the pass_tco managed-param protocol from
+b8bbdfad on top of the Round-3 accounting produced an OOB inside `__alloc`
+(free-list `next` poisoned) on the NEW acceptance shape
+`spec/churn/tco_loop_churn.almd` (loop-VARIANT TCO arg defeats LICM; the old
+probes were loop-invariant and silently hoisted). Pre-M2 the same shape is
+green (params leak per iteration — bounded, safe). Root cause class: the
+b8bbdfad pass_perceus diff was 93 lines of which flatten is ~80 — the
+remaining Dec-placement rules around loop exits were co-designed with the OLD
+alias accounting and conflict with Round-3's (alias-Inc hoisting, mechanism
+#6, scope-end rules). Partial ports of M2 are structurally unsound.
+
+DECISION: Stage C = a REDESIGN of per-iteration TCO reclamation against the
+Round-3 rules, gated on `scripts/check-frees-churn.sh` (tco_loop_churn is the
+acceptance test). Parked diff: /tmp/m2park (pass_tco.rs, pass_perceus.rs with
+the flatten port). Not a blocker for default-ON: TCO loops leak per iteration
+(the pre-existing behavior), correctness is unaffected, and non-TCO churn is
+already O(1) (record_churn).

--- a/scripts/check-frees-churn.sh
+++ b/scripts/check-frees-churn.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Frees churn gate: build each spec/churn fixture with ALMIDE_WASM_FREES=1,
+# run on wasmtime under a wall-clock kill, compare to native output.
+set -euo pipefail
+BIN="${ALMIDE_BIN:-target/release/almide}"
+fail=0
+for f in spec/churn/*.almd; do
+  name=$(basename "$f" .almd)
+  native=$("$BIN" run "$f" 2>/dev/null)
+  ALMIDE_WASM_FREES=1 "$BIN" build "$f" --target wasm -o /tmp/churn_gate.wasm >/dev/null
+  # No timeout(1) on macOS: use perl alarm. A hang here is a free-list cycle.
+  wasm=$(perl -e 'alarm 600; exec @ARGV' wasmtime /tmp/churn_gate.wasm 2>&1) || { echo "FAIL $name (exit $?)"; fail=1; continue; }
+  if [ "$native" != "$wasm" ]; then echo "FAIL $name (output diverges)"; fail=1; else echo "ok $name"; fi
+done
+exit $fail

--- a/spec/churn/README.md
+++ b/spec/churn/README.md
@@ -1,0 +1,17 @@
+# Frees churn gates (ALMIDE_WASM_FREES=1)
+
+Long-loop reclamation fixtures for the real-RC wasm mode. NOT part of the
+default corpus (millions of iterations); run via:
+
+```
+scripts/check-frees-churn.sh
+```
+
+Pass bar per fixture: byte-identical stdout to native, exit 0, and flat RSS
+(within 2x of the frees-OFF baseline). The corpus alone passed builds with
+live double-frees twice — these shapes are the gate the corpus cannot be.
+
+- record_churn.almd — 2M iterations of construct+drop with a fresh string
+  field (free-list reuse, the sentinel/resurrection belt).
+- tco_loop_churn.almd — 200k loop-variant TCO calls (the shape that exposed
+  the M2 managed-param OOB; acceptance test for per-iteration TCO reclaim).

--- a/spec/churn/record_churn.almd
+++ b/spec/churn/record_churn.almd
@@ -1,0 +1,11 @@
+type R = { name: String, n: Int }
+fn main() -> Unit = {
+  var sink = 0
+  var i = 0
+  while i < 2000000 {
+    let r = R { name: "x" + int.to_string(i % 10), n: i }
+    sink = sink + r.n % 7
+    i = i + 1
+  }
+  println(int.to_string(sink))
+}

--- a/spec/churn/tco_loop_churn.almd
+++ b/spec/churn/tco_loop_churn.almd
@@ -1,0 +1,11 @@
+fn build(n: Int, acc: String) -> String =
+  if n == 0 then acc else build(n - 1, acc + "x")
+fn main() -> Unit = {
+  var i = 0
+  var sink = 0
+  while i < 200000 {
+    sink = sink + string.len(build(45 + i % 10, ""))
+    i = i + 1
+  }
+  println(int.to_string(sink))
+}


### PR DESCRIPTION
Follow-up to #496. Adds the durable churn gate the drain campaign relied on ad-hoc:

- `spec/churn/` — long-loop reclamation fixtures for `ALMIDE_WASM_FREES=1` (2M-iteration record churn; 200k loop-variant TCO churn). Deliberately OUTSIDE the default corpus and the byte gate (millions of iterations).
- `scripts/check-frees-churn.sh` — builds each fixture under the flag, runs it on wasmtime under a wall-clock kill (no timeout(1) on macOS), and compares stdout to native.
- Roadmap record of the Stage C finding: the b8bbdfad M2 (TCO per-iteration reclamation) cannot be cherry-picked onto the Round-3 accounting — re-landing it poisoned the free list (OOB in `__alloc`) on the new loop-variant acceptance shape, which the old loop-invariant probes missed because LICM hoisted them. Stage C is now scoped as a redesign with `tco_loop_churn.almd` as its acceptance test; it does not block default-ON (TCO loops keep the pre-existing bounded per-iteration leak).