### PR TITLE
WASM repr fixes: nested let-destructure + generic record field sizing; UnionFind robustness

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/collections.rs
+++ b/crates/almide-codegen/src/emit_wasm/collections.rs
@@ -13,6 +13,13 @@ impl FuncCompiler<'_> {
         let tag = self.resolve_variant_tag(name, result_ty);
         let tag_size: u32 = if tag.is_some() { 4 } else { 0 };
 
+        // Concrete field layout: generic params substituted from result_ty's type
+        // args, so a generic field (`value: T` with T = Int) is sized by its
+        // INSTANTIATED type. The declared field list keeps the unresolved param
+        // (byte_size 4), which under-allocates the record and makes a trailing
+        // field's write run PAST the block — read back as empty/garbage (#650).
+        let concrete_record_fields = self.extract_record_fields(result_ty);
+
         // Compute total size from type definition (includes defaults)
         let type_field_size: u32 = if let Some(ctor_name) = name {
             let mut size = 0u32;
@@ -25,7 +32,9 @@ impl FuncCompiler<'_> {
                 }
             }
             if size == 0 {
-                if let Some(rf) = self.emitter.record_fields.get(ctor_name) {
+                if !concrete_record_fields.is_empty() {
+                    size = concrete_record_fields.iter().map(|(_, ty)| values::byte_size(ty)).sum();
+                } else if let Some(rf) = self.emitter.record_fields.get(ctor_name) {
                     size = rf.iter().map(|(_, ty)| values::byte_size(ty)).sum();
                 }
             }
@@ -76,7 +85,12 @@ impl FuncCompiler<'_> {
                 }
             }
             if found.is_empty() {
-                if let Some(rf) = self.emitter.record_fields.get(ctor_name) {
+                // Prefer the CONCRETE layout so the fallback field types (used when
+                // an explicit field expr is unresolved) and the field ORDER carry
+                // the instantiated generic sizes (#650).
+                if !concrete_record_fields.is_empty() {
+                    found = concrete_record_fields.clone();
+                } else if let Some(rf) = self.emitter.record_fields.get(ctor_name) {
                     found = rf.clone();
                 }
             }

--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -398,49 +398,10 @@ impl FuncCompiler<'_> {
                 self.emit_expr(value);
                 let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, { local_set(scratch); });
-
-                // Destructure pattern
-                match pattern {
-                    almide_ir::IrPattern::Tuple { elements } => {
-                        let elem_types = if let almide_lang::types::Ty::Tuple(tys) = &value.ty {
-                            tys.clone()
-                        } else { vec![] };
-
-                        // #524: the offset advance is UNCONDITIONAL — the
-                        // former placement inside the bind's `if let` meant
-                        // one missing local corrupted every SUBSEQUENT
-                        // element's load offset (active corruption, not just
-                        // a skipped bind).
-                        let mut offset = 0u32;
-                        for (i, elem_pat) in elements.iter().enumerate() {
-                            let elem_ty = elem_types.get(i).cloned().unwrap_or(almide_lang::types::Ty::Int);
-                            if let almide_ir::IrPattern::Bind { var, .. } = elem_pat {
-                                if let Some(&local_idx) = self.var_map.get(&var.0) {
-                                    wasm!(self.func, { local_get(scratch); });
-                                    self.emit_load_at(&elem_ty, offset);
-                                    wasm!(self.func, { local_set(local_idx); });
-                                }
-                            }
-                            offset += super::values::byte_size(&elem_ty);
-                        }
-                    }
-                    almide_ir::IrPattern::RecordPattern { fields: pat_fields, .. } => {
-                        // Record destructure: load each field from record ptr at its offset.
-                        // Field order and types come from the value's type.
-                        let record_fields = self.extract_record_fields(&value.ty);
-                        for pf in pat_fields {
-                            if let Some((offset, field_ty)) = super::values::field_offset(&record_fields, &pf.name) {
-                                // find_var_by_field searches var_map by name
-                                if let Some(&local_idx) = self.find_var_by_field(&pf.name, &record_fields) {
-                                    wasm!(self.func, { local_get(scratch); });
-                                    self.emit_load_at(&field_ty, offset);
-                                    wasm!(self.func, { local_set(local_idx); });
-                                }
-                            }
-                        }
-                    }
-                    _ => {}
-                }
+                // Recursive so a NESTED sub-pattern (`let (a, (b, c)) = …`) binds
+                // its leaves instead of leaving them zeroed (#654); mirrors the
+                // local pre-scan in `scan_destructure_pattern`.
+                self.emit_bind_destructure(pattern, scratch, &value.ty);
                 self.scratch.free_i32(scratch);
             }
 
@@ -1186,6 +1147,71 @@ pub fn collect_locals(
     let mut binds = Vec::new();
     scan_expr(body, &mut binds, var_table, record_fields, variant_info);
     LocalScanResult { binds }
+}
+
+impl FuncCompiler<'_> {
+    /// Bind every leaf of a let-destructure pattern, recursing into nested
+    /// tuple/record sub-patterns. `base_local` holds the aggregate pointer for a
+    /// Tuple/RecordPattern, or the scalar/pointer value for a `Bind`. Mirrors
+    /// `scan_destructure_pattern` (which pre-allocates the leaf locals); without
+    /// the recursion a nested sub-pattern left its leaves zeroed (#654).
+    fn emit_bind_destructure(&mut self, pattern: &almide_ir::IrPattern, base_local: u32, base_ty: &Ty) {
+        match pattern {
+            almide_ir::IrPattern::Bind { var, .. } => {
+                if let Some(&local_idx) = self.var_map.get(&var.0) {
+                    wasm!(self.func, { local_get(base_local); local_set(local_idx); });
+                }
+            }
+            almide_ir::IrPattern::Tuple { elements } => {
+                let elem_types = if let Ty::Tuple(tys) = base_ty { tys.clone() } else { vec![] };
+                let mut offset = 0u32;
+                for (i, elem_pat) in elements.iter().enumerate() {
+                    let elem_ty = elem_types.get(i).cloned().unwrap_or(Ty::Int);
+                    self.emit_destructure_elem(elem_pat, base_local, offset, &elem_ty);
+                    offset += super::values::byte_size(&elem_ty);
+                }
+            }
+            almide_ir::IrPattern::RecordPattern { fields, .. } => {
+                let record_fields = self.extract_record_fields(base_ty);
+                for pf in fields {
+                    if let Some((offset, field_ty)) = super::values::field_offset(&record_fields, &pf.name) {
+                        if let Some(sub) = &pf.pattern {
+                            self.emit_destructure_elem(sub, base_local, offset, &field_ty);
+                        } else if let Some(&local_idx) = self.find_var_by_field(&pf.name, &record_fields) {
+                            wasm!(self.func, { local_get(base_local); });
+                            self.emit_load_at(&field_ty, offset);
+                            wasm!(self.func, { local_set(local_idx); });
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Bind a sub-pattern living at `offset` from `base_local`. A leaf `Bind`
+    /// loads the scalar/pointer directly; a nested aggregate loads its pointer
+    /// and recurses with it as the new base.
+    fn emit_destructure_elem(&mut self, pat: &almide_ir::IrPattern, base_local: u32, offset: u32, elem_ty: &Ty) {
+        match pat {
+            almide_ir::IrPattern::Bind { var, .. } => {
+                if let Some(&local_idx) = self.var_map.get(&var.0) {
+                    wasm!(self.func, { local_get(base_local); });
+                    self.emit_load_at(elem_ty, offset);
+                    wasm!(self.func, { local_set(local_idx); });
+                }
+            }
+            almide_ir::IrPattern::Tuple { .. } | almide_ir::IrPattern::RecordPattern { .. } => {
+                let sub = self.scratch.alloc_i32();
+                wasm!(self.func, { local_get(base_local); });
+                self.emit_load_at(elem_ty, offset);
+                wasm!(self.func, { local_set(sub); });
+                self.emit_bind_destructure(pat, sub, elem_ty);
+                self.scratch.free_i32(sub);
+            }
+            _ => {}
+        }
+    }
 }
 
 // ── LocalScanner: IrVisitor-based local variable collector ──────────

--- a/crates/almide-frontend/src/check/types.rs
+++ b/crates/almide-frontend/src/check/types.rs
@@ -88,7 +88,12 @@ impl UnionFind {
     /// Uses path halving (every other node points to grandparent) for amortized
     /// near-constant time without requiring &mut self.
     pub fn find(&self, mut id: u32) -> u32 {
-        while self.parent[id as usize] != id {
+        // An id past the end of THIS UnionFind was never registered here, so it is
+        // its own representative (a free singleton). This happens when a TyVarId
+        // leaks in from an outer scope after a fresh UnionFind is swapped in for
+        // module/nested inference — returning `id` instead of indexing keeps the
+        // checker total instead of panicking (#653).
+        while (id as usize) < self.parent.len() && self.parent[id as usize] != id {
             id = self.parent[id as usize];
         }
         id
@@ -101,6 +106,9 @@ impl UnionFind {
         let ra = self.find(a);
         let rb = self.find(b);
         if ra == rb { return; }
+        // A root past the end is a foreign/leaked id (see `find`) — this
+        // UnionFind owns no slot for it, so there is nothing to merge (#653).
+        if (ra as usize) >= self.parent.len() || (rb as usize) >= self.parent.len() { return; }
         let (winner, loser) = if self.rank[ra as usize] >= self.rank[rb as usize] { (ra, rb) } else { (rb, ra) };
         self.parent[loser as usize] = winner;
         if self.rank[winner as usize] == self.rank[loser as usize] {
@@ -117,6 +125,9 @@ impl UnionFind {
     /// returns the existing binding for the caller to unify structurally.
     pub fn bind(&mut self, id: u32, ty: Ty) -> Option<Ty> {
         let root = self.find(id);
+        // A foreign/leaked root (past this UnionFind's slots) cannot be bound here
+        // (#653); drop the binding rather than panic — it belongs to another scope.
+        if (root as usize) >= self.bound.len() { return None; }
         let existing = self.bound[root as usize].take();
         self.bound[root as usize] = Some(ty);
         existing
@@ -125,7 +136,7 @@ impl UnionFind {
     /// Get the concrete type bound to `id`'s root, if any.
     pub fn resolve(&self, id: u32) -> Option<&Ty> {
         let root = self.find(id);
-        self.bound[root as usize].as_ref()
+        self.bound.get(root as usize).and_then(|b| b.as_ref())
     }
 
     /// Check whether `var` occurs anywhere inside `ty` (infinite type prevention).

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-90 contracts
+92 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -118,4 +118,6 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-088 | A Rust-keyword function name compiles on both targets |  | active | fixture | 1 |
 | C-089 | A default parameter referencing an earlier parameter is filled with its argument |  | active | fixture | 1 |
 | C-090 | bytes.from_list on a List[Int] parameter compiles on both targets |  | active | fixture | 1 |
+| C-091 | A nested sub-pattern in let-destructuring binds every leaf |  | active | fixture | 1 |
+| C-092 | A generic record field is sized by its instantiated type at construction |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -1058,3 +1058,21 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/bytes_from_list_param.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-091"
+title     = "A nested sub-pattern in let-destructuring binds every leaf"
+statement = "A let-destructuring pattern containing a nested tuple (or record) sub-pattern binds every leaf, byte-identical native == wasm. The WASM emit handled only a flat Bind element and skipped nested sub-patterns — their leaves stayed zeroed; it now recurses, loading each sub-aggregate pointer and binding through it, mirroring the local pre-scan that already allocated those leaf locals."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/nested_tuple_destructure.almd", class = "fixture" },
+]
+
+[[contract]]
+id        = "C-092"
+title     = "A generic record field is sized by its instantiated type at construction"
+statement = "A generic record field is allocated and laid out by its instantiated type, byte-identical native == wasm. The WASM record emit sized the block from the DECLARED field list, so a generic field (value: T) used the unresolved param's default size (4 bytes); a trailing concrete heap field then wrote past the under-allocated block and read back empty, corrupting both the record and any spread of it. Construction now derives size and field order from the concrete (generic-substituted) layout of the result type."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/generic_record_field_size.almd", class = "fixture" },
+]

--- a/spec/wasm_cross/generic_record_field_size.almd
+++ b/spec/wasm_cross/generic_record_field_size.almd
@@ -1,0 +1,25 @@
+// @contract: C-092
+// A generic record field must be sized by its INSTANTIATED type at construction,
+// byte-identical native == wasm. The WASM record emit allocated from the DECLARED
+// field list, so a generic field (`value: T`) used the unresolved param's size
+// (4 bytes); a trailing concrete heap field (`label: String`) then wrote past the
+// under-allocated block and read back empty, corrupting both the record and any
+// spread of it. Construction now uses the concrete (substituted) field layout. #650.
+
+type Box[T] = { value: T, label: String }
+type Pair[A, B] = { first: A, second: B, tag: String }
+
+fn main() -> Unit = {
+  let b = Box { value: 7, label: "old" }       // value: Int (8 bytes) precedes label
+  let b2 = Box { ...b, value: 8 }
+  println("b2=${b2.value} b.label=${b.label} b2.label=${b2.label}")
+
+  let bs = Box { value: "hello", label: "L" }   // value: String (4 bytes)
+  println("${bs.value} ${bs.label}")
+
+  let p = Pair { first: 100, second: "hi", tag: "T" } // two generics + trailing concrete
+  println("${p.first} ${p.second} ${p.tag}")
+
+  let p2 = Pair { ...p, first: 200 }
+  println("${p2.first} ${p2.second} ${p2.tag}")
+}

--- a/spec/wasm_cross/nested_tuple_destructure.almd
+++ b/spec/wasm_cross/nested_tuple_destructure.almd
@@ -1,0 +1,21 @@
+// @contract: C-091
+// A let-destructuring pattern with a NESTED tuple (or record) sub-pattern must
+// bind every leaf, byte-identical native == wasm. The WASM emit only handled a
+// flat `Bind` element and skipped nested sub-patterns, leaving their leaves
+// zeroed; it now recurses (loading the sub-aggregate pointer) exactly like the
+// local pre-scan. #654.
+
+fn main() -> Unit = {
+  let (a, (b, c)) = (1, (2, 3))
+  println("${a} ${b} ${c}")
+
+  let ((x, y), z) = ((4, 5), 6)
+  println("${x} ${y} ${z}")
+
+  let (p, (q, (r, s))) = (7, (8, (9, 10)))
+  println("${p} ${q} ${r} ${s}")
+
+  // nested tuple holding a heap value
+  let (n, (txt, m)) = (11, ("hi", 12))
+  println("${n} ${txt} ${m}")
+}


### PR DESCRIPTION
Round-6 hole-hunt batch — two WASM-codegen divergences (each with a `spec/wasm_cross/*.almd` byte-identical fixture + contract C-091/C-092) plus a checker-robustness hardening.

## Fixes

- **#654 — a nested sub-pattern in a let-destructuring left its leaves zeroed on WASM.** `let (a, (b, c)) = (1, (2, 3))` bound `b`/`c` to 0 because the emit only handled a flat `Bind` element. It now recurses into nested tuple/record sub-patterns (loading each sub-aggregate pointer), mirroring the local pre-scan that already allocates the leaf locals. (C-091)
- **#650 — a generic record field was sized by its declared (unresolved) param on WASM.** `Box[T] = { value: T, label: String }` allocated `value` at the param's 4-byte default, so the trailing `String` wrote PAST the block and read back empty — corrupting the record and any spread of it. Construction now derives size and field order from the concrete (generic-substituted) layout of the result type. (C-092)

## Robustness (partial #653)

- **`UnionFind::find` is now total against a leaked type-var id.** A `TyVarId` from an outer scope could reach a freshly-swapped UnionFind during module/nested inference and OOB-panic (`types.rs:91`) — a checker-soundness ICE where `check` greenlit a program whose deeper inference deterministically crashed. `find`/`union`/`bind`/`resolve` now treat an unregistered id as a free singleton instead of indexing past the end. This **eliminates the ICE class** (the round-6 #653 repro no longer panics, and runs correctly on WASM). NOTE: #653's deeper symptom — a protocol-method UFCS call on an inferred lambda param mis-typing the param as a closure on the NATIVE target (E0308) — is a separate inference bug in the #620/#623 cluster and is **not** closed here; #653 stays open for that.

## Verification

- Full `wasm_cross_target_spec` byte gate green (144/144 fixtures byte-identical native == wasm).
- `almide test spec/` green (269/269 files) — validates the checker UnionFind change is non-regressing on both targets.
- `check-contracts.sh` green (92 contracts); contract README regenerated.

Closes #650
Closes #654