### PR TITLE
Make auto-? target-directed in construction positions

### DIFF
--- a/crates/almide-frontend/src/lower/auto_try.rs
+++ b/crates/almide-frontend/src/lower/auto_try.rs
@@ -313,13 +313,44 @@ fn insert_try(expr: IrExpr, in_match_subject: bool, ctx: &mut TryCtx) -> IrExpr 
         IrExprKind::Lambda { params, body, lambda_id } => IrExprKind::Lambda {
             params, body, lambda_id,
         },
-        IrExprKind::List { elements } => IrExprKind::List {
-            elements: elements.into_iter().map(|e| insert_try(e, false, ctx)).collect(),
-        },
-        IrExprKind::Record { name, fields } => IrExprKind::Record {
-            name,
-            fields: fields.into_iter().map(|(k, v)| (k, insert_try(v, false, ctx))).collect(),
-        },
+        // #555: construction positions are TARGET-DIRECTED like the statement
+        // arms — a Result-typed element/field must KEEP its Result (strip the
+        // auto-`?`), not unwrap it. The unconditional wrap here made
+        // `[step(), step()]: List[Result[..]]` and `Holder { r: step() }` lift
+        // an effect call to Result and then auto-unwrap it, so native built
+        // invalid Rust (E0308) while wasm ran and silently corrupted the value.
+        IrExprKind::List { elements } => {
+            let elem_is_result = match &ty {
+                Ty::Applied(c, args) if *c == TypeConstructorId::List && args.len() == 1 => args[0].is_result(),
+                _ => false,
+            };
+            IrExprKind::List {
+                elements: elements.into_iter()
+                    .map(|e| coerce_to_target(insert_try(e, false, ctx), elem_is_result))
+                    .collect(),
+            }
+        }
+        IrExprKind::Record { name, fields } => {
+            let field_tys: HashMap<Sym, bool> = match &ty {
+                Ty::Record { fields: fs } | Ty::OpenRecord { fields: fs } =>
+                    fs.iter().map(|(n, t)| (*n, t.is_result())).collect(),
+                Ty::Named(tn, _) => ctx.record_fields.get(tn)
+                    .map(|fs| fs.iter().map(|(n, t)| (*n, t.is_result())).collect())
+                    .unwrap_or_default(),
+                _ => name.as_ref().and_then(|n| ctx.record_fields.get(n))
+                    .map(|fs| fs.iter().map(|(n, t)| (*n, t.is_result())).collect())
+                    .unwrap_or_default(),
+            };
+            IrExprKind::Record {
+                name,
+                fields: fields.into_iter()
+                    .map(|(k, v)| {
+                        let tgt = field_tys.get(&k).copied().unwrap_or(false);
+                        (k, coerce_to_target(insert_try(v, false, ctx), tgt))
+                    })
+                    .collect(),
+            }
+        }
         IrExprKind::OptionSome { expr: inner } => IrExprKind::OptionSome {
             expr: Box::new(insert_try(*inner, false, ctx)),
         },
@@ -355,9 +386,19 @@ fn insert_try(expr: IrExpr, in_match_subject: bool, ctx: &mut TryCtx) -> IrExpr 
         IrExprKind::Fan { exprs } => IrExprKind::Fan {
             exprs: exprs.into_iter().map(|e| insert_try(e, false, ctx)).collect(),
         },
-        IrExprKind::Tuple { elements } => IrExprKind::Tuple {
-            elements: elements.into_iter().map(|e| insert_try(e, false, ctx)).collect(),
-        },
+        IrExprKind::Tuple { elements } => {
+            // #555: per-position target-directed coercion (Result-typed tuple
+            // slot keeps its Result).
+            let elem_results: Vec<bool> = match &ty {
+                Ty::Tuple(tys) => tys.iter().map(|t| t.is_result()).collect(),
+                _ => Vec::new(),
+            };
+            IrExprKind::Tuple {
+                elements: elements.into_iter().enumerate()
+                    .map(|(i, e)| coerce_to_target(insert_try(e, false, ctx), elem_results.get(i).copied().unwrap_or(false)))
+                    .collect(),
+            }
+        }
         IrExprKind::SpreadRecord { base, fields } => IrExprKind::SpreadRecord {
             base: Box::new(insert_try(*base, false, ctx)),
             fields: fields.into_iter().map(|(k, v)| (k, insert_try(v, false, ctx))).collect(),
@@ -376,9 +417,18 @@ fn insert_try(expr: IrExpr, in_match_subject: bool, ctx: &mut TryCtx) -> IrExpr 
         IrExprKind::Deref { expr } => IrExprKind::Deref {
             expr: Box::new(insert_try(*expr, false, ctx)),
         },
-        IrExprKind::MapLiteral { entries } => IrExprKind::MapLiteral {
-            entries: entries.into_iter().map(|(k, v)| (insert_try(k, false, ctx), insert_try(v, false, ctx))).collect(),
-        },
+        IrExprKind::MapLiteral { entries } => {
+            // #555: a Result-typed map VALUE keeps its Result.
+            let val_is_result = match &ty {
+                Ty::Applied(c, args) if *c == TypeConstructorId::Map && args.len() == 2 => args[1].is_result(),
+                _ => false,
+            };
+            IrExprKind::MapLiteral {
+                entries: entries.into_iter()
+                    .map(|(k, v)| (insert_try(k, false, ctx), coerce_to_target(insert_try(v, false, ctx), val_is_result)))
+                    .collect(),
+            }
+        }
         IrExprKind::Unwrap { expr: inner } => IrExprKind::Unwrap {
             expr: Box::new(insert_try(*inner, true, ctx)),
         },

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-67 contracts
+68 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -95,4 +95,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-065 | The string position API is codepoint-indexed end-to-end on both targets | 0.26.20 | active | fixture | 1 |
 | C-066 | WASM heap is reclaimed by default (true Perceus) | 0.27.0 | active | fixture | 3 |
 | C-067 | The xs[i] index syntax aborts on out-of-bounds (read and write) |  | active | fixture | 1 |
+| C-068 | Auto-? is target-directed in construction positions |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -846,3 +846,12 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/index_bounds.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-068"
+title     = "Auto-? is target-directed in construction positions"
+statement = "An effect-fn call in a CONSTRUCTION position — a record field, list element, tuple slot, or map value — whose declared TARGET type is `Result[T, E]` KEEPS its Result (the auto-inserted `?` is stripped), exactly like the binding-statement arms (let/assign/index-assign/field-assign). The implicit Result-lift of an effect call plus an unconditional unwrap previously produced invalid native Rust (E0308: a `?` against a Result-typed slot) while wasm RAN and stored a SILENTLY WRONG value (the unwrapped i64 0 instead of the Result). Now byte-identical native == wasm: the Result is preserved at every construction position."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/autotry_construction.almd", class = "fixture" },
+]

--- a/spec/wasm_cross/autotry_construction.almd
+++ b/spec/wasm_cross/autotry_construction.almd
@@ -1,0 +1,18 @@
+// @contract: C-068
+// #555: effect calls in CONSTRUCTION positions (record field, list element,
+// tuple slot) whose TARGET type is Result must KEEP their Result — the
+// auto-? unwrap is target-directed there, exactly like the binding statement
+// arms. Before this, `Holder { r: step() }` and
+// `[step(), step()]: List[Result[..]]` lifted an effect call to Result then
+// auto-unwrapped it: native built invalid Rust (E0308), wasm RAN and printed
+// a SILENTLY WRONG value (42 -> 0). Now both keep the Result, byte-identical.
+type Holder = { r: Result[Int, String] }
+effect fn step() -> Int = 42
+effect fn main() -> Unit = {
+  let h = Holder { r: step() }
+  let rs: List[Result[Int, String]] = [step(), step()]
+  let t: (Result[Int, String], Int) = (step(), 9)
+  println("field ${h.r ?? -1}")
+  println("list ${rs |> list.map((r) => r ?? -1)}")
+  println("tuple ${t.0 ?? -1} ${t.1}")
+}


### PR DESCRIPTION
Closes #555 — the construction-position auto-? silent-wrong from hole-hunt round 2 (Lens B Class 3), the only silent-WRONG-OUTPUT finding of that round.

## The bug

The #485/#489 target-directed auto-? unification covered binding positions (let/assign/index-assign/field-assign) but NOT construction positions. The Record/List/Tuple/Map-literal arms in `lower/auto_try.rs` wrapped every effect call with `?` unconditionally. So `Holder { r: step() }` and `let rs: List[Result[Int, String]] = [step(), step()]` (with `effect fn step() -> Int`) lifted the call to Result and then auto-unwrapped it against a Result-typed target:

- **native** built invalid Rust (E0308: `?` on a Result-typed slot expecting Result);
- **wasm** RAN and stored a SILENTLY WRONG value — `42` printed as `0` (`field ok 0`), exit 0.

A clean `almide check`, a native build refusal, and a wasm silent-wrong run for one program.

## The fix

Each construction arm is now target-directed exactly like the statement arms: the element/field/slot/value target type drives `coerce_to_target`, so a Result-typed position keeps its Result (strips the auto-`?`):

- **List** — element target from the list's `Applied(List, [e])` type.
- **Record** — per-field target from `Ty::Record`/`OpenRecord` field types, or `ctx.record_fields` for a `Ty::Named` (the same registry FieldAssign uses; handles the `Option<Sym>` anonymous-record name).
- **Tuple** — per-slot target from `Ty::Tuple`.
- **Map literal** — value target from `Applied(Map, [k, v])`.

New contract **C-068** + fixture `spec/wasm_cross/autotry_construction.almd`: record field / list element / tuple slot all keep their Result, byte-identical native==wasm (`field 42` / `list [42, 42]` / `tuple 42 9`).

## Gates

native 265/265 · wasm explicit 255/0/10-skip · byte gate 67/67 · **3-way interp harness clean** · cargo full 0 failures · contract links 115/115 symmetric.
