### PR TITLE
Final-IR release verification and a multi-module fmt gate

### DIFF
--- a/crates/almide-codegen/src/pass.rs
+++ b/crates/almide-codegen/src/pass.rs
@@ -331,6 +331,23 @@ impl Pipeline {
 
             executed.push(pass_name);
         }
+
+        // §10 release promotion (#532): one FINAL verification runs in EVERY
+        // profile. The per-pass walk above stays debug/opt-in (it dominates
+        // release codegen time, ~1.2s/file across ~20 passes), but the
+        // END-of-pipeline IR must verify before emission — one walk, ~60 ms,
+        // the same trade wasmparser::validate makes on the wasm side. A
+        // violation is a compiler bug and fails the build in release too.
+        if !verify_ir {
+            let errors = almide_ir::verify_program(&program);
+            if !errors.is_empty() {
+                eprintln!("[IR CHECK] {} error(s) at end of pipeline:", errors.len());
+                for e in &errors {
+                    eprintln!("  {}", e);
+                }
+                panic!("final IR verification failed (release gate, #532)");
+            }
+        }
         program
     }
 }

--- a/tests/fmt_test.rs
+++ b/tests/fmt_test.rs
@@ -530,3 +530,73 @@ fn fmt_output_typechecks_single_file_specs() {
         failures.len(), tested, failures.join("\n\n"));
     assert!(tested > 100, "gate coverage collapsed: only {} files tested", tested);
 }
+
+#[test]
+fn fmt_output_typechecks_multi_module_specs() {
+    // §7 residual (#532): the single-file gate above copies each file ALONE
+    // into a temp dir, so multi-module corpora were excluded (their sibling
+    // modules would be missing). This gate copies the WHOLE spec/integration
+    // tree, formats EVERY .almd in the copy, then re-checks each file with
+    // its (also formatted) siblings present — fmt must preserve meaning
+    // across module boundaries too (imports, cross-module types, aliases).
+    let bin = {
+        if let Ok(b) = std::env::var("ALMIDE_BIN") { b } else {
+            let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+            if !p.exists() { return; } // debug-only invocation: covered in CI by the release run
+            p.to_str().unwrap().to_string()
+        }
+    };
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let src_root = root.join("spec/integration");
+    let files = walkdir(src_root.as_path());
+
+    // Copy the entire tree so every sibling/module is present in the copy.
+    let dir = tempfile::tempdir().unwrap();
+    let dst_root = dir.path().join("integration");
+    for path in &files {
+        let rel = path.strip_prefix(&src_root).unwrap();
+        let dst = dst_root.join(rel);
+        std::fs::create_dir_all(dst.parent().unwrap()).unwrap();
+        std::fs::copy(path, &dst).unwrap();
+    }
+
+    let mut failures = Vec::new();
+    let mut tested = 0u32;
+    // Precompute which ORIGINALS check clean (negative fixtures are out of
+    // scope), then format every copy, then re-check the clean set.
+    let mut clean: Vec<std::path::PathBuf> = Vec::new();
+    for path in &files {
+        let ok = std::process::Command::new(&bin)
+            .args(["check", path.to_str().unwrap()])
+            .output().expect("almide check original").status.success();
+        if ok { clean.push(path.clone()); }
+    }
+    for path in &files {
+        let rel = path.strip_prefix(&src_root).unwrap();
+        let copy = dst_root.join(rel);
+        let fmt_out = std::process::Command::new(&bin)
+            .args(["fmt", copy.to_str().unwrap()])
+            .output().expect("almide fmt");
+        if !fmt_out.status.success() && clean.contains(path) {
+            failures.push(format!("{}: fmt failed:\n{}", path.display(), String::from_utf8_lossy(&fmt_out.stderr)));
+        }
+    }
+    for path in &clean {
+        let rel = path.strip_prefix(&src_root).unwrap();
+        let copy = dst_root.join(rel);
+        let check = std::process::Command::new(&bin)
+            .args(["check", copy.to_str().unwrap()])
+            .output().expect("almide check formatted");
+        if !check.status.success() {
+            failures.push(format!(
+                "{}: original checks clean but the FORMATTED multi-module copy does not — fmt changed meaning:\n{}",
+                path.display(), String::from_utf8_lossy(&check.stdout)
+            ));
+        }
+        tested += 1;
+    }
+    assert!(failures.is_empty(),
+        "fmt multi-module semantic-preservation gate: {} of {} file(s) failed:\n\n{}",
+        failures.len(), tested, failures.join("\n\n"));
+    assert!(tested > 10, "gate coverage collapsed: only {} files tested", tested);
+}


### PR DESCRIPTION
Closes #532 — the §7 and §10 gate-coverage residuals.

## §10: release-mode final verification

The per-pass IR walk stays debug/opt-in (it dominates release codegen time — ~1.2 s/file across ~20 passes), but the pipeline now runs ONE final `verify_program` in EVERY profile before emission — the same trade `wasmparser::validate` makes on the wasm side (one walk, ~60 ms, measured total build 0.68 s on the heaviest fixture). A violation is a compiler bug and now fails a RELEASE build too, instead of only being caught where developers happen to run debug.

## §7: fmt semantic preservation across module boundaries

The single-file gate copies each spec alone into a temp dir, so multi-module corpora were excluded (siblings missing). New `fmt_output_typechecks_multi_module_specs`: copies the WHOLE `spec/integration` tree, formats every `.almd` in the copy, then re-checks each originally-clean file with its (also formatted) siblings present — imports, cross-module types and aliases must survive formatting. Passes on the current corpus (coverage assert ≥ 10 files; actual ~40).

Note: the `Decl::TestWhereDef` printer remains intentionally unimplemented — the module-scope `test where` syntax is unused; the existing marker stands until the syntax ships.

Gates: native 264/264 · wasm explicit 254/0/10-skip · byte gate 67/67 · cargo full 0 failures.
