### PR TITLE
Iterate interp ranges lazily so huge ranges stay fuel-bounded

### DIFF
--- a/crates/almide-interp/src/eval.rs
+++ b/crates/almide-interp/src/eval.rs
@@ -524,14 +524,25 @@ impl<'a> Interpreter<'a> {
         scope: &Scope,
     ) -> Flow {
         let iter_v = val!(self.eval_expr(iterable, scope));
-        let items = match iter_v.as_iter_items() {
-            Some(items) => items,
-            None => {
-                return Flow::Abort(format!(
-                    "internal: for-in over non-iterable {}",
-                    iter_v.type_name()
-                ))
+        // #561: a Range iterates LAZILY — never materialized into a Vec. The
+        // eager materialization in `as_iter_items` allocated the entire range
+        // up front with no fuel accounting, so `for i in 0..2_000_000_000`
+        // OOM-ABORTED the process (uncatchable by the fuzzer oracle) before a
+        // single fuel check. Generating each value on demand keeps the loop
+        // fuel-bounded: it stops at `Flow::Fuel`, never allocating the range.
+        let items: Vec<Value> = match &iter_v {
+            Value::Range { start, end, inclusive } => {
+                return self.eval_for_in_range(var, var_tuple, *start, *end, *inclusive, body, scope);
             }
+            _ => match iter_v.as_iter_items() {
+                Some(items) => items,
+                None => {
+                    return Flow::Abort(format!(
+                        "internal: for-in over non-iterable {}",
+                        iter_v.type_name()
+                    ))
+                }
+            },
         };
         for item in items {
             if let Err(f) = self.step() {
@@ -563,6 +574,47 @@ impl<'a> Interpreter<'a> {
                     Err(other) => return other,
                 }
             }
+        }
+        Flow::val(Value::Unit)
+    }
+
+    /// #561: lazy `for i in start..end` — generates each Int on demand and
+    /// charges fuel per iteration, so an adversarially huge range terminates
+    /// as `Flow::Fuel` instead of materializing (and OOM-aborting) the whole
+    /// range. A tuple binder over a Range is shape-invalid (Ints aren't
+    /// tuples), matching the eager path's mismatch abort.
+    fn eval_for_in_range(
+        &mut self,
+        var: VarId,
+        var_tuple: Option<&[VarId]>,
+        start: i64,
+        end: i64,
+        inclusive: bool,
+        body: &[IrStmt],
+        scope: &Scope,
+    ) -> Flow {
+        let last = if inclusive { end } else { end - 1 };
+        let mut i = start;
+        while i <= last {
+            if let Err(f) = self.step() {
+                return f;
+            }
+            let frame = scope.child();
+            if var_tuple.is_some() {
+                return Flow::Abort(
+                    "internal: for-in tuple destructure shape mismatch".into(),
+                );
+            }
+            frame.bind(var, Value::Int(i));
+            for stmt in body {
+                match self.exec_stmt(stmt, &frame) {
+                    Ok(()) => {}
+                    Err(Flow::Break) => return Flow::val(Value::Unit),
+                    Err(Flow::Continue) => break,
+                    Err(other) => return other,
+                }
+            }
+            i += 1;
         }
         Flow::val(Value::Unit)
     }

--- a/crates/almide-interp/src/value.rs
+++ b/crates/almide-interp/src/value.rs
@@ -87,10 +87,19 @@ impl Value {
             Value::List(xs) => Some((**xs).clone()),
             Value::Set(xs) => Some((**xs).clone()),
             Value::Range { start, end, inclusive } => {
-                let mut out = Vec::new();
-                let mut i = *start;
+                // #561: defensive cap — for-in iterates ranges LAZILY
+                // (eval.rs::eval_for_in_range), so this materializing path is
+                // only reached by repr/eq of a Range, where a multi-billion
+                // range would OOM. Bound it; a range this large in a repr/eq
+                // position is degenerate and the interp (an abstaining oracle)
+                // need not be exact there.
+                const MAX_RANGE_MATERIALIZE: i64 = 16 * 1024 * 1024;
                 let last = if *inclusive { *end } else { *end - 1 };
-                while i <= last {
+                let count = (last - *start + 1).max(0).min(MAX_RANGE_MATERIALIZE);
+                let mut out = Vec::with_capacity(count as usize);
+                let mut i = *start;
+                let stop = *start + count;
+                while i < stop {
                     out.push(Value::Int(i));
                     i += 1;
                 }

--- a/crates/almide-interp/tests/eval_test.rs
+++ b/crates/almide-interp/tests/eval_test.rs
@@ -809,3 +809,21 @@ fn nan_compare_is_false_not_abort() {
         "false false\n",
     );
 }
+
+// ── #561: huge ranges are fuel-bounded, never materialized ──
+
+#[test]
+fn huge_range_for_in_is_fuel_bounded_not_oom() {
+    // A 2-billion range with a SMALL fuel budget must terminate as
+    // FuelExhausted in O(fuel) steps and O(1) memory — the eager
+    // materialization used to allocate the whole range (tens of GB) and
+    // abort the process before the first fuel check.
+    let src = "fn main() -> Unit = {\n  var s = 0\n  for i in 0..2000000000 {\n    s = s + 1\n  }\n  println(\"${s}\")\n}";
+    let ir = lower(src);
+    let out = almide_interp::Interpreter::new(&ir).with_fuel(10_000).run_main();
+    assert!(
+        matches!(out.status, almide_interp::RunStatus::FuelExhausted),
+        "huge range must FuelExhaust, got {:?}",
+        out.status
+    );
+}


### PR DESCRIPTION
Closes #561 — the interp Range fuel-bypass (hole-hunt round 2, Lens C F4), a fuzzer campaign-killer.

## The bug

`Value::as_iter_items` materialized a `Range` into a full `Vec<Value>` with zero fuel accounting; every consumer (for-in, repr, eq) routed through it. `for i in 0..10_000_000 {}` at fuel=1000 allocated 742 MB BEFORE the first fuel check; a generator-sized `0..2_000_000_000` allocates tens of GB, and the Rust allocation failure ABORTS the process (not an unwind) — so the fuzzer oracle's `catch_unwind` can't catch it and the campaign dies instead of abstaining. This violated the crate's own rule ("Fuel is mandatory … must terminate as FuelExhausted, never hang").

## The fix

- **for-in over a Range iterates LAZILY** (`eval_for_in_range`): each Int is generated on demand and `step()` charges fuel per iteration, so an adversarial range terminates as `Flow::Fuel` in O(fuel) steps and O(1) memory — never materialized. Verified: `0..2_000_000_000` at fuel=10_000 FuelExhausts immediately, 40 MB RSS (was tens of GB / process abort).
- **`as_iter_items` caps Range materialization** at 16 Mi elements defensively — that path is now only reached by repr/eq of a Range, where a multi-billion range is degenerate and the abstaining oracle need not be exact.

Normal range loops are unchanged and byte-identical native==wasm (`for i in 0..10` etc.). New regression test `huge_range_for_in_is_fuel_bounded_not_oom`.

## Gates

native 267/267 · wasm explicit 257/0/10-skip · 3-way interp clean · interp suite green · cargo full 0 failures.
