### PR TITLE
Fresh-instantiate unbound generics so a generic fn in an inferred lambda param resolves (#620)

### DIFF
--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -643,6 +643,19 @@ impl Checker {
             e005_fired.push(fired);
         }
         self.arg_spans.clear();
+        // #620: a generic param that NO argument pinned (because the arg was an
+        // unresolved inference var — e.g. `unbox(b)` where `b` is a `list.map`
+        // lambda's not-yet-resolved element) leaves its name UNBOUND in
+        // `bindings`. The back-prop below would then `substitute` the param type
+        // to its LITERAL generic name (`Box[TypeVar("T")]`) and leak it into the
+        // union-find, where it can never be solved to the concrete type that
+        // flows in later (from `list.map`'s collection). Bind each such generic
+        // to a FRESH inference var (shared by the back-prop AND the return type),
+        // so the relation becomes solvable. Generics an argument DID pin keep
+        // their concrete binding; a concrete call is unaffected.
+        for g in &sig.generics {
+            bindings.entry(*g).or_insert_with(|| self.fresh_var());
+        }
         // Verify protocol bounds on generic type parameters
         for (tv_name, proto_names) in &sig.protocol_bounds {
             if let Some(concrete_ty) = bindings.get(tv_name) {

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-80 contracts
+81 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -108,4 +108,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-078 | Phantom record generic param is stripped on the Rust target |  | active | fixture | 1 |
 | C-079 | Variant cases with distinct anonymous-record payloads are target-stable |  | active | fixture | 1 |
 | C-080 | Empty map.from_list / set.from_list resolves its element from the result type |  | active | fixture | 1 |
+| C-081 | Generic fn in an inferred-param lambda resolves its type parameter |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -968,3 +968,12 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/empty_from_list_mono.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-081"
+title     = "Generic fn in an inferred-param lambda resolves its type parameter"
+statement = "A generic function called inside a `list.map` (or similar HOF) lambda whose parameter type is inferred from the collection element compiles and runs byte-identical native == wasm. The generic's type parameter, which flows in only via the HOF's `(A)->B` slot after the lambda body is inferred, is fresh-instantiated before back-propagation instead of leaking its literal name into the union-find, so it resolves to the concrete element type. Verified at two instantiations (Int and String element types)."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/generic_fn_in_inferred_lambda.almd", class = "fixture" },
+]

--- a/spec/wasm_cross/generic_fn_in_inferred_lambda.almd
+++ b/spec/wasm_cross/generic_fn_in_inferred_lambda.almd
@@ -1,0 +1,17 @@
+// @contract: C-081
+// #620: a generic fn called inside a list.map lambda whose param type is left
+// to be inferred from the collection element. The lambda param's generic flowed
+// in only via list.map's (A)->B slot AFTER the body committed unbox's generic T,
+// and `unify_call_arg` does not bind a generic from a TypeVar argument — so T
+// leaked into the union-find as its LITERAL name and never resolved (native
+// [COMPILER BUG] / wasm refused). Now each unbound generic is fresh-instantiated
+// before the back-prop, so T = Box's element = Int resolves. native == wasm.
+type Box[T] = | B(T)
+fn unbox[T](b: Box[T]) -> T = match b { B(x) => x }
+fn main() -> Unit = {
+  let xs: List[Box[Int]] = [B(1), B(2), B(3)]
+  let ys = xs |> list.map((b) => unbox(b))
+  let ss: List[Box[String]] = [B("a"), B("b")]
+  let zs = ss |> list.map((b) => unbox(b))
+  println("${int.to_string(list.len(ys))} ${list.join(zs, ",")}")
+}


### PR DESCRIPTION
## #620 — generic fn in an inferred-param `list.map` lambda leaves a free TypeVar

`xs |> list.map((b) => unbox(b))` with `xs: List[Box[Int]]`, `unbox[T](Box[T]) -> T` — `check` passed but both targets refused (`[COMPILER BUG]` / wasm-build-fail) because the lambda param's type stayed `Box[TypeVar(T)]` post-solve.

### Root (debug-traced)
`crate::types::unify(sig, actual, bindings)` **does not bind a generic when the actual argument is a `TypeVar`** ("a polymorphic type is compatible with anything"). So when `unbox(b)` is checked with `b` an unresolved lambda-param var, `unbox`'s `T` is never pinned in `bindings`. The back-prop then `substitute`s the param type to its **literal** generic name `Box[TypeVar("T")]` and `constrain`s it into the union-find, where `T` is an unbindable literal — it can never unify with the `Int` that flows in later from `list.map`'s collection.

### Fix
After the argument-unification loop, **fresh-instantiate every generic that no argument pinned** (`bindings.entry(g).or_insert_with(|| fresh_var())`), shared by both the back-prop and the return type. The back-prop now constrains `?3 = Box[?freshT]` (a solvable inference var), so `list.map`'s `?3 = Box[Int]` resolves `?freshT = Int`. A concrete call is unaffected (its generics are already bound by the argument).

### Verified
- repro: native == wasm **`3`** (was native COMPILER-BUG / wasm refused)
- fixture exercises Int AND String instantiations: native == wasm `3 a,b`
- **full corpus: native 269/269 · wasm 259/0/10 · cross-target byte gate 70/0 · `cargo test --release` 0 failed** — a core type-checker change with zero regression.
- contract **C-081**

Fifth of the round-5 generics cluster. The remaining #623 (calling a closure-typed lambda param `(f) => f(10)`) is a DIFFERENT root — separate.

Closes #620