### PR TITLE
Reject out-of-range integer literals, type-aware (E024) (#626)

### DIFF
--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -13,6 +13,18 @@ impl Checker {
         if let Some(span) = expr.span {
             self.current_span = Some(span);
         }
+        // #626: register a candidate for any int literal that overflows i64. The
+        // actual range error is decided post-solve against context (a wider
+        // annotation or unary negation may make it valid) — see
+        // `validate_int_overflow_literals`. Registering here (not in the Int arm)
+        // keeps `expr.id` / `expr.span` in scope.
+        if let ExprKind::Int { raw, .. } = &expr.kind {
+            if super::int_literal_overflows_i64(raw) {
+                self.deferred_int_overflow_checks.push(super::IntOverflowSite {
+                    expr_id: expr.id, raw: raw.clone(), negated: false, context_ty: None, span: expr.span,
+                });
+            }
+        }
         let ity = self.infer_expr_inner(expr);
         self.type_map.insert(expr.id, ity.clone());
         ity
@@ -614,7 +626,18 @@ impl Checker {
             }
 
             ExprKind::Unary { op, operand, .. } => {
+                let is_neg_lit = op.as_str() == "-" && matches!(&operand.kind, ExprKind::Int { .. });
+                let oid = operand.id;
                 let t = self.infer_expr(operand);
+                // #626: `-<int literal>` lets the negation reach i64::MIN, whose
+                // magnitude (2^63) overflows a bare positive literal but is a
+                // valid i64. Mark the candidate (registered while inferring the
+                // operand) so its post-solve range check uses the signed MIN bound.
+                if is_neg_lit {
+                    if let Some(site) = self.deferred_int_overflow_checks.iter_mut().find(|s| s.expr_id == oid) {
+                        site.negated = true;
+                    }
+                }
                 match op.as_str() { "not" => Ty::Bool, _ => t }
             }
 
@@ -1371,12 +1394,31 @@ impl Checker {
         } else { t }
     }
 
+    /// Pin the declared type onto an int-overflow candidate when the literal is
+    /// the DIRECT value of an annotated binding (`let x: T = 5…` or `= -5…`), so
+    /// a wider `T` (e.g. `UInt64`) makes a >i64 literal valid post-solve (#626).
+    fn record_int_literal_context(&mut self, value: &ast::Expr, declared: &Ty) {
+        let lit_id = match &value.kind {
+            ExprKind::Int { .. } => Some(value.id),
+            ExprKind::Unary { op, operand, .. } if op.as_str() == "-"
+                && matches!(&operand.kind, ExprKind::Int { .. }) => Some(operand.id),
+            ExprKind::Paren { expr } if matches!(&expr.kind, ExprKind::Int { .. }) => Some(expr.id),
+            _ => None,
+        };
+        if let Some(id) = lit_id {
+            if let Some(site) = self.deferred_int_overflow_checks.iter_mut().find(|s| s.expr_id == id) {
+                site.context_ty = Some(declared.clone());
+            }
+        }
+    }
+
     pub(crate) fn check_stmt(&mut self, stmt: &mut ast::Stmt) {
         match stmt {
             ast::Stmt::Let { name, ty, value, span } => {
                 let val_ty = self.infer_expr(value);
                 let final_ty = if let Some(te) = ty {
                     let declared = self.resolve_type_expr(te);
+                    self.record_int_literal_context(value, &declared);
                     self.constrain(declared.clone(), val_ty, format!("let {}", name));
                     declared
                 } else {
@@ -1397,6 +1439,7 @@ impl Checker {
                 let val_ty = self.infer_expr(value);
                 let final_ty = if let Some(te) = ty {
                     let declared = self.resolve_type_expr(te);
+                    self.record_int_literal_context(value, &declared);
                     self.constrain(declared.clone(), val_ty, format!("let {}", name));
                     declared
                 } else {

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -103,6 +103,80 @@ pub struct Checker {
     /// element type cannot be inferred and it is a compile error (E018) — the
     /// Rust/Swift rule, never silently defaulted. See `docs/contracts` C-058.
     pub(crate) deferred_empty_collection_checks: Vec<EmptyCollectionSite>,
+    /// Integer literals whose magnitude exceeds `i64::MAX`, re-checked post-solve
+    /// against their CONTEXT so the range is type-aware (#626). A bare literal in
+    /// a default `Int` (i64) context that overflows would otherwise SILENTLY fold
+    /// to 0 on both targets (`lower` + both codegens parse with `.unwrap_or(0)`).
+    /// Two valid forms are exempted at registration time, not here: a literal
+    /// bound to / annotated as a wider type (`let u: UInt64 = …`) and the negated
+    /// `i64::MIN` magnitude (`-9223372036854775808`).
+    pub(crate) deferred_int_overflow_checks: Vec<IntOverflowSite>,
+}
+
+/// An integer literal that does not fit `i64`, pending a post-solve range check.
+#[derive(Debug, Clone)]
+pub(crate) struct IntOverflowSite {
+    /// The literal's `ExprId` — used to drop the site if a wider annotation
+    /// later exempts it (the value of `let u: UInt64 = …`).
+    pub expr_id: crate::ast::ExprId,
+    /// Raw lexed text (underscores / radix prefix intact).
+    pub raw: String,
+    /// True when the literal is the operand of a unary minus, so its negation
+    /// (down to `i64::MIN`) is the value that must fit — `2^63` is then valid.
+    pub negated: bool,
+    /// The declared type the literal is bound/annotated to, when it is the direct
+    /// value of `let x: T = …` / `var x: T = …`. `None` ⇒ a default `Int` (i64)
+    /// context. A wider `T` (e.g. `UInt64`) makes a >i64 literal valid.
+    pub context_ty: Option<Ty>,
+    pub span: Option<crate::ast::Span>,
+}
+
+/// True when a bare (non-negative) integer literal does not fit in `i64`.
+/// Mirrors the radix parsing in lowering so the check and the eventual value
+/// agree. A malformed token the lexer would not produce is treated as
+/// non-overflowing (not our error to report).
+pub(crate) fn int_literal_overflows_i64(raw: &str) -> bool {
+    let clean = raw.replace('_', "");
+    let (radix, digits) = if let Some(r) = clean.strip_prefix("0x").or_else(|| clean.strip_prefix("0X")) { (16, r) }
+        else if let Some(r) = clean.strip_prefix("0b").or_else(|| clean.strip_prefix("0B")) { (2, r) }
+        else if let Some(r) = clean.strip_prefix("0o").or_else(|| clean.strip_prefix("0O")) { (8, r) }
+        else { (10, clean.as_str()) };
+    match i64::from_str_radix(digits, radix) {
+        Ok(_) => false,
+        Err(e) => matches!(e.kind(), std::num::IntErrorKind::PosOverflow | std::num::IntErrorKind::NegOverflow),
+    }
+}
+
+/// True when `raw`'s magnitude fits the given type's range. For a SIGNED type
+/// the magnitude bound is `MAX` (or `MAX+1` when `negated`, reaching `MIN`); for
+/// an unsigned type it is the unsigned `MAX`. Non-integer types return false
+/// (the literal does not belong there — left for the normal type checker).
+pub(crate) fn int_literal_fits_type(raw: &str, ty: &Ty, negated: bool) -> bool {
+    let clean = raw.replace('_', "");
+    let (radix, digits) = if let Some(r) = clean.strip_prefix("0x").or_else(|| clean.strip_prefix("0X")) { (16, r) }
+        else if let Some(r) = clean.strip_prefix("0b").or_else(|| clean.strip_prefix("0B")) { (2, r) }
+        else if let Some(r) = clean.strip_prefix("0o").or_else(|| clean.strip_prefix("0O")) { (8, r) }
+        else { (10, clean.as_str()) };
+    let Ok(mag) = u128::from_str_radix(digits, radix) else { return true };
+    // (signed, bit-width) for each integer type; None for non-integer.
+    let limits: Option<(bool, u32)> = match ty {
+        Ty::Int | Ty::Int64 => Some((true, 64)),
+        Ty::Int8 => Some((true, 8)), Ty::Int16 => Some((true, 16)), Ty::Int32 => Some((true, 32)),
+        Ty::UInt8 => Some((false, 8)), Ty::UInt16 => Some((false, 16)),
+        Ty::UInt32 => Some((false, 32)), Ty::UInt64 => Some((false, 64)),
+        _ => None,
+    };
+    match limits {
+        None => true, // not an integer context — not our diagnostic
+        Some((signed, bits)) => {
+            let max: u128 = if signed {
+                if negated { 1u128 << (bits - 1) } else { (1u128 << (bits - 1)) - 1 }
+            } else {
+                (1u128 << bits) - 1
+            };
+            mag <= max
+        }
+    }
 }
 
 /// The construct that produced an empty collection whose element type the
@@ -157,6 +231,7 @@ impl Checker {
             deferred_field_accesses: Vec::new(),
             deferred_map_key_checks: Vec::new(),
             deferred_empty_collection_checks: Vec::new(),
+            deferred_int_overflow_checks: Vec::new(),
         }
     }
 
@@ -318,6 +393,7 @@ impl Checker {
         resolve_type_map(&mut self.type_map, &self.uf);
         self.validate_map_key_types();
         self.validate_empty_collection_elements();
+        self.validate_int_overflow_literals();
         // Unused import warnings
         for imp in &program.imports {
             let (path, alias, span) = match imp {
@@ -474,6 +550,7 @@ impl Checker {
         resolve_type_map(&mut self.type_map, &self.uf);
         self.validate_map_key_types();
         self.validate_empty_collection_elements();
+        self.validate_int_overflow_literals();
         self.current_module_prefix = saved_prefix;
 
         // Restore
@@ -1014,6 +1091,47 @@ impl Checker {
     /// the element is never read. Each `?A` that survived the whole-program solve
     /// (against `self.uf`) had no inference source; a populated/annotated form
     /// would have unified it the normal way and resolved clean here.
+    /// Post-solve range check for int literals that overflow `i64` (#626). The
+    /// effective type is the binding's declared type if one was recorded, else
+    /// the literal's resolved type, else a default `Int` (i64). A literal that
+    /// does not fit that type's range — and is not the negated `i64::MIN`
+    /// magnitude — would silently fold to 0 in codegen, so it is rejected (E024).
+    fn validate_int_overflow_literals(&mut self) {
+        let checks = std::mem::take(&mut self.deferred_int_overflow_checks);
+        for site in checks {
+            // Effective type: explicit binding annotation, else the literal's
+            // own resolved type, else default Int.
+            let eff = site.context_ty.clone()
+                .map(|t| resolve_ty(&t, &self.uf))
+                .or_else(|| self.type_map.get(&site.expr_id).map(|t| resolve_ty(t, &self.uf)))
+                .unwrap_or(Ty::Int);
+            // Only a concrete integer context decides this; an unresolved/var or
+            // non-integer effective type is left to the normal checker.
+            let eff = match eff {
+                Ty::Int | Ty::Int8 | Ty::Int16 | Ty::Int32 | Ty::Int64
+                | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 | Ty::UInt64 => eff,
+                _ => Ty::Int, // fall back to the default Int context
+            };
+            if int_literal_fits_type(&site.raw, &eff, site.negated) { continue; }
+            let mut diag = err(
+                format!("integer literal '{}' is out of range for {}", site.raw, eff.display()),
+                format!(
+                    "{} would silently fold to 0 here; use a literal within the type's range, \
+                     or model larger magnitudes as Float (lossy) or a parsed string",
+                    eff.display(),
+                ),
+                format!("integer literal {}", site.raw),
+            ).with_code("E024");
+            if let Some(s) = site.span {
+                diag.file = self.source_file.clone();
+                diag.line = Some(s.line);
+                diag.col = Some(s.col);
+                if s.end_col > s.col { diag.end_col = Some(s.end_col); }
+            }
+            self.diagnostics.push(diag);
+        }
+    }
+
     fn validate_empty_collection_elements(&mut self) {
         let checks = std::mem::take(&mut self.deferred_empty_collection_checks);
         for site in checks {

--- a/docs/diagnostics/E024.md
+++ b/docs/diagnostics/E024.md
@@ -1,0 +1,54 @@
+# E024 — integer literal out of range
+
+An integer literal whose magnitude does not fit the type it is used as. Lowering
+and both code generators parse the literal with `.unwrap_or(0)`, so an
+out-of-range literal would otherwise **silently fold to 0** on both targets with
+no diagnostic. The check is type-aware and runs after type inference, so the
+range is the literal's *actual* type, not always `i64`.
+
+## Common cases
+
+```almide
+fn main() -> Unit = println(int.to_string(9223372036854775808))  // E024: > i64::MAX in an Int context
+```
+
+`9223372036854775808` is `i64::MAX + 1`. In a default `Int` (i64) context it
+cannot be represented, so it would fold to 0.
+
+## Diagnostic
+
+```
+error[E024]: integer literal '9223372036854775808' is out of range for Int
+  hint: Int would silently fold to 0 here; use a literal within the type's range, or model larger magnitudes as Float (lossy) or a parsed string
+```
+
+## Fix
+
+- Use a wider / unsigned type when the magnitude is legitimate:
+  ```almide
+  let big: UInt64 = 9223372036854775808   // UInt64 reaches 18446744073709551615
+  ```
+- The negated `i64::MIN` magnitude is valid as a signed value (the `-` is what
+  makes it representable):
+  ```almide
+  let lo: Int = -9223372036854775808      // i64::MIN — fine
+  ```
+- Model very large magnitudes as `Float` (lossy) or carry them as a string.
+
+## Why type-aware
+
+The range depends on the literal's context, decided post-solve:
+
+- `Int` / `Int64` → i64 (`-9223372036854775808 .. 9223372036854775807`); a bare
+  positive `9223372036854775808` overflows, but `-9223372036854775808` reaches
+  `i64::MIN` and is valid.
+- `UInt64` → `0 .. 18446744073709551615`; `Int8`/`UInt8`/… use their own widths.
+
+A naive `i64`-only check would wrongly reject a valid `UInt64` literal or the
+negated `i64::MIN`, so the check waits for the literal's resolved/annotated type.
+
+## Related
+
+- E018 — empty collection with an uninferable element type (the sibling
+  "never silently default a slot" rule)
+- `docs/CHEATSHEET.md` — numeric types (`Int`, `Int8`…`UInt64`, `Float`)

--- a/llms.txt
+++ b/llms.txt
@@ -171,6 +171,7 @@ let root_i = float.to_int(root_f)    // truncating
 | E021 | Invalid record construction/pattern shape (positional args on a record, unknown/duplicate/missing field, paren pattern on a record case) | Records take named fields: `Cfg(name: x)` or `Cfg { name: x }`; match record cases as `Case { .. }` |
 | E022 | `!` (unwrap-propagate) outside an effect fn body or test block | Mark the enclosing fn `effect fn`, or use `??` for a fallback value (`!` inside a lambda can't propagate) |
 | E023 | Derived `Codec`/`Ord`/`Hash` not satisfied by a field type | Add `: P` to the offending field type (every field of a `: P` type must itself be `P`) — or hand-write `Type.encode`/`decode` for Codec |
+| E024 | Integer literal out of range for its type (would silently fold to 0) | Use a literal within the type's range; for large magnitudes use `UInt64` (or `Float`, lossy); `-9223372036854775808` (i64::MIN) is valid |
 | E420 | Function visibility violation (callee is private) | Make the callee public, or add a public shim |
 
 A rustc 4-digit code (`error[E0XXX]`) leaking through always indicates

--- a/tests/diagnostics/e024-int-literal-overflow/broken.almd
+++ b/tests/diagnostics/e024-int-literal-overflow/broken.almd
@@ -1,0 +1,4 @@
+// An integer literal whose magnitude exceeds i64::MAX in a default Int (i64)
+// context. Lowering and both codegens parse with `.unwrap_or(0)`, so without
+// E024 this would SILENTLY fold to 0 on both targets — no diagnostic. (#626)
+fn main() -> Unit = println(int.to_string(9223372036854775808))

--- a/tests/diagnostics/e024-int-literal-overflow/fixed.almd
+++ b/tests/diagnostics/e024-int-literal-overflow/fixed.almd
@@ -1,0 +1,8 @@
+// The fix: use a literal within the type's range, or a wider/unsigned type for
+// a larger magnitude. `UInt64` reaches 18446744073709551615; the negated
+// `i64::MIN` magnitude is valid as a signed value.
+fn main() -> Unit = {
+  let big: UInt64 = 9223372036854775808
+  let lo: Int = -9223372036854775808
+  println("${uint64.to_string(big)} ${int.to_string(lo)}")
+}

--- a/tests/diagnostics/e024-int-literal-overflow/meta.toml
+++ b/tests/diagnostics/e024-int-literal-overflow/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E024"
+expects_error = "out of range"
+hint_substring = "fold to 0"


### PR DESCRIPTION
## #626 — an integer literal larger than i64::MAX silently folds to 0

`println(int.to_string(9223372036854775808))` (i64::MAX + 1, default Int context) printed `0` on both targets with no diagnostic — `lower` and both codegens parse with `.unwrap_or(0)`.

### Why the naive fix was wrong (and reverted earlier in #635)
A blanket "reject any literal > i64::MAX at the `Int` arm" false-positived on two valid forms and broke `spec/wasm_cross/map_wide_int_key.almd` and `list_total_order.almd`:
- `let u: UInt64 = 18000000000000000000` — valid `UInt64` (≤ u64::MAX)
- `-9223372036854775808` — `i64::MIN`, valid as a signed value

### Type-aware fix
Mirrors the E018 post-solve pattern. Overflow-candidate literals are **registered** during inference (with their `ExprId`/span); the binding's declared type is pinned when the literal is the direct value of `let x: T = …` / `var x: T = …`; a unary-minus operand is marked `negated`. After constraint solving, each candidate is checked against its **effective type** (annotation → resolved type → default `Int`): i64 range for signed (MAX, or MAX+1 = MIN when negated), u64/sized ranges otherwise. Only then is E024 emitted.

### Verified (the path that saves both completeness AND no-regression)
| case | result |
|---|---|
| `9223372036854775808` in Int context | **E024 fires** ✓ |
| `let u: UInt64 = 18000000000000000000` | clean ✓ |
| `-9223372036854775808` (i64::MIN) | clean ✓ |
| `9223372036854775807` (i64::MAX) | clean ✓ |
| `map_wide_int_key` / `list_total_order` fixtures | clean ✓ (restored) |

- native `spec/` 269/269 · wasm 259/0/10 · cross-target byte gate 70/0 · `cargo test` 0 failed · diagnostic harness + coverage green · docs-gen ok.

### Mechanism
`tests/diagnostics/e024-int-literal-overflow/` (broken asserts E024 code/error/hint; fixed — UInt64 + i64::MIN forms — compiles clean), `docs/diagnostics/E024.md`, llms.txt row — enforced by the hard coverage + docs-gen gates.

Closes #626