### PR TITLE
Metamorphic binding-shape rung for the fuzz ladder

### DIFF
--- a/tools/xtarget-fuzz/src/main.rs
+++ b/tools/xtarget-fuzz/src/main.rs
@@ -13,6 +13,7 @@
 
 mod findings;
 mod generator;
+mod metamorph;
 mod minimize;
 mod oracle;
 mod rng;
@@ -270,8 +271,31 @@ fn worker_loop(
         let outcome = run_ladder(&tc, &gen.source, &file, &wasm, None);
 
         match outcome {
-            Outcome::Clean => {
+            Outcome::Clean { native } => {
                 stats.clean.fetch_add(1, Ordering::Relaxed);
+                // Metamorphic rung (#515): binding-shape variants of clean
+                // SYNTHESIZED programs must be accepted and byte-identical.
+                if matches!(gen.origin, crate::generator::Origin::Synthesis) {
+                    if let Some(finding) =
+                        run_metamorphic(&tc, &gen.source, &native, &work_dir)
+                    {
+                        stats.findings.fetch_add(1, Ordering::Relaxed);
+                        let was_new = sink.record(
+                            cfg.seed,
+                            index,
+                            &gen.origin,
+                            &gen.source,
+                            &gen.source,
+                            &finding,
+                        );
+                        if was_new {
+                            eprintln!(
+                                "  ** FINDING [{:?}] seed={} index={} — {}",
+                                finding.kind, cfg.seed, index, finding.summary
+                            );
+                        }
+                    }
+                }
             }
             Outcome::GeneratorReject { .. } => {
                 stats.generator_rejects.fetch_add(1, Ordering::Relaxed);
@@ -301,6 +325,56 @@ fn worker_loop(
             }
         }
     }
+}
+
+/// The metamorphic rung (#515): check + run every binding-shape variant;
+/// acceptance or output deltas vs the clean original are findings.
+fn run_metamorphic(
+    tc: &Toolchain,
+    source: &str,
+    native: &oracle::RunEvidence,
+    work_dir: &Path,
+) -> Option<oracle::Finding> {
+    let vfile = work_dir.join("prog_metamorph.almd");
+    for (label, variant) in metamorph::binding_variants(source) {
+        if std::fs::write(&vfile, &variant).is_err() {
+            continue;
+        }
+        let chk = tc.check(&vfile);
+        if chk.timed_out {
+            continue; // wall-clock noise, not an acceptance verdict
+        }
+        if !chk.success() {
+            return Some(oracle::Finding {
+                rung: oracle::Rung::Check,
+                kind: oracle::FindingKind::MetamorphicDivergence,
+                summary: format!(
+                    "binding variant `{label}` REJECTED though the original was accepted"
+                ),
+                native: None,
+                wasm: None,
+            });
+        }
+        let run = tc.run_native(&vfile);
+        if run.timed_out || run.spawn_failed {
+            continue;
+        }
+        let v_stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+        if v_stdout != native.stdout || run.exit_code != native.exit_code {
+            return Some(oracle::Finding {
+                rung: oracle::Rung::Run,
+                kind: oracle::FindingKind::MetamorphicDivergence,
+                summary: format!(
+                    "binding variant `{label}` diverged: stdout {:?} vs original {:?}",
+                    v_stdout.chars().take(60).collect::<String>(),
+                    native.stdout.chars().take(60).collect::<String>(),
+                ),
+                native: None,
+                wasm: None,
+            });
+        }
+    }
+    None
 }
 
 /// Per-program scratch dir for native cargo builds (isolated per worker
@@ -447,7 +521,7 @@ fn print_summary(stats: &Stats, sink: &FindingSink, elapsed: Duration, out_dir: 
 
 fn print_outcome(outcome: &Outcome) {
     match outcome {
-        Outcome::Clean => eprintln!("CLEAN — native and wasm agree"),
+        Outcome::Clean { .. } => eprintln!("CLEAN — native and wasm agree"),
         Outcome::GeneratorReject { diagnostics } => {
             eprintln!("GENERATOR REJECT (check failed):\n{diagnostics}")
         }

--- a/tools/xtarget-fuzz/src/metamorph.rs
+++ b/tools/xtarget-fuzz/src/metamorph.rs
@@ -1,0 +1,135 @@
+//! Metamorphic binding-shape variants (#515, completeness §3).
+//!
+//! THE language rule under test: `let x = e` is accepted ⟺ `var x = e` is
+//! accepted ⟺ `var x = d; x = e` is accepted (mod mutability), and the
+//! effect-Result unwrap/coercion applied to `e` is IDENTICAL in every
+//! binding position. The checker and the lowering each implement this rule
+//! once; fixture C-064 pins it pointwise. This module pins it
+//! METAMORPHICALLY: every clean synthesized program is replayed with its
+//! binding shapes rewritten, and any acceptance or behavior delta is a
+//! finding.
+//!
+//! Scope guard: only generator-SHAPED lines are rewritten (`let rN: T =
+//! e;` single-line, bracket/quote balanced), and the rung only runs on
+//! `Origin::Synthesis` programs — corpus mutations can contain arbitrary
+//! text the line heuristic must not touch.
+
+/// True iff the line is a complete one-line `let` statement we can rewrite:
+/// starts with `let `, ends with `;`, and all brackets/quotes are balanced.
+fn is_rewritable_let(trimmed: &str) -> bool {
+    if !trimmed.starts_with("let ") || !trimmed.ends_with(';') {
+        return false;
+    }
+    let mut depth = 0i32;
+    let mut in_str = false;
+    let mut escape = false;
+    for c in trimmed.chars() {
+        if in_str {
+            if escape {
+                escape = false;
+            } else if c == '\\' {
+                escape = true;
+            } else if c == '"' {
+                in_str = false;
+            }
+            continue;
+        }
+        match c {
+            '"' => in_str = true,
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            _ => {}
+        }
+    }
+    depth == 0 && !in_str
+}
+
+/// Variant A: every rewritable `let` becomes `var` — mutability of the
+/// binding must not change what the binding position accepts or computes.
+fn let_to_var(source: &str) -> Option<String> {
+    let mut changed = false;
+    let out: Vec<String> = source
+        .lines()
+        .map(|line| {
+            let trimmed = line.trim_start();
+            if is_rewritable_let(trimmed) {
+                changed = true;
+                let indent = &line[..line.len() - trimmed.len()];
+                format!("{indent}var {}", &trimmed[4..])
+            } else {
+                line.to_string()
+            }
+        })
+        .collect();
+    changed.then(|| out.join("\n"))
+}
+
+/// Variant B: every rewritable `let x: T = e;` becomes
+/// `var x: T = e;\n x = e;` — the ASSIGN position must accept exactly what
+/// the bind position accepted, with identical unwrap/coercion. Generated
+/// synthesis expressions are pure (the denylist excludes nondeterminism),
+/// so the re-evaluation is observably equivalent.
+fn bind_then_assign(source: &str) -> Option<String> {
+    let mut changed = false;
+    let out: Vec<String> = source
+        .lines()
+        .map(|line| {
+            let trimmed = line.trim_start();
+            if is_rewritable_let(trimmed) {
+                if let Some(eq) = trimmed.find(" = ") {
+                    let header = &trimmed[4..eq]; // `name: Ty`
+                    let name = header.split(':').next().unwrap_or(header).trim();
+                    let expr = &trimmed[eq + 3..trimmed.len() - 1]; // sans `;`
+                    changed = true;
+                    let indent = &line[..line.len() - trimmed.len()];
+                    return format!(
+                        "{indent}var {};\n{indent}{name} = {expr};",
+                        &trimmed[4..trimmed.len() - 1]
+                    );
+                }
+            }
+            line.to_string()
+        })
+        .collect();
+    changed.then(|| out.join("\n"))
+}
+
+/// All binding-shape variants of a synthesized program, labeled for the
+/// finding summary.
+pub fn binding_variants(source: &str) -> Vec<(&'static str, String)> {
+    let mut v = Vec::new();
+    if let Some(s) = let_to_var(source) {
+        v.push(("let→var", s));
+    }
+    if let Some(s) = bind_then_assign(source) {
+        v.push(("bind→assign", s));
+    }
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PROG: &str = "fn main() -> Unit = {\n  let x5: Int = int.abs(-3);\n  let y6: String = \"a;b\" + \"c\";\n  println(\"${x5}${y6}\")\n}";
+
+    #[test]
+    fn variants_generated() {
+        let vs = binding_variants(PROG);
+        assert_eq!(vs.len(), 2, "both variants must fire on bind-bearing programs");
+        let (label_a, a) = &vs[0];
+        assert_eq!(*label_a, "let→var");
+        assert!(a.contains("var x5: Int = int.abs(-3);"));
+        assert!(a.contains("var y6: String = \"a;b\" + \"c\";"));
+        let (label_b, b) = &vs[1];
+        assert_eq!(*label_b, "bind→assign");
+        assert!(b.contains("var x5: Int = int.abs(-3);\n  x5 = int.abs(-3);"));
+    }
+
+    #[test]
+    fn multiline_and_strings_untouched() {
+        // unbalanced (multi-line) lets and let-text inside strings are skipped
+        let src = "  let a: Int = f(\n    1);\n  println(\"let r1: Int = 2;\")";
+        assert!(binding_variants(src).is_empty());
+    }
+}

--- a/tools/xtarget-fuzz/src/oracle/ladder.rs
+++ b/tools/xtarget-fuzz/src/oracle/ladder.rs
@@ -21,8 +21,10 @@ pub enum Rung {
 /// The classified result of running the full ladder on one program.
 #[derive(Debug, Clone)]
 pub enum Outcome {
-    /// Passed every rung; native and WASM agreed byte-for-byte.
-    Clean,
+    /// Passed every rung; native and WASM agreed byte-for-byte. Carries
+    /// the native evidence so post-rungs (the metamorphic gate) can
+    /// compare variant behavior without re-running the original.
+    Clean { native: RunEvidence },
 
     /// `almide check` rejected the program. This is a *generator* bug
     /// (we promised well-typed-by-construction), not a compiler finding.
@@ -66,6 +68,9 @@ pub enum FindingKind {
     OutputDivergence,
     /// One side ran, the other failed to run though it built.
     RunFailureDivergence,
+    /// A binding-shape rewrite (let⟺var⟺assign) changed acceptance or
+    /// observable behavior (#515, completeness §3).
+    MetamorphicDivergence,
 }
 
 /// Captured observable behaviour of one execution.
@@ -223,7 +228,7 @@ pub fn run_ladder(
         }
     }
 
-    Outcome::Clean
+    Outcome::Clean { native: nat_ev }
 }
 
 /// fmt round-trip: `parse → fmt → parse → fmt` must be a fixed point.


### PR DESCRIPTION
Closes #515 — the §3 binding-equivalence rule is now checked METAMORPHICALLY on every nightly campaign, not just pointwise by fixture C-064.

## The rung

Every CLEAN synthesized program is replayed under binding-shape rewrites, and any acceptance or behavior delta is a `MetamorphicDivergence` finding:

- **let→var**: every one-line balanced `let x: T = e;` becomes `var` — binding mutability must not change what the position accepts or computes.
- **bind→assign**: `let x: T = e;` becomes `var x: T = e; x = e;` — the ASSIGN position must accept exactly what the bind position accepted, with identical effect-Result unwrap/coercion (the #485/#489 class, checked as a CLASS).

Scope guards: only generator-shaped lines (single-line, bracket/quote balanced — multi-line lets and let-text inside string literals are untouched, unit-tested), and the rung runs only on `Origin::Synthesis` programs since corpus mutations can contain arbitrary text. `Outcome::Clean` now carries the native run evidence so variants compare without re-running the original.

## Validation

A 4-minute local campaign: 304 programs, 249 clean — **498 variant replays, zero metamorphic findings**: the binding rule HOLDS across the synthesis space, consistent with the #489 unification. (The rung's machinery is separately unit-tested; the same campaign reproduced the usual 2-way queue findings, untouched by this PR.)

Fuzzer suite 13/13 green.
