### PR TITLE
Fix interp third-judge semantic gaps: Map/Set eq order, NaN compare, None-unwrap message

### DIFF
--- a/crates/almide-interp/src/eval.rs
+++ b/crates/almide-interp/src/eval.rs
@@ -318,7 +318,13 @@ impl<'a> Interpreter<'a> {
                     Value::Result(Ok(inner)) => Flow::val(*inner),
                     Value::Result(Err(e)) => Flow::Return(Value::Result(Err(e))),
                     Value::Option(Some(inner)) => Flow::val(*inner),
-                    Value::Option(None) => Flow::Return(Value::Option(None)),
+                    // #556: `expr!` on a None propagates an Err whose message is
+                    // "none" on BOTH backends (the codegen lowers Option `!` to
+                    // `ok_or("none")?`). Returning a bare Option(None) made the
+                    // main-error path print the Rust-internal "called
+                    // Option::unwrap() on a None value" — a wrong third vote
+                    // against the native==wasm "Error: none".
+                    Value::Option(None) => Flow::Return(Value::Result(Err(Box::new(Value::str("none".to_string()))))),
                     other => Flow::val(other),
                 }
             }
@@ -984,11 +990,12 @@ impl<'a> Interpreter<'a> {
                     };
                     Flow::val(Value::Bool(res))
                 }
-                None => Flow::Abort(format!(
-                    "internal: ordering {} vs {}",
-                    l.type_name(),
-                    r.type_name()
-                )),
+                // #556 F2: a None here is the NaN case (Float partial_cmp) —
+                // both backends return IEEE false for every NaN comparison
+                // (`<`/`>`/`<=`/`>=`), so the interp must too, NOT abort. A
+                // genuine type-mismatch ordering can't reach here: the checker
+                // rejects it, and codegen never emits cross-type compares.
+                None => Flow::val(Value::Bool(false)),
             },
 
             And | Or => unreachable!("short-circuited above"),

--- a/crates/almide-interp/src/value.rs
+++ b/crates/almide-interp/src/value.rs
@@ -48,8 +48,8 @@ pub enum Value {
     List(Rc<Vec<Value>>),
     Tuple(Rc<Vec<Value>>),
     /// Insertion-ordered dense entries — matches the WASM compact-ordered-dict
-    /// and the native `AlmideMap`. Equality is order-sensitive exactly where
-    /// native is (i.e. it is structural over the ordered entry vec).
+    /// and the native `AlmideMap`. Equality is order-INDEPENDENT (matching
+    /// std HashMap and both backends, #556); iteration/repr preserve order.
     Map(Rc<Vec<(Value, Value)>>),
     /// Insertion-ordered, dedup-on-insert.
     Set(Rc<Vec<Value>>),
@@ -148,8 +148,20 @@ impl PartialEq for Value {
             (Str(a), Str(b)) => a == b,
             (List(a), List(b)) => a == b,
             (Tuple(a), Tuple(b)) => a == b,
-            (Map(a), Map(b)) => a == b,
-            (Set(a), Set(b)) => a == b,
+            // #556: Map/Set `==` is order-INDEPENDENT on both backends
+            // (runtime/rs/src/{map,set}.rs match std HashMap/HashSet); comparing
+            // the ordered entry vecs cast a FALSE clean vote as the third judge
+            // (`["a":1,"b":2] == ["b":2,"a":1]` → backends true, interp false).
+            (Map(a), Map(b)) => {
+                a.len() == b.len()
+                    && a.iter().all(|(k, v)| {
+                        b.iter().any(|(k2, v2)| k == k2 && v == v2)
+                    })
+            }
+            (Set(a), Set(b)) => {
+                a.len() == b.len()
+                    && a.iter().all(|x| b.iter().any(|y| x == y))
+            }
             (
                 Record { name: n1, fields: f1 },
                 Record { name: n2, fields: f2 },

--- a/crates/almide-interp/tests/eval_test.rs
+++ b/crates/almide-interp/tests/eval_test.rs
@@ -787,3 +787,25 @@ fn main() -> Unit = {
     // 3000 * 3001 / 2 = 4_501_500
     expect_out(src, "4501500\n");
 }
+
+// ── #556: Map/Set order-independent ==, NaN-compare IEEE false ──
+
+#[test]
+fn map_eq_order_independent() {
+    expect_out(
+        &main_print(r#"  println("${["a": 1, "b": 2] == ["b": 2, "a": 1]}")"#),
+        "true\n",
+    );
+}
+
+// NOTE: Set `==` order-independence is fixed in value.rs alongside Map, but
+// `set.from_list` is not yet bridged in the interp (F5 latent — the fix takes
+// effect when the bridge is widened), so no runtime test here.
+
+#[test]
+fn nan_compare_is_false_not_abort() {
+    expect_out(
+        &main_print("  let nan = 0.0 / 0.0\n  println(\"${nan < 1.0} ${nan >= 1.0}\")"),
+        "false false\n",
+    );
+}


### PR DESCRIPTION
Closes #556 — interp third-judge semantic gaps (hole-hunt round 2, Lens C), each a false-vote risk against the native==wasm consensus.

- **Map/Set `==` order-independent** (`value.rs`): both backends compare order-independently (`runtime/rs/src/{map,set}.rs` match std HashMap/HashSet); the interp compared ordered entry vecs, casting a CLEAN "false" vote on `["a":1,"b":2] == ["b":2,"a":1]` where both backends say "true". Now size + per-key membership; the Map-variant doc corrected.
- **NaN comparison → IEEE false** (`eval.rs`): `partial_cmp_val` returns None on NaN and the comparison arm aborted ("internal: ordering Float vs Float"); both backends return false for every NaN `<`/`>`/`<=`/`>=`. A genuine cross-type ordering can't reach here (checker rejects it), so None is now false, matching the backends.
- **`expr!` on None → Err("none")** (`eval.rs`): the `!` unwrap of a None returned a bare `Option(None)` that reached main as the Rust-internal "called `Option::unwrap()` on a `None` value"; both backends lower Option `!` to `ok_or("none")?`, so the main-error is "none". This was a LIVE dissent the 3-way harness flagged (`option_none_unwrap_term`) on the fixture added in #533 — now the harness is clean.

Note F5 (Set `==` order + `set.from_list` repr): the eq fix is in place, but `set.from_list` isn't bridged in the interp yet (abstains), so no runtime test — the fix takes effect when the bridge widens (tracked there).

Gates: native 265/265 · wasm explicit 255/0/10-skip · byte gate 67/67 · **3-way interp harness 0 dissent** (was 1) · interp suite green · cargo full 0 failures.
