### PR TITLE
Strip phantom generic params from Rust record structs (#621)

### DIFF
--- a/crates/almide-codegen/src/walker/declarations.rs
+++ b/crates/almide-codegen/src/walker/declarations.rs
@@ -11,7 +11,10 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
     let decl_attrs: Vec<&str> = if ctx.repr_c { vec!["repr_c"] } else { vec![] };
 
     // Build generics string e.g. "<T>" or "<T, U>"
-    let generics_str = if let Some(generics) = &td.generics {
+    let generics_str = if ctx.ann.phantom_param_structs.contains(td.name.as_str()) {
+        // All params phantom (#621): drop them so Rust doesn't reject E0392.
+        String::new()
+    } else if let Some(generics) = &td.generics {
         if generics.is_empty() {
             String::new()
         } else {
@@ -213,7 +216,10 @@ fn render_repr_impl(ctx: &RenderContext, td: &IrTypeDecl) -> Option<String> {
     // reprs compose; rendering them through the same template keeps the impl
     // bounds in lock-step with the type decl (Rust requires the impl to satisfy
     // every bound the type definition declares).
-    let (impl_generics, target_args) = match td.generics.as_ref().filter(|g| !g.is_empty()) {
+    // A fully-phantom record (#621) has its generics stripped from the struct,
+    // so its impl must be ungenerified too (`impl AlmideRepr for Tagged`).
+    let phantom = ctx.ann.phantom_param_structs.contains(td.name.as_str());
+    let (impl_generics, target_args) = match td.generics.as_ref().filter(|g| !g.is_empty() && !phantom) {
         Some(generics) => {
             let impl_bounds = generics.iter().map(|g| {
                 // The type DEFINITION declares each param via `generic_bound`
@@ -541,6 +547,42 @@ pub(super) fn compute_eq_blocked_types(type_decls: &[IrTypeDecl]) -> HashSet<Str
         if !changed { break }
     }
     blocked
+}
+
+/// True when `name` (a generic param) appears anywhere in `ty`, as either a
+/// `TypeVar` or a `Named` reference (lowering may leave either spelling).
+fn ty_mentions_param(ty: &Ty, name: &str) -> bool {
+    match ty {
+        Ty::TypeVar(n) => n.as_str() == name,
+        Ty::Named(n, args) => n.as_str() == name || args.iter().any(|a| ty_mentions_param(a, name)),
+        Ty::Applied(_, args) => args.iter().any(|a| ty_mentions_param(a, name)),
+        Ty::Tuple(elems) => elems.iter().any(|e| ty_mentions_param(e, name)),
+        Ty::Fn { params, ret } => params.iter().any(|p| ty_mentions_param(p, name)) || ty_mentions_param(ret, name),
+        Ty::Record { fields } | Ty::OpenRecord { fields } => fields.iter().any(|(_, t)| ty_mentions_param(t, name)),
+        _ => false,
+    }
+}
+
+/// Record types declaring generic params NONE of which are referenced by any
+/// field — Rust's `error[E0392]` rejects such an unused param, so we strip the
+/// generics from the emitted struct and from every reference to it (#621).
+/// Only fully-phantom records qualify: a partly-used param list still needs its
+/// (used) params, so it is left alone here.
+pub(super) fn compute_phantom_param_structs(type_decls: &[IrTypeDecl]) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for td in type_decls {
+        let Some(generics) = &td.generics else { continue };
+        if generics.is_empty() { continue }
+        let IrTypeDeclKind::Record { fields } = &td.kind else { continue };
+        let any_used = generics.iter().any(|g| {
+            let pname = g.name.as_str();
+            fields.iter().any(|f| ty_mentions_param(&f.ty, pname))
+        });
+        if !any_used {
+            out.insert(td.name.to_string());
+        }
+    }
+    out
 }
 
 thread_local! {

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -503,6 +503,7 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         .cloned()
         .collect();
     ann.eq_blocked_types = super::walker::declarations::compute_eq_blocked_types(&all_type_decls);
+    ann.phantom_param_structs = super::walker::declarations::compute_phantom_param_structs(&all_type_decls);
     // §4 endgame: the legacy pre-index (lazy_top_let_names /
     // eager_force_top_lets / const_top_let_vars) and the mutable-storage
     // register block are GONE — every consumer reads the TopLetStorage

--- a/crates/almide-codegen/src/walker/types.rs
+++ b/crates/almide-codegen/src/walker/types.rs
@@ -89,8 +89,15 @@ pub fn render_type(ctx: &RenderContext, ty: &Ty) -> String {
                 let bare = name.rsplit('.').next().unwrap_or(name);
                 bare.to_string()
             } else {
-                let args_str = args.iter().map(|a| render_type(ctx, a)).collect::<Vec<_>>().join(", ");
                 let bare = name.rsplit('.').next().unwrap_or(name);
+                // A fully-phantom record's struct is emitted WITHOUT generics
+                // (#621), so a reference must drop its type args too.
+                if ctx.ann.phantom_param_structs.contains(name.as_str())
+                    || ctx.ann.phantom_param_structs.contains(bare)
+                {
+                    return bare.to_string();
+                }
+                let args_str = args.iter().map(|a| render_type(ctx, a)).collect::<Vec<_>>().join(", ");
                 format!("{}<{}>", bare, args_str)
             }
         }

--- a/crates/almide-ir/src/annotations.rs
+++ b/crates/almide-ir/src/annotations.rs
@@ -56,6 +56,14 @@ pub struct CodegenAnnotations {
     /// derive `PartialEq` (a field transitively blocks equality — e.g.
     /// contains a Matrix or a function pointer).
     pub eq_blocked_types: HashSet<String>,
+    /// Record types ALL of whose generic params are phantom (declared but used
+    /// by no field). Rust rejects an unused type param (`error[E0392]`), so the
+    /// Rust struct is emitted WITHOUT generics and every `Ty::Named` reference to
+    /// it drops its type args — the params carry no runtime data (codegen erases
+    /// types), so `Tagged[String]` and `Tagged[Int]` share one representation,
+    /// matching the wasm target which already erases them (#621). Construction
+    /// and patterns are unaffected (struct literals carry no type args).
+    pub phantom_param_structs: HashSet<String>,
     /// `Mutability::Var` locals that are captured-and-mutated by a closure. On the
     /// Rust target these are lowered to a shared `Rc<Cell<T>>` / `Rc<RefCell<T>>`
     /// cell (declaration, every read/write, and the closure capture go through the

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-77 contracts
+78 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -105,4 +105,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-075 | lowmisc round-5 cluster: borrowed-param owning binding, effect-Option auto-try strip, matching-error ! passthrough |  | active | fixture | 1 |
 | C-076 | Producer-side in-module variant construction is target-stable |  | active | fixture | 1 |
 | C-077 | Cross-module heap-global init order is dependency-respecting |  | active | fixture | 1 |
+| C-078 | Phantom record generic param is stripped on the Rust target |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -941,3 +941,12 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/r5_mod_global_init_order.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-078"
+title     = "Phantom record generic param is stripped on the Rust target"
+statement = "A record type with a generic param used by no field (a phantom param) compiles and runs byte-identical native == wasm. Rust forbids an unused type param (error[E0392]), so the Rust struct and every reference to it are emitted without generics; the param carries no runtime data (codegen erases types), so distinct instantiations share one representation — matching wasm, which already erases type params."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/phantom_type_param.almd", class = "fixture" },
+]

--- a/spec/wasm_cross/phantom_type_param.almd
+++ b/spec/wasm_cross/phantom_type_param.almd
@@ -1,0 +1,15 @@
+// @contract: C-078
+// #621: a record type whose generic param is PHANTOM (declared but used by no
+// field) compiles + runs byte-identical native == wasm. Rust rejects an unused
+// type param (error[E0392]); native codegen previously emitted
+// `struct Tagged<T> { raw: i64 }` verbatim → invalid Rust, while wasm (which
+// erases types) was fine. The Rust target now strips the phantom param from the
+// struct and from every reference to it; the param carries no runtime data so
+// `Tagged[String]` and `Tagged[Int]` share one representation.
+type Tagged[T] = { raw: Int }
+fn unwrap_tag(t: Tagged[String]) -> Int = t.raw
+fn main() -> Unit = {
+  let a: Tagged[String] = { raw: 7 }
+  let b: Tagged[Int] = { raw: 9 }
+  println("${int.to_string(a.raw)} ${int.to_string(b.raw)} ${int.to_string(unwrap_tag(a))}")
+}


### PR DESCRIPTION
## #621 — phantom record generic param → native invalid Rust (E0392)

`type Tagged[T] = { raw: Int }` declares `T` but no field uses it. Native codegen emitted `pub struct Tagged<T: …> { raw: i64 }` verbatim → rustc `error[E0392]: parameter T is never used`. wasm (which erases type params) was already correct → a cross-target divergence (one of the round-5 generics cluster).

### Fix
A new `phantom_param_structs` annotation marks record types ALL of whose generic params are phantom. On the Rust target their struct, its `AlmideRepr` impl, and every `Ty::Named` reference to it are emitted **without** generics. The params carry no runtime data (codegen erases types), so `Tagged[String]` and `Tagged[Int]` share one representation — exactly what wasm already does. Construction and patterns are untouched (struct literals carry no type args). A partly-used param list is left alone (it still needs its used params).

### Completeness mechanism
`spec/wasm_cross/phantom_type_param.almd` (contract **C-078**) — exercises a phantom-param record at two instantiations + a fn param + repr, proven byte-identical native == wasm by the `wasm_cross_target_spec` gate.

### Verification
- repro: native `7 9 7` == wasm `7 9 7` (was native E0392)
- non-phantom `Box[T] = { v: T }` regression: `Box { v: 5 }` identical both targets (generics preserved)
- native `spec/` 268/268 · wasm 258/0/10 · `cargo test -p almide-codegen -p almide-frontend` 114/0 · contract gate 78 contiguous

First of the round-5 generics cluster (#620 #621 #623 #625 #628); the rest remain tracked (task #18 / the issues).

Closes #621