### PR TITLE
Bind compiled bodies to registered indices: the pairing convention becomes an invariant

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -147,13 +147,27 @@ pub struct CompiledFunc {
     /// Patched raw body bytes (set by data section DCE). If Some, used
     /// instead of `func` during assembly to reflect compacted data offsets.
     pub patched_body: Option<Vec<u8>>,
+    /// The REGISTERED function index this body belongs to (#526). When set,
+    /// `add_compiled` asserts the body lands at exactly that position —
+    /// converting the "compile order mirrors registration order" CONVENTION
+    /// (held across ~157 runtime routines, where a same-signature swap binds
+    /// the wrong body to a name and validates cleanly) into an invariant.
+    pub expected_func_idx: Option<u32>,
 }
 
 impl CompiledFunc {
     /// Construct from a TrackedFunction. This is the ONLY constructor —
     /// enforces that call_targets is always populated.
     pub fn tracked(type_idx: u32, tf: TrackedFunction) -> Self {
-        Self { type_idx, func: tf.inner, call_targets: tf.call_targets, patched_body: None }
+        Self { type_idx, func: tf.inner, call_targets: tf.call_targets, patched_body: None, expected_func_idx: None }
+    }
+
+    /// `tracked` + the registered function index this body is FOR. Prefer
+    /// this in every compile_* that knows its `emitter.rt.*` slot.
+    pub fn tracked_for(func_idx: u32, type_idx: u32, tf: TrackedFunction) -> Self {
+        let mut c = Self::tracked(type_idx, tf);
+        c.expected_func_idx = Some(func_idx);
+        c
     }
 }
 
@@ -645,7 +659,7 @@ impl WasmEmitter {
             def_globals: HashMap::new(),
             top_let_globals_by_name: HashMap::new(),
             top_let_init: Vec::new(),
-            next_global: 5, // 0=heap_ptr, 1=free_list, 2=preopen_table, 3=preopen_count, 4=heap_start
+            next_global: runtime::HEAP_START_GLOBAL_IDX + 1, // fixed globals end at HEAP_START
             func_table: Vec::new(),
             func_to_table_idx: HashMap::new(),
             record_fields: BTreeMap::new(),
@@ -697,6 +711,16 @@ impl WasmEmitter {
 
     /// Add a compiled function body.
     pub fn add_compiled(&mut self, compiled: CompiledFunc) {
+        if let Some(expected) = compiled.expected_func_idx {
+            let landing = self.num_imports + self.compiled.len() as u32;
+            assert_eq!(
+                landing, expected,
+                "[ICE] compiled body for registered func {} landing at index {} — \
+                 registration and compile order diverged (#526); a same-signature \
+                 neighbor swap binds the wrong body to a name and validates cleanly",
+                expected, landing
+            );
+        }
         self.compiled.push(compiled);
     }
 
@@ -1891,7 +1915,19 @@ fn assemble(emitter: &mut WasmEmitter) -> Vec<u8> {
     );
     emitter.rt.heap_start_global = runtime::HEAP_START_GLOBAL_IDX;
 
-    // Top-level let globals
+    // Top-level let globals. POSITIONAL invariant (#526): the section
+    // ignores each entry's recorded index and emits by Vec order after the
+    // five fixed globals — assert the two agree, or one alloc site that
+    // bumped next_global without pushing here silently shifts EVERY later
+    // global (the preopen/free-list collision class).
+    for (i, &(recorded_idx, _, _)) in emitter.top_let_init.iter().enumerate() {
+        let landing = runtime::HEAP_START_GLOBAL_IDX + 1 + i as u32;
+        assert_eq!(
+            recorded_idx, landing,
+            "[ICE] top-let global recorded at index {} emitting at {} (#526)",
+            recorded_idx, landing
+        );
+    }
     for &(_, vt, bits) in &emitter.top_let_init {
         let init = match vt {
             ValType::I64 => wasm_encoder::ConstExpr::i64_const(bits),

--- a/crates/almide-codegen/src/emit_wasm/rt_dec2flt.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_dec2flt.rs
@@ -165,7 +165,7 @@ fn compile_bn_add_small(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.decfloat.bn_add_small, type_idx, f));
 }
 
 /// `__bn_bit_len(p) -> i32`: significant bit count (0 for a zero bignum).
@@ -194,7 +194,7 @@ fn compile_bn_bit_len(emitter: &mut WasmEmitter) {
         i32_const(0);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.decfloat.bn_bit_len, type_idx, f));
 }
 
 /// `__dec2flt(neg, sig_ptr, exp10) -> f64`. Clinger AlgorithmM.
@@ -421,5 +421,5 @@ fn compile_dec2flt(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.decfloat.dec2flt, type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/rt_dragon.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_dragon.rs
@@ -133,7 +133,7 @@ fn compile_norm(emitter: &mut WasmEmitter) {
         local_get(0); local_get(1); i32_store(0);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.norm, type_idx, f));
 }
 
 /// __dragon_mul_small(p, m): p *= m (m treated as u32).
@@ -178,7 +178,7 @@ fn compile_mul_small(emitter: &mut WasmEmitter) {
         local_get(0); local_get(2); i32_store(0);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.mul_small, type_idx, f));
 }
 
 /// __dragon_cmp(a, b) -> i32: -1 if a<b, 0 if eq, 1 if a>b. Assumes normalized.
@@ -216,7 +216,7 @@ fn compile_cmp(emitter: &mut WasmEmitter) {
         i32_const(0);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.cmp, type_idx, f));
 }
 
 /// __dragon_add(dst, src): dst += src.
@@ -266,7 +266,7 @@ fn compile_add(emitter: &mut WasmEmitter) {
         local_get(0); local_get(4); i32_store(0);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.add, type_idx, f));
 }
 
 /// __dragon_sub(dst, src): dst -= src. Requires dst >= src. Normalizes result.
@@ -307,7 +307,7 @@ fn compile_sub(emitter: &mut WasmEmitter) {
         local_get(0); call(emitter.rt.dragon.norm);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.sub, type_idx, f));
 }
 
 /// __dragon_shl(p, bits): p <<= bits.
@@ -374,7 +374,7 @@ fn compile_shl(emitter: &mut WasmEmitter) {
         local_get(0); call(emitter.rt.dragon.norm);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.shl, type_idx, f));
 }
 
 /// __dragon_copy(dst, src): dst = src (len + limbs).
@@ -396,7 +396,7 @@ fn compile_copy(emitter: &mut WasmEmitter) {
         end; end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.copy, type_idx, f));
 }
 
 // ───────────────────────── driver ─────────────────────────
@@ -933,7 +933,7 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { local_get(18); end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.float_to_string, type_idx, f));
 }
 
 // ───────────────────────── float.to_fixed ─────────────────────────
@@ -1355,7 +1355,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { local_get(RESULT); end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.float_to_fixed, type_idx, f));
 }
 
 /// Set bignum at (base+off) to the i64 value in `loc` (two u32 limbs). Standalone

--- a/crates/almide-codegen/src/emit_wasm/rt_encoding.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_encoding.rs
@@ -617,7 +617,7 @@ pub(super) fn compile_hex_decode(emitter: &mut WasmEmitter) {
         local_get(7);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.hex_decode, type_idx, f));
 }
 
 fn emit_hex_char_to_nibble(f: &mut Function) {

--- a/crates/almide-codegen/src/emit_wasm/rt_libm.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_libm.rs
@@ -257,7 +257,7 @@ fn compile_floor(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.floor, type_idx, f));
 }
 
 // ──────────────────────── __libm_scalbn ───────────────────────
@@ -313,7 +313,7 @@ fn compile_scalbn(emitter: &mut WasmEmitter) {
         f64_mul;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.scalbn, type_idx, f));
 }
 
 // ───────────── kernel coefficients (libm k_sin/k_cos/k_tan) ────
@@ -382,7 +382,7 @@ fn compile_k_sin(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.k_sin, type_idx, f));
 }
 
 // ───────────────────────── __libm_k_cos ───────────────────────
@@ -409,7 +409,7 @@ fn compile_k_cos(emitter: &mut WasmEmitter) {
         f64_add;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.k_cos, type_idx, f));
 }
 
 // ───────────────────────── __libm_k_tan ───────────────────────
@@ -518,7 +518,7 @@ fn compile_k_tan(emitter: &mut WasmEmitter) {
         f64_add;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.k_tan, type_idx, f));
 }
 
 // ───────────── rem_pio2 medium-case + small-case helpers ───────
@@ -788,7 +788,7 @@ fn compile_rem_pio2(emitter: &mut WasmEmitter) {
     });
     emit_store_y(&mut f);
     wasm!(f, { local_get(RP_N); end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.rem_pio2, type_idx, f));
 }
 
 // ───────────────────── __libm_rem_pio2_large ──────────────────
@@ -926,7 +926,7 @@ fn compile_rem_pio2_large(emitter: &mut WasmEmitter) {
     emit_rpl_recompute_and_finalize(
         &mut f, scalbn, floor, ipio2, pio2, x1p24_bits, x1p_24_bits,
     );
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.rem_pio2_large, type_idx, f));
 }
 
 /// Emit the 'recompute loop + finalization tail of `rem_pio2_large` into `f`.
@@ -1323,7 +1323,7 @@ fn compile_exp(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.exp, type_idx, f));
 }
 
 // ── shared log reduction (e_log.c kernel; log2/log10 reuse it) ──
@@ -1447,7 +1447,7 @@ fn compile_log(emitter: &mut WasmEmitter) {
         local_get(LG_K); f64_convert_i32_s; f64_const(LOG_LN2_HI); f64_mul; f64_add;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.log, type_idx, f));
 }
 
 // log2/log10 extra-precision tail locals (after r at index 9).
@@ -1488,7 +1488,7 @@ fn compile_log2(emitter: &mut WasmEmitter) {
         local_get(LG_VL); local_get(LG_VH); f64_add;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.log2, type_idx, f));
 }
 
 const IVLN10HI: f64 = 4.34294481878168880939e-01; /* 0x3fdbcb7b, 0x15200000 */
@@ -1524,7 +1524,7 @@ fn compile_log10(emitter: &mut WasmEmitter) {
         local_get(LG_VL); local_get(LG_VH); f64_add;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.log10, type_idx, f));
 }
 
 // ── pow constants (e_pow.c) ──
@@ -2039,5 +2039,5 @@ fn compile_pow(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.pow, type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/rt_numeric.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_numeric.rs
@@ -221,7 +221,7 @@ pub(super) fn compile_int_from_hex(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.int_from_hex, type_idx, f));
 }
 
 /// __float_parse(s: i32) -> i32
@@ -540,7 +540,7 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.float_parse, type_idx, f));
 }
 
 /// Push 1 if `data[i..end]` (i in `i_local`, end in `end_local`, base in
@@ -623,7 +623,7 @@ pub(super) fn compile_float_pow(emitter: &mut WasmEmitter) {
         local_get(0); local_get(1); call(libm_pow);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.float_pow, type_idx, f));
 }
 
 /// __math_sin(x: f64) -> f64
@@ -676,7 +676,7 @@ pub(super) fn compile_math_sin(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.math_sin, type_idx, f));
 }
 
 /// __math_cos(x: f64) -> f64
@@ -726,7 +726,7 @@ pub(super) fn compile_math_cos(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.math_cos, type_idx, f));
 }
 
 /// __math_tan(x: f64) -> f64
@@ -757,7 +757,7 @@ pub(super) fn compile_math_tan(emitter: &mut WasmEmitter) {
         local_get(4); local_get(5); local_get(2); i32_const(1); i32_and; call(k_tan);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.math_tan, type_idx, f));
 }
 
 /// __math_log(x: f64) -> f64 — natural logarithm.
@@ -774,7 +774,7 @@ pub(super) fn compile_math_log(emitter: &mut WasmEmitter) {
         local_get(0); call(libm_log);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.math_log, type_idx, f));
 }
 
 /// __math_log10(x: f64) -> f64 — common logarithm.
@@ -789,7 +789,7 @@ pub(super) fn compile_math_log10(emitter: &mut WasmEmitter) {
         local_get(0); call(libm_log10);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.math_log10, type_idx, f));
 }
 
 /// __math_log2(x: f64) -> f64 — binary logarithm.
@@ -803,7 +803,7 @@ pub(super) fn compile_math_log2(emitter: &mut WasmEmitter) {
         local_get(0); call(libm_log2);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.math_log2, type_idx, f));
 }
 
 /// __math_exp(x: f64) -> f64 — e^x.
@@ -820,5 +820,5 @@ pub(super) fn compile_math_exp(emitter: &mut WasmEmitter) {
         local_get(0); call(libm_exp);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.math_exp, type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/rt_regex.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_regex.rs
@@ -287,7 +287,7 @@ fn compile_compile(emitter: &mut WasmEmitter) {
         local_get(0); i32_const(0); call(parse_alts);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.compile, type_idx, f));
 }
 
 // ─── __rx_parse_alts(pat, in_group) -> alts_ptr ───
@@ -367,7 +367,7 @@ fn compile_parse_alts(emitter: &mut WasmEmitter) {
     });
     wasm!(f, { end; end; }); // end loop, block
     wasm!(f, { local_get(3); end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.parse_alts, type_idx, f));
 }
 
 // ─── __rx_parse_piece(pat) -> piece_ptr ───
@@ -416,7 +416,7 @@ fn compile_parse_piece(emitter: &mut WasmEmitter) {
         local_get(1);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.parse_piece, type_idx, f));
 }
 
 // ─── __rx_parse_atom(pat) -> piece_ptr ───
@@ -517,7 +517,7 @@ fn compile_parse_atom(emitter: &mut WasmEmitter) {
         local_get(1);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.parse_atom, type_idx, f));
 }
 
 // ─── __rx_parse_escape(pat, piece_ptr) -> () ───
@@ -596,7 +596,7 @@ fn compile_parse_escape(emitter: &mut WasmEmitter) {
         global_get(parse_pos); local_get(5); i32_add; global_set(parse_pos);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.parse_escape, type_idx, f));
 }
 
 /// Allocate `nranges` contiguous Range pairs and write a CLASS node into the
@@ -785,7 +785,7 @@ fn compile_parse_class(emitter: &mut WasmEmitter) {
         local_get(1); i32_const(RX_PIECE_Z_OFF); i32_add; local_get(3); i32_store(0);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.parse_class, type_idx, f));
 }
 
 /// Push a const range pair onto the contiguous ranges array (bump arena one
@@ -868,7 +868,7 @@ fn compile_node_matches(emitter: &mut WasmEmitter) {
         i32_const(0);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.node_matches, type_idx, f));
 }
 
 // ─── __rx_match_one(piece_ptr, text, p, caps, ncap) -> bytes_consumed | -1 ───
@@ -925,7 +925,7 @@ fn compile_match_one(emitter: &mut WasmEmitter) {
         end;
     });
     wasm!(f, { i32_const(RX_NO_MATCH); end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.match_one, type_idx, f));
 }
 
 // ─── __rx_match_rep(piece, text, p, caps, ncap, count) -> end | -1 ───
@@ -993,7 +993,7 @@ fn compile_match_rep(emitter: &mut WasmEmitter) {
         i32_const(RX_NO_MATCH);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.match_rep, type_idx, f));
 }
 
 // ─── __rx_match_seq(piece, text, p, caps, ncap) -> end | -1 ───
@@ -1041,7 +1041,7 @@ fn compile_match_seq(emitter: &mut WasmEmitter) {
         call(match_rep);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.match_seq, type_idx, f));
 }
 
 // ─── __rx_match_alts(alts, text, p, caps, ncap) -> end | -1 ───
@@ -1081,7 +1081,7 @@ fn compile_match_alts(emitter: &mut WasmEmitter) {
         i32_const(RX_NO_MATCH);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.match_alts, type_idx, f));
 }
 
 // ─── __rx_find_at(alts, text, start, caps, ncap) -> end | -1 ───
@@ -1124,7 +1124,7 @@ fn compile_find_at(emitter: &mut WasmEmitter) {
         i32_const(RX_NO_MATCH);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.find_at, type_idx, f));
 }
 
 // ════════════════════════════════════════════════════════════════════════

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -270,7 +270,7 @@ fn compile_utf8_width(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.utf8_width, type_idx, f));
 }
 
 /// `utf8_scalar(s, byte_i) -> i64`. Decodes the Unicode scalar at data offset
@@ -317,7 +317,7 @@ fn compile_utf8_scalar(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.utf8_scalar, type_idx, f));
 }
 
 /// `utf8_snap(s, byte_i) -> i32`. Rounds `byte_i` DOWN to the nearest UTF-8
@@ -346,7 +346,7 @@ fn compile_utf8_snap(emitter: &mut WasmEmitter) {
         local_get(3);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.utf8_snap, type_idx, f));
 }
 
 /// `utf8_byte_of_cp(s, n) -> i32`. Walks `n` codepoints from the start and
@@ -374,7 +374,7 @@ fn compile_utf8_byte_of_cp(emitter: &mut WasmEmitter) {
         local_get(3);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.utf8_byte_of_cp, type_idx, f));
 }
 
 /// Count UTF-8 code points in a string (pointer to `[len:i32][bytes...]`).
@@ -406,7 +406,7 @@ fn compile_char_count(emitter: &mut WasmEmitter) {
         local_get(3); i64_extend_i32_u;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.char_count, type_idx, f));
 }
 
 /// `cp_of_byte(s, byte) -> i64`. Codepoint index of byte offset `byte`:
@@ -441,7 +441,7 @@ fn compile_cp_of_byte(emitter: &mut WasmEmitter) {
         local_get(4); i64_extend_i32_u;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.cp_of_byte, type_idx, f));
 }
 
 // ── Core ──
@@ -475,7 +475,7 @@ fn compile_eq(emitter: &mut WasmEmitter) {
         end; end;
     });
     wasm!(f, { i32_const(0); end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.eq, type_idx, f));
 }
 
 fn compile_contains(emitter: &mut WasmEmitter) {
@@ -508,7 +508,7 @@ fn compile_contains(emitter: &mut WasmEmitter) {
         end; end;
         i32_const(0); end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.contains, type_idx, f));
 }
 
 /// The Unicode `White_Space` codepoint ranges, derived AT EMIT TIME from Rust
@@ -619,7 +619,7 @@ fn compile_is_unicode_ws(emitter: &mut WasmEmitter) {
         }
     }
     wasm!(f, { end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.is_unicode_ws, type_idx, f));
 }
 
 /// Emit a forward codepoint loop that advances `pos_local` past leading
@@ -687,7 +687,7 @@ fn compile_trim(emitter: &mut WasmEmitter) {
         call(emitter.rt.string.slice);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.trim, type_idx, f));
 }
 
 // ── Slice / transform ──
@@ -709,7 +709,7 @@ fn compile_slice(emitter: &mut WasmEmitter) {
         end; end;
         local_get(3); end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.slice, type_idx, f));
 }
 
 /// reverse(s): reverse by CODEPOINT. Each codepoint's bytes are copied in
@@ -745,7 +745,7 @@ fn compile_reverse(emitter: &mut WasmEmitter) {
         end; end;
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.reverse, type_idx, f));
 }
 
 fn compile_repeat(emitter: &mut WasmEmitter) {
@@ -766,7 +766,7 @@ fn compile_repeat(emitter: &mut WasmEmitter) {
         end; end;
         local_get(3); end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.repeat, type_idx, f));
 }
 
 fn compile_index_of(emitter: &mut WasmEmitter) {
@@ -802,7 +802,7 @@ fn compile_index_of(emitter: &mut WasmEmitter) {
         end; end;
         i64_const(-1); end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.index_of, type_idx, f));
 }
 
 fn compile_replace(emitter: &mut WasmEmitter) {
@@ -829,7 +829,7 @@ fn compile_replace(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.replace, type_idx, f));
 }
 
 /// Recursive split using index_of. Supports multi-char delimiter.
@@ -930,7 +930,7 @@ fn compile_split(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.split, type_idx, f));
 }
 
 fn compile_join(emitter: &mut WasmEmitter) {
@@ -971,7 +971,7 @@ fn compile_join(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.join, type_idx, f));
 }
 
 fn compile_count(emitter: &mut WasmEmitter) {
@@ -1003,7 +1003,7 @@ fn compile_count(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.count, type_idx, f));
 }
 
 // ── Padding / trimming ──
@@ -1048,7 +1048,7 @@ fn compile_pad_start(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.pad_start, type_idx, f));
 }
 
 /// pad_end(s, width, pad): like pad_start but appended.
@@ -1069,7 +1069,7 @@ fn compile_pad_end(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.pad_end, type_idx, f));
 }
 
 fn compile_trim_start(emitter: &mut WasmEmitter) {
@@ -1088,7 +1088,7 @@ fn compile_trim_start(emitter: &mut WasmEmitter) {
         call(emitter.rt.string.slice);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.trim_start, type_idx, f));
 }
 
 fn compile_trim_end(emitter: &mut WasmEmitter) {
@@ -1108,7 +1108,7 @@ fn compile_trim_end(emitter: &mut WasmEmitter) {
         call(emitter.rt.string.slice);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.trim_end, type_idx, f));
 }
 
 // ── Case transform ──
@@ -1124,7 +1124,7 @@ fn compile_to_upper(emitter: &mut WasmEmitter) {
     let map = emitter.rt.string.str_case_map;
     let mut f = Function::new([]);
     wasm!(f, { local_get(0); i32_const(1); call(map); end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.to_upper, type_idx, f));
 }
 
 fn compile_to_lower(emitter: &mut WasmEmitter) {
@@ -1132,7 +1132,7 @@ fn compile_to_lower(emitter: &mut WasmEmitter) {
     let map = emitter.rt.string.str_case_map;
     let mut f = Function::new([]);
     wasm!(f, { local_get(0); i32_const(0); call(map); end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.to_lower, type_idx, f));
 }
 
 // ── Decompose ──
@@ -1175,7 +1175,7 @@ fn compile_chars(emitter: &mut WasmEmitter) {
         local_get(2); local_get(6); i32_store(0);                // result.len = j
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.chars, type_idx, f));
 }
 
 /// run_length_encode(s) -> List[(String, Int)].
@@ -1253,7 +1253,7 @@ fn compile_run_length_encode(emitter: &mut WasmEmitter) {
         end; end;
         local_get(5); end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.run_length_encode, type_idx, f));
 }
 
 fn compile_lines(emitter: &mut WasmEmitter) {
@@ -1275,7 +1275,7 @@ fn compile_lines(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.lines, type_idx, f));
 }
 
 /// U+FFFD REPLACEMENT CHARACTER — `from_utf8_lossy` emits one per maximal invalid
@@ -1405,7 +1405,7 @@ fn compile_utf8_classify(emitter: &mut WasmEmitter) {
         i32_or;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.utf8_classify, type_idx, f));
 }
 
 /// `from_bytes(list) -> String`: UTF-8-lossy decode of the byte list (each element
@@ -1481,7 +1481,7 @@ fn compile_from_bytes(emitter: &mut WasmEmitter) {
         end; end;
         local_get(OUT); end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.from_bytes, type_idx, f));
 }
 
 fn compile_to_bytes(emitter: &mut WasmEmitter) {
@@ -1503,7 +1503,7 @@ fn compile_to_bytes(emitter: &mut WasmEmitter) {
         end; end;
         local_get(2); end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.to_bytes, type_idx, f));
 }
 
 // ── Full-Unicode case folding ──
@@ -1552,7 +1552,7 @@ fn compile_utf8_emit_scalar(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.utf8_emit_scalar, type_idx, f));
 }
 
 /// `__case_map_lookup(map_sel, scalar) -> i32`. Binary-search the UPPER(0)/LOWER(1)
@@ -1600,7 +1600,7 @@ fn compile_case_map_lookup(emitter: &mut WasmEmitter) {
     } else {
         wasm!(f, { i32_const(-1); end; });
     }
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.case_map_lookup, type_idx, f));
 }
 
 /// `__set_member(set_sel, scalar) -> i32`. 1 iff `scalar` is in the CASED(0) /
@@ -1642,7 +1642,7 @@ fn compile_set_member(emitter: &mut WasmEmitter) {
     } else {
         wasm!(f, { i32_const(0); end; });
     }
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.set_member, type_idx, f));
 }
 
 /// `__final_sigma(s, byte_off) -> i32`. The Unicode `Final_Sigma` rule for a Σ at
@@ -1713,7 +1713,7 @@ fn compile_final_sigma(emitter: &mut WasmEmitter) {
         if_i32; i32_const(0x03C2); else_; i32_const(0x03C3); end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.final_sigma, type_idx, f));
 }
 
 /// `__str_case_map(s, is_upper) -> i32`. The unified two-pass case driver, exact
@@ -1822,7 +1822,7 @@ fn compile_str_case_map(emitter: &mut WasmEmitter) {
         end; end;
         local_get(9); end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.str_case_map, type_idx, f));
 }
 
 /// `__str_capitalize(s) -> i32`. First scalar uppercased (`char::to_uppercase` —
@@ -1888,6 +1888,6 @@ fn compile_str_capitalize(emitter: &mut WasmEmitter) {
         memory_copy;
         local_get(9); end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.capitalize, type_idx, f));
 }
 

--- a/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
@@ -33,7 +33,7 @@ pub(super) fn compile_replace_first(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.replace_first, type_idx, f));
 }
 
 pub(super) fn compile_last_index_of(emitter: &mut WasmEmitter) {
@@ -69,7 +69,7 @@ pub(super) fn compile_last_index_of(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.last_index_of, type_idx, f));
 }
 
 pub(super) fn compile_strip_prefix(emitter: &mut WasmEmitter) {
@@ -100,7 +100,7 @@ pub(super) fn compile_strip_prefix(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.strip_prefix, type_idx, f));
 }
 
 pub(super) fn compile_strip_suffix(emitter: &mut WasmEmitter) {
@@ -130,7 +130,7 @@ pub(super) fn compile_strip_suffix(emitter: &mut WasmEmitter) {
         end;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.strip_suffix, type_idx, f));
 }
 
 // ── Predicates ──
@@ -436,5 +436,5 @@ pub(super) fn compile_cmp(emitter: &mut WasmEmitter) {
     f.instruction(&LocalGet(1)).instruction(&I32Load(mem0));
     f.instruction(&I32Sub);
     f.instruction(&End);
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.cmp, type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/rt_value.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_value.rs
@@ -138,7 +138,7 @@ fn compile_json_escape_string(emitter: &mut WasmEmitter) {
     wasm!(f, { local_get(1); i32_const(cr_char as i32); i32_const(esc_cr as i32); call(replace); local_set(1); });
     wasm!(f, { local_get(1); end; });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.json_escape_string, type_idx, f));
 }
 
 /// __value_stringify(v: i32) -> i32
@@ -295,7 +295,7 @@ fn compile_value_stringify(emitter: &mut WasmEmitter) {
     // Fallback
     wasm!(f, { i32_const(null_str as i32); end; });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.value_stringify, type_idx, f));
 }
 
 /// __json_parse(s: i32) -> i32 (Result[Value, String])
@@ -325,7 +325,7 @@ fn compile_json_parse(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.json_parse, type_idx, f));
 
     compile_json_parse_at(emitter);
 }
@@ -1241,7 +1241,7 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.json_get_path, type_idx, f));
 }
 
 /// __json_set_path(value: i32, path: i32, new_val: i32) -> i32 (Result[Value, String])
@@ -1602,7 +1602,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.json_set_path, type_idx, f));
 }
 
 /// __json_remove_path(value: i32, path: i32) -> i32 (Value)
@@ -1929,5 +1929,5 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.json_remove_path, type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -561,7 +561,7 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
         w.get(1).i32c(hdr).add();
     }
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.alloc, type_idx, f));
 }
 
 /// Whether this emission activates real reference-count frees — the DEFAULT
@@ -592,7 +592,7 @@ fn compile_rc_inc(emitter: &mut WasmEmitter) {
             w.get(0);
         }
         f.instruction(&wasm_encoder::Instruction::End);
-        emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+        emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.rc_inc, type_idx, f));
         return;
     }
 
@@ -636,7 +636,7 @@ fn compile_rc_inc(emitter: &mut WasmEmitter) {
         w.get(0); // return ptr
     }
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.rc_inc, type_idx, f));
 }
 
 fn compile_rc_dec(emitter: &mut WasmEmitter) {
@@ -647,7 +647,7 @@ fn compile_rc_dec(emitter: &mut WasmEmitter) {
         // Bump-and-leak model (default): true no-op (see compile_rc_inc).
         let mut f = Function::new([]);
         f.instruction(&wasm_encoder::Instruction::End);
-        emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+        emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.rc_dec, type_idx, f));
         return;
     }
 
@@ -700,7 +700,7 @@ fn compile_rc_dec(emitter: &mut WasmEmitter) {
         });
     }
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.rc_dec, type_idx, f));
 }
 
 /// __cow_check(ptr) -> ptr. See registration comment in `register_runtime`.
@@ -744,7 +744,7 @@ fn compile_cow_check(emitter: &mut WasmEmitter) {
         w.get(2); // return the fresh clone
     }
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.cow_check, type_idx, f));
 }
 
 // __heap_save() -> i32
@@ -756,7 +756,7 @@ fn compile_heap_save(emitter: &mut WasmEmitter) {
     let mut f = Function::new([]);
     f.instruction(&wasm_encoder::Instruction::GlobalGet(emitter.heap_ptr_global));
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.heap_save, type_idx, f));
 }
 
 // __heap_restore(ptr: i32) -> ()
@@ -780,7 +780,7 @@ fn compile_heap_restore(emitter: &mut WasmEmitter) {
         global_set(emitter.free_list_global);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.heap_restore, type_idx, f));
 }
 
 /// `__alloc_pinned(size) -> ptr` — `__alloc` + stamp the rc header with
@@ -807,7 +807,7 @@ fn compile_alloc_pinned(emitter: &mut WasmEmitter) {
         w.get(1);
     }
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.alloc_pinned, type_idx, f));
 }
 
 /// __println_str(ptr: i32)
@@ -859,7 +859,7 @@ fn compile_println_str(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.println_str, type_idx, f));
 }
 
 /// __int_to_string(n: i64) -> i32
@@ -1045,7 +1045,7 @@ fn compile_int_to_string(emitter: &mut WasmEmitter) {
     // return $result
     wasm!(f, { local_get(6); end; });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.int_to_string, type_idx, f));
 }
 
 /// __println_int(n: i64)
@@ -1061,7 +1061,7 @@ fn compile_println_int(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.println_int, type_idx, f));
 }
 
 /// __concat_str(left: i32, right: i32) -> i32
@@ -1140,7 +1140,7 @@ fn compile_concat_str(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { local_get(5); end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.concat_str, type_idx, f));
 }
 
 /// __string_alloc(data_len: i32) -> ptr
@@ -1171,7 +1171,7 @@ fn compile_string_alloc(emitter: &mut WasmEmitter) {
         w.get(1);
     }
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string_alloc, type_idx, f));
 }
 
 /// __div_trap(msg_ptr: i32)
@@ -1229,7 +1229,7 @@ fn compile_div_trap(emitter: &mut WasmEmitter) {
         call(proc_exit);
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.div_trap, type_idx, f));
 }
 
 /// Capacity-aware string append: if left has room, append in-place; else grow 2x.
@@ -1287,7 +1287,7 @@ fn compile_string_append(emitter: &mut WasmEmitter) {
         end;
     });
     wasm!(f, { end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string_append, type_idx, f));
 }
 
 /// Emit a byte-by-byte copy loop: dst[dst_off+i] = src[src_off+i], 0..len
@@ -1400,7 +1400,7 @@ fn compile_init_preopen_dirs(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.init_preopen_dirs, type_idx, f));
 }
 
 /// __resolve_path(path_ptr: i32, path_len: i32) → i32 (result_ptr)
@@ -1545,7 +1545,7 @@ fn compile_resolve_path(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.resolve_path, type_idx, f));
 }
 
 
@@ -1621,5 +1621,5 @@ pub(super) fn compile_bytes_f16_to_f64(emitter: &mut WasmEmitter) {
         end;
         end;  // close function body
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.bytes_f16_to_f64, type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
@@ -45,7 +45,7 @@ pub(super) fn compile_option_eq_i64(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.option_eq_i64, type_idx, f));
 }
 
 /// __option_eq_str(a: i32, b: i32) -> i32
@@ -83,7 +83,7 @@ pub(super) fn compile_option_eq_str(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.option_eq_str, type_idx, f));
 }
 
 /// __result_eq_i64_str(a: i32, b: i32) -> i32
@@ -128,7 +128,7 @@ pub(super) fn compile_result_eq_i64_str(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.result_eq_i64_str, type_idx, f));
 }
 
 /// __str_contains(haystack: i32, needle: i32) -> i32 (bool)
@@ -185,7 +185,7 @@ pub(super) fn compile_mem_eq(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { i32_const(0); end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.mem_eq, type_idx, f));
 }
 
 /// __list_eq(a: i32, b: i32, elem_size: i32) -> i32
@@ -272,7 +272,7 @@ pub(super) fn compile_list_eq(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { i32_const(0); end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.list_eq, type_idx, f));
 }
 
 /// __list_list_str_cmp(a: i32, b: i32) -> i32
@@ -313,7 +313,7 @@ pub(super) fn compile_list_list_str_cmp(emitter: &mut WasmEmitter) {
         local_get(2); local_get(3); i32_sub;
         end;
     });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.list_list_str_cmp, type_idx, f));
 }
 
 /// __concat_list(a: i32, b: i32, elem_size: i32) -> i32
@@ -403,7 +403,7 @@ pub(super) fn compile_concat_list(emitter: &mut WasmEmitter) {
     });
 
     wasm!(f, { local_get(6); end; });
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.concat_list, type_idx, f));
 }
 
 /// __int_parse(s: i32) -> i32 (Result[Int, String])
@@ -617,5 +617,5 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
         end;
     });
 
-    emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.int_parse, type_idx, f));
 }


### PR DESCRIPTION
Closes #526 (the registration↔compile pairing half; the `almide_rt_` name-format constructor splits into its own follow-up sweep).

## The invariant

`CompiledFunc` now carries the REGISTERED function index it is FOR (`tracked_for`), and `add_compiled` asserts the body lands at exactly that position. The "compile order mirrors registration order" CONVENTION — held by hand across ~157 runtime routines, where a SAME-SIGNATURE neighbor swap binds the wrong body to a name and validates cleanly (the silent class) — is now a build-failure invariant at one chokepoint.

**121 compile sites migrated mechanically** (every `compile_*` whose single `func_type_indices[&emitter.rt.X]` slot makes the identity unambiguous: runtime.rs 19, rt_string 36, rt_regex 12, rt_libm 12, rt_numeric 10, rt_dragon 9, runtime_eq 8, rt_value 6, rt_string_extra 5, rt_dec2flt 3, rt_encoding 1). Multi-body helper fns with several slots were left un-tagged (no false identity). One successful build = all 121 assertions hold.

## Globals hardening (the A-items from the census)

- `next_global: 5` magic literal → `HEAP_START_GLOBAL_IDX + 1` (const-derived).
- The top-let global section emission asserts each entry's RECORDED index equals its emission position — an alloc site bumping `next_global` without pushing to `top_let_init` would have silently shifted every later global (the preopen/free-list collision class).

Full bar: native 264/264 · wasm explicit 254/0/10-skip · byte gate 67/67 · churn 3/3 · cargo full 0 failures.
