### PR TITLE
Box mutually-recursive variant types by cycle reachability

### DIFF
--- a/crates/almide-codegen/src/pass_box_deref.rs
+++ b/crates/almide-codegen/src/pass_box_deref.rs
@@ -3,7 +3,7 @@
 //! When a recursive enum has Box'd fields (e.g., Node(Box<Tree>, Box<Tree>)),
 //! variables bound in match patterns from those fields need *deref when used.
 
-use std::collections::HashSet;
+use std::collections::{HashSet, HashMap};
 use almide_ir::*;
 use almide_lang::types::Ty;
 use super::pass::{NanoPass, PassResult, Target};
@@ -42,24 +42,25 @@ impl NanoPass for BoxDerefPass {
         // Step 3: Populate codegen annotations
         program.codegen_annotations.recursive_enums = recursive.clone();
 
-        // Build boxed_fields: for each recursive enum, find which variant fields reference the enum
+        // Build boxed_fields: for each recursive enum, find which variant fields
+        // reference ANY cycle member (mutual recursion, not only self) (#656).
+        let rec_ref = &recursive;
         program.codegen_annotations.boxed_fields = program.type_decls.iter()
             .chain(program.modules.iter().flat_map(|m| m.type_decls.iter()))
-            .filter(|td| recursive.contains(&*td.name))
+            .filter(|td| rec_ref.contains(&*td.name))
             .filter_map(|td| match &td.kind {
-                IrTypeDeclKind::Variant { cases, .. } => Some((td, cases)),
+                IrTypeDeclKind::Variant { cases, .. } => Some(cases),
                 _ => None,
             })
-            .flat_map(|(td, cases)| {
+            .flat_map(|cases| {
                 cases.iter().flat_map(move |c| {
-                    let name = &td.name;
                     match &c.kind {
                         IrVariantKind::Record { fields } => fields.iter()
-                            .filter(|f| walker::ty_contains_name(&f.ty, name))
+                            .filter(|f| walker::ty_contains_any_recursive(&f.ty, rec_ref))
                             .map(|f| (c.name.to_string(), f.name.to_string()))
                             .collect::<Vec<_>>(),
                         IrVariantKind::Tuple { fields } => fields.iter().enumerate()
-                            .filter(|(_, t)| walker::ty_contains_name(t, name))
+                            .filter(|(_, t)| walker::ty_contains_any_recursive(t, rec_ref))
                             .map(|(i, _)| (c.name.to_string(), format!("{}", i)))
                             .collect::<Vec<_>>(),
                         _ => vec![],
@@ -110,17 +111,54 @@ impl NanoPass for BoxDerefPass {
 }
 
 /// Find recursive enums from a set of type declarations.
+/// Collect every Named/Variant type name appearing anywhere inside `ty`.
+fn collect_type_names(ty: &Ty, out: &mut HashSet<String>) {
+    let names = std::cell::RefCell::new(out);
+    ty.any_child_recursive(&|t| {
+        match t {
+            Ty::Named(n, _) => { names.borrow_mut().insert(n.to_string()); }
+            Ty::Variant { name, .. } => { names.borrow_mut().insert(name.to_string()); }
+            _ => {}
+        }
+        false // visit every child, never short-circuit
+    });
+}
+
+/// A variant type needs a Box indirection iff it participates in a recursion
+/// CYCLE — it can reach itself by following variant-field type references. This
+/// catches mutual recursion (`type A = A(B); type B = B(A)`), not only direct
+/// self-recursion, so neither member is emitted as an infinitely-sized native
+/// enum (E0072) (#656).
 fn find_recursive_enums<'a>(type_decls: impl Iterator<Item = &'a IrTypeDecl>) -> HashSet<String> {
-    let mut recursive = HashSet::new();
+    // Reference graph: type name → names it mentions in any variant field type.
+    let mut graph: HashMap<String, HashSet<String>> = HashMap::new();
     for td in type_decls {
         if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
-            let is_recursive = cases.iter().any(|case| match &case.kind {
-                IrVariantKind::Tuple { fields } => fields.iter().any(|f| ty_contains_name(f, &td.name)),
-                IrVariantKind::Record { fields } => fields.iter().any(|f| ty_contains_name(&f.ty, &td.name)),
-                _ => false,
-            });
-            if is_recursive {
-                recursive.insert(td.name.to_string());
+            let mut refs = HashSet::new();
+            for case in cases {
+                match &case.kind {
+                    IrVariantKind::Tuple { fields } => {
+                        for f in fields { collect_type_names(f, &mut refs); }
+                    }
+                    IrVariantKind::Record { fields } => {
+                        for f in fields { collect_type_names(&f.ty, &mut refs); }
+                    }
+                    _ => {}
+                }
+            }
+            graph.insert(td.name.to_string(), refs);
+        }
+    }
+    // A type is recursive iff it can reach itself through ≥1 edge.
+    let mut recursive = HashSet::new();
+    for start in graph.keys().cloned().collect::<Vec<_>>() {
+        let mut stack: Vec<String> = graph[&start].iter().cloned().collect();
+        let mut visited: HashSet<String> = HashSet::new();
+        while let Some(n) = stack.pop() {
+            if n == start { recursive.insert(start.clone()); break; }
+            if !visited.insert(n.clone()) { continue; }
+            if let Some(next) = graph.get(&n) {
+                stack.extend(next.iter().cloned());
             }
         }
     }
@@ -357,7 +395,7 @@ impl IrVisitor for DerefCollector<'_> {
                 if self.recursive_enums.contains(ename.as_str()) {
                     let td = self.type_decls.iter().find(|td| *ename == td.name);
                     for arm in arms {
-                        collect_deref_from_pattern(&arm.pattern, ename, td, self.name_to_var, self.deref_vars);
+                        collect_deref_from_pattern(&arm.pattern, self.recursive_enums, td, self.name_to_var, self.deref_vars);
                     }
                 }
             }
@@ -377,12 +415,14 @@ fn find_variant_case<'a>(td: Option<&'a IrTypeDecl>, ctor_name: &str) -> Option<
     cases.iter().find(|c| c.name == ctor_name).map(|c| &c.kind)
 }
 
-fn collect_deref_from_pattern(pattern: &IrPattern, enum_name: &str, td: Option<&IrTypeDecl>, name_to_var: &std::collections::HashMap<String, Vec<VarId>>, deref_vars: &mut HashSet<VarId>) {
+fn collect_deref_from_pattern(pattern: &IrPattern, recursive: &HashSet<String>, td: Option<&IrTypeDecl>, name_to_var: &std::collections::HashMap<String, Vec<VarId>>, deref_vars: &mut HashSet<VarId>) {
     match pattern {
         IrPattern::Constructor { name, args } => {
             let Some(IrVariantKind::Tuple { fields }) = find_variant_case(td, name) else { return };
+            // A field bound here is Box'd iff it references ANY cycle member, so
+            // the deref must use the SAME predicate as the Box-rendering site (#656).
             args.iter().enumerate()
-                .filter(|(i, _)| fields.get(*i).map_or(false, |ft| ty_contains_name(ft, enum_name)))
+                .filter(|(i, _)| fields.get(*i).map_or(false, |ft| walker::ty_contains_any_recursive(ft, recursive)))
                 .for_each(|(_, arg)| collect_bind_vars(arg, deref_vars));
         }
         IrPattern::RecordPattern { name, fields, .. } => {
@@ -390,7 +430,7 @@ fn collect_deref_from_pattern(pattern: &IrPattern, enum_name: &str, td: Option<&
             for field_pat in fields {
                 let is_recursive = case_fields.iter()
                     .find(|f| f.name == field_pat.name)
-                    .map_or(false, |f| ty_contains_name(&f.ty, enum_name));
+                    .map_or(false, |f| walker::ty_contains_any_recursive(&f.ty, recursive));
                 if !is_recursive { continue; }
 
                 if let Some(ref p) = field_pat.pattern {
@@ -414,15 +454,5 @@ fn collect_bind_vars(pattern: &IrPattern, deref_vars: &mut HashSet<VarId>) {
             for a in args { collect_bind_vars(a, deref_vars); }
         }
         _ => {}
-    }
-}
-
-fn ty_contains_name(ty: &Ty, name: &str) -> bool {
-    match ty {
-        Ty::Named(n, args) => n == name || args.iter().any(|a| ty_contains_name(a, name)),
-        Ty::Variant { name: vn, .. } => vn == name,
-        Ty::Applied(_, args) => args.iter().any(|a| ty_contains_name(a, name)),
-        Ty::Tuple(elems) => elems.iter().any(|e| ty_contains_name(e, name)),
-        _ => false,
     }
 }

--- a/crates/almide-codegen/src/walker/declarations.rs
+++ b/crates/almide-codegen/src/walker/declarations.rs
@@ -5,7 +5,7 @@ use almide_ir::*;
 use almide_lang::types::Ty;
 use super::RenderContext;
 use super::types::render_type;
-use super::helpers::{template_or, ty_contains_name, render_type_field_fn};
+use super::helpers::{template_or, render_type_field_fn};
 
 pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
     let decl_attrs: Vec<&str> = if ctx.repr_c { vec!["repr_c"] } else { vec![] };
@@ -77,7 +77,9 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                             // Closure payloads (direct or nested in a container) use
                             // Rc<dyn Fn> — same as a struct field.
                             let rendered = render_type_field_fn(ctx, t);
-                            if is_recursive && ty_contains_name(t, &td.name) { format!("std::boxed::Box<{}>", rendered) } else { rendered }
+                            // Box a field referencing ANY cycle member (mutual recursion), not
+                            // just the enclosing type's own name (#656).
+                            if is_recursive && super::ty_contains_any_recursive(t, &ctx.ann.recursive_enums) { format!("std::boxed::Box<{}>", rendered) } else { rendered }
                         }).collect();
                         let fields_str = types.join(", ");
                         // Named params via fn_param template (respects JS/TS)
@@ -98,7 +100,7 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
                         let fields_str = fields.iter()
                             .map(|f| {
                                 let rendered = render_type_field_fn(ctx, &f.ty);
-                                let boxed = if ctx.ann.recursive_enums.contains(&*td.name) && ty_contains_name(&f.ty, &td.name) {
+                                let boxed = if ctx.ann.recursive_enums.contains(&*td.name) && super::ty_contains_any_recursive(&f.ty, &ctx.ann.recursive_enums) {
                                     format!("std::boxed::Box<{}>", rendered)
                                 } else {
                                     rendered

--- a/crates/almide-codegen/src/walker/helpers.rs
+++ b/crates/almide-codegen/src/walker/helpers.rs
@@ -31,6 +31,20 @@ pub fn ty_contains_name(ty: &Ty, name: &str) -> bool {
     })
 }
 
+/// Does `ty` reference ANY type in `recursive` (a set of names that participate
+/// in a recursion cycle)? Generalizes `ty_contains_name` from direct
+/// self-recursion to MUTUAL recursion (`type A = A(B); type B = B(A)`), where a
+/// field references a *different* cycle member rather than the enclosing type's
+/// own name — without an indirection there, native rustc rejects the pair as
+/// infinitely sized (E0072) (#656). Over-inclusion only adds a harmless extra Box.
+pub fn ty_contains_any_recursive(ty: &Ty, recursive: &std::collections::HashSet<String>) -> bool {
+    ty.any_child_recursive(&|t| match t {
+        Ty::Named(n, _) => recursive.contains(n.as_str()),
+        Ty::Variant { name: vn, .. } => recursive.contains(vn.as_str()),
+        _ => false,
+    })
+}
+
 /// Check if an expression tree contains break or continue (for IIFE avoidance)
 pub fn contains_loop_control(expr: &IrExpr) -> bool {
     match &expr.kind {

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -14,6 +14,7 @@ mod types;
 
 // Re-exports for external consumers
 pub use helpers::ty_contains_name;
+pub use helpers::ty_contains_any_recursive;
 pub use types::render_type;
 pub use expressions::render_expr;
 pub use statements::{render_stmt, render_pattern};

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-92 contracts
+93 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -120,4 +120,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-090 | bytes.from_list on a List[Int] parameter compiles on both targets |  | active | fixture | 1 |
 | C-091 | A nested sub-pattern in let-destructuring binds every leaf |  | active | fixture | 1 |
 | C-092 | A generic record field is sized by its instantiated type at construction |  | active | fixture | 1 |
+| C-093 | Mutually-recursive variant types compile on both targets |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -1076,3 +1076,12 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/generic_record_field_size.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-093"
+title     = "Mutually-recursive variant types compile on both targets"
+statement = "Variant types forming a recursion cycle across two or more types (type A = A(B); type B = B(A)) compile and run byte-identical native == wasm. The native enum emit boxed a variant field only when it named the ENCLOSING type, so a mutual cycle emitted both enums without indirection and rustc rejected them as infinitely sized (E0072). Recursion detection is now cycle-based (a type that can reach itself through variant-field references), and the Box-rendering, pattern-deref, and boxed-fields-annotation sites all box a field that references ANY cycle member."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/mutual_recursive_types.almd", class = "fixture" },
+]

--- a/spec/wasm_cross/mutual_recursive_types.almd
+++ b/spec/wasm_cross/mutual_recursive_types.almd
@@ -1,0 +1,40 @@
+// @contract: C-093
+// Mutually-recursive variant types (a cycle spanning two or more types) compile
+// and run byte-identical native == wasm. The native enum emit boxed a field only
+// when it named the ENCLOSING type, so a mutual cycle (`type A = A(B); type B =
+// B(A)`) emitted both enums without indirection — rustc rejects that as infinite
+// size (E0072). Recursion detection is now cycle-based (reachability), and the
+// Box/deref/annotation sites box any field that references a cycle member. #656.
+
+type A = | A(B)
+type B = | BLeaf | BWrap(A)
+
+fn depth(a: A) -> Int = match a {
+  A(b) => match b {
+    BLeaf => 0,
+    BWrap(inner) => 1 + depth(inner),
+  },
+}
+
+// A three-type cycle X -> Y -> Z -> X exercises a longer reachability path.
+type X = | X(Y)
+type Y = | Y(Z)
+type Z = | ZEnd | ZBack(X)
+
+fn zdepth(x: X) -> Int = match x {
+  X(y) => match y {
+    Y(z) => match z {
+      ZEnd => 0,
+      ZBack(inner) => 1 + zdepth(inner),
+    },
+  },
+}
+
+fn main() -> Unit = {
+  let v = A(BWrap(A(BWrap(A(BLeaf)))))
+  println(int.to_string(depth(v)))
+  match v { A(_) => println("ok") }
+
+  let w = X(Y(ZBack(X(Y(ZEnd)))))
+  println(int.to_string(zdepth(w)))
+}


### PR DESCRIPTION
Round-6 hole-hunt — a native-codegen divergence (with a `spec/wasm_cross/*.almd` byte-identical fixture + contract C-093).

## Fix

- **#656 — mutually-recursive variant types produced invalid Rust natively (E0072/E0391 infinite size) while WASM was fine.** The native enum emit boxed a variant field only when its type named the ENCLOSING type, so a mutual cycle (`type A = A(B); type B = B(A)`) emitted both enums without indirection. Recursion detection is now **cycle-based**: `find_recursive_enums` builds the type-reference graph and marks every type that can reach itself, and the three field-boxing sites (the `Box<>` rendering, the pattern-deref collector, and the `boxed_fields` annotation) all box a field that references ANY cycle member — driven by one shared `ty_contains_any_recursive` predicate. Verified on a 2-type cycle and a 3-type cycle (X→Y→Z→X). (C-093)

## Verification

- Full `wasm_cross_target_spec` byte gate green (145/145 fixtures byte-identical native == wasm).
- `almide test spec/` green (269/269 files) — direct self-recursion (`Tree = Leaf | Node(Tree, Tree)`) still works.
- `check-contracts.sh` green (93 contracts); contract README regenerated.

Closes #656