### PR TITLE
Adapt and box var-bound fan thunk lists through both passes

### DIFF
--- a/crates/almide-codegen/src/pass_fan_lowering.rs
+++ b/crates/almide-codegen/src/pass_fan_lowering.rs
@@ -10,13 +10,73 @@ use almide_ir::*;
 /// Strip Try nodes from inside Fan expressions and fan.* call arguments.
 pub fn strip_fan_auto_try(program: &mut IrProgram) {
     for func in &mut program.functions {
+        adapt_var_thunk_lists(&mut func.body);
         func.body = rewrite_expr(std::mem::take(&mut func.body), false);
     }
     for module in &mut program.modules {
         for func in &mut module.functions {
+            adapt_var_thunk_lists(&mut func.body);
             func.body = rewrite_expr(std::mem::take(&mut func.body), false);
         }
     }
+}
+
+/// #599: the Ok-adapter (`ok_adapt_thunk_list`) only descends into an INLINE
+/// `[...]` literal at the fan call site. When a race/any/settle thunk list is
+/// bound to a `let` first — `let ts = [...]; fan.race(ts)` — the call's arg is
+/// a `Var`, the adapter's `_ => arg` passthrough leaves the thunks as the
+/// uniform `Rc<dyn Fn>` repr, and the runtime bound (Send+Sync `Fn()->Result`
+/// native / Result-shaped indirect-call sig wasm) is never satisfied → native
+/// invalid-Rust ICE, wasm trap. A runtime re-wrap (list.map) cannot satisfy the
+/// native Send+Sync bound, so we adapt STRUCTURALLY at the BINDING: collect the
+/// VarIds used as a race/any/settle arg-0, then Ok-adapt the `List` value of
+/// every matching `let` bind (so it reaches the call already adapted).
+fn adapt_var_thunk_lists(body: &mut IrExpr) {
+    use almide_ir::visit::{IrVisitor, walk_expr};
+    use almide_ir::visit_mut::{IrMutVisitor, walk_stmt_mut};
+    use std::collections::HashSet;
+
+    struct Collect { vars: HashSet<u32> }
+    impl IrVisitor for Collect {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            let (is_fan_list, arg0) = match &e.kind {
+                IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. }
+                    if module.as_str() == "fan" && thunk_list_method(func.as_str()) => (true, args.first()),
+                IrExprKind::Call { target: CallTarget::Named { name }, args, .. }
+                    if name.as_str().starts_with("almide_rt_fan_")
+                        && thunk_list_method(name.as_str().trim_start_matches("almide_rt_fan_")) => (true, args.first()),
+                _ => (false, None),
+            };
+            if is_fan_list {
+                if let Some(IrExpr { kind: IrExprKind::Var { id }, .. }) = arg0 {
+                    self.vars.insert(id.0);
+                }
+            }
+            walk_expr(self, e);
+        }
+    }
+    let mut c = Collect { vars: HashSet::new() };
+    c.visit_expr(body);
+    if c.vars.is_empty() { return; }
+
+    struct Adapt { vars: HashSet<u32> }
+    impl IrMutVisitor for Adapt {
+        fn visit_stmt_mut(&mut self, stmt: &mut IrStmt) {
+            if let IrStmtKind::Bind { var, value, .. } = &mut stmt.kind {
+                if self.vars.contains(&var.0) && matches!(&value.kind, IrExprKind::List { .. }) {
+                    let taken = std::mem::replace(value, unit_placeholder());
+                    *value = ok_adapt_thunk_list(taken);
+                }
+            }
+            walk_stmt_mut(self, stmt);
+        }
+    }
+    let mut a = Adapt { vars: c.vars };
+    a.visit_expr_mut(body);
+}
+
+fn unit_placeholder() -> IrExpr {
+    IrExpr { kind: IrExprKind::Unit, ty: almide_lang::types::Ty::Unit, span: None, def_id: None }
 }
 
 // Note: fan.map/race/any come through as CallTarget::Module { module: "fan" }.

--- a/crates/almide-codegen/src/pass_rust_lowering.rs
+++ b/crates/almide-codegen/src/pass_rust_lowering.rs
@@ -24,6 +24,13 @@ impl NanoPass for RustLoweringPass {
         // (A) Box closures sitting in type-erased join slots as `Rc<dyn Fn>`.
         //     Single source of truth — see `box_closures_program` below.
         if box_closures_program(&mut program) { changed = true; }
+        // (A2, #599) A race/any/settle thunk list bound to a `let` first reaches
+        // the call as a `Var`; box_closures_program boxed its elements as the
+        // uniform `Rc<dyn Fn>`, but race/any/settle need `Box<dyn Fn + Send +
+        // Sync>` (Rc is neither). Collect the VarIds used as a race/any/settle
+        // arg-0 and RE-TAG the matching bind's list elements to BoxSendSync —
+        // the var-indirection twin of the inline-list boxing.
+        if rebox_var_thunk_lists(&mut program) { changed = true; }
         // Vars whose Assign must STAY an Assign — their lvalue is not a direct
         // Rust place, so the `xs = xs + [v]` → `xs.push(v)` rewrite would push
         // onto a DISCARDED CLONE and silently lose the write:
@@ -150,6 +157,61 @@ fn fan_method(expr: &IrExpr) -> Option<String> {
 }
 
 /// Box every thunk in a `fan.race/any/settle` thunk-LIST argument.
+fn rebox_var_thunk_lists(program: &mut IrProgram) -> bool {
+    use almide_ir::visit::{IrVisitor, walk_expr};
+    use almide_ir::visit_mut::{IrMutVisitor, walk_stmt_mut};
+    use std::collections::HashSet;
+
+    fn fan_list_var(e: &IrExpr) -> Option<u32> {
+        let (func, args) = match &e.kind {
+            IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. }
+                if module.as_str() == "fan" => (func.as_str().to_string(), args),
+            IrExprKind::Call { target: CallTarget::Named { name }, args, .. }
+                if name.as_str().starts_with("almide_rt_fan_") =>
+                (name.as_str().trim_start_matches("almide_rt_fan_").to_string(), args),
+            _ => return None,
+        };
+        if matches!(func.as_str(), "race" | "any" | "settle") {
+            if let Some(IrExpr { kind: IrExprKind::Var { id }, .. }) = args.first() {
+                return Some(id.0);
+            }
+        }
+        None
+    }
+
+    struct Collect { vars: HashSet<u32> }
+    impl IrVisitor for Collect {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if let Some(id) = fan_list_var(e) { self.vars.insert(id); }
+            walk_expr(self, e);
+        }
+    }
+    let mut c = Collect { vars: HashSet::new() };
+    for func in &program.functions { c.visit_expr(&func.body); }
+    for m in &program.modules { for func in &m.functions { c.visit_expr(&func.body); } }
+    if c.vars.is_empty() { return false; }
+
+    struct Rebox { vars: HashSet<u32>, changed: bool }
+    impl IrMutVisitor for Rebox {
+        fn visit_stmt_mut(&mut self, stmt: &mut IrStmt) {
+            if let IrStmtKind::Bind { var, value, .. } = &mut stmt.kind {
+                if self.vars.contains(&var.0) {
+                    if let IrExprKind::List { elements } = &mut value.kind {
+                        for el in elements.iter_mut() {
+                            self.changed |= box_fan_thunk(el, FnBox::BoxSendSync);
+                        }
+                    }
+                }
+            }
+            walk_stmt_mut(self, stmt);
+        }
+    }
+    let mut r = Rebox { vars: c.vars, changed: false };
+    for func in &mut program.functions { r.visit_expr_mut(&mut func.body); }
+    for m in &mut program.modules { for func in &mut m.functions { r.visit_expr_mut(&mut func.body); } }
+    r.changed
+}
+
 fn box_fan_thunk_list(arg: &mut IrExpr, to: FnBox) -> bool {
     if let IrExprKind::List { elements } = &mut arg.kind {
         let mut c = false;

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -31,7 +31,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-001 | Integer division/modulo by zero is total — it aborts, never traps | 0.24.0 | active | fixture | 3 |
 | C-002 | Signed MIN / -1 overflow aborts, at the TRUE per-width MIN | 0.24.0 | active | fixture | 3 |
 | C-003 | Non-aborting integer div/mod stay byte-identical | 0.24.0 | active | fixture | 1 |
-| C-004 | fan.race / fan.any / fan.map / fan.settle are deterministic by list order | 0.24.0 | active | fixture | 3 |
+| C-004 | fan.race / fan.any / fan.map / fan.settle are deterministic by list order | 0.24.0 | active | fixture | 4 |
 | C-005 | fan error propagation surfaces as the unified main-error abort | 0.24.0 | active | fixture | 5 |
 | C-006 | [fan.timeout is the SOLE documented wall-clock divergence (wasm warns)](C-006-fan-timeout-divergence.md) | 0.24.0 | flagged-for-revision | by-construction | 0 |
 | C-007 | Abortable top-level lets evaluate eagerly at startup | 0.24.0 | active | fixture | 2 |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -101,6 +101,7 @@ evidence  = [
   { path = "spec/wasm_cross/fan_deterministic.almd", class = "fixture" },
   { path = "spec/wasm_cross/fan_map_inline_lambda.almd", class = "fixture" },
   { path = "spec/wasm_cross/fan_pure_thunks.almd", class = "fixture" },
+  { path = "spec/wasm_cross/fan_var_thunk_list.almd", class = "fixture" },
 ]
 
 [[contract]]

--- a/spec/wasm_cross/fan_var_thunk_list.almd
+++ b/spec/wasm_cross/fan_var_thunk_list.almd
@@ -1,0 +1,19 @@
+// @contract: C-004
+// #599: a race/any/settle thunk list bound to a `let` VARIABLE before the fan
+// call (not an inline `[...]` literal) is adapted/boxed identically to the
+// inline form. Before the fix, the #514 inline-list adapter's `_ => arg`
+// passthrough left a var-bound list unadapted: native emitted invalid Rust
+// (Rc<dyn Fn> is not Fn), wasm ran for Result-lambdas but RUNTIME-TRAPPED
+// (indirect call type mismatch) for pure named-fn-ref thunks. Both the
+// frontend Ok-adapter and the Rust Send+Sync boxing now follow the var.
+effect fn one() -> Result[Int, String] = ok(1)
+fn ra() -> Int = 1
+fn rb() -> Int = 2
+effect fn main() -> Unit = {
+  let lam: List[() -> Result[Int, String]] = [() => one()]
+  let r = fan.race(lam)
+  println("race=${r}")
+  let refs: List[() -> Int] = [ra, rb]
+  let s = fan.settle(refs)
+  println("settle=${list.len(s)}")
+}


### PR DESCRIPTION
Closes #599 — fan race/any/settle reject a var-bound thunk list (hole-hunt round 3, Lens E). The #514 inline-list adapter had a var-indirection hole spanning TWO passes.

## The bug

`let ts = [...]; fan.race(ts)` — the call's arg is a `Var`, so both the frontend Ok-adapter (`pass_fan_lowering`) and the Rust Send+Sync boxing (`pass_rust_lowering`) — each of which only descends into an inline `IrExprKind::List` — left the thunks as the uniform `Rc<dyn Fn>` repr. Native: invalid Rust (E0277, `Rc<dyn Fn>` is not `Fn`). Wasm: ran for Result-lambdas, but **runtime-trapped** (`indirect call type mismatch`, exit 134) for pure named-fn-ref thunks. Inline `fan.race([...])` always worked — the var indirection was the trigger; no existing fixture bound a thunk list to a var.

## The fix — follow the binding through both passes

A per-function pre-pass in each pass collects the VarIds used as a race/any/settle arg-0, then adapts/boxes the matching `let` bind's list **at the binding** (a runtime `list.map` re-wrap can't satisfy the native Send+Sync bound, so it must be structural):
- `pass_fan_lowering::adapt_var_thunk_lists` — Ok-adapts non-Result thunks in the bound list.
- `pass_rust_lowering::rebox_var_thunk_lists` — re-tags the bound list's elements from the default `Rc<dyn Fn>` to `Box<dyn Fn + Send + Sync>`.

New fixture `spec/wasm_cross/fan_var_thunk_list.almd` (C-004): a var-bound Result-lambda list through `fan.race` and a var-bound named-fn-ref list through `fan.settle`, byte-identical native==wasm (`race=1` / `settle=2`).

## Gates

native 268/268 · wasm explicit 258/0/10-skip · byte gate 67/67 · cargo full 0 failures · contracts 119/119.
