### PR TITLE
Reject bang unwrap outside an error-propagating context (E022) (#608)

### DIFF
--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -890,6 +890,7 @@ impl Checker {
             ExprKind::Unwrap { expr: inner, .. } => {
                 let t = self.infer_expr(inner);
                 let resolved = resolve_ty(&t, &self.uf);
+                self.check_unwrap_propagation_context();
                 if let Some(inner_ty) = resolved.option_inner().or_else(|| resolved.result_ok_ty()) {
                     inner_ty
                 } else if matches!(&resolved, Ty::Unknown | Ty::TypeVar(_)) {
@@ -1047,6 +1048,34 @@ impl Checker {
         ret
     }
 
+    /// `expr!` propagates the unwrapped error: lowering renders it as `?`
+    /// (effect fn body) or `.unwrap()` (test block). In any other context the
+    /// generated `?` lands in a function/closure that does not return Result,
+    /// which is invalid Rust and a wasm build failure — yet the type checker
+    /// previously accepted it (the `Result/Option → T` rule alone). Error
+    /// propagation is possible exactly where `auto_unwrap` is live (an effect
+    /// fn body, outside any lambda) or inside a `test` block; reject everywhere
+    /// else at type-check time so the failure is a clear diagnostic, not a
+    /// codegen ICE (#608).
+    fn check_unwrap_propagation_context(&mut self) {
+        if self.env.auto_unwrap || self.env.in_test_block {
+            return;
+        }
+        // Inside a lambda within an effect fn the call site *looks* effectful,
+        // but `?` cannot propagate out of the closure (#489) — point there
+        // specifically; otherwise the fn just needs to be `effect fn`.
+        let hint = if self.env.can_call_effect && self.env.lambda_depth > 0 {
+            "`!` cannot propagate an error out of a lambda; use `??` for a fallback value or move the call out of the closure"
+        } else {
+            "Mark the enclosing function as `effect fn`, or use `??` to provide a fallback value"
+        };
+        self.emit(super::err(
+            "operator '!' propagates errors and is only valid inside an `effect fn` body or a `test` block".to_string(),
+            hint,
+            "operator !",
+        ).with_code("E022"));
+    }
+
     fn infer_pipe(&mut self, left: &mut Box<ast::Expr>, right: &mut Box<ast::Expr>) -> Ty {
         // Unwrap postfix operators (??, !, ?) on the RHS so the pipe targets the inner Call.
         // e.g. `xs |> list.find(pred) ?? fallback` → pipe into list.find, then apply ??
@@ -1064,6 +1093,7 @@ impl Checker {
             }
             ExprKind::Unwrap { expr: inner, .. } => {
                 let inner_ty = self.infer_pipe(left, inner);
+                self.check_unwrap_propagation_context();
                 // Annotate the inner expression with its resolved type so the lowering
                 // can construct the correct IR type (e.g., Result[List[T], List[E]] for
                 // result.collect rather than hardcoding Result[T, String]).

--- a/docs/diagnostics/E022.md
+++ b/docs/diagnostics/E022.md
@@ -1,0 +1,62 @@
+# E022 — `!` operator outside an error-propagating context
+
+The postfix `!` operator unwraps an `Option[T]`/`Result[T, E]` to `T`
+**and propagates the error** — lowering renders it as `?` (in an
+`effect fn` body) or `.unwrap()` (in a `test` block). In any other
+context there is nowhere to propagate to: the generated `?` would land
+in a function that does not return `Result`, which is invalid code on
+every target. `!` is therefore only valid inside an `effect fn` body or
+a `test` block.
+
+## Common cases
+
+```almide
+fn parse_or_die(s: String) -> Int = int.parse(s)!   // E022: pure fn
+
+effect fn run() -> Int = {
+  let f = (s: String) => int.parse(s)!              // E022: inside a lambda
+  f("7")
+}
+```
+
+## Diagnostic
+
+```
+error[E022]: operator '!' propagates errors and is only valid inside an `effect fn` body or a `test` block
+  hint: Mark the enclosing function as `effect fn`, or use `??` to provide a fallback value
+```
+
+Inside a lambda the hint is specialized — `!` cannot propagate out of a
+closure (the closure does not return `Result`), so the fix is to supply
+a fallback or move the call out of the closure.
+
+## Fix
+
+- Mark the enclosing function `effect fn` so `!` can propagate:
+  ```almide
+  effect fn parse_or_die(s: String) -> Int = int.parse(s)!
+  ```
+- Or use `??` to provide a fallback value (works in any function):
+  ```almide
+  fn parse_or_zero(s: String) -> Int = int.parse(s) ?? 0
+  ```
+- Inside a lambda, lift the fallible call out, or use `??` within the
+  closure body.
+
+## Why
+
+`!` exists to make error propagation terse where propagation is
+*possible*: an `effect fn` returns `Result`, so the unwrapped error
+becomes an early `Err(...)` return; a `test` block treats an unwrap
+failure as a test failure. A pure `fn` has no error channel — accepting
+`!` there would silently compile to a `?` against a non-`Result` return
+type, which is a codegen failure rather than a clear diagnostic.
+Rejecting it at type-check time keeps the effect boundary honest: a pure
+`fn` signature means "cannot fail," and `!` would break that promise.
+
+## Related
+
+- E006 — Pure fn calls effect fn (the sibling effect-boundary rule)
+- `??` — unwrap with a fallback value (valid in any function)
+- `?` — convert `Result[T, E]` to `Option[T]` (does not propagate)
+- `docs/CHEATSHEET.md` — `??` / `?` / `!` operator reference

--- a/llms.txt
+++ b/llms.txt
@@ -169,6 +169,7 @@ let root_i = float.to_int(root_f)    // truncating
 | E019 | Ambiguous variant constructor (same ctor name in two or more types) | Rename the constructor in one of the types so the name is unique (a qualified `Type.Ctor` is not yet supported) |
 | E020 | Two distinct types share one name with different structures | Rename one of the colliding types |
 | E021 | Invalid record construction/pattern shape (positional args on a record, unknown/duplicate/missing field, paren pattern on a record case) | Records take named fields: `Cfg(name: x)` or `Cfg { name: x }`; match record cases as `Case { .. }` |
+| E022 | `!` (unwrap-propagate) outside an effect fn body or test block | Mark the enclosing fn `effect fn`, or use `??` for a fallback value (`!` inside a lambda can't propagate) |
 | E420 | Function visibility violation (callee is private) | Make the callee public, or add a public shim |
 
 A rustc 4-digit code (`error[E0XXX]`) leaking through always indicates

--- a/tests/diagnostics/e022-bang-outside-effect/broken.almd
+++ b/tests/diagnostics/e022-bang-outside-effect/broken.almd
@@ -1,0 +1,6 @@
+// `!` propagates the unwrapped error, which lowering renders as `?`.
+// In a pure fn (no Result return) that `?` is invalid Rust — and previously
+// the checker accepted it, so the failure surfaced only as a codegen ICE
+// ("codegen produced invalid Rust") on native and a wasm build failure.
+// E022 now rejects it at type-check time. (#608)
+fn parse_or_die(s: String) -> Int = int.parse(s)!

--- a/tests/diagnostics/e022-bang-outside-effect/fixed.almd
+++ b/tests/diagnostics/e022-bang-outside-effect/fixed.almd
@@ -1,0 +1,4 @@
+// The fix: mark the function `effect fn` so `!` can propagate the error,
+// or use `??` to supply a fallback. Either compiles cleanly.
+effect fn parse_or_die(s: String) -> Int = int.parse(s)!
+fn parse_or_zero(s: String) -> Int = int.parse(s) ?? 0

--- a/tests/diagnostics/e022-bang-outside-effect/meta.toml
+++ b/tests/diagnostics/e022-bang-outside-effect/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E022"
+expects_error = "operator '!'"
+hint_substring = "effect fn"


### PR DESCRIPTION
## #608 — `!` accepted by the checker in a pure fn, then ICEs in codegen

### Root cause
`expr!` propagates the unwrapped error: lowering renders it as `?` (effect fn body) or `.unwrap()` (test block). The checker's `Unwrap` rule only required the operand to be `Option`/`Result` — it never checked whether the **enclosing context can propagate the error**. So `int.parse(s)!` in a pure `fn -> Int` type-checked ("No errors found") and then emitted `(int.parse(s))?` inside a function that does not return `Result`:

```
error: codegen produced invalid Rust — this is an Almide bug.
```

(native ICE; wasm build failure). Pure checker-accepts-but-codegen-rejects soundness hole. The same class also hit `!` used **inside a lambda** within an effect fn — `?` can't propagate out of the closure (#489), and that too produced invalid Rust.

### Fix
A single propagation-context gate (`check_unwrap_propagation_context`), called from both the direct and the piped `Unwrap` arms. `!` is valid exactly where error propagation is possible:
- `auto_unwrap` live — an `effect fn` body, outside any lambda, AND
- inside a `test` block (`in_test_block`).

Everywhere else → **E022** with a context-aware hint (lambda vs. mark-effect-fn).

### Completeness mechanism (kill the class, not the instance)
- The gate itself closes the whole class structurally: it tracks *propagation possibility*, not the one `int.parse` shape, so every fallible call in a non-propagating context is caught.
- **Diagnostic fixture** `tests/diagnostics/e022-bang-outside-effect/` — `broken.almd` asserts the E022 code/message/hint; `fixed.almd` (the `effect fn` form **and** the `??` form) is compiled clean by the harness. The harness pins *both* "the error fires" and "the suggested fix actually compiles" — the latter is exactly the meta-gap this class lived in.
- The **hard** coverage gate (`diagnostic_coverage_test.rs`, `SOFT_GATE=false`) forced this PR to also ship `docs/diagnostics/E022.md`; a new `with_code` without its fixture + doc now fails CI.

### Verification
- native `spec/`: 268/268 · wasm `spec/`: 258 passed, 0 failed · detector: 268/268
- `cargo test --release`: 0 FAILED suites (diagnostic harness 4/4, coverage 2/2)
- the heavy `!` user `spec/lang/result_option_matrix_test.almd` still passes (all uses are effect-fn / test)

### Sibling
Same meta-class (checker accepts → codegen ICE) as the Codec-derive field gate (#611), tracked separately — different root cause (derive field-type derivability), shipped on its own branch.