### PR TITLE
Loud failures for the silent guess constellation

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_bytes.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_bytes.rs
@@ -2830,11 +2830,11 @@ impl FuncCompiler<'_> {
         self.emit_typed_append_store(new_buf, old_len, val_i64, val_f64, size_bytes, is_float, /*be=*/ true);
         wasm!(self.func, { end; });
 
-        if let almide_ir::IrExprKind::Var { id } = &buf_expr.kind {
-            if let Some(&local_idx) = self.var_map.get(&id.0) {
-                wasm!(self.func, { local_get(new_buf); local_set(local_idx); });
-            }
-        }
+        // #525 (A8): route through the SHARED write-back — the hand-rolled
+        // var_map-only form silently lost the realloc'd buffer for a
+        // module-global Bytes var and stored the buffer pointer OVER a
+        // shared-cell capture's cell pointer (the Closure-v2 P6 corruption).
+        self.emit_mutator_writeback(buf_expr, new_buf);
 
         self.scratch.free_f64(val_f64);
         self.scratch.free_i64(val_i64);

--- a/crates/almide-codegen/src/emit_wasm/calls_map.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map.rs
@@ -989,7 +989,7 @@ impl FuncCompiler<'_> {
         if let Ty::Record { fields } = key_ty {
             fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect::<Vec<_>>()
         } else if let Ty::Named(name, _) = key_ty {
-            self.emitter.record_fields.get(name.as_str()).cloned().unwrap_or_default()
+            self.emitter.fields_of(name.as_str())
         } else if let Some(fs) = self.emitter.record_fields.get("") {
             fs.clone()
         } else {

--- a/crates/almide-codegen/src/emit_wasm/control.rs
+++ b/crates/almide-codegen/src/emit_wasm/control.rs
@@ -501,7 +501,7 @@ impl FuncCompiler<'_> {
                     let ctor_guard = self.depth_push();
 
                     // Resolve constructor field types from variant info + subject type_args
-                    let ctor_fields = self.emitter.record_fields.get(ctor_name).cloned().unwrap_or_default();
+                    let ctor_fields = self.emitter.fields_of(ctor_name);
                     let subject_type_args: &[Ty] = match subject_ty {
                         Ty::Named(_, args) if !args.is_empty() => args,
                         Ty::Applied(_, args) if !args.is_empty() => args,
@@ -703,7 +703,7 @@ impl FuncCompiler<'_> {
                     let rec_guard = self.depth_push();
 
                     // Bind fields: load each field from subject + tag_offset + field_offset
-                    let case_fields = self.emitter.record_fields.get(ctor_name).cloned().unwrap_or_default();
+                    let case_fields = self.emitter.fields_of(ctor_name);
                     for pf in pat_fields {
                         if let Some((foff, fty)) = values::field_offset(&case_fields, &pf.name) {
                             let total_offset = 4 + foff; // 4 = tag size
@@ -1106,7 +1106,7 @@ impl FuncCompiler<'_> {
                     let ctor_guard = self.depth_push();
 
                     // Bind constructor fields with type param substitution
-                    let ctor_fields = self.emitter.record_fields.get(ctor_name.as_str()).cloned().unwrap_or_default();
+                    let ctor_fields = self.emitter.fields_of(ctor_name.as_str());
                     let type_args: &[Ty] = match inner_ty {
                         Ty::Named(_, args) if !args.is_empty() => args,
                         Ty::Applied(_, args) if !args.is_empty() => args,
@@ -1304,7 +1304,7 @@ impl FuncCompiler<'_> {
                     self.func.instruction(&Instruction::If(bt));
                     let ctor_guard = self.depth_push();
                     // Bind named fields from the variant's record layout
-                    let case_fields = self.emitter.record_fields.get(ctor_name.as_str()).cloned().unwrap_or_default();
+                    let case_fields = self.emitter.fields_of(ctor_name.as_str());
                     for pf in pat_fields {
                         if let Some((foff, fty)) = values::field_offset(&case_fields, &pf.name) {
                             let total_offset = 4 + foff; // 4 = tag size

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -696,6 +696,19 @@ impl WasmEmitter {
     }
 
     /// Add a compiled function body.
+    /// THE ctor-field lookup (#525): a registration MISS is a compiler bug
+    /// (the registration↔lookup name-skew class — cross-module/mangled ctor
+    /// names), not an empty layout. `unwrap_or_default` at the call sites
+    /// conflated None with Some(empty): every pattern bind silently read
+    /// zero-initialized locals, record map-keys never matched, repr printed
+    /// empty. Registered-but-empty stays legal (unit-ish payloads).
+    pub fn fields_of(&self, ctor: &str) -> Vec<(String, almide_lang::types::Ty)> {
+        self.record_fields.get(ctor).cloned().unwrap_or_else(|| panic!(
+            "[ICE] constructor `{}` has no registered field layout (#525 class)",
+            ctor
+        ))
+    }
+
     pub fn add_compiled(&mut self, compiled: CompiledFunc) {
         self.compiled.push(compiled);
     }
@@ -874,8 +887,16 @@ impl FuncCompiler<'_> {
             }
         } else if let Some(&local_idx) = self.var_map.get(&id) {
             wasm!(self.func, { local_get(new_ptr); local_set(local_idx); });
-        } else if let Some(&(global_idx, _)) = self.emitter.top_let_globals.get(&id) {
+        } else if let Some((global_idx, _)) = self.lookup_global(almide_ir::VarId(id)) {
             wasm!(self.func, { local_get(new_ptr); global_set(global_idx); });
+        } else {
+            // #525 (A6): silently SKIPPING the write-back leaves the var
+            // holding a stale pre-realloc pointer — this fn's own doc calls
+            // that "silently wrong". Refuse loudly instead.
+            panic!(
+                "[ICE] mutator write-back target VarId {} resolved to neither local nor global (#525)",
+                id
+            );
         }
     }
 
@@ -2631,7 +2652,12 @@ fn compile_repr_funcs(emitter: &mut WasmEmitter, var_table: &almide_ir::VarTable
         // this is the whole point of keying by instantiation. The dispatch base
         // name is the type's own name (`Tree`), not the mangled key.
         let ty = emitter.repr_func_tys.get(mangled).cloned()
-            .unwrap_or_else(|| almide_lang::types::Ty::Named(almide_base::intern::sym(mangled), Vec::new()));
+            .unwrap_or_else(|| panic!(
+                "[ICE] repr dispatch for `{}` has no registered instantiation — \
+                 fabricating a Named from the MANGLED key silently printed an \
+                 empty repr (#525)",
+                mangled
+            ));
         let base_name = match &ty {
             almide_lang::types::Ty::Named(n, _) => n.to_string(),
             _ => mangled.clone(),

--- a/crates/almide-codegen/src/emit_wasm/values.rs
+++ b/crates/almide-codegen/src/emit_wasm/values.rs
@@ -68,6 +68,14 @@ pub fn byte_size(ty: &Ty) -> u32 {
         Ty::Bytes => 4,  // i32 pointer
         Ty::Matrix => 4, // i32 pointer
         Ty::Unit => 0,
+        // i32 pointer for all heap types. Unknown leaking through a
+        // NON-gated channel (VarTable entries, pattern types) silently
+        // sizes as 4 — an Int slot then strides wrong. Loud in debug,
+        // symmetric with ty_to_valtype's Unknown debug_assert (#525).
+        Ty::Unknown => {
+            debug_assert!(false, "[ICE-debug] byte_size(Ty::Unknown) — unresolved type sized as a pointer (#525)");
+            4
+        }
         _ => 4,          // i32 pointer for all heap types
     }
 }


### PR DESCRIPTION
Closes #525 — the silent guess constellation, each member converted from "wrong output on a miss" to a loud failure or routed through the shared rule.

- **`fields_of(ctor)` ICE accessor**: the five `record_fields.get(...).unwrap_or_default()` sites (record/variant pattern binds in control.rs, map record-keys in calls_map.rs) conflated "no registration" with "empty layout" — a ctor-name skew made every pattern bind silently read zero-initialized locals and record map-keys never match. A registration MISS is now `[ICE] … (#525 class)`; registered-but-empty stays legal. Zero firings across the corpus (registrations are currently total — the assert pins it).
- **repr dispatch fabrication → ICE**: `repr_func_tys` miss fabricated a `Named` from the MANGLED key, whose field lookup then missed → silently empty repr.
- **mutator write-back 4th arm → ICE** (was a silent skip leaving a stale pre-realloc pointer) and the global arm now resolves via `lookup_global` (alias-aware).
- **bytes typed-append write-back** routed through `emit_mutator_writeback` — the hand-rolled var_map-only form silently lost the realloc'd buffer for module-global Bytes and stored the buffer pointer OVER a shared-cell capture's cell pointer.
- **`byte_size(Ty::Unknown)` debug-asserts** (symmetric with `ty_to_valtype`'s) — an Unknown leaking through a non-gated channel no longer sizes as a pointer in silence.

Residual documented in the issue-close: the `resolve_list_elem`/ConcatList `Ty::Int`/`unwrap_or(8)` fallbacks remain reachable ONLY through empty-list channels (`[] + []`), where zero elements make the stride unobservable; non-empty lists are blocked by the AllTypesConcrete gate. The real closure for those channels is consumer-driven `[]` typing, tracked with the §13 queue.

Full bar: native 264/264 · wasm explicit 254/0/10-skip · byte gate 67/67 · churn 3/3 · cargo full 0 failures.
