### PR TITLE
Copy native/ asset subdirectories into the generated crate

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -186,6 +186,22 @@ fn build_cargo_toml(base_toml: &str, native_deps: &[crate::project::NativeDep]) 
 }
 
 /// Copy native/*.rs files from source_root into src_dir and inject mod declarations into code.
+fn copy_dir_recursive(from: &std::path::Path, to: &std::path::Path) -> Result<(), String> {
+    std::fs::create_dir_all(to).map_err(|e| format!("failed to create {}: {}", to.display(), e))?;
+    let entries = std::fs::read_dir(from).map_err(|e| format!("failed to read {}: {}", from.display(), e))?;
+    for entry in entries.flatten() {
+        let src = entry.path();
+        let dst = to.join(entry.file_name());
+        if src.is_dir() {
+            copy_dir_recursive(&src, &dst)?;
+        } else {
+            std::fs::copy(&src, &dst)
+                .map_err(|e| format!("failed to copy {}: {}", src.display(), e))?;
+        }
+    }
+    Ok(())
+}
+
 fn inject_native_modules(code: &mut String, source_root: Option<&std::path::Path>, src_dir: &std::path::Path) -> Result<(), String> {
     let root = match source_root {
         Some(r) => r,
@@ -204,6 +220,11 @@ fn inject_native_modules(code: &mut String, source_root: Option<&std::path::Path
                 std::fs::write(src_dir.join(entry.file_name()), &content)
                     .map_err(|e| format!("failed to write native module {}: {}", stem, e))?;
                 mod_decls.push_str(&format!("mod {};\n", stem));
+            } else if path.is_dir() {
+                // asset subdirectories (e.g. native/wgsl/*.wgsl) travel with
+                // the modules so include_str!("wgsl/...") resolves in the
+                // generated crate
+                copy_dir_recursive(&path, &src_dir.join(entry.file_name()))?;
             }
         }
     }


### PR DESCRIPTION
`inject_native_modules` copies only top-level `native/*.rs` files, so a native module using `include_str!("wgsl/qwen3.wgsl")`-style asset paths fails to compile in the generated crate — the subdirectory never travels.

This adds a recursive copy of `native/`'s subdirectories into the generated `src/` (`.rs` files at top level keep their existing module-injection behavior; only directories are copied as assets).

Motivation: nn extracts its 8 WGSL compute kernels to `native/wgsl/qwen3.wgsl` as a single source of truth shared between the native wgpu host and the browser (fetched at runtime). Verified end-to-end: the native GPU bench reproduces its ids canary unchanged with the kernels included via `include_str!`, and the same file drives the browser path (bit-exact vs native on a seeded tiny model via Deno WebGPU).

One commit, no behavior change for packages without asset subdirectories.