### PR TITLE
State the fan.map mapper rule in its rejection diagnostic

### DIFF
--- a/crates/almide-frontend/src/check/solving.rs
+++ b/crates/almide-frontend/src/check/solving.rs
@@ -24,6 +24,9 @@ impl Checker {
                         "if branches" | "if arm" => "Both branches of `if/then/else` must have the same type",
                         _ => "Fix the expression type or change the expected type",
                     };
+                    let base = if c.context == "fan.map callback" {
+                        "Return ok(value) / err(reason) from the mapper"
+                    } else { base };
                     let hint = Self::hint_with_conversion(base, &exp, &act);
                     // Context-specific try: snippet for the "Unit leak" failure
                     // mode — a statement (assignment / lone `let`) slips into a
@@ -38,9 +41,21 @@ impl Checker {
                     if c.span.is_some() {
                         self.current_span = c.span;
                     }
-                    let mut diag = err(
-                        format!("type mismatch in {}: expected {} but got {}", c.context, exp.display(), act.display()),
-                        hint, c.context.clone()).with_code("E001");
+                    // #547: post-unify rendering is CONTAMINATED for rule-
+                    // bearing constraints (pass 1 partially binds vars even on
+                    // failure, so both sides print with each other's pieces —
+                    // the fan.map case showed `expected fn(Result[..]) -> ..`
+                    // where the param is Int). A constraint that ENCODES a
+                    // language rule states the rule instead of the pair.
+                    let msg = if c.context == "fan.map callback" {
+                        "fan.map callback must return Result[T, String] — \
+                         wrap the value: `(x) => ok(x * 10)`. (race/any/settle \
+                         thunks auto-wrap pure values; map mappers are \
+                         effectful by contract and do not.)".to_string()
+                    } else {
+                        format!("type mismatch in {}: expected {} but got {}", c.context, exp.display(), act.display())
+                    };
+                    let mut diag = err(msg, hint, c.context.clone()).with_code("E001");
                     if let Some(snippet) = try_snippet {
                         diag = diag.with_try(snippet);
                     }

--- a/crates/almide-frontend/src/check/static_dispatch.rs
+++ b/crates/almide-frontend/src/check/static_dispatch.rs
@@ -128,6 +128,29 @@ impl Checker {
                         //     (e.g. `(x) => x * 10` / `(x) => some(...)`) is ill-typed and is
                         //     now reported at check time, instead of silently lowering to
                         //     invalid Rust (E0308: expected Result, found Int/Option).
+                        // #547: a PURE mapper (`(x) => x * 10`) is rejected by
+                        // design, but pushing that through the generic constraint
+                        // produced a garbled expected/actual pair (the param slot
+                        // rendered as Result). When the callback's return type is
+                        // already resolved to a concrete non-Result, state the
+                        // ACTUAL RULE directly instead.
+                        if let Ty::Fn { ret, .. } = resolve_ty(&arg_tys[1], &self.uf) {
+                            let cb_ret = resolve_ty(&ret, &self.uf);
+                            let concrete_non_result = !cb_ret.is_result()
+                                && !matches!(cb_ret, Ty::Unknown | Ty::TypeVar(_));
+                            if concrete_non_result {
+                                self.emit(super::err(
+                                    format!(
+                                        "fan.map callback must return Result but returns {}",
+                                        cb_ret.display()
+                                    ),
+                                    "Wrap the value: `(x) => ok(x * 10)` — fan.map mappers are \
+                                     effectful by contract (race/any/settle thunks auto-wrap, \
+                                     map mappers do not)",
+                                    "fan.map callback".to_string()));
+                                return Some(Ty::Unknown);
+                            }
+                        }
                         let result_elem = self.fresh_var();
                         let callback_ret = Ty::result(result_elem.clone(), Ty::String);
                         self.constrain(arg_tys[1].clone(),


### PR DESCRIPTION
Closes #547 — the garbled diagnostic for (correctly rejected) pure fan.map mappers.

## Root cause

Constraint solving runs in two passes: pass 1 unifies EVERYTHING (partially binding inference vars even when a unification ultimately fails), pass 2 re-checks and renders. By render time both sides of a failed constraint resolve through the contaminated union-find — the fan.map case printed `expected fn(Result[?1, String]) -> Result[?1, String] but got fn(Int) -> Result[?1, String]` where the expected param is actually `Int` and the lambda's return is actually `Int`.

## Fix

A constraint that ENCODES a language rule now states the rule instead of the (unreliable) type pair: the `fan.map callback` context renders

> fan.map callback must return Result[T, String] — wrap the value: `(x) => ok(x * 10)`. (race/any/settle thunks auto-wrap pure values; map mappers are effectful by contract and do not.)

with hint `Return ok(value) / err(reason) from the mapper`. A resolved-type pre-check in the static-dispatch rule catches the annotated-lambda case at collection time with the same wording. The general post-unify contamination remains for generic contexts (truthful rendering needs pre-unify snapshots — an ALS/diagnostics-arc item, noted in the issue close).

Gates: native 265/265 · wasm explicit 255/0/10-skip · diagnostic harnesses green · cargo full 0 failures.
