### PR TITLE
Reject ordering operators on compound types in the checker

### DIFF
--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -603,6 +603,28 @@ impl Checker {
                         }
                         // Unify left/right types so TypeVars in none/err/constructors get resolved
                         self.unify_infer(&lt, &rt);
+                        // Ordering (< <= > >=) is defined ONLY on scalar orderable
+                        // types. On a compound operand (Tuple/Option/Result/List/
+                        // Map/Set/Record/custom) the checker used to pass while
+                        // codegen diverged: native silently relied on Rust's derive
+                        // (and FAILED on records, E0369) and WASM ICEd
+                        // (equality.rs no-comparison arm). Reject uniformly so check
+                        // matches codegen on both targets; equality (== !=) still
+                        // works (deep structural). #652
+                        if matches!(op.as_str(), "<" | ">" | "<=" | ">=") {
+                            let lc = resolve_ty(&lt, &self.uf);
+                            let orderable = matches!(lc,
+                                Ty::Int | Ty::Float | Ty::Int8 | Ty::Int16 | Ty::Int32 | Ty::Int64
+                                | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 | Ty::UInt64
+                                | Ty::Float32 | Ty::Float64 | Ty::String | Ty::Bool
+                                | Ty::Unknown | Ty::TypeVar(_) | Ty::Never);
+                            if !orderable {
+                                self.emit(super::err(
+                                    format!("operator '{}' is not defined for {} — ordering applies to Int, Float, String, and Bool", op, lc.display()),
+                                    "Compare scalar fields explicitly, or use list.sort / list.min / list.max for ordered collections",
+                                    format!("operator {}", op)));
+                            }
+                        }
                         Ty::Bool
                     }
                     "and" | "or" => {

--- a/tests/checker_test.rs
+++ b/tests/checker_test.rs
@@ -1242,3 +1242,44 @@ fn unambiguous_constructor_is_not_flagged() {
          fn main() -> Unit = { println(int.to_string(cmd(Stop))) }"
     );
 }
+
+// ── #652: ordering operators reject compound operands (check ⇄ codegen parity) ──
+
+#[test]
+fn ordering_on_tuple_rejected() {
+    let errs = errors("fn main() -> Unit = println(if (1, 2) < (1, 3) then \"lt\" else \"ge\")");
+    assert!(errs.iter().any(|e| e.contains("not defined for")),
+        "tuple `<` should be rejected, got: {:?}", errs);
+}
+
+#[test]
+fn ordering_on_record_rejected() {
+    let errs = errors(
+        "type P = { x: Int, y: Int }\n\
+         fn main() -> Unit = { let a: P = { x: 1, y: 2 }\n let b: P = { x: 1, y: 3 }\n println(if a > b then \"y\" else \"n\") }"
+    );
+    assert!(errs.iter().any(|e| e.contains("not defined for")),
+        "record `>` should be rejected, got: {:?}", errs);
+}
+
+#[test]
+fn ordering_on_list_rejected() {
+    let errs = errors("fn main() -> Unit = println(if [1, 2] <= [1, 3] then \"a\" else \"b\")");
+    assert!(errs.iter().any(|e| e.contains("not defined for")),
+        "list `<=` should be rejected, got: {:?}", errs);
+}
+
+#[test]
+fn ordering_on_scalars_still_accepted() {
+    // Int / Float / String / Bool ordering must keep working — no false positives.
+    for src in [
+        "fn main() -> Unit = println(if 1 < 2 then \"a\" else \"b\")",
+        "fn main() -> Unit = println(if 1.5 >= 2.0 then \"a\" else \"b\")",
+        "fn main() -> Unit = println(if \"a\" < \"b\" then \"a\" else \"b\")",
+        "fn main() -> Unit = println(if false < true then \"a\" else \"b\")",
+    ] {
+        let errs = errors(src);
+        assert!(!errs.iter().any(|e| e.contains("not defined for")),
+            "scalar ordering should be accepted: {} -> {:?}", src, errs);
+    }
+}


### PR DESCRIPTION
Round-6 hole-hunt — a check-passes / codegen-diverges soundness hole.

## Fix

- **#652 — ordering operators (`<` `<=` `>` `>=`) on compound types: the checker accepted, codegen diverged.** Native silently relied on Rust's auto-derived `Ord` for Tuple/Option/Result/List (and FAILED on records with E0369), while WASM ICEd for every compound operand (`equality.rs` no-comparison arm). Ordering has no well-defined source-level meaning on compound types in Almide, so the checker now rejects it uniformly — `Int`, `Float`, `String`, `Bool` (and the sized-numeric tower) stay accepted, everything else gets a clear diagnostic pointing at `list.sort` / `list.min` / `list.max` for ordered collections. Both targets now emit the **same** error (byte-identical), and `==` / `!=` still work (deep structural equality is unaffected).

## Verification

- The `#652` repro now errors identically on `almide check` and `almide build --target wasm`: `operator '<' is not defined for (Int, Int) — ordering applies to Int, Float, String, and Bool`.
- New `tests/checker_test.rs` cases lock the class: tuple / record / list ordering rejected, and Int / Float / String / Bool ordering still accepted (no false positives).
- `almide test spec/` green (269/269) and the full `wasm_cross_target_spec` byte gate green — no corpus program used compound ordering (`list.sort`/`min`/`max` use a runtime total order, not the source operator).

Closes #652