### PR TITLE
Reject deriving Codec/Ord/Hash when a field type does not derive it (E023) (#611)

### DIFF
--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -9,7 +9,7 @@ use almide_lang::ast;
 use almide_base::diagnostic::Diagnostic;
 use almide_base::intern::{Sym, sym};
 use almide_lang::types::TypeConstructorId;
-use crate::types::{Ty, TypeEnv, FnSig, ProtocolDef, ProtocolMethodSig};
+use crate::types::{Ty, TypeEnv, FnSig, ProtocolDef, ProtocolMethodSig, VariantPayload};
 use super::resolve::resolve_type_expr;
 
 fn err(msg: impl Into<String>, hint: impl Into<String>, ctx: impl Into<String>) -> Diagnostic {
@@ -329,6 +329,118 @@ pub fn register_protocol_decl(env: &mut TypeEnv, name: &str, generics: &Option<V
         generics: gnames,
         methods: method_sigs,
     });
+}
+
+/// Protocols whose auto-derive RECURSES INTO EACH FIELD'S TYPE: deriving them
+/// on a struct/variant emits per-field work that requires the field type to
+/// ALSO satisfy the protocol. `Codec` calls `Field.encode` / `Field.decode`;
+/// `Ord`/`Hash` lower to a Rust `#[derive(Ord/Hash)]` that needs the field's
+/// Rust type to impl it. `Eq`/`Repr` are excluded — every generated struct
+/// gets `PartialEq` + a repr path unconditionally, so a field need not declare
+/// them (gating those would be a false positive).
+const FIELD_RECURSIVE_PROTOCOLS: &[&str] = &["Codec", "Ord", "Hash"];
+
+/// The field-type slots a structural type exposes to its derive: record fields,
+/// and every variant case's payload (tuple positions / record fields).
+fn type_field_slots(ty: &Ty) -> Vec<(String, Ty)> {
+    match ty {
+        Ty::Record { fields } | Ty::OpenRecord { fields } =>
+            fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect(),
+        Ty::Variant { cases, .. } => {
+            let mut out = Vec::new();
+            for c in cases {
+                match &c.payload {
+                    VariantPayload::Unit => {}
+                    VariantPayload::Tuple(ts) => for (i, t) in ts.iter().enumerate() {
+                        out.push((format!("{}.{}", c.name, i), t.clone()));
+                    },
+                    VariantPayload::Record(fs) => for (n, t) in fs {
+                        out.push((n.to_string(), t.clone()));
+                    },
+                }
+            }
+            out
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// The nominal leaf types a derive must recurse into for one field type,
+/// descending through the standard containers (List/Option/Set/Map/Result via
+/// `Applied`, tuples, nested anon records). A `List[Pigment]` field under a
+/// `: Codec` type requires `Pigment` to be Codec, so the leaf is `Pigment`.
+fn collect_leaf_nominals(ty: &Ty, out: &mut Vec<Sym>) {
+    match ty {
+        Ty::Named(n, args) => {
+            out.push(*n);
+            for a in args { collect_leaf_nominals(a, out); }
+        }
+        Ty::Variant { name, .. } => out.push(*name),
+        Ty::Applied(_, args) => for a in args { collect_leaf_nominals(a, out); },
+        Ty::Tuple(elems) => for e in elems { collect_leaf_nominals(e, out); },
+        Ty::Record { fields } | Ty::OpenRecord { fields } =>
+            for (_, t) in fields { collect_leaf_nominals(t, out); },
+        _ => {}
+    }
+}
+
+/// Does user type `leaf` satisfy protocol `proto`? Keyed leniently: `type_protocols`
+/// is interned bare, but a cross-module field type may carry a qualified
+/// `mod.Type` name — accept either spelling. For `Codec`, a hand-written
+/// `Type.encode`/`Type.decode` pair (without a `: Codec` declaration) also
+/// satisfies the requirement, since the derive only needs those functions to exist.
+fn leaf_satisfies(env: &TypeEnv, leaf: Sym, proto: &str) -> bool {
+    let bare = leaf.as_str().rsplit('.').next().unwrap_or(leaf.as_str());
+    let declares = |name: &str| env.type_protocols.get(&sym(name))
+        .map_or(false, |s| s.contains(&sym(proto)));
+    if declares(leaf.as_str()) || declares(bare) {
+        return true;
+    }
+    if proto == "Codec" {
+        let has = |m: &str| env.functions.contains_key(&sym(&format!("{}.{}", leaf, m)))
+            || env.functions.contains_key(&sym(&format!("{}.{}", bare, m)));
+        return has("encode") && has("decode");
+    }
+    false
+}
+
+/// A type that derives a field-recursive protocol (Codec/Ord/Hash) requires
+/// every field type to ALSO satisfy it — otherwise the derive emits a call to a
+/// non-existent `Field.encode` (Codec) or a Rust `#[derive(Ord/Hash)]` over a
+/// field whose Rust type lacks the impl, both of which the checker previously
+/// accepted and codegen then rejected as "invalid Rust" (#611). This validates
+/// the requirement structurally, at the checker, independent of target.
+fn validate_derive_field_support(env: &TypeEnv, diagnostics: &mut Vec<Diagnostic>) {
+    let pairs: Vec<(Sym, Vec<Sym>)> = env.type_protocols.iter()
+        .map(|(ty, protos)| (*ty, protos.iter().copied().collect()))
+        .collect();
+    let mut reported: std::collections::HashSet<(Sym, Sym, Sym)> = std::collections::HashSet::new();
+    for (type_name, protocols) in &pairs {
+        let Some(ty) = env.types.get(type_name) else { continue };
+        let slots = type_field_slots(ty);
+        if slots.is_empty() { continue; }
+        for proto in protocols {
+            let p = proto.as_str();
+            if !FIELD_RECURSIVE_PROTOCOLS.contains(&p) { continue; }
+            for (field_name, field_ty) in &slots {
+                let mut leaves = Vec::new();
+                collect_leaf_nominals(field_ty, &mut leaves);
+                for leaf in leaves {
+                    if leaf == *type_name { continue; }          // self-reference is fine
+                    if !env.types.contains_key(&leaf) { continue; } // not a user nominal → native support
+                    if leaf_satisfies(env, leaf, p) { continue; }
+                    if !reported.insert((*type_name, *proto, leaf)) { continue; }
+                    diagnostics.push(err(
+                        format!("type '{}' derives '{}' but field '{}' has type '{}', which does not derive '{}'",
+                            type_name, p, field_name, leaf, p),
+                        format!("Add `: {}` to the declaration of type '{}' (every field of a `: {}` type must itself be `{}`)",
+                            p, leaf, p, p),
+                        format!("type {} : {}", type_name, p),
+                    ).with_code("E023"));
+                }
+            }
+        }
+    }
 }
 
 /// Validate that types declaring `: ProtocolName` have all required convention methods.
@@ -712,4 +824,5 @@ pub fn register_decls(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, decl
         }
     }
     validate_protocol_impls(env, diagnostics);
+    validate_derive_field_support(env, diagnostics);
 }

--- a/docs/diagnostics/E023.md
+++ b/docs/diagnostics/E023.md
@@ -1,0 +1,61 @@
+# E023 — derived protocol not satisfied by a field type
+
+`Codec`, `Ord`, and `Hash` are **field-recursive** protocols: deriving one
+on a struct or variant generates per-field work that requires *every field
+type to also satisfy the same protocol*.
+
+- `Codec` — the derived `encode`/`decode` call `Field.encode` / `Field.decode`.
+- `Ord` / `Hash` — lower to a Rust `#[derive(Ord/Hash)]` over each field, so
+  each field's underlying type must impl it.
+
+If a field type does not derive the protocol, the generated code references a
+method (or trait impl) that does not exist. The checker now rejects this
+structurally instead of letting it fail later as a codegen error.
+
+## Common cases
+
+```almide
+type Raw = { x: Int }                  // NOT : Codec
+type Wrap: Codec = { item: Raw }       // E023: Raw does not derive Codec
+
+type Point = { x: Int, y: Int }        // NOT : Ord
+type Edge: Ord = { a: Point, b: Point } // E023: Point does not derive Ord
+```
+
+Containers are transparent: a `List[Raw]` / `Option[Raw]` field still requires
+`Raw` to derive the protocol.
+
+## Diagnostic
+
+```
+error[E023]: type 'Wrap' derives 'Codec' but field 'item' has type 'Raw', which does not derive 'Codec'
+  hint: Add `: Codec` to the declaration of type 'Raw' (every field of a `: Codec` type must itself be `Codec`)
+```
+
+## Fix
+
+- Derive the protocol on the field type too:
+  ```almide
+  type Raw: Codec = { x: Int }
+  type Wrap: Codec = { item: Raw }
+  ```
+- For `Codec`, a hand-written `Raw.encode` / `Raw.decode` pair also satisfies
+  the requirement (the derive only needs those functions to exist).
+
+## Why
+
+Derivation is structural recursion: a type is `Codec` only if its parts are
+`Codec`. Accepting `Wrap: Codec` while `Raw` is not Codec would compile to a
+call against a non-existent `Raw.encode` — a codegen failure rather than a
+clear diagnostic. Enforcing the requirement at the type level keeps "this type
+derives P" an honest, transitively-true claim, and makes the fix obvious and
+local.
+
+`Eq` and `Repr` are **not** subject to E023: every generated struct gets
+`PartialEq` and a repr path unconditionally, so a field need not declare them.
+
+## Related
+
+- E020 — duplicate type declaration with a different structure
+- `docs/CHEATSHEET.md` — `: Codec` / `: Ord` / `: Hash` derive reference
+- `docs/STDLIB-SPEC.md` — Codec / value module

--- a/llms.txt
+++ b/llms.txt
@@ -169,6 +169,7 @@ let root_i = float.to_int(root_f)    // truncating
 | E019 | Ambiguous variant constructor (same ctor name in two or more types) | Rename the constructor in one of the types so the name is unique (a qualified `Type.Ctor` is not yet supported) |
 | E020 | Two distinct types share one name with different structures | Rename one of the colliding types |
 | E021 | Invalid record construction/pattern shape (positional args on a record, unknown/duplicate/missing field, paren pattern on a record case) | Records take named fields: `Cfg(name: x)` or `Cfg { name: x }`; match record cases as `Case { .. }` |
+| E023 | Derived `Codec`/`Ord`/`Hash` not satisfied by a field type | Add `: P` to the offending field type (every field of a `: P` type must itself be `P`) — or hand-write `Type.encode`/`decode` for Codec |
 | E420 | Function visibility violation (callee is private) | Make the callee public, or add a public shim |
 
 A rustc 4-digit code (`error[E0XXX]`) leaking through always indicates

--- a/tests/diagnostics/e023-derive-field-not-derivable/broken.almd
+++ b/tests/diagnostics/e023-derive-field-not-derivable/broken.almd
@@ -1,0 +1,8 @@
+// A `: Codec` type whose field type `Raw` does not itself derive Codec.
+// The derived `Wrap.encode` calls `Raw.encode`, which does not exist — the
+// checker used to accept this and codegen then failed ("invalid Rust") on
+// native and the wasm build. E023 rejects it structurally. (#611)
+// (Ord and Hash share the same field-recursive requirement.)
+type Raw = { x: Int }
+type Wrap: Codec = { item: Raw }
+fn main() -> Unit = println("unreachable")

--- a/tests/diagnostics/e023-derive-field-not-derivable/fixed.almd
+++ b/tests/diagnostics/e023-derive-field-not-derivable/fixed.almd
@@ -1,0 +1,4 @@
+// The fix: every field of a `: Codec` type must itself be `: Codec`.
+type Raw: Codec = { x: Int }
+type Wrap: Codec = { item: Raw }
+fn main() -> Unit = println("ok")

--- a/tests/diagnostics/e023-derive-field-not-derivable/meta.toml
+++ b/tests/diagnostics/e023-derive-field-not-derivable/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E023"
+expects_error = "does not derive"
+hint_substring = "must itself be"


### PR DESCRIPTION
## #611 — a `: Codec` (or `: Ord` / `: Hash`) type with a non-deriving field

### Root cause
`Codec`, `Ord`, and `Hash` are **field-recursive** derives:
- `Codec` — the derived `encode`/`decode` call `Field.encode` / `Field.decode`.
- `Ord` / `Hash` — lower to a Rust `#[derive(Ord/Hash)]` over each field.

Both require every field type to *also* satisfy the protocol. The checker only verified the deriving type had its own methods, never the fields. So:

```almide
type Raw = { x: Int }              // NOT : Codec
type Wrap: Codec = { item: Raw }   // checker: "No errors found"
```

type-checked, then emitted a call to the non-existent `Raw.encode` →

```
error: codegen produced invalid Rust — this is an Almide bug.
```

(native ICE; wasm build failure). Same meta-class as #608 — checker accepts, codegen can't compile. Confirmed identically for `Ord` and `Hash`; `Eq`/`Repr` are NOT affected (every generated struct gets `PartialEq` + a repr path unconditionally).

### Fix
A structural derivability gate (`validate_derive_field_support`) run after registration. For each type deriving a field-recursive protocol P ∈ {Codec, Ord, Hash}, it descends every field type through the standard containers (List/Option/Set/Map/Result/tuples) to the nominal leaves and requires each user-defined leaf to satisfy P — `: P` declared, or (for Codec) a hand-written `encode`/`decode` pair. Otherwise **E023**. Self-reference and primitive/stdlib/external leaves are skipped (the latter is the false-positive safety valve).

### Completeness mechanism (kill the class, not the instance)
- The gate is the structural mechanism: it closes the *whole* "derive recurses into a non-deriving field" class for all three protocols and all container nestings, not just `Raw`/`Wrap`.
- **Diagnostic fixture** `tests/diagnostics/e023-derive-field-not-derivable/` — `broken.almd` asserts the code/message/hint; `fixed.almd` is compiled clean by the harness (pinning that the suggested fix actually works — the meta-gap).
- The two **hard** doc gates forced this PR to also ship `docs/diagnostics/E023.md` (coverage gate) and the `llms.txt` E023 row (`docs-gen --check`); a new `with_code` without all three now fails CI.

### Verification
- native `spec/`: 268/268 · wasm `spec/`: 258 passed, 0 failed · detector: 268/268 (no corpus false positives)
- `cargo test --release`: 0 FAILED suites (diagnostic harness 4/4, coverage 2/2, docs-gen 2/2)
- false-positive guards verified: field-derives-P, primitive/List/Option fields, self-recursive, Eq/Repr-not-gated — all clean

### Sibling
Same meta-class as #608 (`!` outside an effect/test context, E022), shipped separately — different root cause.