### PR TITLE
Dispatch cross-module Codec on wasm + surface wasm-only test failures (completeness mechanism)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls.rs
@@ -709,6 +709,18 @@ impl FuncCompiler<'_> {
                         self.emit_call(&target, args, _ret_ty);
                     }
                     _ => {
+                        // #609: a synthesized codec helper for a DEPENDENCY-module
+                        // element type — `__decode_list_varlib.Pigment` — gets
+                        // SPLIT on the dot into module=`__decode_list_varlib`,
+                        // func=`Pigment`. Reassemble and route to the value-codec
+                        // dispatch (the Named arm does this for same-module types).
+                        let full = format!("{}.{}", module.as_str(), func.as_str());
+                        if full.starts_with("__encode_option_") || full.starts_with("__decode_option_")
+                            || full.starts_with("__decode_default_") || full.starts_with("__encode_list_")
+                            || full.starts_with("__decode_list_") {
+                            self.emit_codec_helper(&full, args);
+                            return;
+                        }
                         // Try user module function: almide_rt_{module}_{func}
                         let mod_ident = module.as_str().replace('.', "_");
                         let func_ident = func.as_str().replace('.', "_");
@@ -723,9 +735,30 @@ impl FuncCompiler<'_> {
                                 for arg in args { self.emit_expr(arg); }
                                 wasm!(self.func, { call(func_idx); });
                             } else {
+                                // Cross-module Type.method (#609): a Codec/convention
+                                // method on a type defined in a DEPENDENCY module
+                                // is registered as `almide_rt_{owning}_{Type}_{method}`,
+                                // but the call arrives with module = the TYPE name
+                                // (`Pigment`), so the prefix lookup builds
+                                // `almide_rt_Pigment_decode` and misses. The native
+                                // arm resolves this via MODULE_METHOD_FNS (a
+                                // Rust-only pass); for wasm, find the unique
+                                // func_map key ending in `_{Type}_{method}` under
+                                // the `almide_rt_` namespace.
+                                let suffix = format!("_{}_{}", mod_ident, func_ident);
+                                let mut matches: Vec<u32> = self.emitter.func_map.iter()
+                                    .filter(|(k, _)| k.starts_with("almide_rt_") && k.ends_with(&suffix))
+                                    .map(|(_, &v)| v)
+                                    .collect();
+                                matches.sort_unstable();
+                                matches.dedup();
                                 // Last resort: bare func name (for cross-module calls where
                                 // module name differs from canonical)
                                 if let Some(&func_idx) = self.emitter.func_map.get(func.as_str()) {
+                                    for arg in args { self.emit_expr(arg); }
+                                    wasm!(self.func, { call(func_idx); });
+                                } else if matches.len() == 1 {
+                                    let func_idx = matches[0];
                                     for arg in args { self.emit_expr(arg); }
                                     wasm!(self.func, { call(func_idx); });
                                 } else {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -295,7 +295,21 @@ fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> Wasm
     }));
     let bytes = match bytes {
         Ok(b) => b,
-        Err(_) => return skip("WASM codegen panic".to_string()),
+        // #609 mechanism: a WASM codegen PANIC on a program that type-checks is
+        // a compiler bug (an ICE / [COMPILER BUG]), NOT a benign `// wasm:skip`.
+        // Treating it as a Skip let a wasm-only crash hide behind the native
+        // fallback (`almide test` reported PASS). Report it as a Fail so
+        // `cmd_test_wasm` counts it failed and `cmd_test_fast` surfaces it as a
+        // cross-target divergence even when native passes.
+        Err(e) => {
+            let msg = e.downcast_ref::<String>().map(|s| s.as_str())
+                .or_else(|| e.downcast_ref::<&str>().copied())
+                .unwrap_or("WASM codegen panic");
+            return WasmTestOutcome::Fail {
+                file: test_file.to_string(),
+                detail: format!("  WASM codegen panic: {}\n", msg.lines().next().unwrap_or(msg)),
+            };
+        }
     };
     if prof {
         marks.push(("codegen", std::time::Instant::now()));
@@ -493,10 +507,17 @@ pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
 
     let mut wasm_pass = 0usize;
     let mut fallback: Vec<String> = Vec::new();
+    // #609 mechanism: a wasm FAIL (codegen panic / parse error / output
+    // divergence) is a cross-target BUG, distinct from a benign Skip
+    // (`// wasm:skip`, native-only matrix, unsupported feature). Track Fails so
+    // they surface as failures even when the native fallback passes — otherwise
+    // a wasm-only crash on a type-checking program hides behind native.
+    let mut wasm_fails: Vec<(String, String)> = Vec::new();
     for o in wasm_outcomes {
         match o {
             WasmTestOutcome::Pass { .. } => wasm_pass += 1,
-            WasmTestOutcome::Fail { file, .. } | WasmTestOutcome::Skip { file, .. } => fallback.push(file),
+            WasmTestOutcome::Fail { file, detail } => { wasm_fails.push((file.clone(), detail)); fallback.push(file); }
+            WasmTestOutcome::Skip { file, .. } => fallback.push(file),
         }
     }
 
@@ -539,12 +560,23 @@ pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
     };
 
     let mut failed = 0;
+    let native_failed: std::collections::HashSet<&str> =
+        native_results.iter().filter(|(_, c)| *c != 0).map(|(f, _)| f.as_str()).collect();
     for (file, code) in &native_results {
         if *code != 0 { eprintln!("FAILED: {}", file); failed += 1; }
     }
-    eprintln!("\n{} via WASM, {} via native fallback, {} failed (of {} files)",
-        wasm_pass, fallback.len().saturating_sub(failed), failed, test_files.len());
-    if failed > 0 {
+    // Surface wasm-only failures (native passed but wasm crashed/diverged) —
+    // the cross-target bug class that used to hide behind native fallback.
+    let mut wasm_only = 0;
+    for (file, detail) in &wasm_fails {
+        if !native_failed.contains(file.as_str()) {
+            eprintln!("WASM-FAILED (native passed, cross-target bug): {}\n{}", file, detail);
+            wasm_only += 1;
+        }
+    }
+    eprintln!("\n{} via WASM, {} via native fallback, {} failed, {} wasm-only-failed (of {} files)",
+        wasm_pass, fallback.len().saturating_sub(failed).saturating_sub(wasm_only), failed, wasm_only, test_files.len());
+    if failed > 0 || wasm_only > 0 {
         std::process::exit(1);
     }
     eprintln!("All {} test file(s) passed", test_files.len());

--- a/tests/crossmod_matrix_test.rs
+++ b/tests/crossmod_matrix_test.rs
@@ -33,6 +33,8 @@ const MOD_ALMD: &str = r#"type Emotion = Happy | Sad
 
 type Cfg = { name: String }
 
+type Pigment: Codec = { r: Int, g: Int, b: Int }
+
 let SYSTEM = "hi"
 
 let WORDS = ["a", "b"]
@@ -99,6 +101,27 @@ fn describe(t: Tag) -> String = match t { PolicyTag(_) => "tag", Empty => "empty
 effect fn main() -> Unit = println(describe(PolicyTag(m.Happy)))
 "#,
             expected: "tag",
+            status: Status::Works,
+        },
+        // #609: a derived Codec method on a type defined in ANOTHER module
+        // (`m.Pigment.encode/decode`) ICE'd the WASM emitter (it built the
+        // runtime name from the TYPE name, not the owning module) while native
+        // worked — and `almide test` hid it behind the native fallback. This
+        // cell is the both-target regression lock; it covers the scalar method
+        // AND the synthesized `__decode_list_<mod>.<Type>` helper.
+        Cell {
+            name: "cross_module_codec_roundtrip",
+            main: r#"import self as m
+type Bundle: Codec = { lead: m.Pigment, palette: List[m.Pigment] }
+effect fn main() -> Unit = {
+  let p = m.Pigment { r: 1, g: 2, b: 3 }
+  let one = match m.Pigment.decode(m.Pigment.encode(p)) { ok(v) => v.b, _ => -1 }
+  let bd = Bundle { lead: p, palette: [m.Pigment { r: 4, g: 5, b: 6 }, m.Pigment { r: 7, g: 8, b: 9 }] }
+  let lst = match Bundle.decode(Bundle.encode(bd)) { ok(v) => list.len(v.palette), _ => -1 }
+  println(int.to_string(one) + " " + int.to_string(lst))
+}
+"#,
+            expected: "3 2",
             status: Status::Works,
         },
         Cell {


### PR DESCRIPTION
Closes #609 — cross-module derived Codec ICE'd on wasm AND `almide test` masked it. This PR fixes the bug and installs the COMPLETENESS-MAINTAINING MECHANISM that makes the whole class detectable (per the directive: every hit ships the mechanism that keeps the class detectable, not just the instance).

## The bug (#609)

A derived Codec method on a type in a DEPENDENCY module — `dep.Type.encode/decode`, the exact call in `spec/integration/modules/cross_module_codec_test.almd:19` — works on native but ICE'd the wasm emitter: the call arrives with `module` = the TYPE name (`Pigment`), so the dispatch built `almide_rt_Pigment_decode` and missed the registered `almide_rt_varlib_Pigment_decode`. The native resolution (`MODULE_METHOD_FNS`) is a Rust-only pass.

Two wasm dispatch fixes:
1. The scalar `Type.method`: when the prefix lookup misses, find the unique `func_map` key ending in `_{Type}_{method}` under the `almide_rt_` namespace.
2. The synthesized list helper `__decode_list_varlib.Pigment` (for a `List[dep.Type]` field) was SPLIT on the dot into module/func; reassemble the full name and route it to the value-codec dispatch (the Named arm already did this for same-module types).

## The mechanism (the part the directive asked for)

The bug survived because **`almide test` hid the wasm ICE behind the native fallback** — `compile_and_run_wasm_test` turned a WASM CODEGEN PANIC into a `Skip` (treated like a benign `// wasm:skip`), so a wasm-only crash on a type-checking program reported PASS.

- A wasm codegen PANIC is now a `Fail` (it carries the panic message) — a panic on a program that type-checks is a compiler bug, not a skip. (The author had already learned this for parse errors; codegen panics were the remaining hole.)
- `cmd_test_fast` now tracks wasm `Fail`s distinctly from `Skip`s and reports any file that FAILED on wasm but PASSED on native as a `WASM-FAILED (cross-target bug)` — exit 1. A genuine `// wasm:skip` is unaffected.

Running the full corpus with the detector surfaced exactly one previously-hidden bug (this one); after the fix, `0 wasm-only-failed`, and `spec/` wasm-skips drop 10 → 9. A `cross_module_codec_roundtrip` cell is added to `tests/crossmod_matrix_test.rs` (the both-target gate) as the permanent regression lock — covering the scalar method AND the `__decode_list` helper.

## Gates

native 268/268 · wasm explicit 259/0/9-skip · default `almide test` 0 wasm-only-failed · byte gate 67/67 · crossmod matrix incl. new Codec cell · cargo full 0 failures.
