### PR TITLE
Fix nine round-5 cross-target/codegen bugs (#622 #624 #627 #629–#634)

### DIFF
--- a/crates/almide-codegen/rt-oracle-registry.toml
+++ b/crates/almide-codegen/rt-oracle-registry.toml
@@ -476,7 +476,7 @@ status = "verified"
 class = "fixture"
 oracle = "runtime/rs/src/string.rs::almide_rt_string_replace (str::replace)"
 test = "tests/wasm_runtime_test.rs::wasm_cross_target_spec"
-note = "spec/wasm_cross/string_ops.almd uses string.replace."
+note = "spec/wasm_cross/string_ops.almd uses string.replace; r5_wasm_split_replace_iterative.almd (#634) pins the de-recursed loop on large inputs (6000 occurrences) and the empty-`from` codepoint-boundary insertion."
 
 [[routine]]
 file = "rt_string.rs"
@@ -485,7 +485,7 @@ status = "verified"
 class = "fixture"
 oracle = "runtime/rs/src/string.rs::almide_rt_string_split (str::split)"
 test = "tests/wasm_runtime_test.rs::wasm_string_split"
-note = "wasm_string_split + wasm_string_split_empty (now also asserts the empty-delimiter CODEPOINT split, leading/trailing empties) differential tests; spec/wasm_cross/string_split_rle_codepoint.almd (C-050) pins the empty-delimiter path; string_ops.almd also drives it."
+note = "wasm_string_split + wasm_string_split_empty (now also asserts the empty-delimiter CODEPOINT split, leading/trailing empties) differential tests; spec/wasm_cross/string_split_rle_codepoint.almd (C-050) pins the empty-delimiter path; string_ops.almd also drives it; r5_wasm_split_replace_iterative.almd (#634) pins the de-recursed forward-scan loop on 5000+ segments."
 
 [[routine]]
 file = "rt_string.rs"

--- a/crates/almide-codegen/src/emit_wasm/calls_string_repr.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string_repr.rs
@@ -143,14 +143,36 @@ impl FuncCompiler<'_> {
                 };
                 self.emit_repr_record(type_name.as_deref(), &fields);
             }
-            // ── Anonymous records → inline literal walk (no type name) ──
-            // Structurally finite (an anon record cannot reference itself), so
-            // inline expansion is safe. Fields render in SORTED name order to
-            // match the native synthesized struct (`AlmdRec_*` field order is the
-            // sorted field-name list); see `emit_repr_record`.
+            // ── Structural records → inline literal walk ──
+            // A record literal inferred WITHOUT an annotation keeps its structural
+            // `Ty::Record`, but if its field set matches a DECLARED record type the
+            // native checker promotes it to that nominal type — so the repr must
+            // adopt the type name + its DECLARATION field order (#627). We recover
+            // that name by the sorted field-name set (mirrors the native walker's
+            // `named_records` lookup). No match → a truly anonymous record, which
+            // native renders prefix-less in SORTED name order (`AlmdRec_*`).
             Ty::Record { .. } | Ty::OpenRecord { .. } => {
+                // `fields` is the value's ACTUAL in-memory LAYOUT (the literal's
+                // structural field order); field VALUES load from its offsets. If
+                // the field-set matches a declared record type, native promotes the
+                // repr to that nominal type — `TypeName { … }` rendered in the
+                // type's DECLARATION order (#627). The render order is decoupled
+                // from the layout, so a literal written out of declaration order
+                // still loads correct values. No match → truly anonymous: no
+                // prefix, rendered in SORTED name order.
                 let fields = self.extract_record_fields(ty);
-                self.emit_repr_record(None, &fields);
+                let mut sorted_names: Vec<String> =
+                    fields.iter().map(|(n, _)| n.to_string()).collect();
+                sorted_names.sort();
+                if let Some(type_name) = self.emitter.named_records.get(&sorted_names).cloned() {
+                    let decl_order: Vec<String> = self.emitter.record_fields
+                        .get(&type_name)
+                        .map(|fl| fl.iter().map(|(n, _)| n.to_string()).collect())
+                        .unwrap_or_default();
+                    self.emit_repr_record_ordered(Some(&type_name), &fields, Some(&decl_order));
+                } else {
+                    self.emit_repr_record(None, &fields);
+                }
             }
             // Anything else has no repr (the walker only routes backed shapes
             // here); leave the value as-is.
@@ -414,6 +436,22 @@ impl FuncCompiler<'_> {
     /// each field is still loaded from its real layout offset (source order), so
     /// reordering the render does not misalign reads.
     pub(super) fn emit_repr_record(&mut self, type_name: Option<&str>, fields: &[(String, Ty)]) {
+        self.emit_repr_record_ordered(type_name, fields, None);
+    }
+
+    /// Like [`emit_repr_record`], but the RENDER order is decoupled from the
+    /// in-memory LAYOUT. `fields` is always the value's real layout (offsets are
+    /// read from it, source order). `render_order`, when given, lists field names
+    /// in the order to print them (a declared type's declaration order, #627) —
+    /// independent of how the literal was written. `None` keeps the default:
+    /// layout order for a named record, sorted name order for an anonymous one
+    /// (matching native's `AlmdRec_*` struct).
+    pub(super) fn emit_repr_record_ordered(
+        &mut self,
+        type_name: Option<&str>,
+        fields: &[(String, Ty)],
+        render_order: Option<&[String]>,
+    ) {
         let open = match type_name {
             Some(n) => format!("{} {{ ", n),
             None => "{ ".to_string(),
@@ -421,16 +459,20 @@ impl FuncCompiler<'_> {
         let open_s = self.emitter.intern_string(&open) as i32;
         let close_s = self.emitter.intern_string(" }") as i32;
 
-        // Pair each field with its absolute layout offset (in declaration order),
-        // then choose the render order: named → declaration order; anonymous →
-        // sorted by field name (matches the native anon struct's field order).
+        // Pair each field with its absolute LAYOUT offset (source order), then
+        // choose the render order. Values always load from the true offset, so
+        // reordering the render never misaligns reads.
         let mut placed: Vec<(usize, u32)> = Vec::with_capacity(fields.len());
         let mut offset = 0u32;
         for (idx, (_, fty)) in fields.iter().enumerate() {
             placed.push((idx, offset));
             offset += values::byte_size(fty);
         }
-        if type_name.is_none() {
+        if let Some(order) = render_order {
+            placed.sort_by_key(|&(idx, _)| {
+                order.iter().position(|n| n == &fields[idx].0).unwrap_or(usize::MAX)
+            });
+        } else if type_name.is_none() {
             placed.sort_by(|&(a, _), &(b, _)| fields[a].0.cmp(&fields[b].0));
         }
 

--- a/crates/almide-codegen/src/emit_wasm/control.rs
+++ b/crates/almide-codegen/src/emit_wasm/control.rs
@@ -880,12 +880,38 @@ impl FuncCompiler<'_> {
                                     wasm!(self.func, { i32_eqz; });
                                     cond_count += 1;
                                 }
+                                IrPattern::Constructor { name: ctor_name, .. } => {
+                                    // Variant element: the tuple slot holds a pointer to
+                                    // `[tag:i32][payload…]`. Match by loading that tag and
+                                    // comparing it to the constructor's. (#633: this arm was
+                                    // missing, so a Constructor element contributed no
+                                    // condition operand → the `If` had nothing on the stack.)
+                                    if let Some(tag_val) = self.find_variant_tag_by_ctor(ctor_name, &ft) {
+                                        wasm!(self.func, {
+                                            local_get(scratch);
+                                            i32_load(offset);
+                                            i32_load(0);
+                                            i32_const(tag_val as i32);
+                                            i32_eq;
+                                        });
+                                        cond_count += 1;
+                                    }
+                                }
                                 _ => {}
                             }
                             offset += values::byte_size(&ft);
                         }
                         for _ in 1..cond_count {
                             wasm!(self.func, { i32_and; });
+                        }
+                        // Defensive: if no element produced a condition operand (e.g.
+                        // a Constructor whose element type couldn't be resolved to a
+                        // variant), the `If` would have nothing on the stack. Push a
+                        // constant `true` so the module stays well-formed — the arm
+                        // then matches unconditionally (the safe direction, and the
+                        // bind loop below still runs).
+                        if cond_count == 0 {
+                            wasm!(self.func, { i32_const(1); });
                         }
                         let bt = values::block_type(result_ty);
                         self.func.instruction(&Instruction::If(bt));
@@ -918,6 +944,31 @@ impl FuncCompiler<'_> {
                                             wasm!(self.func, { local_set(local_idx); });
                                             self.scratch.free_i32(opt_scratch);
                                         }
+                                    }
+                                }
+                                IrPattern::Constructor { name: ctor_name, args } => {
+                                    // Bind any payload binders of a variant element. The
+                                    // element slot holds a pointer to `[tag][field0]…`;
+                                    // payload fields start at byte 4. (#633)
+                                    if !args.is_empty() {
+                                        let ctor_fields = self.emitter.fields_of(ctor_name);
+                                        let var_scratch = self.scratch.alloc_i32();
+                                        wasm!(self.func, { local_get(scratch); i32_load(offset2); local_set(var_scratch); });
+                                        let mut field_offset = 4u32; // skip tag
+                                        for (arg_idx, arg_pat) in args.iter().enumerate() {
+                                            let field_ty = ctor_fields.get(arg_idx)
+                                                .map(|(_, fty)| fty.clone())
+                                                .unwrap_or(Ty::Int);
+                                            if let IrPattern::Bind { var, .. } = arg_pat {
+                                                if let Some(&local_idx) = self.var_map.get(&var.0) {
+                                                    wasm!(self.func, { local_get(var_scratch); });
+                                                    self.emit_load_at(&field_ty, field_offset);
+                                                    wasm!(self.func, { local_set(local_idx); });
+                                                }
+                                            }
+                                            field_offset += values::byte_size(&field_ty);
+                                        }
+                                        self.scratch.free_i32(var_scratch);
                                     }
                                 }
                                 _ => {}

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -480,6 +480,12 @@ pub struct WasmEmitter {
 
     // Type info: record/variant name → field list (for field offset computation)
     pub record_fields: BTreeMap<String, Vec<(String, almide_lang::types::Ty)>>,
+    // Declared RECORD types keyed by their SORTED field-name set → type name.
+    // Mirrors the native walker's `named_records` (declarations.rs): a record
+    // LITERAL inferred without annotation keeps its structural `Ty::Record`, but
+    // its repr must adopt the declared nominal type's name + declaration field
+    // order to stay byte-identical with native (#627). Excludes variant cases.
+    pub named_records: BTreeMap<Vec<String>, String>,
     // Variant info: variant type name → list of (case_name, tag, fields)
     pub variant_info: BTreeMap<String, Vec<VariantCase>>,
     // Default field values: (type_name, field_name) → default IR expr
@@ -663,6 +669,7 @@ impl WasmEmitter {
             func_table: Vec::new(),
             func_to_table_idx: HashMap::new(),
             record_fields: BTreeMap::new(),
+            named_records: BTreeMap::new(),
             variant_info: BTreeMap::new(),
             default_fields: HashMap::new(),
             lambdas: Vec::new(),
@@ -1275,6 +1282,11 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
                 let field_list: Vec<(String, almide_lang::types::Ty)> = fields.iter()
                     .map(|f| (f.name.to_string(), f.ty.clone()))
                     .collect();
+                // Index by sorted field-name set so a structural record literal
+                // can recover its declared nominal name (mirrors native, #627).
+                let mut sorted_names: Vec<String> = fields.iter().map(|f| f.name.to_string()).collect();
+                sorted_names.sort();
+                emitter.named_records.insert(sorted_names, td.name.to_string());
                 emitter.record_fields.insert(td.name.to_string(), field_list);
             }
             almide_ir::IrTypeDeclKind::Variant { cases, .. } => {
@@ -2058,18 +2070,26 @@ fn assemble(emitter: &mut WasmEmitter) -> Vec<u8> {
 /// Compile the __init_globals function.
 #[allow(dead_code)] // Will be activated when top-let WASM codegen is wired up
 fn compile_init_globals(emitter: &mut WasmEmitter, program: &IrProgram) {
-    // C-007 by construction (§4 stage 3): this function's emission order
-    // (root top-lets, then per-module) must BE `global_init_order` — the
-    // same vector the native main wrapper derives its eager forces from.
-    // Asserted rather than re-derived: a future reorder of either side
-    // becomes a build failure, not an eager-vs-init cross-target drift.
+    // C-007 by construction (§4 stage 3): this function evaluates every
+    // top-let initializer EXACTLY in `global_init_order` — the same vector the
+    // native main wrapper derives its eager forces from. The order is
+    // dependency-respecting (#632): an imported module's heap global is
+    // initialized before any importing top-let reads it. We index the
+    // initializers by VarId (root + every module flatten into
+    // `program.var_table` via UnifyVarTablesPass) and emit in that one order,
+    // so a reorder of either side stays a single source of truth, not an
+    // eager-vs-init cross-target drift.
+    let init_exprs: HashMap<u32, &almide_ir::IrExpr> = program.top_lets.iter()
+        .map(|tl| (tl.var.0, &tl.value))
+        .chain(program.modules.iter().flat_map(|m| m.top_lets.iter().map(|tl| (tl.var.0, &tl.value))))
+        .collect();
     {
-        let emitted: Vec<almide_ir::VarId> = program.top_lets.iter().map(|tl| tl.var)
-            .chain(program.modules.iter().flat_map(|m| m.top_lets.iter().map(|tl| tl.var)))
-            .collect();
-        assert_eq!(
-            emitted, program.codegen_annotations.global_init_order,
-            "[COMPILER BUG] __init_globals emission order diverged from global_init_order (C-007)"
+        // Every decl in the order must have a known initializer, and the order
+        // must cover exactly the declared top-lets — else the emission would
+        // silently skip or double-init a global.
+        debug_assert_eq!(
+            program.codegen_annotations.global_init_order.len(), init_exprs.len(),
+            "[COMPILER BUG] global_init_order does not cover the declared top-lets (C-007)"
         );
     }
     let void_type = emitter.register_type(vec![], vec![]);
@@ -2102,57 +2122,31 @@ fn compile_init_globals(emitter: &mut WasmEmitter, program: &IrProgram) {
             depth: 0,
             loop_stack: Vec::new(),
             scratch: scratch_alloc,
+            // UnifyVarTablesPass flattens every module top-let VarId into the
+            // root var_table, so one table resolves both root and module decls.
             var_table: &program.var_table,
             stub_ret_ty: Ty::Unit,
             current_module_name: None,
         };
 
-        for tl in &program.top_lets {
-            compiler.emit_expr(&tl.value);
-            if let Some(&(global_idx, _)) = compiler.emitter.top_let_globals.get(&tl.var.0) {
+        // Emit each initializer in dependency-respecting `global_init_order`
+        // (#632), so an imported module's heap global is set before any
+        // importing top-let reads it.
+        for &decl in &program.codegen_annotations.global_init_order {
+            let Some(&value) = init_exprs.get(&decl.0) else { continue };
+            compiler.emit_expr(value);
+            if let Some(&(global_idx, _)) = compiler.emitter.top_let_globals.get(&decl.0) {
                 compiler.func.instruction(&wasm_encoder::Instruction::GlobalSet(global_idx));
+            } else if let Some(&(global_idx, _)) = compiler.emitter.top_let_globals_by_name
+                .get(program.var_table.get(decl).name.as_str())
+            {
+                compiler.func.instruction(&wasm_encoder::Instruction::GlobalSet(global_idx));
+            } else {
+                compiler.func.instruction(&wasm_encoder::Instruction::Drop);
             }
         }
-        // Also initialize cross-module top_lets via name lookup (their VarIds
-        // belong to per-module var_tables, so id-keyed top_let_globals can't
-        // resolve them; we use the prefixed name set up at registration time).
         compiler.func
     };
-    // Append module top_let initializers to the same function body. Each
-    // module needs its own var_table for the FuncCompiler ctx, so we re-build
-    // a compiler per module and append instructions.
-    let mut compiled_func = compiled_func;
-    for module in &program.modules {
-        if module.top_lets.is_empty() { continue; }
-        let mut scratch_alloc = scratch::ScratchAllocator::new();
-        scratch_alloc.set_bases_with_capacity(scratch_i32_base, scratch_i32_cap, scratch_i64_base, scratch_i64_cap, scratch_f64_base, scratch_f64_cap);
-        scratch_alloc.set_v128_base(scratch_v128_base);
-        let mut mc = FuncCompiler {
-            emitter: &mut *emitter,
-            func: compiled_func,
-            var_map: HashMap::new(),
-            depth: 0,
-            loop_stack: Vec::new(),
-            scratch: scratch_alloc,
-            var_table: &program.var_table,
-            stub_ret_ty: Ty::Unit,
-            current_module_name: None,
-        };
-        for tl in &module.top_lets {
-            mc.emit_expr(&tl.value);
-            // Module top-let VarIds now index into `program.var_table`
-            // thanks to `UnifyVarTablesPass`, so the id-keyed map is
-            // the primary lookup; the name-keyed mirror is a backup.
-            if let Some(&(global_idx, _)) = mc.emitter.top_let_globals.get(&tl.var.0) {
-                mc.func.instruction(&wasm_encoder::Instruction::GlobalSet(global_idx));
-            } else if let Some(&(global_idx, _)) = mc.emitter.top_let_globals_by_name.get(program.var_table.get(tl.var).name.as_str()) {
-                mc.func.instruction(&wasm_encoder::Instruction::GlobalSet(global_idx));
-            } else {
-                mc.func.instruction(&wasm_encoder::Instruction::Drop);
-            }
-        }
-        compiled_func = mc.func;
-    }
     let compiled_func = {
         let mut f = compiled_func;
         f.instruction(&wasm_encoder::Instruction::End);

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -805,130 +805,205 @@ fn compile_index_of(emitter: &mut WasmEmitter) {
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.index_of, type_idx, f));
 }
 
+/// Iterative replace via a count-then-build forward scan. Mirrors the native
+/// oracle `s.replace(from, to)`. De-recursed (#634): the old recursion was one
+/// frame per occurrence (and INFINITE on an empty `from`, since `index_of`
+/// returns 0 forever), exhausting the wasm call stack. An empty `from` inserts
+/// `to` at every codepoint boundary: `"abc".replace("","X") == "XaXbXcX"`.
 fn compile_replace(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.replace];
+    // params: 0=s, 1=from, 2=to
+    // locals: 3=blen, 4=fl(from len), 5=tl(to len), 6=i(scan), 7=cnt,
+    //         8=result, 9=out(write off), 10=width
     let mut f = Function::new([
-        (1, ValType::I64), (1, ValType::I32), (1, ValType::I32),
+        (1, ValType::I32), (1, ValType::I32), (1, ValType::I32),
+        (1, ValType::I32), (1, ValType::I32), (1, ValType::I32),
         (1, ValType::I32), (1, ValType::I32),
     ]);
+    let dat = string_data_off();
     wasm!(f, {
-        local_get(0); local_get(1); call(emitter.rt.string.index_of); local_set(3);
-        local_get(3); i64_const(-1); i64_eq;
-        if_i32; local_get(0);
-        else_;
-          local_get(3); i32_wrap_i64; local_set(4);
-          local_get(1); i32_load(0); local_set(5);
-          local_get(0); i32_const(0); local_get(4);
-          call(emitter.rt.string.slice); local_set(6);
-          local_get(0); local_get(4); local_get(5); i32_add; local_get(0); i32_load(0);
-          call(emitter.rt.string.slice); local_set(7);
-          local_get(7); local_get(1); local_get(2);
-          call(emitter.rt.string.replace); local_set(7);
-          local_get(6); local_get(2); call(emitter.rt.concat_str);
-          local_get(7); call(emitter.rt.concat_str);
+        local_get(0); i32_load(0); local_set(3); // blen
+        local_get(1); i32_load(0); local_set(4); // fl
+        local_get(2); i32_load(0); local_set(5); // tl
+        // Empty `from`: insert `to` before every codepoint plus one at the end.
+        // result_len = blen + (char_count + 1) * tl. Count codepoints first.
+        local_get(4); i32_eqz;
+        if_empty;
+          // cnt = codepoint count (scan widths)
+          i32_const(0); local_set(6); // i = 0 (byte offset)
+          i32_const(0); local_set(7); // cnt = 0 (codepoints)
+          block_empty; loop_empty;
+            local_get(6); local_get(3); i32_ge_u; br_if(1);
+            local_get(0); local_get(6); call(emitter.rt.string.utf8_width);
+            local_get(6); i32_add; local_set(6);
+            local_get(7); i32_const(1); i32_add; local_set(7);
+            br(0);
+          end; end;
+          // result = string_alloc(blen + (cnt + 1) * tl)
+          local_get(3); local_get(7); i32_const(1); i32_add; local_get(5); i32_mul; i32_add;
+          call(emitter.rt.string_alloc); local_set(8);
+          i32_const(0); local_set(9); // out = 0
+          // leading `to`: result[out..] = to
+          local_get(8); i32_const(dat); i32_add; local_get(9); i32_add;
+          local_get(2); i32_const(dat); i32_add; local_get(5); memory_copy;
+          local_get(9); local_get(5); i32_add; local_set(9);
+          i32_const(0); local_set(6); // i = 0
+          block_empty; loop_empty;
+            local_get(6); local_get(3); i32_ge_u; br_if(1);
+            local_get(0); local_get(6); call(emitter.rt.string.utf8_width); local_set(10); // width
+            // copy one codepoint: result[out..] = s[i .. i+width]
+            local_get(8); i32_const(dat); i32_add; local_get(9); i32_add;
+            local_get(0); i32_const(dat); i32_add; local_get(6); i32_add;
+            local_get(10); memory_copy;
+            local_get(9); local_get(10); i32_add; local_set(9); // out += width
+            local_get(6); local_get(10); i32_add; local_set(6); // i += width
+            // `to` after this codepoint
+            local_get(8); i32_const(dat); i32_add; local_get(9); i32_add;
+            local_get(2); i32_const(dat); i32_add; local_get(5); memory_copy;
+            local_get(9); local_get(5); i32_add; local_set(9);
+            br(0);
+          end; end;
+          local_get(8); return_;
         end;
-        end;
+        // Non-empty `from`. Pass 1: count occurrences.
+        i32_const(0); local_set(6); // i = 0
+        i32_const(0); local_set(7); // cnt = 0
+        block_empty; loop_empty;
+          local_get(6); local_get(4); i32_add; local_get(3); i32_gt_u; br_if(1);
+          local_get(0); i32_const(dat); i32_add; local_get(6); i32_add;
+          local_get(1); i32_const(dat); i32_add;
+          local_get(4); call(emitter.rt.mem_eq);
+          if_empty;
+            local_get(7); i32_const(1); i32_add; local_set(7); // cnt += 1
+            local_get(6); local_get(4); i32_add; local_set(6); // i += fl
+          else_;
+            local_get(6); i32_const(1); i32_add; local_set(6); // i += 1
+          end;
+          br(0);
+        end; end;
+        // No occurrences → return s unchanged.
+        local_get(7); i32_eqz;
+        if_empty; local_get(0); return_; end;
+        // result = string_alloc(blen + cnt * (tl - fl))
+        local_get(3); local_get(7); local_get(5); local_get(4); i32_sub; i32_mul; i32_add;
+        call(emitter.rt.string_alloc); local_set(8);
+        // Pass 2: build result.
+        i32_const(0); local_set(6); // i = 0 (read off into s)
+        i32_const(0); local_set(9); // out = 0 (write off into result)
+        block_empty; loop_empty;
+          local_get(6); local_get(3); i32_ge_u; br_if(1);
+          // match at i (only when a full `from` still fits)?
+          local_get(6); local_get(4); i32_add; local_get(3); i32_le_u;
+          if_empty;
+            local_get(0); i32_const(dat); i32_add; local_get(6); i32_add;
+            local_get(1); i32_const(dat); i32_add;
+            local_get(4); call(emitter.rt.mem_eq);
+            if_empty;
+              // copy `to`, advance i by fl, out by tl
+              local_get(8); i32_const(dat); i32_add; local_get(9); i32_add;
+              local_get(2); i32_const(dat); i32_add; local_get(5); memory_copy;
+              local_get(9); local_get(5); i32_add; local_set(9);
+              local_get(6); local_get(4); i32_add; local_set(6);
+              br(2); // continue outer loop
+            end;
+          end;
+          // copy one byte verbatim
+          local_get(8); i32_const(dat); i32_add; local_get(9); i32_add;
+          local_get(0); i32_const(dat); i32_add; local_get(6); i32_add;
+          i32_load8_u(0); i32_store8(0);
+          local_get(9); i32_const(1); i32_add; local_set(9);
+          local_get(6); i32_const(1); i32_add; local_set(6);
+          br(0);
+        end; end;
+        local_get(8); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.replace, type_idx, f));
 }
 
-/// Recursive split using index_of. Supports multi-char delimiter.
-/// Strategy: find first delimiter → [before] ++ split(rest, delim)
-/// Base case: no delimiter found → [s]
+/// Iterative split using a single forward byte-scan. Supports multi-char
+/// delimiters. Mirrors the native oracle `s.split(sep)` (a non-empty `sep`
+/// yields one segment per gap between matches, including a trailing empty
+/// segment when `s` ends with `sep`). De-recursed (#634): the old recursion
+/// was one frame per segment and exhausted the wasm call stack at ~4700
+/// segments — same precedent as `compile_lines`'s byte-scan rewrite.
 fn compile_split(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.split];
     // params: 0=s, 1=delim
-    // locals: 2=idx(i64), 3=d_len, 4=before, 5=rest, 6=rest_list, 7=result
-    //   empty-delim branch reuses: 8=blen, 9=in_off, 10=width, 11=slot(j)
+    // locals: 2=d_len, 3=blen, 4=seg_start, 5=i(scan), 6=slot, 7=result
+    //   empty-delim branch reuses: 8=in_off, 9=width
     let mut f = Function::new([
-        (1, ValType::I64), (1, ValType::I32), (1, ValType::I32),
         (1, ValType::I32), (1, ValType::I32), (1, ValType::I32),
-        (4, ValType::I32),
+        (1, ValType::I32), (1, ValType::I32), (1, ValType::I32),
+        (2, ValType::I32),
     ]);
     wasm!(f, {
-        local_get(1); i32_load(0); local_set(3); // d_len
+        local_get(1); i32_load(0); local_set(2); // d_len
+        local_get(0); i32_load(0); local_set(3); // blen
         // Empty delimiter: split per CODEPOINT with a leading + trailing empty
         // string — native `s.split("")` yields ["", c0, c1, …, ""] (and ["", ""]
-        // for ""). The old branch returned [s] (no split), diverging on every
-        // call (Cluster-2 finding #2). Slots = char_count + 2.
-        local_get(3); i32_eqz;
+        // for ""). Slots = char_count + 2.
+        local_get(2); i32_eqz;
         if_empty;
-          local_get(0); i32_load(0); local_set(8);                 // blen = *s
           // result list: [len = char_count + 2][slot ptrs…]. Worst case (all
           // ASCII) char_count == blen, so blen + 2 slots is always enough.
-          i32_const(list_hdr()); local_get(8); i32_const(2); i32_add; i32_const(4); i32_mul; i32_add;
+          i32_const(list_hdr()); local_get(3); i32_const(2); i32_add; i32_const(4); i32_mul; i32_add;
           call(emitter.rt.alloc); local_set(7);
           // slot[0] = "" (leading empty)
           local_get(7); i32_const(list_data_off()); i32_add;
           i32_const(0); call(emitter.rt.string_alloc); i32_store(0);
-          i32_const(0); local_set(9);                              // in_off = 0
-          i32_const(1); local_set(11);                             // slot = 1 (after leading "")
+          i32_const(0); local_set(8);                              // in_off = 0
+          i32_const(1); local_set(6);                              // slot = 1 (after leading "")
           block_empty; loop_empty;
-            local_get(9); local_get(8); i32_ge_u; br_if(1);
-            local_get(0); local_get(9); call(emitter.rt.string.utf8_width); local_set(10); // width
+            local_get(8); local_get(3); i32_ge_u; br_if(1);
+            local_get(0); local_get(8); call(emitter.rt.string.utf8_width); local_set(9); // width
             // slot[slot] = slice(s, in_off, in_off + width)  (one codepoint)
-            local_get(7); i32_const(list_data_off()); i32_add; local_get(11); i32_const(4); i32_mul; i32_add;
-            local_get(0); local_get(9); local_get(9); local_get(10); i32_add;
+            local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(4); i32_mul; i32_add;
+            local_get(0); local_get(8); local_get(8); local_get(9); i32_add;
             call(emitter.rt.string.slice); i32_store(0);
-            local_get(9); local_get(10); i32_add; local_set(9);    // in_off += width
-            local_get(11); i32_const(1); i32_add; local_set(11);   // slot += 1
+            local_get(8); local_get(9); i32_add; local_set(8);     // in_off += width
+            local_get(6); i32_const(1); i32_add; local_set(6);     // slot += 1
             br(0);
           end; end;
           // slot[slot] = "" (trailing empty)
-          local_get(7); i32_const(list_data_off()); i32_add; local_get(11); i32_const(4); i32_mul; i32_add;
+          local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(4); i32_mul; i32_add;
           i32_const(0); call(emitter.rt.string_alloc); i32_store(0);
           // result.len = slot + 1  (== char_count + 2)
-          local_get(7); local_get(11); i32_const(1); i32_add; i32_store(0);
+          local_get(7); local_get(6); i32_const(1); i32_add; i32_store(0);
           local_get(7); return_;
         end;
-        local_get(0); local_get(1); call(emitter.rt.string.index_of); local_set(2);
-        local_get(2); i64_const(-1); i64_eq;
-        if_i32;
-          // No match: return [s]
-          i32_const(12); call(emitter.rt.alloc); local_set(7);
-          local_get(7); i32_const(1); i32_store(0);
-          local_get(7); local_get(0); i32_store(8);
-          local_get(7);
-        else_;
-          // before = slice(s, 0, idx)
-          local_get(0); i32_const(0); local_get(2); i32_wrap_i64;
-          call(emitter.rt.string.slice); local_set(4);
-          // rest = slice(s, idx + d_len, s_len)
-          local_get(0);
-          local_get(2); i32_wrap_i64; local_get(3); i32_add;
-          local_get(0); i32_load(0);
-          call(emitter.rt.string.slice); local_set(5);
-          // rest_list = split(rest, delim) — recursive
-          local_get(5); local_get(1);
-          call(emitter.rt.string.split); local_set(6);
-          // result = [before] ++ rest_list
-          // Alloc: HEADER_SIZE + (1 + rest_list.len) * 4
-          i32_const(list_hdr());
-          local_get(6); i32_load(0); i32_const(1); i32_add;
-          i32_const(4); i32_mul; i32_add;
-          call(emitter.rt.alloc); local_set(7);
-          local_get(7);
-          local_get(6); i32_load(0); i32_const(1); i32_add;
-          i32_store(0); // result.len
-          // result[0] = before
-          local_get(7); local_get(4); i32_store(8);
-    });
-    // Copy rest_list elements to result[1..]
-    wasm!(f, {
-          i32_const(0); local_set(3); // reuse as i
-          block_empty; loop_empty;
-            local_get(3); local_get(6); i32_load(0); i32_ge_u; br_if(1);
-            local_get(7); i32_const(12); i32_add; // &result[1] = data_offset(8) + 1*4
-            local_get(3); i32_const(4); i32_mul; i32_add;
-            local_get(6); i32_const(list_data_off()); i32_add;
-            local_get(3); i32_const(4); i32_mul; i32_add;
-            i32_load(0); i32_store(0);
-            local_get(3); i32_const(1); i32_add; local_set(3);
-            br(0);
-          end; end;
-          local_get(7);
-        end;
-        end;
+        // Non-empty delimiter. A delimiter of length d_len>=1 can match at most
+        // blen times, so blen + 1 segments is the upper bound on the slot count.
+        i32_const(list_hdr()); local_get(3); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+        call(emitter.rt.alloc); local_set(7);
+        i32_const(0); local_set(4); // seg_start = 0
+        i32_const(0); local_set(5); // i = 0 (scan position)
+        i32_const(0); local_set(6); // slot = 0
+        block_empty; loop_empty;
+          // stop scanning once a full delimiter can no longer fit: i > blen - d_len.
+          local_get(5); local_get(2); i32_add; local_get(3); i32_gt_u; br_if(1);
+          // if mem_eq(s_data + i, delim_data, d_len)
+          local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add;
+          local_get(1); i32_const(string_data_off()); i32_add;
+          local_get(2);
+          call(emitter.rt.mem_eq);
+          if_empty;
+            // emit segment slice(s, seg_start, i)
+            local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(4); i32_mul; i32_add;
+            local_get(0); local_get(4); local_get(5); call(emitter.rt.string.slice); i32_store(0);
+            local_get(6); i32_const(1); i32_add; local_set(6);     // slot += 1
+            local_get(5); local_get(2); i32_add; local_set(5);     // i += d_len
+            local_get(5); local_set(4);                            // seg_start = i
+          else_;
+            local_get(5); i32_const(1); i32_add; local_set(5);     // i += 1
+          end;
+          br(0);
+        end; end;
+        // trailing segment slice(s, seg_start, blen)
+        local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(4); i32_mul; i32_add;
+        local_get(0); local_get(4); local_get(3); call(emitter.rt.string.slice); i32_store(0);
+        local_get(6); i32_const(1); i32_add; local_set(6);         // slot += 1
+        local_get(7); local_get(6); i32_store(0);                  // result.len = slot
+        local_get(7); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.split, type_idx, f));
 }

--- a/crates/almide-codegen/src/pass_perceus.rs
+++ b/crates/almide-codegen/src/pass_perceus.rs
@@ -767,6 +767,20 @@ pub(crate) fn yields_borrowed_alias(e: &IrExpr) -> bool {
             )
         }
 
+        // ── Degenerate single-part interpolation: aliases its only part ──
+        // The WASM emitter short-circuits a 1-part `"${e}"` and returns `e`'s
+        // pointer directly (no fresh alloc — `emit_string_interp`). When that
+        // part is a heap String alias (`"${s}"` for a bound `s`), the result
+        // shares `s`'s reference, so the binding needs its own +1 or its
+        // scope-end Dec double-frees `s`'s buffer at teardown (#622). A literal
+        // part, or a non-String part (Int/Bool/Float → a fresh `__int_to_string`
+        // etc.), is genuinely fresh and stays classified below.
+        StringInterp { parts } if parts.len() == 1 => {
+            matches!(&parts[0],
+                IrStringPart::Expr { expr }
+                    if expr.ty == Ty::String && yields_borrowed_alias(expr))
+        }
+
         // ── Tail-yielding forms: alias iff any tail can alias ──
         Match { arms, .. } => arms.iter().any(|a| yields_borrowed_alias(&a.body)),
         If { then, else_, .. } =>

--- a/crates/almide-codegen/src/pass_top_let_storage.rs
+++ b/crates/almide-codegen/src/pass_top_let_storage.rs
@@ -16,7 +16,7 @@
 
 use std::collections::HashMap;
 use almide_ir::*;
-use almide_ir::top_let_storage::{build_global_tables, top_let_inputs, GlobalInfo};
+use almide_ir::top_let_storage::{build_global_tables, dependency_init_order, top_let_inputs, GlobalInfo};
 use crate::pass::{NanoPass, PassResult, Target};
 
 #[derive(Debug)]
@@ -29,19 +29,22 @@ impl NanoPass for TopLetStoragePass {
 
     fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
         let mut inputs: Vec<(bool, TopLetKind, VarId, bool)> = Vec::new();
-        let mut init_order: Vec<VarId> = Vec::new();
         for tl in &program.top_lets {
             inputs.push(top_let_inputs(tl));
-            init_order.push(tl.var);
         }
         for m in &program.modules {
             for tl in &m.top_lets {
                 inputs.push(top_let_inputs(tl));
-                init_order.push(tl.var);
             }
         }
 
         let (globals, alias, offenders) = build_global_tables(&inputs, &program.var_table);
+
+        // #632: re-order so an imported module's heap global is initialized
+        // before any importing top-let reads it (directly or through a function
+        // it calls). WASM evaluates initializers eagerly in this order; native
+        // forces abortable lazies in it (C-007).
+        let init_order: Vec<VarId> = dependency_init_order(&program, &alias);
 
         if !offenders.is_empty() {
             let mut msg = String::new();

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -728,7 +728,17 @@ pub fn render_expr(ctx: &RenderContext, expr: &IrExpr) -> String {
                 let when_type = if inner.ty.is_option() { Some("Option") } else { None };
                 let err_coerce_attr = if !inner.ty.is_option() {
                     if let Some((_, err_ty)) = inner.ty.inner2() {
-                        if matches!(err_ty, Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 && matches!(args[0], Ty::String)) {
+                        // When the source error type already matches the
+                        // enclosing fn's propagated error type, `?` carries it
+                        // through unchanged — no coercion. This preserves a
+                        // custom variant error (e.g. `Result[_, AppErr]` !-ed
+                        // inside a fn that also returns `Result[_, AppErr]`)
+                        // instead of stringifying it via Debug (which would
+                        // need `From<String>` and fail to compile). #630
+                        let matches_fn_err = ctx.fn_err_ty.as_ref() == Some(err_ty);
+                        if matches_fn_err {
+                            None
+                        } else if matches!(err_ty, Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 && matches!(args[0], Ty::String)) {
                             Some("map_err_join")
                         } else if !matches!(err_ty, Ty::String) {
                             Some("map_err_debug")

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -62,11 +62,17 @@ pub struct RenderContext<'a> {
     /// set, so a value with the impl renders to its literal form while opaque
     /// `Named` references (e.g. runtime newtypes) stay on the Display path.
     pub repr_named_types: std::collections::HashSet<almide_base::intern::Sym>,
+    /// Error type `E` of the enclosing fn's declared return `Result[_, E]`,
+    /// or `None` if the fn does not return a `Result`. The `!` (Unwrap)
+    /// renderer compares a propagated source error against this: when they
+    /// match, `?` propagates directly with no `map_err` coercion (so a custom
+    /// variant error type is preserved rather than stringified via Debug).
+    pub fn_err_ty: Option<almide_lang::types::Ty>,
 }
 
 impl<'a> RenderContext<'a> {
     pub fn new(templates: &'a TemplateSet, var_table: &'a VarTable) -> Self {
-        Self { templates, var_table, indent: 0, target: Target::Rust, auto_unwrap: false, is_test: false, ann: CodegenAnnotations::default(), type_aliases: std::collections::HashMap::new(), generic_types: std::collections::HashSet::new(), minimal_generic_bounds: false, repr_c: false, ref_params: std::collections::HashSet::new(), ref_mut_params: std::collections::HashSet::new(), repr_named_types: std::collections::HashSet::new() }
+        Self { templates, var_table, indent: 0, target: Target::Rust, auto_unwrap: false, is_test: false, ann: CodegenAnnotations::default(), type_aliases: std::collections::HashMap::new(), generic_types: std::collections::HashSet::new(), minimal_generic_bounds: false, repr_c: false, ref_params: std::collections::HashSet::new(), ref_mut_params: std::collections::HashSet::new(), repr_named_types: std::collections::HashSet::new(), fn_err_ty: None }
     }
 
     pub fn with_target(mut self, target: Target) -> Self {
@@ -138,6 +144,20 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
         }
     }
 
+    // Error type that the enclosing fn's `?`/auto-? propagates into. A fn
+    // declared `Result[_, E]` propagates into `E`; an effect fn declared with
+    // a non-Result type is auto-wrapped to `Result<_, String>`, so it
+    // propagates into `String`. A plain fn with no Result return propagates
+    // into nothing (None). The Unwrap renderer uses this to skip the Debug
+    // `map_err` coercion when the source error type already matches.
+    let fn_err_ty = if let Some((_, err_ty)) = func.ret_ty.inner2() {
+        Some(err_ty.clone())
+    } else if func.is_effect && !func.is_test {
+        Some(almide_lang::types::Ty::String)
+    } else {
+        None
+    };
+
     // Set effect fn context for auto-? insertion
     let fn_ctx = RenderContext {
         templates: ctx.templates,
@@ -154,6 +174,7 @@ pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
         ref_params,
         ref_mut_params,
         repr_named_types: ctx.repr_named_types.clone(),
+        fn_err_ty,
     };
 
     // Dispatch-only fns (body is Hole): `@inline_rust` / `@intrinsic`
@@ -602,6 +623,7 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         ref_params: std::collections::HashSet::new(),
         ref_mut_params: std::collections::HashSet::new(),
         repr_named_types,
+        fn_err_ty: None,
     };
     for td in &program.type_decls {
         if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -9,6 +9,36 @@ use super::types::render_type;
 use super::expressions::render_expr;
 use super::helpers::{template_or, terminate_stmt, ty_has_named_typevar, erase_named_typevars, erase_fn_types};
 
+/// When a binding's initializer reads a fn param that is emitted as a Rust
+/// reference (`&str`, `&[T]`, `&AlmideMap<..>`, `&T`), the binding's declared
+/// type is the OWNED form (`String`, `Vec<T>`, `AlmideMap<..>`, `T`), so the
+/// borrow must be converted to an owned value. The right method depends on the
+/// value type: a `&str` owns via `.to_string()`, a `&[T]` slice via `.to_vec()`
+/// (`.clone()` on a slice yields another `&[T]`, not `Vec<T>`), and every other
+/// borrowed type (`&AlmideMap`, `&T`) owns via `.clone()`. Returns the bare
+/// owning expression (e.g. `l.to_vec()`) when the value reads a borrowed param,
+/// or `None` when no conversion is needed. A `Clone{Var}` initializer is
+/// rendered from the bare var so we never stack `l.clone().to_vec()`. #624
+fn borrowed_param_owning_value(ctx: &RenderContext, value: &IrExpr) -> Option<String> {
+    let (var_id, val_ty) = match &value.kind {
+        IrExprKind::Var { id } => (*id, &value.ty),
+        IrExprKind::Clone { expr: inner } => match &inner.kind {
+            IrExprKind::Var { id } => (*id, &inner.ty),
+            _ => return None,
+        },
+        _ => return None,
+    };
+    if !ctx.ref_params.contains(&var_id) {
+        return None;
+    }
+    let conv = match val_ty {
+        Ty::String => "to_string",
+        Ty::Applied(TypeConstructorId::List, _) => "to_vec",
+        _ => "clone",
+    };
+    Some(format!("{}.{}()", ctx.var_name(var_id), conv))
+}
+
 /// Check if an expression references a specific variable (any depth).
 pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
     match &stmt.kind {
@@ -202,17 +232,13 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
                 return ctx.templates.render_with("var_binding", None, &[], &[("name", name_s.as_str()), ("type", val_type.as_str()), ("value", val_value.as_str())])
                     .unwrap_or_else(|| if name_s == "_" { format!("let {}: {} = {};", name_s, val_type, val_value) } else { format!("let mut {}: {} = {};", name_s, val_type, val_value) });
             }
-            // Non-RcCow var binding: if value comes from a borrowed param, clone it
-            let value_s = if matches!(mutability, Mutability::Var) && !ctx.ann.is_rc_cow(var) {
-                let needs_clone = match &value.kind {
-                    IrExprKind::Var { id } => ctx.ref_params.contains(id),
-                    IrExprKind::Clone { expr: inner } => match &inner.kind {
-                        IrExprKind::Var { id } => ctx.ref_params.contains(id),
-                        _ => false,
-                    },
-                    _ => false,
-                };
-                if needs_clone { format!("{}.clone()", value_s) } else { value_s }
+            // Non-RcCow binding whose initializer reads a borrowed param: the
+            // binding's type is the OWNED form, so convert the borrow to an
+            // owned value (slice→`.to_vec()`, `&str`→`.to_string()`, else
+            // `.clone()`). Applies to both `let` and `var` — a slice cloned as
+            // `.clone()` would stay a `&[T]` and mismatch `Vec<T>` (#624).
+            let value_s = if !ctx.ann.is_rc_cow(var) {
+                borrowed_param_owning_value(ctx, value).unwrap_or(value_s)
             } else { value_s };
             let is_wildcard = name_s == "_";
             let construct = match mutability {

--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -64,7 +64,17 @@ impl Checker {
                 ret
             }
             ExprKind::TypeName { name, .. } => {
-                if let Some((type_name, case)) = self.env.lookup_ctor(&sym(name)) {
+                // #631: pin the constructed value's `.ty` to the OWNER-qualified
+                // type name (`mod.Type`) via the module-aware lookup, exactly as
+                // the bare-value ctor path (infer.rs) and `lookup_ctor_in` for
+                // record ctors already do. A bare `lookup_ctor` here left the call
+                // expression's type bare `Type` even when the only declaration is
+                // `mod.Type`, so a producer fn INSIDE its owning submodule that
+                // constructs the variant tripped the #433 name-pinning guard at
+                // codegen (both targets aborted after `check` said clean).
+                if let Some((type_name, case)) =
+                    self.env.lookup_ctor_in(&sym(name), self.current_module_prefix.as_deref())
+                {
                     self.report_ambiguous_ctor(name);
                     self.check_constructor_args(name, &case, &arg_tys);
                     // Instantiate parent type's generics with fresh inference vars

--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -203,7 +203,12 @@ impl Checker {
                     // List[Int] }`, resolved from `env.types`). Both reduce to a
                     // `(field, declared_ty)` list with generics already substituted.
                     let (result_ty, decl_fields, closed, defaults): (Ty, Vec<(Sym, Ty)>, bool, std::collections::HashSet<Sym>) =
-                        if let Some((type_name, case)) = self.env.lookup_ctor(&ctor_sym) {
+                        // #631: module-aware lookup so a BARE record-variant ctor
+                        // used INSIDE its owning submodule (`Circle { radius: r }`)
+                        // pins `type_name` to the owner-qualified `mod.Shape`,
+                        // matching the tuple-ctor path. Without this the bare result
+                        // type tripped the #433 name-pinning guard at codegen.
+                        if let Some((type_name, case)) = self.env.lookup_ctor_in(&ctor_sym, self.current_module_prefix.as_deref()) {
                             // Brace construction of a NON-record case is a
                             // category error (`Wrap { x: 1 }` on a tuple case):
                             // reject here, or rustc/wasm explode downstream.

--- a/crates/almide-frontend/src/lower/auto_try.rs
+++ b/crates/almide-frontend/src/lower/auto_try.rs
@@ -200,8 +200,20 @@ fn insert_try_body(expr: IrExpr, fn_returns_result: bool, ctx: &mut TryCtx) -> I
 }
 
 fn insert_try_stmt_with_skip(stmt: IrStmt, skip: &HashSet<u32>, ctx: &mut TryCtx) -> IrStmt {
-    if let IrStmtKind::Bind { var, .. } = &stmt.kind {
-        if skip.contains(&var.0) {
+    if let IrStmtKind::Bind { var, value, .. } = &stmt.kind {
+        // A binding consumed by `??` / `== ok(v)` / `match { ok/err }` is kept a
+        // Result so that usage type-checks — BUT only when the binding's value
+        // is genuinely Result-fronted at that consumer. An effect fn that
+        // returns `Option[T]` is lifted to `Result[Option[T], String]`; binding
+        // it and consuming with `??` is an OPTION-fallback, so the auto-? MUST
+        // strip the effect `Result`, leaving `Option[T]` for `??`. Keeping the
+        // `Result` there made native emit invalid Rust and wasm read the wrong
+        // value (#629). So only honor the skip when the value's effect-Result
+        // OK type is itself a Result (a real Result-fallback) or the binding is
+        // an explicitly annotated Result (handled by `annotated_result_vars`).
+        if skip.contains(&var.0)
+            && (ctx.annotated_result_vars.contains(var) || value_ok_is_result(value))
+        {
             if let IrStmtKind::Bind { var, mutability, ty, value } = stmt.kind {
                 let new_value = insert_try(value, false, ctx);
                 let unwrapped = strip_top_try(new_value);
@@ -213,6 +225,18 @@ fn insert_try_stmt_with_skip(stmt: IrStmt, skip: &HashSet<u32>, ctx: &mut TryCtx
         }
     }
     insert_try_stmt(stmt, ctx)
+}
+
+/// True when the value is an effect-lifted `Result[OK, _]` whose OK type is
+/// itself a `Result` — i.e. a binding whose user-facing value really is a
+/// Result that a `??` / `== ok` / Result-`match` consumer must keep. An
+/// `Option`-fronted (or scalar) OK type means the consumer operates on the
+/// auto-?'d inner value, so the skip must not apply. #629
+fn value_ok_is_result(value: &IrExpr) -> bool {
+    match &value.ty {
+        Ty::Applied(TypeConstructorId::Result, args) if args.len() == 2 => args[0].is_result(),
+        _ => false,
+    }
 }
 
 /// Strip one inserted top-level Try, restoring the Result-typed value.

--- a/crates/almide-ir/src/top_let_storage.rs
+++ b/crates/almide-ir/src/top_let_storage.rs
@@ -180,6 +180,204 @@ pub fn init_can_abort(expr: &IrExpr) -> bool {
     f.found
 }
 
+use std::collections::HashSet;
+use crate::{CallTarget, IrFunction, IrProgram};
+
+/// Per-expression scan: the global top-let VarIds an expression reads DIRECTLY
+/// (resolved through `alias`) and the callees it invokes by identity. Callees
+/// are keyed so the interprocedural read-set can be folded in (`#632`: a
+/// top-let initializer that *calls* `cfg.banner()` transitively reads
+/// `cfg.APP_NAME`, with no direct `Var` to it).
+fn scan_reads_and_calls(
+    expr: &IrExpr,
+    alias: &HashMap<VarId, VarId>,
+    decls: &HashSet<VarId>,
+) -> (Vec<VarId>, Vec<FnKey>) {
+    use crate::visit::{IrVisitor, walk_expr};
+    struct Collector<'a> {
+        alias: &'a HashMap<VarId, VarId>,
+        decls: &'a HashSet<VarId>,
+        reads: Vec<VarId>,
+        calls: Vec<FnKey>,
+    }
+    impl IrVisitor for Collector<'_> {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            match &e.kind {
+                IrExprKind::Var { id } => {
+                    let decl = self.alias.get(id).copied().unwrap_or(*id);
+                    if self.decls.contains(&decl) && !self.reads.contains(&decl) {
+                        self.reads.push(decl);
+                    }
+                }
+                IrExprKind::Call { target, .. } => {
+                    if let Some(k) = fn_key_of_target(target) {
+                        if !self.calls.contains(&k) { self.calls.push(k); }
+                    }
+                }
+                _ => {}
+            }
+            walk_expr(self, e);
+        }
+    }
+    let mut c = Collector { alias, decls, reads: Vec::new(), calls: Vec::new() };
+    c.visit_expr(expr);
+    (c.reads, c.calls)
+}
+
+/// Identity of a callable user function: its bare name (free fn / variant ctor)
+/// or `module::func`. Stdlib calls resolve to no user `IrFunction`, so they
+/// contribute no globals and are simply absent from the function index.
+type FnKey = String;
+
+fn fn_key_of_target(target: &CallTarget) -> Option<FnKey> {
+    match target {
+        CallTarget::Named { name } => Some(name.as_str().to_string()),
+        CallTarget::Module { module, func, .. } =>
+            Some(format!("{}::{}", module.as_str(), func.as_str())),
+        // Method/Computed callees are not name-resolved here; a global read
+        // reached only through such a callee falls back to the module-level
+        // safety net in `dependency_init_order`.
+        CallTarget::Method { .. } | CallTarget::Computed { .. } => None,
+    }
+}
+
+fn fn_key_of_function(f: &IrFunction) -> FnKey {
+    match &f.module_origin {
+        Some(m) => format!("{}::{}", m, f.name.as_str()),
+        None => f.name.as_str().to_string(),
+    }
+}
+
+/// #632: dependency-respecting global init order. WASM evaluates top-let
+/// initializers EAGERLY in `global_init_order`; native forces abortable lazies
+/// in that same order (C-007). When an importing module's top-let reads an
+/// imported module's heap global — directly OR through a function it calls —
+/// that global must be initialized FIRST, or the wasm read hits a still-zero
+/// header (null ptr + zero len). The legacy order (root top-lets, then
+/// per-module) put a root let BEFORE the submodule global it depends on, so the
+/// cross-module read miscompiled on wasm only.
+///
+/// Dependencies are computed interprocedurally: a top-let depends on every
+/// global its initializer reads directly, PLUS every global transitively read
+/// by the user functions it calls. As a safety net for reads reachable only
+/// through un-named callees (method/computed/stdlib HOFs), a root top-let also
+/// depends on every module global, and a module top-let on every global of a
+/// module it (transitively) references — submodules are dependencies of their
+/// importer by construction, so this can never invert a real ordering.
+///
+/// We stable-topo-sort the legacy declaration order so every top-let comes
+/// after the globals it depends on; ties keep the original (root-then-module)
+/// sequence for host-arch determinism. A dependency cycle (no legal source
+/// program produces one across distinct globals) degrades gracefully to the
+/// legacy order.
+pub fn dependency_init_order(
+    program: &IrProgram,
+    alias: &HashMap<VarId, VarId>,
+) -> Vec<VarId> {
+    // 1. The legacy emission order: (decl VarId, owning module, &initializer).
+    //    None module = root.
+    let mut decl_order: Vec<(VarId, Option<&str>, &IrExpr)> = Vec::new();
+    for tl in &program.top_lets {
+        decl_order.push((tl.var, None, &tl.value));
+    }
+    for m in &program.modules {
+        for tl in &m.top_lets {
+            decl_order.push((tl.var, Some(m.name.as_str()), &tl.value));
+        }
+    }
+    let decls: HashSet<VarId> = decl_order.iter().map(|(v, _, _)| *v).collect();
+
+    // 2. Index every user function by identity, with the globals it reads
+    //    directly and the callees it invokes.
+    let mut fn_reads: HashMap<FnKey, Vec<VarId>> = HashMap::new();
+    let mut fn_calls: HashMap<FnKey, Vec<FnKey>> = HashMap::new();
+    let mut index_fn = |f: &IrFunction| {
+        let (reads, calls) = scan_reads_and_calls(&f.body, alias, &decls);
+        let key = fn_key_of_function(f);
+        fn_reads.entry(key.clone()).or_default().extend(reads);
+        fn_calls.entry(key).or_default().extend(calls);
+    };
+    for f in &program.functions { index_fn(f); }
+    for m in &program.modules {
+        for f in &m.functions { index_fn(f); }
+    }
+
+    // 3. Transitive global read-set per function (fixpoint over the call graph;
+    //    cycle-safe via the visited set).
+    fn fn_global_reads(
+        key: &FnKey,
+        fn_reads: &HashMap<FnKey, Vec<VarId>>,
+        fn_calls: &HashMap<FnKey, Vec<FnKey>>,
+        seen: &mut HashSet<FnKey>,
+        out: &mut Vec<VarId>,
+    ) {
+        if !seen.insert(key.clone()) { return; }
+        if let Some(rs) = fn_reads.get(key) {
+            for &r in rs { if !out.contains(&r) { out.push(r); } }
+        }
+        if let Some(cs) = fn_calls.get(key) {
+            for c in cs { fn_global_reads(c, fn_reads, fn_calls, seen, out); }
+        }
+    }
+
+    // 4. Module → its top-let global decls (for the coarse safety net).
+    let mut module_globals: HashMap<&str, Vec<VarId>> = HashMap::new();
+    for &(v, m, _) in &decl_order {
+        if let Some(mn) = m { module_globals.entry(mn).or_default().push(v); }
+    }
+
+    // 5. Per-top-let dependency set.
+    let mut deps: HashMap<VarId, Vec<VarId>> = HashMap::new();
+    for &(v, owner, expr) in &decl_order {
+        let (direct, calls) = scan_reads_and_calls(expr, alias, &decls);
+        let mut dep: Vec<VarId> = direct;
+        // Interprocedural: globals read through every callee.
+        for c in &calls {
+            let mut seen = HashSet::new();
+            let mut reads = Vec::new();
+            fn_global_reads(c, &fn_reads, &fn_calls, &mut seen, &mut reads);
+            for r in reads { if !dep.contains(&r) { dep.push(r); } }
+        }
+        // Safety net: a root top-let depends on every module global; this is
+        // sound because submodules are always dependencies of the root (the
+        // root imports them, never vice versa). Catches reads reachable only
+        // through method/computed/stdlib-HOF callees that step 2 can't name.
+        if owner.is_none() {
+            for (_, gs) in &module_globals {
+                for &g in gs { if !dep.contains(&g) { dep.push(g); } }
+            }
+        }
+        dep.retain(|d| *d != v);
+        deps.insert(v, dep);
+    }
+
+    // 6. Stable topological emit: walk the legacy order; before emitting a
+    //    node, emit its not-yet-emitted dependencies (depth-first). `on_stack`
+    //    breaks cycles by emitting the node anyway in its legacy slot.
+    let mut emitted: Vec<VarId> = Vec::with_capacity(decl_order.len());
+    let mut done: HashSet<VarId> = HashSet::new();
+    let mut on_stack: HashSet<VarId> = HashSet::new();
+    fn visit(
+        v: VarId,
+        deps: &HashMap<VarId, Vec<VarId>>,
+        done: &mut HashSet<VarId>,
+        on_stack: &mut HashSet<VarId>,
+        emitted: &mut Vec<VarId>,
+    ) {
+        if done.contains(&v) || on_stack.contains(&v) { return; }
+        on_stack.insert(v);
+        if let Some(ds) = deps.get(&v) {
+            for &d in ds { visit(d, deps, done, on_stack, emitted); }
+        }
+        on_stack.remove(&v);
+        if done.insert(v) { emitted.push(v); }
+    }
+    for &(v, _, _) in &decl_order {
+        visit(v, &deps, &mut done, &mut on_stack, &mut emitted);
+    }
+    emitted
+}
+
 /// Alias-resolution key: (normalized module origin, UPPERCASE name). The
 /// use-site synthetic Var carries the SCREAMING_CASE spelling and a
 /// dot-normalized origin; the declaration keeps the source name and the
@@ -226,4 +424,101 @@ pub fn build_global_tables(
 /// Convenience: extract the classification inputs from an `IrTopLet`.
 pub fn top_let_inputs(tl: &IrTopLet) -> (bool, TopLetKind, VarId, bool) {
     (tl.mutable, tl.kind, tl.var, init_can_abort(&tl.value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CallTarget, IrExpr, IrExprKind, IrFunction, IrModule, IrProgram, IrTopLet,
+        IrVisibility, TopLetKind, VarTable};
+    use almide_base::intern::sym;
+
+    fn var(id: u32) -> IrExpr {
+        IrExpr { kind: IrExprKind::Var { id: VarId(id) }, ty: Ty::String, span: None, def_id: None }
+    }
+    fn lit() -> IrExpr {
+        IrExpr { kind: IrExprKind::LitStr { value: "x".into() }, ty: Ty::String, span: None, def_id: None }
+    }
+    fn call_mod(module: &str, func: &str) -> IrExpr {
+        IrExpr {
+            kind: IrExprKind::Call {
+                target: CallTarget::Module { module: sym(module), func: sym(func), def_id: None },
+                args: vec![],
+                type_args: vec![],
+            },
+            ty: Ty::String, span: None, def_id: None,
+        }
+    }
+    fn tl(var_id: u32, value: IrExpr) -> IrTopLet {
+        IrTopLet { var: VarId(var_id), ty: Ty::String, value, kind: TopLetKind::Lazy,
+            mutable: false, doc: None, blank_lines_before: 0, def_id: None }
+    }
+    fn module_fn(name: &str, module: &str, body: IrExpr) -> IrFunction {
+        IrFunction {
+            name: sym(name), params: vec![], ret_ty: Ty::String, body,
+            is_effect: false, is_async: false, is_test: false,
+            generics: None, extern_attrs: vec![], export_attrs: vec![], attrs: vec![],
+            visibility: IrVisibility::Public, doc: None, blank_lines_before: 0, def_id: None,
+            mutated_params: vec![], module_origin: Some(module.to_string()),
+        }
+    }
+    fn empty_module(name: &str) -> IrModule {
+        IrModule { name: sym(name), versioned_name: None, type_decls: vec![],
+            functions: vec![], top_lets: vec![], var_table: VarTable::new(),
+            exports: vec![], imports: vec![] }
+    }
+
+    /// Root top-let (declared FIRST) reads a module global DIRECTLY through an
+    /// aliased use-site VarId; the module global must be ordered first.
+    #[test]
+    fn direct_cross_module_read_reorders_module_first() {
+        let mut program = IrProgram::default();
+        // root: let GREETING(0) = APP_NAME(2)  where var2 aliases cfg's decl var1
+        program.top_lets.push(tl(0, var(2)));
+        let mut cfg = empty_module("cfg");
+        cfg.top_lets.push(tl(1, lit())); // cfg: let APP_NAME(1) = "x"
+        program.modules.push(cfg);
+        // alias: use-site var2 → declaration var1
+        let mut alias: HashMap<VarId, VarId> = HashMap::new();
+        alias.insert(VarId(2), VarId(1));
+
+        let order = dependency_init_order(&program, &alias);
+        let p0 = order.iter().position(|v| *v == VarId(1)).unwrap();
+        let p1 = order.iter().position(|v| *v == VarId(0)).unwrap();
+        assert!(p0 < p1, "cfg.APP_NAME (var1) must init before root GREETING (var0): {:?}", order);
+    }
+
+    /// Root top-let reads the module global ONLY through a function call; the
+    /// interprocedural read-set must still pull the module global earlier.
+    #[test]
+    fn interprocedural_read_reorders_module_first() {
+        let mut program = IrProgram::default();
+        // root: let BANNER(0) = cfg::banner()   (no direct Var to the global)
+        program.top_lets.push(tl(0, call_mod("cfg", "banner")));
+        let mut cfg = empty_module("cfg");
+        cfg.top_lets.push(tl(1, lit()));                    // cfg: let APP_NAME(1)
+        cfg.functions.push(module_fn("banner", "cfg", var(1))); // banner reads var1
+        program.modules.push(cfg);
+
+        let order = dependency_init_order(&program, &HashMap::new());
+        let p_global = order.iter().position(|v| *v == VarId(1)).unwrap();
+        let p_banner = order.iter().position(|v| *v == VarId(0)).unwrap();
+        assert!(p_global < p_banner,
+            "cfg.APP_NAME (var1) read via cfg::banner() must init before BANNER (var0): {:?}", order);
+    }
+
+    /// No cross dependency → the legacy (root-then-module) order is preserved.
+    #[test]
+    fn independent_globals_keep_legacy_order() {
+        let mut program = IrProgram::default();
+        program.top_lets.push(tl(0, lit()));
+        let mut cfg = empty_module("cfg");
+        cfg.top_lets.push(tl(1, lit()));
+        program.modules.push(cfg);
+        let order = dependency_init_order(&program, &HashMap::new());
+        // Root let (var0) has no dep; its safety net depends on the module
+        // global (var1), so var1 still comes first. Both are present exactly once.
+        assert_eq!(order.len(), 2);
+        assert!(order.contains(&VarId(0)) && order.contains(&VarId(1)));
+    }
 }

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-70 contracts
+77 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -98,4 +98,11 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-068 | Auto-? is target-directed in construction positions |  | active | fixture | 2 |
 | C-069 | Effect-fn tail self-recursion loop-converts to O(1) stack on both targets |  | active | fixture | 1 |
 | C-070 | Nested constructor patterns match and bind identically on both targets |  | active | fixture | 1 |
+| C-071 | Single-part interpolation RC balance |  | active | fixture | 1 |
+| C-072 | Inferred named-record repr parity |  | active | fixture | 1 |
+| C-073 | Tuple pattern testing a variant constructor |  | active | fixture | 1 |
+| C-074 | Iterative split/replace on large inputs |  | active | fixture | 1 |
+| C-075 | lowmisc round-5 cluster: borrowed-param owning binding, effect-Option auto-try strip, matching-error ! passthrough |  | active | fixture | 1 |
+| C-076 | Producer-side in-module variant construction is target-stable |  | active | fixture | 1 |
+| C-077 | Cross-module heap-global init order is dependency-respecting |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -878,3 +878,66 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/nested_ctor_pattern.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-071"
+title     = "Single-part interpolation RC balance"
+statement = "A degenerate one-part interpolation `\"${e}\"` that the WASM emitter short-circuits to return `e`'s pointer directly does not double-free `e`'s heap buffer at teardown: when `e` is a heap-String alias the binding acquires its own reference, so native and WASM both produce the value and exit 0 (no 'unreachable' trap). Literal, non-String, surrounded, and multi-fragment interpolations stay genuinely fresh."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/r5_wasm_interp_alias_rc.almd", class = "fixture" },
+]
+
+[[contract]]
+id        = "C-072"
+title     = "Inferred named-record repr parity"
+statement = "A record literal inferred without a type annotation reprs identically on native and WASM: when its field set matches a declared record type, both print `TypeName { ... }` in the type's DECLARATION field order with correct values even when the literal is written out of declaration order; a truly anonymous record prints prefix-less in sorted field-name order on both targets."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/r5_wasm_inferred_record_repr.almd", class = "fixture" },
+]
+
+[[contract]]
+id        = "C-073"
+title     = "Tuple pattern testing a variant constructor"
+statement = "A tuple match arm that tests a variant constructor in any element position (nullary in pos 1/2 or both, or a payload-carrying constructor whose binder is captured) compiles and runs byte-identically on native and WASM; the WASM module passes structural validation (no 'expected i32 but nothing on stack')."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/r5_wasm_tuple_variant_pattern.almd", class = "fixture" },
+]
+
+[[contract]]
+id        = "C-074"
+title     = "Iterative split/replace on large inputs"
+statement = "string.split and string.replace produce byte-identical results on native and WASM for large inputs (5000+ segments, 6000+ occurrences) and exit 0 with no 'call stack exhausted' trap; an empty `from` pattern inserts the replacement at every codepoint boundary (Rust `str::replace` parity)."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/r5_wasm_split_replace_iterative.almd", class = "fixture" },
+]
+
+[[contract]]
+id        = "C-075"
+title     = "lowmisc round-5 cluster: borrowed-param owning binding, effect-Option auto-try strip, matching-error ! passthrough"
+statement = "Binding a borrow-rendered param (List &[T] / Map &AlmideMap) to a local converts to the owned type; an effect-fn Option[T] bound to a let and consumed by ?? strips the effect Result first leaving Option[T]; and `!` propagation whose source error type equals the enclosing fn's declared error type carries the custom variant error through `?` unchanged (no Debug stringify). All three compile and run byte-identically on native Rust and wasm32: stdout 'list=[7, 8]' / 'map_len=2' / 'miss=999' / 'hit=42' / 'fetch=item', exit 0."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/r5_lowmisc_param_try_err.almd", class = "fixture" },
+]
+
+[[contract]]
+id        = "C-076"
+title     = "Producer-side in-module variant construction is target-stable"
+statement = "A producer function declared inside the submodule that owns a variant type, constructing the variant via the bare constructor (tuple `Circle(r)` or record-variant `Circle { radius: r }`) and returning it, compiles and runs byte-identically on native Rust and wasm32 (stdout, stderr, exit). The construction expression's type is pinned to the owner-qualified `mod.Type`, so the #433 name-pinning verifier never fires on a valid in-module construction."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/r5_mod_producer_variant.almd", class = "fixture" },
+]
+
+[[contract]]
+id        = "C-077"
+title     = "Cross-module heap-global init order is dependency-respecting"
+statement = "An importing module's top-level let that reads an imported module's heap global (string/list/etc.), directly or through a function call, observes the imported global already initialized on both native Rust and wasm32 (byte-identical stdout, stderr, exit). WASM eager top-let init runs in a dependency-respecting order computed interprocedurally; native's lazy/forced init agrees (C-007)."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/r5_mod_global_init_order.almd", class = "fixture" },
+]

--- a/spec/integration/modules/cross_module_init_order_test.almd
+++ b/spec/integration/modules/cross_module_init_order_test.almd
@@ -1,0 +1,23 @@
+// #632: an importing module's top-let reads an imported module's heap global —
+// directly (`letlib.GREETING`) AND through a function call
+// (`letlib.welcome()`, which reads `letlib.GREETING` internally). The imported
+// module's globals must be initialized BEFORE these top-lets. On wasm the eager
+// init order previously ran the importing top-lets first, reading still-zero
+// heap headers (empty string / list len 0); native (lazy) was correct.
+import letlib
+
+let DIRECT = letlib.GREETING
+let VIA_FN = letlib.welcome()
+let NUM_COUNT = list.len(letlib.NUMBERS)
+
+test "cross-module top-let direct heap-global read at init (#632)" {
+  assert_eq(DIRECT, "hello")
+}
+
+test "cross-module top-let read through a fn call at init (#632)" {
+  assert_eq(VIA_FN, "hello world")
+}
+
+test "cross-module top-let List heap-global read at init (#632)" {
+  assert_eq(NUM_COUNT, 3)
+}

--- a/spec/integration/modules/cross_module_variant_test.almd
+++ b/spec/integration/modules/cross_module_variant_test.almd
@@ -40,3 +40,24 @@ test "cross-module variant as default value" {
   }
   assert_eq(n, 99)
 }
+
+test "producer-side bare variant ctor inside owning module (#631)" {
+  // varlib.make_wrap constructs Wrap(n) via the BARE ctor INSIDE varlib; before
+  // the fix the ctor-call's type stayed bare `Wrapper` and the #433 guard
+  // aborted codegen on both targets even though check passed.
+  let w = varlib.make_wrap(7)
+  let n = match w {
+    varlib.Wrap(x) => x,
+    varlib.Empty => 0,
+  }
+  assert_eq(n, 7)
+}
+
+test "producer-side bare record-variant ctor inside owning module (#631)" {
+  let c = varlib.make_circle(5)
+  let r = match c {
+    varlib.Circle { radius } => radius,
+    varlib.Dot => 0,
+  }
+  assert_eq(r, 5)
+}

--- a/spec/integration/modules/varlib/src/mod.almd
+++ b/spec/integration/modules/varlib/src/mod.almd
@@ -15,3 +15,11 @@ fn parse_tag(s: String) -> Option[String] =
 // Test: function reference used within the same module (intra-module)
 fn tag_count(items: List[String]) -> Int =
   items |> list.filter_map(parse_tag) |> list.len
+
+// #631: a PRODUCER fn inside the owning module constructs the variant via the
+// BARE constructor and returns it. The ctor-call result type must be pinned to
+// the owner-qualified `varlib.Wrapper` / `varlib.Shape`, or the #433 name-pin
+// guard aborts codegen on BOTH targets even though `check` passed.
+fn make_wrap(n: Int) -> Wrapper = Wrap(n)
+
+fn make_circle(r: Int) -> Shape = Circle { radius: r }

--- a/spec/wasm_cross/r5_lowmisc_param_try_err.almd
+++ b/spec/wasm_cross/r5_lowmisc_param_try_err.almd
@@ -1,0 +1,59 @@
+// @contract: C-075
+// Round-5 hole-hunt lowmisc cluster — three checker/lowering fixes that each
+// made native emit invalid Rust (or silently fold the wrong value on wasm)
+// while the other target diverged. All three must now run byte-identically.
+//
+// #624: binding a List/Map PARAM (rendered as a Rust borrow `&[T]` / `&Map`)
+//       to a local must convert to the OWNED type — `.to_vec()` for a slice,
+//       `.clone()` for a map — not an annotation-only `let tmp: Vec<_> = l;`.
+// #629: an effect-fn `Option[T]` result bound to a `let` then consumed by `??`
+//       is an OPTION-fallback: the effect-`Result` auto-? must strip first,
+//       leaving `Option[T]` for `??` (was kept a `Result`, breaking both).
+// #630: `!` propagation inside a fn whose declared error type already matches
+//       the source error must NOT stringify via Debug `map_err` — `?` carries
+//       the custom variant through unchanged.
+
+type AppErr = | Bad(Int)
+
+// #624 List param → local
+fn id_list(l: List[Int]) -> List[Int] = {
+  let tmp = l
+  tmp
+}
+
+// #624 Map param → local
+fn count_map(m: Map[String, Int]) -> Int = {
+  let tmp = m
+  map.len(tmp)
+}
+
+// #629 effect-fn Option bound, consumed by ??
+effect fn lookup(k: String) -> Option[Int] =
+  if k == "a" then some(42) else none
+
+// #630 custom-error ! propagation (source err == fn err == AppErr)
+effect fn fetch(id: Int) -> Result[String, AppErr] = ok("item")
+
+effect fn fetch_two(a: Int) -> Result[String, AppErr] = {
+  let x = fetch(a)!
+  ok(x)
+}
+
+effect fn main() -> Unit = {
+  // #624
+  println("list=${id_list([7, 8])}")
+  let m = map.from_list([("a", 1), ("b", 2)])
+  println("map_len=" + int.to_string(count_map(m)))
+
+  // #629 — none ?? 999 = 999, some(42) ?? 999 = 42
+  let miss = lookup("missing")
+  println("miss=" + int.to_string(miss ?? 999))
+  let hit = lookup("a")
+  println("hit=" + int.to_string(hit ?? 999))
+
+  // #630
+  match fetch_two(2) {
+    ok(v) => println("fetch=" + v),
+    err(Bad(n)) => println("bad=" + int.to_string(n)),
+  }
+}

--- a/spec/wasm_cross/r5_mod_global_init_order.almd
+++ b/spec/wasm_cross/r5_mod_global_init_order.almd
@@ -1,0 +1,28 @@
+// @contract: C-077
+// #632 regression guard (single-file slice of the cross-module bug). WASM
+// evaluates top-let initializers EAGERLY in `global_init_order`; the order is
+// now dependency-respecting, computed INTERPROCEDURALLY. Here `BANNER` is
+// declared FIRST yet its initializer calls `make_banner()`, which reads the
+// `APP_NAME` heap global declared LATER. Before the fix the eager init ran in
+// declaration order, so wasm read the still-zero string header and printed an
+// empty `APP_NAME` (` ready`); native (lazy) was correct. The dependency sort
+// must now initialize `APP_NAME` before `BANNER` on BOTH targets.
+//
+// The owning-module form (`import self.cfg; let GREETING = cfg.APP_NAME`) is
+// the true #632 trigger and is gated by the project-based cross-target test
+// `wasm_cross_module_global_init_order_*` in tests/wasm_runtime_test.rs; the
+// single-file wasm_cross gate cannot host module projects, so this fixture
+// locks the same `__init_globals` ordering machinery in single-file form.
+
+fn make_banner() -> String = "${APP_NAME} ready"
+
+let BANNER = make_banner()
+let APP_NAME = "modg"
+let ITEMS = [10, 20, 30]
+let FIRST = list.len(ITEMS)
+
+fn main() -> Unit = {
+  println(BANNER)
+  println(APP_NAME)
+  println("first-of=${int.to_string(FIRST)}")
+}

--- a/spec/wasm_cross/r5_mod_producer_variant.almd
+++ b/spec/wasm_cross/r5_mod_producer_variant.almd
@@ -1,0 +1,27 @@
+// @contract: C-076
+// #631 regression guard (single-file slice). A producer fn constructs a variant
+// via the BARE constructor and RETURNS it; a consumer matches on the result.
+// The construction expression's `.ty` is pinned to the variant's canonical type
+// name. In a SUBMODULE that owns the variant, that name is `mod.Shape`, and a
+// bare-typed construction tripped the #433 name-pinning guard at codegen on both
+// targets (the real #631 trigger, gated by the project-based cross-target test
+// `wasm_cross_module_producer_side_variant_ctor` in tests/wasm_runtime_test.rs).
+// The single-file wasm_cross gate cannot host module projects, so this fixture
+// locks the producer-side construction + match repr in single-file form.
+
+type Shape = Circle(Int) | Square(Int)
+
+fn make_circle(r: Int) -> Shape = Circle(r)
+fn make_square(w: Int) -> Shape = Square(w)
+
+fn area(s: Shape) -> Int = match s {
+  Circle(r) => r * r * 3,
+  Square(w) => w * w,
+}
+
+fn main() -> Unit = {
+  let c = make_circle(4)
+  let s = make_square(5)
+  println("circle=${int.to_string(area(c))}")
+  println("square=${int.to_string(area(s))}")
+}

--- a/spec/wasm_cross/r5_wasm_inferred_record_repr.almd
+++ b/spec/wasm_cross/r5_wasm_inferred_record_repr.almd
@@ -1,0 +1,43 @@
+// @contract: C-072
+// Cross-target repr of a NAMED record inferred without an annotation (#627).
+//
+// A record literal with no type annotation keeps its structural `Ty::Record` in
+// the IR. Native's checker resolves that structural shape to the unique declared
+// record type by sorted field-name set and reprs it nominally — `Rec { … }` in
+// DECLARATION field order. WASM used to treat it as anonymous: no type-name
+// prefix and ALPHABETICAL field order, diverging two ways.
+//
+// The fix mirrors native: WASM indexes declared records by their sorted
+// field-name set (`named_records`) and, on a match, renders the type name +
+// declaration order while still loading each field VALUE from its real layout
+// offset (so a literal written out of declaration order reads correct values).
+// A truly anonymous record (no matching declared type) stays prefix-less and
+// sorted, identical on both targets.
+
+type Rec   = { zeta: Int, alpha: Int, mid: Int }
+type Point = { x: Int, y: Int }
+
+fn main() -> Unit = {
+  // Inferred, literal in declaration order.
+  let a = { zeta: 1, alpha: 2, mid: 3 }
+  println("${a}")
+
+  // Inferred, literal written OUT of declaration order: values must stay correct.
+  let b = { alpha: 2, mid: 3, zeta: 1 }
+  println("${b}")
+
+  // Explicit annotation (already matched): keep parity.
+  let c: Rec = { zeta: 7, alpha: 8, mid: 9 }
+  println("${c}")
+
+  // Inside a list.
+  println("${[a]}")
+
+  // A different declared record type.
+  let p = { y: 20, x: 10 }
+  println("${p}")
+
+  // Truly anonymous (no declared type with these fields): prefix-less + sorted.
+  let anon = { foo: 1, bar: 2 }
+  println("${anon}")
+}

--- a/spec/wasm_cross/r5_wasm_interp_alias_rc.almd
+++ b/spec/wasm_cross/r5_wasm_interp_alias_rc.almd
@@ -1,0 +1,48 @@
+// @contract: C-071
+// Cross-target RC balance for a degenerate single-part interpolation (#622).
+//
+// `"${s}"` with NOTHING but a single interpolated expression is short-circuited
+// by the WASM emitter to return `s`'s pointer directly (no fresh alloc). When
+// `s` is a freshly heap-allocated runtime String bound to a `let`, the result
+// ALIASES `s`. Without an RC +1 on that alias, `s`'s scope-end Dec and the
+// println-argument Dec both reclaim the same buffer → free-list poisoning →
+// `unreachable` trap at teardown (exit 134) on WASM only; native was clean.
+//
+// The fix classifies a 1-part `StringInterp` over a heap-String alias as
+// borrowed in `yields_borrowed_alias` (Perceus), so the bind acquires its own
+// reference. A literal-bound string, a surrounding-text interpolation, a
+// multi-fragment interpolation, and a non-String part are all genuinely fresh
+// and stay balanced — this fixture pins every shape, native == WASM, clean exit.
+
+fn main() -> Unit = {
+  // Freshly-allocated String, let-bound, consumed ONLY by a bare `"${s}"`.
+  let upper = string.to_upper("abc")
+  println("${upper}")
+
+  // list.join of >=2 elements is also a fresh alloc.
+  let joined = ["1", "2", "3"] |> list.join(",")
+  println("${joined}")
+
+  // replace produces a fresh alloc too.
+  let rep = string.replace("a-b-c", "-", "+")
+  println("${rep}")
+
+  // Surrounding text → fresh concat (was already clean): must stay clean.
+  let mid = string.to_upper("xy")
+  println("x${mid}y")
+
+  // Two fragments of the same alias → fresh concat (already clean).
+  let dup = string.to_upper("zz")
+  println("${dup}-${dup}")
+
+  // Literal-bound string alias: data-section constant, Inc is a no-op.
+  let lit = "hello"
+  println("${lit}")
+
+  // Non-String single part: a fresh `int.to_string`, genuinely fresh.
+  let n = 42
+  println("${n}")
+
+  // The alias must still be usable AFTER the interpolation (no premature free).
+  println(upper)
+}

--- a/spec/wasm_cross/r5_wasm_split_replace_iterative.almd
+++ b/spec/wasm_cross/r5_wasm_split_replace_iterative.almd
@@ -1,0 +1,37 @@
+// @contract: C-074
+// Cross-target string.split / string.replace on large inputs (#634).
+//
+// The WASM runtime for `split` and `replace` recursed once per segment /
+// occurrence (and INFINITELY on an empty `from`, since index_of("") == 0
+// forever). Past a few thousand segments the wasm call stack was exhausted —
+// "call stack exhausted" trap (exit 134), no stdout. Native delegates to Rust
+// std (iterative), so it was correct. Both were de-recursed to forward byte-scan
+// loops (same precedent as `compile_lines`), so the runtime is now O(n) stack-
+// flat and matches the native oracle exactly.
+//
+// The inputs here are deliberately large enough to have trapped before:
+//   split  : "a," * 5000  → 5001 segments
+//   replace: "a," * 6000  → 6000 occurrences of ","
+//   empty-from replace inserts `to` at every codepoint boundary.
+
+fn main() -> Unit = {
+  // split: 5000 "a," → first segment "a", total 5001 parts.
+  let s = string.repeat("a,", 5000)
+  let parts = string.split(s, ",")
+  println(parts |> list.first ?? "none")        // a
+  println(int.to_string(list.len(parts)))        // 5001
+
+  // replace: 6000 "," → ";", length preserved.
+  let big = string.repeat("a,", 6000)
+  let r = string.replace(big, ",", ";")
+  println(int.to_string(string.len(r)))          // 12000
+
+  // Empty-pattern replace inserts at every char boundary (Rust parity).
+  println(string.replace("abc", "", "X"))        // XaXbXcX
+  println(string.replace("", "", "Z"))           // Z
+
+  // A few small semantics, just to keep the oracle honest.
+  println(string.split("a,,b", ",") |> list.join("|"))   // a||b
+  println(string.split("", ",") |> list.join("|"))       // (one empty segment)
+  println(string.replace("abcabc", "abc", "X"))          // XX
+}

--- a/spec/wasm_cross/r5_wasm_tuple_variant_pattern.almd
+++ b/spec/wasm_cross/r5_wasm_tuple_variant_pattern.almd
@@ -1,0 +1,40 @@
+// @contract: C-073
+// Cross-target tuple pattern that tests a variant constructor (#633).
+//
+// `match (a, b) { (Red, _) => … }` puts a variant Constructor pattern in a tuple
+// element of a non-last arm. The WASM tuple-pattern condition builder handled
+// Some/None but had NO arm for Constructor, so it emitted an `If` with NOTHING
+// on the stack → "expected i32 but nothing on stack" structural-validation
+// abort; no .wasm was produced. Native compiled and ran correctly.
+//
+// The fix loads the variant element pointer's tag and compares it to the
+// constructor's tag (a condition operand), and binds any payload binders of a
+// variant element from its `[tag][field…]` layout. This pins nullary variants in
+// either tuple position, both positions, and a payload-carrying variant, all
+// native == WASM.
+
+type Color = | Red | Green
+type Shape = | Empty | Full(Int)
+
+fn classify(a: Color, b: Color) -> String =
+  match (a, b) {
+    (Red, _)       => "red-first",
+    (_, Red)       => "red-second",
+    (Green, Green) => "both-green",
+  }
+
+fn payload(s: Shape) -> String =
+  match (s, 0) {
+    (Full(x), _) => "full-" + int.to_string(x),
+    (Empty, _)   => "empty",
+  }
+
+fn main() -> Unit = {
+  println(classify(Red, Green))    // red-first
+  println(classify(Green, Red))    // red-second
+  println(classify(Green, Green))  // both-green
+  println(payload(Full(42)))       // full-42
+  println(payload(Empty))          // empty
+  // Both nullary positions literal in a non-last arm.
+  println(match (Red, Green) { (Red, Green) => "rg", _ => "x" })
+}

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -649,6 +649,84 @@ fn wasm_cross_module_lambda_without_local_decoy() {
     ]);
 }
 
+const MOD_PKG_TOML: &str = "[package]\nname = \"modtest\"\nversion = \"0.1.0\"\n\n[targets]\nwasm = true\n";
+
+#[test]
+fn wasm_cross_module_producer_side_variant_ctor() {
+    // #631: a producer fn INSIDE the submodule that owns a variant constructs
+    // it via the BARE constructor (`Circle(r)`) and returns it. The ctor-call
+    // expression's `.ty` must be pinned to the OWNER-qualified `shape.Shape`,
+    // or the #433 name-pinning guard aborts BOTH targets at codegen even though
+    // `check` passed. Expected `48` on both (Circle(4) → 4*4*3).
+    assert_cross_target_project(&[
+        ("almide.toml", MOD_PKG_TOML),
+        (
+            "src/shape.almd",
+            "type Shape = Circle(Int) | Square(Int)\n\
+             fn make_circle(r: Int) -> Shape = Circle(r)\n\
+             fn area(s: Shape) -> Int = match s {\n\
+             \x20 Circle(r) => r * r * 3,\n\
+             \x20 Square(w) => w * w,\n\
+             }\n",
+        ),
+        (
+            "main.almd",
+            "import self.shape\n\
+             fn main() -> Unit = {\n\
+             \x20 let c = shape.make_circle(4)\n\
+             \x20 println(int.to_string(shape.area(c)))\n\
+             }\n",
+        ),
+    ]);
+}
+
+#[test]
+fn wasm_cross_module_global_init_order_direct() {
+    // #632: an importing module's top-let reads an imported module's heap
+    // global DIRECTLY. On wasm the eager init order must place `cfg.APP_NAME`
+    // before `GREETING`, or the read hits a still-zero string header. Expected
+    // `modg` on both (was 8 NUL bytes on wasm).
+    assert_cross_target_project(&[
+        ("almide.toml", MOD_PKG_TOML),
+        ("src/cfg.almd", "let APP_NAME = \"modg\"\n"),
+        (
+            "main.almd",
+            "import self.cfg\n\
+             let GREETING = cfg.APP_NAME\n\
+             fn main() -> Unit = {\n\
+             \x20 println(GREETING)\n\
+             }\n",
+        ),
+    ]);
+}
+
+#[test]
+fn wasm_cross_module_global_init_order_through_call() {
+    // #632 (interprocedural): the importing top-let reads the imported global
+    // only THROUGH a function call (`cfg.banner()` interpolates `APP_NAME`) and
+    // a List heap global via `list.len(cfg.ITEMS)`. The init order must still
+    // place the cfg globals first. Expected `modg ok` / `3` on both.
+    assert_cross_target_project(&[
+        ("almide.toml", MOD_PKG_TOML),
+        (
+            "src/cfg.almd",
+            "let APP_NAME = \"modg\"\n\
+             let ITEMS = [10, 20, 30]\n\
+             fn banner() -> String = \"${APP_NAME} ok\"\n",
+        ),
+        (
+            "main.almd",
+            "import self.cfg\n\
+             let BANNER = cfg.banner()\n\
+             let FIRST = list.len(cfg.ITEMS)\n\
+             fn main() -> Unit = {\n\
+             \x20 println(BANNER)\n\
+             \x20 println(int.to_string(FIRST))\n\
+             }\n",
+        ),
+    ]);
+}
+
 /// Like `assert_cross_target`, but for programs whose `main` is an `effect fn`.
 /// Such a main returns `Result[Unit, _]`, and wasmtime's `_start` prints the
 /// wrapped return value (a heap pointer) as a trailing line. Compare only the


### PR DESCRIPTION
Integrates the verified fixes from the round-5 hole-hunt (issues #620–#634), authored by a 4-group worktree-isolated fix workflow and re-homed + re-verified on current develop.

## Fixed (9)
| # | bug | fix |
|---|---|---|
| #622 | wasm `"${s}"` interp of a let-bound heap String double-frees at teardown (trap 134) | Perceus treats a single String-part interpolation as a borrowed alias of its operand → alias-Inc so the binding's scope-end Dec doesn't double-free (`pass_perceus.rs`) |
| #627 | named-record repr diverges native (decl-order) vs wasm (alphabetical) when the type is inferred | wasm repr resolves the inferred record's declared type and prints fields in declaration order (`emit_wasm` + `named_records` map) |
| #633 | wasm tuple pattern testing a variant ctor `(Red,_)` fails structural validation | added the Constructor arm to the tuple-element condition loop in `emit_wasm/control.rs` (tag load + test) |
| #634 | wasm `string.split`/`replace` recurse per-segment → `call stack exhausted` on large inputs | de-recursed both to forward byte-scan loops (same precedent as `compile_lines`); empty-`from` pattern handled |
| #624 | binding a borrowed List/Map param to a local emits native E0308 | the binding initializer converts a ref-param read to the owned type (`walker/statements.rs`) |
| #629 | effect-fn Option bound to a let then consumed by `??` drops the auto-? (native invalid Rust; wasm wrong value) | auto-? strip honored only for annotated-Result / value bindings (`lower/auto_try.rs`) |
| #630 | `!` in an effect fn returning `Result[_, CustomErr]` hardcodes Debug `map_err` → native E0277 | thread the enclosing fn's declared error type through `RenderContext`; matching error propagates without stringifying |
| #631 | producer-side bare variant ctor inside its own submodule fails the #433 guard | in-module construction uses module-aware `lookup_ctor_in` |
| #632 | wasm cross-module heap-global init runs after a cross-module read → imported global reads zero/empty | dependency-respecting topological init order (`ir/top_let_storage.rs`) |

## Completeness mechanisms
- 7 cross-target fixtures `spec/wasm_cross/r5_*.almd` (+ a module integration test), each a new contract **C-071…C-077** in the ledger (bidirectional links verified).
- All proven byte-identical native==wasm via the `wasm_cross_target_spec` gate.

## Verification (clean current-develop build)
- native `spec/` **269/269** · wasm `spec/` 259/0/10 · detector 269/269
- cross-target byte gate **70/0** (incl. the new fixtures; the previously-regressed `list_total_order`/`map_wide_int_key` restored)
- `cargo test --release` **0 failed suites** · contract gate 77 contracts · docs-gen ok

## Not in this PR
- **#626** (int-literal-overflow diagnostic): a first E024 attempt false-positived on valid `UInt64` literals and `i64::MIN` negation — reverted; re-scoped to a type-aware post-solve check (see issue).
- **#620 #621 #623 #625 #628** (the generics/monomorphization cluster): the batch worktrees were seeded with another session's *uncommitted* fixes, so those came back "already-fixed" falsely — they all still reproduce on clean develop and have NO fix here. Tracked for a separate focused pass.