### PR TITLE
Accept pure thunks in fan race/any/settle on both targets

### DIFF
--- a/crates/almide-codegen/src/pass_fan_lowering.rs
+++ b/crates/almide-codegen/src/pass_fan_lowering.rs
@@ -38,23 +38,35 @@ fn rewrite_expr(expr: IrExpr, inside_fan: bool) -> IrExpr {
 
         // Fan module calls (fan.map, fan.race, fan.any, etc.): strip Try from lambda args
         // Matches both Module { "fan" } (before StdlibLowering) and Named { "almide_rt_fan_*" } (after)
-        IrExprKind::Call { target: CallTarget::Module { ref module, .. }, .. }
+        IrExprKind::Call { target: CallTarget::Module { ref module, ref func, .. }, .. }
             if module == "fan" =>
         {
+            let adapt = thunk_list_method(func.as_str());
             let IrExprKind::Call { target, args, type_args } = expr.kind else { unreachable!() };
             IrExprKind::Call {
                 target,
-                args: args.into_iter().map(rewrite_fan_arg).collect(),
+                args: args.into_iter().enumerate()
+                    .map(|(i, a)| {
+                        let a = rewrite_fan_arg(a);
+                        if adapt && i == 0 { ok_adapt_thunk_list(a) } else { a }
+                    })
+                    .collect(),
                 type_args,
             }
         }
         IrExprKind::Call { target: CallTarget::Named { ref name }, .. }
             if name.starts_with("almide_rt_fan_") =>
         {
+            let adapt = thunk_list_method(name.as_str().trim_start_matches("almide_rt_fan_"));
             let IrExprKind::Call { target, args, type_args } = expr.kind else { unreachable!() };
             IrExprKind::Call {
                 target,
-                args: args.into_iter().map(rewrite_fan_arg).collect(),
+                args: args.into_iter().enumerate()
+                    .map(|(i, a)| {
+                        let a = rewrite_fan_arg(a);
+                        if adapt && i == 0 { ok_adapt_thunk_list(a) } else { a }
+                    })
+                    .collect(),
                 type_args,
             }
         }
@@ -223,5 +235,89 @@ fn rewrite_fan_arg(arg: IrExpr) -> IrExpr {
             ty, span, def_id: None,
         },
         _ => rewrite_expr(arg, false),
+    }
+}
+
+
+/// The fan APIs whose FIRST argument is a thunk LIST with a
+/// `Fn() -> Result[T, String]` runtime bound.
+fn thunk_list_method(name: &str) -> bool {
+    matches!(name, "race" | "any" | "settle")
+}
+
+/// #514: the race/any/settle runtimes (both targets) require thunks that
+/// return `Result[T, String]` — native's `Vec<impl Fn() -> Result<T,_>>`
+/// bound, wasm's `(env: i32) -> i32` indirect-call signature. A PURE thunk
+/// (`fn() -> Int`) satisfied the CHECKER but broke each backend in its own
+/// way: native emitted invalid Rust (E0271), wasm trapped with an indirect
+/// call type mismatch. Adapt once, here, for both: wrap every non-Result
+/// thunk so it returns `Ok(value)`.
+fn ok_adapt_thunk_list(arg: IrExpr) -> IrExpr {
+    let ty = arg.ty.clone();
+    let span = arg.span;
+    match arg.kind {
+        IrExprKind::List { elements } => IrExpr {
+            kind: IrExprKind::List {
+                elements: elements.into_iter().map(ok_adapt_thunk).collect(),
+            },
+            ty, span, def_id: None,
+        },
+        _ => IrExpr { kind: arg.kind, ty, span, def_id: arg.def_id },
+    }
+}
+
+fn ok_adapt_thunk(el: IrExpr) -> IrExpr {
+    use almide_lang::types::Ty;
+    let Ty::Fn { params, ret } = &el.ty else { return el };
+    if !params.is_empty() || ret.is_result() {
+        return el;
+    }
+    let span = el.span;
+    let ok_ty = Ty::result((**ret).clone(), Ty::String);
+    let fn_ty = Ty::Fn { params: vec![], ret: Box::new(ok_ty.clone()) };
+    match el.kind {
+        // A literal pure lambda: wrap its BODY — no new call frame needed.
+        IrExprKind::Lambda { params: ps, body, lambda_id } => IrExpr {
+            kind: IrExprKind::Lambda {
+                params: ps,
+                body: Box::new(IrExpr {
+                    ty: ok_ty,
+                    span: body.span,
+                    kind: IrExprKind::ResultOk { expr: body },
+                    def_id: None,
+                }),
+                lambda_id,
+            },
+            ty: fn_ty, span, def_id: None,
+        },
+        // A fn ref / stored closure value: synthesize `() => ok(el())`.
+        _ => {
+            let ret_ty = (**ret).clone();
+            let call = IrExpr {
+                kind: IrExprKind::Call {
+                    target: CallTarget::Computed { callee: Box::new(el) },
+                    args: vec![],
+                    type_args: vec![],
+                },
+                ty: ret_ty,
+                span,
+                def_id: None,
+            };
+            IrExpr {
+                kind: IrExprKind::Lambda {
+                    params: vec![],
+                    body: Box::new(IrExpr {
+                        ty: ok_ty,
+                        span,
+                        kind: IrExprKind::ResultOk { expr: Box::new(call) },
+                        def_id: None,
+                    }),
+                    lambda_id: None,
+                },
+                ty: fn_ty,
+                span,
+                def_id: None,
+            }
+        }
     }
 }

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -31,7 +31,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-001 | Integer division/modulo by zero is total — it aborts, never traps | 0.24.0 | active | fixture | 3 |
 | C-002 | Signed MIN / -1 overflow aborts, at the TRUE per-width MIN | 0.24.0 | active | fixture | 3 |
 | C-003 | Non-aborting integer div/mod stay byte-identical | 0.24.0 | active | fixture | 1 |
-| C-004 | fan.race / fan.any / fan.map / fan.settle are deterministic by list order | 0.24.0 | active | fixture | 2 |
+| C-004 | fan.race / fan.any / fan.map / fan.settle are deterministic by list order | 0.24.0 | active | fixture | 3 |
 | C-005 | fan error propagation surfaces as the unified main-error abort | 0.24.0 | active | fixture | 4 |
 | C-006 | [fan.timeout is the SOLE documented wall-clock divergence (wasm warns)](C-006-fan-timeout-divergence.md) | 0.24.0 | flagged-for-revision | by-construction | 0 |
 | C-007 | Abortable top-level lets evaluate eagerly at startup | 0.24.0 | active | fixture | 2 |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -100,6 +100,7 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/fan_deterministic.almd", class = "fixture" },
   { path = "spec/wasm_cross/fan_map_inline_lambda.almd", class = "fixture" },
+  { path = "spec/wasm_cross/fan_pure_thunks.almd", class = "fixture" },
 ]
 
 [[contract]]

--- a/spec/wasm_cross/fan_pure_thunks.almd
+++ b/spec/wasm_cross/fan_pure_thunks.almd
@@ -1,0 +1,22 @@
+// @contract: C-004
+// #514: race/any/settle thunk lists accept PURE thunks (`fn() -> T`), not
+// only effect thunks — FanLowering wraps each non-Result thunk in an Ok
+// adapter ONCE for both backends. Before that, native emitted invalid Rust
+// (E0271 against the runtime's Fn() -> Result bound) and wasm trapped with
+// an indirect call type mismatch — each backend broken in its own way on a
+// shape the checker accepts. Side-effect ORDER is part of the pin: race
+// evaluates ONLY fns[0] (deterministic, not wall-clock), settle runs all
+// in list order, any skips failures in list order.
+fn thunk_a() -> Int = { println("A"); 1 }
+fn thunk_b() -> Int = { println("B"); 2 }
+fn try_c() -> Result[Int, String] = { println("C"); err("c") }
+fn try_d() -> Result[Int, String] = { println("D"); ok(4) }
+
+effect fn main() -> Unit = {
+  let r = fan.race([thunk_a, thunk_b])
+  println("race=${r}")
+  let a = fan.any([try_c, try_d])
+  println("any=${a}")
+  let s = fan.settle([thunk_a, thunk_b])
+  println("settle=${s}")
+}


### PR DESCRIPTION
Closes #514 — the fan silent-wrong watch item, resolved with a finding heavier than the recorded one.

## What the probe found

The recorded item was "race/any/map-err semantic divergence". Probing side-effect ORDER across targets first required pure thunks (`fn() -> Int`) — and that shape, which the CHECKER accepts, was broken on BOTH targets in different ways:

- **native**: invalid generated Rust (E0271 — the thunk boxed as `dyn Fn() -> i64` against the runtime's `Fn() -> Result<T, String>` bound), build failure;
- **wasm**: built fine, then trapped at runtime with `indirect call type mismatch` (a pure thunk's `(env) -> i64` signature indirect-called as `(i32) -> i32`).

Only effect thunks were ever exercised by fixtures, so the shape went undetected.

## The fix — once, for both targets

`FanLowering` (a both-targets pass) now adapts every non-Result thunk in a race/any/settle thunk list: a literal pure lambda gets its body wrapped in `Ok(...)` (no new call frame); a fn-ref/stored closure becomes `() => ok(el())`. Both backends then see exactly the shape their runtimes require.

## The semantic question, answered

With the shape fixed, the probe runs byte-identical on both targets INCLUDING side-effect order: `race` evaluates only `fns[0]` (deterministic, not wall-clock — the documented uniqueness claim holds on native too), `settle` runs all in list order, `any` skips failures in list order. The recorded "semantic divergence" does not exist in current semantics; what existed was this build/trap split. `fan.timeout` remains the single documented wall-clock exception. New fixture `spec/wasm_cross/fan_pure_thunks.almd` pins all of it as C-004 evidence (110/110 bidirectional links green).

## Gates

Native corpus 264/264 · wasm explicit 254/0/10-skip · byte gate green · churn 3/3 · cargo full 0 failures.
