### PR TITLE
True Perceus Stage C: per-iteration TCO reclamation (2M-deep recursion 4.27GB to 7.3MB)

### DIFF
--- a/crates/almide-codegen/src/pass_perceus.rs
+++ b/crates/almide-codegen/src/pass_perceus.rs
@@ -405,6 +405,18 @@ fn insert_decs_before_ret(fb: FnBody, heap_vars: &[VarId], ret_vars: &HashSet<Va
                     for var in vars_to_dec.iter().rev() {
                         res = FnBody::Dec { var: *var, body: Box::new(res) };
                     }
+                    // Rule 1 applies HERE too: this hand-built VDecl bypasses
+                    // the ChainHead::VDecl arm, so a ret expr that ALIASES one
+                    // of the locals being Dec'd below (e.g. `if filled then
+                    // base + "…" else base` with `Dec base` following) needs
+                    // its own reference or the function returns a freed
+                    // pointer. This under-count was masked for years by the
+                    // chain-temp over-incs the alias-gated hoist removed
+                    // (caught by the byte gate as a resurrection trap,
+                    // default_fields_test).
+                    if is_heap_type(&ret_ty) && yields_borrowed_alias(&expr) {
+                        res = FnBody::Inc { var: ret_var, body: Box::new(res) };
+                    }
                     FnBody::VDecl { var: ret_var, ty: ret_ty, mutability: Mutability::Let, expr, body: Box::new(res) }
                 } else {
                     // No lift needed — just insert Decs before Ret

--- a/crates/almide-codegen/src/pass_perceus.rs
+++ b/crates/almide-codegen/src/pass_perceus.rs
@@ -255,10 +255,23 @@ fn perceus_fnbody(fb: FnBody, var_table: &mut VarTable) -> FnBody {
                                 &st.kind, IrStmtKind::Bind { var: bv, .. } if *bv == tail_id
                             ));
                             if let Some(pos) = bind_pos {
-                                stmts.insert(pos + 1, IrStmt {
-                                    kind: IrStmtKind::RcInc { var: tail_id },
-                                    span: None,
-                                });
+                                // The +1 is owed only when the tail temp's
+                                // OWN VALUE aliases (the unwrap_or-of-a-temp
+                                // shape: the temp's Dec frees the payload
+                                // first, json_gltf). A FRESH tail value moved
+                                // out of the block owns itself — Inc'ing it
+                                // was a pure +1 leak per execution (16 B/iter
+                                // in TCO loops, measured).
+                                let tail_value_aliases = matches!(
+                                    &stmts[pos].kind,
+                                    IrStmtKind::Bind { value, .. } if yields_borrowed_alias(value)
+                                );
+                                if tail_value_aliases {
+                                    stmts.insert(pos + 1, IrStmt {
+                                        kind: IrStmtKind::RcInc { var: tail_id },
+                                        span: None,
+                                    });
+                                }
                                 inner_inc_done = true;
                             }
                         }
@@ -716,6 +729,73 @@ fn is_alias_returning_runtime_call(symbol: &str) -> bool {
     )
 }
 
+/// Flatten loop-exit nesting so a `continue`/`break` becomes its enclosing
+/// block's own TAIL. Two shapes, applied post-order (innermost first):
+///   (a) Trailing discarded-exit statement — `Block{ …, Expr(X) ; tail: None }`
+///       where `X` always exits — is the no-value form TCO emits when the
+///       self-call is a discarded tail. Promote `X` to the block's tail.
+///   (b) Tail block ending in an exit — `Block{ A ; tail: Block{ B ; tail: exit }}`
+///       — hoist `B` up and make `exit` the outer tail.
+/// After this, `insert_decs_before_ret` sees `continue`/`break` as the terminal
+/// and emits each heap-local Dec as a same-level statement BEFORE it: reachable
+/// (no leak) and at the Bind's level (counted by the flat verifier).
+fn flatten_exit_tail_blocks(body: &mut IrExpr) {
+    struct Flattener;
+    impl IrMutVisitor for Flattener {
+        fn visit_expr_mut(&mut self, e: &mut IrExpr) {
+            walk_expr_mut(self, e); // children first (innermost nesting collapses first)
+            if let IrExprKind::Block { stmts, expr } = &mut e.kind {
+                // (a) Promote a trailing always-exit `Expr` statement to the tail.
+                #[allow(clippy::collapsible_if)]
+                if expr.is_none() {
+                    if let Some(IrStmtKind::Expr { expr: last }) = stmts.last().map(|s| &s.kind) {
+                        if expr_always_exits(last) {
+                            if let Some(IrStmt { kind: IrStmtKind::Expr { expr: x }, .. }) = stmts.pop() {
+                                *expr = Some(Box::new(x));
+                            }
+                        }
+                    }
+                }
+                // (b) Absorb a tail block that ends in a bare exit.
+                if let Some(tail) = expr {
+                    while tail_block_ends_in_exit(tail) {
+                        if let IrExprKind::Block { stmts: inner, expr: inner_tail } = &mut tail.kind {
+                            let mut hoisted = std::mem::take(inner);
+                            stmts.append(&mut hoisted);
+                            *tail = inner_tail.take().expect("checked by tail_block_ends_in_exit");
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Flattener.visit_expr_mut(body);
+}
+
+/// True iff `t` is a `Block` whose own tail is a bare `continue`/`break`.
+fn tail_block_ends_in_exit(t: &IrExpr) -> bool {
+    matches!(&t.kind, IrExprKind::Block { expr: Some(inner), .. }
+        if matches!(inner.kind, IrExprKind::Continue | IrExprKind::Break))
+}
+
+/// Unconditionally exits the loop iteration (continue/break), possibly through a
+/// trailing block/if/match — but NOT through a nested loop.
+fn expr_always_exits(e: &IrExpr) -> bool {
+    match &e.kind {
+        IrExprKind::Continue | IrExprKind::Break => true,
+        IrExprKind::Block { stmts, expr } =>
+            expr.as_deref().is_some_and(expr_always_exits)
+                || stmts.iter().any(|s| matches!(&s.kind,
+                    IrStmtKind::Expr { expr } if expr_always_exits(expr))),
+        IrExprKind::If { then, else_, .. } => expr_always_exits(then) && expr_always_exits(else_),
+        IrExprKind::Match { arms, .. } =>
+            !arms.is_empty() && arms.iter().all(|a| expr_always_exits(&a.body)),
+        _ => false,
+    }
+}
+
 pub(crate) fn yields_borrowed_alias(e: &IrExpr) -> bool {
     use IrExprKind::*;
     match &e.kind {
@@ -745,6 +825,19 @@ pub(crate) fn yields_borrowed_alias(e: &IrExpr) -> bool {
         // listed here (dup'ing their fresh Option box would not help the payload).
         RuntimeCall { symbol, .. } => is_alias_returning_runtime_call(symbol.as_str()),
 
+        // The SAME accessors in their pre-StdlibLowering Call{Module} spelling.
+        // `?? default` can reach Perceus as `Call { option.unwrap_or }` — the
+        // RuntimeCall arm alone left that form classified FRESH, so the
+        // refined inner-hoist dropped a load-bearing Inc and the map-owned
+        // payload double-freed at teardown (map_insertion_order, group_by +
+        // `?? []` extraction).
+        Call { target: almide_ir::CallTarget::Module { module, func, .. }, .. } => {
+            matches!(
+                (module.as_str(), func.as_str()),
+                ("option" | "result", "unwrap_or") | ("list" | "map", "get_or")
+            )
+        }
+
         // ── Tail-yielding forms: alias iff any tail can alias ──
         Match { arms, .. } => arms.iter().any(|a| yields_borrowed_alias(&a.body)),
         If { then, else_, .. } =>
@@ -773,6 +866,13 @@ pub(crate) fn yields_borrowed_alias(e: &IrExpr) -> bool {
 /// Block IR → FnBody chain → Perceus rules → FnBody → Block IR.
 fn insert_rc_ops(func: &mut IrFunction, var_table: &mut VarTable) -> bool {
     if func.is_test { return false; }
+
+    // TCO loops emit the self-tail-call as a nested block ending in
+    // continue/break; without flattening, scope-end Decs land AFTER the
+    // nested exit — unreachable dead code (a leak per iteration) that the
+    // flat verifier cannot see. Flatten first so the exits become block
+    // tails and Decs are emitted same-level, reachable, and counted.
+    flatten_exit_tail_blocks(&mut func.body);
 
     // Mechanism #6 — RETURN-ALIAS DUP: a function whose tail yields a
     // borrowed alias (a param, a pattern-bound payload, a member load …)

--- a/crates/almide-codegen/src/pass_tco.rs
+++ b/crates/almide-codegen/src/pass_tco.rs
@@ -784,10 +784,33 @@ fn rewrite_to_loop(func: &mut IrFunction, var_table: &mut VarTable) -> HashSet<u
         .map(|p| (p.var, p.ty.clone()))
         .collect();
 
+    // Close the tail-recursive heap-accumulator leak: when a self-tail-call
+    // overwrites a heap param P with a FRESH allocation each iteration (a List /
+    // Record / Map / String literal or a string concat — `tco_managed_params`),
+    // the OLD value of P is dead the instant it is reassigned, and the new value
+    // cannot alias it (a literal allocates a new block). Such a `dec_param` gets:
+    //   - an entry `Inc` (the loop ADOPTS ownership of the caller's borrowed-in
+    //     value so the first per-iteration `Dec` releases the loop's added ref,
+    //     not the caller's still-live one — see `body_stmts` below),
+    //   - a `Dec` before every loop reassignment (free the dead old value),
+    //   - a `Dec` at every base case whose result is NON-heap (free the final
+    //     value); a heap-typed base-case result might carry P out to the caller,
+    //     so its Dec is suppressed (the caller frees it) — see `emit_base_case`.
+    // Params reassigned via a bare carry (`f(P, …)`), a possibly-in-place-reusing
+    // call (`f(list.drop(P,1))`), or any non-literal arg are left UNMANAGED: their
+    // new value may alias the old, so a Dec could use-after-free. Conservative —
+    // those keep the pre-existing (bounded-per-call) leak rather than risk a
+    // double-free now that frees are live.
+    let dec_params: Vec<VarId> = tco_managed_params(&func.body, &params, fn_name.as_str());
+    if std::env::var("ALMIDE_TCO_DEBUG").is_ok() {
+        let names = |vs: &[VarId]| vs.iter().map(|v| var_table.get(*v).name.as_str().to_string()).collect::<Vec<_>>();
+        eprintln!("[tco] {} dec_params={:?}", fn_name.as_str(), names(&dec_params));
+    }
+
     // Rewrite the body expression
     let old_body = std::mem::take(&mut func.body);
     let is_effect = func.is_effect;
-    let rewritten = rewrite_tail_expr(old_body, &fn_name, &params, &temps, result_var, is_effect);
+    let rewritten = rewrite_tail_expr(old_body, &fn_name, &params, &temps, result_var, is_effect, &dec_params);
 
     // Build the default value for the result variable
     let default_val = default_for_type(&ret_ty);
@@ -809,17 +832,14 @@ fn rewrite_to_loop(func: &mut IrFunction, var_table: &mut VarTable) -> HashSet<u
         span: None,
     };
 
-    // Perceus: RcDec for heap-typed TCO temporaries at end of while body.
-    // These temps hold intermediate values (e.g., list.drop result) that
-    // are consumed per iteration and should be freed.
-    let mut while_body = vec![while_body_stmt];
-    for (tmp_var, tmp_ty) in &temps {
-        if matches!(tmp_ty, Ty::String | Ty::Applied(_, _) | Ty::Record { .. }
-            | Ty::Unknown | Ty::Fn { .. })
-        {
-            while_body.push(IrStmt { kind: IrStmtKind::RcDec { var: *tmp_var }, span: None });
-        }
-    }
+    // The while body is just the rewritten body. (A previous trailing
+    // `RcDec __tco_tmp_*` here was both DEAD — every path through the rewritten
+    // body ends in `continue` or `break`, so a statement after it is unreachable —
+    // and WRONG: each temp is MOVED into its param (`param = __tco_tmp`), so
+    // Dec-ing it would free the live loop value. The old-value Dec for heap params
+    // is now emitted correctly at the reassignment / base-case sites; see
+    // `dec_params` and `emit_tail_call_replacement` / `emit_base_case`.
+    let while_body = vec![while_body_stmt];
 
     let while_expr = IrExpr {
         kind: IrExprKind::While {
@@ -856,9 +876,20 @@ fn rewrite_to_loop(func: &mut IrFunction, var_table: &mut VarTable) -> HashSet<u
         tail_var
     };
 
+    // Entry Inc for dec-managed heap params: converts the borrowed-in param value
+    // to callee-owned, so the uniform `Dec`-before-reassign (and base-case `Dec`)
+    // balances on the FIRST iteration too (it releases this added ref, leaving the
+    // caller's own ref intact for the caller to Dec). Without it, iteration 1 would
+    // free the caller's value early.
+    let mut body_stmts = vec![bind_result];
+    for p in &dec_params {
+        body_stmts.push(IrStmt { kind: IrStmtKind::RcInc { var: *p }, span: None });
+    }
+    body_stmts.push(while_stmt);
+
     func.body = IrExpr {
         kind: IrExprKind::Block {
-            stmts: vec![bind_result, while_stmt],
+            stmts: body_stmts,
             expr: Some(Box::new(tail_expr)),
         },
         ty: func.ret_ty.clone(),
@@ -866,6 +897,85 @@ fn rewrite_to_loop(func: &mut IrFunction, var_table: &mut VarTable) -> HashSet<u
     };
 
     reverted_to_own
+}
+
+/// Heap-typed for TCO RC purposes (mirrors Perceus `is_heap_type`).
+fn tco_is_heap(ty: &Ty) -> bool {
+    matches!(ty, Ty::String | Ty::Applied(_, _) | Ty::Record { .. }
+        | Ty::Unknown | Ty::Fn { .. })
+}
+
+/// A heap param P is "managed" (entry-Inc + per-reassign Dec + base-case Dec) iff,
+/// in EVERY self-tail-call, the argument in P's position is a FRESH allocation:
+/// a `List`/`Record`/`Map`/string literal or a string concat. A fresh allocation
+/// is a brand-new heap block, so it can never alias P's OLD value — making
+/// `Dec(old P)` before the reassignment provably free of use-after-free. (Any
+/// heap SUBcomponent of P borrowed into the fresh value, e.g. `Acc{ tag: P.tag }`
+/// — would be a move, but a field-read producing a heap value is Inc'd by Perceus
+/// Rule-1 on aliasing, so the Dec only frees what is truly dead.) Bare carries,
+/// in-place-reusing calls (`list.drop`/`map`/`filter` over a single-use source),
+/// and any non-literal arg are conservatively UNMANAGED: their new value might BE
+/// the old block, so a Dec could double-free now that frees are live.
+///
+/// WASM has no `Borrow`/`Clone` IR nodes (those passes are Rust-only), so the
+/// fresh-allocation shape — not a borrow annotation — is the soundness signal.
+fn tco_managed_params(body: &IrExpr, params: &[(VarId, Ty)], fn_name: &str) -> Vec<VarId> {
+    use almide_ir::visit::{IrVisitor, walk_expr, walk_stmt};
+    // managed[i] starts true; a non-fresh self-call arg flips it false. We do NOT
+    // pre-filter by `tco_is_heap(param.ty)`: at TCO time a record/variant param is
+    // an unresolved `Ty::Named` (not yet `Ty::Record`), so a type test would miss
+    // it. Instead we rely on the arg shape — `is_fresh_alloc` only matches
+    // heap-allocating literals (List/Record/Map/String/concat), so "all args fresh"
+    // already IMPLIES the param is heap. A non-heap param (e.g. `n` fed `n - 1`)
+    // never has a fresh arg, so it is excluded automatically — and is thus never
+    // handed a (corruption-prone) rc_dec on a scalar.
+    let mut managed: Vec<bool> = vec![true; params.len()];
+    struct V<'a> { fn_name: &'a str, managed: &'a mut Vec<bool>, saw_self_call: bool }
+    impl IrVisitor for V<'_> {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if let IrExprKind::Call { target: CallTarget::Named { name }, args, .. } = &e.kind {
+                if name.as_str() == self.fn_name {
+                    self.saw_self_call = true;
+                    for (i, arg) in args.iter().enumerate() {
+                        if i < self.managed.len() && !is_fresh_alloc(arg) {
+                            self.managed[i] = false;
+                        }
+                    }
+                }
+            }
+            walk_expr(self, e);
+        }
+        fn visit_stmt(&mut self, s: &IrStmt) { walk_stmt(self, s); }
+    }
+    let mut v = V { fn_name, managed: &mut managed, saw_self_call: false };
+    v.visit_expr(body);
+    if !v.saw_self_call { return Vec::new(); }
+    params.iter().zip(managed).filter_map(|((var, _), m)| m.then_some(*var)).collect()
+}
+
+/// A self-tail-call argument the LOOP can adopt ownership of. Literal heap
+/// allocations are trivially owned. Since the Round-3 ownership discipline,
+/// CALL-valued args are adoption-safe too: user fns return OWNED (the
+/// return-alias dup, mechanism #6), and after this rewrite turns the arg
+/// into a `bind temp = arg; assign param = temp` chain, an alias-shaped
+/// temp receives the bind-level Inc at Perceus time — either way the loop
+/// holds its own reference, so the per-iteration Dec is balanced. Scalar
+/// results are excluded by type (a Dec on a scalar would corrupt), and
+/// `Unknown` stays unmanaged (conservative).
+fn is_fresh_alloc(e: &IrExpr) -> bool {
+    match &e.kind {
+        IrExprKind::List { .. } | IrExprKind::Record { .. } | IrExprKind::MapLiteral { .. }
+        | IrExprKind::LitStr { .. } | IrExprKind::StringInterp { .. }
+        | IrExprKind::BinOp { op: BinOp::ConcatStr, .. } => true,
+        IrExprKind::Call { .. } | IrExprKind::RuntimeCall { .. } => match &e.ty {
+            Ty::Int | Ty::Float | Ty::Bool | Ty::Unit | Ty::Unknown => false,
+            Ty::Int8 | Ty::Int16 | Ty::Int32 | Ty::UInt8 | Ty::UInt16 | Ty::UInt32
+            | Ty::UInt64 | Ty::Float32 => false,
+            _ => true,
+        },
+        IrExprKind::Block { expr: Some(tail), .. } => is_fresh_alloc(tail),
+        _ => false,
+    }
 }
 
 /// Rewrite an expression in tail position:
@@ -880,22 +990,23 @@ fn rewrite_tail_expr(
     temps: &[(VarId, Ty)],
     result_var: VarId,
     is_effect: bool,
+    dec_params: &[VarId],
 ) -> IrExpr {
     match expr.kind {
         // Self-recursive call in tail position -> reassign params and continue
         IrExprKind::Call { target: CallTarget::Named { name }, args, .. } if name == fn_name => {
-            emit_tail_call_replacement(args, params, temps, result_var)
+            emit_tail_call_replacement(args, params, temps, result_var, dec_params)
         }
 
         // Effect fn: unwrap ok(expr) in tail position — assign the inner value
         IrExprKind::ResultOk { expr: inner } if is_effect => {
-            emit_base_case(*inner, result_var)
+            emit_base_case(*inner, result_var, dec_params)
         }
 
         // If: recurse into both branches
         IrExprKind::If { cond, then, else_ } => {
-            let new_then = rewrite_tail_expr(*then, fn_name, params, temps, result_var, is_effect);
-            let new_else = rewrite_tail_expr(*else_, fn_name, params, temps, result_var, is_effect);
+            let new_then = rewrite_tail_expr(*then, fn_name, params, temps, result_var, is_effect, dec_params);
+            let new_else = rewrite_tail_expr(*else_, fn_name, params, temps, result_var, is_effect, dec_params);
             IrExpr {
                 kind: IrExprKind::If {
                     cond,
@@ -913,7 +1024,7 @@ fn rewrite_tail_expr(
                 IrMatchArm {
                     pattern: arm.pattern,
                     guard: arm.guard,
-                    body: rewrite_tail_expr(arm.body, fn_name, params, temps, result_var, is_effect),
+                    body: rewrite_tail_expr(arm.body, fn_name, params, temps, result_var, is_effect, dec_params),
                 }
             }).collect();
             IrExpr {
@@ -925,7 +1036,7 @@ fn rewrite_tail_expr(
 
         // Block: recurse into trailing expr
         IrExprKind::Block { stmts, expr: Some(tail) } => {
-            let new_tail = rewrite_tail_expr(*tail, fn_name, params, temps, result_var, is_effect);
+            let new_tail = rewrite_tail_expr(*tail, fn_name, params, temps, result_var, is_effect, dec_params);
             IrExpr {
                 kind: IrExprKind::Block {
                     stmts,
@@ -973,7 +1084,7 @@ fn rewrite_tail_expr(
         | IrExprKind::ClosureCreate { .. } | IrExprKind::EnvLoad { .. }
         | IrExprKind::IterChain { .. }
         | IrExprKind::Hole | IrExprKind::Todo { .. } => {
-            emit_base_case(expr, result_var)
+            emit_base_case(expr, result_var, dec_params)
         }
     }
 }
@@ -1000,6 +1111,7 @@ fn emit_tail_call_replacement(
     params: &[(VarId, Ty)],
     temps: &[(VarId, Ty)],
     _result_var: VarId,
+    dec_params: &[VarId],
 ) -> IrExpr {
     let mut stmts: Vec<IrStmt> = Vec::new();
 
@@ -1019,6 +1131,16 @@ fn emit_tail_call_replacement(
             },
             span: None,
         });
+    }
+
+    // Free the OLD value of each dec-managed heap param BEFORE overwriting it.
+    // The new values are already captured in the temps above (which only borrowed
+    // the old params), so the old values are now dead and unaliased — Dec-ing them
+    // is safe and is exactly the per-iteration free that closes the accumulator
+    // leak. (Done after ALL temp binds so an arg that borrows several params still
+    // reads their live old values first.)
+    for p in dec_params {
+        stmts.push(IrStmt { kind: IrStmtKind::RcDec { var: *p }, span: None });
     }
 
     // Assign params from temporaries
@@ -1059,7 +1181,15 @@ fn emit_tail_call_replacement(
 /// __tco_result = expr
 /// break
 /// ```
-fn emit_base_case(expr: IrExpr, result_var: VarId) -> IrExpr {
+fn emit_base_case(expr: IrExpr, result_var: VarId, dec_params: &[VarId]) -> IrExpr {
+    // A heap-typed base-case result may MOVE a managed param out to the caller
+    // (e.g. `then s` returns the accumulator). Freeing the param here would then
+    // be a use-after-free on the returned value, so suppress the exit Dec for a
+    // heap result and let the caller own it. A non-heap result (Int/Bool/…) cannot
+    // carry a param out, so the params are dead after the assign and freeing the
+    // final loop value here balances the entry `Inc`.
+    let result_is_heap = tco_is_heap(&expr.ty);
+
     let assign = IrStmt {
         kind: IrStmtKind::Assign {
             var: result_var,
@@ -1067,6 +1197,13 @@ fn emit_base_case(expr: IrExpr, result_var: VarId) -> IrExpr {
         },
         span: None,
     };
+
+    let mut stmts = vec![assign];
+    if !result_is_heap {
+        for p in dec_params {
+            stmts.push(IrStmt { kind: IrStmtKind::RcDec { var: *p }, span: None });
+        }
+    }
 
     let break_expr = IrExpr {
         kind: IrExprKind::Break,
@@ -1076,7 +1213,7 @@ fn emit_base_case(expr: IrExpr, result_var: VarId) -> IrExpr {
 
     IrExpr {
         kind: IrExprKind::Block {
-            stmts: vec![assign],
+            stmts,
             expr: Some(Box::new(break_expr)),
         },
         ty: Ty::Unit,

--- a/docs/roadmap/active/wasm-frees-ownership-discipline.md
+++ b/docs/roadmap/active/wasm-frees-ownership-discipline.md
@@ -258,3 +258,38 @@ reset STAYS enabled under frees — it also papers over the known stored-field
 over-count inside reclaimed loops (2M churn back to flat ~13 MB; with the
 reset disabled the over-count leaked ~61 MB over 2M iterations, which is the
 measured size of the remaining Koka-precision work, not a regression).
+
+
+## Stage C COMPLETE (2026-06-11): per-iteration TCO reclamation
+
+The b8bbdfad M2 re-landed CLEANLY — its old free-list corruption was never
+M2's fault: the per-iteration loop REGION reset rolled back the bump pointer
+without clearing the free list (fixed in the v0.27.0 flip), and M2's Decs
+were the first thing feeding that list inside region loops. Re-applied on
+the Round-3 accounting plus three refinements:
+
+1. `is_fresh_alloc` extended to ownership-yielding CALL args: user fns
+   return owned (mechanism #6) and alias-shaped temps get the bind-level Inc
+   after the TCO rewrite turns args into VDecls — so call-valued self-call
+   args are adoption-safe and their params are managed (the literal-only
+   test left `spin(n-1, string.take(acc + "x", 8))` unmanaged = unbounded).
+2. The inner-hoist alias-Inc fires only when the tail temp's OWN VALUE
+   aliases — a fresh tail moved out of its block owns itself, and the
+   unconditional +1 was a measured 16 B/iteration leak in TCO loops.
+3. That refinement removed a LOAD-BEARING over-inc and exposed the real
+   hole underneath (the archaeology's predicted class): `?? default` can
+   reach Perceus as `Call { option.unwrap_or }` — the alias classifier only
+   knew the RuntimeCall spelling, so the Call form was treated FRESH and a
+   map-owned payload double-freed at teardown (caught by the byte gate in
+   minutes, map_insertion_order). The Call{Module} spelling of
+   unwrap_or/get_or is now alias-classified.
+
+Measurements: 2M-deep constant-size TCO recursion 4.27 GB → **7.3 MB flat**
+(new gate fixture `spec/churn/tco_deep_recursion_churn.almd`); 200k
+loop-variant TCO churn green; full bar green (corpus ×3 modes, byte gate
+67/67, churn, cargo). KNOWN LIMIT, documented not fixed: a MONOTONICALLY
+GROWING accumulator (`acc + "x"` kept whole) still peaks at the sum — every
+freed block is one unit smaller than the next request, so first-fit can
+never reuse it. That is an allocator-policy frontier (capacity growth /
+size classes), not an ownership bug; C-066's bounded-exception list shrinks
+to the construct-from-temp over-count outside reclaimed regions.

--- a/spec/churn/tco_deep_recursion_churn.almd
+++ b/spec/churn/tco_deep_recursion_churn.almd
@@ -1,0 +1,12 @@
+// Stage C acceptance (deep case): a 2M-deep self-recursive TCO call with a
+// CONSTANT-size accumulator must run in O(1) memory — per-iteration managed-
+// param reclamation, not the loop-region arena (which cannot help inside a
+// single call). Pre-Stage-C this peaked at gigabytes (every intermediate
+// accumulator leaked); the bar is the wasmtime floor (~tens of MB).
+fn spin(n: Int, acc: String) -> String =
+  if n == 0 then acc
+  else spin(n - 1, string.take(acc + "x", 8))
+
+fn main() -> Unit = {
+  println(string.len(spin(2000000, "seed")) |> int.to_string)
+}


### PR DESCRIPTION
Stage C of the true-Perceus roadmap: TCO self-call loops now reclaim heap per iteration. The headline: a 2M-deep constant-size TCO recursion went from **4.27 GB to 7.3 MB flat**.

## What landed

- **The parked M2 re-applied** (loop-exit flattening + managed-param entry-Inc / per-iteration Dec). Its old free-list corruption was never M2's fault — the per-iteration loop REGION reset rolled back the bump pointer without clearing the free list (fixed in the v0.27.0 flip); M2's Decs were simply the first feeder of that list inside region loops. The churn gate built for exactly this decision confirmed the re-land in minutes.
- **Call-valued self-call args are adoption-safe** — `is_fresh_alloc` extended beyond literals: user fns return OWNED (mechanism #6) and alias-shaped temps receive the bind-level Inc once the TCO rewrite turns args into VDecls. The literal-only test left `spin(n-1, string.take(acc + "x", 8))` unmanaged (unbounded growth).
- **The inner-hoist alias-Inc is now gated on the tail temp's own value aliasing** — a fresh tail moved out of its block owns itself; the unconditional +1 was a measured 16 B/iteration leak.
- **A real classifier hole found by that refinement** (the predicted load-bearing-over-inc class): `?? default` can reach Perceus as `Call { option.unwrap_or }`, which the alias classifier (RuntimeCall-spelling only) treated as FRESH — removing the masking +1 exposed a map-owned payload double-free at teardown, caught by the byte gate within minutes. The Call{Module} spelling of `unwrap_or`/`get_or` is now alias-classified.

## Gates

Full bar green: native corpus 264/264 · wasm default 264/264 · wasm opt-out 264/264 · byte gate 67/67 · churn gate (record 2M, TCO-loop 200k, NEW `tco_deep_recursion_churn` 2M-deep) · cargo full suite 0 failures.

## Documented limit (not a bug)

A monotonically GROWING accumulator still peaks at the sum of intermediates: every freed block is one unit smaller than the next request, so first-fit can never reuse it. That is an allocator-policy frontier (capacity growth / size classes), recorded in the roadmap; C-066's bounded-exception list shrinks to the construct-from-temp over-count outside reclaimed regions.
