### PR TITLE
Implement process.args on WASM via WASI args_get (#645)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls_process.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_process.rs
@@ -268,6 +268,111 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(capacity);
                 self.scratch.free_i32(buf);
             }
+            "args" => {
+                // process.args() -> List[String]
+                // Mirror native almide_rt_process_args = std::env::args().collect()
+                // (argv[0] = program path, then any program args). Uses WASI
+                // args_sizes_get / args_get; builds the same List[String] layout
+                // as stdin_lines above: [count:i32][strptr0:i32][strptr1:i32]...
+                let argc_ptr = self.scratch.alloc_i32();
+                let bufsize_ptr = self.scratch.alloc_i32();
+                let argc = self.scratch.alloc_i32();
+                let buf_size = self.scratch.alloc_i32();
+                let argv_ptr = self.scratch.alloc_i32();
+                let argv_buf = self.scratch.alloc_i32();
+                let result = self.scratch.alloc_i32();
+                let i = self.scratch.alloc_i32();
+                let cstr_ptr = self.scratch.alloc_i32();
+                let str_len = self.scratch.alloc_i32();
+                let str_ptr = self.scratch.alloc_i32();
+                let copy_i = self.scratch.alloc_i32();
+
+                // --- Phase 1: discover argc + total argv buffer size ---
+                wasm!(self.func, {
+                    i32_const(4); call(self.emitter.rt.alloc); local_set(argc_ptr);
+                    i32_const(4); call(self.emitter.rt.alloc); local_set(bufsize_ptr);
+                    local_get(argc_ptr);
+                    local_get(bufsize_ptr);
+                    call(self.emitter.rt.args_sizes_get);
+                    drop; // discard errno
+                    local_get(argc_ptr); i32_load(0); local_set(argc);
+                    local_get(bufsize_ptr); i32_load(0); local_set(buf_size);
+                });
+
+                // --- Phase 2: alloc the pointer array + the string buffer, fill them ---
+                // argv_ptr: argc i32 pointers. argv_buf: buf_size NUL-terminated bytes.
+                // Guard zero-size allocs with a minimum of 4 bytes so alloc never
+                // returns a degenerate pointer (argc is always >= 1 in practice, but
+                // stay defensive).
+                wasm!(self.func, {
+                    // argv_ptr: argc i32 pointers (+4 guard so a zero argc never
+                    // yields a degenerate alloc).
+                    local_get(argc); i32_const(4); i32_mul; i32_const(4); i32_add;
+                    call(self.emitter.rt.alloc); local_set(argv_ptr);
+                    local_get(buf_size); i32_const(4); i32_add;
+                    call(self.emitter.rt.alloc); local_set(argv_buf);
+                    local_get(argv_ptr);
+                    local_get(argv_buf);
+                    call(self.emitter.rt.args_get);
+                    drop; // discard errno
+                });
+
+                // --- Phase 3: build List[String] = [count][strptr0][strptr1]... ---
+                wasm!(self.func, {
+                    local_get(argc); i32_const(4); i32_mul; i32_const(4); i32_add;
+                    call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); local_get(argc); i32_store(0);
+                    i32_const(0); local_set(i);
+                    block_empty; loop_empty;
+                      local_get(i); local_get(argc); i32_ge_u; br_if(1);
+                      // cstr_ptr = argv_ptr[i]
+                      local_get(argv_ptr); local_get(i); i32_const(4); i32_mul; i32_add;
+                      i32_load(0); local_set(cstr_ptr);
+                      // str_len = strlen(cstr_ptr): scan to NUL
+                      i32_const(0); local_set(str_len);
+                      block_empty; loop_empty;
+                        local_get(cstr_ptr); local_get(str_len); i32_add; i32_load8_u(0);
+                        i32_eqz; br_if(1);
+                        local_get(str_len); i32_const(1); i32_add; local_set(str_len);
+                        br(0);
+                      end; end;
+                      // alloc Almide string [len:i32][bytes...]
+                      local_get(str_len); i32_const(4); i32_add;
+                      call(self.emitter.rt.alloc); local_set(str_ptr);
+                      local_get(str_ptr); local_get(str_len); i32_store(0);
+                      // copy str_len bytes from cstr_ptr into str_ptr+4
+                      i32_const(0); local_set(copy_i);
+                      block_empty; loop_empty;
+                        local_get(copy_i); local_get(str_len); i32_ge_u; br_if(1);
+                        local_get(str_ptr); i32_const(4); i32_add; local_get(copy_i); i32_add;
+                        local_get(cstr_ptr); local_get(copy_i); i32_add; i32_load8_u(0);
+                        i32_store8(0);
+                        local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                        br(0);
+                      end; end;
+                      // result[4 + i*4] = str_ptr
+                      local_get(result); i32_const(4); i32_add;
+                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(str_ptr); i32_store(0);
+                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      br(0);
+                    end; end;
+                    local_get(result);
+                });
+
+                self.scratch.free_i32(copy_i);
+                self.scratch.free_i32(str_ptr);
+                self.scratch.free_i32(str_len);
+                self.scratch.free_i32(cstr_ptr);
+                self.scratch.free_i32(i);
+                self.scratch.free_i32(result);
+                self.scratch.free_i32(argv_buf);
+                self.scratch.free_i32(argv_ptr);
+                self.scratch.free_i32(buf_size);
+                self.scratch.free_i32(argc);
+                self.scratch.free_i32(bufsize_ptr);
+                self.scratch.free_i32(argc_ptr);
+            }
             _ => panic!(
                 "[ICE] emit_wasm: no WASM dispatch for `process.{}` — \
                  add an arm in emit_process_call or resolve upstream",

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -383,6 +383,10 @@ pub struct RuntimeFuncs {
     pub fd_readdir: u32,
     pub fd_prestat_get: u32,
     pub fd_prestat_dir_name: u32,
+    /// args_sizes_get(argc_ptr, argv_buf_size_ptr) -> errno — WASI argv discovery (process.args).
+    pub args_sizes_get: u32,
+    /// args_get(argv_ptr, argv_buf_ptr) -> errno — fills the pointer array + NUL-terminated arg strings.
+    pub args_get: u32,
     /// __resolve_path(path_ptr, path_len) → (fd, rel_path_ptr, rel_path_len)
     /// Resolves absolute/relative paths against preopened directories.
     pub resolve_path: u32,
@@ -665,6 +669,8 @@ impl WasmEmitter {
                 fd_readdir: 0,
                 fd_prestat_get: 0,
                 fd_prestat_dir_name: 0,
+                args_sizes_get: 0,
+                args_get: 0,
                 resolve_path: 0,
                 init_preopen_dirs: 0,
                 dragon: rt_dragon::DragonRuntime::default(),
@@ -1214,6 +1220,28 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
         module: "wasi_snapshot_preview1".to_string(),
         name: "fd_readdir".to_string(),
         type_idx: fd_readdir_type_idx,
+    });
+
+    // Import args_sizes_get: (argc_ptr: i32, argv_buf_size_ptr: i32) -> errno
+    let args_sizes_get_type_idx = emitter.register_type(
+        vec![ValType::I32, ValType::I32],
+        vec![ValType::I32],
+    );
+    emitter.imports.push(ImportInfo {
+        module: "wasi_snapshot_preview1".to_string(),
+        name: "args_sizes_get".to_string(),
+        type_idx: args_sizes_get_type_idx,
+    });
+
+    // Import args_get: (argv_ptr: i32, argv_buf_ptr: i32) -> errno
+    let args_get_type_idx = emitter.register_type(
+        vec![ValType::I32, ValType::I32],
+        vec![ValType::I32],
+    );
+    emitter.imports.push(ImportInfo {
+        module: "wasi_snapshot_preview1".to_string(),
+        name: "args_get".to_string(),
+        type_idx: args_get_type_idx,
     });
 
     // Step 1b: @extern(wasm, ...) imports — must be registered before any

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -128,6 +128,20 @@ pub fn register_runtime_imports(emitter: &mut WasmEmitter) {
         vec![ValType::I32],
     );
     emitter.rt.fd_readdir = emitter.register_import(fd_readdir_ty);
+
+    // args_sizes_get(argc_ptr: i32, argv_buf_size_ptr: i32) -> errno
+    let args_sizes_get_ty = emitter.register_type(
+        vec![ValType::I32, ValType::I32],
+        vec![ValType::I32],
+    );
+    emitter.rt.args_sizes_get = emitter.register_import(args_sizes_get_ty);
+
+    // args_get(argv_ptr: i32, argv_buf_ptr: i32) -> errno
+    let args_get_ty = emitter.register_type(
+        vec![ValType::I32, ValType::I32],
+        vec![ValType::I32],
+    );
+    emitter.rt.args_get = emitter.register_import(args_get_ty);
 }
 
 /// Register runtime defined function signatures.

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-95 contracts
+96 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -123,4 +123,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-093 | Mutually-recursive variant types compile on both targets |  | active | fixture | 1 |
 | C-094 | A protocol-method UFCS call on an inferred lambda param resolves the element type |  | active | fixture | 1 |
 | C-095 | json.stringify_pretty is byte-identical indented output across targets |  | active | fixture | 1 |
+| C-096 | process.args works on WASM and matches native |  | active | fixture | 1 |
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -1103,3 +1103,12 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/json_stringify_pretty.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-096"
+title     = "process.args works on WASM and matches native"
+statement = "process.args() runs on the WASM target (previously an emit ICE) and agrees with native. It maps to std::env::args() — argv[0] (the program path) followed by program args — built on WASM from the WASI args_sizes_get / args_get imports into the same List[String] layout native produces. Verified byte-identical native == wasm on the argument COUNT (argv[0] differs between a native temp binary and a wasm module path, so the fixture prints only the length)."
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/process_args.almd", class = "fixture" },
+]

--- a/spec/wasm_cross/process_args.almd
+++ b/spec/wasm_cross/process_args.almd
@@ -1,0 +1,14 @@
+// @contract: C-096
+// process.args() must work on the WASM target (was an emit ICE) and agree with
+// native. It maps to the native std::env::args() — argv[0] (the program path)
+// followed by program args — built on WASM from WASI args_sizes_get / args_get.
+// The cross-target harness runs both legs with NO extra program args, so argv =
+// [program] on both => length 1; argv[0] (a temp binary path vs the wasm module
+// path) DIFFERS between legs, so this fixture prints only the COUNT, never an
+// element, to stay byte-identical. #645
+import process
+
+effect fn main() -> () = {
+  let args = process.args()
+  println(int.to_string(list.len(args)))
+}


### PR DESCRIPTION
Round-6 hole-hunt — a missing WASM dispatch that ICEd.

> Stacked on #675 (#661); retarget to `develop` once that merges.

## Fix

- **#645 — `process.args()` had no WASM dispatch and ICEd the emitter.** It now builds the same `List[String]` native produces (`std::env::args()` → argv[0] + program args) from the WASI `args_sizes_get` / `args_get` imports, mirroring the existing `stdin_lines` hand-written routine. (Fixed a stack-balance bug in the drafted emit — a dangling `argc*4` left on the stack from a stray throwaway alloc — that failed WASM structural validation.)

## Verification

- Fixture `spec/wasm_cross/process_args.almd` (C-096): prints `list.len(process.args())` — byte-identical native == wasm (both `1` with no extra args; argv[0] paths differ between legs, so only the count is printed).
- `process.args()` returns the right count with args too (native `-- a b c` → `4`).

Closes #645