### PR TITLE
Recurse wasm match into nested constructor pattern args (#607)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/control.rs
+++ b/crates/almide-codegen/src/emit_wasm/control.rs
@@ -529,8 +529,13 @@ impl FuncCompiler<'_> {
                     } else { vec![] };
                     let gnames_refs: Vec<&str> = all_gnames.iter().map(|s| s.as_str()).collect();
 
-                    // Check if any args are Literal patterns (need value checks)
-                    let has_literal_args = args.iter().any(|p| matches!(p, IrPattern::Literal { .. }));
+                    // #607: any arg that needs a discriminant test — a literal OR
+                    // a NESTED constructor/Some/None (the inner tag must gate the
+                    // arm or wasm matches the wrong nested case silently).
+                    let has_literal_args = args.iter().any(|p| matches!(p,
+                        IrPattern::Literal { .. } | IrPattern::Constructor { .. }
+                        | IrPattern::Some { .. } | IrPattern::None
+                        | IrPattern::RecordPattern { .. }));
 
                     // Resolve field types
                     let resolved_fields: Vec<Ty> = (0..args.len()).map(|arg_idx| {
@@ -548,19 +553,11 @@ impl FuncCompiler<'_> {
                         let mut field_offset = 4u32;
                         let mut cond_count = 0;
                         for (arg_idx, arg_pat) in args.iter().enumerate() {
-                            let field_ty = &resolved_fields[arg_idx];
-                            if let IrPattern::Literal { expr: lit_expr } = arg_pat {
-                                wasm!(self.func, { local_get(scratch); });
-                                self.emit_load_at(field_ty, field_offset);
-                                self.emit_expr(lit_expr);
-                                match field_ty {
-                                    Ty::Int => { wasm!(self.func, { i64_eq; }); }
-                                    Ty::String => { wasm!(self.func, { call(self.emitter.rt.string.eq); }); }
-                                    _ => { wasm!(self.func, { i32_eq; }); }
-                                }
-                                cond_count += 1;
-                            }
-                            field_offset += values::byte_size(field_ty);
+                            let field_ty = resolved_fields[arg_idx].clone();
+                            // #607: recursive discriminant tests (literal + nested
+                            // ctor tag + Some/None) instead of only top-level literals.
+                            cond_count += self.emit_arg_tests(scratch, field_offset, &field_ty, arg_pat);
+                            field_offset += values::byte_size(&field_ty);
                         }
                         for _ in 1..cond_count {
                             wasm!(self.func, { i32_and; });
@@ -570,22 +567,17 @@ impl FuncCompiler<'_> {
                         Some(self.depth_push())
                     } else { None };
 
-                    // Bind constructor args (tuple payload fields)
+                    // Bind constructor args (recursively — #607). The flat loop
+                    // bound only top-level `Bind`; a nested ctor/Some/record arg's
+                    // inner Binds were SILENTLY DROPPED (bound 0). bind_arg walks
+                    // through nested payloads. (The discriminant tests for those
+                    // nested patterns were emitted in the guard above for non-last
+                    // arms; the last arm is exhaustive so it only binds.)
                     let mut field_offset = 4u32; // skip tag
                     for (arg_idx, arg_pat) in args.iter().enumerate() {
-                        let field_ty = &resolved_fields[arg_idx];
-
-                        if let IrPattern::Bind { var, ty: pat_ty } = arg_pat {
-                            if let Some(&local_idx) = self.var_map.get(&var.0) {
-                                let load_ty = if pat_ty.is_unresolved()
-                                    || matches!(pat_ty, Ty::Named(n, a) if a.is_empty() && n.len() <= 2)
-                                { field_ty } else { pat_ty };
-                                wasm!(self.func, { local_get(scratch); });
-                                self.emit_load_at(load_ty, field_offset);
-                                wasm!(self.func, { local_set(local_idx); });
-                            }
-                        }
-                        field_offset += values::byte_size(field_ty);
+                        let field_ty = resolved_fields[arg_idx].clone();
+                        self.bind_arg(scratch, field_offset, &field_ty, arg_pat);
+                        field_offset += values::byte_size(&field_ty);
                     }
 
                     // Handle guard on constructor
@@ -1008,6 +1000,142 @@ impl FuncCompiler<'_> {
     /// `container_scratch` is the outer pointer (Option ptr or Result ptr).
     /// `inner_offset` is the offset to load the inner value (0 for Option, 4 for Result).
     /// Returns true if body was emitted (for conditional inner patterns like Constructor).
+    /// #607: emit the DISCRIMINANT tests for one constructor-arg pattern at
+    /// `field_offset` inside the ctor pointed to by `ctor_local`, recursively.
+    /// Pushes one i32 bool per test and returns the count. The flat arm-binding
+    /// loop only handled `Bind`/`Literal`; a nested `Constructor`/`Some`/`None`/
+    /// `Ok`/`Err` arg got NO inner discriminant test, so wasm matched the wrong
+    /// arm (silent-wrong, exit 0). `RecordPattern`/`Tuple`/`Bind`/`Wildcard`
+    /// need no test (a record always matches its ctor; binds are unconditional).
+    fn emit_arg_tests(&mut self, ctor_local: u32, field_offset: u32, field_ty: &Ty, pat: &IrPattern) -> u32 {
+        match pat {
+            IrPattern::Literal { expr } => {
+                wasm!(self.func, { local_get(ctor_local); });
+                self.emit_load_at(field_ty, field_offset);
+                self.emit_expr(expr);
+                self.emit_eq_typed(field_ty);
+                1
+            }
+            IrPattern::Constructor { name, args } => {
+                let inner = self.scratch.alloc_i32();
+                wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); local_set(inner); });
+                let mut count = 0;
+                if let Some(tag) = self.find_variant_tag_by_ctor(name, field_ty) {
+                    wasm!(self.func, { local_get(inner); i32_load(0); i32_const(tag as i32); i32_eq; });
+                    count += 1;
+                }
+                let inner_fields = self.emitter.fields_of(name);
+                let mut off = 4u32;
+                for (i, ap) in args.iter().enumerate() {
+                    let aty = inner_fields.get(i).map(|(_, t)| t.clone()).unwrap_or(Ty::Int);
+                    count += self.emit_arg_tests(inner, off, &aty, ap);
+                    off += values::byte_size(&aty);
+                }
+                self.scratch.free_i32(inner);
+                count
+            }
+            IrPattern::Some { .. } => {
+                wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); i32_const(0); i32_ne; });
+                1
+            }
+            IrPattern::None => {
+                wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); i32_eqz; });
+                1
+            }
+            // A variant-RECORD ctor arg (`Held(Circle { r })`) — the inner
+            // `RecordPattern` carries the variant ctor NAME, so its tag must be
+            // tested (Circle vs Square) exactly like a tuple-payload ctor.
+            IrPattern::RecordPattern { name, .. } => {
+                if let Some(tag) = self.find_variant_tag_by_ctor(name, field_ty) {
+                    wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); i32_load(0); i32_const(tag as i32); i32_eq; });
+                    1
+                } else { 0 }
+            }
+            _ => 0,
+        }
+    }
+
+    /// #607: bind every `Bind` var reachable through a constructor-arg pattern at
+    /// `field_offset` inside `ctor_local`, recursing through nested ctor / Some /
+    /// record payloads. The discriminant tests are emitted separately (in the
+    /// arm guard); this only loads + binds, so it runs inside the matched branch.
+    fn bind_arg(&mut self, ctor_local: u32, field_offset: u32, field_ty: &Ty, pat: &IrPattern) {
+        match pat {
+            IrPattern::Bind { var, ty: pat_ty } => {
+                if let Some(&local_idx) = self.var_map.get(&var.0) {
+                    let load_ty = if pat_ty.is_unresolved()
+                        || matches!(pat_ty, Ty::Named(n, a) if a.is_empty() && n.len() <= 2)
+                    { field_ty } else { pat_ty };
+                    wasm!(self.func, { local_get(ctor_local); });
+                    self.emit_load_at(load_ty, field_offset);
+                    wasm!(self.func, { local_set(local_idx); });
+                }
+            }
+            IrPattern::Constructor { name, args } => {
+                let inner = self.scratch.alloc_i32();
+                wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); local_set(inner); });
+                let inner_fields = self.emitter.fields_of(name);
+                let mut off = 4u32;
+                for (i, ap) in args.iter().enumerate() {
+                    let aty = inner_fields.get(i).map(|(_, t)| t.clone()).unwrap_or(Ty::Int);
+                    self.bind_arg(inner, off, &aty, ap);
+                    off += values::byte_size(&aty);
+                }
+                self.scratch.free_i32(inner);
+            }
+            IrPattern::Some { inner: inner_pat } => {
+                // Some payload is at offset 0 of the inner pointer.
+                let inner = self.scratch.alloc_i32();
+                wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); local_set(inner); });
+                let payload_ty = match field_ty {
+                    Ty::Applied(_, a) => a.first().cloned().unwrap_or(Ty::Int),
+                    _ => Ty::Int,
+                };
+                self.bind_arg(inner, 0, &payload_ty, inner_pat);
+                self.scratch.free_i32(inner);
+            }
+            IrPattern::RecordPattern { name, fields: pat_fields, .. } => {
+                // The record value is a pointer at field_offset. For a
+                // variant-RECORD ctor (named) the fields sit AFTER the 4-byte
+                // tag; resolve the ctor's fields for the offsets (mirrors the
+                // top-level RecordPattern arm).
+                let rec = self.scratch.alloc_i32();
+                wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); local_set(rec); });
+                let is_variant = self.find_variant_tag_by_ctor(name, field_ty).is_some();
+                let tag_off = if is_variant { 4u32 } else { 0u32 };
+                let rec_fields = if is_variant {
+                    self.emitter.fields_of(name)
+                } else {
+                    self.extract_record_fields(field_ty)
+                };
+                for pf in pat_fields {
+                    if let Some((off, fty)) = super::values::field_offset(&rec_fields, &pf.name) {
+                        let total = tag_off + off;
+                        match &pf.pattern {
+                            Some(IrPattern::Bind { var, .. }) => {
+                                if let Some(&local_idx) = self.var_map.get(&var.0) {
+                                    wasm!(self.func, { local_get(rec); });
+                                    self.emit_load_at(&fty, total);
+                                    wasm!(self.func, { local_set(local_idx); });
+                                }
+                            }
+                            Some(inner_pat) => self.bind_arg(rec, total, &fty, inner_pat),
+                            None => {
+                                if let Some(&local_idx) = self.find_var_by_field(&pf.name, &rec_fields) {
+                                    wasm!(self.func, { local_get(rec); });
+                                    self.emit_load_at(&fty, total);
+                                    wasm!(self.func, { local_set(local_idx); });
+                                }
+                            }
+                        }
+                    }
+                }
+                self.scratch.free_i32(rec);
+            }
+            _ => {}
+        }
+    }
+
     fn emit_inner_pattern_and_body(
         &mut self,
         inner: &IrPattern,

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-69 contracts
+70 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -97,4 +97,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-067 | The xs[i] index syntax aborts on out-of-bounds (read and write) |  | active | fixture | 1 |
 | C-068 | Auto-? is target-directed in construction positions |  | active | fixture | 2 |
 | C-069 | Effect-fn tail self-recursion loop-converts to O(1) stack on both targets |  | active | fixture | 1 |
+| C-070 | Nested constructor patterns match and bind identically on both targets |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -869,3 +869,12 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/effect_tco.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-070"
+title     = "Nested constructor patterns match and bind identically on both targets"
+statement = "A NESTED pattern as the argument of a user-defined constructor pattern — `Wrap(A(n))`, `Box(Some(n))`, `Held(Circle { r })`, `Node(Leaf(a), Leaf(b))` — emits the inner discriminant test(s) into the arm guard and binds the inner payload(s) recursively, byte-identical native == wasm. The wasm match backend's constructor arm-binding loop previously handled only top-level `Bind`/`Literal` args: a nested ctor / Some / None / variant-record arg got NO inner discriminant test and bound garbage (0), so wasm SILENTLY took the wrong arm (exit 0) while native was correct (and a nested ctor on a recursive boxed variant additionally emitted invalid Rust). Now `emit_arg_tests` recurses the discriminant tests into the guard and `bind_arg` recurses the binding through nested ctor / Some / variant-record payloads."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/nested_ctor_pattern.almd", class = "fixture" },
+]

--- a/spec/wasm_cross/nested_ctor_pattern.almd
+++ b/spec/wasm_cross/nested_ctor_pattern.almd
@@ -1,0 +1,35 @@
+// @contract: C-070
+// #607: a NESTED pattern as the argument of a user-defined constructor pattern
+// (Wrap(A(n)), Box(Some(n)), Held(Circle { r })) is matched + bound identically
+// native == wasm. The wasm match backend's ctor-arm binding loop only handled
+// top-level Bind/Literal, so a nested ctor/Some/None/record arg got NO inner
+// discriminant test and bound garbage (0) — it silently took the wrong arm
+// (exit 0). Now the discriminant tests recurse into the arm guard and binding
+// recurses through the nested payloads.
+type Inner = A(Int) | B(Int)
+type Outer = Wrap(Inner)
+fn pick(o: Outer) -> String = match o {
+  Wrap(A(n)) => "A:" + int.to_string(n),
+  Wrap(B(n)) => "B:" + int.to_string(n),
+}
+
+type Hold = Box(Option[Int])
+fn opt(h: Hold) -> Int = match h { Box(Some(n)) => n, Box(None) => -1 }
+
+type Sh =
+  | Circle { r: Int }
+  | Square { s: Int }
+type HS = Held(Sh)
+fn area(h: HS) -> Int = match h {
+  Held(Circle { r }) => r,
+  Held(Square { s }) => s * 100,
+}
+
+fn main() -> Unit = {
+  println(pick(Wrap(A(7))))
+  println(pick(Wrap(B(9))))
+  println(int.to_string(opt(Box(Some(8)))))
+  println(int.to_string(opt(Box(None))))
+  println(int.to_string(area(Held(Circle { r: 3 }))))
+  println(int.to_string(area(Held(Square { s: 4 }))))
+}


### PR DESCRIPTION
## #607 — wasm match silently ignores nested constructor patterns

### Root cause
The wasm match backend's constructor-arm code (`emit_wasm/control.rs`) only handled **top-level** `Bind`/`Literal` args. A nested pattern as a ctor arg — `Wrap(A(n))`, `Box(Some(n))`, `Box(None)`, `Held(Circle { r })` — got **no inner discriminant test** and bound garbage (`0`). wasm therefore SILENTLY took the wrong arm (exit 0) while native was correct. Pure silent-wrong divergence.

### Fix
Two recursive helpers in `control.rs`:
- `emit_arg_tests` — recurses the inner discriminant test(s) into the arm guard (Literal eq, ctor tag test, `Some`/`None` null-check, variant-record tag test), summing the condition count.
- `bind_arg` — recurses the binding through nested ctor / `Some` / variant-record / plain-record payloads, resolving field offsets (`4+foff` under a variant tag).

### Completeness mechanism (per "kill the class, not the instance")
- **Fixture lock**: `spec/wasm_cross/nested_ctor_pattern.almd` covers plain nested ctor `Wrap(A(n))`, inner `Option` `Box(Some)/Box(None)`, and variant-record `Held(Circle{r})/Held(Square{s})` — byte-identical native == wasm via the `wasm_cross_target_spec` gate.
- **Contract**: new `C-070` in the ledger, bidirectionally linked to the fixture.
- The detection meta-gap (wasm-only silent failures masked by `almide test`'s native fallback) was already closed in #609, so this whole class is now loud going forward.

### Verification
- native `spec/`: all 268 files pass
- wasm explicit `spec/`: 258 passed, 0 failed
- byte gate (`wasm_runtime_test`): 67/67
- `cargo test --release`: 0 FAILED suites
- contract ledger: 122/122 bidirectional

### Out of scope (separate issue)
The native side of `#610` — a nested ctor over a **recursive boxed** variant (`Node(Leaf(a), Leaf(b))`) — still emits invalid Rust (over-deref in `pass_box_deref.rs`). The wasm side of that case is fixed by this PR; the native ICE is tracked in #610. This fixture deliberately uses only non-recursive nested patterns.