### PR TITLE
Fix #501 and #502: module-var append write loss and cross-module spread typing

### DIFF
--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -131,17 +131,26 @@ impl NanoPass for ConcretizeTypesPass {
         // Phase 1b: Propagate top_let types by name into VarTable entries
         // that are cross-module synthetic references (different VarId, same name).
         let mut top_let_types: std::collections::HashMap<String, Ty> = std::collections::HashMap::new();
+        // The use-site synthetic Var carries the SCREAMING_CASE const
+        // spelling (lower/expressions.rs `field.to_uppercase()`) while the
+        // definition keeps the source name — bridge BOTH spellings, or a
+        // lowercase module top-let never propagates (#502 fix C).
+        let mut insert_both = |name: String, ty: &Ty, map: &mut std::collections::HashMap<String, Ty>| {
+            let upper = name.to_uppercase();
+            if upper != name { map.entry(upper).or_insert_with(|| ty.clone()); }
+            map.insert(name, ty.clone());
+        };
         for tl in &program.top_lets {
             if !tl.ty.has_unresolved_deep() {
                 let name = prog_vt.get(tl.var).name.to_string();
-                top_let_types.insert(name, tl.ty.clone());
+                insert_both(name, &tl.ty, &mut top_let_types);
             }
         }
         for module in &program.modules {
             for tl in &module.top_lets {
                 if !tl.ty.has_unresolved_deep() {
                     let name = prog_vt.get(tl.var).name.to_string();
-                    top_let_types.insert(name, tl.ty.clone());
+                    insert_both(name, &tl.ty, &mut top_let_types);
                 }
             }
         }
@@ -1174,6 +1183,15 @@ fn resolve_node_ty(expr: &IrExpr, vt: &VarTable, symbols: &SymbolTable) -> Optio
             // firing for post-lowering shape.
             let target = CallTarget::Named { name: *symbol };
             resolve_call_ret_ty(&target, args, vt, symbols)
+        }
+        // A spread copies its base's record type — the checker's own rule
+        // (infer's SpreadRecord = base passthrough). Without this arm a
+        // cross-module spread base whose type lands late (module top-lets
+        // are checked AFTER main) bottomed out at `_ => None` and was
+        // refused by the AllTypesConcrete gate (#502).
+        IrExprKind::SpreadRecord { base, .. } => {
+            let base_ty = effective_ty(base, vt);
+            if !base_ty.has_unresolved_deep() { Some(base_ty) } else { None }
         }
         _ => None,
     }

--- a/crates/almide-codegen/src/pass_rust_lowering.rs
+++ b/crates/almide-codegen/src/pass_rust_lowering.rs
@@ -24,11 +24,24 @@ impl NanoPass for RustLoweringPass {
         // (A) Box closures sitting in type-erased join slots as `Rc<dyn Fn>`.
         //     Single source of truth — see `box_closures_program` below.
         if box_closures_program(&mut program) { changed = true; }
-        // Shared-cell vars must NOT get the `xs = xs + [v]` → `xs.push(v)` rewrite:
-        // their binding is a `SharedMut`, so `xs.push(v)` renders as `xs.get().push(v)`
-        // — a push onto a discarded clone, losing the reassignment. Left as an Assign,
-        // the walker emits `xs.set(xs.get() + [v])` through the cell. (Closure v2 P6.)
-        let shared: HashSet<VarId> = program.codegen_annotations.shared_mut_vars.clone();
+        // Vars whose Assign must STAY an Assign — their lvalue is not a direct
+        // Rust place, so the `xs = xs + [v]` → `xs.push(v)` rewrite would push
+        // onto a DISCARDED CLONE and silently lose the write:
+        //   - shared cells (`SharedMut`): `xs.get().push(v)` (Closure v2 P6);
+        //   - mutable TOP-LETS (`ModuleRc`): the Method renderer falls through
+        //     to the module-var READ accessor `UPPER.with(|c| (**c.borrow())
+        //     .clone()).push(v)` (#501). Left as an Assign, the walker emits
+        //     the ModuleRc WRITE template, which is also alias-safe: the RHS
+        //     (including reads of the same var) evaluates BEFORE borrow_mut.
+        let mut shared: HashSet<VarId> = program.codegen_annotations.shared_mut_vars.clone();
+        for tl in &program.top_lets {
+            if tl.mutable { shared.insert(tl.var); }
+        }
+        for m in &program.modules {
+            for tl in &m.top_lets {
+                if tl.mutable { shared.insert(tl.var); }
+            }
+        }
         let IrProgram { functions, top_lets, modules, var_table, .. } = &mut program;
         for func in functions.iter_mut() {
             if rewrite_stmts_in_expr(&mut func.body, var_table, &shared) { changed = true; }

--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -36,6 +36,31 @@ fn resolve_in(env: &TypeEnv, te: &ast::TypeExpr, cur_mod: Option<&str>) -> Ty {
 /// as `LazyLock<_>` in generated Rust and `ConcretizeTypes` post-condition
 /// failures on WASM. Recurse structurally through record / list / tuple /
 /// map literals so the cross-module user sees the right type.
+/// Seed type for an UNANNOTATED top-let. `infer_literal_type` covers
+/// literals and anonymous records only; a NAMED constructor (`Cfg { … }`)
+/// fell to `Ty::Unknown`, and because every driver checks MAIN before the
+/// modules, main's inference read that stale Unknown for a cross-module
+/// `m.CFG` — a spread of it then carried Unknown into the AllTypesConcrete
+/// refusal (#502). Resolve the ctor name through the SAME #433 predicate an
+/// explicit `: Cfg` annotation uses, so both spellings seed identically.
+/// Generic decls (unresolved type params) deliberately stay Unknown — the
+/// ctor args are not inferable here and the later module-check writeback
+/// only corrects exact-Unknown seeds.
+pub fn infer_top_let_seed(env: &TypeEnv, prefix: Option<&str>, value: &ast::Expr) -> Ty {
+    match &value.kind {
+        ast::ExprKind::Paren { expr } => infer_top_let_seed(env, prefix, expr),
+        ast::ExprKind::Record { name: Some(n), .. } => {
+            let canonical = super::resolve::canonical_user_type_sym(n.as_str(), &env.types, prefix)
+                .unwrap_or_else(|| sym(n.as_str()));
+            match env.types.get(&canonical) {
+                Some(decl) if !decl.has_unresolved_deep() => Ty::Named(canonical, vec![]),
+                _ => Ty::Unknown,
+            }
+        }
+        _ => infer_literal_type(value),
+    }
+}
+
 pub fn infer_literal_type(expr: &ast::Expr) -> Ty {
     match &expr.kind {
         ast::ExprKind::Int { .. } => Ty::Int,
@@ -673,7 +698,8 @@ pub fn register_decls(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, decl
                 register_impl_decl(env, diagnostics, trait_, for_, methods);
             }
             ast::Decl::TopLet { name, ty, value, .. } => {
-                let rt = ty.as_ref().map(|te| resolve(env, te)).unwrap_or_else(|| infer_literal_type(value));
+                let rt = ty.as_ref().map(|te| resolve(env, te))
+                    .unwrap_or_else(|| infer_top_let_seed(env, prefix, value));
                 let key = prefixed_key(prefix, name);
                 env.top_lets.insert(sym(&key), rt.clone());
                 // Register in DefTable

--- a/spec/integration/modules/cross_module_toplet_byvalue_test.almd
+++ b/spec/integration/modules/cross_module_toplet_byvalue_test.almd
@@ -36,3 +36,19 @@ test "cross-module record top-let list and fn-returned record" {
   assert_eq(toplib.CFGS |> list.len, 2);
   assert_eq(toplib.mk().name, "via-fn")
 }
+
+test "cross-module spread from a record top-let base (#502)" {
+  let c = { ...toplib.CFG, name: "z" };
+  assert_eq(c.name, "z")
+}
+
+test "cross-module spread from a rebound top-let base (#502)" {
+  let x = toplib.CFG;
+  let c = { ...x, name: "y" };
+  assert_eq(c.name, "y")
+}
+
+test "cross-module spread from a fn-returned base (#502)" {
+  let c = { ...toplib.mk(), name: "w" };
+  assert_eq(c.name, "w")
+}

--- a/spec/lang/module_var_test.almd
+++ b/spec/lang/module_var_test.almd
@@ -10,6 +10,19 @@ fn set_label(s: String) -> Unit = {
   label = s
 }
 
+// #501: a single-element self-append INSIDE a module fn must keep its
+// Assign form — the push rewrite pushed onto a discarded clone of the
+// ModuleRc read accessor and silently lost the write.
+fn append_item(n: Int) -> Unit = {
+  items = items + [n]
+}
+
+// Pins the alias-safety of the Assign route: the RHS reads the same var
+// it assigns (evaluates before borrow_mut is taken).
+fn append_len() -> Unit = {
+  items = items + [list.len(items)]
+}
+
 test "module var Int read/write" {
   assert(counter == 0)
   bump()
@@ -48,4 +61,13 @@ test "module var direct assignment in test" {
   assert(counter == 100)
   counter = counter + 1
   assert(counter == 101)
+}
+
+test "module var append through fn keeps the write (#501)" {
+  items = [1, 2]
+  append_item(9)
+  assert(list.len(items) == 3)
+  append_len()
+  assert(list.len(items) == 4)
+  assert((list.get(items, 3) ?? -1) == 3)
 }

--- a/tests/crossmod_matrix_test.rs
+++ b/tests/crossmod_matrix_test.rs
@@ -324,7 +324,7 @@ effect fn main() -> Unit = {
 }
 "#,
             expected: "3",
-            status: Status::KnownBroken("native: a module fn's reassignment of its own non-Copy module var is lost when read cross-module (prints the initial len; ModuleRc replace vs read path desync) — see #501"),
+            status: Status::Works,
         },
         Cell {
             name: "var_toplet_through_closure",
@@ -347,7 +347,7 @@ effect fn main() -> Unit = {
 }
 "#,
             expected: "z",
-            status: Status::KnownBroken("checker leaves a cross-module spread base SpreadRecord ty=Unknown — refused by the AllTypesConcrete gate — see #502"),
+            status: Status::Works,
         },
         Cell {
             name: "tuple_toplet_destructure",


### PR DESCRIPTION
Closes #501, closes #502 — the two born-red matrix cells from #503, both root-caused to single decision sites.

## #501 — `items = items + [n]` inside a module fn silently lost the write (native)

NOT cross-module-specific: the same-file twin was equally broken, hidden because `spec/lang/module_var_test.almd` never exercised the single-element self-append shape inside a fn. `RustLoweringPass::try_rewrite_push` rewrites `xs = xs + [v]` into a `.push(v)` Method call, exempting only `SharedMut` cells — for a mutable top-let (`ModuleRc`) the Method renderer falls through to the module-var READ accessor, so the push landed on a **discarded clone**. Fix: mutable top-lets join the keep-as-Assign exemption (the documented SharedMut precedent) — the Assign route renders the ModuleRc WRITE template and is alias-safe (RHS evaluates before `borrow_mut`). New tests pin append-through-fn AND the self-referential `items = items + [list.len(items)]`.

## #502 — cross-module spread base stuck at `SpreadRecord ty=Unknown`

Three cooperating holes, three small fixes:
- **Checker seed**: an UNANNOTATED named-ctor top-let (`let CFG = Cfg {...}`) seeded `env.top_lets` as `Unknown` (the literal-only seeder has no named-record arm), and every driver checks MAIN before the modules, so main read the stale seed. The seed now resolves the ctor name through the same #433 predicate an explicit `: Cfg` annotation uses (`canonical_user_type_sym`); generic decls deliberately stay Unknown.
- **Belt completion**: `resolve_node_ty` had no `SpreadRecord` arm — the repair belt could fix the base but never the spread. Added the checker's own rule (spread = base passthrough), guarded so it can never override a checker-resolved type.
- **Name bridge**: Phase 1b propagation keyed only the source-case name while the synthetic use-site Var carries the SCREAMING_CASE spelling — both spellings now bridge.

New integration tests cover spread-from-top-let, spread-from-rebound-local, and spread-from-fn-return, both targets.

## Gates

Matrix gate **28/28 Works** (both former KnownBroken cells flipped, ratchet honored), native corpus 264/264, wasm corpus 264/264 (frees default), cargo full suite 0 failures.
