### PR TITLE
Validate named arguments by name and reject calling a non-function value

### DIFF
--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -447,6 +447,19 @@ impl Checker {
                     });
                     return ret.as_ref().clone();
                 }
+                // #558: `n(args)` where `n` is a NON-function local — the call
+                // position makes this an error. Previously this returned the
+                // var's own type unchecked, so the program passed `check` and
+                // then ICE'd in the wasm emitter (`call target not in func_map`)
+                // / leaked a raw rustc E0425 natively.
+                let rty = resolve_ty(&ty, &self.uf);
+                if !matches!(rty, Ty::Unknown | Ty::TypeVar(_)) {
+                    self.emit(super::err(
+                        format!("`{}` is not a function — it has type {}", name, rty.display()),
+                        format!("`{}` is a value; only functions and closures can be called", name),
+                        format!("call to {}()", name)).with_code("E002"));
+                    return Ty::Unknown;
+                }
                 return ty;
             }
             // Triple: (hint, clean fn-name fix for simple try:, rich multi-line snippet).
@@ -566,7 +579,48 @@ impl Checker {
                 bindings.insert(*gname, gty.clone());
             }
         }
-        let concrete_args: Vec<Ty> = arg_tys.iter().map(|a| resolve_ty(a, &self.uf)).collect();
+        let mut concrete_args: Vec<Ty> = arg_tys.iter().map(|a| resolve_ty(a, &self.uf)).collect();
+        // #558: realign named args to the parameter they NAME before validating
+        // (they were appended in source order). Reorder both the arg types and
+        // their spans so E005 points at the right expression. Slots a named call
+        // skips (relying on a default) are filled with the param's own type so
+        // the zip below validates them trivially.
+        // `aligned_raw[i] = Some(arg inference ty)` when param i was supplied
+        // (positional or named); `None` when it relies on a default. The
+        // constraint-propagation loop below uses this so back-propagation
+        // targets the right inference var, and default slots add no constraint.
+        let mut aligned_raw: Option<Vec<Option<Ty>>> = None;
+        if let Some((named_start, ref names)) = self.named_arg_meta {
+            if named_start <= concrete_args.len() {
+                let param_index: std::collections::HashMap<Sym, usize> =
+                    sig.params.iter().enumerate().map(|(i, (pn, _))| (*pn, i)).collect();
+                let mut aligned: Vec<Ty> = sig.params.iter().map(|(_, t)| t.clone()).collect();
+                let mut aligned_spans: Vec<Option<crate::ast::Span>> = vec![None; sig.params.len()];
+                let mut raw: Vec<Option<Ty>> = vec![None; sig.params.len()];
+                let mut ok = true;
+                for i in 0..named_start.min(aligned.len()) {
+                    aligned[i] = concrete_args[i].clone();
+                    aligned_spans[i] = self.arg_spans.get(i).copied().flatten();
+                    raw[i] = arg_tys.get(i).cloned();
+                }
+                for (k, nm) in names.iter().enumerate() {
+                    let src = named_start + k;
+                    match param_index.get(nm) {
+                        Some(&pi) if src < concrete_args.len() => {
+                            aligned[pi] = concrete_args[src].clone();
+                            aligned_spans[pi] = self.arg_spans.get(src).copied().flatten();
+                            raw[pi] = arg_tys.get(src).cloned();
+                        }
+                        _ => { ok = false; break; }
+                    }
+                }
+                if ok {
+                    concrete_args = aligned;
+                    self.arg_spans = aligned_spans;
+                    aligned_raw = Some(raw);
+                }
+            }
+        }
         let mut e005_fired: Vec<bool> = Vec::new();
         for (i, ((pname, pty), aty)) in sig.params.iter().zip(concrete_args.iter()).enumerate() {
             // Point caret at the exact argument expression for E005
@@ -600,11 +654,17 @@ impl Checker {
         }
         // Propagate resolved types back to inference variables
         // Skip constraint for args where E005 already fired (avoids duplicate E001)
-        for (i, ((_, pty), aty)) in sig.params.iter().zip(arg_tys.iter()).enumerate() {
+        for (i, (_, pty)) in sig.params.iter().enumerate() {
             if e005_fired.get(i).copied().unwrap_or(false) { continue; }
+            // The arg inference ty for param i — realigned for named calls; a
+            // None slot (default-filled) gets no constraint.
+            let aty = match &aligned_raw {
+                Some(raw) => match raw.get(i).and_then(|o| o.clone()) { Some(t) => t, None => continue },
+                None => match arg_tys.get(i) { Some(t) => t.clone(), None => continue },
+            };
             let expected = if bindings.is_empty() { pty.clone() } else { crate::types::substitute(pty, &bindings) };
             if expected != Ty::Unknown {
-                self.constrain(expected, aty.clone(), format!("call to {}()", name));
+                self.constrain(expected, aty, format!("call to {}()", name));
             }
         }
         // Instantiate unresolved generics with fresh vars

--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -1035,7 +1035,12 @@ impl Checker {
         args.extend(std::mem::take(named_args).into_iter().map(|(_, e)| e));
         let resolved_type_args: Option<Vec<crate::types::Ty>> = type_args.as_ref().map(|tas|
             tas.iter().map(|te| self.resolve_type_expr(te)).collect());
+        // #558: hand the named-arg shape to check_named_call so it validates
+        // by NAME (matching lowering), not by the appended positional slot.
+        self.named_arg_meta = if named_names.is_empty() { None }
+            else { Some((named_start, named_names.clone())) };
         let ret = self.check_call_with_type_args(callee, args, resolved_type_args.as_deref());
+        self.named_arg_meta = None;
         // Restore named args
         let named_exprs: Vec<ast::Expr> = args.drain(named_start..).collect();
         *named_args = named_names.into_iter().zip(named_exprs).collect();

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -64,6 +64,13 @@ pub struct Checker {
     /// Argument spans for the current call. Set before `check_named_call_*`
     /// so E005 can point at the exact argument expression.
     pub(crate) arg_spans: Vec<Option<crate::ast::Span>>,
+    /// #558: named-arg reordering metadata for the current call —
+    /// `(named_start, names)` where `named_start` is the index in the
+    /// flattened positional args at which named args begin (their values were
+    /// appended in SOURCE order), and `names` is the parallel param-name list.
+    /// `check_named_call` uses this to validate each value against the param it
+    /// NAMES (lowering binds by name), not the positional slot it landed in.
+    pub(crate) named_arg_meta: Option<(usize, Vec<almide_base::intern::Sym>)>,
     pub(crate) constraints: Vec<Constraint>,
     pub(crate) uf: UnionFind,
     /// Module-name prefix active during `infer_module`. `None` for the
@@ -143,6 +150,7 @@ impl Checker {
             call_span_hint: None,
             last_mut_params: Vec::new(),
             arg_spans: Vec::new(),
+            named_arg_meta: None,
             constraints: Vec::new(), uf: UnionFind::new(),
             current_module_prefix: None,
             deferred_tuple_indices: Vec::new(),

--- a/spec/lang/named_args_reorder_test.almd
+++ b/spec/lang/named_args_reorder_test.almd
@@ -1,0 +1,20 @@
+// #558: named arguments are validated against the parameter they NAME, not the
+// positional slot they were written in. A legal middle-skip or out-of-order
+// named call type-checks and runs; an ill-typed named value is rejected by E005
+// naming the right parameter (checker matches lowering's by-name binding).
+fn f(a: Int, b: String = "B", c: Int = 0) -> String =
+  "${int.to_string(a)}${b}${int.to_string(c)}"
+
+fn g(x: Int, y: String) -> String = "${int.to_string(x)}${y}"
+
+test "named middle-skip keeps the default" {
+  assert_eq(f(1, c: 5), "1B5")
+}
+
+test "all-named out of order" {
+  assert_eq(g(y: "s", x: 1), "1s")
+}
+
+test "named after positional" {
+  assert_eq(f(1, b: "z", c: 9), "1z9")
+}


### PR DESCRIPTION
Part of #558 — the checker-accepts-but-lowering-can't-build class from hole-hunt round 2 (Lens B/D). Two of the five holes, the highest-frequency and the ICE-causing ones.

## Named arguments validated positionally → by name (Class 1)

`infer_call` flattened named args into positional slots in SOURCE order and `check_named_call` validated arg i against param i; lowering binds by NAME. So a legal middle-skip `f(1, c: 5)` (with `f(a, b="B", c=0)`) was FALSELY REJECTED (E005 naming the wrong param `b`), and an ill-typed `f(1, c: "boom")` PASSED check then failed the build (native rustc E0308 / wasm structural [COMPILER BUG]).

Fix: `infer_call` records the named-arg shape (`named_start`, names) on the checker; `check_named_call` realigns each named value to the parameter it NAMES before both validation loops (the E005 check AND the constraint-propagation loop — the latter was the second, separately-mis-paired source of the E001). Default-skipped slots are filled with the param type and add no constraint. New `spec/lang/named_args_reorder_test.almd` (middle-skip / all-named-out-of-order / named-after-positional).

## Calling a non-function value → clean rejection (Class C)

`n(3)` where `n` is a non-function local returned the var's own type UNCHECKED, so the program passed `check` then ICE'd in the wasm emitter (`call target not in func_map`, exit 101) / leaked a raw rustc E0425 natively. Now a `[E002] n is not a function — it has type Int` at check time. Closure-valued locals (`let add = (a,b) => ...; add(2,3)`) still call correctly (verified).

Remaining in #558 (kept open): UFCS default-arg fill, the auto-? module allow-list (error.*/testing.assert_ok), and generic `+` on a TypeVar.

## Gates

native 266/266 · wasm explicit 256/0/10-skip · byte gate 67/67 · diagnostic harness 25/25 · cargo full 0 failures.
