### PR TITLE
Use the i64 key path for wide-int map keys in the wasm emitter

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_map.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map.rs
@@ -732,7 +732,10 @@ impl FuncCompiler<'_> {
         use super::engine::layout::{STRING, string as ls};
         let str_data_off = self.emitter.layout_reg.fixed_offset(STRING, ls::DATA) as i32;
         match key_ty {
-            Ty::Int => {
+            // #600: wide ints share the i64 key hash (the value is already i64
+            // on the stack); the get_or/from_list paths call emit_hash_key with
+            // the raw key_ty, so Int64/UInt64 must hash here exactly like Int.
+            Ty::Int | Ty::Int64 | Ty::UInt64 => {
                 let tmp = self.scratch.alloc_i64();
                 wasm!(self.func, {
                     local_tee(tmp);
@@ -937,20 +940,23 @@ impl FuncCompiler<'_> {
         if let Ty::Applied(_, args) = ty { args.first().cloned().unwrap_or(Ty::String) } else { Ty::String }
     }
     pub(super) fn emit_key_load(&mut self, key_ty: &Ty, offset: u32) {
+        // #600: wide ints (Int64/UInt64) share the 8-byte i64 key slot with Int —
+        // emit_hash_key already hashes them via the i64 path, so the access width
+        // must match or the wasm validator trips (expected i32, found i64).
         match key_ty {
-            Ty::Int => { wasm!(self.func, { i64_load(offset); }); }
+            Ty::Int | Ty::Int64 | Ty::UInt64 => { wasm!(self.func, { i64_load(offset); }); }
             _ => { wasm!(self.func, { i32_load(offset); }); }
         }
     }
     pub(super) fn emit_key_store(&mut self, key_ty: &Ty, offset: u32) {
         match key_ty {
-            Ty::Int => { wasm!(self.func, { i64_store(offset); }); }
+            Ty::Int | Ty::Int64 | Ty::UInt64 => { wasm!(self.func, { i64_store(offset); }); }
             _ => { wasm!(self.func, { i32_store(offset); }); }
         }
     }
     pub(super) fn emit_key_eq(&mut self, key_ty: &Ty) {
         match key_ty {
-            Ty::Int => { wasm!(self.func, { i64_eq; }); }
+            Ty::Int | Ty::Int64 | Ty::UInt64 => { wasm!(self.func, { i64_eq; }); }
             Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
             // Tuple keys, and records/Named-records with a heap POINTER field
             // (String / nested list), need STRUCTURAL equality — `mem_eq` would
@@ -1009,13 +1015,13 @@ impl FuncCompiler<'_> {
         }
     }
     pub(super) fn emit_search_key_store(&mut self, key_ty: &Ty, s32: u32, s64: u32) {
-        match key_ty { Ty::Int => { wasm!(self.func, { local_set(s64); }); } _ => { wasm!(self.func, { local_set(s32); }); } }
+        match key_ty { Ty::Int | Ty::Int64 | Ty::UInt64 => { wasm!(self.func, { local_set(s64); }); } _ => { wasm!(self.func, { local_set(s32); }); } }
     }
     pub(super) fn emit_search_key_load(&mut self, key_ty: &Ty, s32: u32, s64: u32) {
-        match key_ty { Ty::Int => { wasm!(self.func, { local_get(s64); }); } _ => { wasm!(self.func, { local_get(s32); }); } }
+        match key_ty { Ty::Int | Ty::Int64 | Ty::UInt64 => { wasm!(self.func, { local_get(s64); }); } _ => { wasm!(self.func, { local_get(s32); }); } }
     }
     pub(super) fn key_valtype(key_ty: &Ty) -> ValType {
-        match key_ty { Ty::Int => ValType::I64, _ => ValType::I32 }
+        match key_ty { Ty::Int | Ty::Int64 | Ty::UInt64 => ValType::I64, _ => ValType::I32 }
     }
     pub(super) fn emit_elem_copy_sized(&mut self, size: u32, dup: bool) {
         // `dup` = the 4-byte slot is a HEAP POINTER being SHARED (source

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -81,7 +81,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-051 | math.log_gamma is bit-identical (both targets use the vendored musl-libm log) | 0.24.0 | active | fixture | 1 |
 | C-052 | A fold over an empty collection requires the collection to carry an element type (no codegen defaulting) | 0.24.0 | active | fixture | 1 |
 | C-053 | list.min/max/sort/sort_by/unique_by are type-directed and total, native == wasm | 0.24.0 | active | fixture | 1 |
-| C-054 | List/string Int counts and indices are i64-clamped before narrowing — no truncation, no OOB | 0.24.0 | active | fixture | 2 |
+| C-054 | List/string Int counts and indices are i64-clamped before narrowing — no truncation, no OOB | 0.24.0 | active | fixture | 3 |
 | C-055 | list.min/max/sort/sort_by over Float use IEEE-754 totalOrder, valid + identical on both targets | 0.24.0 | active | fixture | 2 |
 | C-056 | list.product wraps on i64 overflow, consistent with list.sum and plain `*` | 0.24.0 | active | fixture | 1 |
 | C-057 | Assigning a Unit-returning in-place mutator's result is a checker error on both targets | 0.24.0 | active | fixture | 1 |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -715,6 +715,7 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/list_count_index_truncation.almd", class = "fixture" },
   { path = "spec/wasm_cross/string_count_truncation.almd", class = "fixture" },
+  { path = "spec/wasm_cross/map_wide_int_key.almd", class = "fixture" },
 ]
 
 # ── FLOAT LIST ORDERING = IEEE-754 totalOrder (Cluster-B) ────────────

--- a/spec/wasm_cross/map_wide_int_key.almd
+++ b/spec/wasm_cross/map_wide_int_key.almd
@@ -1,0 +1,18 @@
+// @contract: C-054
+// #600: a Map with a wide hashable scalar key (Int64/UInt64 — 8-byte) builds
+// and runs byte-identical native == wasm. Before the fix, the wasm key-access
+// helpers special-cased only Ty::Int for the i64 path and routed Int64/UInt64
+// keys through i32 ops despite their 8-byte slot, so `map.set(map.new(), k, v)`
+// with an Int64 key crashed the emitter at structural validation
+// ("expected i32, found i64"). (Float keys are unhashable and rejected at
+// check — #598 — so only the hashable wide ints reach codegen here.)
+fn main() -> Unit = {
+  let a: Int64 = 5
+  let b: Int64 = 9000000000000
+  let m = map.from_list([(a, 10), (b, 20)])
+  println("len=${int.to_string(map.len(m))}")
+  println("a=${int.to_string(map.get_or(m, a, -1))} b=${int.to_string(map.get_or(m, b, -1))}")
+  let u: UInt64 = 18000000000000000000
+  let mu = map.set(map.new(), u, 7)
+  println("u=${int.to_string(map.get_or(mu, u, -1))}")
+}


### PR DESCRIPTION
Closes #600 — wasm Map with a wide hashable scalar key (Int64/UInt64) crashed the emitter at structural validation (hole-hunt round 3, Lens F).

## The bug

`map.set(map.new(), k, v)` with an `Int64` key → native "len 1"; `almide build --target wasm` → `[COMPILER BUG] structural validation: expected i32, found i64`. The wasm key-access helpers special-cased ONLY `Ty::Int` for the 8-byte i64 path and routed everything else through i32 ops, while `byte_size` sizes Int64/UInt64 = 8 and `emit_hash_value` already treated `Int | Int64 | UInt64` as the i64 path — so the key slot was sized 8 bytes and the key pushed as i64, then stored/loaded/compared with i32 ops.

## The fix

`Int64`/`UInt64` now ride the i64 key path alongside `Int` in `emit_key_load`, `emit_key_store`, `emit_key_eq`, `emit_search_key_store`, `emit_search_key_load`, `key_valtype`, AND `emit_hash_key` (the get_or/from_list paths call it with the raw key_ty). New fixture `spec/wasm_cross/map_wide_int_key.almd` (C-054): `from_list`/`map.set`/`get_or` with Int64 and UInt64 keys, byte-identical native==wasm.

Scope note: Float/Float64/Float32 keys are UNHASHABLE and now rejected at check (#598), so only the hashable wide ints reach codegen — those are the real gap this closes. (Set[Float]/Set[Int64] were already fine — different element path.)

## Gates

native 268/268 · wasm explicit 258/0/10-skip · byte gate 67/67 · oracle registry 135/135 · cargo full 0 failures · contracts 120/120.
