### PR TITLE
Silent-wrong batch: one global resolution for mutations and rc ops, deterministic rescue, offset fixes

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_lambda.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_lambda.rs
@@ -114,13 +114,18 @@ impl FuncCompiler<'_> {
                     } else {
                         self.emit_store_at(ty, offset);
                     }
-                } else {
-                    match values::ty_to_valtype(ty) {
-                        Some(ValType::I64) => { wasm!(self.func, { i64_const(0); }); }
-                        Some(ValType::F64) => { wasm!(self.func, { f64_const(0.0); }); }
-                        _ => { wasm!(self.func, { i32_const(0); }); }
-                    }
+                } else if let Some((global_idx, _)) = self.lookup_global(*vid) {
+                    // Module-global capture: load through the SHARED lookup
+                    // (the #500-fix sibling this arm was missing — it stored
+                    // a silent typed ZERO into the env).
+                    wasm!(self.func, { global_get(global_idx); });
                     self.emit_store_at(ty, offset);
+                } else {
+                    panic!(
+                        "[ICE] lambda capture `{}` (VarId {}) resolved to neither local nor global (#522 class)",
+                        if (vid.0 as usize) < self.var_table.len() { self.var_table.get(*vid).name.as_str() } else { "?" },
+                        vid.0
+                    );
                 }
             }
 
@@ -202,15 +207,16 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { global_get(global_idx); });
                     self.emit_store_at(ty, offset);
                 } else {
-                    // This should not happen after closure conversion —
-                    // all captured vars should be in var_map (as locals or env-loaded params)
-                    eprintln!("WARNING: ClosureCreate capture var {} not in var_map", vid.0);
-                    match values::ty_to_valtype(ty) {
-                        Some(ValType::I64) => { wasm!(self.func, { i64_const(0); }); }
-                        Some(ValType::F64) => { wasm!(self.func, { f64_const(0.0); }); }
-                        _ => { wasm!(self.func, { i32_const(0); }); }
-                    }
-                    self.emit_store_at(ty, offset);
+                    // Post-#500 every legitimate storage class resolves
+                    // (locals via var_map, globals via lookup_global). A miss
+                    // here previously shipped a ZERO into the env behind a
+                    // stderr warning nobody gates on — the next #500-class
+                    // regression must be a build failure instead.
+                    panic!(
+                        "[ICE] ClosureCreate capture `{}` (VarId {}) resolved to neither local nor global (#522 class)",
+                        if (vid.0 as usize) < self.var_table.len() { self.var_table.get(*vid).name.as_str() } else { "?" },
+                        vid.0
+                    );
                 }
             }
 

--- a/crates/almide-codegen/src/emit_wasm/control.rs
+++ b/crates/almide-codegen/src/emit_wasm/control.rs
@@ -126,15 +126,17 @@ impl FuncCompiler<'_> {
         // Tuple destructure (for list of tuples)
         if let Some(tuple_vars) = var_tuple {
             if let Ty::Tuple(elem_types) = &elem_ty {
+                // #524: offset advance unconditional (a missing local must
+                // not shift every later field's load).
                 let mut field_offset = 0u32;
                 for (i, &tv) in tuple_vars.iter().enumerate() {
+                    let ft = elem_types.get(i).cloned().unwrap_or(Ty::Int);
                     if let Some(&local_idx) = self.var_map.get(&tv.0) {
-                        let ft = elem_types.get(i).cloned().unwrap_or(Ty::Int);
                         wasm!(self.func, { local_get(loop_var); });
                         self.emit_load_at(&ft, field_offset);
                         wasm!(self.func, { local_set(local_idx); });
-                        field_offset += values::byte_size(&ft);
                     }
+                    field_offset += values::byte_size(&ft);
                 }
             }
         }

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -169,11 +169,16 @@ impl FuncCompiler<'_> {
                     let found = if !name.is_empty() {
                         let target_vt = values::ty_to_valtype(&expr.ty);
                         // Find var_map entry with matching name, prefer matching WASM type
+                        // Deterministic selection (#524): prefer a valtype
+                        // match, tie-break by SMALLEST VarId — the former
+                        // bare max_by_key over HashMap iteration made the
+                        // chosen local (and thus the emitted bytes) depend
+                        // on hash order, violating host-determinism.
                         self.var_map.iter()
                             .filter(|(vid, _)| (**vid as usize) < self.var_table.len() && self.var_table.get(almide_ir::VarId(**vid)).name == name)
-                            .max_by_key(|(vid, _)| {
+                            .min_by_key(|(vid, _)| {
                                 let vid_vt = values::ty_to_valtype(&self.var_table.get(almide_ir::VarId(**vid)).ty);
-                                if vid_vt == target_vt { 1u8 } else { 0u8 }
+                                (if vid_vt == target_vt { 0u8 } else { 1u8 }, **vid)
                             })
                             .map(|(_, lidx)| *lidx)
                     } else { None };

--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -19,12 +19,10 @@ impl FuncCompiler<'_> {
             wasm!(self.func, { local_get(local_idx); });
             return true;
         }
-        let name = if (var.0 as usize) < self.var_table.len() {
-            self.var_table.get(*var).name.as_str()
-        } else { "" };
-        if let Some(&(global_idx, _)) = self.emitter.top_let_globals_by_name.get(name)
-            .or_else(|| self.emitter.top_let_globals.get(&var.0))
-        {
+        // §522 class kill: ONE global resolution (id → alias → origin-key →
+        // bare name) shared with the value-read arm. The old bare-name-FIRST
+        // probe could bind a same-named WRONG global silently.
+        if let Some((global_idx, _)) = self.lookup_global(*var) {
             wasm!(self.func, { global_get(global_idx); });
             return true;
         }
@@ -335,6 +333,26 @@ impl FuncCompiler<'_> {
                         call(self.emitter.rt.rc_inc);
                         drop;
                     });
+                } else if let Some((global_idx, _)) = self.lookup_global(*var) {
+                    // Module-global target: emit the Inc through the global.
+                    // Previously BOTH the Inc and the Dec on a global were
+                    // silently dropped — balanced only by mutual omission.
+                    wasm!(self.func, {
+                        global_get(global_idx);
+                        call(self.emitter.rt.rc_inc);
+                        drop;
+                    });
+                } else {
+                    // #523: a Perceus-mandated Inc the emitter cannot resolve
+                    // was previously DROPPED IN SILENCE — an under-count no
+                    // gate could see (the IR belt verifies the IR, not the
+                    // emission), which under default-ON frees is the
+                    // double-free class. Refuse loudly.
+                    panic!(
+                        "[ICE] RcInc target `{}` (VarId {}) resolved to neither local nor global (#523)",
+                        if (var.0 as usize) < self.var_table.len() { self.var_table.get(*var).name.as_str() } else { "?" },
+                        var.0
+                    );
                 }
             }
             IrStmtKind::RcDec { var } => {
@@ -352,6 +370,24 @@ impl FuncCompiler<'_> {
                         let ty = &self.var_table.get(*var).ty;
                         self.emit_typed_rc_dec(ty, local_idx);
                     }
+                } else if let Some((global_idx, _)) = self.lookup_global(*var) {
+                    // Module-global target: run the typed dec through a
+                    // scratch local loaded from the global (symmetric with
+                    // the Inc arm above).
+                    let tmp = self.scratch.alloc_i32();
+                    wasm!(self.func, { global_get(global_idx); local_set(tmp); });
+                    let ty = self.var_table.get(*var).ty.clone();
+                    self.emit_typed_rc_dec(&ty, tmp);
+                    self.scratch.free_i32(tmp);
+                } else {
+                    // #523 twin: a dropped Dec is "only" a leak, but the
+                    // asymmetry with a dropped Inc makes the books unreadable
+                    // — same loud refusal.
+                    panic!(
+                        "[ICE] RcDec target `{}` (VarId {}) resolved to neither local nor global (#523)",
+                        if (var.0 as usize) < self.var_table.len() { self.var_table.get(*var).name.as_str() } else { "?" },
+                        var.0
+                    );
                 }
             }
             IrStmtKind::Comment { .. } => {
@@ -370,20 +406,22 @@ impl FuncCompiler<'_> {
                             tys.clone()
                         } else { vec![] };
 
+                        // #524: the offset advance is UNCONDITIONAL — the
+                        // former placement inside the bind's `if let` meant
+                        // one missing local corrupted every SUBSEQUENT
+                        // element's load offset (active corruption, not just
+                        // a skipped bind).
                         let mut offset = 0u32;
                         for (i, elem_pat) in elements.iter().enumerate() {
+                            let elem_ty = elem_types.get(i).cloned().unwrap_or(almide_lang::types::Ty::Int);
                             if let almide_ir::IrPattern::Bind { var, .. } = elem_pat {
                                 if let Some(&local_idx) = self.var_map.get(&var.0) {
-                                    let elem_ty = elem_types.get(i).cloned().unwrap_or(almide_lang::types::Ty::Int);
                                     wasm!(self.func, { local_get(scratch); });
                                     self.emit_load_at(&elem_ty, offset);
                                     wasm!(self.func, { local_set(local_idx); });
-                                    offset += super::values::byte_size(&elem_ty);
                                 }
-                            } else if let almide_ir::IrPattern::Wildcard = elem_pat {
-                                let elem_ty = elem_types.get(i).cloned().unwrap_or(almide_lang::types::Ty::Int);
-                                offset += super::values::byte_size(&elem_ty);
                             }
+                            offset += super::values::byte_size(&elem_ty);
                         }
                     }
                     almide_ir::IrPattern::RecordPattern { fields: pat_fields, .. } => {
@@ -424,18 +462,19 @@ impl FuncCompiler<'_> {
                         wasm!(self.func, { i32_load(0); });
                     }
                     true
+                } else if let Some((global_idx, _)) = self.lookup_global(*target) {
+                    wasm!(self.func, { global_get(global_idx); });
+                    true
                 } else {
-                    let name = if (target.0 as usize) < self.var_table.len() {
-                        self.var_table.get(*target).name.as_str()
-                    } else { "" };
-                    if let Some(&(global_idx, _)) = self.emitter.top_let_globals_by_name.get(name)
-                        .or_else(|| self.emitter.top_let_globals.get(&target.0))
-                    {
-                        wasm!(self.func, { global_get(global_idx); });
-                        true
-                    } else {
-                        false
-                    }
+                    // Dropping a MUTATION on the floor is the silent-wrong
+                    // class (#522) — refuse loudly. Locals are pre-scanned
+                    // and globals resolve via lookup_global; anything else
+                    // is a compiler bug.
+                    panic!(
+                        "[ICE] index-assign target `{}` (VarId {}) resolved to neither local nor global (#522 class)",
+                        if (target.0 as usize) < self.var_table.len() { self.var_table.get(*target).name.as_str() } else { "?" },
+                        target.0
+                    );
                 };
                 if has_ptr {
                     let data_off = self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA);
@@ -671,11 +710,15 @@ impl FuncCompiler<'_> {
                 // Resolve target: local or global
                 let has_local = self.var_map.get(&target.0).copied();
                 let global_idx = if has_local.is_none() {
-                    let name = if (target.0 as usize) < self.var_table.len() {
-                        self.var_table.get(*target).name.as_str()
-                    } else { "" };
-                    self.emitter.top_let_globals_by_name.get(name).map(|&(g, _)| g)
-                        .or_else(|| self.emitter.top_let_globals.get(&target.0).map(|&(g, _)| g))
+                    let g = self.lookup_global(*target).map(|(g, _)| g);
+                    if g.is_none() {
+                        panic!(
+                            "[ICE] map-insert target `{}` (VarId {}) resolved to neither local nor global (#522 class)",
+                            if (target.0 as usize) < self.var_table.len() { self.var_table.get(*target).name.as_str() } else { "?" },
+                            target.0
+                        );
+                    }
+                    g
                 } else { None };
                 if has_local.is_some() || global_idx.is_some() {
                     let set_args = vec![


### PR DESCRIPTION
Closes #522, closes #523, closes #524 — the silent-wrong batch from the hole-hunt, each closed at the class level.

## #522 — mutation statements through ONE resolution

`emit_var_get`, IndexAssign, and MapInsert resolved globals with their own bare-name-FIRST probes (wrong-global binding on name collision) and silently DROPPED the whole statement on a miss. All three now resolve via the shared `lookup_global` (id → alias → origin-key → bare), and an unresolvable mutation target is a `[ICE] … (#522 class)` build failure. The lambda-capture siblings are included: `emit_lambda_closure`'s capture loop stored a silent typed ZERO into the env on a miss (no lookup_global, no warning — the arm the #500 fix missed) and `emit_closure_create`'s WARNING+zero arm — both now resolve globals then ICE.

## #523 — Perceus rc ops can no longer be dropped in silence

The RcInc/RcDec emission arms skipped silently when the var wasn't a local. Installing the ICE immediately found the live instance: **rc ops targeting MODULE GLOBALS were being dropped on both sides** — balanced only by mutual omission. Globals now emit their rc ops through the global (Inc via `global_get`; typed Dec through a scratch local), and a target resolving to neither local nor global is an ICE. With frees ON by default, a dropped Inc is the double-free class — this was the Phase-2 landmine.

## #524 — determinism and offset compounding

- The Var-arm name-similarity rescue tie-broke `max_by_key` over HashMap iteration — the chosen local (and the emitted bytes) depended on hash order. Now: valtype-match first, smallest VarId tie-break — deterministic.
- Tuple destructure (BindDestructure) and ForIn tuple destructure advanced the element offset INSIDE the bind's `if let` — one missing local corrupted every subsequent element's load. The advance is now unconditional.

## Gates

Native corpus 264/264 · wasm explicit 254/0/10-skip · byte gate 67/67 · churn 3/3 · cargo full suite 0 failures.
