### PR TITLE
Implement string.lines as a true str::lines byte scan

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -1257,23 +1257,62 @@ fn compile_run_length_encode(emitter: &mut WasmEmitter) {
 }
 
 fn compile_lines(emitter: &mut WasmEmitter) {
+    // #601: true `str::lines()` — NOT split-on-\n. Two semantics split must
+    // not have: (1) a final line terminator does NOT yield a trailing empty
+    // line ("a\nb\n" -> [a, b], not [a, b, ""]); (2) a "\r\n" line drops the
+    // trailing "\r". Byte-scan loop mirroring the native oracle
+    // `runtime/rs/src/string.rs::almide_rt_string_lines = s.lines()`.
     let type_idx = emitter.func_type_indices[&emitter.rt.string.lines];
-    let mut f = Function::new([(1, ValType::I32)]);
-    // If input string is empty, return empty list (alloc HEADER_SIZE bytes, len=0)
+    // locals: 1=blen 2=result 3=cur 4=i 5=slot 6=line_end
+    let mut f = Function::new([(6, ValType::I32)]);
+    let dat = string_data_off() as i32;
     wasm!(f, {
-        local_get(0); i32_load(0); i32_eqz;
-        if_i32;
-          i32_const(list_hdr()); call(emitter.rt.alloc); local_set(1);
-          local_get(1); i32_const(0); i32_store(0);
-          local_get(1);
-        else_;
-          i32_const(1); call(emitter.rt.string_alloc); local_set(1);
-          local_get(1); i32_const(1); i32_store(0);
-          local_get(1); i32_const(1); i32_store(string_cap_off() as u32, 0);
-          local_get(1); i32_const(10); i32_store8(string_data_off() as u32);
-          local_get(0); local_get(1); call(emitter.rt.string.split);
+        local_get(0); i32_load(0); local_set(1); // blen
+        // (empty input falls through naturally: the loop body never runs, the
+        // trailing-line guard is false, and result.len stays 0 -> empty list.)
+        // result: header + (blen + 1) slots (upper bound on the line count).
+        i32_const(list_hdr()); local_get(1); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+        call(emitter.rt.alloc); local_set(2);
+        i32_const(0); local_set(3); // cur
+        i32_const(0); local_set(4); // i
+        i32_const(0); local_set(5); // slot
+        block_empty; loop_empty;
+          local_get(4); local_get(1); i32_ge_u; br_if(1); // i >= blen -> done scanning
+          // if byte[i] == '\n'
+          local_get(0); i32_const(dat); i32_add; local_get(4); i32_add; i32_load8_u(0);
+          i32_const(10); i32_eq;
+          if_empty;
+            // line_end = i; strip a trailing '\r' (byte[i-1] == 13 when i > cur)
+            local_get(4); local_set(6);
+            local_get(4); local_get(3); i32_gt_u;
+            if_empty;
+              local_get(0); i32_const(dat); i32_add; local_get(4); i32_const(1); i32_sub; i32_add; i32_load8_u(0);
+              i32_const(13); i32_eq;
+              if_empty;
+                local_get(4); i32_const(1); i32_sub; local_set(6);
+              end;
+            end;
+            // slot[slot] = slice(s, cur, line_end)
+            local_get(2); i32_const(list_data_off()); i32_add; local_get(5); i32_const(4); i32_mul; i32_add;
+            local_get(0); local_get(3); local_get(6); call(emitter.rt.string.slice);
+            i32_store(0);
+            local_get(5); i32_const(1); i32_add; local_set(5); // slot++
+            local_get(4); i32_const(1); i32_add; local_set(3); // cur = i + 1
+          end;
+          local_get(4); i32_const(1); i32_add; local_set(4); // i++
+          br(0);
+        end; end;
+        // trailing non-empty line (input did NOT end at a '\n')
+        local_get(3); local_get(1); i32_lt_u;
+        if_empty;
+          local_get(2); i32_const(list_data_off()); i32_add; local_get(5); i32_const(4); i32_mul; i32_add;
+          local_get(0); local_get(3); local_get(1); call(emitter.rt.string.slice);
+          i32_store(0);
+          local_get(5); i32_const(1); i32_add; local_set(5);
         end;
-        end;
+        local_get(2); local_get(5); i32_store(0); // result.len = slot
+        local_get(2);
+        end; // close the function body
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.lines, type_idx, f));
 }

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -92,7 +92,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-062 | The RawPtr / linear-memory bridge moves bytes byte-identically on both targets | 0.26.15 | active | fixture | 1 |
 | C-063 | Parsing a heterogeneous-nested glTF/JSON document and walking its arrays by element is byte-identical on both targets | 0.26.19 | active | fixture | 1 |
 | C-064 | The effect-fn Result auto-unwrap rule is identical across binding positions and type-directed, byte-identical on both targets | 0.26.20 | active | fixture | 1 |
-| C-065 | The string position API is codepoint-indexed end-to-end on both targets | 0.26.20 | active | fixture | 1 |
+| C-065 | The string position API is codepoint-indexed end-to-end on both targets | 0.26.20 | active | fixture | 2 |
 | C-066 | WASM heap is reclaimed by default (true Perceus) | 0.27.0 | active | fixture | 3 |
 | C-067 | The xs[i] index syntax aborts on out-of-bounds (read and write) |  | active | fixture | 1 |
 | C-068 | Auto-? is target-directed in construction positions |  | active | fixture | 2 |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -839,6 +839,7 @@ since     = "0.26.20"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/string_codepoint_index.almd", class = "fixture" },
+  { path = "spec/wasm_cross/string_lines.almd", class = "fixture" },
 ]
 
 [[contract]]

--- a/spec/wasm_cross/string_lines.almd
+++ b/spec/wasm_cross/string_lines.almd
@@ -1,0 +1,16 @@
+// @contract: C-065
+// #601: string.lines is true str::lines() — a final line terminator does NOT
+// yield a trailing empty line, and a "\r\n" line drops the trailing "\r" —
+// byte-identical native == wasm. The wasm impl was naive split-on-\n (a
+// spurious trailing empty line + retained \r), masked under an inadequate
+// "verified" fixture that only tested the no-trailing-newline subset.
+fn show(s: String) -> String =
+  "${int.to_string(list.len(string.lines(s)))}:${list.join(string.lines(s), "|")}"
+fn main() -> Unit = {
+  println(show("a\nb\n"))
+  println(show("a\nb"))
+  println(show("\n"))
+  println(show("\n\n"))
+  println(show("a\r\nb\r\nc"))
+  println(show(""))
+}

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -324,6 +324,21 @@ fn main() -> Unit = {
   println(int.to_string(list.len(ls)) + " " + ls[2])
 }
 "#);
+    // #601: the cases where naive split-on-\n diverges from str::lines() —
+    // a trailing terminator must NOT add an empty final line, and \r\n drops
+    // the \r. (The case above is the coincidental-equal subset that masked
+    // the divergence under a green "verified" badge.)
+    assert_cross_target(r#"
+fn show(s: String) -> String = "${int.to_string(list.len(string.lines(s)))}:${list.join(string.lines(s), "|")}"
+fn main() -> Unit = {
+  println(show("a\nb\n"))
+  println(show("a\nb"))
+  println(show("\n"))
+  println(show("\n\n"))
+  println(show("a\r\nb\r\nc"))
+  println(show(""))
+}
+"#);
 }
 
 #[test]


### PR DESCRIPTION
Closes #601 — `string.lines` on wasm diverged from the native `str::lines()` oracle under a false-green "verified" badge (hole-hunt round 3, Lens G).

## The bug

`compile_lines` delegated to `string.split` on a single-byte `\n`, which is NOT `str::lines()`:
- **trailing terminator** → a spurious empty final line: `string.lines("a\nb\n")` → native 2, wasm 3.
- **CRLF** → the `\r` was retained: `string.lines("a\r\nb")[0]` → native `a` (1 byte), wasm `a\r` (2 bytes).

Masked because the `verified` rt-oracle fixture (`wasm_string_lines`) only used `"hello\nworld\ntest"` — the exact subset where split-on-`\n` coincidentally equals `str::lines()`.

## The fix

`compile_lines` is now a byte-scan loop mirroring `str::lines()`: each `\n` closes a line `[cur, i)`, stripping a trailing `\r` when `byte[i-1] == '\r'`; a final `\n` does NOT emit a trailing empty line (the loop ends with `cur == len`); empty input falls through to an empty list naturally. Verified across all edge cases (`"a\nb\n"`, `"a\nb"`, `"\n"`, `"\n\n"`, `"a\r\nb\r\nc"`, `""`), byte-identical native==wasm.

The `wasm_string_lines` rt-oracle test is extended with the trailing-newline and CRLF cases (so the green badge now means what it says), plus new `spec/wasm_cross/string_lines.almd` (C-065).

(Implementation note: the wasm! macro does not auto-append the function-body `End` — split carries an extra trailing `end;`; mirrored here.)

## Gates

native 268/268 · wasm explicit 258/0/10-skip · byte gate 67/67 · oracle registry 135/135 · cargo full 0 failures · contracts 121/121.
