### PR TITLE
Completeness §4 Stage 2: declaration emit, eager force, and wasm lookup on the attribute

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -28,6 +28,13 @@ impl FuncCompiler<'_> {
         if let Some(&entry) = self.emitter.top_let_globals.get(&id.0) {
             return Some(entry);
         }
+        // §4 Stage 2: alias-resolve a synthetic cross-module use-site id to
+        // its declaration id — VarId-keyed, no name reconstruction.
+        if let Some(decl) = self.emitter.global_alias.get(&id.0) {
+            if let Some(&entry) = self.emitter.top_let_globals.get(decl) {
+                return Some(entry);
+            }
+        }
         if (id.0 as usize) < self.var_table.len() {
             let vi = self.var_table.get(id);
             if let Some(origin) = vi.module_origin.as_deref() {

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -480,6 +480,11 @@ pub struct WasmEmitter {
     // alias is preserved (value semantics). Empty for non-aliasing programs → the
     // direct mutation path is byte-identical to before.
     pub needs_cow: HashSet<u32>,
+    /// §4 Stage 2: synthetic cross-module use-site VarId → declaration VarId
+    /// (from `codegen_annotations.global_alias`). The PRIMARY resolution for
+    /// module globals — the name-key reconstruction below it is the soak-era
+    /// fallback.
+    pub global_alias: HashMap<u32, u32>,
     // Deep-equality functions per variant type: type_name → func_idx
     pub eq_funcs: HashMap<String, u32>,
     // Almide-literal repr functions per NAMED record/variant type: type_name →
@@ -646,6 +651,7 @@ impl WasmEmitter {
             effect_fns: HashSet::new(),
             mutable_captures: HashSet::new(),
             needs_cow: HashSet::new(),
+            global_alias: HashMap::new(),
             eq_funcs: HashMap::new(),
             repr_funcs: BTreeMap::new(),
             repr_func_tys: BTreeMap::new(),
@@ -910,6 +916,8 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
     // Copy the COW-target var set (AliasCowPass) onto the emitter as bare u32s,
     // mirroring `mutable_captures`. Read at every in-place mutation emit site.
     emitter.needs_cow = program.codegen_annotations.needs_cow.iter().map(|v| v.0).collect();
+    emitter.global_alias = program.codegen_annotations.global_alias.iter()
+        .map(|(k, v)| (k.0, v.0)).collect();
 
     // Phase 0: Collect `@intrinsic(symbol)` → (module, fn_name) from every
     // bundled stdlib source so the `RuntimeCall` fallback path can route

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -328,7 +328,10 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
     // abortable lazy top-lets to force at startup (wasm-eager parity).
     let is_rust_plain_main_with_forces = matches!(ctx.target, Target::Rust)
         && func.name.as_str() == "main" && !func.is_effect && !func.is_test
-        && !ctx.ann.eager_force_top_lets.is_empty();
+        && ctx.ann.global_init_order.iter().any(|v| matches!(
+            ctx.ann.globals.get(v).map(|i| i.storage),
+            Some(almide_ir::top_let_storage::TopLetStorage::Lazy { eager_force: true })
+        ));
 
     // Sanitize function name: spaces/dots/hyphens → underscores.
     // Test blocks already carry `TEST_NAME_PREFIX` from lowering so they
@@ -386,8 +389,10 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
     // Both wrapper shapes first FORCE the abortable lazy top-lets in declaration
     // order, so an aborting initializer (integer `/`/`%`) fires at startup —
     // byte-identical to wasm's eager top-let evaluation in `_start`.
-    let force_lines: String = ctx.ann.eager_force_top_lets.iter()
-        .map(|name| format!("    std::sync::LazyLock::force(&{});\n", name))
+    let force_lines: String = ctx.ann.global_init_order.iter()
+        .filter_map(|v| ctx.ann.globals.get(v))
+        .filter(|i| matches!(i.storage, almide_ir::top_let_storage::TopLetStorage::Lazy { eager_force: true }))
+        .map(|i| format!("    std::sync::LazyLock::force(&{});\n", i.static_name))
         .collect();
     let fn_code = if is_rust_effect_main {
         format!("{}\n\nfn main() {{\n{}    if let Err(__almide_err) = __almide_main() {{\n        eprintln!(\"Error: {{}}\", __almide_err);\n        std::process::exit(1);\n    }}\n}}", fn_code, force_lines)
@@ -853,33 +858,32 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         parts.push(rendered);
     }
 
-    // Top-level lets and vars
+    // Top-level lets and vars — §4 Stage 2: the declaration consumes the
+    // SAME GlobalInfo every reference site dispatches on (storage class and
+    // static name decided once, in the attribute pass). The former
+    // `lazy_vars` mid-emission write is gone — no reader remains.
     for tl in &program.top_lets {
-        let raw_name = ctx.var_table.get(tl.var).name.clone();
         let ty_str = render_type_fn(&ctx, &tl.ty);
         let val_str = render_expr_fn(&ctx, &tl.value);
-        if matches!(tl.kind, TopLetKind::Lazy) {
-            ctx.ann.lazy_vars.insert(tl.var);
-        }
-        // Emit-time prefix from module_origin
-        let var_info = ctx.var_table.get(tl.var);
-        let name_upper = if let Some(ref origin) = var_info.module_origin {
-            format!("ALMIDE_RT_{}_{}", origin.to_uppercase(), raw_name.as_str().to_uppercase())
-        } else {
-            raw_name.to_uppercase()
-        };
-        let name = raw_name;
-        let mut rendered = if tl.mutable && matches!(tl.ty, Ty::Int | Ty::Float | Ty::Bool) {
-            format!("thread_local! {{ static {}: std::cell::Cell<{}> = std::cell::Cell::new({}); }}", name_upper, ty_str, val_str)
-        } else if tl.mutable {
-            format!("thread_local! {{ static {}: std::cell::RefCell<std::rc::Rc<{}>> = std::cell::RefCell::new(std::rc::Rc::new({})); }}", name_upper, ty_str, val_str)
-        } else {
-            let construct = match tl.kind {
-                TopLetKind::Const => "top_let_const",
-                TopLetKind::Lazy => "top_let_lazy",
-            };
-            ctx.templates.render_with(construct, None, &[], &[("name", name_upper.as_str()), ("type", ty_str.as_str()), ("value", val_str.as_str())])
-                .unwrap_or_else(|| format!("const {} = {};", name, val_str))
+        let info = ctx.ann.globals.get(&tl.var).unwrap_or_else(|| panic!(
+            "[COMPILER BUG] top-let `{}` missing from the storage attribute",
+            ctx.var_table.get(tl.var).name.as_str()
+        ));
+        use almide_ir::top_let_storage::TopLetStorage as Tls;
+        let name_upper = info.static_name.as_str();
+        let mut rendered = match info.storage {
+            Tls::Cell =>
+                format!("thread_local! {{ static {}: std::cell::Cell<{}> = std::cell::Cell::new({}); }}", name_upper, ty_str, val_str),
+            Tls::RcRefCell =>
+                format!("thread_local! {{ static {}: std::cell::RefCell<std::rc::Rc<{}>> = std::cell::RefCell::new(std::rc::Rc::new({})); }}", name_upper, ty_str, val_str),
+            Tls::Const | Tls::Lazy { .. } => {
+                let construct = match info.storage {
+                    Tls::Const => "top_let_const",
+                    _ => "top_let_lazy",
+                };
+                ctx.templates.render_with(construct, None, &[], &[("name", name_upper), ("type", ty_str.as_str()), ("value", val_str.as_str())])
+                    .unwrap_or_else(|| format!("const {} = {};", name_upper, val_str))
+            }
         };
         if let Some(ref doc) = tl.doc {
             let doc_lines: String = doc.lines()


### PR DESCRIPTION
Completeness-by-construction §4, Stage 2 (slice 2): the remaining native consumers and the wasm lookup now dispatch on the `TopLetStorage` attribute.

- **Declaration emit** — storage class AND static name come from the same `GlobalInfo` every reference site uses (the hand-rolled `Int|Float|Bool` test, the name re-derivation, and the `TopLetKind` match are gone from the emit site). A top-let missing from the attribute is an ICE. The `lazy_vars` mid-emission write is deleted — it had no readers left after slice 1.
- **Eager force** — the main wrapper derives its `LazyLock::force` lines from `global_init_order` filtered to `Lazy { eager_force: true }`, the same vector wasm's `__init_globals` is meant to consume (C-007 by construction, stage 3).
- **WASM global lookup** — `lookup_global` resolves a synthetic cross-module use-site VarId through `global_alias` (VarId-keyed) FIRST; the `ALMIDE_RT_…` name reconstruction stays only as the soak-era fallback.

Generated-Rust byte-diff: **zero** across all 342 single-file specs for the native flips. Native corpus 264/264 · wasm corpus 264/264 · cargo full suite 0 failures · #500 cross-module smoke shapes byte-identical on wasmtime.

Remaining for the §4 endgame: pass_clone (runs before the attribute pass — needs a pass-position decision), the legacy-predicate deletion after this soak, and stage 2c (Copy-class canonicalization).
