### PR TITLE
Completeness §4 Stage 2: walker reference sites consume the TopLetStorage attribute

### DIFF
--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -164,38 +164,27 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             if ctx.ann.is_shared_mut(id) {
                 return format!("{}.get()", raw_name);
             }
-            let var_info = ctx.var_table.get(*id);
-            // Emit-time prefix: module_origin → "ALMIDE_RT_{ORIGIN}_{NAME}".
-            // `upper` (the thread_local static name) is built from the RAW name via
-            // global_static_name — uppercasing the keyword-escaped `r#box` would
-            // give the invalid `R#BOX`.
-            let (name, upper) = if let Some(ref origin) = var_info.module_origin {
-                let prefixed = format!("ALMIDE_RT_{}_{}", origin.to_uppercase(), raw_name.to_uppercase());
-                (prefixed, ctx.global_static_name(*id))
-            } else {
-                (raw_name.clone(), ctx.global_static_name(*id))
-            };
-            let has_module = var_info.module_origin.is_some();
-            // Module-level mutable var: dispatch by storage type
-            match ctx.ann.get_var_storage(id, &name) {
-                VarStorage::ModuleCell => return format!("{}.with(|c| c.get())", upper),
-                VarStorage::ModuleRc => return format!("{}.with(|c| (**c.borrow()).clone())", upper),
-                _ => {}
+            // §4 Stage 2: a module global is decided by ONE alias-resolved
+            // lookup — storage class AND emitted name come from the same
+            // GlobalInfo the agreement verifier checks. This replaces the
+            // former five-predicate chain (storage-by-name, lazy_vars,
+            // lazy_top_let_names, const_top_let_vars, module_origin
+            // prefixing), whose per-use re-derivation was the #486/#500
+            // drift surface. It also removes the lazy_vars mid-emission
+            // ordering hazard: a Lazy global ALWAYS derefs, regardless of
+            // declaration/use render order.
+            if let Some(info) = ctx.ann.global(*id) {
+                use almide_ir::top_let_storage::TopLetStorage as Tls;
+                return match info.storage {
+                    Tls::Cell => format!("{}.with(|c| c.get())", info.static_name),
+                    Tls::RcRefCell => format!("{}.with(|c| (**c.borrow()).clone())", info.static_name),
+                    Tls::Lazy { .. } => ctx.templates
+                        .render_with("deref_lazy", None, &[], &[("name", info.static_name.as_str())])
+                        .unwrap_or_else(|| info.static_name.clone()),
+                    Tls::Const => info.static_name.clone(),
+                };
             }
-            // Lazy vars need deref. Cross-module vars with module_origin
-            // reference a static LazyLock — auto-deref if the top_let is Lazy.
-            let is_module_lazy = has_module
-                && ctx.ann.lazy_top_let_names.contains(&upper);
-            if ctx.ann.lazy_vars.contains(id) || is_module_lazy {
-                ctx.templates.render_with("deref_lazy", None, &[], &[("name", upper.as_str())])
-                    .unwrap_or_else(|| upper.clone())
-            } else if has_module || ctx.ann.const_top_let_vars.contains(id) {
-                // Const top_lets declare as `const NAME_UPPER` — a lowercase
-                // source binding must not emit its raw name (E0425).
-                upper
-            } else {
-                raw_name
-            }
+            raw_name
         }
         IrExprKind::FnRef { name } => name.to_string(),
 
@@ -682,11 +671,15 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             // Spread requires an owned value. If base is a LazyLock deref
             // (module top_let), clone to get owned.
             if let IrExprKind::Var { id } = &base.kind {
-                let vi = ctx.var_table.get(*id);
-                if vi.module_origin.is_some() || ctx.ann.lazy_vars.contains(id) {
-                    if !base_str.ends_with(".clone()") {
-                        base_str = format!("{}.clone()", base_str);
-                    }
+                // §4 Stage 2: a Lazy global derefs a LazyLock and every
+                // cross-module use renders through an accessor — both need
+                // an owned clone for the spread. Attribute equivalent of the
+                // former (module_origin || lazy_vars) probe.
+                use almide_ir::top_let_storage::TopLetStorage as Tls;
+                let needs_clone = ctx.ann.global_alias.contains_key(id)
+                    || matches!(ctx.ann.global(*id).map(|i| i.storage), Some(Tls::Lazy { .. }));
+                if needs_clone && !base_str.ends_with(".clone()") {
+                    base_str = format!("{}.clone()", base_str);
                 }
             }
             let fields_str = fields.iter()
@@ -1401,9 +1394,10 @@ fn render_runtime_call(ctx: &RenderContext, symbol: &almide_base::intern::Sym, a
             if let IrExprKind::Borrow { expr: inner, .. } | IrExprKind::Clone { expr: inner } = &args[0].kind {
                 if let IrExprKind::Var { id } = &inner.kind {
                     let name = ctx.var_name(*id).to_string();
-                    let upper = ctx.global_static_name(*id);
-                    match ctx.ann.get_var_storage(id, &name) {
-                        VarStorage::ModuleRc => {
+                    // §4 Stage 2: a global target dispatches on the attribute.
+                    if let Some(info) = ctx.ann.global(*id) {
+                        use almide_ir::top_let_storage::TopLetStorage as Tls;
+                        if matches!(info.storage, Tls::RcRefCell) {
                             let rest_args = args[1..].iter().map(|a| render_expr(ctx, a))
                                 .collect::<Vec<_>>().join(", ");
                             let rc_mut = "std::rc::Rc::make_mut(&mut *c.borrow_mut())";
@@ -1412,8 +1406,10 @@ fn render_runtime_call(ctx: &RenderContext, symbol: &almide_base::intern::Sym, a
                             } else {
                                 format!("{}, {}", rc_mut, rest_args)
                             };
-                            return format!("{}.with(|c| {}({}))", upper, symbol.as_str(), call_args);
+                            return format!("{}.with(|c| {}({}))", info.static_name, symbol.as_str(), call_args);
                         }
+                    }
+                    match ctx.ann.get_var_storage(id, &name) {
                         VarStorage::RcCow => {
                             let rest_args = args[1..].iter().map(|a| render_expr(ctx, a))
                                 .collect::<Vec<_>>().join(", ");

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -758,9 +758,15 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
 
     let mut parts = Vec::new();
 
-    // Anonymous record struct definitions (only if anon_records is populated)
+    // Anonymous record struct definitions (only if anon_records is populated).
+    // SORTED iteration: anon_records is a HashMap, and emitting in its raw
+    // iteration order made the generated Rust SOURCE nondeterministic
+    // run-to-run (three runs, three different bytes) — semantically neutral
+    // for rustc but fatal for reproducible builds and any byte-diff gate.
     if !ctx.ann.anon_records.is_empty() {
-        for (field_names, struct_name) in &ctx.ann.anon_records {
+        let mut sorted_anon: Vec<(&Vec<String>, &String)> = ctx.ann.anon_records.iter().collect();
+        sorted_anon.sort_by(|a, b| a.1.cmp(b.1));
+        for (field_names, struct_name) in sorted_anon {
             // A closure field can't be Debug/PartialEq, so such a struct derives
             // Clone only (the `has_fn_fields` struct_decl) and drops the
             // `Debug + PartialEq` generic bounds — derive(Clone) re-adds `T: Clone`

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -231,18 +231,27 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             if ctx.ann.is_shared_mut(var) {
                 return format!("{}.set({});", target_s, render_expr(ctx, value));
             }
-            let upper = ctx.global_static_name(*var);
             let value_s = render_expr(ctx, value);
-            // Storage lookup keys on the PREFIXED static name for module-
-            // origin vars (the name-keyed fallback deliberately refuses
-            // unprefixed names) — passing the bare IR name classified a
-            // cross-module global assign as Local and rendered a bare
-            // `COUNTER = …` (#505).
-            match ctx.ann.get_var_storage(var, &upper) {
-                VarStorage::ModuleCell => format!("{}.with(|c| c.set({}));", upper, value_s),
-                VarStorage::ModuleRc => format!("{}.with(|c| *c.borrow_mut() = std::rc::Rc::new(({}).into()));", upper, value_s),
+            // §4 Stage 2: module globals dispatch on the alias-resolved
+            // attribute (one lookup owns storage AND the emitted name) —
+            // replaces the name-keyed get_var_storage probe whose prefixing
+            // subtleties produced #505. A Lazy/Const global in assign
+            // position is impossible (the checker rejects assignment to an
+            // immutable binding) — encoded as an ICE, not a silent arm.
+            if let Some(info) = ctx.ann.global(*var) {
+                use almide_ir::top_let_storage::TopLetStorage as Tls;
+                return match info.storage {
+                    Tls::Cell => format!("{}.with(|c| c.set({}));", info.static_name, value_s),
+                    Tls::RcRefCell => format!("{}.with(|c| *c.borrow_mut() = std::rc::Rc::new(({}).into()));", info.static_name, value_s),
+                    Tls::Const | Tls::Lazy { .. } => unreachable!(
+                        "[COMPILER BUG] assignment to immutable global `{}` reached codegen",
+                        info.static_name
+                    ),
+                };
+            }
+            match ctx.ann.get_var_storage(var, &target_s) {
                 VarStorage::RcCow => format!("{} = RcCow::new({});", target_s, value_s),
-                VarStorage::Local => ctx.templates.render_with("assignment", None, &[], &[("target", target_s.as_str()), ("value", value_s.as_str())])
+                _ => ctx.templates.render_with("assignment", None, &[], &[("target", target_s.as_str()), ("value", value_s.as_str())])
                     .unwrap_or_else(|| format!("_ = _;")),
             }
         }
@@ -297,11 +306,23 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             if ctx.ann.is_shared_mut(target) {
                 return format!("{}.borrow_mut()[{} as usize] = {};", target_str, idx_str, cast_val);
             }
+            // §4 Stage 2: globals dispatch on the attribute. A scalar Cell
+            // global cannot be index-assigned — the legacy arm emitted a
+            // SILENT NO-OP `c.get();` for that impossible cell; it is now an
+            // ICE so any future routing hole fails the build instead.
+            if let Some(info) = ctx.ann.global(*target) {
+                use almide_ir::top_let_storage::TopLetStorage as Tls;
+                return match info.storage {
+                    Tls::RcRefCell => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut())[{} as usize] = {});", info.static_name, idx_str, cast_val),
+                    other => unreachable!(
+                        "[COMPILER BUG] index-assign to {:?} global `{}`",
+                        other, info.static_name
+                    ),
+                };
+            }
             match ctx.ann.get_var_storage(target, &target_str) {
-                VarStorage::ModuleRc => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut())[{} as usize] = {});", upper, idx_str, cast_val),
-                VarStorage::ModuleCell => format!("{}.with(|c| c.get());", upper),
                 VarStorage::RcCow => format!("{}.make_mut()[{} as usize] = {};", target_str, idx_str, cast_val),
-                VarStorage::Local => format!("{}[{} as usize] = {};", target_str, idx_str, cast_val),
+                _ => format!("{}[{} as usize] = {};", target_str, idx_str, cast_val),
             }
         }
         IrStmtKind::MapInsert { target, key, value } => {
@@ -313,10 +334,19 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             if ctx.ann.is_shared_mut(target) {
                 return format!("{}.borrow_mut().insert({}, {});", target_str, key_str, val_str);
             }
+            if let Some(info) = ctx.ann.global(*target) {
+                use almide_ir::top_let_storage::TopLetStorage as Tls;
+                return match info.storage {
+                    Tls::RcRefCell => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut()).insert({}, {}));", info.static_name, key_str, val_str),
+                    other => unreachable!(
+                        "[COMPILER BUG] map-insert into {:?} global `{}`",
+                        other, info.static_name
+                    ),
+                };
+            }
             match ctx.ann.get_var_storage(target, &target_str) {
-                VarStorage::ModuleRc => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut()).insert({}, {}));", upper, key_str, val_str),
                 VarStorage::RcCow => format!("{}.make_mut().insert({}, {});", target_str, key_str, val_str),
-                VarStorage::ModuleCell | VarStorage::Local => ctx.templates.render_with("map_insert", None, &[], &[("target", target_str.as_str()), ("key", key_str.as_str()), ("value", val_str.as_str())])
+                _ => ctx.templates.render_with("map_insert", None, &[], &[("target", target_str.as_str()), ("key", key_str.as_str()), ("value", val_str.as_str())])
                     .unwrap_or_else(|| "map_set(...)".into()),
             }
         }
@@ -328,10 +358,19 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             if ctx.ann.is_shared_mut(target) {
                 return format!("{}.borrow_mut().{} = {};", target_str, field, val_str);
             }
+            if let Some(info) = ctx.ann.global(*target) {
+                use almide_ir::top_let_storage::TopLetStorage as Tls;
+                return match info.storage {
+                    Tls::RcRefCell => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut()).{} = {});", info.static_name, field, val_str),
+                    other => unreachable!(
+                        "[COMPILER BUG] field-assign to {:?} global `{}`",
+                        other, info.static_name
+                    ),
+                };
+            }
             match ctx.ann.get_var_storage(target, &target_str) {
-                VarStorage::ModuleRc => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut()).{} = {});", upper, field, val_str),
                 VarStorage::RcCow => format!("{}.make_mut().{} = {};", target_str, field, val_str),
-                VarStorage::ModuleCell | VarStorage::Local => format!("{}.{} = {};", target_str, field, val_str),
+                _ => format!("{}.{} = {};", target_str, field, val_str),
             }
         }
         IrStmtKind::BindDestructure { pattern, value } => {
@@ -393,10 +432,16 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             let upper = ctx.global_static_name(*target);
             let a_s = render_expr(ctx, a);
             let b_s = render_expr(ctx, b);
+            if let Some(info) = ctx.ann.global(*target) {
+                use almide_ir::top_let_storage::TopLetStorage as Tls;
+                return match info.storage {
+                    Tls::RcRefCell => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut()).swap({} as usize, {} as usize));", info.static_name, a_s, b_s),
+                    other => unreachable!("[COMPILER BUG] list-swap on {:?} global `{}`", other, info.static_name),
+                };
+            }
             match ctx.ann.get_var_storage(target, &t) {
-                VarStorage::ModuleRc => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut()).swap({} as usize, {} as usize));", upper, a_s, b_s),
                 VarStorage::RcCow => format!("{}.make_mut().swap({} as usize, {} as usize);", t, a_s, b_s),
-                VarStorage::ModuleCell | VarStorage::Local => ctx.templates.render_with("peep_swap", None, &[], &[("target", &t), ("a", &a_s), ("b", &b_s)])
+                _ => ctx.templates.render_with("peep_swap", None, &[], &[("target", &t), ("a", &a_s), ("b", &b_s)])
                     .unwrap_or_else(|| format!("{}.swap({}, {});", t, a_s, b_s)),
             }
         }
@@ -404,10 +449,16 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             let t = ctx.var_name(*target).to_string();
             let upper = ctx.global_static_name(*target);
             let e = render_expr(ctx, end);
+            if let Some(info) = ctx.ann.global(*target) {
+                use almide_ir::top_let_storage::TopLetStorage as Tls;
+                return match info.storage {
+                    Tls::RcRefCell => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut())[..={} as usize].reverse());", info.static_name, e),
+                    other => unreachable!("[COMPILER BUG] list-reverse on {:?} global `{}`", other, info.static_name),
+                };
+            }
             match ctx.ann.get_var_storage(target, &t) {
-                VarStorage::ModuleRc => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut())[..={} as usize].reverse());", upper, e),
                 VarStorage::RcCow => format!("{}.make_mut()[..={} as usize].reverse();", t, e),
-                VarStorage::ModuleCell | VarStorage::Local => ctx.templates.render_with("peep_reverse", None, &[], &[("target", &t), ("end", &e)])
+                _ => ctx.templates.render_with("peep_reverse", None, &[], &[("target", &t), ("end", &e)])
                     .unwrap_or_else(|| format!("{}[..={} as usize].reverse();", t, e)),
             }
         }
@@ -415,10 +466,16 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             let t = ctx.var_name(*target).to_string();
             let upper = ctx.global_static_name(*target);
             let e = render_expr(ctx, end);
+            if let Some(info) = ctx.ann.global(*target) {
+                use almide_ir::top_let_storage::TopLetStorage as Tls;
+                return match info.storage {
+                    Tls::RcRefCell => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut())[..={} as usize].rotate_left(1));", info.static_name, e),
+                    other => unreachable!("[COMPILER BUG] list-rotate on {:?} global `{}`", other, info.static_name),
+                };
+            }
             match ctx.ann.get_var_storage(target, &t) {
-                VarStorage::ModuleRc => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut())[..={} as usize].rotate_left(1));", upper, e),
                 VarStorage::RcCow => format!("{}.make_mut()[..={} as usize].rotate_left(1);", t, e),
-                VarStorage::ModuleCell | VarStorage::Local => ctx.templates.render_with("peep_rotate_left", None, &[], &[("target", &t), ("end", &e)])
+                _ => ctx.templates.render_with("peep_rotate_left", None, &[], &[("target", &t), ("end", &e)])
                     .unwrap_or_else(|| format!("{}[..={} as usize].rotate_left(1);", t, e)),
             }
         }
@@ -427,16 +484,25 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             let s = ctx.var_name(*src).to_string();
             let upper_d = ctx.global_static_name(*dst);
             let n = render_expr(ctx, len);
+            // §4 Stage 2: both the dst write AND the src re-read dispatch on
+            // the attribute (the src probe was the 9th hand-rolled copy of
+            // the ModuleRc protocol).
+            let src_read = match ctx.ann.global(*src) {
+                Some(si) if matches!(si.storage, almide_ir::top_let_storage::TopLetStorage::RcRefCell) =>
+                    format!("{}.with(|c| c.borrow().clone())", si.static_name),
+                _ => s.clone(),
+            };
+            if let Some(info) = ctx.ann.global(*dst) {
+                use almide_ir::top_let_storage::TopLetStorage as Tls;
+                return match info.storage {
+                    Tls::RcRefCell => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut())[..{n} as usize].copy_from_slice(&{src_read}[..{n} as usize]));", info.static_name, n=n, src_read=src_read),
+                    other => unreachable!("[COMPILER BUG] copy-slice into {:?} global `{}`", other, info.static_name),
+                };
+            }
             match ctx.ann.get_var_storage(dst, &d) {
-                VarStorage::ModuleRc => {
-                    let src_read = if matches!(ctx.ann.get_var_storage(src, &s), VarStorage::ModuleRc) {
-                        format!("{}.with(|c| c.borrow().clone())", ctx.global_static_name(*src))
-                    } else { s.clone() };
-                    format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut())[..{n} as usize].copy_from_slice(&{src_read}[..{n} as usize]));", upper_d, n=n, src_read=src_read)
-                }
-                VarStorage::RcCow => format!("{}.make_mut()[..{} as usize].copy_from_slice(&{}[..{} as usize]);", d, n, s, n),
-                VarStorage::ModuleCell | VarStorage::Local => ctx.templates.render_with("peep_copy_slice", None, &[], &[("dst", &d), ("src", &s), ("n", &n)])
-                    .unwrap_or_else(|| format!("{}[..{} as usize].copy_from_slice(&{}[..{} as usize]);", d, n, s, n)),
+                VarStorage::RcCow => format!("{}.make_mut()[..{} as usize].copy_from_slice(&{}[..{} as usize]);", d, n, src_read, n),
+                _ => ctx.templates.render_with("peep_copy_slice", None, &[], &[("dst", &d), ("src", &src_read), ("n", &n)])
+                    .unwrap_or_else(|| format!("{}[..{} as usize].copy_from_slice(&{}[..{} as usize]);", d, n, src_read, n)),
             }
         }
         IrStmtKind::Comment { text } => format!("// {}", text),


### PR DESCRIPTION
Completeness-by-construction §4, Stage 2 (slice 1): the walker's REFERENCE-SITE consumers now dispatch on the alias-resolved `TopLetStorage` attribute instead of re-deriving storage per site.

## Flipped (each verified generated-Rust **byte-identical** across all 342 single-file specs)

- **Var read** — the five-predicate chain (storage-by-name probe, `lazy_vars`, `lazy_top_let_names`, `const_top_let_vars`, module_origin prefixing) is now ONE `ann.global(id)` lookup + a total match. This also removes the `lazy_vars` mid-emission ordering hazard by construction (a Lazy global always derefs, independent of declaration/use render order).
- **Assign / IndexAssign / MapInsert / FieldAssign / ListSwap / ListReverse / ListRotateLeft / ListCopySlice** — the nine hand-copied ModuleRc write protocols dispatch on the attribute; the impossible cells (assign to an immutable global, index-assign to a scalar Cell — previously a SILENT NO-OP `c.get();` arm) are now `[COMPILER BUG]` ICEs.
- **In-place mutator routing and the spread-base clone probe** — same treatment.

The legacy predicates are still COMPUTED and the Stage-1 agreement verifier still asserts they match the attribute every build (the soak); deleting them is the next slice along with the declaration-emit and pass_clone flips.

## Also: generated-Rust source determinism

Setting up the byte gate exposed that the generated Rust source was **nondeterministic run-to-run** (three runs, three different bytes): anonymous-record declarations were emitted in raw `HashMap` iteration order. Now sorted. (The wasm target has a whole determinism belt; native source emission had no gate at all.)

## Gates

342-file generated-Rust byte-diff: **zero** vs the pre-flip baseline (after the determinism fix) · native corpus 264/264 · wasm corpus 264/264 · cargo full suite 0 failures (storage matrix 29/29 included).
