### PR TITLE
Calling an unresolved closure-typed lambda param yields the call result (#623)

### DIFF
--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -470,7 +470,19 @@ impl Checker {
                         format!("call to {}()", name)).with_code("E002"));
                     return Ty::Unknown;
                 }
-                return ty;
+                // #623: `f` is an as-yet-unresolved inference var being CALLED — so
+                // it MUST be a function. Constrain it to `(arg_tys) -> ?ret` and
+                // return `?ret`, not `f`'s own type. Returning `ty` typed the call
+                // result as f's CLOSURE type (e.g. `(f) => f(10)` in a `list.map`
+                // lambda became `((Int)->Int) -> ((Int)->Int)` instead of
+                // `((Int)->Int) -> Int`), so codegen emitted a closure body that
+                // returns a closure where it returns the call result (invalid Rust
+                // / wrong wasm). `?ret` is resolved from context — e.g. the element
+                // type `(Int)->Int` flowing in from `list.map` pins `?ret = Int`.
+                let ret = self.fresh_var();
+                let fn_ty = Ty::Fn { params: arg_tys.to_vec(), ret: Box::new(ret.clone()) };
+                self.constrain(fn_ty, ty, format!("call to {}()", name));
+                return ret;
             }
             // Triple: (hint, clean fn-name fix for simple try:, rich multi-line snippet).
             // `rich_snippet` overrides `fix_name` when present — used for hallucinations

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-81 contracts
+82 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -109,4 +109,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-079 | Variant cases with distinct anonymous-record payloads are target-stable |  | active | fixture | 1 |
 | C-080 | Empty map.from_list / set.from_list resolves its element from the result type |  | active | fixture | 1 |
 | C-081 | Generic fn in an inferred-param lambda resolves its type parameter |  | active | fixture | 1 |
+| C-082 | Calling a closure-typed lambda parameter yields the call result, not the closure |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -977,3 +977,12 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/generic_fn_in_inferred_lambda.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-082"
+title     = "Calling a closure-typed lambda parameter yields the call result, not the closure"
+statement = "A lambda whose body CALLS one of its parameters — `(f) => f(10)` over a `List[(Int)->Int]` via `list.map` — compiles and runs byte-identical native == wasm. When the called parameter's type is an unresolved inference var at the call site, the call constrains it to `(args)->?ret` and yields `?ret` (resolved from context), not the parameter's own closure type — so the HOF result is `List[?ret]`, not a list of closures. Verified for Int and String closure element types."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/call_closure_lambda_param.almd", class = "fixture" },
+]

--- a/spec/wasm_cross/call_closure_lambda_param.almd
+++ b/spec/wasm_cross/call_closure_lambda_param.almd
@@ -1,0 +1,15 @@
+// @contract: C-082
+// #623: calling a lambda parameter that is itself a closure — `(f) => f(10)` in
+// a list.map over a List[(Int)->Int]. When `f`'s type is an unresolved inference
+// var at the call site, the body was typed as f's OWN closure type, not the call
+// RESULT, so list.map's result became List[(Int)->Int] and codegen emitted a
+// closure body returning a closure (native invalid Rust E0271 / wrong wasm). The
+// call now constrains f to `(args)->?ret` and returns `?ret` (resolved to Int
+// from the element type). native == wasm.
+fn main() -> Unit = {
+  let fns: List[(Int) -> Int] = [(x: Int) => x + 1, (x: Int) => x * 2]
+  let applied = list.map(fns, (f) => f(10))
+  let strs: List[(String) -> String] = [(s: String) => s + "!"]
+  let greeted = list.map(strs, (g) => g("hi"))
+  println("${int.to_string(applied[0])} ${int.to_string(applied[1])} ${greeted[0]}")
+}


### PR DESCRIPTION
## #623 — `(f) => f(10)` over a `List[(Int)->Int]` mis-types the lambda body

`list.map(fns, (f) => f(10))` with `fns: List[(Int)->Int]` — `check` passed, but the emitted lambda was

```rust
move |f: Rc<dyn Fn(i64)->i64>| (f.clone())(10i64)
    as Rc<dyn Fn(Rc<dyn Fn(i64)->i64>) -> Rc<dyn Fn(i64)->i64>>   // ret should be i64!
```

i.e. the body `f(10)` was typed as f's OWN closure type, not the call RESULT, so `list.map`'s result became `List[(Int)->Int]` and rustc rejected it (`E0271: closure returns i64, expected Rc<dyn Fn>`).

### Root
When a call's callee is a local var whose type is still an **unresolved inference var** (`f` in an eagerly-inferred lambda body, before `list.map` flows in its `(Int)->Int` element type), `check_named_call`'s fallback did `return ty` — the var's OWN type — instead of treating the var as a function.

### Fix
Calling an unresolved var means it MUST be a function: constrain it to `(arg_tys) -> ?ret` and return `?ret`. The element type flowing in from `list.map` then pins `?ret = Int`, so the body is `Int` and the HOF result is `List[Int]`.

### Verified
- idiomatic `(f) => f(10)`: native == wasm — applied/strs fixture prints `11 20 hi!`
- the original unsound `rr[0](5)` (calling an `Int`) is now correctly REJECTED with E001 (was wrongly accepted) — the finding's expected behavior
- **full corpus: native 269/269 · wasm 259/0/10 · cross-target byte gate 70/0 · `cargo test --release` 0 failed** — second core type-checker change, zero regression
- contract **C-082**

**This closes the LAST of the round-5 generics cluster** (#621 #628 #626 #625 #620 #623 all fixed).

Closes #623