### PR TITLE
Fill default arguments for UFCS calls

### DIFF
--- a/crates/almide-frontend/src/lower/calls.rs
+++ b/crates/almide-frontend/src/lower/calls.rs
@@ -107,6 +107,25 @@ pub(super) fn lower_call(ctx: &mut LowerCtx, callee: &ast::Expr, args: &[ast::Ex
         }
     }
 
+    // #558: UFCS default-arg fill. A bare `x.foo()` lowers to a `Method`
+    // target whose object the EMITTER prepends as arg 0 — but the Named
+    // branches above never fire, so a free fn with defaults (`fn foo(a, b=10)`
+    // called `x.foo()`) reached codegen one arg short (invalid Rust / wasm
+    // stack underflow). When the method names a known free fn with defaults,
+    // fill them here, counting the (not-yet-prepended) object as arg 0.
+    if let CallTarget::Method { method, .. } = &target {
+        if !method.as_str().contains('.') {
+            if let Some(defaults) = ctx.fn_defaults.get(method).cloned() {
+                // provided = object (1) + explicit positional args
+                let provided = 1 + ir_args.len();
+                ir_args.extend(
+                    defaults.iter().skip(provided)
+                        .filter_map(|d| d.as_ref().map(|expr| lower_expr(ctx, expr)))
+                );
+            }
+        }
+    }
+
     // Stage 1b: retype Int/Float literal args that flow into sized
     // numeric params (`Int32`, `UInt8`, `Float32`, ...). Mirrors the
     // let-binding coercion in `statements.rs::override_record_literal_ty`

--- a/spec/lang/ufcs_default_args_test.almd
+++ b/spec/lang/ufcs_default_args_test.almd
@@ -1,0 +1,21 @@
+// #558: a UFCS call `x.foo()` fills the free fn's default args, counting the
+// object as the first argument — `fn add(a, b = 10)` called `5.add()` becomes
+// `add(5, 10)`. Before this, the Method-target default-fill was skipped and
+// codegen emitted `add(5)` one arg short (invalid Rust / wasm stack underflow).
+fn add(a: Int, b: Int = 10) -> Int = a + b
+fn scale(x: Int, by: Int = 2, plus: Int = 1) -> Int = x * by + plus
+
+test "UFCS fills a single default" {
+  assert_eq(5.add(), 15)
+  assert_eq(5.add(20), 25)
+}
+
+test "UFCS fills multiple trailing defaults" {
+  assert_eq(3.scale(), 7)
+  assert_eq(3.scale(4), 13)
+  assert_eq(3.scale(4, 5), 17)
+}
+
+test "regular call still fills defaults" {
+  assert_eq(add(5), 15)
+}


### PR DESCRIPTION
Part of #558 — the UFCS default-arg hole (the fourth of five).

## The bug

A bare `x.foo()` lowers to a `CallTarget::Method` whose object the emitter prepends as arg 0. But both default-fill branches in `lower/calls.rs` gated on `CallTarget::Named`, so a free fn with defaults called via UFCS — `fn add(a, b = 10)` called `5.add()` — reached codegen one arg short (`add(5)`): native built invalid Rust, wasm underflowed the stack.

## The fix

When a bare (non-module-qualified) `Method` names a known free fn with defaults, fill the missing trailing defaults at lowering — counting the not-yet-prepended object as arg 0, so `5.add()` → `add(5, 10)` and `3.scale()` → `scale(3, 2, 1)`. New `spec/lang/ufcs_default_args_test.almd` (single default, multiple trailing defaults, regular-call parity).

This closes the 4th of #558's five holes. The 5th — generic `+` on an unbounded TypeVar (`fn dup[T](x) = x + x`; `dup("ab")`) — is the remaining item: it is caught LOUDLY today (the #532 release IR-verification gate rejects the post-mono `AddInt` with non-Int operands), so it is not silent; a CLEAN check-time diagnostic requires either operator-bound semantics for generics or a mono-time check — a design decision tracked on #558.

## Gates

native 267/267 · wasm explicit 257/0/10-skip · byte gate 67/67 · cargo full 0 failures.
