### PR TITLE
Pin the resolved divergence queue and scope the settle side-effect exception

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -32,13 +32,13 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-002 | Signed MIN / -1 overflow aborts, at the TRUE per-width MIN | 0.24.0 | active | fixture | 3 |
 | C-003 | Non-aborting integer div/mod stay byte-identical | 0.24.0 | active | fixture | 1 |
 | C-004 | fan.race / fan.any / fan.map / fan.settle are deterministic by list order | 0.24.0 | active | fixture | 3 |
-| C-005 | fan error propagation surfaces as the unified main-error abort | 0.24.0 | active | fixture | 4 |
+| C-005 | fan error propagation surfaces as the unified main-error abort | 0.24.0 | active | fixture | 5 |
 | C-006 | [fan.timeout is the SOLE documented wall-clock divergence (wasm warns)](C-006-fan-timeout-divergence.md) | 0.24.0 | flagged-for-revision | by-construction | 0 |
 | C-007 | Abortable top-level lets evaluate eagerly at startup | 0.24.0 | active | fixture | 2 |
-| C-008 | [Compound interpolation renders the Almide-literal repr (containers)](C-008-009-010-repr.md) | 0.24.0 | active | fixture | 1 |
+| C-008 | [Compound interpolation renders the Almide-literal repr (containers)](C-008-009-010-repr.md) | 0.24.0 | active | fixture | 2 |
 | C-009 | [Record / variant / anonymous-record interpolation repr (field sorting)](C-008-009-010-repr.md) | 0.24.0 | active | fixture | 2 |
 | C-010 | [Recursive / generic ADT interpolation repr keyed by instantiation](C-008-009-010-repr.md) | 0.24.0 | active | fixture | 2 |
-| C-011 | Bare-float interpolation Display drops .0; float.to_string keeps it | 0.24.0 | active | fixture | 4 |
+| C-011 | Bare-float interpolation Display drops .0; float.to_string keeps it | 0.24.0 | active | fixture | 5 |
 | C-012 | Const-folded non-finite floats emit named constants | 0.24.0 | active | fixture | 1 |
 | C-013 | Map is a compact-ordered-dict: iteration is insertion order | 0.24.0 | active | fixture | 3 |
 | C-014 | Set is insertion-ordered and deterministic | 0.24.0 | active | fixture | 1 |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -94,7 +94,7 @@ evidence  = [
 [[contract]]
 id        = "C-004"
 title     = "fan.race / fan.any / fan.map / fan.settle are deterministic by list order"
-statement = "`fan.race` returns thunk[0]'s settled result in LIST ORDER (Ok or Err), NOT wall-clock fastest. `fan.any` tries thunks in list order and returns the first Ok. `fan.map` runs element fns sequentially in list order; `fan.settle` returns results in list order. All are byte-identical native == wasm. (race takes thunk[0] even on Err; any skips failures to find an Ok.)"
+statement = "`fan.race` returns thunk[0]'s settled result in LIST ORDER (Ok or Err), NOT wall-clock fastest. `fan.any` tries thunks in list order and returns the first Ok. `fan.map` runs element fns sequentially in list order; `fan.settle` returns results in list order. All are byte-identical native == wasm. (race takes thunk[0] even on Err; any skips failures to find an Ok.) EXCEPTION: fan.settle THUNK side-effect interleaving is wall-clock on native (real threads) and sequential on wasm — settle pins its RESULT list order only."
 since     = "0.24.0"
 status    = "active"
 evidence  = [
@@ -114,6 +114,7 @@ evidence  = [
   { path = "spec/wasm_cross/fan_map_inline_err.almd", class = "fixture" },
   { path = "spec/wasm_cross/fan_any_allfail.almd", class = "fixture" },
   { path = "spec/wasm_cross/fan_race_err.almd", class = "fixture" },
+  { path = "spec/wasm_cross/option_none_unwrap_term.almd", class = "fixture" },
 ]
 
 [[contract]]
@@ -149,6 +150,7 @@ status    = "active"
 doc       = "C-008-009-010-repr.md"
 evidence  = [
   { path = "spec/wasm_cross/compound_repr_interp.almd", class = "fixture" },
+  { path = "spec/wasm_cross/repr_parity_pin.almd", class = "fixture" },
 ]
 
 [[contract]]
@@ -187,6 +189,7 @@ evidence  = [
   { path = "spec/wasm_cross/float_concrete.almd", class = "fixture" },
   { path = "spec/wasm_cross/num_edge_to_string.almd", class = "fixture" },
   { path = "spec/wasm_cross/int_float_ops.almd", class = "fixture" },
+  { path = "spec/wasm_cross/float_interp_forms.almd", class = "fixture" },
 ]
 
 [[contract]]

--- a/spec/wasm_cross/fan_pure_thunks.almd
+++ b/spec/wasm_cross/fan_pure_thunks.almd
@@ -4,11 +4,16 @@
 // adapter ONCE for both backends. Before that, native emitted invalid Rust
 // (E0271 against the runtime's Fn() -> Result bound) and wasm trapped with
 // an indirect call type mismatch — each backend broken in its own way on a
-// shape the checker accepts. Side-effect ORDER is part of the pin: race
-// evaluates ONLY fns[0] (deterministic, not wall-clock), settle runs all
-// in list order, any skips failures in list order.
+// shape the checker accepts. Side-effect ORDER is pinned for race (only
+// fns[0] is evaluated — deterministic, not wall-clock) and any (sequential
+// in list order). It is NOT pinned for settle: native runs settle thunks
+// on REAL THREADS, so their print interleaving is wall-clock (caught as a
+// 1-in-N gate flake: native printed B,A under load). Settle's RESULT list
+// order is deterministic and IS pinned; its thunks here are silent.
 fn thunk_a() -> Int = { println("A"); 1 }
 fn thunk_b() -> Int = { println("B"); 2 }
+fn quiet_a() -> Int = 1
+fn quiet_b() -> Int = 2
 fn try_c() -> Result[Int, String] = { println("C"); err("c") }
 fn try_d() -> Result[Int, String] = { println("D"); ok(4) }
 
@@ -17,6 +22,6 @@ effect fn main() -> Unit = {
   println("race=${r}")
   let a = fan.any([try_c, try_d])
   println("any=${a}")
-  let s = fan.settle([thunk_a, thunk_b])
+  let s = fan.settle([quiet_a, quiet_b])
   println("settle=${s}")
 }

--- a/spec/wasm_cross/float_interp_forms.almd
+++ b/spec/wasm_cross/float_interp_forms.almd
@@ -1,0 +1,9 @@
+// @contract: C-011
+// PR-3 queue item (#533): float string-interpolation forms that historically
+// diverged — `${0.0}`, negative zero, and the shortest-roundtrip 0.3 — pinned
+// byte-identical native == wasm.
+fn main() -> Unit = {
+  println("${0.0} ${1.5} ${-0.0}")
+  println("${0.3}")
+  println("${1.0 / 3.0}")
+}

--- a/spec/wasm_cross/option_none_unwrap_term.almd
+++ b/spec/wasm_cross/option_none_unwrap_term.almd
@@ -1,0 +1,9 @@
+// @contract: C-005
+// §13 item (#533): unwrapping a None with `!` terminates IDENTICALLY on both
+// targets — same exit code, same stderr shape (the unified main-error exit),
+// no silent continuation and no wasm-only trap formatting.
+effect fn main() -> Unit = {
+  let xs: List[Int] = []
+  let r = list.get(xs, 5)!
+  println("after=${r}")
+}

--- a/spec/wasm_cross/repr_parity_pin.almd
+++ b/spec/wasm_cross/repr_parity_pin.almd
@@ -1,0 +1,13 @@
+// @contract: C-008
+// PR-3 queue item (#533): records / variants (tuple AND record payloads) /
+// tuples / containers-of-variants interpolate with identical repr on both
+// targets.
+type Shape = Circle(Float) | Rect { w: Int, h: Int }
+type P = { x: Int, name: String }
+fn main() -> Unit = {
+  println("${Circle(1.5)}")
+  println("${Rect { w: 3, h: 4 }}")
+  println("${P { x: 1, name: "a" }}")
+  println("${[Circle(2.0)]}")
+  println("${(1, "t", 2.5)}")
+}

--- a/tools/xtarget-fuzz/Cargo.lock
+++ b/tools/xtarget-fuzz/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.24.0"
+version = "0.27.3"
 dependencies = [
  "almide-base",
  "almide-codegen",
@@ -33,8 +33,8 @@ dependencies = [
  "almide-optimize",
  "almide-tools",
  "clap",
+ "fs2",
  "lasso",
- "libc",
  "lsp-server",
  "lsp-types",
  "semver",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "egg"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb749745461743bb477fba3ef87c663d5965876155c676c9489cfe0963de5ab"
+checksum = "dd40cfd4196d7a8f882ace95d623d4d6734588e502b4e188675a7c2f55eb4fb4"
 dependencies = [
  "env_logger",
  "hashbrown 0.15.5",
@@ -326,7 +326,6 @@ dependencies = [
  "num-traits",
  "quanta",
  "rustc-hash",
- "saturating",
  "smallvec",
  "symbol_table",
  "symbolic_expressions",
@@ -362,6 +361,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "futures-core"
@@ -649,12 +658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "saturating"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,11 +725,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -797,44 +800,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "unicode-ident"
@@ -907,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.225.0"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f7eac0445cac73bcf09e6a97f83248d64356dccf9f2b100199769b6b42464e5"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
  "wasmparser",
@@ -917,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.225.0"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e5456165f81e64cb9908a0fe9b9d852c2c74582aa3fe2be3c2da57f937d3ae"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.15.5",
@@ -977,12 +978,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "xtarget-fuzz"


### PR DESCRIPTION
Closes #533 — the recorded cross-target divergence queue, resolved by measurement: every item probed, three turn out ALREADY FIXED by intervening work (pinned now so they stay fixed), one was a checker-diagnostic bug (filed separately), and the probing exposed one real contract-boundary error in yesterday's fan fixture (fixed here).

- **`${0.0}` float interpolation** → byte-identical today (`0 1.5 -0` / `0.3` / shortest-roundtrip thirds). Pinned as `float_interp_forms.almd` (C-011).
- **records/variants repr parity** → byte-identical today across tuple-payload variants, record-payload variants, records, containers-of-variants, tuples. Pinned as `repr_parity_pin.almd` (C-008).
- **Option-None `!` termination** → identical exit code and abort shape. Pinned as `option_none_unwrap_term.almd` (C-005).
- **fan.map inline-closure** → the original validator break was fixed earlier (`fan_map_inline_lambda.almd` exists); what remains is a GARBLED diagnostic when a pure mapper is (correctly) rejected — filed as #547, no cross-target divergence.
- **fan.settle side-effect scope (found by these pins)**: the #546 fixture pinned settle THUNK print order, which on native runs on REAL THREADS — wall-clock interleaving, caught as a 1-in-N gate flake (`B,A` under load). The fixture now uses silent settle thunks and C-004's statement records the exception explicitly: settle pins its RESULT list order only; race (fns[0]-only) and any (sequential) keep their side-effect order pins.

Gates: native 264/264 · wasm explicit 254/0/10-skip · byte gate 67/67 **run twice** (de-flake verified) · contract links 113/113 symmetric.
