### PR TITLE
Borrow record-typed params by reference instead of cloning per call (#647)

### DIFF
--- a/crates/almide-codegen/src/pass_borrow_inference.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference.rs
@@ -56,6 +56,18 @@ thread_local! {
     // keep `data: &Vec<u8>` instead of collapsing to `Vec<u8>` on the first
     // pass and never recovering.
     static CURRENT_FN: RefCell<Option<String>> = RefCell::new(None);
+    // Names of user-declared RECORD types (`type Tok = { … }`). A param of such a
+    // type is `Ty::Named("Tok")` (not a structural `Ty::Record`), so without this
+    // set `is_heap_type`/`intrinsic_borrow_mode` treat it as Own and every reader
+    // deep-clones the whole record. Records get borrow inference like structural
+    // records; user VARIANTs stay Own (conservative — variant borrowing is not
+    // generalized here). #647
+    static RECORD_NAMES: RefCell<std::collections::HashSet<String>> = RefCell::new(std::collections::HashSet::new());
+}
+
+/// Is `name` a user-declared record type (eligible for record borrow inference)?
+fn is_record_type_name(name: &str) -> bool {
+    RECORD_NAMES.with(|r| r.borrow().contains(name))
 }
 
 fn lookup_user_borrows(callee: &str) -> Option<Vec<ParamBorrow>> {
@@ -82,6 +94,23 @@ fn lookup_user_borrows(callee: &str) -> Option<Vec<ParamBorrow>> {
 /// safety.
 pub fn infer_borrow_signatures(program: &mut IrProgram) -> HashMap<String, Vec<ParamBorrow>> {
     let mut sigs: HashMap<String, Vec<ParamBorrow>> = HashMap::new();
+
+    // Record the names of every user-declared RECORD type so a `t: Tok` param
+    // (`Ty::Named`) is borrow-inferred like a structural record instead of being
+    // deep-cloned at every read (#647).
+    RECORD_NAMES.with(|r| {
+        let mut set = r.borrow_mut();
+        set.clear();
+        let mut collect = |decls: &[IrTypeDecl]| {
+            for td in decls {
+                if matches!(td.kind, IrTypeDeclKind::Record { .. }) {
+                    set.insert(td.name.to_string());
+                }
+            }
+        };
+        collect(&program.type_decls);
+        for m in &program.modules { collect(&m.type_decls); }
+    });
 
     // Seed `sigs` with `@intrinsic` fns from every bundled stdlib
     // module — including ones that weren't lowered into
@@ -202,7 +231,7 @@ pub fn infer_borrow_signatures(program: &mut IrProgram) -> HashMap<String, Vec<P
 
         MOD_SCOPE.with(|m| *m.borrow_mut() = None);
         for func in &mut program.functions {
-            if func.is_test || is_derive_fn(&func.name) || is_monomorphized(&func.name) || func.generics.as_ref().map_or(false, |g| !g.is_empty()) { continue; }
+            if func.is_test || is_derive_fn(func) || is_monomorphized(&func.name) || func.generics.as_ref().map_or(false, |g| !g.is_empty()) { continue; }
             let borrows = infer_function_borrows(func);
             // Always record the signature (including all-Own) so that the
             // fixed-point iteration can distinguish "known to be Own" from
@@ -219,7 +248,7 @@ pub fn infer_borrow_signatures(program: &mut IrProgram) -> HashMap<String, Vec<P
             let mod_name = module.name.to_string();
             MOD_SCOPE.with(|m| *m.borrow_mut() = Some(mod_name.clone()));
             for func in &mut module.functions {
-                if func.is_test || is_derive_fn(&func.name) || is_monomorphized(&func.name) || func.generics.as_ref().map_or(false, |g| !g.is_empty()) { continue; }
+                if func.is_test || is_derive_fn(func) || is_monomorphized(&func.name) || func.generics.as_ref().map_or(false, |g| !g.is_empty()) { continue; }
                 let borrows = infer_function_borrows(func);
                 sigs.insert(format!("{}::{}", mod_name, func.name), borrows.clone());
                 // `ResolveCallsPass` rewrites bundled-Almide calls to
@@ -339,9 +368,19 @@ fn infer_function_borrows(func: &IrFunction) -> Vec<ParamBorrow> {
     }).collect()
 }
 
-fn is_derive_fn(name: &str) -> bool {
-    name.contains("_encode") || name.contains("_decode") || name.contains("_eq")
-        || name.contains("_display") || name.contains("_to_string") || name.contains("_from_")
+fn is_derive_fn(func: &IrFunction) -> bool {
+    // Auto-derived convention methods are excluded from borrow inference — they
+    // are a generated API surface whose call sites (often cross-module, where the
+    // borrow signature can't be looked up) pass owned values, so a Ref param would
+    // mismatch (E0308). Once record borrow inference is enabled (#647), a
+    // record-typed derived `encode(p: Pigment)` would otherwise become `&Pigment`
+    // and break those owned-arg call sites.
+    //
+    // Identification is structural, NOT name-based: `lower/mod.rs` stamps every
+    // generated convention fn with a synthetic `@derived` attribute at the single
+    // point it produces them. The generator is the source of truth — we never
+    // guess from the method name (`encode`/`eq`/...), which a user could also use.
+    func.attrs.iter().any(|a| a.name.as_str() == "derived")
 }
 
 fn is_monomorphized(name: &str) -> bool {
@@ -428,6 +467,10 @@ fn intrinsic_borrow_mode(ty: &Ty) -> ParamBorrow {
         | Ty::Applied(TypeConstructorId::Set, _)
             => ParamBorrow::Ref,
 
+        // A user-declared RECORD type (`t: Tok` → `Ty::Named("Tok")`) borrows like
+        // a structural record (#647). Non-record Named types fall through to Own.
+        Ty::Named(n, _) if is_record_type_name(n.as_str()) => ParamBorrow::Ref,
+
         // Option / Result → Own. `.unwrap_or` / `.map` consume the
         // container, and the walker renders `.is_some()` /
         // `.is_none()` via `Fn(Option<T>) -> bool` signatures that
@@ -465,7 +508,7 @@ fn is_heap_type(ty: &Ty) -> bool {
         | Ty::Applied(TypeConstructorId::Set, _)
         | Ty::Record { .. }
         | Ty::OpenRecord { .. }
-    )
+    ) || matches!(ty, Ty::Named(n, _) if is_record_type_name(n.as_str()))
 }
 
 /// Check if a parameter variable needs ownership.
@@ -538,8 +581,19 @@ fn check_needs_ownership(expr: &IrExpr, var: VarId, needs: &mut bool) {
             if let CallTarget::Named { name } = target {
                 if let Some(borrows) = lookup_user_borrows(name.as_str()) {
                     for (i, arg) in args.iter().enumerate() {
+                        // The callee borrows slot `i` (Ref/RefSlice/RefStr)
+                        // → forwarding a heap-typed var into it does NOT
+                        // consume the var, so the outer param can stay
+                        // borrowed. Previously gated to `Ty::Bytes` only;
+                        // generalized to every heap type (records, lists,
+                        // strings) so the natural `vocab_id(t, ..)` /
+                        // `merge_rank(t, ..)` factoring no longer clones the
+                        // whole record per call (#647). Downstream rendering
+                        // is type-agnostic: walker/mod.rs:264 emits `&T`,
+                        // ref_params (walker/mod.rs:146) + the `&t`→`t`
+                        // collapse (walker/expressions.rs:847) already work.
                         let borrowed = borrows.get(i).map_or(false, |b| !matches!(b, ParamBorrow::Own))
-                            && matches!(arg.ty, Ty::Bytes);
+                            && is_heap_type(&arg.ty);
                         if !borrowed && is_var(arg, var) { *needs = true; return; }
                     }
                     for arg in args { check_needs_ownership(arg, var, needs); }

--- a/crates/almide-frontend/src/lower/mod.rs
+++ b/crates/almide-frontend/src/lower/mod.rs
@@ -391,7 +391,15 @@ fn lower_program_with_prefix(prog: &ast::Program, env: &TypeEnv, type_map: &Type
     }
 
     // Auto-derive: generate convention functions for types that declare deriving but lack custom impl
-    let auto_derived = generate_auto_derives(&mut ctx, &type_decls, &functions);
+    let mut auto_derived = generate_auto_derives(&mut ctx, &type_decls, &functions);
+    // Stamp every generated convention fn with a synthetic `@derived` marker.
+    // This is the authoritative signal that a function is compiler-generated:
+    // downstream passes (e.g. borrow inference, #647) must not name-match
+    // `encode`/`decode`/`eq`/... to recognise derives — the generator is the
+    // single source of truth, so it records the fact structurally here.
+    for f in &mut auto_derived {
+        f.attrs.push(ast::Attribute { name: sym("derived"), args: vec![], span: None });
+    }
     functions.extend(auto_derived);
 
     // Collect effect fn names from TypeEnv (user-defined + stdlib)

--- a/tests/nanopass_test.rs
+++ b/tests/nanopass_test.rs
@@ -31,6 +31,22 @@ fn mk_program(functions: Vec<IrFunction>, var_table: VarTable) -> IrProgram {
     IrProgram { functions, var_table, ..Default::default() }
 }
 
+fn mk_record_decl(name: &str, fields: &[(&str, Ty)]) -> IrTypeDecl {
+    IrTypeDecl {
+        name: sym(name),
+        kind: IrTypeDeclKind::Record {
+            fields: fields.iter().map(|(fname, fty)| IrFieldDecl {
+                name: sym(fname), ty: fty.clone(), default: None, alias: None, attrs: vec![],
+            }).collect(),
+        },
+        deriving: None,
+        generics: None,
+        visibility: IrVisibility::Public,
+        doc: None,
+        blank_lines_before: 0,
+    }
+}
+
 fn run_pass<P: NanoPass>(pass: &P, program: IrProgram, target: Target) -> IrProgram {
     pass.run(program, target).program
 }
@@ -381,6 +397,62 @@ mod borrow_insertion {
 
         assert_eq!(result.functions[0].params[0].borrow, ParamBorrow::Own,
             "Int param should remain Own");
+    }
+
+    #[test]
+    fn record_param_reffed_when_only_field_read() {
+        // type Tok = { kind: String, value: Int }
+        // fn score(t: Tok) -> Int = t.value
+        // The record param is only field-read, never consumed → &Tok (Ref).
+        // Locks the #647 perf win: record-typed leaf readers borrow instead of
+        // deep-cloning the whole record on every call.
+        let mut vt = VarTable::new();
+        let tok = Ty::Named(sym("Tok"), vec![]);
+        let p = mk_param(&mut vt, "t", tok.clone());
+        let var_id = p.var;
+        let body = mk_expr(IrExprKind::Member {
+            object: Box::new(mk_expr(IrExprKind::Var { id: var_id }, tok.clone())),
+            field: sym("value"),
+        }, Ty::Int);
+        let func = mk_fn("score", vec![p], Ty::Int, body, false);
+
+        let mut program = mk_program(vec![func], vt);
+        program.type_decls = vec![mk_record_decl("Tok", &[("kind", Ty::String), ("value", Ty::Int)])];
+        let result = run_pass(&BorrowInsertionPass, program, Target::Rust);
+
+        assert_eq!(result.functions[0].params[0].borrow, ParamBorrow::Ref,
+            "Record param only field-read should borrow as &Tok (#647), got {:?}",
+            result.functions[0].params[0].borrow);
+    }
+
+    #[test]
+    fn derived_fn_record_param_stays_own() {
+        // @derived fn encode(p: Tok) -> Int = p.value
+        // Auto-derived convention fns are excluded from borrow inference: their
+        // call sites (often cross-module, where the borrow signature can't be
+        // looked up) pass OWNED values, so a Ref param would mismatch (E0308).
+        // Identification is structural — the `@derived` attribute the generator
+        // stamps — NOT the method name. So a derived fn that field-reads a record
+        // must keep Own even though plain inference would make it Ref (see
+        // record_param_reffed_when_only_field_read).
+        let mut vt = VarTable::new();
+        let tok = Ty::Named(sym("Tok"), vec![]);
+        let p = mk_param(&mut vt, "p", tok.clone());
+        let var_id = p.var;
+        let body = mk_expr(IrExprKind::Member {
+            object: Box::new(mk_expr(IrExprKind::Var { id: var_id }, tok.clone())),
+            field: sym("value"),
+        }, Ty::Int);
+        let mut func = mk_fn("encode", vec![p], Ty::Int, body, false);
+        func.attrs.push(almide::ast::Attribute { name: sym("derived"), args: vec![], span: None });
+
+        let mut program = mk_program(vec![func], vt);
+        program.type_decls = vec![mk_record_decl("Tok", &[("kind", Ty::String), ("value", Ty::Int)])];
+        let result = run_pass(&BorrowInsertionPass, program, Target::Rust);
+
+        assert_eq!(result.functions[0].params[0].borrow, ParamBorrow::Own,
+            "@derived fn param must stay Own (excluded from borrow inference), got {:?}",
+            result.functions[0].params[0].borrow);
     }
 }
 

--- a/tests/snapshots/codegen_snapshot_test__record.snap
+++ b/tests/snapshots/codegen_snapshot_test__record.snap
@@ -6,6 +6,6 @@ pub fn origin() -> Point {
     Point { x: 0i64, y: 0i64 }
 }
 
-pub fn translate(p: Point, dx: i64, dy: i64) -> Point {
+pub fn translate(p: &Point, dx: i64, dy: i64) -> Point {
     Point { x: (p.x + dx), y: (p.y + dy) }
 }


### PR DESCRIPTION
Closes #647.

## Problem

A param of a user record type (`fn score(t: Tok)`) was treated as `Own`, so every
reader received an owned `Tok` and the natural LLM factoring — passing the same
record into a chain of small helpers — deep-cloned the whole record on each call.
The reporter measured 21x end-to-end (71s → 3.4s) on a 600k-string dictionary
workload. This is a direct hit on the design goal: code an LLM writes naturally
silently falls into the 71s world.

## Fix

Borrow inference now treats a `Ty::Named` that resolves to a user **record**
declaration the same as a structural record: a read-only param becomes `&Tok`
instead of `Tok`.

- `RECORD_NAMES` is populated once per `infer_borrow_signatures` from
  `program.type_decls` + every module's `type_decls`, so `t: Tok`
  (`Ty::Named("Tok")`, not a structural `Ty::Record`) is recognised.
- `intrinsic_borrow_mode` / `is_heap_type` recognise record-named types.
- `check_needs_ownership`: forwarding a heap-typed var into a callee slot that
  itself borrows no longer counts as a consume (was gated to `Ty::Bytes`; now any
  heap type), so `vocab_id(t, …)` / `merge_rank(t, …)` factoring stays borrowed.

Variants stay `Own` (conservative — variant borrowing is not generalized here).

## Derived-fn exclusion is now structural, not name-based

Auto-derived convention methods (`encode`/`decode`/`eq`/…) must stay `Own`: their
call sites are often cross-module where the borrow signature can't be looked up
and pass owned values, so a `&Pigment` param would mismatch (E0308). The previous
exclusion guessed from the method name — fragile, and a user method named `encode`
would be misclassified. Now the derive generator stamps a synthetic `@derived`
attribute on every function it produces, at the single point it produces them
(`lower/mod.rs`, shared by root and module lowering), and borrow inference keys
off that attribute alone.

## Verification

- New nanopass unit tests lock both directions: `record_param_reffed_when_only_field_read`
  (perf win) and `derived_fn_record_param_stays_own` (cross-module regression guard).
- `spec/integration/modules/cross_module_codec_test.almd` (derived codec across
  modules) passes — the exact E0308 regression scenario.
- Full spec corpus 269/269 (native + wasm); `wasm_cross_target_spec` byte gate green.
- `score(t: Tok)` now emits `fn score(t: &Tok)`; native and wasm output identical.