### PR TITLE
Reject an undecidable type slot with E025 (#662)

### DIFF
--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -1459,7 +1459,14 @@ impl Checker {
                     // unless this binding is later used as a `match x { ok(_) =>
                     // ..., err(_) => ... }` subject — in which case the user
                     // wants to inspect the Result directly.
-                    self.effect_unwrap_rhs(t, self.env.skip_auto_unwrap_for.contains(&sym(name)))
+                    let unwrapped = self.effect_unwrap_rhs(t, self.env.skip_auto_unwrap_for.contains(&sym(name)));
+                    // #662: an un-annotated binding whose value type carries an
+                    // unconstrained phantom slot (only an un-exercised branch
+                    // could pin it) is undecidable — re-check post-solve.
+                    self.deferred_unresolved_binding_checks.push(super::UnresolvedBindingSite {
+                        ty: unwrapped.clone(), name: Some(name.to_string()), span: value.span,
+                    });
+                    unwrapped
                 };
                 if let Some(s) = span {
                     self.env.var_decl_locs.insert(sym(name), (s.line, s.col));
@@ -1478,7 +1485,12 @@ impl Checker {
                     let t = resolve_ty(&val_ty, &self.uf);
                     // Same rule as Let, including the usage-skip: a `var r =
                     // effectCall()` later matched on ok/err keeps the Result.
-                    self.effect_unwrap_rhs(t, self.env.skip_auto_unwrap_for.contains(&sym(name)))
+                    let unwrapped = self.effect_unwrap_rhs(t, self.env.skip_auto_unwrap_for.contains(&sym(name)));
+                    // #662: same undecidable-phantom-slot re-check as Let.
+                    self.deferred_unresolved_binding_checks.push(super::UnresolvedBindingSite {
+                        ty: unwrapped.clone(), name: Some(name.to_string()), span: value.span,
+                    });
+                    unwrapped
                 };
                 if let Some(s) = span {
                     self.env.var_decl_locs.insert(sym(name), (s.line, s.col));
@@ -1626,7 +1638,15 @@ impl Checker {
             }
             ast::Stmt::FieldAssign { value, .. } => { self.infer_expr(value); }
             ast::Stmt::Guard { cond, else_, .. } => { self.infer_expr(cond); self.infer_expr(else_); }
-            ast::Stmt::Expr { expr, .. } => { self.infer_expr(expr); }
+            ast::Stmt::Expr { expr, .. } => {
+                let t = self.infer_expr(expr);
+                // #662: a discarded expression statement whose type carries an
+                // unconstrained phantom slot (e.g. a bare `result.or_else(r0,
+                // (e) => ok(0))`) is undecidable — re-check post-solve.
+                self.deferred_unresolved_binding_checks.push(super::UnresolvedBindingSite {
+                    ty: resolve_ty(&t, &self.uf), name: None, span: expr.span,
+                });
+            }
             ast::Stmt::Comment { .. } | ast::Stmt::Error { .. } => {}
         }
     }

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -117,6 +117,19 @@ pub struct Checker {
     /// bound to / annotated as a wider type (`let u: UInt64 = …`) and the negated
     /// `i64::MIN` magnitude (`-9223372036854775808`).
     pub(crate) deferred_int_overflow_checks: Vec<IntOverflowSite>,
+    /// Un-annotated value bindings / discarded expression statements whose
+    /// inferred type must be fully decidable. Each entry carries the binding's
+    /// value `Ty` (with inference vars intact), an optional binding name (for the
+    /// diagnostic's wording / fix), and the span. Validated post-solve by
+    /// [`Checker::validate_unresolved_binding_types`]: if the resolved type still
+    /// holds an unbound `?`-prefixed inference var ANYWHERE after the whole
+    /// program is solved, that slot was never pinned by context (e.g. the error
+    /// type of `result.or_else(r0, (e) => ok(0))`, only reachable through the
+    /// un-exercised `err` branch). That is a compile error (E025) — the same
+    /// Rust/Swift rule E018 enforces for empty collections, never silently
+    /// defaulted. Without it the value passed `check` and then tripped the
+    /// ConcretizeTypes COMPILER-BUG gate on BOTH targets (#662).
+    pub(crate) deferred_unresolved_binding_checks: Vec<UnresolvedBindingSite>,
 }
 
 /// An integer literal that does not fit `i64`, pending a post-solve range check.
@@ -205,6 +218,21 @@ pub(crate) enum EmptyCollectionKind {
     ForInEmpty,
 }
 
+/// One un-annotated binding / discarded expression to re-check after constraint
+/// solving for an undecidable (never-pinned) inference var (#662).
+#[derive(Debug, Clone)]
+pub(crate) struct UnresolvedBindingSite {
+    /// The binding's / expression's value type, with inference vars intact.
+    /// Resolved against the union-find post-solve; an unbound `?N` survivor means
+    /// the type was never pinned by context.
+    pub ty: Ty,
+    /// The binding name (`let`/`var`), or `None` for a discarded expression
+    /// statement. Drives the diagnostic's primary fix (annotate the binding).
+    pub name: Option<String>,
+    /// Source span of the offending expression.
+    pub span: Option<crate::ast::Span>,
+}
+
 /// One empty-collection producer to re-check after constraint solving.
 #[derive(Debug, Clone)]
 pub(crate) struct EmptyCollectionSite {
@@ -239,6 +267,7 @@ impl Checker {
             deferred_map_key_checks: Vec::new(),
             deferred_empty_collection_checks: Vec::new(),
             deferred_int_overflow_checks: Vec::new(),
+            deferred_unresolved_binding_checks: Vec::new(),
         }
     }
 
@@ -401,6 +430,7 @@ impl Checker {
         self.validate_map_key_types();
         self.validate_empty_collection_elements();
         self.validate_int_overflow_literals();
+        self.validate_unresolved_binding_types();
         // Unused import warnings
         for imp in &program.imports {
             let (path, alias, span) = match imp {
@@ -558,6 +588,7 @@ impl Checker {
         self.validate_map_key_types();
         self.validate_empty_collection_elements();
         self.validate_int_overflow_literals();
+        self.validate_unresolved_binding_types();
         self.current_module_prefix = saved_prefix;
 
         // Restore
@@ -1192,6 +1223,77 @@ impl Checker {
                 hint,
                 format!("{} with no element-type context", what),
             ).with_code("E018").with_try(try_fix);
+            if let Some(s) = site.span {
+                diag.file = self.source_file.clone();
+                diag.line = Some(s.line);
+                diag.col = Some(s.col);
+                if s.end_col > s.col { diag.end_col = Some(s.end_col); }
+            }
+            self.diagnostics.push(diag);
+        }
+    }
+
+    /// Post-solve: reject an un-annotated binding / discarded expression whose
+    /// type still carries an unbound `?`-prefixed inference var anywhere in its
+    /// tree. Such a var had NO inference source for the whole program (a phantom
+    /// slot only reachable through an un-exercised branch — e.g. the error type
+    /// of `result.or_else(r0, (e) => ok(0))`). Firing here, in the frontend,
+    /// makes the error identical on BOTH targets and gives a `type annotation
+    /// needed` diagnostic (cf. Rust E0282 / the sibling empty-collection E018)
+    /// instead of the cryptic ConcretizeTypes COMPILER-BUG gate ICE (#662). A
+    /// fully-decidable program leaves every binding type concrete, so this only
+    /// fires on the genuinely-undecidable case; sites are deduped so a binding
+    /// reused N times yields one error.
+    fn validate_unresolved_binding_types(&mut self) {
+        let checks = std::mem::take(&mut self.deferred_unresolved_binding_checks);
+        let mut reported: std::collections::HashSet<(Option<u32>, Option<u32>)> = std::collections::HashSet::new();
+        for site in checks {
+            let resolved = resolve_ty(&site.ty, &self.uf);
+            // A WHOLLY-Unknown binding type is error-recovery (a prior error was
+            // already reported) or a structure the checker leaves Unknown but
+            // codegen resolves (e.g. a cross-module variant `match` whose arms are
+            // concrete). Neither is a genuinely-undecidable SLOT, so skip it — only
+            // fire when a CONCRETE outer type carries an undecidable inner slot
+            // (`Result[Int, ?]`, never pinned). Without this guard E025 false-fired
+            // on valid cross-module variant matches.
+            if matches!(resolved, Ty::Unknown) { continue; }
+            // An unbound `?`-prefixed inference var (`fresh_var` the solver never
+            // bound) anywhere in the tree is undecidable. A BARE `TypeVar` (`T`,
+            // no `?`) is a rigid generic param — concrete in its scope — so it
+            // must NOT trigger this (mirrors `has_unconstrained_element`).
+            let undecidable = resolved.any_child_recursive(&|t: &Ty| match t {
+                Ty::Unknown => true,
+                Ty::TypeVar(n) => n.as_str().starts_with('?'),
+                _ => false,
+            });
+            if !undecidable { continue; }
+            let key = (site.span.map(|s| s.line as u32), site.span.map(|s| s.col as u32));
+            if !reported.insert(key) { continue; }
+            let what = match &site.name {
+                Some(n) => format!("binding '{}'", n),
+                None => "this expression".to_string(),
+            };
+            let fix = match &site.name {
+                Some(n) => format!(
+                    "Annotate the binding with the full type, e.g. `let {}: Result[Int, String] = ...`. \
+                     An unconstrained slot (such as the error type of a value that is always `ok(...)`, \
+                     reachable only through an un-exercised branch) cannot be inferred and is never \
+                     silently defaulted (Almide follows Rust/Swift; cf. Rust E0282).",
+                    n,
+                ),
+                None => "Bind the expression to an explicitly-typed `let`, e.g. \
+                     `let r: Result[Int, String] = ...`, so the unconstrained slot is pinned. \
+                     An unconstrained type slot cannot be inferred and is never silently defaulted \
+                     (Almide follows Rust/Swift; cf. Rust E0282).".to_string(),
+            };
+            let mut diag = err(
+                format!("cannot infer a concrete type for {} (type {})", what, resolved.display()),
+                fix,
+                format!("{} with an unconstrained type", what),
+            ).with_code("E025");
+            if let Some(n) = &site.name {
+                diag = diag.with_try(format!("let {}: Result[Int, String] = ...", n));
+            }
             if let Some(s) = site.span {
                 diag.file = self.source_file.clone();
                 diag.line = Some(s.line);

--- a/docs/diagnostics/E025.md
+++ b/docs/diagnostics/E025.md
@@ -1,0 +1,26 @@
+# E025 — cannot infer a concrete type (unconstrained type slot)
+
+A binding's type contains a slot that no context ever pins down. The classic case
+is the error type of a value that is statically always `ok(...)` — it is only
+reachable through an un-exercised `err` branch, so it stays unconstrained.
+
+```almide
+fn main() -> Unit = {
+  let r0: Result[Int, String] = ok(7)
+  let r = result.or_else(r0, (e) => ok(0))   // ← error type never pinned
+  println("done")
+}
+```
+
+Almide follows the Rust/Swift rule (cf. Rust E0282): an undecidable type slot is a
+compile error even if no value of that type is ever constructed; it is never
+silently defaulted (which would let `check` pass and codegen fail).
+
+## Fix
+
+Annotate the binding (or the lambda result) with the full type so the slot is
+pinned:
+
+```almide
+let r: Result[Int, String] = result.or_else(r0, (e) => ok(0))
+```

--- a/llms.txt
+++ b/llms.txt
@@ -172,6 +172,7 @@ let root_i = float.to_int(root_f)    // truncating
 | E022 | `!` (unwrap-propagate) outside an effect fn body or test block | Mark the enclosing fn `effect fn`, or use `??` for a fallback value (`!` inside a lambda can't propagate) |
 | E023 | Derived `Codec`/`Ord`/`Hash` not satisfied by a field type | Add `: P` to the offending field type (every field of a `: P` type must itself be `P`) — or hand-write `Type.encode`/`decode` for Codec |
 | E024 | Integer literal out of range for its type (would silently fold to 0) | Use a literal within the type's range; for large magnitudes use `UInt64` (or `Float`, lossy); `-9223372036854775808` (i64::MIN) is valid |
+| E025 | Cannot infer a concrete type — an undecidable type slot (e.g. the error type of a value that is always `ok(...)`) was never pinned | Annotate the binding with its full type (`let r: Result[Int, String] = ...`); an unconstrained slot is an error even if never constructed, never silently defaulted |
 | E420 | Function visibility violation (callee is private) | Make the callee public, or add a public shim |
 
 A rustc 4-digit code (`error[E0XXX]`) leaking through always indicates

--- a/tests/checker_test.rs
+++ b/tests/checker_test.rs
@@ -1283,3 +1283,23 @@ fn ordering_on_scalars_still_accepted() {
             "scalar ordering should be accepted: {} -> {:?}", src, errs);
     }
 }
+
+// ── #662: undecidable (unconstrained) type slot is rejected (E025), not ICE'd ──
+
+#[test]
+fn check_e025_unconstrained_error_type() {
+    let errs = errors(
+        "fn main() -> Unit = {\n  let r0: Result[Int, String] = ok(7)\n  let r = result.or_else(r0, (e) => ok(0))\n  println(\"done\")\n}"
+    );
+    assert!(errs.iter().any(|e| e.contains("cannot infer a concrete type")),
+        "expected E025 unconstrained-type error, got: {:?}", errs);
+}
+
+#[test]
+fn check_e025_annotated_ok() {
+    let errs = errors(
+        "fn main() -> Unit = {\n  let r0: Result[Int, String] = ok(7)\n  let r: Result[Int, String] = result.or_else(r0, (e) => ok(0))\n  println(\"done\")\n}"
+    );
+    assert!(!errs.iter().any(|e| e.contains("cannot infer a concrete type")),
+        "annotated binding should resolve cleanly, got: {:?}", errs);
+}

--- a/tests/diagnostics/e025-unconstrained-error-type/broken.almd
+++ b/tests/diagnostics/e025-unconstrained-error-type/broken.almd
@@ -1,0 +1,9 @@
+// #662: `result.or_else`'s error type is reachable only through the un-exercised
+// `err` branch; the lambda always returns `ok(0)`, so it is never pinned. `check`
+// used to pass and the ConcretizeTypes gate then ICE'd on both targets. It is now
+// a clean E025 "cannot infer a concrete type" (type annotation needed).
+fn main() -> Unit = {
+  let r0: Result[Int, String] = ok(7)
+  let r = result.or_else(r0, (e) => ok(0))
+  println("done")
+}

--- a/tests/diagnostics/e025-unconstrained-error-type/fixed.almd
+++ b/tests/diagnostics/e025-unconstrained-error-type/fixed.almd
@@ -1,0 +1,7 @@
+// Annotating the binding pins the error type, so or_else resolves to a concrete
+// Result[Int, String] and the program compiles + runs on both targets.
+fn main() -> Unit = {
+  let r0: Result[Int, String] = ok(7)
+  let r: Result[Int, String] = result.or_else(r0, (e) => ok(0))
+  println("done")
+}

--- a/tests/diagnostics/e025-unconstrained-error-type/meta.toml
+++ b/tests/diagnostics/e025-unconstrained-error-type/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E025"
+expects_error = "cannot infer a concrete type"
+hint_substring = "never silently defaulted"


### PR DESCRIPTION
Round-6 hole-hunt — a check-passes / codegen-refuses soundness hole.

## Fix

- **#662 — `result.or_else(r0, (e) => ok(0))` (and any generic fn whose new type param is reachable only through an un-exercised branch) passed `check` but then ICEd the ConcretizeTypes gate on BOTH targets** ("N expression(s) still carry an unresolved type"). The lambda always returns `ok(...)`, so the result's error type `F` is never pinned — a genuinely undecidable slot. Following the established empty-collection rule (E018) and Rust/Swift (E0282), the checker now REJECTS it cleanly with **E025 "cannot infer a concrete type"** (annotate the binding) instead of greenlighting a program codegen can't lower.

  The validation fires on an un-annotated `let`/`var`/bare-statement binding whose resolved type carries an unbound `?`-inference-var inside a CONCRETE outer type (`Result[Int, ?]`). A wholly-`Unknown` binding type is skipped — that's error-recovery or a cross-module variant `match` the checker leaves Unknown but codegen resolves, NOT an undecidable slot (this guard removes a false-positive on valid cross-module variant matches).

## Verification

- New `tests/diagnostics/e025-unconstrained-error-type/` (broken → E025, fixed → checks + runs `done`), `docs/diagnostics/E025.md`, and the `llms.txt` row — satisfying the hard diagnostic-coverage + docs-gen gates. New `checker_test` cases lock both the rejection and the annotated-clean case.
- `almide test spec/` green (269/269 — no false-positive regression), `wasm_cross_target_spec` byte gate green, `diagnostic_harness` + `docs_gen` green.

Closes #662