### PR TITLE
Resolve the recorded spec contradictions

### DIFF
--- a/docs/specs/effect-system.md
+++ b/docs/specs/effect-system.md
@@ -135,7 +135,30 @@ effect fn example() -> Result[Unit, String] = {
 }
 ```
 
-Test: `spec/lang/fan_test.almd`, `spec/lang/fan_race_test.almd`, `spec/lang/fan_map_test.almd`
+### Determinism contract (C-004)
+
+`fan` の並行 API は**決定的核**を契約として持つ(native ⇄ wasm byte-identical、
+契約台帳 C-004、fixture: `spec/wasm_cross/fan_deterministic.almd`,
+`spec/wasm_cross/fan_pure_thunks.almd`):
+
+- `fan.race(thunks)` — **thunk[0] の settled 結果**(リスト順決定、wall-clock ではない)。
+  thunk[0] **のみ**が評価される: 副作用順序も決定的。
+  (Go の select が仕様で RANDOM を要求するのと対照的な設計選択。)
+- `fan.any(thunks)` — リスト順に逐次試行し最初の Ok。副作用順序も決定的。
+- `fan.settle(thunks)` — **結果リストの順序のみ**を契約する。native は実スレッドで
+  実行するため thunk 内副作用の交互順は wall-clock(契約外)。wasm は逐次。
+- `fan.timeout` — wall-clock 例外として契約済み(N=1、cross-target 等価性の対象外)。
+
+### Thunk typing
+
+`race` / `any` / `settle` の thunk は純粋(`fn() -> T`)でも effect
+(`fn() -> Result[T, String]`)でもよい — 非 Result thunk は FanLowering が
+両ターゲット共通で `Ok` アダプタに包む(v0.27.3+、#514)。
+**`fan.map` だけは mapper が明示的に Result を返す必要がある**
+(`(x) => ok(x * 10)`)— mapper の戻り型推論は thunk と違い困難なため、
+純粋 mapper は check 時に拒否される(意図的な非対称、診断改善は #547)。
+
+Test: `spec/lang/fan_test.almd`, `spec/lang/fan_race_test.almd`, `spec/lang/fan_map_test.almd`, `spec/wasm_cross/fan_pure_thunks.almd`
 
 ## 6. `test` Blocks
 

--- a/docs/specs/result-option-effect.md
+++ b/docs/specs/result-option-effect.md
@@ -48,9 +48,14 @@ effect fn の外で `!` を使うとコンパイルエラー。
 | `Result[T, E]` | `T` | `match expr { Ok(v) => v, Err(_) => fallback }` |
 | `Option[T]` | `T` | `match expr { Some(v) => v, None => fallback }` |
 
-**型判定ルール**: `inner.ty` が `Option[T]` なら Option テンプレート、それ以外は Result テンプレート。
+**型判定ルール**: チェッカーが型主導で確定する — `Option[T]` なら Option、
+`Result[T, E]` なら Result、**それ以外の型はコンパイルエラー**
+(`operator '??' requires Option or Result type but got Int` の形で拒否)。
+v0.26.20 の unwrap 規則統一(#485/#489)で checker と lowering が単一規則を共有する。
 
-**⚠ 既知の問題**: 型が `Unknown` のとき Result 扱いになる。型推論が失敗すると壊れる。
+旧記述の「`Unknown` のとき Result 扱いになる」は死んだ: `Ty::Unknown` が
+codegen に到達するビルドは AllTypesConcrete ゲートが拒否するため、
+テンプレート選択が Unknown を見ることは構造的にない(#534 矛盾バーンダウン)。
 
 ## 3. effect fn
 
@@ -156,10 +161,13 @@ guard condition else { diverge_expr }
 2. `Never` 型（`process.exit()`, `panic()` 等）
 3. `Unit`（ループ制御: break/continue に変換）
 
-### ⚠ 現状の問題
+### 解決履歴
 
 - `process.exit()` の戻り値型が `-> !` (never) になったことで guard else での使用は修正済み
-- ただし Almide の型システムに Never 型が存在しないため、型チェッカーレベルでの保証はない
+- `Ty::Never` は v0.10.3 で型システムに実装済み(本ファイル末尾の表どおり)。
+  Never はどの型にも代入可能で、guard else / if then / match arm の腕として
+  型チェッカーが正しく受理する — 「型システムに Never が無い」という旧記述は
+  実装前の文章の残骸であり、削除した(#534 矛盾バーンダウン)。
 
 ## 7. テストで確認済みの動作
 


### PR DESCRIPTION
Closes #534 — the recorded prose↔behavior and prose↔prose contradictions, resolved against measured behavior with fixture citations.

- **Never self-contradiction** (`result-option-effect.md`): the "現状の問題" block claimed "Almide の型システムに Never 型が存在しない" while the SAME FILE's verification table says `Ty::Never` 実装済み (v0.10.3) ✅. The stale pre-implementation sentence is replaced with the resolution history.
- **`??` Unknown→Result caveat** (`result-option-effect.md`): the documented "型が Unknown のとき Result 扱い" hazard is dead twice over — the unwrap rule became type-directed and checker/lowering-shared in v0.26.20 (#485/#489; non-Option/Result operands are a check-time error, verified by probe), and `Ty::Unknown` cannot reach template selection past the AllTypesConcrete gate. The prose now states the live rule.
- **fan determinism contract** (`effect-system.md`): the spec described fan blocks but never the race/any/settle ordering contract. New section documents the C-004 deterministic kernel exactly as measured and pinned this week: race = thunk[0] only (side-effect order included; the anti-Go-select design choice), any = sequential, settle = RESULT order only (native thunks run on real threads — interleaving is wall-clock, the documented exception), timeout = the N=1 wall-clock exception. Plus the thunk-typing rule shipped in #546: pure thunks Ok-adapted for race/any/settle, fan.map intentionally requires explicit `ok(...)` (#547 tracks its diagnostic).
- **matrix/bytes "empty pages"**: stale — both pages are fully written (tables + naming conventions); no change needed, recorded here so the ledger item dies.

docs-gen gate green.
