### PR TITLE
Canonicalize copy-ness onto one classifier with named projections

### DIFF
--- a/crates/almide-codegen/src/pass_capture_clone.rs
+++ b/crates/almide-codegen/src/pass_capture_clone.rs
@@ -706,11 +706,7 @@ fn replace_vars_stmt(stmt: &mut IrStmt, renames: &std::collections::HashMap<VarI
 }
 
 fn needs_clone_type(ty: &Ty) -> bool {
-    matches!(ty,
-        Ty::String | Ty::Applied(_, _) |
-        Ty::Record { .. } | Ty::OpenRecord { .. } |
-        Ty::Named(_, _) | Ty::Matrix | Ty::Bytes |
-        Ty::Variant { .. } | Ty::Fn { .. } |
-        Ty::TypeVar(_)
-    )
+    // §4 stage 2c (#531): derived from THE copy-ness classifier — see the
+    // projection table in almide_ir::top_let_storage (note the tuple cell).
+    almide_ir::top_let_storage::capture_clone_wrap(ty)
 }

--- a/crates/almide-codegen/src/pass_clone.rs
+++ b/crates/almide-codegen/src/pass_clone.rs
@@ -132,18 +132,9 @@ fn count_syntactic(expr: &IrExpr, counts: &mut HashMap<VarId, u32>) {
 // ── Clone ID classification ────────────────────────────────────────
 
 fn needs_clone(ty: &Ty) -> bool {
-    match ty {
-        Ty::String | Ty::Applied(_, _) |
-        Ty::Record { .. } | Ty::OpenRecord { .. } |
-        Ty::Named(_, _) | Ty::Matrix | Ty::Bytes |
-        Ty::Variant { .. } | Ty::Fn { .. } |
-        Ty::TypeVar(_) => true,
-        // A tuple needs cloning when any element needs cloning. Pure numeric
-        // tuples like `(Int, Int)` are Copy in the Rust target and can be
-        // moved out of an index access directly.
-        Ty::Tuple(elements) => elements.iter().any(needs_clone),
-        _ => false,
-    }
+    // §4 stage 2c (#531): derived from THE copy-ness classifier — see the
+    // projection table in almide_ir::top_let_storage.
+    !almide_ir::top_let_storage::clone_free(ty)
 }
 
 /// Split clone candidates into "always clone" and "eligible for last-use move".

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -814,7 +814,7 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
             // (no clone). Copy shared-mut vars stay on the `Cell` `.get()` path below.
             if let IrExprKind::Var { id } = &inner.kind {
                 if ctx.ann.is_shared_mut(id)
-                    && !matches!(ctx.var_table.get(*id).ty, Ty::Int | Ty::Float | Ty::Bool)
+                    && !almide_ir::top_let_storage::capture_copy_cell(&ctx.var_table.get(*id).ty)
                 {
                     let var_name = ctx.var_name(*id).to_string();
                     return if *mutable {

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -519,7 +519,9 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         impl almide_ir::visit::IrVisitor for VarBindCollector {
             fn visit_stmt(&mut self, stmt: &IrStmt) {
                 if let IrStmtKind::Bind { var, mutability: almide_ir::Mutability::Var, ty, .. } = &stmt.kind {
-                    if !matches!(ty, Ty::Int | Ty::Float | Ty::Bool | Ty::Unit | Ty::Unknown) {
+                    // §4 stage 2c (#531): derived from THE copy-ness
+                    // classifier (projection table in top_let_storage).
+                    if !almide_ir::top_let_storage::rccow_copyish(ty) {
                         self.vars.insert(var.0);
                     }
                 }

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -21,7 +21,7 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
                 // Copy scalars use `Rc<Cell<T>>` (P3); non-Copy values use `SharedMut`
                 // (`Rc<RefCell<T>>`, P6). A `__cap_*` capture rename is an `Rc::clone`
                 // of the original for either kind, so the closure shares the SAME cell.
-                let is_copy = matches!(ty, Ty::Int | Ty::Float | Ty::Bool);
+                let is_copy = almide_ir::top_let_storage::capture_copy_cell(ty);
                 let fresh_cell = |ctx: &RenderContext| if is_copy {
                     format!("std::rc::Rc::new(std::cell::Cell::new({}))", render_expr(ctx, value))
                 } else {

--- a/crates/almide-ir/src/top_let_storage.rs
+++ b/crates/almide-ir/src/top_let_storage.rs
@@ -43,6 +43,67 @@ pub fn copy_class(ty: &Ty) -> CopyClass {
     }
 }
 
+// ── Copy-ness projections (§4 stage 2c, #531) ───────────────────────────
+//
+// ONE classifier, FOUR named projections. The four historic predicates
+// (walker storage rule, pass_clone's needs_clone, the RcCow eligibility
+// test, capture-clone's shared-cell test) were free-standing `matches!`
+// lists that agreed only by coincidence; they now live HERE, side by side,
+// and every edge-cell difference is explicit and intentional:
+//
+//   projection         Int/Float/Bool  sized-numeric  Unit/RawPtr  Unknown  numeric-tuple
+//   storage Cell       yes             no             n/a          no       no
+//   clone_free         yes             yes            yes          yes      yes
+//   rccow_copyish      yes             no             Unit only    yes      no
+//   capture_copy_cell  yes             no             no           no       no
+//
+// The conservative cells (sized numerics outside clone_free's column) are
+// candidates for future REVIEWED widening — widening any of them changes
+// generated storage and must come with its own fixture + byte-diff review.
+
+/// pass_clone projection: types whose values move without a `.clone()` on
+/// the Rust target (Copy or trivially-rebuildable). The exact complement of
+/// the historic `needs_clone`.
+pub fn clone_free(ty: &Ty) -> bool {
+    match ty {
+        Ty::String | Ty::Applied(_, _)
+        | Ty::Record { .. } | Ty::OpenRecord { .. }
+        | Ty::Named(_, _) | Ty::Matrix | Ty::Bytes
+        | Ty::Variant { .. } | Ty::Fn { .. }
+        | Ty::TypeVar(_) => false,
+        Ty::Tuple(elements) => elements.iter().all(clone_free),
+        _ => true,
+    }
+}
+
+/// RcCow-eligibility projection: a mutable LOCAL of one of these types
+/// stays a plain `let mut` (no COW wrapper) even when captured.
+pub fn rccow_copyish(ty: &Ty) -> bool {
+    matches!(ty, Ty::Int | Ty::Float | Ty::Bool | Ty::Unit | Ty::Unknown)
+}
+
+/// Capture clone-wrap projection (pass_capture_clone): heap values captured
+/// by a lambda get a `__cap` clone. Differs from `clone_free` in ONE cell —
+/// tuples are NOT clone-wrapped here regardless of their elements (the
+/// capture path moves tuples whole); widening that cell is a reviewed
+/// future delta.
+pub fn capture_clone_wrap(ty: &Ty) -> bool {
+    matches!(ty,
+        Ty::String | Ty::Applied(_, _)
+        | Ty::Record { .. } | Ty::OpenRecord { .. }
+        | Ty::Named(_, _) | Ty::Matrix | Ty::Bytes
+        | Ty::Variant { .. } | Ty::Fn { .. }
+        | Ty::TypeVar(_)
+    )
+}
+
+/// Capture-cell projection: a `var` local of one of these types captured by
+/// a closure becomes an `Rc<Cell<T>>` shared cell (Closure v2 P3); non-Copy
+/// captures take the SharedMut heap-cell path (P6) instead.
+pub fn capture_copy_cell(ty: &Ty) -> bool {
+    copy_class(ty) == CopyClass::Scalar
+}
+
 /// The storage class of one top-let on the native target. WASM stores every
 /// top-let as one mutable global; this enum still drives its init-order and
 /// const-evaluability decisions.


### PR DESCRIPTION
Closes #531 — §4 stage 2c: the scattered copy-ness predicates are canonicalized onto the ONE classifier in `almide_ir::top_let_storage`, as named projections with an explicit edge-cell table.

## What moved

The census found FIVE free-standing `matches!` lists that encoded "is this type Copy-ish?" and agreed only by coincidence (the #486/#500 drift pattern, applied to types instead of storage):

1. walker storage rule (Cell vs RcRefCell) — already derived via `copy_class` since §4 stage 1;
2. `pass_clone::needs_clone` → now `!clone_free(ty)`;
3. the RcCow eligibility test (walker collector) → now `rccow_copyish(ty)`;
4. the capture shared-cell pick (Rc<Cell> vs SharedMut, two walker sites) → now `capture_copy_cell(ty)`;
5. `pass_capture_clone::needs_clone_type` (a FIFTH instance the issue's census missed — same list as #2 but WITHOUT tuple recursion) → now `capture_clone_wrap(ty)`.

All five projections live side by side in `top_let_storage.rs` under one table documenting exactly which edge cells differ (sized numerics, Unit/RawPtr, Unknown, numeric tuples) — every difference is now explicit and intentional instead of an accident of five hand-maintained lists.

## Behavior

ZERO behavior delta by construction: each projection reproduces its historic set exactly. The conservative cells (e.g. sized numerics not Cell-classified, the capture-wrap tuple cell) are recorded in the table as candidates for future REVIEWED widening — each such widening changes generated storage and must bring its own fixture + byte-diff review.

Full bar (on a rebased tree including #548's de-flake): native 264/264 · wasm explicit 254/0/10-skip · byte gate 67/67 · churn 3/3 · cargo full 0 failures. (One byte-gate run before the rebase reproduced the KNOWN settle-thunk flake from the pre-#548 fixture — confirming #548's fix was the right call, not masking anything here.)
