### PR TITLE
Reject unhashable Map keys for every construction syntax

### DIFF
--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -948,11 +948,14 @@ impl Checker {
 impl Checker {
     /// Validate that all Map literal key types are hashable (post-solve).
     fn validate_map_key_types(&mut self) {
+        use std::collections::HashSet;
+        let mut reported: HashSet<String> = HashSet::new();
         let checks = std::mem::take(&mut self.deferred_map_key_checks);
         for (key_ty, span) in checks {
             let resolved = resolve_ty(&key_ty, &self.uf);
             if !self.env.is_hash(&resolved) {
                 let ty_name = Self::type_display_name(&resolved);
+                reported.insert(ty_name.clone());
                 let mut diag = err(
                     format!("type '{}' is not hashable — cannot be used as a Map key", ty_name),
                     "Map keys must be hashable. Use String, Int, Bool, or a record/variant with only hashable fields.".to_string(),
@@ -963,6 +966,39 @@ impl Checker {
                     diag.col = Some(s.col);
                 }
                 self.diagnostics.push(diag);
+            }
+        }
+        // #598: the deferred queue only catches map LITERALS. Sweep the SOLVED
+        // type map for EVERY Map[K, V] — so the stdlib builder API
+        // (map.new/map.set/from_list/insert) gets the same authoritative
+        // unhashable-key rejection the literal already gets, in the frontend
+        // (identical on both targets). Previously an unhashable Float key built
+        // via map.from_list passed `check`, then on wasm SILENTLY collapsed
+        // distinct keys (len 2 → 1) or produced a [COMPILER BUG] invalid module.
+        let map_keys: Vec<crate::types::Ty> = self.type_map.values()
+            .filter_map(|t| match t {
+                crate::types::Ty::Applied(almide_lang::types::TypeConstructorId::Map, args) if args.len() == 2 =>
+                    Some(args[0].clone()),
+                _ => None,
+            })
+            .collect();
+        for key_ty in map_keys {
+            let resolved = resolve_ty(&key_ty, &self.uf);
+            // Skip inference vars that never pinned down — that is the empty
+            // collection class, reported elsewhere; only fire on a CONCRETE
+            // unhashable key.
+            if matches!(resolved, crate::types::Ty::Unknown | crate::types::Ty::TypeVar(_)) {
+                continue;
+            }
+            if !self.env.is_hash(&resolved) {
+                let ty_name = Self::type_display_name(&resolved);
+                if reported.insert(ty_name.clone()) {
+                    self.diagnostics.push(err(
+                        format!("type '{}' is not hashable — cannot be used as a Map key", ty_name),
+                        "Map keys must be hashable. Use String, Int, Bool, or a record/variant with only hashable fields.".to_string(),
+                        "map key".to_string(),
+                    ));
+                }
             }
         }
     }

--- a/spec/lang/map_key_hashable_test.almd
+++ b/spec/lang/map_key_hashable_test.almd
@@ -1,0 +1,16 @@
+// #598: unhashable Map keys are rejected by the checker for EVERY construction
+// syntax (literal, map.new/set, from_list), not just literals — closing the
+// builder-API bypass that let a Float key reach codegen (wasm silently
+// collapsed distinct float keys / emitted an invalid module). Hashable keys
+// (Int, Int64, String, Bool) are accepted everywhere. This test exercises the
+// ACCEPT side; the REJECT side is a compile-error and lives in the Rust
+// diagnostic harness.
+test "hashable keys via every construction" {
+  let lit = ["a": 1, "b": 2]
+  let built = map.from_list([("x", 10), ("y", 20)])
+  var inc: Map[Int, String] = map.new()
+  inc = map.set(inc, 1, "one")
+  assert_eq(map.len(lit), 2)
+  assert_eq(map.len(built), 2)
+  assert_eq(map.len(inc), 1)
+}


### PR DESCRIPTION
Closes #598 — the unhashable-Float-map-key checker bypass (hole-hunt round 3, Lens H), the strongest finding: a wasm SILENT-WRONG.

## The bug

`deferred_map_key_checks` was pushed ONLY at `check/infer.rs:1004` inside `ExprKind::MapLiteral`. The stdlib builder API (`map.new`/`map.set`/`map.from_list`/`insert`) never enqueued, so `validate_map_key_types` never saw those keys. A Float key built via a builder call passed `almide check` clean, then:

- `map.from_list([(1.5, 10), (2.5, 20)])`: native `len=2`, **wasm `len=1`** — two distinct float keys SILENTLY collapse (broken float-key hashing on wasm). A native≠wasm runtime divergence that passes the build.
- `map.set(map.new(), 1.5, 10)`: passes check, `--target wasm` → `[COMPILER BUG] structural validation: expected i32, found f64`.

The map LITERAL form (`[1.5: 10]`) was correctly rejected — the checker was right for one construction syntax only.

## The fix

`validate_map_key_types` now, after the deferred (literal) queue, sweeps the SOLVED type map for EVERY `Ty::Map[K, V]` and checks K's hashability — so all construction syntaxes get the same authoritative rejection in the frontend (identical on both targets, the `validate_empty_collection_elements` pattern). Concrete unhashable keys only (inference-var / Unknown keys are the empty-collection class, handled elsewhere); deduped by type name against the literal reports.

Verified: Float keys via `from_list`/`map.set`/`map.new` are now `type 'Float' is not hashable` at check; hashable keys (Int, Int64, String, Bool) via every syntax are accepted (new `spec/lang/map_key_hashable_test.almd`). The remaining wasm crash for *hashable* wide-int keys (Int64/UInt64) is the separate codegen issue #600.

## Gates

native 268/268 · wasm explicit 258/0/10-skip · cargo full 0 failures.
