### PR TITLE
Resolve empty map.from_list / set.from_list element type from the result (#625)

### DIFF
--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -770,6 +770,65 @@ struct Concretizer<'a> {
     enclosing_ret: &'a Ty,
 }
 
+impl<'a> Concretizer<'a> {
+    /// Resolve the empty-list argument element type of `map.from_list(arg)` /
+    /// `set.from_list(arg)` from the expected Map/Set type `ret`, pinning the
+    /// arg expression, any Borrow/Clone/Deref wrappers, and the ANF-temp's
+    /// VarTable entry — the element only flows through the generic return, so
+    /// the checker can leave it `List[(?K,?V)]` past the WASM gate (#625).
+    fn pin_from_list_arg_elem(&mut self, ret: &Ty, value: &mut IrExpr) {
+        use almide_lang::types::constructor::TypeConstructorId as TCI;
+        if ret.has_unresolved_deep() { return; }
+        // `map.from_list` canonicalizes to `map.from_entries`, and by the WASM
+        // emit passes it is a `RuntimeCall` (`almide_rt_map_from_entries`), not a
+        // `Module` call — match both forms for each module (set keeps `from_list`).
+        let from_list_kind = |module: &str, func: &str| -> (bool, bool) {
+            let fl = func == "from_list" || func == "from_entries";
+            (module == "map" && fl, module == "set" && fl)
+        };
+        let (is_map, is_set) = match &value.kind {
+            IrExprKind::Call { target: CallTarget::Module { module, func, .. }, .. } =>
+                from_list_kind(module.as_str(), func.as_str()),
+            IrExprKind::RuntimeCall { symbol, .. } => {
+                let s = symbol.as_str();
+                (s.contains("map_from_entries") || s.contains("map_from_list"),
+                 s.contains("set_from_entries") || s.contains("set_from_list"))
+            }
+            _ => return,
+        };
+        let elem = if is_map {
+            match ret { Ty::Applied(TCI::Map, kv) if kv.len() == 2 => Ty::Tuple(vec![kv[0].clone(), kv[1].clone()]), _ => return }
+        } else if is_set {
+            match ret { Ty::Applied(TCI::Set, e) if e.len() == 1 => e[0].clone(), _ => return }
+        } else { return };
+        let list_ty = Ty::Applied(TCI::List, vec![elem]);
+        let args = match &mut value.kind {
+            IrExprKind::Call { args, .. } | IrExprKind::RuntimeCall { args, .. } => args,
+            _ => return,
+        };
+        {
+            if args.len() != 1 || !args[0].ty.has_unresolved_deep() { return; }
+            propagate_expected_ty(&mut args[0], &list_ty);
+            // Walk through wrappers to the Var, pinning each ty and the VarTable.
+            let mut node = &mut args[0];
+            loop {
+                if node.ty.has_unresolved_deep() { node.ty = list_ty.clone(); }
+                match &mut node.kind {
+                    IrExprKind::Borrow { expr, .. } | IrExprKind::Clone { expr } | IrExprKind::Deref { expr } => node = expr,
+                    IrExprKind::Var { id } => {
+                        let i = id.0 as usize;
+                        if i < self.vt.entries.len() && self.vt.entries[i].ty.has_unresolved_deep() {
+                            self.vt.entries[i].ty = list_ty.clone();
+                        }
+                        break;
+                    }
+                    _ => break,
+                }
+            }
+        }
+    }
+}
+
 impl<'a> IrMutVisitor for Concretizer<'a> {
     fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
         // Custom Match handling: propagate subject ty into pattern bindings
@@ -854,6 +913,22 @@ impl<'a> IrMutVisitor for Concretizer<'a> {
                 }
             }
         }
+        // #625: `map.from_list([])` / `set.from_list([])` — the empty-list
+        // argument's element type is determined ONLY by the call's return
+        // (`Map[K,V]` ← `List[(K,V)]`, `Set[E]` ← `List[E]`). The checker can
+        // leave that arg `List[(?K,?V)]` (the K,V flow only through the generic
+        // signature's return, not through any literal element), which would slip
+        // past this gate on native but be refused by the WASM concretization
+        // gate. Derive the arg element from the resolved return type here.
+        // #625: `map.from_list([])` / `set.from_list([])` where the call is NOT
+        // the direct value of an annotated binding — derive the empty arg's
+        // element from the call's own (resolved) return type. The annotated-bind
+        // case is handled more reliably in `visit_stmt_mut`.
+        {
+            let ret_ty = expr.ty.clone();
+            self.pin_from_list_arg_elem(&ret_ty, expr);
+        }
+
         // Record literal construction: push the declared field types from
         // the registered type down into field value expressions whose own
         // inference left them unresolved (typically `Applied(List,
@@ -945,6 +1020,13 @@ impl<'a> IrMutVisitor for Concretizer<'a> {
                     self.vt.entries[var.0 as usize].ty = value.ty.clone();
                 }
             }
+            // #625: `let m: Map[K,V] = map.from_list(arg)` / `set.from_list`.
+            // The arg's element type flows ONLY through the generic call's
+            // return, so the checker can leave it `List[(?K,?V)]`. The BIND's
+            // declared type is the reliable source (the call's own ty may not
+            // be resolved on every pass), so derive the arg element from it and
+            // pin the arg (and its ANF-temp VarTable entry) before the gate.
+            self.pin_from_list_arg_elem(ty, value);
         }
         // Destructuring let: `let (k, v) = pair`, `let some(x) = opt`, … The
         // checker can leave the bound pattern vars `Unknown` when the subject's

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-79 contracts
+80 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -107,4 +107,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-077 | Cross-module heap-global init order is dependency-respecting |  | active | fixture | 1 |
 | C-078 | Phantom record generic param is stripped on the Rust target |  | active | fixture | 1 |
 | C-079 | Variant cases with distinct anonymous-record payloads are target-stable |  | active | fixture | 1 |
+| C-080 | Empty map.from_list / set.from_list resolves its element from the result type |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -959,3 +959,12 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/anon_record_variant_payloads.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-080"
+title     = "Empty map.from_list / set.from_list resolves its element from the result type"
+statement = "`map.from_list([])` / `set.from_list([])` with an annotated result type compiles and runs byte-identical native == wasm. The empty-list argument's element type flows only through the generic call's return (Map[K,V] from List[(K,V)], Set[E] from List[E]); the checker can leave it an unresolved List slot, which native tolerates but the WASM concretization gate refuses. ConcretizeTypes derives the argument element from the call's resolved Map/Set type — matching both the Module-call and the lowered RuntimeCall (`almide_rt_map_from_entries`) forms — pinning the empty list (and its ANF temp) before the gate."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/empty_from_list_mono.almd", class = "fixture" },
+]

--- a/spec/wasm_cross/empty_from_list_mono.almd
+++ b/spec/wasm_cross/empty_from_list_mono.almd
@@ -1,0 +1,16 @@
+// @contract: C-080
+// #625: `map.from_list([])` / `set.from_list([])` with an annotated result type.
+// The empty-list argument's element type flows ONLY through the generic call's
+// return (Map[K,V] <- List[(K,V)], Set[E] <- List[E]); the checker can leave it
+// List[(?K,?V)] / List[?E], which native tolerates but the WASM concretization
+// gate refuses. ConcretizeTypes now derives the arg element from the call's
+// resolved Map/Set type (matching both the Module-call and the lowered
+// RuntimeCall forms). Both targets build and run byte-identical.
+fn main() -> Unit = {
+  let m: Map[String, Int] = map.from_list([])
+  let s: Set[Int] = set.from_list([])
+  let m2: Map[Int, String] = map.from_list([(1, "a"), (2, "b")])
+  println(int.to_string(map.len(m)))
+  println(int.to_string(set.len(s)))
+  println(int.to_string(map.len(m2)))
+}


### PR DESCRIPTION
## #625 — `map.from_list([])` with a known Map type is refused on wasm

`let e: Map[String, Int] = map.from_list([])` printed `0` natively but the **wasm** build was refused by the concretization gate (`[COMPILER BUG] internal type resolution failed`). The empty-list argument's element type flows ONLY through the generic call's return (`Map[K,V] ← List[(K,V)]`), so the checker can leave it `List[(?K,?V)]`. Native tolerates the residual TypeVar; wasm refuses. The arg is ANF-lifted to `__anf_0`, whose `List[Tuple[K,V]]` slipped the gate.

### Fix
`ConcretizeTypes` derives the empty arg's element from the call's resolved `Map`/`Set` type and pins the arg (plus any Borrow/Clone/Deref wrapper and the ANF-temp's VarTable entry). It matches **both** the `Module` call form (early passes) and the lowered **`RuntimeCall`** form (`almide_rt_map_from_entries`, post-`StdlibLowering`) — the latter was the missing piece (`map.from_list` canonicalizes to `map.from_entries`).

### Verification
- `map.from_list([])`, `set.from_list([])`, the original repro: native == wasm `0` (were wasm-refused)
- non-empty `map.from_list([(1,"a"),(2,"b")])`: native == wasm (regression clean)
- native `spec/` 269/269 · wasm 259/0/10 · cross-target byte gate 70/0 · `cargo test` 0 failed
- fixture `spec/wasm_cross/empty_from_list_mono.almd` → contract **C-080**

Fourth of the round-5 generics cluster (#621 #628 #626 done; #620 #623 remain).

Closes #625