### PR TITLE
Close the §5 silent-trap holdouts

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/equality.rs
+++ b/crates/almide-codegen/src/emit_wasm/equality.rs
@@ -793,10 +793,18 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(left);
                 self.scratch.free_i32(right);
             }
-            // TypeVar/Unknown: unresolved type — dead-code residue from error
-            // recovery may reach here; live code is guarded by
-            // assert_types_concretized. Keep the trap for that case only.
-            (ty, _) if ty.is_unresolved() => { wasm!(self.func, { unreachable; }); }
+            // TypeVar/Unknown (#517): the AllTypesConcrete hard gate refuses
+            // any build whose expression types are unresolved, and comparison
+            // operands ARE expressions — nothing live can reach this arm. The
+            // former runtime trap could bury a future gate hole as a silent
+            // late crash; fail the build instead.
+            (ty, _) if ty.is_unresolved() => {
+                panic!(
+                    "[ICE] emit_wasm: comparison on unresolved type `{:?}` reached emission — \
+                     the AllTypesConcrete gate should have refused this build (#517)",
+                    ty
+                );
+            }
             (l, _) => {
                 // A RESOLVED type with no comparison emission is a
                 // compiler bug — fail the build (§5: no silent traps).


### PR DESCRIPTION
Closes #517 — the §5 (no-silent-traps) holdouts.

- **equality.rs unresolved arm → ICE**: the runtime `unreachable` was kept as "dead-code residue from error recovery may reach here" caution. Since then the AllTypesConcrete gate became a hard build refusal over expression types, and comparison operands ARE expressions — nothing live can reach the arm. The trap could only have buried a FUTURE gate hole as a late silent crash; it now fails the build (corpus + byte gate confirm zero firings).
- **calls.rs closure-call else arms**: already resolved by the intervening refactors — the only remaining `unreachable` emissions in calls.rs are the LEGITIMATE assert/panic/assert_eq/assert_ne semantics (user-facing traps, not compiler-bug burials). Verified by sweep.

Full bar: native 264/264 · wasm explicit 254/0/10-skip · byte gate 67/67 · cargo full 0 failures.
