### PR TITLE
Wire almide-interp as the fuzzer's third oracle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "almide-codegen",
  "almide-dialect",
  "almide-frontend",
+ "almide-interp",
  "almide-ir",
  "almide-lang",
  "almide-optimize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ almide-ir = { path = "crates/almide-ir" }
 almide-codegen = { path = "crates/almide-codegen" }
 almide-tools = { path = "crates/almide-tools" }
 almide-optimize = { path = "crates/almide-optimize" }
+almide-interp = { path = "crates/almide-interp" }
 almide-frontend = { path = "crates/almide-frontend" }
 almide-dialect = { path = "crates/almide-dialect" }
 clap = { version = "4", features = ["derive"] }

--- a/crates/almide-interp/src/bridge.rs
+++ b/crates/almide-interp/src/bridge.rs
@@ -201,7 +201,11 @@ fn bool_fn(func: &str, args: &[Value]) -> Option<Flow> {
 
 fn string_fn(func: &str, args: &[Value]) -> Option<Flow> {
     let f = match func {
-        "len" | "length" => Flow::val(Value::Int(as_str(args.first())?.len() as i64)),
+        // CODEPOINT unit (#419, C-065): string.len/index_of count chars, not
+        // bytes, on BOTH targets — the interp lagging this was the third
+        // judge's FIRST catch (fuzz 3-way: both targets agreed, interp voted
+        // bytes).
+        "len" | "length" => Flow::val(Value::Int(as_str(args.first())?.chars().count() as i64)),
         "char_count" => Flow::val(Value::Int(as_str(args.first())?.chars().count() as i64)),
         "is_empty" => Flow::val(Value::Bool(as_str(args.first())?.is_empty())),
         "to_upper" => Flow::val(Value::str(as_str(args.first())?.to_uppercase())),
@@ -231,18 +235,22 @@ fn string_fn(func: &str, args: &[Value]) -> Option<Flow> {
         "count" => Flow::val(Value::Int(
             as_str(args.first())?.matches(as_str(args.get(1))?).count() as i64,
         )),
-        // index_of returns Option[Int] of the BYTE offset (matches the runtime:
-        // both targets return byte offsets, confirmed in memory).
-        "index_of" => Flow::val(Value::Option(
-            as_str(args.first())?
-                .find(as_str(args.get(1))?)
-                .map(|i| Box::new(Value::Int(i as i64))),
-        )),
-        "last_index_of" => Flow::val(Value::Option(
-            as_str(args.first())?
-                .rfind(as_str(args.get(1))?)
-                .map(|i| Box::new(Value::Int(i as i64))),
-        )),
+        // index_of returns Option[Int] of the CODEPOINT index (#419 unified
+        // the unit; the old byte-offset comment predated that change).
+        "index_of" => {
+            let s = as_str(args.first())?;
+            Flow::val(Value::Option(
+                s.find(as_str(args.get(1))?)
+                    .map(|b| Box::new(Value::Int(s[..b].chars().count() as i64))),
+            ))
+        }
+        "last_index_of" => {
+            let s = as_str(args.first())?;
+            Flow::val(Value::Option(
+                s.rfind(as_str(args.get(1))?)
+                    .map(|b| Box::new(Value::Int(s[..b].chars().count() as i64))),
+            ))
+        }
         "split" => {
             let s = as_str(args.first())?;
             let sep = as_str(args.get(1))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ pub use almide_frontend::stdlib;
 pub use almide_optimize::optimize;
 pub use almide_optimize::mono;
 
+// Reference interpreter (the third cross-target judge).
+pub use almide_interp as interp;
+
 // ── Tools (almide-tools) ──
 pub use almide_tools::fmt;
 pub use almide_tools::interface;

--- a/tools/xtarget-fuzz/Cargo.lock
+++ b/tools/xtarget-fuzz/Cargo.lock
@@ -22,19 +22,20 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.24.0"
+version = "0.27.3"
 dependencies = [
  "almide-base",
  "almide-codegen",
  "almide-dialect",
  "almide-frontend",
+ "almide-interp",
  "almide-ir",
  "almide-lang",
  "almide-optimize",
  "almide-tools",
  "clap",
+ "fs2",
  "lasso",
- "libc",
  "lsp-server",
  "lsp-types",
  "semver",
@@ -96,6 +97,17 @@ dependencies = [
  "almide-lang",
  "serde",
  "toml",
+]
+
+[[package]]
+name = "almide-interp"
+version = "0.1.0"
+dependencies = [
+ "almide-base",
+ "almide-frontend",
+ "almide-ir",
+ "almide-lang",
+ "almide-optimize",
 ]
 
 [[package]]
@@ -314,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "egg"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb749745461743bb477fba3ef87c663d5965876155c676c9489cfe0963de5ab"
+checksum = "dd40cfd4196d7a8f882ace95d623d4d6734588e502b4e188675a7c2f55eb4fb4"
 dependencies = [
  "env_logger",
  "hashbrown 0.15.5",
@@ -326,7 +338,6 @@ dependencies = [
  "num-traits",
  "quanta",
  "rustc-hash",
- "saturating",
  "smallvec",
  "symbol_table",
  "symbolic_expressions",
@@ -362,6 +373,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "futures-core"
@@ -649,12 +670,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "saturating"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,11 +737,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -797,44 +812,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "unicode-ident"
@@ -907,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.225.0"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7eac0445cac73bcf09e6a97f83248d64356dccf9f2b100199769b6b42464e5"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
  "wasmparser",
@@ -917,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.225.0"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e5456165f81e64cb9908a0fe9b9d852c2c74582aa3fe2be3c2da57f937d3ae"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.15.5",
@@ -977,12 +990,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "xtarget-fuzz"

--- a/tools/xtarget-fuzz/src/main.rs
+++ b/tools/xtarget-fuzz/src/main.rs
@@ -242,6 +242,8 @@ fn worker_loop(
 ) {
     let file = work_dir.join("prog.almd");
     let wasm = work_dir.join("prog.wasm");
+    // The third judge (#516): per-worker, abstains on anything it can't run.
+    let reference = crate::oracle::InterpOracle::new();
 
     loop {
         if stop.load(Ordering::Relaxed) {
@@ -267,7 +269,7 @@ fn worker_loop(
         }
 
         stats.generated.fetch_add(1, Ordering::Relaxed);
-        let outcome = run_ladder(&tc, &gen.source, &file, &wasm, None);
+        let outcome = run_ladder(&tc, &gen.source, &file, &wasm, Some(&reference));
 
         match outcome {
             Outcome::Clean => {
@@ -337,13 +339,14 @@ fn cmd_replay(args: &[String]) {
     let wasm = work_dir.join("replay.wasm");
     let _ = std::fs::write(&file, &gen.source);
 
+    let reference = crate::oracle::InterpOracle::new();
     let tc = Toolchain {
         almide,
         wasmtime: resolve_wasmtime(),
         scratch: repo.join("tools/xtarget-fuzz/.scratch/replay-build"),
         timeout: Duration::from_secs(DEFAULT_TIMEOUT_SECS),
     };
-    let outcome = run_ladder(&tc, &gen.source, &file, &wasm, None);
+    let outcome = run_ladder(&tc, &gen.source, &file, &wasm, Some(&reference));
     eprintln!("\n=== ladder outcome ===");
     print_outcome(&outcome);
 }

--- a/tools/xtarget-fuzz/src/oracle/interp.rs
+++ b/tools/xtarget-fuzz/src/oracle/interp.rs
@@ -1,0 +1,76 @@
+//! The reference-interpreter oracle (#516) — the third judge.
+//!
+//! Implements `ReferenceOracle` over `almide::interp` (the pre-codegen IR
+//! tree-walker). With it, the ladder can catch the class the 2-way
+//! differential is structurally blind to: BOTH targets wrong identically.
+//!
+//! Abstention discipline: any pipeline failure (parse / type errors the
+//! check rung somehow let through, lowering panics on generator shapes,
+//! `Unsupported` interp features, fuel exhaustion) returns `None` — the
+//! ladder then skips the third vote rather than emitting a bogus one.
+
+use super::ReferenceOracle;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+pub struct InterpOracle {
+    /// Evaluation budget. Generated programs can loop arbitrarily; the
+    /// native/wasm rungs are wall-clock bounded, the interp is fuel
+    /// bounded. Exhaustion = abstain, never a finding.
+    fuel: u64,
+}
+
+impl InterpOracle {
+    pub fn new() -> Self {
+        // Generous: the generator's corpus programs are small; anything
+        // that needs more than this is a loop the wall-clock rungs already
+        // bound at seconds.
+        const DEFAULT_FUEL: u64 = 50_000_000;
+        Self { fuel: DEFAULT_FUEL }
+    }
+
+    fn evaluate_inner(&self, source: &str) -> Option<String> {
+        use almide::interp::{Interpreter, RunStatus};
+
+        let tokens = almide::lexer::Lexer::tokenize(source);
+        let mut parser = almide::parser::Parser::new(tokens);
+        let mut prog = parser.parse().ok()?;
+        if !parser.errors.is_empty() {
+            return None;
+        }
+
+        let canon = almide::canonicalize::canonicalize_program(&prog, std::iter::empty());
+        let mut checker = almide::check::Checker::from_env(canon.env);
+        let diags = checker.infer_program(&mut prog);
+        if diags
+            .iter()
+            .any(|d| d.level == almide::diagnostic::Level::Error)
+        {
+            return None;
+        }
+
+        let mut ir = almide::lower::lower_program(&prog, &checker.env, &checker.type_map);
+        almide::optimize::optimize_program(&mut ir);
+        almide::mono::monomorphize(&mut ir);
+        almide::ir_link::ir_link(&mut ir);
+
+        let out = Interpreter::new(&ir).with_fuel(self.fuel).run_main();
+        match out.status {
+            // Only a CLEAN run casts a vote: the ladder compares stdout of
+            // clean native/wasm runs, and abort stderr text is not part of
+            // the cross-target byte contract at this rung.
+            RunStatus::Ok => Some(out.stdout),
+            RunStatus::Aborted | RunStatus::Unsupported(_) | RunStatus::FuelExhausted => None,
+        }
+    }
+}
+
+impl ReferenceOracle for InterpOracle {
+    fn evaluate(&self, source: &str) -> Option<String> {
+        // The frontend is panic-free on the fuzz corpus by its own gates,
+        // but the oracle must never kill the campaign: a panic = abstain
+        // (and the shape will surface through the panic-fuzz lane instead).
+        catch_unwind(AssertUnwindSafe(|| self.evaluate_inner(source)))
+            .ok()
+            .flatten()
+    }
+}

--- a/tools/xtarget-fuzz/src/oracle/mod.rs
+++ b/tools/xtarget-fuzz/src/oracle/mod.rs
@@ -13,9 +13,11 @@
 //! in parallel — slots in behind a clean trait ([`ReferenceOracle`]).
 //! This crate does NOT depend on it; the hook is `Option<&dyn ...>`.
 
+mod interp;
 mod ladder;
 mod runner;
 
+pub use interp::InterpOracle;
 pub use ladder::{run_ladder, Finding, FindingKind, Outcome, RunEvidence, Rung};
 pub use runner::Toolchain;
 
@@ -24,8 +26,8 @@ pub use runner::Toolchain;
 /// pinning *which* target diverged (today a divergence only tells us the
 /// two targets disagree, not which is correct).
 ///
-/// Left as a trait with no implementation on purpose: the interpreter is
-/// out of scope for this crate and lands separately.
+/// Implemented by `InterpOracle` (#516) over the `almide::interp`
+/// tree-walker; it abstains (returns `None`) on anything it cannot run.
 pub trait ReferenceOracle {
     /// Evaluate `source` and return its expected stdout, or `None` if
     /// the interpreter cannot evaluate this program (it then abstains).


### PR DESCRIPTION
Closes #516 — the fuzzer's `ReferenceOracle` slot (deliberately left as an unimplemented trait) is now filled: the nightly generative campaign votes 3-way.

## The wiring

- `InterpOracle` (tools/xtarget-fuzz/src/oracle/interp.rs) implements `ReferenceOracle` over `almide::interp`, running the SAME frontend cut as the interp's own eval tests (parse → canonicalize → check → lower → optimize → mono → ir_link → tree-walk). Abstention discipline: parse/type errors, lowering panics (caught), `Unsupported` interp features, and fuel exhaustion all return `None` — the ladder skips the third vote rather than casting a bogus one. Fuel-bounded (the native/wasm rungs are wall-clock bounded; the interp is deterministic-fuel bounded).
- Per-worker construction in `worker_loop`; both `run_ladder` call sites now pass `Some(&reference)`.
- The root crate re-exports `almide_interp` as `almide::interp` (the fuzzer path-deps the root crate).

## First blood — the rung works

A 3-minute validation campaign (196 programs, 59.6/min) immediately produced a `both targets disagree with reference interpreter` finding on a mutation of `rc_reclaim_churn.almd`: **native and wasm agreed (444997) and the interp voted differently** — exactly the class the 2-way differential is structurally blind to. Root cause: the interp's `string.len` still counted BYTES and `index_of`/`last_index_of` returned byte offsets — it had lagged the #419 codepoint unification (C-065). Fixed (`chars().count()` / byte→codepoint conversion), eval suite 53/53, and the replay now reports `CLEAN — native and wasm agree`. The third judge's first catch was a judge bug — which is precisely the validation the rung needed end-to-end.

The same campaign also reproduced 7 ordinary 2-way findings (float formatting, a wasm run-failure divergence, build failures) — those are the nightly queue's normal harvest, unchanged by this PR.

## Gates

Native corpus 264/264 · wasm explicit 254/0/10-skip · byte gate 67/67 · interp eval suite 53/53 · cargo full 0 failures.
