### PR TITLE
Prune unreachable functions before WASM emit (#644)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/closures.rs
+++ b/crates/almide-codegen/src/emit_wasm/closures.rs
@@ -14,9 +14,23 @@ use super::{CompiledFunc, FuncCompiler, LambdaInfo, WasmEmitter};
 use super::values;
 use super::statements;
 
+/// #644: true iff a function (top-level when `module` is None, else a module fn)
+/// is reachable from the entry surface. Mirrors the gate in `emit_wasm::emit`,
+/// using the SAME `registered_keys` spellings so the closure scanners and the
+/// body-compile loops agree on exactly which functions are live.
+fn fn_reachable(reachable: &HashSet<String>, module: Option<&str>, fname: &str) -> bool {
+    super::reachability::registered_keys(module, fname)
+        .iter()
+        .any(|k| reachable.contains(k))
+}
+
 /// Walk all function bodies to find Lambda and FnRef nodes.
 /// Register lambda functions and FnRef wrappers in the emitter.
-pub(super) fn pre_scan_closures(program: &IrProgram, emitter: &mut WasmEmitter) {
+pub(super) fn pre_scan_closures(
+    program: &IrProgram,
+    emitter: &mut WasmEmitter,
+    reachable_fns: &HashSet<String>,
+) {
     // Collect all lambdas (in tree-walk order)
     let mut lambda_exprs: Vec<(Vec<(VarId, almide_lang::types::Ty)>, IrExpr, Vec<u32>, Option<u32>)> = Vec::new();
     let mut fn_ref_set: HashSet<String> = HashSet::new();
@@ -33,6 +47,10 @@ pub(super) fn pre_scan_closures(program: &IrProgram, emitter: &mut WasmEmitter) 
     }
 
     for func in &program.functions {
+        // #644: a dead function's lambdas are dead too — skip them so their
+        // bodies (which may hit a native-only intrinsic) are never compiled.
+        // `compile_lambda_bodies` applies the identical filter → index alignment.
+        if !fn_reachable(reachable_fns, None, func.name.as_str()) { continue; }
         let scope_vars: HashSet<u32> = func.params.iter().map(|p| p.var.0).collect();
         scan_closures(&func.body, scope_vars, &mut mutable_vars, &mut lambda_exprs, &mut fn_ref_set);
     }
@@ -44,7 +62,9 @@ pub(super) fn pre_scan_closures(program: &IrProgram, emitter: &mut WasmEmitter) 
     // IDENTICAL to compile_lambda_bodies so the positional index aligns.
     // (Closure v2, P0.)
     for module in &program.modules {
+        let mod_name = module.name.to_string();
         for func in &module.functions {
+            if !fn_reachable(reachable_fns, Some(&mod_name), func.name.as_str()) { continue; }
             let scope_vars: HashSet<u32> = func.params.iter().map(|p| p.var.0).collect();
             scan_closures(&func.body, scope_vars, &mut mutable_vars, &mut lambda_exprs, &mut fn_ref_set);
         }
@@ -140,10 +160,13 @@ pub(super) fn pre_scan_closures(program: &IrProgram, emitter: &mut WasmEmitter) 
     // the table so call_indirect can dispatch them.
     let mut closure_create_set: HashSet<String> = HashSet::new();
     for func in &program.functions {
+        if !fn_reachable(reachable_fns, None, func.name.as_str()) { continue; }
         collect_closure_creates(&func.body, &mut closure_create_set);
     }
     for module in &program.modules {
+        let mod_name = module.name.to_string();
         for func in &module.functions {
+            if !fn_reachable(reachable_fns, Some(&mod_name), func.name.as_str()) { continue; }
             collect_closure_creates(&func.body, &mut closure_create_set);
         }
     }
@@ -167,13 +190,20 @@ pub(super) fn pre_scan_closures(program: &IrProgram, emitter: &mut WasmEmitter) 
 }
 
 /// Compile lambda bodies and FnRef wrappers.
-pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitter) {
+pub(super) fn compile_lambda_bodies(
+    program: &IrProgram,
+    emitter: &mut WasmEmitter,
+    reachable_fns: &HashSet<String>,
+) {
     // Re-scan to get lambda bodies (in same order as pre-scan)
     let mut lambda_exprs: Vec<(Vec<(VarId, almide_lang::types::Ty)>, IrExpr, Vec<u32>, Option<u32>)> = Vec::new();
     let mut fn_ref_set: HashSet<String> = HashSet::new();
     let mut mutable_vars: HashSet<u32> = HashSet::new();
 
     for func in &program.functions {
+        // #644: identical reachable-fn filter to pre_scan_closures — dead
+        // functions contribute no lambdas, so emitter.lambdas[i] stays aligned.
+        if !fn_reachable(reachable_fns, None, func.name.as_str()) { continue; }
         let scope_vars: HashSet<u32> = func.params.iter().map(|p| p.var.0).collect();
         scan_closures(&func.body, scope_vars, &mut mutable_vars, &mut lambda_exprs, &mut fn_ref_set);
     }
@@ -181,7 +211,9 @@ pub(super) fn compile_lambda_bodies(program: &IrProgram, emitter: &mut WasmEmitt
     // modules) so emitter.lambdas[i] lines up with the pre-scan registration.
     // (Closure v2, P0.)
     for module in &program.modules {
+        let mod_name = module.name.to_string();
         for func in &module.functions {
+            if !fn_reachable(reachable_fns, Some(&mod_name), func.name.as_str()) { continue; }
             let scope_vars: HashSet<u32> = func.params.iter().map(|p| p.var.0).collect();
             scan_closures(&func.body, scope_vars, &mut mutable_vars, &mut lambda_exprs, &mut fn_ref_set);
         }

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -68,6 +68,7 @@ pub mod statements;
 mod functions;
 pub mod scratch;
 mod dce;
+pub(crate) mod reachability;
 
 use std::collections::HashMap;
 // BTreeMap for record_fields / variant_info: their iteration order reaches
@@ -168,6 +169,19 @@ impl CompiledFunc {
         let mut c = Self::tracked(type_idx, tf);
         c.expected_func_idx = Some(func_idx);
         c
+    }
+
+    /// A minimal trapping body for `type_idx`: `unreachable; end`. Valid for ANY
+    /// signature (`unreachable` is stack-polymorphic). Used by the #644
+    /// reachability prune to occupy the slot of an unreachable function whose
+    /// real body would panic the emitter (native-only intrinsic), and matched by
+    /// the post-compile DCE stub shape. `call_targets` is empty so DCE sees no
+    /// outgoing edges from it.
+    pub fn trap_stub(type_idx: u32) -> Self {
+        let mut tf = TrackedFunction::new([]);
+        tf.instruction(&wasm_encoder::Instruction::Unreachable);
+        tf.instruction(&wasm_encoder::Instruction::End);
+        Self::tracked(type_idx, tf)
     }
 }
 
@@ -1616,10 +1630,36 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
         None
     };
 
+    // Phase 1.9: Reachability prune (#644). Compute which user/module function
+    // bodies the entry surface can actually reach, BEFORE any body (or the
+    // lambdas inside it) is scanned/compiled. The post-compile
+    // `dce::eliminate_dead_code` cannot help here: an unreachable body that
+    // references a native-only intrinsic (e.g. a matrix Q8 op with no WASM
+    // runtime) PANICS the emitter while *compiling* it, long before DCE runs. So
+    // unreachable bodies are emitted as `unreachable` stubs instead of compiled —
+    // they can never be called, and the native target already drops them (the
+    // Rust linker discards the dead fn). Roots: `main`, every exported `pub fn`,
+    // every test (the test runner calls them), and every fn named by a top-level
+    // `let` initializer (run by `__init_globals`). The set OVER-approximates
+    // reachability (see reachability.rs), so a body is stubbed only when truly
+    // unreachable. Computed before `pre_scan_closures` so that pass can skip the
+    // lambdas of dead functions too (their bodies can equally hit a native-only
+    // intrinsic) while keeping the lambda-table index aligned with
+    // `compile_lambda_bodies` (both consult the SAME set, same iteration order).
+    // Shared with the CLI native-only-op pre-check (lib.rs) so both agree which
+    // bodies are dead — an unreachable native-only intrinsic must neither ICE the
+    // emit nor fail the pre-check (#644).
+    let reachable_fns = reachability::reachable_fn_names(program);
+    // True iff a function registered under `keys` is reachable (any spelling).
+    let is_reachable = |keys: &[String]| keys.iter().any(|k| reachable_fns.contains(k));
+
     // Pre-scan for lambdas and FnRefs — only these need element table entries.
     // (Previously all user functions were added unconditionally, bloating the
     // element table and preventing DCE from eliminating unused functions.)
-    closures::pre_scan_closures(program, &mut emitter);
+    // Lambdas of unreachable functions (#644) get no table slot / body —
+    // `compile_lambda_bodies` applies the identical reachable-fn filter to keep
+    // the `emitter.lambdas[i]` ↔ body index alignment (Closure v2 P0).
+    closures::pre_scan_closures(program, &mut emitter, &reachable_fns);
 
     // Pre-register variant deep-equality functions (must be before compilation starts)
     register_variant_eq_funcs(&mut emitter);
@@ -1641,10 +1681,17 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
             continue;
         }
         let type_idx = user_meta[user_idx];
-        // Pass init_globals_idx to main function so top-level lets get initialized
-        let is_main = func.name == "main" && !func.is_test;
-        let init_idx = if is_main { init_globals_idx } else { None };
-        let compiled = functions::compile_function_with_init(&mut emitter, func, &program.var_table, type_idx, init_idx);
+        // #644: unreachable top-level fns are emitted as trapping stubs — their
+        // real body may reference a native-only intrinsic that would panic emit.
+        // `main`/tests/exports are roots, so they are always reachable here.
+        let compiled = if is_reachable(&reachability::registered_keys(None, func.name.as_str())) {
+            // Pass init_globals_idx to main function so top-level lets get initialized
+            let is_main = func.name == "main" && !func.is_test;
+            let init_idx = if is_main { init_globals_idx } else { None };
+            functions::compile_function_with_init(&mut emitter, func, &program.var_table, type_idx, init_idx)
+        } else {
+            CompiledFunc::trap_stub(type_idx)
+        };
         emitter.add_compiled(compiled);
         user_idx += 1;
     }
@@ -1655,7 +1702,15 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
         let module = &program.modules[mi];
         let func = &module.functions[fi];
         let mod_name = module.name.to_string();
-        let compiled = functions::compile_module_function(&mut emitter, func, &program.var_table, type_idx, &mod_name);
+        // #644: a merely-imported module's unused fns (e.g. tensor loaders that
+        // call native-only matrix intrinsics) are stubbed when unreachable, so
+        // importing such a module no longer forces WASM-compiling code the entry
+        // never runs — the exact import-graph trap from the issue.
+        let compiled = if is_reachable(&reachability::registered_keys(Some(&mod_name), func.name.as_str())) {
+            functions::compile_module_function(&mut emitter, func, &program.var_table, type_idx, &mod_name)
+        } else {
+            CompiledFunc::trap_stub(type_idx)
+        };
         emitter.add_compiled(compiled);
     }
 
@@ -1690,7 +1745,7 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
     }
 
     // Lambda bodies and FnRef wrappers
-    closures::compile_lambda_bodies(program, &mut emitter);
+    closures::compile_lambda_bodies(program, &mut emitter, &reachable_fns);
 
     // Compile variant deep-equality functions (bodies, after all user code)
     compile_variant_eq_funcs(&mut emitter, &program.var_table);

--- a/crates/almide-codegen/src/emit_wasm/reachability.rs
+++ b/crates/almide-codegen/src/emit_wasm/reachability.rs
@@ -1,0 +1,182 @@
+//! Reachability-based dead-function elimination for WASM emit (#644).
+//!
+//! The post-compile `dce::eliminate_dead_code` cannot help when an UNREACHABLE
+//! function's body references a native-only intrinsic (e.g. a matrix Q8 op with
+//! no WASM runtime): emit panics while *compiling* that body, long before DCE
+//! runs. So we compute reachability over the IR *before* compilation and stub
+//! out the bodies that the entry surface can never reach. A module that merely
+//! imports another whose unused fns touch native-only code then compiles for
+//! WASM — matching the user's intuition ("I never call it") and the native
+//! target, which already compiles it fine (Rust's own linker drops the dead fn).
+//!
+//! Soundness contract: this set is an OVER-approximation of the truly-reachable
+//! functions — every name a call could resolve to is marked, so a function is
+//! pruned only when NONE of its registered names is reachable. A false prune
+//! would turn a working call into a runtime trap; a false keep merely compiles
+//! one extra body (and post-compile DCE stubs it anyway). When in doubt, keep.
+
+use std::collections::{HashSet, VecDeque};
+
+use almide_ir::visit::{walk_expr, IrVisitor};
+use almide_ir::{CallTarget, IrExpr, IrExprKind, IrProgram};
+
+/// Collect every function-name an expression tree could *call*: direct
+/// `Named`/`Module` call targets, `RuntimeCall` symbols, and the function names
+/// referenced as values (`FnRef`, lifted `ClosureCreate`). Module targets
+/// contribute BOTH the bare `func` and the `module.func` qualified key, because
+/// intra-module calls resolve via the qualified name while cross-module/lifted
+/// references resolve via the bare name (see `emit_call` in calls.rs).
+struct CallNameCollector<'a> {
+    out: &'a mut HashSet<String>,
+}
+
+impl IrVisitor for CallNameCollector<'_> {
+    fn visit_expr(&mut self, expr: &IrExpr) {
+        match &expr.kind {
+            IrExprKind::Call { target, .. } | IrExprKind::TailCall { target, .. } => {
+                add_target(target, self.out);
+            }
+            IrExprKind::RuntimeCall { symbol, .. } => {
+                self.out.insert(symbol.to_string());
+            }
+            IrExprKind::FnRef { name } => {
+                self.out.insert(name.to_string());
+            }
+            IrExprKind::ClosureCreate { func_name, .. } => {
+                self.out.insert(func_name.to_string());
+            }
+            _ => {}
+        }
+        // Always recurse for nested calls (args, lambda bodies, match arms, …).
+        walk_expr(self, expr);
+    }
+}
+
+fn add_target(target: &CallTarget, out: &mut HashSet<String>) {
+    match target {
+        CallTarget::Named { name } => {
+            out.insert(name.to_string());
+            // `mod.func` written as a bare Named (the dotted-name fast path in
+            // emit_call) — record the bare tail too so it matches a fn registered
+            // under either spelling.
+            if let Some(dot) = name.as_str().rfind('.') {
+                out.insert(name.as_str()[dot + 1..].to_string());
+            }
+        }
+        CallTarget::Module { module, func, .. } => {
+            out.insert(func.to_string());
+            out.insert(format!("{}.{}", module, func));
+        }
+        // Method/Computed have no static callee name; their object/callee
+        // sub-expressions are walked by the visitor (args + receiver).
+        CallTarget::Computed { .. } | CallTarget::Method { .. } => {}
+    }
+}
+
+/// All the names under which a function with source name `fname` in module
+/// `module` (None for top-level `program.functions`) may be REGISTERED in
+/// `func_map`, mirroring `register_func` calls in mod.rs. A function is reachable
+/// iff any of these is in the reachable name set.
+pub(crate) fn registered_keys(module: Option<&str>, fname: &str) -> Vec<String> {
+    match module {
+        None => vec![fname.to_string()],
+        Some(m) => {
+            let sanitized = fname.replace(' ', "_").replace('-', "_").replace('.', "_");
+            let mod_ident = m.replace('.', "_");
+            vec![
+                fname.to_string(),                               // bare alias
+                format!("{}.{}", m, fname),                      // qualified
+                format!("almide_rt_{}_{}", mod_ident, sanitized), // mangled symbol
+            ]
+        }
+    }
+}
+
+/// Collect the call-names directly referenced by a single root expression
+/// (a top-level `let` initializer, which `__init_globals` runs at startup).
+pub(super) fn names_called_in(expr: &IrExpr, out: &mut HashSet<String>) {
+    CallNameCollector { out }.visit_expr(expr);
+}
+
+/// Compute the set of reachable function NAMES (all spellings) starting from
+/// `roots`, following call edges through `program.functions` and every
+/// `program.modules[*].functions` body. Lambda bodies are reached transitively
+/// because their parent function's body contains the `Lambda`/`ClosureCreate`
+/// node and the visitor walks into it.
+pub(super) fn compute_reachable_fn_names(
+    program: &IrProgram,
+    roots: impl IntoIterator<Item = String>,
+) -> HashSet<String> {
+    // Index every defined function body by all of its registered key spellings.
+    // A single body can be enqueued via any of its names.
+    let mut by_name: std::collections::HashMap<String, &IrExpr> = std::collections::HashMap::new();
+    for f in &program.functions {
+        for k in registered_keys(None, f.name.as_str()) {
+            by_name.entry(k).or_insert(&f.body);
+        }
+    }
+    for m in &program.modules {
+        let mname = m.name.to_string();
+        for f in &m.functions {
+            for k in registered_keys(Some(&mname), f.name.as_str()) {
+                by_name.entry(k).or_insert(&f.body);
+            }
+        }
+    }
+
+    let mut reachable: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+    for r in roots {
+        if reachable.insert(r.clone()) {
+            queue.push_back(r);
+        }
+    }
+
+    while let Some(name) = queue.pop_front() {
+        let Some(body) = by_name.get(name.as_str()).copied() else { continue };
+        let mut called: HashSet<String> = HashSet::new();
+        CallNameCollector { out: &mut called }.visit_expr(body);
+        for c in called {
+            if reachable.insert(c.clone()) {
+                queue.push_back(c);
+            }
+        }
+    }
+
+    reachable
+}
+
+/// Reachable-function name set for a whole program, using the SAME roots the WASM
+/// emitter prunes by: `main`, exported `pub fn`s, tests (when not library mode),
+/// and any fn named by a top-level-`let` initializer (run by `__init_globals`).
+/// Shared by the emitter's body-compile gate AND the CLI's native-only-op
+/// pre-check (lib.rs), so an unreachable native-only intrinsic the emitter stubs
+/// is equally ignored by the pre-check — the build no longer fails on dead code
+/// the program can never run (#644).
+pub(crate) fn reachable_fn_names(program: &IrProgram) -> HashSet<String> {
+    let has_main = program.functions.iter().any(|f| f.name.as_str() == "main" && !f.is_test);
+    let has_tests = program.functions.iter().any(|f| f.is_test);
+    let library_mode = !has_main && !has_tests;
+    let mut roots: HashSet<String> = HashSet::new();
+    if has_main {
+        roots.insert("main".to_string());
+    }
+    for func in &program.functions {
+        if func.is_test {
+            if !library_mode {
+                roots.insert(func.name.to_string());
+            }
+        } else if matches!(func.visibility, almide_ir::IrVisibility::Public) {
+            roots.insert(func.name.to_string());
+        }
+    }
+    for tl in &program.top_lets {
+        names_called_in(&tl.value, &mut roots);
+    }
+    for m in &program.modules {
+        for tl in &m.top_lets {
+            names_called_in(&tl.value, &mut roots);
+        }
+    }
+    compute_reachable_fn_names(program, roots)
+}

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -232,11 +232,36 @@ pub fn program_uses_native_only_matrix_on_wasm(program: &IrProgram) -> Option<&'
             walk_stmt(self, stmt);
         }
     }
+    // Only REACHABLE bodies can block the build: an unreachable native-only op
+    // (e.g. in an imported module's unused fn) is pruned by the WASM emitter, so it
+    // must not fail the build. Uses the SAME reachability the emitter prunes by, so
+    // the pre-check and the emit agree (#644).
+    let reachable = emit_wasm::reachability::reachable_fn_names(program);
+    let is_reachable = |module: Option<&str>, name: &str| {
+        emit_wasm::reachability::registered_keys(module, name)
+            .iter()
+            .any(|k| reachable.contains(k))
+    };
     let mut scan = Scan { found: None };
     for func in &program.functions {
+        if !is_reachable(None, func.name.as_str()) {
+            continue;
+        }
         scan.visit_expr(&func.body);
         if scan.found.is_some() {
             return scan.found;
+        }
+    }
+    for m in &program.modules {
+        let mname = m.name.to_string();
+        for func in &m.functions {
+            if !is_reachable(Some(&mname), func.name.as_str()) {
+                continue;
+            }
+            scan.visit_expr(&func.body);
+            if scan.found.is_some() {
+                return scan.found;
+            }
         }
     }
     None

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -1478,3 +1478,44 @@ fn successful_main_exits_zero_both_targets() {
         assert_eq!(wout, "7");
     }
 }
+
+/// #644: an unreachable `local fn` that references a native-only matrix intrinsic
+/// must NOT break the WASM build. The reachability prune drops the dead body
+/// (and the CLI native-only pre-check, sharing the same reachability, ignores it)
+/// so the build succeeds instead of ICEing/refusing. `local` is required because
+/// Almide functions are PUBLIC by default — an exported root that is never pruned.
+#[test]
+fn dead_local_native_only_intrinsic_does_not_break_wasm_build() {
+    let bin = almide_bin();
+    if Command::new(&bin).arg("--version").output().is_err() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("dead.almd");
+    std::fs::write(
+        &src,
+        "local fn dead(h: Matrix, w: Bytes, g: List[Int]) -> Matrix = {\n  \
+           let (out, _a, _b) = matrix.qwen3_block_q1_0_kv(h, h, h, w, g, g, 0, 4, 2, 8, 16, 10000.0, 0.00001)\n  \
+           out\n}\n\
+         fn main() -> Unit = println(\"ok\")\n",
+    )
+    .unwrap();
+    let out_wasm = dir.path().join("dead.wasm");
+    let r = Command::new(&bin)
+        .args([
+            "build",
+            src.to_str().unwrap(),
+            "--target",
+            "wasm",
+            "-o",
+            out_wasm.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success() && out_wasm.exists(),
+        "WASM build of a program with a dead native-only intrinsic should succeed (#644).\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&r.stdout),
+        String::from_utf8_lossy(&r.stderr)
+    );
+}


### PR DESCRIPTION
Round-6 hole-hunt — a WASM build that fails on code the program never runs.

## Fix

- **#644 — an unreachable function whose body references a native-only intrinsic (a matrix Q1.0/Q8 packed-GGUF op with a native runtime but no WASM lowering) broke `build --target wasm`.** The import graph forced WASM-compilation of code the entry never reaches; the emitter ICEd while *compiling* that body, and the CLI's native-only-op pre-check refused it — long before the post-compile DCE (which only stubs already-compiled bodies) could help. Native compiles the same graph fine (the Rust linker drops the dead fn).

  New `emit_wasm/reachability.rs` computes an IR call-graph reachability set from the real roots (`main`, exported `pub fn`s, tests, top-level-`let`-called fns) **before** any body is scanned or compiled; unreachable user/module bodies are emitted as trapping `unreachable` stubs instead of compiled (lambdas of dead fns are skipped identically to keep the Closure-v2 table alignment). The CLI's `program_uses_native_only_matrix_on_wasm` pre-check now consults the **same** reachability, so a dead native-only op neither ICEs the emit nor fails the pre-check. A reachable native-only op still refuses with the existing clear message.

  Note: Almide functions are PUBLIC by default (each an export root), so only an explicit `local fn` (or an uncalled imported-module fn) is eligible for the prune — matching the real-world `gguf_prims`-style module split this unblocks.

## Verification

- New `tests/wasm_runtime_test.rs::dead_local_native_only_intrinsic_does_not_break_wasm_build` — a `local fn` calling `matrix.qwen3_block_q1_0_kv` with a `println` main builds to WASM successfully (was: ICE/refuse).
- Full `wasm_cross_target_spec` byte gate green (145/145) — no over-pruning; `almide test spec/` green (269/269).

Closes #644