### PR TITLE
Derive the auto-? first-arg exemption from callee signatures

### DIFF
--- a/crates/almide-frontend/src/lower/auto_try.rs
+++ b/crates/almide-frontend/src/lower/auto_try.rs
@@ -11,6 +11,7 @@
 
 use std::collections::{HashMap, HashSet};
 use almide_ir::*;
+use almide_base::intern::sym;
 use almide_base::intern::Sym;
 use crate::types::{Ty, TypeConstructorId};
 
@@ -26,10 +27,13 @@ struct TryCtx<'a> {
     /// a `-> Result[..]`-declared effect fn has the same Bind.ty but takes
     /// the auto-`?` (#485).
     annotated_result_vars: &'a HashSet<VarId>,
+    /// #558: qualified fn keys (`module.func`) whose FIRST param is
+    /// Result/Option — that arg keeps its Result (no auto-?).
+    first_arg_unwraps: &'a HashSet<Sym>,
 }
 
 /// Insert auto-? (Try nodes) in all effect fn bodies of the program.
-pub fn insert_auto_try(program: &mut IrProgram, annotated_result_vars: &HashSet<VarId>) {
+pub fn insert_auto_try(program: &mut IrProgram, annotated_result_vars: &HashSet<VarId>, first_arg_unwraps: &HashSet<Sym>) {
     // Record decls (root + modules) so FieldAssign can resolve a Named
     // target type to its field types. Decl names are canonical (qualified
     // `mod.Type` for user-module types), matching Ty::Named on var types.
@@ -43,7 +47,7 @@ pub fn insert_auto_try(program: &mut IrProgram, annotated_result_vars: &HashSet<
     for func in functions.iter_mut() {
         if func.is_effect && !func.is_test {
             let returns_result = func.ret_ty.is_result();
-            let mut ctx = TryCtx { var_table, record_fields: &record_fields, annotated_result_vars };
+            let mut ctx = TryCtx { var_table, record_fields: &record_fields, annotated_result_vars, first_arg_unwraps };
             func.body = insert_try_body(std::mem::take(&mut func.body), returns_result, &mut ctx);
         }
     }
@@ -52,7 +56,7 @@ pub fn insert_auto_try(program: &mut IrProgram, annotated_result_vars: &HashSet<
         for func in functions.iter_mut() {
             if func.is_effect {
                 let returns_result = func.ret_ty.is_result();
-                let mut ctx = TryCtx { var_table, record_fields: &record_fields, annotated_result_vars };
+                let mut ctx = TryCtx { var_table, record_fields: &record_fields, annotated_result_vars, first_arg_unwraps };
                 func.body = insert_try_body(std::mem::take(&mut func.body), returns_result, &mut ctx);
             }
         }
@@ -299,9 +303,21 @@ fn insert_try(expr: IrExpr, in_match_subject: bool, ctx: &mut TryCtx) -> IrExpr 
             // becomes `result.unwrap_or((int.parse(s))?, d)`, unwrapping the Result
             // the callee needs (E0308 at build; passes check/test). The `true` flag
             // suppresses only the top-level wrap of that arg, like a match subject.
-            let skip_first = matches!(&target,
-                CallTarget::Module { module, .. }
-                    if module.as_str() == "result" || module.as_str() == "option");
+            // #558: skip the auto-? on arg 0 when the callee's FIRST param is
+            // Result/Option (derived from signatures), generalizing the old
+            // hardcoded result/option module list — error.context/message,
+            // testing.assert_ok and any user fn taking a Result first are now
+            // covered. result/option stay as a fallback for intrinsic keys.
+            let skip_first = match &target {
+                CallTarget::Module { module, func, .. } => {
+                    module.as_str() == "result" || module.as_str() == "option"
+                        || ctx.first_arg_unwraps.contains(&sym(&format!("{}.{}", module.as_str(), func.as_str())))
+                }
+                // A USER fn whose first param is Result/Option (e.g.
+                // `fn take(r: Result[..], ..)`) — its sig key is the bare name.
+                CallTarget::Named { name } => ctx.first_arg_unwraps.contains(name),
+                _ => false,
+            };
             IrExprKind::Call {
                 target,
                 args: args.into_iter().enumerate()

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -418,7 +418,18 @@ fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &Type
     // Auto-? insertion: wrap Result-typed calls in Try nodes.
     // This bridges the gap between checker (auto_unwrap strips Result
     // from bindings) and IR (Call nodes carry Result types).
-    auto_try::insert_auto_try(&mut program, &annotated_result_vars);
+    // #558: callees whose FIRST parameter is Result/Option must NOT have that
+    // arg auto-?'d (it would unwrap the very value the callee consumes —
+    // `error.context(inner(), msg)`, `result.unwrap_or(r, d)`, …). Derive the
+    // set from the signature table instead of a hardcoded module-name list.
+    let first_arg_unwraps: std::collections::HashSet<almide_base::intern::Sym> = env.functions.iter()
+        .filter_map(|(k, sig)| {
+            let first_is_opt_result = sig.params.first()
+                .map_or(false, |(_, t)| t.is_result() || matches!(t, almide_lang::types::Ty::Applied(almide_lang::types::TypeConstructorId::Option, _)));
+            if first_is_opt_result { Some(*k) } else { None }
+        })
+        .collect();
+    auto_try::insert_auto_try(&mut program, &annotated_result_vars, &first_arg_unwraps);
 
     // Collect stdlib modules used in root functions/top_lets.
     // ir_link extends this with modules from dependencies.

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -95,6 +95,6 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-065 | The string position API is codepoint-indexed end-to-end on both targets | 0.26.20 | active | fixture | 1 |
 | C-066 | WASM heap is reclaimed by default (true Perceus) | 0.27.0 | active | fixture | 3 |
 | C-067 | The xs[i] index syntax aborts on out-of-bounds (read and write) |  | active | fixture | 1 |
-| C-068 | Auto-? is target-directed in construction positions |  | active | fixture | 1 |
+| C-068 | Auto-? is target-directed in construction positions |  | active | fixture | 2 |
 | C-069 | Effect-fn tail self-recursion loop-converts to O(1) stack on both targets |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -854,6 +854,7 @@ statement = "An effect-fn call in a CONSTRUCTION position — a record field, li
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/autotry_construction.almd", class = "fixture" },
+  { path = "spec/wasm_cross/autotry_result_first_arg.almd", class = "fixture" },
 ]
 
 [[contract]]

--- a/spec/wasm_cross/autotry_result_first_arg.almd
+++ b/spec/wasm_cross/autotry_result_first_arg.almd
@@ -1,0 +1,17 @@
+// @contract: C-068
+// #558: a callee whose FIRST parameter is Result/Option must NOT have that
+// arg auto-?'d — it consumes the Result itself. The exemption is derived from
+// SIGNATURES, generalizing the old hardcoded result/option module list to
+// error.message, testing.assert_ok, and any USER fn taking a Result first.
+// Before this, `error.message(inner(0))` and `take(inner(0))` unwrapped the
+// arg (native E0308 build fail / wasm structural [COMPILER BUG]).
+import error
+fn inner(x: Int) -> Result[Int, String] = if x > 0 then ok(x) else err("neg")
+fn take(r: Result[Int, String], label: String) -> String =
+  "${label}=${result.unwrap_or(r, -9)}"
+effect fn main() -> Unit = {
+  println(error.message(inner(0)))
+  println(take(inner(5), "a"))
+  println(take(inner(0), "b"))
+  println("${result.unwrap_or(inner(0), -1)}")
+}


### PR DESCRIPTION
Part of #558 — the auto-? module allow-list hole (Lens D Class B), the third of five.

## The bug

`lower/auto_try.rs` suppressed the auto-? on a call's FIRST argument only for `module == "result" || module == "option"` (so `result.unwrap_or(int.parse(s), d)` keeps its Result arg). Every OTHER callee whose first param is Result/Option — `error.message`, `error.context`, `testing.assert_ok`, and any USER fn `fn take(r: Result[..], ..)` — got its Result arg auto-unwrapped: native built invalid Rust (E0308: `?` against a Result param) and wasm produced a structural `[COMPILER BUG]`. This hit the documented `error.context`/`error.message` idiom LLMs are told to write.

## The fix

The exemption is now DERIVED FROM SIGNATURES, not a module-name list: `lower_program` builds the set of fn keys whose first parameter is Result/Option from `env.functions`, and `auto_try` skips the arg-0 auto-? when the callee (a `Module` stdlib call OR a `Named` user fn) is in that set. `result`/`option` remain as a fallback for intrinsic keys. New fixture `spec/wasm_cross/autotry_result_first_arg.almd` covers `error.message`, a user `take(r: Result, ..)`, and `result.unwrap_or`, byte-identical native==wasm.

Found while building the fixture: **`error.context` itself produces garbled output on wasm** (even the success path) while native is correct — a SEPARATE pre-existing wasm runtime bug, filed as #591. The fixture uses `error.message` (clean on both) to avoid it.

Remaining in #558 (kept open): UFCS default-arg fill, and generic `+` on a TypeVar.

## Gates

native 266/266 · wasm explicit 256/0/10-skip · byte gate 67/67 · cargo full 0 failures · contracts 117/117.
