### PR TITLE
Bounds-check xs[i] read and write with a unified out-of-bounds abort on both targets

### DIFF
--- a/codegen/templates/rust.toml
+++ b/codegen/templates/rust.toml
@@ -43,7 +43,7 @@ template = "almide_mod!({left}, {right})"
 template = "{expr}.{field}"
 
 [index_access]
-template = "{object}[{index} as usize]"
+template = "almide_index!({object}, {index})"
 
 [pipe_call]
 template = "{callee}({pipe_arg}, {args})"

--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -390,6 +390,25 @@ impl FuncCompiler<'_> {
         self.scratch.free_i64(idx);
     }
 
+    /// Trap with the UNIFIED abort ("Error: index out of bounds\n" + exit 1)
+    /// unless `0 <= idx < len`, checking the FULL i64 so a >= 2^32 index can
+    /// never truncate into range (#554/C-072). `idx64_local` holds the i64
+    /// index; `ptr_local` points at the list/bytes header whose len is at
+    /// offset 0. Leaves the stack unchanged.
+    pub(super) fn emit_index_bound_guard(&mut self, idx64_local: u32, ptr_local: u32, oob_msg: i32, div_trap: u32) {
+        wasm!(self.func, {
+            // if (idx as u64) >= (len as u64) { abort }  — a negative i64 wraps
+            // to a huge u64 and is caught by the same compare.
+            local_get(idx64_local);
+            local_get(ptr_local); i32_load(0); i64_extend_i32_u;
+            i64_ge_u;
+            if_empty;
+              i32_const(oob_msg);
+              call(div_trap);
+            end;
+        });
+    }
+
     /// Copy one element from [stack: dst_addr, src_addr] based on type.
     pub(super) fn emit_elem_copy(&mut self, ty: &Ty) {
         match values::ty_to_valtype(ty) {

--- a/crates/almide-codegen/src/emit_wasm/collections.rs
+++ b/crates/almide-codegen/src/emit_wasm/collections.rs
@@ -286,30 +286,38 @@ impl FuncCompiler<'_> {
         let ptr = self.scratch.alloc_i32();
         wasm!(self.func, { local_set(ptr); });
 
-        // index → i32 local
+        // index → i32 local, BOUNDS-CHECKED on the FULL i64 first (#554/C-072).
+        // The prior code did `i32_wrap_i64` BEFORE the u32 compare, so an index
+        // >= 2^32 truncated to a small in-range value and silently read the
+        // WRONG element. Check the full i64 against len (zero-extended) so the
+        // high bits cannot be lost, and abort through the UNIFIED div_trap path
+        // ("Error: index out of bounds\n" + exit 1) instead of a bare
+        // `unreachable` trap — byte-identical to native's abort contract.
         let idx = self.scratch.alloc_i32();
+        let oob_msg = self.emitter.intern_string("Error: index out of bounds\n") as i32;
+        let div_trap = self.emitter.rt.div_trap;
         if let IrExprKind::LitInt { value } = &index.kind {
-            wasm!(self.func, { i32_const(*value as i32); local_set(idx); });
+            let v = *value;
+            // Constant index: the bound is dynamic (len), so still guard, but the
+            // index itself fits i32 once we know it is non-negative and < 2^31.
+            let idx64 = self.scratch.alloc_i64();
+            wasm!(self.func, { i64_const(v); local_set(idx64); });
+            self.emit_index_bound_guard(idx64, ptr, oob_msg, div_trap);
+            wasm!(self.func, { local_get(idx64); i32_wrap_i64; local_set(idx); });
+            self.scratch.free_i64(idx64);
         } else {
+            let idx64 = self.scratch.alloc_i64();
             self.emit_expr(index);
             if matches!(&index.ty, Ty::Int) {
-                wasm!(self.func, { i32_wrap_i64; });
+                wasm!(self.func, { local_set(idx64); });
+            } else {
+                // narrow-int index already i32 on the stack — widen to i64
+                wasm!(self.func, { i64_extend_i32_s; local_set(idx64); });
             }
-            wasm!(self.func, { local_set(idx); });
+            self.emit_index_bound_guard(idx64, ptr, oob_msg, div_trap);
+            wasm!(self.func, { local_get(idx64); i32_wrap_i64; local_set(idx); });
+            self.scratch.free_i64(idx64);
         }
-
-        // Bounds check: trap if (idx as u32) >= len (len at list/bytes offset 0).
-        // A negative idx wraps to a huge u32 and is also caught. Native panics on
-        // OOB; trapping here stops the WASM OOB read — the prior code computed the
-        // address with no check and returned garbage past the buffer (undefined
-        // behavior). (Exact panic message + exit-code parity with native is a
-        // separate runtime-panic-unification contract item.)
-        wasm!(self.func, {
-            local_get(idx);
-            local_get(ptr); i32_load(0);
-            i32_ge_u;
-            if_empty; unreachable; end;
-        });
 
         // addr = ptr + data_off + idx * elem_size
         wasm!(self.func, { local_get(ptr); i32_const(data_off as i32); i32_add; local_get(idx); });

--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -478,31 +478,42 @@ impl FuncCompiler<'_> {
                 };
                 if has_ptr {
                     let data_off = self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA);
+                    // #554/C-072: the write path had NO bounds check — an OOB
+                    // `xs[i] = v` was a silent heap WRITE into adjacent
+                    // allocator memory (exit 0) while native panicked. Capture
+                    // the list pointer, GUARD the index on the full i64
+                    // (negative / >= 2^32 caught, no truncation), then store.
+                    let ptr_l = self.scratch.alloc_i32();
+                    wasm!(self.func, { local_set(ptr_l); });
+                    let oob_msg = self.emitter.intern_string("Error: index out of bounds\n") as i32;
+                    let div_trap = self.emitter.rt.div_trap;
+                    let idx64 = self.scratch.alloc_i64();
                     if let IrExprKind::LitInt { value: idx_val } = &index.kind {
-                        let offset = data_off + (*idx_val as u32) * elem_size;
-                        self.emit_expr(value);
-                        if is_bytes {
-                            wasm!(self.func, { i32_wrap_i64; i32_store8(offset); });
-                        } else {
-                            self.emit_store_at(&value.ty, offset);
-                        }
+                        wasm!(self.func, { i64_const(*idx_val); local_set(idx64); });
                     } else {
-                        wasm!(self.func, { i32_const(data_off as i32); i32_add; });
                         self.emit_expr(index);
                         if matches!(&index.ty, almide_lang::types::Ty::Int) {
-                            wasm!(self.func, { i32_wrap_i64; });
-                        }
-                        if elem_size > 1 {
-                            wasm!(self.func, { i32_const(elem_size as i32); i32_mul; });
-                        }
-                        wasm!(self.func, { i32_add; });
-                        self.emit_expr(value);
-                        if is_bytes {
-                            wasm!(self.func, { i32_wrap_i64; i32_store8(0); });
+                            wasm!(self.func, { local_set(idx64); });
                         } else {
-                            self.emit_store_at(&value.ty, 0);
+                            wasm!(self.func, { i64_extend_i32_s; local_set(idx64); });
                         }
                     }
+                    self.emit_index_bound_guard(idx64, ptr_l, oob_msg, div_trap);
+                    // addr = ptr + data_off + idx * elem_size
+                    wasm!(self.func, { local_get(ptr_l); i32_const(data_off as i32); i32_add;
+                                       local_get(idx64); i32_wrap_i64; });
+                    if elem_size > 1 {
+                        wasm!(self.func, { i32_const(elem_size as i32); i32_mul; });
+                    }
+                    wasm!(self.func, { i32_add; });
+                    self.emit_expr(value);
+                    if is_bytes {
+                        wasm!(self.func, { i32_wrap_i64; i32_store8(0); });
+                    } else {
+                        self.emit_store_at(&value.ty, 0);
+                    }
+                    self.scratch.free_i64(idx64);
+                    self.scratch.free_i32(ptr_l);
                 }
             }
             IrStmtKind::FieldAssign { target, field, value } => {

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -419,6 +419,13 @@ fn rust_runtime_prelude(for_crate: bool) -> String {
     // (`Error: <msg>\n` + exit 1) and to the WASM div/mod trap.
     s.push_str(&format!("{macro_attr}macro_rules! almide_div {{ ($a:expr, $b:expr) => {{{{ let (__a, __b) = ($a, $b); match __a.checked_div(__b) {{ Some(__v) => __v, None => {{ eprintln!(\"Error: {{}}\", if __b == 0 {{ \"division by zero\" }} else {{ \"integer overflow\" }}); std::process::exit(1); }} }} }}}}; }}\n"));
     s.push_str(&format!("{macro_attr}macro_rules! almide_mod {{ ($a:expr, $b:expr) => {{{{ let (__a, __b) = ($a, $b); match __a.checked_rem(__b) {{ Some(__v) => __v, None => {{ eprintln!(\"Error: {{}}\", if __b == 0 {{ \"division by zero\" }} else {{ \"integer overflow\" }}); std::process::exit(1); }} }} }}}}; }}\n"));
+    // almide_index!/almide_index_set!: bounds-checked `xs[i]` get/set that abort
+    // with the UNIFIED message (`Error: index out of bounds\n` + exit 1), so a
+    // native OOB index matches the wasm trap and the div/mod abort contract
+    // (#554/C-072) instead of a raw Rust panic (exit 101). i64 index is range-
+    // checked against len as usize; negative or >= len aborts.
+    s.push_str(&format!("{macro_attr}macro_rules! almide_index {{ ($xs:expr, $i:expr) => {{{{ let (__xs, __i) = (&$xs, $i as i64); if __i < 0 || (__i as u64) >= __xs.len() as u64 {{ eprintln!(\"Error: index out of bounds\"); std::process::exit(1); }} __xs[__i as usize].clone() }}}}; }}\n"));
+    s.push_str(&format!("{macro_attr}macro_rules! almide_index_set {{ ($xs:expr, $i:expr, $v:expr) => {{{{ let __i = $i as i64; if __i < 0 || (__i as u64) >= $xs.len() as u64 {{ eprintln!(\"Error: index out of bounds\"); std::process::exit(1); }} $xs[__i as usize] = $v; }}}}; }}\n"));
     // RcCow<T>: COW value type. Clone = Rc::clone (O(1)), mutation = Rc::make_mut (COW).
     // Inspired by Swift's value type semantics.
     s.push_str(&format!("{vis}struct RcCow<T>({vis}std::rc::Rc<T>);\n"));

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -304,7 +304,7 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             let cast_val = if is_bytes { format!("{} as u8", val_str) } else { val_str };
             // Shared-mut non-Copy var (`SharedMut`, P6): index through the cell.
             if ctx.ann.is_shared_mut(target) {
-                return format!("{}.borrow_mut()[{} as usize] = {};", target_str, idx_str, cast_val);
+                return format!("almide_index_set!({}.borrow_mut(), {}, {});", target_str, idx_str, cast_val);
             }
             // §4 Stage 2: globals dispatch on the attribute. A scalar Cell
             // global cannot be index-assigned — the legacy arm emitted a
@@ -313,16 +313,19 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
             if let Some(info) = ctx.ann.global(*target) {
                 use almide_ir::top_let_storage::TopLetStorage as Tls;
                 return match info.storage {
-                    Tls::RcRefCell => format!("{}.with(|c| std::rc::Rc::make_mut(&mut *c.borrow_mut())[{} as usize] = {});", info.static_name, idx_str, cast_val),
+                    Tls::RcRefCell => format!("{}.with(|c| almide_index_set!(std::rc::Rc::make_mut(&mut *c.borrow_mut()), {}, {}));", info.static_name, idx_str, cast_val),
                     other => unreachable!(
                         "[COMPILER BUG] index-assign to {:?} global `{}`",
                         other, info.static_name
                     ),
                 };
             }
+            // #554: bounds-checked store — a native OOB `xs[i] = v` aborts with
+            // the unified `Error: index out of bounds` + exit 1 (matching wasm
+            // and the div/mod contract) instead of a raw panic (exit 101).
             match ctx.ann.get_var_storage(target) {
-                VarStorage::RcCow => format!("{}.make_mut()[{} as usize] = {};", target_str, idx_str, cast_val),
-                _ => format!("{}[{} as usize] = {};", target_str, idx_str, cast_val),
+                VarStorage::RcCow => format!("almide_index_set!({}.make_mut(), {}, {});", target_str, idx_str, cast_val),
+                _ => format!("almide_index_set!({}, {}, {});", target_str, idx_str, cast_val),
             }
         }
         IrStmtKind::MapInsert { target, key, value } => {

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-66 contracts
+67 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -94,4 +94,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-064 | The effect-fn Result auto-unwrap rule is identical across binding positions and type-directed, byte-identical on both targets | 0.26.20 | active | fixture | 1 |
 | C-065 | The string position API is codepoint-indexed end-to-end on both targets | 0.26.20 | active | fixture | 1 |
 | C-066 | WASM heap is reclaimed by default (true Perceus) | 0.27.0 | active | fixture | 3 |
+| C-067 | The xs[i] index syntax aborts on out-of-bounds (read and write) |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -837,3 +837,12 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/string_codepoint_index.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-067"
+title     = "The xs[i] index syntax aborts on out-of-bounds (read and write)"
+statement = "The index-operator path `xs[i]` (both read `xs[i]` and write `xs[i] = v`) is the ASSERT-in-bounds form: an out-of-bounds, negative, or >= 2^32 index ABORTS with the unified `Error: index out of bounds\n` + exit 1, byte-identical native == wasm — distinct from the stdlib `list.get`/`set` ops (C-054) which take native's no-op / default path. The check runs on the FULL i64 before the wasm i32 narrowing (so an index >= 2^32 can never truncate into range and read/write the wrong slot) and applies to the WRITE path too (previously wasm had no write-path bounds check — an OOB `xs[i] = v` was a silent heap write into adjacent allocator memory, exit 0; native panicked exit 101). Native routes through the `almide_index!`/`almide_index_set!` macros, wasm through `emit_index_bound_guard` + the unified `div_trap`, so neither a native panic (exit 101) nor a wasm `unreachable` trap (exit 134) is observable."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/index_bounds.almd", class = "fixture" },
+]

--- a/spec/wasm_cross/index_bounds.almd
+++ b/spec/wasm_cross/index_bounds.almd
@@ -1,0 +1,14 @@
+// @contract: C-067
+// #554: the xs[i] index SYNTAX path (read AND write) aborts on OOB with the
+// UNIFIED contract — "Error: index out of bounds\n" + exit 1 — byte-identical
+// native == wasm, NOT a native panic (101) nor a wasm `unreachable` trap (134).
+// Previously wasm had NO write-path check (silent heap corruption, exit 0) and
+// wrapped the index to i32 before the read check (silent wrong element for
+// indices >= 2^32). In-bounds reads/writes stay correct.
+fn pick(n: Int) -> Int = n
+fn main() -> Unit = {
+  var xs = [10, 20, 30]
+  xs[1] = 99
+  println("${xs[0]} ${xs[1]} ${xs[2]}")
+  println(int.to_string(xs[pick(10)]))
+}


### PR DESCRIPTION
Closes #554 — the critical silent-corruption finding from hole-hunt round 2 (Lens D, ranked #1).

## The bug (wasm, silent)

The `xs[i]` index SYNTAX path had two silent failures on wasm that the stdlib `list.*` clamp contract (C-054) never covered:

- **A4 — `xs[i] = v` OOB was a silent heap WRITE** (exit 0) into adjacent allocator memory; IndexAssign emit had NO bounds check on the dynamic-index store path. Same heap-poisoning family as the historic fs free-list trap.
- **A2 — read at index ≥ 2³² silently returned the WRONG element** (exit 0): the read path did `i32_wrap_i64` BEFORE its u32 bounds check, so a huge index truncated into range.

Native panicked loudly (exit 101) in all cases, but with a non-contract shape, and `xs[i]` reads/writes had no portable abort.

## The fix — unified abort, both targets, both paths

- **wasm**: a new `emit_index_bound_guard` checks the FULL i64 index against len (negative / ≥ 2³² caught, no truncation) and aborts through the existing `div_trap` with `Error: index out of bounds\n` + exit 1. Wired into BOTH the read path (`collections.rs`) and the previously-unchecked write path (`statements.rs` IndexAssign).
- **native**: new `almide_index!` / `almide_index_set!` macros (mirroring `almide_div!`) range-check and abort with the identical message + exit 1, replacing raw Rust `vec[i]` panics. Wired into the `index_access` template and all IndexAssign arms (plain / RcCow / SharedMut / RcRefCell global).

New contract **C-067** ("the xs[i] index syntax aborts on out-of-bounds") + fixture `spec/wasm_cross/index_bounds.almd` (in-bounds read+write correct; OOB read aborts byte-identical). All four round-2 repros now native==wasm: read OOB / write OOB / index ≥ 2³² / in-bounds.

## Gates

native 265/265 · wasm explicit 255/0/10-skip · byte gate 67/67 · churn 3/3 · cargo full 0 failures · contract links 114/114 symmetric.
