### PR TITLE
Fix #500: cross-module var top-lets miscompiled on both targets

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_lambda.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_lambda.rs
@@ -192,10 +192,13 @@ impl FuncCompiler<'_> {
                     // Perceus closure capture rc_inc is now handled by PerceusPass (IR-level RcInc)
                     wasm!(self.func, { local_get(local_idx); });
                     self.emit_store_at(ty, offset);
-                } else if let Some(&(global_idx, _)) = self.emitter.top_let_globals.get(&vid.0) {
-                    // A module-level `let`/`var` (e.g. `let BASE = 100`) captured by
-                    // the closure lives in a WASM global, not the function-local
-                    // var_map — load it from the global into the capture env.
+                } else if let Some((global_idx, _)) = self.lookup_global(*vid) {
+                    // A module-level `let`/`var` captured by the closure lives
+                    // in a WASM global, not the function-local var_map — load
+                    // it via the SHARED global lookup (id, then the
+                    // module_origin-prefixed key, then the bare name). The old
+                    // id-only lookup missed cross-module synthetic VarIds and
+                    // fell to the silent-zero arm below (#500).
                     wasm!(self.func, { global_get(global_idx); });
                     self.emit_store_at(ty, offset);
                 } else {

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -18,6 +18,35 @@ pub(super) enum CmpKind {
 }
 
 impl FuncCompiler<'_> {
+    /// Resolve a VarId to its wasm GLOBAL, the one rule shared by every
+    /// consumer (value read, closure capture): id-keyed first, then the
+    /// module_origin-reconstructed `ALMIDE_RT_<MOD>_<NAME>` key, then the
+    /// bare VarTable name. Lowering produces CLEAN names + module_origin
+    /// (the #486-era rework) — any consumer doing only one of these lookups
+    /// re-creates the #500 silent-zero class.
+    pub(super) fn lookup_global(&self, id: almide_ir::VarId) -> Option<(u32, ValType)> {
+        if let Some(&entry) = self.emitter.top_let_globals.get(&id.0) {
+            return Some(entry);
+        }
+        if (id.0 as usize) < self.var_table.len() {
+            let vi = self.var_table.get(id);
+            if let Some(origin) = vi.module_origin.as_deref() {
+                let key = format!(
+                    "ALMIDE_RT_{}_{}",
+                    origin.to_uppercase().replace('.', "_"),
+                    vi.name.as_str().to_uppercase(),
+                );
+                if let Some(&entry) = self.emitter.top_let_globals_by_name.get(&key) {
+                    return Some(entry);
+                }
+            }
+            if let Some(&entry) = self.emitter.top_let_globals_by_name.get(vi.name.as_str()) {
+                return Some(entry);
+            }
+        }
+        None
+    }
+
     /// Emit `expr` as a value that is about to be MOVE-STORED into a constructor
     /// or value-builder (a record field, list/tuple element, Option/Result
     /// payload, or a `value.str/array/object` box). These builders take the raw
@@ -102,11 +131,26 @@ impl FuncCompiler<'_> {
                         wasm!(self.func, { local_get(local_idx); });
                     }
                 } else if let Some(&(global_idx, _)) = {
-                    // Try name-based lookup FIRST: cross-module synthetic Vars
-                    // (ALMIDE_RT_<MOD>_<NAME>) must resolve by name because their
-                    // VarIds can collide with unrelated globals after unification.
-                    let name = if (id.0 as usize) < self.var_table.len() { self.var_table.get(*id).name.as_str() } else { "" };
-                    self.emitter.top_let_globals_by_name.get(name)
+                    // Name-based lookup FIRST: cross-module synthetic Vars
+                    // must resolve by name because their VarIds can collide
+                    // with unrelated globals after unification. Lowering
+                    // produces a CLEAN uppercase name + module_origin (the
+                    // #486-era rework) — the prefixed ALMIDE_RT_<MOD>_<NAME>
+                    // key must be reconstructed from module_origin here, or
+                    // a cross-module global read silently missed every key
+                    // and fell to the typed-zero fallback (#500).
+                    if (id.0 as usize) < self.var_table.len() {
+                        let vi = self.var_table.get(*id);
+                        let by_origin = vi.module_origin.as_deref().and_then(|origin| {
+                            let key = format!(
+                                "ALMIDE_RT_{}_{}",
+                                origin.to_uppercase().replace('.', "_"),
+                                vi.name.as_str().to_uppercase(),
+                            );
+                            self.emitter.top_let_globals_by_name.get(&key)
+                        });
+                        by_origin.or_else(|| self.emitter.top_let_globals_by_name.get(vi.name.as_str()))
+                    } else { None }
                 } {
                     wasm!(self.func, { global_get(global_idx); });
                 } else if let Some(&(global_idx, _)) = self.emitter.top_let_globals.get(&id.0) {
@@ -129,6 +173,20 @@ impl FuncCompiler<'_> {
                     if let Some(local_idx) = found {
                         wasm!(self.func, { local_get(local_idx); });
                     } else {
+                        // A module-origin var that reached this point missed
+                        // every global key — that is a compiler bug, and the
+                        // old typed-zero fallback turned it into SILENT WRONG
+                        // OUTPUT (a cross-module `var` read printed 0 / empty,
+                        // #500). Refuse loudly instead.
+                        if (id.0 as usize) < self.var_table.len() {
+                            let vi = self.var_table.get(*id);
+                            if vi.module_origin.is_some() {
+                                panic!(
+                                    "[ICE] cross-module global `{}` (origin {:?}) resolved to no wasm global —                                      storage registration and lookup disagree (#500 class)",
+                                    vi.name.as_str(), vi.module_origin
+                                );
+                            }
+                        }
                         // Truly not in scope — push typed zero
                         match values::ty_to_valtype(&expr.ty) {
                             Some(ValType::I64) => { wasm!(self.func, { i64_const(0); }); }

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -528,13 +528,16 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
             }
         };
         for tl in &program.top_lets {
-            register(&mut ann, tl, ctx.var_table, None);
-        }
-        for module in &program.modules {
-            let mod_name = module.name.as_str();
-            for tl in &module.top_lets {
-                register(&mut ann, tl, ctx.var_table, Some(mod_name));
-            }
+            // Post-IrLinkFlatten, MODULE top-lets live here too — their
+            // module is recoverable only via VarInfo.module_origin. The old
+            // `for module in &program.modules` loop below this point was
+            // DEAD (modules are emptied before render; see the debug_assert
+            // further down), so the ALMIDE_RT_-prefixed storage key was
+            // never registered and a cross-module `var` use classified as
+            // Local → rendered the raw thread_local as a value (#500,
+            // native E0308 / wasm silent zero).
+            let origin = ctx.var_table.get(tl.var).module_origin.as_deref();
+            register(&mut ann, tl, ctx.var_table, origin);
         }
     }
     // Classify function-local `var` bindings:

--- a/tests/crossmod_matrix_test.rs
+++ b/tests/crossmod_matrix_test.rs
@@ -53,6 +53,26 @@ let N = 7
 fn mk() -> Cfg = Cfg { name: "via-fn" }
 
 effect fn estep(n: Int) -> Int = n + 1
+
+var count = 0
+
+var title = "init"
+
+var nums = [1, 2]
+
+let PAIR = ("a", 1)
+
+fn bump() -> Unit = {
+  count = count + 1
+}
+
+fn retitle(s: String) -> Unit = {
+  title = s
+}
+
+fn add_num(n: Int) -> Unit = {
+  nums = nums + [n]
+}
 "#;
 
 enum Status {
@@ -254,6 +274,90 @@ effect fn main() -> Unit = {
 effect fn main() -> Unit = println(int.to_string(string.len(m.SYSTEM)))
 "#,
             expected: "2",
+            status: Status::Works,
+        },
+        Cell {
+            name: "var_scalar_toplet_read",
+            main: r#"import self as m
+effect fn main() -> Unit = println(int.to_string(m.count))
+"#,
+            expected: "0",
+            status: Status::Works,
+        },
+        Cell {
+            name: "var_scalar_mutate_via_fn",
+            main: r#"import self as m
+effect fn main() -> Unit = {
+  m.bump()
+  m.bump()
+  println(int.to_string(m.count))
+}
+"#,
+            expected: "2",
+            status: Status::Works,
+        },
+        Cell {
+            name: "var_string_toplet_read",
+            main: r#"import self as m
+effect fn main() -> Unit = println(m.title)
+"#,
+            expected: "init",
+            status: Status::Works,
+        },
+        Cell {
+            name: "var_string_reassign_via_fn",
+            main: r#"import self as m
+effect fn main() -> Unit = {
+  m.retitle("x")
+  println(m.title)
+}
+"#,
+            expected: "x",
+            status: Status::Works,
+        },
+        Cell {
+            name: "var_list_inplace_via_fn",
+            main: r#"import self as m
+effect fn main() -> Unit = {
+  m.add_num(3)
+  println(int.to_string(list.len(m.nums)))
+}
+"#,
+            expected: "3",
+            status: Status::KnownBroken("native: a module fn's reassignment of its own non-Copy module var is lost when read cross-module (prints the initial len; ModuleRc replace vs read path desync) — see #501"),
+        },
+        Cell {
+            name: "var_toplet_through_closure",
+            main: r#"import self as m
+effect fn main() -> Unit = {
+  m.bump()
+  let f = () => m.count
+  println(int.to_string(f()))
+}
+"#,
+            expected: "1",
+            status: Status::Works,
+        },
+        Cell {
+            name: "spread_from_toplet_base",
+            main: r#"import self as m
+effect fn main() -> Unit = {
+  let c = { ...m.CFG, name: "z" }
+  println(c.name)
+}
+"#,
+            expected: "z",
+            status: Status::KnownBroken("checker leaves a cross-module spread base SpreadRecord ty=Unknown — refused by the AllTypesConcrete gate — see #502"),
+        },
+        Cell {
+            name: "tuple_toplet_destructure",
+            main: r#"import self as m
+effect fn main() -> Unit = {
+  let (s, n) = m.PAIR
+  println(s + int.to_string(n))
+}
+"#,
+            expected: "a1",
             status: Status::Works,
         },
         Cell {


### PR DESCRIPTION
Closes #500. Found by the completeness-by-construction §4 (TopLetStorage) census: the (mutability × module-origin) matrix cells had zero corpus coverage, and cross-module `var` reads were broken on BOTH targets — native rustc `E0308`/`E0277`, wasm **silently wrong** (typed-zero fallback: printed `0` / empty, mutations lost).

## Fixes

- **Native**: the only code registering `ALMIDE_RT_<MOD>_<NAME>` storage keys iterated `program.modules` — dead since `IrLinkFlatten` empties modules before render. The live loop now derives the prefixed key from `VarInfo.module_origin`; the dead loop is deleted.
- **WASM read path**: lowering produces CLEAN uppercase names + `module_origin` (the #486-era rework), but the wasm global lookup still expected old-style `ALMIDE_RT_`-prefixed var names — every key missed and the read fell to the silent typed-zero arm. There is now ONE shared `lookup_global` (id → module_origin-prefixed key → bare name) used by the value-read arm and the closure-capture materializer (which had the same id-only hole).
- **Silent-wrong belt**: a module-origin var that misses every global key is now a loud `[ICE]` instead of a typed zero — the next producer/consumer desync becomes a build failure, not wrong output.

## Matrix gate: 8 new cells

6 pass with the fix (scalar read, mutate-via-fn, string read, string reassign, list in-place… through-closure, tuple destructure, plus a spread pin), and **2 were born red and stay declared `KnownBroken`** under the ratchet, each filed:
- #501 — a module fn's reassignment of its own non-Copy module var is lost when read cross-module (native prints the initial value).
- #502 — a cross-module spread base leaves `SpreadRecord ty=Unknown` (refused by the AllTypesConcrete gate).

Verification: matrix gate green (26 Works + 2 asserted-failing), native corpus 264/264, wasm corpus 264/264 (frees default), cargo full suite 0 failures.