### PR TITLE
Loop-convert effect-fn tail recursion through the auto-? and Ok wrappers

### DIFF
--- a/crates/almide-codegen/src/pass_tco.rs
+++ b/crates/almide-codegen/src/pass_tco.rs
@@ -418,7 +418,7 @@ fn is_tco_candidate(func: &IrFunction) -> bool {
     if !can_default_init(&func.ret_ty) {
         return false;
     }
-    let (has_any, all_in_tail) = all_self_calls_in_tail_pos(&func.body, &func.name);
+    let (has_any, all_in_tail) = all_self_calls_in_tail_pos(&func.body, &func.name, func.is_effect);
     has_any && all_in_tail
 }
 
@@ -435,7 +435,7 @@ fn is_tco_candidate(func: &IrFunction) -> bool {
 /// - Subject of Match
 /// - Inside BinOp, UnOp, or any compound expression
 /// - Block.stmts (only Block.expr can be tail)
-fn all_self_calls_in_tail_pos(expr: &IrExpr, fn_name: &str) -> (bool, bool) {
+fn all_self_calls_in_tail_pos(expr: &IrExpr, fn_name: &str, is_effect: bool) -> (bool, bool) {
     match &expr.kind {
         // Direct self-call in tail position
         IrExprKind::Call { target: CallTarget::Named { name }, .. } if name == fn_name => {
@@ -448,8 +448,8 @@ fn all_self_calls_in_tail_pos(expr: &IrExpr, fn_name: &str) -> (bool, bool) {
             if cond_has && !cond_all {
                 return (true, false);
             }
-            let (then_has, then_all) = all_self_calls_in_tail_pos(then, fn_name);
-            let (else_has, else_all) = all_self_calls_in_tail_pos(else_, fn_name);
+            let (then_has, then_all) = all_self_calls_in_tail_pos(then, fn_name, is_effect);
+            let (else_has, else_all) = all_self_calls_in_tail_pos(else_, fn_name, is_effect);
             let has = cond_has || then_has || else_has;
             let all = (!cond_has || cond_all) && (!then_has || then_all) && (!else_has || else_all);
             (has, all)
@@ -462,7 +462,7 @@ fn all_self_calls_in_tail_pos(expr: &IrExpr, fn_name: &str) -> (bool, bool) {
                 return (true, false);
             }
             let (has, all) = arms.iter().fold((subj_has, !subj_has || subj_all), |(has, all), arm| {
-                let (arm_has, arm_all) = all_self_calls_in_tail_pos(&arm.body, fn_name);
+                let (arm_has, arm_all) = all_self_calls_in_tail_pos(&arm.body, fn_name, is_effect);
                 let (g_has, g_all) = arm.guard.as_ref().map_or((false, true), |g| scan_non_tail(g, fn_name));
                 (has || arm_has || g_has, all && (!arm_has || arm_all) && (!g_has || g_all))
             });
@@ -477,10 +477,35 @@ fn all_self_calls_in_tail_pos(expr: &IrExpr, fn_name: &str) -> (bool, bool) {
                 (has || s_has, all && (!s_has || s_all))
             });
             let (has, all) = expr.as_ref().map_or((has, all), |tail| {
-                let (t_has, t_all) = all_self_calls_in_tail_pos(tail, fn_name);
+                let (t_has, t_all) = all_self_calls_in_tail_pos(tail, fn_name, is_effect);
                 (has || t_has, all && (!t_has || t_all))
             });
             (has, all)
+        }
+
+        // #557: `expr!` / `expr?` wrapping a tail self-call. Since auto-? moved
+        // into the frontend (cc70ebc4), an effect fn's tail self-call reaches
+        // TCO already wrapped as `Try{Call self}` on every arm — without this
+        // arm `is_tco_candidate` returned false and the loop conversion was
+        // lost, so every implicitly-lifted recursive `effect fn` ran O(n) stack
+        // and crashed on BOTH targets. A `?` on a tail self-call is still a tail
+        // call: Ok continues the recursion, Err short-circuits (and in loop form
+        // the only Err sources are base cases, so the `?` is subsumed).
+        IrExprKind::Try { expr: inner } | IrExprKind::Unwrap { expr: inner } => {
+            match &inner.kind {
+                IrExprKind::Call { target: CallTarget::Named { name }, .. } if name == fn_name => (true, true),
+                _ => scan_non_tail(inner, fn_name),
+            }
+        }
+
+        // #557: on the WASM arm ResultPropagation runs BEFORE TCO, so an effect
+        // fn's tail is already `Ok(<tail>)`. Treat the Ok wrapper as
+        // tail-transparent for effect fns (it is the propagation wrapper, not a
+        // user value) so `Ok(Try(Call self))` / `Ok(0)` are seen in tail
+        // position. For non-effect fns Ok is a real construction and stays
+        // opaque.
+        IrExprKind::ResultOk { expr: inner } if is_effect => {
+            all_self_calls_in_tail_pos(inner, fn_name, is_effect)
         }
 
         // Anything else: scan for non-tail self-calls.
@@ -504,7 +529,6 @@ fn all_self_calls_in_tail_pos(expr: &IrExpr, fn_name: &str) -> (bool, bool) {
         | IrExprKind::StringInterp { .. }
         | IrExprKind::ResultOk { .. } | IrExprKind::ResultErr { .. }
         | IrExprKind::OptionSome { .. } | IrExprKind::OptionNone
-        | IrExprKind::Try { .. } | IrExprKind::Unwrap { .. }
         | IrExprKind::UnwrapOr { .. } | IrExprKind::ToOption { .. }
         | IrExprKind::OptionalChain { .. } | IrExprKind::Await { .. }
         | IrExprKind::Clone { .. } | IrExprKind::Deref { .. }
@@ -998,9 +1022,26 @@ fn rewrite_tail_expr(
             emit_tail_call_replacement(args, params, temps, result_var, dec_params)
         }
 
-        // Effect fn: unwrap ok(expr) in tail position — assign the inner value
+        // #557: `(self-call)?` / `(self-call)!` — a frontend auto-? wrapping a
+        // tail self-call loop-converts IDENTICALLY to the bare self-call (the
+        // `?` is subsumed by the loop; an Err can only originate at a base
+        // case, never the recursion).
+        IrExprKind::Try { expr: inner } | IrExprKind::Unwrap { expr: inner }
+            if matches!(&inner.kind, IrExprKind::Call { target: CallTarget::Named { name }, .. } if name == fn_name) =>
+        {
+            match inner.kind {
+                IrExprKind::Call { args, .. } => emit_tail_call_replacement(args, params, temps, result_var, dec_params),
+                _ => unreachable!("guard guarantees a self-call"),
+            }
+        }
+
+        // Effect fn: the Ok(..) propagation wrapper is tail-transparent —
+        // RECURSE into it so `Ok(Try(Call self))` reaches the tail-call arm and
+        // `Ok(0)` reaches the base-case arm (#557). Previously this eagerly
+        // emitted the whole inner as a base case, so a wasm-arm
+        // `Ok(Try(Call self))` was mis-emitted as a base value (no loop).
         IrExprKind::ResultOk { expr: inner } if is_effect => {
-            emit_base_case(*inner, result_var, dec_params)
+            rewrite_tail_expr(*inner, fn_name, params, temps, result_var, is_effect, dec_params)
         }
 
         // If: recurse into both branches

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-68 contracts
+69 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -96,4 +96,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-066 | WASM heap is reclaimed by default (true Perceus) | 0.27.0 | active | fixture | 3 |
 | C-067 | The xs[i] index syntax aborts on out-of-bounds (read and write) |  | active | fixture | 1 |
 | C-068 | Auto-? is target-directed in construction positions |  | active | fixture | 1 |
+| C-069 | Effect-fn tail self-recursion loop-converts to O(1) stack on both targets |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -855,3 +855,12 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/autotry_construction.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-069"
+title     = "Effect-fn tail self-recursion loop-converts to O(1) stack on both targets"
+statement = "A self-recursive `effect fn` whose recursive call is in tail position runs in O(1) native/wasm stack (loop-converted), identically to the non-effect equivalent — not O(n) frames that overflow at ~1e5 depth. The auto-? desugar moved into the frontend (cc70ebc4), so the tail self-call reaches TailCallOpt already wrapped as `Try{Call self}` (Rust arm) or `Ok(Try(Call self))` (wasm arm, where ResultPropagation precedes TCO); TCO sees through both wrappers — the `?` is subsumed by the loop (an Err can only originate at a base case) and the `Ok` propagation wrapper is tail-transparent for effect fns. The Err short-circuit at a base case still fires. Before the fix every implicitly-lifted recursive effect fn crashed at ~1e5 depth (native stack overflow exit, wasm call-stack-exhausted trap) while the identical non-effect fn was O(1)."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/effect_tco.almd", class = "fixture" },
+]

--- a/docs/roadmap/done/tail-call-optimization.md
+++ b/docs/roadmap/done/tail-call-optimization.md
@@ -51,7 +51,7 @@ Key details:
 
 1. **Tail position analysis**: Walk IR to identify tail-position calls
 2. **Codegen transform**: Emit loop wrapper + continue pattern for detected functions
-3. **Effect fn support**: TCO with `Result` return type (tail call in Ok path)
+3. **Effect fn support**: TCO through the frontend auto-? wrapper — a tail `Try{Call self}` (Rust arm) / `Ok(Try(Call self))` (wasm arm) loop-converts; the `?` is subsumed and the Ok propagation wrapper is tail-transparent (#557, C-069). Both the implicit `-> T` lift and the explicit `-> Result[T, E]` spelling are covered.
 
 ## Phase
 

--- a/spec/wasm_cross/effect_tco.almd
+++ b/spec/wasm_cross/effect_tco.almd
@@ -1,0 +1,23 @@
+// @contract: C-069
+// #557: an effect fn's tail self-recursion must loop-convert to O(1) stack on
+// BOTH targets. The frontend auto-? wraps the tail self-call as Try{Call self}
+// (and ResultPropagation on the wasm arm further wraps it Ok(Try(Call self))),
+// which TCO must see THROUGH. Before the fix, every implicitly-lifted recursive
+// effect fn ran O(n) stack and crashed at ~1e5 depth (native stack overflow /
+// wasm call-stack trap). Three shapes: plain accumulate, an Err early-exit base
+// case (the `?` short-circuit must still fire), and a managed-param carry.
+effect fn sum_to(n: Int, acc: Int) -> Int =
+  if n <= 0 then acc else sum_to(n - 1, acc + n)
+
+effect fn checked(n: Int) -> Int =
+  if n < 0 then fail("negative")
+  else if n == 0 then 0
+  else checked(n - 1)
+
+effect fn fail(msg: String) -> Int = err(msg)!
+
+effect fn main() -> Unit = {
+  let s = sum_to(1000000, 0)
+  let c = checked(2000000)
+  println("${s} ${c}")
+}


### PR DESCRIPTION
Closes #557 — the effect-fn TCO regression from hole-hunt round 2 (Lens A), empirically proven: idiomatic recursive `effect fn`s crashed at ~1e5 depth on BOTH targets.

## Root cause

Commit cc70ebc4 moved the auto-? desugar into the FRONTEND, so an implicitly-lifted `effect fn f(n) -> Int` reaches `TailCallOpt` with its tail self-call already wrapped as `Try{Call self}`. `all_self_calls_in_tail_pos` had no Try arm (Try → scan_non_tail → "not all tail") → `is_tco_candidate` false → no loop conversion. The identical non-effect fn was O(1); the effect fn ran O(n) stack and crashed (native stack overflow / wasm call-stack trap). The `-> Result[T, E]` spelling still worked, pinning the frontend Try wrapper as the sole disqualifier.

A second layer: on the WASM arm `ResultPropagation` runs BEFORE TCO, so the tail is further wrapped `Ok(Try(Call self))`.

## Fix

`pass_tco.rs` now sees through both wrappers:
- `all_self_calls_in_tail_pos` + `rewrite_tail_expr` treat tail `Try{Call self}` / `Unwrap{Call self}` as a tail call — the `?` is subsumed by the loop (an Err can only originate at a base case, never the recursion).
- `ResultOk{..}` is made tail-transparent FOR EFFECT FNS (threaded `is_effect` through the detector; the rewriter recurses into the Ok instead of emitting the inner as a base value) — so the wasm-arm `Ok(Try(Call self))` reaches the tail-call arm and `Ok(0)` reaches the base-case arm. Non-effect `Ok(..)` stays opaque (a real construction).

Both targets now loop-convert at depth 5e6 (was a crash at ~5e4). The Err short-circuit at a base case still fires (verified via a `fail()`-base-case fixture).

New contract **C-069** + fixture `spec/wasm_cross/effect_tco.almd` (accumulate / Err-early-exit / managed-carry, all O(1), byte-identical). Stale `docs/roadmap/done/tail-call-optimization.md` line corrected.

## Gates

native 265/265 · wasm explicit 255/0/10-skip · byte gate 67/67 (codegen snapshots unchanged for non-effect) · 3-way interp clean · cargo full 0 failures · contracts 116/116.
