### PR TITLE
Register anonymous-record variant payload types from declarations (#628)

### DIFF
--- a/crates/almide-codegen/src/walker/declarations.rs
+++ b/crates/almide-codegen/src/walker/declarations.rs
@@ -340,6 +340,15 @@ pub fn collect_anon_records(program: &IrProgram, named: &HashMap<Vec<String>, St
     let named_set: HashSet<Vec<String>> = named.keys().cloned().collect();
     let mut seen: HashSet<Vec<String>> = HashSet::new();
 
+    // Collect from TYPE DECLARATIONS — a variant case payload or record field
+    // whose type is an anonymous record (e.g. `| Square({ s: Int })`) may NEVER
+    // be constructed in the program, so it is reachable only here; without this
+    // its struct goes unregistered and `render_type` falls back to emitting the
+    // bare field name as a type → `Square(s)` → rustc E0425 (#628).
+    for td in program.type_decls.iter().chain(program.modules.iter().flat_map(|m| m.type_decls.iter())) {
+        collect_anon_from_type_decl(td, &named_set, &mut seen);
+    }
+
     // Collect from all types AND expressions in the program
     for func in &program.functions {
         for p in &func.params { collect_anon_from_ty(&p.ty, &named_set, &mut seen); }
@@ -371,6 +380,30 @@ pub fn collect_anon_records(program: &IrProgram, named: &HashMap<Vec<String>, St
         map.insert(key, name);
     }
     map
+}
+
+/// Descend a type declaration's field / variant-payload types, registering any
+/// anonymous record reachable only from the declaration (never constructed).
+fn collect_anon_from_type_decl(td: &IrTypeDecl, named: &HashSet<Vec<String>>, seen: &mut HashSet<Vec<String>>) {
+    match &td.kind {
+        IrTypeDeclKind::Record { fields } => {
+            for f in fields { collect_anon_from_ty(&f.ty, named, seen); }
+        }
+        IrTypeDeclKind::Variant { cases, .. } => {
+            for c in cases {
+                match &c.kind {
+                    IrVariantKind::Unit => {}
+                    IrVariantKind::Tuple { fields } => {
+                        for t in fields { collect_anon_from_ty(t, named, seen); }
+                    }
+                    IrVariantKind::Record { fields } => {
+                        for f in fields { collect_anon_from_ty(&f.ty, named, seen); }
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
 }
 
 fn collect_anon_from_expr(expr: &IrExpr, named: &HashSet<Vec<String>>, seen: &mut HashSet<Vec<String>>) {

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-77 contracts
+78 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -105,4 +105,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-075 | lowmisc round-5 cluster: borrowed-param owning binding, effect-Option auto-try strip, matching-error ! passthrough |  | active | fixture | 1 |
 | C-076 | Producer-side in-module variant construction is target-stable |  | active | fixture | 1 |
 | C-077 | Cross-module heap-global init order is dependency-respecting |  | active | fixture | 1 |
+| C-079 | Variant cases with distinct anonymous-record payloads are target-stable |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -941,3 +941,12 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/r5_mod_global_init_order.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-079"
+title     = "Variant cases with distinct anonymous-record payloads are target-stable"
+statement = "A variant whose cases carry anonymous-record payloads with different field-name sets compiles and runs byte-identical native == wasm, including for a payload type that appears only in the declaration (never constructed). The anonymous-record collector scans declaration field/payload types, so every payload lowers to its generated struct (`AlmdRec_<fields>`) instead of native falling back to the bare field name as a type (rustc E0425)."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/anon_record_variant_payloads.almd", class = "fixture" },
+]

--- a/spec/wasm_cross/anon_record_variant_payloads.almd
+++ b/spec/wasm_cross/anon_record_variant_payloads.almd
@@ -1,0 +1,21 @@
+// @contract: C-079
+// #628: a variant with >=2 cases carrying ANONYMOUS-RECORD payloads of DIFFERENT
+// field-name sets. A payload anon record that is never constructed (only present
+// in the type decl) was not registered, so native codegen emitted the bare field
+// name as a type (`Square(s)`) -> rustc E0425; wasm (type-erased) was fine. The
+// anon-record collector now scans variant/record payload types in declarations.
+type Shape =
+  | Circle({ r: Int })
+  | Square({ s: Int })
+  | Rect({ w: Int, h: Int })
+fn area(sh: Shape) -> Int = match sh {
+  Circle(c) => c.r * c.r * 3,
+  Square(c) => c.s * c.s,
+  Rect(c) => c.w * c.h,
+}
+fn main() -> Unit = {
+  println(int.to_string(area(Circle({ r: 2 }))))
+  println(int.to_string(area(Square({ s: 5 }))))
+  println(int.to_string(area(Rect({ w: 3, h: 4 }))))
+  println("${Square({ s: 9 })}")
+}


### PR DESCRIPTION
## #628 — variant case with an anon-record payload of a distinct field set → native E0425

`type Shape = | Circle({ r: Int }) | Square({ s: Int })`. `Circle({ r })` is constructed so its anon record registers; `Square`'s `{ s }` is reachable only from the type declaration, so the collector never saw it. `render_type`'s fallback then emitted the bare field name as a type:

```rust
pub enum Shape { Circle(AlmdRec_r<i64>), Square(s) }   // error[E0425]: cannot find type `s`
```

wasm (type-erased) was fine → a cross-target divergence (round-5 generics cluster).

### Fix
`collect_anon_records` now also scans the field / variant-payload types of every type **declaration** (`collect_anon_from_type_decl`), so an anon-record payload that is never constructed still registers and lowers to its `AlmdRec_<fields>` struct.

### Completeness mechanism
`spec/wasm_cross/anon_record_variant_payloads.almd` (contract **C-079**) — three cases with distinct anon-record payloads (one never matched destructively), constructed + area-matched + repr'd, byte-identical native == wasm.

### Verification
- repro: `Square(AlmdRec_s<i64>)` now emitted (was `Square(s)`); native == wasm `Circle({ r: 9 })`
- fixture: native == wasm `12 / 25 / 12 / Square({ s: 9 })`
- native `spec/` 269/269 · wasm 259/0/10

> Stacks on #636 (#621, C-078); rebase after that merges so C-079 is contiguous.

Closes #628