### PR TITLE
Pin an inferred lambda param to its expected element type before checking the body (#653)

### DIFF
--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -46,8 +46,83 @@ impl Checker {
         }
     }
 
+    /// Resolve the callee of a call to its function signature, for the two
+    /// shapes that can name a higher-order function with a `Fn`-typed parameter:
+    /// a bare `Ident` (user fn / selectively-imported stdlib fn) or
+    /// `module.field` (`list.map`, an aliased import, or a user `module.fn`).
+    /// Returns the signature so the eager-arg pass can pin an inferred lambda
+    /// param to the element type BEFORE the lambda body is checked. Returns
+    /// `None` for anything else (the call then infers args bottom-up as before).
+    fn lookup_call_sig(&self, callee: &ast::Expr) -> Option<crate::types::FnSig> {
+        match &callee.kind {
+            ExprKind::Ident { name, .. } => {
+                self.env.functions.get(&sym(name)).cloned()
+            }
+            ExprKind::Member { object, field, .. } => {
+                let module = match &object.kind {
+                    ExprKind::Ident { name, .. } => name.as_str(),
+                    _ => return None,
+                };
+                // Honor import aliases (e.g. `gpu` -> `snaidhm.web.gpu`).
+                let canonical = self.env.import_table.resolve(module)
+                    .map(|s| s.as_str().to_string())
+                    .unwrap_or_else(|| module.to_string());
+                let key = format!("{}.{}", canonical, field);
+                self.env.functions.get(&sym(&key)).cloned()
+                    .or_else(|| crate::stdlib::lookup_sig(&canonical, field))
+            }
+            _ => None,
+        }
+    }
+
     pub(crate) fn check_call_with_type_args(&mut self, callee: &mut ast::Expr, args: &mut [ast::Expr], type_args: Option<&[Ty]>) -> Ty {
-        let arg_tys: Vec<Ty> = args.iter_mut().map(|a| self.infer_expr(a)).collect();
+        // Expected-type-directed argument inference (#653). The default is
+        // strictly-left-to-right bottom-up inference of every argument. The one
+        // place that breaks down is an INFERRED lambda param passed to a
+        // higher-order function inside a generic body: `list.map(xs, (e) =>
+        // e.name())` where `xs: List[T]`, `T: Labelled`. Inferred bottom-up,
+        // `e` is a fresh var, so `e.name()` cannot see the protocol bound and
+        // collapses `e` into a closure type (`Fn() -> String`) -- the later
+        // `(T)->U` constraint can no longer undo that, yielding a spurious
+        // native E0308. Fix: resolve the callee's signature up front; as we
+        // infer args left-to-right we unify each non-lambda arg against its
+        // declared param to learn the generic bindings (`A := T`), then, just
+        // before inferring a lambda arg whose param slot is a `Fn`, pin the
+        // lambda's (unannotated) params to the substituted expected element
+        // type (`T`, carrying the bound). The lambda body then resolves
+        // `e.name()` via the protocol path. Calls without a `Fn`-param sig are
+        // unaffected -- they take the plain bottom-up path below.
+        let call_sig = self.lookup_call_sig(callee);
+        let arg_tys: Vec<Ty> = {
+            let mut bindings: HashMap<Sym, Ty> = HashMap::new();
+            let mut tys: Vec<Ty> = Vec::with_capacity(args.len());
+            for (i, a) in args.iter_mut().enumerate() {
+                // Pin an unannotated lambda's params to the expected element
+                // types substituted with bindings learned from earlier args.
+                let pinned = if matches!(&a.kind, ExprKind::Lambda { .. }) {
+                    call_sig.as_ref()
+                        .and_then(|sig| sig.params.get(i))
+                        .map(|(_, pty)| crate::types::substitute(pty, &bindings))
+                        .and_then(|pty| match pty {
+                            Ty::Fn { params, .. } => Some(params),
+                            _ => None,
+                        })
+                } else { None };
+                let prev_hint = self.lambda_arg_hint.take();
+                self.lambda_arg_hint = pinned;
+                let aty = self.infer_expr(a);
+                self.lambda_arg_hint = prev_hint;
+                // Accumulate generic bindings from this arg so later lambda
+                // params can be pinned. Lambdas contribute nothing new here.
+                if let Some(sig) = &call_sig {
+                    if let Some((_, pty)) = sig.params.get(i) {
+                        crate::types::unify(pty, &resolve_ty(&aty, &self.uf), &mut bindings);
+                    }
+                }
+                tys.push(aty);
+            }
+            tys
+        };
         let callee_span_snapshot = callee.span;
         match &mut callee.kind {
             ExprKind::Ident { name, .. } => {

--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -878,8 +878,18 @@ impl Checker {
                 let saved_auto_unwrap = self.env.auto_unwrap;
                 self.env.auto_unwrap = false;
                 self.env.lambda_depth += 1;
-                let param_tys: Vec<Ty> = params.iter().map(|p| {
-                    let ty = p.ty.as_ref().map(|te| self.resolve_type_expr(te)).unwrap_or_else(|| self.fresh_var());
+                // Expected-type hint from the enclosing call (#653): when this
+                // lambda is an argument whose parameter slot is a `Fn`, the
+                // caller pins each UNANNOTATED param to the expected element
+                // type (e.g. `T` carrying a protocol bound) so the body resolves
+                // method calls on the param via the protocol path instead of
+                // collapsing it into a closure type. An explicit annotation on
+                // the param always wins; the hint only fills inferred slots.
+                let param_hint = self.lambda_arg_hint.take();
+                let param_tys: Vec<Ty> = params.iter().enumerate().map(|(i, p)| {
+                    let ty = p.ty.as_ref().map(|te| self.resolve_type_expr(te))
+                        .or_else(|| param_hint.as_ref().and_then(|h| h.get(i).cloned()))
+                        .unwrap_or_else(|| self.fresh_var());
                     let concrete = resolve_ty(&ty, &self.uf);
                     self.env.define_var(&p.name, concrete);
                     ty

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -71,6 +71,12 @@ pub struct Checker {
     /// `check_named_call` uses this to validate each value against the param it
     /// NAMES (lowering binds by name), not the positional slot it landed in.
     pub(crate) named_arg_meta: Option<(usize, Vec<almide_base::intern::Sym>)>,
+    /// Expected-type hint for the NEXT lambda argument's parameters (#653).
+    /// Set by `check_call_with_type_args` immediately before inferring a lambda
+    /// arg whose call-parameter slot is a `Fn`; consumed (taken) by the
+    /// `ExprKind::Lambda` inference arm to type unannotated params from the
+    /// expected element type instead of a fresh var. `None` everywhere else.
+    pub(crate) lambda_arg_hint: Option<Vec<crate::types::Ty>>,
     pub(crate) constraints: Vec<Constraint>,
     pub(crate) uf: UnionFind,
     /// Module-name prefix active during `infer_module`. `None` for the
@@ -225,6 +231,7 @@ impl Checker {
             last_mut_params: Vec::new(),
             arg_spans: Vec::new(),
             named_arg_meta: None,
+            lambda_arg_hint: None,
             constraints: Vec::new(), uf: UnionFind::new(),
             current_module_prefix: None,
             deferred_tuple_indices: Vec::new(),

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-93 contracts
+94 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -121,4 +121,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-091 | A nested sub-pattern in let-destructuring binds every leaf |  | active | fixture | 1 |
 | C-092 | A generic record field is sized by its instantiated type at construction |  | active | fixture | 1 |
 | C-093 | Mutually-recursive variant types compile on both targets |  | active | fixture | 1 |
+| C-094 | A protocol-method UFCS call on an inferred lambda param resolves the element type |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -1085,3 +1085,12 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/mutual_recursive_types.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-094"
+title     = "A protocol-method UFCS call on an inferred lambda param resolves the element type"
+statement = "A higher-order call whose lambda argument has an UNANNOTATED parameter used as a protocol-method receiver (`list.map(xs, (e) => e.name())` where `xs: List[T]`, `T: Labelled`) compiles and runs byte-identical native == wasm. The checker resolves the callee signature up front and pins the lambda's inferred param to the expected element type (carrying its protocol bound) before inferring the body, so `e.name()` resolves via the protocol path instead of collapsing `e` into a closure type (which native rendered as `Rc<dyn Fn() -> String>`, rustc E0308). Verified for a stdlib HOF and a user-defined HOF."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/protocol_ufcs_inferred_lambda.almd", class = "fixture" },
+]

--- a/spec/wasm_cross/protocol_ufcs_inferred_lambda.almd
+++ b/spec/wasm_cross/protocol_ufcs_inferred_lambda.almd
@@ -1,0 +1,28 @@
+// @contract: C-094
+// #653: a UFCS protocol-method call on an INFERRED lambda param passed to a
+// higher-order function inside a generic body. The lambda was inferred bottom-up
+// before the HOF's `(T)->U` parameter slot pinned its param, so `e` was a fresh
+// var: `e.name()` could not see the protocol bound and collapsed `e` into a
+// closure type (`Fn() -> String`), which native rendered as
+// `move |e: Rc<dyn Fn() -> String>| ...` (rustc E0308: expected the element type).
+// The checker now pins an unannotated lambda param to the callee's expected
+// element type (carrying its protocol bound) BEFORE inferring the body.
+// (Direct HOF calls; the piped `xs |> list.filter(...)` form is a known follow-up.)
+
+protocol Labelled {
+  fn name(a: Self) -> String
+}
+type A: Labelled = { x: Int }
+fn A.name(a: A) -> String = int.to_string(a.x)
+
+// Stdlib HOF (list.map) with an inferred lambda param using a protocol method.
+fn names[T: Labelled](xs: List[T]) -> List[String] = list.map(xs, (e) => e.name())
+
+// A USER-defined HOF gets the same pinning (not just stdlib).
+fn apply_all[T](xs: List[T], f: (T) -> String) -> List[String] = list.map(xs, f)
+fn labels[T: Labelled](xs: List[T]) -> List[String] = apply_all(xs, (e) => e.name())
+
+fn main() -> Unit = {
+  println(string.join(names([A { x: 1 }, A { x: 2 }]), ","))
+  println(string.join(labels([A { x: 7 }]), ","))
+}


### PR DESCRIPTION
Round-6 hole-hunt — a checker-soundness hole where `check` passed but native codegen produced invalid Rust.

## Fix

- **#653 — a protocol-method UFCS call on an INFERRED lambda param inside a generic HOF body mis-typed the param as a closure on native (E0308).** `fn names[T: Labelled](xs: List[T]) = list.map(xs, (e) => e.name())`: arguments were inferred strictly bottom-up before the callee's `(T)->U` parameter slot could pin the lambda, so `e` was a fresh inference var — `e.name()` couldn't see the protocol bound and collapsed `e` into `Fn() -> String`, which native rendered as `move |e: Rc<dyn Fn() -> String>| A_name(...)` → rustc E0308. (WASM ran correctly; the prior **UnionFind-total** change in #670 already removed the ICE this case used to hit.)

  The checker now does expected-type-directed argument inference: it resolves the callee's signature up front, learns generic bindings (`A := T`) from each non-lambda arg, and pins an unannotated lambda's params to the substituted expected element type — carrying the protocol bound — **before** inferring the lambda body. `e.name()` then resolves via the protocol-method path. Calls without a `Fn`-typed param slot are unaffected (plain bottom-up). Architecturally correct: the type is fixed in the checker (source of truth), not patched in lowering/codegen. Generalizes to stdlib and user-defined HOFs.

  Known follow-up: the **piped** form (`xs |> list.filter((e) => e.name())`) routes through a separate `infer_pipe_direct` path that still infers args eagerly; threading the same hint there cleanly (without disturbing chained-pipe unification) is left for a focused change. The issue's direct-call repro is fully fixed.

## Verification

- Fixture `spec/wasm_cross/protocol_ufcs_inferred_lambda.almd` (C-094): `list.map` + a user-defined HOF, byte-identical native == wasm.
- Full `wasm_cross_target_spec` byte gate green (146/146), `almide test spec/` green (269/269), `checker_test` green (165/165) — the new expected-type inference is non-regressing.

Closes #653