### PR TITLE
Eliminate magic numbers in the WASM emitter: named constants + ValueObject operand enforcement

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls.rs
@@ -8,6 +8,21 @@ use wasm_encoder::ValType;
 use super::FuncCompiler;
 use super::values;
 
+// ---------------------------------------------------------------------------
+// Named immediate constants used in inline WASM emission below.
+// ---------------------------------------------------------------------------
+/// ASCII code for ':' (colon), used when building the ": " separator string.
+const ASCII_COLON: i32 = 58;
+/// ASCII code for ' ' (space), used when building the ": " separator string.
+const ASCII_SPACE: i32 = 32;
+/// Byte length (and initial capacity) of the two-character ": " separator string.
+const COLON_SPACE_LEN: i32 = 2;
+/// Byte size of a WASM Result object: [tag: i32][value: i32].
+const RESULT_SIZE: i32 = 8;
+/// Byte size of an i32 / pointer value — used as the per-element stride when
+/// iterating over a list of closure pointers (each element is one i32 ptr).
+const PTR_BYTES: i32 = 4;
+
 /// Signed / unsigned / float kind for sized numeric WASM conversion
 /// dispatch. See `emit_sized_conv_call`.
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -622,17 +637,17 @@ impl FuncCompiler<'_> {
                         wasm!(self.func, {
                               local_set(s2);
                               // Build ": " separator [len=2][cap=2][':'][' ']
-                              i32_const(2); call(self.emitter.rt.string_alloc); local_set(s3);
-                              local_get(s3); i32_const(2); i32_store(0);
-                              local_get(s3); i32_const(2); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
-                              local_get(s3); i32_const(58); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
-                              local_get(s3); i32_const(32); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32 + 1);
+                              i32_const(COLON_SPACE_LEN); call(self.emitter.rt.string_alloc); local_set(s3);
+                              local_get(s3); i32_const(COLON_SPACE_LEN); i32_store(0);
+                              local_get(s3); i32_const(COLON_SPACE_LEN); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
+                              local_get(s3); i32_const(ASCII_COLON); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
+                              local_get(s3); i32_const(ASCII_SPACE); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32 + 1);
                               // concat: msg + ": " + original
                               local_get(s2); local_get(s3); call(self.emitter.rt.concat_str);
                               local_get(s1); call(self.emitter.rt.concat_str);
                               local_set(s1);
                               // Build new err Result
-                              i32_const(8); call(self.emitter.rt.alloc); local_set(s);
+                              i32_const(RESULT_SIZE); call(self.emitter.rt.alloc); local_set(s);
                               local_get(s); i32_const(1); i32_store(0);
                               local_get(s); local_get(s1); i32_store(4);
                               local_get(s);
@@ -652,11 +667,11 @@ impl FuncCompiler<'_> {
                         let s1 = self.scratch.alloc_i32();
                         wasm!(self.func, {
                             local_set(s);
-                            i32_const(2); call(self.emitter.rt.string_alloc); local_set(s1);
-                            local_get(s1); i32_const(2); i32_store(0);
-                            local_get(s1); i32_const(2); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
-                            local_get(s1); i32_const(58); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32); // ':'
-                            local_get(s1); i32_const(32); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32 + 1); // ' '
+                            i32_const(COLON_SPACE_LEN); call(self.emitter.rt.string_alloc); local_set(s1);
+                            local_get(s1); i32_const(COLON_SPACE_LEN); i32_store(0);
+                            local_get(s1); i32_const(COLON_SPACE_LEN); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
+                            local_get(s1); i32_const(ASCII_COLON); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32); // ':'
+                            local_get(s1); i32_const(ASCII_SPACE); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32 + 1); // ' '
                             local_get(s); local_get(s1); call(self.emitter.rt.concat_str);
                         });
                         self.emit_expr(&args[1]);
@@ -1221,7 +1236,7 @@ impl FuncCompiler<'_> {
                 // Empty list: alloc 4 bytes, len=0
                 let tmp = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc);
+                    i32_const(list_hdr()); call(self.emitter.rt.alloc);
                     local_set(tmp);
                     local_get(tmp);
                     i32_const(0); i32_store(0);
@@ -1237,7 +1252,7 @@ impl FuncCompiler<'_> {
                 // err("stub") — tag=1, value=empty string
                 let tmp = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc);
+                    i32_const(RESULT_SIZE); call(self.emitter.rt.alloc);
                     local_set(tmp);
                     local_get(tmp);
                     i32_const(1); i32_store(0); // tag=err
@@ -1533,7 +1548,7 @@ impl FuncCompiler<'_> {
                     local_get(err_ptr); i32_eqz;
                     if_i32;
                       // Ok(dst): [tag:0][list ptr@4]
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(res);
+                      i32_const(RESULT_SIZE); call(self.emitter.rt.alloc); local_set(res);
                       local_get(res); i32_const(0); i32_store(0);
                       local_get(res); local_get(dst); i32_store(4);
                       local_get(res);
@@ -1566,7 +1581,7 @@ impl FuncCompiler<'_> {
                     local_get(list_scratch); i32_load(0); i32_eqz; // len == 0
                     if_empty;
                       // Err("fan.race: no candidates"): [tag:1][msg@4]
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(out);
+                      i32_const(RESULT_SIZE); call(self.emitter.rt.alloc); local_set(out);
                       local_get(out); i32_const(1); i32_store(0);
                       local_get(out); i32_const(fail_msg); i32_store(4);
                     else_;
@@ -1610,7 +1625,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); local_get(list_scratch); i32_load(0); i32_ge_u; br_if(1);
                       local_get(list_scratch); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(PTR_BYTES); i32_mul; i32_add;
                       i32_load(0); local_set(closure);
                       local_get(closure); i32_load(4); // env
                       local_get(closure); i32_load(0); // table_idx
@@ -1633,7 +1648,7 @@ impl FuncCompiler<'_> {
                     // All failed → Err("fan.any: all candidates failed"): [tag:1][msg@4].
                     local_get(out); i32_eqz;
                     if_empty;
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(out);
+                      i32_const(RESULT_SIZE); call(self.emitter.rt.alloc); local_set(out);
                       local_get(out); i32_const(1); i32_store(0);
                       local_get(out); i32_const(fail_msg); i32_store(4);
                     end;
@@ -1657,14 +1672,14 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_set(list_scratch);
                     // Alloc result list
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(list_scratch); i32_load(0); i32_const(4); i32_mul; i32_add;
+                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(list_scratch); i32_load(0); i32_const(PTR_BYTES); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); local_get(list_scratch); i32_load(0); i32_store(0);
                     i32_const(0); local_set(i);
                     block_empty; loop_empty;
                       local_get(i); local_get(list_scratch); i32_load(0); i32_ge_u; br_if(1);
                       local_get(list_scratch); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(PTR_BYTES); i32_mul; i32_add;
                       i32_load(0); local_set(closure);
                       local_get(closure); i32_load(4);
                       local_get(closure); i32_load(0);
@@ -1686,7 +1701,7 @@ impl FuncCompiler<'_> {
                       local_set(res_val);
                       // result[i] address
                       local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(PTR_BYTES); i32_mul; i32_add;
                       // value, then store
                       local_get(res_val);
                       i32_store(0);

--- a/crates/almide-codegen/src/emit_wasm/calls.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls.rs
@@ -1,5 +1,6 @@
 //! Function call emission — emit_call and related helpers.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use almide_ir::{CallTarget, IrExpr};
 use super::rt_string::{string_data_off, string_hdr, string_cap_off, list_data_off, list_hdr};
 use almide_lang::types::Ty;
@@ -132,9 +133,9 @@ impl FuncCompiler<'_> {
                                 let false_str = self.emitter.intern_string("false");
                                 wasm!(self.func, {
                                     if_i32;
-                                    i32_const(true_str as i32);
+                                    i32_const(Imm32(true_str as i32));
                                     else_;
-                                    i32_const(false_str as i32);
+                                    i32_const(Imm32(false_str as i32));
                                     end;
                                     call(self.emitter.rt.println_str);
                                 });
@@ -150,7 +151,7 @@ impl FuncCompiler<'_> {
                                 // Unsupported type: skip arg and print "<unsupported>"
                                 let s = self.emitter.intern_string("<unsupported>");
                                 wasm!(self.func, {
-                                    i32_const(s as i32);
+                                    i32_const(Imm32(s as i32));
                                     call(self.emitter.rt.println_str);
                                 });
                             }
@@ -173,7 +174,7 @@ impl FuncCompiler<'_> {
                     "panic" => {
                         // panic(msg) — print "PANIC: " + msg to stderr, then trap
                         let prefix = self.emitter.intern_string("PANIC: ");
-                        wasm!(self.func, { i32_const(prefix as i32); });
+                        wasm!(self.func, { i32_const(Imm32(prefix as i32)); });
                         self.emit_expr(&args[0]);
                         wasm!(self.func, {
                             call(self.emitter.rt.concat_str);
@@ -198,26 +199,26 @@ impl FuncCompiler<'_> {
                         let closure = self.scratch.alloc_i32();
                         let res = self.scratch.alloc_i32();
                         self.emit_expr(&args[0]);
-                        wasm!(self.func, { local_set(closure); });
+                        wasm!(self.func, { local_set(Local(closure)); });
                         // Call closure: (env) → i32 (Result ptr)
                         wasm!(self.func, {
-                            local_get(closure); i32_load(4); // env
-                            local_get(closure); i32_load(0); // table_idx
+                            local_get(Local(closure)); i32_load(4); // env
+                            local_get(Local(closure)); i32_load(0); // table_idx
                         });
                         {
                             let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
                             wasm!(self.func, { call_indirect(ti, 0); });
                         }
-                        wasm!(self.func, { local_set(res); });
+                        wasm!(self.func, { local_set(Local(res)); });
                         // tag==0 (ok) means no throw → trap
                         wasm!(self.func, {
-                            local_get(res); i32_load(0); i32_eqz;
+                            local_get(Local(res)); i32_load(0); i32_eqz;
                             if_empty;
                             unreachable;
                             end;
                         });
                         // tag!=0 (err): check err string contains expected msg
-                        wasm!(self.func, { local_get(res); i32_load(4); }); // err string ptr
+                        wasm!(self.func, { local_get(Local(res)); i32_load(4); }); // err string ptr
                         self.emit_expr(&args[1]); // expected msg
                         wasm!(self.func, {
                             call(self.emitter.rt.string.contains);
@@ -293,7 +294,7 @@ impl FuncCompiler<'_> {
                         self.emit_expr(&args[0]);
                         wasm!(self.func, {
                             i32_load(0);
-                            i32_const(0);
+                            i32_const(Imm32(0));
                             i32_ne;
                             if_empty;
                             unreachable;
@@ -343,13 +344,13 @@ impl FuncCompiler<'_> {
                                 let variant_size = self.variant_alloc_size(name);
                                 let scratch = self.scratch.alloc_i32();
                                 wasm!(self.func, {
-                                    i32_const(variant_size as i32);
+                                    i32_const(Imm32(variant_size as i32));
                                     call(self.emitter.rt.alloc);
-                                    local_set(scratch);
-                                    local_get(scratch);
-                                    i32_const(tag as i32);
+                                    local_set(Local(scratch));
+                                    local_get(Local(scratch));
+                                    i32_const(Imm32(tag as i32));
                                     i32_store(0);
-                                    local_get(scratch);
+                                    local_get(Local(scratch));
                                 });
                                 self.scratch.free_i32(scratch);
                                 return;
@@ -363,12 +364,12 @@ impl FuncCompiler<'_> {
                                 let total_size = self.variant_alloc_size(name).max(4 + payload_size);
                                 let scratch = self.scratch.alloc_i32();
                                 wasm!(self.func, {
-                                    i32_const(total_size as i32);
+                                    i32_const(Imm32(total_size as i32));
                                     call(self.emitter.rt.alloc);
-                                    local_set(scratch);
+                                    local_set(Local(scratch));
                                     // Write tag
-                                    local_get(scratch);
-                                    i32_const(tag as i32);
+                                    local_get(Local(scratch));
+                                    i32_const(Imm32(tag as i32));
                                     i32_store(0);
                                 });
                                 // Write args — through the stored-field
@@ -378,12 +379,12 @@ impl FuncCompiler<'_> {
                                 // binding still owned and later Dec'd.
                                 let mut offset = 4u32;
                                 for arg in args {
-                                    wasm!(self.func, { local_get(scratch); });
+                                    wasm!(self.func, { local_get(Local(scratch)); });
                                     self.emit_stored_field(arg);
                                     self.emit_store_at(&arg.ty, offset);
                                     offset += values::byte_size(&arg.ty);
                                 }
-                                wasm!(self.func, { local_get(scratch); });
+                                wasm!(self.func, { local_get(Local(scratch)); });
                                 self.scratch.free_i32(scratch);
                                 return;
                             }
@@ -602,15 +603,15 @@ impl FuncCompiler<'_> {
                         let s1 = self.scratch.alloc_i32();
                         self.emit_expr(&args[0]);
                         wasm!(self.func, {
-                            local_set(s);
-                            local_get(s); i32_load(0); i32_eqz; // tag == 0?
+                            local_set(Local(s));
+                            local_get(Local(s)); i32_load(0); i32_eqz; // tag == 0?
                             if_i32;
                               // ok → empty string
-                              i32_const(0); call(self.emitter.rt.string_alloc); local_set(s1);
-                              local_get(s1); i32_const(0); i32_store(0);
-                              local_get(s1);
+                              i32_const(Imm32(0)); call(self.emitter.rt.string_alloc); local_set(Local(s1));
+                              local_get(Local(s1)); i32_const(Imm32(0)); i32_store(0);
+                              local_get(Local(s1));
                             else_;
-                              local_get(s); i32_load(4); // err string ptr
+                              local_get(Local(s)); i32_load(4); // err string ptr
                             end;
                         });
                         self.scratch.free_i32(s1);
@@ -625,32 +626,32 @@ impl FuncCompiler<'_> {
                         let s3 = self.scratch.alloc_i32();
                         self.emit_expr(&args[0]);
                         wasm!(self.func, {
-                            local_set(s);
-                            local_get(s); i32_load(0); i32_eqz; // tag == 0 (ok)?
+                            local_set(Local(s));
+                            local_get(Local(s)); i32_load(0); i32_eqz; // tag == 0 (ok)?
                             if_i32;
-                              local_get(s); // pass ok through
+                              local_get(Local(s)); // pass ok through
                             else_;
                               // Build new err with context: "msg: original_err"
-                              local_get(s); i32_load(4); local_set(s1); // original err string
+                              local_get(Local(s)); i32_load(4); local_set(Local(s1)); // original err string
                         });
                         self.emit_expr(&args[1]); // context msg
                         wasm!(self.func, {
-                              local_set(s2);
+                              local_set(Local(s2));
                               // Build ": " separator [len=2][cap=2][':'][' ']
-                              i32_const(COLON_SPACE_LEN); call(self.emitter.rt.string_alloc); local_set(s3);
-                              local_get(s3); i32_const(COLON_SPACE_LEN); i32_store(0);
-                              local_get(s3); i32_const(COLON_SPACE_LEN); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
-                              local_get(s3); i32_const(ASCII_COLON); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
-                              local_get(s3); i32_const(ASCII_SPACE); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32 + 1);
+                              i32_const(Imm32(COLON_SPACE_LEN)); call(self.emitter.rt.string_alloc); local_set(Local(s3));
+                              local_get(Local(s3)); i32_const(Imm32(COLON_SPACE_LEN)); i32_store(0);
+                              local_get(Local(s3)); i32_const(Imm32(COLON_SPACE_LEN)); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
+                              local_get(Local(s3)); i32_const(Imm32(ASCII_COLON)); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
+                              local_get(Local(s3)); i32_const(Imm32(ASCII_SPACE)); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32 + 1);
                               // concat: msg + ": " + original
-                              local_get(s2); local_get(s3); call(self.emitter.rt.concat_str);
-                              local_get(s1); call(self.emitter.rt.concat_str);
-                              local_set(s1);
+                              local_get(Local(s2)); local_get(Local(s3)); call(self.emitter.rt.concat_str);
+                              local_get(Local(s1)); call(self.emitter.rt.concat_str);
+                              local_set(Local(s1));
                               // Build new err Result
-                              i32_const(RESULT_SIZE); call(self.emitter.rt.alloc); local_set(s);
-                              local_get(s); i32_const(1); i32_store(0);
-                              local_get(s); local_get(s1); i32_store(4);
-                              local_get(s);
+                              i32_const(Imm32(RESULT_SIZE)); call(self.emitter.rt.alloc); local_set(Local(s));
+                              local_get(Local(s)); i32_const(Imm32(1)); i32_store(0);
+                              local_get(Local(s)); local_get(Local(s1)); i32_store(4);
+                              local_get(Local(s));
                             end;
                         });
                         self.scratch.free_i32(s3);
@@ -666,13 +667,13 @@ impl FuncCompiler<'_> {
                         let s = self.scratch.alloc_i32();
                         let s1 = self.scratch.alloc_i32();
                         wasm!(self.func, {
-                            local_set(s);
-                            i32_const(COLON_SPACE_LEN); call(self.emitter.rt.string_alloc); local_set(s1);
-                            local_get(s1); i32_const(COLON_SPACE_LEN); i32_store(0);
-                            local_get(s1); i32_const(COLON_SPACE_LEN); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
-                            local_get(s1); i32_const(ASCII_COLON); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32); // ':'
-                            local_get(s1); i32_const(ASCII_SPACE); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32 + 1); // ' '
-                            local_get(s); local_get(s1); call(self.emitter.rt.concat_str);
+                            local_set(Local(s));
+                            i32_const(Imm32(COLON_SPACE_LEN)); call(self.emitter.rt.string_alloc); local_set(Local(s1));
+                            local_get(Local(s1)); i32_const(Imm32(COLON_SPACE_LEN)); i32_store(0);
+                            local_get(Local(s1)); i32_const(Imm32(COLON_SPACE_LEN)); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
+                            local_get(Local(s1)); i32_const(Imm32(ASCII_COLON)); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32); // ':'
+                            local_get(Local(s1)); i32_const(Imm32(ASCII_SPACE)); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32 + 1); // ' '
+                            local_get(Local(s)); local_get(Local(s1)); call(self.emitter.rt.concat_str);
                         });
                         self.emit_expr(&args[1]);
                         wasm!(self.func, { call(self.emitter.rt.concat_str); });
@@ -1007,11 +1008,11 @@ impl FuncCompiler<'_> {
 
                 // Evaluate callee → closure ptr
                 self.emit_expr(callee);
-                wasm!(self.func, { local_set(scratch); });
+                wasm!(self.func, { local_set(Local(scratch)); });
 
                 // Push env_ptr (first hidden arg)
                 wasm!(self.func, {
-                    local_get(scratch);
+                    local_get(Local(scratch));
                     i32_load(4);
                 });
 
@@ -1022,7 +1023,7 @@ impl FuncCompiler<'_> {
 
                 // Push table_idx (on top of stack for call_indirect)
                 wasm!(self.func, {
-                    local_get(scratch);
+                    local_get(Local(scratch));
                     i32_load(0);
                 });
 
@@ -1159,11 +1160,11 @@ impl FuncCompiler<'_> {
                 // Closure tail call: same setup as emit_call but return_call_indirect
                 let scratch = self.scratch.alloc_i32();
                 self.emit_expr(callee);
-                wasm!(self.func, { local_set(scratch); });
+                wasm!(self.func, { local_set(Local(scratch)); });
 
                 // Push env_ptr (first hidden arg)
                 wasm!(self.func, {
-                    local_get(scratch);
+                    local_get(Local(scratch));
                     i32_load(4);
                 });
 
@@ -1173,7 +1174,7 @@ impl FuncCompiler<'_> {
 
                 // Push table_idx
                 wasm!(self.func, {
-                    local_get(scratch);
+                    local_get(Local(scratch));
                     i32_load(0);
                 });
 
@@ -1217,18 +1218,18 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_typed_default(&mut self, ty: &Ty) {
         use almide_lang::types::constructor::TypeConstructorId;
         match ty {
-            Ty::Int => { wasm!(self.func, { i64_const(0); }); }
+            Ty::Int => { wasm!(self.func, { i64_const(Imm64(0)); }); }
             Ty::Float => { wasm!(self.func, { f64_const(0.0); }); }
-            Ty::Bool => { wasm!(self.func, { i32_const(0); }); }
+            Ty::Bool => { wasm!(self.func, { i32_const(Imm32(0)); }); }
             Ty::String => {
                 // Empty string: alloc string_hdr() bytes, len=0
                 let tmp = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(0); call(self.emitter.rt.string_alloc);
-                    local_set(tmp);
-                    local_get(tmp);
-                    i32_const(0); i32_store(0);
-                    local_get(tmp);
+                    i32_const(Imm32(0)); call(self.emitter.rt.string_alloc);
+                    local_set(Local(tmp));
+                    local_get(Local(tmp));
+                    i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(tmp));
                 });
                 self.scratch.free_i32(tmp);
             }
@@ -1236,30 +1237,30 @@ impl FuncCompiler<'_> {
                 // Empty list: alloc 4 bytes, len=0
                 let tmp = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(list_hdr()); call(self.emitter.rt.alloc);
-                    local_set(tmp);
-                    local_get(tmp);
-                    i32_const(0); i32_store(0);
-                    local_get(tmp);
+                    i32_const(Imm32(list_hdr())); call(self.emitter.rt.alloc);
+                    local_set(Local(tmp));
+                    local_get(Local(tmp));
+                    i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(tmp));
                 });
                 self.scratch.free_i32(tmp);
             }
             Ty::Applied(TypeConstructorId::Option, _) => {
                 // none
-                wasm!(self.func, { i32_const(0); });
+                wasm!(self.func, { i32_const(Imm32(0)); });
             }
             Ty::Applied(TypeConstructorId::Result, _) => {
                 // err("stub") — tag=1, value=empty string
                 let tmp = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(RESULT_SIZE); call(self.emitter.rt.alloc);
-                    local_set(tmp);
-                    local_get(tmp);
-                    i32_const(1); i32_store(0); // tag=err
-                    local_get(tmp);
-                    i32_const(0); call(self.emitter.rt.string_alloc);
+                    i32_const(Imm32(RESULT_SIZE)); call(self.emitter.rt.alloc);
+                    local_set(Local(tmp));
+                    local_get(Local(tmp));
+                    i32_const(Imm32(1)); i32_store(0); // tag=err
+                    local_get(Local(tmp));
+                    i32_const(Imm32(0)); call(self.emitter.rt.string_alloc);
                     i32_store(4); // empty string at offset 4
-                    local_get(tmp);
+                    local_get(Local(tmp));
                 });
                 self.scratch.free_i32(tmp);
             }
@@ -1268,11 +1269,11 @@ impl FuncCompiler<'_> {
                 // Generic pointer type: return 0 (null)
                 // For records/tuples, this may still crash on field access.
                 match values::ty_to_valtype(ty) {
-                    Some(ValType::I64) => { wasm!(self.func, { i64_const(0); }); }
+                    Some(ValType::I64) => { wasm!(self.func, { i64_const(Imm64(0)); }); }
                     Some(ValType::F64) => { wasm!(self.func, { f64_const(0.0); }); }
-                    Some(ValType::I32) => { wasm!(self.func, { i32_const(0); }); }
+                    Some(ValType::I32) => { wasm!(self.func, { i32_const(Imm32(0)); }); }
                     None => {}
-                    _ => { wasm!(self.func, { i32_const(0); }); }
+                    _ => { wasm!(self.func, { i32_const(Imm32(0)); }); }
                 }
             }
         }
@@ -1377,7 +1378,7 @@ impl FuncCompiler<'_> {
                     let dst_u = matches!(dst_kind, SizedKind::UInt);
                     if dst_u {
                         let mask = ((1u64 << dst_bits) - 1) as i32;
-                        self.func.instruction(&Instruction::I32Const(mask));
+                        wasm!(self.func, { i32_const(Imm32(mask)); });
                         self.func.instruction(&Instruction::I32And);
                     } else {
                         let instr = if dst_bits == 8 { Instruction::I32Extend8S }
@@ -1431,7 +1432,7 @@ impl FuncCompiler<'_> {
                 if dst_bits < 32 {
                     if dst_u {
                         let mask = ((1u64 << dst_bits) - 1) as i32;
-                        self.func.instruction(&Instruction::I32Const(mask));
+                        wasm!(self.func, { i32_const(Imm32(mask)); });
                         self.func.instruction(&Instruction::I32And);
                     } else {
                         let instr = if dst_bits == 8 { Instruction::I32Extend8S }
@@ -1499,26 +1500,26 @@ impl FuncCompiler<'_> {
                 let res = self.scratch.alloc_i32();
                 let err_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    i32_const(0); local_set(err_ptr);
-                    local_get(xs); i32_load(0); local_set(len);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(len); i32_const(out_es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_set(Local(closure));
+                    i32_const(Imm32(0)); local_set(Local(err_ptr));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(len)); i32_const(Imm32(out_es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                       // Call closure(elem) — closure returns Result ptr (i32)
-                      local_get(closure); i32_load(4); // env
-                      local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(xs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 // call_indirect: (env, elem) → i32 (Result ptr)
                 {
@@ -1528,32 +1529,32 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      local_set(res);
+                      local_set(Local(res));
                       // First element Err: stash it and break out of loop+block (DON'T
                       // trap/return). Depths from inside this `if`: if=0, loop=1, block=2.
-                      local_get(res); i32_load(0); i32_const(0); i32_ne;
-                      if_empty; local_get(res); local_set(err_ptr); br(2); end;
+                      local_get(Local(res)); i32_load(0); i32_const(Imm32(0)); i32_ne;
+                      if_empty; local_get(Local(res)); local_set(Local(err_ptr)); br(2); end;
                       // Store unwrapped ok value into dst
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(out_es); i32_mul; i32_add;
-                      local_get(res);
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(out_es)); i32_mul; i32_add;
+                      local_get(Local(res));
                 });
                 self.emit_load_at(&out_elem_ty, 4);
                 self.emit_store_at(&out_elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                     // Produce a Result ptr: err_ptr if an element failed, else Ok(dst).
-                    local_get(err_ptr); i32_eqz;
+                    local_get(Local(err_ptr)); i32_eqz;
                     if_i32;
                       // Ok(dst): [tag:0][list ptr@4]
-                      i32_const(RESULT_SIZE); call(self.emitter.rt.alloc); local_set(res);
-                      local_get(res); i32_const(0); i32_store(0);
-                      local_get(res); local_get(dst); i32_store(4);
-                      local_get(res);
+                      i32_const(Imm32(RESULT_SIZE)); call(self.emitter.rt.alloc); local_set(Local(res));
+                      local_get(Local(res)); i32_const(Imm32(0)); i32_store(0);
+                      local_get(Local(res)); local_get(Local(dst)); i32_store(4);
+                      local_get(Local(res));
                     else_;
-                      local_get(err_ptr);
+                      local_get(Local(err_ptr));
                     end;
                 });
                 self.scratch.free_i32(err_ptr);
@@ -1577,27 +1578,27 @@ impl FuncCompiler<'_> {
                 let data_off = self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32;
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(list_scratch);
-                    local_get(list_scratch); i32_load(0); i32_eqz; // len == 0
+                    local_set(Local(list_scratch));
+                    local_get(Local(list_scratch)); i32_load(0); i32_eqz; // len == 0
                     if_empty;
                       // Err("fan.race: no candidates"): [tag:1][msg@4]
-                      i32_const(RESULT_SIZE); call(self.emitter.rt.alloc); local_set(out);
-                      local_get(out); i32_const(1); i32_store(0);
-                      local_get(out); i32_const(fail_msg); i32_store(4);
+                      i32_const(Imm32(RESULT_SIZE)); call(self.emitter.rt.alloc); local_set(Local(out));
+                      local_get(Local(out)); i32_const(Imm32(1)); i32_store(0);
+                      local_get(Local(out)); i32_const(Imm32(fail_msg)); i32_store(4);
                     else_;
                       // out = fns[0]()
-                      local_get(list_scratch); i32_const(data_off); i32_add; i32_load(0); local_set(closure);
-                      local_get(closure); i32_load(4); // env
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(list_scratch)); i32_const(Imm32(data_off)); i32_add; i32_load(0); local_set(Local(closure));
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 {
                     let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      local_set(out);
+                      local_set(Local(out));
                     end;
-                    local_get(out);
+                    local_get(Local(out));
                 });
                 self.scratch.free_i32(out);
                 self.scratch.free_i32(closure);
@@ -1619,40 +1620,40 @@ impl FuncCompiler<'_> {
                 let fail_msg = self.emitter.intern_string("fan.any: all candidates failed") as i32;
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(list_scratch);
-                    i32_const(0); local_set(i);
-                    i32_const(0); local_set(out);
+                    local_set(Local(list_scratch));
+                    i32_const(Imm32(0)); local_set(Local(i));
+                    i32_const(Imm32(0)); local_set(Local(out));
                     block_empty; loop_empty;
-                      local_get(i); local_get(list_scratch); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(list_scratch); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(PTR_BYTES); i32_mul; i32_add;
-                      i32_load(0); local_set(closure);
-                      local_get(closure); i32_load(4); // env
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(i)); local_get(Local(list_scratch)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(list_scratch)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add;
+                      i32_load(0); local_set(Local(closure));
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 {
                     let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      local_set(res);
+                      local_set(Local(res));
                       // First Ok (tag==0): this thunk's Ok Result IS the result; break.
-                      local_get(res); i32_load(0); i32_eqz;
+                      local_get(Local(res)); i32_load(0); i32_eqz;
                       if_empty;
-                        local_get(res); local_set(out);
+                        local_get(Local(res)); local_set(Local(out));
                         br(2); // break out of loop + block (if=0, loop=1, block=2)
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                     // All failed → Err("fan.any: all candidates failed"): [tag:1][msg@4].
-                    local_get(out); i32_eqz;
+                    local_get(Local(out)); i32_eqz;
                     if_empty;
-                      i32_const(RESULT_SIZE); call(self.emitter.rt.alloc); local_set(out);
-                      local_get(out); i32_const(1); i32_store(0);
-                      local_get(out); i32_const(fail_msg); i32_store(4);
+                      i32_const(Imm32(RESULT_SIZE)); call(self.emitter.rt.alloc); local_set(Local(out));
+                      local_get(Local(out)); i32_const(Imm32(1)); i32_store(0);
+                      local_get(Local(out)); i32_const(Imm32(fail_msg)); i32_store(4);
                     end;
-                    local_get(out);
+                    local_get(Local(out));
                 });
                 self.scratch.free_i32(out);
                 self.scratch.free_i32(closure);
@@ -1670,19 +1671,19 @@ impl FuncCompiler<'_> {
                 let res_val = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(list_scratch);
+                    local_set(Local(list_scratch));
                     // Alloc result list
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(list_scratch); i32_load(0); i32_const(PTR_BYTES); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); local_get(list_scratch); i32_load(0); i32_store(0);
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(list_scratch)); i32_load(0); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); local_get(Local(list_scratch)); i32_load(0); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(list_scratch); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(list_scratch); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(PTR_BYTES); i32_mul; i32_add;
-                      i32_load(0); local_set(closure);
-                      local_get(closure); i32_load(4);
-                      local_get(closure); i32_load(0);
+                      local_get(Local(i)); local_get(Local(list_scratch)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(list_scratch)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add;
+                      i32_load(0); local_set(Local(closure));
+                      local_get(Local(closure)); i32_load(4);
+                      local_get(Local(closure)); i32_load(0);
                 });
                 {
                     let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
@@ -1698,17 +1699,17 @@ impl FuncCompiler<'_> {
                 // the reverse order, writing the list address INTO the Result block).
                 wasm!(self.func, {
                       call(self.emitter.rt.rc_inc);
-                      local_set(res_val);
+                      local_set(Local(res_val));
                       // result[i] address
-                      local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(PTR_BYTES); i32_mul; i32_add;
+                      local_get(Local(result)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add;
                       // value, then store
-                      local_get(res_val);
+                      local_get(Local(res_val));
                       i32_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(res_val);
                 self.scratch.free_i32(closure);
@@ -1722,9 +1723,9 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(closure); i32_load(4); // env
-                    local_get(closure); i32_load(0); // table_idx
+                    local_set(Local(closure));
+                    local_get(Local(closure)); i32_load(4); // env
+                    local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 {
                     let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::I32]);

--- a/crates/almide-codegen/src/emit_wasm/calls_bytes.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_bytes.rs
@@ -2,6 +2,7 @@
 //!
 //! Memory layout: [len:i32][data:u8...]  (same as String)
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::FuncCompiler;
 use almide_ir::IrExpr;
 
@@ -110,31 +111,31 @@ impl FuncCompiler<'_> {
                 let idx = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(idx);
+                    i32_wrap_i64; local_set(Local(idx));
                     // bounds check: idx < 0 || idx >= len → none (0)
-                    local_get(idx);
-                    local_get(buf); i32_load(0);
+                    local_get(Local(idx));
+                    local_get(Local(buf)); i32_load(0);
                     i32_ge_u;
-                    local_get(idx); i32_const(0); i32_lt_s;
+                    local_get(Local(idx)); i32_const(Imm32(0)); i32_lt_s;
                     i32_or;
                     if_i32;
-                      i32_const(0); // none
+                      i32_const(Imm32(0)); // none
                     else_;
                       // alloc 8 bytes for i64 value
-                      i32_const(I64_BYTES);
+                      i32_const(Imm32(I64_BYTES));
                       call(self.emitter.rt.alloc);
-                      local_set(result);
-                      local_get(result);
+                      local_set(Local(result));
+                      local_get(Local(result));
                       // load byte as u8 → i64
-                      local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(idx); i32_add;
+                      local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(idx)); i32_add;
                       i32_load8_u(0);
                       i64_extend_i32_u;
                       i64_store(0);
-                      local_get(result);
+                      local_get(Local(result));
                     end;
                 });
                 self.scratch.free_i32(result);
@@ -146,22 +147,22 @@ impl FuncCompiler<'_> {
                 let buf = self.scratch.alloc_i32();
                 let idx = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(idx);
-                    local_get(idx);
-                    local_get(buf); i32_load(0);
+                    i32_wrap_i64; local_set(Local(idx));
+                    local_get(Local(idx));
+                    local_get(Local(buf)); i32_load(0);
                     i32_ge_u;
-                    local_get(idx); i32_const(0); i32_lt_s;
+                    local_get(Local(idx)); i32_const(Imm32(0)); i32_lt_s;
                     i32_or;
                     if_i64;
                 });
                 self.emit_expr(&args[2]); // default
                 wasm!(self.func, {
                     else_;
-                      local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(idx); i32_add;
+                      local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(idx)); i32_add;
                       i32_load8_u(0);
                       i64_extend_i32_u;
                     end;
@@ -175,22 +176,22 @@ impl FuncCompiler<'_> {
                 let idx = self.scratch.alloc_i32();
                 let val = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(idx); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(idx)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(val);
+                    i32_wrap_i64; local_set(Local(val));
                     // bounds check: idx < len
-                    local_get(idx); local_get(buf); i32_load(0); i32_lt_u;
+                    local_get(Local(idx)); local_get(Local(buf)); i32_load(0); i32_lt_u;
                     if_empty;
                       // store byte: mem[buf + 4 + idx] = val
-                      local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(idx); i32_add;
-                      local_get(val);
+                      local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(idx)); i32_add;
+                      local_get(Local(val));
                       i32_store8(0);
                     end;
                     // return buf pointer
-                    local_get(buf);
+                    local_get(Local(buf));
                 });
                 self.scratch.free_i32(val);
                 self.scratch.free_i32(idx);
@@ -203,17 +204,17 @@ impl FuncCompiler<'_> {
                 let idx = self.scratch.alloc_i32();
                 let val = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(idx); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(idx)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(val);
+                    i32_wrap_i64; local_set(Local(val));
                     // bounds check: idx < len
-                    local_get(idx); local_get(buf); i32_load(0); i32_lt_u;
+                    local_get(Local(idx)); local_get(Local(buf)); i32_load(0); i32_lt_u;
                     if_empty;
-                      local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(idx); i32_add;
-                      local_get(val);
+                      local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(idx)); i32_add;
+                      local_get(Local(val));
                       i32_store8(0);
                     end;
                 });
@@ -227,20 +228,20 @@ impl FuncCompiler<'_> {
                 let ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(n);
+                    i32_wrap_i64; local_set(Local(n));
                     // alloc 4 + n bytes
-                    local_get(n); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
+                    local_get(Local(n)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
                     call(self.emitter.rt.alloc);
-                    local_set(ptr);
+                    local_set(Local(ptr));
                     // store length + cap
-                    local_get(ptr); local_get(n); i32_store(0);
-                    local_get(ptr); local_get(n); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
+                    local_get(Local(ptr)); local_get(Local(n)); i32_store(0);
+                    local_get(Local(ptr)); local_get(Local(n)); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
                     // zero the data region
-                    local_get(ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                    i32_const(0);
-                    local_get(n);
+                    local_get(Local(ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                    i32_const(Imm32(0));
+                    local_get(Local(n));
                     memory_fill;
-                    local_get(ptr);
+                    local_get(Local(ptr));
                 });
                 self.scratch.free_i32(ptr);
                 self.scratch.free_i32(n);
@@ -255,29 +256,29 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(xs);
-                    local_get(xs); i32_load(0); local_set(len);
+                    local_set(Local(xs));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
                     // alloc 4 + len
-                    local_get(len); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
+                    local_get(Local(len)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
                     call(self.emitter.rt.alloc);
-                    local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
+                    local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
                     // loop: copy each i64 as u8
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                       // dst_byte_addr = dst + 4 + i
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add;
                       // src_elem = xs + 4 + i*8 → load i64, wrap to i32, store as u8
-                      local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_add;
                       i64_load(0);
                       i32_wrap_i64;
                       i32_store8(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(len);
@@ -293,30 +294,30 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(src);
-                    local_get(src); i32_load(0); local_set(len);
+                    local_set(Local(src));
+                    local_get(Local(src)); i32_load(0); local_set(Local(len));
                     // alloc 4 + len*8
-                    local_get(len); i32_const(I64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
+                    local_get(Local(len)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
                     call(self.emitter.rt.alloc);
-                    local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
+                    local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
                     // loop
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                       // dst + 4 + i*8
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_add;
                       // load u8 from src + 4 + i, extend to i64
-                      local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(i); i32_add;
+                      local_get(Local(src)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_add;
                       i32_load8_u(0);
                       i64_extend_i32_u;
                       i64_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(len);
@@ -331,35 +332,35 @@ impl FuncCompiler<'_> {
                 let new_len = self.scratch.alloc_i32();
                 let dst = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(src); });
+                wasm!(self.func, { local_set(Local(src)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(s); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(s)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(e);
+                    i32_wrap_i64; local_set(Local(e));
                     // clamp start to [0, len]
-                    local_get(s); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(s); end;
-                    local_get(s); local_get(src); i32_load(0); i32_gt_u;
-                    if_empty; local_get(src); i32_load(0); local_set(s); end;
+                    local_get(Local(s)); i32_const(Imm32(0)); i32_lt_s;
+                    if_empty; i32_const(Imm32(0)); local_set(Local(s)); end;
+                    local_get(Local(s)); local_get(Local(src)); i32_load(0); i32_gt_u;
+                    if_empty; local_get(Local(src)); i32_load(0); local_set(Local(s)); end;
                     // clamp end to [start, len]
-                    local_get(e); local_get(s); i32_lt_s;
-                    if_empty; local_get(s); local_set(e); end;
-                    local_get(e); local_get(src); i32_load(0); i32_gt_u;
-                    if_empty; local_get(src); i32_load(0); local_set(e); end;
+                    local_get(Local(e)); local_get(Local(s)); i32_lt_s;
+                    if_empty; local_get(Local(s)); local_set(Local(e)); end;
+                    local_get(Local(e)); local_get(Local(src)); i32_load(0); i32_gt_u;
+                    if_empty; local_get(Local(src)); i32_load(0); local_set(Local(e)); end;
                     // new_len = e - s
-                    local_get(e); local_get(s); i32_sub; local_set(new_len);
+                    local_get(Local(e)); local_get(Local(s)); i32_sub; local_set(Local(new_len));
                     // alloc
-                    local_get(new_len); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
+                    local_get(Local(new_len)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
                     call(self.emitter.rt.alloc);
-                    local_set(dst);
-                    local_get(dst); local_get(new_len); i32_store(0);
+                    local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(new_len)); i32_store(0);
                     // memory.copy(dst+4, src+4+s, new_len)
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                    local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(s); i32_add;
-                    local_get(new_len);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                    local_get(Local(src)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(s)); i32_add;
+                    local_get(Local(new_len));
                     memory_copy;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(dst);
                 self.scratch.free_i32(new_len);
@@ -375,31 +376,31 @@ impl FuncCompiler<'_> {
                 let len_a = self.scratch.alloc_i32();
                 let len_b = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(b);
-                    local_get(a); i32_load(0); local_set(len_a);
-                    local_get(b); i32_load(0); local_set(len_b);
+                    local_set(Local(b));
+                    local_get(Local(a)); i32_load(0); local_set(Local(len_a));
+                    local_get(Local(b)); i32_load(0); local_set(Local(len_b));
                     // alloc 4 + len_a + len_b
-                    local_get(len_a); local_get(len_b); i32_add; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
+                    local_get(Local(len_a)); local_get(Local(len_b)); i32_add; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
                     call(self.emitter.rt.alloc);
-                    local_set(dst);
+                    local_set(Local(dst));
                     // store total length
-                    local_get(dst);
-                    local_get(len_a); local_get(len_b); i32_add;
+                    local_get(Local(dst));
+                    local_get(Local(len_a)); local_get(Local(len_b)); i32_add;
                     i32_store(0);
                     // copy a data
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                    local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                    local_get(len_a);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                    local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                    local_get(Local(len_a));
                     memory_copy;
                     // copy b data
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(len_a); i32_add;
-                    local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                    local_get(len_b);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(len_a)); i32_add;
+                    local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                    local_get(Local(len_b));
                     memory_copy;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(len_b);
                 self.scratch.free_i32(len_a);
@@ -416,34 +417,34 @@ impl FuncCompiler<'_> {
                 let total = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(src); });
+                wasm!(self.func, { local_set(Local(src)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(n);
+                    i32_wrap_i64; local_set(Local(n));
                     // clamp n to >= 0
-                    local_get(n); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(n); end;
-                    local_get(src); i32_load(0); local_set(src_len);
-                    local_get(src_len); local_get(n); i32_mul; local_set(total);
+                    local_get(Local(n)); i32_const(Imm32(0)); i32_lt_s;
+                    if_empty; i32_const(Imm32(0)); local_set(Local(n)); end;
+                    local_get(Local(src)); i32_load(0); local_set(Local(src_len));
+                    local_get(Local(src_len)); local_get(Local(n)); i32_mul; local_set(Local(total));
                     // alloc 4 + total
-                    local_get(total); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
+                    local_get(Local(total)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
                     call(self.emitter.rt.alloc);
-                    local_set(dst);
-                    local_get(dst); local_get(total); i32_store(0);
+                    local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(total)); i32_store(0);
                     // loop: copy src data n times
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(n); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(n)); i32_ge_u; br_if(1);
                       // dst + 4 + i*src_len
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(i); local_get(src_len); i32_mul; i32_add;
-                      local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(src_len);
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(i)); local_get(Local(src_len)); i32_mul; i32_add;
+                      local_get(Local(src)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(src_len));
                       memory_copy;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(total);
@@ -460,29 +461,29 @@ impl FuncCompiler<'_> {
                 let old_len = self.scratch.alloc_i32();
                 let new_buf = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]); // buf ptr
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]); // val (i64)
                 wasm!(self.func, { i32_wrap_i64; }); // val as i32
                 let val = self.scratch.alloc_i32();
-                wasm!(self.func, { local_set(val); });
+                wasm!(self.func, { local_set(Local(val)); });
                 wasm!(self.func, {
                     // old_len = buf[0]
-                    local_get(buf); i32_load(0); local_set(old_len);
+                    local_get(Local(buf)); i32_load(0); local_set(Local(old_len));
                     // new_buf = alloc(hdr + old_len + 1)
-                    local_get(old_len); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32 + 1); i32_add;
+                    local_get(Local(old_len)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32 + 1)); i32_add;
                     call(self.emitter.rt.alloc);
-                    local_set(new_buf);
+                    local_set(Local(new_buf));
                     // new_buf.len = old_len + 1, new_buf.cap = same
-                    local_get(new_buf); local_get(old_len); i32_const(1); i32_add; i32_store(0);
-                    local_get(new_buf); local_get(old_len); i32_const(1); i32_add; i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
+                    local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(1)); i32_add; i32_store(0);
+                    local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(1)); i32_add; i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
                     // copy old data: new_buf+4 <- buf+4, old_len bytes
-                    local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                    local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                    local_get(old_len);
+                    local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                    local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                    local_get(Local(old_len));
                     memory_copy;
                     // new_buf[4 + old_len] = val
-                    local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(old_len); i32_add;
-                    local_get(val); i32_store8(0);
+                    local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(old_len)); i32_add;
+                    local_get(Local(val)); i32_store8(0);
                 });
                 // Update the variable: need to store new_buf back
                 // The buf variable is the first arg — if it's a Var, update the local
@@ -495,7 +496,7 @@ impl FuncCompiler<'_> {
             "clear" => {
                 // bytes.clear(b): set len to 0
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_const(0); i32_store(0); });
+                wasm!(self.func, { i32_const(Imm32(0)); i32_store(0); });
             }
             "append_f64_le" => {
                 // bytes.append_f64_le(b, val): append 8 bytes (f64 little-endian).
@@ -506,26 +507,26 @@ impl FuncCompiler<'_> {
                 let new_buf = self.scratch.alloc_i32();
                 let fval = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]); // buf ptr
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]); // val: f64 on stack
                 wasm!(self.func, {
-                    local_set(fval);
+                    local_set(Local(fval));
                     // old_len = buf[0]
-                    local_get(buf); i32_load(0); local_set(old_len);
+                    local_get(Local(buf)); i32_load(0); local_set(Local(old_len));
                     // new_buf = alloc(4 + old_len + 8)
-                    local_get(old_len); i32_const(BYTES_HDR_F64_ALLOC_SIZE); i32_add;
+                    local_get(Local(old_len)); i32_const(Imm32(BYTES_HDR_F64_ALLOC_SIZE)); i32_add;
                     call(self.emitter.rt.alloc);
-                    local_set(new_buf);
+                    local_set(Local(new_buf));
                     // new_buf[0] = old_len + 8
-                    local_get(new_buf); local_get(old_len); i32_const(F64_BYTES); i32_add; i32_store(0);
+                    local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(F64_BYTES)); i32_add; i32_store(0);
                     // copy old data: new_buf+4 <- buf+4, old_len bytes
-                    local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                    local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                    local_get(old_len);
+                    local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                    local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                    local_get(Local(old_len));
                     memory_copy;
                     // *(new_buf + 4 + old_len) = fval (f64 LE)
-                    local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(old_len); i32_add;
-                    local_get(fval);
+                    local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(old_len)); i32_add;
+                    local_get(Local(fval));
                     f64_store(0);
                 });
                 self.emit_mutator_writeback(&args[0], new_buf);
@@ -565,7 +566,7 @@ impl FuncCompiler<'_> {
             "ends_with" => self.emit_bytes_prefix_match(args, /*at_end=*/true),
             "contains" => {
                 self.emit_bytes_index_of_inner(args);
-                wasm!(self.func, { i32_const(-1); i64_extend_i32_s; i64_ne; });
+                wasm!(self.func, { i32_const(Imm32(-1)); i64_extend_i32_s; i64_ne; });
             }
             "index_of" => {
                 self.emit_bytes_index_of_inner(args);
@@ -573,14 +574,14 @@ impl FuncCompiler<'_> {
                 let pos_i64 = self.scratch.alloc_i64();
                 let opt_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(pos_i64);
-                    local_get(pos_i64); i64_const(0); i64_lt_s;
+                    local_set(Local(pos_i64));
+                    local_get(Local(pos_i64)); i64_const(Imm64(0)); i64_lt_s;
                     if_i32;
-                        i32_const(0);
+                        i32_const(Imm32(0));
                     else_;
-                        i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(opt_ptr);
-                        local_get(opt_ptr); local_get(pos_i64); i64_store(0);
-                        local_get(opt_ptr);
+                        i32_const(Imm32(I64_BYTES)); call(self.emitter.rt.alloc); local_set(Local(opt_ptr));
+                        local_get(Local(opt_ptr)); local_get(Local(pos_i64)); i64_store(0);
+                        local_get(Local(opt_ptr));
                     end;
                 });
                 self.scratch.free_i32(opt_ptr);
@@ -605,7 +606,7 @@ impl FuncCompiler<'_> {
                 let buf = self.scratch.alloc_i32();
                 let res = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 // Push buf, validate, branch on result
                 let dummy_arg = IrExpr {
                     kind: args[0].kind.clone(),
@@ -616,15 +617,15 @@ impl FuncCompiler<'_> {
                 let err_str = self.emitter.intern_string("invalid UTF-8");
                 wasm!(self.func, {
                     if_i32;
-                        i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(res);
-                        local_get(res); i32_const(0); i32_store(0);
-                        local_get(res); local_get(buf); i32_store(4);
-                        local_get(res);
+                        i32_const(Imm32(I64_BYTES)); call(self.emitter.rt.alloc); local_set(Local(res));
+                        local_get(Local(res)); i32_const(Imm32(0)); i32_store(0);
+                        local_get(Local(res)); local_get(Local(buf)); i32_store(4);
+                        local_get(Local(res));
                     else_;
-                        i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(res);
-                        local_get(res); i32_const(1); i32_store(0);
-                        local_get(res); i32_const(err_str as i32); i32_store(4);
-                        local_get(res);
+                        i32_const(Imm32(I64_BYTES)); call(self.emitter.rt.alloc); local_set(Local(res));
+                        local_get(Local(res)); i32_const(Imm32(1)); i32_store(0);
+                        local_get(Local(res)); i32_const(Imm32(err_str as i32)); i32_store(4);
+                        local_get(Local(res));
                     end;
                 });
                 self.scratch.free_i32(res);
@@ -637,19 +638,19 @@ impl FuncCompiler<'_> {
                 let addr = self.scratch.alloc_i32();
                 let fval = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
                     i32_wrap_i64;
-                    local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; i32_add;
-                    local_set(addr);
+                    local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; i32_add;
+                    local_set(Local(addr));
                 });
                 self.emit_expr(&args[2]); // val: f64 on stack
                 wasm!(self.func, {
-                    local_set(fval);
+                    local_set(Local(fval));
                     // push addr, then demoted val, then store
-                    local_get(addr);
-                    local_get(fval);
+                    local_get(Local(addr));
+                    local_get(Local(fval));
                     f32_demote_f64;
                     f32_store(0);
                 });
@@ -664,15 +665,15 @@ impl FuncCompiler<'_> {
                 let pos = self.scratch.alloc_i32();
                 let val = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(pos); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(pos)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(val);
+                    i32_wrap_i64; local_set(Local(val));
                     // address = buf + 4 + pos
-                    local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos); i32_add;
-                    local_get(val);
+                    local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos)); i32_add;
+                    local_get(Local(val));
                     i32_store16(0);
                 });
                 self.scratch.free_i32(val);
@@ -704,7 +705,7 @@ impl FuncCompiler<'_> {
                 // bytes.data_ptr(b) → Int (i64)
                 // Return pointer to data region: buf + 4
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; i64_extend_i32_u; });
+                wasm!(self.func, { i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; i64_extend_i32_u; });
             }
             // ── RawPtr / linear-memory bridge (#440) ──
             // A RawPtr is an i32 linear-memory byte offset. `as_ptr`/`as_mut_ptr`
@@ -714,7 +715,7 @@ impl FuncCompiler<'_> {
                 // bytes.as_ptr(b) / as_mut_ptr(b) → RawPtr (i32 data offset)
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
                     i32_add;
                 });
             }
@@ -724,19 +725,19 @@ impl FuncCompiler<'_> {
                 let src = self.scratch.alloc_i32();
                 let dst = self.scratch.alloc_i32();
                 let n = self.scratch.alloc_i32();
-                self.emit_expr(&args[0]); wasm!(self.func, { local_set(src); });            // src bytes ptr
-                self.emit_expr(&args[1]); wasm!(self.func, { local_set(dst); });            // dst raw offset (i32 RawPtr)
-                self.emit_expr(&args[2]); wasm!(self.func, { i32_wrap_i64; local_set(n); }); // cap (Int i64 → i32)
+                self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(src)); });            // src bytes ptr
+                self.emit_expr(&args[1]); wasm!(self.func, { local_set(Local(dst)); });            // dst raw offset (i32 RawPtr)
+                self.emit_expr(&args[2]); wasm!(self.func, { i32_wrap_i64; local_set(Local(n)); }); // cap (Int i64 → i32)
                 wasm!(self.func, {
-                    local_get(n); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(n); end;
-                    local_get(n); local_get(src); i32_load(0); i32_gt_u;
-                    if_empty; local_get(src); i32_load(0); local_set(n); end;
-                    local_get(dst);
-                    local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                    local_get(n);
+                    local_get(Local(n)); i32_const(Imm32(0)); i32_lt_s;
+                    if_empty; i32_const(Imm32(0)); local_set(Local(n)); end;
+                    local_get(Local(n)); local_get(Local(src)); i32_load(0); i32_gt_u;
+                    if_empty; local_get(Local(src)); i32_load(0); local_set(Local(n)); end;
+                    local_get(Local(dst));
+                    local_get(Local(src)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                    local_get(Local(n));
                     memory_copy;
-                    local_get(n); i64_extend_i32_u;
+                    local_get(Local(n)); i64_extend_i32_u;
                 });
                 self.scratch.free_i32(n);
                 self.scratch.free_i32(dst);
@@ -747,20 +748,20 @@ impl FuncCompiler<'_> {
                 let src = self.scratch.alloc_i32();
                 let len = self.scratch.alloc_i32();
                 let dst = self.scratch.alloc_i32();
-                self.emit_expr(&args[0]); wasm!(self.func, { local_set(src); });              // ptr (i32 RawPtr)
-                self.emit_expr(&args[1]); wasm!(self.func, { i32_wrap_i64; local_set(len); }); // len (Int i64 → i32)
+                self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(src)); });              // ptr (i32 RawPtr)
+                self.emit_expr(&args[1]); wasm!(self.func, { i32_wrap_i64; local_set(Local(len)); }); // len (Int i64 → i32)
                 wasm!(self.func, {
-                    local_get(len); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(len); end;
-                    local_get(len); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
+                    local_get(Local(len)); i32_const(Imm32(0)); i32_lt_s;
+                    if_empty; i32_const(Imm32(0)); local_set(Local(len)); end;
+                    local_get(Local(len)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
                     call(self.emitter.rt.alloc);
-                    local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                    local_get(src);
-                    local_get(len);
+                    local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                    local_get(Local(src));
+                    local_get(Local(len));
                     memory_copy;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(dst);
                 self.scratch.free_i32(len);
@@ -846,24 +847,24 @@ impl FuncCompiler<'_> {
                 let len = self.scratch.alloc_i32();
                 let dst = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
                     i32_wrap_i64;
-                    local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; i32_add; local_set(src);
+                    local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; i32_add; local_set(Local(src));
                 });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(len);
+                    i32_wrap_i64; local_set(Local(len));
                     // alloc 4 + len
-                    local_get(len); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                    local_get(src);
-                    local_get(len);
+                    local_get(Local(len)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                    local_get(Local(src));
+                    local_get(Local(len));
                     memory_copy;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(dst);
                 self.scratch.free_i32(len);
@@ -879,25 +880,25 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let lval = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(pos); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(pos)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(n);
-                    i32_const(0); local_set(i);
+                    i32_wrap_i64; local_set(Local(n));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(n); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(n)); i32_ge_u; br_if(1);
                       // Load u32 len from buf + 4 + pos
-                      local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos); i32_add;
-                      i32_load(0); local_set(lval);
+                      local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos)); i32_add;
+                      i32_load(0); local_set(Local(lval));
                       // pos += 4 + len
-                      local_get(pos); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(lval); i32_add;
-                      local_set(pos);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(pos)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(lval)); i32_add;
+                      local_set(Local(pos));
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(pos); i64_extend_i32_u;
+                    local_get(Local(pos)); i64_extend_i32_u;
                 });
                 self.scratch.free_i32(lval);
                 self.scratch.free_i32(i);
@@ -915,43 +916,43 @@ impl FuncCompiler<'_> {
                 let lval = self.scratch.alloc_i32();
                 let s = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(pos); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(pos)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(n);
+                    i32_wrap_i64; local_set(Local(n));
                     // alloc list: 4 + n*4
-                    local_get(n); i32_const(I32_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); local_get(n); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_get(Local(n)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); local_get(Local(n)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(n); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(n)); i32_ge_u; br_if(1);
                       // len at [buf+4+pos]
-                      local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos); i32_add;
-                      i32_load(0); local_set(lval);
+                      local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos)); i32_add;
+                      i32_load(0); local_set(Local(lval));
                       // alloc string: [len][bytes]
-                      local_get(lval); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      call(self.emitter.rt.alloc); local_set(s);
-                      local_get(s); local_get(lval); i32_store(0);
+                      local_get(Local(lval)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      call(self.emitter.rt.alloc); local_set(Local(s));
+                      local_get(Local(s)); local_get(Local(lval)); i32_store(0);
                       // memcpy bytes: dst = s+4, src = buf+4+pos+4, n = lval
-                      local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(pos); i32_add; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(lval);
+                      local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(pos)); i32_add; i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(lval));
                       memory_copy;
                       // result[i] = s
-                      local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      local_get(s); i32_store(0);
+                      local_get(Local(result)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      local_get(Local(s)); i32_store(0);
                       // pos += 4 + len
-                      local_get(pos); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(lval); i32_add;
-                      local_set(pos);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(pos)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(lval)); i32_add;
+                      local_set(Local(pos));
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(s);
                 self.scratch.free_i32(lval);
@@ -985,25 +986,25 @@ impl FuncCompiler<'_> {
                 };
                 let out_bytes: i32 = 8;  // list elem size (i64 or f64)
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(pos); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(pos)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(n);
+                    i32_wrap_i64; local_set(Local(n));
                     // alloc list: 4 + n * out_bytes
-                    local_get(n); i32_const(out_bytes); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); local_get(n); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_get(Local(n)); i32_const(Imm32(out_bytes)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); local_get(Local(n)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(n); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(n)); i32_ge_u; br_if(1);
                       // dst = result + 4 + i * out_bytes
-                      local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(i); i32_const(out_bytes); i32_mul; i32_add;
+                      local_get(Local(result)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(out_bytes)); i32_mul; i32_add;
                       // src addr = buf + 4 + pos + i * elem_bytes
-                      local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos); i32_add;
-                      local_get(i); i32_const(elem_bytes); i32_mul; i32_add;
+                      local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(elem_bytes)); i32_mul; i32_add;
                 });
                 // i16/u16 LE: native load, sign/zero extend
                 if !is_be && (method == "read_i16_le_array" || method == "read_u16_le_array") {
@@ -1018,19 +1019,19 @@ impl FuncCompiler<'_> {
                     let dst_addr = self.scratch.alloc_i32();
                     let src_addr = self.scratch.alloc_i32();
                     let acc = self.scratch.alloc_i64();
-                    wasm!(self.func, { local_set(src_addr); local_set(dst_addr); });
+                    wasm!(self.func, { local_set(Local(src_addr)); local_set(Local(dst_addr)); });
                     // Build acc = (b[0] << (8*(n-1))) | (b[1] << (8*(n-2))) | ... | b[n-1]
-                    wasm!(self.func, { i64_const(0); local_set(acc); });
+                    wasm!(self.func, { i64_const(Imm64(0)); local_set(Local(acc)); });
                     for i in 0..(elem_bytes as u32) {
                         let shift = 8 * ((elem_bytes as u32) - 1 - i) as i64;
                         wasm!(self.func, {
-                            local_get(acc);
-                            local_get(src_addr);
+                            local_get(Local(acc));
+                            local_get(Local(src_addr));
                             i32_load8_u(i as u64);
                             i64_extend_i32_u;
-                            i64_const(shift); i64_shl;
+                            i64_const(Imm64(shift)); i64_shl;
                             i64_or;
-                            local_set(acc);
+                            local_set(Local(acc));
                         });
                     }
                     // Now write into dst_addr based on method
@@ -1038,41 +1039,41 @@ impl FuncCompiler<'_> {
                         "read_i16_be_array" => {
                             // sign-extend 16-bit
                             wasm!(self.func, {
-                                local_get(dst_addr);
-                                local_get(acc); i32_wrap_i64; i32_const(I16_BITS); i32_shl;
-                                i32_const(I16_BITS); i32_shr_s;
+                                local_get(Local(dst_addr));
+                                local_get(Local(acc)); i32_wrap_i64; i32_const(Imm32(I16_BITS)); i32_shl;
+                                i32_const(Imm32(I16_BITS)); i32_shr_s;
                                 i64_extend_i32_s;
                                 i64_store(0);
                             });
                         }
                         "read_u16_be_array" => {
-                            wasm!(self.func, { local_get(dst_addr); local_get(acc); i64_store(0); });
+                            wasm!(self.func, { local_get(Local(dst_addr)); local_get(Local(acc)); i64_store(0); });
                         }
                         "read_i32_be_array" => {
                             // sign-extend 32-bit value
                             wasm!(self.func, {
-                                local_get(dst_addr);
-                                local_get(acc); i32_wrap_i64; i64_extend_i32_s;
+                                local_get(Local(dst_addr));
+                                local_get(Local(acc)); i32_wrap_i64; i64_extend_i32_s;
                                 i64_store(0);
                             });
                         }
                         "read_u32_be_array" => {
-                            wasm!(self.func, { local_get(dst_addr); local_get(acc); i64_store(0); });
+                            wasm!(self.func, { local_get(Local(dst_addr)); local_get(Local(acc)); i64_store(0); });
                         }
                         "read_i64_be_array" => {
-                            wasm!(self.func, { local_get(dst_addr); local_get(acc); i64_store(0); });
+                            wasm!(self.func, { local_get(Local(dst_addr)); local_get(Local(acc)); i64_store(0); });
                         }
                         "read_f32_be_array" => {
                             wasm!(self.func, {
-                                local_get(dst_addr);
-                                local_get(acc); i32_wrap_i64; f32_reinterpret_i32; f64_promote_f32;
+                                local_get(Local(dst_addr));
+                                local_get(Local(acc)); i32_wrap_i64; f32_reinterpret_i32; f64_promote_f32;
                                 f64_store(0);
                             });
                         }
                         "read_f64_be_array" => {
                             wasm!(self.func, {
-                                local_get(dst_addr);
-                                local_get(acc); f64_reinterpret_i64;
+                                local_get(Local(dst_addr));
+                                local_get(Local(acc)); f64_reinterpret_i64;
                                 f64_store(0);
                             });
                         }
@@ -1110,10 +1111,10 @@ impl FuncCompiler<'_> {
                     }
                 }
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(result);
@@ -1132,7 +1133,7 @@ impl FuncCompiler<'_> {
     fn emit_typed_byte_read(&mut self, buf_expr: &IrExpr, pos_expr: &IrExpr, op: ByteReadOp) {
         // Compute address = buf + 4 + pos.
         self.emit_expr(buf_expr);
-        wasm!(self.func, { i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; });
+        wasm!(self.func, { i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; });
         self.emit_expr(pos_expr);
         wasm!(self.func, { i32_wrap_i64; i32_add; });
 
@@ -1178,37 +1179,37 @@ impl FuncCompiler<'_> {
         let new_buf = self.scratch.alloc_i32();
         let val_i64 = self.scratch.alloc_i64();
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(buf); });
+        wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { local_set(val_i64); });
+        wasm!(self.func, { local_set(Local(val_i64)); });
         // old_len = buf[0]
         wasm!(self.func, {
-            local_get(buf); i32_load(0); local_set(old_len);
+            local_get(Local(buf)); i32_load(0); local_set(Local(old_len));
         });
         // new_buf = alloc(hdr + old_len + size_bytes)
         let str_hdr = self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32;
         let str_cap_off = self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP);
         wasm!(self.func, {
-            local_get(old_len); i32_const(str_hdr + size_bytes as i32); i32_add;
-            call(self.emitter.rt.alloc); local_set(new_buf);
+            local_get(Local(old_len)); i32_const(Imm32(str_hdr + size_bytes as i32)); i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(new_buf));
             // new_buf.len = old_len + size_bytes, new_buf.cap = same
-            local_get(new_buf); local_get(old_len); i32_const(size_bytes as i32); i32_add; i32_store(0);
-            local_get(new_buf); local_get(old_len); i32_const(size_bytes as i32); i32_add; i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
-            local_get(new_buf); local_get(old_len); i32_const(size_bytes as i32); i32_add; i32_store(str_cap_off);
+            local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(size_bytes as i32)); i32_add; i32_store(0);
+            local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(size_bytes as i32)); i32_add; i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
+            local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(size_bytes as i32)); i32_add; i32_store(str_cap_off);
             // memcpy old data
-            local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            local_get(old_len);
+            local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            local_get(Local(old_len));
             memory_copy;
             // address = new_buf + 4 + old_len
-            local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(old_len); i32_add;
+            local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(old_len)); i32_add;
         });
         // Store with width-specific opcode. Almide Int is i64; narrow first.
         match size_bytes {
-            1 => { wasm!(self.func, { local_get(val_i64); i32_wrap_i64; i32_store8(0); }); }
-            2 => { wasm!(self.func, { local_get(val_i64); i32_wrap_i64; i32_store16(0); }); }
-            4 => { wasm!(self.func, { local_get(val_i64); i32_wrap_i64; i32_store(0); }); }
-            8 => { wasm!(self.func, { local_get(val_i64); i64_store(0); }); }
+            1 => { wasm!(self.func, { local_get(Local(val_i64)); i32_wrap_i64; i32_store8(0); }); }
+            2 => { wasm!(self.func, { local_get(Local(val_i64)); i32_wrap_i64; i32_store16(0); }); }
+            4 => { wasm!(self.func, { local_get(Local(val_i64)); i32_wrap_i64; i32_store(0); }); }
+            8 => { wasm!(self.func, { local_get(Local(val_i64)); i64_store(0); }); }
             _ => panic!("emit_bytes_append_i: unsupported size_bytes {size_bytes}"),
         }
         // Update the variable in-place when arg[0] is a Var.
@@ -1227,25 +1228,25 @@ impl FuncCompiler<'_> {
         let new_buf = self.scratch.alloc_i32();
         let fval = self.scratch.alloc_f64();
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(buf); });
+        wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { local_set(fval); });
+        wasm!(self.func, { local_set(Local(fval)); });
         wasm!(self.func, {
-            local_get(buf); i32_load(0); local_set(old_len);
-            local_get(old_len); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32 + size_bytes as i32); i32_add;
-            call(self.emitter.rt.alloc); local_set(new_buf);
-            local_get(new_buf); local_get(old_len); i32_const(size_bytes as i32); i32_add; i32_store(0);
-            local_get(new_buf); local_get(old_len); i32_const(size_bytes as i32); i32_add; i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
-            local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            local_get(old_len);
+            local_get(Local(buf)); i32_load(0); local_set(Local(old_len));
+            local_get(Local(old_len)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32 + size_bytes as i32)); i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(new_buf));
+            local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(size_bytes as i32)); i32_add; i32_store(0);
+            local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(size_bytes as i32)); i32_add; i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
+            local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            local_get(Local(old_len));
             memory_copy;
-            local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(old_len); i32_add;
+            local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(old_len)); i32_add;
         });
         if as_f32 {
-            wasm!(self.func, { local_get(fval); f32_demote_f64; f32_store(0); });
+            wasm!(self.func, { local_get(Local(fval)); f32_demote_f64; f32_store(0); });
         } else {
-            wasm!(self.func, { local_get(fval); f64_store(0); });
+            wasm!(self.func, { local_get(Local(fval)); f64_store(0); });
         }
         let _ = as_f32; // satisfy unused-var lint when both branches identical
         self.emit_mutator_writeback(&args[0], new_buf);
@@ -1262,34 +1263,34 @@ impl FuncCompiler<'_> {
         let src = self.scratch.alloc_i32();
         let acc = self.scratch.alloc_i64();
         self.emit_expr(buf_expr);
-        wasm!(self.func, { local_set(buf); });
+        wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(pos_expr);
         wasm!(self.func, {
             i32_wrap_i64;
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; i32_add; local_set(src);
-            i64_const(0); local_set(acc);
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; i32_add; local_set(Local(src));
+            i64_const(Imm64(0)); local_set(Local(acc));
         });
         for i in 0..size_bytes {
             let shift = 8 * (size_bytes - 1 - i) as i64;
             wasm!(self.func, {
-                local_get(acc);
-                local_get(src);
+                local_get(Local(acc));
+                local_get(Local(src));
                 i32_load8_u(i as u64);
                 i64_extend_i32_u;
-                i64_const(shift); i64_shl;
+                i64_const(Imm64(shift)); i64_shl;
                 i64_or;
-                local_set(acc);
+                local_set(Local(acc));
             });
         }
         if signed && size_bytes < 8 {
             // Sign-extend a sub-64-bit value to i64. Shift left then arithmetic right.
             let pad = 64 - 8 * size_bytes as i64;
             wasm!(self.func, {
-                local_get(acc); i64_const(pad); i64_shl;
-                i64_const(pad); i64_shr_s;
+                local_get(Local(acc)); i64_const(Imm64(pad)); i64_shl;
+                i64_const(Imm64(pad)); i64_shr_s;
             });
         } else {
-            wasm!(self.func, { local_get(acc); });
+            wasm!(self.func, { local_get(Local(acc)); });
         }
         self.scratch.free_i64(acc);
         self.scratch.free_i32(src);
@@ -1314,20 +1315,20 @@ impl FuncCompiler<'_> {
         let pos = self.scratch.alloc_i32();
         let val_i64 = self.scratch.alloc_i64();
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(buf); });
+        wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { i32_wrap_i64; local_set(pos); });
+        wasm!(self.func, { i32_wrap_i64; local_set(Local(pos)); });
         self.emit_expr(&args[2]);
         wasm!(self.func, {
-            local_set(val_i64);
+            local_set(Local(val_i64));
             // address = buf + 4 + pos
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos); i32_add;
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos)); i32_add;
         });
         match size_bytes {
-            1 => { wasm!(self.func, { local_get(val_i64); i32_wrap_i64; i32_store8(0); }); }
-            2 => { wasm!(self.func, { local_get(val_i64); i32_wrap_i64; i32_store16(0); }); }
-            4 => { wasm!(self.func, { local_get(val_i64); i32_wrap_i64; i32_store(0); }); }
-            8 => { wasm!(self.func, { local_get(val_i64); i64_store(0); }); }
+            1 => { wasm!(self.func, { local_get(Local(val_i64)); i32_wrap_i64; i32_store8(0); }); }
+            2 => { wasm!(self.func, { local_get(Local(val_i64)); i32_wrap_i64; i32_store16(0); }); }
+            4 => { wasm!(self.func, { local_get(Local(val_i64)); i32_wrap_i64; i32_store(0); }); }
+            8 => { wasm!(self.func, { local_get(Local(val_i64)); i64_store(0); }); }
             _ => panic!("emit_bytes_set_i: unsupported size_bytes {size_bytes}"),
         }
         self.scratch.free_i64(val_i64);
@@ -1341,18 +1342,18 @@ impl FuncCompiler<'_> {
         let pos = self.scratch.alloc_i32();
         let fval = self.scratch.alloc_f64();
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(buf); });
+        wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { i32_wrap_i64; local_set(pos); });
+        wasm!(self.func, { i32_wrap_i64; local_set(Local(pos)); });
         self.emit_expr(&args[2]);
         wasm!(self.func, {
-            local_set(fval);
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos); i32_add;
+            local_set(Local(fval));
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos)); i32_add;
         });
         if as_f32 {
-            wasm!(self.func, { local_get(fval); f32_demote_f64; f32_store(0); });
+            wasm!(self.func, { local_get(Local(fval)); f32_demote_f64; f32_store(0); });
         } else {
-            wasm!(self.func, { local_get(fval); f64_store(0); });
+            wasm!(self.func, { local_get(Local(fval)); f64_store(0); });
         }
         let _ = size_bytes; // fixed by `as_f32` (4 vs 8); kept for parity with append helper
         self.scratch.free_f64(fval);
@@ -1366,19 +1367,19 @@ impl FuncCompiler<'_> {
         let pos = self.scratch.alloc_i32();
         let val_i64 = self.scratch.alloc_i64();
         let dst = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
-        self.emit_expr(&args[1]); wasm!(self.func, { i32_wrap_i64; local_set(pos); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
+        self.emit_expr(&args[1]); wasm!(self.func, { i32_wrap_i64; local_set(Local(pos)); });
         self.emit_expr(&args[2]); wasm!(self.func, {
-            local_set(val_i64);
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos); i32_add; local_set(dst);
+            local_set(Local(val_i64));
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos)); i32_add; local_set(Local(dst));
         });
         for i in 0..size_bytes {
             let shift = 8 * (size_bytes - 1 - i) as i64;
             wasm!(self.func, {
-                local_get(dst);
-                local_get(val_i64); i64_const(shift); i64_shr_u;
+                local_get(Local(dst));
+                local_get(Local(val_i64)); i64_const(Imm64(shift)); i64_shr_u;
                 i32_wrap_i64;
-                i32_const(LOW_BYTE_MASK); i32_and;
+                i32_const(Imm32(LOW_BYTE_MASK)); i32_and;
                 i32_store8(i as u64);
             });
         }
@@ -1394,26 +1395,26 @@ impl FuncCompiler<'_> {
         let pos = self.scratch.alloc_i32();
         let bits = self.scratch.alloc_i64();
         let dst = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
-        self.emit_expr(&args[1]); wasm!(self.func, { i32_wrap_i64; local_set(pos); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
+        self.emit_expr(&args[1]); wasm!(self.func, { i32_wrap_i64; local_set(Local(pos)); });
         self.emit_expr(&args[2]);
         if size_bytes == 4 {
             wasm!(self.func, {
-                f32_demote_f64; i32_reinterpret_f32; i64_extend_i32_u; local_set(bits);
+                f32_demote_f64; i32_reinterpret_f32; i64_extend_i32_u; local_set(Local(bits));
             });
         } else {
-            wasm!(self.func, { i64_reinterpret_f64; local_set(bits); });
+            wasm!(self.func, { i64_reinterpret_f64; local_set(Local(bits)); });
         }
         wasm!(self.func, {
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos); i32_add; local_set(dst);
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos)); i32_add; local_set(Local(dst));
         });
         for i in 0..size_bytes {
             let shift = 8 * (size_bytes - 1 - i) as i64;
             wasm!(self.func, {
-                local_get(dst);
-                local_get(bits); i64_const(shift); i64_shr_u;
+                local_get(Local(dst));
+                local_get(Local(bits)); i64_const(Imm64(shift)); i64_shr_u;
                 i32_wrap_i64;
-                i32_const(LOW_BYTE_MASK); i32_and;
+                i32_const(Imm32(LOW_BYTE_MASK)); i32_and;
                 i32_store8(i as u64);
             });
         }
@@ -1432,30 +1433,30 @@ impl FuncCompiler<'_> {
         let val_i64 = self.scratch.alloc_i64();
         let dst = self.scratch.alloc_i32();
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(buf); });
+        wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]);
         wasm!(self.func, {
-            local_set(val_i64);
-            local_get(buf); i32_load(0); local_set(old_len);
-            local_get(old_len); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32 + size_bytes as i32); i32_add;
-            call(self.emitter.rt.alloc); local_set(new_buf);
-            local_get(new_buf); local_get(old_len); i32_const(size_bytes as i32); i32_add; i32_store(0);
-            local_get(new_buf); local_get(old_len); i32_const(size_bytes as i32); i32_add; i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
-            local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            local_get(old_len);
+            local_set(Local(val_i64));
+            local_get(Local(buf)); i32_load(0); local_set(Local(old_len));
+            local_get(Local(old_len)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32 + size_bytes as i32)); i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(new_buf));
+            local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(size_bytes as i32)); i32_add; i32_store(0);
+            local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(size_bytes as i32)); i32_add; i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
+            local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            local_get(Local(old_len));
             memory_copy;
-            local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(old_len); i32_add;
-            local_set(dst);
+            local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(old_len)); i32_add;
+            local_set(Local(dst));
         });
         // Write MSB-first: byte at offset i = (val >> (8*(size-1-i))) & 0xff
         for i in 0..size_bytes {
             let shift = 8 * (size_bytes - 1 - i) as i64;
             wasm!(self.func, {
-                local_get(dst);
-                local_get(val_i64); i64_const(shift); i64_shr_u;
+                local_get(Local(dst));
+                local_get(Local(val_i64)); i64_const(Imm64(shift)); i64_shr_u;
                 i32_wrap_i64;
-                i32_const(LOW_BYTE_MASK); i32_and;
+                i32_const(Imm32(LOW_BYTE_MASK)); i32_and;
                 i32_store8(i as u64);
             });
         }
@@ -1475,7 +1476,7 @@ impl FuncCompiler<'_> {
         let bits = self.scratch.alloc_i64();
         let dst = self.scratch.alloc_i32();
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(buf); });
+        wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]); // f64 on stack
         if size_bytes == 4 {
             // Demote to f32, reinterpret as i32 bits, extend to i64 for shifting.
@@ -1483,34 +1484,34 @@ impl FuncCompiler<'_> {
                 f32_demote_f64;
                 i32_reinterpret_f32;
                 i64_extend_i32_u;
-                local_set(bits);
+                local_set(Local(bits));
             });
         } else {
             wasm!(self.func, {
                 i64_reinterpret_f64;
-                local_set(bits);
+                local_set(Local(bits));
             });
         }
         wasm!(self.func, {
-            local_get(buf); i32_load(0); local_set(old_len);
-            local_get(old_len); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32 + size_bytes as i32); i32_add;
-            call(self.emitter.rt.alloc); local_set(new_buf);
-            local_get(new_buf); local_get(old_len); i32_const(size_bytes as i32); i32_add; i32_store(0);
-            local_get(new_buf); local_get(old_len); i32_const(size_bytes as i32); i32_add; i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
-            local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            local_get(old_len);
+            local_get(Local(buf)); i32_load(0); local_set(Local(old_len));
+            local_get(Local(old_len)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32 + size_bytes as i32)); i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(new_buf));
+            local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(size_bytes as i32)); i32_add; i32_store(0);
+            local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(size_bytes as i32)); i32_add; i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
+            local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            local_get(Local(old_len));
             memory_copy;
-            local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(old_len); i32_add;
-            local_set(dst);
+            local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(old_len)); i32_add;
+            local_set(Local(dst));
         });
         for i in 0..size_bytes {
             let shift = 8 * (size_bytes - 1 - i) as i64;
             wasm!(self.func, {
-                local_get(dst);
-                local_get(bits); i64_const(shift); i64_shr_u;
+                local_get(Local(dst));
+                local_get(Local(bits)); i64_const(Imm64(shift)); i64_shr_u;
                 i32_wrap_i64;
-                i32_const(LOW_BYTE_MASK); i32_and;
+                i32_const(Imm32(LOW_BYTE_MASK)); i32_and;
                 i32_store8(i as u64);
             });
         }
@@ -1537,12 +1538,12 @@ impl FuncCompiler<'_> {
     fn emit_cursor_pack_tuple(&mut self, new_pos_local: u32, opt_ptr_local: u32) {
         let tuple = self.scratch.alloc_i32();
         wasm!(self.func, {
-            i32_const(CURSOR_TUPLE_BYTES); call(self.emitter.rt.alloc); local_set(tuple);
+            i32_const(Imm32(CURSOR_TUPLE_BYTES)); call(self.emitter.rt.alloc); local_set(Local(tuple));
             // tuple[0..8] = new_pos (i64)
-            local_get(tuple); local_get(new_pos_local); i64_store(0);
+            local_get(Local(tuple)); local_get(Local(new_pos_local)); i64_store(0);
             // tuple[8..12] = opt_ptr (i32)
-            local_get(tuple); local_get(opt_ptr_local); i32_store(8);
-            local_get(tuple);
+            local_get(Local(tuple)); local_get(Local(opt_ptr_local)); i32_store(8);
+            local_get(Local(tuple));
         });
         self.scratch.free_i32(tuple);
     }
@@ -1553,18 +1554,18 @@ impl FuncCompiler<'_> {
         let n = self.scratch.alloc_i64();
         let len = self.scratch.alloc_i64();
         let np = self.scratch.alloc_i64();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
-        self.emit_expr(&args[1]); wasm!(self.func, { local_set(pos); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
+        self.emit_expr(&args[1]); wasm!(self.func, { local_set(Local(pos)); });
         self.emit_expr(&args[2]); wasm!(self.func, {
-            local_set(n);
-            local_get(buf); i32_load(0); i64_extend_i32_u; local_set(len);
-            local_get(pos); local_get(n); i64_add; local_set(np);
+            local_set(Local(n));
+            local_get(Local(buf)); i32_load(0); i64_extend_i32_u; local_set(Local(len));
+            local_get(Local(pos)); local_get(Local(n)); i64_add; local_set(Local(np));
             // result = if np > len then len else np
-            local_get(np); local_get(len); i64_gt_s;
+            local_get(Local(np)); local_get(Local(len)); i64_gt_s;
             if_i64;
-              local_get(len);
+              local_get(Local(len));
             else_;
-              local_get(np);
+              local_get(Local(np));
             end;
         });
         self.scratch.free_i64(np);
@@ -1577,10 +1578,10 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_bytes_eof(&mut self, args: &[IrExpr]) {
         let buf = self.scratch.alloc_i32();
         let pos = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            i32_wrap_i64; local_set(pos);
-            local_get(pos); local_get(buf); i32_load(0); i32_ge_u;
+            i32_wrap_i64; local_set(Local(pos));
+            local_get(Local(pos)); local_get(Local(buf)); i32_load(0); i32_ge_u;
         });
         self.scratch.free_i32(pos);
         self.scratch.free_i32(buf);
@@ -1596,30 +1597,30 @@ impl FuncCompiler<'_> {
         let len = self.scratch.alloc_i32();
         let dst = self.scratch.alloc_i32();
         let i = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            local_set(closure);
-            local_get(buf); i32_load(0); local_set(len);
-            local_get(len); call(self.emitter.rt.string_alloc); local_set(dst);
-            local_get(dst); local_get(len); i32_store(0);
-            i32_const(0); local_set(i);
+            local_set(Local(closure));
+            local_get(Local(buf)); i32_load(0); local_set(Local(len));
+            local_get(Local(len)); call(self.emitter.rt.string_alloc); local_set(Local(dst));
+            local_get(Local(dst)); local_get(Local(len)); i32_store(0);
+            i32_const(Imm32(0)); local_set(Local(i));
             block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                 // dst[i] = (i32) f((i64) b[i])
-                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add;
+                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add;
                 // closure call args: env, arg, table_idx
-                local_get(closure); i32_load(4);
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add;
+                local_get(Local(closure)); i32_load(4);
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add;
                 i32_load8_u(0); i64_extend_i32_u;
-                local_get(closure); i32_load(0);
+                local_get(Local(closure)); i32_load(0);
         });
         self.emit_closure_call(&almide_lang::types::Ty::Int, &almide_lang::types::Ty::Int);
         wasm!(self.func, {
                 i32_wrap_i64; i32_store8(0);
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
             end; end;
-            local_get(dst);
+            local_get(Local(dst));
         });
         self.scratch.free_i32(i);
         self.scratch.free_i32(dst);
@@ -1637,28 +1638,28 @@ impl FuncCompiler<'_> {
         let n = self.scratch.alloc_i32();
         let dst = self.scratch.alloc_i32();
         let i = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(a); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(a)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            local_set(b);
-            local_get(a); i32_load(0); local_set(alen);
-            local_get(b); i32_load(0); local_set(blen);
-            local_get(alen); local_get(blen); i32_lt_u;
-            if_i32; local_get(alen); else_; local_get(blen); end;
-            local_set(n);
-            local_get(n); call(self.emitter.rt.string_alloc); local_set(dst);
-            local_get(dst); local_get(n); i32_store(0);
-            i32_const(0); local_set(i);
+            local_set(Local(b));
+            local_get(Local(a)); i32_load(0); local_set(Local(alen));
+            local_get(Local(b)); i32_load(0); local_set(Local(blen));
+            local_get(Local(alen)); local_get(Local(blen)); i32_lt_u;
+            if_i32; local_get(Local(alen)); else_; local_get(Local(blen)); end;
+            local_set(Local(n));
+            local_get(Local(n)); call(self.emitter.rt.string_alloc); local_set(Local(dst));
+            local_get(Local(dst)); local_get(Local(n)); i32_store(0);
+            i32_const(Imm32(0)); local_set(Local(i));
             block_empty; loop_empty;
-                local_get(i); local_get(n); i32_ge_u; br_if(1);
-                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add;
-                local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add; i32_load8_u(0);
-                local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add; i32_load8_u(0);
+                local_get(Local(i)); local_get(Local(n)); i32_ge_u; br_if(1);
+                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add;
+                local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add; i32_load8_u(0);
+                local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add; i32_load8_u(0);
                 i32_xor;
                 i32_store8(0);
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
             end; end;
-            local_get(dst);
+            local_get(Local(dst));
         });
         self.scratch.free_i32(i);
         self.scratch.free_i32(dst);
@@ -1678,59 +1679,59 @@ impl FuncCompiler<'_> {
         let pad = self.scratch.alloc_i32();
         let dst = self.scratch.alloc_i32();
         let i = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
-        self.emit_expr(&args[1]); wasm!(self.func, { i32_wrap_i64; local_set(target); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
+        self.emit_expr(&args[1]); wasm!(self.func, { i32_wrap_i64; local_set(Local(target)); });
         self.emit_expr(&args[2]); wasm!(self.func, {
-            i32_wrap_i64; local_set(val);
-            local_get(buf); i32_load(0); local_set(blen);
+            i32_wrap_i64; local_set(Local(val));
+            local_get(Local(buf)); i32_load(0); local_set(Local(blen));
             // If blen >= target → clone unchanged
-            local_get(blen); local_get(target); i32_ge_u;
+            local_get(Local(blen)); local_get(Local(target)); i32_ge_u;
             if_i32;
-                local_get(blen); call(self.emitter.rt.string_alloc); local_set(dst);
-                local_get(dst); local_get(buf); local_get(blen); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; memory_copy;
-                local_get(dst);
+                local_get(Local(blen)); call(self.emitter.rt.string_alloc); local_set(Local(dst));
+                local_get(Local(dst)); local_get(Local(buf)); local_get(Local(blen)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; memory_copy;
+                local_get(Local(dst));
             else_;
-                local_get(target); local_get(blen); i32_sub; local_set(pad);
-                local_get(target); call(self.emitter.rt.string_alloc); local_set(dst);
-                local_get(dst); local_get(target); i32_store(0);
+                local_get(Local(target)); local_get(Local(blen)); i32_sub; local_set(Local(pad));
+                local_get(Local(target)); call(self.emitter.rt.string_alloc); local_set(Local(dst));
+                local_get(Local(dst)); local_get(Local(target)); i32_store(0);
         });
         if left {
             wasm!(self.func, {
                 // Fill [0, pad) with val
-                i32_const(0); local_set(i);
+                i32_const(Imm32(0)); local_set(Local(i));
                 block_empty; loop_empty;
-                    local_get(i); local_get(pad); i32_ge_u; br_if(1);
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add;
-                    local_get(val); i32_store8(0);
-                    local_get(i); i32_const(1); i32_add; local_set(i);
+                    local_get(Local(i)); local_get(Local(pad)); i32_ge_u; br_if(1);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add;
+                    local_get(Local(val)); i32_store8(0);
+                    local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                     br(0);
                 end; end;
                 // Copy original into [pad..target)
-                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pad); i32_add;
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                local_get(blen);
+                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pad)); i32_add;
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                local_get(Local(blen));
                 memory_copy;
             });
         } else {
             wasm!(self.func, {
                 // Copy original into [0..blen)
-                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                local_get(blen);
+                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                local_get(Local(blen));
                 memory_copy;
                 // Fill [blen..target) with val
-                i32_const(0); local_set(i);
+                i32_const(Imm32(0)); local_set(Local(i));
                 block_empty; loop_empty;
-                    local_get(i); local_get(pad); i32_ge_u; br_if(1);
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(blen); i32_add; local_get(i); i32_add;
-                    local_get(val); i32_store8(0);
-                    local_get(i); i32_const(1); i32_add; local_set(i);
+                    local_get(Local(i)); local_get(Local(pad)); i32_ge_u; br_if(1);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(blen)); i32_add; local_get(Local(i)); i32_add;
+                    local_get(Local(val)); i32_store8(0);
+                    local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                     br(0);
                 end; end;
             });
         }
         wasm!(self.func, {
-                local_get(dst);
+                local_get(Local(dst));
             end;
         });
         self.scratch.free_i32(i);
@@ -1753,33 +1754,33 @@ impl FuncCompiler<'_> {
         let src_len = self.scratch.alloc_i32();
         let avail_dst = self.scratch.alloc_i32();
         let avail_src = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(dst); });
-        self.emit_expr(&args[1]); wasm!(self.func, { local_set(src); });
-        self.emit_expr(&args[2]); wasm!(self.func, { i32_wrap_i64; local_set(dst_off); });
-        self.emit_expr(&args[3]); wasm!(self.func, { i32_wrap_i64; local_set(src_off); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(dst)); });
+        self.emit_expr(&args[1]); wasm!(self.func, { local_set(Local(src)); });
+        self.emit_expr(&args[2]); wasm!(self.func, { i32_wrap_i64; local_set(Local(dst_off)); });
+        self.emit_expr(&args[3]); wasm!(self.func, { i32_wrap_i64; local_set(Local(src_off)); });
         self.emit_expr(&args[4]); wasm!(self.func, {
-            i32_wrap_i64; local_set(len);
-            local_get(dst); i32_load(0); local_set(dst_len);
-            local_get(src); i32_load(0); local_set(src_len);
+            i32_wrap_i64; local_set(Local(len));
+            local_get(Local(dst)); i32_load(0); local_set(Local(dst_len));
+            local_get(Local(src)); i32_load(0); local_set(Local(src_len));
             // If either offset out of range → no-op
-            local_get(dst_off); local_get(dst_len); i32_ge_u;
-            local_get(src_off); local_get(src_len); i32_ge_u; i32_or;
+            local_get(Local(dst_off)); local_get(Local(dst_len)); i32_ge_u;
+            local_get(Local(src_off)); local_get(Local(src_len)); i32_ge_u; i32_or;
             if_empty;
                 // skip
             else_;
                 // Clamp len to min(len, dst_len - dst_off, src_len - src_off)
-                local_get(dst_len); local_get(dst_off); i32_sub; local_set(avail_dst);
-                local_get(src_len); local_get(src_off); i32_sub; local_set(avail_src);
-                local_get(len); local_get(avail_dst); i32_lt_u;
-                if_i32; local_get(len); else_; local_get(avail_dst); end;
-                local_set(len);
-                local_get(len); local_get(avail_src); i32_lt_u;
-                if_i32; local_get(len); else_; local_get(avail_src); end;
-                local_set(len);
+                local_get(Local(dst_len)); local_get(Local(dst_off)); i32_sub; local_set(Local(avail_dst));
+                local_get(Local(src_len)); local_get(Local(src_off)); i32_sub; local_set(Local(avail_src));
+                local_get(Local(len)); local_get(Local(avail_dst)); i32_lt_u;
+                if_i32; local_get(Local(len)); else_; local_get(Local(avail_dst)); end;
+                local_set(Local(len));
+                local_get(Local(len)); local_get(Local(avail_src)); i32_lt_u;
+                if_i32; local_get(Local(len)); else_; local_get(Local(avail_src)); end;
+                local_set(Local(len));
                 // memcpy: dst+4+dst_off ← src+4+src_off, len bytes
-                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(dst_off); i32_add;
-                local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(src_off); i32_add;
-                local_get(len);
+                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(dst_off)); i32_add;
+                local_get(Local(src)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(src_off)); i32_add;
+                local_get(Local(len));
                 memory_copy;
             end;
         });
@@ -1802,23 +1803,23 @@ impl FuncCompiler<'_> {
         let i = self.scratch.alloc_i32();
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(buf);
-            local_get(buf); i32_load(0); local_set(len);
-            local_get(len); call(self.emitter.rt.string_alloc); local_set(dst);
-            local_get(dst); local_get(len); i32_store(0);
-            i32_const(0); local_set(i);
+            local_set(Local(buf));
+            local_get(Local(buf)); i32_load(0); local_set(Local(len));
+            local_get(Local(len)); call(self.emitter.rt.string_alloc); local_set(Local(dst));
+            local_get(Local(dst)); local_get(Local(len)); i32_store(0);
+            i32_const(Imm32(0)); local_set(Local(i));
             block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                 // dst[4 + i] = buf[4 + (len - 1 - i)]
-                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add;
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                local_get(len); i32_const(1); i32_sub; local_get(i); i32_sub; i32_add;
+                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add;
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                local_get(Local(len)); i32_const(Imm32(1)); i32_sub; local_get(Local(i)); i32_sub; i32_add;
                 i32_load8_u(0);
                 i32_store8(0);
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
             end; end;
-            local_get(dst);
+            local_get(Local(dst));
         });
         self.scratch.free_i32(i);
         self.scratch.free_i32(dst);
@@ -1833,17 +1834,17 @@ impl FuncCompiler<'_> {
         let len = self.scratch.alloc_i32();
         let i = self.scratch.alloc_i32();
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(buf); });
+        wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]);
         wasm!(self.func, {
-            i32_wrap_i64; local_set(val);
-            local_get(buf); i32_load(0); local_set(len);
-            i32_const(0); local_set(i);
+            i32_wrap_i64; local_set(Local(val));
+            local_get(Local(buf)); i32_load(0); local_set(Local(len));
+            i32_const(Imm32(0)); local_set(Local(i));
             block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add;
-                local_get(val); i32_store8(0);
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add;
+                local_get(Local(val)); i32_store8(0);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
             end; end;
         });
@@ -1861,32 +1862,32 @@ impl FuncCompiler<'_> {
         let val = self.scratch.alloc_i32();
         let len = self.scratch.alloc_i32();
         let dst = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
-        self.emit_expr(&args[1]); wasm!(self.func, { i32_wrap_i64; local_set(pos); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
+        self.emit_expr(&args[1]); wasm!(self.func, { i32_wrap_i64; local_set(Local(pos)); });
         self.emit_expr(&args[2]); wasm!(self.func, {
-            i32_wrap_i64; local_set(val);
-            local_get(buf); i32_load(0); local_set(len);
+            i32_wrap_i64; local_set(Local(val));
+            local_get(Local(buf)); i32_load(0); local_set(Local(len));
             // Clamp pos to [0, len]
-            local_get(pos); i32_const(0); i32_lt_s;
-            if_empty; i32_const(0); local_set(pos); end;
-            local_get(pos); local_get(len); i32_gt_u;
-            if_empty; local_get(len); local_set(pos); end;
+            local_get(Local(pos)); i32_const(Imm32(0)); i32_lt_s;
+            if_empty; i32_const(Imm32(0)); local_set(Local(pos)); end;
+            local_get(Local(pos)); local_get(Local(len)); i32_gt_u;
+            if_empty; local_get(Local(len)); local_set(Local(pos)); end;
             // alloc len + 5
-            local_get(len); i32_const(1); i32_add; call(self.emitter.rt.string_alloc); local_set(dst);
+            local_get(Local(len)); i32_const(Imm32(1)); i32_add; call(self.emitter.rt.string_alloc); local_set(Local(dst));
             // memcpy [0, pos)
-            local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            local_get(pos);
+            local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            local_get(Local(pos));
             memory_copy;
             // store val at dst+data_off+pos
-            local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos); i32_add;
-            local_get(val); i32_store8(0);
+            local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos)); i32_add;
+            local_get(Local(val)); i32_store8(0);
             // memcpy [pos, len) → dst+data_off+pos+1
-            local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 + 1); i32_add; local_get(pos); i32_add;
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos); i32_add;
-            local_get(len); local_get(pos); i32_sub;
+            local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 + 1)); i32_add; local_get(Local(pos)); i32_add;
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos)); i32_add;
+            local_get(Local(len)); local_get(Local(pos)); i32_sub;
             memory_copy;
-            local_get(dst);
+            local_get(Local(dst));
         });
         self.scratch.free_i32(dst);
         self.scratch.free_i32(len);
@@ -1901,29 +1902,29 @@ impl FuncCompiler<'_> {
         let pos = self.scratch.alloc_i32();
         let len = self.scratch.alloc_i32();
         let dst = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            i32_wrap_i64; local_set(pos);
-            local_get(buf); i32_load(0); local_set(len);
+            i32_wrap_i64; local_set(Local(pos));
+            local_get(Local(buf)); i32_load(0); local_set(Local(len));
             // If pos out of range → clone len+4 bytes
-            local_get(pos); local_get(len); i32_ge_u;
+            local_get(Local(pos)); local_get(Local(len)); i32_ge_u;
             if_i32;
-                local_get(len); call(self.emitter.rt.string_alloc); local_set(dst);
-                local_get(dst); local_get(buf); local_get(len); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; memory_copy;
-                local_get(dst);
+                local_get(Local(len)); call(self.emitter.rt.string_alloc); local_set(Local(dst));
+                local_get(Local(dst)); local_get(Local(buf)); local_get(Local(len)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; memory_copy;
+                local_get(Local(dst));
             else_;
-                local_get(len); i32_const(1); i32_sub; call(self.emitter.rt.string_alloc); local_set(dst);
+                local_get(Local(len)); i32_const(Imm32(1)); i32_sub; call(self.emitter.rt.string_alloc); local_set(Local(dst));
                 // memcpy [0, pos)
-                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                local_get(pos);
+                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                local_get(Local(pos));
                 memory_copy;
                 // memcpy [pos+1, len)
-                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos); i32_add;
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 + 1); i32_add; local_get(pos); i32_add;
-                local_get(len); local_get(pos); i32_sub; i32_const(1); i32_sub;
+                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos)); i32_add;
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 + 1)); i32_add; local_get(Local(pos)); i32_add;
+                local_get(Local(len)); local_get(Local(pos)); i32_sub; i32_const(Imm32(1)); i32_sub;
                 memory_copy;
-                local_get(dst);
+                local_get(Local(dst));
             end;
         });
         self.scratch.free_i32(dst);
@@ -1944,47 +1945,47 @@ impl FuncCompiler<'_> {
         let off = self.scratch.alloc_i32();
         let chunk_len = self.scratch.alloc_i32();
         let chunk = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            i32_wrap_i64; local_set(size);
-            local_get(buf); i32_load(0); local_set(len);
+            i32_wrap_i64; local_set(Local(size));
+            local_get(Local(buf)); i32_load(0); local_set(Local(len));
             // n_chunks = ceil(len / size); if size == 0 → 0
-            local_get(size); i32_eqz;
-            if_i32; i32_const(0);
+            local_get(Local(size)); i32_eqz;
+            if_i32; i32_const(Imm32(0));
             else_;
-                local_get(len); local_get(size); i32_add; i32_const(1); i32_sub;
-                local_get(size); i32_div_u;
+                local_get(Local(len)); local_get(Local(size)); i32_add; i32_const(Imm32(1)); i32_sub;
+                local_get(Local(size)); i32_div_u;
             end;
-            local_set(n_chunks);
+            local_set(Local(n_chunks));
             // alloc List header: 4 + n_chunks*4
-            local_get(n_chunks); i32_const(I32_BYTES); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            call(self.emitter.rt.alloc); local_set(result);
-            local_get(result); local_get(n_chunks); i32_store(0);
-            i32_const(0); local_set(i);
-            i32_const(0); local_set(off);
+            local_get(Local(n_chunks)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(result));
+            local_get(Local(result)); local_get(Local(n_chunks)); i32_store(0);
+            i32_const(Imm32(0)); local_set(Local(i));
+            i32_const(Imm32(0)); local_set(Local(off));
             block_empty; loop_empty;
-                local_get(i); local_get(n_chunks); i32_ge_u; br_if(1);
+                local_get(Local(i)); local_get(Local(n_chunks)); i32_ge_u; br_if(1);
                 // chunk_len = min(size, len - off)
-                local_get(len); local_get(off); i32_sub;
-                local_get(size); local_get(len); local_get(off); i32_sub; i32_lt_u;
-                if_i32; local_get(size); else_; local_get(len); local_get(off); i32_sub; end;
-                local_set(chunk_len);
+                local_get(Local(len)); local_get(Local(off)); i32_sub;
+                local_get(Local(size)); local_get(Local(len)); local_get(Local(off)); i32_sub; i32_lt_u;
+                if_i32; local_get(Local(size)); else_; local_get(Local(len)); local_get(Local(off)); i32_sub; end;
+                local_set(Local(chunk_len));
                 // alloc chunk: 4 + chunk_len
-                local_get(chunk_len); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                call(self.emitter.rt.alloc); local_set(chunk);
-                local_get(chunk); local_get(chunk_len); i32_store(0);
-                local_get(chunk); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(off); i32_add;
-                local_get(chunk_len);
+                local_get(Local(chunk_len)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                call(self.emitter.rt.alloc); local_set(Local(chunk));
+                local_get(Local(chunk)); local_get(Local(chunk_len)); i32_store(0);
+                local_get(Local(chunk)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(off)); i32_add;
+                local_get(Local(chunk_len));
                 memory_copy;
                 // result.elems[i] = chunk
-                local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                local_get(chunk); i32_store(0);
-                local_get(off); local_get(size); i32_add; local_set(off);
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(result)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                local_get(Local(chunk)); i32_store(0);
+                local_get(Local(off)); local_get(Local(size)); i32_add; local_set(Local(off));
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
             end; end;
-            local_get(result);
+            local_get(Local(result));
         });
         self.scratch.free_i32(chunk);
         self.scratch.free_i32(chunk_len);
@@ -2013,79 +2014,79 @@ impl FuncCompiler<'_> {
         let chunk = self.scratch.alloc_i32();
         let chunk_len = self.scratch.alloc_i32();
         let out_idx = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
         if lf {
             // sep is implicit "\n" — alloc a 1-byte sep buffer at runtime.
             wasm!(self.func, {
-                i32_const(1); call(self.emitter.rt.string_alloc); local_set(sep);
-                local_get(sep); i32_const(1); i32_store(0);
-                local_get(sep); i32_const(1); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
-                local_get(sep); i32_const(ASCII_LF); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
+                i32_const(Imm32(1)); call(self.emitter.rt.string_alloc); local_set(Local(sep));
+                local_get(Local(sep)); i32_const(Imm32(1)); i32_store(0);
+                local_get(Local(sep)); i32_const(Imm32(1)); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
+                local_get(Local(sep)); i32_const(Imm32(ASCII_LF)); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
             });
         } else {
             self.emit_expr(&args[1]);
-            wasm!(self.func, { local_set(sep); });
+            wasm!(self.func, { local_set(Local(sep)); });
         }
         wasm!(self.func, {
-            local_get(buf); i32_load(0); local_set(blen);
-            local_get(sep); i32_load(0); local_set(plen);
+            local_get(Local(buf)); i32_load(0); local_set(Local(blen));
+            local_get(Local(sep)); i32_load(0); local_set(Local(plen));
         });
         if lf {
             // For lines: count = number of '\n' bytes; trailing '\n' adds nothing.
             wasm!(self.func, {
-                i32_const(0); local_set(count);
-                i32_const(0); local_set(i);
+                i32_const(Imm32(0)); local_set(Local(count));
+                i32_const(Imm32(0)); local_set(Local(i));
                 block_empty; loop_empty;
-                    local_get(i); local_get(blen); i32_ge_u; br_if(1);
-                    local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add;
-                    i32_load8_u(0); i32_const(ASCII_LF); i32_eq;
-                    if_empty; local_get(count); i32_const(1); i32_add; local_set(count); end;
-                    local_get(i); i32_const(1); i32_add; local_set(i);
+                    local_get(Local(i)); local_get(Local(blen)); i32_ge_u; br_if(1);
+                    local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add;
+                    i32_load8_u(0); i32_const(Imm32(ASCII_LF)); i32_eq;
+                    if_empty; local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count)); end;
+                    local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                     br(0);
                 end; end;
                 // If buffer doesn't end with newline, add 1 for the final line.
-                local_get(blen); i32_eqz;
+                local_get(Local(blen)); i32_eqz;
                 if_empty;
                     // empty buffer → count stays 0
                 else_;
-                    local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(blen); i32_const(1); i32_sub; i32_add;
-                    i32_load8_u(0); i32_const(ASCII_LF); i32_ne;
-                    if_empty; local_get(count); i32_const(1); i32_add; local_set(count); end;
+                    local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(blen)); i32_const(Imm32(1)); i32_sub; i32_add;
+                    i32_load8_u(0); i32_const(Imm32(ASCII_LF)); i32_ne;
+                    if_empty; local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count)); end;
                 end;
             });
         } else {
             // Generic split. Empty sep → 1 part (whole buffer).
             wasm!(self.func, {
-                i32_const(1); local_set(count);
-                local_get(plen); i32_eqz;
+                i32_const(Imm32(1)); local_set(Local(count));
+                local_get(Local(plen)); i32_eqz;
                 if_empty;
                     // empty sep — count stays 1, skip scan
                 else_;
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                        local_get(i); local_get(plen); i32_add; local_get(blen); i32_gt_u; br_if(1);
+                        local_get(Local(i)); local_get(Local(plen)); i32_add; local_get(Local(blen)); i32_gt_u; br_if(1);
                         // compare buf[i..i+plen] == sep[0..plen]; out_idx = match flag
-                        i32_const(0); local_set(j);
-                        i32_const(1); local_set(out_idx);
+                        i32_const(Imm32(0)); local_set(Local(j));
+                        i32_const(Imm32(1)); local_set(Local(out_idx));
                         block_empty; loop_empty;
-                            local_get(j); local_get(plen); i32_ge_u; br_if(1);
-                            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add; local_get(j); i32_add;
+                            local_get(Local(j)); local_get(Local(plen)); i32_ge_u; br_if(1);
+                            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add; local_get(Local(j)); i32_add;
                             i32_load8_u(0);
-                            local_get(sep); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(j); i32_add;
+                            local_get(Local(sep)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(j)); i32_add;
                             i32_load8_u(0);
                             i32_ne;
                             if_empty;
-                                i32_const(0); local_set(out_idx); br(2);
+                                i32_const(Imm32(0)); local_set(Local(out_idx)); br(2);
                             end;
-                            local_get(j); i32_const(1); i32_add; local_set(j);
+                            local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                             br(0);
                         end; end;
-                        local_get(out_idx);
+                        local_get(Local(out_idx));
                         if_empty;
-                            local_get(count); i32_const(1); i32_add; local_set(count);
-                            local_get(i); local_get(plen); i32_add; local_set(i);
+                            local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count));
+                            local_get(Local(i)); local_get(Local(plen)); i32_add; local_set(Local(i));
                         else_;
-                            local_get(i); i32_const(1); i32_add; local_set(i);
+                            local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                         end;
                         br(0);
                     end; end;
@@ -2094,52 +2095,52 @@ impl FuncCompiler<'_> {
         }
         // Second pass: build the actual list using count chunks.
         wasm!(self.func, {
-            local_get(count); i32_const(I32_BYTES); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            call(self.emitter.rt.alloc); local_set(result);
-            local_get(result); local_get(count); i32_store(0);
-            i32_const(0); local_set(start);
-            i32_const(0); local_set(out_idx);
-            i32_const(0); local_set(i);
+            local_get(Local(count)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(result));
+            local_get(Local(result)); local_get(Local(count)); i32_store(0);
+            i32_const(Imm32(0)); local_set(Local(start));
+            i32_const(Imm32(0)); local_set(Local(out_idx));
+            i32_const(Imm32(0)); local_set(Local(i));
             block_empty; loop_empty;
-                local_get(out_idx); local_get(count); i32_ge_u; br_if(1);
+                local_get(Local(out_idx)); local_get(Local(count)); i32_ge_u; br_if(1);
                 // Find next sep starting at i (or end).
                 block_empty; loop_empty;
-                    local_get(i); local_get(plen); i32_add; local_get(blen); i32_gt_u; br_if(1);
+                    local_get(Local(i)); local_get(Local(plen)); i32_add; local_get(Local(blen)); i32_gt_u; br_if(1);
                     // compare buf[i..i+plen] == sep
-                    i32_const(0); local_set(j);
-                    i32_const(1); local_set(chunk_len); // reuse: match flag
+                    i32_const(Imm32(0)); local_set(Local(j));
+                    i32_const(Imm32(1)); local_set(Local(chunk_len)); // reuse: match flag
                     block_empty; loop_empty;
-                        local_get(j); local_get(plen); i32_ge_u; br_if(1);
-                        local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add; local_get(j); i32_add;
+                        local_get(Local(j)); local_get(Local(plen)); i32_ge_u; br_if(1);
+                        local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add; local_get(Local(j)); i32_add;
                         i32_load8_u(0);
-                        local_get(sep); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(j); i32_add;
+                        local_get(Local(sep)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(j)); i32_add;
                         i32_load8_u(0);
-                        i32_ne; if_empty; i32_const(0); local_set(chunk_len); br(2); end;
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        i32_ne; if_empty; i32_const(Imm32(0)); local_set(Local(chunk_len)); br(2); end;
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                     end; end;
-                    local_get(chunk_len); br_if(1); // matched → break inner
-                    local_get(i); i32_const(1); i32_add; local_set(i);
+                    local_get(Local(chunk_len)); br_if(1); // matched → break inner
+                    local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                     br(0);
                 end; end;
                 // chunk = buf[start..i] (or buf[start..blen] when no further match)
-                local_get(i); local_get(plen); i32_add; local_get(blen); i32_gt_u;
-                if_empty; local_get(blen); local_set(i); end;
-                local_get(i); local_get(start); i32_sub; local_set(chunk_len);
-                local_get(chunk_len); call(self.emitter.rt.string_alloc); local_set(chunk);
-                local_get(chunk); local_get(chunk_len); i32_store(0);
-                local_get(chunk); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(start); i32_add;
-                local_get(chunk_len);
+                local_get(Local(i)); local_get(Local(plen)); i32_add; local_get(Local(blen)); i32_gt_u;
+                if_empty; local_get(Local(blen)); local_set(Local(i)); end;
+                local_get(Local(i)); local_get(Local(start)); i32_sub; local_set(Local(chunk_len));
+                local_get(Local(chunk_len)); call(self.emitter.rt.string_alloc); local_set(Local(chunk));
+                local_get(Local(chunk)); local_get(Local(chunk_len)); i32_store(0);
+                local_get(Local(chunk)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(start)); i32_add;
+                local_get(Local(chunk_len));
                 memory_copy;
-                local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(out_idx); i32_const(I32_BYTES); i32_mul; i32_add;
-                local_get(chunk); i32_store(0);
-                local_get(out_idx); i32_const(1); i32_add; local_set(out_idx);
-                local_get(i); local_get(plen); i32_add; local_set(i);
-                local_get(i); local_set(start);
+                local_get(Local(result)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(out_idx)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                local_get(Local(chunk)); i32_store(0);
+                local_get(Local(out_idx)); i32_const(Imm32(1)); i32_add; local_set(Local(out_idx));
+                local_get(Local(i)); local_get(Local(plen)); i32_add; local_set(Local(i));
+                local_get(Local(i)); local_set(Local(start));
                 br(0);
             end; end;
-            local_get(result);
+            local_get(Local(result));
         });
         self.scratch.free_i32(out_idx);
         self.scratch.free_i32(chunk_len);
@@ -2166,42 +2167,42 @@ impl FuncCompiler<'_> {
         let i = self.scratch.alloc_i32();
         let off = self.scratch.alloc_i32();
         let result = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(b); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(b)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            local_set(pat);
-            local_get(b); i32_load(0); local_set(blen);
-            local_get(pat); i32_load(0); local_set(plen);
-            i32_const(1); local_set(result);
+            local_set(Local(pat));
+            local_get(Local(b)); i32_load(0); local_set(Local(blen));
+            local_get(Local(pat)); i32_load(0); local_set(Local(plen));
+            i32_const(Imm32(1)); local_set(Local(result));
             // If pat longer than b → false and skip loop.
-            local_get(plen); local_get(blen); i32_gt_u;
+            local_get(Local(plen)); local_get(Local(blen)); i32_gt_u;
             if_empty;
-                i32_const(0); local_set(result);
+                i32_const(Imm32(0)); local_set(Local(result));
             else_;
         });
         if at_end {
             wasm!(self.func, {
-                local_get(blen); local_get(plen); i32_sub; local_set(off);
+                local_get(Local(blen)); local_get(Local(plen)); i32_sub; local_set(Local(off));
             });
         } else {
-            wasm!(self.func, { i32_const(0); local_set(off); });
+            wasm!(self.func, { i32_const(Imm32(0)); local_set(Local(off)); });
         }
         wasm!(self.func, {
-                i32_const(0); local_set(i);
+                i32_const(Imm32(0)); local_set(Local(i));
                 block_empty; loop_empty;
-                    local_get(i); local_get(plen); i32_ge_u; br_if(1);
-                    local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(off); i32_add; local_get(i); i32_add;
+                    local_get(Local(i)); local_get(Local(plen)); i32_ge_u; br_if(1);
+                    local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(off)); i32_add; local_get(Local(i)); i32_add;
                     i32_load8_u(0);
-                    local_get(pat); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add;
+                    local_get(Local(pat)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add;
                     i32_load8_u(0);
                     i32_ne;
                     if_empty;
-                        i32_const(0); local_set(result); br(2);
+                        i32_const(Imm32(0)); local_set(Local(result)); br(2);
                     end;
-                    local_get(i); i32_const(1); i32_add; local_set(i);
+                    local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                     br(0);
                 end; end;
             end;
-            local_get(result);
+            local_get(Local(result));
         });
         self.scratch.free_i32(result);
         self.scratch.free_i32(off);
@@ -2223,48 +2224,48 @@ impl FuncCompiler<'_> {
         let i = self.scratch.alloc_i32();
         let j = self.scratch.alloc_i32();
         let result = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(b); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(b)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            local_set(pat);
-            local_get(b); i32_load(0); local_set(blen);
-            local_get(pat); i32_load(0); local_set(plen);
-            i32_const(-1); local_set(result);
+            local_set(Local(pat));
+            local_get(Local(b)); i32_load(0); local_set(Local(blen));
+            local_get(Local(pat)); i32_load(0); local_set(Local(plen));
+            i32_const(Imm32(-1)); local_set(Local(result));
             // Empty pattern → 0
-            local_get(plen); i32_eqz;
+            local_get(Local(plen)); i32_eqz;
             if_empty;
-                i32_const(0); local_set(result);
+                i32_const(Imm32(0)); local_set(Local(result));
             else_;
-                local_get(plen); local_get(blen); i32_gt_u;
+                local_get(Local(plen)); local_get(Local(blen)); i32_gt_u;
                 if_empty;
                     // result stays -1
                 else_;
-                    local_get(blen); local_get(plen); i32_sub; local_set(limit);
-                    i32_const(0); local_set(i);
+                    local_get(Local(blen)); local_get(Local(plen)); i32_sub; local_set(Local(limit));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                        local_get(i); local_get(limit); i32_gt_u; br_if(1);
-                        i32_const(0); local_set(j);
+                        local_get(Local(i)); local_get(Local(limit)); i32_gt_u; br_if(1);
+                        i32_const(Imm32(0)); local_set(Local(j));
                         block_empty; loop_empty;
-                            local_get(j); local_get(plen); i32_ge_u; br_if(1);
-                            local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add; local_get(j); i32_add;
+                            local_get(Local(j)); local_get(Local(plen)); i32_ge_u; br_if(1);
+                            local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add; local_get(Local(j)); i32_add;
                             i32_load8_u(0);
-                            local_get(pat); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(j); i32_add;
+                            local_get(Local(pat)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(j)); i32_add;
                             i32_load8_u(0);
                             i32_ne; br_if(1);
-                            local_get(j); i32_const(1); i32_add; local_set(j);
+                            local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                             br(0);
                         end; end;
                         // If we reached j == plen, full match.
-                        local_get(j); local_get(plen); i32_eq;
+                        local_get(Local(j)); local_get(Local(plen)); i32_eq;
                         if_empty;
-                            local_get(i); local_set(result);
+                            local_get(Local(i)); local_set(Local(result));
                             br(3);
                         end;
-                        local_get(i); i32_const(1); i32_add; local_set(i);
+                        local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                         br(0);
                     end; end;
                 end;
             end;
-            local_get(result); i64_extend_i32_s;
+            local_get(Local(result)); i64_extend_i32_s;
         });
         self.scratch.free_i32(result);
         self.scratch.free_i32(j);
@@ -2287,37 +2288,37 @@ impl FuncCompiler<'_> {
         let av = self.scratch.alloc_i32();
         let bv = self.scratch.alloc_i32();
         let result = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(a); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(a)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            local_set(b);
-            local_get(a); i32_load(0); local_set(alen);
-            local_get(b); i32_load(0); local_set(blen);
+            local_set(Local(b));
+            local_get(Local(a)); i32_load(0); local_set(Local(alen));
+            local_get(Local(b)); i32_load(0); local_set(Local(blen));
             // minlen = min(alen, blen)
-            local_get(alen); local_get(blen); i32_lt_u;
-            if_i32; local_get(alen); else_; local_get(blen); end;
-            local_set(minlen);
-            i32_const(0); local_set(result);
-            i32_const(0); local_set(i);
+            local_get(Local(alen)); local_get(Local(blen)); i32_lt_u;
+            if_i32; local_get(Local(alen)); else_; local_get(Local(blen)); end;
+            local_set(Local(minlen));
+            i32_const(Imm32(0)); local_set(Local(result));
+            i32_const(Imm32(0)); local_set(Local(i));
             block_empty; loop_empty;
-                local_get(i); local_get(minlen); i32_ge_u; br_if(1);
-                local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add; i32_load8_u(0); local_set(av);
-                local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add; i32_load8_u(0); local_set(bv);
-                local_get(av); local_get(bv); i32_lt_u;
-                if_empty; i32_const(-1); local_set(result); br(2); end;
-                local_get(av); local_get(bv); i32_gt_u;
-                if_empty; i32_const(1); local_set(result); br(2); end;
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); local_get(Local(minlen)); i32_ge_u; br_if(1);
+                local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add; i32_load8_u(0); local_set(Local(av));
+                local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add; i32_load8_u(0); local_set(Local(bv));
+                local_get(Local(av)); local_get(Local(bv)); i32_lt_u;
+                if_empty; i32_const(Imm32(-1)); local_set(Local(result)); br(2); end;
+                local_get(Local(av)); local_get(Local(bv)); i32_gt_u;
+                if_empty; i32_const(Imm32(1)); local_set(Local(result)); br(2); end;
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
             end; end;
             // All shared bytes equal → shorter is less.
-            local_get(result); i32_eqz;
+            local_get(Local(result)); i32_eqz;
             if_empty;
-                local_get(alen); local_get(blen); i32_lt_u;
-                if_empty; i32_const(-1); local_set(result); end;
-                local_get(alen); local_get(blen); i32_gt_u;
-                if_empty; i32_const(1); local_set(result); end;
+                local_get(Local(alen)); local_get(Local(blen)); i32_lt_u;
+                if_empty; i32_const(Imm32(-1)); local_set(Local(result)); end;
+                local_get(Local(alen)); local_get(Local(blen)); i32_gt_u;
+                if_empty; i32_const(Imm32(1)); local_set(Local(result)); end;
             end;
-            local_get(result); i64_extend_i32_s;
+            local_get(Local(result)); i64_extend_i32_s;
         });
         self.scratch.free_i32(result);
         self.scratch.free_i32(bv);
@@ -2345,62 +2346,62 @@ impl FuncCompiler<'_> {
         let fb = self.scratch.alloc_i32();
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(buf);
-            local_get(buf); i32_load(0); local_set(len);
-            i32_const(0); local_set(i);
-            i32_const(1); local_set(valid);
+            local_set(Local(buf));
+            local_get(Local(buf)); i32_load(0); local_set(Local(len));
+            i32_const(Imm32(0)); local_set(Local(i));
+            i32_const(Imm32(1)); local_set(Local(valid));
             block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add; i32_load8_u(0); local_set(b);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(i)); i32_add; i32_load8_u(0); local_set(Local(b));
                 // ASCII fast path
-                local_get(b); i32_const(UTF8_1B_MAX); i32_lt_u;
+                local_get(Local(b)); i32_const(Imm32(UTF8_1B_MAX)); i32_lt_u;
                 if_empty;
-                    local_get(i); i32_const(1); i32_add; local_set(i);
+                    local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                     br(2); // continue outer loop
                 end;
                 // Determine number of follow-bytes
-                local_get(b); i32_const(UTF8_2B_LEAD_MIN); i32_lt_u;
+                local_get(Local(b)); i32_const(Imm32(UTF8_2B_LEAD_MIN)); i32_lt_u;
                 if_empty;
-                    i32_const(0); local_set(valid); br(2);
+                    i32_const(Imm32(0)); local_set(Local(valid)); br(2);
                 end;
-                local_get(b); i32_const(UTF8_3B_LEAD_MIN); i32_lt_u;
-                if_i32; i32_const(1); else_;
-                  local_get(b); i32_const(UTF8_4B_LEAD_MIN); i32_lt_u;
-                  if_i32; i32_const(UTF8_3B_FOLLOW_COUNT); else_;
-                    local_get(b); i32_const(UTF8_4B_LEAD_MAX); i32_lt_u;
-                    if_i32; i32_const(UTF8_4B_FOLLOW_COUNT); else_; i32_const(-1); end;
+                local_get(Local(b)); i32_const(Imm32(UTF8_3B_LEAD_MIN)); i32_lt_u;
+                if_i32; i32_const(Imm32(1)); else_;
+                  local_get(Local(b)); i32_const(Imm32(UTF8_4B_LEAD_MIN)); i32_lt_u;
+                  if_i32; i32_const(Imm32(UTF8_3B_FOLLOW_COUNT)); else_;
+                    local_get(Local(b)); i32_const(Imm32(UTF8_4B_LEAD_MAX)); i32_lt_u;
+                    if_i32; i32_const(Imm32(UTF8_4B_FOLLOW_COUNT)); else_; i32_const(Imm32(-1)); end;
                   end;
                 end;
-                local_set(need);
+                local_set(Local(need));
                 // need == -1 → invalid
-                local_get(need); i32_const(-1); i32_eq;
+                local_get(Local(need)); i32_const(Imm32(-1)); i32_eq;
                 if_empty;
-                    i32_const(0); local_set(valid); br(2);
+                    i32_const(Imm32(0)); local_set(Local(valid)); br(2);
                 end;
                 // Bounds: i + 1 + need > len → invalid
-                local_get(i); i32_const(1); i32_add; local_get(need); i32_add; local_get(len); i32_gt_u;
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_get(Local(need)); i32_add; local_get(Local(len)); i32_gt_u;
                 if_empty;
-                    i32_const(0); local_set(valid); br(2);
+                    i32_const(Imm32(0)); local_set(Local(valid)); br(2);
                 end;
                 // Walk follow-bytes
-                i32_const(0); local_set(k);
+                i32_const(Imm32(0)); local_set(Local(k));
                 block_empty; loop_empty;
-                    local_get(k); local_get(need); i32_ge_u; br_if(1);
-                    local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 + 1); i32_add;
-                    local_get(i); i32_add; local_get(k); i32_add;
-                    i32_load8_u(0); local_set(fb);
-                    local_get(fb); i32_const(UTF8_CONT_BYTE_MIN); i32_lt_u;
-                    local_get(fb); i32_const(UTF8_CONT_BYTE_MAX); i32_ge_u; i32_or;
+                    local_get(Local(k)); local_get(Local(need)); i32_ge_u; br_if(1);
+                    local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 + 1)); i32_add;
+                    local_get(Local(i)); i32_add; local_get(Local(k)); i32_add;
+                    i32_load8_u(0); local_set(Local(fb));
+                    local_get(Local(fb)); i32_const(Imm32(UTF8_CONT_BYTE_MIN)); i32_lt_u;
+                    local_get(Local(fb)); i32_const(Imm32(UTF8_CONT_BYTE_MAX)); i32_ge_u; i32_or;
                     if_empty;
-                        i32_const(0); local_set(valid); br(4);
+                        i32_const(Imm32(0)); local_set(Local(valid)); br(4);
                     end;
-                    local_get(k); i32_const(1); i32_add; local_set(k);
+                    local_get(Local(k)); i32_const(Imm32(1)); i32_add; local_set(Local(k));
                     br(0);
                 end; end;
-                local_get(i); i32_const(1); i32_add; local_get(need); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_get(Local(need)); i32_add; local_set(Local(i));
                 br(0);
             end; end;
-            local_get(valid);
+            local_get(Local(valid));
         });
         self.scratch.free_i32(fb);
         self.scratch.free_i32(k);
@@ -2421,13 +2422,13 @@ impl FuncCompiler<'_> {
         let opt_ptr = self.scratch.alloc_i32();
         let payload = self.scratch.alloc_i32();
         let val = self.scratch.alloc_i64();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            local_set(pos);
-            local_get(pos); i32_wrap_i64; local_set(pos_i32);
+            local_set(Local(pos));
+            local_get(Local(pos)); i32_wrap_i64; local_set(Local(pos_i32));
             // bounds: pos + width <= len?
-            local_get(pos_i32); i32_const(width as i32); i32_add;
-            local_get(buf); i32_load(0);
+            local_get(Local(pos_i32)); i32_const(Imm32(width as i32)); i32_add;
+            local_get(Local(buf)); i32_load(0);
             i32_le_u;
             if_empty;
               // in-bounds: read value
@@ -2435,32 +2436,32 @@ impl FuncCompiler<'_> {
         // Push value as i64 (for storing in the option payload).
         if big_endian {
             // BE: byte-by-byte
-            wasm!(self.func, { i64_const(0); local_set(val); });
+            wasm!(self.func, { i64_const(Imm64(0)); local_set(Local(val)); });
             for i in 0..width {
                 let shift = 8 * (width - 1 - i) as i64;
                 wasm!(self.func, {
-                    local_get(val);
-                    local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
+                    local_get(Local(val));
+                    local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos_i32)); i32_add;
                     i32_load8_u(i as u64);
                     i64_extend_i32_u;
-                    i64_const(shift); i64_shl;
+                    i64_const(Imm64(shift)); i64_shl;
                     i64_or;
-                    local_set(val);
+                    local_set(Local(val));
                 });
             }
             // Sign-extend if signed and width < 8
             if signed && width < 8 {
                 let pad = 64 - 8 * width as i64;
                 wasm!(self.func, {
-                    local_get(val); i64_const(pad); i64_shl;
-                    i64_const(pad); i64_shr_s;
-                    local_set(val);
+                    local_get(Local(val)); i64_const(Imm64(pad)); i64_shl;
+                    i64_const(Imm64(pad)); i64_shr_s;
+                    local_set(Local(val));
                 });
             }
         } else {
             // LE: native loads
             wasm!(self.func, {
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos_i32)); i32_add;
             });
             match (width, signed) {
                 (1, _) => { wasm!(self.func, { i32_load8_u(0); i64_extend_i32_u; }); }
@@ -2471,18 +2472,18 @@ impl FuncCompiler<'_> {
                 (8, _) => { wasm!(self.func, { i64_load(0); }); }
                 _ => panic!("unsupported width {width}"),
             }
-            wasm!(self.func, { local_set(val); });
+            wasm!(self.func, { local_set(Local(val)); });
         }
         // alloc 8-byte payload, store val, set opt_ptr
         wasm!(self.func, {
-            i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(payload);
-            local_get(payload); local_get(val); i64_store(0);
-            local_get(payload); local_set(opt_ptr);
-            local_get(pos); i64_const(width as i64); i64_add; local_set(new_pos);
+            i32_const(Imm32(I64_BYTES)); call(self.emitter.rt.alloc); local_set(Local(payload));
+            local_get(Local(payload)); local_get(Local(val)); i64_store(0);
+            local_get(Local(payload)); local_set(Local(opt_ptr));
+            local_get(Local(pos)); i64_const(Imm64(width as i64)); i64_add; local_set(Local(new_pos));
             else_;
               // out-of-bounds: opt_ptr=0, new_pos=pos
-              i32_const(0); local_set(opt_ptr);
-              local_get(pos); local_set(new_pos);
+              i32_const(Imm32(0)); local_set(Local(opt_ptr));
+              local_get(Local(pos)); local_set(Local(new_pos));
             end;
         });
         self.emit_cursor_pack_tuple(new_pos, opt_ptr);
@@ -2505,58 +2506,58 @@ impl FuncCompiler<'_> {
         let opt_ptr = self.scratch.alloc_i32();
         let payload = self.scratch.alloc_i32();
         let fval = self.scratch.alloc_f64();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            local_set(pos);
-            local_get(pos); i32_wrap_i64; local_set(pos_i32);
-            local_get(pos_i32); i32_const(width as i32); i32_add;
-            local_get(buf); i32_load(0);
+            local_set(Local(pos));
+            local_get(Local(pos)); i32_wrap_i64; local_set(Local(pos_i32));
+            local_get(Local(pos_i32)); i32_const(Imm32(width as i32)); i32_add;
+            local_get(Local(buf)); i32_load(0);
             i32_le_u;
             if_empty;
         });
         if big_endian {
             // Build i64 bits BE, then reinterpret to float.
             let bits = self.scratch.alloc_i64();
-            wasm!(self.func, { i64_const(0); local_set(bits); });
+            wasm!(self.func, { i64_const(Imm64(0)); local_set(Local(bits)); });
             for i in 0..width {
                 let shift = 8 * (width - 1 - i) as i64;
                 wasm!(self.func, {
-                    local_get(bits);
-                    local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
+                    local_get(Local(bits));
+                    local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos_i32)); i32_add;
                     i32_load8_u(i as u64);
                     i64_extend_i32_u;
-                    i64_const(shift); i64_shl;
+                    i64_const(Imm64(shift)); i64_shl;
                     i64_or;
-                    local_set(bits);
+                    local_set(Local(bits));
                 });
             }
             if width == 4 {
                 wasm!(self.func, {
-                    local_get(bits); i32_wrap_i64; f32_reinterpret_i32; f64_promote_f32;
-                    local_set(fval);
+                    local_get(Local(bits)); i32_wrap_i64; f32_reinterpret_i32; f64_promote_f32;
+                    local_set(Local(fval));
                 });
             } else {
-                wasm!(self.func, { local_get(bits); f64_reinterpret_i64; local_set(fval); });
+                wasm!(self.func, { local_get(Local(bits)); f64_reinterpret_i64; local_set(Local(fval)); });
             }
             self.scratch.free_i64(bits);
         } else {
             wasm!(self.func, {
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos_i32)); i32_add;
             });
             if width == 4 {
-                wasm!(self.func, { f32_load(0); f64_promote_f32; local_set(fval); });
+                wasm!(self.func, { f32_load(0); f64_promote_f32; local_set(Local(fval)); });
             } else {
-                wasm!(self.func, { f64_load(0); local_set(fval); });
+                wasm!(self.func, { f64_load(0); local_set(Local(fval)); });
             }
         }
         wasm!(self.func, {
-            i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(payload);
-            local_get(payload); local_get(fval); f64_store(0);
-            local_get(payload); local_set(opt_ptr);
-            local_get(pos); i64_const(width as i64); i64_add; local_set(new_pos);
+            i32_const(Imm32(I64_BYTES)); call(self.emitter.rt.alloc); local_set(Local(payload));
+            local_get(Local(payload)); local_get(Local(fval)); f64_store(0);
+            local_get(Local(payload)); local_set(Local(opt_ptr));
+            local_get(Local(pos)); i64_const(Imm64(width as i64)); i64_add; local_set(Local(new_pos));
             else_;
-              i32_const(0); local_set(opt_ptr);
-              local_get(pos); local_set(new_pos);
+              i32_const(Imm32(0)); local_set(Local(opt_ptr));
+              local_get(Local(pos)); local_set(Local(new_pos));
             end;
         });
         self.emit_cursor_pack_tuple(new_pos, opt_ptr);
@@ -2579,33 +2580,33 @@ impl FuncCompiler<'_> {
         let new_pos = self.scratch.alloc_i64();
         let opt_ptr = self.scratch.alloc_i32();
         let dst = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            local_set(pos);
-            local_get(pos); i32_wrap_i64; local_set(pos_i32);
+            local_set(Local(pos));
+            local_get(Local(pos)); i32_wrap_i64; local_set(Local(pos_i32));
         });
         self.emit_expr(&args[2]); wasm!(self.func, {
-            i32_wrap_i64; local_set(n_i32);
-            local_get(pos_i32); local_get(n_i32); i32_add;
-            local_get(buf); i32_load(0);
+            i32_wrap_i64; local_set(Local(n_i32));
+            local_get(Local(pos_i32)); local_get(Local(n_i32)); i32_add;
+            local_get(Local(buf)); i32_load(0);
             i32_le_u;
             if_empty;
               // alloc Bytes: 4 + n bytes
-              local_get(n_i32); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-              call(self.emitter.rt.alloc); local_set(dst);
-              local_get(dst); local_get(n_i32); i32_store(0);
+              local_get(Local(n_i32)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+              call(self.emitter.rt.alloc); local_set(Local(dst));
+              local_get(Local(dst)); local_get(Local(n_i32)); i32_store(0);
               // memcpy data
-              local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-              local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
-              local_get(n_i32);
+              local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+              local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos_i32)); i32_add;
+              local_get(Local(n_i32));
               memory_copy;
               // Wrap the Bytes pointer in an Option cell (4 bytes).
-              i32_const(OPT_CELL_BYTES); call(self.emitter.rt.alloc); local_set(opt_ptr);
-              local_get(opt_ptr); local_get(dst); i32_store(0);
-              local_get(pos); local_get(n_i32); i64_extend_i32_u; i64_add; local_set(new_pos);
+              i32_const(Imm32(OPT_CELL_BYTES)); call(self.emitter.rt.alloc); local_set(Local(opt_ptr));
+              local_get(Local(opt_ptr)); local_get(Local(dst)); i32_store(0);
+              local_get(Local(pos)); local_get(Local(n_i32)); i64_extend_i32_u; i64_add; local_set(Local(new_pos));
             else_;
-              i32_const(0); local_set(opt_ptr);
-              local_get(pos); local_set(new_pos);
+              i32_const(Imm32(0)); local_set(Local(opt_ptr));
+              local_get(Local(pos)); local_set(Local(new_pos));
             end;
         });
         self.emit_cursor_pack_tuple(new_pos, opt_ptr);
@@ -2627,24 +2628,24 @@ impl FuncCompiler<'_> {
         let new_pos = self.scratch.alloc_i64();
         let opt_ptr = self.scratch.alloc_i32();
         let payload = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            local_set(pos);
-            local_get(pos); i32_wrap_i64; local_set(pos_i32);
-            local_get(pos_i32); i32_const(1); i32_add;
-            local_get(buf); i32_load(0);
+            local_set(Local(pos));
+            local_get(Local(pos)); i32_wrap_i64; local_set(Local(pos_i32));
+            local_get(Local(pos_i32)); i32_const(Imm32(1)); i32_add;
+            local_get(Local(buf)); i32_load(0);
             i32_le_u;
             if_empty;
-              i32_const(OPT_CELL_BYTES); call(self.emitter.rt.alloc); local_set(payload);
-              local_get(payload);
-              local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
-              i32_load8_u(0); i32_const(0); i32_ne;
+              i32_const(Imm32(OPT_CELL_BYTES)); call(self.emitter.rt.alloc); local_set(Local(payload));
+              local_get(Local(payload));
+              local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos_i32)); i32_add;
+              i32_load8_u(0); i32_const(Imm32(0)); i32_ne;
               i32_store(0);
-              local_get(payload); local_set(opt_ptr);
-              local_get(pos); i64_const(1); i64_add; local_set(new_pos);
+              local_get(Local(payload)); local_set(Local(opt_ptr));
+              local_get(Local(pos)); i64_const(Imm64(1)); i64_add; local_set(Local(new_pos));
             else_;
-              i32_const(0); local_set(opt_ptr);
-              local_get(pos); local_set(new_pos);
+              i32_const(Imm32(0)); local_set(Local(opt_ptr));
+              local_get(Local(pos)); local_set(Local(new_pos));
             end;
         });
         self.emit_cursor_pack_tuple(new_pos, opt_ptr);
@@ -2667,25 +2668,25 @@ impl FuncCompiler<'_> {
         let opt_ptr = self.scratch.alloc_i32();
         let payload = self.scratch.alloc_i32();
         let fval = self.scratch.alloc_f64();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            local_set(pos);
-            local_get(pos); i32_wrap_i64; local_set(pos_i32);
-            local_get(pos_i32); i32_const(F16_BYTES); i32_add;
-            local_get(buf); i32_load(0);
+            local_set(Local(pos));
+            local_get(Local(pos)); i32_wrap_i64; local_set(Local(pos_i32));
+            local_get(Local(pos_i32)); i32_const(Imm32(F16_BYTES)); i32_add;
+            local_get(Local(buf)); i32_load(0);
             i32_le_u;
             if_empty;
-              local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
+              local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos_i32)); i32_add;
               i32_load16_u(0);
               call(self.emitter.rt.bytes_f16_to_f64);
-              local_set(fval);
-              i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(payload);
-              local_get(payload); local_get(fval); f64_store(0);
-              local_get(payload); local_set(opt_ptr);
-              local_get(pos); i64_const(F16_BYTES_I64); i64_add; local_set(new_pos);
+              local_set(Local(fval));
+              i32_const(Imm32(I64_BYTES)); call(self.emitter.rt.alloc); local_set(Local(payload));
+              local_get(Local(payload)); local_get(Local(fval)); f64_store(0);
+              local_get(Local(payload)); local_set(Local(opt_ptr));
+              local_get(Local(pos)); i64_const(Imm64(F16_BYTES_I64)); i64_add; local_set(Local(new_pos));
             else_;
-              i32_const(0); local_set(opt_ptr);
-              local_get(pos); local_set(new_pos);
+              i32_const(Imm32(0)); local_set(Local(opt_ptr));
+              local_get(Local(pos)); local_set(Local(new_pos));
             end;
         });
         self.emit_cursor_pack_tuple(new_pos, opt_ptr);
@@ -2711,54 +2712,54 @@ impl FuncCompiler<'_> {
         let slen = self.scratch.alloc_i32();
         let str_ptr = self.scratch.alloc_i32();
         let buf_len = self.scratch.alloc_i32();
-        self.emit_expr(&args[0]); wasm!(self.func, { local_set(buf); });
+        self.emit_expr(&args[0]); wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(&args[1]); wasm!(self.func, {
-            local_set(pos);
-            local_get(pos); i32_wrap_i64; local_set(pos_i32);
-            local_get(buf); i32_load(0); local_set(buf_len);
+            local_set(Local(pos));
+            local_get(Local(pos)); i32_wrap_i64; local_set(Local(pos_i32));
+            local_get(Local(buf)); i32_load(0); local_set(Local(buf_len));
             // Prefix bounds: pos + 4 (u32 prefix size) <= len?
-            local_get(pos_i32); i32_const(U32_PREFIX_SIZE); i32_add;
-            local_get(buf_len); i32_le_u;
+            local_get(Local(pos_i32)); i32_const(Imm32(U32_PREFIX_SIZE)); i32_add;
+            local_get(Local(buf_len)); i32_le_u;
             if_empty;
               // Read u32 BE length (4 bytes, big-endian).
-              i32_const(0); local_set(slen);
-              local_get(slen);
-              local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
-              i32_load8_u(0); i32_const(BYTE_SHIFT_24); i32_shl; i32_or;
-              local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
-              i32_load8_u(1); i32_const(BYTE_SHIFT_16); i32_shl; i32_or;
-              local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
-              i32_load8_u(2); i32_const(BYTE_SHIFT_8); i32_shl; i32_or;
-              local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
+              i32_const(Imm32(0)); local_set(Local(slen));
+              local_get(Local(slen));
+              local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos_i32)); i32_add;
+              i32_load8_u(0); i32_const(Imm32(BYTE_SHIFT_24)); i32_shl; i32_or;
+              local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos_i32)); i32_add;
+              i32_load8_u(1); i32_const(Imm32(BYTE_SHIFT_16)); i32_shl; i32_or;
+              local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos_i32)); i32_add;
+              i32_load8_u(2); i32_const(Imm32(BYTE_SHIFT_8)); i32_shl; i32_or;
+              local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos_i32)); i32_add;
               i32_load8_u(3); i32_or;
-              local_set(slen);
+              local_set(Local(slen));
               // Body bounds: pos + 4 + slen <= len?
-              local_get(pos_i32); i32_const(U32_PREFIX_SIZE); i32_add; local_get(slen); i32_add;
-              local_get(buf_len); i32_le_u;
+              local_get(Local(pos_i32)); i32_const(Imm32(U32_PREFIX_SIZE)); i32_add; local_get(Local(slen)); i32_add;
+              local_get(Local(buf_len)); i32_le_u;
               if_empty;
                 // Alloc String: [len:i32][utf8...]
-                local_get(slen); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                call(self.emitter.rt.alloc); local_set(str_ptr);
-                local_get(str_ptr); local_get(slen); i32_store(0); // len
-                local_get(str_ptr); local_get(slen); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP)); // cap
-                local_get(str_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add; i32_const(U32_PREFIX_SIZE); i32_add;
-                local_get(slen);
+                local_get(Local(slen)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                call(self.emitter.rt.alloc); local_set(Local(str_ptr));
+                local_get(Local(str_ptr)); local_get(Local(slen)); i32_store(0); // len
+                local_get(Local(str_ptr)); local_get(Local(slen)); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP)); // cap
+                local_get(Local(str_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(pos_i32)); i32_add; i32_const(Imm32(U32_PREFIX_SIZE)); i32_add;
+                local_get(Local(slen));
                 memory_copy;
                 // Option[String] cell is a 4-byte pointer wrapper.
-                i32_const(OPT_CELL_BYTES); call(self.emitter.rt.alloc); local_set(opt_ptr);
-                local_get(opt_ptr); local_get(str_ptr); i32_store(0);
+                i32_const(Imm32(OPT_CELL_BYTES)); call(self.emitter.rt.alloc); local_set(Local(opt_ptr));
+                local_get(Local(opt_ptr)); local_get(Local(str_ptr)); i32_store(0);
                 // new_pos = pos + 4 + slen
-                local_get(pos); i64_const(U32_PREFIX_SIZE_I64); i64_add;
-                local_get(slen); i64_extend_i32_u; i64_add;
-                local_set(new_pos);
+                local_get(Local(pos)); i64_const(Imm64(U32_PREFIX_SIZE_I64)); i64_add;
+                local_get(Local(slen)); i64_extend_i32_u; i64_add;
+                local_set(Local(new_pos));
               else_;
-                i32_const(0); local_set(opt_ptr);
-                local_get(pos); local_set(new_pos);
+                i32_const(Imm32(0)); local_set(Local(opt_ptr));
+                local_get(Local(pos)); local_set(Local(new_pos));
               end;
             else_;
-              i32_const(0); local_set(opt_ptr);
-              local_get(pos); local_set(new_pos);
+              i32_const(Imm32(0)); local_set(Local(opt_ptr));
+              local_get(Local(pos)); local_set(Local(new_pos));
             end;
         });
         self.emit_cursor_pack_tuple(new_pos, opt_ptr);
@@ -2865,36 +2866,36 @@ impl FuncCompiler<'_> {
         let val_f64 = self.scratch.alloc_f64();
 
         self.emit_expr(buf_expr);
-        wasm!(self.func, { local_set(buf); });
+        wasm!(self.func, { local_set(Local(buf)); });
 
         // Normalise value to canonical width (i64 for int, f64 for float).
         self.emit_expr(val_expr);
         if is_float {
             if is_sized_f32_val(val_expr) { wasm!(self.func, { f64_promote_f32; }); }
-            wasm!(self.func, { local_set(val_f64); });
+            wasm!(self.func, { local_set(Local(val_f64)); });
         } else {
             if is_sized_i32_val(val_expr) { wasm!(self.func, { i64_extend_i32_u; }); }
-            wasm!(self.func, { local_set(val_i64); });
+            wasm!(self.func, { local_set(Local(val_i64)); });
         }
 
         self.emit_expr(endian_expr);
-        wasm!(self.func, { i32_load(0); local_set(endian_tag); });
+        wasm!(self.func, { i32_load(0); local_set(Local(endian_tag)); });
 
         // Alloc fresh buffer wider by `size_bytes`, memcpy old data.
         wasm!(self.func, {
-            local_get(buf); i32_load(0); local_set(old_len);
-            local_get(old_len); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32 + size_bytes as i32); i32_add;
-            call(self.emitter.rt.alloc); local_set(new_buf);
-            local_get(new_buf); local_get(old_len); i32_const(size_bytes as i32); i32_add; i32_store(0);
-            local_get(new_buf); local_get(old_len); i32_const(size_bytes as i32); i32_add; i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
-            local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-            local_get(old_len);
+            local_get(Local(buf)); i32_load(0); local_set(Local(old_len));
+            local_get(Local(old_len)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32 + size_bytes as i32)); i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(new_buf));
+            local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(size_bytes as i32)); i32_add; i32_store(0);
+            local_get(Local(new_buf)); local_get(Local(old_len)); i32_const(Imm32(size_bytes as i32)); i32_add; i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP));
+            local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+            local_get(Local(old_len));
             memory_copy;
         });
 
         // Store destination = new_buf + 4 + old_len.
-        wasm!(self.func, { local_get(endian_tag); i32_eqz; if_empty; });
+        wasm!(self.func, { local_get(Local(endian_tag)); i32_eqz; if_empty; });
         self.emit_typed_append_store(new_buf, old_len, val_i64, val_f64, size_bytes, is_float, /*be=*/ false);
         wasm!(self.func, { else_; });
         self.emit_typed_append_store(new_buf, old_len, val_i64, val_f64, size_bytes, is_float, /*be=*/ true);
@@ -2932,21 +2933,21 @@ impl FuncCompiler<'_> {
         let val_f64 = self.scratch.alloc_f64();
 
         self.emit_expr(buf_expr);
-        wasm!(self.func, { local_set(buf); });
+        wasm!(self.func, { local_set(Local(buf)); });
         self.emit_expr(offset_expr);
-        wasm!(self.func, { i32_wrap_i64; local_set(offset); });
+        wasm!(self.func, { i32_wrap_i64; local_set(Local(offset)); });
         self.emit_expr(val_expr);
         if is_float {
             if is_sized_f32_val(val_expr) { wasm!(self.func, { f64_promote_f32; }); }
-            wasm!(self.func, { local_set(val_f64); });
+            wasm!(self.func, { local_set(Local(val_f64)); });
         } else {
             if is_sized_i32_val(val_expr) { wasm!(self.func, { i64_extend_i32_u; }); }
-            wasm!(self.func, { local_set(val_i64); });
+            wasm!(self.func, { local_set(Local(val_i64)); });
         }
         self.emit_expr(endian_expr);
-        wasm!(self.func, { i32_load(0); local_set(endian_tag); });
+        wasm!(self.func, { i32_load(0); local_set(Local(endian_tag)); });
 
-        wasm!(self.func, { local_get(endian_tag); i32_eqz; if_empty; });
+        wasm!(self.func, { local_get(Local(endian_tag)); i32_eqz; if_empty; });
         self.emit_typed_set_store(buf, offset, val_i64, val_f64, size_bytes, is_float, /*be=*/ false);
         wasm!(self.func, { else_; });
         self.emit_typed_set_store(buf, offset, val_i64, val_f64, size_bytes, is_float, /*be=*/ true);
@@ -2971,7 +2972,7 @@ impl FuncCompiler<'_> {
         be: bool,
     ) {
         wasm!(self.func, {
-            local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(old_len); i32_add;
+            local_get(Local(new_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(old_len)); i32_add;
         });
         self.emit_typed_store_body(val_i64, val_f64, size_bytes, is_float, be);
     }
@@ -2988,7 +2989,7 @@ impl FuncCompiler<'_> {
         be: bool,
     ) {
         wasm!(self.func, {
-            local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(offset); i32_add;
+            local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(offset)); i32_add;
         });
         self.emit_typed_store_body(val_i64, val_f64, size_bytes, is_float, be);
     }
@@ -3005,15 +3006,15 @@ impl FuncCompiler<'_> {
     ) {
         if is_float {
             match (size_bytes, be) {
-                (4, false) => { wasm!(self.func, { local_get(val_f64); f32_demote_f64; f32_store(0); }); }
-                (8, false) => { wasm!(self.func, { local_get(val_f64); f64_store(0); }); }
+                (4, false) => { wasm!(self.func, { local_get(Local(val_f64)); f32_demote_f64; f32_store(0); }); }
+                (8, false) => { wasm!(self.func, { local_get(Local(val_f64)); f64_store(0); }); }
                 (4, true) => {
-                    wasm!(self.func, { local_get(val_f64); f32_demote_f64; i32_reinterpret_f32; });
+                    wasm!(self.func, { local_get(Local(val_f64)); f32_demote_f64; i32_reinterpret_f32; });
                     self.emit_bswap32_on_stack();
                     wasm!(self.func, { i32_store(0); });
                 }
                 (8, true) => {
-                    wasm!(self.func, { local_get(val_f64); i64_reinterpret_f64; });
+                    wasm!(self.func, { local_get(Local(val_f64)); i64_reinterpret_f64; });
                     self.emit_bswap64_on_stack();
                     wasm!(self.func, { i64_store(0); });
                 }
@@ -3021,22 +3022,22 @@ impl FuncCompiler<'_> {
             }
         } else {
             match (size_bytes, be) {
-                (1, _) => { wasm!(self.func, { local_get(val_i64); i32_wrap_i64; i32_store8(0); }); }
-                (2, false) => { wasm!(self.func, { local_get(val_i64); i32_wrap_i64; i32_store16(0); }); }
-                (4, false) => { wasm!(self.func, { local_get(val_i64); i32_wrap_i64; i32_store(0); }); }
-                (8, false) => { wasm!(self.func, { local_get(val_i64); i64_store(0); }); }
+                (1, _) => { wasm!(self.func, { local_get(Local(val_i64)); i32_wrap_i64; i32_store8(0); }); }
+                (2, false) => { wasm!(self.func, { local_get(Local(val_i64)); i32_wrap_i64; i32_store16(0); }); }
+                (4, false) => { wasm!(self.func, { local_get(Local(val_i64)); i32_wrap_i64; i32_store(0); }); }
+                (8, false) => { wasm!(self.func, { local_get(Local(val_i64)); i64_store(0); }); }
                 (2, true) => {
-                    wasm!(self.func, { local_get(val_i64); i32_wrap_i64; });
+                    wasm!(self.func, { local_get(Local(val_i64)); i32_wrap_i64; });
                     self.emit_bswap16_on_stack();
                     wasm!(self.func, { i32_store16(0); });
                 }
                 (4, true) => {
-                    wasm!(self.func, { local_get(val_i64); i32_wrap_i64; });
+                    wasm!(self.func, { local_get(Local(val_i64)); i32_wrap_i64; });
                     self.emit_bswap32_on_stack();
                     wasm!(self.func, { i32_store(0); });
                 }
                 (8, true) => {
-                    wasm!(self.func, { local_get(val_i64); });
+                    wasm!(self.func, { local_get(Local(val_i64)); });
                     self.emit_bswap64_on_stack();
                     wasm!(self.func, { i64_store(0); });
                 }
@@ -3049,9 +3050,9 @@ impl FuncCompiler<'_> {
     fn emit_bswap16_on_stack(&mut self) {
         let v = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(v);
-            local_get(v); i32_const(BYTE_SHIFT_8); i32_shr_u;
-            local_get(v); i32_const(LOW_BYTE_MASK); i32_and; i32_const(BYTE_SHIFT_8); i32_shl;
+            local_set(Local(v));
+            local_get(Local(v)); i32_const(Imm32(BYTE_SHIFT_8)); i32_shr_u;
+            local_get(Local(v)); i32_const(Imm32(LOW_BYTE_MASK)); i32_and; i32_const(Imm32(BYTE_SHIFT_8)); i32_shl;
             i32_or;
         });
         self.scratch.free_i32(v);
@@ -3061,18 +3062,18 @@ impl FuncCompiler<'_> {
     fn emit_bswap32_on_stack(&mut self) {
         let v = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(v);
+            local_set(Local(v));
             // byte3 → byte0
-            local_get(v); i32_const(BYTE_SHIFT_24); i32_shr_u;
+            local_get(Local(v)); i32_const(Imm32(BYTE_SHIFT_24)); i32_shr_u;
             // byte2 → byte1
-            local_get(v); i32_const(BYTE_SHIFT_8); i32_shr_u; i32_const(BSWAP16_HIGH_MASK); i32_and;
+            local_get(Local(v)); i32_const(Imm32(BYTE_SHIFT_8)); i32_shr_u; i32_const(Imm32(BSWAP16_HIGH_MASK)); i32_and;
             i32_or;
             // byte1 → byte2
-            local_get(v); i32_const(BYTE_SHIFT_8); i32_shl;
-            i32_const(BSWAP32_BYTE2_MASK); i32_and;
+            local_get(Local(v)); i32_const(Imm32(BYTE_SHIFT_8)); i32_shl;
+            i32_const(Imm32(BSWAP32_BYTE2_MASK)); i32_and;
             i32_or;
             // byte0 → byte3
-            local_get(v); i32_const(BYTE_SHIFT_24); i32_shl;
+            local_get(Local(v)); i32_const(Imm32(BYTE_SHIFT_24)); i32_shl;
             i32_or;
         });
         self.scratch.free_i32(v);
@@ -3084,14 +3085,14 @@ impl FuncCompiler<'_> {
         let hi = self.scratch.alloc_i32();
         let v = self.scratch.alloc_i64();
         wasm!(self.func, {
-            local_set(v);
-            local_get(v); i32_wrap_i64; local_set(lo);
-            local_get(v); i64_const(I32_BITS_I64); i64_shr_u; i32_wrap_i64; local_set(hi);
+            local_set(Local(v));
+            local_get(Local(v)); i32_wrap_i64; local_set(Local(lo));
+            local_get(Local(v)); i64_const(Imm64(I32_BITS_I64)); i64_shr_u; i32_wrap_i64; local_set(Local(hi));
         });
-        wasm!(self.func, { local_get(lo); });
+        wasm!(self.func, { local_get(Local(lo)); });
         self.emit_bswap32_on_stack();
-        wasm!(self.func, { i64_extend_i32_u; i64_const(I32_BITS_I64); i64_shl; });
-        wasm!(self.func, { local_get(hi); });
+        wasm!(self.func, { i64_extend_i32_u; i64_const(Imm64(I32_BITS_I64)); i64_shl; });
+        wasm!(self.func, { local_get(Local(hi)); });
         self.emit_bswap32_on_stack();
         wasm!(self.func, { i64_extend_i32_u; i64_or; });
         self.scratch.free_i64(v);

--- a/crates/almide-codegen/src/emit_wasm/calls_bytes.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_bytes.rs
@@ -5,6 +5,76 @@
 use super::FuncCompiler;
 use almide_ir::IrExpr;
 
+// ── Named constants for WASM immediate values ──────────────────────────────
+//
+// Each const names one specific role; the same numeric value may appear
+// under multiple names when the roles differ.
+
+/// Byte size of an `i64` value (used for list-element stride and payload allocs).
+const I64_BYTES: i32 = 8;
+/// Byte size of an `f64` value (append_f64_le new-length delta).
+const F64_BYTES: i32 = 8;
+/// Byte size of an `i32` value / pointer (used for list-of-i32-pointer stride).
+const I32_BYTES: i32 = 4;
+/// Alloc size for a single-pointer Option wrapper cell (holds one i32 pointer).
+const OPT_CELL_BYTES: i32 = 4;
+/// Byte size of an `f16` value (read_f16_le_at cursor advance).
+const F16_BYTES: i32 = 2;
+/// Byte size of an `f16` value as `i64` (cursor new_pos delta in `i64_const`).
+const F16_BYTES_I64: i64 = 2;
+/// Byte size of a `u32` prefix field (read_string_be_at header size).
+const U32_PREFIX_SIZE: i32 = 4;
+/// Byte size of a `u32` prefix field as `i64` (new_pos advance in `i64_const`).
+const U32_PREFIX_SIZE_I64: i64 = 4;
+
+/// Combined alloc size for `append_f64_le`: bytes header (4) + f64 (8) = 12.
+/// Hardcoded here because the call bypasses `layout_reg.header_size` + size.
+const BYTES_HDR_F64_ALLOC_SIZE: i32 = 12;
+/// Alloc size for the cursor result tuple `(Int, Option[T])`:
+/// `[i64 pos: 8 bytes][i32 opt_ptr: 4 bytes]` = 12 bytes total.
+const CURSOR_TUPLE_BYTES: i32 = 12;
+
+// Byte-level bit-shift amounts (how many bits to shift by 1 / 2 / 3 / 4 bytes).
+const BYTE_SHIFT_8: i32 = 8;
+const BYTE_SHIFT_16: i32 = 16;
+const BYTE_SHIFT_24: i32 = 24;
+/// Shift amount to split an `i64` into two i32 halves (emit_bswap64).
+const I32_BITS_I64: i64 = 32;
+
+/// Bit-width of an i16 value; used for sign-extension via shl+shr_s pair.
+const I16_BITS: i32 = 16;
+
+// Byte masks used in big-endian byte assembly / bswap helpers.
+/// Low byte mask (0xFF).
+const LOW_BYTE_MASK: i32 = 0xFF;
+/// Mask selecting the high byte of a u16 (0xFF00), used in bswap16.
+const BSWAP16_HIGH_MASK: i32 = 0xFF00;
+/// Mask selecting byte 2 of a u32 (0x00FF0000), used in bswap32.
+const BSWAP32_BYTE2_MASK: i32 = 0x00FF0000_u32 as i32;
+
+// UTF-8 byte-range constants used in `emit_bytes_is_valid_utf8`.
+/// Upper bound (exclusive) of the ASCII range (== 0x80).
+const UTF8_1B_MAX: i32 = 0x80;
+/// Minimum valid lead byte for a 2-byte UTF-8 sequence.
+const UTF8_2B_LEAD_MIN: i32 = 0xC2;
+/// Minimum lead byte for a 3-byte UTF-8 sequence.
+const UTF8_3B_LEAD_MIN: i32 = 0xE0;
+/// Minimum lead byte for a 4-byte UTF-8 sequence.
+const UTF8_4B_LEAD_MIN: i32 = 0xF0;
+/// Upper bound (exclusive) of valid 4-byte lead bytes.
+const UTF8_4B_LEAD_MAX: i32 = 0xF5;
+/// Number of follow-bytes required after a 3-byte lead.
+const UTF8_3B_FOLLOW_COUNT: i32 = 2;
+/// Number of follow-bytes required after a 4-byte lead.
+const UTF8_4B_FOLLOW_COUNT: i32 = 3;
+/// Minimum value of a UTF-8 continuation byte (0x80).
+const UTF8_CONT_BYTE_MIN: i32 = 0x80;
+/// Upper bound (exclusive) of UTF-8 continuation bytes (0xC0).
+const UTF8_CONT_BYTE_MAX: i32 = 0xC0;
+
+/// ASCII code for line feed '\n'.
+const ASCII_LF: i32 = 10;
+
 /// Requested primitive load for the typed byte-read family.
 #[derive(Clone, Copy)]
 enum ByteReadOp {
@@ -54,7 +124,7 @@ impl FuncCompiler<'_> {
                       i32_const(0); // none
                     else_;
                       // alloc 8 bytes for i64 value
-                      i32_const(8);
+                      i32_const(I64_BYTES);
                       call(self.emitter.rt.alloc);
                       local_set(result);
                       local_get(result);
@@ -200,7 +270,7 @@ impl FuncCompiler<'_> {
                       local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add;
                       // src_elem = xs + 4 + i*8 → load i64, wrap to i32, store as u8
                       local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
                       i64_load(0);
                       i32_wrap_i64;
                       i32_store8(0);
@@ -226,7 +296,7 @@ impl FuncCompiler<'_> {
                     local_set(src);
                     local_get(src); i32_load(0); local_set(len);
                     // alloc 4 + len*8
-                    local_get(len); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
+                    local_get(len); i32_const(I64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
                     call(self.emitter.rt.alloc);
                     local_set(dst);
                     local_get(dst); local_get(len); i32_store(0);
@@ -236,7 +306,7 @@ impl FuncCompiler<'_> {
                       local_get(i); local_get(len); i32_ge_u; br_if(1);
                       // dst + 4 + i*8
                       local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
                       // load u8 from src + 4 + i, extend to i64
                       local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
                       local_get(i); i32_add;
@@ -443,11 +513,11 @@ impl FuncCompiler<'_> {
                     // old_len = buf[0]
                     local_get(buf); i32_load(0); local_set(old_len);
                     // new_buf = alloc(4 + old_len + 8)
-                    local_get(old_len); i32_const(12); i32_add;
+                    local_get(old_len); i32_const(BYTES_HDR_F64_ALLOC_SIZE); i32_add;
                     call(self.emitter.rt.alloc);
                     local_set(new_buf);
                     // new_buf[0] = old_len + 8
-                    local_get(new_buf); local_get(old_len); i32_const(8); i32_add; i32_store(0);
+                    local_get(new_buf); local_get(old_len); i32_const(F64_BYTES); i32_add; i32_store(0);
                     // copy old data: new_buf+4 <- buf+4, old_len bytes
                     local_get(new_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
                     local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
@@ -508,7 +578,7 @@ impl FuncCompiler<'_> {
                     if_i32;
                         i32_const(0);
                     else_;
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(opt_ptr);
+                        i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(opt_ptr);
                         local_get(opt_ptr); local_get(pos_i64); i64_store(0);
                         local_get(opt_ptr);
                     end;
@@ -546,12 +616,12 @@ impl FuncCompiler<'_> {
                 let err_str = self.emitter.intern_string("invalid UTF-8");
                 wasm!(self.func, {
                     if_i32;
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(res);
+                        i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(res);
                         local_get(res); i32_const(0); i32_store(0);
                         local_get(res); local_get(buf); i32_store(4);
                         local_get(res);
                     else_;
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(res);
+                        i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(res);
                         local_get(res); i32_const(1); i32_store(0);
                         local_get(res); i32_const(err_str as i32); i32_store(4);
                         local_get(res);
@@ -852,7 +922,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     i32_wrap_i64; local_set(n);
                     // alloc list: 4 + n*4
-                    local_get(n); i32_const(4); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
+                    local_get(n); i32_const(I32_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); local_get(n); i32_store(0);
                     i32_const(0); local_set(i);
@@ -873,7 +943,7 @@ impl FuncCompiler<'_> {
                       memory_copy;
                       // result[i] = s
                       local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       local_get(s); i32_store(0);
                       // pos += 4 + len
                       local_get(pos); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(lval); i32_add;
@@ -969,8 +1039,8 @@ impl FuncCompiler<'_> {
                             // sign-extend 16-bit
                             wasm!(self.func, {
                                 local_get(dst_addr);
-                                local_get(acc); i32_wrap_i64; i32_const(16); i32_shl;
-                                i32_const(16); i32_shr_s;
+                                local_get(acc); i32_wrap_i64; i32_const(I16_BITS); i32_shl;
+                                i32_const(I16_BITS); i32_shr_s;
                                 i64_extend_i32_s;
                                 i64_store(0);
                             });
@@ -1308,7 +1378,7 @@ impl FuncCompiler<'_> {
                 local_get(dst);
                 local_get(val_i64); i64_const(shift); i64_shr_u;
                 i32_wrap_i64;
-                i32_const(0xFF); i32_and;
+                i32_const(LOW_BYTE_MASK); i32_and;
                 i32_store8(i as u64);
             });
         }
@@ -1343,7 +1413,7 @@ impl FuncCompiler<'_> {
                 local_get(dst);
                 local_get(bits); i64_const(shift); i64_shr_u;
                 i32_wrap_i64;
-                i32_const(0xFF); i32_and;
+                i32_const(LOW_BYTE_MASK); i32_and;
                 i32_store8(i as u64);
             });
         }
@@ -1385,7 +1455,7 @@ impl FuncCompiler<'_> {
                 local_get(dst);
                 local_get(val_i64); i64_const(shift); i64_shr_u;
                 i32_wrap_i64;
-                i32_const(0xFF); i32_and;
+                i32_const(LOW_BYTE_MASK); i32_and;
                 i32_store8(i as u64);
             });
         }
@@ -1440,7 +1510,7 @@ impl FuncCompiler<'_> {
                 local_get(dst);
                 local_get(bits); i64_const(shift); i64_shr_u;
                 i32_wrap_i64;
-                i32_const(0xFF); i32_and;
+                i32_const(LOW_BYTE_MASK); i32_and;
                 i32_store8(i as u64);
             });
         }
@@ -1467,7 +1537,7 @@ impl FuncCompiler<'_> {
     fn emit_cursor_pack_tuple(&mut self, new_pos_local: u32, opt_ptr_local: u32) {
         let tuple = self.scratch.alloc_i32();
         wasm!(self.func, {
-            i32_const(12); call(self.emitter.rt.alloc); local_set(tuple);
+            i32_const(CURSOR_TUPLE_BYTES); call(self.emitter.rt.alloc); local_set(tuple);
             // tuple[0..8] = new_pos (i64)
             local_get(tuple); local_get(new_pos_local); i64_store(0);
             // tuple[8..12] = opt_ptr (i32)
@@ -1887,7 +1957,7 @@ impl FuncCompiler<'_> {
             end;
             local_set(n_chunks);
             // alloc List header: 4 + n_chunks*4
-            local_get(n_chunks); i32_const(4); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
+            local_get(n_chunks); i32_const(I32_BYTES); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
             call(self.emitter.rt.alloc); local_set(result);
             local_get(result); local_get(n_chunks); i32_store(0);
             i32_const(0); local_set(i);
@@ -1908,7 +1978,7 @@ impl FuncCompiler<'_> {
                 local_get(chunk_len);
                 memory_copy;
                 // result.elems[i] = chunk
-                local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                 local_get(chunk); i32_store(0);
                 local_get(off); local_get(size); i32_add; local_set(off);
                 local_get(i); i32_const(1); i32_add; local_set(i);
@@ -1950,7 +2020,7 @@ impl FuncCompiler<'_> {
                 i32_const(1); call(self.emitter.rt.string_alloc); local_set(sep);
                 local_get(sep); i32_const(1); i32_store(0);
                 local_get(sep); i32_const(1); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
-                local_get(sep); i32_const(10); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
+                local_get(sep); i32_const(ASCII_LF); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
             });
         } else {
             self.emit_expr(&args[1]);
@@ -1968,7 +2038,7 @@ impl FuncCompiler<'_> {
                 block_empty; loop_empty;
                     local_get(i); local_get(blen); i32_ge_u; br_if(1);
                     local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add;
-                    i32_load8_u(0); i32_const(10); i32_eq;
+                    i32_load8_u(0); i32_const(ASCII_LF); i32_eq;
                     if_empty; local_get(count); i32_const(1); i32_add; local_set(count); end;
                     local_get(i); i32_const(1); i32_add; local_set(i);
                     br(0);
@@ -1979,7 +2049,7 @@ impl FuncCompiler<'_> {
                     // empty buffer → count stays 0
                 else_;
                     local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(blen); i32_const(1); i32_sub; i32_add;
-                    i32_load8_u(0); i32_const(10); i32_ne;
+                    i32_load8_u(0); i32_const(ASCII_LF); i32_ne;
                     if_empty; local_get(count); i32_const(1); i32_add; local_set(count); end;
                 end;
             });
@@ -2024,7 +2094,7 @@ impl FuncCompiler<'_> {
         }
         // Second pass: build the actual list using count chunks.
         wasm!(self.func, {
-            local_get(count); i32_const(4); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
+            local_get(count); i32_const(I32_BYTES); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
             call(self.emitter.rt.alloc); local_set(result);
             local_get(result); local_get(count); i32_store(0);
             i32_const(0); local_set(start);
@@ -2062,7 +2132,7 @@ impl FuncCompiler<'_> {
                 local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(start); i32_add;
                 local_get(chunk_len);
                 memory_copy;
-                local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(out_idx); i32_const(4); i32_mul; i32_add;
+                local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(out_idx); i32_const(I32_BYTES); i32_mul; i32_add;
                 local_get(chunk); i32_store(0);
                 local_get(out_idx); i32_const(1); i32_add; local_set(out_idx);
                 local_get(i); local_get(plen); i32_add; local_set(i);
@@ -2283,22 +2353,22 @@ impl FuncCompiler<'_> {
                 local_get(i); local_get(len); i32_ge_u; br_if(1);
                 local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(i); i32_add; i32_load8_u(0); local_set(b);
                 // ASCII fast path
-                local_get(b); i32_const(128); i32_lt_u;
+                local_get(b); i32_const(UTF8_1B_MAX); i32_lt_u;
                 if_empty;
                     local_get(i); i32_const(1); i32_add; local_set(i);
                     br(2); // continue outer loop
                 end;
                 // Determine number of follow-bytes
-                local_get(b); i32_const(0xC2); i32_lt_u;
+                local_get(b); i32_const(UTF8_2B_LEAD_MIN); i32_lt_u;
                 if_empty;
                     i32_const(0); local_set(valid); br(2);
                 end;
-                local_get(b); i32_const(0xE0); i32_lt_u;
+                local_get(b); i32_const(UTF8_3B_LEAD_MIN); i32_lt_u;
                 if_i32; i32_const(1); else_;
-                  local_get(b); i32_const(0xF0); i32_lt_u;
-                  if_i32; i32_const(2); else_;
-                    local_get(b); i32_const(0xF5); i32_lt_u;
-                    if_i32; i32_const(3); else_; i32_const(-1); end;
+                  local_get(b); i32_const(UTF8_4B_LEAD_MIN); i32_lt_u;
+                  if_i32; i32_const(UTF8_3B_FOLLOW_COUNT); else_;
+                    local_get(b); i32_const(UTF8_4B_LEAD_MAX); i32_lt_u;
+                    if_i32; i32_const(UTF8_4B_FOLLOW_COUNT); else_; i32_const(-1); end;
                   end;
                 end;
                 local_set(need);
@@ -2319,8 +2389,8 @@ impl FuncCompiler<'_> {
                     local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 + 1); i32_add;
                     local_get(i); i32_add; local_get(k); i32_add;
                     i32_load8_u(0); local_set(fb);
-                    local_get(fb); i32_const(0x80); i32_lt_u;
-                    local_get(fb); i32_const(0xC0); i32_ge_u; i32_or;
+                    local_get(fb); i32_const(UTF8_CONT_BYTE_MIN); i32_lt_u;
+                    local_get(fb); i32_const(UTF8_CONT_BYTE_MAX); i32_ge_u; i32_or;
                     if_empty;
                         i32_const(0); local_set(valid); br(4);
                     end;
@@ -2405,7 +2475,7 @@ impl FuncCompiler<'_> {
         }
         // alloc 8-byte payload, store val, set opt_ptr
         wasm!(self.func, {
-            i32_const(8); call(self.emitter.rt.alloc); local_set(payload);
+            i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(payload);
             local_get(payload); local_get(val); i64_store(0);
             local_get(payload); local_set(opt_ptr);
             local_get(pos); i64_const(width as i64); i64_add; local_set(new_pos);
@@ -2480,7 +2550,7 @@ impl FuncCompiler<'_> {
             }
         }
         wasm!(self.func, {
-            i32_const(8); call(self.emitter.rt.alloc); local_set(payload);
+            i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(payload);
             local_get(payload); local_get(fval); f64_store(0);
             local_get(payload); local_set(opt_ptr);
             local_get(pos); i64_const(width as i64); i64_add; local_set(new_pos);
@@ -2530,7 +2600,7 @@ impl FuncCompiler<'_> {
               local_get(n_i32);
               memory_copy;
               // Wrap the Bytes pointer in an Option cell (4 bytes).
-              i32_const(4); call(self.emitter.rt.alloc); local_set(opt_ptr);
+              i32_const(OPT_CELL_BYTES); call(self.emitter.rt.alloc); local_set(opt_ptr);
               local_get(opt_ptr); local_get(dst); i32_store(0);
               local_get(pos); local_get(n_i32); i64_extend_i32_u; i64_add; local_set(new_pos);
             else_;
@@ -2565,7 +2635,7 @@ impl FuncCompiler<'_> {
             local_get(buf); i32_load(0);
             i32_le_u;
             if_empty;
-              i32_const(4); call(self.emitter.rt.alloc); local_set(payload);
+              i32_const(OPT_CELL_BYTES); call(self.emitter.rt.alloc); local_set(payload);
               local_get(payload);
               local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
               i32_load8_u(0); i32_const(0); i32_ne;
@@ -2601,7 +2671,7 @@ impl FuncCompiler<'_> {
         self.emit_expr(&args[1]); wasm!(self.func, {
             local_set(pos);
             local_get(pos); i32_wrap_i64; local_set(pos_i32);
-            local_get(pos_i32); i32_const(2); i32_add;
+            local_get(pos_i32); i32_const(F16_BYTES); i32_add;
             local_get(buf); i32_load(0);
             i32_le_u;
             if_empty;
@@ -2609,10 +2679,10 @@ impl FuncCompiler<'_> {
               i32_load16_u(0);
               call(self.emitter.rt.bytes_f16_to_f64);
               local_set(fval);
-              i32_const(8); call(self.emitter.rt.alloc); local_set(payload);
+              i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(payload);
               local_get(payload); local_get(fval); f64_store(0);
               local_get(payload); local_set(opt_ptr);
-              local_get(pos); i64_const(2); i64_add; local_set(new_pos);
+              local_get(pos); i64_const(F16_BYTES_I64); i64_add; local_set(new_pos);
             else_;
               i32_const(0); local_set(opt_ptr);
               local_get(pos); local_set(new_pos);
@@ -2647,23 +2717,23 @@ impl FuncCompiler<'_> {
             local_get(pos); i32_wrap_i64; local_set(pos_i32);
             local_get(buf); i32_load(0); local_set(buf_len);
             // Prefix bounds: pos + 4 (u32 prefix size) <= len?
-            local_get(pos_i32); i32_const(4); i32_add;
+            local_get(pos_i32); i32_const(U32_PREFIX_SIZE); i32_add;
             local_get(buf_len); i32_le_u;
             if_empty;
               // Read u32 BE length (4 bytes, big-endian).
               i32_const(0); local_set(slen);
               local_get(slen);
               local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
-              i32_load8_u(0); i32_const(24); i32_shl; i32_or;
+              i32_load8_u(0); i32_const(BYTE_SHIFT_24); i32_shl; i32_or;
               local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
-              i32_load8_u(1); i32_const(16); i32_shl; i32_or;
+              i32_load8_u(1); i32_const(BYTE_SHIFT_16); i32_shl; i32_or;
               local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
-              i32_load8_u(2); i32_const(8); i32_shl; i32_or;
+              i32_load8_u(2); i32_const(BYTE_SHIFT_8); i32_shl; i32_or;
               local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add;
               i32_load8_u(3); i32_or;
               local_set(slen);
               // Body bounds: pos + 4 + slen <= len?
-              local_get(pos_i32); i32_const(4); i32_add; local_get(slen); i32_add;
+              local_get(pos_i32); i32_const(U32_PREFIX_SIZE); i32_add; local_get(slen); i32_add;
               local_get(buf_len); i32_le_u;
               if_empty;
                 // Alloc String: [len:i32][utf8...]
@@ -2672,14 +2742,14 @@ impl FuncCompiler<'_> {
                 local_get(str_ptr); local_get(slen); i32_store(0); // len
                 local_get(str_ptr); local_get(slen); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP)); // cap
                 local_get(str_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add; i32_const(4); i32_add;
+                local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(pos_i32); i32_add; i32_const(U32_PREFIX_SIZE); i32_add;
                 local_get(slen);
                 memory_copy;
                 // Option[String] cell is a 4-byte pointer wrapper.
-                i32_const(4); call(self.emitter.rt.alloc); local_set(opt_ptr);
+                i32_const(OPT_CELL_BYTES); call(self.emitter.rt.alloc); local_set(opt_ptr);
                 local_get(opt_ptr); local_get(str_ptr); i32_store(0);
                 // new_pos = pos + 4 + slen
-                local_get(pos); i64_const(4); i64_add;
+                local_get(pos); i64_const(U32_PREFIX_SIZE_I64); i64_add;
                 local_get(slen); i64_extend_i32_u; i64_add;
                 local_set(new_pos);
               else_;
@@ -2980,8 +3050,8 @@ impl FuncCompiler<'_> {
         let v = self.scratch.alloc_i32();
         wasm!(self.func, {
             local_set(v);
-            local_get(v); i32_const(8); i32_shr_u;
-            local_get(v); i32_const(0xFF); i32_and; i32_const(8); i32_shl;
+            local_get(v); i32_const(BYTE_SHIFT_8); i32_shr_u;
+            local_get(v); i32_const(LOW_BYTE_MASK); i32_and; i32_const(BYTE_SHIFT_8); i32_shl;
             i32_or;
         });
         self.scratch.free_i32(v);
@@ -2993,16 +3063,16 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
             local_set(v);
             // byte3 → byte0
-            local_get(v); i32_const(24); i32_shr_u;
+            local_get(v); i32_const(BYTE_SHIFT_24); i32_shr_u;
             // byte2 → byte1
-            local_get(v); i32_const(8); i32_shr_u; i32_const(0xFF00); i32_and;
+            local_get(v); i32_const(BYTE_SHIFT_8); i32_shr_u; i32_const(BSWAP16_HIGH_MASK); i32_and;
             i32_or;
             // byte1 → byte2
-            local_get(v); i32_const(8); i32_shl;
-            i32_const(0x00FF0000_u32 as i32); i32_and;
+            local_get(v); i32_const(BYTE_SHIFT_8); i32_shl;
+            i32_const(BSWAP32_BYTE2_MASK); i32_and;
             i32_or;
             // byte0 → byte3
-            local_get(v); i32_const(24); i32_shl;
+            local_get(v); i32_const(BYTE_SHIFT_24); i32_shl;
             i32_or;
         });
         self.scratch.free_i32(v);
@@ -3016,11 +3086,11 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
             local_set(v);
             local_get(v); i32_wrap_i64; local_set(lo);
-            local_get(v); i64_const(32); i64_shr_u; i32_wrap_i64; local_set(hi);
+            local_get(v); i64_const(I32_BITS_I64); i64_shr_u; i32_wrap_i64; local_set(hi);
         });
         wasm!(self.func, { local_get(lo); });
         self.emit_bswap32_on_stack();
-        wasm!(self.func, { i64_extend_i32_u; i64_const(32); i64_shl; });
+        wasm!(self.func, { i64_extend_i32_u; i64_const(I32_BITS_I64); i64_shl; });
         wasm!(self.func, { local_get(hi); });
         self.emit_bswap32_on_stack();
         wasm!(self.func, { i64_extend_i32_u; i64_or; });

--- a/crates/almide-codegen/src/emit_wasm/calls_datetime.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_datetime.rs
@@ -1,5 +1,6 @@
 //! datetime module + decimal helpers — WASM codegen dispatch.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::FuncCompiler;
 use almide_ir::IrExpr;
 use almide_lang::types::Ty;
@@ -88,39 +89,39 @@ impl FuncCompiler<'_> {
                 let m = self.scratch.alloc_i64();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(year); });
+                wasm!(self.func, { local_set(Local(year)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(month); });
+                wasm!(self.func, { local_set(Local(month)); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { local_set(day); });
+                wasm!(self.func, { local_set(Local(day)); });
                 self.emit_expr(&args[3]);
-                wasm!(self.func, { local_set(hour); });
+                wasm!(self.func, { local_set(Local(hour)); });
                 self.emit_expr(&args[4]);
-                wasm!(self.func, { local_set(minute); });
+                wasm!(self.func, { local_set(Local(minute)); });
                 self.emit_expr(&args[5]);
-                wasm!(self.func, { local_set(second); });
+                wasm!(self.func, { local_set(Local(second)); });
 
                 wasm!(self.func, {
-                    i64_const(JDN_MONTH_ADJ); local_get(month); i64_sub; i64_const(MONTHS_PER_YEAR); i64_div_s; local_set(a);
-                    local_get(year); i64_const(JDN_YEAR_BIAS); i64_add; local_get(a); i64_sub; local_set(y);
-                    local_get(month); i64_const(MONTHS_PER_YEAR); local_get(a); i64_mul; i64_add; i64_const(JDN_MONTH_SHIFT); i64_sub; local_set(m);
-                    local_get(day);
-                    i64_const(JDN_DAYS_COEFF); local_get(m); i64_mul; i64_const(JDN_DAYS_ADJ); i64_add; i64_const(JDN_DAYS_DIV); i64_div_s;
+                    i64_const(Imm64(JDN_MONTH_ADJ)); local_get(Local(month)); i64_sub; i64_const(Imm64(MONTHS_PER_YEAR)); i64_div_s; local_set(Local(a));
+                    local_get(Local(year)); i64_const(Imm64(JDN_YEAR_BIAS)); i64_add; local_get(Local(a)); i64_sub; local_set(Local(y));
+                    local_get(Local(month)); i64_const(Imm64(MONTHS_PER_YEAR)); local_get(Local(a)); i64_mul; i64_add; i64_const(Imm64(JDN_MONTH_SHIFT)); i64_sub; local_set(Local(m));
+                    local_get(Local(day));
+                    i64_const(Imm64(JDN_DAYS_COEFF)); local_get(Local(m)); i64_mul; i64_const(Imm64(JDN_DAYS_ADJ)); i64_add; i64_const(Imm64(JDN_DAYS_DIV)); i64_div_s;
                     i64_add;
-                    i64_const(DAYS_PER_YEAR); local_get(y); i64_mul;
+                    i64_const(Imm64(DAYS_PER_YEAR)); local_get(Local(y)); i64_mul;
                     i64_add;
-                    local_get(y); i64_const(JDN_LEAP_DIV); i64_div_s;
+                    local_get(Local(y)); i64_const(Imm64(JDN_LEAP_DIV)); i64_div_s;
                     i64_add;
-                    local_get(y); i64_const(JDN_CENTURY_DIV); i64_div_s;
+                    local_get(Local(y)); i64_const(Imm64(JDN_CENTURY_DIV)); i64_div_s;
                     i64_sub;
-                    local_get(y); i64_const(JDN_LEAP_EXCEPTION_DIV); i64_div_s;
+                    local_get(Local(y)); i64_const(Imm64(JDN_LEAP_EXCEPTION_DIV)); i64_div_s;
                     i64_add;
-                    i64_const(JDN_EPOCH_ADJ); i64_sub;
-                    i64_const(JDN_UNIX_EPOCH); i64_sub;
-                    i64_const(SECS_PER_DAY); i64_mul;
-                    local_get(hour); i64_const(SECS_PER_HOUR); i64_mul; i64_add;
-                    local_get(minute); i64_const(SECS_PER_MINUTE); i64_mul; i64_add;
-                    local_get(second); i64_add;
+                    i64_const(Imm64(JDN_EPOCH_ADJ)); i64_sub;
+                    i64_const(Imm64(JDN_UNIX_EPOCH)); i64_sub;
+                    i64_const(Imm64(SECS_PER_DAY)); i64_mul;
+                    local_get(Local(hour)); i64_const(Imm64(SECS_PER_HOUR)); i64_mul; i64_add;
+                    local_get(Local(minute)); i64_const(Imm64(SECS_PER_MINUTE)); i64_mul; i64_add;
+                    local_get(Local(second)); i64_add;
                 });
 
                 self.scratch.free_i64(m);
@@ -144,46 +145,46 @@ impl FuncCompiler<'_> {
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(ts);
+                    local_set(Local(ts));
                     // floor(ts / SECS_PER_DAY)
-                    local_get(ts); i64_const(0); i64_ge_s;
+                    local_get(Local(ts)); i64_const(Imm64(0)); i64_ge_s;
                     if_i64;
-                      local_get(ts); i64_const(SECS_PER_DAY); i64_div_s;
+                      local_get(Local(ts)); i64_const(Imm64(SECS_PER_DAY)); i64_div_s;
                     else_;
-                      local_get(ts); i64_const(SECS_PER_DAY_M1); i64_sub; i64_const(SECS_PER_DAY); i64_div_s;
+                      local_get(Local(ts)); i64_const(Imm64(SECS_PER_DAY_M1)); i64_sub; i64_const(Imm64(SECS_PER_DAY)); i64_div_s;
                     end;
-                    local_set(d);
-                    local_get(d); i64_const(JDN_UNIX_EPOCH); i64_add; local_set(d);
-                    local_get(d); i64_const(JDN_INV_C1); i64_add;
-                    i64_const(JDN_LEAP_DIV); local_get(d); i64_mul; i64_const(JDN_INV_C2); i64_add;
-                    i64_const(JDN_DAYS_PER_400YR); i64_div_s; i64_const(JDN_GREG_CORR); i64_mul; i64_const(JDN_LEAP_DIV); i64_div_s;
-                    i64_add; i64_const(JDN_INV_C3); i64_sub;
-                    local_set(f);
-                    i64_const(JDN_LEAP_DIV); local_get(f); i64_mul; i64_const(JDN_MONTH_SHIFT); i64_add; local_set(e);
-                    local_get(e); i64_const(JDN_DAYS_PER_4YR); i64_rem_s; i64_const(JDN_LEAP_DIV); i64_div_s; local_set(g);
-                    i64_const(JDN_DAYS_DIV); local_get(g); i64_mul; i64_const(JDN_DAYS_ADJ); i64_add; local_set(h);
+                    local_set(Local(d));
+                    local_get(Local(d)); i64_const(Imm64(JDN_UNIX_EPOCH)); i64_add; local_set(Local(d));
+                    local_get(Local(d)); i64_const(Imm64(JDN_INV_C1)); i64_add;
+                    i64_const(Imm64(JDN_LEAP_DIV)); local_get(Local(d)); i64_mul; i64_const(Imm64(JDN_INV_C2)); i64_add;
+                    i64_const(Imm64(JDN_DAYS_PER_400YR)); i64_div_s; i64_const(Imm64(JDN_GREG_CORR)); i64_mul; i64_const(Imm64(JDN_LEAP_DIV)); i64_div_s;
+                    i64_add; i64_const(Imm64(JDN_INV_C3)); i64_sub;
+                    local_set(Local(f));
+                    i64_const(Imm64(JDN_LEAP_DIV)); local_get(Local(f)); i64_mul; i64_const(Imm64(JDN_MONTH_SHIFT)); i64_add; local_set(Local(e));
+                    local_get(Local(e)); i64_const(Imm64(JDN_DAYS_PER_4YR)); i64_rem_s; i64_const(Imm64(JDN_LEAP_DIV)); i64_div_s; local_set(Local(g));
+                    i64_const(Imm64(JDN_DAYS_DIV)); local_get(Local(g)); i64_mul; i64_const(Imm64(JDN_DAYS_ADJ)); i64_add; local_set(Local(h));
                 });
 
                 match func {
                     "day" => {
                         wasm!(self.func, {
-                            local_get(h); i64_const(JDN_DAYS_COEFF); i64_rem_s; i64_const(JDN_DAYS_DIV); i64_div_s; i64_const(1); i64_add;
+                            local_get(Local(h)); i64_const(Imm64(JDN_DAYS_COEFF)); i64_rem_s; i64_const(Imm64(JDN_DAYS_DIV)); i64_div_s; i64_const(Imm64(1)); i64_add;
                         });
                     }
                     "month" => {
                         wasm!(self.func, {
-                            local_get(h); i64_const(JDN_DAYS_COEFF); i64_div_s; i64_const(JDN_MONTH_OFS); i64_add;
-                            i64_const(MONTHS_PER_YEAR); i64_rem_s; i64_const(1); i64_add;
+                            local_get(Local(h)); i64_const(Imm64(JDN_DAYS_COEFF)); i64_div_s; i64_const(Imm64(JDN_MONTH_OFS)); i64_add;
+                            i64_const(Imm64(MONTHS_PER_YEAR)); i64_rem_s; i64_const(Imm64(1)); i64_add;
                         });
                     }
                     "year" => {
                         let mm = self.scratch.alloc_i64();
                         wasm!(self.func, {
-                            local_get(h); i64_const(JDN_DAYS_COEFF); i64_div_s; i64_const(JDN_MONTH_OFS); i64_add;
-                            i64_const(MONTHS_PER_YEAR); i64_rem_s; i64_const(1); i64_add;
-                            local_set(mm);
-                            local_get(e); i64_const(JDN_DAYS_PER_4YR); i64_div_s; i64_const(JDN_INV_YEAR_BIAS); i64_sub;
-                            i64_const(JDN_MONTH_ADJ); local_get(mm); i64_sub; i64_const(MONTHS_PER_YEAR); i64_div_s;
+                            local_get(Local(h)); i64_const(Imm64(JDN_DAYS_COEFF)); i64_div_s; i64_const(Imm64(JDN_MONTH_OFS)); i64_add;
+                            i64_const(Imm64(MONTHS_PER_YEAR)); i64_rem_s; i64_const(Imm64(1)); i64_add;
+                            local_set(Local(mm));
+                            local_get(Local(e)); i64_const(Imm64(JDN_DAYS_PER_4YR)); i64_div_s; i64_const(Imm64(JDN_INV_YEAR_BIAS)); i64_sub;
+                            i64_const(Imm64(JDN_MONTH_ADJ)); local_get(Local(mm)); i64_sub; i64_const(Imm64(MONTHS_PER_YEAR)); i64_div_s;
                             i64_add;
                         });
                         self.scratch.free_i64(mm);
@@ -201,24 +202,24 @@ impl FuncCompiler<'_> {
             "hour" => {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i64_const(SECS_PER_DAY); i64_rem_s;
-                    i64_const(SECS_PER_DAY); i64_add; i64_const(SECS_PER_DAY); i64_rem_s;
-                    i64_const(SECS_PER_HOUR); i64_div_s;
+                    i64_const(Imm64(SECS_PER_DAY)); i64_rem_s;
+                    i64_const(Imm64(SECS_PER_DAY)); i64_add; i64_const(Imm64(SECS_PER_DAY)); i64_rem_s;
+                    i64_const(Imm64(SECS_PER_HOUR)); i64_div_s;
                 });
             }
             "minute" => {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i64_const(SECS_PER_HOUR); i64_rem_s;
-                    i64_const(SECS_PER_HOUR); i64_add; i64_const(SECS_PER_HOUR); i64_rem_s;
-                    i64_const(SECS_PER_MINUTE); i64_div_s;
+                    i64_const(Imm64(SECS_PER_HOUR)); i64_rem_s;
+                    i64_const(Imm64(SECS_PER_HOUR)); i64_add; i64_const(Imm64(SECS_PER_HOUR)); i64_rem_s;
+                    i64_const(Imm64(SECS_PER_MINUTE)); i64_div_s;
                 });
             }
             "second" => {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i64_const(SECS_PER_MINUTE); i64_rem_s;
-                    i64_const(SECS_PER_MINUTE); i64_add; i64_const(SECS_PER_MINUTE); i64_rem_s;
+                    i64_const(Imm64(SECS_PER_MINUTE)); i64_rem_s;
+                    i64_const(Imm64(SECS_PER_MINUTE)); i64_add; i64_const(Imm64(SECS_PER_MINUTE)); i64_rem_s;
                 });
             }
             "now" => {
@@ -227,34 +228,34 @@ impl FuncCompiler<'_> {
                 // alloc returns (8n+4), need 8-byte aligned for i64 store.
                 let time_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(ALIGN8_BUF_BYTES); call(self.emitter.rt.alloc);
-                    i32_const(ALIGN8_MASK_LOW); i32_add; i32_const(ALIGN8_MASK_NEG); i32_and;
-                    local_set(time_ptr);
-                    i32_const(0); // clock_id: realtime
-                    i64_const(0); // precision
-                    local_get(time_ptr);
+                    i32_const(Imm32(ALIGN8_BUF_BYTES)); call(self.emitter.rt.alloc);
+                    i32_const(Imm32(ALIGN8_MASK_LOW)); i32_add; i32_const(Imm32(ALIGN8_MASK_NEG)); i32_and;
+                    local_set(Local(time_ptr));
+                    i32_const(Imm32(0)); // clock_id: realtime
+                    i64_const(Imm64(0)); // precision
+                    local_get(Local(time_ptr));
                     call(self.emitter.rt.clock_time_get);
                     drop; // discard error code
                     // Load i64 nanoseconds, convert to seconds
-                    local_get(time_ptr); i64_load(0);
-                    i64_const(NANOS_PER_SEC); i64_div_u;
+                    local_get(Local(time_ptr)); i64_load(0);
+                    i64_const(Imm64(NANOS_PER_SEC)); i64_div_u;
                 });
                 self.scratch.free_i32(time_ptr);
             }
             "add_days" => {
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i64_const(SECS_PER_DAY); i64_mul; i64_add; });
+                wasm!(self.func, { i64_const(Imm64(SECS_PER_DAY)); i64_mul; i64_add; });
             }
             "add_hours" => {
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i64_const(SECS_PER_HOUR); i64_mul; i64_add; });
+                wasm!(self.func, { i64_const(Imm64(SECS_PER_HOUR)); i64_mul; i64_add; });
             }
             "add_minutes" => {
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i64_const(SECS_PER_MINUTE); i64_mul; i64_add; });
+                wasm!(self.func, { i64_const(Imm64(SECS_PER_MINUTE)); i64_mul; i64_add; });
             }
             "add_seconds" => {
                 self.emit_expr(&args[0]);
@@ -282,7 +283,7 @@ impl FuncCompiler<'_> {
             "diff_days" => {
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i64_sub; i64_const(SECS_PER_DAY); i64_div_s; });
+                wasm!(self.func, { i64_sub; i64_const(Imm64(SECS_PER_DAY)); i64_div_s; });
             }
             "format" => {
                 // Stub: return int.to_string(ts), ignore fmt
@@ -296,10 +297,10 @@ impl FuncCompiler<'_> {
                 let ts = self.scratch.alloc_i64();
                 let ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(ts); });
+                wasm!(self.func, { local_set(Local(ts)); });
 
                 wasm!(self.func, {
-                    i32_const(ISO_STRING_LEN); call(self.emitter.rt.string_alloc); local_set(ptr);
+                    i32_const(Imm32(ISO_STRING_LEN)); call(self.emitter.rt.string_alloc); local_set(Local(ptr));
                 });
 
                 let d = self.scratch.alloc_i64();
@@ -315,49 +316,49 @@ impl FuncCompiler<'_> {
                 let se = self.scratch.alloc_i64();
 
                 wasm!(self.func, {
-                    local_get(ts); i64_const(0); i64_ge_s;
+                    local_get(Local(ts)); i64_const(Imm64(0)); i64_ge_s;
                     if_i64;
-                      local_get(ts); i64_const(SECS_PER_DAY); i64_div_s;
+                      local_get(Local(ts)); i64_const(Imm64(SECS_PER_DAY)); i64_div_s;
                     else_;
-                      local_get(ts); i64_const(SECS_PER_DAY_M1); i64_sub; i64_const(SECS_PER_DAY); i64_div_s;
+                      local_get(Local(ts)); i64_const(Imm64(SECS_PER_DAY_M1)); i64_sub; i64_const(Imm64(SECS_PER_DAY)); i64_div_s;
                     end;
-                    local_set(d);
-                    local_get(d); i64_const(JDN_UNIX_EPOCH); i64_add; local_set(d);
-                    local_get(d); i64_const(JDN_INV_C1); i64_add;
-                    i64_const(JDN_LEAP_DIV); local_get(d); i64_mul; i64_const(JDN_INV_C2); i64_add;
-                    i64_const(JDN_DAYS_PER_400YR); i64_div_s; i64_const(JDN_GREG_CORR); i64_mul; i64_const(JDN_LEAP_DIV); i64_div_s;
-                    i64_add; i64_const(JDN_INV_C3); i64_sub; local_set(f);
-                    i64_const(JDN_LEAP_DIV); local_get(f); i64_mul; i64_const(JDN_MONTH_SHIFT); i64_add; local_set(e);
-                    local_get(e); i64_const(JDN_DAYS_PER_4YR); i64_rem_s; i64_const(JDN_LEAP_DIV); i64_div_s; local_set(g);
-                    i64_const(JDN_DAYS_DIV); local_get(g); i64_mul; i64_const(JDN_DAYS_ADJ); i64_add; local_set(h);
-                    local_get(h); i64_const(JDN_DAYS_COEFF); i64_rem_s; i64_const(JDN_DAYS_DIV); i64_div_s; i64_const(1); i64_add; local_set(dy);
-                    local_get(h); i64_const(JDN_DAYS_COEFF); i64_div_s; i64_const(JDN_MONTH_OFS); i64_add;
-                    i64_const(MONTHS_PER_YEAR); i64_rem_s; i64_const(1); i64_add; local_set(mo);
-                    local_get(e); i64_const(JDN_DAYS_PER_4YR); i64_div_s; i64_const(JDN_INV_YEAR_BIAS); i64_sub;
-                    i64_const(JDN_MONTH_ADJ); local_get(mo); i64_sub; i64_const(MONTHS_PER_YEAR); i64_div_s;
-                    i64_add; local_set(yr);
-                    local_get(ts); i64_const(SECS_PER_DAY); i64_rem_s; i64_const(SECS_PER_DAY); i64_add; i64_const(SECS_PER_DAY); i64_rem_s;
-                    local_set(d);
-                    local_get(d); i64_const(SECS_PER_HOUR); i64_div_s; local_set(hr);
-                    local_get(d); i64_const(SECS_PER_HOUR); i64_rem_s; i64_const(SECS_PER_MINUTE); i64_div_s; local_set(mi);
-                    local_get(d); i64_const(SECS_PER_MINUTE); i64_rem_s; local_set(se);
+                    local_set(Local(d));
+                    local_get(Local(d)); i64_const(Imm64(JDN_UNIX_EPOCH)); i64_add; local_set(Local(d));
+                    local_get(Local(d)); i64_const(Imm64(JDN_INV_C1)); i64_add;
+                    i64_const(Imm64(JDN_LEAP_DIV)); local_get(Local(d)); i64_mul; i64_const(Imm64(JDN_INV_C2)); i64_add;
+                    i64_const(Imm64(JDN_DAYS_PER_400YR)); i64_div_s; i64_const(Imm64(JDN_GREG_CORR)); i64_mul; i64_const(Imm64(JDN_LEAP_DIV)); i64_div_s;
+                    i64_add; i64_const(Imm64(JDN_INV_C3)); i64_sub; local_set(Local(f));
+                    i64_const(Imm64(JDN_LEAP_DIV)); local_get(Local(f)); i64_mul; i64_const(Imm64(JDN_MONTH_SHIFT)); i64_add; local_set(Local(e));
+                    local_get(Local(e)); i64_const(Imm64(JDN_DAYS_PER_4YR)); i64_rem_s; i64_const(Imm64(JDN_LEAP_DIV)); i64_div_s; local_set(Local(g));
+                    i64_const(Imm64(JDN_DAYS_DIV)); local_get(Local(g)); i64_mul; i64_const(Imm64(JDN_DAYS_ADJ)); i64_add; local_set(Local(h));
+                    local_get(Local(h)); i64_const(Imm64(JDN_DAYS_COEFF)); i64_rem_s; i64_const(Imm64(JDN_DAYS_DIV)); i64_div_s; i64_const(Imm64(1)); i64_add; local_set(Local(dy));
+                    local_get(Local(h)); i64_const(Imm64(JDN_DAYS_COEFF)); i64_div_s; i64_const(Imm64(JDN_MONTH_OFS)); i64_add;
+                    i64_const(Imm64(MONTHS_PER_YEAR)); i64_rem_s; i64_const(Imm64(1)); i64_add; local_set(Local(mo));
+                    local_get(Local(e)); i64_const(Imm64(JDN_DAYS_PER_4YR)); i64_div_s; i64_const(Imm64(JDN_INV_YEAR_BIAS)); i64_sub;
+                    i64_const(Imm64(JDN_MONTH_ADJ)); local_get(Local(mo)); i64_sub; i64_const(Imm64(MONTHS_PER_YEAR)); i64_div_s;
+                    i64_add; local_set(Local(yr));
+                    local_get(Local(ts)); i64_const(Imm64(SECS_PER_DAY)); i64_rem_s; i64_const(Imm64(SECS_PER_DAY)); i64_add; i64_const(Imm64(SECS_PER_DAY)); i64_rem_s;
+                    local_set(Local(d));
+                    local_get(Local(d)); i64_const(Imm64(SECS_PER_HOUR)); i64_div_s; local_set(Local(hr));
+                    local_get(Local(d)); i64_const(Imm64(SECS_PER_HOUR)); i64_rem_s; i64_const(Imm64(SECS_PER_MINUTE)); i64_div_s; local_set(Local(mi));
+                    local_get(Local(d)); i64_const(Imm64(SECS_PER_MINUTE)); i64_rem_s; local_set(Local(se));
                 });
 
                 let d_off = self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA);
                 self.emit_write_decimal_digits(ptr, d_off, yr, 4);        // YYYY
-                wasm!(self.func, { local_get(ptr); i32_const(ASCII_HYPHEN); i32_store8(d_off + 4); }); // -
+                wasm!(self.func, { local_get(Local(ptr)); i32_const(Imm32(ASCII_HYPHEN)); i32_store8(d_off + 4); }); // -
                 self.emit_write_decimal_digits(ptr, d_off + 5, mo, 2);    // MM
-                wasm!(self.func, { local_get(ptr); i32_const(ASCII_HYPHEN); i32_store8(d_off + 7); }); // -
+                wasm!(self.func, { local_get(Local(ptr)); i32_const(Imm32(ASCII_HYPHEN)); i32_store8(d_off + 7); }); // -
                 self.emit_write_decimal_digits(ptr, d_off + 8, dy, 2);    // DD
-                wasm!(self.func, { local_get(ptr); i32_const(ASCII_T); i32_store8(d_off + 10); }); // T
+                wasm!(self.func, { local_get(Local(ptr)); i32_const(Imm32(ASCII_T)); i32_store8(d_off + 10); }); // T
                 self.emit_write_decimal_digits(ptr, d_off + 11, hr, 2);   // HH
-                wasm!(self.func, { local_get(ptr); i32_const(ASCII_COLON); i32_store8(d_off + 13); }); // :
+                wasm!(self.func, { local_get(Local(ptr)); i32_const(Imm32(ASCII_COLON)); i32_store8(d_off + 13); }); // :
                 self.emit_write_decimal_digits(ptr, d_off + 14, mi, 2);   // MM
-                wasm!(self.func, { local_get(ptr); i32_const(ASCII_COLON); i32_store8(d_off + 16); }); // :
+                wasm!(self.func, { local_get(Local(ptr)); i32_const(Imm32(ASCII_COLON)); i32_store8(d_off + 16); }); // :
                 self.emit_write_decimal_digits(ptr, d_off + 17, se, 2);   // SS
-                wasm!(self.func, { local_get(ptr); i32_const(ASCII_Z); i32_store8(d_off + 19); }); // Z
+                wasm!(self.func, { local_get(Local(ptr)); i32_const(Imm32(ASCII_Z)); i32_store8(d_off + 19); }); // Z
 
-                wasm!(self.func, { local_get(ptr); });
+                wasm!(self.func, { local_get(Local(ptr)); });
 
                 self.scratch.free_i64(se);
                 self.scratch.free_i64(mi);
@@ -379,17 +380,17 @@ impl FuncCompiler<'_> {
                 let wd = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(ts);
-                    local_get(ts); i64_const(0); i64_ge_s;
+                    local_set(Local(ts));
+                    local_get(Local(ts)); i64_const(Imm64(0)); i64_ge_s;
                     if_i64;
-                      local_get(ts); i64_const(SECS_PER_DAY); i64_div_s;
+                      local_get(Local(ts)); i64_const(Imm64(SECS_PER_DAY)); i64_div_s;
                     else_;
-                      local_get(ts); i64_const(SECS_PER_DAY_M1); i64_sub; i64_const(SECS_PER_DAY); i64_div_s;
+                      local_get(Local(ts)); i64_const(Imm64(SECS_PER_DAY_M1)); i64_sub; i64_const(Imm64(SECS_PER_DAY)); i64_div_s;
                     end;
-                    i64_const(WEEKDAY_EPOCH_OFS); i64_add;
-                    i64_const(DAYS_PER_WEEK); i64_rem_s;
-                    i64_const(DAYS_PER_WEEK); i64_add; i64_const(DAYS_PER_WEEK); i64_rem_s;
-                    local_set(wd);
+                    i64_const(Imm64(WEEKDAY_EPOCH_OFS)); i64_add;
+                    i64_const(Imm64(DAYS_PER_WEEK)); i64_rem_s;
+                    i64_const(Imm64(DAYS_PER_WEEK)); i64_add; i64_const(Imm64(DAYS_PER_WEEK)); i64_rem_s;
+                    local_set(Local(wd));
                 });
 
                 let sun = self.emitter.intern_string("Sunday");
@@ -401,25 +402,25 @@ impl FuncCompiler<'_> {
                 let sat = self.emitter.intern_string("Saturday");
 
                 wasm!(self.func, {
-                    local_get(wd); i64_eqz;
-                    if_i32; i32_const(sun as i32);
+                    local_get(Local(wd)); i64_eqz;
+                    if_i32; i32_const(Imm32(sun as i32));
                     else_;
-                      local_get(wd); i64_const(1); i64_eq;
-                      if_i32; i32_const(mon as i32);
+                      local_get(Local(wd)); i64_const(Imm64(1)); i64_eq;
+                      if_i32; i32_const(Imm32(mon as i32));
                       else_;
-                        local_get(wd); i64_const(WD_TUE); i64_eq;
-                        if_i32; i32_const(tue as i32);
+                        local_get(Local(wd)); i64_const(Imm64(WD_TUE)); i64_eq;
+                        if_i32; i32_const(Imm32(tue as i32));
                         else_;
-                          local_get(wd); i64_const(WD_WED); i64_eq;
-                          if_i32; i32_const(wed as i32);
+                          local_get(Local(wd)); i64_const(Imm64(WD_WED)); i64_eq;
+                          if_i32; i32_const(Imm32(wed as i32));
                           else_;
-                            local_get(wd); i64_const(WD_THU); i64_eq;
-                            if_i32; i32_const(thu as i32);
+                            local_get(Local(wd)); i64_const(Imm64(WD_THU)); i64_eq;
+                            if_i32; i32_const(Imm32(thu as i32));
                             else_;
-                              local_get(wd); i64_const(WD_FRI); i64_eq;
-                              if_i32; i32_const(fri as i32);
+                              local_get(Local(wd)); i64_const(Imm64(WD_FRI)); i64_eq;
+                              if_i32; i32_const(Imm32(fri as i32));
                               else_;
-                                i32_const(sat as i32);
+                                i32_const(Imm32(sat as i32));
                               end;
                             end;
                           end;
@@ -443,16 +444,16 @@ impl FuncCompiler<'_> {
                 let se = self.scratch.alloc_i64();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); });
+                wasm!(self.func, { local_set(Local(s)); });
 
                 let err_msg = self.emitter.intern_string("invalid datetime format");
                 wasm!(self.func, {
-                    local_get(s); i32_load(0); i32_const(ISO_MIN_INPUT_LEN); i32_lt_u;
+                    local_get(Local(s)); i32_load(0); i32_const(Imm32(ISO_MIN_INPUT_LEN)); i32_lt_u;
                     if_i32;
-                      i32_const(RESULT_ERR_ALLOC); call(self.emitter.rt.alloc); local_set(result);
-                      local_get(result); i32_const(1); i32_store(0);
-                      local_get(result); i32_const(err_msg as i32); i32_store(4);
-                      local_get(result);
+                      i32_const(Imm32(RESULT_ERR_ALLOC)); call(self.emitter.rt.alloc); local_set(Local(result));
+                      local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                      local_get(Local(result)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                      local_get(Local(result));
                     else_;
                 });
 
@@ -467,27 +468,27 @@ impl FuncCompiler<'_> {
                 let y = self.scratch.alloc_i64();
                 let m = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    i64_const(JDN_MONTH_ADJ); local_get(mo); i64_sub; i64_const(MONTHS_PER_YEAR); i64_div_s; local_set(a);
-                    local_get(yr); i64_const(JDN_YEAR_BIAS); i64_add; local_get(a); i64_sub; local_set(y);
-                    local_get(mo); i64_const(MONTHS_PER_YEAR); local_get(a); i64_mul; i64_add; i64_const(JDN_MONTH_SHIFT); i64_sub; local_set(m);
-                    local_get(dy);
-                    i64_const(JDN_DAYS_COEFF); local_get(m); i64_mul; i64_const(JDN_DAYS_ADJ); i64_add; i64_const(JDN_DAYS_DIV); i64_div_s; i64_add;
-                    i64_const(DAYS_PER_YEAR); local_get(y); i64_mul; i64_add;
-                    local_get(y); i64_const(JDN_LEAP_DIV); i64_div_s; i64_add;
-                    local_get(y); i64_const(JDN_CENTURY_DIV); i64_div_s; i64_sub;
-                    local_get(y); i64_const(JDN_LEAP_EXCEPTION_DIV); i64_div_s; i64_add;
-                    i64_const(JDN_EPOCH_ADJ); i64_sub;
-                    i64_const(JDN_UNIX_EPOCH); i64_sub;
-                    i64_const(SECS_PER_DAY); i64_mul;
-                    local_get(hr); i64_const(SECS_PER_HOUR); i64_mul; i64_add;
-                    local_get(mi); i64_const(SECS_PER_MINUTE); i64_mul; i64_add;
-                    local_get(se); i64_add;
-                    local_set(yr); // reuse as timestamp
+                    i64_const(Imm64(JDN_MONTH_ADJ)); local_get(Local(mo)); i64_sub; i64_const(Imm64(MONTHS_PER_YEAR)); i64_div_s; local_set(Local(a));
+                    local_get(Local(yr)); i64_const(Imm64(JDN_YEAR_BIAS)); i64_add; local_get(Local(a)); i64_sub; local_set(Local(y));
+                    local_get(Local(mo)); i64_const(Imm64(MONTHS_PER_YEAR)); local_get(Local(a)); i64_mul; i64_add; i64_const(Imm64(JDN_MONTH_SHIFT)); i64_sub; local_set(Local(m));
+                    local_get(Local(dy));
+                    i64_const(Imm64(JDN_DAYS_COEFF)); local_get(Local(m)); i64_mul; i64_const(Imm64(JDN_DAYS_ADJ)); i64_add; i64_const(Imm64(JDN_DAYS_DIV)); i64_div_s; i64_add;
+                    i64_const(Imm64(DAYS_PER_YEAR)); local_get(Local(y)); i64_mul; i64_add;
+                    local_get(Local(y)); i64_const(Imm64(JDN_LEAP_DIV)); i64_div_s; i64_add;
+                    local_get(Local(y)); i64_const(Imm64(JDN_CENTURY_DIV)); i64_div_s; i64_sub;
+                    local_get(Local(y)); i64_const(Imm64(JDN_LEAP_EXCEPTION_DIV)); i64_div_s; i64_add;
+                    i64_const(Imm64(JDN_EPOCH_ADJ)); i64_sub;
+                    i64_const(Imm64(JDN_UNIX_EPOCH)); i64_sub;
+                    i64_const(Imm64(SECS_PER_DAY)); i64_mul;
+                    local_get(Local(hr)); i64_const(Imm64(SECS_PER_HOUR)); i64_mul; i64_add;
+                    local_get(Local(mi)); i64_const(Imm64(SECS_PER_MINUTE)); i64_mul; i64_add;
+                    local_get(Local(se)); i64_add;
+                    local_set(Local(yr)); // reuse as timestamp
                     // Build ok Result: [tag=0:i32][timestamp:i64] = 12 bytes
-                    i32_const(RESULT_OK_ALLOC); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(0); i32_store(0);
-                    local_get(result); local_get(yr); i64_store(4);
-                    local_get(result);
+                    i32_const(Imm32(RESULT_OK_ALLOC)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result)); local_get(Local(yr)); i64_store(4);
+                    local_get(Local(result));
                     end;
                 });
 
@@ -511,15 +512,15 @@ impl FuncCompiler<'_> {
                 // Allocate 16 bytes so we can round up to 8-byte boundary.
                 let time_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(ALIGN8_BUF_BYTES); call(self.emitter.rt.alloc);
-                    i32_const(ALIGN8_MASK_LOW); i32_add; i32_const(ALIGN8_MASK_NEG); i32_and;
-                    local_set(time_ptr);
-                    i32_const(1); // clock_id: monotonic
-                    i64_const(1); // precision: 1ns
-                    local_get(time_ptr);
+                    i32_const(Imm32(ALIGN8_BUF_BYTES)); call(self.emitter.rt.alloc);
+                    i32_const(Imm32(ALIGN8_MASK_LOW)); i32_add; i32_const(Imm32(ALIGN8_MASK_NEG)); i32_and;
+                    local_set(Local(time_ptr));
+                    i32_const(Imm32(1)); // clock_id: monotonic
+                    i64_const(Imm64(1)); // precision: 1ns
+                    local_get(Local(time_ptr));
                     call(self.emitter.rt.clock_time_get);
                     drop; // discard error code
-                    local_get(time_ptr); i64_load(0);
+                    local_get(Local(time_ptr)); i64_load(0);
                 });
                 self.scratch.free_i32(time_ptr);
             }
@@ -534,16 +535,16 @@ impl FuncCompiler<'_> {
     /// Write N decimal digits of an i64 value to a string buffer at a given byte offset.
     pub(super) fn emit_write_decimal_digits(&mut self, ptr: u32, byte_offset: u32, val: u32, num_digits: u32) {
         let tmp = self.scratch.alloc_i64();
-        wasm!(self.func, { local_get(val); local_set(tmp); });
+        wasm!(self.func, { local_get(Local(val)); local_set(Local(tmp)); });
         for i in (0..num_digits).rev() {
             let off = byte_offset + i;
             wasm!(self.func, {
-                local_get(ptr);
-                local_get(tmp); i64_const(DECIMAL_BASE); i64_rem_s;
-                i64_const(ASCII_ZERO); i64_add;
+                local_get(Local(ptr));
+                local_get(Local(tmp)); i64_const(Imm64(DECIMAL_BASE)); i64_rem_s;
+                i64_const(Imm64(ASCII_ZERO)); i64_add;
                 i32_wrap_i64;
                 i32_store8(off);
-                local_get(tmp); i64_const(DECIMAL_BASE); i64_div_s; local_set(tmp);
+                local_get(Local(tmp)); i64_const(Imm64(DECIMAL_BASE)); i64_div_s; local_set(Local(tmp));
             });
         }
         self.scratch.free_i64(tmp);
@@ -552,15 +553,15 @@ impl FuncCompiler<'_> {
     /// Parse N decimal ASCII digits from a string buffer into an i64 local.
     pub(super) fn emit_parse_digits(&mut self, str_local: u32, char_offset: u32, num_digits: u32, dest: u32) {
         let data_off = self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA);
-        wasm!(self.func, { i64_const(0); local_set(dest); });
+        wasm!(self.func, { i64_const(Imm64(0)); local_set(Local(dest)); });
         for i in 0..num_digits {
             let off = data_off + char_offset + i;
             wasm!(self.func, {
-                local_get(dest); i64_const(DECIMAL_BASE); i64_mul;
-                local_get(str_local); i32_load8_u(off);
-                i64_extend_i32_u; i64_const(ASCII_ZERO); i64_sub;
+                local_get(Local(dest)); i64_const(Imm64(DECIMAL_BASE)); i64_mul;
+                local_get(Local(str_local)); i32_load8_u(off);
+                i64_extend_i32_u; i64_const(Imm64(ASCII_ZERO)); i64_sub;
                 i64_add;
-                local_set(dest);
+                local_set(Local(dest));
             });
         }
     }

--- a/crates/almide-codegen/src/emit_wasm/calls_datetime.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_datetime.rs
@@ -6,6 +6,69 @@ use almide_lang::types::Ty;
 use super::values;
 use wasm_encoder::Instruction;
 
+// ── Time unit constants ────────────────────────────────────────────────────────
+const SECS_PER_DAY: i64 = 86400;
+const SECS_PER_DAY_M1: i64 = 86399; // SECS_PER_DAY - 1; used for floor-div of negative timestamps
+const SECS_PER_HOUR: i64 = 3600;
+const SECS_PER_MINUTE: i64 = 60;
+const NANOS_PER_SEC: i64 = 1_000_000_000;
+
+// ── Julian Day Number (forward JDN) constants ─────────────────────────────────
+// Algorithm: a=(14-month)/12, y=year+4800-a, m=month+12*a-3
+// jdn = day + (153*m+2)/5 + 365*y + y/4 - y/100 + y/400 - 32045
+const JDN_MONTH_ADJ: i64 = 14;       // a = (14 - month) / 12
+const MONTHS_PER_YEAR: i64 = 12;
+const JDN_YEAR_BIAS: i64 = 4800;     // y = year + 4800 - a
+const JDN_MONTH_SHIFT: i64 = 3;      // m = month + 12*a - 3
+const JDN_DAYS_COEFF: i64 = 153;     // coefficient in (153*m+2)/5
+const JDN_DAYS_ADJ: i64 = 2;         // addend in (153*m+2)/5
+const JDN_DAYS_DIV: i64 = 5;         // divisor in (153*m+2)/5
+const DAYS_PER_YEAR: i64 = 365;
+const JDN_LEAP_DIV: i64 = 4;         // y/4 leap-year term
+const JDN_CENTURY_DIV: i64 = 100;    // y/100 century term
+const JDN_LEAP_EXCEPTION_DIV: i64 = 400; // y/400 exception term
+const JDN_EPOCH_ADJ: i64 = 32045;    // constant subtracted at end of forward JDN
+const JDN_UNIX_EPOCH: i64 = 2440588; // JDN of 1970-01-01 (Unix epoch)
+
+// ── Inverse JDN (Richards 2013) constants ─────────────────────────────────────
+// Converts JDN back to (year, month, day).
+const JDN_INV_C1: i64 = 1401;        // civil-calendar day offset
+const JDN_INV_C2: i64 = 274277;      // Gregorian correction numerator
+const JDN_DAYS_PER_400YR: i64 = 146097; // days in a 400-year Gregorian cycle
+const JDN_GREG_CORR: i64 = 3;        // factor in Gregorian correction (C2/C3*3/4)
+const JDN_INV_C3: i64 = 38;          // correction offset subtracted after Gregorian step
+const JDN_DAYS_PER_4YR: i64 = 1461;  // days in a 4-year Julian cycle
+const JDN_MONTH_OFS: i64 = 2;        // month-numbering offset in h/153+2
+const JDN_INV_YEAR_BIAS: i64 = 4716; // year bias subtracted in inverse JDN
+
+// ── Weekday constants ─────────────────────────────────────────────────────────
+// 0=Sunday, 1=Monday, 2=Tuesday, 3=Wednesday, 4=Thursday, 5=Friday, 6=Saturday
+const DAYS_PER_WEEK: i64 = 7;
+const WEEKDAY_EPOCH_OFS: i64 = 4;    // Jan 1 1970 was a Thursday (day 4 in 0=Sun scheme)
+const WD_TUE: i64 = 2;
+const WD_WED: i64 = 3;
+const WD_THU: i64 = 4;               // also reused as WEEKDAY_EPOCH_OFS (same day)
+const WD_FRI: i64 = 5;
+
+// ── Decimal digit helpers ─────────────────────────────────────────────────────
+const DECIMAL_BASE: i64 = 10;
+const ASCII_ZERO: i64 = 48;          // '0'; used as i64 for digit encode/decode
+
+// ── ASCII character codes for ISO-8601 separators (i32 for i32_store8) ───────
+const ASCII_HYPHEN: i32 = 45;        // '-'
+const ASCII_COLON: i32 = 58;         // ':'
+const ASCII_T: i32 = 84;             // 'T'
+const ASCII_Z: i32 = 90;             // 'Z'
+
+// ── Memory / allocation sizes ─────────────────────────────────────────────────
+const ISO_STRING_LEN: i32 = 20;      // byte length of "YYYY-MM-DDTHH:MM:SSZ"
+const ISO_MIN_INPUT_LEN: i32 = 19;   // minimum i32_load(0) check for parse_iso
+const RESULT_ERR_ALLOC: i32 = 8;     // bytes for Err Result: [tag:i32][ptr:i32]
+const RESULT_OK_ALLOC: i32 = 12;     // bytes for Ok Result: [tag:i32][timestamp:i64]
+const ALIGN8_BUF_BYTES: i32 = 16;    // allocation buf to guarantee 8-byte alignment
+const ALIGN8_MASK_LOW: i32 = 7;      // round-up addend: ptr + 7 & -8
+const ALIGN8_MASK_NEG: i32 = -8;     // alignment mask (0xFFFFFFF8)
+
 impl FuncCompiler<'_> {
     pub(super) fn emit_datetime_call(&mut self, func: &str, args: &[IrExpr]) {
         match func {
@@ -38,25 +101,25 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { local_set(second); });
 
                 wasm!(self.func, {
-                    i64_const(14); local_get(month); i64_sub; i64_const(12); i64_div_s; local_set(a);
-                    local_get(year); i64_const(4800); i64_add; local_get(a); i64_sub; local_set(y);
-                    local_get(month); i64_const(12); local_get(a); i64_mul; i64_add; i64_const(3); i64_sub; local_set(m);
+                    i64_const(JDN_MONTH_ADJ); local_get(month); i64_sub; i64_const(MONTHS_PER_YEAR); i64_div_s; local_set(a);
+                    local_get(year); i64_const(JDN_YEAR_BIAS); i64_add; local_get(a); i64_sub; local_set(y);
+                    local_get(month); i64_const(MONTHS_PER_YEAR); local_get(a); i64_mul; i64_add; i64_const(JDN_MONTH_SHIFT); i64_sub; local_set(m);
                     local_get(day);
-                    i64_const(153); local_get(m); i64_mul; i64_const(2); i64_add; i64_const(5); i64_div_s;
+                    i64_const(JDN_DAYS_COEFF); local_get(m); i64_mul; i64_const(JDN_DAYS_ADJ); i64_add; i64_const(JDN_DAYS_DIV); i64_div_s;
                     i64_add;
-                    i64_const(365); local_get(y); i64_mul;
+                    i64_const(DAYS_PER_YEAR); local_get(y); i64_mul;
                     i64_add;
-                    local_get(y); i64_const(4); i64_div_s;
+                    local_get(y); i64_const(JDN_LEAP_DIV); i64_div_s;
                     i64_add;
-                    local_get(y); i64_const(100); i64_div_s;
+                    local_get(y); i64_const(JDN_CENTURY_DIV); i64_div_s;
                     i64_sub;
-                    local_get(y); i64_const(400); i64_div_s;
+                    local_get(y); i64_const(JDN_LEAP_EXCEPTION_DIV); i64_div_s;
                     i64_add;
-                    i64_const(32045); i64_sub;
-                    i64_const(2440588); i64_sub;
-                    i64_const(86400); i64_mul;
-                    local_get(hour); i64_const(3600); i64_mul; i64_add;
-                    local_get(minute); i64_const(60); i64_mul; i64_add;
+                    i64_const(JDN_EPOCH_ADJ); i64_sub;
+                    i64_const(JDN_UNIX_EPOCH); i64_sub;
+                    i64_const(SECS_PER_DAY); i64_mul;
+                    local_get(hour); i64_const(SECS_PER_HOUR); i64_mul; i64_add;
+                    local_get(minute); i64_const(SECS_PER_MINUTE); i64_mul; i64_add;
                     local_get(second); i64_add;
                 });
 
@@ -82,45 +145,45 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(ts);
-                    // floor(ts / 86400)
+                    // floor(ts / SECS_PER_DAY)
                     local_get(ts); i64_const(0); i64_ge_s;
                     if_i64;
-                      local_get(ts); i64_const(86400); i64_div_s;
+                      local_get(ts); i64_const(SECS_PER_DAY); i64_div_s;
                     else_;
-                      local_get(ts); i64_const(86399); i64_sub; i64_const(86400); i64_div_s;
+                      local_get(ts); i64_const(SECS_PER_DAY_M1); i64_sub; i64_const(SECS_PER_DAY); i64_div_s;
                     end;
                     local_set(d);
-                    local_get(d); i64_const(2440588); i64_add; local_set(d);
-                    local_get(d); i64_const(1401); i64_add;
-                    i64_const(4); local_get(d); i64_mul; i64_const(274277); i64_add;
-                    i64_const(146097); i64_div_s; i64_const(3); i64_mul; i64_const(4); i64_div_s;
-                    i64_add; i64_const(38); i64_sub;
+                    local_get(d); i64_const(JDN_UNIX_EPOCH); i64_add; local_set(d);
+                    local_get(d); i64_const(JDN_INV_C1); i64_add;
+                    i64_const(JDN_LEAP_DIV); local_get(d); i64_mul; i64_const(JDN_INV_C2); i64_add;
+                    i64_const(JDN_DAYS_PER_400YR); i64_div_s; i64_const(JDN_GREG_CORR); i64_mul; i64_const(JDN_LEAP_DIV); i64_div_s;
+                    i64_add; i64_const(JDN_INV_C3); i64_sub;
                     local_set(f);
-                    i64_const(4); local_get(f); i64_mul; i64_const(3); i64_add; local_set(e);
-                    local_get(e); i64_const(1461); i64_rem_s; i64_const(4); i64_div_s; local_set(g);
-                    i64_const(5); local_get(g); i64_mul; i64_const(2); i64_add; local_set(h);
+                    i64_const(JDN_LEAP_DIV); local_get(f); i64_mul; i64_const(JDN_MONTH_SHIFT); i64_add; local_set(e);
+                    local_get(e); i64_const(JDN_DAYS_PER_4YR); i64_rem_s; i64_const(JDN_LEAP_DIV); i64_div_s; local_set(g);
+                    i64_const(JDN_DAYS_DIV); local_get(g); i64_mul; i64_const(JDN_DAYS_ADJ); i64_add; local_set(h);
                 });
 
                 match func {
                     "day" => {
                         wasm!(self.func, {
-                            local_get(h); i64_const(153); i64_rem_s; i64_const(5); i64_div_s; i64_const(1); i64_add;
+                            local_get(h); i64_const(JDN_DAYS_COEFF); i64_rem_s; i64_const(JDN_DAYS_DIV); i64_div_s; i64_const(1); i64_add;
                         });
                     }
                     "month" => {
                         wasm!(self.func, {
-                            local_get(h); i64_const(153); i64_div_s; i64_const(2); i64_add;
-                            i64_const(12); i64_rem_s; i64_const(1); i64_add;
+                            local_get(h); i64_const(JDN_DAYS_COEFF); i64_div_s; i64_const(JDN_MONTH_OFS); i64_add;
+                            i64_const(MONTHS_PER_YEAR); i64_rem_s; i64_const(1); i64_add;
                         });
                     }
                     "year" => {
                         let mm = self.scratch.alloc_i64();
                         wasm!(self.func, {
-                            local_get(h); i64_const(153); i64_div_s; i64_const(2); i64_add;
-                            i64_const(12); i64_rem_s; i64_const(1); i64_add;
+                            local_get(h); i64_const(JDN_DAYS_COEFF); i64_div_s; i64_const(JDN_MONTH_OFS); i64_add;
+                            i64_const(MONTHS_PER_YEAR); i64_rem_s; i64_const(1); i64_add;
                             local_set(mm);
-                            local_get(e); i64_const(1461); i64_div_s; i64_const(4716); i64_sub;
-                            i64_const(14); local_get(mm); i64_sub; i64_const(12); i64_div_s;
+                            local_get(e); i64_const(JDN_DAYS_PER_4YR); i64_div_s; i64_const(JDN_INV_YEAR_BIAS); i64_sub;
+                            i64_const(JDN_MONTH_ADJ); local_get(mm); i64_sub; i64_const(MONTHS_PER_YEAR); i64_div_s;
                             i64_add;
                         });
                         self.scratch.free_i64(mm);
@@ -138,24 +201,24 @@ impl FuncCompiler<'_> {
             "hour" => {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i64_const(86400); i64_rem_s;
-                    i64_const(86400); i64_add; i64_const(86400); i64_rem_s;
-                    i64_const(3600); i64_div_s;
+                    i64_const(SECS_PER_DAY); i64_rem_s;
+                    i64_const(SECS_PER_DAY); i64_add; i64_const(SECS_PER_DAY); i64_rem_s;
+                    i64_const(SECS_PER_HOUR); i64_div_s;
                 });
             }
             "minute" => {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i64_const(3600); i64_rem_s;
-                    i64_const(3600); i64_add; i64_const(3600); i64_rem_s;
-                    i64_const(60); i64_div_s;
+                    i64_const(SECS_PER_HOUR); i64_rem_s;
+                    i64_const(SECS_PER_HOUR); i64_add; i64_const(SECS_PER_HOUR); i64_rem_s;
+                    i64_const(SECS_PER_MINUTE); i64_div_s;
                 });
             }
             "second" => {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i64_const(60); i64_rem_s;
-                    i64_const(60); i64_add; i64_const(60); i64_rem_s;
+                    i64_const(SECS_PER_MINUTE); i64_rem_s;
+                    i64_const(SECS_PER_MINUTE); i64_add; i64_const(SECS_PER_MINUTE); i64_rem_s;
                 });
             }
             "now" => {
@@ -164,8 +227,8 @@ impl FuncCompiler<'_> {
                 // alloc returns (8n+4), need 8-byte aligned for i64 store.
                 let time_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(16); call(self.emitter.rt.alloc);
-                    i32_const(7); i32_add; i32_const(-8); i32_and;
+                    i32_const(ALIGN8_BUF_BYTES); call(self.emitter.rt.alloc);
+                    i32_const(ALIGN8_MASK_LOW); i32_add; i32_const(ALIGN8_MASK_NEG); i32_and;
                     local_set(time_ptr);
                     i32_const(0); // clock_id: realtime
                     i64_const(0); // precision
@@ -174,24 +237,24 @@ impl FuncCompiler<'_> {
                     drop; // discard error code
                     // Load i64 nanoseconds, convert to seconds
                     local_get(time_ptr); i64_load(0);
-                    i64_const(1000000000); i64_div_u;
+                    i64_const(NANOS_PER_SEC); i64_div_u;
                 });
                 self.scratch.free_i32(time_ptr);
             }
             "add_days" => {
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i64_const(86400); i64_mul; i64_add; });
+                wasm!(self.func, { i64_const(SECS_PER_DAY); i64_mul; i64_add; });
             }
             "add_hours" => {
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i64_const(3600); i64_mul; i64_add; });
+                wasm!(self.func, { i64_const(SECS_PER_HOUR); i64_mul; i64_add; });
             }
             "add_minutes" => {
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i64_const(60); i64_mul; i64_add; });
+                wasm!(self.func, { i64_const(SECS_PER_MINUTE); i64_mul; i64_add; });
             }
             "add_seconds" => {
                 self.emit_expr(&args[0]);
@@ -219,7 +282,7 @@ impl FuncCompiler<'_> {
             "diff_days" => {
                 self.emit_expr(&args[0]);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i64_sub; i64_const(86400); i64_div_s; });
+                wasm!(self.func, { i64_sub; i64_const(SECS_PER_DAY); i64_div_s; });
             }
             "format" => {
                 // Stub: return int.to_string(ts), ignore fmt
@@ -236,7 +299,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { local_set(ts); });
 
                 wasm!(self.func, {
-                    i32_const(20); call(self.emitter.rt.string_alloc); local_set(ptr);
+                    i32_const(ISO_STRING_LEN); call(self.emitter.rt.string_alloc); local_set(ptr);
                 });
 
                 let d = self.scratch.alloc_i64();
@@ -254,45 +317,45 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_get(ts); i64_const(0); i64_ge_s;
                     if_i64;
-                      local_get(ts); i64_const(86400); i64_div_s;
+                      local_get(ts); i64_const(SECS_PER_DAY); i64_div_s;
                     else_;
-                      local_get(ts); i64_const(86399); i64_sub; i64_const(86400); i64_div_s;
+                      local_get(ts); i64_const(SECS_PER_DAY_M1); i64_sub; i64_const(SECS_PER_DAY); i64_div_s;
                     end;
                     local_set(d);
-                    local_get(d); i64_const(2440588); i64_add; local_set(d);
-                    local_get(d); i64_const(1401); i64_add;
-                    i64_const(4); local_get(d); i64_mul; i64_const(274277); i64_add;
-                    i64_const(146097); i64_div_s; i64_const(3); i64_mul; i64_const(4); i64_div_s;
-                    i64_add; i64_const(38); i64_sub; local_set(f);
-                    i64_const(4); local_get(f); i64_mul; i64_const(3); i64_add; local_set(e);
-                    local_get(e); i64_const(1461); i64_rem_s; i64_const(4); i64_div_s; local_set(g);
-                    i64_const(5); local_get(g); i64_mul; i64_const(2); i64_add; local_set(h);
-                    local_get(h); i64_const(153); i64_rem_s; i64_const(5); i64_div_s; i64_const(1); i64_add; local_set(dy);
-                    local_get(h); i64_const(153); i64_div_s; i64_const(2); i64_add;
-                    i64_const(12); i64_rem_s; i64_const(1); i64_add; local_set(mo);
-                    local_get(e); i64_const(1461); i64_div_s; i64_const(4716); i64_sub;
-                    i64_const(14); local_get(mo); i64_sub; i64_const(12); i64_div_s;
+                    local_get(d); i64_const(JDN_UNIX_EPOCH); i64_add; local_set(d);
+                    local_get(d); i64_const(JDN_INV_C1); i64_add;
+                    i64_const(JDN_LEAP_DIV); local_get(d); i64_mul; i64_const(JDN_INV_C2); i64_add;
+                    i64_const(JDN_DAYS_PER_400YR); i64_div_s; i64_const(JDN_GREG_CORR); i64_mul; i64_const(JDN_LEAP_DIV); i64_div_s;
+                    i64_add; i64_const(JDN_INV_C3); i64_sub; local_set(f);
+                    i64_const(JDN_LEAP_DIV); local_get(f); i64_mul; i64_const(JDN_MONTH_SHIFT); i64_add; local_set(e);
+                    local_get(e); i64_const(JDN_DAYS_PER_4YR); i64_rem_s; i64_const(JDN_LEAP_DIV); i64_div_s; local_set(g);
+                    i64_const(JDN_DAYS_DIV); local_get(g); i64_mul; i64_const(JDN_DAYS_ADJ); i64_add; local_set(h);
+                    local_get(h); i64_const(JDN_DAYS_COEFF); i64_rem_s; i64_const(JDN_DAYS_DIV); i64_div_s; i64_const(1); i64_add; local_set(dy);
+                    local_get(h); i64_const(JDN_DAYS_COEFF); i64_div_s; i64_const(JDN_MONTH_OFS); i64_add;
+                    i64_const(MONTHS_PER_YEAR); i64_rem_s; i64_const(1); i64_add; local_set(mo);
+                    local_get(e); i64_const(JDN_DAYS_PER_4YR); i64_div_s; i64_const(JDN_INV_YEAR_BIAS); i64_sub;
+                    i64_const(JDN_MONTH_ADJ); local_get(mo); i64_sub; i64_const(MONTHS_PER_YEAR); i64_div_s;
                     i64_add; local_set(yr);
-                    local_get(ts); i64_const(86400); i64_rem_s; i64_const(86400); i64_add; i64_const(86400); i64_rem_s;
+                    local_get(ts); i64_const(SECS_PER_DAY); i64_rem_s; i64_const(SECS_PER_DAY); i64_add; i64_const(SECS_PER_DAY); i64_rem_s;
                     local_set(d);
-                    local_get(d); i64_const(3600); i64_div_s; local_set(hr);
-                    local_get(d); i64_const(3600); i64_rem_s; i64_const(60); i64_div_s; local_set(mi);
-                    local_get(d); i64_const(60); i64_rem_s; local_set(se);
+                    local_get(d); i64_const(SECS_PER_HOUR); i64_div_s; local_set(hr);
+                    local_get(d); i64_const(SECS_PER_HOUR); i64_rem_s; i64_const(SECS_PER_MINUTE); i64_div_s; local_set(mi);
+                    local_get(d); i64_const(SECS_PER_MINUTE); i64_rem_s; local_set(se);
                 });
 
                 let d_off = self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA);
                 self.emit_write_decimal_digits(ptr, d_off, yr, 4);        // YYYY
-                wasm!(self.func, { local_get(ptr); i32_const(45); i32_store8(d_off + 4); }); // -
+                wasm!(self.func, { local_get(ptr); i32_const(ASCII_HYPHEN); i32_store8(d_off + 4); }); // -
                 self.emit_write_decimal_digits(ptr, d_off + 5, mo, 2);    // MM
-                wasm!(self.func, { local_get(ptr); i32_const(45); i32_store8(d_off + 7); }); // -
+                wasm!(self.func, { local_get(ptr); i32_const(ASCII_HYPHEN); i32_store8(d_off + 7); }); // -
                 self.emit_write_decimal_digits(ptr, d_off + 8, dy, 2);    // DD
-                wasm!(self.func, { local_get(ptr); i32_const(84); i32_store8(d_off + 10); }); // T
+                wasm!(self.func, { local_get(ptr); i32_const(ASCII_T); i32_store8(d_off + 10); }); // T
                 self.emit_write_decimal_digits(ptr, d_off + 11, hr, 2);   // HH
-                wasm!(self.func, { local_get(ptr); i32_const(58); i32_store8(d_off + 13); }); // :
+                wasm!(self.func, { local_get(ptr); i32_const(ASCII_COLON); i32_store8(d_off + 13); }); // :
                 self.emit_write_decimal_digits(ptr, d_off + 14, mi, 2);   // MM
-                wasm!(self.func, { local_get(ptr); i32_const(58); i32_store8(d_off + 16); }); // :
+                wasm!(self.func, { local_get(ptr); i32_const(ASCII_COLON); i32_store8(d_off + 16); }); // :
                 self.emit_write_decimal_digits(ptr, d_off + 17, se, 2);   // SS
-                wasm!(self.func, { local_get(ptr); i32_const(90); i32_store8(d_off + 19); }); // Z
+                wasm!(self.func, { local_get(ptr); i32_const(ASCII_Z); i32_store8(d_off + 19); }); // Z
 
                 wasm!(self.func, { local_get(ptr); });
 
@@ -319,13 +382,13 @@ impl FuncCompiler<'_> {
                     local_set(ts);
                     local_get(ts); i64_const(0); i64_ge_s;
                     if_i64;
-                      local_get(ts); i64_const(86400); i64_div_s;
+                      local_get(ts); i64_const(SECS_PER_DAY); i64_div_s;
                     else_;
-                      local_get(ts); i64_const(86399); i64_sub; i64_const(86400); i64_div_s;
+                      local_get(ts); i64_const(SECS_PER_DAY_M1); i64_sub; i64_const(SECS_PER_DAY); i64_div_s;
                     end;
-                    i64_const(4); i64_add;
-                    i64_const(7); i64_rem_s;
-                    i64_const(7); i64_add; i64_const(7); i64_rem_s;
+                    i64_const(WEEKDAY_EPOCH_OFS); i64_add;
+                    i64_const(DAYS_PER_WEEK); i64_rem_s;
+                    i64_const(DAYS_PER_WEEK); i64_add; i64_const(DAYS_PER_WEEK); i64_rem_s;
                     local_set(wd);
                 });
 
@@ -344,16 +407,16 @@ impl FuncCompiler<'_> {
                       local_get(wd); i64_const(1); i64_eq;
                       if_i32; i32_const(mon as i32);
                       else_;
-                        local_get(wd); i64_const(2); i64_eq;
+                        local_get(wd); i64_const(WD_TUE); i64_eq;
                         if_i32; i32_const(tue as i32);
                         else_;
-                          local_get(wd); i64_const(3); i64_eq;
+                          local_get(wd); i64_const(WD_WED); i64_eq;
                           if_i32; i32_const(wed as i32);
                           else_;
-                            local_get(wd); i64_const(4); i64_eq;
+                            local_get(wd); i64_const(WD_THU); i64_eq;
                             if_i32; i32_const(thu as i32);
                             else_;
-                              local_get(wd); i64_const(5); i64_eq;
+                              local_get(wd); i64_const(WD_FRI); i64_eq;
                               if_i32; i32_const(fri as i32);
                               else_;
                                 i32_const(sat as i32);
@@ -384,9 +447,9 @@ impl FuncCompiler<'_> {
 
                 let err_msg = self.emitter.intern_string("invalid datetime format");
                 wasm!(self.func, {
-                    local_get(s); i32_load(0); i32_const(19); i32_lt_u;
+                    local_get(s); i32_load(0); i32_const(ISO_MIN_INPUT_LEN); i32_lt_u;
                     if_i32;
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                      i32_const(RESULT_ERR_ALLOC); call(self.emitter.rt.alloc); local_set(result);
                       local_get(result); i32_const(1); i32_store(0);
                       local_get(result); i32_const(err_msg as i32); i32_store(4);
                       local_get(result);
@@ -404,24 +467,24 @@ impl FuncCompiler<'_> {
                 let y = self.scratch.alloc_i64();
                 let m = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    i64_const(14); local_get(mo); i64_sub; i64_const(12); i64_div_s; local_set(a);
-                    local_get(yr); i64_const(4800); i64_add; local_get(a); i64_sub; local_set(y);
-                    local_get(mo); i64_const(12); local_get(a); i64_mul; i64_add; i64_const(3); i64_sub; local_set(m);
+                    i64_const(JDN_MONTH_ADJ); local_get(mo); i64_sub; i64_const(MONTHS_PER_YEAR); i64_div_s; local_set(a);
+                    local_get(yr); i64_const(JDN_YEAR_BIAS); i64_add; local_get(a); i64_sub; local_set(y);
+                    local_get(mo); i64_const(MONTHS_PER_YEAR); local_get(a); i64_mul; i64_add; i64_const(JDN_MONTH_SHIFT); i64_sub; local_set(m);
                     local_get(dy);
-                    i64_const(153); local_get(m); i64_mul; i64_const(2); i64_add; i64_const(5); i64_div_s; i64_add;
-                    i64_const(365); local_get(y); i64_mul; i64_add;
-                    local_get(y); i64_const(4); i64_div_s; i64_add;
-                    local_get(y); i64_const(100); i64_div_s; i64_sub;
-                    local_get(y); i64_const(400); i64_div_s; i64_add;
-                    i64_const(32045); i64_sub;
-                    i64_const(2440588); i64_sub;
-                    i64_const(86400); i64_mul;
-                    local_get(hr); i64_const(3600); i64_mul; i64_add;
-                    local_get(mi); i64_const(60); i64_mul; i64_add;
+                    i64_const(JDN_DAYS_COEFF); local_get(m); i64_mul; i64_const(JDN_DAYS_ADJ); i64_add; i64_const(JDN_DAYS_DIV); i64_div_s; i64_add;
+                    i64_const(DAYS_PER_YEAR); local_get(y); i64_mul; i64_add;
+                    local_get(y); i64_const(JDN_LEAP_DIV); i64_div_s; i64_add;
+                    local_get(y); i64_const(JDN_CENTURY_DIV); i64_div_s; i64_sub;
+                    local_get(y); i64_const(JDN_LEAP_EXCEPTION_DIV); i64_div_s; i64_add;
+                    i64_const(JDN_EPOCH_ADJ); i64_sub;
+                    i64_const(JDN_UNIX_EPOCH); i64_sub;
+                    i64_const(SECS_PER_DAY); i64_mul;
+                    local_get(hr); i64_const(SECS_PER_HOUR); i64_mul; i64_add;
+                    local_get(mi); i64_const(SECS_PER_MINUTE); i64_mul; i64_add;
                     local_get(se); i64_add;
                     local_set(yr); // reuse as timestamp
                     // Build ok Result: [tag=0:i32][timestamp:i64] = 12 bytes
-                    i32_const(12); call(self.emitter.rt.alloc); local_set(result);
+                    i32_const(RESULT_OK_ALLOC); call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); i32_const(0); i32_store(0);
                     local_get(result); local_get(yr); i64_store(4);
                     local_get(result);
@@ -448,8 +511,8 @@ impl FuncCompiler<'_> {
                 // Allocate 16 bytes so we can round up to 8-byte boundary.
                 let time_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(16); call(self.emitter.rt.alloc);
-                    i32_const(7); i32_add; i32_const(-8); i32_and;
+                    i32_const(ALIGN8_BUF_BYTES); call(self.emitter.rt.alloc);
+                    i32_const(ALIGN8_MASK_LOW); i32_add; i32_const(ALIGN8_MASK_NEG); i32_and;
                     local_set(time_ptr);
                     i32_const(1); // clock_id: monotonic
                     i64_const(1); // precision: 1ns
@@ -476,11 +539,11 @@ impl FuncCompiler<'_> {
             let off = byte_offset + i;
             wasm!(self.func, {
                 local_get(ptr);
-                local_get(tmp); i64_const(10); i64_rem_s;
-                i64_const(48); i64_add;
+                local_get(tmp); i64_const(DECIMAL_BASE); i64_rem_s;
+                i64_const(ASCII_ZERO); i64_add;
                 i32_wrap_i64;
                 i32_store8(off);
-                local_get(tmp); i64_const(10); i64_div_s; local_set(tmp);
+                local_get(tmp); i64_const(DECIMAL_BASE); i64_div_s; local_set(tmp);
             });
         }
         self.scratch.free_i64(tmp);
@@ -493,9 +556,9 @@ impl FuncCompiler<'_> {
         for i in 0..num_digits {
             let off = data_off + char_offset + i;
             wasm!(self.func, {
-                local_get(dest); i64_const(10); i64_mul;
+                local_get(dest); i64_const(DECIMAL_BASE); i64_mul;
                 local_get(str_local); i32_load8_u(off);
-                i64_extend_i32_u; i64_const(48); i64_sub;
+                i64_extend_i32_u; i64_const(ASCII_ZERO); i64_sub;
                 i64_add;
                 local_set(dest);
             });

--- a/crates/almide-codegen/src/emit_wasm/calls_env.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_env.rs
@@ -6,6 +6,20 @@ use almide_lang::types::Ty;
 use super::values;
 use wasm_encoder::Instruction;
 
+// ── Immediate constants used by env WASM emit ─────────────────────────────
+/// Byte size of a single i32 value; used to alloc the len field of an empty list.
+const I32_BYTES: i32 = 4;
+/// Scratch buffer size for a WASI clock_time_get i64 result (over-alloc for alignment).
+const CLOCK_BUF_ALLOC_BYTES: i32 = 16;
+/// Low bits that must be zero for 8-byte alignment (round-up mask: add this, then AND with ALIGN8_NEG_MASK).
+const ALIGN8_MASK: i32 = 7;
+/// AND mask that clears the low 3 bits, aligning a pointer down to an 8-byte boundary.
+const ALIGN8_NEG_MASK: i32 = -8;
+/// Nanoseconds in one second; divides a WASI nanosecond timestamp to produce Unix seconds.
+const NANOS_PER_SEC: i64 = 1_000_000_000;
+/// Nanoseconds in one millisecond; divides a WASI nanosecond timestamp to produce milliseconds.
+const NANOS_PER_MILLI: i64 = 1_000_000;
+
 impl FuncCompiler<'_> {
     pub(super) fn emit_env_call(&mut self, func: &str, args: &[IrExpr]) {
         match func {
@@ -13,7 +27,7 @@ impl FuncCompiler<'_> {
                 // env.args() → List[String]: return empty list (WASI args not implemented yet)
                 let s = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc); local_set(s);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(s);
                     local_get(s); i32_const(0); i32_store(0);
                     local_get(s);
                 });
@@ -25,8 +39,8 @@ impl FuncCompiler<'_> {
                 // alloc returns (8n+4), need 8-byte aligned for i64 store.
                 let time_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(16); call(self.emitter.rt.alloc);
-                    i32_const(7); i32_add; i32_const(-8); i32_and;
+                    i32_const(CLOCK_BUF_ALLOC_BYTES); call(self.emitter.rt.alloc);
+                    i32_const(ALIGN8_MASK); i32_add; i32_const(ALIGN8_NEG_MASK); i32_and;
                     local_set(time_ptr);
                     i32_const(0); // clock_id: realtime
                     i64_const(0); // precision
@@ -34,7 +48,7 @@ impl FuncCompiler<'_> {
                     call(self.emitter.rt.clock_time_get);
                     drop; // discard error code
                     local_get(time_ptr); i64_load(0);
-                    i64_const(1000000000); i64_div_u;
+                    i64_const(NANOS_PER_SEC); i64_div_u;
                 });
                 self.scratch.free_i32(time_ptr);
             }
@@ -44,8 +58,8 @@ impl FuncCompiler<'_> {
                 // alloc returns (8n+4), need 8-byte aligned for i64 store.
                 let time_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(16); call(self.emitter.rt.alloc);
-                    i32_const(7); i32_add; i32_const(-8); i32_and;
+                    i32_const(CLOCK_BUF_ALLOC_BYTES); call(self.emitter.rt.alloc);
+                    i32_const(ALIGN8_MASK); i32_add; i32_const(ALIGN8_NEG_MASK); i32_and;
                     local_set(time_ptr);
                     i32_const(0); // clock_id: realtime
                     i64_const(0); // precision
@@ -53,7 +67,7 @@ impl FuncCompiler<'_> {
                     call(self.emitter.rt.clock_time_get);
                     drop; // discard error code
                     local_get(time_ptr); i64_load(0);
-                    i64_const(1000000); i64_div_u;
+                    i64_const(NANOS_PER_MILLI); i64_div_u;
                 });
                 self.scratch.free_i32(time_ptr);
             }

--- a/crates/almide-codegen/src/emit_wasm/calls_env.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_env.rs
@@ -1,5 +1,6 @@
 //! env module: environment access — WASM codegen dispatch.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::FuncCompiler;
 use almide_ir::IrExpr;
 use almide_lang::types::Ty;
@@ -27,9 +28,9 @@ impl FuncCompiler<'_> {
                 // env.args() → List[String]: return empty list (WASI args not implemented yet)
                 let s = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(s);
-                    local_get(s); i32_const(0); i32_store(0);
-                    local_get(s);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc); local_set(Local(s));
+                    local_get(Local(s)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(s));
                 });
                 self.scratch.free_i32(s);
             }
@@ -39,16 +40,16 @@ impl FuncCompiler<'_> {
                 // alloc returns (8n+4), need 8-byte aligned for i64 store.
                 let time_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(CLOCK_BUF_ALLOC_BYTES); call(self.emitter.rt.alloc);
-                    i32_const(ALIGN8_MASK); i32_add; i32_const(ALIGN8_NEG_MASK); i32_and;
-                    local_set(time_ptr);
-                    i32_const(0); // clock_id: realtime
-                    i64_const(0); // precision
-                    local_get(time_ptr);
+                    i32_const(Imm32(CLOCK_BUF_ALLOC_BYTES)); call(self.emitter.rt.alloc);
+                    i32_const(Imm32(ALIGN8_MASK)); i32_add; i32_const(Imm32(ALIGN8_NEG_MASK)); i32_and;
+                    local_set(Local(time_ptr));
+                    i32_const(Imm32(0)); // clock_id: realtime
+                    i64_const(Imm64(0)); // precision
+                    local_get(Local(time_ptr));
                     call(self.emitter.rt.clock_time_get);
                     drop; // discard error code
-                    local_get(time_ptr); i64_load(0);
-                    i64_const(NANOS_PER_SEC); i64_div_u;
+                    local_get(Local(time_ptr)); i64_load(0);
+                    i64_const(Imm64(NANOS_PER_SEC)); i64_div_u;
                 });
                 self.scratch.free_i32(time_ptr);
             }
@@ -58,26 +59,26 @@ impl FuncCompiler<'_> {
                 // alloc returns (8n+4), need 8-byte aligned for i64 store.
                 let time_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(CLOCK_BUF_ALLOC_BYTES); call(self.emitter.rt.alloc);
-                    i32_const(ALIGN8_MASK); i32_add; i32_const(ALIGN8_NEG_MASK); i32_and;
-                    local_set(time_ptr);
-                    i32_const(0); // clock_id: realtime
-                    i64_const(0); // precision
-                    local_get(time_ptr);
+                    i32_const(Imm32(CLOCK_BUF_ALLOC_BYTES)); call(self.emitter.rt.alloc);
+                    i32_const(Imm32(ALIGN8_MASK)); i32_add; i32_const(Imm32(ALIGN8_NEG_MASK)); i32_and;
+                    local_set(Local(time_ptr));
+                    i32_const(Imm32(0)); // clock_id: realtime
+                    i64_const(Imm64(0)); // precision
+                    local_get(Local(time_ptr));
                     call(self.emitter.rt.clock_time_get);
                     drop; // discard error code
-                    local_get(time_ptr); i64_load(0);
-                    i64_const(NANOS_PER_MILLI); i64_div_u;
+                    local_get(Local(time_ptr)); i64_load(0);
+                    i64_const(Imm64(NANOS_PER_MILLI)); i64_div_u;
                 });
                 self.scratch.free_i32(time_ptr);
             }
             "os" => {
                 let s = self.emitter.intern_string("wasi");
-                wasm!(self.func, { i32_const(s as i32); });
+                wasm!(self.func, { i32_const(Imm32(s as i32)); });
             }
             "temp_dir" => {
                 let s = self.emitter.intern_string("/tmp");
-                wasm!(self.func, { i32_const(s as i32); });
+                wasm!(self.func, { i32_const(Imm32(s as i32)); });
             }
             _ => panic!(
                 "[ICE] emit_wasm: no WASM dispatch for `env.{}` — \

--- a/crates/almide-codegen/src/emit_wasm/calls_fs.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_fs.rs
@@ -6,6 +6,92 @@ use almide_lang::types::Ty;
 use super::values;
 use wasm_encoder::Instruction;
 
+/// Named WASM immediate constants for fs-call codegen.
+mod imm {
+    // ── byte widths ────────────────────────────────────────────────────
+    /// Byte size of an i32 / pointer (used to alloc i32-sized scratch slots,
+    /// and as the pointer stride in List[String] and Result-pair payload offset).
+    pub const I32_BYTES: i32 = 4;
+    /// Byte size of an i64 element (stride in List[Int] element array).
+    pub const I64_BYTES: i32 = 8;
+    /// Byte size of a two-field i32 pair: Result/IOV struct [tag:i32, payload:i32].
+    pub const RESULT_PAIR_BYTES: i32 = I64_BYTES; // 2 × I32_BYTES
+    /// Byte size of a Result[Int, String] slot [tag:i32, pad:i32, value:i64].
+    pub const RESULT_INT_BYTES: i32 = 16;
+
+    // ── WASI filestat (64-byte struct) ─────────────────────────────────
+    /// Total byte size of the WASI filestat_t buffer to allocate.
+    pub const WASI_FILESTAT_BUF_BYTES: i32 = 64;
+    /// Byte offset of the filetype field within filestat_t (dev:8 + ino:8 = 16).
+    pub const WASI_FILESTAT_OFFSET_FILETYPE: i32 = 16;
+    /// Byte offset of the st_size field within filestat_t.
+    pub const WASI_FILESTAT_OFFSET_SIZE: i32 = 32;
+    /// Byte offset of the st_mtim field within filestat_t (nanoseconds).
+    pub const WASI_FILESTAT_OFFSET_MTIM: i32 = 40;
+
+    // ── WASI dirent ────────────────────────────────────────────────────
+    /// Byte size of a WASI dirent header (d_next:8 + d_ino:8 + d_namlen:4 + d_type:4).
+    pub const WASI_DIRENT_HEADER_BYTES: i32 = 24;
+    /// Byte offset of d_namlen within a WASI dirent (d_next:8 + d_ino:8).
+    pub const WASI_DIRENT_OFFSET_NAMLEN: i32 = 16;
+    /// Byte offset of the first name character within a WASI dirent (= header size).
+    pub const WASI_DIRENT_OFFSET_NAME: i32 = 24;
+    /// Byte offset of the second name character within a WASI dirent (for ".." check).
+    pub const WASI_DIRENT_OFFSET_NAME1: i32 = 25;
+    /// Name length of the ".." directory entry (used to identify it by length).
+    pub const DOTDOT_NAME_LEN: i32 = 2;
+
+    // ── WASI path_open flags / rights ─────────────────────────────────
+    /// oflags: O_CREAT | O_TRUNC — create and truncate on open for write.
+    pub const WASI_OFLAGS_CREAT_TRUNC: i32 = 9;
+    /// oflags: O_DIRECTORY — open target as a directory.
+    pub const WASI_OFLAGS_DIRECTORY: i32 = 2;
+    /// rights: fd_read (2) | fd_seek (4) — minimum rights to read a file.
+    pub const WASI_RIGHTS_FD_READ_SEEK: i64 = 6;
+    /// rights: fd_write (64) — right to write to a file.
+    pub const WASI_RIGHTS_FD_WRITE: i64 = 64;
+    /// rights: fd_readdir (0x4000) — right to read directory entries.
+    pub const WASI_RIGHTS_FD_READDIR: i64 = 0x4000;
+
+    // ── WASI filetypes ─────────────────────────────────────────────────
+    /// WASI filetype value: directory.
+    pub const WASI_FILETYPE_DIRECTORY: i32 = 3;
+    /// WASI filetype value: regular file.
+    pub const WASI_FILETYPE_REGULAR_FILE: i32 = 4;
+    /// WASI filetype value: symbolic link.
+    pub const WASI_FILETYPE_SYMLINK: i32 = 7;
+
+    // ── WASI errno ─────────────────────────────────────────────────────
+    /// WASI errno EEXIST: file or directory already exists (mkdir_p success case).
+    pub const WASI_ERRNO_EEXIST: i32 = 20;
+
+    // ── readdir ────────────────────────────────────────────────────────
+    /// Byte size of the readdir buffer (4 KiB).
+    pub const WASI_READDIR_BUF_BYTES: i32 = 4096;
+
+    // ── Almide stat record layout ──────────────────────────────────────
+    // Record: [size:i64(8)][is_dir:i32(4)][is_file:i32(4)][modified:i64(8)] = 24 bytes.
+    /// Byte offset of the is_dir field in the Almide stat record.
+    pub const STAT_REC_OFFSET_IS_DIR: i32 = I64_BYTES; // after size:i64
+    /// Byte offset of the is_file field in the Almide stat record.
+    pub const STAT_REC_OFFSET_IS_FILE: i32 = 12;
+    /// Byte offset of the modified field in the Almide stat record.
+    pub const STAT_REC_OFFSET_MODIFIED: i32 = 16;
+    /// Total byte size of the Almide stat record.
+    pub const STAT_REC_BYTES: i32 = 24;
+
+    // ── ASCII character codes ──────────────────────────────────────────
+    /// ASCII code for '.' (used to identify "." and ".." directory entries).
+    pub const ASCII_DOT: i32 = 46;
+    /// ASCII code for '/' (path separator, used in mkdir_p segment scan).
+    pub const ASCII_SLASH: i32 = 47;
+
+    // ── time conversion ────────────────────────────────────────────────
+    /// Nanoseconds per second (converts WASI nanosecond timestamps to seconds).
+    pub const NANOS_PER_SEC: i64 = 1_000_000_000;
+}
+use imm::*;
+
 impl FuncCompiler<'_> {
     pub(super) fn emit_fs_call(&mut self, func: &str, args: &[IrExpr]) {
         match func {
@@ -33,7 +119,7 @@ impl FuncCompiler<'_> {
 
                 // Allocate fd_out (4 bytes) via bump allocator
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
                 });
 
                 // path_open(resolved_fd, dirflags=0, path_ptr, path_len, oflags=0,
@@ -44,7 +130,7 @@ impl FuncCompiler<'_> {
                     local_get(path_ptr);
                     local_get(path_len);
                     i32_const(0);
-                    i64_const(6);
+                    i64_const(WASI_RIGHTS_FD_READ_SEEK);
                     i64_const(0);
                     i32_const(0);
                     local_get(fd_out_ptr);
@@ -62,7 +148,7 @@ impl FuncCompiler<'_> {
                 // Build err result
                 let err_msg = self.emitter.intern_string("file not found");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -76,7 +162,7 @@ impl FuncCompiler<'_> {
 
                 // fd_filestat_get(fd, stat_buf) — stat_buf needs 64 bytes (allocator guarantees 8-byte alignment)
                 wasm!(self.func, {
-                    i32_const(64); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
                     local_get(opened_fd);
                     local_get(stat_buf);
                     call(self.emitter.rt.fd_filestat_get);
@@ -85,7 +171,7 @@ impl FuncCompiler<'_> {
 
                 // file_size = i32(stat_buf[32..40]) — file size is at offset 32 as i64, take lower 32 bits
                 wasm!(self.func, {
-                    local_get(stat_buf); i32_const(32); i32_add; i32_load(0); local_set(file_size);
+                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_SIZE); i32_add; i32_load(0); local_set(file_size);
                 });
 
                 // Allocate buffer for file data
@@ -95,14 +181,14 @@ impl FuncCompiler<'_> {
 
                 // Build iov struct: [buf_ptr:i32, buf_len:i32]
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
                     local_get(iov_ptr); local_get(data_buf); i32_store(0);
                     local_get(iov_ptr); local_get(file_size); i32_store(4);
                 });
 
                 // nread_ptr
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(nread_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nread_ptr);
                 });
 
                 // fd_read(fd, iov_ptr, 1, nread_ptr)
@@ -150,7 +236,7 @@ impl FuncCompiler<'_> {
 
                 // Build ok result: [tag=0:i32][str_ptr:i32]
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); local_get(str_ptr); i32_store(4);
                     local_get(result_ptr);
@@ -197,7 +283,7 @@ impl FuncCompiler<'_> {
 
                 // Allocate fd_out
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
                 });
 
                 // path_open(resolved_fd, dirflags=0, path_ptr, path_len,
@@ -208,8 +294,8 @@ impl FuncCompiler<'_> {
                     i32_const(0);
                     local_get(path_ptr);
                     local_get(path_len);
-                    i32_const(9);
-                    i64_const(64);
+                    i32_const(WASI_OFLAGS_CREAT_TRUNC);
+                    i64_const(WASI_RIGHTS_FD_WRITE);
                     i64_const(0);
                     i32_const(0);
                     local_get(fd_out_ptr);
@@ -226,7 +312,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("failed to open file for writing");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -240,14 +326,14 @@ impl FuncCompiler<'_> {
 
                 // Build iov: [content_ptr+4, content_len]
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
                     local_get(iov_ptr); local_get(content_str); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; i32_store(0);
                     local_get(iov_ptr); local_get(content_str); i32_load(0); i32_store(4);
                 });
 
                 // nwritten_ptr
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(nwritten_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nwritten_ptr);
                 });
 
                 // fd_write(fd, iov_ptr, 1, nwritten_ptr)
@@ -269,7 +355,7 @@ impl FuncCompiler<'_> {
 
                 // Build ok(unit) result: [tag=0:i32][0:i32]
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); i32_const(0); i32_store(4);
                     local_get(result_ptr);
@@ -302,7 +388,7 @@ impl FuncCompiler<'_> {
 
                 // Allocate 64-byte stat buffer (allocator guarantees 8-byte alignment)
                 wasm!(self.func, {
-                    i32_const(64); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
                 });
 
                 // path_filestat_get(resolved_fd, flags=0, path_ptr, path_len, stat_buf)
@@ -346,14 +432,14 @@ impl FuncCompiler<'_> {
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
                 });
 
                 // path_open for reading
                 wasm!(self.func, {
                     local_get(resolved_fd); i32_const(0);
                     local_get(path_ptr); local_get(path_len);
-                    i32_const(0); i64_const(6); i64_const(0); i32_const(0);
+                    i32_const(0); i64_const(WASI_RIGHTS_FD_READ_SEEK); i64_const(0); i32_const(0);
                     local_get(fd_out_ptr);
                     call(self.emitter.rt.path_open);
                     local_set(errno);
@@ -365,7 +451,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("file not found");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -375,19 +461,19 @@ impl FuncCompiler<'_> {
                 // stat for file size
                 wasm!(self.func, {
                     local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
-                    i32_const(64); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
                     local_get(opened_fd); local_get(stat_buf);
                     call(self.emitter.rt.fd_filestat_get); drop;
-                    local_get(stat_buf); i32_const(32); i32_add; i32_load(0); local_set(file_size);
+                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_SIZE); i32_add; i32_load(0); local_set(file_size);
                 });
 
                 // Read raw bytes
                 wasm!(self.func, {
                     local_get(file_size); call(self.emitter.rt.alloc_pinned); local_set(data_buf);
-                    i32_const(8); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
                     local_get(iov_ptr); local_get(data_buf); i32_store(0);
                     local_get(iov_ptr); local_get(file_size); i32_store(4);
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(nread_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nread_ptr);
                     local_get(opened_fd); local_get(iov_ptr); i32_const(1); local_get(nread_ptr);
                     call(self.emitter.rt.fd_read); drop;
                     local_get(opened_fd); call(self.emitter.rt.fd_close); drop;
@@ -396,7 +482,7 @@ impl FuncCompiler<'_> {
 
                 // Build List[Int]: [len:i32][cap:i32][i64 * count]
                 wasm!(self.func, {
-                    local_get(file_size); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(file_size); i32_const(I64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(list_ptr);
                     local_get(list_ptr); local_get(file_size); i32_store(0);
                 });
@@ -407,7 +493,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                     local_get(counter); local_get(file_size); i32_ge_u; br_if(1);
                     local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(counter); i32_const(8); i32_mul; i32_add;
+                    local_get(counter); i32_const(I64_BYTES); i32_mul; i32_add;
                     local_get(data_buf); local_get(counter); i32_add; i32_load8_u(0);
                     i64_extend_i32_u;
                     i64_store(0);
@@ -418,7 +504,7 @@ impl FuncCompiler<'_> {
 
                 // ok(list_ptr)
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); local_get(list_ptr); i32_store(4);
                     local_get(result_ptr);
@@ -474,7 +560,7 @@ impl FuncCompiler<'_> {
                     local_get(counter); local_get(count); i32_ge_u; br_if(1);
                     local_get(byte_buf); local_get(counter); i32_add;
                     local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(counter); i32_const(8); i32_mul; i32_add;
+                    local_get(counter); i32_const(I64_BYTES); i32_mul; i32_add;
                     i64_load(0); i32_wrap_i64;
                     i32_store8(0);
                     local_get(counter); i32_const(1); i32_add; local_set(counter);
@@ -483,14 +569,14 @@ impl FuncCompiler<'_> {
                 });
 
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
                 });
 
                 // path_open for writing (O_CREAT|O_TRUNC=9)
                 wasm!(self.func, {
                     local_get(resolved_fd); i32_const(0);
                     local_get(path_ptr); local_get(path_len);
-                    i32_const(9); i64_const(64); i64_const(0); i32_const(0);
+                    i32_const(WASI_OFLAGS_CREAT_TRUNC); i64_const(WASI_RIGHTS_FD_WRITE); i64_const(0); i32_const(0);
                     local_get(fd_out_ptr);
                     call(self.emitter.rt.path_open);
                     local_set(errno);
@@ -502,7 +588,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("failed to open file for writing");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -511,10 +597,10 @@ impl FuncCompiler<'_> {
 
                 wasm!(self.func, {
                     local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
-                    i32_const(8); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
                     local_get(iov_ptr); local_get(byte_buf); i32_store(0);
                     local_get(iov_ptr); local_get(count); i32_store(4);
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(nwritten_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nwritten_ptr);
                     local_get(opened_fd); local_get(iov_ptr); i32_const(1); local_get(nwritten_ptr);
                     call(self.emitter.rt.fd_write); drop;
                     local_get(opened_fd); call(self.emitter.rt.fd_close); drop;
@@ -522,7 +608,7 @@ impl FuncCompiler<'_> {
 
                 // ok(unit)
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); i32_const(0); i32_store(4);
                     local_get(result_ptr);
@@ -566,7 +652,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, { local_set(content_str); });
 
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
                 });
 
                 // path_open: oflags=O_CREAT(1), rights=fd_write(64), fdflags=APPEND(1)
@@ -574,7 +660,7 @@ impl FuncCompiler<'_> {
                     local_get(resolved_fd); i32_const(0);
                     local_get(path_ptr); local_get(path_len);
                     i32_const(1);
-                    i64_const(64); i64_const(0);
+                    i64_const(WASI_RIGHTS_FD_WRITE); i64_const(0);
                     i32_const(1);
                     local_get(fd_out_ptr);
                     call(self.emitter.rt.path_open);
@@ -587,7 +673,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("failed to open file for appending");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -596,10 +682,10 @@ impl FuncCompiler<'_> {
 
                 wasm!(self.func, {
                     local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
-                    i32_const(8); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
                     local_get(iov_ptr); local_get(content_str); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; i32_store(0);
                     local_get(iov_ptr); local_get(content_str); i32_load(0); i32_store(4);
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(nwritten_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nwritten_ptr);
                     local_get(opened_fd); local_get(iov_ptr); i32_const(1); local_get(nwritten_ptr);
                     call(self.emitter.rt.fd_write); drop;
                     local_get(opened_fd); call(self.emitter.rt.fd_close); drop;
@@ -607,7 +693,7 @@ impl FuncCompiler<'_> {
 
                 // ok(unit)
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); i32_const(0); i32_store(4);
                     local_get(result_ptr);
@@ -651,7 +737,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                     local_get(seg_end); local_get(path_len); i32_ge_u; br_if(1);
                     local_get(path_ptr); local_get(seg_end); i32_add; i32_load8_u(0);
-                    i32_const(47); i32_eq; br_if(1);
+                    i32_const(ASCII_SLASH); i32_eq; br_if(1);
                     local_get(seg_end); i32_const(1); i32_add; local_set(seg_end);
                     br(0);
                     end; end;
@@ -678,12 +764,12 @@ impl FuncCompiler<'_> {
                 // errno==0 or errno==20 (EEXIST) -> ok
                 wasm!(self.func, {
                     local_get(errno); i32_eqz;
-                    local_get(errno); i32_const(20); i32_eq;
+                    local_get(errno); i32_const(WASI_ERRNO_EEXIST); i32_eq;
                     i32_or;
                     if_i32;
                 });
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); i32_const(0); i32_store(4);
                     local_get(result_ptr);
@@ -691,7 +777,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("failed to create directory");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -720,7 +806,7 @@ impl FuncCompiler<'_> {
                 // ok path: split the string by '\n'
                 let text_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_get(res); i32_const(4); i32_add; i32_load(0); local_set(text_ptr);
+                    local_get(res); i32_const(I32_BYTES); i32_add; i32_load(0); local_set(text_ptr);
                     local_get(text_ptr);
                     call(self.emitter.rt.string.lines);
                 });
@@ -728,7 +814,7 @@ impl FuncCompiler<'_> {
                 let list_val = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     local_set(list_val);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); local_get(list_val); i32_store(4);
                     local_get(result_ptr);
@@ -768,7 +854,7 @@ impl FuncCompiler<'_> {
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
                 });
 
                 // path_open for directory: dirflags=1(symlink follow), oflags=O_DIRECTORY(2)
@@ -776,8 +862,8 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_get(resolved_fd); i32_const(1);
                     local_get(path_ptr); local_get(path_len);
-                    i32_const(2);
-                    i64_const(0x4000);
+                    i32_const(WASI_OFLAGS_DIRECTORY);
+                    i64_const(WASI_RIGHTS_FD_READDIR);
                     i64_const(0);
                     i32_const(0);
                     local_get(fd_out_ptr);
@@ -791,7 +877,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("failed to open directory");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -804,15 +890,15 @@ impl FuncCompiler<'_> {
 
                 // Allocate readdir buffer (4KB) and bufused output
                 wasm!(self.func, {
-                    i32_const(4096); call(self.emitter.rt.alloc_pinned); local_set(dir_buf);
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(bufused_ptr);
+                    i32_const(WASI_READDIR_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(dir_buf);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(bufused_ptr);
                 });
 
                 // fd_readdir(fd, buf, buf_len, cookie=0, bufused_ptr)
                 wasm!(self.func, {
                     local_get(opened_fd);
                     local_get(dir_buf);
-                    i32_const(4096);
+                    i32_const(WASI_READDIR_BUF_BYTES);
                     i64_const(0);
                     local_get(bufused_ptr);
                     call(self.emitter.rt.fd_readdir);
@@ -828,9 +914,9 @@ impl FuncCompiler<'_> {
                     i32_const(0); local_set(offset);
                     i32_const(0); local_set(list_count);
                     block_empty; loop_empty;
-                    local_get(offset); i32_const(24); i32_add;
+                    local_get(offset); i32_const(WASI_DIRENT_HEADER_BYTES); i32_add;
                     local_get(bufused); i32_gt_u; br_if(1);
-                    local_get(dir_buf); local_get(offset); i32_add; i32_const(16); i32_add;
+                    local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAMLEN); i32_add;
                     i32_load(0); local_set(entry_name_len);
 
                     // skip = (namlen==1 && name[0]=='.') || (namlen==2 && name[0]=='.' && name[1]=='.')
@@ -838,17 +924,17 @@ impl FuncCompiler<'_> {
                     // Check "."
                     local_get(entry_name_len); i32_const(1); i32_eq;
                     if_empty;
-                      local_get(dir_buf); local_get(offset); i32_add; i32_const(24); i32_add;
-                      i32_load8_u(0); i32_const(46); i32_eq;
+                      local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME); i32_add;
+                      i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
                       if_empty; i32_const(1); local_set(skip); end;
                     end;
                     // Check ".."
-                    local_get(entry_name_len); i32_const(2); i32_eq;
+                    local_get(entry_name_len); i32_const(DOTDOT_NAME_LEN); i32_eq;
                     if_empty;
-                      local_get(dir_buf); local_get(offset); i32_add; i32_const(24); i32_add;
-                      i32_load8_u(0); i32_const(46); i32_eq;
-                      local_get(dir_buf); local_get(offset); i32_add; i32_const(25); i32_add;
-                      i32_load8_u(0); i32_const(46); i32_eq;
+                      local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME); i32_add;
+                      i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
+                      local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME1); i32_add;
+                      i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
                       i32_and;
                       if_empty; i32_const(1); local_set(skip); end;
                     end;
@@ -859,7 +945,7 @@ impl FuncCompiler<'_> {
                     end;
 
                     // Advance offset
-                    local_get(offset); i32_const(24); i32_add; local_get(entry_name_len); i32_add;
+                    local_get(offset); i32_const(WASI_DIRENT_HEADER_BYTES); i32_add; local_get(entry_name_len); i32_add;
                     local_set(offset);
                     br(0);
                     end; end;
@@ -867,7 +953,7 @@ impl FuncCompiler<'_> {
 
                 // Allocate List[String]: [len:i32][cap:i32][ptr:i32 * count]
                 wasm!(self.func, {
-                    local_get(list_count); i32_const(4); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(list_count); i32_const(I32_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(list_ptr);
                     local_get(list_ptr); local_get(list_count); i32_store(0);
                 });
@@ -878,25 +964,25 @@ impl FuncCompiler<'_> {
                     i32_const(0); local_set(offset);
                     i32_const(0); local_set(counter);
                     block_empty; loop_empty;
-                    local_get(offset); i32_const(24); i32_add;
+                    local_get(offset); i32_const(WASI_DIRENT_HEADER_BYTES); i32_add;
                     local_get(bufused); i32_gt_u; br_if(1);
-                    local_get(dir_buf); local_get(offset); i32_add; i32_const(16); i32_add;
+                    local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAMLEN); i32_add;
                     i32_load(0); local_set(entry_name_len);
 
                     // skip = (namlen==1 && name[0]=='.') || (namlen==2 && name[0]=='.' && name[1]=='.')
                     i32_const(0); local_set(skip);
                     local_get(entry_name_len); i32_const(1); i32_eq;
                     if_empty;
-                      local_get(dir_buf); local_get(offset); i32_add; i32_const(24); i32_add;
-                      i32_load8_u(0); i32_const(46); i32_eq;
+                      local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME); i32_add;
+                      i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
                       if_empty; i32_const(1); local_set(skip); end;
                     end;
-                    local_get(entry_name_len); i32_const(2); i32_eq;
+                    local_get(entry_name_len); i32_const(DOTDOT_NAME_LEN); i32_eq;
                     if_empty;
-                      local_get(dir_buf); local_get(offset); i32_add; i32_const(24); i32_add;
-                      i32_load8_u(0); i32_const(46); i32_eq;
-                      local_get(dir_buf); local_get(offset); i32_add; i32_const(25); i32_add;
-                      i32_load8_u(0); i32_const(46); i32_eq;
+                      local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME); i32_add;
+                      i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
+                      local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME1); i32_add;
+                      i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
                       i32_and;
                       if_empty; i32_const(1); local_set(skip); end;
                     end;
@@ -909,7 +995,7 @@ impl FuncCompiler<'_> {
                     end;
 
                     // Advance offset
-                    local_get(offset); i32_const(24); i32_add; local_get(entry_name_len); i32_add;
+                    local_get(offset); i32_const(WASI_DIRENT_HEADER_BYTES); i32_add; local_get(entry_name_len); i32_add;
                     local_set(offset);
                     br(0);
                     end; end;
@@ -923,7 +1009,7 @@ impl FuncCompiler<'_> {
 
                 // ok(list_ptr)
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); local_get(list_ptr); i32_store(4);
                     local_get(result_ptr);
@@ -972,7 +1058,7 @@ impl FuncCompiler<'_> {
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(64); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
                     // flags=0: do NOT follow symlinks
                     local_get(resolved_fd); i32_const(0);
                     local_get(path_ptr); local_get(path_len);
@@ -983,8 +1069,8 @@ impl FuncCompiler<'_> {
                     if_i32;
                       i32_const(0);
                     else_;
-                      local_get(stat_buf); i32_const(16); i32_add; i32_load8_u(0);
-                      i32_const(7); i32_eq;
+                      local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_FILETYPE); i32_add; i32_load8_u(0);
+                      i32_const(WASI_FILETYPE_SYMLINK); i32_eq;
                     end;
                 });
 
@@ -1025,14 +1111,14 @@ impl FuncCompiler<'_> {
                 self.emit_fs_resolve_path(dst_str, dst_ptr, dst_len, dst_resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
                 });
 
                 // Open source for reading
                 wasm!(self.func, {
                     local_get(src_resolved_fd); i32_const(0);
                     local_get(src_ptr); local_get(src_len);
-                    i32_const(0); i64_const(6); i64_const(0); i32_const(0);
+                    i32_const(0); i64_const(WASI_RIGHTS_FD_READ_SEEK); i64_const(0); i32_const(0);
                     local_get(fd_out_ptr);
                     call(self.emitter.rt.path_open);
                     local_set(errno);
@@ -1044,7 +1130,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("failed to open source file");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -1054,15 +1140,15 @@ impl FuncCompiler<'_> {
                 // Read source content
                 wasm!(self.func, {
                     local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
-                    i32_const(64); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
                     local_get(opened_fd); local_get(stat_buf);
                     call(self.emitter.rt.fd_filestat_get); drop;
-                    local_get(stat_buf); i32_const(32); i32_add; i32_load(0); local_set(file_size);
+                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_SIZE); i32_add; i32_load(0); local_set(file_size);
                     local_get(file_size); call(self.emitter.rt.alloc_pinned); local_set(data_buf);
-                    i32_const(8); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
                     local_get(iov_ptr); local_get(data_buf); i32_store(0);
                     local_get(iov_ptr); local_get(file_size); i32_store(4);
-                    i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(nrw_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nrw_ptr);
                     local_get(opened_fd); local_get(iov_ptr); i32_const(1); local_get(nrw_ptr);
                     call(self.emitter.rt.fd_read); drop;
                     local_get(opened_fd); call(self.emitter.rt.fd_close); drop;
@@ -1073,7 +1159,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_get(dst_resolved_fd); i32_const(0);
                     local_get(dst_ptr); local_get(dst_len);
-                    i32_const(9); i64_const(64); i64_const(0); i32_const(0);
+                    i32_const(WASI_OFLAGS_CREAT_TRUNC); i64_const(WASI_RIGHTS_FD_WRITE); i64_const(0); i32_const(0);
                     local_get(fd_out_ptr);
                     call(self.emitter.rt.path_open);
                     local_set(errno);
@@ -1085,7 +1171,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg2 = self.emitter.intern_string("failed to open destination file");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg2 as i32); i32_store(4);
                     local_get(result_ptr);
@@ -1104,7 +1190,7 @@ impl FuncCompiler<'_> {
 
                 // ok(unit) -- close nested if blocks
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); i32_const(0); i32_store(4);
                     local_get(result_ptr);
@@ -1166,7 +1252,7 @@ impl FuncCompiler<'_> {
                     if_i32;
                 });
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); i32_const(0); i32_store(4);
                     local_get(result_ptr);
@@ -1174,7 +1260,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("failed to rename");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -1217,7 +1303,7 @@ impl FuncCompiler<'_> {
                     if_i32;
                 });
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); i32_const(0); i32_store(4);
                     local_get(result_ptr);
@@ -1225,7 +1311,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("failed to remove file");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -1266,7 +1352,7 @@ impl FuncCompiler<'_> {
                     if_i32;
                 });
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); i32_const(0); i32_store(4);
                     local_get(result_ptr);
@@ -1286,7 +1372,7 @@ impl FuncCompiler<'_> {
                     if_i32;
                 });
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); i32_const(0); i32_store(4);
                     local_get(result_ptr);
@@ -1294,7 +1380,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("failed to remove path");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -1324,7 +1410,7 @@ impl FuncCompiler<'_> {
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(64); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
                     local_get(resolved_fd); i32_const(1);
                     local_get(path_ptr); local_get(path_len);
                     local_get(stat_buf);
@@ -1339,19 +1425,19 @@ impl FuncCompiler<'_> {
                 // ok: file size at offset 32 as i64
                 // Result[Int, String] = [tag:i32][padding:i32][i64] = 16 bytes
                 wasm!(self.func, {
-                    i32_const(16); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_INT_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(8); i32_add;
-                    local_get(stat_buf); i32_const(32); i32_add; i64_load(0);
+                    local_get(result_ptr); i32_const(RESULT_PAIR_BYTES); i32_add;
+                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_SIZE); i32_add; i64_load(0);
                     i64_store(0);
                     local_get(result_ptr);
                     else_;
                 });
                 let err_msg = self.emitter.intern_string("file not found");
                 wasm!(self.func, {
-                    i32_const(16); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_INT_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(8); i32_add;
+                    local_get(result_ptr); i32_const(RESULT_PAIR_BYTES); i32_add;
                     i32_const(err_msg as i32); i64_extend_i32_u; i64_store(0);
                     local_get(result_ptr);
                     end;
@@ -1381,7 +1467,7 @@ impl FuncCompiler<'_> {
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(64); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
                     local_get(resolved_fd); i32_const(1);
                     local_get(path_ptr); local_get(path_len);
                     local_get(stat_buf);
@@ -1394,20 +1480,20 @@ impl FuncCompiler<'_> {
                     if_i32;
                 });
                 wasm!(self.func, {
-                    i32_const(16); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_INT_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(8); i32_add;
-                    local_get(stat_buf); i32_const(40); i32_add; i64_load(0);
-                    i64_const(1000000000); i64_div_u;
+                    local_get(result_ptr); i32_const(RESULT_PAIR_BYTES); i32_add;
+                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_MTIM); i32_add; i64_load(0);
+                    i64_const(NANOS_PER_SEC); i64_div_u;
                     i64_store(0);
                     local_get(result_ptr);
                     else_;
                 });
                 let err_msg = self.emitter.intern_string("file not found");
                 wasm!(self.func, {
-                    i32_const(16); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_INT_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(8); i32_add;
+                    local_get(result_ptr); i32_const(RESULT_PAIR_BYTES); i32_add;
                     i32_const(err_msg as i32); i64_extend_i32_u; i64_store(0);
                     local_get(result_ptr);
                     end;
@@ -1437,7 +1523,7 @@ impl FuncCompiler<'_> {
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(64); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
                     local_get(resolved_fd); i32_const(1);
                     local_get(path_ptr); local_get(path_len);
                     local_get(stat_buf);
@@ -1452,31 +1538,31 @@ impl FuncCompiler<'_> {
 
                 // Record: [size:i64(8)][is_dir:i32(4)][is_file:i32(4)][modified:i64(8)] = 24 bytes
                 wasm!(self.func, {
-                    i32_const(24); call(self.emitter.rt.alloc); local_set(rec_ptr);
+                    i32_const(STAT_REC_BYTES); call(self.emitter.rt.alloc); local_set(rec_ptr);
                     // size at stat offset 32
                     local_get(rec_ptr);
-                    local_get(stat_buf); i32_const(32); i32_add; i64_load(0);
+                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_SIZE); i32_add; i64_load(0);
                     i64_store(0);
                     // is_dir: filetype at offset 16 == 3
-                    local_get(rec_ptr); i32_const(8); i32_add;
-                    local_get(stat_buf); i32_const(16); i32_add; i32_load8_u(0);
-                    i32_const(3); i32_eq;
+                    local_get(rec_ptr); i32_const(STAT_REC_OFFSET_IS_DIR); i32_add;
+                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_FILETYPE); i32_add; i32_load8_u(0);
+                    i32_const(WASI_FILETYPE_DIRECTORY); i32_eq;
                     i32_store(0);
                     // is_file: filetype at offset 16 == 4
-                    local_get(rec_ptr); i32_const(12); i32_add;
-                    local_get(stat_buf); i32_const(16); i32_add; i32_load8_u(0);
-                    i32_const(4); i32_eq;
+                    local_get(rec_ptr); i32_const(STAT_REC_OFFSET_IS_FILE); i32_add;
+                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_FILETYPE); i32_add; i32_load8_u(0);
+                    i32_const(WASI_FILETYPE_REGULAR_FILE); i32_eq;
                     i32_store(0);
                     // modified: mtim at stat offset 40, nanoseconds -> seconds
-                    local_get(rec_ptr); i32_const(16); i32_add;
-                    local_get(stat_buf); i32_const(40); i32_add; i64_load(0);
-                    i64_const(1000000000); i64_div_u;
+                    local_get(rec_ptr); i32_const(STAT_REC_OFFSET_MODIFIED); i32_add;
+                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_MTIM); i32_add; i64_load(0);
+                    i64_const(NANOS_PER_SEC); i64_div_u;
                     i64_store(0);
                 });
 
                 // ok(rec_ptr)
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(0); i32_store(0);
                     local_get(result_ptr); local_get(rec_ptr); i32_store(4);
                     local_get(result_ptr);
@@ -1484,7 +1570,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("file not found");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -1507,7 +1593,7 @@ impl FuncCompiler<'_> {
                 let result_ptr = self.scratch.alloc_i32();
                 let err_msg = self.emitter.intern_string("not supported in WASM");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
                     local_get(result_ptr); i32_const(1); i32_store(0);
                     local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
                     local_get(result_ptr);
@@ -1537,7 +1623,7 @@ impl FuncCompiler<'_> {
                     // Err payload: String pointer (already interned).
                     i32_const(msg as i32); local_set(msg_str);
                     // Result[Bytes, String] layout: [tag:i32=1 for err, payload:i32]
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); i32_const(1); i32_store(0);
                     local_get(result); local_get(msg_str); i32_store(4);
                     local_get(result);
@@ -1589,7 +1675,7 @@ impl FuncCompiler<'_> {
         self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
         wasm!(self.func, {
-            i32_const(64); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+            i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
             // flags=1 (follow symlinks) for is_dir/is_file
             local_get(resolved_fd); i32_const(1);
             local_get(path_ptr); local_get(path_len);
@@ -1601,7 +1687,7 @@ impl FuncCompiler<'_> {
               i32_const(0);
             else_;
               // filetype at stat offset 16
-              local_get(stat_buf); i32_const(16); i32_add; i32_load8_u(0);
+              local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_FILETYPE); i32_add; i32_load8_u(0);
               i32_const(expected_filetype);
               i32_eq;
             end;
@@ -1630,7 +1716,7 @@ impl FuncCompiler<'_> {
             block_empty; loop_empty;
             local_get(copy_i); local_get(entry_name_len); i32_ge_u; br_if(1);
             local_get(str_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(copy_i); i32_add;
-            local_get(dir_buf); local_get(offset); i32_add; i32_const(24); i32_add;
+            local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME); i32_add;
             local_get(copy_i); i32_add; i32_load8_u(0);
             i32_store8(0);
             local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
@@ -1638,7 +1724,7 @@ impl FuncCompiler<'_> {
             end; end;
             // Store in list
             local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-            local_get(counter); i32_const(4); i32_mul; i32_add;
+            local_get(counter); i32_const(I32_BYTES); i32_mul; i32_add;
             local_get(str_ptr); i32_store(0);
             local_get(counter); i32_const(1); i32_add; local_set(counter);
         });
@@ -1666,13 +1752,13 @@ impl FuncCompiler<'_> {
         self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
         wasm!(self.func, {
-            i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+            i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
         });
 
         wasm!(self.func, {
             local_get(resolved_fd); i32_const(0);
             local_get(path_ptr); local_get(path_len);
-            i32_const(0); i64_const(6); i64_const(0); i32_const(0);
+            i32_const(0); i64_const(WASI_RIGHTS_FD_READ_SEEK); i64_const(0); i32_const(0);
             local_get(fd_out_ptr);
             call(self.emitter.rt.path_open);
             local_set(errno);
@@ -1684,7 +1770,7 @@ impl FuncCompiler<'_> {
         });
         let err_msg = self.emitter.intern_string("file not found");
         wasm!(self.func, {
-            i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+            i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
             local_get(result_ptr); i32_const(1); i32_store(0);
             local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
             local_get(result_ptr);
@@ -1693,15 +1779,15 @@ impl FuncCompiler<'_> {
 
         wasm!(self.func, {
             local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
-            i32_const(64); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+            i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
             local_get(opened_fd); local_get(stat_buf);
             call(self.emitter.rt.fd_filestat_get); drop;
-            local_get(stat_buf); i32_const(32); i32_add; i32_load(0); local_set(file_size);
+            local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_SIZE); i32_add; i32_load(0); local_set(file_size);
             local_get(file_size); call(self.emitter.rt.alloc_pinned); local_set(data_buf);
-            i32_const(8); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr); // iov struct [buf_ptr:i32, buf_len:i32]
+            i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr); // iov struct [buf_ptr:i32, buf_len:i32]
             local_get(iov_ptr); local_get(data_buf); i32_store(0);
             local_get(iov_ptr); local_get(file_size); i32_store(4);
-            i32_const(4); call(self.emitter.rt.alloc_pinned); local_set(nread_ptr);
+            i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nread_ptr);
             local_get(opened_fd); local_get(iov_ptr); i32_const(1); local_get(nread_ptr);
             call(self.emitter.rt.fd_read); drop;
             local_get(opened_fd); call(self.emitter.rt.fd_close); drop;
@@ -1730,7 +1816,7 @@ impl FuncCompiler<'_> {
         self.scratch.free_i32(counter);
 
         wasm!(self.func, {
-            i32_const(8); call(self.emitter.rt.alloc); local_set(result_ptr);
+            i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
             local_get(result_ptr); i32_const(0); i32_store(0);
             local_get(result_ptr); local_get(str_ptr); i32_store(4);
             local_get(result_ptr);

--- a/crates/almide-codegen/src/emit_wasm/calls_fs.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_fs.rs
@@ -1,5 +1,6 @@
 //! fs module + helpers — WASM codegen dispatch.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::FuncCompiler;
 use almide_ir::IrExpr;
 use almide_lang::types::Ty;
@@ -114,96 +115,96 @@ impl FuncCompiler<'_> {
                 let errno = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 // Allocate fd_out (4 bytes) via bump allocator
                 wasm!(self.func, {
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(fd_out_ptr));
                 });
 
                 // path_open(resolved_fd, dirflags=0, path_ptr, path_len, oflags=0,
                 //           rights=fd_read|fd_seek (2|4=6), inheriting=0, fdflags=0, fd_out_ptr)
                 wasm!(self.func, {
-                    local_get(resolved_fd);
-                    i32_const(0);
-                    local_get(path_ptr);
-                    local_get(path_len);
-                    i32_const(0);
-                    i64_const(WASI_RIGHTS_FD_READ_SEEK);
-                    i64_const(0);
-                    i32_const(0);
-                    local_get(fd_out_ptr);
+                    local_get(Local(resolved_fd));
+                    i32_const(Imm32(0));
+                    local_get(Local(path_ptr));
+                    local_get(Local(path_len));
+                    i32_const(Imm32(0));
+                    i64_const(Imm64(WASI_RIGHTS_FD_READ_SEEK));
+                    i64_const(Imm64(0));
+                    i32_const(Imm32(0));
+                    local_get(Local(fd_out_ptr));
                     call(self.emitter.rt.path_open);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 // If errno != 0, return err("file not found")
                 wasm!(self.func, {
-                    local_get(errno);
-                    i32_const(0);
+                    local_get(Local(errno));
+                    i32_const(Imm32(0));
                     i32_ne;
                     if_i32;
                 });
                 // Build err result
                 let err_msg = self.emitter.intern_string("file not found");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
 
                 // Load opened fd
                 wasm!(self.func, {
-                    local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
+                    local_get(Local(fd_out_ptr)); i32_load(0); local_set(Local(opened_fd));
                 });
 
                 // fd_filestat_get(fd, stat_buf) — stat_buf needs 64 bytes (allocator guarantees 8-byte alignment)
                 wasm!(self.func, {
-                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
-                    local_get(opened_fd);
-                    local_get(stat_buf);
+                    i32_const(Imm32(WASI_FILESTAT_BUF_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(stat_buf));
+                    local_get(Local(opened_fd));
+                    local_get(Local(stat_buf));
                     call(self.emitter.rt.fd_filestat_get);
                     drop;
                 });
 
                 // file_size = i32(stat_buf[32..40]) — file size is at offset 32 as i64, take lower 32 bits
                 wasm!(self.func, {
-                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_SIZE); i32_add; i32_load(0); local_set(file_size);
+                    local_get(Local(stat_buf)); i32_const(Imm32(WASI_FILESTAT_OFFSET_SIZE)); i32_add; i32_load(0); local_set(Local(file_size));
                 });
 
                 // Allocate buffer for file data
                 wasm!(self.func, {
-                    local_get(file_size); call(self.emitter.rt.alloc_pinned); local_set(data_buf);
+                    local_get(Local(file_size)); call(self.emitter.rt.alloc_pinned); local_set(Local(data_buf));
                 });
 
                 // Build iov struct: [buf_ptr:i32, buf_len:i32]
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
-                    local_get(iov_ptr); local_get(data_buf); i32_store(0);
-                    local_get(iov_ptr); local_get(file_size); i32_store(4);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(iov_ptr));
+                    local_get(Local(iov_ptr)); local_get(Local(data_buf)); i32_store(0);
+                    local_get(Local(iov_ptr)); local_get(Local(file_size)); i32_store(4);
                 });
 
                 // nread_ptr
                 wasm!(self.func, {
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nread_ptr);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(nread_ptr));
                 });
 
                 // fd_read(fd, iov_ptr, 1, nread_ptr)
                 wasm!(self.func, {
-                    local_get(opened_fd);
-                    local_get(iov_ptr);
-                    i32_const(1);
-                    local_get(nread_ptr);
+                    local_get(Local(opened_fd));
+                    local_get(Local(iov_ptr));
+                    i32_const(Imm32(1));
+                    local_get(Local(nread_ptr));
                     call(self.emitter.rt.fd_read);
                     drop;
                 });
 
                 // fd_close(fd)
                 wasm!(self.func, {
-                    local_get(opened_fd);
+                    local_get(Local(opened_fd));
                     call(self.emitter.rt.fd_close);
                     drop;
                 });
@@ -211,24 +212,24 @@ impl FuncCompiler<'_> {
                 // Build Almide String: [len:i32][data:u8...]
                 // Use nread as actual length (may be <= file_size)
                 wasm!(self.func, {
-                    local_get(nread_ptr); i32_load(0); local_set(file_size);
-                    local_get(file_size); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(str_ptr);
-                    local_get(str_ptr); local_get(file_size); i32_store(0);
+                    local_get(Local(nread_ptr)); i32_load(0); local_set(Local(file_size));
+                    local_get(Local(file_size)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(str_ptr));
+                    local_get(Local(str_ptr)); local_get(Local(file_size)); i32_store(0);
                 });
 
                 // Copy data_buf[0..file_size] to str_ptr+4
                 // Byte-by-byte copy loop
                 let counter = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(0); local_set(counter);
+                    i32_const(Imm32(0)); local_set(Local(counter));
                     block_empty; loop_empty;
-                    local_get(counter); local_get(file_size); i32_ge_u; br_if(1);
-                    local_get(str_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(counter); i32_add;
-                    local_get(data_buf); local_get(counter); i32_add;
+                    local_get(Local(counter)); local_get(Local(file_size)); i32_ge_u; br_if(1);
+                    local_get(Local(str_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(counter)); i32_add;
+                    local_get(Local(data_buf)); local_get(Local(counter)); i32_add;
                     i32_load8_u(0);
                     i32_store8(0);
-                    local_get(counter); i32_const(1); i32_add; local_set(counter);
+                    local_get(Local(counter)); i32_const(Imm32(1)); i32_add; local_set(Local(counter));
                     br(0);
                     end; end;
                 });
@@ -236,10 +237,10 @@ impl FuncCompiler<'_> {
 
                 // Build ok result: [tag=0:i32][str_ptr:i32]
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); local_get(str_ptr); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); local_get(Local(str_ptr)); i32_store(4);
+                    local_get(Local(result_ptr));
                     end;
                 });
 
@@ -274,91 +275,91 @@ impl FuncCompiler<'_> {
 
                 // Evaluate path
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 // Evaluate content
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(content_str); });
+                wasm!(self.func, { local_set(Local(content_str)); });
 
                 // Allocate fd_out
                 wasm!(self.func, {
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(fd_out_ptr));
                 });
 
                 // path_open(resolved_fd, dirflags=0, path_ptr, path_len,
                 //           oflags=O_CREAT|O_TRUNC(=9),
                 //           rights=fd_write(=64), inheriting=0, fdflags=0, fd_out_ptr)
                 wasm!(self.func, {
-                    local_get(resolved_fd);
-                    i32_const(0);
-                    local_get(path_ptr);
-                    local_get(path_len);
-                    i32_const(WASI_OFLAGS_CREAT_TRUNC);
-                    i64_const(WASI_RIGHTS_FD_WRITE);
-                    i64_const(0);
-                    i32_const(0);
-                    local_get(fd_out_ptr);
+                    local_get(Local(resolved_fd));
+                    i32_const(Imm32(0));
+                    local_get(Local(path_ptr));
+                    local_get(Local(path_len));
+                    i32_const(Imm32(WASI_OFLAGS_CREAT_TRUNC));
+                    i64_const(Imm64(WASI_RIGHTS_FD_WRITE));
+                    i64_const(Imm64(0));
+                    i32_const(Imm32(0));
+                    local_get(Local(fd_out_ptr));
                     call(self.emitter.rt.path_open);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 // If errno != 0, return err
                 wasm!(self.func, {
-                    local_get(errno);
-                    i32_const(0);
+                    local_get(Local(errno));
+                    i32_const(Imm32(0));
                     i32_ne;
                     if_i32;
                 });
                 let err_msg = self.emitter.intern_string("failed to open file for writing");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
 
                 // Load opened fd
                 wasm!(self.func, {
-                    local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
+                    local_get(Local(fd_out_ptr)); i32_load(0); local_set(Local(opened_fd));
                 });
 
                 // Build iov: [content_ptr+4, content_len]
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
-                    local_get(iov_ptr); local_get(content_str); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; i32_store(0);
-                    local_get(iov_ptr); local_get(content_str); i32_load(0); i32_store(4);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(iov_ptr));
+                    local_get(Local(iov_ptr)); local_get(Local(content_str)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; i32_store(0);
+                    local_get(Local(iov_ptr)); local_get(Local(content_str)); i32_load(0); i32_store(4);
                 });
 
                 // nwritten_ptr
                 wasm!(self.func, {
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nwritten_ptr);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(nwritten_ptr));
                 });
 
                 // fd_write(fd, iov_ptr, 1, nwritten_ptr)
                 wasm!(self.func, {
-                    local_get(opened_fd);
-                    local_get(iov_ptr);
-                    i32_const(1);
-                    local_get(nwritten_ptr);
+                    local_get(Local(opened_fd));
+                    local_get(Local(iov_ptr));
+                    i32_const(Imm32(1));
+                    local_get(Local(nwritten_ptr));
                     call(self.emitter.rt.fd_write);
                     drop;
                 });
 
                 // fd_close(fd)
                 wasm!(self.func, {
-                    local_get(opened_fd);
+                    local_get(Local(opened_fd));
                     call(self.emitter.rt.fd_close);
                     drop;
                 });
 
                 // Build ok(unit) result: [tag=0:i32][0:i32]
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(0); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(4);
+                    local_get(Local(result_ptr));
                     end;
                 });
 
@@ -383,21 +384,21 @@ impl FuncCompiler<'_> {
                 let stat_buf = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 // Allocate 64-byte stat buffer (allocator guarantees 8-byte alignment)
                 wasm!(self.func, {
-                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+                    i32_const(Imm32(WASI_FILESTAT_BUF_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(stat_buf));
                 });
 
                 // path_filestat_get(resolved_fd, flags=0, path_ptr, path_len, stat_buf)
                 wasm!(self.func, {
-                    local_get(resolved_fd);
-                    i32_const(0);
-                    local_get(path_ptr);
-                    local_get(path_len);
-                    local_get(stat_buf);
+                    local_get(Local(resolved_fd));
+                    i32_const(Imm32(0));
+                    local_get(Local(path_ptr));
+                    local_get(Local(path_len));
+                    local_get(Local(stat_buf));
                     call(self.emitter.rt.path_filestat_get);
                     // errno == 0 → true (1), else false (0)
                     i32_eqz;
@@ -428,86 +429,86 @@ impl FuncCompiler<'_> {
                 let counter = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(fd_out_ptr));
                 });
 
                 // path_open for reading
                 wasm!(self.func, {
-                    local_get(resolved_fd); i32_const(0);
-                    local_get(path_ptr); local_get(path_len);
-                    i32_const(0); i64_const(WASI_RIGHTS_FD_READ_SEEK); i64_const(0); i32_const(0);
-                    local_get(fd_out_ptr);
+                    local_get(Local(resolved_fd)); i32_const(Imm32(0));
+                    local_get(Local(path_ptr)); local_get(Local(path_len));
+                    i32_const(Imm32(0)); i64_const(Imm64(WASI_RIGHTS_FD_READ_SEEK)); i64_const(Imm64(0)); i32_const(Imm32(0));
+                    local_get(Local(fd_out_ptr));
                     call(self.emitter.rt.path_open);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_const(0); i32_ne;
+                    local_get(Local(errno)); i32_const(Imm32(0)); i32_ne;
                     if_i32;
                 });
                 let err_msg = self.emitter.intern_string("file not found");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
 
                 // stat for file size
                 wasm!(self.func, {
-                    local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
-                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
-                    local_get(opened_fd); local_get(stat_buf);
+                    local_get(Local(fd_out_ptr)); i32_load(0); local_set(Local(opened_fd));
+                    i32_const(Imm32(WASI_FILESTAT_BUF_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(stat_buf));
+                    local_get(Local(opened_fd)); local_get(Local(stat_buf));
                     call(self.emitter.rt.fd_filestat_get); drop;
-                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_SIZE); i32_add; i32_load(0); local_set(file_size);
+                    local_get(Local(stat_buf)); i32_const(Imm32(WASI_FILESTAT_OFFSET_SIZE)); i32_add; i32_load(0); local_set(Local(file_size));
                 });
 
                 // Read raw bytes
                 wasm!(self.func, {
-                    local_get(file_size); call(self.emitter.rt.alloc_pinned); local_set(data_buf);
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
-                    local_get(iov_ptr); local_get(data_buf); i32_store(0);
-                    local_get(iov_ptr); local_get(file_size); i32_store(4);
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nread_ptr);
-                    local_get(opened_fd); local_get(iov_ptr); i32_const(1); local_get(nread_ptr);
+                    local_get(Local(file_size)); call(self.emitter.rt.alloc_pinned); local_set(Local(data_buf));
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(iov_ptr));
+                    local_get(Local(iov_ptr)); local_get(Local(data_buf)); i32_store(0);
+                    local_get(Local(iov_ptr)); local_get(Local(file_size)); i32_store(4);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(nread_ptr));
+                    local_get(Local(opened_fd)); local_get(Local(iov_ptr)); i32_const(Imm32(1)); local_get(Local(nread_ptr));
                     call(self.emitter.rt.fd_read); drop;
-                    local_get(opened_fd); call(self.emitter.rt.fd_close); drop;
-                    local_get(nread_ptr); i32_load(0); local_set(file_size);
+                    local_get(Local(opened_fd)); call(self.emitter.rt.fd_close); drop;
+                    local_get(Local(nread_ptr)); i32_load(0); local_set(Local(file_size));
                 });
 
                 // Build List[Int]: [len:i32][cap:i32][i64 * count]
                 wasm!(self.func, {
-                    local_get(file_size); i32_const(I64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(list_ptr);
-                    local_get(list_ptr); local_get(file_size); i32_store(0);
+                    local_get(Local(file_size)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(list_ptr));
+                    local_get(Local(list_ptr)); local_get(Local(file_size)); i32_store(0);
                 });
 
                 // Copy each byte as i64
                 wasm!(self.func, {
-                    i32_const(0); local_set(counter);
+                    i32_const(Imm32(0)); local_set(Local(counter));
                     block_empty; loop_empty;
-                    local_get(counter); local_get(file_size); i32_ge_u; br_if(1);
-                    local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(counter); i32_const(I64_BYTES); i32_mul; i32_add;
-                    local_get(data_buf); local_get(counter); i32_add; i32_load8_u(0);
+                    local_get(Local(counter)); local_get(Local(file_size)); i32_ge_u; br_if(1);
+                    local_get(Local(list_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(counter)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_add;
+                    local_get(Local(data_buf)); local_get(Local(counter)); i32_add; i32_load8_u(0);
                     i64_extend_i32_u;
                     i64_store(0);
-                    local_get(counter); i32_const(1); i32_add; local_set(counter);
+                    local_get(Local(counter)); i32_const(Imm32(1)); i32_add; local_set(Local(counter));
                     br(0);
                     end; end;
                 });
 
                 // ok(list_ptr)
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); local_get(list_ptr); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); local_get(Local(list_ptr)); i32_store(4);
+                    local_get(Local(result_ptr));
                     end;
                 });
 
@@ -545,73 +546,73 @@ impl FuncCompiler<'_> {
                 let counter = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(list_ptr); });
+                wasm!(self.func, { local_set(Local(list_ptr)); });
 
                 // Convert List[Int] (i64 elements) to byte buffer
                 wasm!(self.func, {
-                    local_get(list_ptr); i32_load(0); local_set(count);
-                    local_get(count); call(self.emitter.rt.alloc_pinned); local_set(byte_buf);
-                    i32_const(0); local_set(counter);
+                    local_get(Local(list_ptr)); i32_load(0); local_set(Local(count));
+                    local_get(Local(count)); call(self.emitter.rt.alloc_pinned); local_set(Local(byte_buf));
+                    i32_const(Imm32(0)); local_set(Local(counter));
                     block_empty; loop_empty;
-                    local_get(counter); local_get(count); i32_ge_u; br_if(1);
-                    local_get(byte_buf); local_get(counter); i32_add;
-                    local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(counter); i32_const(I64_BYTES); i32_mul; i32_add;
+                    local_get(Local(counter)); local_get(Local(count)); i32_ge_u; br_if(1);
+                    local_get(Local(byte_buf)); local_get(Local(counter)); i32_add;
+                    local_get(Local(list_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(counter)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_add;
                     i64_load(0); i32_wrap_i64;
                     i32_store8(0);
-                    local_get(counter); i32_const(1); i32_add; local_set(counter);
+                    local_get(Local(counter)); i32_const(Imm32(1)); i32_add; local_set(Local(counter));
                     br(0);
                     end; end;
                 });
 
                 wasm!(self.func, {
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(fd_out_ptr));
                 });
 
                 // path_open for writing (O_CREAT|O_TRUNC=9)
                 wasm!(self.func, {
-                    local_get(resolved_fd); i32_const(0);
-                    local_get(path_ptr); local_get(path_len);
-                    i32_const(WASI_OFLAGS_CREAT_TRUNC); i64_const(WASI_RIGHTS_FD_WRITE); i64_const(0); i32_const(0);
-                    local_get(fd_out_ptr);
+                    local_get(Local(resolved_fd)); i32_const(Imm32(0));
+                    local_get(Local(path_ptr)); local_get(Local(path_len));
+                    i32_const(Imm32(WASI_OFLAGS_CREAT_TRUNC)); i64_const(Imm64(WASI_RIGHTS_FD_WRITE)); i64_const(Imm64(0)); i32_const(Imm32(0));
+                    local_get(Local(fd_out_ptr));
                     call(self.emitter.rt.path_open);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_const(0); i32_ne;
+                    local_get(Local(errno)); i32_const(Imm32(0)); i32_ne;
                     if_i32;
                 });
                 let err_msg = self.emitter.intern_string("failed to open file for writing");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
 
                 wasm!(self.func, {
-                    local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
-                    local_get(iov_ptr); local_get(byte_buf); i32_store(0);
-                    local_get(iov_ptr); local_get(count); i32_store(4);
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nwritten_ptr);
-                    local_get(opened_fd); local_get(iov_ptr); i32_const(1); local_get(nwritten_ptr);
+                    local_get(Local(fd_out_ptr)); i32_load(0); local_set(Local(opened_fd));
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(iov_ptr));
+                    local_get(Local(iov_ptr)); local_get(Local(byte_buf)); i32_store(0);
+                    local_get(Local(iov_ptr)); local_get(Local(count)); i32_store(4);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(nwritten_ptr));
+                    local_get(Local(opened_fd)); local_get(Local(iov_ptr)); i32_const(Imm32(1)); local_get(Local(nwritten_ptr));
                     call(self.emitter.rt.fd_write); drop;
-                    local_get(opened_fd); call(self.emitter.rt.fd_close); drop;
+                    local_get(Local(opened_fd)); call(self.emitter.rt.fd_close); drop;
                 });
 
                 // ok(unit)
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(0); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(4);
+                    local_get(Local(result_ptr));
                     end;
                 });
 
@@ -645,58 +646,58 @@ impl FuncCompiler<'_> {
                 let errno = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(content_str); });
+                wasm!(self.func, { local_set(Local(content_str)); });
 
                 wasm!(self.func, {
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(fd_out_ptr));
                 });
 
                 // path_open: oflags=O_CREAT(1), rights=fd_write(64), fdflags=APPEND(1)
                 wasm!(self.func, {
-                    local_get(resolved_fd); i32_const(0);
-                    local_get(path_ptr); local_get(path_len);
-                    i32_const(1);
-                    i64_const(WASI_RIGHTS_FD_WRITE); i64_const(0);
-                    i32_const(1);
-                    local_get(fd_out_ptr);
+                    local_get(Local(resolved_fd)); i32_const(Imm32(0));
+                    local_get(Local(path_ptr)); local_get(Local(path_len));
+                    i32_const(Imm32(1));
+                    i64_const(Imm64(WASI_RIGHTS_FD_WRITE)); i64_const(Imm64(0));
+                    i32_const(Imm32(1));
+                    local_get(Local(fd_out_ptr));
                     call(self.emitter.rt.path_open);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_const(0); i32_ne;
+                    local_get(Local(errno)); i32_const(Imm32(0)); i32_ne;
                     if_i32;
                 });
                 let err_msg = self.emitter.intern_string("failed to open file for appending");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
 
                 wasm!(self.func, {
-                    local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
-                    local_get(iov_ptr); local_get(content_str); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; i32_store(0);
-                    local_get(iov_ptr); local_get(content_str); i32_load(0); i32_store(4);
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nwritten_ptr);
-                    local_get(opened_fd); local_get(iov_ptr); i32_const(1); local_get(nwritten_ptr);
+                    local_get(Local(fd_out_ptr)); i32_load(0); local_set(Local(opened_fd));
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(iov_ptr));
+                    local_get(Local(iov_ptr)); local_get(Local(content_str)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; i32_store(0);
+                    local_get(Local(iov_ptr)); local_get(Local(content_str)); i32_load(0); i32_store(4);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(nwritten_ptr));
+                    local_get(Local(opened_fd)); local_get(Local(iov_ptr)); i32_const(Imm32(1)); local_get(Local(nwritten_ptr));
                     call(self.emitter.rt.fd_write); drop;
-                    local_get(opened_fd); call(self.emitter.rt.fd_close); drop;
+                    local_get(Local(opened_fd)); call(self.emitter.rt.fd_close); drop;
                 });
 
                 // ok(unit)
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(0); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(4);
+                    local_get(Local(result_ptr));
                     end;
                 });
 
@@ -722,29 +723,29 @@ impl FuncCompiler<'_> {
                 let errno = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 // Iterative mkdir_p: create each prefix segment
                 let seg_end = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(0); local_set(seg_end);
+                    i32_const(Imm32(0)); local_set(Local(seg_end));
                     block_empty; loop_empty;
-                    local_get(seg_end); local_get(path_len); i32_ge_u; br_if(1);
+                    local_get(Local(seg_end)); local_get(Local(path_len)); i32_ge_u; br_if(1);
                     // Advance seg_end past current char
-                    local_get(seg_end); i32_const(1); i32_add; local_set(seg_end);
+                    local_get(Local(seg_end)); i32_const(Imm32(1)); i32_add; local_set(Local(seg_end));
                     // Skip to next '/' or end of path
                     block_empty; loop_empty;
-                    local_get(seg_end); local_get(path_len); i32_ge_u; br_if(1);
-                    local_get(path_ptr); local_get(seg_end); i32_add; i32_load8_u(0);
-                    i32_const(ASCII_SLASH); i32_eq; br_if(1);
-                    local_get(seg_end); i32_const(1); i32_add; local_set(seg_end);
+                    local_get(Local(seg_end)); local_get(Local(path_len)); i32_ge_u; br_if(1);
+                    local_get(Local(path_ptr)); local_get(Local(seg_end)); i32_add; i32_load8_u(0);
+                    i32_const(Imm32(ASCII_SLASH)); i32_eq; br_if(1);
+                    local_get(Local(seg_end)); i32_const(Imm32(1)); i32_add; local_set(Local(seg_end));
                     br(0);
                     end; end;
                     // Try creating directory for path[0..seg_end]
-                    local_get(resolved_fd);
-                    local_get(path_ptr);
-                    local_get(seg_end);
+                    local_get(Local(resolved_fd));
+                    local_get(Local(path_ptr));
+                    local_get(Local(seg_end));
                     call(self.emitter.rt.path_create_directory);
                     drop;
                     br(0);
@@ -754,33 +755,33 @@ impl FuncCompiler<'_> {
 
                 // Final attempt: create the full path and check error
                 wasm!(self.func, {
-                    local_get(resolved_fd);
-                    local_get(path_ptr);
-                    local_get(path_len);
+                    local_get(Local(resolved_fd));
+                    local_get(Local(path_ptr));
+                    local_get(Local(path_len));
                     call(self.emitter.rt.path_create_directory);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 // errno==0 or errno==20 (EEXIST) -> ok
                 wasm!(self.func, {
-                    local_get(errno); i32_eqz;
-                    local_get(errno); i32_const(WASI_ERRNO_EEXIST); i32_eq;
+                    local_get(Local(errno)); i32_eqz;
+                    local_get(Local(errno)); i32_const(Imm32(WASI_ERRNO_EEXIST)); i32_eq;
                     i32_or;
                     if_i32;
                 });
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(0); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
                 let err_msg = self.emitter.intern_string("failed to create directory");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     end;
                 });
 
@@ -798,28 +799,28 @@ impl FuncCompiler<'_> {
                 let res = self.scratch.alloc_i32();
                 let tag = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(res);
-                    local_get(res); i32_load(0); local_set(tag);
-                    local_get(tag); i32_eqz;
+                    local_set(Local(res));
+                    local_get(Local(res)); i32_load(0); local_set(Local(tag));
+                    local_get(Local(tag)); i32_eqz;
                     if_i32;
                 });
                 // ok path: split the string by '\n'
                 let text_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_get(res); i32_const(I32_BYTES); i32_add; i32_load(0); local_set(text_ptr);
-                    local_get(text_ptr);
+                    local_get(Local(res)); i32_const(Imm32(I32_BYTES)); i32_add; i32_load(0); local_set(Local(text_ptr));
+                    local_get(Local(text_ptr));
                     call(self.emitter.rt.string.lines);
                 });
                 let result_ptr = self.scratch.alloc_i32();
                 let list_val = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(list_val);
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); local_get(list_val); i32_store(4);
-                    local_get(result_ptr);
+                    local_set(Local(list_val));
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); local_get(Local(list_val)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
-                    local_get(res);
+                    local_get(Local(res));
                     end;
                 });
 
@@ -850,144 +851,144 @@ impl FuncCompiler<'_> {
                 let counter = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(fd_out_ptr));
                 });
 
                 // path_open for directory: dirflags=1(symlink follow), oflags=O_DIRECTORY(2)
                 // rights = fd_readdir(0x4000)
                 wasm!(self.func, {
-                    local_get(resolved_fd); i32_const(1);
-                    local_get(path_ptr); local_get(path_len);
-                    i32_const(WASI_OFLAGS_DIRECTORY);
-                    i64_const(WASI_RIGHTS_FD_READDIR);
-                    i64_const(0);
-                    i32_const(0);
-                    local_get(fd_out_ptr);
+                    local_get(Local(resolved_fd)); i32_const(Imm32(1));
+                    local_get(Local(path_ptr)); local_get(Local(path_len));
+                    i32_const(Imm32(WASI_OFLAGS_DIRECTORY));
+                    i64_const(Imm64(WASI_RIGHTS_FD_READDIR));
+                    i64_const(Imm64(0));
+                    i32_const(Imm32(0));
+                    local_get(Local(fd_out_ptr));
                     call(self.emitter.rt.path_open);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_const(0); i32_ne;
+                    local_get(Local(errno)); i32_const(Imm32(0)); i32_ne;
                     if_i32;
                 });
                 let err_msg = self.emitter.intern_string("failed to open directory");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
 
                 wasm!(self.func, {
-                    local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
+                    local_get(Local(fd_out_ptr)); i32_load(0); local_set(Local(opened_fd));
                 });
 
                 // Allocate readdir buffer (4KB) and bufused output
                 wasm!(self.func, {
-                    i32_const(WASI_READDIR_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(dir_buf);
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(bufused_ptr);
+                    i32_const(Imm32(WASI_READDIR_BUF_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(dir_buf));
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(bufused_ptr));
                 });
 
                 // fd_readdir(fd, buf, buf_len, cookie=0, bufused_ptr)
                 wasm!(self.func, {
-                    local_get(opened_fd);
-                    local_get(dir_buf);
-                    i32_const(WASI_READDIR_BUF_BYTES);
-                    i64_const(0);
-                    local_get(bufused_ptr);
+                    local_get(Local(opened_fd));
+                    local_get(Local(dir_buf));
+                    i32_const(Imm32(WASI_READDIR_BUF_BYTES));
+                    i64_const(Imm64(0));
+                    local_get(Local(bufused_ptr));
                     call(self.emitter.rt.fd_readdir);
                     drop;
-                    local_get(bufused_ptr); i32_load(0); local_set(bufused);
-                    local_get(opened_fd); call(self.emitter.rt.fd_close); drop;
+                    local_get(Local(bufused_ptr)); i32_load(0); local_set(Local(bufused));
+                    local_get(Local(opened_fd)); call(self.emitter.rt.fd_close); drop;
                 });
 
                 // First pass: count entries (skipping "." and "..")
                 // WASI dirent: d_next(8) + d_ino(8) + d_namlen(4) + d_type(4) = 24 bytes header
                 let skip = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(0); local_set(offset);
-                    i32_const(0); local_set(list_count);
+                    i32_const(Imm32(0)); local_set(Local(offset));
+                    i32_const(Imm32(0)); local_set(Local(list_count));
                     block_empty; loop_empty;
-                    local_get(offset); i32_const(WASI_DIRENT_HEADER_BYTES); i32_add;
-                    local_get(bufused); i32_gt_u; br_if(1);
-                    local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAMLEN); i32_add;
-                    i32_load(0); local_set(entry_name_len);
+                    local_get(Local(offset)); i32_const(Imm32(WASI_DIRENT_HEADER_BYTES)); i32_add;
+                    local_get(Local(bufused)); i32_gt_u; br_if(1);
+                    local_get(Local(dir_buf)); local_get(Local(offset)); i32_add; i32_const(Imm32(WASI_DIRENT_OFFSET_NAMLEN)); i32_add;
+                    i32_load(0); local_set(Local(entry_name_len));
 
                     // skip = (namlen==1 && name[0]=='.') || (namlen==2 && name[0]=='.' && name[1]=='.')
-                    i32_const(0); local_set(skip);
+                    i32_const(Imm32(0)); local_set(Local(skip));
                     // Check "."
-                    local_get(entry_name_len); i32_const(1); i32_eq;
+                    local_get(Local(entry_name_len)); i32_const(Imm32(1)); i32_eq;
                     if_empty;
-                      local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME); i32_add;
-                      i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
-                      if_empty; i32_const(1); local_set(skip); end;
+                      local_get(Local(dir_buf)); local_get(Local(offset)); i32_add; i32_const(Imm32(WASI_DIRENT_OFFSET_NAME)); i32_add;
+                      i32_load8_u(0); i32_const(Imm32(ASCII_DOT)); i32_eq;
+                      if_empty; i32_const(Imm32(1)); local_set(Local(skip)); end;
                     end;
                     // Check ".."
-                    local_get(entry_name_len); i32_const(DOTDOT_NAME_LEN); i32_eq;
+                    local_get(Local(entry_name_len)); i32_const(Imm32(DOTDOT_NAME_LEN)); i32_eq;
                     if_empty;
-                      local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME); i32_add;
-                      i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
-                      local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME1); i32_add;
-                      i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
+                      local_get(Local(dir_buf)); local_get(Local(offset)); i32_add; i32_const(Imm32(WASI_DIRENT_OFFSET_NAME)); i32_add;
+                      i32_load8_u(0); i32_const(Imm32(ASCII_DOT)); i32_eq;
+                      local_get(Local(dir_buf)); local_get(Local(offset)); i32_add; i32_const(Imm32(WASI_DIRENT_OFFSET_NAME1)); i32_add;
+                      i32_load8_u(0); i32_const(Imm32(ASCII_DOT)); i32_eq;
                       i32_and;
-                      if_empty; i32_const(1); local_set(skip); end;
+                      if_empty; i32_const(Imm32(1)); local_set(Local(skip)); end;
                     end;
                     // Count if not skipped
-                    local_get(skip); i32_eqz;
+                    local_get(Local(skip)); i32_eqz;
                     if_empty;
-                      local_get(list_count); i32_const(1); i32_add; local_set(list_count);
+                      local_get(Local(list_count)); i32_const(Imm32(1)); i32_add; local_set(Local(list_count));
                     end;
 
                     // Advance offset
-                    local_get(offset); i32_const(WASI_DIRENT_HEADER_BYTES); i32_add; local_get(entry_name_len); i32_add;
-                    local_set(offset);
+                    local_get(Local(offset)); i32_const(Imm32(WASI_DIRENT_HEADER_BYTES)); i32_add; local_get(Local(entry_name_len)); i32_add;
+                    local_set(Local(offset));
                     br(0);
                     end; end;
                 });
 
                 // Allocate List[String]: [len:i32][cap:i32][ptr:i32 * count]
                 wasm!(self.func, {
-                    local_get(list_count); i32_const(I32_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(list_ptr);
-                    local_get(list_ptr); local_get(list_count); i32_store(0);
+                    local_get(Local(list_count)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(list_ptr));
+                    local_get(Local(list_ptr)); local_get(Local(list_count)); i32_store(0);
                 });
 
                 // Second pass: build string entries (same skip logic as counting pass)
                 let copy_i = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(0); local_set(offset);
-                    i32_const(0); local_set(counter);
+                    i32_const(Imm32(0)); local_set(Local(offset));
+                    i32_const(Imm32(0)); local_set(Local(counter));
                     block_empty; loop_empty;
-                    local_get(offset); i32_const(WASI_DIRENT_HEADER_BYTES); i32_add;
-                    local_get(bufused); i32_gt_u; br_if(1);
-                    local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAMLEN); i32_add;
-                    i32_load(0); local_set(entry_name_len);
+                    local_get(Local(offset)); i32_const(Imm32(WASI_DIRENT_HEADER_BYTES)); i32_add;
+                    local_get(Local(bufused)); i32_gt_u; br_if(1);
+                    local_get(Local(dir_buf)); local_get(Local(offset)); i32_add; i32_const(Imm32(WASI_DIRENT_OFFSET_NAMLEN)); i32_add;
+                    i32_load(0); local_set(Local(entry_name_len));
 
                     // skip = (namlen==1 && name[0]=='.') || (namlen==2 && name[0]=='.' && name[1]=='.')
-                    i32_const(0); local_set(skip);
-                    local_get(entry_name_len); i32_const(1); i32_eq;
+                    i32_const(Imm32(0)); local_set(Local(skip));
+                    local_get(Local(entry_name_len)); i32_const(Imm32(1)); i32_eq;
                     if_empty;
-                      local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME); i32_add;
-                      i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
-                      if_empty; i32_const(1); local_set(skip); end;
+                      local_get(Local(dir_buf)); local_get(Local(offset)); i32_add; i32_const(Imm32(WASI_DIRENT_OFFSET_NAME)); i32_add;
+                      i32_load8_u(0); i32_const(Imm32(ASCII_DOT)); i32_eq;
+                      if_empty; i32_const(Imm32(1)); local_set(Local(skip)); end;
                     end;
-                    local_get(entry_name_len); i32_const(DOTDOT_NAME_LEN); i32_eq;
+                    local_get(Local(entry_name_len)); i32_const(Imm32(DOTDOT_NAME_LEN)); i32_eq;
                     if_empty;
-                      local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME); i32_add;
-                      i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
-                      local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME1); i32_add;
-                      i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
+                      local_get(Local(dir_buf)); local_get(Local(offset)); i32_add; i32_const(Imm32(WASI_DIRENT_OFFSET_NAME)); i32_add;
+                      i32_load8_u(0); i32_const(Imm32(ASCII_DOT)); i32_eq;
+                      local_get(Local(dir_buf)); local_get(Local(offset)); i32_add; i32_const(Imm32(WASI_DIRENT_OFFSET_NAME1)); i32_add;
+                      i32_load8_u(0); i32_const(Imm32(ASCII_DOT)); i32_eq;
                       i32_and;
-                      if_empty; i32_const(1); local_set(skip); end;
+                      if_empty; i32_const(Imm32(1)); local_set(Local(skip)); end;
                     end;
                     // Build entry if not skipped
-                    local_get(skip); i32_eqz;
+                    local_get(Local(skip)); i32_eqz;
                     if_empty;
                 });
                 self.emit_fs_list_dir_build_entry(copy_i, entry_name_len, str_ptr, dir_buf, offset, list_ptr, counter);
@@ -995,8 +996,8 @@ impl FuncCompiler<'_> {
                     end;
 
                     // Advance offset
-                    local_get(offset); i32_const(WASI_DIRENT_HEADER_BYTES); i32_add; local_get(entry_name_len); i32_add;
-                    local_set(offset);
+                    local_get(Local(offset)); i32_const(Imm32(WASI_DIRENT_HEADER_BYTES)); i32_add; local_get(Local(entry_name_len)); i32_add;
+                    local_set(Local(offset));
                     br(0);
                     end; end;
                 });
@@ -1004,15 +1005,15 @@ impl FuncCompiler<'_> {
 
                 // Update list count
                 wasm!(self.func, {
-                    local_get(list_ptr); local_get(counter); i32_store(0);
+                    local_get(Local(list_ptr)); local_get(Local(counter)); i32_store(0);
                 });
 
                 // ok(list_ptr)
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); local_get(list_ptr); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); local_get(Local(list_ptr)); i32_store(4);
+                    local_get(Local(result_ptr));
                     end;
                 });
 
@@ -1054,23 +1055,23 @@ impl FuncCompiler<'_> {
                 let errno = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+                    i32_const(Imm32(WASI_FILESTAT_BUF_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(stat_buf));
                     // flags=0: do NOT follow symlinks
-                    local_get(resolved_fd); i32_const(0);
-                    local_get(path_ptr); local_get(path_len);
-                    local_get(stat_buf);
+                    local_get(Local(resolved_fd)); i32_const(Imm32(0));
+                    local_get(Local(path_ptr)); local_get(Local(path_len));
+                    local_get(Local(stat_buf));
                     call(self.emitter.rt.path_filestat_get);
-                    local_set(errno);
-                    local_get(errno); i32_const(0); i32_ne;
+                    local_set(Local(errno));
+                    local_get(Local(errno)); i32_const(Imm32(0)); i32_ne;
                     if_i32;
-                      i32_const(0);
+                      i32_const(Imm32(0));
                     else_;
-                      local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_FILETYPE); i32_add; i32_load8_u(0);
-                      i32_const(WASI_FILETYPE_SYMLINK); i32_eq;
+                      local_get(Local(stat_buf)); i32_const(Imm32(WASI_FILESTAT_OFFSET_FILETYPE)); i32_add; i32_load8_u(0);
+                      i32_const(Imm32(WASI_FILETYPE_SYMLINK)); i32_eq;
                     end;
                 });
 
@@ -1103,97 +1104,97 @@ impl FuncCompiler<'_> {
                 let errno = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(src_str); });
+                wasm!(self.func, { local_set(Local(src_str)); });
                 self.emit_fs_resolve_path(src_str, src_ptr, src_len, src_resolved_fd);
 
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(dst_str); });
+                wasm!(self.func, { local_set(Local(dst_str)); });
                 self.emit_fs_resolve_path(dst_str, dst_ptr, dst_len, dst_resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(fd_out_ptr));
                 });
 
                 // Open source for reading
                 wasm!(self.func, {
-                    local_get(src_resolved_fd); i32_const(0);
-                    local_get(src_ptr); local_get(src_len);
-                    i32_const(0); i64_const(WASI_RIGHTS_FD_READ_SEEK); i64_const(0); i32_const(0);
-                    local_get(fd_out_ptr);
+                    local_get(Local(src_resolved_fd)); i32_const(Imm32(0));
+                    local_get(Local(src_ptr)); local_get(Local(src_len));
+                    i32_const(Imm32(0)); i64_const(Imm64(WASI_RIGHTS_FD_READ_SEEK)); i64_const(Imm64(0)); i32_const(Imm32(0));
+                    local_get(Local(fd_out_ptr));
                     call(self.emitter.rt.path_open);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_const(0); i32_ne;
+                    local_get(Local(errno)); i32_const(Imm32(0)); i32_ne;
                     if_i32;
                 });
                 let err_msg = self.emitter.intern_string("failed to open source file");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
 
                 // Read source content
                 wasm!(self.func, {
-                    local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
-                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
-                    local_get(opened_fd); local_get(stat_buf);
+                    local_get(Local(fd_out_ptr)); i32_load(0); local_set(Local(opened_fd));
+                    i32_const(Imm32(WASI_FILESTAT_BUF_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(stat_buf));
+                    local_get(Local(opened_fd)); local_get(Local(stat_buf));
                     call(self.emitter.rt.fd_filestat_get); drop;
-                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_SIZE); i32_add; i32_load(0); local_set(file_size);
-                    local_get(file_size); call(self.emitter.rt.alloc_pinned); local_set(data_buf);
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr);
-                    local_get(iov_ptr); local_get(data_buf); i32_store(0);
-                    local_get(iov_ptr); local_get(file_size); i32_store(4);
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nrw_ptr);
-                    local_get(opened_fd); local_get(iov_ptr); i32_const(1); local_get(nrw_ptr);
+                    local_get(Local(stat_buf)); i32_const(Imm32(WASI_FILESTAT_OFFSET_SIZE)); i32_add; i32_load(0); local_set(Local(file_size));
+                    local_get(Local(file_size)); call(self.emitter.rt.alloc_pinned); local_set(Local(data_buf));
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(iov_ptr));
+                    local_get(Local(iov_ptr)); local_get(Local(data_buf)); i32_store(0);
+                    local_get(Local(iov_ptr)); local_get(Local(file_size)); i32_store(4);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(nrw_ptr));
+                    local_get(Local(opened_fd)); local_get(Local(iov_ptr)); i32_const(Imm32(1)); local_get(Local(nrw_ptr));
                     call(self.emitter.rt.fd_read); drop;
-                    local_get(opened_fd); call(self.emitter.rt.fd_close); drop;
-                    local_get(nrw_ptr); i32_load(0); local_set(file_size);
+                    local_get(Local(opened_fd)); call(self.emitter.rt.fd_close); drop;
+                    local_get(Local(nrw_ptr)); i32_load(0); local_set(Local(file_size));
                 });
 
                 // Open dst for writing
                 wasm!(self.func, {
-                    local_get(dst_resolved_fd); i32_const(0);
-                    local_get(dst_ptr); local_get(dst_len);
-                    i32_const(WASI_OFLAGS_CREAT_TRUNC); i64_const(WASI_RIGHTS_FD_WRITE); i64_const(0); i32_const(0);
-                    local_get(fd_out_ptr);
+                    local_get(Local(dst_resolved_fd)); i32_const(Imm32(0));
+                    local_get(Local(dst_ptr)); local_get(Local(dst_len));
+                    i32_const(Imm32(WASI_OFLAGS_CREAT_TRUNC)); i64_const(Imm64(WASI_RIGHTS_FD_WRITE)); i64_const(Imm64(0)); i32_const(Imm32(0));
+                    local_get(Local(fd_out_ptr));
                     call(self.emitter.rt.path_open);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_const(0); i32_ne;
+                    local_get(Local(errno)); i32_const(Imm32(0)); i32_ne;
                     if_i32;
                 });
                 let err_msg2 = self.emitter.intern_string("failed to open destination file");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg2 as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg2 as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
 
                 // Write data to dst
                 wasm!(self.func, {
-                    local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
-                    local_get(iov_ptr); local_get(data_buf); i32_store(0);
-                    local_get(iov_ptr); local_get(file_size); i32_store(4);
-                    local_get(opened_fd); local_get(iov_ptr); i32_const(1); local_get(nrw_ptr);
+                    local_get(Local(fd_out_ptr)); i32_load(0); local_set(Local(opened_fd));
+                    local_get(Local(iov_ptr)); local_get(Local(data_buf)); i32_store(0);
+                    local_get(Local(iov_ptr)); local_get(Local(file_size)); i32_store(4);
+                    local_get(Local(opened_fd)); local_get(Local(iov_ptr)); i32_const(Imm32(1)); local_get(Local(nrw_ptr));
                     call(self.emitter.rt.fd_write); drop;
-                    local_get(opened_fd); call(self.emitter.rt.fd_close); drop;
+                    local_get(Local(opened_fd)); call(self.emitter.rt.fd_close); drop;
                 });
 
                 // ok(unit) -- close nested if blocks
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(0); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(4);
+                    local_get(Local(result_ptr));
                     end;
                     end;
                 });
@@ -1230,40 +1231,40 @@ impl FuncCompiler<'_> {
                 let errno = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(src_str); });
+                wasm!(self.func, { local_set(Local(src_str)); });
                 self.emit_fs_resolve_path(src_str, src_ptr, src_len, src_resolved_fd);
 
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(dst_str); });
+                wasm!(self.func, { local_set(Local(dst_str)); });
                 self.emit_fs_resolve_path(dst_str, dst_ptr, dst_len, dst_resolved_fd);
 
                 // path_rename(old_fd, old_path, old_len, new_fd, new_path, new_len)
                 wasm!(self.func, {
-                    local_get(src_resolved_fd);
-                    local_get(src_ptr); local_get(src_len);
-                    local_get(dst_resolved_fd);
-                    local_get(dst_ptr); local_get(dst_len);
+                    local_get(Local(src_resolved_fd));
+                    local_get(Local(src_ptr)); local_get(Local(src_len));
+                    local_get(Local(dst_resolved_fd));
+                    local_get(Local(dst_ptr)); local_get(Local(dst_len));
                     call(self.emitter.rt.path_rename);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_eqz;
+                    local_get(Local(errno)); i32_eqz;
                     if_i32;
                 });
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(0); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
                 let err_msg = self.emitter.intern_string("failed to rename");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     end;
                 });
 
@@ -1288,33 +1289,33 @@ impl FuncCompiler<'_> {
                 let errno = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    local_get(resolved_fd);
-                    local_get(path_ptr); local_get(path_len);
+                    local_get(Local(resolved_fd));
+                    local_get(Local(path_ptr)); local_get(Local(path_len));
                     call(self.emitter.rt.path_unlink_file);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_eqz;
+                    local_get(Local(errno)); i32_eqz;
                     if_i32;
                 });
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(0); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
                 let err_msg = self.emitter.intern_string("failed to remove file");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     end;
                 });
 
@@ -1336,54 +1337,54 @@ impl FuncCompiler<'_> {
                 let errno = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 // Try path_unlink_file first
                 wasm!(self.func, {
-                    local_get(resolved_fd);
-                    local_get(path_ptr); local_get(path_len);
+                    local_get(Local(resolved_fd));
+                    local_get(Local(path_ptr)); local_get(Local(path_len));
                     call(self.emitter.rt.path_unlink_file);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_eqz;
+                    local_get(Local(errno)); i32_eqz;
                     if_i32;
                 });
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(0); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
 
                 // Try path_remove_directory
                 wasm!(self.func, {
-                    local_get(resolved_fd);
-                    local_get(path_ptr); local_get(path_len);
+                    local_get(Local(resolved_fd));
+                    local_get(Local(path_ptr)); local_get(Local(path_len));
                     call(self.emitter.rt.path_remove_directory);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_eqz;
+                    local_get(Local(errno)); i32_eqz;
                     if_i32;
                 });
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(0); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
                 let err_msg = self.emitter.intern_string("failed to remove path");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     end;
                     end;
                 });
@@ -1406,40 +1407,40 @@ impl FuncCompiler<'_> {
                 let errno = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
-                    local_get(resolved_fd); i32_const(1);
-                    local_get(path_ptr); local_get(path_len);
-                    local_get(stat_buf);
+                    i32_const(Imm32(WASI_FILESTAT_BUF_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(stat_buf));
+                    local_get(Local(resolved_fd)); i32_const(Imm32(1));
+                    local_get(Local(path_ptr)); local_get(Local(path_len));
+                    local_get(Local(stat_buf));
                     call(self.emitter.rt.path_filestat_get);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_eqz;
+                    local_get(Local(errno)); i32_eqz;
                     if_i32;
                 });
                 // ok: file size at offset 32 as i64
                 // Result[Int, String] = [tag:i32][padding:i32][i64] = 16 bytes
                 wasm!(self.func, {
-                    i32_const(RESULT_INT_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(RESULT_PAIR_BYTES); i32_add;
-                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_SIZE); i32_add; i64_load(0);
+                    i32_const(Imm32(RESULT_INT_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(RESULT_PAIR_BYTES)); i32_add;
+                    local_get(Local(stat_buf)); i32_const(Imm32(WASI_FILESTAT_OFFSET_SIZE)); i32_add; i64_load(0);
                     i64_store(0);
-                    local_get(result_ptr);
+                    local_get(Local(result_ptr));
                     else_;
                 });
                 let err_msg = self.emitter.intern_string("file not found");
                 wasm!(self.func, {
-                    i32_const(RESULT_INT_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(RESULT_PAIR_BYTES); i32_add;
-                    i32_const(err_msg as i32); i64_extend_i32_u; i64_store(0);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_INT_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(RESULT_PAIR_BYTES)); i32_add;
+                    i32_const(Imm32(err_msg as i32)); i64_extend_i32_u; i64_store(0);
+                    local_get(Local(result_ptr));
                     end;
                 });
 
@@ -1463,39 +1464,39 @@ impl FuncCompiler<'_> {
                 let errno = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
-                    local_get(resolved_fd); i32_const(1);
-                    local_get(path_ptr); local_get(path_len);
-                    local_get(stat_buf);
+                    i32_const(Imm32(WASI_FILESTAT_BUF_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(stat_buf));
+                    local_get(Local(resolved_fd)); i32_const(Imm32(1));
+                    local_get(Local(path_ptr)); local_get(Local(path_len));
+                    local_get(Local(stat_buf));
                     call(self.emitter.rt.path_filestat_get);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_eqz;
+                    local_get(Local(errno)); i32_eqz;
                     if_i32;
                 });
                 wasm!(self.func, {
-                    i32_const(RESULT_INT_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); i32_const(RESULT_PAIR_BYTES); i32_add;
-                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_MTIM); i32_add; i64_load(0);
-                    i64_const(NANOS_PER_SEC); i64_div_u;
+                    i32_const(Imm32(RESULT_INT_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(RESULT_PAIR_BYTES)); i32_add;
+                    local_get(Local(stat_buf)); i32_const(Imm32(WASI_FILESTAT_OFFSET_MTIM)); i32_add; i64_load(0);
+                    i64_const(Imm64(NANOS_PER_SEC)); i64_div_u;
                     i64_store(0);
-                    local_get(result_ptr);
+                    local_get(Local(result_ptr));
                     else_;
                 });
                 let err_msg = self.emitter.intern_string("file not found");
                 wasm!(self.func, {
-                    i32_const(RESULT_INT_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(RESULT_PAIR_BYTES); i32_add;
-                    i32_const(err_msg as i32); i64_extend_i32_u; i64_store(0);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_INT_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(RESULT_PAIR_BYTES)); i32_add;
+                    i32_const(Imm32(err_msg as i32)); i64_extend_i32_u; i64_store(0);
+                    local_get(Local(result_ptr));
                     end;
                 });
 
@@ -1519,61 +1520,61 @@ impl FuncCompiler<'_> {
                 let errno = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(path_str); });
+                wasm!(self.func, { local_set(Local(path_str)); });
                 self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
                 wasm!(self.func, {
-                    i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
-                    local_get(resolved_fd); i32_const(1);
-                    local_get(path_ptr); local_get(path_len);
-                    local_get(stat_buf);
+                    i32_const(Imm32(WASI_FILESTAT_BUF_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(stat_buf));
+                    local_get(Local(resolved_fd)); i32_const(Imm32(1));
+                    local_get(Local(path_ptr)); local_get(Local(path_len));
+                    local_get(Local(stat_buf));
                     call(self.emitter.rt.path_filestat_get);
-                    local_set(errno);
+                    local_set(Local(errno));
                 });
 
                 wasm!(self.func, {
-                    local_get(errno); i32_eqz;
+                    local_get(Local(errno)); i32_eqz;
                     if_i32;
                 });
 
                 // Record: [size:i64(8)][is_dir:i32(4)][is_file:i32(4)][modified:i64(8)] = 24 bytes
                 wasm!(self.func, {
-                    i32_const(STAT_REC_BYTES); call(self.emitter.rt.alloc); local_set(rec_ptr);
+                    i32_const(Imm32(STAT_REC_BYTES)); call(self.emitter.rt.alloc); local_set(Local(rec_ptr));
                     // size at stat offset 32
-                    local_get(rec_ptr);
-                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_SIZE); i32_add; i64_load(0);
+                    local_get(Local(rec_ptr));
+                    local_get(Local(stat_buf)); i32_const(Imm32(WASI_FILESTAT_OFFSET_SIZE)); i32_add; i64_load(0);
                     i64_store(0);
                     // is_dir: filetype at offset 16 == 3
-                    local_get(rec_ptr); i32_const(STAT_REC_OFFSET_IS_DIR); i32_add;
-                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_FILETYPE); i32_add; i32_load8_u(0);
-                    i32_const(WASI_FILETYPE_DIRECTORY); i32_eq;
+                    local_get(Local(rec_ptr)); i32_const(Imm32(STAT_REC_OFFSET_IS_DIR)); i32_add;
+                    local_get(Local(stat_buf)); i32_const(Imm32(WASI_FILESTAT_OFFSET_FILETYPE)); i32_add; i32_load8_u(0);
+                    i32_const(Imm32(WASI_FILETYPE_DIRECTORY)); i32_eq;
                     i32_store(0);
                     // is_file: filetype at offset 16 == 4
-                    local_get(rec_ptr); i32_const(STAT_REC_OFFSET_IS_FILE); i32_add;
-                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_FILETYPE); i32_add; i32_load8_u(0);
-                    i32_const(WASI_FILETYPE_REGULAR_FILE); i32_eq;
+                    local_get(Local(rec_ptr)); i32_const(Imm32(STAT_REC_OFFSET_IS_FILE)); i32_add;
+                    local_get(Local(stat_buf)); i32_const(Imm32(WASI_FILESTAT_OFFSET_FILETYPE)); i32_add; i32_load8_u(0);
+                    i32_const(Imm32(WASI_FILETYPE_REGULAR_FILE)); i32_eq;
                     i32_store(0);
                     // modified: mtim at stat offset 40, nanoseconds -> seconds
-                    local_get(rec_ptr); i32_const(STAT_REC_OFFSET_MODIFIED); i32_add;
-                    local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_MTIM); i32_add; i64_load(0);
-                    i64_const(NANOS_PER_SEC); i64_div_u;
+                    local_get(Local(rec_ptr)); i32_const(Imm32(STAT_REC_OFFSET_MODIFIED)); i32_add;
+                    local_get(Local(stat_buf)); i32_const(Imm32(WASI_FILESTAT_OFFSET_MTIM)); i32_add; i64_load(0);
+                    i64_const(Imm64(NANOS_PER_SEC)); i64_div_u;
                     i64_store(0);
                 });
 
                 // ok(rec_ptr)
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(0); i32_store(0);
-                    local_get(result_ptr); local_get(rec_ptr); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result_ptr)); local_get(Local(rec_ptr)); i32_store(4);
+                    local_get(Local(result_ptr));
                     else_;
                 });
                 let err_msg = self.emitter.intern_string("file not found");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                     end;
                 });
 
@@ -1593,17 +1594,17 @@ impl FuncCompiler<'_> {
                 let result_ptr = self.scratch.alloc_i32();
                 let err_msg = self.emitter.intern_string("not supported in WASM");
                 wasm!(self.func, {
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-                    local_get(result_ptr); i32_const(1); i32_store(0);
-                    local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-                    local_get(result_ptr);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+                    local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                    local_get(Local(result_ptr));
                 });
                 self.scratch.free_i32(result_ptr);
             }
             "temp_dir" => {
                 // fs.temp_dir() -> String: return "/tmp"
                 let s = self.emitter.intern_string("/tmp");
-                wasm!(self.func, { i32_const(s as i32); });
+                wasm!(self.func, { i32_const(Imm32(s as i32)); });
             }
             "read_bytes_raw" => {
                 // fs.read_bytes_raw(path: String) -> Result[Bytes, String].
@@ -1621,12 +1622,12 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     // Err payload: String pointer (already interned).
-                    i32_const(msg as i32); local_set(msg_str);
+                    i32_const(Imm32(msg as i32)); local_set(Local(msg_str));
                     // Result[Bytes, String] layout: [tag:i32=1 for err, payload:i32]
-                    i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(1); i32_store(0);
-                    local_get(result); local_get(msg_str); i32_store(4);
-                    local_get(result);
+                    i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(result)); local_get(Local(msg_str)); i32_store(4);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(msg_str);
@@ -1649,14 +1650,14 @@ impl FuncCompiler<'_> {
         let resolve_result = self.scratch.alloc_i32();
         wasm!(self.func, {
             // Call __resolve_path(path_ptr, path_len) → result_ptr [fd, rel_ptr, rel_len]
-            local_get(path_str); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; // raw path bytes (skip string length prefix)
-            local_get(path_str); i32_load(0);            // path byte length
+            local_get(Local(path_str)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; // raw path bytes (skip string length prefix)
+            local_get(Local(path_str)); i32_load(0);            // path byte length
             call(self.emitter.rt.resolve_path);
-            local_set(resolve_result);
+            local_set(Local(resolve_result));
             // Unpack result
-            local_get(resolve_result); i32_load(0); local_set(resolved_fd);
-            local_get(resolve_result); i32_load(4); local_set(path_ptr);
-            local_get(resolve_result); i32_load(8); local_set(path_len);
+            local_get(Local(resolve_result)); i32_load(0); local_set(Local(resolved_fd));
+            local_get(Local(resolve_result)); i32_load(4); local_set(Local(path_ptr));
+            local_get(Local(resolve_result)); i32_load(8); local_set(Local(path_len));
         });
         self.scratch.free_i32(resolve_result);
     }
@@ -1671,24 +1672,24 @@ impl FuncCompiler<'_> {
         let errno = self.scratch.alloc_i32();
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(path_str); });
+        wasm!(self.func, { local_set(Local(path_str)); });
         self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
         wasm!(self.func, {
-            i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
+            i32_const(Imm32(WASI_FILESTAT_BUF_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(stat_buf));
             // flags=1 (follow symlinks) for is_dir/is_file
-            local_get(resolved_fd); i32_const(1);
-            local_get(path_ptr); local_get(path_len);
-            local_get(stat_buf);
+            local_get(Local(resolved_fd)); i32_const(Imm32(1));
+            local_get(Local(path_ptr)); local_get(Local(path_len));
+            local_get(Local(stat_buf));
             call(self.emitter.rt.path_filestat_get);
-            local_set(errno);
-            local_get(errno); i32_const(0); i32_ne;
+            local_set(Local(errno));
+            local_get(Local(errno)); i32_const(Imm32(0)); i32_ne;
             if_i32;
-              i32_const(0);
+              i32_const(Imm32(0));
             else_;
               // filetype at stat offset 16
-              local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_FILETYPE); i32_add; i32_load8_u(0);
-              i32_const(expected_filetype);
+              local_get(Local(stat_buf)); i32_const(Imm32(WASI_FILESTAT_OFFSET_FILETYPE)); i32_add; i32_load8_u(0);
+              i32_const(Imm32(expected_filetype));
               i32_eq;
             end;
         });
@@ -1708,25 +1709,25 @@ impl FuncCompiler<'_> {
         dir_buf: u32, offset: u32, list_ptr: u32, counter: u32,
     ) {
         wasm!(self.func, {
-            local_get(entry_name_len); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
-            call(self.emitter.rt.alloc); local_set(str_ptr);
-            local_get(str_ptr); local_get(entry_name_len); i32_store(0);
+            local_get(Local(entry_name_len)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(str_ptr));
+            local_get(Local(str_ptr)); local_get(Local(entry_name_len)); i32_store(0);
             // Copy name bytes
-            i32_const(0); local_set(copy_i);
+            i32_const(Imm32(0)); local_set(Local(copy_i));
             block_empty; loop_empty;
-            local_get(copy_i); local_get(entry_name_len); i32_ge_u; br_if(1);
-            local_get(str_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(copy_i); i32_add;
-            local_get(dir_buf); local_get(offset); i32_add; i32_const(WASI_DIRENT_OFFSET_NAME); i32_add;
-            local_get(copy_i); i32_add; i32_load8_u(0);
+            local_get(Local(copy_i)); local_get(Local(entry_name_len)); i32_ge_u; br_if(1);
+            local_get(Local(str_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(copy_i)); i32_add;
+            local_get(Local(dir_buf)); local_get(Local(offset)); i32_add; i32_const(Imm32(WASI_DIRENT_OFFSET_NAME)); i32_add;
+            local_get(Local(copy_i)); i32_add; i32_load8_u(0);
             i32_store8(0);
-            local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+            local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
             br(0);
             end; end;
             // Store in list
-            local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-            local_get(counter); i32_const(I32_BYTES); i32_mul; i32_add;
-            local_get(str_ptr); i32_store(0);
-            local_get(counter); i32_const(1); i32_add; local_set(counter);
+            local_get(Local(list_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+            local_get(Local(counter)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+            local_get(Local(str_ptr)); i32_store(0);
+            local_get(Local(counter)); i32_const(Imm32(1)); i32_add; local_set(Local(counter));
         });
     }
 
@@ -1748,78 +1749,78 @@ impl FuncCompiler<'_> {
         let errno = self.scratch.alloc_i32();
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(path_str); });
+        wasm!(self.func, { local_set(Local(path_str)); });
         self.emit_fs_resolve_path(path_str, path_ptr, path_len, resolved_fd);
 
         wasm!(self.func, {
-            i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(fd_out_ptr);
+            i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(fd_out_ptr));
         });
 
         wasm!(self.func, {
-            local_get(resolved_fd); i32_const(0);
-            local_get(path_ptr); local_get(path_len);
-            i32_const(0); i64_const(WASI_RIGHTS_FD_READ_SEEK); i64_const(0); i32_const(0);
-            local_get(fd_out_ptr);
+            local_get(Local(resolved_fd)); i32_const(Imm32(0));
+            local_get(Local(path_ptr)); local_get(Local(path_len));
+            i32_const(Imm32(0)); i64_const(Imm64(WASI_RIGHTS_FD_READ_SEEK)); i64_const(Imm64(0)); i32_const(Imm32(0));
+            local_get(Local(fd_out_ptr));
             call(self.emitter.rt.path_open);
-            local_set(errno);
+            local_set(Local(errno));
         });
 
         wasm!(self.func, {
-            local_get(errno); i32_const(0); i32_ne;
+            local_get(Local(errno)); i32_const(Imm32(0)); i32_ne;
             if_i32;
         });
         let err_msg = self.emitter.intern_string("file not found");
         wasm!(self.func, {
-            i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-            local_get(result_ptr); i32_const(1); i32_store(0);
-            local_get(result_ptr); i32_const(err_msg as i32); i32_store(4);
-            local_get(result_ptr);
+            i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+            local_get(Local(result_ptr)); i32_const(Imm32(1)); i32_store(0);
+            local_get(Local(result_ptr)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+            local_get(Local(result_ptr));
             else_;
         });
 
         wasm!(self.func, {
-            local_get(fd_out_ptr); i32_load(0); local_set(opened_fd);
-            i32_const(WASI_FILESTAT_BUF_BYTES); call(self.emitter.rt.alloc_pinned); local_set(stat_buf);
-            local_get(opened_fd); local_get(stat_buf);
+            local_get(Local(fd_out_ptr)); i32_load(0); local_set(Local(opened_fd));
+            i32_const(Imm32(WASI_FILESTAT_BUF_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(stat_buf));
+            local_get(Local(opened_fd)); local_get(Local(stat_buf));
             call(self.emitter.rt.fd_filestat_get); drop;
-            local_get(stat_buf); i32_const(WASI_FILESTAT_OFFSET_SIZE); i32_add; i32_load(0); local_set(file_size);
-            local_get(file_size); call(self.emitter.rt.alloc_pinned); local_set(data_buf);
-            i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc_pinned); local_set(iov_ptr); // iov struct [buf_ptr:i32, buf_len:i32]
-            local_get(iov_ptr); local_get(data_buf); i32_store(0);
-            local_get(iov_ptr); local_get(file_size); i32_store(4);
-            i32_const(I32_BYTES); call(self.emitter.rt.alloc_pinned); local_set(nread_ptr);
-            local_get(opened_fd); local_get(iov_ptr); i32_const(1); local_get(nread_ptr);
+            local_get(Local(stat_buf)); i32_const(Imm32(WASI_FILESTAT_OFFSET_SIZE)); i32_add; i32_load(0); local_set(Local(file_size));
+            local_get(Local(file_size)); call(self.emitter.rt.alloc_pinned); local_set(Local(data_buf));
+            i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(iov_ptr)); // iov struct [buf_ptr:i32, buf_len:i32]
+            local_get(Local(iov_ptr)); local_get(Local(data_buf)); i32_store(0);
+            local_get(Local(iov_ptr)); local_get(Local(file_size)); i32_store(4);
+            i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc_pinned); local_set(Local(nread_ptr));
+            local_get(Local(opened_fd)); local_get(Local(iov_ptr)); i32_const(Imm32(1)); local_get(Local(nread_ptr));
             call(self.emitter.rt.fd_read); drop;
-            local_get(opened_fd); call(self.emitter.rt.fd_close); drop;
-            local_get(nread_ptr); i32_load(0); local_set(file_size);
+            local_get(Local(opened_fd)); call(self.emitter.rt.fd_close); drop;
+            local_get(Local(nread_ptr)); i32_load(0); local_set(Local(file_size));
         });
 
         wasm!(self.func, {
-            local_get(file_size); i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32); i32_add;
-            call(self.emitter.rt.alloc); local_set(str_ptr);
-            local_get(str_ptr); local_get(file_size); i32_store(0);
+            local_get(Local(file_size)); i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32)); i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(str_ptr));
+            local_get(Local(str_ptr)); local_get(Local(file_size)); i32_store(0);
         });
 
         let counter = self.scratch.alloc_i32();
         wasm!(self.func, {
-            i32_const(0); local_set(counter);
+            i32_const(Imm32(0)); local_set(Local(counter));
             block_empty; loop_empty;
-            local_get(counter); local_get(file_size); i32_ge_u; br_if(1);
-            local_get(str_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(counter); i32_add;
-            local_get(data_buf); local_get(counter); i32_add;
+            local_get(Local(counter)); local_get(Local(file_size)); i32_ge_u; br_if(1);
+            local_get(Local(str_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(counter)); i32_add;
+            local_get(Local(data_buf)); local_get(Local(counter)); i32_add;
             i32_load8_u(0);
             i32_store8(0);
-            local_get(counter); i32_const(1); i32_add; local_set(counter);
+            local_get(Local(counter)); i32_const(Imm32(1)); i32_add; local_set(Local(counter));
             br(0);
             end; end;
         });
         self.scratch.free_i32(counter);
 
         wasm!(self.func, {
-            i32_const(RESULT_PAIR_BYTES); call(self.emitter.rt.alloc); local_set(result_ptr);
-            local_get(result_ptr); i32_const(0); i32_store(0);
-            local_get(result_ptr); local_get(str_ptr); i32_store(4);
-            local_get(result_ptr);
+            i32_const(Imm32(RESULT_PAIR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result_ptr));
+            local_get(Local(result_ptr)); i32_const(Imm32(0)); i32_store(0);
+            local_get(Local(result_ptr)); local_get(Local(str_ptr)); i32_store(4);
+            local_get(Local(result_ptr));
             end;
         });
 

--- a/crates/almide-codegen/src/emit_wasm/calls_http.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_http.rs
@@ -6,6 +6,22 @@ use almide_lang::types::Ty;
 use super::values;
 use wasm_encoder::Instruction;
 
+// Named constants for WASM immediate operands used in the HTTP emitter.
+mod imm {
+    /// Byte size of one i32 value / pointer (4 bytes).
+    /// Also used as the stride when indexing pointer-arrays in list data.
+    pub const I32_BYTES: i32 = 4;
+    /// Byte size of an (i32, i32) tuple — two adjacent pointer fields.
+    pub const TUPLE2_BYTES: i32 = 8;
+    /// Byte size of the Response struct: status:i64 (8) + body:i32 (4) + headers:i32 (4).
+    pub const RESP_BYTES: i32 = 16;
+    /// HTTP 302 Found / Redirect status code.
+    pub const HTTP_REDIRECT: i64 = 302;
+    /// HTTP 404 Not Found status code.
+    pub const HTTP_NOT_FOUND: i64 = 404;
+}
+use imm::*;
+
 impl FuncCompiler<'_> {
     pub(super) fn emit_http_call(&mut self, func: &str, args: &[IrExpr]) {
         match func {
@@ -13,7 +29,7 @@ impl FuncCompiler<'_> {
                 // http.response(status: Int, body: String) → Response
                 let s = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(16); call(self.emitter.rt.alloc); local_set(s);
+                    i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(s);
                     local_get(s);
                 });
                 self.emit_expr(&args[0]); // status: i64
@@ -23,7 +39,7 @@ impl FuncCompiler<'_> {
                     i32_store(8);
                     // Empty headers list
                     local_get(s);
-                    i32_const(4); call(self.emitter.rt.alloc);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc);
                 });
                 let empty_list = self.scratch.alloc_i32();
                 wasm!(self.func, {
@@ -42,7 +58,7 @@ impl FuncCompiler<'_> {
                 let hdr_list = self.scratch.alloc_i32();
                 let tuple_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(16); call(self.emitter.rt.alloc); local_set(s);
+                    i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(s);
                     local_get(s);
                 });
                 self.emit_expr(&args[0]);
@@ -53,10 +69,10 @@ impl FuncCompiler<'_> {
                 let ct_key = self.emitter.intern_string("Content-Type");
                 let ct_val = self.emitter.intern_string("application/json");
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(tuple_ptr);
+                    i32_const(TUPLE2_BYTES); call(self.emitter.rt.alloc); local_set(tuple_ptr);
                     local_get(tuple_ptr); i32_const(ct_key as i32); i32_store(0);
                     local_get(tuple_ptr); i32_const(ct_val as i32); i32_store(4);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + 4); call(self.emitter.rt.alloc); local_set(hdr_list);
+                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + I32_BYTES); call(self.emitter.rt.alloc); local_set(hdr_list);
                     local_get(hdr_list); i32_const(1); i32_store(0); // len = 1
                     local_get(hdr_list); local_get(tuple_ptr); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32 as u32); // data[0] = tuple_ptr
                     local_get(s); local_get(hdr_list); i32_store(12);
@@ -78,7 +94,7 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { local_set(resp); });
                 wasm!(self.func, {
-                    i32_const(16); call(self.emitter.rt.alloc); local_set(new_resp);
+                    i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(new_resp);
                     local_get(new_resp);
                 });
                 self.emit_expr(&args[1]); // new status: i64
@@ -123,7 +139,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); local_get(len); i32_ge_u; br_if(1);
                       local_get(hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0); local_set(pair_ptr);
                       local_get(pair_ptr); i32_load(0);
                       local_get(key);
@@ -131,7 +147,7 @@ impl FuncCompiler<'_> {
                       if_empty;
                         // Found: build Some(string_ptr) by allocating a 4-byte
                         // cell and storing the value pointer inside.
-                        i32_const(4); call(self.emitter.rt.alloc); local_set(some_ptr);
+                        i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(some_ptr);
                         local_get(some_ptr); local_get(pair_ptr); i32_load(4); i32_store(0);
                         local_get(some_ptr); local_set(result);
                         br(2);
@@ -167,14 +183,14 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
                     local_set(val_scratch);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(tuple_ptr);
+                    i32_const(TUPLE2_BYTES); call(self.emitter.rt.alloc); local_set(tuple_ptr);
                     local_get(tuple_ptr); local_get(key_scratch); i32_store(0);
                     local_get(tuple_ptr); local_get(val_scratch); i32_store(4);
                     // Copy old headers + append new
                     local_get(resp); i32_load(12); local_set(old_hdrs);
                     local_get(old_hdrs); i32_load(0); i32_const(1); i32_add;
                     local_set(val_scratch); // reuse as new_len
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(val_scratch); i32_const(4); i32_mul; i32_add;
+                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(val_scratch); i32_const(I32_BYTES); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(new_hdrs);
                     local_get(new_hdrs); local_get(val_scratch); i32_store(0);
                     // Copy old header ptrs
@@ -182,19 +198,19 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(key_scratch); local_get(old_hdrs); i32_load(0); i32_ge_u; br_if(1);
                       local_get(new_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(key_scratch); i32_const(4); i32_mul; i32_add;
+                      local_get(key_scratch); i32_const(I32_BYTES); i32_mul; i32_add;
                       local_get(old_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(key_scratch); i32_const(4); i32_mul; i32_add;
+                      local_get(key_scratch); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0); i32_store(0);
                       local_get(key_scratch); i32_const(1); i32_add; local_set(key_scratch);
                       br(0);
                     end; end;
                     // Append new tuple at end
                     local_get(new_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(old_hdrs); i32_load(0); i32_const(4); i32_mul; i32_add;
+                    local_get(old_hdrs); i32_load(0); i32_const(I32_BYTES); i32_mul; i32_add;
                     local_get(tuple_ptr); i32_store(0);
                     // Build new response
-                    i32_const(16); call(self.emitter.rt.alloc); local_set(new_resp);
+                    i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(new_resp);
                     local_get(new_resp); local_get(resp); i64_load(0); i64_store(0);
                     local_get(new_resp); local_get(resp); i32_load(8); i32_store(8);
                     local_get(new_resp); local_get(new_hdrs); i32_store(12);
@@ -227,27 +243,27 @@ impl FuncCompiler<'_> {
                 let new_len = self.scratch.alloc_i32();
                 let ci = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(tuple_ptr);
+                    i32_const(TUPLE2_BYTES); call(self.emitter.rt.alloc); local_set(tuple_ptr);
                     local_get(tuple_ptr); i32_const(cookie_key as i32); i32_store(0);
                     local_get(tuple_ptr); local_get(cookie_val); i32_store(4);
                     local_get(resp); i32_load(12); local_set(old_hdrs);
                     local_get(old_hdrs); i32_load(0); i32_const(1); i32_add; local_set(new_len);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(new_len); i32_const(4); i32_mul; i32_add;
+                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(new_len); i32_const(I32_BYTES); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(new_hdrs);
                     local_get(new_hdrs); local_get(new_len); i32_store(0);
                     i32_const(0); local_set(ci);
                     block_empty; loop_empty;
                       local_get(ci); local_get(old_hdrs); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(new_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(ci); i32_const(4); i32_mul; i32_add;
-                      local_get(old_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(ci); i32_const(4); i32_mul; i32_add;
+                      local_get(new_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(ci); i32_const(I32_BYTES); i32_mul; i32_add;
+                      local_get(old_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(ci); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0); i32_store(0);
                       local_get(ci); i32_const(1); i32_add; local_set(ci);
                       br(0);
                     end; end;
                     local_get(new_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(old_hdrs); i32_load(0); i32_const(4); i32_mul; i32_add;
+                    local_get(old_hdrs); i32_load(0); i32_const(I32_BYTES); i32_mul; i32_add;
                     local_get(tuple_ptr); i32_store(0);
-                    i32_const(16); call(self.emitter.rt.alloc); local_set(new_resp);
+                    i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(new_resp);
                     local_get(new_resp); local_get(resp); i64_load(0); i64_store(0);
                     local_get(new_resp); local_get(resp); i32_load(8); i32_store(8);
                     local_get(new_resp); local_get(new_hdrs); i32_store(12);
@@ -272,7 +288,7 @@ impl FuncCompiler<'_> {
                 let len = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 let tuple = self.scratch.alloc_i32();
-                wasm!(self.func, { i32_const(16); call(self.emitter.rt.alloc); local_set(s); local_get(s); });
+                wasm!(self.func, { i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(s); local_get(s); });
                 self.emit_expr(&args[0]); // status
                 wasm!(self.func, { i64_store(0); local_get(s); });
                 self.emit_expr(&args[1]); // body
@@ -282,7 +298,7 @@ impl FuncCompiler<'_> {
                     local_set(hdr_map);
                     local_get(hdr_map); i32_load(0); local_set(len);
                     // Build headers list from Swiss Table map entries
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(len); i32_const(4); i32_mul; i32_add;
+                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(len); i32_const(I32_BYTES); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(hdr_list);
                     local_get(hdr_list); local_get(len); i32_store(0);
                 });
@@ -308,7 +324,7 @@ impl FuncCompiler<'_> {
                       i32_const(es as i32); memory_copy;
                       // hdr_list[i] = tuple
                       local_get(hdr_list); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       local_get(tuple); i32_store(0);
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -327,26 +343,26 @@ impl FuncCompiler<'_> {
             }
             "not_found" => {
                 let s = self.scratch.alloc_i32();
-                wasm!(self.func, { i32_const(16); call(self.emitter.rt.alloc); local_set(s); local_get(s); i64_const(404); i64_store(0); local_get(s); });
+                wasm!(self.func, { i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(s); local_get(s); i64_const(HTTP_NOT_FOUND); i64_store(0); local_get(s); });
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { i32_store(8); });
                 let empty = self.scratch.alloc_i32();
-                wasm!(self.func, { i32_const(4); call(self.emitter.rt.alloc); local_set(empty); local_get(empty); i32_const(0); i32_store(0); local_get(s); local_get(empty); i32_store(12); local_get(s); });
+                wasm!(self.func, { i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(empty); local_get(empty); i32_const(0); i32_store(0); local_get(s); local_get(empty); i32_store(12); local_get(s); });
                 self.scratch.free_i32(empty);
                 self.scratch.free_i32(s);
             }
             "redirect" => {
                 let s = self.scratch.alloc_i32();
                 let empty_body = self.emitter.intern_string("");
-                wasm!(self.func, { i32_const(16); call(self.emitter.rt.alloc); local_set(s); local_get(s); i64_const(302); i64_store(0); local_get(s); i32_const(empty_body as i32); i32_store(8); });
+                wasm!(self.func, { i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(s); local_get(s); i64_const(HTTP_REDIRECT); i64_store(0); local_get(s); i32_const(empty_body as i32); i32_store(8); });
                 let loc_key = self.emitter.intern_string("Location");
                 let tuple = self.scratch.alloc_i32();
                 let hdrs = self.scratch.alloc_i32();
-                wasm!(self.func, { i32_const(8); call(self.emitter.rt.alloc); local_set(tuple); local_get(tuple); i32_const(loc_key as i32); i32_store(0); local_get(tuple); });
+                wasm!(self.func, { i32_const(TUPLE2_BYTES); call(self.emitter.rt.alloc); local_set(tuple); local_get(tuple); i32_const(loc_key as i32); i32_store(0); local_get(tuple); });
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     i32_store(4);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + 4); call(self.emitter.rt.alloc); local_set(hdrs);
+                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + I32_BYTES); call(self.emitter.rt.alloc); local_set(hdrs);
                     local_get(hdrs); i32_const(1); i32_store(0);
                     local_get(hdrs); local_get(tuple); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32 as u32);
                     local_get(s); local_get(hdrs); i32_store(12); local_get(s);

--- a/crates/almide-codegen/src/emit_wasm/calls_http.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_http.rs
@@ -1,5 +1,6 @@
 //! http module — WASM codegen dispatch.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::FuncCompiler;
 use almide_ir::IrExpr;
 use almide_lang::types::Ty;
@@ -29,25 +30,25 @@ impl FuncCompiler<'_> {
                 // http.response(status: Int, body: String) → Response
                 let s = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(s);
-                    local_get(s);
+                    i32_const(Imm32(RESP_BYTES)); call(self.emitter.rt.alloc); local_set(Local(s));
+                    local_get(Local(s));
                 });
                 self.emit_expr(&args[0]); // status: i64
-                wasm!(self.func, { i64_store(0); local_get(s); });
+                wasm!(self.func, { i64_store(0); local_get(Local(s)); });
                 self.emit_expr(&args[1]); // body: i32 str
                 wasm!(self.func, {
                     i32_store(8);
                     // Empty headers list
-                    local_get(s);
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc);
+                    local_get(Local(s));
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc);
                 });
                 let empty_list = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(empty_list);
-                    local_get(empty_list); i32_const(0); i32_store(0);
-                    local_get(empty_list);
+                    local_set(Local(empty_list));
+                    local_get(Local(empty_list)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(empty_list));
                     i32_store(12);
-                    local_get(s);
+                    local_get(Local(s));
                 });
                 self.scratch.free_i32(empty_list);
                 self.scratch.free_i32(s);
@@ -58,25 +59,25 @@ impl FuncCompiler<'_> {
                 let hdr_list = self.scratch.alloc_i32();
                 let tuple_ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(s);
-                    local_get(s);
+                    i32_const(Imm32(RESP_BYTES)); call(self.emitter.rt.alloc); local_set(Local(s));
+                    local_get(Local(s));
                 });
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i64_store(0); local_get(s); });
+                wasm!(self.func, { i64_store(0); local_get(Local(s)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, { i32_store(8); });
                 // Build headers list with Content-Type: application/json
                 let ct_key = self.emitter.intern_string("Content-Type");
                 let ct_val = self.emitter.intern_string("application/json");
                 wasm!(self.func, {
-                    i32_const(TUPLE2_BYTES); call(self.emitter.rt.alloc); local_set(tuple_ptr);
-                    local_get(tuple_ptr); i32_const(ct_key as i32); i32_store(0);
-                    local_get(tuple_ptr); i32_const(ct_val as i32); i32_store(4);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + I32_BYTES); call(self.emitter.rt.alloc); local_set(hdr_list);
-                    local_get(hdr_list); i32_const(1); i32_store(0); // len = 1
-                    local_get(hdr_list); local_get(tuple_ptr); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32 as u32); // data[0] = tuple_ptr
-                    local_get(s); local_get(hdr_list); i32_store(12);
-                    local_get(s);
+                    i32_const(Imm32(TUPLE2_BYTES)); call(self.emitter.rt.alloc); local_set(Local(tuple_ptr));
+                    local_get(Local(tuple_ptr)); i32_const(Imm32(ct_key as i32)); i32_store(0);
+                    local_get(Local(tuple_ptr)); i32_const(Imm32(ct_val as i32)); i32_store(4);
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + I32_BYTES)); call(self.emitter.rt.alloc); local_set(Local(hdr_list));
+                    local_get(Local(hdr_list)); i32_const(Imm32(1)); i32_store(0); // len = 1
+                    local_get(Local(hdr_list)); local_get(Local(tuple_ptr)); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32 as u32); // data[0] = tuple_ptr
+                    local_get(Local(s)); local_get(Local(hdr_list)); i32_store(12);
+                    local_get(Local(s));
                 });
                 self.scratch.free_i32(tuple_ptr);
                 self.scratch.free_i32(hdr_list);
@@ -92,17 +93,17 @@ impl FuncCompiler<'_> {
                 let resp = self.scratch.alloc_i32();
                 let new_resp = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(resp); });
+                wasm!(self.func, { local_set(Local(resp)); });
                 wasm!(self.func, {
-                    i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(new_resp);
-                    local_get(new_resp);
+                    i32_const(Imm32(RESP_BYTES)); call(self.emitter.rt.alloc); local_set(Local(new_resp));
+                    local_get(Local(new_resp));
                 });
                 self.emit_expr(&args[1]); // new status: i64
                 wasm!(self.func, {
                     i64_store(0);
-                    local_get(new_resp); local_get(resp); i32_load(8); i32_store(8);
-                    local_get(new_resp); local_get(resp); i32_load(12); i32_store(12);
-                    local_get(new_resp);
+                    local_get(Local(new_resp)); local_get(Local(resp)); i32_load(8); i32_store(8);
+                    local_get(Local(new_resp)); local_get(Local(resp)); i32_load(12); i32_store(12);
+                    local_get(Local(new_resp));
                 });
                 self.scratch.free_i32(new_resp);
                 self.scratch.free_i32(resp);
@@ -128,34 +129,34 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i32();
                 let some_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(resp); });
+                wasm!(self.func, { local_set(Local(resp)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(key);
-                    i32_const(0); local_set(result); // default: none
-                    local_get(resp); i32_load(12); local_set(hdrs);
-                    local_get(hdrs); i32_load(0); local_set(len);
-                    i32_const(0); local_set(i);
+                    local_set(Local(key));
+                    i32_const(Imm32(0)); local_set(Local(result)); // default: none
+                    local_get(Local(resp)); i32_load(12); local_set(Local(hdrs));
+                    local_get(Local(hdrs)); i32_load(0); local_set(Local(len));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      i32_load(0); local_set(pair_ptr);
-                      local_get(pair_ptr); i32_load(0);
-                      local_get(key);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(hdrs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      i32_load(0); local_set(Local(pair_ptr));
+                      local_get(Local(pair_ptr)); i32_load(0);
+                      local_get(Local(key));
                       call(self.emitter.rt.string.eq);
                       if_empty;
                         // Found: build Some(string_ptr) by allocating a 4-byte
                         // cell and storing the value pointer inside.
-                        i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(some_ptr);
-                        local_get(some_ptr); local_get(pair_ptr); i32_load(4); i32_store(0);
-                        local_get(some_ptr); local_set(result);
+                        i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc); local_set(Local(some_ptr));
+                        local_get(Local(some_ptr)); local_get(Local(pair_ptr)); i32_load(4); i32_store(0);
+                        local_get(Local(some_ptr)); local_set(Local(result));
                         br(2);
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(some_ptr);
                 self.scratch.free_i32(result);
@@ -174,47 +175,47 @@ impl FuncCompiler<'_> {
                 let new_hdrs = self.scratch.alloc_i32();
                 let tuple_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(resp); });
+                wasm!(self.func, { local_set(Local(resp)); });
                 // Build new tuple (key, value)
                 let key_scratch = self.scratch.alloc_i32();
                 let val_scratch = self.scratch.alloc_i32();
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(key_scratch); });
+                wasm!(self.func, { local_set(Local(key_scratch)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    local_set(val_scratch);
-                    i32_const(TUPLE2_BYTES); call(self.emitter.rt.alloc); local_set(tuple_ptr);
-                    local_get(tuple_ptr); local_get(key_scratch); i32_store(0);
-                    local_get(tuple_ptr); local_get(val_scratch); i32_store(4);
+                    local_set(Local(val_scratch));
+                    i32_const(Imm32(TUPLE2_BYTES)); call(self.emitter.rt.alloc); local_set(Local(tuple_ptr));
+                    local_get(Local(tuple_ptr)); local_get(Local(key_scratch)); i32_store(0);
+                    local_get(Local(tuple_ptr)); local_get(Local(val_scratch)); i32_store(4);
                     // Copy old headers + append new
-                    local_get(resp); i32_load(12); local_set(old_hdrs);
-                    local_get(old_hdrs); i32_load(0); i32_const(1); i32_add;
-                    local_set(val_scratch); // reuse as new_len
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(val_scratch); i32_const(I32_BYTES); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(new_hdrs);
-                    local_get(new_hdrs); local_get(val_scratch); i32_store(0);
+                    local_get(Local(resp)); i32_load(12); local_set(Local(old_hdrs));
+                    local_get(Local(old_hdrs)); i32_load(0); i32_const(Imm32(1)); i32_add;
+                    local_set(Local(val_scratch)); // reuse as new_len
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(val_scratch)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(new_hdrs));
+                    local_get(Local(new_hdrs)); local_get(Local(val_scratch)); i32_store(0);
                     // Copy old header ptrs
-                    i32_const(0); local_set(key_scratch); // reuse as i
+                    i32_const(Imm32(0)); local_set(Local(key_scratch)); // reuse as i
                     block_empty; loop_empty;
-                      local_get(key_scratch); local_get(old_hdrs); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(new_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(key_scratch); i32_const(I32_BYTES); i32_mul; i32_add;
-                      local_get(old_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(key_scratch); i32_const(I32_BYTES); i32_mul; i32_add;
+                      local_get(Local(key_scratch)); local_get(Local(old_hdrs)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(new_hdrs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(key_scratch)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      local_get(Local(old_hdrs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(key_scratch)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
                       i32_load(0); i32_store(0);
-                      local_get(key_scratch); i32_const(1); i32_add; local_set(key_scratch);
+                      local_get(Local(key_scratch)); i32_const(Imm32(1)); i32_add; local_set(Local(key_scratch));
                       br(0);
                     end; end;
                     // Append new tuple at end
-                    local_get(new_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(old_hdrs); i32_load(0); i32_const(I32_BYTES); i32_mul; i32_add;
-                    local_get(tuple_ptr); i32_store(0);
+                    local_get(Local(new_hdrs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(old_hdrs)); i32_load(0); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                    local_get(Local(tuple_ptr)); i32_store(0);
                     // Build new response
-                    i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(new_resp);
-                    local_get(new_resp); local_get(resp); i64_load(0); i64_store(0);
-                    local_get(new_resp); local_get(resp); i32_load(8); i32_store(8);
-                    local_get(new_resp); local_get(new_hdrs); i32_store(12);
-                    local_get(new_resp);
+                    i32_const(Imm32(RESP_BYTES)); call(self.emitter.rt.alloc); local_set(Local(new_resp));
+                    local_get(Local(new_resp)); local_get(Local(resp)); i64_load(0); i64_store(0);
+                    local_get(Local(new_resp)); local_get(Local(resp)); i32_load(8); i32_store(8);
+                    local_get(Local(new_resp)); local_get(Local(new_hdrs)); i32_store(12);
+                    local_get(Local(new_resp));
                 });
                 self.scratch.free_i32(val_scratch);
                 self.scratch.free_i32(key_scratch);
@@ -229,12 +230,12 @@ impl FuncCompiler<'_> {
                 let resp = self.scratch.alloc_i32();
                 let cookie_val = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(resp); });
+                wasm!(self.func, { local_set(Local(resp)); });
                 self.emit_expr(&args[1]);
                 let eq_str = self.emitter.intern_string("=");
-                wasm!(self.func, { i32_const(eq_str as i32); call(self.emitter.rt.concat_str); });
+                wasm!(self.func, { i32_const(Imm32(eq_str as i32)); call(self.emitter.rt.concat_str); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { call(self.emitter.rt.concat_str); local_set(cookie_val); });
+                wasm!(self.func, { call(self.emitter.rt.concat_str); local_set(Local(cookie_val)); });
                 let cookie_key = self.emitter.intern_string("Set-Cookie");
                 let tuple_ptr = self.scratch.alloc_i32();
                 let new_hdrs = self.scratch.alloc_i32();
@@ -243,31 +244,31 @@ impl FuncCompiler<'_> {
                 let new_len = self.scratch.alloc_i32();
                 let ci = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(TUPLE2_BYTES); call(self.emitter.rt.alloc); local_set(tuple_ptr);
-                    local_get(tuple_ptr); i32_const(cookie_key as i32); i32_store(0);
-                    local_get(tuple_ptr); local_get(cookie_val); i32_store(4);
-                    local_get(resp); i32_load(12); local_set(old_hdrs);
-                    local_get(old_hdrs); i32_load(0); i32_const(1); i32_add; local_set(new_len);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(new_len); i32_const(I32_BYTES); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(new_hdrs);
-                    local_get(new_hdrs); local_get(new_len); i32_store(0);
-                    i32_const(0); local_set(ci);
+                    i32_const(Imm32(TUPLE2_BYTES)); call(self.emitter.rt.alloc); local_set(Local(tuple_ptr));
+                    local_get(Local(tuple_ptr)); i32_const(Imm32(cookie_key as i32)); i32_store(0);
+                    local_get(Local(tuple_ptr)); local_get(Local(cookie_val)); i32_store(4);
+                    local_get(Local(resp)); i32_load(12); local_set(Local(old_hdrs));
+                    local_get(Local(old_hdrs)); i32_load(0); i32_const(Imm32(1)); i32_add; local_set(Local(new_len));
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(new_len)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(new_hdrs));
+                    local_get(Local(new_hdrs)); local_get(Local(new_len)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(ci));
                     block_empty; loop_empty;
-                      local_get(ci); local_get(old_hdrs); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(new_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(ci); i32_const(I32_BYTES); i32_mul; i32_add;
-                      local_get(old_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(ci); i32_const(I32_BYTES); i32_mul; i32_add;
+                      local_get(Local(ci)); local_get(Local(old_hdrs)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(new_hdrs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(ci)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      local_get(Local(old_hdrs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(ci)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
                       i32_load(0); i32_store(0);
-                      local_get(ci); i32_const(1); i32_add; local_set(ci);
+                      local_get(Local(ci)); i32_const(Imm32(1)); i32_add; local_set(Local(ci));
                       br(0);
                     end; end;
-                    local_get(new_hdrs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(old_hdrs); i32_load(0); i32_const(I32_BYTES); i32_mul; i32_add;
-                    local_get(tuple_ptr); i32_store(0);
-                    i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(new_resp);
-                    local_get(new_resp); local_get(resp); i64_load(0); i64_store(0);
-                    local_get(new_resp); local_get(resp); i32_load(8); i32_store(8);
-                    local_get(new_resp); local_get(new_hdrs); i32_store(12);
-                    local_get(new_resp);
+                    local_get(Local(new_hdrs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(old_hdrs)); i32_load(0); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                    local_get(Local(tuple_ptr)); i32_store(0);
+                    i32_const(Imm32(RESP_BYTES)); call(self.emitter.rt.alloc); local_set(Local(new_resp));
+                    local_get(Local(new_resp)); local_get(Local(resp)); i64_load(0); i64_store(0);
+                    local_get(Local(new_resp)); local_get(Local(resp)); i32_load(8); i32_store(8);
+                    local_get(Local(new_resp)); local_get(Local(new_hdrs)); i32_store(12);
+                    local_get(Local(new_resp));
                 });
                 self.scratch.free_i32(ci);
                 self.scratch.free_i32(new_resp);
@@ -288,19 +289,19 @@ impl FuncCompiler<'_> {
                 let len = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 let tuple = self.scratch.alloc_i32();
-                wasm!(self.func, { i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(s); local_get(s); });
+                wasm!(self.func, { i32_const(Imm32(RESP_BYTES)); call(self.emitter.rt.alloc); local_set(Local(s)); local_get(Local(s)); });
                 self.emit_expr(&args[0]); // status
-                wasm!(self.func, { i64_store(0); local_get(s); });
+                wasm!(self.func, { i64_store(0); local_get(Local(s)); });
                 self.emit_expr(&args[1]); // body
                 wasm!(self.func, { i32_store(8); });
                 self.emit_expr(&args[2]); // headers map
                 wasm!(self.func, {
-                    local_set(hdr_map);
-                    local_get(hdr_map); i32_load(0); local_set(len);
+                    local_set(Local(hdr_map));
+                    local_get(Local(hdr_map)); i32_load(0); local_set(Local(len));
                     // Build headers list from Swiss Table map entries
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(len); i32_const(I32_BYTES); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(hdr_list);
-                    local_get(hdr_list); local_get(len); i32_store(0);
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(len)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(hdr_list));
+                    local_get(Local(hdr_list)); local_get(Local(len)); i32_store(0);
                 });
                 // Dense COD walk: emit entries[0..len] in insertion order (output index == i).
                 let (ks, vs) = self.map_kv_sizes(&args[2].ty);
@@ -309,28 +310,28 @@ impl FuncCompiler<'_> {
                 let map_cap = self.scratch.alloc_i32();
                 let map_eb = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_get(hdr_map); i32_load(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::CAP)); local_set(map_cap);
+                    local_get(Local(hdr_map)); i32_load(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::CAP)); local_set(Local(map_cap));
                 });
                 self.emit_dict_entries_base(hdr_map, map_cap);
                 wasm!(self.func, {
-                    local_set(map_eb);
-                    i32_const(0); local_set(i);
+                    local_set(Local(map_eb));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                       // tuple = copy of entries[i] (key@0, val@ks — es bytes contiguous)
-                      i32_const(es as i32); call(self.emitter.rt.alloc); local_set(tuple);
-                      local_get(tuple);
-                      local_get(map_eb); local_get(i); i32_const(es as i32); i32_mul; i32_add;
-                      i32_const(es as i32); memory_copy;
+                      i32_const(Imm32(es as i32)); call(self.emitter.rt.alloc); local_set(Local(tuple));
+                      local_get(Local(tuple));
+                      local_get(Local(map_eb)); local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                      i32_const(Imm32(es as i32)); memory_copy;
                       // hdr_list[i] = tuple
-                      local_get(hdr_list); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      local_get(tuple); i32_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(hdr_list)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      local_get(Local(tuple)); i32_store(0);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(s); local_get(hdr_list); i32_store(12);
-                    local_get(s);
+                    local_get(Local(s)); local_get(Local(hdr_list)); i32_store(12);
+                    local_get(Local(s));
                 });
                 self.scratch.free_i32(map_eb);
                 self.scratch.free_i32(map_cap);
@@ -343,29 +344,29 @@ impl FuncCompiler<'_> {
             }
             "not_found" => {
                 let s = self.scratch.alloc_i32();
-                wasm!(self.func, { i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(s); local_get(s); i64_const(HTTP_NOT_FOUND); i64_store(0); local_get(s); });
+                wasm!(self.func, { i32_const(Imm32(RESP_BYTES)); call(self.emitter.rt.alloc); local_set(Local(s)); local_get(Local(s)); i64_const(Imm64(HTTP_NOT_FOUND)); i64_store(0); local_get(Local(s)); });
                 self.emit_expr(&args[0]);
                 wasm!(self.func, { i32_store(8); });
                 let empty = self.scratch.alloc_i32();
-                wasm!(self.func, { i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(empty); local_get(empty); i32_const(0); i32_store(0); local_get(s); local_get(empty); i32_store(12); local_get(s); });
+                wasm!(self.func, { i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc); local_set(Local(empty)); local_get(Local(empty)); i32_const(Imm32(0)); i32_store(0); local_get(Local(s)); local_get(Local(empty)); i32_store(12); local_get(Local(s)); });
                 self.scratch.free_i32(empty);
                 self.scratch.free_i32(s);
             }
             "redirect" => {
                 let s = self.scratch.alloc_i32();
                 let empty_body = self.emitter.intern_string("");
-                wasm!(self.func, { i32_const(RESP_BYTES); call(self.emitter.rt.alloc); local_set(s); local_get(s); i64_const(HTTP_REDIRECT); i64_store(0); local_get(s); i32_const(empty_body as i32); i32_store(8); });
+                wasm!(self.func, { i32_const(Imm32(RESP_BYTES)); call(self.emitter.rt.alloc); local_set(Local(s)); local_get(Local(s)); i64_const(Imm64(HTTP_REDIRECT)); i64_store(0); local_get(Local(s)); i32_const(Imm32(empty_body as i32)); i32_store(8); });
                 let loc_key = self.emitter.intern_string("Location");
                 let tuple = self.scratch.alloc_i32();
                 let hdrs = self.scratch.alloc_i32();
-                wasm!(self.func, { i32_const(TUPLE2_BYTES); call(self.emitter.rt.alloc); local_set(tuple); local_get(tuple); i32_const(loc_key as i32); i32_store(0); local_get(tuple); });
+                wasm!(self.func, { i32_const(Imm32(TUPLE2_BYTES)); call(self.emitter.rt.alloc); local_set(Local(tuple)); local_get(Local(tuple)); i32_const(Imm32(loc_key as i32)); i32_store(0); local_get(Local(tuple)); });
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     i32_store(4);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + I32_BYTES); call(self.emitter.rt.alloc); local_set(hdrs);
-                    local_get(hdrs); i32_const(1); i32_store(0);
-                    local_get(hdrs); local_get(tuple); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32 as u32);
-                    local_get(s); local_get(hdrs); i32_store(12); local_get(s);
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + I32_BYTES)); call(self.emitter.rt.alloc); local_set(Local(hdrs));
+                    local_get(Local(hdrs)); i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(hdrs)); local_get(Local(tuple)); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32 as u32);
+                    local_get(Local(s)); local_get(Local(hdrs)); i32_store(12); local_get(Local(s));
                 });
                 self.scratch.free_i32(hdrs);
                 self.scratch.free_i32(tuple);

--- a/crates/almide-codegen/src/emit_wasm/calls_io.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_io.rs
@@ -1,5 +1,6 @@
 //! io module — WASM codegen dispatch.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::FuncCompiler;
 use super::rt_string::{string_data_off, string_hdr, string_cap_off, list_data_off, list_hdr};
 use almide_ir::IrExpr;
@@ -39,17 +40,17 @@ impl FuncCompiler<'_> {
                 let s = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
+                    local_set(Local(s));
                     // iov[0].buf = s + string_data_off() (skip length prefix)
-                    i32_const(0);
-                    local_get(s); i32_const(string_data_off()); i32_add;
+                    i32_const(Imm32(0));
+                    local_get(Local(s)); i32_const(Imm32(string_data_off())); i32_add;
                     i32_store(0);
                     // iov[0].len = *s (load length)
-                    i32_const(IOV_LEN_ADDR);
-                    local_get(s); i32_load(0);
+                    i32_const(Imm32(IOV_LEN_ADDR));
+                    local_get(Local(s)); i32_load(0);
                     i32_store(0);
                     // fd_write(stdout=1, iovs=0, iovs_len=1, nwritten=8)
-                    i32_const(1); i32_const(0); i32_const(1); i32_const(NWRITTEN_ADDR);
+                    i32_const(Imm32(1)); i32_const(Imm32(0)); i32_const(Imm32(1)); i32_const(Imm32(NWRITTEN_ADDR));
                     call(self.emitter.rt.fd_write);
                     drop;
                 });
@@ -73,13 +74,13 @@ impl FuncCompiler<'_> {
 
                 // Initial capacity = 256
                 wasm!(self.func, {
-                    i32_const(READ_LINE_INIT_CAP); call(self.emitter.rt.alloc); local_set(buf);
-                    i32_const(READ_LINE_INIT_CAP); local_set(capacity);
-                    i32_const(0); local_set(len);
+                    i32_const(Imm32(READ_LINE_INIT_CAP)); call(self.emitter.rt.alloc); local_set(Local(buf));
+                    i32_const(Imm32(READ_LINE_INIT_CAP)); local_set(Local(capacity));
+                    i32_const(Imm32(0)); local_set(Local(len));
                     // Allocate iov (8 bytes) and nread (4 bytes) and byte_buf (1 byte)
-                    i32_const(IOV_SIZE); call(self.emitter.rt.alloc); local_set(iov_ptr);
-                    i32_const(I32_SIZE); call(self.emitter.rt.alloc); local_set(nread_ptr);
-                    i32_const(1); call(self.emitter.rt.alloc); local_set(byte_buf);
+                    i32_const(Imm32(IOV_SIZE)); call(self.emitter.rt.alloc); local_set(Local(iov_ptr));
+                    i32_const(Imm32(I32_SIZE)); call(self.emitter.rt.alloc); local_set(Local(nread_ptr));
+                    i32_const(Imm32(1)); call(self.emitter.rt.alloc); local_set(Local(byte_buf));
                 });
 
                 // Main read loop
@@ -89,78 +90,78 @@ impl FuncCompiler<'_> {
 
                 // Grow buffer if full: len >= capacity
                 wasm!(self.func, {
-                    local_get(len); local_get(capacity); i32_ge_u;
+                    local_get(Local(len)); local_get(Local(capacity)); i32_ge_u;
                     if_empty;
                       // Double capacity
-                      local_get(capacity); i32_const(BUF_GROW_FACTOR); i32_mul; local_set(capacity);
-                      local_get(capacity); call(self.emitter.rt.alloc); local_set(new_buf);
+                      local_get(Local(capacity)); i32_const(Imm32(BUF_GROW_FACTOR)); i32_mul; local_set(Local(capacity));
+                      local_get(Local(capacity)); call(self.emitter.rt.alloc); local_set(Local(new_buf));
                       // Copy old data
-                      i32_const(0); local_set(copy_i);
+                      i32_const(Imm32(0)); local_set(Local(copy_i));
                       block_empty; loop_empty;
-                        local_get(copy_i); local_get(len); i32_ge_u; br_if(1);
-                        local_get(new_buf); local_get(copy_i); i32_add;
-                        local_get(buf); local_get(copy_i); i32_add; i32_load8_u(0);
+                        local_get(Local(copy_i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                        local_get(Local(new_buf)); local_get(Local(copy_i)); i32_add;
+                        local_get(Local(buf)); local_get(Local(copy_i)); i32_add; i32_load8_u(0);
                         i32_store8(0);
-                        local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                        local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                         br(0);
                       end; end;
-                      local_get(new_buf); local_set(buf);
+                      local_get(Local(new_buf)); local_set(Local(buf));
                     end;
                 });
 
                 // Set up iov to read 1 byte into byte_buf
                 wasm!(self.func, {
-                    local_get(iov_ptr); local_get(byte_buf); i32_store(0);
-                    local_get(iov_ptr); i32_const(1); i32_store(4);
+                    local_get(Local(iov_ptr)); local_get(Local(byte_buf)); i32_store(0);
+                    local_get(Local(iov_ptr)); i32_const(Imm32(1)); i32_store(4);
                     // fd_read(stdin=0, iov_ptr, 1, nread_ptr)
-                    i32_const(0);
-                    local_get(iov_ptr);
-                    i32_const(1);
-                    local_get(nread_ptr);
+                    i32_const(Imm32(0));
+                    local_get(Local(iov_ptr));
+                    i32_const(Imm32(1));
+                    local_get(Local(nread_ptr));
                     call(self.emitter.rt.fd_read);
                     drop;
                 });
 
                 // Check nread: if 0, EOF → break
                 wasm!(self.func, {
-                    local_get(nread_ptr); i32_load(0); local_set(nread_val);
-                    local_get(nread_val); i32_eqz;
+                    local_get(Local(nread_ptr)); i32_load(0); local_set(Local(nread_val));
+                    local_get(Local(nread_val)); i32_eqz;
                     br_if(1); // break outer block
                 });
 
                 // Load byte, check for '\n'
                 wasm!(self.func, {
-                    local_get(byte_buf); i32_load8_u(0); local_set(byte_val);
-                    local_get(byte_val); i32_const(ASCII_NEWLINE); i32_eq; // '\n'
+                    local_get(Local(byte_buf)); i32_load8_u(0); local_set(Local(byte_val));
+                    local_get(Local(byte_val)); i32_const(Imm32(ASCII_NEWLINE)); i32_eq; // '\n'
                     br_if(1); // break outer block (don't include '\n' in result)
                 });
 
                 // Append byte to buffer
                 wasm!(self.func, {
-                    local_get(buf); local_get(len); i32_add;
-                    local_get(byte_val);
+                    local_get(Local(buf)); local_get(Local(len)); i32_add;
+                    local_get(Local(byte_val));
                     i32_store8(0);
-                    local_get(len); i32_const(1); i32_add; local_set(len);
+                    local_get(Local(len)); i32_const(Imm32(1)); i32_add; local_set(Local(len));
                     br(0); // continue loop
                     end; end; // end loop, end block
                 });
 
                 // Build Almide string [len:i32][data:u8...]
                 wasm!(self.func, {
-                    local_get(len); i32_const(string_hdr()); i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); local_get(len); i32_store(0);
+                    local_get(Local(len)); i32_const(Imm32(string_hdr())); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); local_get(Local(len)); i32_store(0);
                     // Copy buf[0..len] to result+string_data_off()
-                    i32_const(0); local_set(copy_i);
+                    i32_const(Imm32(0)); local_set(Local(copy_i));
                     block_empty; loop_empty;
-                      local_get(copy_i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(result); i32_const(string_data_off()); i32_add; local_get(copy_i); i32_add;
-                      local_get(buf); local_get(copy_i); i32_add; i32_load8_u(0);
+                      local_get(Local(copy_i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(result)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(copy_i)); i32_add;
+                      local_get(Local(buf)); local_get(Local(copy_i)); i32_add; i32_load8_u(0);
                       i32_store8(0);
-                      local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                      local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
 
                 self.scratch.free_i32(result);
@@ -192,11 +193,11 @@ impl FuncCompiler<'_> {
 
                 // Initial capacity = 4096
                 wasm!(self.func, {
-                    i32_const(READ_ALL_CHUNK_SIZE); call(self.emitter.rt.alloc); local_set(buf);
-                    i32_const(READ_ALL_CHUNK_SIZE); local_set(capacity);
-                    i32_const(0); local_set(len);
-                    i32_const(IOV_SIZE); call(self.emitter.rt.alloc); local_set(iov_ptr);
-                    i32_const(I32_SIZE); call(self.emitter.rt.alloc); local_set(nread_ptr);
+                    i32_const(Imm32(READ_ALL_CHUNK_SIZE)); call(self.emitter.rt.alloc); local_set(Local(buf));
+                    i32_const(Imm32(READ_ALL_CHUNK_SIZE)); local_set(Local(capacity));
+                    i32_const(Imm32(0)); local_set(Local(len));
+                    i32_const(Imm32(IOV_SIZE)); call(self.emitter.rt.alloc); local_set(Local(iov_ptr));
+                    i32_const(Imm32(I32_SIZE)); call(self.emitter.rt.alloc); local_set(Local(nread_ptr));
                 });
 
                 // Read loop
@@ -206,66 +207,66 @@ impl FuncCompiler<'_> {
 
                 // Ensure we have room for at least 4096 bytes
                 wasm!(self.func, {
-                    local_get(capacity); local_get(len); i32_sub;
-                    i32_const(READ_ALL_CHUNK_SIZE); i32_lt_u;
+                    local_get(Local(capacity)); local_get(Local(len)); i32_sub;
+                    i32_const(Imm32(READ_ALL_CHUNK_SIZE)); i32_lt_u;
                     if_empty;
                       // Double capacity
-                      local_get(capacity); i32_const(BUF_GROW_FACTOR); i32_mul; local_set(capacity);
-                      local_get(capacity); call(self.emitter.rt.alloc); local_set(new_buf);
+                      local_get(Local(capacity)); i32_const(Imm32(BUF_GROW_FACTOR)); i32_mul; local_set(Local(capacity));
+                      local_get(Local(capacity)); call(self.emitter.rt.alloc); local_set(Local(new_buf));
                       // Copy old data
-                      i32_const(0); local_set(copy_i);
+                      i32_const(Imm32(0)); local_set(Local(copy_i));
                       block_empty; loop_empty;
-                        local_get(copy_i); local_get(len); i32_ge_u; br_if(1);
-                        local_get(new_buf); local_get(copy_i); i32_add;
-                        local_get(buf); local_get(copy_i); i32_add; i32_load8_u(0);
+                        local_get(Local(copy_i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                        local_get(Local(new_buf)); local_get(Local(copy_i)); i32_add;
+                        local_get(Local(buf)); local_get(Local(copy_i)); i32_add; i32_load8_u(0);
                         i32_store8(0);
-                        local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                        local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                         br(0);
                       end; end;
-                      local_get(new_buf); local_set(buf);
+                      local_get(Local(new_buf)); local_set(Local(buf));
                     end;
                 });
 
                 // Read chunk into buf+len, up to (capacity - len) bytes
                 wasm!(self.func, {
-                    local_get(iov_ptr); local_get(buf); local_get(len); i32_add; i32_store(0);
-                    local_get(iov_ptr); local_get(capacity); local_get(len); i32_sub; i32_store(4);
+                    local_get(Local(iov_ptr)); local_get(Local(buf)); local_get(Local(len)); i32_add; i32_store(0);
+                    local_get(Local(iov_ptr)); local_get(Local(capacity)); local_get(Local(len)); i32_sub; i32_store(4);
                     // fd_read(stdin=0, iov_ptr, 1, nread_ptr)
-                    i32_const(0);
-                    local_get(iov_ptr);
-                    i32_const(1);
-                    local_get(nread_ptr);
+                    i32_const(Imm32(0));
+                    local_get(Local(iov_ptr));
+                    i32_const(Imm32(1));
+                    local_get(Local(nread_ptr));
                     call(self.emitter.rt.fd_read);
                     drop;
                 });
 
                 // Check nread: if 0, EOF → break
                 wasm!(self.func, {
-                    local_get(nread_ptr); i32_load(0); local_set(nread_val);
-                    local_get(nread_val); i32_eqz;
+                    local_get(Local(nread_ptr)); i32_load(0); local_set(Local(nread_val));
+                    local_get(Local(nread_val)); i32_eqz;
                     br_if(1);
                     // Advance len
-                    local_get(len); local_get(nread_val); i32_add; local_set(len);
+                    local_get(Local(len)); local_get(Local(nread_val)); i32_add; local_set(Local(len));
                     br(0);
                     end; end; // end loop, end block
                 });
 
                 // Build Almide string [len:i32][data:u8...]
                 wasm!(self.func, {
-                    local_get(len); i32_const(string_hdr()); i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); local_get(len); i32_store(0);
+                    local_get(Local(len)); i32_const(Imm32(string_hdr())); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); local_get(Local(len)); i32_store(0);
                     // Copy buf[0..len] to result+string_data_off()
-                    i32_const(0); local_set(copy_i);
+                    i32_const(Imm32(0)); local_set(Local(copy_i));
                     block_empty; loop_empty;
-                      local_get(copy_i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(result); i32_const(string_data_off()); i32_add; local_get(copy_i); i32_add;
-                      local_get(buf); local_get(copy_i); i32_add; i32_load8_u(0);
+                      local_get(Local(copy_i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(result)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(copy_i)); i32_add;
+                      local_get(Local(buf)); local_get(Local(copy_i)); i32_add; i32_load8_u(0);
                       i32_store8(0);
-                      local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                      local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
 
                 self.scratch.free_i32(result);
@@ -287,22 +288,22 @@ impl FuncCompiler<'_> {
                 let nread_ptr = self.scratch.alloc_i32();
 
                 wasm!(self.func, {
-                    i32_const(1); call(self.emitter.rt.alloc); local_set(byte_buf);
-                    i32_const(IOV_SIZE); call(self.emitter.rt.alloc); local_set(iov_ptr);
-                    i32_const(I32_SIZE); call(self.emitter.rt.alloc); local_set(nread_ptr);
+                    i32_const(Imm32(1)); call(self.emitter.rt.alloc); local_set(Local(byte_buf));
+                    i32_const(Imm32(IOV_SIZE)); call(self.emitter.rt.alloc); local_set(Local(iov_ptr));
+                    i32_const(Imm32(I32_SIZE)); call(self.emitter.rt.alloc); local_set(Local(nread_ptr));
                     // iov: buf = byte_buf, len = 1
-                    local_get(iov_ptr); local_get(byte_buf); i32_store(0);
-                    local_get(iov_ptr); i32_const(1); i32_store(4);
+                    local_get(Local(iov_ptr)); local_get(Local(byte_buf)); i32_store(0);
+                    local_get(Local(iov_ptr)); i32_const(Imm32(1)); i32_store(4);
                     // fd_read(stdin=0, iov, 1, nread_ptr)
-                    i32_const(0); local_get(iov_ptr); i32_const(1); local_get(nread_ptr);
+                    i32_const(Imm32(0)); local_get(Local(iov_ptr)); i32_const(Imm32(1)); local_get(Local(nread_ptr));
                     call(self.emitter.rt.fd_read);
                     drop;
                     // if nread == 0 → -1i64, else byte as i64
-                    local_get(nread_ptr); i32_load(0); i32_eqz;
+                    local_get(Local(nread_ptr)); i32_load(0); i32_eqz;
                     if_i64;
-                      i64_const(-1);
+                      i64_const(Imm64(-1));
                     else_;
-                      local_get(byte_buf); i32_load8_u(0); i64_extend_i32_u;
+                      local_get(Local(byte_buf)); i32_load8_u(0); i64_extend_i32_u;
                     end;
                 });
 
@@ -325,30 +326,30 @@ impl FuncCompiler<'_> {
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(n);
+                    i32_wrap_i64; local_set(Local(n));
                     // Allocate raw read buffer of n bytes
-                    local_get(n); call(self.emitter.rt.alloc); local_set(raw_buf);
-                    i32_const(IOV_SIZE); call(self.emitter.rt.alloc); local_set(iov_ptr);
-                    i32_const(I32_SIZE); call(self.emitter.rt.alloc); local_set(nread_ptr);
-                    i32_const(0); local_set(total);
+                    local_get(Local(n)); call(self.emitter.rt.alloc); local_set(Local(raw_buf));
+                    i32_const(Imm32(IOV_SIZE)); call(self.emitter.rt.alloc); local_set(Local(iov_ptr));
+                    i32_const(Imm32(I32_SIZE)); call(self.emitter.rt.alloc); local_set(Local(nread_ptr));
+                    i32_const(Imm32(0)); local_set(Local(total));
                 });
 
                 // Read loop: keep reading until total == n or EOF
                 wasm!(self.func, {
                     block_empty; loop_empty;
                       // Check if done
-                      local_get(total); local_get(n); i32_ge_u; br_if(1);
+                      local_get(Local(total)); local_get(Local(n)); i32_ge_u; br_if(1);
                       // iov: buf = raw_buf + total, len = n - total
-                      local_get(iov_ptr); local_get(raw_buf); local_get(total); i32_add; i32_store(0);
-                      local_get(iov_ptr); local_get(n); local_get(total); i32_sub; i32_store(4);
+                      local_get(Local(iov_ptr)); local_get(Local(raw_buf)); local_get(Local(total)); i32_add; i32_store(0);
+                      local_get(Local(iov_ptr)); local_get(Local(n)); local_get(Local(total)); i32_sub; i32_store(4);
                       // fd_read(stdin=0, iov, 1, nread_ptr)
-                      i32_const(0); local_get(iov_ptr); i32_const(1); local_get(nread_ptr);
+                      i32_const(Imm32(0)); local_get(Local(iov_ptr)); i32_const(Imm32(1)); local_get(Local(nread_ptr));
                       call(self.emitter.rt.fd_read);
                       drop;
                       // Check nread
-                      local_get(nread_ptr); i32_load(0); local_set(nread_val);
-                      local_get(nread_val); i32_eqz; br_if(1); // EOF → break
-                      local_get(total); local_get(nread_val); i32_add; local_set(total);
+                      local_get(Local(nread_ptr)); i32_load(0); local_set(Local(nread_val));
+                      local_get(Local(nread_val)); i32_eqz; br_if(1); // EOF → break
+                      local_get(Local(total)); local_get(Local(nread_val)); i32_add; local_set(Local(total));
                       br(0);
                     end; end;
                 });
@@ -356,21 +357,21 @@ impl FuncCompiler<'_> {
                 // Build List[Int]: [total:i32][i64 * total]
                 wasm!(self.func, {
                     // Allocate: self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + total * I64_BYTES
-                    local_get(total); i32_const(I64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(list_ptr);
-                    local_get(list_ptr); local_get(total); i32_store(0);
+                    local_get(Local(total)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(list_ptr));
+                    local_get(Local(list_ptr)); local_get(Local(total)); i32_store(0);
                     // Copy bytes → i64 elements
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(total); i32_ge_u; br_if(1);
-                      local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
-                      local_get(raw_buf); local_get(i); i32_add; i32_load8_u(0); i64_extend_i32_u;
+                      local_get(Local(i)); local_get(Local(total)); i32_ge_u; br_if(1);
+                      local_get(Local(list_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(raw_buf)); local_get(Local(i)); i32_add; i32_load8_u(0); i64_extend_i32_u;
                       i64_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(list_ptr);
+                    local_get(Local(list_ptr));
                 });
 
                 self.scratch.free_i32(i);
@@ -389,14 +390,14 @@ impl FuncCompiler<'_> {
                     let s = self.scratch.alloc_i32();
                     self.emit_expr(&args[0]);
                     wasm!(self.func, {
-                        local_set(s);
-                        i32_const(0);
-                        local_get(s); i32_const(string_data_off()); i32_add;
+                        local_set(Local(s));
+                        i32_const(Imm32(0));
+                        local_get(Local(s)); i32_const(Imm32(string_data_off())); i32_add;
                         i32_store(0);
-                        i32_const(IOV_LEN_ADDR);
-                        local_get(s); i32_load(0);
+                        i32_const(Imm32(IOV_LEN_ADDR));
+                        local_get(Local(s)); i32_load(0);
                         i32_store(0);
-                        i32_const(1); i32_const(0); i32_const(1); i32_const(NWRITTEN_ADDR);
+                        i32_const(Imm32(1)); i32_const(Imm32(0)); i32_const(Imm32(1)); i32_const(Imm32(NWRITTEN_ADDR));
                         call(self.emitter.rt.fd_write);
                         drop;
                     });
@@ -409,23 +410,23 @@ impl FuncCompiler<'_> {
                     let i = self.scratch.alloc_i32();
                     self.emit_expr(&args[0]);
                     wasm!(self.func, {
-                        local_set(list_ptr);
-                        local_get(list_ptr); i32_load(0); local_set(len);
-                        local_get(len); call(self.emitter.rt.alloc); local_set(tmp_buf);
-                        i32_const(0); local_set(i);
+                        local_set(Local(list_ptr));
+                        local_get(Local(list_ptr)); i32_load(0); local_set(Local(len));
+                        local_get(Local(len)); call(self.emitter.rt.alloc); local_set(Local(tmp_buf));
+                        i32_const(Imm32(0)); local_set(Local(i));
                         block_empty; loop_empty;
-                          local_get(i); local_get(len); i32_ge_u; br_if(1);
-                          local_get(tmp_buf); local_get(i); i32_add;
-                          local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
+                          local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                          local_get(Local(tmp_buf)); local_get(Local(i)); i32_add;
+                          local_get(Local(list_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(i)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_add;
                           i64_load(0); i32_wrap_i64;
                           i32_store8(0);
-                          local_get(i); i32_const(1); i32_add; local_set(i);
+                          local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                           br(0);
                         end; end;
-                        i32_const(0); local_get(tmp_buf); i32_store(0);
-                        i32_const(IOV_LEN_ADDR); local_get(len); i32_store(0);
-                        i32_const(1); i32_const(0); i32_const(1); i32_const(NWRITTEN_ADDR);
+                        i32_const(Imm32(0)); local_get(Local(tmp_buf)); i32_store(0);
+                        i32_const(Imm32(IOV_LEN_ADDR)); local_get(Local(len)); i32_store(0);
+                        i32_const(Imm32(1)); i32_const(Imm32(0)); i32_const(Imm32(1)); i32_const(Imm32(NWRITTEN_ADDR));
                         call(self.emitter.rt.fd_write);
                         drop;
                     });

--- a/crates/almide-codegen/src/emit_wasm/calls_io.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_io.rs
@@ -7,6 +7,29 @@ use almide_lang::types::Ty;
 use super::values;
 use wasm_encoder::Instruction;
 
+// ── scratch-memory layout for fd_write / fd_read iov + nwritten ──────────────
+// Linear memory scratch area:
+//   [0..4)  iov[0].buf  (i32 pointer)
+//   [4..8)  iov[0].len  (i32 byte count)
+//   [8..12) nwritten    (i32 output from fd_write / nread from fd_read)
+const IOV_LEN_ADDR:   i32 = 4;   // byte offset of iov[0].len in scratch
+const NWRITTEN_ADDR:  i32 = 8;   // byte offset of nwritten/nread result
+
+// ── allocation sizes ──────────────────────────────────────────────────────────
+const IOV_SIZE:   i32 = 8;   // bytes for one iov entry (buf:i32 + len:i32)
+const I32_SIZE:   i32 = 4;   // bytes for a single i32 (nread/nwritten output cell)
+
+// ── per-element size in List[Int] (each element is an i64) ───────────────────
+const I64_BYTES:  i32 = 8;   // byte width of one i64 list element
+
+// ── buffer management ─────────────────────────────────────────────────────────
+const BUF_GROW_FACTOR:    i32 = 2;    // factor by which we double on realloc
+const READ_LINE_INIT_CAP: i32 = 256;  // initial capacity for read_line accumulation buffer
+const READ_ALL_CHUNK_SIZE: i32 = 4096; // chunk size (and initial capacity) for read_all
+
+// ── character codes ───────────────────────────────────────────────────────────
+const ASCII_NEWLINE: i32 = 10; // '\n'
+
 impl FuncCompiler<'_> {
     pub(super) fn emit_io_call(&mut self, func: &str, args: &[IrExpr]) {
         match func {
@@ -22,11 +45,11 @@ impl FuncCompiler<'_> {
                     local_get(s); i32_const(string_data_off()); i32_add;
                     i32_store(0);
                     // iov[0].len = *s (load length)
-                    i32_const(4);
+                    i32_const(IOV_LEN_ADDR);
                     local_get(s); i32_load(0);
                     i32_store(0);
                     // fd_write(stdout=1, iovs=0, iovs_len=1, nwritten=8)
-                    i32_const(1); i32_const(0); i32_const(1); i32_const(8);
+                    i32_const(1); i32_const(0); i32_const(1); i32_const(NWRITTEN_ADDR);
                     call(self.emitter.rt.fd_write);
                     drop;
                 });
@@ -50,12 +73,12 @@ impl FuncCompiler<'_> {
 
                 // Initial capacity = 256
                 wasm!(self.func, {
-                    i32_const(256); call(self.emitter.rt.alloc); local_set(buf);
-                    i32_const(256); local_set(capacity);
+                    i32_const(READ_LINE_INIT_CAP); call(self.emitter.rt.alloc); local_set(buf);
+                    i32_const(READ_LINE_INIT_CAP); local_set(capacity);
                     i32_const(0); local_set(len);
                     // Allocate iov (8 bytes) and nread (4 bytes) and byte_buf (1 byte)
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(iov_ptr);
-                    i32_const(4); call(self.emitter.rt.alloc); local_set(nread_ptr);
+                    i32_const(IOV_SIZE); call(self.emitter.rt.alloc); local_set(iov_ptr);
+                    i32_const(I32_SIZE); call(self.emitter.rt.alloc); local_set(nread_ptr);
                     i32_const(1); call(self.emitter.rt.alloc); local_set(byte_buf);
                 });
 
@@ -69,7 +92,7 @@ impl FuncCompiler<'_> {
                     local_get(len); local_get(capacity); i32_ge_u;
                     if_empty;
                       // Double capacity
-                      local_get(capacity); i32_const(2); i32_mul; local_set(capacity);
+                      local_get(capacity); i32_const(BUF_GROW_FACTOR); i32_mul; local_set(capacity);
                       local_get(capacity); call(self.emitter.rt.alloc); local_set(new_buf);
                       // Copy old data
                       i32_const(0); local_set(copy_i);
@@ -108,7 +131,7 @@ impl FuncCompiler<'_> {
                 // Load byte, check for '\n'
                 wasm!(self.func, {
                     local_get(byte_buf); i32_load8_u(0); local_set(byte_val);
-                    local_get(byte_val); i32_const(10); i32_eq; // '\n'
+                    local_get(byte_val); i32_const(ASCII_NEWLINE); i32_eq; // '\n'
                     br_if(1); // break outer block (don't include '\n' in result)
                 });
 
@@ -169,11 +192,11 @@ impl FuncCompiler<'_> {
 
                 // Initial capacity = 4096
                 wasm!(self.func, {
-                    i32_const(4096); call(self.emitter.rt.alloc); local_set(buf);
-                    i32_const(4096); local_set(capacity);
+                    i32_const(READ_ALL_CHUNK_SIZE); call(self.emitter.rt.alloc); local_set(buf);
+                    i32_const(READ_ALL_CHUNK_SIZE); local_set(capacity);
                     i32_const(0); local_set(len);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(iov_ptr);
-                    i32_const(4); call(self.emitter.rt.alloc); local_set(nread_ptr);
+                    i32_const(IOV_SIZE); call(self.emitter.rt.alloc); local_set(iov_ptr);
+                    i32_const(I32_SIZE); call(self.emitter.rt.alloc); local_set(nread_ptr);
                 });
 
                 // Read loop
@@ -184,10 +207,10 @@ impl FuncCompiler<'_> {
                 // Ensure we have room for at least 4096 bytes
                 wasm!(self.func, {
                     local_get(capacity); local_get(len); i32_sub;
-                    i32_const(4096); i32_lt_u;
+                    i32_const(READ_ALL_CHUNK_SIZE); i32_lt_u;
                     if_empty;
                       // Double capacity
-                      local_get(capacity); i32_const(2); i32_mul; local_set(capacity);
+                      local_get(capacity); i32_const(BUF_GROW_FACTOR); i32_mul; local_set(capacity);
                       local_get(capacity); call(self.emitter.rt.alloc); local_set(new_buf);
                       // Copy old data
                       i32_const(0); local_set(copy_i);
@@ -265,8 +288,8 @@ impl FuncCompiler<'_> {
 
                 wasm!(self.func, {
                     i32_const(1); call(self.emitter.rt.alloc); local_set(byte_buf);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(iov_ptr);
-                    i32_const(4); call(self.emitter.rt.alloc); local_set(nread_ptr);
+                    i32_const(IOV_SIZE); call(self.emitter.rt.alloc); local_set(iov_ptr);
+                    i32_const(I32_SIZE); call(self.emitter.rt.alloc); local_set(nread_ptr);
                     // iov: buf = byte_buf, len = 1
                     local_get(iov_ptr); local_get(byte_buf); i32_store(0);
                     local_get(iov_ptr); i32_const(1); i32_store(4);
@@ -305,8 +328,8 @@ impl FuncCompiler<'_> {
                     i32_wrap_i64; local_set(n);
                     // Allocate raw read buffer of n bytes
                     local_get(n); call(self.emitter.rt.alloc); local_set(raw_buf);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(iov_ptr);
-                    i32_const(4); call(self.emitter.rt.alloc); local_set(nread_ptr);
+                    i32_const(IOV_SIZE); call(self.emitter.rt.alloc); local_set(iov_ptr);
+                    i32_const(I32_SIZE); call(self.emitter.rt.alloc); local_set(nread_ptr);
                     i32_const(0); local_set(total);
                 });
 
@@ -332,8 +355,8 @@ impl FuncCompiler<'_> {
 
                 // Build List[Int]: [total:i32][i64 * total]
                 wasm!(self.func, {
-                    // Allocate: self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + total * 8
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    // Allocate: self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + total * I64_BYTES
+                    local_get(total); i32_const(I64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(list_ptr);
                     local_get(list_ptr); local_get(total); i32_store(0);
                     // Copy bytes → i64 elements
@@ -341,7 +364,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); local_get(total); i32_ge_u; br_if(1);
                       local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
                       local_get(raw_buf); local_get(i); i32_add; i32_load8_u(0); i64_extend_i32_u;
                       i64_store(0);
                       local_get(i); i32_const(1); i32_add; local_set(i);
@@ -370,10 +393,10 @@ impl FuncCompiler<'_> {
                         i32_const(0);
                         local_get(s); i32_const(string_data_off()); i32_add;
                         i32_store(0);
-                        i32_const(4);
+                        i32_const(IOV_LEN_ADDR);
                         local_get(s); i32_load(0);
                         i32_store(0);
-                        i32_const(1); i32_const(0); i32_const(1); i32_const(8);
+                        i32_const(1); i32_const(0); i32_const(1); i32_const(NWRITTEN_ADDR);
                         call(self.emitter.rt.fd_write);
                         drop;
                     });
@@ -394,15 +417,15 @@ impl FuncCompiler<'_> {
                           local_get(i); local_get(len); i32_ge_u; br_if(1);
                           local_get(tmp_buf); local_get(i); i32_add;
                           local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(i); i32_const(8); i32_mul; i32_add;
+                          local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
                           i64_load(0); i32_wrap_i64;
                           i32_store8(0);
                           local_get(i); i32_const(1); i32_add; local_set(i);
                           br(0);
                         end; end;
                         i32_const(0); local_get(tmp_buf); i32_store(0);
-                        i32_const(4); local_get(len); i32_store(0);
-                        i32_const(1); i32_const(0); i32_const(1); i32_const(8);
+                        i32_const(IOV_LEN_ADDR); local_get(len); i32_store(0);
+                        i32_const(1); i32_const(0); i32_const(1); i32_const(NWRITTEN_ADDR);
                         call(self.emitter.rt.fd_write);
                         drop;
                     });

--- a/crates/almide-codegen/src/emit_wasm/calls_lambda.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_lambda.rs
@@ -1,5 +1,6 @@
 //! Lambda and closure emission for WASM codegen.
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use almide_ir::VarId;
 use almide_lang::types::Ty;
 use wasm_encoder::ValType;
@@ -18,19 +19,19 @@ impl FuncCompiler<'_> {
             // Allocate closure: [table_idx: i32][env_ptr: i32] = 8 bytes
             let scratch = self.scratch.alloc_i32();
             wasm!(self.func, {
-                i32_const(CLOSURE_BYTES);
+                i32_const(Imm32(CLOSURE_BYTES));
                 call(self.emitter.rt.alloc);
-                local_set(scratch);
+                local_set(Local(scratch));
                 // Store table_idx
-                local_get(scratch);
-                i32_const(wrapper_table_idx as i32);
+                local_get(Local(scratch));
+                i32_const(Imm32(wrapper_table_idx as i32));
                 i32_store(0);
                 // Store env_ptr = 0
-                local_get(scratch);
-                i32_const(0);
+                local_get(Local(scratch));
+                i32_const(Imm32(0));
                 i32_store(4);
                 // Return closure ptr
-                local_get(scratch);
+                local_get(Local(scratch));
             });
             self.scratch.free_i32(scratch);
         } else {
@@ -83,16 +84,16 @@ impl FuncCompiler<'_> {
         if captures.is_empty() {
             // No captures: allocate closure [table_idx, 0]
             wasm!(self.func, {
-                i32_const(CLOSURE_BYTES);
+                i32_const(Imm32(CLOSURE_BYTES));
                 call(self.emitter.rt.alloc);
-                local_set(scratch);
-                local_get(scratch);
-                i32_const(table_idx as i32);
+                local_set(Local(scratch));
+                local_get(Local(scratch));
+                i32_const(Imm32(table_idx as i32));
                 i32_store(0);
-                local_get(scratch);
-                i32_const(0);
+                local_get(Local(scratch));
+                i32_const(Imm32(0));
                 i32_store(4);
-                local_get(scratch);
+                local_get(Local(scratch));
             });
             self.scratch.free_i32(scratch);
         } else {
@@ -100,18 +101,18 @@ impl FuncCompiler<'_> {
             let env_size = (captures.len() as u32) * 8;
             let env_scratch = scratch;
             wasm!(self.func, {
-                i32_const(env_size as i32);
+                i32_const(Imm32(env_size as i32));
                 call(self.emitter.rt.alloc);
-                local_set(env_scratch);
+                local_set(Local(env_scratch));
             });
 
             // Store each captured variable into env
             for (ci, (vid, ty)) in captures.iter().enumerate() {
                 let offset = (ci as u32) * 8;
                 let is_cell = self.emitter.mutable_captures.contains(&vid.0);
-                wasm!(self.func, { local_get(env_scratch); });
+                wasm!(self.func, { local_get(Local(env_scratch)); });
                 if let Some(&local_idx) = self.var_map.get(&vid.0) {
-                    wasm!(self.func, { local_get(local_idx); });
+                    wasm!(self.func, { local_get(Local(local_idx)); });
                     if is_cell {
                         // Mutable capture: local is cell ptr (i32), store as i32
                         wasm!(self.func, { i32_store(offset); });
@@ -136,16 +137,16 @@ impl FuncCompiler<'_> {
             // Allocate closure: [table_idx, env_ptr]
             let closure_scratch = self.scratch.alloc_i32();
             wasm!(self.func, {
-                i32_const(CLOSURE_BYTES);
+                i32_const(Imm32(CLOSURE_BYTES));
                 call(self.emitter.rt.alloc);
-                local_set(closure_scratch);
-                local_get(closure_scratch);
-                i32_const(table_idx as i32);
+                local_set(Local(closure_scratch));
+                local_get(Local(closure_scratch));
+                i32_const(Imm32(table_idx as i32));
                 i32_store(0);
-                local_get(closure_scratch);
-                local_get(env_scratch);
+                local_get(Local(closure_scratch));
+                local_get(Local(env_scratch));
                 i32_store(4);
-                local_get(closure_scratch);
+                local_get(Local(closure_scratch));
             });
             self.scratch.free_i32(closure_scratch);
             self.scratch.free_i32(env_scratch);
@@ -172,34 +173,34 @@ impl FuncCompiler<'_> {
         if captures.is_empty() {
             // No captures: closure = [table_idx, 0]
             wasm!(self.func, {
-                i32_const(CLOSURE_BYTES);
+                i32_const(Imm32(CLOSURE_BYTES));
                 call(self.emitter.rt.alloc);
-                local_set(scratch);
-                local_get(scratch);
-                i32_const(table_idx);
+                local_set(Local(scratch));
+                local_get(Local(scratch));
+                i32_const(Imm32(table_idx));
                 i32_store(0);
-                local_get(scratch);
-                i32_const(0);
+                local_get(Local(scratch));
+                i32_const(Imm32(0));
                 i32_store(4);
-                local_get(scratch);
+                local_get(Local(scratch));
             });
         } else {
             // Allocate env
             let env_size = (captures.len() as u32) * 8;
             let env_scratch = self.scratch.alloc_i32();
             wasm!(self.func, {
-                i32_const(env_size as i32);
+                i32_const(Imm32(env_size as i32));
                 call(self.emitter.rt.alloc);
-                local_set(env_scratch);
+                local_set(Local(env_scratch));
             });
 
             // Store each captured variable into env
             for (ci, (vid, ty)) in captures.iter().enumerate() {
                 let offset = (ci as u32) * 8;
-                wasm!(self.func, { local_get(env_scratch); });
+                wasm!(self.func, { local_get(Local(env_scratch)); });
                 if let Some(&local_idx) = self.var_map.get(&vid.0) {
                     // Perceus closure capture rc_inc is now handled by PerceusPass (IR-level RcInc)
-                    wasm!(self.func, { local_get(local_idx); });
+                    wasm!(self.func, { local_get(Local(local_idx)); });
                     self.emit_store_at(ty, offset);
                 } else if let Some((global_idx, _)) = self.lookup_global(*vid) {
                     // A module-level `let`/`var` captured by the closure lives
@@ -227,16 +228,16 @@ impl FuncCompiler<'_> {
             // Allocate closure pair [table_idx, env_ptr]
             let closure_scratch = self.scratch.alloc_i32();
             wasm!(self.func, {
-                i32_const(CLOSURE_BYTES);
+                i32_const(Imm32(CLOSURE_BYTES));
                 call(self.emitter.rt.alloc);
-                local_set(closure_scratch);
-                local_get(closure_scratch);
-                i32_const(table_idx);
+                local_set(Local(closure_scratch));
+                local_get(Local(closure_scratch));
+                i32_const(Imm32(table_idx));
                 i32_store(0);
-                local_get(closure_scratch);
-                local_get(env_scratch);
+                local_get(Local(closure_scratch));
+                local_get(Local(env_scratch));
                 i32_store(4);
-                local_get(closure_scratch);
+                local_get(Local(closure_scratch));
             });
             self.scratch.free_i32(closure_scratch);
             self.scratch.free_i32(env_scratch);

--- a/crates/almide-codegen/src/emit_wasm/calls_lambda.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_lambda.rs
@@ -7,6 +7,10 @@ use wasm_encoder::ValType;
 use super::FuncCompiler;
 use super::values;
 
+// Named constants for WASM immediate values used in closure layout.
+/// Byte size of a closure struct: [table_idx: i32][env_ptr: i32] = 4 + 4 bytes.
+const CLOSURE_BYTES: i32 = 8;
+
 impl FuncCompiler<'_> {
     /// Emit a FnRef as a closure: allocate [wrapper_table_idx, 0] on heap.
     pub(super) fn emit_fn_ref_closure(&mut self, name: &str) {
@@ -14,7 +18,7 @@ impl FuncCompiler<'_> {
             // Allocate closure: [table_idx: i32][env_ptr: i32] = 8 bytes
             let scratch = self.scratch.alloc_i32();
             wasm!(self.func, {
-                i32_const(8);
+                i32_const(CLOSURE_BYTES);
                 call(self.emitter.rt.alloc);
                 local_set(scratch);
                 // Store table_idx
@@ -79,7 +83,7 @@ impl FuncCompiler<'_> {
         if captures.is_empty() {
             // No captures: allocate closure [table_idx, 0]
             wasm!(self.func, {
-                i32_const(8);
+                i32_const(CLOSURE_BYTES);
                 call(self.emitter.rt.alloc);
                 local_set(scratch);
                 local_get(scratch);
@@ -132,7 +136,7 @@ impl FuncCompiler<'_> {
             // Allocate closure: [table_idx, env_ptr]
             let closure_scratch = self.scratch.alloc_i32();
             wasm!(self.func, {
-                i32_const(8);
+                i32_const(CLOSURE_BYTES);
                 call(self.emitter.rt.alloc);
                 local_set(closure_scratch);
                 local_get(closure_scratch);
@@ -168,7 +172,7 @@ impl FuncCompiler<'_> {
         if captures.is_empty() {
             // No captures: closure = [table_idx, 0]
             wasm!(self.func, {
-                i32_const(8);
+                i32_const(CLOSURE_BYTES);
                 call(self.emitter.rt.alloc);
                 local_set(scratch);
                 local_get(scratch);
@@ -223,7 +227,7 @@ impl FuncCompiler<'_> {
             // Allocate closure pair [table_idx, env_ptr]
             let closure_scratch = self.scratch.alloc_i32();
             wasm!(self.func, {
-                i32_const(8);
+                i32_const(CLOSURE_BYTES);
                 call(self.emitter.rt.alloc);
                 local_set(closure_scratch);
                 local_get(closure_scratch);

--- a/crates/almide-codegen/src/emit_wasm/calls_list.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list.rs
@@ -1,5 +1,6 @@
 //! List stdlib call dispatch for WASM codegen (non-closure functions).
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::FuncCompiler;
 use super::values;
 use almide_ir::IrExpr;
@@ -48,38 +49,38 @@ impl FuncCompiler<'_> {
                 let len = self.scratch.alloc_i32();
                 // Store xs, len, i
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); local_get(xs); i32_load(0); local_set(len); });
+                wasm!(self.func, { local_set(Local(xs)); local_get(Local(xs)); i32_load(0); local_set(Local(len)); });
                 self.emit_expr(&args[1]); // i: i64
                 // idx = min_u(i, len); in_bounds = (i_u < len) on the full i64,
                 // so a negative OR a >= 2^32 index returns the default rather
                 // than wrapping to a small in-range slot (C-054). The unsigned
                 // test folds both `i < 0` and `i >= len` into one comparison.
                 self.emit_checked_index_i32(len, in_bounds);
-                wasm!(self.func, { local_set(idx); });
+                wasm!(self.func, { local_set(Local(idx)); });
                 // in_bounds ? xs[idx] : default
                 let load_at = |this: &mut Self| {
                     wasm!(this.func, {
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(idx)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
                     });
                 };
                 match vt {
                     ValType::I64 => {
-                        wasm!(self.func, { local_get(in_bounds); if_i64; });
+                        wasm!(self.func, { local_get(Local(in_bounds)); if_i64; });
                         load_at(self);
                         wasm!(self.func, { i64_load(0); else_; });
                         self.emit_expr(&args[2]);
                         wasm!(self.func, { end; });
                     }
                     ValType::F64 => {
-                        wasm!(self.func, { local_get(in_bounds); if_f64; });
+                        wasm!(self.func, { local_get(Local(in_bounds)); if_f64; });
                         load_at(self);
                         wasm!(self.func, { f64_load(0); else_; });
                         self.emit_expr(&args[2]);
                         wasm!(self.func, { end; });
                     }
                     _ => {
-                        wasm!(self.func, { local_get(in_bounds); if_i32; });
+                        wasm!(self.func, { local_get(Local(in_bounds)); if_i32; });
                         load_at(self);
                         wasm!(self.func, { i32_load(0); else_; });
                         self.emit_expr(&args[2]);
@@ -101,7 +102,7 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); local_get(xs); i32_load(0); local_set(len); });
+                wasm!(self.func, { local_set(Local(xs)); local_get(Local(xs)); i32_load(0); local_set(Local(len)); });
                 self.emit_expr(&args[1]);
                 // new_len = min_u(n, len): take's UNSIGNED `min(n as usize, len)`
                 // IS the clamp, computed on the i64 count before narrowing
@@ -109,24 +110,24 @@ impl FuncCompiler<'_> {
                 // whole list, matching native `take(n as usize)`.
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::LenLocal(len));
                 wasm!(self.func, {
-                    local_set(new_len);
-                    i32_const(list_hdr); local_get(new_len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(new_len); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_set(Local(new_len));
+                    i32_const(Imm32(list_hdr)); local_get(Local(new_len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(new_len)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(new_len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(new_len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(dst);
@@ -145,7 +146,7 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); local_get(xs); i32_load(0); local_set(len); });
+                wasm!(self.func, { local_set(Local(xs)); local_get(Local(xs)); i32_load(0); local_set(Local(len)); });
                 self.emit_expr(&args[1]);
                 // start = min_u(n, len) on the i64 count (C-054); then
                 // new_len = len - start can never underflow. A negative `n`
@@ -153,28 +154,28 @@ impl FuncCompiler<'_> {
                 // matching native `skip(n as usize)`.
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::LenLocal(len));
                 wasm!(self.func, {
-                    local_set(start);
+                    local_set(Local(start));
                     // new_len = len - start
-                    local_get(len); local_get(start); i32_sub;
-                    local_set(new_len);
-                    i32_const(list_hdr); local_get(new_len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(new_len); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_get(Local(len)); local_get(Local(start)); i32_sub;
+                    local_set(Local(new_len));
+                    i32_const(Imm32(list_hdr)); local_get(Local(new_len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(new_len)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(new_len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(start); local_get(i); i32_add;
-                      i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(new_len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(start)); local_get(Local(i)); i32_add;
+                      i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(dst);
@@ -195,8 +196,8 @@ impl FuncCompiler<'_> {
                 let len = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(xs);
-                    local_get(xs); i32_load(0); local_set(len);
+                    local_set(Local(xs));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
                 });
                 // Saturate start/end to [0, len] on the i64 index BEFORE
                 // narrowing (C-054), UNSIGNED — native `list.slice` is
@@ -210,35 +211,35 @@ impl FuncCompiler<'_> {
                 //   if s >= e { [] } else { xs[s..e] }
                 self.emit_expr(&args[1]); // start (i64)
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::LenLocal(len));
-                wasm!(self.func, { local_set(start); });
+                wasm!(self.func, { local_set(Local(start)); });
                 self.emit_expr(&args[2]); // end (i64)
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::LenLocal(len));
                 wasm!(self.func, {
-                    local_set(end);
+                    local_set(Local(end));
                     // new_len = (end > start) ? end - start : 0
-                    local_get(end); local_get(start); i32_sub;
-                      i32_const(0);
-                      local_get(end); local_get(start); i32_gt_u; select;
-                    local_set(new_len);
-                    i32_const(list_hdr); local_get(new_len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(new_len); i32_store(0);
+                    local_get(Local(end)); local_get(Local(start)); i32_sub;
+                      i32_const(Imm32(0));
+                      local_get(Local(end)); local_get(Local(start)); i32_gt_u; select;
+                    local_set(Local(new_len));
+                    i32_const(Imm32(list_hdr)); local_get(Local(new_len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(new_len)); i32_store(0);
                     // copy loop: dst[i] = xs[start + i] for i in 0..new_len (len reused as i)
-                    i32_const(0); local_set(len);
+                    i32_const(Imm32(0)); local_set(Local(len));
                     block_empty; loop_empty;
-                      local_get(len); local_get(new_len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(len); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(start); local_get(len); i32_add;
-                      i32_const(es); i32_mul; i32_add;
+                      local_get(Local(len)); local_get(Local(new_len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(start)); local_get(Local(len)); i32_add;
+                      i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(len); i32_const(1); i32_add; local_set(len);
+                      local_get(Local(len)); i32_const(Imm32(1)); i32_add; local_set(Local(len));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(len);
                 self.scratch.free_i32(dst);
@@ -256,31 +257,31 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(xs);
-                    local_get(xs); i32_load(0); local_set(len);
+                    local_set(Local(xs));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
                     // alloc dst
-                    i32_const(list_hdr); local_get(len); i32_const(elem_size as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
                     // loop: dst[i] = src[len-1-i]
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                       // dst addr
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
                       // src addr
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(len); i32_const(1); i32_sub; local_get(i); i32_sub;
-                      i32_const(elem_size as i32); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(len)); i32_const(Imm32(1)); i32_sub; local_get(Local(i)); i32_sub;
+                      i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
                 });
                 // Copy elem_size bytes
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(dst);
@@ -294,30 +295,30 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_wrap_i64; local_set(start_val); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(start_val)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
                     i32_wrap_i64;
-                    local_get(start_val); i32_sub; // len = end - start
-                    local_set(len);
-                    local_get(len); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(len); end; // clamp to 0
+                    local_get(Local(start_val)); i32_sub; // len = end - start
+                    local_set(Local(len));
+                    local_get(Local(len)); i32_const(Imm32(0)); i32_lt_s;
+                    if_empty; i32_const(Imm32(0)); local_set(Local(len)); end; // clamp to 0
                     // alloc
-                    i32_const(list_hdr); local_get(len); i32_const(I64_BYTES); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0); // dst.len
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0); // dst.len
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
-                      local_get(start_val); local_get(i); i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(start_val)); local_get(Local(i)); i32_add;
                       i64_extend_i32_s;
                       i64_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(dst);
@@ -332,16 +333,16 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(xs);
-                    local_get(xs); i32_load(0); i32_eqz;
-                    if_i32; i32_const(0); // none
+                    local_set(Local(xs));
+                    local_get(Local(xs)); i32_load(0); i32_eqz;
+                    if_i32; i32_const(Imm32(0)); // none
                     else_;
-                      i32_const(elem_size as i32); call(self.emitter.rt.alloc); local_set(result);
-                      local_get(result);
-                      local_get(xs); i32_const(list_data_off); i32_add;
+                      i32_const(Imm32(elem_size as i32)); call(self.emitter.rt.alloc); local_set(Local(result));
+                      local_get(Local(result));
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
-                wasm!(self.func, { local_get(result); end; });
+                wasm!(self.func, { local_get(Local(result)); end; });
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(xs);
             }
@@ -352,19 +353,19 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(xs);
-                    local_get(xs); i32_load(0); i32_eqz;
-                    if_i32; i32_const(0);
+                    local_set(Local(xs));
+                    local_get(Local(xs)); i32_load(0); i32_eqz;
+                    if_i32; i32_const(Imm32(0));
                     else_;
-                      i32_const(elem_size as i32); call(self.emitter.rt.alloc); local_set(result);
-                      local_get(result);
+                      i32_const(Imm32(elem_size as i32)); call(self.emitter.rt.alloc); local_set(Local(result));
+                      local_get(Local(result));
                       // src = xs + 4 + (len-1) * elem_size
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(xs); i32_load(0); i32_const(1); i32_sub;
-                      i32_const(elem_size as i32); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(xs)); i32_load(0); i32_const(Imm32(1)); i32_sub;
+                      i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
-                wasm!(self.func, { local_get(result); end; });
+                wasm!(self.func, { local_get(Local(result)); end; });
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(xs);
             }
@@ -379,20 +380,20 @@ impl FuncCompiler<'_> {
                 let acc = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(xs);
-                    i64_const(0); local_set(acc);
-                    i32_const(0); local_set(i);
+                    local_set(Local(xs));
+                    i64_const(Imm64(0)); local_set(Local(acc));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(acc);
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(xs)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(acc));
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_add;
                       i64_load(0);
-                      i64_add; local_set(acc);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      i64_add; local_set(Local(acc));
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(acc);
+                    local_get(Local(acc));
                 });
                 self.scratch.free_i64(acc);
                 self.scratch.free_i32(i);
@@ -404,20 +405,20 @@ impl FuncCompiler<'_> {
                 let acc = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(xs);
-                    i64_const(1); local_set(acc);
-                    i32_const(0); local_set(i);
+                    local_set(Local(xs));
+                    i64_const(Imm64(1)); local_set(Local(acc));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(acc);
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(xs)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(acc));
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I64_BYTES)); i32_mul; i32_add;
                       i64_load(0);
-                      i64_mul; local_set(acc);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      i64_mul; local_set(Local(acc));
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(acc);
+                    local_get(Local(acc));
                 });
                 self.scratch.free_i64(acc);
                 self.scratch.free_i32(i);
@@ -443,56 +444,56 @@ impl FuncCompiler<'_> {
                 let j = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(xss);
+                    local_set(Local(xss));
                     // Pass 1: count total elements
-                    i32_const(0); local_set(total);
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(total));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(xss); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(total);
-                      local_get(xss); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add; // &xss[i]
+                      local_get(Local(i)); local_get(Local(xss)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(total));
+                      local_get(Local(xss)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; // &xss[i]
                       i32_load(0); // inner list ptr
                       i32_load(0); // inner list len
-                      i32_add; local_set(total);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      i32_add; local_set(Local(total));
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                     // Alloc result
-                    i32_const(list_hdr); local_get(total); i32_const(elem_size as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(total); i32_store(0);
+                    i32_const(Imm32(list_hdr)); local_get(Local(total)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(total)); i32_store(0);
                     // Pass 2: copy
-                    i32_const(0); local_set(total); // dst offset (in elements)
-                    i32_const(0); local_set(i); // i (outer)
+                    i32_const(Imm32(0)); local_set(Local(total)); // dst offset (in elements)
+                    i32_const(Imm32(0)); local_set(Local(i)); // i (outer)
                     block_empty; loop_empty;
-                      local_get(i); local_get(xss); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(xss)); i32_load(0); i32_ge_u; br_if(1);
                       // inner = xss[i]
-                      local_get(xss); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      i32_load(0); local_set(inner);
+                      local_get(Local(xss)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      i32_load(0); local_set(Local(inner));
                       // Copy inner elements
-                      i32_const(0); local_set(j);
+                      i32_const(Imm32(0)); local_set(Local(j));
                       block_empty; loop_empty;
-                        local_get(j); local_get(inner); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(j)); local_get(Local(inner)); i32_load(0); i32_ge_u; br_if(1);
                         // dst[dst_offset + j]
-                        local_get(dst); i32_const(list_data_off); i32_add;
-                        local_get(total); local_get(j); i32_add;
-                        i32_const(elem_size as i32); i32_mul; i32_add;
+                        local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(total)); local_get(Local(j)); i32_add;
+                        i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
                         // src inner[j]
-                        local_get(inner); i32_const(list_data_off); i32_add;
-                        local_get(j); i32_const(elem_size as i32); i32_mul; i32_add;
+                        local_get(Local(inner)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(j)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
-                      local_get(total); local_get(inner); i32_load(0); i32_add; local_set(total);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(total)); local_get(Local(inner)); i32_load(0); i32_add; local_set(Local(total));
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(j);
                 self.scratch.free_i32(inner);
@@ -535,42 +536,42 @@ impl FuncCompiler<'_> {
                 let cmp = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(xs);
-                    local_get(xs); i32_load(0); i32_eqz;
-                    if_i32; i32_const(0); // none
+                    local_set(Local(xs));
+                    local_get(Local(xs)); i32_load(0); i32_eqz;
+                    if_i32; i32_const(Imm32(0)); // none
                     else_;
                       // best = xs[0]
-                      local_get(xs); i32_const(list_data_off); i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_set(best);
-                      i32_const(1); local_set(i); // i=1
+                      local_set(Local(best));
+                      i32_const(Imm32(1)); local_set(Local(i)); // i=1
                       block_empty; loop_empty;
-                        local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(i)); local_get(Local(xs)); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { local_set(candidate); });
+                wasm!(self.func, { local_set(Local(candidate)); });
                 // cmp = sign(candidate <=> best)
-                wasm!(self.func, { local_get(candidate); local_get(best); });
+                wasm!(self.func, { local_get(Local(candidate)); local_get(Local(best)); });
                 self.emit_ord_cmp3(&elem_ty);
-                wasm!(self.func, { local_set(cmp); });
+                wasm!(self.func, { local_set(Local(cmp)); });
                 if is_max {
-                    wasm!(self.func, { local_get(cmp); i32_const(0); i32_gt_s; });
+                    wasm!(self.func, { local_get(Local(cmp)); i32_const(Imm32(0)); i32_gt_s; });
                 } else {
-                    wasm!(self.func, { local_get(cmp); i32_const(0); i32_lt_s; });
+                    wasm!(self.func, { local_get(Local(cmp)); i32_const(Imm32(0)); i32_lt_s; });
                 }
                 wasm!(self.func, {
-                        if_empty; local_get(candidate); local_set(best); end;
-                        local_get(i); i32_const(1); i32_add; local_set(i);
+                        if_empty; local_get(Local(candidate)); local_set(Local(best)); end;
+                        local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                         br(0);
                       end; end;
                       // some(best): allocate a payload slot sized for the element
                       // and store best at offset 0 with the matching width.
-                      i32_const(es); call(self.emitter.rt.alloc); local_set(out);
-                      local_get(out); local_get(best);
+                      i32_const(Imm32(es)); call(self.emitter.rt.alloc); local_set(Local(out));
+                      local_get(Local(out)); local_get(Local(best));
                 });
                 // SHARE: the winner pointer aliases an element of a list the
                 // caller still owns; the some() box must own its own ref —
@@ -581,7 +582,7 @@ impl FuncCompiler<'_> {
                 }
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(out);
+                      local_get(Local(out));
                     end;
                 });
                 self.scratch.free_i32(cmp);
@@ -604,43 +605,43 @@ impl FuncCompiler<'_> {
                 let src_i = self.scratch.alloc_i32();
                 let dst_i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]); // sep
-                wasm!(self.func, { local_set(sep); });
+                wasm!(self.func, { local_set(Local(sep)); });
                 wasm!(self.func, {
-                    local_get(xs); i32_load(0); local_set(len);
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
                     // new_len = max(0, 2*len - 1)
-                    local_get(len); i32_eqz;
+                    local_get(Local(len)); i32_eqz;
                     if_i32;
                       // empty list
-                      i32_const(list_hdr); call(self.emitter.rt.alloc); local_set(dst);
-                      local_get(dst); i32_const(0); i32_store(0);
-                      local_get(dst);
+                      i32_const(Imm32(list_hdr)); call(self.emitter.rt.alloc); local_set(Local(dst));
+                      local_get(Local(dst)); i32_const(Imm32(0)); i32_store(0);
+                      local_get(Local(dst));
                     else_;
-                      local_get(len); i32_const(INTERSPERSE_LEN_FACTOR); i32_mul; i32_const(1); i32_sub; local_set(new_len);
-                      i32_const(list_hdr); local_get(new_len); i32_const(elem_size as i32); i32_mul; i32_add;
-                      call(self.emitter.rt.alloc); local_set(dst);
-                      local_get(dst); local_get(new_len); i32_store(0);
+                      local_get(Local(len)); i32_const(Imm32(INTERSPERSE_LEN_FACTOR)); i32_mul; i32_const(Imm32(1)); i32_sub; local_set(Local(new_len));
+                      i32_const(Imm32(list_hdr)); local_get(Local(new_len)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
+                      call(self.emitter.rt.alloc); local_set(Local(dst));
+                      local_get(Local(dst)); local_get(Local(new_len)); i32_store(0);
                       // Fill
-                      i32_const(0); local_set(src_i);
-                      i32_const(0); local_set(dst_i);
+                      i32_const(Imm32(0)); local_set(Local(src_i));
+                      i32_const(Imm32(0)); local_set(Local(dst_i));
                       block_empty; loop_empty;
-                        local_get(src_i); local_get(len); i32_ge_u; br_if(1);
+                        local_get(Local(src_i)); local_get(Local(len)); i32_ge_u; br_if(1);
                         // Copy xs[src_i] to dst[dst_i]
-                        local_get(dst); i32_const(list_data_off); i32_add;
-                        local_get(dst_i); i32_const(elem_size as i32); i32_mul; i32_add;
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(src_i); i32_const(elem_size as i32); i32_mul; i32_add;
+                        local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(dst_i)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(src_i)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(dst_i); i32_const(1); i32_add; local_set(dst_i);
+                        local_get(Local(dst_i)); i32_const(Imm32(1)); i32_add; local_set(Local(dst_i));
                         // Insert sep if not last
-                        local_get(src_i); local_get(len); i32_const(1); i32_sub; i32_lt_u;
+                        local_get(Local(src_i)); local_get(Local(len)); i32_const(Imm32(1)); i32_sub; i32_lt_u;
                         if_empty;
-                          local_get(dst); i32_const(list_data_off); i32_add;
-                          local_get(dst_i); i32_const(elem_size as i32); i32_mul; i32_add;
-                          local_get(sep);
+                          local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                          local_get(Local(dst_i)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
+                          local_get(Local(sep));
                 });
                 // SHARE: the sep value's source survives; every stored slot
                 // needs its own reference.
@@ -649,12 +650,12 @@ impl FuncCompiler<'_> {
                 }
                 self.emit_elem_store(&elem_ty);
                 wasm!(self.func, {
-                          local_get(dst_i); i32_const(1); i32_add; local_set(dst_i);
+                          local_get(Local(dst_i)); i32_const(Imm32(1)); i32_add; local_set(Local(dst_i));
                         end;
-                        local_get(src_i); i32_const(1); i32_add; local_set(src_i);
+                        local_get(Local(src_i)); i32_const(Imm32(1)); i32_add; local_set(Local(src_i));
                         br(0);
                       end; end;
-                      local_get(dst);
+                      local_get(Local(dst));
                     end;
                 });
                 self.scratch.free_i32(dst_i);
@@ -680,51 +681,51 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let tup = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(ys);
+                    local_set(Local(ys));
                     // len = min(xs.len, ys.len)
-                    local_get(xs); i32_load(0);
-                    local_get(ys); i32_load(0);
+                    local_get(Local(xs)); i32_load(0);
+                    local_get(Local(ys)); i32_load(0);
                     i32_lt_u;
                     if_i32;
-                      local_get(xs); i32_load(0);
+                      local_get(Local(xs)); i32_load(0);
                     else_;
-                      local_get(ys); i32_load(0);
+                      local_get(Local(ys)); i32_load(0);
                     end;
-                    local_set(len);
+                    local_set(Local(len));
                     // Alloc result: list of ptrs to tuples
-                    i32_const(list_hdr); local_get(len); i32_const(I32_BYTES); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                       // Alloc tuple
-                      i32_const(tuple_size as i32); call(self.emitter.rt.alloc); local_set(tup);
+                      i32_const(Imm32(tuple_size as i32)); call(self.emitter.rt.alloc); local_set(Local(tup));
                       // Copy a: tuple[0] = xs[i]
-                      local_get(tup);
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(a_size as i32); i32_mul; i32_add;
+                      local_get(Local(tup));
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(a_size as i32)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&a_ty);
                 // Copy b: tuple[a_size] = ys[i]
                 wasm!(self.func, {
-                      local_get(tup); i32_const(a_size as i32); i32_add;
-                      local_get(ys); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(b_size as i32); i32_mul; i32_add;
+                      local_get(Local(tup)); i32_const(Imm32(a_size as i32)); i32_add;
+                      local_get(Local(ys)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(b_size as i32)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&b_ty);
                 wasm!(self.func, {
                       // result[i] = tuple_ptr
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      local_get(tup); i32_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      local_get(Local(tup)); i32_store(0);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(tup);
                 self.scratch.free_i32(i);
@@ -746,59 +747,59 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let val = self.scratch.alloc(val_vt);
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); local_get(xs); i32_load(0); local_set(len); });
+                wasm!(self.func, { local_set(Local(xs)); local_get(Local(xs)); i32_load(0); local_set(Local(len)); });
                 self.emit_expr(&args[1]); // i: i64
                 // idx = min_u(i, len); in_bounds = (i_u < len) on the full i64.
                 // Native `list.set` no-ops when i is OOB (`get_mut` → None), so
                 // a huge/negative i64 must take the no-op path, not wrap to a
                 // small in-range index and overwrite the wrong slot (C-054).
                 self.emit_checked_index_i32(len, in_bounds);
-                wasm!(self.func, { local_set(idx); });
+                wasm!(self.func, { local_set(Local(idx)); });
                 // Evaluate `val` EAGERLY (native passes it by value before the
                 // call), then store conditionally — so a side-effecting value
                 // expr runs whether or not the index is in bounds. Stored-field
                 // contract: an alias value gets its own reference.
                 self.emit_stored_field(&args[2]);
                 wasm!(self.func, {
-                    local_set(val);
+                    local_set(Local(val));
                     // Alloc copy
-                    i32_const(list_hdr); local_get(len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
                     // Copy all elements
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                     // Overwrite dst[idx] with val — only when in bounds.
-                    local_get(in_bounds);
+                    local_get(Local(in_bounds));
                     if_empty;
                 });
                 // Release the owned copy of the element being replaced (it
                 // received +1 in the copy loop above and loses this slot).
                 if crate::pass_perceus::is_heap_type(&elem_ty) {
                     wasm!(self.func, {
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(idx); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(idx)); i32_const(Imm32(es)); i32_mul; i32_add;
                       i32_load(0); call(self.emitter.rt.rc_dec);
                     });
                 }
                 wasm!(self.func, {
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(idx); i32_const(es); i32_mul; i32_add;
-                      local_get(val);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(idx)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(val));
                 });
                 self.emit_elem_store(&elem_ty);
-                wasm!(self.func, { end; local_get(dst); });
+                wasm!(self.func, { end; local_get(Local(dst)); });
                 self.scratch.free(val, val_vt);
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(dst);
@@ -817,7 +818,7 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); local_get(xs); i32_load(0); local_set(old_len); });
+                wasm!(self.func, { local_set(Local(xs)); local_get(Local(xs)); i32_load(0); local_set(Local(old_len)); });
                 self.emit_expr(&args[1]);
                 // idx = min_u(i, old_len) on the full i64 (C-054): out-of-range
                 // or negative indices append at the end, mirroring native's
@@ -825,49 +826,49 @@ impl FuncCompiler<'_> {
                 // let an index >= 2^32 wrap to a small in-range insert point.
                 self.emit_clamp_index_to_len_i32(old_len);
                 wasm!(self.func, {
-                    local_set(idx);
+                    local_set(Local(idx));
                     // new_len = old_len + 1
-                    i32_const(list_hdr); local_get(old_len); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(old_len); i32_const(1); i32_add; i32_store(0);
+                    i32_const(Imm32(list_hdr)); local_get(Local(old_len)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(old_len)); i32_const(Imm32(1)); i32_add; i32_store(0);
                     // Copy [0..idx)
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(idx); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(idx)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                 });
                 // Insert val at idx (stored-field: alias values dup)
                 wasm!(self.func, {
-                    local_get(dst); i32_const(list_data_off); i32_add;
-                    local_get(idx); i32_const(es); i32_mul; i32_add;
+                    local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_get(Local(idx)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_stored_field(&args[2]);
                 self.emit_elem_store(&elem_ty);
                 // Copy [idx..old_len)
                 wasm!(self.func, {
-                    local_get(idx); local_set(i);
+                    local_get(Local(idx)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(old_len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(old_len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(dst);
@@ -886,7 +887,7 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); local_get(xs); i32_load(0); local_set(old_len); });
+                wasm!(self.func, { local_set(Local(xs)); local_get(Local(xs)); i32_load(0); local_set(Local(old_len)); });
                 self.emit_expr(&args[1]);
                 // idx = min_u(i, old_len); in_bounds = (i_u < old_len) on the
                 // full i64. Native is a no-op when i >= len; an index >= 2^32
@@ -894,50 +895,50 @@ impl FuncCompiler<'_> {
                 // and remove the wrong element (C-054).
                 self.emit_checked_index_i32(old_len, in_bounds);
                 wasm!(self.func, {
-                    local_set(idx);
-                    local_get(in_bounds);
+                    local_set(Local(idx));
+                    local_get(Local(in_bounds));
                     if_i32;
                     // new_len = old_len - 1
-                    i32_const(list_hdr); local_get(old_len); i32_const(1); i32_sub; i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(old_len); i32_const(1); i32_sub; i32_store(0);
+                    i32_const(Imm32(list_hdr)); local_get(Local(old_len)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(old_len)); i32_const(Imm32(1)); i32_sub; i32_store(0);
                     // Copy [0..idx)
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(idx); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(idx)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                 });
                 // Copy [idx+1..old_len)
                 wasm!(self.func, {
-                    local_get(idx); i32_const(1); i32_add; local_set(i);
+                    local_get(Local(idx)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(old_len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(1); i32_sub; i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(old_len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                     else_;
                     // i >= len → return the list unchanged. SHARE: the result
                     // is a SECOND reference to xs (native returns a clone) —
                     // without the inc the result temp's Dec freed xs's live
                     // backing (list_count_index_truncation silent corruption).
-                    local_get(xs); call(self.emitter.rt.rc_inc);
+                    local_get(Local(xs)); call(self.emitter.rt.rc_inc);
                     end;
                 });
                 self.scratch.free_i32(i);
@@ -964,7 +965,7 @@ impl FuncCompiler<'_> {
                 let len = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(list); local_get(list); i32_load(0); local_set(len); });
+                wasm!(self.func, { local_set(Local(list)); local_get(Local(list)); i32_load(0); local_set(Local(len)); });
                 self.emit_expr(&args[1]);
                 // Index is normally Int (i64); a tuple-index residual may arrive
                 // already i32. For the i64 case the bounds check runs on the FULL
@@ -973,31 +974,31 @@ impl FuncCompiler<'_> {
                 // keeps the simple unsigned compare.
                 if matches!(&args[1].ty, Ty::Int) || args[1].ty.is_unresolved() {
                     self.emit_checked_index_i32(len, in_bounds);
-                    wasm!(self.func, { local_set(idx); });
+                    wasm!(self.func, { local_set(Local(idx)); });
                 } else {
                     wasm!(self.func, {
-                        local_set(idx);
-                        local_get(idx); local_get(len); i32_lt_u; local_set(in_bounds);
+                        local_set(Local(idx));
+                        local_get(Local(idx)); local_get(Local(len)); i32_lt_u; local_set(Local(in_bounds));
                     });
                 }
                 wasm!(self.func, {
                     // bounds: !in_bounds → none(0)
-                    local_get(in_bounds);
+                    local_get(Local(in_bounds));
                     i32_eqz;
                     if_i32;
-                    i32_const(0); // none
+                    i32_const(Imm32(0)); // none
                     else_;
                     // alloc
-                    i32_const(elem_size as i32);
+                    i32_const(Imm32(elem_size as i32));
                     call(self.emitter.rt.alloc);
-                    local_set(result);
+                    local_set(Local(result));
                     // dst=result, src=list+4+idx*elem_size
-                    local_get(result);
-                    local_get(list);
-                    i32_const(list_data_off);
+                    local_get(Local(result));
+                    local_get(Local(list));
+                    i32_const(Imm32(list_data_off));
                     i32_add;
-                    local_get(idx);
-                    i32_const(elem_size as i32);
+                    local_get(Local(idx));
+                    i32_const(Imm32(elem_size as i32));
                     i32_mul;
                     i32_add;
                 });
@@ -1010,7 +1011,7 @@ impl FuncCompiler<'_> {
                 }
                 self.emit_store_at(&elem_ty, 0); // store at dst
                 wasm!(self.func, {
-                    local_get(result); // return ptr
+                    local_get(Local(result)); // return ptr
                     end;
                 });
                 self.scratch.free_i32(result);
@@ -1034,28 +1035,28 @@ impl FuncCompiler<'_> {
                 // native `xs.contains(&x)`, not pointer identity.
                 let target = self.scratch.alloc(target_vt);
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(list_ptr); });
+                wasm!(self.func, { local_set(Local(list_ptr)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(target);
-                    i32_const(0); local_set(idx);
-                    i32_const(0); local_set(result); // result = false
+                    local_set(Local(target));
+                    i32_const(Imm32(0)); local_set(Local(idx));
+                    i32_const(Imm32(0)); local_set(Local(result)); // result = false
                     block_empty; loop_empty;
-                      local_get(idx); local_get(list_ptr); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(list_ptr); i32_const(list_data_off); i32_add;
-                      local_get(idx); i32_const(elem_size as i32); i32_mul; i32_add;
+                      local_get(Local(idx)); local_get(Local(list_ptr)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(list_ptr)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(idx)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { local_get(target); });
+                wasm!(self.func, { local_get(Local(target)); });
                 self.emit_eq_typed(&elem_ty);
                 wasm!(self.func, {
                       if_empty;
-                        i32_const(1); local_set(result); br(2);
+                        i32_const(Imm32(1)); local_set(Local(result)); br(2);
                       end;
-                      local_get(idx); i32_const(1); i32_add; local_set(idx);
+                      local_get(Local(idx)); i32_const(Imm32(1)); i32_add; local_set(Local(idx));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free(target, target_vt);
                 self.scratch.free_i32(result);
@@ -1095,36 +1096,36 @@ impl FuncCompiler<'_> {
                 let cap64 = self.scratch.alloc_i64();
                 // Evaluate the requested capacity once (it is an i64 Int).
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(cap64); });
+                wasm!(self.func, { local_set(Local(cap64)); });
                 // cap_local = clamp(req, 0, max_cap), done on the i64 value so
                 // the lossy wrap to i32 happens only on an already-safe number.
                 wasm!(self.func, {
-                    local_get(cap64); i64_const(0); i64_lt_s;
+                    local_get(Local(cap64)); i64_const(Imm64(0)); i64_lt_s;
                     if_i32;
-                      i32_const(0);                          // negative → empty
+                      i32_const(Imm32(0));                          // negative → empty
                     else_;
-                      local_get(cap64);
-                      i32_const(max_cap as i32); i64_extend_i32_s; i64_gt_s;
+                      local_get(Local(cap64));
+                      i32_const(Imm32(max_cap as i32)); i64_extend_i32_s; i64_gt_s;
                       if_i32;
-                        i32_const(max_cap as i32);           // saturate
+                        i32_const(Imm32(max_cap as i32));           // saturate
                       else_;
-                        local_get(cap64); i32_wrap_i64;      // fits
+                        local_get(Local(cap64)); i32_wrap_i64;      // fits
                       end;
                     end;
-                    local_set(cap_local);
+                    local_set(Local(cap_local));
                 });
                 // alloc: hdr + cap * elem_size  (cap is clamped → no overflow)
                 wasm!(self.func, {
-                    i32_const(list_hdr);
-                    local_get(cap_local); i32_const(elem_size as i32); i32_mul;
+                    i32_const(Imm32(list_hdr));
+                    local_get(Local(cap_local)); i32_const(Imm32(elem_size as i32)); i32_mul;
                     i32_add;
                     call(self.emitter.rt.alloc);
-                    local_set(new_ptr);
+                    local_set(Local(new_ptr));
                     // len = 0
-                    local_get(new_ptr); i32_const(0); i32_store(0);
+                    local_get(Local(new_ptr)); i32_const(Imm32(0)); i32_store(0);
                     // cap = clamped capacity (matches the backing buffer)
-                    local_get(new_ptr); local_get(cap_local); i32_store(4);
-                    local_get(new_ptr);
+                    local_get(Local(new_ptr)); local_get(Local(cap_local)); i32_store(4);
+                    local_get(Local(new_ptr));
                 });
                 self.scratch.free_i64(cap64);
                 self.scratch.free_i32(cap_local);
@@ -1147,29 +1148,29 @@ impl FuncCompiler<'_> {
                 // effects); stored-field contract — an alias value pushed
                 // into the list needs its own reference.
                 self.emit_stored_field(&args[1]);
-                wasm!(self.func, { local_set(val_scratch); });
+                wasm!(self.func, { local_set(Local(val_scratch)); });
 
                 // Read xs pointer, len, cap
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(ptr); });
+                wasm!(self.func, { local_set(Local(ptr)); });
                 wasm!(self.func, {
-                    local_get(ptr); i32_load(0); local_set(len_local);
-                    local_get(ptr); i32_load(4); local_set(cap_local);
+                    local_get(Local(ptr)); i32_load(0); local_set(Local(len_local));
+                    local_get(Local(ptr)); i32_load(4); local_set(Local(cap_local));
                 });
 
                 // if len < cap: write in place (fast path)
                 wasm!(self.func, {
-                    local_get(len_local);
-                    local_get(cap_local);
+                    local_get(Local(len_local));
+                    local_get(Local(cap_local));
                     i32_lt_u;
                     if_empty;
                 });
                 // Fast path: write element at ptr + 8 + len * elem_size
                 wasm!(self.func, {
-                    local_get(ptr); i32_const(list_data_off); i32_add;
-                    local_get(len_local); i32_const(elem_size as i32); i32_mul;
+                    local_get(Local(ptr)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_get(Local(len_local)); i32_const(Imm32(elem_size as i32)); i32_mul;
                     i32_add;
-                    local_get(val_scratch);
+                    local_get(Local(val_scratch));
                 });
                 match vt {
                     ValType::I64 => { wasm!(self.func, { i64_store(0); }); }
@@ -1178,8 +1179,8 @@ impl FuncCompiler<'_> {
                 }
                 // Increment len
                 wasm!(self.func, {
-                    local_get(ptr);
-                    local_get(len_local); i32_const(1); i32_add;
+                    local_get(Local(ptr));
+                    local_get(Local(len_local)); i32_const(Imm32(1)); i32_add;
                     i32_store(0);
                     else_;
                 });
@@ -1189,62 +1190,62 @@ impl FuncCompiler<'_> {
                 // we MUST ensure new_cap >= len+1 to avoid buffer overflow.
                 wasm!(self.func, {
                     // cap_local = max(cap * 2, PUSH_MIN_INIT_CAP)
-                    local_get(cap_local); i32_const(1); i32_shl;
-                    i32_const(PUSH_MIN_INIT_CAP);
+                    local_get(Local(cap_local)); i32_const(Imm32(1)); i32_shl;
+                    i32_const(Imm32(PUSH_MIN_INIT_CAP));
                     i32_gt_u;
                     if_i32;
-                      local_get(cap_local); i32_const(1); i32_shl;
+                      local_get(Local(cap_local)); i32_const(Imm32(1)); i32_shl;
                     else_;
-                      i32_const(PUSH_MIN_INIT_CAP);
+                      i32_const(Imm32(PUSH_MIN_INIT_CAP));
                     end;
-                    local_set(cap_local);
+                    local_set(Local(cap_local));
                     // cap_local = max(cap_local, len + 1)
-                    local_get(cap_local);
-                    local_get(len_local); i32_const(1); i32_add;
+                    local_get(Local(cap_local));
+                    local_get(Local(len_local)); i32_const(Imm32(1)); i32_add;
                     i32_lt_u;
                     if_empty;
-                      local_get(len_local); i32_const(1); i32_add;
-                      local_set(cap_local);
+                      local_get(Local(len_local)); i32_const(Imm32(1)); i32_add;
+                      local_set(Local(cap_local));
                     end;
                 });
 
                 // Ensure new_cap > len (edge case: cap=0, len=0 → new_cap=8 > 0 ✓)
                 // Allocate: 8 + new_cap * elem_size
                 wasm!(self.func, {
-                    i32_const(list_hdr);
-                    local_get(cap_local); i32_const(elem_size as i32); i32_mul;
+                    i32_const(Imm32(list_hdr));
+                    local_get(Local(cap_local)); i32_const(Imm32(elem_size as i32)); i32_mul;
                     i32_add;
                     call(self.emitter.rt.alloc);
-                    local_set(new_ptr);
+                    local_set(Local(new_ptr));
                 });
 
                 // Write new len = old_len + 1
                 wasm!(self.func, {
-                    local_get(new_ptr);
-                    local_get(len_local); i32_const(1); i32_add;
+                    local_get(Local(new_ptr));
+                    local_get(Local(len_local)); i32_const(Imm32(1)); i32_add;
                     i32_store(0);
                 });
                 // Write new cap
                 wasm!(self.func, {
-                    local_get(new_ptr);
-                    local_get(cap_local);
+                    local_get(Local(new_ptr));
+                    local_get(Local(cap_local));
                     i32_store(4);
                 });
 
                 // Copy old data: memory.copy(new_ptr+8, ptr+8, len * elem_size)
                 wasm!(self.func, {
-                    local_get(new_ptr); i32_const(list_data_off); i32_add;
-                    local_get(ptr); i32_const(list_data_off); i32_add;
-                    local_get(len_local); i32_const(elem_size as i32); i32_mul;
+                    local_get(Local(new_ptr)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_get(Local(ptr)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_get(Local(len_local)); i32_const(Imm32(elem_size as i32)); i32_mul;
                     memory_copy;
                 });
 
                 // Write new element at new_ptr + 8 + len * elem_size
                 wasm!(self.func, {
-                    local_get(new_ptr); i32_const(list_data_off); i32_add;
-                    local_get(len_local); i32_const(elem_size as i32); i32_mul;
+                    local_get(Local(new_ptr)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_get(Local(len_local)); i32_const(Imm32(elem_size as i32)); i32_mul;
                     i32_add;
-                    local_get(val_scratch);
+                    local_get(Local(val_scratch));
                 });
                 match vt {
                     ValType::I64 => { wasm!(self.func, { i64_store(0); }); }
@@ -1274,40 +1275,40 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(list_ptr); });
-                wasm!(self.func, { local_get(list_ptr); i32_load(0); local_set(len); });
+                wasm!(self.func, { local_set(Local(list_ptr)); });
+                wasm!(self.func, { local_get(Local(list_ptr)); i32_load(0); local_set(Local(len)); });
 
                 // if len == 0 → none (0)
                 // else → decrement len, copy last element into alloc'd payload
                 wasm!(self.func, {
-                    local_get(len); i32_eqz;
+                    local_get(Local(len)); i32_eqz;
                     if_i32;
-                      i32_const(0); // none
+                      i32_const(Imm32(0)); // none
                     else_;
                 });
 
                 // Decrement len in place
                 wasm!(self.func, {
-                    local_get(list_ptr);
-                    local_get(len); i32_const(1); i32_sub;
+                    local_get(Local(list_ptr));
+                    local_get(Local(len)); i32_const(Imm32(1)); i32_sub;
                     i32_store(0);
                 });
 
                 // Allocate payload (no tag — Option uses ptr==0 for none)
                 wasm!(self.func, {
-                    i32_const(elem_size as i32);
+                    i32_const(Imm32(elem_size as i32));
                     call(self.emitter.rt.alloc);
-                    local_set(result);
+                    local_set(Local(result));
                     // Copy last element: dst=result, src=list+4+(len-1)*elem_size
-                    local_get(result);
-                    local_get(list_ptr); i32_const(list_data_off); i32_add;
-                    local_get(len); i32_const(1); i32_sub;
-                    i32_const(elem_size as i32); i32_mul; i32_add;
+                    local_get(Local(result));
+                    local_get(Local(list_ptr)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_get(Local(len)); i32_const(Imm32(1)); i32_sub;
+                    i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(result);
+                      local_get(Local(result));
                     end;
                 });
 
@@ -1318,7 +1319,7 @@ impl FuncCompiler<'_> {
             "clear" => {
                 // clear(xs) → Unit. Sets len to 0 in place.
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_const(0); i32_store(0); });
+                wasm!(self.func, { i32_const(Imm32(0)); i32_store(0); });
             }
             _ => return self.emit_list_closure_call(method, args),
         }

--- a/crates/almide-codegen/src/emit_wasm/calls_list.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list.rs
@@ -6,6 +6,23 @@ use almide_ir::IrExpr;
 use almide_lang::types::Ty;
 use wasm_encoder::ValType;
 
+// Named immediates used in WASM instruction arguments.
+// The byte-identity gate enforces that replacing these names with their
+// literal values produces bit-for-bit identical output.
+mod imm {
+    /// Byte width of an i32 / pointer value on the WASM heap (4 bytes).
+    pub(super) const I32_BYTES: i32 = 4;
+    /// Byte width of an i64 / Int value on the WASM heap (8 bytes).
+    pub(super) const I64_BYTES: i32 = 8;
+    /// Factor by which `intersperse` expands the element count before subtracting
+    /// the trailing separator: new_len = 2 * len - 1.
+    pub(super) const INTERSPERSE_LEN_FACTOR: i32 = 2;
+    /// Minimum element capacity allocated in the `push` slow path when the list
+    /// has no pre-reserved capacity: max(cap * 2, len + 1, PUSH_MIN_INIT_CAP).
+    pub(super) const PUSH_MIN_INIT_CAP: i32 = 8;
+}
+use imm::*;
+
 impl FuncCompiler<'_> {
     /// Dispatch a list stdlib method call (non-closure). Returns true if handled.
     pub(super) fn emit_list_call(&mut self, method: &str, args: &[IrExpr]) -> bool {
@@ -286,14 +303,14 @@ impl FuncCompiler<'_> {
                     local_get(len); i32_const(0); i32_lt_s;
                     if_empty; i32_const(0); local_set(len); end; // clamp to 0
                     // alloc
-                    i32_const(list_hdr); local_get(len); i32_const(8); i32_mul; i32_add;
+                    i32_const(list_hdr); local_get(len); i32_const(I64_BYTES); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(len); i32_store(0); // dst.len
                     i32_const(0); local_set(i);
                     block_empty; loop_empty;
                       local_get(i); local_get(len); i32_ge_u; br_if(1);
                       local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
                       local_get(start_val); local_get(i); i32_add;
                       i64_extend_i32_s;
                       i64_store(0);
@@ -369,7 +386,7 @@ impl FuncCompiler<'_> {
                       local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
                       local_get(acc);
                       local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
                       i64_load(0);
                       i64_add; local_set(acc);
                       local_get(i); i32_const(1); i32_add; local_set(i);
@@ -394,7 +411,7 @@ impl FuncCompiler<'_> {
                       local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
                       local_get(acc);
                       local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(I64_BYTES); i32_mul; i32_add;
                       i64_load(0);
                       i64_mul; local_set(acc);
                       local_get(i); i32_const(1); i32_add; local_set(i);
@@ -434,7 +451,7 @@ impl FuncCompiler<'_> {
                       local_get(i); local_get(xss); i32_load(0); i32_ge_u; br_if(1);
                       local_get(total);
                       local_get(xss); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add; // &xss[i]
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add; // &xss[i]
                       i32_load(0); // inner list ptr
                       i32_load(0); // inner list len
                       i32_add; local_set(total);
@@ -452,7 +469,7 @@ impl FuncCompiler<'_> {
                       local_get(i); local_get(xss); i32_load(0); i32_ge_u; br_if(1);
                       // inner = xss[i]
                       local_get(xss); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0); local_set(inner);
                       // Copy inner elements
                       i32_const(0); local_set(j);
@@ -600,7 +617,7 @@ impl FuncCompiler<'_> {
                       local_get(dst); i32_const(0); i32_store(0);
                       local_get(dst);
                     else_;
-                      local_get(len); i32_const(2); i32_mul; i32_const(1); i32_sub; local_set(new_len);
+                      local_get(len); i32_const(INTERSPERSE_LEN_FACTOR); i32_mul; i32_const(1); i32_sub; local_set(new_len);
                       i32_const(list_hdr); local_get(new_len); i32_const(elem_size as i32); i32_mul; i32_add;
                       call(self.emitter.rt.alloc); local_set(dst);
                       local_get(dst); local_get(new_len); i32_store(0);
@@ -678,7 +695,7 @@ impl FuncCompiler<'_> {
                     end;
                     local_set(len);
                     // Alloc result: list of ptrs to tuples
-                    i32_const(list_hdr); local_get(len); i32_const(4); i32_mul; i32_add;
+                    i32_const(list_hdr); local_get(len); i32_const(I32_BYTES); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(len); i32_store(0);
                     i32_const(0); local_set(i);
@@ -702,7 +719,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                       // result[i] = tuple_ptr
                       local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       local_get(tup); i32_store(0);
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -1171,14 +1188,14 @@ impl FuncCompiler<'_> {
                 // cap=0 is common (lists created without explicit cap), so
                 // we MUST ensure new_cap >= len+1 to avoid buffer overflow.
                 wasm!(self.func, {
-                    // cap_local = max(cap * 2, 8)
+                    // cap_local = max(cap * 2, PUSH_MIN_INIT_CAP)
                     local_get(cap_local); i32_const(1); i32_shl;
-                    i32_const(8);
+                    i32_const(PUSH_MIN_INIT_CAP);
                     i32_gt_u;
                     if_i32;
                       local_get(cap_local); i32_const(1); i32_shl;
                     else_;
-                      i32_const(8);
+                      i32_const(PUSH_MIN_INIT_CAP);
                     end;
                     local_set(cap_local);
                     // cap_local = max(cap_local, len + 1)

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
@@ -10,6 +10,20 @@ use almide_ir::IrExpr;
 use almide_lang::types::Ty;
 use wasm_encoder::ValType;
 
+/// Named WASM immediate constants for list-closure call codegen.
+mod imm {
+    // ── byte widths ────────────────────────────────────────────────────
+    /// Byte size of an i32 / pointer (stride in a list-of-pointers array).
+    pub const I32_BYTES: i32 = 4;
+    /// Byte size of an i64 element (size to alloc for a boxed Int value).
+    pub const I64_BYTES: i32 = 8;
+
+    // ── sort guard ─────────────────────────────────────────────────────
+    /// Minimum list length that requires sorting (len < 2 → already sorted).
+    pub const SORT_MIN_LEN: i32 = 2;
+}
+use imm::*;
+
 impl FuncCompiler<'_> {
     /// Dispatch a list stdlib closure-based call. Returns true if handled.
     pub(super) fn emit_list_closure_call(&mut self, method: &str, args: &[IrExpr]) -> bool {
@@ -95,7 +109,7 @@ impl FuncCompiler<'_> {
                 self.emit_closure_call(&elem_ty, &Ty::Bool);
                 wasm!(self.func, {
                       if_empty;
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(tmp);
+                        i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(tmp);
                         local_get(tmp); local_get(i); i64_extend_i32_u; i64_store(0);
                         local_get(tmp); local_set(result); br(2);
                       end;
@@ -459,7 +473,7 @@ impl FuncCompiler<'_> {
                     local_set(closure);
                     local_get(xs); i32_load(0); local_set(len);
                     // Alloc temp list-of-lists: [len][ptr0][ptr1]...
-                    i32_const(list_hdr); local_get(len); i32_const(4); i32_mul; i32_add;
+                    i32_const(list_hdr); local_get(len); i32_const(I32_BYTES); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(lol);
                     local_get(lol); local_get(len); i32_store(0);
                     i32_const(0); local_set(i);
@@ -467,7 +481,7 @@ impl FuncCompiler<'_> {
                       local_get(i); local_get(len); i32_ge_u; br_if(1);
                       // Call f(xs[i]) → List[B]
                       local_get(lol); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add; // dst addr for result ptr
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add; // dst addr for result ptr
                       local_get(closure); i32_load(4); // env
                       local_get(xs); i32_const(list_data_off); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
@@ -491,7 +505,7 @@ impl FuncCompiler<'_> {
                       local_get(i); local_get(lol); i32_load(0); i32_ge_u; br_if(1);
                       local_get(total);
                       local_get(lol); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0); i32_load(0);
                       i32_add; local_set(total);
                       local_get(i); i32_const(1); i32_add; local_set(i);
@@ -509,7 +523,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); local_get(lol); i32_load(0); i32_ge_u; br_if(1);
                       local_get(lol); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0); local_set(inner);
                       i32_const(0); local_set(j);
                       block_empty; loop_empty;
@@ -747,7 +761,7 @@ impl FuncCompiler<'_> {
                     end;
                     local_set(num_chunks);
                     // Alloc outer: 4 + num_chunks * 4 (list of ptrs)
-                    i32_const(list_hdr); local_get(num_chunks); i32_const(4); i32_mul; i32_add;
+                    i32_const(list_hdr); local_get(num_chunks); i32_const(I32_BYTES); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(outer);
                     local_get(outer); local_get(num_chunks); i32_store(0);
                     i32_const(0); local_set(i);
@@ -780,7 +794,7 @@ impl FuncCompiler<'_> {
                       end; end;
                       // outer[i] = inner_ptr
                       local_get(outer); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       local_get(inner); i32_store(0);
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -832,7 +846,7 @@ impl FuncCompiler<'_> {
                     end;
                     local_set(num_win);
                     // Alloc outer: 4 + num_win * 4
-                    i32_const(list_hdr); local_get(num_win); i32_const(4); i32_mul; i32_add;
+                    i32_const(list_hdr); local_get(num_win); i32_const(I32_BYTES); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(outer);
                     local_get(outer); local_get(num_win); i32_store(0);
                     i32_const(0); local_set(i);
@@ -859,7 +873,7 @@ impl FuncCompiler<'_> {
                       end; end;
                       // outer[i] = inner_ptr
                       local_get(outer); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       local_get(inner); i32_store(0);
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);
@@ -1078,7 +1092,7 @@ impl FuncCompiler<'_> {
                 // the loop into an infinite memory-walker.
                 wasm!(self.func, {
                     block_empty;
-                      local_get(len); i32_const(2); i32_lt_u; br_if(0);
+                      local_get(len); i32_const(SORT_MIN_LEN); i32_lt_u; br_if(0);
                     i32_const(0); local_set(i); // i (outer)
                     block_empty; loop_empty;
                       local_get(i); local_get(len); i32_const(1); i32_sub; i32_ge_u; br_if(1);

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure.rs
@@ -4,6 +4,7 @@
 //! reduce, flat_map, filter_map, sort_by, take_while, drop_while, count,
 //! partition, update, scan, zip_with, unique_by.
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use super::FuncCompiler;
 use super::values;
 use almide_ir::IrExpr;
@@ -41,40 +42,40 @@ impl FuncCompiler<'_> {
                 let tmp = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    i32_const(0); local_set(i); // i=0
-                    i32_const(0); local_set(result); // result (default: none)
+                    local_set(Local(closure));
+                    i32_const(Imm32(0)); local_set(Local(i)); // i=0
+                    i32_const(Imm32(0)); local_set(Local(result)); // result (default: none)
                     block_empty; loop_empty;
-                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(xs)); i32_load(0); i32_ge_u; br_if(1);
                       // Call pred(xs[i])
-                      local_get(closure); i32_load(4); // env
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 self.emit_closure_call(&elem_ty, &Ty::Bool);
                 wasm!(self.func, {
                       if_empty;
                         // Found: alloc some(xs[i])
-                        i32_const(es); call(self.emitter.rt.alloc); local_set(tmp);
-                        local_get(tmp);
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        i32_const(Imm32(es)); call(self.emitter.rt.alloc); local_set(Local(tmp));
+                        local_get(Local(tmp));
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(tmp); local_set(result); br(2);
+                        local_get(Local(tmp)); local_set(Local(result)); br(2);
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result); // result (none if not found)
+                    local_get(Local(result)); // result (none if not found)
                 });
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(tmp);
@@ -92,31 +93,31 @@ impl FuncCompiler<'_> {
                 let tmp = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    i32_const(0); local_set(i);
-                    i32_const(0); local_set(result); // result (default: none)
+                    local_set(Local(closure));
+                    i32_const(Imm32(0)); local_set(Local(i));
+                    i32_const(Imm32(0)); local_set(Local(result)); // result (default: none)
                     block_empty; loop_empty;
-                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4); // env
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(xs)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 self.emit_closure_call(&elem_ty, &Ty::Bool);
                 wasm!(self.func, {
                       if_empty;
-                        i32_const(I64_BYTES); call(self.emitter.rt.alloc); local_set(tmp);
-                        local_get(tmp); local_get(i); i64_extend_i32_u; i64_store(0);
-                        local_get(tmp); local_set(result); br(2);
+                        i32_const(Imm32(I64_BYTES)); call(self.emitter.rt.alloc); local_set(Local(tmp));
+                        local_get(Local(tmp)); local_get(Local(i)); i64_extend_i32_u; i64_store(0);
+                        local_get(Local(tmp)); local_set(Local(result)); br(2);
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result); // result (none if not found)
+                    local_get(Local(result)); // result (none if not found)
                 });
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(tmp);
@@ -133,27 +134,27 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    i32_const(0); local_set(i);
-                    i32_const(0); local_set(result); // result (default: false)
+                    local_set(Local(closure));
+                    i32_const(Imm32(0)); local_set(Local(i));
+                    i32_const(Imm32(0)); local_set(Local(result)); // result (default: false)
                     block_empty; loop_empty;
-                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4);
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(xs)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4);
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 self.emit_closure_call(&elem_ty, &Ty::Bool);
                 wasm!(self.func, {
-                      if_empty; i32_const(1); local_set(result); br(2); end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      if_empty; i32_const(Imm32(1)); local_set(Local(result)); br(2); end;
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result); // result
+                    local_get(Local(result)); // result
                 });
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(i);
@@ -168,28 +169,28 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    i32_const(0); local_set(i);
-                    i32_const(1); local_set(result); // result (default: true)
+                    local_set(Local(closure));
+                    i32_const(Imm32(0)); local_set(Local(i));
+                    i32_const(Imm32(1)); local_set(Local(result)); // result (default: true)
                     block_empty; loop_empty;
-                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4);
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(xs)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4);
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 self.emit_closure_call(&elem_ty, &Ty::Bool);
                 wasm!(self.func, {
                       i32_eqz;
-                      if_empty; i32_const(0); local_set(result); br(2); end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      if_empty; i32_const(Imm32(0)); local_set(Local(result)); br(2); end;
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result); // result
+                    local_get(Local(result)); // result
                 });
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(i);
@@ -203,22 +204,22 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    i32_const(0); local_set(i);
+                    local_set(Local(closure));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4);
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(xs)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4);
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 self.emit_closure_call(&elem_ty, &Ty::Unit);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                 });
@@ -238,7 +239,7 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); local_get(xs); i32_load(0); local_set(len); });
+                wasm!(self.func, { local_set(Local(xs)); local_get(Local(xs)); i32_load(0); local_set(Local(len)); });
                 self.emit_expr(&args[1]);
                 // n = min_u(n, len) on the i64 count (C-054); then
                 // start = len - n and new_len = len - start never underflow. A
@@ -246,31 +247,31 @@ impl FuncCompiler<'_> {
                 // whole list, matching native take_end (`n as usize >= len`).
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::LenLocal(len));
                 wasm!(self.func, {
-                    local_set(n);
+                    local_set(Local(n));
                     // start = len - n  (n already <= len, so >= 0)
-                    local_get(len); local_get(n); i32_sub;
-                    local_set(start);
+                    local_get(Local(len)); local_get(Local(n)); i32_sub;
+                    local_set(Local(start));
                     // new_len = len - start
-                    local_get(len); local_get(start); i32_sub;
-                    local_set(new_len);
-                    i32_const(list_hdr); local_get(new_len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(new_len); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_get(Local(len)); local_get(Local(start)); i32_sub;
+                    local_set(Local(new_len));
+                    i32_const(Imm32(list_hdr)); local_get(Local(new_len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(new_len)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(new_len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(start); local_get(i); i32_add;
-                      i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(new_len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(start)); local_get(Local(i)); i32_add;
+                      i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(dst);
@@ -291,7 +292,7 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); local_get(xs); i32_load(0); local_set(len); });
+                wasm!(self.func, { local_set(Local(xs)); local_get(Local(xs)); i32_load(0); local_set(Local(len)); });
                 self.emit_expr(&args[1]);
                 // n = min_u(n, len) on the i64 count (C-054); then
                 // new_len = len - n never underflows and the wrapped-huge
@@ -300,26 +301,26 @@ impl FuncCompiler<'_> {
                 // matching native drop_end (`n as usize >= len`).
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::LenLocal(len));
                 wasm!(self.func, {
-                    local_set(n);
-                    local_get(len); local_get(n); i32_sub;
-                    local_set(new_len); // new_len = len - n  (>= 0)
-                    i32_const(list_hdr); local_get(new_len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(new_len); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_set(Local(n));
+                    local_get(Local(len)); local_get(Local(n)); i32_sub;
+                    local_set(Local(new_len)); // new_len = len - n  (>= 0)
+                    i32_const(Imm32(list_hdr)); local_get(Local(new_len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(new_len)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(new_len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(new_len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(dst);
@@ -338,7 +339,7 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]); // val
-                wasm!(self.func, { local_set(val); });
+                wasm!(self.func, { local_set(Local(val)); });
                 self.emit_expr(&args[1]); // n
                 // Unsigned-saturate the i64 count to a non-negative i32 BEFORE
                 // narrowing (C-054). A bare i32_wrap_i64 turned `2^32` into 0
@@ -356,16 +357,16 @@ impl FuncCompiler<'_> {
                 const REPEAT_MAX_COUNT: i64 = i32::MAX as i64;
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::Const(REPEAT_MAX_COUNT));
                 wasm!(self.func, {
-                    local_set(n);
-                    i32_const(list_hdr); local_get(n); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(n); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_set(Local(n));
+                    i32_const(Imm32(list_hdr)); local_get(Local(n)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(n)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(n); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(val);
+                      local_get(Local(i)); local_get(Local(n)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(val));
                 });
                 // The result owns n references to the SAME element block —
                 // without one inc per stored slot, a deep Dec of the result
@@ -378,10 +379,10 @@ impl FuncCompiler<'_> {
                 }
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(dst);
@@ -399,31 +400,31 @@ impl FuncCompiler<'_> {
                 let acc = self.scratch.alloc(acc_vt);
                 let tmp = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]); // fn(a, b) -> a
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(xs); i32_load(0); i32_eqz;
-                    if_i32; i32_const(0); // empty → none
+                    local_set(Local(closure));
+                    local_get(Local(xs)); i32_load(0); i32_eqz;
+                    if_i32; i32_const(Imm32(0)); // empty → none
                     else_;
                       // acc = xs[0]
-                      local_get(xs); i32_const(list_data_off); i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { local_set(acc); });
+                wasm!(self.func, { local_set(Local(acc)); });
                 wasm!(self.func, {
-                      i32_const(1); local_set(i); // i = 1
+                      i32_const(Imm32(1)); local_set(Local(i)); // i = 1
                       block_empty; loop_empty;
-                        local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(i)); local_get(Local(xs)); i32_load(0); i32_ge_u; br_if(1);
                         // Call f(acc, xs[i])
-                        local_get(closure); i32_load(4); // env
-                        local_get(acc); // acc
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(closure)); i32_load(4); // env
+                        local_get(Local(acc)); // acc
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        local_get(closure); i32_load(0); // table_idx
+                        local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 // call_indirect (env, a, b) → a
                 {
@@ -432,16 +433,16 @@ impl FuncCompiler<'_> {
                     self.emit_call_indirect(ct, values::ret_type(&elem_ty));
                 }
                 wasm!(self.func, {
-                        local_set(acc); // update acc
-                        local_get(i); i32_const(1); i32_add; local_set(i);
+                        local_set(Local(acc)); // update acc
+                        local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                         br(0);
                       end; end;
                       // Wrap acc in some
-                      i32_const(es); call(self.emitter.rt.alloc); local_set(tmp);
-                      local_get(tmp); local_get(acc);
+                      i32_const(Imm32(es)); call(self.emitter.rt.alloc); local_set(Local(tmp));
+                      local_get(Local(tmp)); local_get(Local(acc));
                 });
                 self.emit_store_at(&elem_ty, 0);
-                wasm!(self.func, { local_get(tmp); end; });
+                wasm!(self.func, { local_get(Local(tmp)); end; });
                 self.scratch.free_i32(tmp);
                 self.scratch.free(acc, acc_vt);
                 self.scratch.free_i32(i);
@@ -467,82 +468,82 @@ impl FuncCompiler<'_> {
                 let inner = self.scratch.alloc_i32();
                 let j = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(xs); i32_load(0); local_set(len);
+                    local_set(Local(closure));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
                     // Alloc temp list-of-lists: [len][ptr0][ptr1]...
-                    i32_const(list_hdr); local_get(len); i32_const(I32_BYTES); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(lol);
-                    local_get(lol); local_get(len); i32_store(0);
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(lol));
+                    local_get(Local(lol)); local_get(Local(len)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                       // Call f(xs[i]) → List[B]
-                      local_get(lol); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add; // dst addr for result ptr
-                      local_get(closure); i32_load(4); // env
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(lol)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; // dst addr for result ptr
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 self.emit_closure_call(&elem_ty, &Ty::Unknown); // returns List ptr (i32)
                 wasm!(self.func, {
                       i32_store(0); // store result list ptr
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                 });
                 // Flatten: count total elements
                 wasm!(self.func, {
-                    i32_const(0); local_set(total);
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(total));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(lol); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(total);
-                      local_get(lol); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(lol)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(total));
+                      local_get(Local(lol)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
                       i32_load(0); i32_load(0);
-                      i32_add; local_set(total);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      i32_add; local_set(Local(total));
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                     // Alloc result
-                    i32_const(list_hdr); local_get(total); i32_const(out_es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); local_get(total); i32_store(0);
+                    i32_const(Imm32(list_hdr)); local_get(Local(total)); i32_const(Imm32(out_es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); local_get(Local(total)); i32_store(0);
                 });
                 // Copy all sub-list elements
                 wasm!(self.func, {
-                    i32_const(0); local_set(total); // reuse as dst_offset
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(total)); // reuse as dst_offset
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(lol); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(lol); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      i32_load(0); local_set(inner);
-                      i32_const(0); local_set(j);
+                      local_get(Local(i)); local_get(Local(lol)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(lol)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      i32_load(0); local_set(Local(inner));
+                      i32_const(Imm32(0)); local_set(Local(j));
                       block_empty; loop_empty;
-                        local_get(j); local_get(inner); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(result); i32_const(list_data_off); i32_add;
-                        local_get(total); i32_const(out_es); i32_mul; i32_add;
-                        local_get(inner); i32_const(list_data_off); i32_add;
-                        local_get(j); i32_const(out_es); i32_mul; i32_add;
+                        local_get(Local(j)); local_get(Local(inner)); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(result)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(total)); i32_const(Imm32(out_es)); i32_mul; i32_add;
+                        local_get(Local(inner)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(j)); i32_const(Imm32(out_es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&out_elem_ty);
                 wasm!(self.func, {
-                        local_get(total); i32_const(1); i32_add; local_set(total);
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(total)); i32_const(Imm32(1)); i32_add; local_set(Local(total));
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(j);
                 self.scratch.free_i32(inner);
@@ -578,47 +579,47 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let opt = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(xs); i32_load(0); local_set(len);
-                    i32_const(list_hdr); local_get(len); i32_const(out_es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); i32_const(0); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_set(Local(closure));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(out_es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); i32_const(Imm32(0)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4); // env
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0);
+                      local_get(Local(closure)); i32_load(0);
                 });
                 self.emit_closure_call(&elem_ty, &Ty::Unknown); // returns Option ptr (i32)
                 wasm!(self.func, {
-                      local_set(opt); // option result
-                      local_get(opt); i32_const(0); i32_ne;
+                      local_set(Local(opt)); // option result
+                      local_get(Local(opt)); i32_const(Imm32(0)); i32_ne;
                       if_empty;
                         // Append unwrapped value to result
-                        local_get(dst); i32_const(list_data_off); i32_add;
-                        local_get(dst); i32_load(0); i32_const(out_es); i32_mul; i32_add;
-                        local_get(opt); // some ptr
+                        local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(dst)); i32_load(0); i32_const(Imm32(out_es)); i32_mul; i32_add;
+                        local_get(Local(opt)); // some ptr
                 });
                 // Load inner value from some ptr
                 self.emit_load_at(&out_elem_ty, 0);
                 self.emit_store_at(&out_elem_ty, 0);
                 wasm!(self.func, {
-                        local_get(dst);
-                        local_get(dst); i32_load(0); i32_const(1); i32_add;
+                        local_get(Local(dst));
+                        local_get(Local(dst)); i32_load(0); i32_const(Imm32(1)); i32_add;
                         i32_store(0);
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(opt);
                 self.scratch.free_i32(i);
@@ -642,67 +643,67 @@ impl FuncCompiler<'_> {
                 let k = self.scratch.alloc_i32();
                 let tmp = self.scratch.alloc(elem_vt);
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); local_get(xs); i32_load(0); local_set(len); });
+                wasm!(self.func, { local_set(Local(xs)); local_get(Local(xs)); i32_load(0); local_set(Local(len)); });
                 // Both indices checked on the full i64 (C-054): a negative or
                 // >= 2^32 index must take native's no-op path, not wrap to a
                 // small in-range slot and swap the wrong pair. idx_* are
                 // saturated to [0,len]; in_* gate the in-place swap.
                 self.emit_expr(&args[1]); // i
                 self.emit_checked_index_i32(len, in_i);
-                wasm!(self.func, { local_set(idx_i); });
+                wasm!(self.func, { local_set(Local(idx_i)); });
                 self.emit_expr(&args[2]); // j
                 self.emit_checked_index_i32(len, in_j);
                 wasm!(self.func, {
-                    local_set(idx_j);
+                    local_set(Local(idx_j));
                     // Alloc copy
-                    i32_const(list_hdr); local_get(len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
                     // Copy all elements
-                    i32_const(0); local_set(k);
+                    i32_const(Imm32(0)); local_set(Local(k));
                     block_empty; loop_empty;
-                      local_get(k); local_get(len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(k); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(k); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(k)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(k)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(k)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(k); i32_const(1); i32_add; local_set(k);
+                      local_get(Local(k)); i32_const(Imm32(1)); i32_add; local_set(Local(k));
                       br(0);
                     end; end;
                 });
                 // Native is a no-op (returns the copy unchanged) unless BOTH
                 // indices are in range (in_i && in_j, computed on the full i64).
                 wasm!(self.func, {
-                    local_get(in_i); local_get(in_j); i32_and;
+                    local_get(Local(in_i)); local_get(Local(in_j)); i32_and;
                     if_empty;
                 });
                 // Swap dst[i] and dst[j] using typed scratch local as temp
                 // tmp = dst[i]
                 wasm!(self.func, {
-                    local_get(dst); i32_const(list_data_off); i32_add;
-                    local_get(idx_i); i32_const(es); i32_mul; i32_add;
+                    local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_get(Local(idx_i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { local_set(tmp); });
+                wasm!(self.func, { local_set(Local(tmp)); });
                 // dst[i] = dst[j]
                 wasm!(self.func, {
-                    local_get(dst); i32_const(list_data_off); i32_add;
-                    local_get(idx_i); i32_const(es); i32_mul; i32_add;
-                    local_get(dst); i32_const(list_data_off); i32_add;
-                    local_get(idx_j); i32_const(es); i32_mul; i32_add;
+                    local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_get(Local(idx_i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_get(Local(idx_j)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 // dst[j] = tmp
                 wasm!(self.func, {
-                    local_get(dst); i32_const(list_data_off); i32_add;
-                    local_get(idx_j); i32_const(es); i32_mul; i32_add;
-                    local_get(tmp);
+                    local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_get(Local(idx_j)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    local_get(Local(tmp));
                 });
                 self.emit_store_at(&elem_ty, 0);
-                wasm!(self.func, { end; local_get(dst); });
+                wasm!(self.func, { end; local_get(Local(dst)); });
                 self.scratch.free(tmp, elem_vt);
                 self.scratch.free_i32(k);
                 self.scratch.free_i32(dst);
@@ -728,7 +729,7 @@ impl FuncCompiler<'_> {
                 let inner = self.scratch.alloc_i32();
                 let j = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); local_get(xs); i32_load(0); local_set(len); });
+                wasm!(self.func, { local_set(Local(xs)); local_get(Local(xs)); i32_load(0); local_set(Local(len)); });
                 self.emit_expr(&args[1]); // n
                 // Unsigned-saturate n to [0, i32::MAX] on the i64 count (C-054)
                 // so a huge chunk size cannot wrap to a small in-range value.
@@ -741,7 +742,7 @@ impl FuncCompiler<'_> {
                 const CHUNK_MAX_N: i64 = i32::MAX as i64;
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::Const(CHUNK_MAX_N));
                 wasm!(self.func, {
-                    local_set(n);
+                    local_set(Local(n));
                     // num_chunks: (n != 0 && n >= len) → one chunk of all (0
                     // when len == 0, matching native `[].chunks(k>0)` = empty);
                     // else ceil(len / n) = (len + n - 1) / n. The fast path
@@ -749,57 +750,57 @@ impl FuncCompiler<'_> {
                     // excludes n == 0, which falls through to the `i32_div_u`
                     // by 0 so it still traps (matches native `chunks(0)` panic,
                     // including `[].chunks(0)`).
-                    local_get(n); i32_eqz; i32_eqz;          // n != 0
-                    local_get(n); local_get(len); i32_ge_u;  // n >= len
+                    local_get(Local(n)); i32_eqz; i32_eqz;          // n != 0
+                    local_get(Local(n)); local_get(Local(len)); i32_ge_u;  // n >= len
                     i32_and;
                     if_i32;
-                      local_get(len); i32_const(0); i32_gt_u;
-                      if_i32; i32_const(1); else_; i32_const(0); end;
+                      local_get(Local(len)); i32_const(Imm32(0)); i32_gt_u;
+                      if_i32; i32_const(Imm32(1)); else_; i32_const(Imm32(0)); end;
                     else_;
-                      local_get(len); local_get(n); i32_add; i32_const(1); i32_sub;
-                      local_get(n); i32_div_u;
+                      local_get(Local(len)); local_get(Local(n)); i32_add; i32_const(Imm32(1)); i32_sub;
+                      local_get(Local(n)); i32_div_u;
                     end;
-                    local_set(num_chunks);
+                    local_set(Local(num_chunks));
                     // Alloc outer: 4 + num_chunks * 4 (list of ptrs)
-                    i32_const(list_hdr); local_get(num_chunks); i32_const(I32_BYTES); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(outer);
-                    local_get(outer); local_get(num_chunks); i32_store(0);
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(list_hdr)); local_get(Local(num_chunks)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(outer));
+                    local_get(Local(outer)); local_get(Local(num_chunks)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(num_chunks); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(num_chunks)); i32_ge_u; br_if(1);
                       // chunk_len = min(n, len - i*n)
-                      local_get(len); local_get(i); local_get(n); i32_mul; i32_sub;
-                      local_set(chunk_len);
-                      local_get(chunk_len); local_get(n); i32_gt_u;
-                      if_empty; local_get(n); local_set(chunk_len); end;
+                      local_get(Local(len)); local_get(Local(i)); local_get(Local(n)); i32_mul; i32_sub;
+                      local_set(Local(chunk_len));
+                      local_get(Local(chunk_len)); local_get(Local(n)); i32_gt_u;
+                      if_empty; local_get(Local(n)); local_set(Local(chunk_len)); end;
                       // Alloc inner: 4 + chunk_len * es
-                      i32_const(list_hdr); local_get(chunk_len); i32_const(es); i32_mul; i32_add;
-                      call(self.emitter.rt.alloc); local_set(inner);
-                      local_get(inner); local_get(chunk_len); i32_store(0);
+                      i32_const(Imm32(list_hdr)); local_get(Local(chunk_len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      call(self.emitter.rt.alloc); local_set(Local(inner));
+                      local_get(Local(inner)); local_get(Local(chunk_len)); i32_store(0);
                       // Copy elements
-                      i32_const(0); local_set(j);
+                      i32_const(Imm32(0)); local_set(Local(j));
                       block_empty; loop_empty;
-                        local_get(j); local_get(chunk_len); i32_ge_u; br_if(1);
-                        local_get(inner); i32_const(list_data_off); i32_add;
-                        local_get(j); i32_const(es); i32_mul; i32_add;
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(i); local_get(n); i32_mul;
-                        local_get(j); i32_add;
-                        i32_const(es); i32_mul; i32_add;
+                        local_get(Local(j)); local_get(Local(chunk_len)); i32_ge_u; br_if(1);
+                        local_get(Local(inner)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(j)); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(i)); local_get(Local(n)); i32_mul;
+                        local_get(Local(j)); i32_add;
+                        i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
                       // outer[i] = inner_ptr
-                      local_get(outer); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      local_get(inner); i32_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(outer)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      local_get(Local(inner)); i32_store(0);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(outer);
+                    local_get(Local(outer));
                 });
                 self.scratch.free_i32(j);
                 self.scratch.free_i32(inner);
@@ -824,7 +825,7 @@ impl FuncCompiler<'_> {
                 let inner = self.scratch.alloc_i32();
                 let j = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); local_get(xs); i32_load(0); local_set(len); });
+                wasm!(self.func, { local_set(Local(xs)); local_get(Local(xs)); i32_load(0); local_set(Local(len)); });
                 self.emit_expr(&args[1]);
                 // Unsigned-saturate n to [0, i32::MAX] on the i64 count (C-054)
                 // so a huge window size cannot wrap to a small in-range value.
@@ -836,49 +837,49 @@ impl FuncCompiler<'_> {
                 const WINDOWS_MAX_N: i64 = i32::MAX as i64;
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::Const(WINDOWS_MAX_N));
                 wasm!(self.func, {
-                    local_set(n);
+                    local_set(Local(n));
                     // num_win = if len >= n then len - n + 1 else 0
-                    local_get(len); local_get(n); i32_ge_u;
+                    local_get(Local(len)); local_get(Local(n)); i32_ge_u;
                     if_i32;
-                      local_get(len); local_get(n); i32_sub; i32_const(1); i32_add;
+                      local_get(Local(len)); local_get(Local(n)); i32_sub; i32_const(Imm32(1)); i32_add;
                     else_;
-                      i32_const(0);
+                      i32_const(Imm32(0));
                     end;
-                    local_set(num_win);
+                    local_set(Local(num_win));
                     // Alloc outer: 4 + num_win * 4
-                    i32_const(list_hdr); local_get(num_win); i32_const(I32_BYTES); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(outer);
-                    local_get(outer); local_get(num_win); i32_store(0);
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(list_hdr)); local_get(Local(num_win)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(outer));
+                    local_get(Local(outer)); local_get(Local(num_win)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(num_win); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(num_win)); i32_ge_u; br_if(1);
                       // Alloc inner: 4 + n * es
-                      i32_const(list_hdr); local_get(n); i32_const(es); i32_mul; i32_add;
-                      call(self.emitter.rt.alloc); local_set(inner);
-                      local_get(inner); local_get(n); i32_store(0);
+                      i32_const(Imm32(list_hdr)); local_get(Local(n)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      call(self.emitter.rt.alloc); local_set(Local(inner));
+                      local_get(Local(inner)); local_get(Local(n)); i32_store(0);
                       // Copy n elements starting at i
-                      i32_const(0); local_set(j);
+                      i32_const(Imm32(0)); local_set(Local(j));
                       block_empty; loop_empty;
-                        local_get(j); local_get(n); i32_ge_u; br_if(1);
-                        local_get(inner); i32_const(list_data_off); i32_add;
-                        local_get(j); i32_const(es); i32_mul; i32_add;
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(i); local_get(j); i32_add;
-                        i32_const(es); i32_mul; i32_add;
+                        local_get(Local(j)); local_get(Local(n)); i32_ge_u; br_if(1);
+                        local_get(Local(inner)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(j)); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(i)); local_get(Local(j)); i32_add;
+                        i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
                       // outer[i] = inner_ptr
-                      local_get(outer); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      local_get(inner); i32_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(outer)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      local_get(Local(inner)); i32_store(0);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(outer);
+                    local_get(Local(outer));
                 });
                 self.scratch.free_i32(j);
                 self.scratch.free_i32(inner);
@@ -900,36 +901,36 @@ impl FuncCompiler<'_> {
                 let out_count = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(xs);
-                    local_get(xs); i32_load(0); local_set(len);
+                    local_set(Local(xs));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
                     // Alloc dst (max = len)
-                    i32_const(list_hdr); local_get(len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    i32_const(0); local_set(out_count);
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    i32_const(Imm32(0)); local_set(Local(out_count));
                     // If empty, return empty
-                    local_get(len); i32_eqz;
+                    local_get(Local(len)); i32_eqz;
                     if_empty;
-                      local_get(dst); i32_const(0); i32_store(0);
+                      local_get(Local(dst)); i32_const(Imm32(0)); i32_store(0);
                     else_;
                       // Always include first element
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty); // SHARE: copy from borrowed xs into fresh dst
                 wasm!(self.func, {
-                      i32_const(1); local_set(out_count); // out_count = 1
-                      i32_const(1); local_set(i); // i = 1
+                      i32_const(Imm32(1)); local_set(Local(out_count)); // out_count = 1
+                      i32_const(Imm32(1)); local_set(Local(i)); // i = 1
                       block_empty; loop_empty;
-                        local_get(i); local_get(len); i32_ge_u; br_if(1);
+                        local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                         // Compare xs[i] with xs[i-1]
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(i); i32_const(1); i32_sub;
-                        i32_const(es); i32_mul; i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(1)); i32_sub;
+                        i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 // Structural eq: collapse consecutive value-equal elements
@@ -939,21 +940,21 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                         i32_eqz; // not equal → include
                         if_empty;
-                          local_get(dst); i32_const(list_data_off); i32_add;
-                          local_get(out_count); i32_const(es); i32_mul; i32_add;
-                          local_get(xs); i32_const(list_data_off); i32_add;
-                          local_get(i); i32_const(es); i32_mul; i32_add;
+                          local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                          local_get(Local(out_count)); i32_const(Imm32(es)); i32_mul; i32_add;
+                          local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                          local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty); // SHARE: copy from borrowed xs into fresh dst
                 wasm!(self.func, {
-                          local_get(out_count); i32_const(1); i32_add; local_set(out_count);
+                          local_get(Local(out_count)); i32_const(Imm32(1)); i32_add; local_set(Local(out_count));
                         end;
-                        local_get(i); i32_const(1); i32_add; local_set(i);
+                        local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                         br(0);
                       end; end;
-                      local_get(dst); local_get(out_count); i32_store(0);
+                      local_get(Local(dst)); local_get(Local(out_count)); i32_store(0);
                     end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(out_count);
                 self.scratch.free_i32(i);
@@ -1018,48 +1019,48 @@ impl FuncCompiler<'_> {
                 let tmp_key = if key_is_str { self.scratch.alloc_i32() } else { self.scratch.alloc_i64() };
                 let tmp_elem = self.scratch.alloc(elem_vt);
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(xs); i32_load(0); local_set(len);
+                    local_set(Local(closure));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
                     // Alloc copy of elements
-                    i32_const(list_hdr); local_get(len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
                     // Copy all elements
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 // SHARE: copy the borrowed source elements into the fresh sorted
                 // result — dup so the result owns them (the in-place swaps below just
                 // rearrange these owned references; the source's Dec is balanced).
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                 });
                 // Alloc keys array: len * ks
                 wasm!(self.func, {
-                    local_get(len); i32_const(ks); i32_mul;
-                    call(self.emitter.rt.alloc); local_set(keys);
+                    local_get(Local(len)); i32_const(Imm32(ks)); i32_mul;
+                    call(self.emitter.rt.alloc); local_set(Local(keys));
                     // Compute keys for all elements
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4); // env
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 self.emit_closure_call(&elem_ty, &key_ty);
                 // Float key → i64 totalOrder key (so it rides the i64 path).
@@ -1068,21 +1069,21 @@ impl FuncCompiler<'_> {
                 }
                 if key_is_str {
                     wasm!(self.func, {
-                          local_set(tmp_key);
-                          local_get(keys);
-                          local_get(i); i32_const(ks); i32_mul; i32_add;
-                          local_get(tmp_key); i32_store(0);
+                          local_set(Local(tmp_key));
+                          local_get(Local(keys));
+                          local_get(Local(i)); i32_const(Imm32(ks)); i32_mul; i32_add;
+                          local_get(Local(tmp_key)); i32_store(0);
                     });
                 } else {
                     wasm!(self.func, {
-                          local_set(tmp_key);
-                          local_get(keys);
-                          local_get(i); i32_const(ks); i32_mul; i32_add;
-                          local_get(tmp_key); i64_store(0);
+                          local_set(Local(tmp_key));
+                          local_get(Local(keys));
+                          local_get(Local(i)); i32_const(Imm32(ks)); i32_mul; i32_add;
+                          local_get(Local(tmp_key)); i64_store(0);
                     });
                 }
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                 });
@@ -1092,18 +1093,18 @@ impl FuncCompiler<'_> {
                 // the loop into an infinite memory-walker.
                 wasm!(self.func, {
                     block_empty;
-                      local_get(len); i32_const(SORT_MIN_LEN); i32_lt_u; br_if(0);
-                    i32_const(0); local_set(i); // i (outer)
+                      local_get(Local(len)); i32_const(Imm32(SORT_MIN_LEN)); i32_lt_u; br_if(0);
+                    i32_const(Imm32(0)); local_set(Local(i)); // i (outer)
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_const(1); i32_sub; i32_ge_u; br_if(1);
-                      i32_const(0); local_set(j); // j (inner)
+                      local_get(Local(i)); local_get(Local(len)); i32_const(Imm32(1)); i32_sub; i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(j)); // j (inner)
                       block_empty; loop_empty;
                         // j < len - 1 - i
-                        local_get(len); i32_const(1); i32_sub; local_get(i); i32_sub;
-                        local_get(j); i32_le_u; br_if(1);
+                        local_get(Local(len)); i32_const(Imm32(1)); i32_sub; local_get(Local(i)); i32_sub;
+                        local_get(Local(j)); i32_le_u; br_if(1);
                         // Compare keys[j] > keys[j+1]
-                        local_get(keys);
-                        local_get(j); i32_const(ks); i32_mul; i32_add;
+                        local_get(Local(keys));
+                        local_get(Local(j)); i32_const(Imm32(ks)); i32_mul; i32_add;
                 });
                 // Load keys[j] and keys[j+1] at the storage width, then ask the
                 // type-directed total-order emitter whether keys[j] > keys[j+1]
@@ -1112,15 +1113,15 @@ impl FuncCompiler<'_> {
                 if key_is_str {
                     wasm!(self.func, {
                         i32_load(0);
-                        local_get(keys);
-                        local_get(j); i32_const(1); i32_add; i32_const(ks); i32_mul; i32_add;
+                        local_get(Local(keys));
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(ks)); i32_mul; i32_add;
                         i32_load(0);
                     });
                 } else {
                     wasm!(self.func, {
                         i64_load(0);
-                        local_get(keys);
-                        local_get(j); i32_const(1); i32_add; i32_const(ks); i32_mul; i32_add;
+                        local_get(Local(keys));
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(ks)); i32_mul; i32_add;
                         i64_load(0);
                     });
                 }
@@ -1130,72 +1131,72 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { i64_gt_s; });
                 } else {
                     self.emit_ord_cmp3(&cmp_key_ty);
-                    wasm!(self.func, { i32_const(0); i32_gt_s; });
+                    wasm!(self.func, { i32_const(Imm32(0)); i32_gt_s; });
                 }
                 wasm!(self.func, {
                         if_empty;
                           // Swap keys[j] and keys[j+1]
-                          local_get(keys);
-                          local_get(j); i32_const(ks); i32_mul; i32_add;
+                          local_get(Local(keys));
+                          local_get(Local(j)); i32_const(Imm32(ks)); i32_mul; i32_add;
                 });
                 if key_is_str {
                     wasm!(self.func, {
-                          i32_load(0); local_set(tmp_key);
-                          local_get(keys);
-                          local_get(j); i32_const(ks); i32_mul; i32_add;
-                          local_get(keys);
-                          local_get(j); i32_const(1); i32_add; i32_const(ks); i32_mul; i32_add;
+                          i32_load(0); local_set(Local(tmp_key));
+                          local_get(Local(keys));
+                          local_get(Local(j)); i32_const(Imm32(ks)); i32_mul; i32_add;
+                          local_get(Local(keys));
+                          local_get(Local(j)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(ks)); i32_mul; i32_add;
                           i32_load(0); i32_store(0);
-                          local_get(keys);
-                          local_get(j); i32_const(1); i32_add; i32_const(ks); i32_mul; i32_add;
-                          local_get(tmp_key); i32_store(0);
+                          local_get(Local(keys));
+                          local_get(Local(j)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(ks)); i32_mul; i32_add;
+                          local_get(Local(tmp_key)); i32_store(0);
                     });
                 } else {
                     wasm!(self.func, {
-                          i64_load(0); local_set(tmp_key);
-                          local_get(keys);
-                          local_get(j); i32_const(ks); i32_mul; i32_add;
-                          local_get(keys);
-                          local_get(j); i32_const(1); i32_add; i32_const(ks); i32_mul; i32_add;
+                          i64_load(0); local_set(Local(tmp_key));
+                          local_get(Local(keys));
+                          local_get(Local(j)); i32_const(Imm32(ks)); i32_mul; i32_add;
+                          local_get(Local(keys));
+                          local_get(Local(j)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(ks)); i32_mul; i32_add;
                           i64_load(0); i64_store(0);
-                          local_get(keys);
-                          local_get(j); i32_const(1); i32_add; i32_const(ks); i32_mul; i32_add;
-                          local_get(tmp_key); i64_store(0);
+                          local_get(Local(keys));
+                          local_get(Local(j)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(ks)); i32_mul; i32_add;
+                          local_get(Local(tmp_key)); i64_store(0);
                     });
                 }
                 wasm!(self.func, {
                           // Swap dst[j] and dst[j+1] using typed scratch local
                           // tmp_elem = dst[j]
-                          local_get(dst); i32_const(list_data_off); i32_add;
-                          local_get(j); i32_const(es); i32_mul; i32_add;
+                          local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                          local_get(Local(j)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                          local_set(tmp_elem);
+                          local_set(Local(tmp_elem));
                           // dst[j] = dst[j+1]
-                          local_get(dst); i32_const(list_data_off); i32_add;
-                          local_get(j); i32_const(es); i32_mul; i32_add;
-                          local_get(dst); i32_const(list_data_off); i32_add;
-                          local_get(j); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
+                          local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                          local_get(Local(j)); i32_const(Imm32(es)); i32_mul; i32_add;
+                          local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                          local_get(Local(j)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
                           // dst[j+1] = tmp_elem
-                          local_get(dst); i32_const(list_data_off); i32_add;
-                          local_get(j); i32_const(1); i32_add; i32_const(es); i32_mul; i32_add;
-                          local_get(tmp_elem);
+                          local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                          local_get(Local(j)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(es)); i32_mul; i32_add;
+                          local_get(Local(tmp_elem));
                 });
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
                         end; // end if (swap needed)
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end; // end inner loop
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end; // end outer loop
                     end; // end len<2 guard block
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free(tmp_elem, elem_vt);
                 if key_is_str { self.scratch.free_i32(tmp_key); } else { self.scratch.free_i64(tmp_key); }

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
@@ -5,6 +5,7 @@
 
 // ── Named constants for WASM immediates ───────────────────────────────────────
 /// Minimum load-factor denominator for group_by map capacity: cap >= len * 2.
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 const MAP_CAP_FACTOR: i32 = 2;
 /// Log₂ of the SIMD batch size (8 i64 elements → shift right by 3 = divide by 8).
 const SIMD_ELEMS_LOG2: i32 = 3;
@@ -53,47 +54,47 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let copy_i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(xs); i32_load(0); local_set(len);
-                    i32_const(0); local_set(count);
+                    local_set(Local(closure));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
+                    i32_const(Imm32(0)); local_set(Local(count));
                     block_empty; loop_empty;
-                      local_get(count); local_get(len); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4); // env
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(count); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(count)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(count)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 self.emit_closure_call(&elem_ty, &Ty::Bool);
                 wasm!(self.func, {
                       i32_eqz; br_if(1);
-                      local_get(count); i32_const(1); i32_add; local_set(count);
+                      local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count));
                       br(0);
                     end; end;
                     // Alloc result
-                    i32_const(list_hdr); local_get(count); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(count); i32_store(0);
+                    i32_const(Imm32(list_hdr)); local_get(Local(count)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(count)); i32_store(0);
                     // Copy loop
-                    i32_const(0); local_set(copy_i);
+                    i32_const(Imm32(0)); local_set(Local(copy_i));
                     block_empty; loop_empty;
-                      local_get(copy_i); local_get(count); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(copy_i); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(copy_i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(copy_i)); local_get(Local(count)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(copy_i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(copy_i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                      local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(copy_i);
                 self.scratch.free_i32(dst);
@@ -114,50 +115,50 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let copy_i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(xs); i32_load(0); local_set(len);
-                    i32_const(0); local_set(start);
+                    local_set(Local(closure));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
+                    i32_const(Imm32(0)); local_set(Local(start));
                     block_empty; loop_empty;
-                      local_get(start); local_get(len); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4); // env
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(start); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(start)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(start)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 self.emit_closure_call(&elem_ty, &Ty::Bool);
                 wasm!(self.func, {
                       i32_eqz; br_if(1);
-                      local_get(start); i32_const(1); i32_add; local_set(start);
+                      local_get(Local(start)); i32_const(Imm32(1)); i32_add; local_set(Local(start));
                       br(0);
                     end; end;
                     // new_len = len - start
-                    local_get(len); local_get(start); i32_sub; local_set(new_len);
+                    local_get(Local(len)); local_get(Local(start)); i32_sub; local_set(Local(new_len));
                     // Alloc result
-                    i32_const(list_hdr); local_get(new_len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(new_len); i32_store(0);
+                    i32_const(Imm32(list_hdr)); local_get(Local(new_len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(new_len)); i32_store(0);
                     // Copy loop
-                    i32_const(0); local_set(copy_i);
+                    i32_const(Imm32(0)); local_set(Local(copy_i));
                     block_empty; loop_empty;
-                      local_get(copy_i); local_get(new_len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(copy_i); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(start); local_get(copy_i); i32_add;
-                      i32_const(es); i32_mul; i32_add;
+                      local_get(Local(copy_i)); local_get(Local(new_len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(copy_i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(start)); local_get(Local(copy_i)); i32_add;
+                      i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                      local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(copy_i);
                 self.scratch.free_i32(dst);
@@ -176,31 +177,31 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let cnt = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    i32_const(0); local_set(i);
-                    i32_const(0); local_set(cnt);
+                    local_set(Local(closure));
+                    i32_const(Imm32(0)); local_set(Local(i));
+                    i32_const(Imm32(0)); local_set(Local(cnt));
                     block_empty; loop_empty;
-                      local_get(i); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4); // env
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(xs)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 self.emit_closure_call(&elem_ty, &Ty::Bool);
                 wasm!(self.func, {
                       if_empty;
-                        local_get(cnt); i32_const(1); i32_add; local_set(cnt);
+                        local_get(Local(cnt)); i32_const(Imm32(1)); i32_add; local_set(Local(cnt));
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(cnt); i64_extend_i32_u;
+                    local_get(Local(cnt)); i64_extend_i32_u;
                 });
                 self.scratch.free_i32(cnt);
                 self.scratch.free_i32(i);
@@ -221,61 +222,61 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let tuple_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(xs); i32_load(0); local_set(len);
-                    i32_const(list_hdr); local_get(len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(true_list);
-                    i32_const(list_hdr); local_get(len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(false_list);
-                    i32_const(0); local_set(true_cnt);
-                    i32_const(0); local_set(false_cnt);
-                    i32_const(0); local_set(i);
+                    local_set(Local(closure));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(true_list));
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(false_list));
+                    i32_const(Imm32(0)); local_set(Local(true_cnt));
+                    i32_const(Imm32(0)); local_set(Local(false_cnt));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4); // env
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 self.emit_closure_call(&elem_ty, &Ty::Bool);
                 wasm!(self.func, {
                       if_i32;
-                        local_get(true_list); i32_const(list_data_off); i32_add;
-                        local_get(true_cnt); i32_const(es); i32_mul; i32_add;
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(true_list)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(true_cnt)); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(true_cnt); i32_const(1); i32_add; local_set(true_cnt);
-                        i32_const(0);
+                        local_get(Local(true_cnt)); i32_const(Imm32(1)); i32_add; local_set(Local(true_cnt));
+                        i32_const(Imm32(0));
                       else_;
-                        local_get(false_list); i32_const(list_data_off); i32_add;
-                        local_get(false_cnt); i32_const(es); i32_mul; i32_add;
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(false_list)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(false_cnt)); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(false_cnt); i32_const(1); i32_add; local_set(false_cnt);
-                        i32_const(0);
+                        local_get(Local(false_cnt)); i32_const(Imm32(1)); i32_add; local_set(Local(false_cnt));
+                        i32_const(Imm32(0));
                       end;
                       drop;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(true_list); local_get(true_cnt); i32_store(0);
-                    local_get(false_list); local_get(false_cnt); i32_store(0);
-                    i32_const(list_hdr); call(self.emitter.rt.alloc); local_set(tuple_ptr);
-                    local_get(tuple_ptr); local_get(true_list); i32_store(0);
-                    local_get(tuple_ptr); local_get(false_list); i32_store(4);
-                    local_get(tuple_ptr);
+                    local_get(Local(true_list)); local_get(Local(true_cnt)); i32_store(0);
+                    local_get(Local(false_list)); local_get(Local(false_cnt)); i32_store(0);
+                    i32_const(Imm32(list_hdr)); call(self.emitter.rt.alloc); local_set(Local(tuple_ptr));
+                    local_get(Local(tuple_ptr)); local_get(Local(true_list)); i32_store(0);
+                    local_get(Local(tuple_ptr)); local_get(Local(false_list)); i32_store(4);
+                    local_get(Local(tuple_ptr));
                 });
                 self.scratch.free_i32(tuple_ptr);
                 self.scratch.free_i32(i);
@@ -299,7 +300,7 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let copy_i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); local_get(xs); i32_load(0); local_set(len); });
+                wasm!(self.func, { local_set(Local(xs)); local_get(Local(xs)); i32_load(0); local_set(Local(len)); });
                 self.emit_expr(&args[1]);
                 // idx = min_u(i, len); in_bounds = (i_u < len) on the full i64.
                 // Native `list.update` is a no-op when i is OOB AND does NOT
@@ -307,33 +308,33 @@ impl FuncCompiler<'_> {
                 // i64 must take that path, not wrap to a small in-range slot
                 // and run f on the wrong element (C-054).
                 self.emit_checked_index_i32(len, in_bounds);
-                wasm!(self.func, { local_set(idx); });
+                wasm!(self.func, { local_set(Local(idx)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    local_set(closure);
+                    local_set(Local(closure));
                     // Alloc copy
-                    i32_const(list_hdr); local_get(len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
                     // Copy all elements
-                    i32_const(0); local_set(copy_i);
+                    i32_const(Imm32(0)); local_set(Local(copy_i));
                     block_empty; loop_empty;
-                      local_get(copy_i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(list_data_off); i32_add;
-                      local_get(copy_i); i32_const(es); i32_mul; i32_add;
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(copy_i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(copy_i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(copy_i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(copy_i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                      local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                       br(0);
                     end; end;
                 });
                 // Replace dst[idx] with f(dst[idx]) — only when in bounds.
                 // Native skips both the write AND the f-call on OOB.
                 wasm!(self.func, {
-                    local_get(in_bounds);
+                    local_get(Local(in_bounds));
                     if_empty;
                 });
                 // Release the owned copy of the element being replaced (it
@@ -344,26 +345,26 @@ impl FuncCompiler<'_> {
                 // before any reuse since nothing allocates in between.
                 if crate::pass_perceus::is_heap_type(&elem_ty) {
                     wasm!(self.func, {
-                        local_get(dst); i32_const(list_data_off); i32_add;
-                        local_get(idx); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(idx)); i32_const(Imm32(es)); i32_mul; i32_add;
                         i32_load(0); call(self.emitter.rt.rc_dec);
                     });
                 }
                 wasm!(self.func, {
-                    local_get(dst); i32_const(list_data_off); i32_add;
-                    local_get(idx); i32_const(es); i32_mul; i32_add;
+                    local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_get(Local(idx)); i32_const(Imm32(es)); i32_mul; i32_add;
                     // Call f(dst[idx])
-                    local_get(closure); i32_load(4); // env
-                    local_get(dst); i32_const(list_data_off); i32_add;
-                    local_get(idx); i32_const(es); i32_mul; i32_add;
+                    local_get(Local(closure)); i32_load(4); // env
+                    local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_get(Local(idx)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                    local_get(closure); i32_load(0); // table_idx
+                    local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 self.emit_closure_call(&elem_ty, &elem_ty);
                 self.emit_elem_store(&elem_ty);
-                wasm!(self.func, { end; local_get(dst); });
+                wasm!(self.func, { end; local_get(Local(dst)); });
                 self.scratch.free_i32(copy_i);
                 self.scratch.free_i32(dst);
                 self.scratch.free_i32(len);
@@ -385,27 +386,27 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let acc = self.scratch.alloc(acc_vt);
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(acc); });
+                wasm!(self.func, { local_set(Local(acc)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(xs); i32_load(0); local_set(len);
-                    i32_const(list_hdr); local_get(len); i32_const(acc_size); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); local_get(len); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_set(Local(closure));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(acc_size)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); local_get(Local(len)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4); // env
-                      local_get(acc);
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(acc));
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32, acc_vt];
@@ -413,20 +414,20 @@ impl FuncCompiler<'_> {
                     self.emit_call_indirect(ct, vec![acc_vt]);
                 }
                 wasm!(self.func, {
-                      local_set(acc);
-                      local_get(result); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(acc_size); i32_mul; i32_add;
-                      local_get(acc);
+                      local_set(Local(acc));
+                      local_get(Local(result)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(acc_size)); i32_mul; i32_add;
+                      local_get(Local(acc));
                 });
                 match acc_vt {
                     ValType::F64 => { wasm!(self.func, { f64_store(0); }); }
                     _ => { wasm!(self.func, { i64_store(0); }); }
                 }
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free(acc, acc_vt);
                 self.scratch.free_i32(i);
@@ -459,44 +460,44 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(ys); });
+                wasm!(self.func, { local_set(Local(ys)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    local_set(closure);
+                    local_set(Local(closure));
                     // len = min(xs.len, ys.len)
-                    local_get(xs); i32_load(0);
-                    local_get(ys); i32_load(0);
+                    local_get(Local(xs)); i32_load(0);
+                    local_get(Local(ys)); i32_load(0);
                     i32_lt_u;
                     if_i32;
-                      local_get(xs); i32_load(0);
+                      local_get(Local(xs)); i32_load(0);
                     else_;
-                      local_get(ys); i32_load(0);
+                      local_get(Local(ys)); i32_load(0);
                     end;
-                    local_set(len);
-                    i32_const(list_hdr); local_get(len); i32_const(out_size); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); local_get(len); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_set(Local(len));
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(out_size)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); local_get(Local(len)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                       // dst addr
-                      local_get(result); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(out_size); i32_mul; i32_add;
+                      local_get(Local(result)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(out_size)); i32_mul; i32_add;
                       // Call f(xs[i], ys[i])
-                      local_get(closure); i32_load(4); // env
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(a_size); i32_mul; i32_add;
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(a_size)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&a_ty, 0);
                 wasm!(self.func, {
-                      local_get(ys); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(b_size); i32_mul; i32_add;
+                      local_get(Local(ys)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(b_size)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&b_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 {
                     let mut ct = vec![ValType::I32];
@@ -510,10 +511,10 @@ impl FuncCompiler<'_> {
                     _ => { wasm!(self.func, { i32_store(0); }); }
                 }
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(result);
@@ -549,92 +550,92 @@ impl FuncCompiler<'_> {
                 let found = self.scratch.alloc_i32();
                 let key_val = self.scratch.alloc(key_vt);
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(xs); i32_load(0); local_set(len);
+                    local_set(Local(closure));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
                     // Alloc keys array: len * ks
-                    local_get(len); i32_const(ks); i32_mul;
-                    call(self.emitter.rt.alloc); local_set(keys);
+                    local_get(Local(len)); i32_const(Imm32(ks)); i32_mul;
+                    call(self.emitter.rt.alloc); local_set(Local(keys));
                     // Compute all keys
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4); // env
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 self.emit_closure_call(&elem_ty, &key_ty);
                 wasm!(self.func, {
-                      local_set(key_val);
-                      local_get(keys);
-                      local_get(i); i32_const(ks); i32_mul; i32_add;
-                      local_get(key_val);
+                      local_set(Local(key_val));
+                      local_get(Local(keys));
+                      local_get(Local(i)); i32_const(Imm32(ks)); i32_mul; i32_add;
+                      local_get(Local(key_val));
                 });
                 self.emit_store_at(&key_ty, 0);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                 });
                 // Build result: include xs[i] if keys[i] not in seen_keys[0..out_count]
                 wasm!(self.func, {
-                    i32_const(list_hdr); local_get(len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(len); i32_const(ks); i32_mul;
-                    call(self.emitter.rt.alloc); local_set(seen_keys);
-                    i32_const(0); local_set(out_count);
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(len)); i32_const(Imm32(ks)); i32_mul;
+                    call(self.emitter.rt.alloc); local_set(Local(seen_keys));
+                    i32_const(Imm32(0)); local_set(Local(out_count));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(keys);
-                      local_get(i); i32_const(ks); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(keys));
+                      local_get(Local(i)); i32_const(Imm32(ks)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&key_ty, 0);
                 wasm!(self.func, {
-                      local_set(key_val);
-                      i32_const(0); local_set(j);
-                      i32_const(0); local_set(found);
+                      local_set(Local(key_val));
+                      i32_const(Imm32(0)); local_set(Local(j));
+                      i32_const(Imm32(0)); local_set(Local(found));
                       block_empty; loop_empty;
-                        local_get(j); local_get(out_count); i32_ge_u; br_if(1);
-                        local_get(seen_keys);
-                        local_get(j); i32_const(ks); i32_mul; i32_add;
+                        local_get(Local(j)); local_get(Local(out_count)); i32_ge_u; br_if(1);
+                        local_get(Local(seen_keys));
+                        local_get(Local(j)); i32_const(Imm32(ks)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&key_ty, 0);
-                wasm!(self.func, { local_get(key_val); });
+                wasm!(self.func, { local_get(Local(key_val)); });
                 self.emit_eq_typed(&key_ty);
                 wasm!(self.func, {
-                        if_empty; i32_const(1); local_set(found); br(2); end;
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        if_empty; i32_const(Imm32(1)); local_set(Local(found)); br(2); end;
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
-                      local_get(found); i32_eqz;
+                      local_get(Local(found)); i32_eqz;
                       if_empty;
-                        local_get(dst); i32_const(list_data_off); i32_add;
-                        local_get(out_count); i32_const(es); i32_mul; i32_add;
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(out_count)); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(seen_keys);
-                        local_get(out_count); i32_const(ks); i32_mul; i32_add;
-                        local_get(key_val);
+                        local_get(Local(seen_keys));
+                        local_get(Local(out_count)); i32_const(Imm32(ks)); i32_mul; i32_add;
+                        local_get(Local(key_val));
                 });
                 self.emit_store_at(&key_ty, 0);
                 wasm!(self.func, {
-                        local_get(out_count); i32_const(1); i32_add; local_set(out_count);
+                        local_get(Local(out_count)); i32_const(Imm32(1)); i32_add; local_set(Local(out_count));
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst); local_get(out_count); i32_store(0);
-                    local_get(dst);
+                    local_get(Local(dst)); local_get(Local(out_count)); i32_store(0);
+                    local_get(Local(dst));
                 });
                 self.scratch.free(key_val, key_vt);
                 self.scratch.free_i32(found);
@@ -675,37 +676,37 @@ impl FuncCompiler<'_> {
                 let cur_key = if key_is_i64 { self.scratch.alloc_i64() } else { self.scratch.alloc_i32() };
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(xs); i32_load(0); local_set(len);
+                    local_set(Local(closure));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
                 });
 
                 // Phase 1: Compute keys
                 wasm!(self.func, {
-                    local_get(len); i32_const(ks); i32_mul;
-                    call(self.emitter.rt.alloc); local_set(keys_arr);
-                    i32_const(0); local_set(i);
+                    local_get(Local(len)); i32_const(Imm32(ks)); i32_mul;
+                    call(self.emitter.rt.alloc); local_set(Local(keys_arr));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(closure); i32_load(4);
-                      local_get(xs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(closure)); i32_load(4);
+                      local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 self.emit_closure_call(&elem_ty, &key_ty);
-                wasm!(self.func, { local_set(cur_key); });
+                wasm!(self.func, { local_set(Local(cur_key)); });
                 wasm!(self.func, {
-                      local_get(keys_arr);
-                      local_get(i); i32_const(ks); i32_mul; i32_add;
-                      local_get(cur_key);
+                      local_get(Local(keys_arr));
+                      local_get(Local(i)); i32_const(Imm32(ks)); i32_mul; i32_add;
+                      local_get(Local(cur_key));
                 });
                 if key_is_i64 { wasm!(self.func, { i64_store(0); }); }
                 else { wasm!(self.func, { i32_store(0); }); }
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                 });
@@ -720,144 +721,144 @@ impl FuncCompiler<'_> {
                 let probe_idx = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     // cap = next power of 2 >= max(len * 2, INITIAL_CAP)
-                    i32_const(lm::INITIAL_CAP as i32); local_set(cap_local);
+                    i32_const(Imm32(lm::INITIAL_CAP as i32)); local_set(Local(cap_local));
                     block_empty; loop_empty;
-                      local_get(cap_local); local_get(len); i32_const(MAP_CAP_FACTOR); i32_mul; i32_ge_u; br_if(1);
-                      local_get(cap_local); i32_const(1); i32_shl; local_set(cap_local);
+                      local_get(Local(cap_local)); local_get(Local(len)); i32_const(Imm32(MAP_CAP_FACTOR)); i32_mul; i32_ge_u; br_if(1);
+                      local_get(Local(cap_local)); i32_const(Imm32(1)); i32_shl; local_set(Local(cap_local));
                       br(0);
                     end; end;
                 });
                 self.emit_dict_alloc(map_ptr, cap_local, entry_size as u32);
                 self.emit_dict_index_base(map_ptr, cap_local);
-                wasm!(self.func, { local_set(ib); });
+                wasm!(self.func, { local_set(Local(ib)); });
                 self.emit_dict_entries_base(map_ptr, cap_local);
-                wasm!(self.func, { local_set(eb); });
+                wasm!(self.func, { local_set(Local(eb)); });
                 wasm!(self.func, {
-                    i32_const(0); local_set(map_len);
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(map_len));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                       // Load key[i]
-                      local_get(keys_arr);
-                      local_get(i); i32_const(ks); i32_mul; i32_add;
+                      local_get(Local(keys_arr));
+                      local_get(Local(i)); i32_const(Imm32(ks)); i32_mul; i32_add;
                 });
-                if key_is_i64 { wasm!(self.func, { i64_load(0); local_set(cur_key); }); }
-                else { wasm!(self.func, { i32_load(0); local_set(cur_key); }); }
+                if key_is_i64 { wasm!(self.func, { i64_load(0); local_set(Local(cur_key)); }); }
+                else { wasm!(self.func, { i32_load(0); local_set(Local(cur_key)); }); }
                 // Hash key → h1 (probe index) + h2 (tag). Push the RAW key (i64 for
                 // an Int key, ptr for String); `emit_hash_key` consumes the key's
                 // natural type and does its OWN i32 reduction. Pre-wrapping an Int
                 // key to i32 here fed `emit_hash_key`'s `local.tee` (an i64 temp) an
                 // i32 → "local.set's value type must be correct" (invalid module).
-                wasm!(self.func, { local_get(cur_key); });
+                wasm!(self.func, { local_get(Local(cur_key)); });
                 self.emit_hash_key(&key_ty);
                 self.emit_h1_h2(cap_local, probe_idx, h2);
                 // Probe for existing key or empty slot
                 wasm!(self.func, {
-                      i32_const(-1); local_set(found_idx);
+                      i32_const(Imm32(-1)); local_set(Local(found_idx));
                       block_empty; loop_empty;
                 });
                 self.emit_swiss_tag_load(map_ptr, probe_idx);
                 wasm!(self.func, {
-                        local_set(j); // reuse j as tag
-                        local_get(j); i32_eqz;
+                        local_set(Local(j)); // reuse j as tag
+                        local_get(Local(j)); i32_eqz;
                         if_empty;
                           // Empty slot: not found
                           br(2);
                         end;
-                        local_get(j); local_get(h2); i32_eq;
+                        local_get(Local(j)); local_get(Local(h2)); i32_eq;
                         if_empty;
                           // Tag matches: deref index[probe_idx]-1 → dense entry, compare key
-                          local_get(ib); local_get(probe_idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
-                          i32_load(0); i32_const(1); i32_sub; local_set(cand_ei);
-                          local_get(eb); local_get(cand_ei); i32_const(entry_size); i32_mul; i32_add;
+                          local_get(Local(ib)); local_get(Local(probe_idx)); i32_const(Imm32(lm::INDEX_SLOT_SIZE as i32)); i32_mul; i32_add;
+                          i32_load(0); i32_const(Imm32(1)); i32_sub; local_set(Local(cand_ei));
+                          local_get(Local(eb)); local_get(Local(cand_ei)); i32_const(Imm32(entry_size)); i32_mul; i32_add;
                 });
-                if key_is_i64 { wasm!(self.func, { i64_load(0); local_get(cur_key); i64_eq; }); }
+                if key_is_i64 { wasm!(self.func, { i64_load(0); local_get(Local(cur_key)); i64_eq; }); }
                 else {
-                    wasm!(self.func, { i32_load(0); local_get(cur_key); });
+                    wasm!(self.func, { i32_load(0); local_get(Local(cur_key)); });
                     self.emit_key_eq(&key_ty);
                 }
                 wasm!(self.func, {
                           if_empty;
-                            local_get(cand_ei); local_set(found_idx);
+                            local_get(Local(cand_ei)); local_set(Local(found_idx));
                             br(3);
                           end;
                         end;
                         // Advance probe
-                        local_get(probe_idx); i32_const(1); i32_add;
-                        local_get(cap_local); i32_const(1); i32_sub; i32_and;
-                        local_set(probe_idx);
+                        local_get(Local(probe_idx)); i32_const(Imm32(1)); i32_add;
+                        local_get(Local(cap_local)); i32_const(Imm32(1)); i32_sub; i32_and;
+                        local_set(Local(probe_idx));
                         br(0);
                       end; end;
 
-                      local_get(found_idx); i32_const(-1); i32_ne;
+                      local_get(Local(found_idx)); i32_const(Imm32(-1)); i32_ne;
                       if_empty;
                         // === Found: append element to existing list ===
-                        local_get(eb); local_get(found_idx); i32_const(entry_size); i32_mul; i32_add;
-                        i32_const(ks); i32_add;
+                        local_get(Local(eb)); local_get(Local(found_idx)); i32_const(Imm32(entry_size)); i32_mul; i32_add;
+                        i32_const(Imm32(ks)); i32_add;
                         i32_load(0);
-                        local_set(old_list);
-                        local_get(old_list); i32_load(0); local_set(old_len);
-                        i32_const(list_hdr);
-                        local_get(old_len); i32_const(1); i32_add;
-                        i32_const(es); i32_mul; i32_add;
-                        call(self.emitter.rt.alloc); local_set(new_list);
-                        local_get(new_list);
-                        local_get(old_len); i32_const(1); i32_add; i32_store(0);
-                        local_get(new_list); i32_const(list_data_off); i32_add;
-                        local_get(old_list); i32_const(list_data_off); i32_add;
-                        local_get(old_len); i32_const(es); i32_mul;
+                        local_set(Local(old_list));
+                        local_get(Local(old_list)); i32_load(0); local_set(Local(old_len));
+                        i32_const(Imm32(list_hdr));
+                        local_get(Local(old_len)); i32_const(Imm32(1)); i32_add;
+                        i32_const(Imm32(es)); i32_mul; i32_add;
+                        call(self.emitter.rt.alloc); local_set(Local(new_list));
+                        local_get(Local(new_list));
+                        local_get(Local(old_len)); i32_const(Imm32(1)); i32_add; i32_store(0);
+                        local_get(Local(new_list)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(old_list)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(old_len)); i32_const(Imm32(es)); i32_mul;
                         memory_copy;
-                        local_get(new_list); i32_const(list_data_off); i32_add;
-                        local_get(old_len); i32_const(es); i32_mul; i32_add;
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(new_list)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(old_len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
                         // Update list ptr in entry
-                        local_get(eb); local_get(found_idx); i32_const(entry_size); i32_mul; i32_add;
-                        i32_const(ks); i32_add;
-                        local_get(new_list); i32_store(0);
+                        local_get(Local(eb)); local_get(Local(found_idx)); i32_const(Imm32(entry_size)); i32_mul; i32_add;
+                        i32_const(Imm32(ks)); i32_add;
+                        local_get(Local(new_list)); i32_store(0);
                       else_;
                         // === Not found: append a new dense entry at map_len ===
                 });
                 // Write tag (h2) at the probe slot
-                wasm!(self.func, { local_get(h2); });
+                wasm!(self.func, { local_get(Local(h2)); });
                 self.emit_swiss_tag_store(map_ptr, probe_idx);
                 wasm!(self.func, {
                         // index[probe_idx] = map_len + 1 (1-based pointer into dense entries)
-                        local_get(ib); local_get(probe_idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
-                        local_get(map_len); i32_const(1); i32_add; i32_store(0);
+                        local_get(Local(ib)); local_get(Local(probe_idx)); i32_const(Imm32(lm::INDEX_SLOT_SIZE as i32)); i32_mul; i32_add;
+                        local_get(Local(map_len)); i32_const(Imm32(1)); i32_add; i32_store(0);
                         // Write key at dense entries[map_len]
-                        local_get(eb); local_get(map_len); i32_const(entry_size); i32_mul; i32_add;
-                        local_get(cur_key);
+                        local_get(Local(eb)); local_get(Local(map_len)); i32_const(Imm32(entry_size)); i32_mul; i32_add;
+                        local_get(Local(cur_key));
                 });
                 if key_is_i64 { wasm!(self.func, { i64_store(0); }); }
                 else { wasm!(self.func, { i32_store(0); }); }
                 wasm!(self.func, {
                         // Create single-element list
-                        i32_const(list_hdr); i32_const(es); i32_add;
-                        call(self.emitter.rt.alloc); local_set(new_list);
-                        local_get(new_list); i32_const(1); i32_store(0);
-                        local_get(new_list); i32_const(list_data_off); i32_add;
-                        local_get(xs); i32_const(list_data_off); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        i32_const(Imm32(list_hdr)); i32_const(Imm32(es)); i32_add;
+                        call(self.emitter.rt.alloc); local_set(Local(new_list));
+                        local_get(Local(new_list)); i32_const(Imm32(1)); i32_store(0);
+                        local_get(Local(new_list)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
                         // Write list ptr at dense entries[map_len] + ks
-                        local_get(eb); local_get(map_len); i32_const(entry_size); i32_mul; i32_add;
-                        i32_const(ks); i32_add;
-                        local_get(new_list); i32_store(0);
-                        local_get(map_len); i32_const(1); i32_add; local_set(map_len);
+                        local_get(Local(eb)); local_get(Local(map_len)); i32_const(Imm32(entry_size)); i32_mul; i32_add;
+                        i32_const(Imm32(ks)); i32_add;
+                        local_get(Local(new_list)); i32_store(0);
+                        local_get(Local(map_len)); i32_const(Imm32(1)); i32_add; local_set(Local(map_len));
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(map_ptr); local_get(map_len); i32_store(0);
-                    local_get(map_ptr);
+                    local_get(Local(map_ptr)); local_get(Local(map_len)); i32_store(0);
+                    local_get(Local(map_ptr));
                 });
                 self.scratch.free_i32(probe_idx);
                 self.scratch.free_i32(h2);
@@ -901,47 +902,47 @@ impl FuncCompiler<'_> {
                 let out_count = self.scratch.alloc_i32();
                 let is_inline_lambda = matches!(&args[1].kind, almide_ir::IrExprKind::Lambda { .. });
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(src); });
+                wasm!(self.func, { local_set(Local(src)); });
                 if !is_inline_lambda {
                     self.emit_expr(&args[1]);
-                    wasm!(self.func, { local_set(closure); });
+                    wasm!(self.func, { local_set(Local(closure)); });
                 }
                 if in_place {
                     // In-place: dst = src (compact matching elements to front)
                     wasm!(self.func, {
-                        i32_const(0); local_set(out_count);
-                        local_get(src); local_set(dst);
-                        local_get(src); i32_const(list_data_off); i32_add;
-                        local_tee(src_ptr);
-                        local_get(src); i32_load(0); i32_const(elem_size as i32); i32_mul;
-                        i32_add; local_set(end_ptr);
-                        local_get(src); i32_const(list_data_off); i32_add;
-                        local_set(dst_ptr);
+                        i32_const(Imm32(0)); local_set(Local(out_count));
+                        local_get(Local(src)); local_set(Local(dst));
+                        local_get(Local(src)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_tee(Local(src_ptr));
+                        local_get(Local(src)); i32_load(0); i32_const(Imm32(elem_size as i32)); i32_mul;
+                        i32_add; local_set(Local(end_ptr));
+                        local_get(Local(src)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_set(Local(dst_ptr));
                         block_empty; loop_empty;
                     });
                 } else {
                     wasm!(self.func, {
                         // Alloc max-size output
-                        i32_const(list_hdr);
-                        local_get(src); i32_load(0);
-                        i32_const(elem_size as i32); i32_mul; i32_add;
-                        call(self.emitter.rt.alloc); local_set(dst);
-                        i32_const(0); local_set(out_count);
+                        i32_const(Imm32(list_hdr));
+                        local_get(Local(src)); i32_load(0);
+                        i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
+                        call(self.emitter.rt.alloc); local_set(Local(dst));
+                        i32_const(Imm32(0)); local_set(Local(out_count));
                         // src_ptr = src + DATA_OFFSET
-                        local_get(src); i32_const(list_data_off); i32_add;
-                        local_tee(src_ptr);
+                        local_get(Local(src)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_tee(Local(src_ptr));
                         // end_ptr = src_ptr + len * elem_size
-                        local_get(src); i32_load(0); i32_const(elem_size as i32); i32_mul;
-                        i32_add; local_set(end_ptr);
+                        local_get(Local(src)); i32_load(0); i32_const(Imm32(elem_size as i32)); i32_mul;
+                        i32_add; local_set(Local(end_ptr));
                         // dst_ptr = dst + DATA_OFFSET
-                        local_get(dst); i32_const(list_data_off); i32_add;
-                        local_set(dst_ptr);
+                        local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_set(Local(dst_ptr));
                         block_empty; loop_empty;
                     });
                 }
                 let depth_guard = self.depth_push_n(2);
                 wasm!(self.func, {
-                    local_get(src_ptr); local_get(end_ptr); i32_ge_u; br_if(1);
+                    local_get(Local(src_ptr)); local_get(Local(end_ptr)); i32_ge_u; br_if(1);
                 });
                 let filter_param_local;
                 if let almide_ir::IrExprKind::Lambda { params, body, .. } = &args[1].kind {
@@ -949,9 +950,9 @@ impl FuncCompiler<'_> {
                     let pvt = values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32);
                     filter_param_local = Some((self.scratch.alloc(pvt), pvt));
                     let pl = filter_param_local.unwrap().0;
-                    wasm!(self.func, { local_get(src_ptr); });
+                    wasm!(self.func, { local_get(Local(src_ptr)); });
                     self.emit_load_at(&elem_ty, 0);
-                    wasm!(self.func, { local_set(pl); });
+                    wasm!(self.func, { local_set(Local(pl)); });
                     if let Some(vid) = param_var {
                         self.var_map.insert(vid.0, pl);
                     }
@@ -962,42 +963,42 @@ impl FuncCompiler<'_> {
                 } else {
                     filter_param_local = None;
                     wasm!(self.func, {
-                        local_get(closure); i32_load(4); // env
-                        local_get(src_ptr);
+                        local_get(Local(closure)); i32_load(4); // env
+                        local_get(Local(src_ptr));
                     });
                     self.emit_load_at(&elem_ty, 0);
-                    wasm!(self.func, { local_get(closure); i32_load(0); }); // table_idx
+                    wasm!(self.func, { local_get(Local(closure)); i32_load(0); }); // table_idx
                     self.emit_closure_call(&elem_ty, &Ty::Bool);
                 }
                 // Branchless: always write, conditionally advance dst_ptr
                 let pred_result = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(pred_result);
-                    local_get(dst_ptr);
+                    local_set(Local(pred_result));
+                    local_get(Local(dst_ptr));
                 });
                 if let Some((pl, _)) = filter_param_local {
-                    wasm!(self.func, { local_get(pl); });
+                    wasm!(self.func, { local_get(Local(pl)); });
                 } else {
-                    wasm!(self.func, { local_get(src_ptr); });
+                    wasm!(self.func, { local_get(Local(src_ptr)); });
                     self.emit_load_at(&elem_ty, 0);
                 }
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
                     // dst_ptr += pred_result * elem_size (branchless)
-                    local_get(dst_ptr);
-                    local_get(pred_result); i32_const(elem_size as i32); i32_mul;
-                    i32_add; local_set(dst_ptr);
+                    local_get(Local(dst_ptr));
+                    local_get(Local(pred_result)); i32_const(Imm32(elem_size as i32)); i32_mul;
+                    i32_add; local_set(Local(dst_ptr));
                     // out_count += pred_result
-                    local_get(out_count); local_get(pred_result); i32_add; local_set(out_count);
+                    local_get(Local(out_count)); local_get(Local(pred_result)); i32_add; local_set(Local(out_count));
                     // src_ptr += elem_size
-                    local_get(src_ptr); i32_const(elem_size as i32); i32_add; local_set(src_ptr);
+                    local_get(Local(src_ptr)); i32_const(Imm32(elem_size as i32)); i32_add; local_set(Local(src_ptr));
                     br(0);
                 });
                 self.scratch.free_i32(pred_result);
                 self.depth_pop(depth_guard);
                 wasm!(self.func, {
                     end; end;
-                    local_get(dst); local_get(out_count); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(out_count)); i32_store(0);
                 });
                 // SHARE dup: kept elements are second references into the
                 // surviving source list. Walk dst[0..out_count] once —
@@ -1005,19 +1006,19 @@ impl FuncCompiler<'_> {
                 if crate::pass_perceus::is_heap_type(&elem_ty) {
                     let wi = self.scratch.alloc_i32();
                     wasm!(self.func, {
-                        i32_const(0); local_set(wi);
+                        i32_const(Imm32(0)); local_set(Local(wi));
                         block_empty; loop_empty;
-                            local_get(wi); local_get(out_count); i32_ge_u; br_if(1);
-                            local_get(dst); i32_const(list_data_off); i32_add;
-                            local_get(wi); i32_const(elem_size as i32); i32_mul; i32_add;
+                            local_get(Local(wi)); local_get(Local(out_count)); i32_ge_u; br_if(1);
+                            local_get(Local(dst)); i32_const(Imm32(list_data_off)); i32_add;
+                            local_get(Local(wi)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
                             i32_load(0); call(self.emitter.rt.rc_inc); drop;
-                            local_get(wi); i32_const(1); i32_add; local_set(wi);
+                            local_get(Local(wi)); i32_const(Imm32(1)); i32_add; local_set(Local(wi));
                             br(0);
                         end; end;
                     });
                     self.scratch.free_i32(wi);
                 }
-                wasm!(self.func, { local_get(dst); });
+                wasm!(self.func, { local_get(Local(dst)); });
                 if let Some((pl, pvt)) = filter_param_local {
                     self.scratch.free(pl, pvt);
                 }
@@ -1082,38 +1083,38 @@ impl FuncCompiler<'_> {
                     // Fused pipeline: iterate source with pointer-based iteration
                     let (source_expr, stages) = self.extract_pipeline(&args[0]);
                     self.emit_expr(source_expr);
-                    wasm!(self.func, { local_set(list_ptr); });
+                    wasm!(self.func, { local_set(Local(list_ptr)); });
                     let source_elem_ty = self.resolve_list_elem(source_expr, None);
                     let source_elem_size = values::byte_size(&source_elem_ty);
                     // See the non-fused path: dup an alias accumulator seed so the
                     // fold loop owns its reference and the caller's Dec of the seed
                     // local cannot double-free the (empty-list) returned result.
                     self.emit_stored_field(&args[1]);
-                    wasm!(self.func, { local_set(acc); });
+                    wasm!(self.func, { local_set(Local(acc)); });
                     // Pointer-based iteration: ptr and end instead of idx
                     let ptr = self.scratch.alloc_i32();
                     let end_ptr = self.scratch.alloc_i32();
                     wasm!(self.func, {
                         // ptr = list_ptr + DATA_OFFSET
-                        local_get(list_ptr); i32_const(list_data_off); i32_add;
-                        local_set(ptr);
+                        local_get(Local(list_ptr)); i32_const(Imm32(list_data_off)); i32_add;
+                        local_set(Local(ptr));
                         // end = ptr + len * elem_size
-                        local_get(ptr);
-                        local_get(list_ptr); i32_load(0); i32_const(source_elem_size as i32); i32_mul;
-                        i32_add; local_set(end_ptr);
+                        local_get(Local(ptr));
+                        local_get(Local(list_ptr)); i32_load(0); i32_const(Imm32(source_elem_size as i32)); i32_mul;
+                        i32_add; local_set(Local(end_ptr));
                         block_empty; loop_empty;
                     });
                     let depth_guard = self.depth_push_n(2);
                     wasm!(self.func, {
-                        local_get(ptr); local_get(end_ptr); i32_ge_u; br_if(1);
+                        local_get(Local(ptr)); local_get(Local(end_ptr)); i32_ge_u; br_if(1);
                     });
                     // Load source element via pointer
                     let mut cur_ty = source_elem_ty.clone();
                     let mut cur_vt = values::ty_to_valtype(&cur_ty).unwrap_or(ValType::I32);
                     let mut cur_local = self.scratch.alloc(cur_vt);
-                    wasm!(self.func, { local_get(ptr); });
+                    wasm!(self.func, { local_get(Local(ptr)); });
                     self.emit_load_at(&cur_ty, 0);
-                    wasm!(self.func, { local_set(cur_local); });
+                    wasm!(self.func, { local_set(Local(cur_local)); });
                     // Apply each pipeline stage
                     let mut skip_label_depth = 0u32;
                     for stage in &stages {
@@ -1130,12 +1131,12 @@ impl FuncCompiler<'_> {
                                     let new_vt = values::ty_to_valtype(&new_ty).unwrap_or(ValType::I32);
                                     if new_vt != cur_vt {
                                         let new_local = self.scratch.alloc(new_vt);
-                                        wasm!(self.func, { local_set(new_local); });
+                                        wasm!(self.func, { local_set(Local(new_local)); });
                                         self.scratch.free(cur_local, cur_vt);
                                         cur_local = new_local;
                                         cur_vt = new_vt;
                                     } else {
-                                        wasm!(self.func, { local_set(cur_local); });
+                                        wasm!(self.func, { local_set(Local(cur_local)); });
                                     }
                                     if let Some((vid, _)) = params.first() {
                                         self.var_map.remove(&vid.0);
@@ -1156,7 +1157,7 @@ impl FuncCompiler<'_> {
                                     wasm!(self.func, {
                                         i32_eqz;
                                         if_empty;
-                                          local_get(ptr); i32_const(source_elem_size as i32); i32_add; local_set(ptr);
+                                          local_get(Local(ptr)); i32_const(Imm32(source_elem_size as i32)); i32_add; local_set(Local(ptr));
                                           br(1); // br to loop_empty
                                         end;
                                     });
@@ -1171,17 +1172,17 @@ impl FuncCompiler<'_> {
                         if let Some(vid) = acc_param { self.var_map.insert(vid.0, acc); }
                         if let Some(vid) = elem_param { self.var_map.insert(vid.0, cur_local); }
                         self.emit_expr(body);
-                        wasm!(self.func, { local_set(acc); });
+                        wasm!(self.func, { local_set(Local(acc)); });
                         if let Some(vid) = acc_param { self.var_map.remove(&vid.0); }
                         if let Some(vid) = elem_param { self.var_map.remove(&vid.0); }
                     }
                     self.scratch.free(cur_local, cur_vt);
                     wasm!(self.func, {
-                        local_get(ptr); i32_const(source_elem_size as i32); i32_add; local_set(ptr);
+                        local_get(Local(ptr)); i32_const(Imm32(source_elem_size as i32)); i32_add; local_set(Local(ptr));
                         br(0);
                     });
                     self.depth_pop(depth_guard);
-                    wasm!(self.func, { end; end; local_get(acc); });
+                    wasm!(self.func, { end; end; local_get(Local(acc)); });
                     self.scratch.free_i32(end_ptr);
                     self.scratch.free_i32(ptr);
                     self.scratch.free(acc, acc_vt);
@@ -1196,37 +1197,37 @@ impl FuncCompiler<'_> {
                 let ptr = self.scratch.alloc_i32();
                 let end_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(list_ptr); });
+                wasm!(self.func, { local_set(Local(list_ptr)); });
                 // The accumulator is MOVE-STORED into the fold loop and returned
                 // as the result (unchanged when the list is empty). Dup an alias
                 // seed so the loop owns its own reference and the caller's
                 // scope-end Dec of the seed local does not double-free the result.
                 self.emit_stored_field(&args[1]);
-                wasm!(self.func, { local_set(acc); });
+                wasm!(self.func, { local_set(Local(acc)); });
                 if !is_inline_lambda {
                     self.emit_expr(&args[2]);
-                    wasm!(self.func, { local_set(closure); });
+                    wasm!(self.func, { local_set(Local(closure)); });
                 }
                 wasm!(self.func, {
                     // ptr = list_ptr + DATA_OFFSET
-                    local_get(list_ptr); i32_const(list_data_off); i32_add;
-                    local_tee(ptr);
+                    local_get(Local(list_ptr)); i32_const(Imm32(list_data_off)); i32_add;
+                    local_tee(Local(ptr));
                     // end_ptr = ptr + len * elem_size
-                    local_get(list_ptr); i32_load(0); i32_const(elem_size as i32); i32_mul;
-                    i32_add; local_set(end_ptr);
+                    local_get(Local(list_ptr)); i32_load(0); i32_const(Imm32(elem_size as i32)); i32_mul;
+                    i32_add; local_set(Local(end_ptr));
                     block_empty; loop_empty;
                 });
                 let depth_guard = self.depth_push_n(2);
                 wasm!(self.func, {
-                    local_get(ptr); local_get(end_ptr); i32_ge_u; br_if(1);
+                    local_get(Local(ptr)); local_get(Local(end_ptr)); i32_ge_u; br_if(1);
                 });
                 if let almide_ir::IrExprKind::Lambda { params, body, .. } = &args[2].kind {
                     let acc_param = params.first().map(|(v, _)| *v);
                     let elem_param = params.get(1).map(|(v, _)| *v);
                     let elem_local = self.scratch.alloc(values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32));
-                    wasm!(self.func, { local_get(ptr); });
+                    wasm!(self.func, { local_get(Local(ptr)); });
                     self.emit_load_at(&elem_ty, 0);
-                    wasm!(self.func, { local_set(elem_local); });
+                    wasm!(self.func, { local_set(Local(elem_local)); });
                     if let Some(vid) = acc_param {
                         self.var_map.insert(vid.0, acc);
                     }
@@ -1243,12 +1244,12 @@ impl FuncCompiler<'_> {
                     self.scratch.free(elem_local, values::ty_to_valtype(&elem_ty).unwrap_or(ValType::I32));
                 } else {
                     wasm!(self.func, {
-                        local_get(closure); i32_load(4); // env
-                        local_get(acc);
-                        local_get(ptr);
+                        local_get(Local(closure)); i32_load(4); // env
+                        local_get(Local(acc));
+                        local_get(Local(ptr));
                     });
                     self.emit_load_at(&elem_ty, 0);
-                    wasm!(self.func, { local_get(closure); i32_load(0); }); // table_idx
+                    wasm!(self.func, { local_get(Local(closure)); i32_load(0); }); // table_idx
                     {
                         let mut ct = vec![ValType::I32]; // env
                         if let Some(vt) = values::ty_to_valtype(&acc_ty_resolved) { ct.push(vt); }
@@ -1257,12 +1258,12 @@ impl FuncCompiler<'_> {
                     }
                 }
                 wasm!(self.func, {
-                    local_set(acc);
-                    local_get(ptr); i32_const(elem_size as i32); i32_add; local_set(ptr);
+                    local_set(Local(acc));
+                    local_get(Local(ptr)); i32_const(Imm32(elem_size as i32)); i32_add; local_set(Local(ptr));
                     br(0);
                 });
                 self.depth_pop(depth_guard);
-                wasm!(self.func, { end; end; local_get(acc); });
+                wasm!(self.func, { end; end; local_get(Local(acc)); });
                 self.scratch.free_i32(end_ptr);
                 self.scratch.free_i32(ptr);
                 self.scratch.free(acc, acc_vt);
@@ -1418,33 +1419,33 @@ impl FuncCompiler<'_> {
         let in_place = self.is_single_use_var(list_arg) && in_size == out_size;
 
         self.emit_expr(list_arg);
-        wasm!(self.func, { local_set(src_local); });
+        wasm!(self.func, { local_set(Local(src_local)); });
         if direct_fn.is_none() && !matches!(&fn_arg.kind, almide_ir::IrExprKind::Lambda { .. }) {
             self.emit_expr(fn_arg);
-            wasm!(self.func, { local_set(closure_local); });
+            wasm!(self.func, { local_set(Local(closure_local)); });
         }
         let len_local = self.scratch.alloc_i32();
         if in_place {
             // In-place: dst = src (no allocation)
             wasm!(self.func, {
-                local_get(src_local); i32_load(0); local_set(len_local);
-                local_get(src_local); local_set(dst_local);
-                local_get(src_local); i32_const(list_data_off); i32_add; local_set(src_ptr);
-                local_get(src_local); i32_const(list_data_off); i32_add; local_set(dst_ptr);
-                local_get(src_ptr); local_get(len_local); i32_const(in_size as i32); i32_mul; i32_add; local_set(end_ptr);
+                local_get(Local(src_local)); i32_load(0); local_set(Local(len_local));
+                local_get(Local(src_local)); local_set(Local(dst_local));
+                local_get(Local(src_local)); i32_const(Imm32(list_data_off)); i32_add; local_set(Local(src_ptr));
+                local_get(Local(src_local)); i32_const(Imm32(list_data_off)); i32_add; local_set(Local(dst_ptr));
+                local_get(Local(src_ptr)); local_get(Local(len_local)); i32_const(Imm32(in_size as i32)); i32_mul; i32_add; local_set(Local(end_ptr));
             });
         } else {
             wasm!(self.func, {
-                local_get(src_local); i32_load(0); local_set(len_local);
+                local_get(Local(src_local)); i32_load(0); local_set(Local(len_local));
                 // alloc dst
-                i32_const(list_hdr);
-                local_get(len_local); i32_const(out_size as i32); i32_mul; i32_add;
-                call(self.emitter.rt.alloc); local_set(dst_local);
-                local_get(dst_local); local_get(len_local); i32_store(0);
+                i32_const(Imm32(list_hdr));
+                local_get(Local(len_local)); i32_const(Imm32(out_size as i32)); i32_mul; i32_add;
+                call(self.emitter.rt.alloc); local_set(Local(dst_local));
+                local_get(Local(dst_local)); local_get(Local(len_local)); i32_store(0);
                 // Pointer-based iteration
-                local_get(src_local); i32_const(list_data_off); i32_add; local_set(src_ptr);
-                local_get(dst_local); i32_const(list_data_off); i32_add; local_set(dst_ptr);
-                local_get(src_ptr); local_get(len_local); i32_const(in_size as i32); i32_mul; i32_add; local_set(end_ptr);
+                local_get(Local(src_local)); i32_const(Imm32(list_data_off)); i32_add; local_set(Local(src_ptr));
+                local_get(Local(dst_local)); i32_const(Imm32(list_data_off)); i32_add; local_set(Local(dst_ptr));
+                local_get(Local(src_ptr)); local_get(Local(len_local)); i32_const(Imm32(in_size as i32)); i32_mul; i32_add; local_set(Local(end_ptr));
             });
         }
 
@@ -1457,33 +1458,33 @@ impl FuncCompiler<'_> {
             let simd_vec = if !use_shift { Some(self.scratch.alloc_v128()) } else { None };
             // simd_end = src_ptr + (len / 8) * 64  (round down to multiple of 8)
             wasm!(self.func, {
-                local_get(src_ptr);
-                local_get(len_local); i32_const(SIMD_ELEMS_LOG2); i32_shr_u; // len / 8
-                i32_const(SIMD_BATCH_BYTES); i32_mul;
-                i32_add; local_set(simd_end);
+                local_get(Local(src_ptr));
+                local_get(Local(len_local)); i32_const(Imm32(SIMD_ELEMS_LOG2)); i32_shr_u; // len / 8
+                i32_const(Imm32(SIMD_BATCH_BYTES)); i32_mul;
+                i32_add; local_set(Local(simd_end));
             });
             if let Some(sv) = simd_vec {
                 wasm!(self.func, {
-                    i64_const(simd_const_val);
+                    i64_const(Imm64(simd_const_val));
                     i64x2_splat;
-                    local_set(sv);
+                    local_set(Local(sv));
                 });
             }
 
             // Emit a single SIMD operation: load from src_ptr+offset, apply op, store to dst_ptr+offset
             let emit_simd_op = |fc: &mut FuncCompiler, offset: u64, sv: Option<u32>| {
                 wasm!(fc.func, {
-                    local_get(dst_ptr);
-                    local_get(src_ptr);
+                    local_get(Local(dst_ptr));
+                    local_get(Local(src_ptr));
                     v128_load(offset);
                 });
                 if use_shift {
                     let shift = (simd_const_val as u64).trailing_zeros();
-                    wasm!(fc.func, { i32_const(shift as i32); });
+                    wasm!(fc.func, { i32_const(Imm32(shift as i32)); });
                     fc.func.instruction(&wasm_encoder::Instruction::I64x2Shl);
                 } else {
                     let sv = sv.unwrap();
-                    wasm!(fc.func, { local_get(sv); });
+                    wasm!(fc.func, { local_get(Local(sv)); });
                     match simd_kind {
                         SimdMapOp::Mul => { wasm!(fc.func, { i64x2_mul; }); }
                         SimdMapOp::Add => { wasm!(fc.func, { i64x2_add; }); }
@@ -1495,7 +1496,7 @@ impl FuncCompiler<'_> {
 
             wasm!(self.func, {
                 block_empty; loop_empty;
-                  local_get(src_ptr); local_get(simd_end); i32_ge_u; br_if(1);
+                  local_get(Local(src_ptr)); local_get(Local(simd_end)); i32_ge_u; br_if(1);
             });
             // 4× unrolled: process 8 elements (64 bytes) per iteration
             emit_simd_op(self, 0, simd_vec);
@@ -1503,8 +1504,8 @@ impl FuncCompiler<'_> {
             emit_simd_op(self, 32, simd_vec);
             emit_simd_op(self, 48, simd_vec);
             wasm!(self.func, {
-                  local_get(src_ptr); i32_const(SIMD_BATCH_BYTES); i32_add; local_set(src_ptr);
-                  local_get(dst_ptr); i32_const(SIMD_BATCH_BYTES); i32_add; local_set(dst_ptr);
+                  local_get(Local(src_ptr)); i32_const(Imm32(SIMD_BATCH_BYTES)); i32_add; local_set(Local(src_ptr));
+                  local_get(Local(dst_ptr)); i32_const(Imm32(SIMD_BATCH_BYTES)); i32_add; local_set(Local(dst_ptr));
                   br(0);
                 end; end;
             });
@@ -1519,16 +1520,16 @@ impl FuncCompiler<'_> {
         let depth_guard = self.depth_push_n(2);
 
         wasm!(self.func, {
-            local_get(src_ptr); local_get(end_ptr); i32_ge_u; br_if(1);
+            local_get(Local(src_ptr)); local_get(Local(end_ptr)); i32_ge_u; br_if(1);
             // dst addr on stack
-            local_get(dst_ptr);
+            local_get(Local(dst_ptr));
         });
         if let almide_ir::IrExprKind::Lambda { params, body, .. } = &fn_arg.kind {
             let param_var = params.first().map(|(v, _)| *v);
             let param_local = self.scratch.alloc(values::ty_to_valtype(&in_elem_ty).unwrap_or(ValType::I32));
-            wasm!(self.func, { local_get(src_ptr); });
+            wasm!(self.func, { local_get(Local(src_ptr)); });
             self.emit_load_at(&in_elem_ty, 0);
-            wasm!(self.func, { local_set(param_local); });
+            wasm!(self.func, { local_set(Local(param_local)); });
             // Bind param var to local
             if let Some(vid) = param_var {
                 self.var_map.insert(vid.0, param_local);
@@ -1541,25 +1542,25 @@ impl FuncCompiler<'_> {
             self.scratch.free(param_local, values::ty_to_valtype(&in_elem_ty).unwrap_or(ValType::I32));
         } else if let Some(fn_idx) = direct_fn {
             wasm!(self.func, {
-                i32_const(0);
-                local_get(src_ptr);
+                i32_const(Imm32(0));
+                local_get(Local(src_ptr));
             });
             self.emit_load_at(&in_elem_ty, 0);
             wasm!(self.func, { call(fn_idx); });
         } else {
             wasm!(self.func, {
-                local_get(closure_local); i32_load(4);
-                local_get(src_ptr);
+                local_get(Local(closure_local)); i32_load(4);
+                local_get(Local(src_ptr));
             });
             self.emit_load_at(&in_elem_ty, 0);
-            wasm!(self.func, { local_get(closure_local); i32_load(0); });
+            wasm!(self.func, { local_get(Local(closure_local)); i32_load(0); });
             self.emit_closure_call(&in_elem_ty, &out_elem_ty);
         }
         self.emit_store_at(&out_elem_ty, 0);
 
         wasm!(self.func, {
-            local_get(src_ptr); i32_const(in_size as i32); i32_add; local_set(src_ptr);
-            local_get(dst_ptr); i32_const(out_size as i32); i32_add; local_set(dst_ptr);
+            local_get(Local(src_ptr)); i32_const(Imm32(in_size as i32)); i32_add; local_set(Local(src_ptr));
+            local_get(Local(dst_ptr)); i32_const(Imm32(out_size as i32)); i32_add; local_set(Local(dst_ptr));
             br(0);
         });
         self.depth_pop(depth_guard);
@@ -1567,10 +1568,10 @@ impl FuncCompiler<'_> {
 
         // Perceus: if source was single-use and NOT in-place, free via rc_dec.
         if !in_place && self.is_single_use_var(list_arg) {
-            wasm!(self.func, { local_get(src_local); call(self.emitter.rt.rc_dec); });
+            wasm!(self.func, { local_get(Local(src_local)); call(self.emitter.rt.rc_dec); });
         }
 
-        wasm!(self.func, { local_get(dst_local); });
+        wasm!(self.func, { local_get(Local(dst_local)); });
 
         self.scratch.free_i32(len_local);
         self.scratch.free_i32(end_ptr);

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
@@ -3,6 +3,15 @@
 //! Functions: take_while, drop_while, count, partition, update, scan, zip_with,
 //! unique_by, group_by, shuffle, filter, fold, map, and the emit_list_map helper.
 
+// ── Named constants for WASM immediates ───────────────────────────────────────
+/// Minimum load-factor denominator for group_by map capacity: cap >= len * 2.
+const MAP_CAP_FACTOR: i32 = 2;
+/// Log₂ of the SIMD batch size (8 i64 elements → shift right by 3 = divide by 8).
+const SIMD_ELEMS_LOG2: i32 = 3;
+/// Byte stride of one SIMD batch: 8 i64 elements × 8 bytes each = 64 bytes.
+const SIMD_BATCH_BYTES: i32 = 64;
+// ─────────────────────────────────────────────────────────────────────────────
+
 use super::FuncCompiler;
 use super::values;
 use almide_ir::{BinOp, IrExpr, IrExprKind};
@@ -713,7 +722,7 @@ impl FuncCompiler<'_> {
                     // cap = next power of 2 >= max(len * 2, INITIAL_CAP)
                     i32_const(lm::INITIAL_CAP as i32); local_set(cap_local);
                     block_empty; loop_empty;
-                      local_get(cap_local); local_get(len); i32_const(2); i32_mul; i32_ge_u; br_if(1);
+                      local_get(cap_local); local_get(len); i32_const(MAP_CAP_FACTOR); i32_mul; i32_ge_u; br_if(1);
                       local_get(cap_local); i32_const(1); i32_shl; local_set(cap_local);
                       br(0);
                     end; end;
@@ -1449,8 +1458,8 @@ impl FuncCompiler<'_> {
             // simd_end = src_ptr + (len / 8) * 64  (round down to multiple of 8)
             wasm!(self.func, {
                 local_get(src_ptr);
-                local_get(len_local); i32_const(3); i32_shr_u; // len / 8
-                i32_const(64); i32_mul;
+                local_get(len_local); i32_const(SIMD_ELEMS_LOG2); i32_shr_u; // len / 8
+                i32_const(SIMD_BATCH_BYTES); i32_mul;
                 i32_add; local_set(simd_end);
             });
             if let Some(sv) = simd_vec {
@@ -1494,8 +1503,8 @@ impl FuncCompiler<'_> {
             emit_simd_op(self, 32, simd_vec);
             emit_simd_op(self, 48, simd_vec);
             wasm!(self.func, {
-                  local_get(src_ptr); i32_const(64); i32_add; local_set(src_ptr);
-                  local_get(dst_ptr); i32_const(64); i32_add; local_set(dst_ptr);
+                  local_get(src_ptr); i32_const(SIMD_BATCH_BYTES); i32_add; local_set(src_ptr);
+                  local_get(dst_ptr); i32_const(SIMD_BATCH_BYTES); i32_add; local_set(dst_ptr);
                   br(0);
                 end; end;
             });

--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -10,6 +10,20 @@ use almide_lang::types::Ty;
 use wasm_encoder::{Function, Instruction, ValType};
 use super::engine::layout::{LIST, list as ll};
 
+/// Named WASM immediate constants for list helper codegen.
+mod imm {
+    // ── byte widths ────────────────────────────────────────────────────
+    /// Byte size of an i32 / pointer (stride in a list-of-pointers array).
+    pub(super) const I32_BYTES: i32 = 4;
+
+    // ── sort constants ─────────────────────────────────────────────────
+    /// Minimum list length that requires sorting (len < 2 → already sorted/trivial).
+    pub(super) const SORT_MIN_LEN: i32 = 2;
+    /// Merge sort doubling factor: each pass doubles the merge width (`width * 2`).
+    pub(super) const MERGE_STRIDE: i32 = 2;
+}
+use imm::*;
+
 /// Upper bound for `emit_clamp_count_to_i32` — the value a too-large `Int`
 /// count saturates to (mirrors native's `min(n, len)` / capacity-ceiling).
 #[derive(Clone, Copy)]
@@ -613,7 +627,7 @@ impl FuncCompiler<'_> {
         let is_desc = self.scratch.alloc_i32();
         let scan_done = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_get(len); i32_const(2); i32_lt_u;
+            local_get(len); i32_const(SORT_MIN_LEN); i32_lt_u;
             if_empty;
               // len < 2: nothing to sort, but still copy the 0/1 source elements
               // to dst. The sort-proper path (scan_done==0) copies src→dst, but
@@ -726,7 +740,7 @@ impl FuncCompiler<'_> {
                 local_get(i); local_get(width); i32_add; local_set(mid);
                 local_get(mid); local_get(len); i32_gt_u;
                 if_empty; local_get(len); local_set(mid); end;
-                local_get(i); local_get(width); i32_const(2); i32_mul; i32_add; local_set(right);
+                local_get(i); local_get(width); i32_const(MERGE_STRIDE); i32_mul; i32_add; local_set(right);
                 local_get(right); local_get(len); i32_gt_u;
                 if_empty; local_get(len); local_set(right); end;
                 // merge dst[left..mid] and dst[mid..right] into tmp[left..right]
@@ -790,11 +804,11 @@ impl FuncCompiler<'_> {
                   br(0);
                 end; end;
                 // i += width * 2
-                local_get(i); local_get(width); i32_const(2); i32_mul; i32_add; local_set(i);
+                local_get(i); local_get(width); i32_const(MERGE_STRIDE); i32_mul; i32_add; local_set(i);
                 br(0);
               end; end;
               // width *= 2
-              local_get(width); i32_const(2); i32_mul; local_set(width);
+              local_get(width); i32_const(MERGE_STRIDE); i32_mul; local_set(width);
               br(0);
             end; end;
             end; // end if scan_done == 0
@@ -819,7 +833,7 @@ impl FuncCompiler<'_> {
                 block_empty; loop_empty;
                     local_get(di); local_get(dl); i32_ge_u; br_if(1);
                     local_get(dst); i32_const(data_off); i32_add;
-                    local_get(di); i32_const(4); i32_mul; i32_add;
+                    local_get(di); i32_const(I32_BYTES); i32_mul; i32_add;
                     i32_load(0); call(self.emitter.rt.rc_inc); drop;
                     local_get(di); i32_const(1); i32_add; local_set(di);
                     br(0);
@@ -996,7 +1010,7 @@ impl FuncCompiler<'_> {
             // Alloc dst: [len] + len * ptr_size(4)
             i32_const(self.emitter.layout_reg.header_size(LIST) as i32);
             local_get(len_local);
-            i32_const(4); // each entry is a tuple ptr (i32)
+            i32_const(I32_BYTES); // each entry is a tuple ptr (i32)
             i32_mul;
             i32_add;
             call(self.emitter.rt.alloc);
@@ -1051,7 +1065,7 @@ impl FuncCompiler<'_> {
             i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32);
             i32_add;
             local_get(idx_local);
-            i32_const(4); // tuple ptrs are i32
+            i32_const(I32_BYTES); // tuple ptrs are i32
             i32_mul;
             i32_add;
             local_get(tuple_ptr);

--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -3,6 +3,7 @@
 //! Utility functions used by both calls_list.rs and calls_list_closure.rs:
 //! list_elem_ty, emit_elem_copy, emit_elem_store.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::{FuncCompiler, WasmEmitter};
 use super::values;
 use almide_ir::IrExpr;
@@ -295,14 +296,14 @@ impl FuncCompiler<'_> {
     /// byte-budget cap, or `chunk`/`windows`'s `i32::MAX` "huge" sentinel).
     pub(super) fn emit_clamp_count_to_i32(&mut self, hi: ClampHi) {
         let count = self.scratch.alloc_i64();
-        wasm!(self.func, { local_set(count); });
+        wasm!(self.func, { local_set(Local(count)); });
         // min_u(count, hi): `[count, hi, count <_u hi]` selects `count` when it
         // fits and `hi` otherwise. The comparison is UNSIGNED so a negative i64
         // (huge as u64) saturates to `hi` — matching native's `n as usize`.
         // `hi` is non-negative; widening it via `i64_extend_i32_u` is lossless.
-        wasm!(self.func, { local_get(count); });
+        wasm!(self.func, { local_get(Local(count)); });
         self.emit_push_clamp_hi_i64(&hi);
-        wasm!(self.func, { local_get(count); });
+        wasm!(self.func, { local_get(Local(count)); });
         self.emit_push_clamp_hi_i64(&hi);
         wasm!(self.func, {
             i64_lt_u; select;
@@ -330,18 +331,18 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_clamp_count_signed_i32(&mut self, hi: ClampHi) {
         let idx = self.scratch.alloc_i64();
         wasm!(self.func, {
-            local_set(idx);
+            local_set(Local(idx));
             // lo-clamp: max(idx, 0). `[idx, 0, idx >= 0]` selects `idx` when
             // non-negative and `0` for a negative i64 (matches `idx.max(0)`).
-            local_get(idx); i64_const(0);
-              local_get(idx); i64_const(0); i64_ge_s; select;
-            local_set(idx);
+            local_get(Local(idx)); i64_const(Imm64(0));
+              local_get(Local(idx)); i64_const(Imm64(0)); i64_ge_s; select;
+            local_set(Local(idx));
         });
         // hi-clamp: min(idx, hi). `idx` is now non-negative, so signed and
         // unsigned compare agree; `i64_le_s` is fine.
-        wasm!(self.func, { local_get(idx); });
+        wasm!(self.func, { local_get(Local(idx)); });
         self.emit_push_clamp_hi_i64(&hi);
-        wasm!(self.func, { local_get(idx); });
+        wasm!(self.func, { local_get(Local(idx)); });
         self.emit_push_clamp_hi_i64(&hi);
         wasm!(self.func, {
             i64_le_s; select;
@@ -353,8 +354,8 @@ impl FuncCompiler<'_> {
     /// Push the clamp ceiling as an i64 (non-negative).
     fn emit_push_clamp_hi_i64(&mut self, hi: &ClampHi) {
         match *hi {
-            ClampHi::LenLocal(idx) => { wasm!(self.func, { local_get(idx); i64_extend_i32_u; }); }
-            ClampHi::Const(n) => { wasm!(self.func, { i64_const(n); }); }
+            ClampHi::LenLocal(idx) => { wasm!(self.func, { local_get(Local(idx)); i64_extend_i32_u; }); }
+            ClampHi::Const(n) => { wasm!(self.func, { i64_const(Imm64(n)); }); }
         }
     }
 
@@ -369,10 +370,10 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_clamp_index_to_len_i32(&mut self, len_local: u32) {
         let idx = self.scratch.alloc_i64();
         wasm!(self.func, {
-            local_set(idx);
-            local_get(idx);
-            local_get(len_local); i64_extend_i32_u;
-              local_get(idx); local_get(len_local); i64_extend_i32_u; i64_lt_u; select;
+            local_set(Local(idx));
+            local_get(Local(idx));
+            local_get(Local(len_local)); i64_extend_i32_u;
+              local_get(Local(idx)); local_get(Local(len_local)); i64_extend_i32_u; i64_lt_u; select;
             i32_wrap_i64;
         });
         self.scratch.free_i64(idx);
@@ -391,14 +392,14 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_checked_index_i32(&mut self, len_local: u32, in_bounds_local: u32) {
         let idx = self.scratch.alloc_i64();
         wasm!(self.func, {
-            local_set(idx);
+            local_set(Local(idx));
             // in_bounds = idx_u < len_u  (on the full i64, no truncation)
-            local_get(idx); local_get(len_local); i64_extend_i32_u; i64_lt_u;
-            local_set(in_bounds_local);
+            local_get(Local(idx)); local_get(Local(len_local)); i64_extend_i32_u; i64_lt_u;
+            local_set(Local(in_bounds_local));
             // saturated idx = min_u(idx, len) so addressing never goes OOB
-            local_get(idx);
-            local_get(len_local); i64_extend_i32_u;
-              local_get(idx); local_get(len_local); i64_extend_i32_u; i64_lt_u; select;
+            local_get(Local(idx));
+            local_get(Local(len_local)); i64_extend_i32_u;
+              local_get(Local(idx)); local_get(Local(len_local)); i64_extend_i32_u; i64_lt_u; select;
             i32_wrap_i64;
         });
         self.scratch.free_i64(idx);
@@ -413,11 +414,11 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
             // if (idx as u64) >= (len as u64) { abort }  — a negative i64 wraps
             // to a huge u64 and is caught by the same compare.
-            local_get(idx64_local);
-            local_get(ptr_local); i32_load(0); i64_extend_i32_u;
+            local_get(Local(idx64_local));
+            local_get(Local(ptr_local)); i32_load(0); i64_extend_i32_u;
             i64_ge_u;
             if_empty;
-              i32_const(oob_msg);
+              i32_const(Imm32(oob_msg));
               call(div_trap);
             end;
         });
@@ -529,18 +530,18 @@ impl FuncCompiler<'_> {
             // C-055.
             SortKind::Float => {
                 self.emit_ord_cmp3(&Ty::Float);
-                wasm!(self.func, { i32_const(0); i32_le_s; });
+                wasm!(self.func, { i32_const(Imm32(0)); i32_le_s; });
             }
             SortKind::String => {
-                wasm!(self.func, { call(self.emitter.rt.string.cmp); i32_const(0); i32_le_s; });
+                wasm!(self.func, { call(self.emitter.rt.string.cmp); i32_const(Imm32(0)); i32_le_s; });
             }
             SortKind::ListString => {
-                wasm!(self.func, { call(self.emitter.rt.list_list_str_cmp); i32_const(0); i32_le_s; });
+                wasm!(self.func, { call(self.emitter.rt.list_list_str_cmp); i32_const(Imm32(0)); i32_le_s; });
             }
             SortKind::Ord(ty) => {
                 let ty = ty.clone();
                 self.emit_ord_cmp3(&ty);
-                wasm!(self.func, { i32_const(0); i32_le_s; });
+                wasm!(self.func, { i32_const(Imm32(0)); i32_le_s; });
             }
         }
     }
@@ -614,12 +615,12 @@ impl FuncCompiler<'_> {
         // 1. Alloc dst + pre-scan source for asc/desc detection.
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(xs_ptr);
-            local_get(xs_ptr); i32_load(0); local_set(len);
+            local_set(Local(xs_ptr));
+            local_get(Local(xs_ptr)); i32_load(0); local_set(Local(len));
             // alloc dst
-            i32_const(self.emitter.layout_reg.header_size(LIST) as i32); local_get(len); i32_const(es as i32); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(dst);
-            local_get(dst); local_get(len); i32_store(0);
+            i32_const(Imm32(self.emitter.layout_reg.header_size(LIST) as i32)); local_get(Local(len)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(dst));
+            local_get(Local(dst)); local_get(Local(len)); i32_store(0);
         });
 
         // 2. Pre-scan SOURCE (xs_ptr) for asc/desc before copying.
@@ -627,31 +628,31 @@ impl FuncCompiler<'_> {
         let is_desc = self.scratch.alloc_i32();
         let scan_done = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_get(len); i32_const(SORT_MIN_LEN); i32_lt_u;
+            local_get(Local(len)); i32_const(Imm32(SORT_MIN_LEN)); i32_lt_u;
             if_empty;
               // len < 2: nothing to sort, but still copy the 0/1 source elements
               // to dst. The sort-proper path (scan_done==0) copies src→dst, but
               // this short-circuit skipped it — so dst's data stayed the zeroed
               // alloc and a singleton sort returned a zeroed element.
-              local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-              local_get(xs_ptr); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-              local_get(len); i32_const(es as i32); i32_mul;
+              local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+              local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+              local_get(Local(len)); i32_const(Imm32(es as i32)); i32_mul;
               memory_copy;
-              i32_const(1); local_set(scan_done);
+              i32_const(Imm32(1)); local_set(Local(scan_done));
             else_;
-              i32_const(1); local_set(is_asc);
-              i32_const(1); local_set(is_desc);
-              i32_const(0); local_set(i);
+              i32_const(Imm32(1)); local_set(Local(is_asc));
+              i32_const(Imm32(1)); local_set(Local(is_desc));
+              i32_const(Imm32(0)); local_set(Local(i));
               block_empty; loop_empty;
-                local_get(i); local_get(len); i32_const(1); i32_sub; i32_ge_u; br_if(1);
+                local_get(Local(i)); local_get(Local(len)); i32_const(Imm32(1)); i32_sub; i32_ge_u; br_if(1);
                 // Load xs[i] and xs[i+1]
-                local_get(xs_ptr); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                local_get(i); i32_const(es as i32); i32_mul; i32_add;
+                local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         kind.emit_load(&mut self.func); // xs[i]
         wasm!(self.func, {
-                local_get(xs_ptr); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                local_get(i); i32_const(1); i32_add; i32_const(es as i32); i32_mul; i32_add;
+                local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         kind.emit_load(&mut self.func); // xs[i+1]
         // Check: if dst[i] > dst[i+1] → not ascending
@@ -661,55 +662,55 @@ impl FuncCompiler<'_> {
         self.emit_sort_le_cmp(&kind); // dst[i] <= dst[i+1]
         wasm!(self.func, {
                 i32_eqz;
-                if_empty; i32_const(0); local_set(is_asc); end;
+                if_empty; i32_const(Imm32(0)); local_set(Local(is_asc)); end;
                 // Check descending: xs[i] >= xs[i+1]
-                local_get(xs_ptr); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                local_get(i); i32_const(1); i32_add; i32_const(es as i32); i32_mul; i32_add;
+                local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         kind.emit_load(&mut self.func); // xs[i+1]
         wasm!(self.func, {
-                local_get(xs_ptr); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                local_get(i); i32_const(es as i32); i32_mul; i32_add;
+                local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         kind.emit_load(&mut self.func); // xs[i]
         self.emit_sort_le_cmp(&kind); // dst[i+1] <= dst[i]
         wasm!(self.func, {
                 i32_eqz;
-                if_empty; i32_const(0); local_set(is_desc); end;
+                if_empty; i32_const(Imm32(0)); local_set(Local(is_desc)); end;
                 // Early exit if neither
-                local_get(is_asc); local_get(is_desc); i32_or; i32_eqz;
+                local_get(Local(is_asc)); local_get(Local(is_desc)); i32_or; i32_eqz;
                 br_if(1); // break scan loop
-                local_get(i); i32_const(1); i32_add; local_set(i); br(0);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i)); br(0);
               end; end;
               // Determine result
-              local_get(is_asc);
+              local_get(Local(is_asc));
               if_empty;
                 // Already sorted: just bulk copy
-                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                local_get(xs_ptr); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                local_get(len); i32_const(es as i32); i32_mul;
+                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+                local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+                local_get(Local(len)); i32_const(Imm32(es as i32)); i32_mul;
                 memory_copy;
-                i32_const(1); local_set(scan_done);
+                i32_const(Imm32(1)); local_set(Local(scan_done));
               else_;
-                local_get(is_desc);
+                local_get(Local(is_desc));
                 if_empty;
                   // Reverse copy: dst[i] = src[len-1-i] (1 pass, no swap)
-                  i32_const(0); local_set(i);
+                  i32_const(Imm32(0)); local_set(Local(i));
                   block_empty; loop_empty;
-                    local_get(i); local_get(len); i32_ge_u; br_if(1);
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                    local_get(i); i32_const(es as i32); i32_mul; i32_add;
-                    local_get(xs_ptr); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                    local_get(len); i32_const(1); i32_sub; local_get(i); i32_sub;
-                    i32_const(es as i32); i32_mul; i32_add;
+                    local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+                    local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                    local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+                    local_get(Local(len)); i32_const(Imm32(1)); i32_sub; local_get(Local(i)); i32_sub;
+                    i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         kind.emit_copy_one(&mut self.func);
         wasm!(self.func, {
-                    local_get(i); i32_const(1); i32_add; local_set(i); br(0);
+                    local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i)); br(0);
                   end; end;
-                  i32_const(1); local_set(scan_done);
+                  i32_const(Imm32(1)); local_set(Local(scan_done));
                 else_;
-                  i32_const(0); local_set(scan_done);
+                  i32_const(Imm32(0)); local_set(Local(scan_done));
                 end;
               end;
             end;
@@ -719,100 +720,100 @@ impl FuncCompiler<'_> {
 
         // 3. Bottom-up merge sort (only if scan_done == 0).
         wasm!(self.func, {
-            local_get(scan_done); i32_eqz;
+            local_get(Local(scan_done)); i32_eqz;
             if_empty;
             // Copy source to dst + alloc tmp for merge
-            local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-            local_get(xs_ptr); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-            local_get(len); i32_const(es as i32); i32_mul;
+            local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+            local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+            local_get(Local(len)); i32_const(Imm32(es as i32)); i32_mul;
             memory_copy;
-            local_get(len); i32_const(es as i32); i32_mul;
-            call(self.emitter.rt.alloc); local_set(tmp);
-            i32_const(1); local_set(width);
+            local_get(Local(len)); i32_const(Imm32(es as i32)); i32_mul;
+            call(self.emitter.rt.alloc); local_set(Local(tmp));
+            i32_const(Imm32(1)); local_set(Local(width));
             block_empty; loop_empty;
-              local_get(width); local_get(len); i32_ge_u; br_if(1);
+              local_get(Local(width)); local_get(Local(len)); i32_ge_u; br_if(1);
               // for i = 0; i < len; i += width*2
-              i32_const(0); local_set(i);
+              i32_const(Imm32(0)); local_set(Local(i));
               block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                 // left = i, mid = min(i+width, len), right = min(i+2*width, len)
-                local_get(i); local_set(left);
-                local_get(i); local_get(width); i32_add; local_set(mid);
-                local_get(mid); local_get(len); i32_gt_u;
-                if_empty; local_get(len); local_set(mid); end;
-                local_get(i); local_get(width); i32_const(MERGE_STRIDE); i32_mul; i32_add; local_set(right);
-                local_get(right); local_get(len); i32_gt_u;
-                if_empty; local_get(len); local_set(right); end;
+                local_get(Local(i)); local_set(Local(left));
+                local_get(Local(i)); local_get(Local(width)); i32_add; local_set(Local(mid));
+                local_get(Local(mid)); local_get(Local(len)); i32_gt_u;
+                if_empty; local_get(Local(len)); local_set(Local(mid)); end;
+                local_get(Local(i)); local_get(Local(width)); i32_const(Imm32(MERGE_STRIDE)); i32_mul; i32_add; local_set(Local(right));
+                local_get(Local(right)); local_get(Local(len)); i32_gt_u;
+                if_empty; local_get(Local(len)); local_set(Local(right)); end;
                 // merge dst[left..mid] and dst[mid..right] into tmp[left..right]
-                local_get(left); local_set(li);
-                local_get(mid); local_set(ri);
-                local_get(left); local_set(k);
+                local_get(Local(left)); local_set(Local(li));
+                local_get(Local(mid)); local_set(Local(ri));
+                local_get(Local(left)); local_set(Local(k));
                 block_empty; loop_empty;
-                  local_get(k); local_get(right); i32_ge_u; br_if(1);
+                  local_get(Local(k)); local_get(Local(right)); i32_ge_u; br_if(1);
                   // if li < mid && (ri >= right || dst[li] <= dst[ri])
-                  local_get(li); local_get(mid); i32_lt_u;
+                  local_get(Local(li)); local_get(Local(mid)); i32_lt_u;
                   if_i32;
-                    local_get(ri); local_get(right); i32_ge_u;
+                    local_get(Local(ri)); local_get(Local(right)); i32_ge_u;
                     if_i32;
-                      i32_const(1); // ri exhausted, use left
+                      i32_const(Imm32(1)); // ri exhausted, use left
                     else_;
                       // compare dst[li] <= dst[ri]
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add; local_get(li); i32_const(es as i32); i32_mul; i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add; local_get(Local(li)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         kind.emit_load(&mut self.func); // load dst[li]
         wasm!(self.func, {
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add; local_get(ri); i32_const(es as i32); i32_mul; i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add; local_get(Local(ri)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         kind.emit_load(&mut self.func); // load dst[ri]
         self.emit_sort_le_cmp(&kind); // dst[li] <= dst[ri]
         wasm!(self.func, {
                     end;
                   else_;
-                    i32_const(0); // li exhausted, use right
+                    i32_const(Imm32(0)); // li exhausted, use right
                   end;
                   // if result: copy from left (li), else copy from right (ri)
                   if_empty;
                     // tmp[k] = dst[li]; li++
-                    local_get(tmp); local_get(k); i32_const(es as i32); i32_mul; i32_add;
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add; local_get(li); i32_const(es as i32); i32_mul; i32_add;
+                    local_get(Local(tmp)); local_get(Local(k)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add; local_get(Local(li)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         kind.emit_copy_one(&mut self.func);
         wasm!(self.func, {
-                    local_get(li); i32_const(1); i32_add; local_set(li);
+                    local_get(Local(li)); i32_const(Imm32(1)); i32_add; local_set(Local(li));
                   else_;
                     // tmp[k] = dst[ri]; ri++
-                    local_get(tmp); local_get(k); i32_const(es as i32); i32_mul; i32_add;
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add; local_get(ri); i32_const(es as i32); i32_mul; i32_add;
+                    local_get(Local(tmp)); local_get(Local(k)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add; local_get(Local(ri)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         kind.emit_copy_one(&mut self.func);
         wasm!(self.func, {
-                    local_get(ri); i32_const(1); i32_add; local_set(ri);
+                    local_get(Local(ri)); i32_const(Imm32(1)); i32_add; local_set(Local(ri));
                   end;
-                  local_get(k); i32_const(1); i32_add; local_set(k);
+                  local_get(Local(k)); i32_const(Imm32(1)); i32_add; local_set(Local(k));
                   br(0);
                 end; end;
                 // copy tmp[left..right] back to dst[left..right]
-                local_get(left); local_set(k);
+                local_get(Local(left)); local_set(Local(k));
                 block_empty; loop_empty;
-                  local_get(k); local_get(right); i32_ge_u; br_if(1);
-                  local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add; local_get(k); i32_const(es as i32); i32_mul; i32_add;
-                  local_get(tmp); local_get(k); i32_const(es as i32); i32_mul; i32_add;
+                  local_get(Local(k)); local_get(Local(right)); i32_ge_u; br_if(1);
+                  local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add; local_get(Local(k)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                  local_get(Local(tmp)); local_get(Local(k)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         kind.emit_copy_one(&mut self.func);
         wasm!(self.func, {
-                  local_get(k); i32_const(1); i32_add; local_set(k);
+                  local_get(Local(k)); i32_const(Imm32(1)); i32_add; local_set(Local(k));
                   br(0);
                 end; end;
                 // i += width * 2
-                local_get(i); local_get(width); i32_const(MERGE_STRIDE); i32_mul; i32_add; local_set(i);
+                local_get(Local(i)); local_get(Local(width)); i32_const(Imm32(MERGE_STRIDE)); i32_mul; i32_add; local_set(Local(i));
                 br(0);
               end; end;
               // width *= 2
-              local_get(width); i32_const(MERGE_STRIDE); i32_mul; local_set(width);
+              local_get(Local(width)); i32_const(Imm32(MERGE_STRIDE)); i32_mul; local_set(Local(width));
               br(0);
             end; end;
             end; // end if scan_done == 0
-            local_get(dst);
+            local_get(Local(dst));
         });
 
         // 3.5 SHARE dup: every element pointer was copied from the SOURCE
@@ -826,19 +827,19 @@ impl FuncCompiler<'_> {
             let dl = self.scratch.alloc_i32();
             let data_off = self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32;
             wasm!(self.func, {
-                local_set(di); // borrow di as the result holder briefly
-                local_get(di); i32_load(0); local_set(dl);
-                local_get(di); local_set(dst);
-                i32_const(0); local_set(di);
+                local_set(Local(di)); // borrow di as the result holder briefly
+                local_get(Local(di)); i32_load(0); local_set(Local(dl));
+                local_get(Local(di)); local_set(Local(dst));
+                i32_const(Imm32(0)); local_set(Local(di));
                 block_empty; loop_empty;
-                    local_get(di); local_get(dl); i32_ge_u; br_if(1);
-                    local_get(dst); i32_const(data_off); i32_add;
-                    local_get(di); i32_const(I32_BYTES); i32_mul; i32_add;
+                    local_get(Local(di)); local_get(Local(dl)); i32_ge_u; br_if(1);
+                    local_get(Local(dst)); i32_const(Imm32(data_off)); i32_add;
+                    local_get(Local(di)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
                     i32_load(0); call(self.emitter.rt.rc_inc); drop;
-                    local_get(di); i32_const(1); i32_add; local_set(di);
+                    local_get(Local(di)); i32_const(Imm32(1)); i32_add; local_set(Local(di));
                     br(0);
                 end; end;
-                local_get(dst);
+                local_get(Local(dst));
             });
             self.scratch.free_i32(dl);
             self.scratch.free_i32(di);
@@ -878,33 +879,33 @@ impl FuncCompiler<'_> {
         let search_val = self.scratch.alloc(search_vt);
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(xs_ptr); });
+        wasm!(self.func, { local_set(Local(xs_ptr)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { local_set(search_val); });
+        wasm!(self.func, { local_set(Local(search_val)); });
         wasm!(self.func, {
-            i32_const(0); local_set(i); // i
-            i32_const(0); local_set(result); // result (default: none)
+            i32_const(Imm32(0)); local_set(Local(i)); // i
+            i32_const(Imm32(0)); local_set(Local(result)); // result (default: none)
             block_empty; loop_empty;
-              local_get(i);
-              local_get(xs_ptr); i32_load(0); // len
+              local_get(Local(i));
+              local_get(Local(xs_ptr)); i32_load(0); // len
               i32_ge_u; br_if(1);
-              local_get(xs_ptr); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-              local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
+              local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+              local_get(Local(i)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
         });
         self.emit_load_at(&elem_ty, 0);
-        wasm!(self.func, { local_get(search_val); });
+        wasm!(self.func, { local_get(Local(search_val)); });
         self.emit_eq_typed(&elem_ty);
         wasm!(self.func, {
               if_empty;
                 // Found: store some(i) and break
-                i32_const(self.emitter.layout_reg.header_size(LIST) as i32); call(self.emitter.rt.alloc); local_set(found_ptr);
-                local_get(found_ptr); local_get(i); i64_extend_i32_u; i64_store(0);
-                local_get(found_ptr); local_set(result); br(2);
+                i32_const(Imm32(self.emitter.layout_reg.header_size(LIST) as i32)); call(self.emitter.rt.alloc); local_set(Local(found_ptr));
+                local_get(Local(found_ptr)); local_get(Local(i)); i64_extend_i32_u; i64_store(0);
+                local_get(Local(found_ptr)); local_set(Local(result)); br(2);
               end;
-              local_get(i); i32_const(1); i32_add; local_set(i);
+              local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
               br(0);
             end; end;
-            local_get(result); // result (none if not found)
+            local_get(Local(result)); // result (none if not found)
         });
 
         self.scratch.free(search_val, search_vt);
@@ -927,56 +928,56 @@ impl FuncCompiler<'_> {
 
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(src);
-            local_get(src); i32_load(0); local_set(src_len); // src_len
-            i32_const(self.emitter.layout_reg.header_size(LIST) as i32); local_get(src_len); i32_const(es); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(dst); // dst
-            local_get(dst); i32_const(0); i32_store(0);
-            i32_const(0); local_set(i); // i
+            local_set(Local(src));
+            local_get(Local(src)); i32_load(0); local_set(Local(src_len)); // src_len
+            i32_const(Imm32(self.emitter.layout_reg.header_size(LIST) as i32)); local_get(Local(src_len)); i32_const(Imm32(es)); i32_mul; i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(dst)); // dst
+            local_get(Local(dst)); i32_const(Imm32(0)); i32_store(0);
+            i32_const(Imm32(0)); local_set(Local(i)); // i
             block_empty; loop_empty;
-              local_get(i); local_get(src_len); i32_ge_u; br_if(1);
+              local_get(Local(i)); local_get(Local(src_len)); i32_ge_u; br_if(1);
               // Check if src[i] already in dst
-              i32_const(0); local_set(j); // j
-              i32_const(0); local_set(found); // found
+              i32_const(Imm32(0)); local_set(Local(j)); // j
+              i32_const(Imm32(0)); local_set(Local(found)); // found
               block_empty; loop_empty;
-                local_get(j); local_get(dst); i32_load(0); i32_ge_u; br_if(1);
-                local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                local_get(i); i32_const(es); i32_mul; i32_add;
+                local_get(Local(j)); local_get(Local(dst)); i32_load(0); i32_ge_u; br_if(1);
+                local_get(Local(src)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
         });
         self.emit_load_at(&elem_ty, 0);
         wasm!(self.func, {
-                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                local_get(j); i32_const(es); i32_mul; i32_add;
+                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+                local_get(Local(j)); i32_const(Imm32(es)); i32_mul; i32_add;
         });
         self.emit_load_at(&elem_ty, 0);
         // Structural eq: collapse all value-equal elements (String + compound),
         // matching native unique-by-`==`, not by pointer identity.
         self.emit_eq_typed(&elem_ty);
         wasm!(self.func, {
-                if_empty; i32_const(1); local_set(found); br(2); end;
-                local_get(j); i32_const(1); i32_add; local_set(j);
+                if_empty; i32_const(Imm32(1)); local_set(Local(found)); br(2); end;
+                local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                 br(0);
               end; end;
-              local_get(found); i32_eqz;
+              local_get(Local(found)); i32_eqz;
               if_empty;
-                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                local_get(dst); i32_load(0); i32_const(es); i32_mul; i32_add;
-                local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32); i32_add;
-                local_get(i); i32_const(es); i32_mul; i32_add;
+                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+                local_get(Local(dst)); i32_load(0); i32_const(Imm32(es)); i32_mul; i32_add;
+                local_get(Local(src)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
         });
         // SHARE: a unique element copied from the borrowed source list into the fresh
         // result — dup it so the result owns its reference (else the source's
         // scope-end Dec deep-frees the element the result now holds).
         self.emit_elem_copy_owned(&elem_ty);
         wasm!(self.func, {
-                local_get(dst);
-                local_get(dst); i32_load(0); i32_const(1); i32_add;
+                local_get(Local(dst));
+                local_get(Local(dst)); i32_load(0); i32_const(Imm32(1)); i32_add;
                 i32_store(0);
               end;
-              local_get(i); i32_const(1); i32_add; local_set(i);
+              local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
               br(0);
             end; end;
-            local_get(dst);
+            local_get(Local(dst));
         });
 
         self.scratch.free_i32(found);
@@ -1002,53 +1003,53 @@ impl FuncCompiler<'_> {
         // Store src
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(src_ptr);
+            local_set(Local(src_ptr));
             // len
-            local_get(src_ptr);
+            local_get(Local(src_ptr));
             i32_load(0);
-            local_set(len_local);
+            local_set(Local(len_local));
             // Alloc dst: [len] + len * ptr_size(4)
-            i32_const(self.emitter.layout_reg.header_size(LIST) as i32);
-            local_get(len_local);
-            i32_const(I32_BYTES); // each entry is a tuple ptr (i32)
+            i32_const(Imm32(self.emitter.layout_reg.header_size(LIST) as i32));
+            local_get(Local(len_local));
+            i32_const(Imm32(I32_BYTES)); // each entry is a tuple ptr (i32)
             i32_mul;
             i32_add;
             call(self.emitter.rt.alloc);
-            local_set(dst_ptr);
+            local_set(Local(dst_ptr));
             // Store len in dst
-            local_get(dst_ptr);
-            local_get(len_local);
+            local_get(Local(dst_ptr));
+            local_get(Local(len_local));
             i32_store(0);
             // Loop: create tuples
-            i32_const(0);
-            local_set(idx_local);
+            i32_const(Imm32(0));
+            local_set(Local(idx_local));
             block_empty;
             loop_empty;
         });
         let depth_guard = self.depth_push_n(2);
 
         wasm!(self.func, {
-            local_get(idx_local);
-            local_get(len_local);
+            local_get(Local(idx_local));
+            local_get(Local(len_local));
             i32_ge_u;
             br_if(1);
             // Alloc tuple: [index:i64][element]
-            i32_const(tuple_size as i32);
+            i32_const(Imm32(tuple_size as i32));
             call(self.emitter.rt.alloc);
-            local_set(tuple_ptr); // tuple_ptr
+            local_set(Local(tuple_ptr)); // tuple_ptr
             // tuple.index = idx (as i64)
-            local_get(tuple_ptr);
-            local_get(idx_local);
+            local_get(Local(tuple_ptr));
+            local_get(Local(idx_local));
             i64_extend_i32_u;
             i64_store(0);
             // tuple.element = src[idx]
-            local_get(tuple_ptr);
+            local_get(Local(tuple_ptr));
             // Load src element
-            local_get(src_ptr);
-            i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32);
+            local_get(Local(src_ptr));
+            i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32));
             i32_add;
-            local_get(idx_local);
-            i32_const(elem_size as i32);
+            local_get(Local(idx_local));
+            i32_const(Imm32(elem_size as i32));
             i32_mul;
             i32_add;
         });
@@ -1061,20 +1062,20 @@ impl FuncCompiler<'_> {
 
         wasm!(self.func, {
             // dst[idx] = tuple_ptr
-            local_get(dst_ptr);
-            i32_const(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32);
+            local_get(Local(dst_ptr));
+            i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32));
             i32_add;
-            local_get(idx_local);
-            i32_const(I32_BYTES); // tuple ptrs are i32
+            local_get(Local(idx_local));
+            i32_const(Imm32(I32_BYTES)); // tuple ptrs are i32
             i32_mul;
             i32_add;
-            local_get(tuple_ptr);
+            local_get(Local(tuple_ptr));
             i32_store(0);
             // idx++
-            local_get(idx_local);
-            i32_const(1);
+            local_get(Local(idx_local));
+            i32_const(Imm32(1));
             i32_add;
-            local_set(idx_local);
+            local_set(Local(idx_local));
             br(0);
         });
 
@@ -1083,7 +1084,7 @@ impl FuncCompiler<'_> {
             end;
             end;
             // Return dst
-            local_get(dst_ptr);
+            local_get(Local(dst_ptr));
         });
 
         self.scratch.free_i32(tuple_ptr);

--- a/crates/almide-codegen/src/emit_wasm/calls_map.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map.rs
@@ -6,6 +6,7 @@
 //! Total size = 8 + cap + cap * entry_size.
 //! Cap is always a power of 2. Resize at 75% load factor.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::FuncCompiler;
 use super::values;
 use almide_ir::IrExpr;
@@ -38,11 +39,11 @@ impl FuncCompiler<'_> {
                 // Empty map: header only, cap=0
                 let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(map_hdr);
-                    call(self.emitter.rt.alloc); local_set(scratch);
-                    local_get(scratch); i32_const(0); i32_store(0);
-                    local_get(scratch); i32_const(0); i32_store(map_cap_off);
-                    local_get(scratch);
+                    i32_const(Imm32(map_hdr));
+                    call(self.emitter.rt.alloc); local_set(Local(scratch));
+                    local_get(Local(scratch)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(scratch)); i32_const(Imm32(0)); i32_store(map_cap_off);
+                    local_get(Local(scratch));
                 });
                 self.scratch.free_i32(scratch);
             }
@@ -73,56 +74,56 @@ impl FuncCompiler<'_> {
                 let vc = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
                 self.emit_search_key_store(&key_ty, sk32, sk64);
 
                 wasm!(self.func, {
-                    i32_const(0); local_set(result);
-                    local_get(m); i32_load(map_cap_off); local_set(cap);
-                    local_get(cap); i32_eqz;
+                    i32_const(Imm32(0)); local_set(Local(result));
+                    local_get(Local(m)); i32_load(map_cap_off); local_set(Local(cap));
+                    local_get(Local(cap)); i32_eqz;
                     if_empty; else_;
                 });
                 self.emit_dict_index_base(m, cap);
-                wasm!(self.func, { local_set(ib); });
+                wasm!(self.func, { local_set(Local(ib)); });
                 self.emit_dict_entries_base(m, cap);
-                wasm!(self.func, { local_set(eb); });
+                wasm!(self.func, { local_set(Local(eb)); });
                 self.emit_search_key_load(&key_ty, sk32, sk64);
                 self.emit_hash_key(&key_ty);
                 self.emit_h1_h2(cap, idx, h2);
                 wasm!(self.func, {
                     block_empty; loop_empty;
-                      local_get(m); i32_const(map_tags_off); i32_add;
-                      local_get(idx); i32_add; i32_load8_u(0); local_set(tg);
-                      local_get(tg); i32_eqz; br_if(1); // empty slot → absent
-                      local_get(tg); local_get(h2); i32_eq;
+                      local_get(Local(m)); i32_const(Imm32(map_tags_off)); i32_add;
+                      local_get(Local(idx)); i32_add; i32_load8_u(0); local_set(Local(tg));
+                      local_get(Local(tg)); i32_eqz; br_if(1); // empty slot → absent
+                      local_get(Local(tg)); local_get(Local(h2)); i32_eq;
                       if_empty;
                         // ei = index[idx] - 1 ; entry = eb + ei*es (key @0)
-                        local_get(ib); local_get(idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
-                        i32_load(0); i32_const(1); i32_sub; local_set(ei);
-                        local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
+                        local_get(Local(ib)); local_get(Local(idx)); i32_const(Imm32(lm::INDEX_SLOT_SIZE as i32)); i32_mul; i32_add;
+                        i32_load(0); i32_const(Imm32(1)); i32_sub; local_set(Local(ei));
+                        local_get(Local(eb)); local_get(Local(ei)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 self.emit_search_key_load(&key_ty, sk32, sk64);
                 self.emit_key_eq(&key_ty);
                 wasm!(self.func, {
                         if_empty;
-                          i32_const(vs as i32); call(self.emitter.rt.alloc); local_set(vc);
-                          local_get(vc);
-                          local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
-                          i32_const(ks as i32); i32_add;
+                          i32_const(Imm32(vs as i32)); call(self.emitter.rt.alloc); local_set(Local(vc));
+                          local_get(Local(vc));
+                          local_get(Local(eb)); local_get(Local(ei)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                          i32_const(Imm32(ks as i32)); i32_add;
                 });
                 self.emit_elem_copy_sized(vs, false);
                 wasm!(self.func, {
-                          local_get(vc); local_set(result); br(3);
+                          local_get(Local(vc)); local_set(Local(result)); br(3);
                         end;
                       end;
-                      local_get(idx); i32_const(1); i32_add;
-                      local_get(cap); i32_const(1); i32_sub; i32_and;
-                      local_set(idx); br(0);
+                      local_get(Local(idx)); i32_const(Imm32(1)); i32_add;
+                      local_get(Local(cap)); i32_const(Imm32(1)); i32_sub; i32_and;
+                      local_set(Local(idx)); br(0);
                     end; end;
                     end; // cap!=0
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(vc);
                 self.scratch.free_i32(result);
@@ -156,45 +157,45 @@ impl FuncCompiler<'_> {
                 let found = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
                 self.emit_search_key_store(&key_ty, sk32, sk64);
                 wasm!(self.func, {
-                    i32_const(0); local_set(found);
-                    local_get(m); i32_load(map_cap_off); local_set(cap);
-                    local_get(cap); i32_eqz;
+                    i32_const(Imm32(0)); local_set(Local(found));
+                    local_get(Local(m)); i32_load(map_cap_off); local_set(Local(cap));
+                    local_get(Local(cap)); i32_eqz;
                     if_empty; else_;
                 });
                 self.emit_dict_index_base(m, cap);
-                wasm!(self.func, { local_set(ib); });
+                wasm!(self.func, { local_set(Local(ib)); });
                 self.emit_dict_entries_base(m, cap);
-                wasm!(self.func, { local_set(eb); });
+                wasm!(self.func, { local_set(Local(eb)); });
                 self.emit_search_key_load(&key_ty, sk32, sk64);
                 self.emit_hash_key(&key_ty);
                 self.emit_h1_h2(cap, idx, h2);
                 wasm!(self.func, {
                     block_empty; loop_empty;
-                      local_get(m); i32_const(map_tags_off); i32_add;
-                      local_get(idx); i32_add; i32_load8_u(0); local_set(tg);
-                      local_get(tg); i32_eqz; br_if(1);
-                      local_get(tg); local_get(h2); i32_eq;
+                      local_get(Local(m)); i32_const(Imm32(map_tags_off)); i32_add;
+                      local_get(Local(idx)); i32_add; i32_load8_u(0); local_set(Local(tg));
+                      local_get(Local(tg)); i32_eqz; br_if(1);
+                      local_get(Local(tg)); local_get(Local(h2)); i32_eq;
                       if_empty;
-                        local_get(ib); local_get(idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
-                        i32_load(0); i32_const(1); i32_sub; local_set(ei);
-                        local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
+                        local_get(Local(ib)); local_get(Local(idx)); i32_const(Imm32(lm::INDEX_SLOT_SIZE as i32)); i32_mul; i32_add;
+                        i32_load(0); i32_const(Imm32(1)); i32_sub; local_set(Local(ei));
+                        local_get(Local(eb)); local_get(Local(ei)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 self.emit_search_key_load(&key_ty, sk32, sk64);
                 self.emit_key_eq(&key_ty);
                 wasm!(self.func, {
-                        if_empty; i32_const(1); local_set(found); br(3); end;
+                        if_empty; i32_const(Imm32(1)); local_set(Local(found)); br(3); end;
                       end;
-                      local_get(idx); i32_const(1); i32_add;
-                      local_get(cap); i32_const(1); i32_sub; i32_and;
-                      local_set(idx); br(0);
+                      local_get(Local(idx)); i32_const(Imm32(1)); i32_add;
+                      local_get(Local(cap)); i32_const(Imm32(1)); i32_sub; i32_and;
+                      local_set(Local(idx)); br(0);
                     end; end;
                     end;
-                    local_get(found); i32_eqz;
+                    local_get(Local(found)); i32_eqz;
                 });
                 match vt {
                     ValType::I64 => { wasm!(self.func, { if_i64; }); }
@@ -204,8 +205,8 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[2]);
                 wasm!(self.func, { else_; });
                 wasm!(self.func, {
-                    local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
-                    i32_const(ks as i32); i32_add;
+                    local_get(Local(eb)); local_get(Local(ei)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                    i32_const(Imm32(ks as i32)); i32_add;
                 });
                 self.emit_load_at(&val_ty, 0);
                 wasm!(self.func, { end; });
@@ -239,45 +240,45 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
                 self.emit_search_key_store(&key_ty, sk32, sk64);
                 wasm!(self.func, {
-                    i32_const(0); local_set(result);
-                    local_get(m); i32_load(map_cap_off); local_set(cap);
-                    local_get(cap); i32_eqz;
+                    i32_const(Imm32(0)); local_set(Local(result));
+                    local_get(Local(m)); i32_load(map_cap_off); local_set(Local(cap));
+                    local_get(Local(cap)); i32_eqz;
                     if_empty; else_;
                 });
                 self.emit_dict_index_base(m, cap);
-                wasm!(self.func, { local_set(ib); });
+                wasm!(self.func, { local_set(Local(ib)); });
                 self.emit_dict_entries_base(m, cap);
-                wasm!(self.func, { local_set(eb); });
+                wasm!(self.func, { local_set(Local(eb)); });
                 self.emit_search_key_load(&key_ty, sk32, sk64);
                 self.emit_hash_key(&key_ty);
                 self.emit_h1_h2(cap, idx, h2);
                 wasm!(self.func, {
                     block_empty; loop_empty;
-                      local_get(m); i32_const(map_tags_off); i32_add;
-                      local_get(idx); i32_add; i32_load8_u(0); local_set(tg);
-                      local_get(tg); i32_eqz; br_if(1);
-                      local_get(tg); local_get(h2); i32_eq;
+                      local_get(Local(m)); i32_const(Imm32(map_tags_off)); i32_add;
+                      local_get(Local(idx)); i32_add; i32_load8_u(0); local_set(Local(tg));
+                      local_get(Local(tg)); i32_eqz; br_if(1);
+                      local_get(Local(tg)); local_get(Local(h2)); i32_eq;
                       if_empty;
-                        local_get(ib); local_get(idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
-                        i32_load(0); i32_const(1); i32_sub; local_set(ei);
-                        local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
+                        local_get(Local(ib)); local_get(Local(idx)); i32_const(Imm32(lm::INDEX_SLOT_SIZE as i32)); i32_mul; i32_add;
+                        i32_load(0); i32_const(Imm32(1)); i32_sub; local_set(Local(ei));
+                        local_get(Local(eb)); local_get(Local(ei)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 self.emit_search_key_load(&key_ty, sk32, sk64);
                 self.emit_key_eq(&key_ty);
                 wasm!(self.func, {
-                        if_empty; i32_const(1); local_set(result); br(3); end;
+                        if_empty; i32_const(Imm32(1)); local_set(Local(result)); br(3); end;
                       end;
-                      local_get(idx); i32_const(1); i32_add;
-                      local_get(cap); i32_const(1); i32_sub; i32_and;
-                      local_set(idx); br(0);
+                      local_get(Local(idx)); i32_const(Imm32(1)); i32_add;
+                      local_get(Local(cap)); i32_const(Imm32(1)); i32_sub; i32_and;
+                      local_set(Local(idx)); br(0);
                     end; end;
                     end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(tg);
@@ -310,12 +311,12 @@ impl FuncCompiler<'_> {
                 let eb = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 // Materialize the (key,val) into a temp entry buffer (key@0, val@ks).
-                wasm!(self.func, { i32_const(es as i32); call(self.emitter.rt.alloc); local_set(tmp); local_get(tmp); });
+                wasm!(self.func, { i32_const(Imm32(es as i32)); call(self.emitter.rt.alloc); local_set(Local(tmp)); local_get(Local(tmp)); });
                 self.emit_expr(&args[1]);
                 self.emit_key_store(&key_ty, 0);
-                wasm!(self.func, { local_get(tmp); i32_const(ks as i32); i32_add; });
+                wasm!(self.func, { local_get(Local(tmp)); i32_const(Imm32(ks as i32)); i32_add; });
                 self.emit_expr(&args[2]);
                 match vt {
                     ValType::I64 => { wasm!(self.func, { i64_store(0); }); }
@@ -323,18 +324,18 @@ impl FuncCompiler<'_> {
                     _ => { wasm!(self.func, { i32_store(0); }); }
                 }
                 wasm!(self.func, {
-                    local_get(m); i32_load(map_cap_off); local_set(old_cap);
-                    local_get(m); i32_load(0); i32_const(1); i32_add; local_set(n);
+                    local_get(Local(m)); i32_load(map_cap_off); local_set(Local(old_cap));
+                    local_get(Local(m)); i32_load(0); i32_const(Imm32(1)); i32_add; local_set(Local(n));
                 });
                 self.emit_dict_fit_cap(n, cap);
                 self.emit_dict_alloc(nm, cap, es);
                 self.emit_dict_recap(m, old_cap, nm, cap, es, &key_ty, Some((&key_ty, &val_ty)));
                 self.emit_dict_index_base(nm, cap);
-                wasm!(self.func, { local_set(ib); });
+                wasm!(self.func, { local_set(Local(ib)); });
                 self.emit_dict_entries_base(nm, cap);
-                wasm!(self.func, { local_set(eb); });
+                wasm!(self.func, { local_set(Local(eb)); });
                 self.emit_dict_put_entry(nm, cap, ib, eb, tmp, es, ks, vs, &key_ty, &val_ty);
-                wasm!(self.func, { local_get(nm); });
+                wasm!(self.func, { local_get(Local(nm)); });
 
                 self.scratch.free_i32(eb);
                 self.scratch.free_i32(ib);
@@ -360,12 +361,12 @@ impl FuncCompiler<'_> {
                 let eb = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 // Materialize the (key,val) into a temp entry buffer (key@0, val@ks).
-                wasm!(self.func, { i32_const(es as i32); call(self.emitter.rt.alloc); local_set(tmp); local_get(tmp); });
+                wasm!(self.func, { i32_const(Imm32(es as i32)); call(self.emitter.rt.alloc); local_set(Local(tmp)); local_get(Local(tmp)); });
                 self.emit_expr(&args[1]);
                 self.emit_key_store(&key_ty, 0);
-                wasm!(self.func, { local_get(tmp); i32_const(ks as i32); i32_add; });
+                wasm!(self.func, { local_get(Local(tmp)); i32_const(Imm32(ks as i32)); i32_add; });
                 self.emit_expr(&args[2]);
                 match vt {
                     ValType::I64 => { wasm!(self.func, { i64_store(0); }); }
@@ -374,22 +375,22 @@ impl FuncCompiler<'_> {
                 }
                 // Ensure allocated (cap==0 → fresh INITIAL_CAP table into m).
                 wasm!(self.func, {
-                    local_get(m); i32_load(map_cap_off); local_set(cap);
-                    local_get(cap); i32_eqz;
+                    local_get(Local(m)); i32_load(map_cap_off); local_set(Local(cap));
+                    local_get(Local(cap)); i32_eqz;
                     if_empty;
-                      i32_const(lm::INITIAL_CAP as i32); local_set(cap);
+                      i32_const(Imm32(lm::INITIAL_CAP as i32)); local_set(Local(cap));
                 });
                 self.emit_dict_alloc(m, cap, es);
                 wasm!(self.func, { end; });
                 self.emit_dict_index_base(m, cap);
-                wasm!(self.func, { local_set(ib); });
+                wasm!(self.func, { local_set(Local(ib)); });
                 self.emit_dict_entries_base(m, cap);
-                wasm!(self.func, { local_set(eb); });
+                wasm!(self.func, { local_set(Local(eb)); });
                 self.emit_dict_put_entry(m, cap, ib, eb, tmp, es, ks, vs, &key_ty, &val_ty);
                 // Grow if the load factor is exceeded (only a new key can trip it).
                 wasm!(self.func, {
-                    local_get(m); i32_load(0); i32_const(lm::LOAD_DEN as i32); i32_mul;
-                    local_get(cap); i32_const(lm::LOAD_NUM as i32); i32_mul;
+                    local_get(Local(m)); i32_load(0); i32_const(Imm32(lm::LOAD_DEN as i32)); i32_mul;
+                    local_get(Local(cap)); i32_const(Imm32(lm::LOAD_NUM as i32)); i32_mul;
                     i32_gt_u;
                     if_empty;
                 });
@@ -426,26 +427,26 @@ impl FuncCompiler<'_> {
                 let entry = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
                 self.emit_search_key_store(&key_ty, sk32, sk64);
                 wasm!(self.func, {
-                    local_get(m); i32_load(map_cap_off); local_set(cap_old);
-                    local_get(m); i32_load(0); local_set(len);
+                    local_get(Local(m)); i32_load(map_cap_off); local_set(Local(cap_old));
+                    local_get(Local(m)); i32_load(0); local_set(Local(len));
                 });
                 self.emit_dict_fit_cap(len, new_cap);
                 self.emit_dict_alloc(nm, new_cap, es);
                 self.emit_dict_entries_base(m, cap_old);
-                wasm!(self.func, { local_set(eb_old); });
+                wasm!(self.func, { local_set(Local(eb_old)); });
                 self.emit_dict_entries_base(nm, new_cap);
                 wasm!(self.func, {
-                    local_set(eb_new);
-                    i32_const(0); local_set(ne);
-                    i32_const(0); local_set(i);
+                    local_set(Local(eb_new));
+                    i32_const(Imm32(0)); local_set(Local(ne));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add; local_set(entry);
-                      local_get(entry);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(eb_old)); local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add; local_set(Local(entry));
+                      local_get(Local(entry));
                 });
                 self.emit_key_load(&key_ty, 0);
                 self.emit_search_key_load(&key_ty, sk32, sk64);
@@ -453,8 +454,8 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                       i32_eqz;
                       if_empty;  // key != search key → keep (append densely)
-                        local_get(eb_new); local_get(ne); i32_const(es as i32); i32_mul; i32_add;
-                        local_get(entry); i32_const(es as i32); memory_copy;
+                        local_get(Local(eb_new)); local_get(Local(ne)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                        local_get(Local(entry)); i32_const(Imm32(es as i32)); memory_copy;
                 });
                 // SHARE dup: the source dict survives `remove` and owns the
                 // kept entries — the survivor copy needs its own references.
@@ -463,24 +464,24 @@ impl FuncCompiler<'_> {
                     let vh = crate::pass_perceus::is_heap_type(&self.map_val_ty(&args[0].ty));
                     if kh {
                         wasm!(self.func, {
-                        local_get(eb_new); local_get(ne); i32_const(es as i32); i32_mul; i32_add;
+                        local_get(Local(eb_new)); local_get(Local(ne)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
                         i32_load(0); call(self.emitter.rt.rc_inc); drop;
                         });
                     }
                     if vh {
                         wasm!(self.func, {
-                        local_get(eb_new); local_get(ne); i32_const(es as i32); i32_mul; i32_add;
-                        i32_const(ks as i32); i32_add;
+                        local_get(Local(eb_new)); local_get(Local(ne)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                        i32_const(Imm32(ks as i32)); i32_add;
                         i32_load(0); call(self.emitter.rt.rc_inc); drop;
                         });
                     }
                 }
                 wasm!(self.func, {
-                        local_get(ne); i32_const(1); i32_add; local_set(ne);
+                        local_get(Local(ne)); i32_const(Imm32(1)); i32_add; local_set(Local(ne));
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i); br(0);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i)); br(0);
                     end; end;
-                    local_get(nm); local_get(ne); i32_store(0); // nm.len = survivor count
+                    local_get(Local(nm)); local_get(Local(ne)); i32_store(0); // nm.len = survivor count
                 });
                 self.emit_dict_rebuild_index(nm, new_cap, es, &key_ty);
                 if is_delete {
@@ -488,7 +489,7 @@ impl FuncCompiler<'_> {
                     self.emit_mutator_writeback(&args[0], nm);
                 } else {
                     // remove: returns the rebuilt map as the expression value.
-                    wasm!(self.func, { local_get(nm); });
+                    wasm!(self.func, { local_get(Local(nm)); });
                 }
                 self.scratch.free_i32(entry);
                 self.scratch.free_i32(eb_new);
@@ -520,26 +521,26 @@ impl FuncCompiler<'_> {
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(m);
-                    local_get(m); i32_load(0); local_set(len);
-                    local_get(m); i32_load(map_cap_off); local_set(cap);
+                    local_set(Local(m));
+                    local_get(Local(m)); i32_load(0); local_set(Local(len));
+                    local_get(Local(m)); i32_load(map_cap_off); local_set(Local(cap));
                 });
                 self.emit_dict_entries_base(m, cap);
                 wasm!(self.func, {
-                    local_set(eb);
-                    i32_const(list_hdr); local_get(len); i32_const(elem_size as i32); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); local_get(len); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_set(Local(eb));
+                    i32_const(Imm32(list_hdr)); local_get(Local(len)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); local_get(Local(len)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                 });
                 match method {
                     "keys" => {
                         wasm!(self.func, {
-                            local_get(result); i32_const(list_data_off); i32_add;
-                            local_get(i); i32_const(ks as i32); i32_mul; i32_add;
-                            local_get(eb); local_get(i); i32_const(es as i32); i32_mul; i32_add;
+                            local_get(Local(result)); i32_const(Imm32(list_data_off)); i32_add;
+                            local_get(Local(i)); i32_const(Imm32(ks as i32)); i32_mul; i32_add;
+                            local_get(Local(eb)); local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
                         });
                         // SHARE: the dict survives and owns these keys.
                         let dup = crate::pass_perceus::is_heap_type(&self.map_key_ty(&args[0].ty));
@@ -547,30 +548,30 @@ impl FuncCompiler<'_> {
                     }
                     "values" => {
                         wasm!(self.func, {
-                            local_get(result); i32_const(list_data_off); i32_add;
-                            local_get(i); i32_const(vs as i32); i32_mul; i32_add;
-                            local_get(eb); local_get(i); i32_const(es as i32); i32_mul; i32_add;
-                            i32_const(ks as i32); i32_add;
+                            local_get(Local(result)); i32_const(Imm32(list_data_off)); i32_add;
+                            local_get(Local(i)); i32_const(Imm32(vs as i32)); i32_mul; i32_add;
+                            local_get(Local(eb)); local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                            i32_const(Imm32(ks as i32)); i32_add;
                         });
                         let dup = crate::pass_perceus::is_heap_type(&self.map_val_ty(&args[0].ty));
                         self.emit_elem_copy_sized(vs, dup);
                     }
                     _ => {
                         wasm!(self.func, {
-                            i32_const(es as i32); call(self.emitter.rt.alloc); local_set(tp);
-                            local_get(tp);
-                            local_get(eb); local_get(i); i32_const(es as i32); i32_mul; i32_add;
-                            i32_const(es as i32); memory_copy;
-                            local_get(result); i32_const(list_data_off); i32_add;
-                            local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
-                            local_get(tp); i32_store(0);
+                            i32_const(Imm32(es as i32)); call(self.emitter.rt.alloc); local_set(Local(tp));
+                            local_get(Local(tp));
+                            local_get(Local(eb)); local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                            i32_const(Imm32(es as i32)); memory_copy;
+                            local_get(Local(result)); i32_const(Imm32(list_data_off)); i32_add;
+                            local_get(Local(i)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
+                            local_get(Local(tp)); i32_store(0);
                         });
                     }
                 }
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i); br(0);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i)); br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(tp);
                 self.scratch.free_i32(eb);
@@ -603,36 +604,36 @@ impl FuncCompiler<'_> {
                 let src = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(ma); });
+                wasm!(self.func, { local_set(Local(ma)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(mb);
-                    local_get(ma); i32_load(map_cap_off); local_set(cap_a);
-                    local_get(mb); i32_load(map_cap_off); local_set(cap_b);
-                    local_get(mb); i32_load(0); local_set(len_b);
-                    local_get(ma); i32_load(0); local_get(len_b); i32_add; local_set(n);
+                    local_set(Local(mb));
+                    local_get(Local(ma)); i32_load(map_cap_off); local_set(Local(cap_a));
+                    local_get(Local(mb)); i32_load(map_cap_off); local_set(Local(cap_b));
+                    local_get(Local(mb)); i32_load(0); local_set(Local(len_b));
+                    local_get(Local(ma)); i32_load(0); local_get(Local(len_b)); i32_add; local_set(Local(n));
                 });
                 self.emit_dict_fit_cap(n, r_cap);
                 self.emit_dict_alloc(result, r_cap, es);
                 self.emit_dict_recap(ma, cap_a, result, r_cap, es, &key_ty, Some((&key_ty, &val_ty)));
                 self.emit_dict_index_base(result, r_cap);
-                wasm!(self.func, { local_set(ib); });
+                wasm!(self.func, { local_set(Local(ib)); });
                 self.emit_dict_entries_base(result, r_cap);
-                wasm!(self.func, { local_set(eb); });
+                wasm!(self.func, { local_set(Local(eb)); });
                 self.emit_dict_entries_base(mb, cap_b);
                 wasm!(self.func, {
-                    local_set(eb_b);
-                    i32_const(0); local_set(j);
+                    local_set(Local(eb_b));
+                    i32_const(Imm32(0)); local_set(Local(j));
                     block_empty; loop_empty;
-                      local_get(j); local_get(len_b); i32_ge_u; br_if(1);
-                      local_get(eb_b); local_get(j); i32_const(es as i32); i32_mul; i32_add; local_set(src);
+                      local_get(Local(j)); local_get(Local(len_b)); i32_ge_u; br_if(1);
+                      local_get(Local(eb_b)); local_get(Local(j)); i32_const(Imm32(es as i32)); i32_mul; i32_add; local_set(Local(src));
                 });
                 let val_ty = self.map_val_ty(&args[0].ty);
                 self.emit_dict_put_entry(result, r_cap, ib, eb, src, es, ks, vs, &key_ty, &val_ty);
                 wasm!(self.func, {
-                      local_get(j); i32_const(1); i32_add; local_set(j); br(0);
+                      local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j)); br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(src);
                 self.scratch.free_i32(j);
@@ -670,28 +671,28 @@ impl FuncCompiler<'_> {
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(pairs);
-                    local_get(pairs); i32_load(0); local_set(plen);
+                    local_set(Local(pairs));
+                    local_get(Local(pairs)); i32_load(0); local_set(Local(plen));
                 });
                 self.emit_dict_fit_cap(plen, cap);
                 self.emit_dict_alloc(result, cap, es);
                 self.emit_dict_index_base(result, cap);
-                wasm!(self.func, { local_set(ib); });
+                wasm!(self.func, { local_set(Local(ib)); });
                 self.emit_dict_entries_base(result, cap);
                 wasm!(self.func, {
-                    local_set(eb);
-                    i32_const(0); local_set(i);
+                    local_set(Local(eb));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(plen); i32_ge_u; br_if(1);
-                      local_get(pairs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(PTR_SIZE); i32_mul; i32_add;
-                      i32_load(0); local_set(tp); // tp = pairs.data[i] = (K,V) tuple ptr
+                      local_get(Local(i)); local_get(Local(plen)); i32_ge_u; br_if(1);
+                      local_get(Local(pairs)); i32_const(Imm32(list_data_off)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(PTR_SIZE)); i32_mul; i32_add;
+                      i32_load(0); local_set(Local(tp)); // tp = pairs.data[i] = (K,V) tuple ptr
                 });
                 self.emit_dict_put_entry(result, cap, ib, eb, tp, es, ks, vs, &key_ty, &val_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i); br(0);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i)); br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(tp);
                 self.scratch.free_i32(i);
@@ -705,10 +706,10 @@ impl FuncCompiler<'_> {
             "clear" => {
                 let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(map_hdr);
-                    call(self.emitter.rt.alloc); local_set(scratch);
-                    local_get(scratch); i32_const(0); i32_store(0);
-                    local_get(scratch); i32_const(0); i32_store(map_cap_off);
+                    i32_const(Imm32(map_hdr));
+                    call(self.emitter.rt.alloc); local_set(Local(scratch));
+                    local_get(Local(scratch)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(scratch)); i32_const(Imm32(0)); i32_store(map_cap_off);
                 });
                 // clear allocates a fresh empty map; write it back to the binding —
                 // into the cell for a mutable capture. clear -> Unit, so nothing is
@@ -729,14 +730,14 @@ impl FuncCompiler<'_> {
         use super::engine::layout::map as lm;
         let ht = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_tee(ht);
-            local_get(cap); i32_const(1); i32_sub; i32_and;
-            local_set(idx_local);
-            local_get(ht);
-            i32_const(lm::H2_SHIFT as i32); i32_shr_u; i32_const(lm::H2_MASK as i32); i32_and;
-            local_tee(h2_local);
+            local_tee(Local(ht));
+            local_get(Local(cap)); i32_const(Imm32(1)); i32_sub; i32_and;
+            local_set(Local(idx_local));
+            local_get(Local(ht));
+            i32_const(Imm32(lm::H2_SHIFT as i32)); i32_shr_u; i32_const(Imm32(lm::H2_MASK as i32)); i32_and;
+            local_tee(Local(h2_local));
             i32_eqz;
-            if_empty; i32_const(1); local_set(h2_local); end; // avoid 0 (empty)
+            if_empty; i32_const(Imm32(1)); local_set(Local(h2_local)); end; // avoid 0 (empty)
         });
         self.scratch.free_i32(ht);
     }
@@ -751,11 +752,11 @@ impl FuncCompiler<'_> {
             Ty::Int | Ty::Int64 | Ty::UInt64 => {
                 let tmp = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_tee(tmp);
-                    i64_const(I64_HALF_BITS); i64_shr_u;
-                    local_get(tmp); i64_xor;
-                    i64_const(HASH_MIX_MUL); i64_mul;
-                    i64_const(I64_HALF_BITS); i64_shr_u;
+                    local_tee(Local(tmp));
+                    i64_const(Imm64(I64_HALF_BITS)); i64_shr_u;
+                    local_get(Local(tmp)); i64_xor;
+                    i64_const(Imm64(HASH_MIX_MUL)); i64_mul;
+                    i64_const(Imm64(I64_HALF_BITS)); i64_shr_u;
                     i32_wrap_i64;
                 });
                 self.scratch.free_i64(tmp);
@@ -766,22 +767,22 @@ impl FuncCompiler<'_> {
                 let slen = self.scratch.alloc_i32();
                 let si = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(s);
-                    i32_const(FNV1A_OFFSET_BASIS); local_set(h);
-                    local_get(s); i32_load(0); local_set(slen);
-                    i32_const(0); local_set(si);
+                    local_set(Local(s));
+                    i32_const(Imm32(FNV1A_OFFSET_BASIS)); local_set(Local(h));
+                    local_get(Local(s)); i32_load(0); local_set(Local(slen));
+                    i32_const(Imm32(0)); local_set(Local(si));
                     block_empty; loop_empty;
-                      local_get(si); local_get(slen); i32_ge_u; br_if(1);
-                      local_get(h);
-                      local_get(s); i32_const(str_data_off); i32_add;
-                      local_get(si); i32_add; i32_load8_u(0);
+                      local_get(Local(si)); local_get(Local(slen)); i32_ge_u; br_if(1);
+                      local_get(Local(h));
+                      local_get(Local(s)); i32_const(Imm32(str_data_off)); i32_add;
+                      local_get(Local(si)); i32_add; i32_load8_u(0);
                       i32_xor;
-                      i32_const(FNV1A_PRIME); i32_mul;
-                      local_set(h);
-                      local_get(si); i32_const(1); i32_add; local_set(si);
+                      i32_const(Imm32(FNV1A_PRIME)); i32_mul;
+                      local_set(Local(h));
+                      local_get(Local(si)); i32_const(Imm32(1)); i32_add; local_set(Local(si));
                       br(0);
                     end; end;
-                    local_get(h);
+                    local_get(Local(h));
                 });
                 self.scratch.free_i32(si);
                 self.scratch.free_i32(slen);
@@ -820,19 +821,19 @@ impl FuncCompiler<'_> {
                         let ptr = self.scratch.alloc_i32();
                         let h = self.scratch.alloc_i32();
                         wasm!(self.func, {
-                            local_set(ptr);
-                            i32_const(FNV1A_OFFSET_BASIS); local_set(h);
+                            local_set(Local(ptr));
+                            i32_const(Imm32(FNV1A_OFFSET_BASIS)); local_set(Local(h));
                         });
                         for b in 0..size {
                             wasm!(self.func, {
-                                local_get(h);
-                                local_get(ptr); i32_load8_u(b);
+                                local_get(Local(h));
+                                local_get(Local(ptr)); i32_load8_u(b);
                                 i32_xor;
-                                i32_const(FNV1A_PRIME); i32_mul;
-                                local_set(h);
+                                i32_const(Imm32(FNV1A_PRIME)); i32_mul;
+                                local_set(Local(h));
                             });
                         }
-                        wasm!(self.func, { local_get(h); });
+                        wasm!(self.func, { local_get(Local(h)); });
                         self.scratch.free_i32(h);
                         self.scratch.free_i32(ptr);
                     }
@@ -879,25 +880,25 @@ impl FuncCompiler<'_> {
         let ptr = self.scratch.alloc_i32();
         let h = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(ptr);
-            i32_const(FNV1A_OFFSET_BASIS); local_set(h);
+            local_set(Local(ptr));
+            i32_const(Imm32(FNV1A_OFFSET_BASIS)); local_set(Local(h));
         });
         let mut offset = 0u32;
         for (_, fty) in fields {
             // h = (h ^ field_hash) * FNV_prime
             wasm!(self.func, {
-                local_get(ptr);
+                local_get(Local(ptr));
             });
             self.emit_load_at(fty, offset);
             self.emit_hash_value(fty);
             wasm!(self.func, {
-                local_get(h); i32_xor;
-                i32_const(FNV1A_PRIME); i32_mul;
-                local_set(h);
+                local_get(Local(h)); i32_xor;
+                i32_const(Imm32(FNV1A_PRIME)); i32_mul;
+                local_set(Local(h));
             });
             offset += values::byte_size(fty);
         }
-        wasm!(self.func, { local_get(h); });
+        wasm!(self.func, { local_get(Local(h)); });
         self.scratch.free_i32(h);
         self.scratch.free_i32(ptr);
     }
@@ -916,8 +917,8 @@ impl FuncCompiler<'_> {
             Ty::Float | Ty::Float64 => {
                 let tmp = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    i64_reinterpret_f64; local_tee(tmp);
-                    i64_const(I64_HALF_BITS); i64_shr_u; local_get(tmp); i64_xor;
+                    i64_reinterpret_f64; local_tee(Local(tmp));
+                    i64_const(Imm64(I64_HALF_BITS)); i64_shr_u; local_get(Local(tmp)); i64_xor;
                     i32_wrap_i64;
                 });
                 self.scratch.free_i64(tmp);
@@ -995,7 +996,7 @@ impl FuncCompiler<'_> {
                     if size == 0 {
                         wasm!(self.func, { i32_eq; });
                     } else {
-                        wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
+                        wasm!(self.func, { i32_const(Imm32(size as i32)); call(self.emitter.rt.mem_eq); });
                     }
                 }
             }
@@ -1028,10 +1029,10 @@ impl FuncCompiler<'_> {
         }
     }
     pub(super) fn emit_search_key_store(&mut self, key_ty: &Ty, s32: u32, s64: u32) {
-        match key_ty { Ty::Int | Ty::Int64 | Ty::UInt64 => { wasm!(self.func, { local_set(s64); }); } _ => { wasm!(self.func, { local_set(s32); }); } }
+        match key_ty { Ty::Int | Ty::Int64 | Ty::UInt64 => { wasm!(self.func, { local_set(Local(s64)); }); } _ => { wasm!(self.func, { local_set(Local(s32)); }); } }
     }
     pub(super) fn emit_search_key_load(&mut self, key_ty: &Ty, s32: u32, s64: u32) {
-        match key_ty { Ty::Int | Ty::Int64 | Ty::UInt64 => { wasm!(self.func, { local_get(s64); }); } _ => { wasm!(self.func, { local_get(s32); }); } }
+        match key_ty { Ty::Int | Ty::Int64 | Ty::UInt64 => { wasm!(self.func, { local_get(Local(s64)); }); } _ => { wasm!(self.func, { local_get(Local(s32)); }); } }
     }
     pub(super) fn key_valtype(key_ty: &Ty) -> ValType {
         match key_ty { Ty::Int | Ty::Int64 | Ty::UInt64 => ValType::I64, _ => ValType::I32 }
@@ -1058,7 +1059,7 @@ impl FuncCompiler<'_> {
     /// Push the INDEX region base `map + header + cap` (slots start after the tags).
     pub(super) fn emit_dict_index_base(&mut self, map: u32, cap: u32) {
         let hdr = self.emitter.layout_reg.header_size(super::engine::layout::SWISS_MAP) as i32;
-        wasm!(self.func, { local_get(map); i32_const(hdr); i32_add; local_get(cap); i32_add; });
+        wasm!(self.func, { local_get(Local(map)); i32_const(Imm32(hdr)); i32_add; local_get(Local(cap)); i32_add; });
     }
 
     /// Push the dense ENTRIES base `map + header + cap + cap*INDEX_SLOT_SIZE`.
@@ -1066,9 +1067,9 @@ impl FuncCompiler<'_> {
         use super::engine::layout::{SWISS_MAP, map as lm};
         let hdr = self.emitter.layout_reg.header_size(SWISS_MAP) as i32;
         wasm!(self.func, {
-            local_get(map); i32_const(hdr); i32_add;
-            local_get(cap); i32_add;
-            local_get(cap); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
+            local_get(Local(map)); i32_const(Imm32(hdr)); i32_add;
+            local_get(Local(cap)); i32_add;
+            local_get(Local(cap)); i32_const(Imm32(lm::INDEX_SLOT_SIZE as i32)); i32_mul; i32_add;
         });
     }
 
@@ -1082,14 +1083,14 @@ impl FuncCompiler<'_> {
         let per_slot = 1 + lm::INDEX_SLOT_SIZE as i32 + es as i32;
         let tag_plus_index = 1 + lm::INDEX_SLOT_SIZE as i32;
         wasm!(self.func, {
-            i32_const(hdr); local_get(cap); i32_const(per_slot); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(out);
-            local_get(out); i32_const(0); i32_store(0);             // len = 0
-            local_get(out); local_get(cap); i32_store(cap_off, 0);  // cap
+            i32_const(Imm32(hdr)); local_get(Local(cap)); i32_const(Imm32(per_slot)); i32_mul; i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(out));
+            local_get(Local(out)); i32_const(Imm32(0)); i32_store(0);             // len = 0
+            local_get(Local(out)); local_get(Local(cap)); i32_store(cap_off, 0);  // cap
             // zero tags+index: memory_fill(out+header, 0, cap*(1+INDEX_SLOT_SIZE))
-            local_get(out); i32_const(hdr); i32_add;
-            i32_const(0);
-            local_get(cap); i32_const(tag_plus_index); i32_mul;
+            local_get(Local(out)); i32_const(Imm32(hdr)); i32_add;
+            i32_const(Imm32(0));
+            local_get(Local(cap)); i32_const(Imm32(tag_plus_index)); i32_mul;
             memory_fill(0);
         });
     }
@@ -1099,12 +1100,12 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_dict_fit_cap(&mut self, n: u32, cap_out: u32) {
         use super::engine::layout::map as lm;
         wasm!(self.func, {
-            i32_const(lm::INITIAL_CAP as i32); local_set(cap_out);
+            i32_const(Imm32(lm::INITIAL_CAP as i32)); local_set(Local(cap_out));
             block_empty; loop_empty;
-              local_get(n); i32_const(lm::LOAD_DEN as i32); i32_mul;
-              local_get(cap_out); i32_const(lm::LOAD_NUM as i32); i32_mul;
+              local_get(Local(n)); i32_const(Imm32(lm::LOAD_DEN as i32)); i32_mul;
+              local_get(Local(cap_out)); i32_const(Imm32(lm::LOAD_NUM as i32)); i32_mul;
               i32_le_u; br_if(1);
-              local_get(cap_out); i32_const(1); i32_shl; local_set(cap_out);
+              local_get(Local(cap_out)); i32_const(Imm32(1)); i32_shl; local_set(Local(cap_out));
               br(0);
             end; end;
         });
@@ -1123,32 +1124,32 @@ impl FuncCompiler<'_> {
         let ib = self.scratch.alloc_i32();
         let idx = self.scratch.alloc_i32();
         let h2 = self.scratch.alloc_i32();
-        wasm!(self.func, { local_get(map); i32_load(0); local_set(len); });
+        wasm!(self.func, { local_get(Local(map)); i32_load(0); local_set(Local(len)); });
         self.emit_dict_index_base(map, cap);
-        wasm!(self.func, { local_set(ib); });
+        wasm!(self.func, { local_set(Local(ib)); });
         self.emit_dict_entries_base(map, cap);
         wasm!(self.func, {
-            local_set(eb);
-            i32_const(0); local_set(i);
+            local_set(Local(eb));
+            i32_const(Imm32(0)); local_set(Local(i));
             block_empty; loop_empty;
-              local_get(i); local_get(len); i32_ge_u; br_if(1);
-              local_get(eb); local_get(i); i32_const(es as i32); i32_mul; i32_add;
+              local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+              local_get(Local(eb)); local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         self.emit_key_load(key_ty, 0);
         self.emit_hash_key(key_ty);
         self.emit_h1_h2(cap, idx, h2);
         wasm!(self.func, {
               block_empty; loop_empty;
-                local_get(map); i32_const(tags_off); i32_add;
-                local_get(idx); i32_add; i32_load8_u(0); i32_eqz; br_if(1);
-                local_get(idx); i32_const(1); i32_add;
-                local_get(cap); i32_const(1); i32_sub; i32_and; local_set(idx); br(0);
+                local_get(Local(map)); i32_const(Imm32(tags_off)); i32_add;
+                local_get(Local(idx)); i32_add; i32_load8_u(0); i32_eqz; br_if(1);
+                local_get(Local(idx)); i32_const(Imm32(1)); i32_add;
+                local_get(Local(cap)); i32_const(Imm32(1)); i32_sub; i32_and; local_set(Local(idx)); br(0);
               end; end;
-              local_get(map); i32_const(tags_off); i32_add; local_get(idx); i32_add;
-              local_get(h2); i32_store8(0);
-              local_get(ib); local_get(idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
-              local_get(i); i32_const(1); i32_add; i32_store(0);
-              local_get(i); i32_const(1); i32_add; local_set(i); br(0);
+              local_get(Local(map)); i32_const(Imm32(tags_off)); i32_add; local_get(Local(idx)); i32_add;
+              local_get(Local(h2)); i32_store8(0);
+              local_get(Local(ib)); local_get(Local(idx)); i32_const(Imm32(lm::INDEX_SLOT_SIZE as i32)); i32_mul; i32_add;
+              local_get(Local(i)); i32_const(Imm32(1)); i32_add; i32_store(0);
+              local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i)); br(0);
             end; end;
         });
         self.scratch.free_i32(h2);
@@ -1164,12 +1165,12 @@ impl FuncCompiler<'_> {
     /// be `emit_dict_alloc`-ed at `dst_cap` (entries stride `es`, tags+index zeroed).
     pub(super) fn emit_dict_recap(&mut self, src: u32, src_cap: u32, dst: u32, dst_cap: u32, es: u32, key_ty: &Ty, dup: Option<(&Ty, &Ty)>) {
         let len = self.scratch.alloc_i32();
-        wasm!(self.func, { local_get(src); i32_load(0); local_set(len); });
+        wasm!(self.func, { local_get(Local(src)); i32_load(0); local_set(Local(len)); });
         self.emit_dict_entries_base(dst, dst_cap); // memory_copy dest
         self.emit_dict_entries_base(src, src_cap); // memory_copy src
         wasm!(self.func, {
-            local_get(len); i32_const(es as i32); i32_mul; memory_copy;
-            local_get(dst); local_get(len); i32_store(0); // dst.len = src.len
+            local_get(Local(len)); i32_const(Imm32(es as i32)); i32_mul; memory_copy;
+            local_get(Local(dst)); local_get(Local(len)); i32_store(0); // dst.len = src.len
         });
         // SHARE vs MOVE: `dup = Some((K, V))` when the SOURCE dict survives
         // (map.set / map.merge build a sibling) — every copied heap key/val
@@ -1183,26 +1184,26 @@ impl FuncCompiler<'_> {
                 let di = self.scratch.alloc_i32();
                 let de = self.scratch.alloc_i32();
                 self.emit_dict_entries_base(dst, dst_cap);
-                wasm!(self.func, { local_set(de); i32_const(0); local_set(di); });
+                wasm!(self.func, { local_set(Local(de)); i32_const(Imm32(0)); local_set(Local(di)); });
                 wasm!(self.func, {
                     block_empty; loop_empty;
-                        local_get(di); local_get(len); i32_ge_u; br_if(1);
+                        local_get(Local(di)); local_get(Local(len)); i32_ge_u; br_if(1);
                 });
                 if kh {
                     wasm!(self.func, {
-                        local_get(de); local_get(di); i32_const(es as i32); i32_mul; i32_add;
+                        local_get(Local(de)); local_get(Local(di)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
                         i32_load(0); call(self.emitter.rt.rc_inc); drop;
                     });
                 }
                 if vh {
                     wasm!(self.func, {
-                        local_get(de); local_get(di); i32_const(es as i32); i32_mul; i32_add;
-                        i32_const(ks as i32); i32_add;
+                        local_get(Local(de)); local_get(Local(di)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                        i32_const(Imm32(ks as i32)); i32_add;
                         i32_load(0); call(self.emitter.rt.rc_inc); drop;
                     });
                 }
                 wasm!(self.func, {
-                        local_get(di); i32_const(1); i32_add; local_set(di);
+                        local_get(Local(di)); i32_const(Imm32(1)); i32_add; local_set(Local(di));
                         br(0);
                     end; end;
                 });
@@ -1220,10 +1221,10 @@ impl FuncCompiler<'_> {
         use super::engine::layout::map as lm;
         let nc = self.scratch.alloc_i32();
         let nm = self.scratch.alloc_i32();
-        wasm!(self.func, { local_get(cap); i32_const(lm::GROWTH_SHIFT as i32); i32_shl; local_set(nc); });
+        wasm!(self.func, { local_get(Local(cap)); i32_const(Imm32(lm::GROWTH_SHIFT as i32)); i32_shl; local_set(Local(nc)); });
         self.emit_dict_alloc(nm, nc, es);
         self.emit_dict_recap(map, cap, nm, nc, es, key_ty, None);
-        wasm!(self.func, { local_get(nm); local_set(map); local_get(nc); local_set(cap); });
+        wasm!(self.func, { local_get(Local(nm)); local_set(Local(map)); local_get(Local(nc)); local_set(Local(cap)); });
         self.scratch.free_i32(nm);
         self.scratch.free_i32(nc);
     }
@@ -1240,41 +1241,41 @@ impl FuncCompiler<'_> {
         let h2 = self.scratch.alloc_i32();
         let tg = self.scratch.alloc_i32();
         let ei = self.scratch.alloc_i32();
-        wasm!(self.func, { local_get(src); });
+        wasm!(self.func, { local_get(Local(src)); });
         self.emit_key_load(key_ty, 0);
         self.emit_hash_key(key_ty);
         self.emit_h1_h2(cap, idx, h2);
         wasm!(self.func, {
             block_empty; loop_empty;
-              local_get(map); i32_const(tags_off); i32_add; local_get(idx); i32_add; i32_load8_u(0); local_set(tg);
-              local_get(tg); i32_eqz; br_if(1);              // empty slot → new key
-              local_get(tg); local_get(h2); i32_eq;
+              local_get(Local(map)); i32_const(Imm32(tags_off)); i32_add; local_get(Local(idx)); i32_add; i32_load8_u(0); local_set(Local(tg));
+              local_get(Local(tg)); i32_eqz; br_if(1);              // empty slot → new key
+              local_get(Local(tg)); local_get(Local(h2)); i32_eq;
               if_empty;
-                local_get(ib); local_get(idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
-                i32_load(0); i32_const(1); i32_sub; local_set(ei);   // ei = index[idx]-1
-                local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
+                local_get(Local(ib)); local_get(Local(idx)); i32_const(Imm32(lm::INDEX_SLOT_SIZE as i32)); i32_mul; i32_add;
+                i32_load(0); i32_const(Imm32(1)); i32_sub; local_set(Local(ei));   // ei = index[idx]-1
+                local_get(Local(eb)); local_get(Local(ei)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         self.emit_key_load(key_ty, 0);          // existing entry key
-        wasm!(self.func, { local_get(src); });
+        wasm!(self.func, { local_get(Local(src)); });
         self.emit_key_load(key_ty, 0);          // src key
         self.emit_key_eq(key_ty);
         wasm!(self.func, {
                 br_if(2);                        // equal → existing, ei set, exit probe
               end;
-              local_get(idx); i32_const(1); i32_add;
-              local_get(cap); i32_const(1); i32_sub; i32_and; local_set(idx); br(0);
+              local_get(Local(idx)); i32_const(Imm32(1)); i32_add;
+              local_get(Local(cap)); i32_const(Imm32(1)); i32_sub; i32_and; local_set(Local(idx)); br(0);
             end; end;
             // New key (tg==0): append at dense entries[len].
-            local_get(tg); i32_eqz;
+            local_get(Local(tg)); i32_eqz;
             if_empty;
-              local_get(map); i32_load(0); local_set(ei);          // ei = len
-              local_get(map); i32_const(tags_off); i32_add; local_get(idx); i32_add;
-              local_get(h2); i32_store8(0);                        // tags[idx] = h2
-              local_get(ib); local_get(idx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
-              local_get(ei); i32_const(1); i32_add; i32_store(0);  // index[idx] = ei+1
-              local_get(map); local_get(ei); i32_const(1); i32_add; i32_store(0); // map.len = ei+1
-              local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
-              local_get(src); i32_const(ks as i32); memory_copy;   // copy key bytes
+              local_get(Local(map)); i32_load(0); local_set(Local(ei));          // ei = len
+              local_get(Local(map)); i32_const(Imm32(tags_off)); i32_add; local_get(Local(idx)); i32_add;
+              local_get(Local(h2)); i32_store8(0);                        // tags[idx] = h2
+              local_get(Local(ib)); local_get(Local(idx)); i32_const(Imm32(lm::INDEX_SLOT_SIZE as i32)); i32_mul; i32_add;
+              local_get(Local(ei)); i32_const(Imm32(1)); i32_add; i32_store(0);  // index[idx] = ei+1
+              local_get(Local(map)); local_get(Local(ei)); i32_const(Imm32(1)); i32_add; i32_store(0); // map.len = ei+1
+              local_get(Local(eb)); local_get(Local(ei)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+              local_get(Local(src)); i32_const(Imm32(ks as i32)); memory_copy;   // copy key bytes
         });
         // SHARE: a NEW heap key was just copied (by reference) from the borrowed
         // source — dup it so the dict owns its own reference, else the source's
@@ -1282,23 +1283,23 @@ impl FuncCompiler<'_> {
         // the new-key path (an existing key keeps the reference it already owns).
         if Self::is_heap_type(key_ty) {
             wasm!(self.func, {
-              local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add;
+              local_get(Local(eb)); local_get(Local(ei)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
               i32_load(0); call(self.emitter.rt.rc_inc); drop;
             });
         }
         wasm!(self.func, {
             end;
             // Copy value bytes into entries[ei]+ks (both new and existing).
-            local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add; i32_const(ks as i32); i32_add;
-            local_get(src); i32_const(ks as i32); i32_add;
-            i32_const(vs as i32); memory_copy;
+            local_get(Local(eb)); local_get(Local(ei)); i32_const(Imm32(es as i32)); i32_mul; i32_add; i32_const(Imm32(ks as i32)); i32_add;
+            local_get(Local(src)); i32_const(Imm32(ks as i32)); i32_add;
+            i32_const(Imm32(vs as i32)); memory_copy;
         });
         // SHARE: the heap value was copied (by reference) from the borrowed source —
         // dup it for the same reason. (Overwriting an existing heap value leaks the
         // old one — a separate, non-crashing gap, not a double-free.)
         if Self::is_heap_type(val_ty) {
             wasm!(self.func, {
-              local_get(eb); local_get(ei); i32_const(es as i32); i32_mul; i32_add; i32_const(ks as i32); i32_add;
+              local_get(Local(eb)); local_get(Local(ei)); i32_const(Imm32(es as i32)); i32_mul; i32_add; i32_const(Imm32(ks as i32)); i32_add;
               i32_load(0); call(self.emitter.rt.rc_inc); drop;
             });
         }
@@ -1312,13 +1313,13 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_closure_env(&mut self, closure: u32) {
         use super::engine::layout::{CLOSURE_PAIR, closure as lc};
         let off = self.emitter.layout_reg.fixed_offset(CLOSURE_PAIR, lc::ENV_PTR);
-        wasm!(self.func, { local_get(closure); i32_load(off); });
+        wasm!(self.func, { local_get(Local(closure)); i32_load(off); });
     }
 
     /// Push a closure pair's function-table index.
     pub(super) fn emit_closure_table_idx(&mut self, closure: u32) {
         use super::engine::layout::{CLOSURE_PAIR, closure as lc};
         let off = self.emitter.layout_reg.fixed_offset(CLOSURE_PAIR, lc::TABLE_IDX);
-        wasm!(self.func, { local_get(closure); i32_load(off); });
+        wasm!(self.func, { local_get(Local(closure)); i32_load(off); });
     }
 }

--- a/crates/almide-codegen/src/emit_wasm/calls_map.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map.rs
@@ -12,6 +12,19 @@ use almide_ir::IrExpr;
 use almide_lang::types::Ty;
 use wasm_encoder::ValType;
 
+// ── Named immediates — every raw constant in this file is listed here. ──
+// Hashing constants (FNV-1a 32-bit and Fibonacci/Knuth i64 mix):
+/// FNV-1a 32-bit offset basis (initial hash accumulator value).
+const FNV1A_OFFSET_BASIS: i32 = 0x811C9DC5u32 as i32;
+/// FNV-1a 32-bit prime (multiplicative step).
+const FNV1A_PRIME: i32 = 0x01000193u32 as i32;
+/// Fibonacci/Knuth multiplicative hash multiplier for i64 keys (fold high↔low).
+const HASH_MIX_MUL: i64 = 0x9E3779B97F4A7C15u64 as i64;
+/// Shift amount to fold the high 32 bits of an i64 into the low 32 bits.
+const I64_HALF_BITS: i64 = 32;
+/// Byte size of an i32 (pointer) — stride for tuple-pointer arrays in list data.
+const PTR_SIZE: i32 = 4;
+
 impl FuncCompiler<'_> {
     pub(super) fn emit_map_call(&mut self, method: &str, args: &[IrExpr]) -> bool {
         use super::engine::layout::{SWISS_MAP, LIST, map as lm, list as ll};
@@ -671,7 +684,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); local_get(plen); i32_ge_u; br_if(1);
                       local_get(pairs); i32_const(list_data_off); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(PTR_SIZE); i32_mul; i32_add;
                       i32_load(0); local_set(tp); // tp = pairs.data[i] = (K,V) tuple ptr
                 });
                 self.emit_dict_put_entry(result, cap, ib, eb, tp, es, ks, vs, &key_ty, &val_ty);
@@ -739,10 +752,10 @@ impl FuncCompiler<'_> {
                 let tmp = self.scratch.alloc_i64();
                 wasm!(self.func, {
                     local_tee(tmp);
-                    i64_const(32); i64_shr_u;
+                    i64_const(I64_HALF_BITS); i64_shr_u;
                     local_get(tmp); i64_xor;
-                    i64_const(0x9E3779B97F4A7C15u64 as i64); i64_mul;
-                    i64_const(32); i64_shr_u;
+                    i64_const(HASH_MIX_MUL); i64_mul;
+                    i64_const(I64_HALF_BITS); i64_shr_u;
                     i32_wrap_i64;
                 });
                 self.scratch.free_i64(tmp);
@@ -754,7 +767,7 @@ impl FuncCompiler<'_> {
                 let si = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     local_set(s);
-                    i32_const(0x811C9DC5u32 as i32); local_set(h);
+                    i32_const(FNV1A_OFFSET_BASIS); local_set(h);
                     local_get(s); i32_load(0); local_set(slen);
                     i32_const(0); local_set(si);
                     block_empty; loop_empty;
@@ -763,7 +776,7 @@ impl FuncCompiler<'_> {
                       local_get(s); i32_const(str_data_off); i32_add;
                       local_get(si); i32_add; i32_load8_u(0);
                       i32_xor;
-                      i32_const(0x01000193u32 as i32); i32_mul;
+                      i32_const(FNV1A_PRIME); i32_mul;
                       local_set(h);
                       local_get(si); i32_const(1); i32_add; local_set(si);
                       br(0);
@@ -808,14 +821,14 @@ impl FuncCompiler<'_> {
                         let h = self.scratch.alloc_i32();
                         wasm!(self.func, {
                             local_set(ptr);
-                            i32_const(0x811C9DC5u32 as i32); local_set(h);
+                            i32_const(FNV1A_OFFSET_BASIS); local_set(h);
                         });
                         for b in 0..size {
                             wasm!(self.func, {
                                 local_get(h);
                                 local_get(ptr); i32_load8_u(b);
                                 i32_xor;
-                                i32_const(0x01000193u32 as i32); i32_mul;
+                                i32_const(FNV1A_PRIME); i32_mul;
                                 local_set(h);
                             });
                         }
@@ -867,7 +880,7 @@ impl FuncCompiler<'_> {
         let h = self.scratch.alloc_i32();
         wasm!(self.func, {
             local_set(ptr);
-            i32_const(0x811C9DC5u32 as i32); local_set(h);
+            i32_const(FNV1A_OFFSET_BASIS); local_set(h);
         });
         let mut offset = 0u32;
         for (_, fty) in fields {
@@ -879,7 +892,7 @@ impl FuncCompiler<'_> {
             self.emit_hash_value(fty);
             wasm!(self.func, {
                 local_get(h); i32_xor;
-                i32_const(0x01000193u32 as i32); i32_mul;
+                i32_const(FNV1A_PRIME); i32_mul;
                 local_set(h);
             });
             offset += values::byte_size(fty);
@@ -904,7 +917,7 @@ impl FuncCompiler<'_> {
                 let tmp = self.scratch.alloc_i64();
                 wasm!(self.func, {
                     i64_reinterpret_f64; local_tee(tmp);
-                    i64_const(32); i64_shr_u; local_get(tmp); i64_xor;
+                    i64_const(I64_HALF_BITS); i64_shr_u; local_get(tmp); i64_xor;
                     i32_wrap_i64;
                 });
                 self.scratch.free_i64(tmp);

--- a/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
@@ -2,6 +2,7 @@
 //!
 //! Handles: fold, each, any, all, count, filter, map, find, update.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::FuncCompiler;
 use super::values;
 use almide_ir::IrExpr;
@@ -27,26 +28,26 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 let it = self.map_iter_begin(&args[0], ks + vs);
                 self.emit_expr(&args[1]); // init
-                wasm!(self.func, { local_set(acc); });
+                wasm!(self.func, { local_set(Local(acc)); });
                 self.emit_expr(&args[2]); // closure
-                wasm!(self.func, { local_set(closure); });
+                wasm!(self.func, { local_set(Local(closure)); });
                 self.map_iter_loop_head(&it);
                 // f(env, acc, key, val)
-                wasm!(self.func, { local_get(closure); i32_load(4); local_get(acc); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(4); local_get(Local(acc)); });
                 self.map_iter_key_addr(&it);
                 self.emit_key_load(&key_ty, 0);
                 self.map_iter_val_addr(&it, ks);
                 self.emit_load_at(&val_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
                     let mut ct = vec![ValType::I32, acc_vt, key_vt];
                     if let Some(vt) = values::ty_to_valtype(&val_ty) { ct.push(vt); }
                     self.emit_call_indirect(ct, vec![acc_vt]);
                 }
-                wasm!(self.func, { local_set(acc); });
+                wasm!(self.func, { local_set(Local(acc)); });
                 self.map_iter_loop_tail(&it);
-                wasm!(self.func, { local_get(acc); });
+                wasm!(self.func, { local_get(Local(acc)); });
                 self.scratch.free(acc, acc_vt);
                 self.scratch.free_i32(closure);
                 self.map_iter_end(it);
@@ -58,14 +59,14 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 let it = self.map_iter_begin(&args[0], ks + vs);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(closure); });
+                wasm!(self.func, { local_set(Local(closure)); });
                 self.map_iter_loop_head(&it);
-                wasm!(self.func, { local_get(closure); i32_load(4); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(4); });
                 self.map_iter_key_addr(&it);
                 self.emit_key_load(&key_ty, 0);
                 self.map_iter_val_addr(&it, ks);
                 self.emit_load_at(&val_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
                     let mut ct = vec![ValType::I32, key_vt];
@@ -84,14 +85,14 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i32();
                 let it = self.map_iter_begin(&args[0], ks + vs);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(closure); i32_const(0); local_set(result); });
+                wasm!(self.func, { local_set(Local(closure)); i32_const(Imm32(0)); local_set(Local(result)); });
                 self.map_iter_loop_head(&it);
-                wasm!(self.func, { local_get(closure); i32_load(4); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(4); });
                 self.map_iter_key_addr(&it);
                 self.emit_key_load(&key_ty, 0);
                 self.map_iter_val_addr(&it, ks);
                 self.emit_load_at(&val_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
                     let mut ct = vec![ValType::I32, key_vt];
@@ -99,10 +100,10 @@ impl FuncCompiler<'_> {
                     self.emit_call_indirect(ct, vec![ValType::I32]);
                 }
                 wasm!(self.func, {
-                    if_empty; i32_const(1); local_set(result); br(2); end;
+                    if_empty; i32_const(Imm32(1)); local_set(Local(result)); br(2); end;
                 });
                 self.map_iter_loop_tail(&it);
-                wasm!(self.func, { local_get(result); });
+                wasm!(self.func, { local_get(Local(result)); });
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(closure);
                 self.map_iter_end(it);
@@ -115,14 +116,14 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i32();
                 let it = self.map_iter_begin(&args[0], ks + vs);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(closure); i32_const(1); local_set(result); });
+                wasm!(self.func, { local_set(Local(closure)); i32_const(Imm32(1)); local_set(Local(result)); });
                 self.map_iter_loop_head(&it);
-                wasm!(self.func, { local_get(closure); i32_load(4); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(4); });
                 self.map_iter_key_addr(&it);
                 self.emit_key_load(&key_ty, 0);
                 self.map_iter_val_addr(&it, ks);
                 self.emit_load_at(&val_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
                     let mut ct = vec![ValType::I32, key_vt];
@@ -131,10 +132,10 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                     i32_eqz;
-                    if_empty; i32_const(0); local_set(result); br(2); end;
+                    if_empty; i32_const(Imm32(0)); local_set(Local(result)); br(2); end;
                 });
                 self.map_iter_loop_tail(&it);
-                wasm!(self.func, { local_get(result); });
+                wasm!(self.func, { local_get(Local(result)); });
                 self.scratch.free_i32(result);
                 self.scratch.free_i32(closure);
                 self.map_iter_end(it);
@@ -147,14 +148,14 @@ impl FuncCompiler<'_> {
                 let cnt = self.scratch.alloc_i64();
                 let it = self.map_iter_begin(&args[0], ks + vs);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(closure); i64_const(0); local_set(cnt); });
+                wasm!(self.func, { local_set(Local(closure)); i64_const(Imm64(0)); local_set(Local(cnt)); });
                 self.map_iter_loop_head(&it);
-                wasm!(self.func, { local_get(closure); i32_load(4); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(4); });
                 self.map_iter_key_addr(&it);
                 self.emit_key_load(&key_ty, 0);
                 self.map_iter_val_addr(&it, ks);
                 self.emit_load_at(&val_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
                     let mut ct = vec![ValType::I32, key_vt];
@@ -163,11 +164,11 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                     if_empty;
-                      local_get(cnt); i64_const(1); i64_add; local_set(cnt);
+                      local_get(Local(cnt)); i64_const(Imm64(1)); i64_add; local_set(Local(cnt));
                     end;
                 });
                 self.map_iter_loop_tail(&it);
-                wasm!(self.func, { local_get(cnt); });
+                wasm!(self.func, { local_get(Local(cnt)); });
                 self.scratch.free_i64(cnt);
                 self.scratch.free_i32(closure);
                 self.map_iter_end(it);
@@ -195,33 +196,33 @@ impl FuncCompiler<'_> {
                 let entry = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(m); i32_load(map_cap_off); local_set(cap);
-                    local_get(m); i32_load(0); local_set(len);
+                    local_set(Local(closure));
+                    local_get(Local(m)); i32_load(map_cap_off); local_set(Local(cap));
+                    local_get(Local(m)); i32_load(0); local_set(Local(len));
                 });
                 self.emit_dict_alloc(nm, cap, es);
                 self.emit_dict_index_base(nm, cap);
-                wasm!(self.func, { local_set(ib); });
+                wasm!(self.func, { local_set(Local(ib)); });
                 self.emit_dict_entries_base(nm, cap);
-                wasm!(self.func, { local_set(eb_new); });
+                wasm!(self.func, { local_set(Local(eb_new)); });
                 self.emit_dict_entries_base(m, cap);
                 wasm!(self.func, {
-                    local_set(eb_old);
-                    i32_const(0); local_set(i);
+                    local_set(Local(eb_old));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(eb_old); local_get(i); i32_const(es as i32); i32_mul; i32_add; local_set(entry);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(eb_old)); local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add; local_set(Local(entry));
                       // pred(env, k, v)
-                      local_get(closure); i32_load(4); // env
-                      local_get(entry);
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(entry));
                 });
                 self.emit_key_load(&key_ty, 0);
-                wasm!(self.func, { local_get(entry); i32_const(ks as i32); i32_add; });
+                wasm!(self.func, { local_get(Local(entry)); i32_const(Imm32(ks as i32)); i32_add; });
                 self.emit_load_at(&val_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); }); // table_idx
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); }); // table_idx
                 {
                     let key_vt = Self::key_valtype(&key_ty);
                     let mut ct = vec![ValType::I32, key_vt];
@@ -232,9 +233,9 @@ impl FuncCompiler<'_> {
                 self.emit_dict_put_entry(nm, cap, ib, eb_new, entry, es, ks, vs, &key_ty, &val_ty);
                 wasm!(self.func, {
                       end; // pred-true if
-                      local_get(i); i32_const(1); i32_add; local_set(i); br(0);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i)); br(0);
                     end; end;
-                    local_get(nm);
+                    local_get(Local(nm));
                 });
                 self.scratch.free_i32(entry);
                 self.scratch.free_i32(i);
@@ -268,7 +269,7 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 let it = self.map_iter_begin(&args[0], es_old);
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(closure); });
+                wasm!(self.func, { local_set(Local(closure)); });
                 // Allocate a fresh table at the new entry stride, then copy the
                 // value-width-independent prefix (header + tags + index) verbatim
                 // from the source so len/cap/tags/index match exactly.
@@ -278,47 +279,47 @@ impl FuncCompiler<'_> {
                 let hdr = self.emitter.layout_reg.header_size(super::engine::layout::SWISS_MAP) as i32;
                 let tag_plus_index = 1 + lm::INDEX_SLOT_SIZE as i32;
                 wasm!(self.func, {
-                    local_get(new_map);
-                    local_get(it.map);
-                    i32_const(hdr);
-                    local_get(it.cap); i32_const(tag_plus_index); i32_mul; i32_add;
+                    local_get(Local(new_map));
+                    local_get(Local(it.map));
+                    i32_const(Imm32(hdr));
+                    local_get(Local(it.cap)); i32_const(Imm32(tag_plus_index)); i32_mul; i32_add;
                     memory_copy;
                 });
                 let new_eb = self.scratch.alloc_i32();
                 self.emit_dict_entries_base(new_map, it.cap);
-                wasm!(self.func, { local_set(new_eb); });
+                wasm!(self.func, { local_set(Local(new_eb)); });
                 self.map_iter_loop_head(&it);
                 // Copy the key bytes (unchanged) from source entry i into dst entry i.
                 wasm!(self.func, {
-                    local_get(new_eb);
-                    local_get(it.i); i32_const(es_new as i32); i32_mul; i32_add;
-                    local_get(it.eb);
-                    local_get(it.i); i32_const(es_old as i32); i32_mul; i32_add;
-                    i32_const(ks as i32); memory_copy;
+                    local_get(Local(new_eb));
+                    local_get(Local(it.i)); i32_const(Imm32(es_new as i32)); i32_mul; i32_add;
+                    local_get(Local(it.eb));
+                    local_get(Local(it.i)); i32_const(Imm32(es_old as i32)); i32_mul; i32_add;
+                    i32_const(Imm32(ks as i32)); memory_copy;
                 });
                 // SHARE: the source dict survives and owns these keys.
                 if crate::pass_perceus::is_heap_type(&self.map_key_ty(&args[0].ty)) {
                     wasm!(self.func, {
-                        local_get(new_eb);
-                        local_get(it.i); i32_const(es_new as i32); i32_mul; i32_add;
+                        local_get(Local(new_eb));
+                        local_get(Local(it.i)); i32_const(Imm32(es_new as i32)); i32_mul; i32_add;
                         i32_load(0); call(self.emitter.rt.rc_inc); drop;
                     });
                 }
                 // dst = new_eb + i*es_new + ks (new val addr in the rebuilt table)
                 wasm!(self.func, {
-                    local_get(new_eb);
-                    local_get(it.i); i32_const(es_new as i32); i32_mul; i32_add;
-                    i32_const(ks as i32); i32_add;
+                    local_get(Local(new_eb));
+                    local_get(Local(it.i)); i32_const(Imm32(es_new as i32)); i32_mul; i32_add;
+                    i32_const(Imm32(ks as i32)); i32_add;
                 });
                 // f(env, old_val) → new_val, then store at the new value width.
-                wasm!(self.func, { local_get(closure); i32_load(4); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(4); });
                 self.map_iter_val_addr(&it, ks);
                 self.emit_load_at(&val_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 self.emit_closure_call(&val_ty, &new_val_ty);
                 self.emit_store_at(&new_val_ty, 0);
                 self.map_iter_loop_tail(&it);
-                wasm!(self.func, { local_get(new_map); });
+                wasm!(self.func, { local_get(Local(new_map)); });
                 self.scratch.free_i32(new_eb);
                 self.scratch.free_i32(new_map);
                 self.scratch.free_i32(closure);
@@ -343,28 +344,28 @@ impl FuncCompiler<'_> {
                 let tuple_ptr = self.scratch.alloc_i32();
                 let ent = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(map_ptr); });
+                wasm!(self.func, { local_set(Local(map_ptr)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(map_ptr); i32_load(0); local_set(len);
-                    local_get(map_ptr); i32_load(map_cap_off); local_set(cap);
+                    local_set(Local(closure));
+                    local_get(Local(map_ptr)); i32_load(0); local_set(Local(len));
+                    local_get(Local(map_ptr)); i32_load(map_cap_off); local_set(Local(cap));
                 });
                 self.emit_dict_entries_base(map_ptr, cap);
                 wasm!(self.func, {
-                    local_set(eb);
-                    i32_const(0); local_set(i);
-                    i32_const(0); local_set(result); // none
+                    local_set(Local(eb));
+                    i32_const(Imm32(0)); local_set(Local(i));
+                    i32_const(Imm32(0)); local_set(Local(result)); // none
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(eb); local_get(i); i32_const(entry as i32); i32_mul; i32_add; local_set(ent);
-                      local_get(closure); i32_load(4);
-                      local_get(ent);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(eb)); local_get(Local(i)); i32_const(Imm32(entry as i32)); i32_mul; i32_add; local_set(Local(ent));
+                      local_get(Local(closure)); i32_load(4);
+                      local_get(Local(ent));
                 });
                 self.emit_key_load(&key_ty, 0);
-                wasm!(self.func, { local_get(ent); i32_const(ks as i32); i32_add; });
+                wasm!(self.func, { local_get(Local(ent)); i32_const(Imm32(ks as i32)); i32_add; });
                 self.emit_load_at(&val_ty, 0);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 {
                     let key_vt = Self::key_valtype(&key_ty);
                     let mut ct = vec![ValType::I32, key_vt];
@@ -374,16 +375,16 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                       if_empty;
                         // Alloc the (key, val) tuple (one contiguous block) and wrap in Some.
-                        i32_const(entry as i32); call(self.emitter.rt.alloc); local_set(tuple_ptr);
-                        local_get(tuple_ptr); local_get(ent); i32_const(entry as i32); memory_copy;
-                        i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); local_get(tuple_ptr); i32_store(0);
+                        i32_const(Imm32(entry as i32)); call(self.emitter.rt.alloc); local_set(Local(tuple_ptr));
+                        local_get(Local(tuple_ptr)); local_get(Local(ent)); i32_const(Imm32(entry as i32)); memory_copy;
+                        i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); local_get(Local(tuple_ptr)); i32_store(0);
                         br(2); // break out of loop
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result); // result (none=0 or some ptr)
+                    local_get(Local(result)); // result (none=0 or some ptr)
                 });
                 self.scratch.free_i32(ent);
                 self.scratch.free_i32(tuple_ptr);
@@ -420,43 +421,43 @@ impl FuncCompiler<'_> {
                 let total_size = self.scratch.alloc_i32();
                 let valaddr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(map_ptr); });
+                wasm!(self.func, { local_set(Local(map_ptr)); });
                 self.emit_expr(&args[1]); // key
                 self.emit_search_key_store(&key_ty, sk32, sk64);
                 self.emit_expr(&args[2]); // closure f
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(map_ptr); i32_load(0); local_set(len);
-                    local_get(map_ptr); i32_load(map_cap_off); local_set(cap);
+                    local_set(Local(closure));
+                    local_get(Local(map_ptr)); i32_load(0); local_set(Local(len));
+                    local_get(Local(map_ptr)); i32_load(map_cap_off); local_set(Local(cap));
                 });
                 self.emit_dict_entries_base(map_ptr, cap);
                 wasm!(self.func, {
-                    local_set(eb);
-                    i32_const(0); local_set(i);
-                    i32_const(-1); local_set(found_idx);
+                    local_set(Local(eb));
+                    i32_const(Imm32(0)); local_set(Local(i));
+                    i32_const(Imm32(-1)); local_set(Local(found_idx));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(eb); local_get(i); i32_const(entry as i32); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(eb)); local_get(Local(i)); i32_const(Imm32(entry as i32)); i32_mul; i32_add;
                 });
                 self.emit_key_load(&key_ty, 0);
                 self.emit_search_key_load(&key_ty, sk32, sk64);
                 self.emit_key_eq(&key_ty);
                 wasm!(self.func, {
-                      if_empty; local_get(i); local_set(found_idx); br(2); end; // found → break
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      if_empty; local_get(Local(i)); local_set(Local(found_idx)); br(2); end; // found → break
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                     // If not found, return the original map unchanged —
                     // SHARE: the result is a SECOND reference to the input.
-                    local_get(found_idx); i32_const(0); i32_lt_s;
-                    if_i32; local_get(map_ptr); call(self.emitter.rt.rc_inc);
+                    local_get(Local(found_idx)); i32_const(Imm32(0)); i32_lt_s;
+                    if_i32; local_get(Local(map_ptr)); call(self.emitter.rt.rc_inc);
                     else_;
                       // Byte-copy the whole COD table: header + cap*per_slot.
-                      i32_const(map_hdr);
-                      local_get(cap); i32_const(per_slot); i32_mul; i32_add;
-                      local_tee(total_size);
-                      call(self.emitter.rt.alloc); local_set(new_map);
-                      local_get(new_map); local_get(map_ptr); local_get(total_size);
+                      i32_const(Imm32(map_hdr));
+                      local_get(Local(cap)); i32_const(Imm32(per_slot)); i32_mul; i32_add;
+                      local_tee(Local(total_size));
+                      call(self.emitter.rt.alloc); local_set(Local(new_map));
+                      local_get(Local(new_map)); local_get(Local(map_ptr)); local_get(Local(total_size));
                       memory_copy;
                 });
                 // SHARE dup over the copied table: the source survives and
@@ -470,27 +471,27 @@ impl FuncCompiler<'_> {
                         let di = self.scratch.alloc_i32();
                         let de = self.scratch.alloc_i32();
                         let dlen = self.scratch.alloc_i32();
-                        wasm!(self.func, { local_get(new_map); i32_load(0); local_set(dlen); });
+                        wasm!(self.func, { local_get(Local(new_map)); i32_load(0); local_set(Local(dlen)); });
                         self.emit_dict_entries_base(new_map, cap);
-                        wasm!(self.func, { local_set(de); i32_const(0); local_set(di);
+                        wasm!(self.func, { local_set(Local(de)); i32_const(Imm32(0)); local_set(Local(di));
                             block_empty; loop_empty;
-                                local_get(di); local_get(dlen); i32_ge_u; br_if(1);
+                                local_get(Local(di)); local_get(Local(dlen)); i32_ge_u; br_if(1);
                         });
                         if kh {
                             wasm!(self.func, {
-                                local_get(de); local_get(di); i32_const(entry as i32); i32_mul; i32_add;
+                                local_get(Local(de)); local_get(Local(di)); i32_const(Imm32(entry as i32)); i32_mul; i32_add;
                                 i32_load(0); call(self.emitter.rt.rc_inc); drop;
                             });
                         }
                         if vh {
                             wasm!(self.func, {
-                                local_get(de); local_get(di); i32_const(entry as i32); i32_mul; i32_add;
-                                i32_const(ks as i32); i32_add;
+                                local_get(Local(de)); local_get(Local(di)); i32_const(Imm32(entry as i32)); i32_mul; i32_add;
+                                i32_const(Imm32(ks as i32)); i32_add;
                                 i32_load(0); call(self.emitter.rt.rc_inc); drop;
                             });
                         }
                         wasm!(self.func, {
-                                local_get(di); i32_const(1); i32_add; local_set(di);
+                                local_get(Local(di)); i32_const(Imm32(1)); i32_add; local_set(Local(di));
                                 br(0);
                             end; end;
                         });
@@ -502,11 +503,11 @@ impl FuncCompiler<'_> {
                 // valaddr = dense entries base(new_map, cap) + found_idx*entry + ks
                 self.emit_dict_entries_base(new_map, cap);
                 wasm!(self.func, {
-                      local_get(found_idx); i32_const(entry as i32); i32_mul; i32_add;
-                      i32_const(ks as i32); i32_add; local_set(valaddr);
-                      local_get(valaddr);              // dst val addr
-                      local_get(closure); i32_load(4); // env
-                      local_get(valaddr);              // load old val from same addr
+                      local_get(Local(found_idx)); i32_const(Imm32(entry as i32)); i32_mul; i32_add;
+                      i32_const(Imm32(ks as i32)); i32_add; local_set(Local(valaddr));
+                      local_get(Local(valaddr));              // dst val addr
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(valaddr));              // load old val from same addr
                 });
                 self.emit_load_at(&val_ty, 0);
                 // Capture the OLD value before the overwrite so its dup'd
@@ -514,18 +515,18 @@ impl FuncCompiler<'_> {
                 // the closure result replaces it.
                 let old_val = if crate::pass_perceus::is_heap_type(&val_ty) {
                     let ov = self.scratch.alloc_i32();
-                    wasm!(self.func, { local_tee(ov); });
+                    wasm!(self.func, { local_tee(Local(ov)); });
                     Some(ov)
                 } else { None };
-                wasm!(self.func, { local_get(closure); i32_load(0); }); // table_idx
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); }); // table_idx
                 self.emit_closure_call(&val_ty, &val_ty);
                 self.emit_store_at(&val_ty, 0);
                 if let Some(ov) = old_val {
-                    wasm!(self.func, { local_get(ov); call(self.emitter.rt.rc_dec); });
+                    wasm!(self.func, { local_get(Local(ov)); call(self.emitter.rt.rc_dec); });
                     self.scratch.free_i32(ov);
                 }
                 wasm!(self.func, {
-                      local_get(new_map);
+                      local_get(Local(new_map));
                     end;
                 });
                 self.scratch.free_i32(valaddr);
@@ -574,12 +575,12 @@ impl FuncCompiler<'_> {
         let i = self.scratch.alloc_i32();
         self.emit_expr(map_expr);
         wasm!(self.func, {
-            local_set(map);
-            local_get(map); i32_load(0); local_set(len);
-            local_get(map); i32_load(map_cap_off); local_set(cap);
+            local_set(Local(map));
+            local_get(Local(map)); i32_load(0); local_set(Local(len));
+            local_get(Local(map)); i32_load(map_cap_off); local_set(Local(cap));
         });
         self.emit_dict_entries_base(map, cap);
-        wasm!(self.func, { local_set(eb); i32_const(0); local_set(i); });
+        wasm!(self.func, { local_set(Local(eb)); i32_const(Imm32(0)); local_set(Local(i)); });
         MapIter { map, cap, len, eb, i, entry_size }
     }
 
@@ -588,31 +589,31 @@ impl FuncCompiler<'_> {
     pub(super) fn map_iter_loop_head(&mut self, it: &MapIter) {
         wasm!(self.func, {
             block_empty; loop_empty;
-              local_get(it.i); local_get(it.len); i32_ge_u; br_if(1);
+              local_get(Local(it.i)); local_get(Local(it.len)); i32_ge_u; br_if(1);
         });
     }
 
     /// Emit: push address of current entry's key onto stack.
     pub(super) fn map_iter_key_addr(&mut self, it: &MapIter) {
         wasm!(self.func, {
-            local_get(it.eb);
-            local_get(it.i); i32_const(it.entry_size as i32); i32_mul; i32_add;
+            local_get(Local(it.eb));
+            local_get(Local(it.i)); i32_const(Imm32(it.entry_size as i32)); i32_mul; i32_add;
         });
     }
 
     /// Emit: push address of current entry's value onto stack.
     pub(super) fn map_iter_val_addr(&mut self, it: &MapIter, key_size: u32) {
         wasm!(self.func, {
-            local_get(it.eb);
-            local_get(it.i); i32_const(it.entry_size as i32); i32_mul; i32_add;
-            i32_const(key_size as i32); i32_add;
+            local_get(Local(it.eb));
+            local_get(Local(it.i)); i32_const(Imm32(it.entry_size as i32)); i32_mul; i32_add;
+            i32_const(Imm32(key_size as i32)); i32_add;
         });
     }
 
     /// Emit loop footer: i++, br(0), end, end.
     pub(super) fn map_iter_loop_tail(&mut self, it: &MapIter) {
         wasm!(self.func, {
-            local_get(it.i); i32_const(1); i32_add; local_set(it.i);
+            local_get(Local(it.i)); i32_const(Imm32(1)); i32_add; local_set(Local(it.i));
             br(0);
           end; end;
         });

--- a/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_map_closure.rs
@@ -7,6 +7,10 @@ use super::values;
 use almide_ir::IrExpr;
 use wasm_encoder::ValType;
 
+// ── Named constants ──────────────────────────────────────────────────────────
+/// Byte width of an i32 / WASM pointer (used to size a one-pointer Some-box).
+const I32_BYTES: i32 = 4;
+
 impl FuncCompiler<'_> {
     pub(super) fn emit_map_closure_call(&mut self, method: &str, args: &[IrExpr]) -> bool {
         match method {
@@ -372,7 +376,7 @@ impl FuncCompiler<'_> {
                         // Alloc the (key, val) tuple (one contiguous block) and wrap in Some.
                         i32_const(entry as i32); call(self.emitter.rt.alloc); local_set(tuple_ptr);
                         local_get(tuple_ptr); local_get(ent); i32_const(entry as i32); memory_copy;
-                        i32_const(4); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); local_get(tuple_ptr); i32_store(0);
                         br(2); // break out of loop
                       end;

--- a/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
@@ -6,6 +6,7 @@
 // ── Named immediates ──────────────────────────────────────────────────────────
 // Element widths / byte sizes
 /// Bytes per f64 matrix element.
+use crate::emit_wasm::engine::{Imm32, Local};
 const F64_BYTES: i32 = 8;
 /// Bytes per f32 element (to_bytes_f32_le / from_bytes_f32_le).
 const F32_BYTES: i32 = 4;
@@ -136,45 +137,45 @@ impl FuncCompiler<'_> {
                 let ptr = self.scratch.alloc_i32();
                 let total = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_wrap_i64; local_set(rows); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(rows)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(cols);
+                    i32_wrap_i64; local_set(Local(cols));
                     // total_bytes = 8 + rows*cols*8
-                    local_get(rows); local_get(cols); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(Local(rows)); local_get(Local(cols)); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
                     call(self.emitter.rt.alloc);
-                    local_set(ptr);
+                    local_set(Local(ptr));
                     // store rows, cols
-                    local_get(ptr); local_get(rows); i32_store(0);
-                    local_get(ptr); local_get(cols); i32_store(4);
+                    local_get(Local(ptr)); local_get(Local(rows)); i32_store(0);
+                    local_get(Local(ptr)); local_get(Local(cols)); i32_store(4);
                 });
                 if method == "zeros" {
                     // zero-fill data
                     wasm!(self.func, {
-                        local_get(ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        i32_const(0);
-                        local_get(total); i32_const(F64_BYTES); i32_mul;
+                        local_get(Local(ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        i32_const(Imm32(0));
+                        local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul;
                         memory_fill;
                     });
                 } else {
                     // fill with 1.0
                     let i = self.scratch.alloc_i32();
                     wasm!(self.func, {
-                        i32_const(0); local_set(i);
+                        i32_const(Imm32(0)); local_set(Local(i));
                         block_empty; loop_empty;
-                          local_get(i); local_get(total); i32_ge_u; br_if(1);
-                          local_get(ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                          local_get(Local(i)); local_get(Local(total)); i32_ge_u; br_if(1);
+                          local_get(Local(ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                           f64_const(1.0);
                           f64_store(0);
-                          local_get(i); i32_const(1); i32_add; local_set(i);
+                          local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                           br(0);
                         end; end;
                     });
                     self.scratch.free_i32(i);
                 }
-                wasm!(self.func, { local_get(ptr); });
+                wasm!(self.func, { local_get(Local(ptr)); });
                 self.scratch.free_i32(total);
                 self.scratch.free_i32(ptr);
                 self.scratch.free_i32(cols);
@@ -194,15 +195,15 @@ impl FuncCompiler<'_> {
                 let t = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(m);
-                    i32_const(SHAPE_TUPLE_BYTES); call(self.emitter.rt.alloc); local_set(t);
-                    local_get(t);
-                    local_get(m); i32_load(0); i64_extend_i32_u;
+                    local_set(Local(m));
+                    i32_const(Imm32(SHAPE_TUPLE_BYTES)); call(self.emitter.rt.alloc); local_set(Local(t));
+                    local_get(Local(t));
+                    local_get(Local(m)); i32_load(0); i64_extend_i32_u;
                     i64_store(0);
-                    local_get(t);
-                    local_get(m); i32_load(4); i64_extend_i32_u;
+                    local_get(Local(t));
+                    local_get(Local(m)); i32_load(4); i64_extend_i32_u;
                     i64_store(8);
-                    local_get(t);
+                    local_get(Local(t));
                 });
                 self.scratch.free_i32(t);
                 self.scratch.free_i32(m);
@@ -213,17 +214,17 @@ impl FuncCompiler<'_> {
                 let row = self.scratch.alloc_i32();
                 let col = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(row); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(row)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(col);
+                    i32_wrap_i64; local_set(Local(col));
                     // offset = 8 + (row * cols + col) * 8
-                    local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(row); local_get(m); i32_load(4); i32_mul;
-                    local_get(col); i32_add;
-                    i32_const(F64_BYTES); i32_mul;
+                    local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(row)); local_get(Local(m)); i32_load(4); i32_mul;
+                    local_get(Local(col)); i32_add;
+                    i32_const(Imm32(F64_BYTES)); i32_mul;
                     i32_add;
                     f64_load(0);
                 });
@@ -240,39 +241,39 @@ impl FuncCompiler<'_> {
                 let cols = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(src);
-                    local_get(src); i32_load(0); local_set(rows);
-                    local_get(src); i32_load(4); local_set(cols);
+                    local_set(Local(src));
+                    local_get(Local(src)); i32_load(0); local_set(Local(rows));
+                    local_get(Local(src)); i32_load(4); local_set(Local(cols));
                     // alloc dst: [cols, rows, data...]
-                    local_get(cols); local_get(rows); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(cols); i32_store(0);
-                    local_get(dst); local_get(rows); i32_store(4);
+                    local_get(Local(cols)); local_get(Local(rows)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(cols)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(rows)); i32_store(4);
                     // loop: dst[c][r] = src[r][c]
-                    i32_const(0); local_set(r);
+                    i32_const(Imm32(0)); local_set(Local(r));
                     block_empty; loop_empty;
-                      local_get(r); local_get(rows); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(c);
+                      local_get(Local(r)); local_get(Local(rows)); i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(cols); i32_ge_u; br_if(1);
+                        local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
                         // dst offset: 8 + (c * rows + r) * 8
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); local_get(rows); i32_mul; local_get(r); i32_add;
-                        i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(c)); local_get(Local(rows)); i32_mul; local_get(Local(r)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         // src offset: 8 + (r * cols + c) * 8
-                        local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(r); local_get(cols); i32_mul; local_get(c); i32_add;
-                        i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(src)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(r)); local_get(Local(cols)); i32_mul; local_get(Local(c)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         f64_load(0);
                         f64_store(0);
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
-                      local_get(r); i32_const(1); i32_add; local_set(r);
+                      local_get(Local(r)); i32_const(Imm32(1)); i32_add; local_set(Local(r));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(cols);
                 self.scratch.free_i32(rows);
@@ -289,22 +290,22 @@ impl FuncCompiler<'_> {
                 let total = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(b);
-                    local_get(a); i32_load(0); local_get(a); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(a); i32_load(0); i32_store(0);
-                    local_get(dst); local_get(a); i32_load(4); i32_store(4);
-                    i32_const(0); local_set(i);
+                    local_set(Local(b));
+                    local_get(Local(a)); i32_load(0); local_get(Local(a)); i32_load(4); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(a)); i32_load(0); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(a)); i32_load(4); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     // SIMD loop: 2 elements per iter
                     block_empty; loop_empty;
-                      local_get(i); i32_const(1); i32_add; local_get(total); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; v128_load(0);
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; v128_load(0);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_get(Local(total)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; v128_load(0);
+                      local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; v128_load(0);
                 });
                 match method {
                     "add" => { wasm!(self.func, { f64x2_add; }); }
@@ -314,15 +315,15 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                       v128_store(0);
-                      local_get(i); i32_const(SIMD_F64_LANES); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(SIMD_F64_LANES)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                     // Scalar tail (1 element if total is odd)
-                    local_get(i); local_get(total); i32_lt_u;
+                    local_get(Local(i)); local_get(Local(total)); i32_lt_u;
                     if_empty;
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                      local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
                 });
                 match method {
                     "add" => { wasm!(self.func, { f64_add; }); }
@@ -333,7 +334,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                       f64_store(0);
                     end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(total);
@@ -363,122 +364,122 @@ impl FuncCompiler<'_> {
                 let a_ik = self.scratch.alloc_f64();
                 const TILE: i32 = 32;
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(b);
-                    local_get(a); i32_load(0); local_set(ra);
-                    local_get(a); i32_load(4); local_set(ca);
-                    local_get(b); i32_load(4); local_set(cb);
+                    local_set(Local(b));
+                    local_get(Local(a)); i32_load(0); local_set(Local(ra));
+                    local_get(Local(a)); i32_load(4); local_set(Local(ca));
+                    local_get(Local(b)); i32_load(4); local_set(Local(cb));
                     // alloc + zero result
-                    local_get(ra); local_get(cb); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(ra); i32_store(0);
-                    local_get(dst); local_get(cb); i32_store(4);
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    i32_const(0);
-                    local_get(ra); local_get(cb); i32_mul; i32_const(F64_BYTES); i32_mul;
+                    local_get(Local(ra)); local_get(Local(cb)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(ra)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cb)); i32_store(4);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    i32_const(Imm32(0));
+                    local_get(Local(ra)); local_get(Local(cb)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
                     memory_fill;
                     // Tiled loops: i0, k0, j0 (tile starts)
-                    i32_const(0); local_set(i0);
+                    i32_const(Imm32(0)); local_set(Local(i0));
                     block_empty; loop_empty;
-                      local_get(i0); local_get(ra); i32_ge_u; br_if(1);
+                      local_get(Local(i0)); local_get(Local(ra)); i32_ge_u; br_if(1);
                       // i1 = min(i0+TILE, ra)
-                      local_get(i0); i32_const(TILE); i32_add; local_set(i1);
-                      local_get(i1); local_get(ra); i32_gt_u;
-                      if_empty; local_get(ra); local_set(i1); end;
+                      local_get(Local(i0)); i32_const(Imm32(TILE)); i32_add; local_set(Local(i1));
+                      local_get(Local(i1)); local_get(Local(ra)); i32_gt_u;
+                      if_empty; local_get(Local(ra)); local_set(Local(i1)); end;
 
-                      i32_const(0); local_set(k0);
+                      i32_const(Imm32(0)); local_set(Local(k0));
                       block_empty; loop_empty;
-                        local_get(k0); local_get(ca); i32_ge_u; br_if(1);
-                        local_get(k0); i32_const(TILE); i32_add; local_set(k1);
-                        local_get(k1); local_get(ca); i32_gt_u;
-                        if_empty; local_get(ca); local_set(k1); end;
+                        local_get(Local(k0)); local_get(Local(ca)); i32_ge_u; br_if(1);
+                        local_get(Local(k0)); i32_const(Imm32(TILE)); i32_add; local_set(Local(k1));
+                        local_get(Local(k1)); local_get(Local(ca)); i32_gt_u;
+                        if_empty; local_get(Local(ca)); local_set(Local(k1)); end;
 
-                        i32_const(0); local_set(j0);
+                        i32_const(Imm32(0)); local_set(Local(j0));
                         block_empty; loop_empty;
-                          local_get(j0); local_get(cb); i32_ge_u; br_if(1);
-                          local_get(j0); i32_const(TILE); i32_add; local_set(j1);
-                          local_get(j1); local_get(cb); i32_gt_u;
-                          if_empty; local_get(cb); local_set(j1); end;
+                          local_get(Local(j0)); local_get(Local(cb)); i32_ge_u; br_if(1);
+                          local_get(Local(j0)); i32_const(Imm32(TILE)); i32_add; local_set(Local(j1));
+                          local_get(Local(j1)); local_get(Local(cb)); i32_gt_u;
+                          if_empty; local_get(Local(cb)); local_set(Local(j1)); end;
 
                           // Inner tile: i, k, j
-                          local_get(i0); local_set(i);
+                          local_get(Local(i0)); local_set(Local(i));
                           block_empty; loop_empty;
-                            local_get(i); local_get(i1); i32_ge_u; br_if(1);
+                            local_get(Local(i)); local_get(Local(i1)); i32_ge_u; br_if(1);
 
-                            local_get(k0); local_set(k);
+                            local_get(Local(k0)); local_set(Local(k));
                             block_empty; loop_empty;
-                              local_get(k); local_get(k1); i32_ge_u; br_if(1);
+                              local_get(Local(k)); local_get(Local(k1)); i32_ge_u; br_if(1);
                               // a_ik = A[i][k]
-                              local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                              local_get(i); local_get(ca); i32_mul; local_get(k); i32_add;
-                              i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                              local_set(a_ik);
+                              local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                              local_get(Local(i)); local_get(Local(ca)); i32_mul; local_get(Local(k)); i32_add;
+                              i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                              local_set(Local(a_ik));
 
                               // SIMD inner loop: j steps by 2 (f64x2)
                               // j1_even = j1 & ~1 (round down to even)
-                              local_get(j0); local_set(j);
+                              local_get(Local(j0)); local_set(Local(j));
                               block_empty; loop_empty;
                                 // if j+1 >= j1, exit SIMD loop
-                                local_get(j); i32_const(1); i32_add; local_get(j1); i32_gt_u; br_if(1);
+                                local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_get(Local(j1)); i32_gt_u; br_if(1);
                                 // addr_c = dst + 8 + (i*cb + j)*8
-                                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                                local_get(i); local_get(cb); i32_mul; local_get(j); i32_add;
-                                i32_const(F64_BYTES); i32_mul; i32_add;
+                                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                                local_get(Local(i)); local_get(Local(cb)); i32_mul; local_get(Local(j)); i32_add;
+                                i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                                 // v_c = load C[i][j..j+2]
-                                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                                local_get(i); local_get(cb); i32_mul; local_get(j); i32_add;
-                                i32_const(F64_BYTES); i32_mul; i32_add;
+                                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                                local_get(Local(i)); local_get(Local(cb)); i32_mul; local_get(Local(j)); i32_add;
+                                i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                                 v128_load(0);
                                 // v_a = splat(a_ik)
-                                local_get(a_ik); f64x2_splat;
+                                local_get(Local(a_ik)); f64x2_splat;
                                 // v_b = load B[k][j..j+2]
-                                local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                                local_get(k); local_get(cb); i32_mul; local_get(j); i32_add;
-                                i32_const(F64_BYTES); i32_mul; i32_add;
+                                local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                                local_get(Local(k)); local_get(Local(cb)); i32_mul; local_get(Local(j)); i32_add;
+                                i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                                 v128_load(0);
                                 // v_c += v_a * v_b
                                 f64x2_mul; f64x2_add;
                                 // store C[i][j..j+2]
                                 v128_store(0);
 
-                                local_get(j); i32_const(SIMD_F64_LANES); i32_add; local_set(j);
+                                local_get(Local(j)); i32_const(Imm32(SIMD_F64_LANES)); i32_add; local_set(Local(j));
                                 br(0);
                               end; end;
                               // Scalar remainder: if j < j1, process 1 more element
-                              local_get(j); local_get(j1); i32_lt_u;
+                              local_get(Local(j)); local_get(Local(j1)); i32_lt_u;
                               if_empty;
-                                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                                local_get(i); local_get(cb); i32_mul; local_get(j); i32_add;
-                                i32_const(F64_BYTES); i32_mul; i32_add;
-                                local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                                local_get(i); local_get(cb); i32_mul; local_get(j); i32_add;
-                                i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                                local_get(a_ik);
-                                local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                                local_get(k); local_get(cb); i32_mul; local_get(j); i32_add;
-                                i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
+                                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                                local_get(Local(i)); local_get(Local(cb)); i32_mul; local_get(Local(j)); i32_add;
+                                i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                                local_get(Local(i)); local_get(Local(cb)); i32_mul; local_get(Local(j)); i32_add;
+                                i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                                local_get(Local(a_ik));
+                                local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                                local_get(Local(k)); local_get(Local(cb)); i32_mul; local_get(Local(j)); i32_add;
+                                i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
                                 f64_mul; f64_add; f64_store(0);
                               end;
-                              local_get(k); i32_const(1); i32_add; local_set(k);
+                              local_get(Local(k)); i32_const(Imm32(1)); i32_add; local_set(Local(k));
                               br(0);
                             end; end;
-                            local_get(i); i32_const(1); i32_add; local_set(i);
+                            local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                             br(0);
                           end; end;
 
-                          local_get(j0); i32_const(TILE); i32_add; local_set(j0);
+                          local_get(Local(j0)); i32_const(Imm32(TILE)); i32_add; local_set(Local(j0));
                           br(0);
                         end; end;
-                        local_get(k0); i32_const(TILE); i32_add; local_set(k0);
+                        local_get(Local(k0)); i32_const(Imm32(TILE)); i32_add; local_set(Local(k0));
                         br(0);
                       end; end;
-                      local_get(i0); i32_const(TILE); i32_add; local_set(i0);
+                      local_get(Local(i0)); i32_const(Imm32(TILE)); i32_add; local_set(Local(i0));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(a_ik);
                 self.scratch.free_i32(j1);
@@ -505,39 +506,39 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let s = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
                 // scalar could be Int or Float — convert to f64
                 if matches!(&args[1].ty, almide_lang::types::Ty::Int) {
                     wasm!(self.func, { f64_convert_i64_s; });
                 }
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(m); i32_load(0); i32_store(0);
-                    local_get(dst); local_get(m); i32_load(4); i32_store(4);
-                    i32_const(0); local_set(i);
+                    local_set(Local(s));
+                    local_get(Local(m)); i32_load(0); local_get(Local(m)); i32_load(4); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(m)); i32_load(0); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(m)); i32_load(4); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     // SIMD f64x2 inner loop
                     block_empty; loop_empty;
-                      local_get(i); i32_const(1); i32_add; local_get(total); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      v128_load(0); local_get(s); f64x2_splat; f64x2_mul;
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_get(Local(total)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      v128_load(0); local_get(Local(s)); f64x2_splat; f64x2_mul;
                       v128_store(0);
-                      local_get(i); i32_const(SIMD_F64_LANES); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(SIMD_F64_LANES)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                     // Scalar tail (1 element if total is odd)
-                    local_get(i); local_get(total); i32_lt_u;
+                    local_get(Local(i)); local_get(Local(total)); i32_lt_u;
                     if_empty;
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      f64_load(0); local_get(s); f64_mul;
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      f64_load(0); local_get(Local(s)); f64_mul;
                       f64_store(0);
                     end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(s);
                 self.scratch.free_i32(i);
@@ -560,71 +561,71 @@ impl FuncCompiler<'_> {
                 let ka = self.scratch.alloc_f64();
                 let kb = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
                 if matches!(&args[1].ty, almide_lang::types::Ty::Int) {
                     wasm!(self.func, { f64_convert_i64_s; });
                 }
-                wasm!(self.func, { local_set(ka); });
+                wasm!(self.func, { local_set(Local(ka)); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { local_set(b); });
+                wasm!(self.func, { local_set(Local(b)); });
                 self.emit_expr(&args[3]);
                 if matches!(&args[3].ty, almide_lang::types::Ty::Int) {
                     wasm!(self.func, { f64_convert_i64_s; });
                 }
                 wasm!(self.func, {
-                    local_set(kb);
+                    local_set(Local(kb));
                     // total = rows * cols
-                    local_get(a); i32_load(0); local_get(a); i32_load(4); i32_mul; local_set(total);
+                    local_get(Local(a)); i32_load(0); local_get(Local(a)); i32_load(4); i32_mul; local_set(Local(total));
                     // alloc 8 + total*8
-                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
                     // copy header
-                    local_get(dst); local_get(a); i32_load(0); i32_store(0);
-                    local_get(dst); local_get(a); i32_load(4); i32_store(4);
-                    i32_const(0); local_set(i);
+                    local_get(Local(dst)); local_get(Local(a)); i32_load(0); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(a)); i32_load(4); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
 
                     // SIMD f64x2 inner loop: process 2 f64 elements per iteration.
                     // Loop invariant: i + 1 < total (room for 2 lanes).
                     block_empty; loop_empty;
                       // exit when i+1 >= total (no room for full lane)
-                      local_get(i); i32_const(1); i32_add; local_get(total); i32_ge_u; br_if(1);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_get(Local(total)); i32_ge_u; br_if(1);
                       // dst addr = dst + 8 + i*8
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       // v_a = load a[i..i+2]
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       v128_load(0);
                       // v_a *= splat(ka)
-                      local_get(ka); f64x2_splat;
+                      local_get(Local(ka)); f64x2_splat;
                       f64x2_mul;
                       // v_b = load b[i..i+2]
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       v128_load(0);
                       // v_b *= splat(kb)
-                      local_get(kb); f64x2_splat;
+                      local_get(Local(kb)); f64x2_splat;
                       f64x2_mul;
                       // v_a + v_b
                       f64x2_add;
                       // store dst[i..i+2]
                       v128_store(0);
                       // i += 2
-                      local_get(i); i32_const(SIMD_F64_LANES); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(SIMD_F64_LANES)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
 
                     // Scalar tail: process one trailing element if total is odd.
-                    local_get(i); local_get(total); i32_lt_u;
+                    local_get(Local(i)); local_get(Local(total)); i32_lt_u;
                     if_empty;
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                      local_get(ka); f64_mul;
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                      local_get(kb); f64_mul;
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                      local_get(Local(ka)); f64_mul;
+                      local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                      local_get(Local(kb)); f64_mul;
                       f64_add;
                       f64_store(0);
                     end;
 
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(kb);
                 self.scratch.free_f64(ka);
@@ -649,66 +650,66 @@ impl FuncCompiler<'_> {
                 let kb = self.scratch.alloc_f64();
                 let kc = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
                 if matches!(&args[1].ty, almide_lang::types::Ty::Int) { wasm!(self.func, { f64_convert_i64_s; }); }
-                wasm!(self.func, { local_set(ka); });
+                wasm!(self.func, { local_set(Local(ka)); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { local_set(b); });
+                wasm!(self.func, { local_set(Local(b)); });
                 self.emit_expr(&args[3]);
                 if matches!(&args[3].ty, almide_lang::types::Ty::Int) { wasm!(self.func, { f64_convert_i64_s; }); }
-                wasm!(self.func, { local_set(kb); });
+                wasm!(self.func, { local_set(Local(kb)); });
                 self.emit_expr(&args[4]);
-                wasm!(self.func, { local_set(c); });
+                wasm!(self.func, { local_set(Local(c)); });
                 self.emit_expr(&args[5]);
                 if matches!(&args[5].ty, almide_lang::types::Ty::Int) { wasm!(self.func, { f64_convert_i64_s; }); }
                 wasm!(self.func, {
-                    local_set(kc);
-                    local_get(a); i32_load(0); local_get(a); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(a); i32_load(0); i32_store(0);
-                    local_get(dst); local_get(a); i32_load(4); i32_store(4);
-                    i32_const(0); local_set(i);
+                    local_set(Local(kc));
+                    local_get(Local(a)); i32_load(0); local_get(Local(a)); i32_load(4); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(a)); i32_load(0); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(a)); i32_load(4); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
 
                     block_empty; loop_empty;
-                      local_get(i); i32_const(1); i32_add; local_get(total); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_get(Local(total)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       v128_load(0);
-                      local_get(ka); f64x2_splat;
+                      local_get(Local(ka)); f64x2_splat;
                       f64x2_mul;
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       v128_load(0);
-                      local_get(kb); f64x2_splat;
+                      local_get(Local(kb)); f64x2_splat;
                       f64x2_mul;
                       f64x2_add;
-                      local_get(c); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(c)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       v128_load(0);
-                      local_get(kc); f64x2_splat;
+                      local_get(Local(kc)); f64x2_splat;
                       f64x2_mul;
                       f64x2_add;
                       v128_store(0);
-                      local_get(i); i32_const(SIMD_F64_LANES); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(SIMD_F64_LANES)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
 
                     // Scalar tail
-                    local_get(i); local_get(total); i32_lt_u;
+                    local_get(Local(i)); local_get(Local(total)); i32_lt_u;
                     if_empty;
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                      local_get(ka); f64_mul;
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                      local_get(kb); f64_mul;
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                      local_get(Local(ka)); f64_mul;
+                      local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                      local_get(Local(kb)); f64_mul;
                       f64_add;
-                      local_get(c); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                      local_get(kc); f64_mul;
+                      local_get(Local(c)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                      local_get(Local(kc)); f64_mul;
                       f64_add;
                       f64_store(0);
                     end;
 
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(kc);
                 self.scratch.free_f64(kb);
@@ -732,48 +733,48 @@ impl FuncCompiler<'_> {
                 let row_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(src);
-                    local_get(src); i32_load(0); local_set(nrows);
+                    local_set(Local(src));
+                    local_get(Local(src)); i32_load(0); local_set(Local(nrows));
                     // cols from first row (or 0)
-                    local_get(nrows); i32_eqz;
+                    local_get(Local(nrows)); i32_eqz;
                     if_i32;
-                      i32_const(0);
+                      i32_const(Imm32(0));
                     else_;
-                      local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; i32_load(0); // ptr to first row
+                      local_get(Local(src)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; i32_load(0); // ptr to first row
                       i32_load(0); // len of first row
                     end;
-                    local_set(ncols);
+                    local_set(Local(ncols));
                     // alloc matrix
-                    local_get(nrows); local_get(ncols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(nrows); i32_store(0);
-                    local_get(dst); local_get(ncols); i32_store(4);
+                    local_get(Local(nrows)); local_get(Local(ncols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(nrows)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(ncols)); i32_store(4);
                     // copy data
-                    i32_const(0); local_set(r);
+                    i32_const(Imm32(0)); local_set(Local(r));
                     block_empty; loop_empty;
-                      local_get(r); local_get(nrows); i32_ge_u; br_if(1);
+                      local_get(Local(r)); local_get(Local(nrows)); i32_ge_u; br_if(1);
                       // row_ptr = *(src + 4 + r*4)  (pointer to inner list)
-                      local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(r); i32_const(I32_BYTES); i32_mul; i32_add;
-                      i32_load(0); local_set(row_ptr);
-                      i32_const(0); local_set(c);
+                      local_get(Local(src)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(r)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      i32_load(0); local_set(Local(row_ptr));
+                      i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(ncols); i32_ge_u; br_if(1);
+                        local_get(Local(c)); local_get(Local(ncols)); i32_ge_u; br_if(1);
                         // dst[r][c] = row_ptr->data[c]
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(r); local_get(ncols); i32_mul; local_get(c); i32_add;
-                        i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(row_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(r)); local_get(Local(ncols)); i32_mul; local_get(Local(c)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(row_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         f64_load(0); f64_store(0);
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
-                      local_get(r); i32_const(1); i32_add; local_set(r);
+                      local_get(Local(r)); i32_const(Imm32(1)); i32_add; local_set(Local(r));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(row_ptr);
                 self.scratch.free_i32(c);
@@ -794,42 +795,42 @@ impl FuncCompiler<'_> {
                 let row_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(m);
-                    local_get(m); i32_load(0); local_set(nrows);
-                    local_get(m); i32_load(4); local_set(ncols);
+                    local_set(Local(m));
+                    local_get(Local(m)); i32_load(0); local_set(Local(nrows));
+                    local_get(Local(m)); i32_load(4); local_set(Local(ncols));
                     // alloc outer list: [len:i32][ptr0:i32][ptr1:i32]...
-                    local_get(nrows); i32_const(I32_BYTES); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(outer);
-                    local_get(outer); local_get(nrows); i32_store(0);
+                    local_get(Local(nrows)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(outer));
+                    local_get(Local(outer)); local_get(Local(nrows)); i32_store(0);
                     // create each row list
-                    i32_const(0); local_set(r);
+                    i32_const(Imm32(0)); local_set(Local(r));
                     block_empty; loop_empty;
-                      local_get(r); local_get(nrows); i32_ge_u; br_if(1);
+                      local_get(Local(r)); local_get(Local(nrows)); i32_ge_u; br_if(1);
                       // alloc row: [len:i32][f64...]
-                      local_get(ncols); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      call(self.emitter.rt.alloc); local_set(row_ptr);
-                      local_get(row_ptr); local_get(ncols); i32_store(0);
+                      local_get(Local(ncols)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      call(self.emitter.rt.alloc); local_set(Local(row_ptr));
+                      local_get(Local(row_ptr)); local_get(Local(ncols)); i32_store(0);
                       // copy data
-                      i32_const(0); local_set(c);
+                      i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(ncols); i32_ge_u; br_if(1);
-                        local_get(row_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(r); local_get(ncols); i32_mul; local_get(c); i32_add;
-                        i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(c)); local_get(Local(ncols)); i32_ge_u; br_if(1);
+                        local_get(Local(row_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(r)); local_get(Local(ncols)); i32_mul; local_get(Local(c)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         f64_load(0); f64_store(0);
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
                       // store row ptr in outer list
-                      local_get(outer); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(r); i32_const(I32_BYTES); i32_mul; i32_add;
-                      local_get(row_ptr); i32_store(0);
-                      local_get(r); i32_const(1); i32_add; local_set(r);
+                      local_get(Local(outer)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(r)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      local_get(Local(row_ptr)); i32_store(0);
+                      local_get(Local(r)); i32_const(Imm32(1)); i32_add; local_set(Local(r));
                       br(0);
                     end; end;
-                    local_get(outer);
+                    local_get(Local(outer));
                 });
                 self.scratch.free_i32(row_ptr);
                 self.scratch.free_i32(c);
@@ -847,35 +848,35 @@ impl FuncCompiler<'_> {
                 let total = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(m); i32_load(0); i32_store(0);
-                    local_get(dst); local_get(m); i32_load(4); i32_store(4);
-                    i32_const(0); local_set(i);
+                    local_set(Local(closure));
+                    local_get(Local(m)); i32_load(0); local_get(Local(m)); i32_load(4); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(m)); i32_load(0); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(m)); i32_load(4); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(total); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(total)); i32_ge_u; br_if(1);
                       // dst[i] = f(m[i])
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       // call closure: env, arg, table_idx
-                      local_get(closure); i32_load(4); // env
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       f64_load(0); // element value
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 self.emit_closure_call(&almide_lang::types::Ty::Float, &almide_lang::types::Ty::Float);
                 wasm!(self.func, {
                       f64_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(total);
@@ -894,43 +895,43 @@ impl FuncCompiler<'_> {
                 let r = self.scratch.alloc_i32();
                 let c = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(bias);
-                    local_get(m); i32_load(0); local_set(rows);
-                    local_get(m); i32_load(4); local_set(cols);
-                    local_get(rows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(rows); i32_store(0);
-                    local_get(dst); local_get(cols); i32_store(4);
-                    i32_const(0); local_set(r);
+                    local_set(Local(bias));
+                    local_get(Local(m)); i32_load(0); local_set(Local(rows));
+                    local_get(Local(m)); i32_load(4); local_set(Local(cols));
+                    local_get(Local(rows)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(rows)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cols)); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(r));
                     block_empty; loop_empty;
-                      local_get(r); local_get(rows); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(c);
+                      local_get(Local(r)); local_get(Local(rows)); i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(cols); i32_ge_u; br_if(1);
+                        local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
                         // dst[r,c] = m[r,c] + bias[c]
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(r); local_get(cols); i32_mul; local_get(c); i32_add;
-                        i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(r); local_get(cols); i32_mul; local_get(c); i32_add;
-                        i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(r)); local_get(Local(cols)); i32_mul; local_get(Local(c)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(r)); local_get(Local(cols)); i32_mul; local_get(Local(c)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         f64_load(0);
-                        local_get(bias); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(bias)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         f64_load(0);
                         f64_add;
                         f64_store(0);
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
-                      local_get(r); i32_const(1); i32_add; local_set(r);
+                      local_get(Local(r)); i32_const(Imm32(1)); i32_add; local_set(Local(r));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(c);
                 self.scratch.free_i32(r);
@@ -949,30 +950,30 @@ impl FuncCompiler<'_> {
                 let cols = self.scratch.alloc_i32();
                 let nrows = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(start); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(start)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(end_);
-                    local_get(m); i32_load(4); local_set(cols);
+                    i32_wrap_i64; local_set(Local(end_));
+                    local_get(Local(m)); i32_load(4); local_set(Local(cols));
                     // nrows = end - start (clamped >= 0)
-                    local_get(end_); local_get(start); i32_sub; local_set(nrows);
-                    local_get(nrows); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(nrows); end;
+                    local_get(Local(end_)); local_get(Local(start)); i32_sub; local_set(Local(nrows));
+                    local_get(Local(nrows)); i32_const(Imm32(0)); i32_lt_s;
+                    if_empty; i32_const(Imm32(0)); local_set(Local(nrows)); end;
                     // alloc + header
-                    local_get(nrows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(nrows); i32_store(0);
-                    local_get(dst); local_get(cols); i32_store(4);
+                    local_get(Local(nrows)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(nrows)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cols)); i32_store(4);
                     // memcpy: dst.data, m.data + start*cols*8, nrows*cols*8
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(start); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul; i32_add;
-                    local_get(nrows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(start)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                    local_get(Local(nrows)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
                     memory_copy;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(nrows);
                 self.scratch.free_i32(cols);
@@ -989,23 +990,23 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(m);
-                    local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(m); i32_load(0); i32_store(0);
-                    local_get(dst); local_get(m); i32_load(4); i32_store(4);
-                    i32_const(0); local_set(i);
+                    local_set(Local(m));
+                    local_get(Local(m)); i32_load(0); local_get(Local(m)); i32_load(4); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(m)); i32_load(0); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(m)); i32_load(4); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(total); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(total)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       f64_load(0); f64_neg;
                       f64_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(total);
@@ -1022,32 +1023,32 @@ impl FuncCompiler<'_> {
                 let x = self.scratch.alloc_f64();
                 let result = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(exp);
-                    local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(m); i32_load(0); i32_store(0);
-                    local_get(dst); local_get(m); i32_load(4); i32_store(4);
-                    i32_const(0); local_set(i);
+                    local_set(Local(exp));
+                    local_get(Local(m)); i32_load(0); local_get(Local(m)); i32_load(4); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(m)); i32_load(0); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(m)); i32_load(4); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(total); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(total)); i32_ge_u; br_if(1);
                       // Load x into a local so it's stable across the call.
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                      local_set(x);
+                      local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                      local_set(Local(x));
                       // Compute pow(x, exp) via __float_pow runtime.
-                      local_get(x); local_get(exp); call(self.emitter.rt.float_pow);
-                      local_set(result);
+                      local_get(Local(x)); local_get(Local(exp)); call(self.emitter.rt.float_pow);
+                      local_set(Local(result));
                       // Store at dst+8+i*8
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      local_get(result);
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(result));
                       f64_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(result);
                 self.scratch.free_f64(x);
@@ -1067,31 +1068,31 @@ impl FuncCompiler<'_> {
                 let x = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(m);
-                    local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(m); i32_load(0); i32_store(0);
-                    local_get(dst); local_get(m); i32_load(4); i32_store(4);
-                    i32_const(0); local_set(i);
+                    local_set(Local(m));
+                    local_get(Local(m)); i32_load(0); local_get(Local(m)); i32_load(4); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(m)); i32_load(0); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(m)); i32_load(4); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(total); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(total)); i32_ge_u; br_if(1);
                       // x = m.data[i]
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      f64_load(0); local_set(x);
+                      local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      f64_load(0); local_set(Local(x));
                       // dst.data[i] = gelu(x)
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                 });
                 // tanh(z) via runtime helper or expansion: tanh(z) = (e^(2z)-1)/(e^(2z)+1)
                 // Compute inner = K * (x + 0.044715 * x^3)
                 wasm!(self.func, {
                       f64_const(0.7978845608028654);
-                      local_get(x);
+                      local_get(Local(x));
                       f64_const(0.044715);
-                      local_get(x); local_get(x); f64_mul;
-                      local_get(x); f64_mul;
+                      local_get(Local(x)); local_get(Local(x)); f64_mul;
+                      local_get(Local(x)); f64_mul;
                       f64_mul;
                       f64_add;
                       f64_mul;
@@ -1107,19 +1108,19 @@ impl FuncCompiler<'_> {
                 });
                 let e2 = self.scratch.alloc_f64();
                 wasm!(self.func, {
-                      local_set(e2);
-                      local_get(e2); f64_const(1.0); f64_sub;
-                      local_get(e2); f64_const(1.0); f64_add;
+                      local_set(Local(e2));
+                      local_get(Local(e2)); f64_const(1.0); f64_sub;
+                      local_get(Local(e2)); f64_const(1.0); f64_add;
                       f64_div;
                       // stack: tanh_inner. compute 0.5 * x * (1 + tanh)
                       f64_const(1.0); f64_add;
-                      local_get(x); f64_mul;
+                      local_get(Local(x)); f64_mul;
                       f64_const(0.5); f64_mul;
                       f64_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(e2);
                 self.scratch.free_f64(x);
@@ -1142,85 +1143,85 @@ impl FuncCompiler<'_> {
                 let v = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(m);
-                    local_get(m); i32_load(0); local_set(rows);
-                    local_get(m); i32_load(4); local_set(cols);
-                    local_get(rows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(rows); i32_store(0);
-                    local_get(dst); local_get(cols); i32_store(4);
-                    i32_const(0); local_set(r);
+                    local_set(Local(m));
+                    local_get(Local(m)); i32_load(0); local_set(Local(rows));
+                    local_get(Local(m)); i32_load(4); local_set(Local(cols));
+                    local_get(Local(rows)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(rows)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cols)); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(r));
                     block_empty; loop_empty;
-                      local_get(r); local_get(rows); i32_ge_u; br_if(1);
+                      local_get(Local(r)); local_get(Local(rows)); i32_ge_u; br_if(1);
                       // row_off = 8 + r*cols*8 (offset to row r in data)
-                      local_get(r); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                      i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_set(row_off);
+                      local_get(Local(r)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                      i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_set(Local(row_off));
                       // max = m[r, 0], scan row 1..cols (NaN-safe init).
-                      local_get(m); local_get(row_off); i32_add;
-                      f64_load(0); local_set(max);
-                      i32_const(1); local_set(c);
+                      local_get(Local(m)); local_get(Local(row_off)); i32_add;
+                      f64_load(0); local_set(Local(max));
+                      i32_const(Imm32(1)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(cols); i32_ge_u; br_if(1);
-                        local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
-                        f64_load(0); local_set(v);
-                        local_get(v); local_get(max); f64_gt;
-                        if_empty; local_get(v); local_set(max); end;
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
+                        local_get(Local(m)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        f64_load(0); local_set(Local(v));
+                        local_get(Local(v)); local_get(Local(max)); f64_gt;
+                        if_empty; local_get(Local(v)); local_set(Local(max)); end;
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
                       // exps + sum
-                      f64_const(0.0); local_set(sum);
-                      i32_const(0); local_set(c);
+                      f64_const(0.0); local_set(Local(sum));
+                      i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(cols); i32_ge_u; br_if(1);
-                        local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
-                        f64_load(0); local_get(max); f64_sub;
-                        call(self.emitter.rt.math_exp); local_set(v);
+                        local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
+                        local_get(Local(m)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        f64_load(0); local_get(Local(max)); f64_sub;
+                        call(self.emitter.rt.math_exp); local_set(Local(v));
                         // dst[r, c] = v
-                        local_get(dst); local_get(row_off); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(v); f64_store(0);
-                        local_get(sum); local_get(v); f64_add; local_set(sum);
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(v)); f64_store(0);
+                        local_get(Local(sum)); local_get(Local(v)); f64_add; local_set(Local(sum));
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
                       // Sum guard: NaN/Inf/zero fall-back to uniform.
-                      local_get(sum); f64_const(0.0); f64_le;
-                      local_get(sum); local_get(sum); f64_ne;
+                      local_get(Local(sum)); f64_const(0.0); f64_le;
+                      local_get(Local(sum)); local_get(Local(sum)); f64_ne;
                       i32_or;
                       if_empty;
-                        local_get(cols); f64_convert_i32_u; local_set(sum);
-                        i32_const(0); local_set(c);
+                        local_get(Local(cols)); f64_convert_i32_u; local_set(Local(sum));
+                        i32_const(Imm32(0)); local_set(Local(c));
                         block_empty; loop_empty;
-                          local_get(c); local_get(cols); i32_ge_u; br_if(1);
-                          local_get(dst); local_get(row_off); i32_add;
-                          local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
+                          local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
+                          local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                          local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                           f64_const(1.0); f64_store(0);
-                          local_get(c); i32_const(1); i32_add; local_set(c);
+                          local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                           br(0);
                         end; end;
                       end;
                       // Normalize: dst[r,c] /= sum
-                      i32_const(0); local_set(c);
+                      i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(cols); i32_ge_u; br_if(1);
-                        local_get(dst); local_get(row_off); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(dst); local_get(row_off); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
+                        local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         f64_load(0);
-                        local_get(sum); f64_div;
+                        local_get(Local(sum)); f64_div;
                         f64_store(0);
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
-                      local_get(r); i32_const(1); i32_add; local_set(r);
+                      local_get(Local(r)); i32_const(Imm32(1)); i32_add; local_set(Local(r));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(v);
                 self.scratch.free_f64(sum);
@@ -1251,88 +1252,88 @@ impl FuncCompiler<'_> {
                 let cnt = self.scratch.alloc_f64();
                 let tmp = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(gamma); });
+                wasm!(self.func, { local_set(Local(gamma)); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { local_set(beta); });
+                wasm!(self.func, { local_set(Local(beta)); });
                 self.emit_expr(&args[3]);
                 wasm!(self.func, {
-                    local_set(eps);
-                    local_get(m); i32_load(0); local_set(rows);
-                    local_get(m); i32_load(4); local_set(cols);
-                    local_get(rows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(rows); i32_store(0);
-                    local_get(dst); local_get(cols); i32_store(4);
+                    local_set(Local(eps));
+                    local_get(Local(m)); i32_load(0); local_set(Local(rows));
+                    local_get(Local(m)); i32_load(4); local_set(Local(cols));
+                    local_get(Local(rows)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(rows)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cols)); i32_store(4);
                     // cnt = (f64) cols
-                    local_get(cols); f64_convert_i32_u; local_set(cnt);
-                    i32_const(0); local_set(r);
+                    local_get(Local(cols)); f64_convert_i32_u; local_set(Local(cnt));
+                    i32_const(Imm32(0)); local_set(Local(r));
                     block_empty; loop_empty;
-                      local_get(r); local_get(rows); i32_ge_u; br_if(1);
-                      local_get(r); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                      i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_set(row_off);
+                      local_get(Local(r)); local_get(Local(rows)); i32_ge_u; br_if(1);
+                      local_get(Local(r)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                      i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_set(Local(row_off));
                       // mean
-                      f64_const(0.0); local_set(mean);
-                      i32_const(0); local_set(c);
+                      f64_const(0.0); local_set(Local(mean));
+                      i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(cols); i32_ge_u; br_if(1);
-                        local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
+                        local_get(Local(m)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         f64_load(0);
-                        local_get(mean); f64_add; local_set(mean);
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(mean)); f64_add; local_set(Local(mean));
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
-                      local_get(mean); local_get(cnt); f64_div; local_set(mean);
+                      local_get(Local(mean)); local_get(Local(cnt)); f64_div; local_set(Local(mean));
                       // var
-                      f64_const(0.0); local_set(var);
-                      i32_const(0); local_set(c);
+                      f64_const(0.0); local_set(Local(var));
+                      i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(cols); i32_ge_u; br_if(1);
-                        local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
-                        f64_load(0); local_get(mean); f64_sub; local_set(tmp);
-                        local_get(tmp); local_get(tmp); f64_mul;
-                        local_get(var); f64_add; local_set(var);
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
+                        local_get(Local(m)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        f64_load(0); local_get(Local(mean)); f64_sub; local_set(Local(tmp));
+                        local_get(Local(tmp)); local_get(Local(tmp)); f64_mul;
+                        local_get(Local(var)); f64_add; local_set(Local(var));
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
-                      local_get(var); local_get(cnt); f64_div; local_set(var);
+                      local_get(Local(var)); local_get(Local(cnt)); f64_div; local_set(Local(var));
                       // Clamp var to [0, +inf) and replace NaN with 0 so sqrt is stable.
-                      local_get(var); local_get(var); f64_ne;  // NaN check
-                      if_empty; f64_const(0.0); local_set(var); end;
-                      local_get(var); f64_const(0.0); f64_lt;
-                      if_empty; f64_const(0.0); local_set(var); end;
+                      local_get(Local(var)); local_get(Local(var)); f64_ne;  // NaN check
+                      if_empty; f64_const(0.0); local_set(Local(var)); end;
+                      local_get(Local(var)); f64_const(0.0); f64_lt;
+                      if_empty; f64_const(0.0); local_set(Local(var)); end;
                       // inv = 1 / sqrt(var + eps)
                       f64_const(1.0);
-                      local_get(var); local_get(eps); f64_add; f64_sqrt;
-                      f64_div; local_set(inv);
+                      local_get(Local(var)); local_get(Local(eps)); f64_add; f64_sqrt;
+                      f64_div; local_set(Local(inv));
                       // Apply (x - mean) * inv * gamma[c] + beta[c]
-                      i32_const(0); local_set(c);
+                      i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(cols); i32_ge_u; br_if(1);
-                        local_get(dst); local_get(row_off); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
-                        f64_load(0); local_get(mean); f64_sub;
-                        local_get(inv); f64_mul;
-                        local_get(gamma); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
+                        local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(m)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        f64_load(0); local_get(Local(mean)); f64_sub;
+                        local_get(Local(inv)); f64_mul;
+                        local_get(Local(gamma)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         f64_load(0); f64_mul;
-                        local_get(beta); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(beta)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         f64_load(0); f64_add;
                         f64_store(0);
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
-                      local_get(r); i32_const(1); i32_add; local_set(r);
+                      local_get(Local(r)); i32_const(Imm32(1)); i32_add; local_set(Local(r));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(tmp);
                 self.scratch.free_f64(cnt);
@@ -1369,66 +1370,66 @@ impl FuncCompiler<'_> {
                 let cnt = self.scratch.alloc_f64();
                 let tmp = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(gamma); });
+                wasm!(self.func, { local_set(Local(gamma)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    local_set(eps);
-                    local_get(m); i32_load(0); local_set(rows);
-                    local_get(m); i32_load(4); local_set(cols);
-                    local_get(rows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(rows); i32_store(0);
-                    local_get(dst); local_get(cols); i32_store(4);
-                    local_get(cols); f64_convert_i32_u; local_set(cnt);
-                    i32_const(0); local_set(r);
+                    local_set(Local(eps));
+                    local_get(Local(m)); i32_load(0); local_set(Local(rows));
+                    local_get(Local(m)); i32_load(4); local_set(Local(cols));
+                    local_get(Local(rows)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(rows)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cols)); i32_store(4);
+                    local_get(Local(cols)); f64_convert_i32_u; local_set(Local(cnt));
+                    i32_const(Imm32(0)); local_set(Local(r));
                     block_empty; loop_empty;
-                      local_get(r); local_get(rows); i32_ge_u; br_if(1);
-                      local_get(r); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                      i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_set(row_off);
+                      local_get(Local(r)); local_get(Local(rows)); i32_ge_u; br_if(1);
+                      local_get(Local(r)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                      i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_set(Local(row_off));
                       // sq = Σ m[r, c]²
-                      f64_const(0.0); local_set(sq);
-                      i32_const(0); local_set(c);
+                      f64_const(0.0); local_set(Local(sq));
+                      i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(cols); i32_ge_u; br_if(1);
-                        local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
-                        f64_load(0); local_set(tmp);
-                        local_get(tmp); local_get(tmp); f64_mul;
-                        local_get(sq); f64_add; local_set(sq);
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
+                        local_get(Local(m)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        f64_load(0); local_set(Local(tmp));
+                        local_get(Local(tmp)); local_get(Local(tmp)); f64_mul;
+                        local_get(Local(sq)); f64_add; local_set(Local(sq));
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
                       // NaN-guard on sq (Σx² may be NaN if any x is NaN).
-                      local_get(sq); local_get(sq); f64_ne;
-                      if_empty; f64_const(0.0); local_set(sq); end;
+                      local_get(Local(sq)); local_get(Local(sq)); f64_ne;
+                      if_empty; f64_const(0.0); local_set(Local(sq)); end;
                       // inv = 1 / sqrt(sq / cnt + eps)
                       f64_const(1.0);
-                      local_get(sq); local_get(cnt); f64_div;
-                      local_get(eps); f64_add; f64_sqrt;
-                      f64_div; local_set(inv);
+                      local_get(Local(sq)); local_get(Local(cnt)); f64_div;
+                      local_get(Local(eps)); f64_add; f64_sqrt;
+                      f64_div; local_set(Local(inv));
                       // dst[r, c] = m[r, c] * inv * gamma[c]
-                      i32_const(0); local_set(c);
+                      i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(cols); i32_ge_u; br_if(1);
-                        local_get(dst); local_get(row_off); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
-                        f64_load(0); local_get(inv); f64_mul;
-                        local_get(gamma); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
+                        local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(m)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        f64_load(0); local_get(Local(inv)); f64_mul;
+                        local_get(Local(gamma)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         f64_load(0); f64_mul;
                         f64_store(0);
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
-                      local_get(r); i32_const(1); i32_add; local_set(r);
+                      local_get(Local(r)); i32_const(Imm32(1)); i32_add; local_set(Local(r));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(tmp);
                 self.scratch.free_f64(cnt);
@@ -1466,76 +1467,76 @@ impl FuncCompiler<'_> {
                 let tmp = self.scratch.alloc_f64();
                 let sig = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(x); });
+                wasm!(self.func, { local_set(Local(x)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(wg); });
+                wasm!(self.func, { local_set(Local(wg)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    local_set(wu);
-                    local_get(x); i32_load(0); local_set(r);
-                    local_get(x); i32_load(4); local_set(d_in);
-                    local_get(wg); i32_load(0); local_set(d_out);
+                    local_set(Local(wu));
+                    local_get(Local(x)); i32_load(0); local_set(Local(r));
+                    local_get(Local(x)); i32_load(4); local_set(Local(d_in));
+                    local_get(Local(wg)); i32_load(0); local_set(Local(d_out));
                     // alloc dst = r × d_out
-                    local_get(r); local_get(d_out); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(r); i32_store(0);
-                    local_get(dst); local_get(d_out); i32_store(4);
-                    i32_const(0); local_set(i);
+                    local_get(Local(r)); local_get(Local(d_out)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(r)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(d_out)); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(r); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(j);
+                      local_get(Local(i)); local_get(Local(r)); i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(j));
                       block_empty; loop_empty;
-                        local_get(j); local_get(d_out); i32_ge_u; br_if(1);
-                        f64_const(0.0); local_set(g);
-                        f64_const(0.0); local_set(u);
-                        i32_const(0); local_set(k);
+                        local_get(Local(j)); local_get(Local(d_out)); i32_ge_u; br_if(1);
+                        f64_const(0.0); local_set(Local(g));
+                        f64_const(0.0); local_set(Local(u));
+                        i32_const(Imm32(0)); local_set(Local(k));
                         block_empty; loop_empty;
-                          local_get(k); local_get(d_in); i32_ge_u; br_if(1);
+                          local_get(Local(k)); local_get(Local(d_in)); i32_ge_u; br_if(1);
                           // tmp = x[i, k]
-                          local_get(x); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(i); local_get(d_in); i32_mul; local_get(k); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add;
-                          f64_load(0); local_set(tmp);
+                          local_get(Local(x)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(i)); local_get(Local(d_in)); i32_mul; local_get(Local(k)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                          f64_load(0); local_set(Local(tmp));
                           // g += tmp * w_gate[j, k]
-                          local_get(tmp);
-                          local_get(wg); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(j); local_get(d_in); i32_mul; local_get(k); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add;
+                          local_get(Local(tmp));
+                          local_get(Local(wg)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(j)); local_get(Local(d_in)); i32_mul; local_get(Local(k)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                           f64_load(0); f64_mul;
-                          local_get(g); f64_add; local_set(g);
+                          local_get(Local(g)); f64_add; local_set(Local(g));
                           // u += tmp * w_up[j, k]
-                          local_get(tmp);
-                          local_get(wu); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(j); local_get(d_in); i32_mul; local_get(k); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add;
+                          local_get(Local(tmp));
+                          local_get(Local(wu)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(j)); local_get(Local(d_in)); i32_mul; local_get(Local(k)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                           f64_load(0); f64_mul;
-                          local_get(u); f64_add; local_set(u);
-                          local_get(k); i32_const(1); i32_add; local_set(k);
+                          local_get(Local(u)); f64_add; local_set(Local(u));
+                          local_get(Local(k)); i32_const(Imm32(1)); i32_add; local_set(Local(k));
                           br(0);
                         end; end;
                         // sig = 1 / (1 + exp(-g)), with -g clamped to ±40 so
                         // exp() can't overflow to ∞ (σ saturates anyway).
-                        f64_const(0.0); local_get(g); f64_sub;
+                        f64_const(0.0); local_get(Local(g)); f64_sub;
                         f64_const(40.0); f64_min;
                         f64_const(-40.0); f64_max;
                         call(self.emitter.rt.math_exp);
-                        f64_const(1.0); f64_add; local_set(tmp); // tmp = 1 + exp(-g)
-                        f64_const(1.0); local_get(tmp); f64_div; local_set(sig);
+                        f64_const(1.0); f64_add; local_set(Local(tmp)); // tmp = 1 + exp(-g)
+                        f64_const(1.0); local_get(Local(tmp)); f64_div; local_set(Local(sig));
                         // out[i, j] = g * sig * u
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(i); local_get(d_out); i32_mul; local_get(j); i32_add;
-                        i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(g); local_get(sig); f64_mul;
-                        local_get(u); f64_mul;
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(i)); local_get(Local(d_out)); i32_mul; local_get(Local(j)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(g)); local_get(Local(sig)); f64_mul;
+                        local_get(Local(u)); f64_mul;
                         f64_store(0);
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(sig);
                 self.scratch.free_f64(tmp);
@@ -1571,60 +1572,60 @@ impl FuncCompiler<'_> {
                 let k = self.scratch.alloc_i32();
                 let acc = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(q); });
+                wasm!(self.func, { local_set(Local(q)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(kt); });
+                wasm!(self.func, { local_set(Local(kt)); });
                 self.emit_expr(&args[2]);
                 if matches!(&args[2].ty, almide_lang::types::Ty::Int) {
                     wasm!(self.func, { f64_convert_i64_s; });
                 }
                 wasm!(self.func, {
-                    local_set(scale);
-                    local_get(q); i32_load(0); local_set(qr);
-                    local_get(q); i32_load(4); local_set(inner);
-                    local_get(kt); i32_load(4); local_set(ktc);
+                    local_set(Local(scale));
+                    local_get(Local(q)); i32_load(0); local_set(Local(qr));
+                    local_get(Local(q)); i32_load(4); local_set(Local(inner));
+                    local_get(Local(kt)); i32_load(4); local_set(Local(ktc));
                     // alloc dst = qr × ktc
-                    local_get(qr); local_get(ktc); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(qr); i32_store(0);
-                    local_get(dst); local_get(ktc); i32_store(4);
+                    local_get(Local(qr)); local_get(Local(ktc)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(qr)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(ktc)); i32_store(4);
                     // Phase 1: dst[i, j] = scale * Σ_k q[i, k] * kt[k, j]
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(qr); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(j);
+                      local_get(Local(i)); local_get(Local(qr)); i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(j));
                       block_empty; loop_empty;
-                        local_get(j); local_get(ktc); i32_ge_u; br_if(1);
-                        f64_const(0.0); local_set(acc);
-                        i32_const(0); local_set(k);
+                        local_get(Local(j)); local_get(Local(ktc)); i32_ge_u; br_if(1);
+                        f64_const(0.0); local_set(Local(acc));
+                        i32_const(Imm32(0)); local_set(Local(k));
                         block_empty; loop_empty;
-                          local_get(k); local_get(inner); i32_ge_u; br_if(1);
+                          local_get(Local(k)); local_get(Local(inner)); i32_ge_u; br_if(1);
                           // q[i, k]
-                          local_get(q); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(i); local_get(inner); i32_mul; local_get(k); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add;
+                          local_get(Local(q)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(i)); local_get(Local(inner)); i32_mul; local_get(Local(k)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                           f64_load(0);
                           // kt[k, j]
-                          local_get(kt); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(k); local_get(ktc); i32_mul; local_get(j); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add;
+                          local_get(Local(kt)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(k)); local_get(Local(ktc)); i32_mul; local_get(Local(j)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                           f64_load(0);
                           f64_mul;
-                          local_get(acc); f64_add; local_set(acc);
-                          local_get(k); i32_const(1); i32_add; local_set(k);
+                          local_get(Local(acc)); f64_add; local_set(Local(acc));
+                          local_get(Local(k)); i32_const(Imm32(1)); i32_add; local_set(Local(k));
                           br(0);
                         end; end;
                         // dst[i, j] = scale * acc
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(i); local_get(ktc); i32_mul; local_get(j); i32_add;
-                        i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(acc); local_get(scale); f64_mul;
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(i)); local_get(Local(ktc)); i32_mul; local_get(Local(j)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(acc)); local_get(Local(scale)); f64_mul;
                         f64_store(0);
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                 });
@@ -1643,75 +1644,75 @@ impl FuncCompiler<'_> {
                 let v = self.scratch.alloc_f64();
                 wasm!(self.func, {
                     // Phase 2: row-softmax in place on dst.
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(qr); i32_ge_u; br_if(1);
-                      local_get(i); local_get(ktc); i32_mul; i32_const(F64_BYTES); i32_mul;
-                      i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_set(row_off);
+                      local_get(Local(i)); local_get(Local(qr)); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(ktc)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                      i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_set(Local(row_off));
                       // maxv = dst[i, 0]; scan 1..ktc
-                      local_get(dst); local_get(row_off); i32_add;
-                      f64_load(0); local_set(maxv);
-                      i32_const(1); local_set(j);
+                      local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                      f64_load(0); local_set(Local(maxv));
+                      i32_const(Imm32(1)); local_set(Local(j));
                       block_empty; loop_empty;
-                        local_get(j); local_get(ktc); i32_ge_u; br_if(1);
-                        local_get(dst); local_get(row_off); i32_add;
-                        local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
-                        f64_load(0); local_set(v);
-                        local_get(v); local_get(maxv); f64_gt;
-                        if_empty; local_get(v); local_set(maxv); end;
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(j)); local_get(Local(ktc)); i32_ge_u; br_if(1);
+                        local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(j)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        f64_load(0); local_set(Local(v));
+                        local_get(Local(v)); local_get(Local(maxv)); f64_gt;
+                        if_empty; local_get(Local(v)); local_set(Local(maxv)); end;
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
                       // dst[i, j] = exp(dst[i, j] - maxv); sum
-                      f64_const(0.0); local_set(sumv);
-                      i32_const(0); local_set(j);
+                      f64_const(0.0); local_set(Local(sumv));
+                      i32_const(Imm32(0)); local_set(Local(j));
                       block_empty; loop_empty;
-                        local_get(j); local_get(ktc); i32_ge_u; br_if(1);
-                        local_get(dst); local_get(row_off); i32_add;
-                        local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(dst); local_get(row_off); i32_add;
-                        local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
-                        f64_load(0); local_get(maxv); f64_sub;
-                        call(self.emitter.rt.math_exp); local_set(v);
-                        local_get(v); f64_store(0);
-                        local_get(sumv); local_get(v); f64_add; local_set(sumv);
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(j)); local_get(Local(ktc)); i32_ge_u; br_if(1);
+                        local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(j)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(j)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        f64_load(0); local_get(Local(maxv)); f64_sub;
+                        call(self.emitter.rt.math_exp); local_set(Local(v));
+                        local_get(Local(v)); f64_store(0);
+                        local_get(Local(sumv)); local_get(Local(v)); f64_add; local_set(Local(sumv));
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
                       // Sum guard: NaN/Inf/zero → uniform distribution.
-                      local_get(sumv); f64_const(0.0); f64_le;
-                      local_get(sumv); local_get(sumv); f64_ne;
+                      local_get(Local(sumv)); f64_const(0.0); f64_le;
+                      local_get(Local(sumv)); local_get(Local(sumv)); f64_ne;
                       i32_or;
                       if_empty;
-                        local_get(ktc); f64_convert_i32_u; local_set(sumv);
-                        i32_const(0); local_set(j);
+                        local_get(Local(ktc)); f64_convert_i32_u; local_set(Local(sumv));
+                        i32_const(Imm32(0)); local_set(Local(j));
                         block_empty; loop_empty;
-                          local_get(j); local_get(ktc); i32_ge_u; br_if(1);
-                          local_get(dst); local_get(row_off); i32_add;
-                          local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
+                          local_get(Local(j)); local_get(Local(ktc)); i32_ge_u; br_if(1);
+                          local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                          local_get(Local(j)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                           f64_const(1.0); f64_store(0);
-                          local_get(j); i32_const(1); i32_add; local_set(j);
+                          local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                           br(0);
                         end; end;
                       end;
                       // normalize
-                      i32_const(0); local_set(j);
+                      i32_const(Imm32(0)); local_set(Local(j));
                       block_empty; loop_empty;
-                        local_get(j); local_get(ktc); i32_ge_u; br_if(1);
-                        local_get(dst); local_get(row_off); i32_add;
-                        local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(dst); local_get(row_off); i32_add;
-                        local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(j)); local_get(Local(ktc)); i32_ge_u; br_if(1);
+                        local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(j)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(dst)); local_get(Local(row_off)); i32_add;
+                        local_get(Local(j)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         f64_load(0);
-                        local_get(sumv); f64_div;
+                        local_get(Local(sumv)); f64_div;
                         f64_store(0);
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(v);
                 self.scratch.free_f64(sumv);
@@ -1753,106 +1754,106 @@ impl FuncCompiler<'_> {
                 let neg_scale = self.scratch.alloc_f64();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(data); });
+                wasm!(self.func, { local_set(Local(data)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(off); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(off)); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { i32_wrap_i64; local_set(cols); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(cols)); });
                 self.emit_expr(&args[3]);
-                wasm!(self.func, { local_set(ids); });
+                wasm!(self.func, { local_set(Local(ids)); });
 
                 wasm!(self.func, {
-                    local_get(ids); i32_load(0); local_set(n_rows);
-                    local_get(cols); i32_const(LOG2_Q1_0_BLOCK_SIZE); i32_shr_u; local_set(n_bpr);
-                    local_get(data); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(off); i32_add;
-                    local_set(data_base);
+                    local_get(Local(ids)); i32_load(0); local_set(Local(n_rows));
+                    local_get(Local(cols)); i32_const(Imm32(LOG2_Q1_0_BLOCK_SIZE)); i32_shr_u; local_set(Local(n_bpr));
+                    local_get(Local(data)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(off)); i32_add;
+                    local_set(Local(data_base));
                     // dst = alloc(8 + n_rows*cols*8)
-                    local_get(n_rows); local_get(cols); i32_mul;
-                    i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(n_rows); i32_store(0);
-                    local_get(dst); local_get(cols); i32_store(4);
-                    i32_const(0); local_set(i);
+                    local_get(Local(n_rows)); local_get(Local(cols)); i32_mul;
+                    i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(n_rows)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cols)); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(n_rows); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(n_rows)); i32_ge_u; br_if(1);
                       // rid = row_ids[i] as i32
-                      local_get(ids); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(ids)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       i64_load(0); i32_wrap_i64;
-                      local_set(rid);
+                      local_set(Local(rid));
                       // row_src_off = rid * n_bpr * 18
-                      local_get(rid); local_get(n_bpr); i32_mul;
-                      i32_const(Q1_0_BLOCK_BYTES); i32_mul;
-                      local_set(row_src_off);
-                      i32_const(0); local_set(b);
+                      local_get(Local(rid)); local_get(Local(n_bpr)); i32_mul;
+                      i32_const(Imm32(Q1_0_BLOCK_BYTES)); i32_mul;
+                      local_set(Local(row_src_off));
+                      i32_const(Imm32(0)); local_set(Local(b));
                       block_empty; loop_empty;
-                        local_get(b); local_get(n_bpr); i32_ge_u; br_if(1);
-                        local_get(data_base);
-                        local_get(row_src_off); i32_add;
-                        local_get(b); i32_const(Q1_0_BLOCK_BYTES); i32_mul;
+                        local_get(Local(b)); local_get(Local(n_bpr)); i32_ge_u; br_if(1);
+                        local_get(Local(data_base));
+                        local_get(Local(row_src_off)); i32_add;
+                        local_get(Local(b)); i32_const(Imm32(Q1_0_BLOCK_BYTES)); i32_mul;
                         i32_add;
-                        local_set(block_start);
-                        local_get(block_start); i32_load8_u(0);
-                        local_get(block_start); i32_load8_u(1);
-                        i32_const(F64_BYTES); i32_shl;
+                        local_set(Local(block_start));
+                        local_get(Local(block_start)); i32_load8_u(0);
+                        local_get(Local(block_start)); i32_load8_u(1);
+                        i32_const(Imm32(F64_BYTES)); i32_shl;
                         i32_or;
-                        local_set(scale_raw);
-                        local_get(scale_raw); i32_const(FP16_SIGN_BIT_POS); i32_shr_u; i32_const(1); i32_and;
-                        local_set(sign);
-                        local_get(scale_raw); i32_const(FP16_EXP_SHIFT); i32_shr_u; i32_const(FP16_EXP_BITS_MASK); i32_and;
-                        local_set(expv);
-                        local_get(scale_raw); i32_const(FP16_MANTISSA_MASK); i32_and;
-                        local_set(mant);
-                        local_get(sign); i32_const(F32_SIGN_SHIFT); i32_shl;
-                        local_get(expv); i32_const(FP16_EXP_BIAS_DIFF); i32_add; i32_const(F32_EXP_SHIFT); i32_shl;
+                        local_set(Local(scale_raw));
+                        local_get(Local(scale_raw)); i32_const(Imm32(FP16_SIGN_BIT_POS)); i32_shr_u; i32_const(Imm32(1)); i32_and;
+                        local_set(Local(sign));
+                        local_get(Local(scale_raw)); i32_const(Imm32(FP16_EXP_SHIFT)); i32_shr_u; i32_const(Imm32(FP16_EXP_BITS_MASK)); i32_and;
+                        local_set(Local(expv));
+                        local_get(Local(scale_raw)); i32_const(Imm32(FP16_MANTISSA_MASK)); i32_and;
+                        local_set(Local(mant));
+                        local_get(Local(sign)); i32_const(Imm32(F32_SIGN_SHIFT)); i32_shl;
+                        local_get(Local(expv)); i32_const(Imm32(FP16_EXP_BIAS_DIFF)); i32_add; i32_const(Imm32(F32_EXP_SHIFT)); i32_shl;
                         i32_or;
-                        local_get(mant); i32_const(FP16_MANT_TO_F32_SHIFT); i32_shl;
+                        local_get(Local(mant)); i32_const(Imm32(FP16_MANT_TO_F32_SHIFT)); i32_shl;
                         i32_or;
-                        local_set(f32bits);
-                        local_get(expv); i32_eqz;
+                        local_set(Local(f32bits));
+                        local_get(Local(expv)); i32_eqz;
                         if_empty;
-                          local_get(sign); i32_const(F32_SIGN_SHIFT); i32_shl; local_set(f32bits);
+                          local_get(Local(sign)); i32_const(Imm32(F32_SIGN_SHIFT)); i32_shl; local_set(Local(f32bits));
                         end;
-                        local_get(f32bits); f32_reinterpret_i32; f64_promote_f32;
-                        local_set(scale);
-                        f64_const(0.0); local_get(scale); f64_sub; local_set(neg_scale);
-                        local_get(block_start); i32_const(Q1_0_SCALE_BYTES); i32_add; local_set(bits_start);
-                        i32_const(0); local_set(k_local);
+                        local_get(Local(f32bits)); f32_reinterpret_i32; f64_promote_f32;
+                        local_set(Local(scale));
+                        f64_const(0.0); local_get(Local(scale)); f64_sub; local_set(Local(neg_scale));
+                        local_get(Local(block_start)); i32_const(Imm32(Q1_0_SCALE_BYTES)); i32_add; local_set(Local(bits_start));
+                        i32_const(Imm32(0)); local_set(Local(k_local));
                         block_empty; loop_empty;
-                          local_get(k_local); i32_const(Q1_0_BLOCK_SIZE); i32_ge_u; br_if(1);
-                          local_get(bits_start);
-                          local_get(k_local); i32_const(LOG2_BITS_PER_BYTE); i32_shr_u;
+                          local_get(Local(k_local)); i32_const(Imm32(Q1_0_BLOCK_SIZE)); i32_ge_u; br_if(1);
+                          local_get(Local(bits_start));
+                          local_get(Local(k_local)); i32_const(Imm32(LOG2_BITS_PER_BYTE)); i32_shr_u;
                           i32_add;
                           i32_load8_u(0);
-                          local_get(k_local); i32_const(BITS_PER_BYTE_MASK); i32_and; i32_shr_u;
-                          i32_const(1); i32_and;
-                          local_set(bit);
+                          local_get(Local(k_local)); i32_const(Imm32(BITS_PER_BYTE_MASK)); i32_and; i32_shr_u;
+                          i32_const(Imm32(1)); i32_and;
+                          local_set(Local(bit));
                           // dst[8 + (i*cols + b*128 + k_local)*8] = bit? scale : neg_scale
-                          local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(i); local_get(cols); i32_mul;
-                          local_get(b); i32_const(Q1_0_BLOCK_SIZE); i32_mul; i32_add;
-                          local_get(k_local); i32_add;
-                          i32_const(F64_BYTES); i32_mul;
+                          local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(i)); local_get(Local(cols)); i32_mul;
+                          local_get(Local(b)); i32_const(Imm32(Q1_0_BLOCK_SIZE)); i32_mul; i32_add;
+                          local_get(Local(k_local)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul;
                           i32_add;
-                          local_get(bit);
+                          local_get(Local(bit));
                           if_f64;
-                            local_get(scale);
+                            local_get(Local(scale));
                           else_;
-                            local_get(neg_scale);
+                            local_get(Local(neg_scale));
                           end;
                           f64_store(0);
-                          local_get(k_local); i32_const(1); i32_add; local_set(k_local);
+                          local_get(Local(k_local)); i32_const(Imm32(1)); i32_add; local_set(Local(k_local));
                           br(0);
                         end; end;
-                        local_get(b); i32_const(1); i32_add; local_set(b);
+                        local_get(Local(b)); i32_const(Imm32(1)); i32_add; local_set(Local(b));
                         br(0);
                       end; end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(neg_scale);
                 self.scratch.free_f64(scale);
@@ -1891,45 +1892,45 @@ impl FuncCompiler<'_> {
                 let xv = self.scratch.alloc_f64();
                 let sig = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(b); });
+                wasm!(self.func, { local_set(Local(b)); });
                 let math_exp = self.emitter.rt.math_exp;
                 wasm!(self.func, {
-                    local_get(a); i32_load(0); local_set(rows);
-                    local_get(a); i32_load(4); local_set(cols);
-                    local_get(rows); local_get(cols); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(rows); i32_store(0);
-                    local_get(dst); local_get(cols); i32_store(4);
-                    i32_const(0); local_set(k);
+                    local_get(Local(a)); i32_load(0); local_set(Local(rows));
+                    local_get(Local(a)); i32_load(4); local_set(Local(cols));
+                    local_get(Local(rows)); local_get(Local(cols)); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(rows)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cols)); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(k));
                     block_empty; loop_empty;
-                      local_get(k); local_get(total); i32_ge_u; br_if(1);
+                      local_get(Local(k)); local_get(Local(total)); i32_ge_u; br_if(1);
                       // xv = a[k]
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(k); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(k)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       f64_load(0);
-                      local_set(xv);
+                      local_set(Local(xv));
                       // sig = 1 / (1 + exp(-xv))
-                      f64_const(0.0); local_get(xv); f64_sub;
+                      f64_const(0.0); local_get(Local(xv)); f64_sub;
                       call(math_exp);
                       f64_const(1.0); f64_add;
-                      local_set(sig);
-                      f64_const(1.0); local_get(sig); f64_div; local_set(sig);
+                      local_set(Local(sig));
+                      f64_const(1.0); local_get(Local(sig)); f64_div; local_set(Local(sig));
                       // result = xv * sig * b[k]
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(k); i32_const(F64_BYTES); i32_mul; i32_add;
-                      local_get(xv); local_get(sig); f64_mul;
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(k); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(k)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(xv)); local_get(Local(sig)); f64_mul;
+                      local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(k)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       f64_load(0);
                       f64_mul;
                       f64_store(0);
-                      local_get(k); i32_const(1); i32_add; local_set(k);
+                      local_get(Local(k)); i32_const(Imm32(1)); i32_add; local_set(Local(k));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(sig);
                 self.scratch.free_f64(xv);
@@ -1986,154 +1987,154 @@ impl FuncCompiler<'_> {
                 let x_v = self.scratch.alloc_v128();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(x); });
+                wasm!(self.func, { local_set(Local(x)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(w_bytes); });
+                wasm!(self.func, { local_set(Local(w_bytes)); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { i32_wrap_i64; local_set(w_off); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(w_off)); });
                 self.emit_expr(&args[3]);
-                wasm!(self.func, { i32_wrap_i64; local_set(out); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(out)); });
                 self.emit_expr(&args[4]);
-                wasm!(self.func, { i32_wrap_i64; local_set(n_in); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(n_in)); });
 
                 wasm!(self.func, {
-                    local_get(x); i32_load(0); local_set(x_rows);
+                    local_get(Local(x)); i32_load(0); local_set(Local(x_rows));
                     // w_data = w_bytes + 4 + w_off
-                    local_get(w_bytes); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(w_off); i32_add;
-                    local_set(w_data);
+                    local_get(Local(w_bytes)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(w_off)); i32_add;
+                    local_set(Local(w_data));
                     // n_bpr = n_in / 128
-                    local_get(n_in); i32_const(LOG2_Q1_0_BLOCK_SIZE); i32_shr_u; local_set(n_bpr);
+                    local_get(Local(n_in)); i32_const(Imm32(LOG2_Q1_0_BLOCK_SIZE)); i32_shr_u; local_set(Local(n_bpr));
                     // dst = alloc(8 + x_rows*out*8); header
-                    local_get(x_rows); local_get(out); i32_mul;
-                    i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(x_rows); i32_store(0);
-                    local_get(dst); local_get(out); i32_store(4);
+                    local_get(Local(x_rows)); local_get(Local(out)); i32_mul;
+                    i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(x_rows)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(out)); i32_store(4);
                     // for i in 0..x_rows
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(x_rows); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(x_rows)); i32_ge_u; br_if(1);
                       // for j in 0..out
-                      i32_const(0); local_set(j);
+                      i32_const(Imm32(0)); local_set(Local(j));
                       block_empty; loop_empty;
-                        local_get(j); local_get(out); i32_ge_u; br_if(1);
+                        local_get(Local(j)); local_get(Local(out)); i32_ge_u; br_if(1);
                         // sum_v = f64x2(0.0, 0.0)
                         f64_const(0.0); f64x2_splat;
-                        local_set(sum_v);
+                        local_set(Local(sum_v));
                         // for b in 0..n_bpr
-                        i32_const(0); local_set(b);
+                        i32_const(Imm32(0)); local_set(Local(b));
                         block_empty; loop_empty;
-                          local_get(b); local_get(n_bpr); i32_ge_u; br_if(1);
+                          local_get(Local(b)); local_get(Local(n_bpr)); i32_ge_u; br_if(1);
                           // block_start = w_data + j*n_bpr*18 + b*18
-                          local_get(w_data);
-                          local_get(j); local_get(n_bpr); i32_mul;
-                          local_get(b); i32_add;
-                          i32_const(Q1_0_BLOCK_BYTES); i32_mul;
+                          local_get(Local(w_data));
+                          local_get(Local(j)); local_get(Local(n_bpr)); i32_mul;
+                          local_get(Local(b)); i32_add;
+                          i32_const(Imm32(Q1_0_BLOCK_BYTES)); i32_mul;
                           i32_add;
-                          local_set(block_start);
+                          local_set(Local(block_start));
                           // scale_raw = block[0] | block[1]<<8
-                          local_get(block_start); i32_load8_u(0);
-                          local_get(block_start); i32_load8_u(1);
-                          i32_const(F64_BYTES); i32_shl;
+                          local_get(Local(block_start)); i32_load8_u(0);
+                          local_get(Local(block_start)); i32_load8_u(1);
+                          i32_const(Imm32(F64_BYTES)); i32_shl;
                           i32_or;
-                          local_set(scale_raw);
-                          local_get(scale_raw); i32_const(FP16_SIGN_BIT_POS); i32_shr_u; i32_const(1); i32_and;
-                          local_set(sign);
-                          local_get(scale_raw); i32_const(FP16_EXP_SHIFT); i32_shr_u; i32_const(FP16_EXP_BITS_MASK); i32_and;
-                          local_set(expv);
-                          local_get(scale_raw); i32_const(FP16_MANTISSA_MASK); i32_and;
-                          local_set(mant);
+                          local_set(Local(scale_raw));
+                          local_get(Local(scale_raw)); i32_const(Imm32(FP16_SIGN_BIT_POS)); i32_shr_u; i32_const(Imm32(1)); i32_and;
+                          local_set(Local(sign));
+                          local_get(Local(scale_raw)); i32_const(Imm32(FP16_EXP_SHIFT)); i32_shr_u; i32_const(Imm32(FP16_EXP_BITS_MASK)); i32_and;
+                          local_set(Local(expv));
+                          local_get(Local(scale_raw)); i32_const(Imm32(FP16_MANTISSA_MASK)); i32_and;
+                          local_set(Local(mant));
                           // f32bits: normal case (exp + 112) << 23
-                          local_get(sign); i32_const(F32_SIGN_SHIFT); i32_shl;
-                          local_get(expv); i32_const(FP16_EXP_BIAS_DIFF); i32_add; i32_const(F32_EXP_SHIFT); i32_shl;
+                          local_get(Local(sign)); i32_const(Imm32(F32_SIGN_SHIFT)); i32_shl;
+                          local_get(Local(expv)); i32_const(Imm32(FP16_EXP_BIAS_DIFF)); i32_add; i32_const(Imm32(F32_EXP_SHIFT)); i32_shl;
                           i32_or;
-                          local_get(mant); i32_const(FP16_MANT_TO_F32_SHIFT); i32_shl;
+                          local_get(Local(mant)); i32_const(Imm32(FP16_MANT_TO_F32_SHIFT)); i32_shl;
                           i32_or;
-                          local_set(f32bits);
+                          local_set(Local(f32bits));
                           // If exp == 0 force zero (sign bit only).
-                          local_get(expv); i32_eqz;
+                          local_get(Local(expv)); i32_eqz;
                           if_empty;
-                            local_get(sign); i32_const(F32_SIGN_SHIFT); i32_shl; local_set(f32bits);
+                            local_get(Local(sign)); i32_const(Imm32(F32_SIGN_SHIFT)); i32_shl; local_set(Local(f32bits));
                           end;
-                          local_get(f32bits); f32_reinterpret_i32; f64_promote_f32;
-                          local_set(scale);
-                          f64_const(0.0); local_get(scale); f64_sub; local_set(neg_scale);
-                          local_get(block_start); i32_const(Q1_0_SCALE_BYTES); i32_add; local_set(bits_start);
+                          local_get(Local(f32bits)); f32_reinterpret_i32; f64_promote_f32;
+                          local_set(Local(scale));
+                          f64_const(0.0); local_get(Local(scale)); f64_sub; local_set(Local(neg_scale));
+                          local_get(Local(block_start)); i32_const(Imm32(Q1_0_SCALE_BYTES)); i32_add; local_set(Local(bits_start));
                           // for pair_idx in 0..64
-                          i32_const(0); local_set(pair_idx);
+                          i32_const(Imm32(0)); local_set(Local(pair_idx));
                           block_empty; loop_empty;
-                            local_get(pair_idx); i32_const(Q1_0_PAIRS_PER_BLOCK); i32_ge_u; br_if(1);
+                            local_get(Local(pair_idx)); i32_const(Imm32(Q1_0_PAIRS_PER_BLOCK)); i32_ge_u; br_if(1);
                             // byte_idx = pair_idx >> 2  (each byte holds 4 pairs = 8 bits)
-                            local_get(pair_idx); i32_const(LOG2_PAIRS_PER_BYTE); i32_shr_u;
-                            local_set(byte_idx);
+                            local_get(Local(pair_idx)); i32_const(Imm32(LOG2_PAIRS_PER_BYTE)); i32_shr_u;
+                            local_set(Local(byte_idx));
                             // bit_shift = (pair_idx & 3) << 1
-                            local_get(pair_idx); i32_const(PAIRS_PER_BYTE_MASK); i32_and;
-                            i32_const(1); i32_shl;
-                            local_set(bit_shift);
+                            local_get(Local(pair_idx)); i32_const(Imm32(PAIRS_PER_BYTE_MASK)); i32_and;
+                            i32_const(Imm32(1)); i32_shl;
+                            local_set(Local(bit_shift));
                             // byte_val = block[bits_start + byte_idx]
-                            local_get(bits_start); local_get(byte_idx); i32_add;
+                            local_get(Local(bits_start)); local_get(Local(byte_idx)); i32_add;
                             i32_load8_u(0);
-                            local_set(byte_val);
+                            local_set(Local(byte_val));
                             // bit0 = (byte_val >> bit_shift) & 1
-                            local_get(byte_val); local_get(bit_shift); i32_shr_u;
-                            i32_const(1); i32_and;
-                            local_set(bit0);
+                            local_get(Local(byte_val)); local_get(Local(bit_shift)); i32_shr_u;
+                            i32_const(Imm32(1)); i32_and;
+                            local_set(Local(bit0));
                             // bit1 = (byte_val >> (bit_shift + 1)) & 1
-                            local_get(byte_val);
-                            local_get(bit_shift); i32_const(1); i32_add; i32_shr_u;
-                            i32_const(1); i32_and;
-                            local_set(bit1);
+                            local_get(Local(byte_val));
+                            local_get(Local(bit_shift)); i32_const(Imm32(1)); i32_add; i32_shr_u;
+                            i32_const(Imm32(1)); i32_and;
+                            local_set(Local(bit1));
                             // w0 = bit0 ? scale : neg_scale
-                            local_get(bit0);
-                            if_f64; local_get(scale); else_; local_get(neg_scale); end;
-                            local_set(w0);
+                            local_get(Local(bit0));
+                            if_f64; local_get(Local(scale)); else_; local_get(Local(neg_scale)); end;
+                            local_set(Local(w0));
                             // w1 = bit1 ? scale : neg_scale
-                            local_get(bit1);
-                            if_f64; local_get(scale); else_; local_get(neg_scale); end;
-                            local_set(w1);
+                            local_get(Local(bit1));
+                            if_f64; local_get(Local(scale)); else_; local_get(Local(neg_scale)); end;
+                            local_set(Local(w1));
                             // w_v = f64x2{w0, w1}
-                            local_get(w0); f64x2_splat;
-                            local_get(w1); f64x2_replace_lane(1);
-                            local_set(w_v);
+                            local_get(Local(w0)); f64x2_splat;
+                            local_get(Local(w1)); f64x2_replace_lane(1);
+                            local_set(Local(w_v));
                             // x_addr = x + 8 + (i*n_in + b*128 + pair_idx*2) * 8
-                            local_get(x); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                            local_get(i); local_get(n_in); i32_mul;
-                            local_get(b); i32_const(Q1_0_BLOCK_SIZE); i32_mul; i32_add;
-                            local_get(pair_idx); i32_const(1); i32_shl; i32_add;
-                            i32_const(F64_BYTES); i32_mul;
+                            local_get(Local(x)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                            local_get(Local(i)); local_get(Local(n_in)); i32_mul;
+                            local_get(Local(b)); i32_const(Imm32(Q1_0_BLOCK_SIZE)); i32_mul; i32_add;
+                            local_get(Local(pair_idx)); i32_const(Imm32(1)); i32_shl; i32_add;
+                            i32_const(Imm32(F64_BYTES)); i32_mul;
                             i32_add;
                             v128_load(0);
-                            local_set(x_v);
+                            local_set(Local(x_v));
                             // sum_v = sum_v + x_v * w_v
-                            local_get(sum_v);
-                            local_get(x_v); local_get(w_v); f64x2_mul;
+                            local_get(Local(sum_v));
+                            local_get(Local(x_v)); local_get(Local(w_v)); f64x2_mul;
                             f64x2_add;
-                            local_set(sum_v);
-                            local_get(pair_idx); i32_const(1); i32_add; local_set(pair_idx);
+                            local_set(Local(sum_v));
+                            local_get(Local(pair_idx)); i32_const(Imm32(1)); i32_add; local_set(Local(pair_idx));
                             br(0);
                           end; end;
-                          local_get(b); i32_const(1); i32_add; local_set(b);
+                          local_get(Local(b)); i32_const(Imm32(1)); i32_add; local_set(Local(b));
                           br(0);
                         end; end;
                         // dst[i, j] = sum_v[0] + sum_v[1]
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(i); local_get(out); i32_mul;
-                        local_get(j); i32_add;
-                        i32_const(F64_BYTES); i32_mul;
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(i)); local_get(Local(out)); i32_mul;
+                        local_get(Local(j)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul;
                         i32_add;
-                        local_get(sum_v); f64x2_extract_lane(0);
-                        local_get(sum_v); f64x2_extract_lane(1);
+                        local_get(Local(sum_v)); f64x2_extract_lane(0);
+                        local_get(Local(sum_v)); f64x2_extract_lane(1);
                         f64_add;
                         f64_store(0);
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_v128(x_v);
                 self.scratch.free_v128(w_v);
@@ -2185,53 +2186,53 @@ impl FuncCompiler<'_> {
                 let k = self.scratch.alloc_i32();
                 let rid = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(ids); });
+                wasm!(self.func, { local_set(Local(ids)); });
                 wasm!(self.func, {
-                    local_get(m); i32_load(0); local_set(src_rows);
-                    local_get(m); i32_load(4); local_set(cols);
-                    local_get(ids); i32_load(0); local_set(n_out);
-                    local_get(cols); i32_const(F64_BYTES); i32_mul; local_set(row_bytes);
+                    local_get(Local(m)); i32_load(0); local_set(Local(src_rows));
+                    local_get(Local(m)); i32_load(4); local_set(Local(cols));
+                    local_get(Local(ids)); i32_load(0); local_set(Local(n_out));
+                    local_get(Local(cols)); i32_const(Imm32(F64_BYTES)); i32_mul; local_set(Local(row_bytes));
                     // out = alloc(8 + n_out*row_bytes)
-                    local_get(n_out); local_get(row_bytes); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(n_out); i32_store(0);
-                    local_get(dst); local_get(cols); i32_store(4);
-                    i32_const(0); local_set(k);
+                    local_get(Local(n_out)); local_get(Local(row_bytes)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(n_out)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cols)); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(k));
                     block_empty; loop_empty;
-                      local_get(k); local_get(n_out); i32_ge_u; br_if(1);
+                      local_get(Local(k)); local_get(Local(n_out)); i32_ge_u; br_if(1);
                       // rid = (i64)ids[4 + k*8] as i32
-                      local_get(ids); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(k); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(ids)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(k)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       i64_load(0);
                       i32_wrap_i64;
-                      local_set(rid);
+                      local_set(Local(rid));
                       // if rid < 0 or rid >= src_rows, write zeros; else copy
-                      local_get(rid); i32_const(0); i32_lt_s;
-                      local_get(rid); local_get(src_rows); i32_ge_u;
+                      local_get(Local(rid)); i32_const(Imm32(0)); i32_lt_s;
+                      local_get(Local(rid)); local_get(Local(src_rows)); i32_ge_u;
                       i32_or;
                       if_empty;
                         // memory.fill 0 (dst + 8 + k*row_bytes, 0, row_bytes)
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(k); local_get(row_bytes); i32_mul; i32_add;
-                        i32_const(0);
-                        local_get(row_bytes);
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(k)); local_get(Local(row_bytes)); i32_mul; i32_add;
+                        i32_const(Imm32(0));
+                        local_get(Local(row_bytes));
                         memory_fill;
                       else_;
                         // memcpy(dst + 8 + k*row_bytes, m + 8 + rid*row_bytes, row_bytes)
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(k); local_get(row_bytes); i32_mul; i32_add;
-                        local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(rid); local_get(row_bytes); i32_mul; i32_add;
-                        local_get(row_bytes);
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(k)); local_get(Local(row_bytes)); i32_mul; i32_add;
+                        local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(rid)); local_get(Local(row_bytes)); i32_mul; i32_add;
+                        local_get(Local(row_bytes));
                         memory_copy;
                       end;
-                      local_get(k); i32_const(1); i32_add; local_set(k);
+                      local_get(Local(k)); i32_const(Imm32(1)); i32_add; local_set(Local(k));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(rid);
                 self.scratch.free_i32(k);
@@ -2279,18 +2280,18 @@ impl FuncCompiler<'_> {
                 let inv_freq = self.scratch.alloc_f64();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(x); });
+                wasm!(self.func, { local_set(Local(x)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(n_heads); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(n_heads)); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { i32_wrap_i64; local_set(head_dim); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(head_dim)); });
                 self.emit_expr(&args[3]);
-                wasm!(self.func, { local_set(theta); });
+                wasm!(self.func, { local_set(Local(theta)); });
                 if method == "rope_rotate_at" {
                     self.emit_expr(&args[4]);
-                    wasm!(self.func, { i32_wrap_i64; local_set(start_pos); });
+                    wasm!(self.func, { i32_wrap_i64; local_set(Local(start_pos)); });
                 } else {
-                    wasm!(self.func, { i32_const(0); local_set(start_pos); });
+                    wasm!(self.func, { i32_const(Imm32(0)); local_set(Local(start_pos)); });
                 }
 
                 let math_log = self.emitter.rt.math_log;
@@ -2299,78 +2300,78 @@ impl FuncCompiler<'_> {
                 let math_cos = self.emitter.rt.math_cos;
 
                 wasm!(self.func, {
-                    local_get(head_dim); i32_const(1); i32_shr_u; local_set(half);
-                    local_get(head_dim); f64_convert_i32_u; local_set(head_dim_f);
-                    local_get(theta); call(math_log); local_set(log_theta);
-                    local_get(x); i32_load(0); local_set(rows);
-                    local_get(x); i32_load(4); local_set(cols);
+                    local_get(Local(head_dim)); i32_const(Imm32(1)); i32_shr_u; local_set(Local(half));
+                    local_get(Local(head_dim)); f64_convert_i32_u; local_set(Local(head_dim_f));
+                    local_get(Local(theta)); call(math_log); local_set(Local(log_theta));
+                    local_get(Local(x)); i32_load(0); local_set(Local(rows));
+                    local_get(Local(x)); i32_load(4); local_set(Local(cols));
                     // total_bytes = 8 + rows*cols*8
-                    local_get(rows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_set(total_bytes);
-                    local_get(total_bytes); call(self.emitter.rt.alloc); local_set(dst);
+                    local_get(Local(rows)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_set(Local(total_bytes));
+                    local_get(Local(total_bytes)); call(self.emitter.rt.alloc); local_set(Local(dst));
                     // memory.copy(dst, x, total_bytes)
-                    local_get(dst); local_get(x); local_get(total_bytes); memory_copy;
-                    i32_const(0); local_set(p);
+                    local_get(Local(dst)); local_get(Local(x)); local_get(Local(total_bytes)); memory_copy;
+                    i32_const(Imm32(0)); local_set(Local(p));
                     block_empty; loop_empty;
-                      local_get(p); local_get(rows); i32_ge_u; br_if(1);
-                      local_get(p); local_get(start_pos); i32_add;
-                      f64_convert_i32_u; local_set(pos_f);
-                      i32_const(0); local_set(h);
+                      local_get(Local(p)); local_get(Local(rows)); i32_ge_u; br_if(1);
+                      local_get(Local(p)); local_get(Local(start_pos)); i32_add;
+                      f64_convert_i32_u; local_set(Local(pos_f));
+                      i32_const(Imm32(0)); local_set(Local(h));
                       block_empty; loop_empty;
-                        local_get(h); local_get(n_heads); i32_ge_u; br_if(1);
-                        i32_const(0); local_set(i_pair);
+                        local_get(Local(h)); local_get(Local(n_heads)); i32_ge_u; br_if(1);
+                        i32_const(Imm32(0)); local_set(Local(i_pair));
                         block_empty; loop_empty;
-                          local_get(i_pair); local_get(half); i32_ge_u; br_if(1);
+                          local_get(Local(i_pair)); local_get(Local(half)); i32_ge_u; br_if(1);
                           // j0 = h*head_dim + 2*i
-                          local_get(h); local_get(head_dim); i32_mul;
-                          local_get(i_pair); i32_const(1); i32_shl;
+                          local_get(Local(h)); local_get(Local(head_dim)); i32_mul;
+                          local_get(Local(i_pair)); i32_const(Imm32(1)); i32_shl;
                           i32_add;
-                          local_set(j0);
+                          local_set(Local(j0));
                           // pair_off = 8 + p*cols*8 + j0*8
-                          i32_const(F64_BYTES);
-                          local_get(p); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
+                          i32_const(Imm32(F64_BYTES));
+                          local_get(Local(p)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
                           i32_add;
-                          local_get(j0); i32_const(F64_BYTES); i32_mul;
+                          local_get(Local(j0)); i32_const(Imm32(F64_BYTES)); i32_mul;
                           i32_add;
-                          local_set(pair_off);
+                          local_set(Local(pair_off));
                           // x0, x1 from source
-                          local_get(x); local_get(pair_off); i32_add; f64_load(0); local_set(x0);
-                          local_get(x); local_get(pair_off); i32_add; f64_load(8); local_set(x1);
+                          local_get(Local(x)); local_get(Local(pair_off)); i32_add; f64_load(0); local_set(Local(x0));
+                          local_get(Local(x)); local_get(Local(pair_off)); i32_add; f64_load(8); local_set(Local(x1));
                           // two_i_f = (2i) as f64
-                          local_get(i_pair); i32_const(1); i32_shl;
-                          f64_convert_i32_u; local_set(two_i_f);
+                          local_get(Local(i_pair)); i32_const(Imm32(1)); i32_shl;
+                          f64_convert_i32_u; local_set(Local(two_i_f));
                           // inv_freq = exp(-(two_i_f / head_dim_f) * log_theta)
                           f64_const(0.0);
-                          local_get(two_i_f); local_get(head_dim_f); f64_div;
-                          local_get(log_theta); f64_mul;
+                          local_get(Local(two_i_f)); local_get(Local(head_dim_f)); f64_div;
+                          local_get(Local(log_theta)); f64_mul;
                           f64_sub;
-                          call(math_exp); local_set(inv_freq);
+                          call(math_exp); local_set(Local(inv_freq));
                           // angle = pos_f * inv_freq
-                          local_get(pos_f); local_get(inv_freq); f64_mul; local_set(angle);
-                          local_get(angle); call(math_sin); local_set(s);
-                          local_get(angle); call(math_cos); local_set(c);
+                          local_get(Local(pos_f)); local_get(Local(inv_freq)); f64_mul; local_set(Local(angle));
+                          local_get(Local(angle)); call(math_sin); local_set(Local(s));
+                          local_get(Local(angle)); call(math_cos); local_set(Local(c));
                           // store new_x0 = x0*c - x1*s
-                          local_get(dst); local_get(pair_off); i32_add;
-                          local_get(x0); local_get(c); f64_mul;
-                          local_get(x1); local_get(s); f64_mul;
+                          local_get(Local(dst)); local_get(Local(pair_off)); i32_add;
+                          local_get(Local(x0)); local_get(Local(c)); f64_mul;
+                          local_get(Local(x1)); local_get(Local(s)); f64_mul;
                           f64_sub;
                           f64_store(0);
                           // store new_x1 = x0*s + x1*c  (offset +8)
-                          local_get(dst); local_get(pair_off); i32_add;
-                          local_get(x0); local_get(s); f64_mul;
-                          local_get(x1); local_get(c); f64_mul;
+                          local_get(Local(dst)); local_get(Local(pair_off)); i32_add;
+                          local_get(Local(x0)); local_get(Local(s)); f64_mul;
+                          local_get(Local(x1)); local_get(Local(c)); f64_mul;
                           f64_add;
                           f64_store(8);
-                          local_get(i_pair); i32_const(1); i32_add; local_set(i_pair);
+                          local_get(Local(i_pair)); i32_const(Imm32(1)); i32_add; local_set(Local(i_pair));
                           br(0);
                         end; end;
-                        local_get(h); i32_const(1); i32_add; local_set(h);
+                        local_get(Local(h)); i32_const(Imm32(1)); i32_add; local_set(Local(h));
                         br(0);
                       end; end;
-                      local_get(p); i32_const(1); i32_add; local_set(p);
+                      local_get(Local(p)); i32_const(Imm32(1)); i32_add; local_set(Local(p));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(inv_freq);
                 self.scratch.free_f64(x1);
@@ -2415,36 +2416,36 @@ impl FuncCompiler<'_> {
                 let extra_bytes = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(base); });
+                wasm!(self.func, { local_set(Local(base)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(extra); });
+                wasm!(self.func, { local_set(Local(extra)); });
 
                 wasm!(self.func, {
-                    local_get(base); i32_load(0); local_set(r_base);
-                    local_get(extra); i32_load(0); local_set(r_extra);
-                    local_get(base); i32_load(4); local_set(cols_l);
-                    local_get(r_base); local_get(r_extra); i32_add; local_set(r_total);
+                    local_get(Local(base)); i32_load(0); local_set(Local(r_base));
+                    local_get(Local(extra)); i32_load(0); local_set(Local(r_extra));
+                    local_get(Local(base)); i32_load(4); local_set(Local(cols_l));
+                    local_get(Local(r_base)); local_get(Local(r_extra)); i32_add; local_set(Local(r_total));
                     // row_bytes = cols * 8
-                    local_get(cols_l); i32_const(F64_BYTES); i32_mul; local_set(row_bytes);
-                    local_get(r_base); local_get(row_bytes); i32_mul; local_set(base_bytes);
-                    local_get(r_extra); local_get(row_bytes); i32_mul; local_set(extra_bytes);
+                    local_get(Local(cols_l)); i32_const(Imm32(F64_BYTES)); i32_mul; local_set(Local(row_bytes));
+                    local_get(Local(r_base)); local_get(Local(row_bytes)); i32_mul; local_set(Local(base_bytes));
+                    local_get(Local(r_extra)); local_get(Local(row_bytes)); i32_mul; local_set(Local(extra_bytes));
                     // alloc = 8 + total rows * cols * 8
-                    local_get(r_total); local_get(row_bytes); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(r_total); i32_store(0);
-                    local_get(dst); local_get(cols_l); i32_store(4);
+                    local_get(Local(r_total)); local_get(Local(row_bytes)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(r_total)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cols_l)); i32_store(4);
                     // memory.copy(dst+8, base+8, base_bytes)
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(base); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(base_bytes);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(base)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(base_bytes));
                     memory_copy;
                     // memory.copy(dst+8+base_bytes, extra+8, extra_bytes)
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(base_bytes); i32_add;
-                    local_get(extra); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(extra_bytes);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(base_bytes)); i32_add;
+                    local_get(Local(extra)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(extra_bytes));
                     memory_copy;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
 
                 self.scratch.free_i32(extra_bytes);
@@ -2494,99 +2495,99 @@ impl FuncCompiler<'_> {
 
                 // Evaluate args.
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(data); });
+                wasm!(self.func, { local_set(Local(data)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(off); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(off)); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { i32_wrap_i64; local_set(rows); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(rows)); });
                 self.emit_expr(&args[3]);
-                wasm!(self.func, { i32_wrap_i64; local_set(cols); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(cols)); });
 
                 // total = rows * cols; dst = alloc(8 + total*8); write header.
                 wasm!(self.func, {
-                    local_get(rows); local_get(cols); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(rows); i32_store(0);
-                    local_get(dst); local_get(cols); i32_store(4);
+                    local_get(Local(rows)); local_get(Local(cols)); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(rows)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cols)); i32_store(4);
                     // data_off = data_ptr + 4 (skip bytes-len header) + offset
-                    local_get(data); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(off); i32_add;
-                    local_set(data_off);
-                    i32_const(0); local_set(k);
+                    local_get(Local(data)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(off)); i32_add;
+                    local_set(Local(data_off));
+                    i32_const(Imm32(0)); local_set(Local(k));
                     block_empty; loop_empty;
-                      local_get(k); local_get(total); i32_ge_u; br_if(1);
+                      local_get(Local(k)); local_get(Local(total)); i32_ge_u; br_if(1);
                       // On a fresh 128-block boundary, reload scale & neg_scale.
-                      local_get(k); i32_const(Q1_0_BLOCK_SIZE_MASK); i32_and; i32_eqz;
+                      local_get(Local(k)); i32_const(Imm32(Q1_0_BLOCK_SIZE_MASK)); i32_and; i32_eqz;
                       if_empty;
                         // block_start = data_off + (k / 128) * 18
-                        local_get(data_off);
-                        local_get(k); i32_const(LOG2_Q1_0_BLOCK_SIZE); i32_shr_u;
-                        i32_const(Q1_0_BLOCK_BYTES); i32_mul;
+                        local_get(Local(data_off));
+                        local_get(Local(k)); i32_const(Imm32(LOG2_Q1_0_BLOCK_SIZE)); i32_shr_u;
+                        i32_const(Imm32(Q1_0_BLOCK_BYTES)); i32_mul;
                         i32_add;
-                        local_set(block_start);
+                        local_set(Local(block_start));
                         // scale_raw (u16 LE) = byte[0] | byte[1] << 8
-                        local_get(block_start); i32_load8_u(0);
-                        local_get(block_start); i32_load8_u(1);
-                        i32_const(F64_BYTES); i32_shl;
+                        local_get(Local(block_start)); i32_load8_u(0);
+                        local_get(Local(block_start)); i32_load8_u(1);
+                        i32_const(Imm32(F64_BYTES)); i32_shl;
                         i32_or;
-                        local_set(scale_raw);
+                        local_set(Local(scale_raw));
                         // Decompose fp16 bits into sign / exp / mantissa.
-                        local_get(scale_raw); i32_const(FP16_SIGN_BIT_POS); i32_shr_u;
-                        i32_const(1); i32_and;
-                        local_set(sign);
-                        local_get(scale_raw); i32_const(FP16_EXP_SHIFT); i32_shr_u;
-                        i32_const(FP16_EXP_BITS_MASK); i32_and;
-                        local_set(expv);
-                        local_get(scale_raw); i32_const(FP16_MANTISSA_MASK); i32_and;
-                        local_set(mant);
+                        local_get(Local(scale_raw)); i32_const(Imm32(FP16_SIGN_BIT_POS)); i32_shr_u;
+                        i32_const(Imm32(1)); i32_and;
+                        local_set(Local(sign));
+                        local_get(Local(scale_raw)); i32_const(Imm32(FP16_EXP_SHIFT)); i32_shr_u;
+                        i32_const(Imm32(FP16_EXP_BITS_MASK)); i32_and;
+                        local_set(Local(expv));
+                        local_get(Local(scale_raw)); i32_const(Imm32(FP16_MANTISSA_MASK)); i32_and;
+                        local_set(Local(mant));
                         // f32bits = (sign << 31) | ((exp + 112) << 23) | (mant << 13)
-                        local_get(sign); i32_const(F32_SIGN_SHIFT); i32_shl;
-                        local_get(expv); i32_const(FP16_EXP_BIAS_DIFF); i32_add; i32_const(F32_EXP_SHIFT); i32_shl;
+                        local_get(Local(sign)); i32_const(Imm32(F32_SIGN_SHIFT)); i32_shl;
+                        local_get(Local(expv)); i32_const(Imm32(FP16_EXP_BIAS_DIFF)); i32_add; i32_const(Imm32(F32_EXP_SHIFT)); i32_shl;
                         i32_or;
-                        local_get(mant); i32_const(FP16_MANT_TO_F32_SHIFT); i32_shl;
+                        local_get(Local(mant)); i32_const(Imm32(FP16_MANT_TO_F32_SHIFT)); i32_shl;
                         i32_or;
-                        local_set(f32bits);
+                        local_set(Local(f32bits));
                         // If exp == 0 force f32bits to zero (sign-only).
-                        local_get(expv); i32_eqz;
+                        local_get(Local(expv)); i32_eqz;
                         if_empty;
-                          local_get(sign); i32_const(F32_SIGN_SHIFT); i32_shl; local_set(f32bits);
+                          local_get(Local(sign)); i32_const(Imm32(F32_SIGN_SHIFT)); i32_shl; local_set(Local(f32bits));
                         end;
                         // scale = f64 from the reconstructed f32 bits.
-                        local_get(f32bits); f32_reinterpret_i32; f64_promote_f32;
-                        local_set(scale);
-                        f64_const(0.0); local_get(scale); f64_sub;
-                        local_set(neg_scale);
-                        local_get(block_start); i32_const(Q1_0_SCALE_BYTES); i32_add;
-                        local_set(bits_start);
+                        local_get(Local(f32bits)); f32_reinterpret_i32; f64_promote_f32;
+                        local_set(Local(scale));
+                        f64_const(0.0); local_get(Local(scale)); f64_sub;
+                        local_set(Local(neg_scale));
+                        local_get(Local(block_start)); i32_const(Imm32(Q1_0_SCALE_BYTES)); i32_add;
+                        local_set(Local(bits_start));
                       end;
                       // byte_idx = bits_start + ((k & 127) >> 3) = bits_start + ((k >> 3) & 15)
-                      local_get(bits_start);
-                      local_get(k); i32_const(LOG2_BITS_PER_BYTE); i32_shr_u; i32_const(Q1_0_DATA_BYTE_MASK); i32_and;
+                      local_get(Local(bits_start));
+                      local_get(Local(k)); i32_const(Imm32(LOG2_BITS_PER_BYTE)); i32_shr_u; i32_const(Imm32(Q1_0_DATA_BYTE_MASK)); i32_and;
                       i32_add;
-                      local_set(byte_idx);
+                      local_set(Local(byte_idx));
                       // bit_off = k & 7
-                      local_get(k); i32_const(BITS_PER_BYTE_MASK); i32_and; local_set(bit_off);
+                      local_get(Local(k)); i32_const(Imm32(BITS_PER_BYTE_MASK)); i32_and; local_set(Local(bit_off));
                       // bit = (byte >> bit_off) & 1
-                      local_get(byte_idx); i32_load8_u(0);
-                      local_get(bit_off); i32_shr_u;
-                      i32_const(1); i32_and;
-                      local_set(bit);
+                      local_get(Local(byte_idx)); i32_load8_u(0);
+                      local_get(Local(bit_off)); i32_shr_u;
+                      i32_const(Imm32(1)); i32_and;
+                      local_set(Local(bit));
                       // dst[8 + k*8] = bit == 1 ? scale : neg_scale
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(k); i32_const(F64_BYTES); i32_mul; i32_add;
-                      local_get(bit);
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(k)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      local_get(Local(bit));
                       if_f64;
-                        local_get(scale);
+                        local_get(Local(scale));
                       else_;
-                        local_get(neg_scale);
+                        local_get(Local(neg_scale));
                       end;
                       f64_store(0);
-                      local_get(k); i32_const(1); i32_add; local_set(k);
+                      local_get(Local(k)); i32_const(Imm32(1)); i32_add; local_set(Local(k));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(neg_scale);
                 self.scratch.free_f64(scale);
@@ -2624,66 +2625,66 @@ impl FuncCompiler<'_> {
                 let k = self.scratch.alloc_i32();
                 let s = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(x); });
+                wasm!(self.func, { local_set(Local(x)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(w); });
+                wasm!(self.func, { local_set(Local(w)); });
                 if with_bias {
                     self.emit_expr(&args[2]);
-                    wasm!(self.func, { local_set(b); });
+                    wasm!(self.func, { local_set(Local(b)); });
                 }
                 wasm!(self.func, {
-                    local_get(x); i32_load(0); local_set(xr);
-                    local_get(x); i32_load(4); local_set(nin);
-                    local_get(w); i32_load(0); local_set(wr);
-                    local_get(xr); local_get(wr); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(xr); i32_store(0);
-                    local_get(dst); local_get(wr); i32_store(4);
-                    i32_const(0); local_set(i);
+                    local_get(Local(x)); i32_load(0); local_set(Local(xr));
+                    local_get(Local(x)); i32_load(4); local_set(Local(nin));
+                    local_get(Local(w)); i32_load(0); local_set(Local(wr));
+                    local_get(Local(xr)); local_get(Local(wr)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(xr)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(wr)); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(xr); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(j);
+                      local_get(Local(i)); local_get(Local(xr)); i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(j));
                       block_empty; loop_empty;
-                        local_get(j); local_get(wr); i32_ge_u; br_if(1);
-                        f64_const(0.0); local_set(s);
-                        i32_const(0); local_set(k);
+                        local_get(Local(j)); local_get(Local(wr)); i32_ge_u; br_if(1);
+                        f64_const(0.0); local_set(Local(s));
+                        i32_const(Imm32(0)); local_set(Local(k));
                         block_empty; loop_empty;
-                          local_get(k); local_get(nin); i32_ge_u; br_if(1);
+                          local_get(Local(k)); local_get(Local(nin)); i32_ge_u; br_if(1);
                           // x[i,k]
-                          local_get(x); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(i); local_get(nin); i32_mul; local_get(k); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
+                          local_get(Local(x)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(i)); local_get(Local(nin)); i32_mul; local_get(Local(k)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
                           // weight[j,k]
-                          local_get(w); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(j); local_get(nin); i32_mul; local_get(k); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                          f64_mul; local_get(s); f64_add; local_set(s);
-                          local_get(k); i32_const(1); i32_add; local_set(k);
+                          local_get(Local(w)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(j)); local_get(Local(nin)); i32_mul; local_get(Local(k)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                          f64_mul; local_get(Local(s)); f64_add; local_set(Local(s));
+                          local_get(Local(k)); i32_const(Imm32(1)); i32_add; local_set(Local(k));
                           br(0);
                         end; end;
                         // dst[i,j] = s + bias[j] (if with_bias)
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(i); local_get(wr); i32_mul; local_get(j); i32_add;
-                        i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(s);
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(i)); local_get(Local(wr)); i32_mul; local_get(Local(j)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(s));
                 });
                 if with_bias {
                     wasm!(self.func, {
-                        local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(j)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                         f64_load(0); f64_add;
                     });
                 }
                 wasm!(self.func, {
                         f64_store(0);
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(s);
                 self.scratch.free_i32(k);
@@ -2707,40 +2708,40 @@ impl FuncCompiler<'_> {
                 let c = self.scratch.alloc_i32();
                 let mv = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(mv);
-                    local_get(m); i32_load(0); local_set(rows);
-                    local_get(m); i32_load(4); local_set(cols);
-                    local_get(rows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(rows); i32_store(0);
-                    local_get(dst); local_get(cols); i32_store(4);
-                    i32_const(0); local_set(r);
+                    local_set(Local(mv));
+                    local_get(Local(m)); i32_load(0); local_set(Local(rows));
+                    local_get(Local(m)); i32_load(4); local_set(Local(cols));
+                    local_get(Local(rows)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(rows)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cols)); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(r));
                     block_empty; loop_empty;
-                      local_get(r); local_get(rows); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(c);
+                      local_get(Local(r)); local_get(Local(rows)); i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
-                        local_get(c); local_get(cols); i32_ge_u; br_if(1);
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(r); local_get(cols); i32_mul; local_get(c); i32_add;
-                        i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(r); local_get(cols); i32_mul; local_get(c); i32_add;
-                        i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                        local_get(c); local_get(r); i32_gt_u;
-                        if_f64; local_get(mv); else_; f64_const(0.0); end;
+                        local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(r)); local_get(Local(cols)); i32_mul; local_get(Local(c)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(r)); local_get(Local(cols)); i32_mul; local_get(Local(c)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                        local_get(Local(c)); local_get(Local(r)); i32_gt_u;
+                        if_f64; local_get(Local(mv)); else_; f64_const(0.0); end;
                         f64_add;
                         f64_store(0);
-                        local_get(c); i32_const(1); i32_add; local_set(c);
+                        local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
-                      local_get(r); i32_const(1); i32_add; local_set(r);
+                      local_get(Local(r)); i32_const(Imm32(1)); i32_add; local_set(Local(r));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(mv);
                 self.scratch.free_i32(c);
@@ -2777,66 +2778,66 @@ impl FuncCompiler<'_> {
                 let v = self.scratch.alloc_f64();
                 let w = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(q); });
+                wasm!(self.func, { local_set(Local(q)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(kk); });
+                wasm!(self.func, { local_set(Local(kk)); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { local_set(vv); });
+                wasm!(self.func, { local_set(Local(vv)); });
                 self.emit_expr(&args[3]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(nh);
-                    local_get(q); i32_load(0); local_set(sq);
-                    local_get(kk); i32_load(0); local_set(sk);
-                    local_get(q); i32_load(4); local_set(dm);
-                    local_get(dm); local_get(nh); i32_div_u; local_set(dh);
+                    i32_wrap_i64; local_set(Local(nh));
+                    local_get(Local(q)); i32_load(0); local_set(Local(sq));
+                    local_get(Local(kk)); i32_load(0); local_set(Local(sk));
+                    local_get(Local(q)); i32_load(4); local_set(Local(dm));
+                    local_get(Local(dm)); local_get(Local(nh)); i32_div_u; local_set(Local(dh));
                     // scale = 1/sqrt(dh)
                     f64_const(1.0);
-                    local_get(dh); f64_convert_i32_u; f64_sqrt;
-                    f64_div; local_set(scale);
+                    local_get(Local(dh)); f64_convert_i32_u; f64_sqrt;
+                    f64_div; local_set(Local(scale));
                     // Alloc dst (sq, dm), zero
-                    local_get(sq); local_get(dm); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(sq); i32_store(0);
-                    local_get(dst); local_get(dm); i32_store(4);
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    i32_const(0);
-                    local_get(sq); local_get(dm); i32_mul; i32_const(F64_BYTES); i32_mul;
+                    local_get(Local(sq)); local_get(Local(dm)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(sq)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(dm)); i32_store(4);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    i32_const(Imm32(0));
+                    local_get(Local(sq)); local_get(Local(dm)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
                     memory_fill;
                     // Alloc scores (sq, sk) reused per head
-                    local_get(sq); local_get(sk); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    call(self.emitter.rt.alloc); local_set(scores);
+                    local_get(Local(sq)); local_get(Local(sk)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    call(self.emitter.rt.alloc); local_set(Local(scores));
                     // Per head
-                    i32_const(0); local_set(h);
+                    i32_const(Imm32(0)); local_set(Local(h));
                     block_empty; loop_empty;
-                      local_get(h); local_get(nh); i32_ge_u; br_if(1);
-                      local_get(h); local_get(dh); i32_mul; local_set(col0);
+                      local_get(Local(h)); local_get(Local(nh)); i32_ge_u; br_if(1);
+                      local_get(Local(h)); local_get(Local(dh)); i32_mul; local_set(Local(col0));
                       // scores[i,j] = (sum_k q[i,col0+k]*k[j,col0+k]) * scale + mask
-                      i32_const(0); local_set(i);
+                      i32_const(Imm32(0)); local_set(Local(i));
                       block_empty; loop_empty;
-                        local_get(i); local_get(sq); i32_ge_u; br_if(1);
-                        i32_const(0); local_set(j);
+                        local_get(Local(i)); local_get(Local(sq)); i32_ge_u; br_if(1);
+                        i32_const(Imm32(0)); local_set(Local(j));
                         block_empty; loop_empty;
-                          local_get(j); local_get(sk); i32_ge_u; br_if(1);
-                          f64_const(0.0); local_set(acc);
-                          i32_const(0); local_set(kki);
+                          local_get(Local(j)); local_get(Local(sk)); i32_ge_u; br_if(1);
+                          f64_const(0.0); local_set(Local(acc));
+                          i32_const(Imm32(0)); local_set(Local(kki));
                           block_empty; loop_empty;
-                            local_get(kki); local_get(dh); i32_ge_u; br_if(1);
+                            local_get(Local(kki)); local_get(Local(dh)); i32_ge_u; br_if(1);
                             // q[i, col0+kki]
-                            local_get(q); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                            local_get(i); local_get(dm); i32_mul;
-                            local_get(col0); i32_add; local_get(kki); i32_add;
-                            i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
+                            local_get(Local(q)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                            local_get(Local(i)); local_get(Local(dm)); i32_mul;
+                            local_get(Local(col0)); i32_add; local_get(Local(kki)); i32_add;
+                            i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
                             // k[j, col0+kki]
-                            local_get(kk); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                            local_get(j); local_get(dm); i32_mul;
-                            local_get(col0); i32_add; local_get(kki); i32_add;
-                            i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                            f64_mul; local_get(acc); f64_add; local_set(acc);
-                            local_get(kki); i32_const(1); i32_add; local_set(kki);
+                            local_get(Local(kk)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                            local_get(Local(j)); local_get(Local(dm)); i32_mul;
+                            local_get(Local(col0)); i32_add; local_get(Local(kki)); i32_add;
+                            i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                            f64_mul; local_get(Local(acc)); f64_add; local_set(Local(acc));
+                            local_get(Local(kki)); i32_const(Imm32(1)); i32_add; local_set(Local(kki));
                             br(0);
                           end; end;
-                          local_get(acc); local_get(scale); f64_mul; local_set(acc);
+                          local_get(Local(acc)); local_get(Local(scale)); f64_mul; local_set(Local(acc));
                 });
                 if causal {
                     wasm!(self.func, {
@@ -2847,116 +2848,116 @@ impl FuncCompiler<'_> {
                           // with cached K of length sk - sq) the cached
                           // prefix is always visible, and the new query
                           // sees its own key plus everything before.
-                          local_get(j);
-                          local_get(sk); local_get(sq); i32_sub;
-                          local_get(i); i32_add;
+                          local_get(Local(j));
+                          local_get(Local(sk)); local_get(Local(sq)); i32_sub;
+                          local_get(Local(i)); i32_add;
                           i32_gt_u;
                           if_f64; f64_const(-1.0e9); else_; f64_const(0.0); end;
-                          local_get(acc); f64_add; local_set(acc);
+                          local_get(Local(acc)); f64_add; local_set(Local(acc));
                     });
                 }
                 wasm!(self.func, {
                           // scores[i*sk + j] = acc
-                          local_get(scores);
-                          local_get(i); local_get(sk); i32_mul; local_get(j); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add;
-                          local_get(acc); f64_store(0);
-                          local_get(j); i32_const(1); i32_add; local_set(j);
+                          local_get(Local(scores));
+                          local_get(Local(i)); local_get(Local(sk)); i32_mul; local_get(Local(j)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                          local_get(Local(acc)); f64_store(0);
+                          local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                           br(0);
                         end; end;
                         // Softmax row i — NaN/Inf-defensive.
                         // Initialise max with scores[i*sk] (instead of -1e308 sentinel)
                         // so a single NaN can't poison the whole row via
                         // f64_gt-returns-false-for-NaN.
-                        local_get(scores);
-                        local_get(i); local_get(sk); i32_mul;
-                        i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                        local_set(max);
-                        i32_const(1); local_set(j);
+                        local_get(Local(scores));
+                        local_get(Local(i)); local_get(Local(sk)); i32_mul;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                        local_set(Local(max));
+                        i32_const(Imm32(1)); local_set(Local(j));
                         block_empty; loop_empty;
-                          local_get(j); local_get(sk); i32_ge_u; br_if(1);
-                          local_get(scores);
-                          local_get(i); local_get(sk); i32_mul; local_get(j); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0); local_set(v);
-                          local_get(v); local_get(max); f64_gt;
-                          if_empty; local_get(v); local_set(max); end;
-                          local_get(j); i32_const(1); i32_add; local_set(j);
+                          local_get(Local(j)); local_get(Local(sk)); i32_ge_u; br_if(1);
+                          local_get(Local(scores));
+                          local_get(Local(i)); local_get(Local(sk)); i32_mul; local_get(Local(j)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0); local_set(Local(v));
+                          local_get(Local(v)); local_get(Local(max)); f64_gt;
+                          if_empty; local_get(Local(v)); local_set(Local(max)); end;
+                          local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                           br(0);
                         end; end;
-                        f64_const(0.0); local_set(sum);
-                        i32_const(0); local_set(j);
+                        f64_const(0.0); local_set(Local(sum));
+                        i32_const(Imm32(0)); local_set(Local(j));
                         block_empty; loop_empty;
-                          local_get(j); local_get(sk); i32_ge_u; br_if(1);
-                          local_get(scores);
-                          local_get(i); local_get(sk); i32_mul; local_get(j); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add;
-                          local_get(scores);
-                          local_get(i); local_get(sk); i32_mul; local_get(j); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                          local_get(max); f64_sub; call(self.emitter.rt.math_exp); local_set(v);
-                          local_get(v); f64_store(0);
-                          local_get(sum); local_get(v); f64_add; local_set(sum);
-                          local_get(j); i32_const(1); i32_add; local_set(j);
+                          local_get(Local(j)); local_get(Local(sk)); i32_ge_u; br_if(1);
+                          local_get(Local(scores));
+                          local_get(Local(i)); local_get(Local(sk)); i32_mul; local_get(Local(j)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                          local_get(Local(scores));
+                          local_get(Local(i)); local_get(Local(sk)); i32_mul; local_get(Local(j)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                          local_get(Local(max)); f64_sub; call(self.emitter.rt.math_exp); local_set(Local(v));
+                          local_get(Local(v)); f64_store(0);
+                          local_get(Local(sum)); local_get(Local(v)); f64_add; local_set(Local(sum));
+                          local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                           br(0);
                         end; end;
                         // Sum guard: if sum is non-positive or non-finite, fall back
                         // to uniform distribution over sk (avoid 0/0 → NaN cascade).
-                        local_get(sum); f64_const(0.0); f64_le;
-                        local_get(sum); local_get(sum); f64_ne;  // NaN check
+                        local_get(Local(sum)); f64_const(0.0); f64_le;
+                        local_get(Local(sum)); local_get(Local(sum)); f64_ne;  // NaN check
                         i32_or;
                         if_empty;
-                          local_get(sk); f64_convert_i32_u; local_set(sum);
+                          local_get(Local(sk)); f64_convert_i32_u; local_set(Local(sum));
                           // Re-fill scores row with 1.0 (will become 1/sk after div)
-                          i32_const(0); local_set(j);
+                          i32_const(Imm32(0)); local_set(Local(j));
                           block_empty; loop_empty;
-                            local_get(j); local_get(sk); i32_ge_u; br_if(1);
-                            local_get(scores);
-                            local_get(i); local_get(sk); i32_mul; local_get(j); i32_add;
-                            i32_const(F64_BYTES); i32_mul; i32_add;
+                            local_get(Local(j)); local_get(Local(sk)); i32_ge_u; br_if(1);
+                            local_get(Local(scores));
+                            local_get(Local(i)); local_get(Local(sk)); i32_mul; local_get(Local(j)); i32_add;
+                            i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                             f64_const(1.0); f64_store(0);
-                            local_get(j); i32_const(1); i32_add; local_set(j);
+                            local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                             br(0);
                           end; end;
                         end;
                         // dst[i, col0..col1] += (scores[i,j] / sum) * v[j, col0..col1]
-                        i32_const(0); local_set(j);
+                        i32_const(Imm32(0)); local_set(Local(j));
                         block_empty; loop_empty;
-                          local_get(j); local_get(sk); i32_ge_u; br_if(1);
-                          local_get(scores);
-                          local_get(i); local_get(sk); i32_mul; local_get(j); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                          local_get(sum); f64_div; local_set(w);
+                          local_get(Local(j)); local_get(Local(sk)); i32_ge_u; br_if(1);
+                          local_get(Local(scores));
+                          local_get(Local(i)); local_get(Local(sk)); i32_mul; local_get(Local(j)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                          local_get(Local(sum)); f64_div; local_set(Local(w));
                           // Add w * v[j, col0+kki] to dst[i, col0+kki]
-                          i32_const(0); local_set(kki);
+                          i32_const(Imm32(0)); local_set(Local(kki));
                           block_empty; loop_empty;
-                            local_get(kki); local_get(dh); i32_ge_u; br_if(1);
-                            local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                            local_get(i); local_get(dm); i32_mul;
-                            local_get(col0); i32_add; local_get(kki); i32_add;
-                            i32_const(F64_BYTES); i32_mul; i32_add;
-                            local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                            local_get(i); local_get(dm); i32_mul;
-                            local_get(col0); i32_add; local_get(kki); i32_add;
-                            i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                            local_get(vv); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                            local_get(j); local_get(dm); i32_mul;
-                            local_get(col0); i32_add; local_get(kki); i32_add;
-                            i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                            local_get(w); f64_mul; f64_add;
+                            local_get(Local(kki)); local_get(Local(dh)); i32_ge_u; br_if(1);
+                            local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                            local_get(Local(i)); local_get(Local(dm)); i32_mul;
+                            local_get(Local(col0)); i32_add; local_get(Local(kki)); i32_add;
+                            i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                            local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                            local_get(Local(i)); local_get(Local(dm)); i32_mul;
+                            local_get(Local(col0)); i32_add; local_get(Local(kki)); i32_add;
+                            i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                            local_get(Local(vv)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                            local_get(Local(j)); local_get(Local(dm)); i32_mul;
+                            local_get(Local(col0)); i32_add; local_get(Local(kki)); i32_add;
+                            i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                            local_get(Local(w)); f64_mul; f64_add;
                             f64_store(0);
-                            local_get(kki); i32_const(1); i32_add; local_set(kki);
+                            local_get(Local(kki)); i32_const(Imm32(1)); i32_add; local_set(Local(kki));
                             br(0);
                           end; end;
-                          local_get(j); i32_const(1); i32_add; local_set(j);
+                          local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                           br(0);
                         end; end;
-                        local_get(i); i32_const(1); i32_add; local_set(i);
+                        local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                         br(0);
                       end; end;
-                      local_get(h); i32_const(1); i32_add; local_set(h);
+                      local_get(Local(h)); i32_const(Imm32(1)); i32_add; local_set(Local(h));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(w);
                 self.scratch.free_f64(v);
@@ -2990,17 +2991,17 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(m);
-                    local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul; local_set(bytes_len);
+                    local_set(Local(m));
+                    local_get(Local(m)); i32_load(0); local_get(Local(m)); i32_load(4); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; local_set(Local(bytes_len));
                     // alloc bytes buffer with header
-                    local_get(bytes_len); call(self.emitter.rt.string_alloc); local_set(dst);
+                    local_get(Local(bytes_len)); call(self.emitter.rt.string_alloc); local_set(Local(dst));
                     // memcpy: dst+data_off ← m+data_off, bytes_len bytes
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(bytes_len);
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(bytes_len));
                     memory_copy;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(dst);
                 self.scratch.free_i32(bytes_len);
@@ -3018,22 +3019,22 @@ impl FuncCompiler<'_> {
                 let dst_addr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(m);
-                    local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(F32_BYTES); i32_mul; local_set(bytes_len);
-                    local_get(bytes_len); call(self.emitter.rt.string_alloc); local_set(dst);
-                    i32_const(0); local_set(i);
+                    local_set(Local(m));
+                    local_get(Local(m)); i32_load(0); local_get(Local(m)); i32_load(4); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F32_BYTES)); i32_mul; local_set(Local(bytes_len));
+                    local_get(Local(bytes_len)); call(self.emitter.rt.string_alloc); local_set(Local(dst));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(total); i32_ge_u; br_if(1);
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; local_set(src_addr);
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F32_BYTES); i32_mul; i32_add; local_set(dst_addr);
-                      local_get(dst_addr);
-                      local_get(src_addr); f64_load(0); f32_demote_f64;
+                      local_get(Local(i)); local_get(Local(total)); i32_ge_u; br_if(1);
+                      local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; local_set(Local(src_addr));
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(i)); i32_const(Imm32(F32_BYTES)); i32_mul; i32_add; local_set(Local(dst_addr));
+                      local_get(Local(dst_addr));
+                      local_get(Local(src_addr)); f64_load(0); f32_demote_f64;
                       f32_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(dst_addr);
                 self.scratch.free_i32(src_addr);
@@ -3052,25 +3053,25 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let total = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(off); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(off)); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { i32_wrap_i64; local_set(r); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(r)); });
                 self.emit_expr(&args[3]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(c);
-                    local_get(r); local_get(c); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(r); i32_store(0);
-                    local_get(dst); local_get(c); i32_store(4);
+                    i32_wrap_i64; local_set(Local(c));
+                    local_get(Local(r)); local_get(Local(c)); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(r)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(c)); i32_store(4);
                     // memcpy: dst+8 ← buf+4+off, total*8 bytes
-                    local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(off); i32_add;
-                    local_get(total); i32_const(F64_BYTES); i32_mul;
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(off)); i32_add;
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul;
                     memory_copy;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(total);
                 self.scratch.free_i32(dst);
@@ -3089,31 +3090,31 @@ impl FuncCompiler<'_> {
                 let total = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(buf); });
+                wasm!(self.func, { local_set(Local(buf)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(off); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(off)); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { i32_wrap_i64; local_set(r); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(r)); });
                 self.emit_expr(&args[3]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(c);
-                    local_get(r); local_get(c); i32_mul; local_set(total);
-                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(r); i32_store(0);
-                    local_get(dst); local_get(c); i32_store(4);
-                    i32_const(0); local_set(i);
+                    i32_wrap_i64; local_set(Local(c));
+                    local_get(Local(r)); local_get(Local(c)); i32_mul; local_set(Local(total));
+                    local_get(Local(total)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(r)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(c)); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(total); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(total)); i32_ge_u; br_if(1);
                       // dst[data] + i * 8
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                       // src = buf + 4 + off + i * elem_bytes
-                      local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(off); i32_add;
+                      local_get(Local(buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_get(Local(off)); i32_add;
                 });
                 let elem_bytes: i32 = if is_f16 { 2 } else { 4 };
                 wasm!(self.func, {
-                      local_get(i); i32_const(elem_bytes); i32_mul; i32_add;
+                      local_get(Local(i)); i32_const(Imm32(elem_bytes)); i32_mul; i32_add;
                 });
                 if is_f16 {
                     wasm!(self.func, {
@@ -3125,10 +3126,10 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                       f64_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(total);
@@ -3162,86 +3163,86 @@ impl FuncCompiler<'_> {
                 let tc = self.scratch.alloc_i32();
                 let s = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(inp); });
+                wasm!(self.func, { local_set(Local(inp)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(w); });
+                wasm!(self.func, { local_set(Local(w)); });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { local_set(b); });
+                wasm!(self.func, { local_set(Local(b)); });
                 self.emit_expr(&args[3]);
-                wasm!(self.func, { i32_wrap_i64; local_set(kk); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(kk)); });
                 self.emit_expr(&args[4]);
-                wasm!(self.func, { i32_wrap_i64; local_set(st); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(st)); });
                 self.emit_expr(&args[5]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(pd);
-                    local_get(inp); i32_load(0); local_set(tin);
-                    local_get(inp); i32_load(4); local_set(ich);
-                    local_get(w); i32_load(0); local_set(och);
+                    i32_wrap_i64; local_set(Local(pd));
+                    local_get(Local(inp)); i32_load(0); local_set(Local(tin));
+                    local_get(Local(inp)); i32_load(4); local_set(Local(ich));
+                    local_get(Local(w)); i32_load(0); local_set(Local(och));
                     // tout = (tin + 2*pd - kk) / st + 1
-                    local_get(tin); local_get(pd); i32_const(CONV1D_PADDING_SIDES); i32_mul; i32_add;
-                    local_get(kk); i32_sub; local_get(st); i32_div_u;
-                    i32_const(1); i32_add; local_set(tout);
+                    local_get(Local(tin)); local_get(Local(pd)); i32_const(Imm32(CONV1D_PADDING_SIDES)); i32_mul; i32_add;
+                    local_get(Local(kk)); i32_sub; local_get(Local(st)); i32_div_u;
+                    i32_const(Imm32(1)); i32_add; local_set(Local(tout));
                     // Alloc dst (tout, och)
-                    local_get(tout); local_get(och); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(tout); i32_store(0);
-                    local_get(dst); local_get(och); i32_store(4);
+                    local_get(Local(tout)); local_get(Local(och)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(tout)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(och)); i32_store(4);
                     // For each t, o:
-                    i32_const(0); local_set(t);
+                    i32_const(Imm32(0)); local_set(Local(t));
                     block_empty; loop_empty;
-                      local_get(t); local_get(tout); i32_ge_u; br_if(1);
-                      local_get(t); local_get(st); i32_mul; local_set(base);
-                      i32_const(0); local_set(o);
+                      local_get(Local(t)); local_get(Local(tout)); i32_ge_u; br_if(1);
+                      local_get(Local(t)); local_get(Local(st)); i32_mul; local_set(Local(base));
+                      i32_const(Imm32(0)); local_set(Local(o));
                       block_empty; loop_empty;
-                        local_get(o); local_get(och); i32_ge_u; br_if(1);
+                        local_get(Local(o)); local_get(Local(och)); i32_ge_u; br_if(1);
                         // s = bias[o]
-                        local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(o); i32_const(F64_BYTES); i32_mul; i32_add;
-                        f64_load(0); local_set(s);
-                        i32_const(0); local_set(cc);
+                        local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(o)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        f64_load(0); local_set(Local(s));
+                        i32_const(Imm32(0)); local_set(Local(cc));
                         block_empty; loop_empty;
-                          local_get(cc); local_get(ich); i32_ge_u; br_if(1);
-                          i32_const(0); local_set(ki);
+                          local_get(Local(cc)); local_get(Local(ich)); i32_ge_u; br_if(1);
+                          i32_const(Imm32(0)); local_set(Local(ki));
                           block_empty; loop_empty;
-                            local_get(ki); local_get(kk); i32_ge_u; br_if(1);
+                            local_get(Local(ki)); local_get(Local(kk)); i32_ge_u; br_if(1);
                             // tp = base + ki; if (tp >= pd && tp < pd+tin): use
-                            local_get(base); local_get(ki); i32_add; local_set(tp);
-                            local_get(tp); local_get(pd); i32_ge_u;
-                            local_get(tp); local_get(pd); local_get(tin); i32_add; i32_lt_u;
+                            local_get(Local(base)); local_get(Local(ki)); i32_add; local_set(Local(tp));
+                            local_get(Local(tp)); local_get(Local(pd)); i32_ge_u;
+                            local_get(Local(tp)); local_get(Local(pd)); local_get(Local(tin)); i32_add; i32_lt_u;
                             i32_and;
                             if_empty;
-                              local_get(tp); local_get(pd); i32_sub; local_set(tc);
+                              local_get(Local(tp)); local_get(Local(pd)); i32_sub; local_set(Local(tc));
                               // weight[o][cc*kk + ki]
-                              local_get(w); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                              local_get(o); local_get(ich); i32_mul; local_get(kk); i32_mul;
-                              local_get(cc); local_get(kk); i32_mul; i32_add;
-                              local_get(ki); i32_add;
-                              i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
+                              local_get(Local(w)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                              local_get(Local(o)); local_get(Local(ich)); i32_mul; local_get(Local(kk)); i32_mul;
+                              local_get(Local(cc)); local_get(Local(kk)); i32_mul; i32_add;
+                              local_get(Local(ki)); i32_add;
+                              i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
                               // input[tc][cc]
-                              local_get(inp); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                              local_get(tc); local_get(ich); i32_mul; local_get(cc); i32_add;
-                              i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                              f64_mul; local_get(s); f64_add; local_set(s);
+                              local_get(Local(inp)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                              local_get(Local(tc)); local_get(Local(ich)); i32_mul; local_get(Local(cc)); i32_add;
+                              i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                              f64_mul; local_get(Local(s)); f64_add; local_set(Local(s));
                             end;
-                            local_get(ki); i32_const(1); i32_add; local_set(ki);
+                            local_get(Local(ki)); i32_const(Imm32(1)); i32_add; local_set(Local(ki));
                             br(0);
                           end; end;
-                          local_get(cc); i32_const(1); i32_add; local_set(cc);
+                          local_get(Local(cc)); i32_const(Imm32(1)); i32_add; local_set(Local(cc));
                           br(0);
                         end; end;
                         // dst[t, o] = s
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(t); local_get(och); i32_mul; local_get(o); i32_add;
-                        i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(s); f64_store(0);
-                        local_get(o); i32_const(1); i32_add; local_set(o);
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(t)); local_get(Local(och)); i32_mul; local_get(Local(o)); i32_add;
+                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(s)); f64_store(0);
+                        local_get(Local(o)); i32_const(Imm32(1)); i32_add; local_set(Local(o));
                         br(0);
                       end; end;
-                      local_get(t); i32_const(1); i32_add; local_set(t);
+                      local_get(Local(t)); i32_const(Imm32(1)); i32_add; local_set(Local(t));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_f64(s);
                 self.scratch.free_i32(tc);
@@ -3277,56 +3278,56 @@ impl FuncCompiler<'_> {
                 let c = self.scratch.alloc_i32();
                 let sub = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(n);
-                    local_get(m); i32_load(0); local_set(rows);
-                    local_get(m); i32_load(4); local_set(cols);
-                    local_get(cols); local_get(n); i32_div_u; local_set(chunk);
+                    i32_wrap_i64; local_set(Local(n));
+                    local_get(Local(m)); i32_load(0); local_set(Local(rows));
+                    local_get(Local(m)); i32_load(4); local_set(Local(cols));
+                    local_get(Local(cols)); local_get(Local(n)); i32_div_u; local_set(Local(chunk));
                     // Alloc list: 4 + n*4
-                    local_get(n); i32_const(I32_BYTES); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(list_ptr);
-                    local_get(list_ptr); local_get(n); i32_store(0);
-                    i32_const(0); local_set(h);
+                    local_get(Local(n)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(list_ptr));
+                    local_get(Local(list_ptr)); local_get(Local(n)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(h));
                     block_empty; loop_empty;
-                      local_get(h); local_get(n); i32_ge_u; br_if(1);
+                      local_get(Local(h)); local_get(Local(n)); i32_ge_u; br_if(1);
                       // Alloc sub-matrix (rows, chunk)
-                      local_get(rows); local_get(chunk); i32_mul; i32_const(F64_BYTES); i32_mul;
-                      i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      call(self.emitter.rt.alloc); local_set(sub);
-                      local_get(sub); local_get(rows); i32_store(0);
-                      local_get(sub); local_get(chunk); i32_store(4);
+                      local_get(Local(rows)); local_get(Local(chunk)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                      i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      call(self.emitter.rt.alloc); local_set(Local(sub));
+                      local_get(Local(sub)); local_get(Local(rows)); i32_store(0);
+                      local_get(Local(sub)); local_get(Local(chunk)); i32_store(4);
                       // Copy rows: sub[r][c] = m[r][h*chunk + c]
-                      i32_const(0); local_set(r);
+                      i32_const(Imm32(0)); local_set(Local(r));
                       block_empty; loop_empty;
-                        local_get(r); local_get(rows); i32_ge_u; br_if(1);
-                        i32_const(0); local_set(c);
+                        local_get(Local(r)); local_get(Local(rows)); i32_ge_u; br_if(1);
+                        i32_const(Imm32(0)); local_set(Local(c));
                         block_empty; loop_empty;
-                          local_get(c); local_get(chunk); i32_ge_u; br_if(1);
-                          local_get(sub); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(r); local_get(chunk); i32_mul; local_get(c); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add;
-                          local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(r); local_get(cols); i32_mul;
-                          local_get(h); local_get(chunk); i32_mul; i32_add;
-                          local_get(c); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add;
+                          local_get(Local(c)); local_get(Local(chunk)); i32_ge_u; br_if(1);
+                          local_get(Local(sub)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(r)); local_get(Local(chunk)); i32_mul; local_get(Local(c)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                          local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(r)); local_get(Local(cols)); i32_mul;
+                          local_get(Local(h)); local_get(Local(chunk)); i32_mul; i32_add;
+                          local_get(Local(c)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                           f64_load(0); f64_store(0);
-                          local_get(c); i32_const(1); i32_add; local_set(c);
+                          local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                           br(0);
                         end; end;
-                        local_get(r); i32_const(1); i32_add; local_set(r);
+                        local_get(Local(r)); i32_const(Imm32(1)); i32_add; local_set(Local(r));
                         br(0);
                       end; end;
                       // list[h] = sub
-                      local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(h); i32_const(I32_BYTES); i32_mul; i32_add;
-                      local_get(sub); i32_store(0);
-                      local_get(h); i32_const(1); i32_add; local_set(h);
+                      local_get(Local(list_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(h)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      local_get(Local(sub)); i32_store(0);
+                      local_get(Local(h)); i32_const(Imm32(1)); i32_add; local_set(Local(h));
                       br(0);
                     end; end;
-                    local_get(list_ptr);
+                    local_get(Local(list_ptr));
                 });
                 self.scratch.free_i32(sub);
                 self.scratch.free_i32(c);
@@ -3357,65 +3358,65 @@ impl FuncCompiler<'_> {
                 let c = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(lst);
-                    local_get(lst); i32_load(0); local_set(n);
+                    local_set(Local(lst));
+                    local_get(Local(lst)); i32_load(0); local_set(Local(n));
                     // first = lst[0]
-                    local_get(lst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; i32_load(0); local_set(first);
-                    local_get(first); i32_load(0); local_set(rows);
+                    local_get(Local(lst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; i32_load(0); local_set(Local(first));
+                    local_get(Local(first)); i32_load(0); local_set(Local(rows));
                     // Sum total_cols
-                    i32_const(0); local_set(total_cols);
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(total_cols));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(n); i32_ge_u; br_if(1);
-                      local_get(lst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      i32_load(0); local_set(sub);
-                      local_get(total_cols); local_get(sub); i32_load(4); i32_add;
-                      local_set(total_cols);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); local_get(Local(n)); i32_ge_u; br_if(1);
+                      local_get(Local(lst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      i32_load(0); local_set(Local(sub));
+                      local_get(Local(total_cols)); local_get(Local(sub)); i32_load(4); i32_add;
+                      local_set(Local(total_cols));
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                     // Alloc dst (rows, total_cols)
-                    local_get(rows); local_get(total_cols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(rows); i32_store(0);
-                    local_get(dst); local_get(total_cols); i32_store(4);
+                    local_get(Local(rows)); local_get(Local(total_cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(rows)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(total_cols)); i32_store(4);
                     // Fill: for each submatrix, copy its rows into dst at col_off
-                    i32_const(0); local_set(col_off);
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(col_off));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(n); i32_ge_u; br_if(1);
-                      local_get(lst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      i32_load(0); local_set(sub);
-                      local_get(sub); i32_load(4); local_set(sub_cols);
-                      i32_const(0); local_set(r);
+                      local_get(Local(i)); local_get(Local(n)); i32_ge_u; br_if(1);
+                      local_get(Local(lst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      i32_load(0); local_set(Local(sub));
+                      local_get(Local(sub)); i32_load(4); local_set(Local(sub_cols));
+                      i32_const(Imm32(0)); local_set(Local(r));
                       block_empty; loop_empty;
-                        local_get(r); local_get(rows); i32_ge_u; br_if(1);
-                        i32_const(0); local_set(c);
+                        local_get(Local(r)); local_get(Local(rows)); i32_ge_u; br_if(1);
+                        i32_const(Imm32(0)); local_set(Local(c));
                         block_empty; loop_empty;
-                          local_get(c); local_get(sub_cols); i32_ge_u; br_if(1);
+                          local_get(Local(c)); local_get(Local(sub_cols)); i32_ge_u; br_if(1);
                           // dst[r, col_off + c] = sub[r, c]
-                          local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(r); local_get(total_cols); i32_mul;
-                          local_get(col_off); i32_add; local_get(c); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add;
-                          local_get(sub); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(r); local_get(sub_cols); i32_mul; local_get(c); i32_add;
-                          i32_const(F64_BYTES); i32_mul; i32_add;
+                          local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(r)); local_get(Local(total_cols)); i32_mul;
+                          local_get(Local(col_off)); i32_add; local_get(Local(c)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                          local_get(Local(sub)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(r)); local_get(Local(sub_cols)); i32_mul; local_get(Local(c)); i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
                           f64_load(0); f64_store(0);
-                          local_get(c); i32_const(1); i32_add; local_set(c);
+                          local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                           br(0);
                         end; end;
-                        local_get(r); i32_const(1); i32_add; local_set(r);
+                        local_get(Local(r)); i32_const(Imm32(1)); i32_add; local_set(Local(r));
                         br(0);
                       end; end;
-                      local_get(col_off); local_get(sub_cols); i32_add; local_set(col_off);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(col_off)); local_get(Local(sub_cols)); i32_add; local_set(Local(col_off));
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(c);
                 self.scratch.free_i32(r);
@@ -3441,48 +3442,48 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let idx = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(indices);
-                    local_get(m); i32_load(0); local_set(n_rows_src);
-                    local_get(m); i32_load(4); local_set(cols);
-                    local_get(indices); i32_load(0); local_set(n);
+                    local_set(Local(indices));
+                    local_get(Local(m)); i32_load(0); local_set(Local(n_rows_src));
+                    local_get(Local(m)); i32_load(4); local_set(Local(cols));
+                    local_get(Local(indices)); i32_load(0); local_set(Local(n));
                     // Alloc dst (n, cols)
-                    local_get(n); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
-                    i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(n); i32_store(0);
-                    local_get(dst); local_get(cols); i32_store(4);
-                    i32_const(0); local_set(i);
+                    local_get(Local(n)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
+                    i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(n)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(cols)); i32_store(4);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(n); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(n)); i32_ge_u; br_if(1);
                       // idx = indices[i] (i64 → i32)
-                      local_get(indices); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
-                      i64_load(0); i32_wrap_i64; local_set(idx);
+                      local_get(Local(indices)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                      i64_load(0); i32_wrap_i64; local_set(Local(idx));
                       // bounds clamp: if idx >= n_rows_src: zero the row, else memcpy
-                      local_get(idx); local_get(n_rows_src); i32_ge_u;
+                      local_get(Local(idx)); local_get(Local(n_rows_src)); i32_ge_u;
                       if_empty;
                         // Zero
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(i); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul; i32_add;
-                        i32_const(0);
-                        local_get(cols); i32_const(F64_BYTES); i32_mul;
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(i)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        i32_const(Imm32(0));
+                        local_get(Local(cols)); i32_const(Imm32(F64_BYTES)); i32_mul;
                         memory_fill;
                       else_;
                         // memcpy: dst[i] ← m[idx]
-                        local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(i); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(idx); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul; i32_add;
-                        local_get(cols); i32_const(F64_BYTES); i32_mul;
+                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(i)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(idx)); local_get(Local(cols)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(cols)); i32_const(Imm32(F64_BYTES)); i32_mul;
                         memory_copy;
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(idx);
                 self.scratch.free_i32(i);
@@ -3504,34 +3505,34 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let s = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(m); });
+                wasm!(self.func, { local_set(Local(m)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { i32_wrap_i64; local_set(row); });
+                wasm!(self.func, { i32_wrap_i64; local_set(Local(row)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    local_set(vec);
-                    local_get(m); i32_load(4); local_set(cols);
-                    local_get(vec); i32_load(0); local_set(vlen);
+                    local_set(Local(vec));
+                    local_get(Local(m)); i32_load(4); local_set(Local(cols));
+                    local_get(Local(vec)); i32_load(0); local_set(Local(vlen));
                     // n = min(cols, vlen)
-                    local_get(cols); local_get(vlen); i32_lt_u;
-                    if_i32; local_get(cols); else_; local_get(vlen); end;
-                    local_set(n);
-                    f64_const(0.0); local_set(s);
-                    i32_const(0); local_set(i);
+                    local_get(Local(cols)); local_get(Local(vlen)); i32_lt_u;
+                    if_i32; local_get(Local(cols)); else_; local_get(Local(vlen)); end;
+                    local_set(Local(n));
+                    f64_const(0.0); local_set(Local(s));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(n); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(n)); i32_ge_u; br_if(1);
                       // m[row, i]
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(row); local_get(cols); i32_mul; local_get(i); i32_add;
-                      i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
+                      local_get(Local(m)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(row)); local_get(Local(cols)); i32_mul; local_get(Local(i)); i32_add;
+                      i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
                       // vec[i]
-                      local_get(vec); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                      f64_mul; local_get(s); f64_add; local_set(s);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(vec)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                      f64_mul; local_get(Local(s)); f64_add; local_set(Local(s));
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(s);
+                    local_get(Local(s));
                 });
                 self.scratch.free_f64(s);
                 self.scratch.free_i32(i);

--- a/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
@@ -3,6 +3,68 @@
 //! Memory layout: [rows:i32][cols:i32][data:f64...]  (row-major, 8 bytes per element)
 //! Total size: 8 + rows*cols*8
 
+// ── Named immediates ──────────────────────────────────────────────────────────
+// Element widths / byte sizes
+/// Bytes per f64 matrix element.
+const F64_BYTES: i32 = 8;
+/// Bytes per f32 element (to_bytes_f32_le / from_bytes_f32_le).
+const F32_BYTES: i32 = 4;
+/// Bytes per i32 pointer slot in a list-of-pointers.
+const I32_BYTES: i32 = 4;
+/// Number of f64 lanes in a WASM f64x2 SIMD vector (inner-loop stride).
+const SIMD_F64_LANES: i32 = 2;
+/// Bytes for a two-field i64 tuple (rows, cols shape result).
+const SHAPE_TUPLE_BYTES: i32 = 16;
+
+// Q1_0 quantization block constants
+/// Number of weights packed per Q1_0 block.
+const Q1_0_BLOCK_SIZE: i32 = 128;
+/// Bitmask for within-block weight index (Q1_0_BLOCK_SIZE - 1).
+const Q1_0_BLOCK_SIZE_MASK: i32 = 127;
+/// log2 of Q1_0_BLOCK_SIZE; used as right-shift to convert index → block number.
+const LOG2_Q1_0_BLOCK_SIZE: i32 = 7;
+/// Total bytes per Q1_0 block: 2 bytes fp16 scale + 16 bytes sign bits.
+const Q1_0_BLOCK_BYTES: i32 = 18;
+/// Bytes of fp16 scale header at the start of each Q1_0 block.
+const Q1_0_SCALE_BYTES: i32 = 2;
+/// SIMD pairs per Q1_0 block (Q1_0_BLOCK_SIZE / SIMD_F64_LANES).
+const Q1_0_PAIRS_PER_BLOCK: i32 = 64;
+/// log2(PAIRS_PER_BYTE): each byte holds 4 (2-bit-wide) pairs; used as right-shift.
+const LOG2_PAIRS_PER_BYTE: i32 = 2;
+/// Bitmask for within-byte pair position (4 pairs per byte → mask = 3).
+const PAIRS_PER_BYTE_MASK: i32 = 3;
+
+// Bit-level constants for bit-packed Q1_0 sign data
+/// log2(BITS_PER_BYTE); used as right-shift to convert bit index → byte index.
+const LOG2_BITS_PER_BYTE: i32 = 3;
+/// Mask for the byte-within-block index in Q1_0: 16 data bytes per block → mask = 15.
+const Q1_0_DATA_BYTE_MASK: i32 = 15;
+/// Bitmask for within-byte bit position (8 bits per byte → mask = 7).
+const BITS_PER_BYTE_MASK: i32 = 7;
+
+// fp16 → f32 conversion bit-field constants
+/// Sign bit position in a 16-bit fp16 word.
+const FP16_SIGN_BIT_POS: i32 = 15;
+/// Exponent field right-shift in a 16-bit fp16 word.
+const FP16_EXP_SHIFT: i32 = 10;
+/// 5-bit mask for the fp16 exponent field (2^5 - 1 = 31).
+const FP16_EXP_BITS_MASK: i32 = 31;
+/// 10-bit mask for the fp16 mantissa field (2^10 - 1 = 1023).
+const FP16_MANTISSA_MASK: i32 = 1023;
+/// f32 exponent field left-shift (f32 exponent starts at bit 23).
+const F32_EXP_SHIFT: i32 = 23;
+/// Shift to align a 10-bit fp16 mantissa to the 23-bit f32 mantissa (23 - 10 = 13).
+const FP16_MANT_TO_F32_SHIFT: i32 = 13;
+/// f32 sign bit position (bit 31).
+const F32_SIGN_SHIFT: i32 = 31;
+/// Exponent bias difference between f32 (127) and fp16 (15): 127 - 15 = 112.
+const FP16_EXP_BIAS_DIFF: i32 = 112;
+
+// conv1d constant
+/// Number of sides that padding is applied to in conv1d (left + right = 2).
+const CONV1D_PADDING_SIDES: i32 = 2;
+// ─────────────────────────────────────────────────────────────────────────────
+
 use super::FuncCompiler;
 use almide_ir::{IrExpr, IrExprKind, CallTarget};
 use almide_lang::types::Ty;
@@ -80,7 +142,7 @@ impl FuncCompiler<'_> {
                     i32_wrap_i64; local_set(cols);
                     // total_bytes = 8 + rows*cols*8
                     local_get(rows); local_get(cols); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc);
                     local_set(ptr);
                     // store rows, cols
@@ -92,7 +154,7 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, {
                         local_get(ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         i32_const(0);
-                        local_get(total); i32_const(8); i32_mul;
+                        local_get(total); i32_const(F64_BYTES); i32_mul;
                         memory_fill;
                     });
                 } else {
@@ -103,7 +165,7 @@ impl FuncCompiler<'_> {
                         block_empty; loop_empty;
                           local_get(i); local_get(total); i32_ge_u; br_if(1);
                           local_get(ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(i); i32_const(8); i32_mul; i32_add;
+                          local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                           f64_const(1.0);
                           f64_store(0);
                           local_get(i); i32_const(1); i32_add; local_set(i);
@@ -133,7 +195,7 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(m);
-                    i32_const(16); call(self.emitter.rt.alloc); local_set(t);
+                    i32_const(SHAPE_TUPLE_BYTES); call(self.emitter.rt.alloc); local_set(t);
                     local_get(t);
                     local_get(m); i32_load(0); i64_extend_i32_u;
                     i64_store(0);
@@ -161,7 +223,7 @@ impl FuncCompiler<'_> {
                     local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     local_get(row); local_get(m); i32_load(4); i32_mul;
                     local_get(col); i32_add;
-                    i32_const(8); i32_mul;
+                    i32_const(F64_BYTES); i32_mul;
                     i32_add;
                     f64_load(0);
                 });
@@ -182,7 +244,7 @@ impl FuncCompiler<'_> {
                     local_get(src); i32_load(0); local_set(rows);
                     local_get(src); i32_load(4); local_set(cols);
                     // alloc dst: [cols, rows, data...]
-                    local_get(cols); local_get(rows); i32_mul; i32_const(8); i32_mul;
+                    local_get(cols); local_get(rows); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(cols); i32_store(0);
@@ -197,11 +259,11 @@ impl FuncCompiler<'_> {
                         // dst offset: 8 + (c * rows + r) * 8
                         local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(c); local_get(rows); i32_mul; local_get(r); i32_add;
-                        i32_const(8); i32_mul; i32_add;
+                        i32_const(F64_BYTES); i32_mul; i32_add;
                         // src offset: 8 + (r * cols + c) * 8
                         local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(r); local_get(cols); i32_mul; local_get(c); i32_add;
-                        i32_const(8); i32_mul; i32_add;
+                        i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0);
                         f64_store(0);
                         local_get(c); i32_const(1); i32_add; local_set(c);
@@ -232,7 +294,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_set(b);
                     local_get(a); i32_load(0); local_get(a); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(a); i32_load(0); i32_store(0);
                     local_get(dst); local_get(a); i32_load(4); i32_store(4);
@@ -240,9 +302,9 @@ impl FuncCompiler<'_> {
                     // SIMD loop: 2 elements per iter
                     block_empty; loop_empty;
                       local_get(i); i32_const(1); i32_add; local_get(total); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add; v128_load(0);
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add; v128_load(0);
+                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; v128_load(0);
+                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; v128_load(0);
                 });
                 match method {
                     "add" => { wasm!(self.func, { f64x2_add; }); }
@@ -252,15 +314,15 @@ impl FuncCompiler<'_> {
                 }
                 wasm!(self.func, {
                       v128_store(0);
-                      local_get(i); i32_const(2); i32_add; local_set(i);
+                      local_get(i); i32_const(SIMD_F64_LANES); i32_add; local_set(i);
                       br(0);
                     end; end;
                     // Scalar tail (1 element if total is odd)
                     local_get(i); local_get(total); i32_lt_u;
                     if_empty;
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add; f64_load(0);
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add; f64_load(0);
+                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
+                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                 });
                 match method {
                     "add" => { wasm!(self.func, { f64_add; }); }
@@ -309,14 +371,14 @@ impl FuncCompiler<'_> {
                     local_get(a); i32_load(4); local_set(ca);
                     local_get(b); i32_load(4); local_set(cb);
                     // alloc + zero result
-                    local_get(ra); local_get(cb); i32_mul; i32_const(8); i32_mul;
+                    local_get(ra); local_get(cb); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(ra); i32_store(0);
                     local_get(dst); local_get(cb); i32_store(4);
                     local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     i32_const(0);
-                    local_get(ra); local_get(cb); i32_mul; i32_const(8); i32_mul;
+                    local_get(ra); local_get(cb); i32_mul; i32_const(F64_BYTES); i32_mul;
                     memory_fill;
                     // Tiled loops: i0, k0, j0 (tile starts)
                     i32_const(0); local_set(i0);
@@ -352,7 +414,7 @@ impl FuncCompiler<'_> {
                               // a_ik = A[i][k]
                               local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                               local_get(i); local_get(ca); i32_mul; local_get(k); i32_add;
-                              i32_const(8); i32_mul; i32_add; f64_load(0);
+                              i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                               local_set(a_ik);
 
                               // SIMD inner loop: j steps by 2 (f64x2)
@@ -364,25 +426,25 @@ impl FuncCompiler<'_> {
                                 // addr_c = dst + 8 + (i*cb + j)*8
                                 local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                                 local_get(i); local_get(cb); i32_mul; local_get(j); i32_add;
-                                i32_const(8); i32_mul; i32_add;
+                                i32_const(F64_BYTES); i32_mul; i32_add;
                                 // v_c = load C[i][j..j+2]
                                 local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                                 local_get(i); local_get(cb); i32_mul; local_get(j); i32_add;
-                                i32_const(8); i32_mul; i32_add;
+                                i32_const(F64_BYTES); i32_mul; i32_add;
                                 v128_load(0);
                                 // v_a = splat(a_ik)
                                 local_get(a_ik); f64x2_splat;
                                 // v_b = load B[k][j..j+2]
                                 local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                                 local_get(k); local_get(cb); i32_mul; local_get(j); i32_add;
-                                i32_const(8); i32_mul; i32_add;
+                                i32_const(F64_BYTES); i32_mul; i32_add;
                                 v128_load(0);
                                 // v_c += v_a * v_b
                                 f64x2_mul; f64x2_add;
                                 // store C[i][j..j+2]
                                 v128_store(0);
 
-                                local_get(j); i32_const(2); i32_add; local_set(j);
+                                local_get(j); i32_const(SIMD_F64_LANES); i32_add; local_set(j);
                                 br(0);
                               end; end;
                               // Scalar remainder: if j < j1, process 1 more element
@@ -390,14 +452,14 @@ impl FuncCompiler<'_> {
                               if_empty;
                                 local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                                 local_get(i); local_get(cb); i32_mul; local_get(j); i32_add;
-                                i32_const(8); i32_mul; i32_add;
+                                i32_const(F64_BYTES); i32_mul; i32_add;
                                 local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                                 local_get(i); local_get(cb); i32_mul; local_get(j); i32_add;
-                                i32_const(8); i32_mul; i32_add; f64_load(0);
+                                i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                                 local_get(a_ik);
                                 local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                                 local_get(k); local_get(cb); i32_mul; local_get(j); i32_add;
-                                i32_const(8); i32_mul; i32_add; f64_load(0);
+                                i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                                 f64_mul; f64_add; f64_store(0);
                               end;
                               local_get(k); i32_const(1); i32_add; local_set(k);
@@ -452,7 +514,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_set(s);
                     local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(m); i32_load(0); i32_store(0);
                     local_get(dst); local_get(m); i32_load(4); i32_store(4);
@@ -460,18 +522,18 @@ impl FuncCompiler<'_> {
                     // SIMD f64x2 inner loop
                     block_empty; loop_empty;
                       local_get(i); i32_const(1); i32_add; local_get(total); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       v128_load(0); local_get(s); f64x2_splat; f64x2_mul;
                       v128_store(0);
-                      local_get(i); i32_const(2); i32_add; local_set(i);
+                      local_get(i); i32_const(SIMD_F64_LANES); i32_add; local_set(i);
                       br(0);
                     end; end;
                     // Scalar tail (1 element if total is odd)
                     local_get(i); local_get(total); i32_lt_u;
                     if_empty;
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       f64_load(0); local_get(s); f64_mul;
                       f64_store(0);
                     end;
@@ -515,7 +577,7 @@ impl FuncCompiler<'_> {
                     // total = rows * cols
                     local_get(a); i32_load(0); local_get(a); i32_load(4); i32_mul; local_set(total);
                     // alloc 8 + total*8
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     // copy header
                     local_get(dst); local_get(a); i32_load(0); i32_store(0);
@@ -528,15 +590,15 @@ impl FuncCompiler<'_> {
                       // exit when i+1 >= total (no room for full lane)
                       local_get(i); i32_const(1); i32_add; local_get(total); i32_ge_u; br_if(1);
                       // dst addr = dst + 8 + i*8
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       // v_a = load a[i..i+2]
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       v128_load(0);
                       // v_a *= splat(ka)
                       local_get(ka); f64x2_splat;
                       f64x2_mul;
                       // v_b = load b[i..i+2]
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       v128_load(0);
                       // v_b *= splat(kb)
                       local_get(kb); f64x2_splat;
@@ -546,17 +608,17 @@ impl FuncCompiler<'_> {
                       // store dst[i..i+2]
                       v128_store(0);
                       // i += 2
-                      local_get(i); i32_const(2); i32_add; local_set(i);
+                      local_get(i); i32_const(SIMD_F64_LANES); i32_add; local_set(i);
                       br(0);
                     end; end;
 
                     // Scalar tail: process one trailing element if total is odd.
                     local_get(i); local_get(total); i32_lt_u;
                     if_empty;
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add; f64_load(0);
+                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                       local_get(ka); f64_mul;
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add; f64_load(0);
+                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                       local_get(kb); f64_mul;
                       f64_add;
                       f64_store(0);
@@ -603,7 +665,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_set(kc);
                     local_get(a); i32_load(0); local_get(a); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(a); i32_load(0); i32_store(0);
                     local_get(dst); local_get(a); i32_load(4); i32_store(4);
@@ -611,36 +673,36 @@ impl FuncCompiler<'_> {
 
                     block_empty; loop_empty;
                       local_get(i); i32_const(1); i32_add; local_get(total); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       v128_load(0);
                       local_get(ka); f64x2_splat;
                       f64x2_mul;
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       v128_load(0);
                       local_get(kb); f64x2_splat;
                       f64x2_mul;
                       f64x2_add;
-                      local_get(c); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(c); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       v128_load(0);
                       local_get(kc); f64x2_splat;
                       f64x2_mul;
                       f64x2_add;
                       v128_store(0);
-                      local_get(i); i32_const(2); i32_add; local_set(i);
+                      local_get(i); i32_const(SIMD_F64_LANES); i32_add; local_set(i);
                       br(0);
                     end; end;
 
                     // Scalar tail
                     local_get(i); local_get(total); i32_lt_u;
                     if_empty;
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add; f64_load(0);
+                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                       local_get(ka); f64_mul;
-                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add; f64_load(0);
+                      local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                       local_get(kb); f64_mul;
                       f64_add;
-                      local_get(c); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add; f64_load(0);
+                      local_get(c); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                       local_get(kc); f64_mul;
                       f64_add;
                       f64_store(0);
@@ -682,7 +744,7 @@ impl FuncCompiler<'_> {
                     end;
                     local_set(ncols);
                     // alloc matrix
-                    local_get(nrows); local_get(ncols); i32_mul; i32_const(8); i32_mul;
+                    local_get(nrows); local_get(ncols); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(nrows); i32_store(0);
@@ -693,7 +755,7 @@ impl FuncCompiler<'_> {
                       local_get(r); local_get(nrows); i32_ge_u; br_if(1);
                       // row_ptr = *(src + 4 + r*4)  (pointer to inner list)
                       local_get(src); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(r); i32_const(4); i32_mul; i32_add;
+                      local_get(r); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0); local_set(row_ptr);
                       i32_const(0); local_set(c);
                       block_empty; loop_empty;
@@ -701,9 +763,9 @@ impl FuncCompiler<'_> {
                         // dst[r][c] = row_ptr->data[c]
                         local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(r); local_get(ncols); i32_mul; local_get(c); i32_add;
-                        i32_const(8); i32_mul; i32_add;
+                        i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(row_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); f64_store(0);
                         local_get(c); i32_const(1); i32_add; local_set(c);
                         br(0);
@@ -736,7 +798,7 @@ impl FuncCompiler<'_> {
                     local_get(m); i32_load(0); local_set(nrows);
                     local_get(m); i32_load(4); local_set(ncols);
                     // alloc outer list: [len:i32][ptr0:i32][ptr1:i32]...
-                    local_get(nrows); i32_const(4); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
+                    local_get(nrows); i32_const(I32_BYTES); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(outer);
                     local_get(outer); local_get(nrows); i32_store(0);
                     // create each row list
@@ -744,7 +806,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(r); local_get(nrows); i32_ge_u; br_if(1);
                       // alloc row: [len:i32][f64...]
-                      local_get(ncols); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
+                      local_get(ncols); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                       call(self.emitter.rt.alloc); local_set(row_ptr);
                       local_get(row_ptr); local_get(ncols); i32_store(0);
                       // copy data
@@ -752,17 +814,17 @@ impl FuncCompiler<'_> {
                       block_empty; loop_empty;
                         local_get(c); local_get(ncols); i32_ge_u; br_if(1);
                         local_get(row_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(r); local_get(ncols); i32_mul; local_get(c); i32_add;
-                        i32_const(8); i32_mul; i32_add;
+                        i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); f64_store(0);
                         local_get(c); i32_const(1); i32_add; local_set(c);
                         br(0);
                       end; end;
                       // store row ptr in outer list
                       local_get(outer); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(r); i32_const(4); i32_mul; i32_add;
+                      local_get(r); i32_const(I32_BYTES); i32_mul; i32_add;
                       local_get(row_ptr); i32_store(0);
                       local_get(r); i32_const(1); i32_add; local_set(r);
                       br(0);
@@ -790,7 +852,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_set(closure);
                     local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(m); i32_load(0); i32_store(0);
                     local_get(dst); local_get(m); i32_load(4); i32_store(4);
@@ -799,11 +861,11 @@ impl FuncCompiler<'_> {
                       local_get(i); local_get(total); i32_ge_u; br_if(1);
                       // dst[i] = f(m[i])
                       local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       // call closure: env, arg, table_idx
                       local_get(closure); i32_load(4); // env
                       local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       f64_load(0); // element value
                       local_get(closure); i32_load(0); // table_idx
                 });
@@ -838,7 +900,7 @@ impl FuncCompiler<'_> {
                     local_set(bias);
                     local_get(m); i32_load(0); local_set(rows);
                     local_get(m); i32_load(4); local_set(cols);
-                    local_get(rows); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                    local_get(rows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(rows); i32_store(0);
@@ -852,13 +914,13 @@ impl FuncCompiler<'_> {
                         // dst[r,c] = m[r,c] + bias[c]
                         local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(r); local_get(cols); i32_mul; local_get(c); i32_add;
-                        i32_const(8); i32_mul; i32_add;
+                        i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(r); local_get(cols); i32_mul; local_get(c); i32_add;
-                        i32_const(8); i32_mul; i32_add;
+                        i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0);
                         local_get(bias); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0);
                         f64_add;
                         f64_store(0);
@@ -899,7 +961,7 @@ impl FuncCompiler<'_> {
                     local_get(nrows); i32_const(0); i32_lt_s;
                     if_empty; i32_const(0); local_set(nrows); end;
                     // alloc + header
-                    local_get(nrows); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                    local_get(nrows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(nrows); i32_store(0);
@@ -907,8 +969,8 @@ impl FuncCompiler<'_> {
                     // memcpy: dst.data, m.data + start*cols*8, nrows*cols*8
                     local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                    local_get(start); local_get(cols); i32_mul; i32_const(8); i32_mul; i32_add;
-                    local_get(nrows); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                    local_get(start); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul; i32_add;
+                    local_get(nrows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                     memory_copy;
                     local_get(dst);
                 });
@@ -929,15 +991,15 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_set(m);
                     local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(m); i32_load(0); i32_store(0);
                     local_get(dst); local_get(m); i32_load(4); i32_store(4);
                     i32_const(0); local_set(i);
                     block_empty; loop_empty;
                       local_get(i); local_get(total); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
+                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       f64_load(0); f64_neg;
                       f64_store(0);
                       local_get(i); i32_const(1); i32_add; local_set(i);
@@ -965,7 +1027,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_set(exp);
                     local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(m); i32_load(0); i32_store(0);
                     local_get(dst); local_get(m); i32_load(4); i32_store(4);
@@ -973,13 +1035,13 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); local_get(total); i32_ge_u; br_if(1);
                       // Load x into a local so it's stable across the call.
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add; f64_load(0);
+                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                       local_set(x);
                       // Compute pow(x, exp) via __float_pow runtime.
                       local_get(x); local_get(exp); call(self.emitter.rt.float_pow);
                       local_set(result);
                       // Store at dst+8+i*8
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       local_get(result);
                       f64_store(0);
                       local_get(i); i32_const(1); i32_add; local_set(i);
@@ -1007,7 +1069,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_set(m);
                     local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(m); i32_load(0); i32_store(0);
                     local_get(dst); local_get(m); i32_load(4); i32_store(4);
@@ -1016,11 +1078,11 @@ impl FuncCompiler<'_> {
                       local_get(i); local_get(total); i32_ge_u; br_if(1);
                       // x = m.data[i]
                       local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       f64_load(0); local_set(x);
                       // dst.data[i] = gelu(x)
                       local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                 });
                 // tanh(z) via runtime helper or expansion: tanh(z) = (e^(2z)-1)/(e^(2z)+1)
                 // Compute inner = K * (x + 0.044715 * x^3)
@@ -1083,7 +1145,7 @@ impl FuncCompiler<'_> {
                     local_set(m);
                     local_get(m); i32_load(0); local_set(rows);
                     local_get(m); i32_load(4); local_set(cols);
-                    local_get(rows); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                    local_get(rows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(rows); i32_store(0);
@@ -1092,7 +1154,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(r); local_get(rows); i32_ge_u; br_if(1);
                       // row_off = 8 + r*cols*8 (offset to row r in data)
-                      local_get(r); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                      local_get(r); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                       i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_set(row_off);
                       // max = m[r, 0], scan row 1..cols (NaN-safe init).
                       local_get(m); local_get(row_off); i32_add;
@@ -1101,7 +1163,7 @@ impl FuncCompiler<'_> {
                       block_empty; loop_empty;
                         local_get(c); local_get(cols); i32_ge_u; br_if(1);
                         local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); local_set(v);
                         local_get(v); local_get(max); f64_gt;
                         if_empty; local_get(v); local_set(max); end;
@@ -1114,12 +1176,12 @@ impl FuncCompiler<'_> {
                       block_empty; loop_empty;
                         local_get(c); local_get(cols); i32_ge_u; br_if(1);
                         local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); local_get(max); f64_sub;
                         call(self.emitter.rt.math_exp); local_set(v);
                         // dst[r, c] = v
                         local_get(dst); local_get(row_off); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(v); f64_store(0);
                         local_get(sum); local_get(v); f64_add; local_set(sum);
                         local_get(c); i32_const(1); i32_add; local_set(c);
@@ -1135,7 +1197,7 @@ impl FuncCompiler<'_> {
                         block_empty; loop_empty;
                           local_get(c); local_get(cols); i32_ge_u; br_if(1);
                           local_get(dst); local_get(row_off); i32_add;
-                          local_get(c); i32_const(8); i32_mul; i32_add;
+                          local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                           f64_const(1.0); f64_store(0);
                           local_get(c); i32_const(1); i32_add; local_set(c);
                           br(0);
@@ -1146,9 +1208,9 @@ impl FuncCompiler<'_> {
                       block_empty; loop_empty;
                         local_get(c); local_get(cols); i32_ge_u; br_if(1);
                         local_get(dst); local_get(row_off); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(dst); local_get(row_off); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0);
                         local_get(sum); f64_div;
                         f64_store(0);
@@ -1199,7 +1261,7 @@ impl FuncCompiler<'_> {
                     local_set(eps);
                     local_get(m); i32_load(0); local_set(rows);
                     local_get(m); i32_load(4); local_set(cols);
-                    local_get(rows); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                    local_get(rows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(rows); i32_store(0);
@@ -1209,7 +1271,7 @@ impl FuncCompiler<'_> {
                     i32_const(0); local_set(r);
                     block_empty; loop_empty;
                       local_get(r); local_get(rows); i32_ge_u; br_if(1);
-                      local_get(r); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                      local_get(r); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                       i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_set(row_off);
                       // mean
                       f64_const(0.0); local_set(mean);
@@ -1217,7 +1279,7 @@ impl FuncCompiler<'_> {
                       block_empty; loop_empty;
                         local_get(c); local_get(cols); i32_ge_u; br_if(1);
                         local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0);
                         local_get(mean); f64_add; local_set(mean);
                         local_get(c); i32_const(1); i32_add; local_set(c);
@@ -1230,7 +1292,7 @@ impl FuncCompiler<'_> {
                       block_empty; loop_empty;
                         local_get(c); local_get(cols); i32_ge_u; br_if(1);
                         local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); local_get(mean); f64_sub; local_set(tmp);
                         local_get(tmp); local_get(tmp); f64_mul;
                         local_get(var); f64_add; local_set(var);
@@ -1252,16 +1314,16 @@ impl FuncCompiler<'_> {
                       block_empty; loop_empty;
                         local_get(c); local_get(cols); i32_ge_u; br_if(1);
                         local_get(dst); local_get(row_off); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); local_get(mean); f64_sub;
                         local_get(inv); f64_mul;
                         local_get(gamma); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); f64_mul;
                         local_get(beta); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); f64_add;
                         f64_store(0);
                         local_get(c); i32_const(1); i32_add; local_set(c);
@@ -1315,7 +1377,7 @@ impl FuncCompiler<'_> {
                     local_set(eps);
                     local_get(m); i32_load(0); local_set(rows);
                     local_get(m); i32_load(4); local_set(cols);
-                    local_get(rows); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                    local_get(rows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(rows); i32_store(0);
@@ -1324,7 +1386,7 @@ impl FuncCompiler<'_> {
                     i32_const(0); local_set(r);
                     block_empty; loop_empty;
                       local_get(r); local_get(rows); i32_ge_u; br_if(1);
-                      local_get(r); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                      local_get(r); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                       i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_set(row_off);
                       // sq = Σ m[r, c]²
                       f64_const(0.0); local_set(sq);
@@ -1332,7 +1394,7 @@ impl FuncCompiler<'_> {
                       block_empty; loop_empty;
                         local_get(c); local_get(cols); i32_ge_u; br_if(1);
                         local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); local_set(tmp);
                         local_get(tmp); local_get(tmp); f64_mul;
                         local_get(sq); f64_add; local_set(sq);
@@ -1352,12 +1414,12 @@ impl FuncCompiler<'_> {
                       block_empty; loop_empty;
                         local_get(c); local_get(cols); i32_ge_u; br_if(1);
                         local_get(dst); local_get(row_off); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(m); local_get(row_off); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); local_get(inv); f64_mul;
                         local_get(gamma); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(c); i32_const(8); i32_mul; i32_add;
+                        local_get(c); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); f64_mul;
                         f64_store(0);
                         local_get(c); i32_const(1); i32_add; local_set(c);
@@ -1414,7 +1476,7 @@ impl FuncCompiler<'_> {
                     local_get(x); i32_load(4); local_set(d_in);
                     local_get(wg); i32_load(0); local_set(d_out);
                     // alloc dst = r × d_out
-                    local_get(r); local_get(d_out); i32_mul; i32_const(8); i32_mul;
+                    local_get(r); local_get(d_out); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(r); i32_store(0);
@@ -1433,20 +1495,20 @@ impl FuncCompiler<'_> {
                           // tmp = x[i, k]
                           local_get(x); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(i); local_get(d_in); i32_mul; local_get(k); i32_add;
-                          i32_const(8); i32_mul; i32_add;
+                          i32_const(F64_BYTES); i32_mul; i32_add;
                           f64_load(0); local_set(tmp);
                           // g += tmp * w_gate[j, k]
                           local_get(tmp);
                           local_get(wg); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(j); local_get(d_in); i32_mul; local_get(k); i32_add;
-                          i32_const(8); i32_mul; i32_add;
+                          i32_const(F64_BYTES); i32_mul; i32_add;
                           f64_load(0); f64_mul;
                           local_get(g); f64_add; local_set(g);
                           // u += tmp * w_up[j, k]
                           local_get(tmp);
                           local_get(wu); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(j); local_get(d_in); i32_mul; local_get(k); i32_add;
-                          i32_const(8); i32_mul; i32_add;
+                          i32_const(F64_BYTES); i32_mul; i32_add;
                           f64_load(0); f64_mul;
                           local_get(u); f64_add; local_set(u);
                           local_get(k); i32_const(1); i32_add; local_set(k);
@@ -1463,7 +1525,7 @@ impl FuncCompiler<'_> {
                         // out[i, j] = g * sig * u
                         local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(i); local_get(d_out); i32_mul; local_get(j); i32_add;
-                        i32_const(8); i32_mul; i32_add;
+                        i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(g); local_get(sig); f64_mul;
                         local_get(u); f64_mul;
                         f64_store(0);
@@ -1522,7 +1584,7 @@ impl FuncCompiler<'_> {
                     local_get(q); i32_load(4); local_set(inner);
                     local_get(kt); i32_load(4); local_set(ktc);
                     // alloc dst = qr × ktc
-                    local_get(qr); local_get(ktc); i32_mul; i32_const(8); i32_mul;
+                    local_get(qr); local_get(ktc); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(qr); i32_store(0);
@@ -1541,12 +1603,12 @@ impl FuncCompiler<'_> {
                           // q[i, k]
                           local_get(q); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(i); local_get(inner); i32_mul; local_get(k); i32_add;
-                          i32_const(8); i32_mul; i32_add;
+                          i32_const(F64_BYTES); i32_mul; i32_add;
                           f64_load(0);
                           // kt[k, j]
                           local_get(kt); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(k); local_get(ktc); i32_mul; local_get(j); i32_add;
-                          i32_const(8); i32_mul; i32_add;
+                          i32_const(F64_BYTES); i32_mul; i32_add;
                           f64_load(0);
                           f64_mul;
                           local_get(acc); f64_add; local_set(acc);
@@ -1556,7 +1618,7 @@ impl FuncCompiler<'_> {
                         // dst[i, j] = scale * acc
                         local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(i); local_get(ktc); i32_mul; local_get(j); i32_add;
-                        i32_const(8); i32_mul; i32_add;
+                        i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(acc); local_get(scale); f64_mul;
                         f64_store(0);
                         local_get(j); i32_const(1); i32_add; local_set(j);
@@ -1584,7 +1646,7 @@ impl FuncCompiler<'_> {
                     i32_const(0); local_set(i);
                     block_empty; loop_empty;
                       local_get(i); local_get(qr); i32_ge_u; br_if(1);
-                      local_get(i); local_get(ktc); i32_mul; i32_const(8); i32_mul;
+                      local_get(i); local_get(ktc); i32_mul; i32_const(F64_BYTES); i32_mul;
                       i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_set(row_off);
                       // maxv = dst[i, 0]; scan 1..ktc
                       local_get(dst); local_get(row_off); i32_add;
@@ -1593,7 +1655,7 @@ impl FuncCompiler<'_> {
                       block_empty; loop_empty;
                         local_get(j); local_get(ktc); i32_ge_u; br_if(1);
                         local_get(dst); local_get(row_off); i32_add;
-                        local_get(j); i32_const(8); i32_mul; i32_add;
+                        local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); local_set(v);
                         local_get(v); local_get(maxv); f64_gt;
                         if_empty; local_get(v); local_set(maxv); end;
@@ -1606,9 +1668,9 @@ impl FuncCompiler<'_> {
                       block_empty; loop_empty;
                         local_get(j); local_get(ktc); i32_ge_u; br_if(1);
                         local_get(dst); local_get(row_off); i32_add;
-                        local_get(j); i32_const(8); i32_mul; i32_add;
+                        local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(dst); local_get(row_off); i32_add;
-                        local_get(j); i32_const(8); i32_mul; i32_add;
+                        local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); local_get(maxv); f64_sub;
                         call(self.emitter.rt.math_exp); local_set(v);
                         local_get(v); f64_store(0);
@@ -1626,7 +1688,7 @@ impl FuncCompiler<'_> {
                         block_empty; loop_empty;
                           local_get(j); local_get(ktc); i32_ge_u; br_if(1);
                           local_get(dst); local_get(row_off); i32_add;
-                          local_get(j); i32_const(8); i32_mul; i32_add;
+                          local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
                           f64_const(1.0); f64_store(0);
                           local_get(j); i32_const(1); i32_add; local_set(j);
                           br(0);
@@ -1637,9 +1699,9 @@ impl FuncCompiler<'_> {
                       block_empty; loop_empty;
                         local_get(j); local_get(ktc); i32_ge_u; br_if(1);
                         local_get(dst); local_get(row_off); i32_add;
-                        local_get(j); i32_const(8); i32_mul; i32_add;
+                        local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(dst); local_get(row_off); i32_add;
-                        local_get(j); i32_const(8); i32_mul; i32_add;
+                        local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0);
                         local_get(sumv); f64_div;
                         f64_store(0);
@@ -1701,13 +1763,13 @@ impl FuncCompiler<'_> {
 
                 wasm!(self.func, {
                     local_get(ids); i32_load(0); local_set(n_rows);
-                    local_get(cols); i32_const(7); i32_shr_u; local_set(n_bpr);
+                    local_get(cols); i32_const(LOG2_Q1_0_BLOCK_SIZE); i32_shr_u; local_set(n_bpr);
                     local_get(data); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     local_get(off); i32_add;
                     local_set(data_base);
                     // dst = alloc(8 + n_rows*cols*8)
                     local_get(n_rows); local_get(cols); i32_mul;
-                    i32_const(8); i32_mul;
+                    i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(n_rows); i32_store(0);
@@ -1717,62 +1779,62 @@ impl FuncCompiler<'_> {
                       local_get(i); local_get(n_rows); i32_ge_u; br_if(1);
                       // rid = row_ids[i] as i32
                       local_get(ids); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       i64_load(0); i32_wrap_i64;
                       local_set(rid);
                       // row_src_off = rid * n_bpr * 18
                       local_get(rid); local_get(n_bpr); i32_mul;
-                      i32_const(18); i32_mul;
+                      i32_const(Q1_0_BLOCK_BYTES); i32_mul;
                       local_set(row_src_off);
                       i32_const(0); local_set(b);
                       block_empty; loop_empty;
                         local_get(b); local_get(n_bpr); i32_ge_u; br_if(1);
                         local_get(data_base);
                         local_get(row_src_off); i32_add;
-                        local_get(b); i32_const(18); i32_mul;
+                        local_get(b); i32_const(Q1_0_BLOCK_BYTES); i32_mul;
                         i32_add;
                         local_set(block_start);
                         local_get(block_start); i32_load8_u(0);
                         local_get(block_start); i32_load8_u(1);
-                        i32_const(8); i32_shl;
+                        i32_const(F64_BYTES); i32_shl;
                         i32_or;
                         local_set(scale_raw);
-                        local_get(scale_raw); i32_const(15); i32_shr_u; i32_const(1); i32_and;
+                        local_get(scale_raw); i32_const(FP16_SIGN_BIT_POS); i32_shr_u; i32_const(1); i32_and;
                         local_set(sign);
-                        local_get(scale_raw); i32_const(10); i32_shr_u; i32_const(31); i32_and;
+                        local_get(scale_raw); i32_const(FP16_EXP_SHIFT); i32_shr_u; i32_const(FP16_EXP_BITS_MASK); i32_and;
                         local_set(expv);
-                        local_get(scale_raw); i32_const(1023); i32_and;
+                        local_get(scale_raw); i32_const(FP16_MANTISSA_MASK); i32_and;
                         local_set(mant);
-                        local_get(sign); i32_const(31); i32_shl;
-                        local_get(expv); i32_const(112); i32_add; i32_const(23); i32_shl;
+                        local_get(sign); i32_const(F32_SIGN_SHIFT); i32_shl;
+                        local_get(expv); i32_const(FP16_EXP_BIAS_DIFF); i32_add; i32_const(F32_EXP_SHIFT); i32_shl;
                         i32_or;
-                        local_get(mant); i32_const(13); i32_shl;
+                        local_get(mant); i32_const(FP16_MANT_TO_F32_SHIFT); i32_shl;
                         i32_or;
                         local_set(f32bits);
                         local_get(expv); i32_eqz;
                         if_empty;
-                          local_get(sign); i32_const(31); i32_shl; local_set(f32bits);
+                          local_get(sign); i32_const(F32_SIGN_SHIFT); i32_shl; local_set(f32bits);
                         end;
                         local_get(f32bits); f32_reinterpret_i32; f64_promote_f32;
                         local_set(scale);
                         f64_const(0.0); local_get(scale); f64_sub; local_set(neg_scale);
-                        local_get(block_start); i32_const(2); i32_add; local_set(bits_start);
+                        local_get(block_start); i32_const(Q1_0_SCALE_BYTES); i32_add; local_set(bits_start);
                         i32_const(0); local_set(k_local);
                         block_empty; loop_empty;
-                          local_get(k_local); i32_const(128); i32_ge_u; br_if(1);
+                          local_get(k_local); i32_const(Q1_0_BLOCK_SIZE); i32_ge_u; br_if(1);
                           local_get(bits_start);
-                          local_get(k_local); i32_const(3); i32_shr_u;
+                          local_get(k_local); i32_const(LOG2_BITS_PER_BYTE); i32_shr_u;
                           i32_add;
                           i32_load8_u(0);
-                          local_get(k_local); i32_const(7); i32_and; i32_shr_u;
+                          local_get(k_local); i32_const(BITS_PER_BYTE_MASK); i32_and; i32_shr_u;
                           i32_const(1); i32_and;
                           local_set(bit);
                           // dst[8 + (i*cols + b*128 + k_local)*8] = bit? scale : neg_scale
                           local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(i); local_get(cols); i32_mul;
-                          local_get(b); i32_const(128); i32_mul; i32_add;
+                          local_get(b); i32_const(Q1_0_BLOCK_SIZE); i32_mul; i32_add;
                           local_get(k_local); i32_add;
-                          i32_const(8); i32_mul;
+                          i32_const(F64_BYTES); i32_mul;
                           i32_add;
                           local_get(bit);
                           if_f64;
@@ -1837,7 +1899,7 @@ impl FuncCompiler<'_> {
                     local_get(a); i32_load(0); local_set(rows);
                     local_get(a); i32_load(4); local_set(cols);
                     local_get(rows); local_get(cols); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(rows); i32_store(0);
                     local_get(dst); local_get(cols); i32_store(4);
@@ -1846,7 +1908,7 @@ impl FuncCompiler<'_> {
                       local_get(k); local_get(total); i32_ge_u; br_if(1);
                       // xv = a[k]
                       local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(k); i32_const(8); i32_mul; i32_add;
+                      local_get(k); i32_const(F64_BYTES); i32_mul; i32_add;
                       f64_load(0);
                       local_set(xv);
                       // sig = 1 / (1 + exp(-xv))
@@ -1857,10 +1919,10 @@ impl FuncCompiler<'_> {
                       f64_const(1.0); local_get(sig); f64_div; local_set(sig);
                       // result = xv * sig * b[k]
                       local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(k); i32_const(8); i32_mul; i32_add;
+                      local_get(k); i32_const(F64_BYTES); i32_mul; i32_add;
                       local_get(xv); local_get(sig); f64_mul;
                       local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(k); i32_const(8); i32_mul; i32_add;
+                      local_get(k); i32_const(F64_BYTES); i32_mul; i32_add;
                       f64_load(0);
                       f64_mul;
                       f64_store(0);
@@ -1941,10 +2003,10 @@ impl FuncCompiler<'_> {
                     local_get(w_off); i32_add;
                     local_set(w_data);
                     // n_bpr = n_in / 128
-                    local_get(n_in); i32_const(7); i32_shr_u; local_set(n_bpr);
+                    local_get(n_in); i32_const(LOG2_Q1_0_BLOCK_SIZE); i32_shr_u; local_set(n_bpr);
                     // dst = alloc(8 + x_rows*out*8); header
                     local_get(x_rows); local_get(out); i32_mul;
-                    i32_const(8); i32_mul;
+                    i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(x_rows); i32_store(0);
@@ -1968,46 +2030,46 @@ impl FuncCompiler<'_> {
                           local_get(w_data);
                           local_get(j); local_get(n_bpr); i32_mul;
                           local_get(b); i32_add;
-                          i32_const(18); i32_mul;
+                          i32_const(Q1_0_BLOCK_BYTES); i32_mul;
                           i32_add;
                           local_set(block_start);
                           // scale_raw = block[0] | block[1]<<8
                           local_get(block_start); i32_load8_u(0);
                           local_get(block_start); i32_load8_u(1);
-                          i32_const(8); i32_shl;
+                          i32_const(F64_BYTES); i32_shl;
                           i32_or;
                           local_set(scale_raw);
-                          local_get(scale_raw); i32_const(15); i32_shr_u; i32_const(1); i32_and;
+                          local_get(scale_raw); i32_const(FP16_SIGN_BIT_POS); i32_shr_u; i32_const(1); i32_and;
                           local_set(sign);
-                          local_get(scale_raw); i32_const(10); i32_shr_u; i32_const(31); i32_and;
+                          local_get(scale_raw); i32_const(FP16_EXP_SHIFT); i32_shr_u; i32_const(FP16_EXP_BITS_MASK); i32_and;
                           local_set(expv);
-                          local_get(scale_raw); i32_const(1023); i32_and;
+                          local_get(scale_raw); i32_const(FP16_MANTISSA_MASK); i32_and;
                           local_set(mant);
                           // f32bits: normal case (exp + 112) << 23
-                          local_get(sign); i32_const(31); i32_shl;
-                          local_get(expv); i32_const(112); i32_add; i32_const(23); i32_shl;
+                          local_get(sign); i32_const(F32_SIGN_SHIFT); i32_shl;
+                          local_get(expv); i32_const(FP16_EXP_BIAS_DIFF); i32_add; i32_const(F32_EXP_SHIFT); i32_shl;
                           i32_or;
-                          local_get(mant); i32_const(13); i32_shl;
+                          local_get(mant); i32_const(FP16_MANT_TO_F32_SHIFT); i32_shl;
                           i32_or;
                           local_set(f32bits);
                           // If exp == 0 force zero (sign bit only).
                           local_get(expv); i32_eqz;
                           if_empty;
-                            local_get(sign); i32_const(31); i32_shl; local_set(f32bits);
+                            local_get(sign); i32_const(F32_SIGN_SHIFT); i32_shl; local_set(f32bits);
                           end;
                           local_get(f32bits); f32_reinterpret_i32; f64_promote_f32;
                           local_set(scale);
                           f64_const(0.0); local_get(scale); f64_sub; local_set(neg_scale);
-                          local_get(block_start); i32_const(2); i32_add; local_set(bits_start);
+                          local_get(block_start); i32_const(Q1_0_SCALE_BYTES); i32_add; local_set(bits_start);
                           // for pair_idx in 0..64
                           i32_const(0); local_set(pair_idx);
                           block_empty; loop_empty;
-                            local_get(pair_idx); i32_const(64); i32_ge_u; br_if(1);
+                            local_get(pair_idx); i32_const(Q1_0_PAIRS_PER_BLOCK); i32_ge_u; br_if(1);
                             // byte_idx = pair_idx >> 2  (each byte holds 4 pairs = 8 bits)
-                            local_get(pair_idx); i32_const(2); i32_shr_u;
+                            local_get(pair_idx); i32_const(LOG2_PAIRS_PER_BYTE); i32_shr_u;
                             local_set(byte_idx);
                             // bit_shift = (pair_idx & 3) << 1
-                            local_get(pair_idx); i32_const(3); i32_and;
+                            local_get(pair_idx); i32_const(PAIRS_PER_BYTE_MASK); i32_and;
                             i32_const(1); i32_shl;
                             local_set(bit_shift);
                             // byte_val = block[bits_start + byte_idx]
@@ -2038,9 +2100,9 @@ impl FuncCompiler<'_> {
                             // x_addr = x + 8 + (i*n_in + b*128 + pair_idx*2) * 8
                             local_get(x); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                             local_get(i); local_get(n_in); i32_mul;
-                            local_get(b); i32_const(128); i32_mul; i32_add;
+                            local_get(b); i32_const(Q1_0_BLOCK_SIZE); i32_mul; i32_add;
                             local_get(pair_idx); i32_const(1); i32_shl; i32_add;
-                            i32_const(8); i32_mul;
+                            i32_const(F64_BYTES); i32_mul;
                             i32_add;
                             v128_load(0);
                             local_set(x_v);
@@ -2059,7 +2121,7 @@ impl FuncCompiler<'_> {
                         local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(i); local_get(out); i32_mul;
                         local_get(j); i32_add;
-                        i32_const(8); i32_mul;
+                        i32_const(F64_BYTES); i32_mul;
                         i32_add;
                         local_get(sum_v); f64x2_extract_lane(0);
                         local_get(sum_v); f64x2_extract_lane(1);
@@ -2130,7 +2192,7 @@ impl FuncCompiler<'_> {
                     local_get(m); i32_load(0); local_set(src_rows);
                     local_get(m); i32_load(4); local_set(cols);
                     local_get(ids); i32_load(0); local_set(n_out);
-                    local_get(cols); i32_const(8); i32_mul; local_set(row_bytes);
+                    local_get(cols); i32_const(F64_BYTES); i32_mul; local_set(row_bytes);
                     // out = alloc(8 + n_out*row_bytes)
                     local_get(n_out); local_get(row_bytes); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
@@ -2142,7 +2204,7 @@ impl FuncCompiler<'_> {
                       local_get(k); local_get(n_out); i32_ge_u; br_if(1);
                       // rid = (i64)ids[4 + k*8] as i32
                       local_get(ids); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(k); i32_const(8); i32_mul; i32_add;
+                      local_get(k); i32_const(F64_BYTES); i32_mul; i32_add;
                       i64_load(0);
                       i32_wrap_i64;
                       local_set(rid);
@@ -2243,7 +2305,7 @@ impl FuncCompiler<'_> {
                     local_get(x); i32_load(0); local_set(rows);
                     local_get(x); i32_load(4); local_set(cols);
                     // total_bytes = 8 + rows*cols*8
-                    local_get(rows); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                    local_get(rows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_set(total_bytes);
                     local_get(total_bytes); call(self.emitter.rt.alloc); local_set(dst);
                     // memory.copy(dst, x, total_bytes)
@@ -2265,10 +2327,10 @@ impl FuncCompiler<'_> {
                           i32_add;
                           local_set(j0);
                           // pair_off = 8 + p*cols*8 + j0*8
-                          i32_const(8);
-                          local_get(p); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                          i32_const(F64_BYTES);
+                          local_get(p); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                           i32_add;
-                          local_get(j0); i32_const(8); i32_mul;
+                          local_get(j0); i32_const(F64_BYTES); i32_mul;
                           i32_add;
                           local_set(pair_off);
                           // x0, x1 from source
@@ -2363,7 +2425,7 @@ impl FuncCompiler<'_> {
                     local_get(base); i32_load(4); local_set(cols_l);
                     local_get(r_base); local_get(r_extra); i32_add; local_set(r_total);
                     // row_bytes = cols * 8
-                    local_get(cols_l); i32_const(8); i32_mul; local_set(row_bytes);
+                    local_get(cols_l); i32_const(F64_BYTES); i32_mul; local_set(row_bytes);
                     local_get(r_base); local_get(row_bytes); i32_mul; local_set(base_bytes);
                     local_get(r_extra); local_get(row_bytes); i32_mul; local_set(extra_bytes);
                     // alloc = 8 + total rows * cols * 8
@@ -2443,7 +2505,7 @@ impl FuncCompiler<'_> {
                 // total = rows * cols; dst = alloc(8 + total*8); write header.
                 wasm!(self.func, {
                     local_get(rows); local_get(cols); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul;
+                    local_get(total); i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(rows); i32_store(0);
@@ -2456,56 +2518,56 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(k); local_get(total); i32_ge_u; br_if(1);
                       // On a fresh 128-block boundary, reload scale & neg_scale.
-                      local_get(k); i32_const(127); i32_and; i32_eqz;
+                      local_get(k); i32_const(Q1_0_BLOCK_SIZE_MASK); i32_and; i32_eqz;
                       if_empty;
                         // block_start = data_off + (k / 128) * 18
                         local_get(data_off);
-                        local_get(k); i32_const(7); i32_shr_u;
-                        i32_const(18); i32_mul;
+                        local_get(k); i32_const(LOG2_Q1_0_BLOCK_SIZE); i32_shr_u;
+                        i32_const(Q1_0_BLOCK_BYTES); i32_mul;
                         i32_add;
                         local_set(block_start);
                         // scale_raw (u16 LE) = byte[0] | byte[1] << 8
                         local_get(block_start); i32_load8_u(0);
                         local_get(block_start); i32_load8_u(1);
-                        i32_const(8); i32_shl;
+                        i32_const(F64_BYTES); i32_shl;
                         i32_or;
                         local_set(scale_raw);
                         // Decompose fp16 bits into sign / exp / mantissa.
-                        local_get(scale_raw); i32_const(15); i32_shr_u;
+                        local_get(scale_raw); i32_const(FP16_SIGN_BIT_POS); i32_shr_u;
                         i32_const(1); i32_and;
                         local_set(sign);
-                        local_get(scale_raw); i32_const(10); i32_shr_u;
-                        i32_const(31); i32_and;
+                        local_get(scale_raw); i32_const(FP16_EXP_SHIFT); i32_shr_u;
+                        i32_const(FP16_EXP_BITS_MASK); i32_and;
                         local_set(expv);
-                        local_get(scale_raw); i32_const(1023); i32_and;
+                        local_get(scale_raw); i32_const(FP16_MANTISSA_MASK); i32_and;
                         local_set(mant);
                         // f32bits = (sign << 31) | ((exp + 112) << 23) | (mant << 13)
-                        local_get(sign); i32_const(31); i32_shl;
-                        local_get(expv); i32_const(112); i32_add; i32_const(23); i32_shl;
+                        local_get(sign); i32_const(F32_SIGN_SHIFT); i32_shl;
+                        local_get(expv); i32_const(FP16_EXP_BIAS_DIFF); i32_add; i32_const(F32_EXP_SHIFT); i32_shl;
                         i32_or;
-                        local_get(mant); i32_const(13); i32_shl;
+                        local_get(mant); i32_const(FP16_MANT_TO_F32_SHIFT); i32_shl;
                         i32_or;
                         local_set(f32bits);
                         // If exp == 0 force f32bits to zero (sign-only).
                         local_get(expv); i32_eqz;
                         if_empty;
-                          local_get(sign); i32_const(31); i32_shl; local_set(f32bits);
+                          local_get(sign); i32_const(F32_SIGN_SHIFT); i32_shl; local_set(f32bits);
                         end;
                         // scale = f64 from the reconstructed f32 bits.
                         local_get(f32bits); f32_reinterpret_i32; f64_promote_f32;
                         local_set(scale);
                         f64_const(0.0); local_get(scale); f64_sub;
                         local_set(neg_scale);
-                        local_get(block_start); i32_const(2); i32_add;
+                        local_get(block_start); i32_const(Q1_0_SCALE_BYTES); i32_add;
                         local_set(bits_start);
                       end;
                       // byte_idx = bits_start + ((k & 127) >> 3) = bits_start + ((k >> 3) & 15)
                       local_get(bits_start);
-                      local_get(k); i32_const(3); i32_shr_u; i32_const(15); i32_and;
+                      local_get(k); i32_const(LOG2_BITS_PER_BYTE); i32_shr_u; i32_const(Q1_0_DATA_BYTE_MASK); i32_and;
                       i32_add;
                       local_set(byte_idx);
                       // bit_off = k & 7
-                      local_get(k); i32_const(7); i32_and; local_set(bit_off);
+                      local_get(k); i32_const(BITS_PER_BYTE_MASK); i32_and; local_set(bit_off);
                       // bit = (byte >> bit_off) & 1
                       local_get(byte_idx); i32_load8_u(0);
                       local_get(bit_off); i32_shr_u;
@@ -2513,7 +2575,7 @@ impl FuncCompiler<'_> {
                       local_set(bit);
                       // dst[8 + k*8] = bit == 1 ? scale : neg_scale
                       local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(k); i32_const(8); i32_mul; i32_add;
+                      local_get(k); i32_const(F64_BYTES); i32_mul; i32_add;
                       local_get(bit);
                       if_f64;
                         local_get(scale);
@@ -2573,7 +2635,7 @@ impl FuncCompiler<'_> {
                     local_get(x); i32_load(0); local_set(xr);
                     local_get(x); i32_load(4); local_set(nin);
                     local_get(w); i32_load(0); local_set(wr);
-                    local_get(xr); local_get(wr); i32_mul; i32_const(8); i32_mul;
+                    local_get(xr); local_get(wr); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(xr); i32_store(0);
@@ -2591,11 +2653,11 @@ impl FuncCompiler<'_> {
                           // x[i,k]
                           local_get(x); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(i); local_get(nin); i32_mul; local_get(k); i32_add;
-                          i32_const(8); i32_mul; i32_add; f64_load(0);
+                          i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                           // weight[j,k]
                           local_get(w); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(j); local_get(nin); i32_mul; local_get(k); i32_add;
-                          i32_const(8); i32_mul; i32_add; f64_load(0);
+                          i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                           f64_mul; local_get(s); f64_add; local_set(s);
                           local_get(k); i32_const(1); i32_add; local_set(k);
                           br(0);
@@ -2603,13 +2665,13 @@ impl FuncCompiler<'_> {
                         // dst[i,j] = s + bias[j] (if with_bias)
                         local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(i); local_get(wr); i32_mul; local_get(j); i32_add;
-                        i32_const(8); i32_mul; i32_add;
+                        i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(s);
                 });
                 if with_bias {
                     wasm!(self.func, {
                         local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(j); i32_const(8); i32_mul; i32_add;
+                        local_get(j); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); f64_add;
                     });
                 }
@@ -2651,7 +2713,7 @@ impl FuncCompiler<'_> {
                     local_set(mv);
                     local_get(m); i32_load(0); local_set(rows);
                     local_get(m); i32_load(4); local_set(cols);
-                    local_get(rows); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                    local_get(rows); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(rows); i32_store(0);
@@ -2664,10 +2726,10 @@ impl FuncCompiler<'_> {
                         local_get(c); local_get(cols); i32_ge_u; br_if(1);
                         local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(r); local_get(cols); i32_mul; local_get(c); i32_add;
-                        i32_const(8); i32_mul; i32_add;
+                        i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(r); local_get(cols); i32_mul; local_get(c); i32_add;
-                        i32_const(8); i32_mul; i32_add; f64_load(0);
+                        i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                         local_get(c); local_get(r); i32_gt_u;
                         if_f64; local_get(mv); else_; f64_const(0.0); end;
                         f64_add;
@@ -2732,17 +2794,17 @@ impl FuncCompiler<'_> {
                     local_get(dh); f64_convert_i32_u; f64_sqrt;
                     f64_div; local_set(scale);
                     // Alloc dst (sq, dm), zero
-                    local_get(sq); local_get(dm); i32_mul; i32_const(8); i32_mul;
+                    local_get(sq); local_get(dm); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(sq); i32_store(0);
                     local_get(dst); local_get(dm); i32_store(4);
                     local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     i32_const(0);
-                    local_get(sq); local_get(dm); i32_mul; i32_const(8); i32_mul;
+                    local_get(sq); local_get(dm); i32_mul; i32_const(F64_BYTES); i32_mul;
                     memory_fill;
                     // Alloc scores (sq, sk) reused per head
-                    local_get(sq); local_get(sk); i32_mul; i32_const(8); i32_mul;
+                    local_get(sq); local_get(sk); i32_mul; i32_const(F64_BYTES); i32_mul;
                     call(self.emitter.rt.alloc); local_set(scores);
                     // Per head
                     i32_const(0); local_set(h);
@@ -2764,12 +2826,12 @@ impl FuncCompiler<'_> {
                             local_get(q); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                             local_get(i); local_get(dm); i32_mul;
                             local_get(col0); i32_add; local_get(kki); i32_add;
-                            i32_const(8); i32_mul; i32_add; f64_load(0);
+                            i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                             // k[j, col0+kki]
                             local_get(kk); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                             local_get(j); local_get(dm); i32_mul;
                             local_get(col0); i32_add; local_get(kki); i32_add;
-                            i32_const(8); i32_mul; i32_add; f64_load(0);
+                            i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                             f64_mul; local_get(acc); f64_add; local_set(acc);
                             local_get(kki); i32_const(1); i32_add; local_set(kki);
                             br(0);
@@ -2797,7 +2859,7 @@ impl FuncCompiler<'_> {
                           // scores[i*sk + j] = acc
                           local_get(scores);
                           local_get(i); local_get(sk); i32_mul; local_get(j); i32_add;
-                          i32_const(8); i32_mul; i32_add;
+                          i32_const(F64_BYTES); i32_mul; i32_add;
                           local_get(acc); f64_store(0);
                           local_get(j); i32_const(1); i32_add; local_set(j);
                           br(0);
@@ -2808,14 +2870,14 @@ impl FuncCompiler<'_> {
                         // f64_gt-returns-false-for-NaN.
                         local_get(scores);
                         local_get(i); local_get(sk); i32_mul;
-                        i32_const(8); i32_mul; i32_add; f64_load(0);
+                        i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                         local_set(max);
                         i32_const(1); local_set(j);
                         block_empty; loop_empty;
                           local_get(j); local_get(sk); i32_ge_u; br_if(1);
                           local_get(scores);
                           local_get(i); local_get(sk); i32_mul; local_get(j); i32_add;
-                          i32_const(8); i32_mul; i32_add; f64_load(0); local_set(v);
+                          i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0); local_set(v);
                           local_get(v); local_get(max); f64_gt;
                           if_empty; local_get(v); local_set(max); end;
                           local_get(j); i32_const(1); i32_add; local_set(j);
@@ -2827,10 +2889,10 @@ impl FuncCompiler<'_> {
                           local_get(j); local_get(sk); i32_ge_u; br_if(1);
                           local_get(scores);
                           local_get(i); local_get(sk); i32_mul; local_get(j); i32_add;
-                          i32_const(8); i32_mul; i32_add;
+                          i32_const(F64_BYTES); i32_mul; i32_add;
                           local_get(scores);
                           local_get(i); local_get(sk); i32_mul; local_get(j); i32_add;
-                          i32_const(8); i32_mul; i32_add; f64_load(0);
+                          i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                           local_get(max); f64_sub; call(self.emitter.rt.math_exp); local_set(v);
                           local_get(v); f64_store(0);
                           local_get(sum); local_get(v); f64_add; local_set(sum);
@@ -2850,7 +2912,7 @@ impl FuncCompiler<'_> {
                             local_get(j); local_get(sk); i32_ge_u; br_if(1);
                             local_get(scores);
                             local_get(i); local_get(sk); i32_mul; local_get(j); i32_add;
-                            i32_const(8); i32_mul; i32_add;
+                            i32_const(F64_BYTES); i32_mul; i32_add;
                             f64_const(1.0); f64_store(0);
                             local_get(j); i32_const(1); i32_add; local_set(j);
                             br(0);
@@ -2862,7 +2924,7 @@ impl FuncCompiler<'_> {
                           local_get(j); local_get(sk); i32_ge_u; br_if(1);
                           local_get(scores);
                           local_get(i); local_get(sk); i32_mul; local_get(j); i32_add;
-                          i32_const(8); i32_mul; i32_add; f64_load(0);
+                          i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                           local_get(sum); f64_div; local_set(w);
                           // Add w * v[j, col0+kki] to dst[i, col0+kki]
                           i32_const(0); local_set(kki);
@@ -2871,15 +2933,15 @@ impl FuncCompiler<'_> {
                             local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                             local_get(i); local_get(dm); i32_mul;
                             local_get(col0); i32_add; local_get(kki); i32_add;
-                            i32_const(8); i32_mul; i32_add;
+                            i32_const(F64_BYTES); i32_mul; i32_add;
                             local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                             local_get(i); local_get(dm); i32_mul;
                             local_get(col0); i32_add; local_get(kki); i32_add;
-                            i32_const(8); i32_mul; i32_add; f64_load(0);
+                            i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                             local_get(vv); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                             local_get(j); local_get(dm); i32_mul;
                             local_get(col0); i32_add; local_get(kki); i32_add;
-                            i32_const(8); i32_mul; i32_add; f64_load(0);
+                            i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                             local_get(w); f64_mul; f64_add;
                             f64_store(0);
                             local_get(kki); i32_const(1); i32_add; local_set(kki);
@@ -2930,7 +2992,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_set(m);
                     local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul; local_set(bytes_len);
+                    local_get(total); i32_const(F64_BYTES); i32_mul; local_set(bytes_len);
                     // alloc bytes buffer with header
                     local_get(bytes_len); call(self.emitter.rt.string_alloc); local_set(dst);
                     // memcpy: dst+data_off ← m+data_off, bytes_len bytes
@@ -2958,13 +3020,13 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_set(m);
                     local_get(m); i32_load(0); local_get(m); i32_load(4); i32_mul; local_set(total);
-                    local_get(total); i32_const(4); i32_mul; local_set(bytes_len);
+                    local_get(total); i32_const(F32_BYTES); i32_mul; local_set(bytes_len);
                     local_get(bytes_len); call(self.emitter.rt.string_alloc); local_set(dst);
                     i32_const(0); local_set(i);
                     block_empty; loop_empty;
                       local_get(i); local_get(total); i32_ge_u; br_if(1);
-                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(8); i32_mul; i32_add; local_set(src_addr);
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(4); i32_mul; i32_add; local_set(dst_addr);
+                      local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; local_set(src_addr);
+                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(i); i32_const(F32_BYTES); i32_mul; i32_add; local_set(dst_addr);
                       local_get(dst_addr);
                       local_get(src_addr); f64_load(0); f32_demote_f64;
                       f32_store(0);
@@ -2999,14 +3061,14 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     i32_wrap_i64; local_set(c);
                     local_get(r); local_get(c); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(r); i32_store(0);
                     local_get(dst); local_get(c); i32_store(4);
                     // memcpy: dst+8 ← buf+4+off, total*8 bytes
                     local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(off); i32_add;
-                    local_get(total); i32_const(8); i32_mul;
+                    local_get(total); i32_const(F64_BYTES); i32_mul;
                     memory_copy;
                     local_get(dst);
                 });
@@ -3036,7 +3098,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     i32_wrap_i64; local_set(c);
                     local_get(r); local_get(c); i32_mul; local_set(total);
-                    local_get(total); i32_const(8); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
+                    local_get(total); i32_const(F64_BYTES); i32_mul; i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(r); i32_store(0);
                     local_get(dst); local_get(c); i32_store(4);
@@ -3045,7 +3107,7 @@ impl FuncCompiler<'_> {
                       local_get(i); local_get(total); i32_ge_u; br_if(1);
                       // dst[data] + i * 8
                       local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       // src = buf + 4 + off + i * elem_bytes
                       local_get(buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_get(off); i32_add;
                 });
@@ -3116,11 +3178,11 @@ impl FuncCompiler<'_> {
                     local_get(inp); i32_load(4); local_set(ich);
                     local_get(w); i32_load(0); local_set(och);
                     // tout = (tin + 2*pd - kk) / st + 1
-                    local_get(tin); local_get(pd); i32_const(2); i32_mul; i32_add;
+                    local_get(tin); local_get(pd); i32_const(CONV1D_PADDING_SIDES); i32_mul; i32_add;
                     local_get(kk); i32_sub; local_get(st); i32_div_u;
                     i32_const(1); i32_add; local_set(tout);
                     // Alloc dst (tout, och)
-                    local_get(tout); local_get(och); i32_mul; i32_const(8); i32_mul;
+                    local_get(tout); local_get(och); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(tout); i32_store(0);
@@ -3135,7 +3197,7 @@ impl FuncCompiler<'_> {
                         local_get(o); local_get(och); i32_ge_u; br_if(1);
                         // s = bias[o]
                         local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(o); i32_const(8); i32_mul; i32_add;
+                        local_get(o); i32_const(F64_BYTES); i32_mul; i32_add;
                         f64_load(0); local_set(s);
                         i32_const(0); local_set(cc);
                         block_empty; loop_empty;
@@ -3155,11 +3217,11 @@ impl FuncCompiler<'_> {
                               local_get(o); local_get(ich); i32_mul; local_get(kk); i32_mul;
                               local_get(cc); local_get(kk); i32_mul; i32_add;
                               local_get(ki); i32_add;
-                              i32_const(8); i32_mul; i32_add; f64_load(0);
+                              i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                               // input[tc][cc]
                               local_get(inp); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                               local_get(tc); local_get(ich); i32_mul; local_get(cc); i32_add;
-                              i32_const(8); i32_mul; i32_add; f64_load(0);
+                              i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                               f64_mul; local_get(s); f64_add; local_set(s);
                             end;
                             local_get(ki); i32_const(1); i32_add; local_set(ki);
@@ -3171,7 +3233,7 @@ impl FuncCompiler<'_> {
                         // dst[t, o] = s
                         local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                         local_get(t); local_get(och); i32_mul; local_get(o); i32_add;
-                        i32_const(8); i32_mul; i32_add;
+                        i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(s); f64_store(0);
                         local_get(o); i32_const(1); i32_add; local_set(o);
                         br(0);
@@ -3223,14 +3285,14 @@ impl FuncCompiler<'_> {
                     local_get(m); i32_load(4); local_set(cols);
                     local_get(cols); local_get(n); i32_div_u; local_set(chunk);
                     // Alloc list: 4 + n*4
-                    local_get(n); i32_const(4); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
+                    local_get(n); i32_const(I32_BYTES); i32_mul; i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(list_ptr);
                     local_get(list_ptr); local_get(n); i32_store(0);
                     i32_const(0); local_set(h);
                     block_empty; loop_empty;
                       local_get(h); local_get(n); i32_ge_u; br_if(1);
                       // Alloc sub-matrix (rows, chunk)
-                      local_get(rows); local_get(chunk); i32_mul; i32_const(8); i32_mul;
+                      local_get(rows); local_get(chunk); i32_mul; i32_const(F64_BYTES); i32_mul;
                       i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                       call(self.emitter.rt.alloc); local_set(sub);
                       local_get(sub); local_get(rows); i32_store(0);
@@ -3244,12 +3306,12 @@ impl FuncCompiler<'_> {
                           local_get(c); local_get(chunk); i32_ge_u; br_if(1);
                           local_get(sub); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(r); local_get(chunk); i32_mul; local_get(c); i32_add;
-                          i32_const(8); i32_mul; i32_add;
+                          i32_const(F64_BYTES); i32_mul; i32_add;
                           local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(r); local_get(cols); i32_mul;
                           local_get(h); local_get(chunk); i32_mul; i32_add;
                           local_get(c); i32_add;
-                          i32_const(8); i32_mul; i32_add;
+                          i32_const(F64_BYTES); i32_mul; i32_add;
                           f64_load(0); f64_store(0);
                           local_get(c); i32_const(1); i32_add; local_set(c);
                           br(0);
@@ -3259,7 +3321,7 @@ impl FuncCompiler<'_> {
                       end; end;
                       // list[h] = sub
                       local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(h); i32_const(4); i32_mul; i32_add;
+                      local_get(h); i32_const(I32_BYTES); i32_mul; i32_add;
                       local_get(sub); i32_store(0);
                       local_get(h); i32_const(1); i32_add; local_set(h);
                       br(0);
@@ -3306,7 +3368,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); local_get(n); i32_ge_u; br_if(1);
                       local_get(lst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0); local_set(sub);
                       local_get(total_cols); local_get(sub); i32_load(4); i32_add;
                       local_set(total_cols);
@@ -3314,7 +3376,7 @@ impl FuncCompiler<'_> {
                       br(0);
                     end; end;
                     // Alloc dst (rows, total_cols)
-                    local_get(rows); local_get(total_cols); i32_mul; i32_const(8); i32_mul;
+                    local_get(rows); local_get(total_cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(rows); i32_store(0);
@@ -3325,7 +3387,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); local_get(n); i32_ge_u; br_if(1);
                       local_get(lst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0); local_set(sub);
                       local_get(sub); i32_load(4); local_set(sub_cols);
                       i32_const(0); local_set(r);
@@ -3338,10 +3400,10 @@ impl FuncCompiler<'_> {
                           local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(r); local_get(total_cols); i32_mul;
                           local_get(col_off); i32_add; local_get(c); i32_add;
-                          i32_const(8); i32_mul; i32_add;
+                          i32_const(F64_BYTES); i32_mul; i32_add;
                           local_get(sub); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                           local_get(r); local_get(sub_cols); i32_mul; local_get(c); i32_add;
-                          i32_const(8); i32_mul; i32_add;
+                          i32_const(F64_BYTES); i32_mul; i32_add;
                           f64_load(0); f64_store(0);
                           local_get(c); i32_const(1); i32_add; local_set(c);
                           br(0);
@@ -3387,7 +3449,7 @@ impl FuncCompiler<'_> {
                     local_get(m); i32_load(4); local_set(cols);
                     local_get(indices); i32_load(0); local_set(n);
                     // Alloc dst (n, cols)
-                    local_get(n); local_get(cols); i32_mul; i32_const(8); i32_mul;
+                    local_get(n); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul;
                     i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(n); i32_store(0);
@@ -3397,24 +3459,24 @@ impl FuncCompiler<'_> {
                       local_get(i); local_get(n); i32_ge_u; br_if(1);
                       // idx = indices[i] (i64 → i32)
                       local_get(indices); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add;
                       i64_load(0); i32_wrap_i64; local_set(idx);
                       // bounds clamp: if idx >= n_rows_src: zero the row, else memcpy
                       local_get(idx); local_get(n_rows_src); i32_ge_u;
                       if_empty;
                         // Zero
                         local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(i); local_get(cols); i32_mul; i32_const(8); i32_mul; i32_add;
+                        local_get(i); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul; i32_add;
                         i32_const(0);
-                        local_get(cols); i32_const(8); i32_mul;
+                        local_get(cols); i32_const(F64_BYTES); i32_mul;
                         memory_fill;
                       else_;
                         // memcpy: dst[i] ← m[idx]
                         local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(i); local_get(cols); i32_mul; i32_const(8); i32_mul; i32_add;
+                        local_get(i); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul; i32_add;
                         local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(idx); local_get(cols); i32_mul; i32_const(8); i32_mul; i32_add;
-                        local_get(cols); i32_const(8); i32_mul;
+                        local_get(idx); local_get(cols); i32_mul; i32_const(F64_BYTES); i32_mul; i32_add;
+                        local_get(cols); i32_const(F64_BYTES); i32_mul;
                         memory_copy;
                       end;
                       local_get(i); i32_const(1); i32_add; local_set(i);
@@ -3461,10 +3523,10 @@ impl FuncCompiler<'_> {
                       // m[row, i]
                       local_get(m); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
                       local_get(row); local_get(cols); i32_mul; local_get(i); i32_add;
-                      i32_const(8); i32_mul; i32_add; f64_load(0);
+                      i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                       // vec[i]
                       local_get(vec); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add; f64_load(0);
+                      local_get(i); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                       f64_mul; local_get(s); f64_add; local_set(s);
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);

--- a/crates/almide-codegen/src/emit_wasm/calls_numeric.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_numeric.rs
@@ -1,5 +1,6 @@
 //! Float, Int, and Math stdlib call dispatch for WASM codegen.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::FuncCompiler;
 use almide_ir::IrExpr;
 use almide_lang::types::Ty;
@@ -53,11 +54,11 @@ impl FuncCompiler<'_> {
         // val_if_true when cond != 0. cond = (bits >= FULL_WIDTH_BITS).
         wasm!(self.func, {
             // val_if_true = u64::MAX  (saturated mask for bits >= 64)
-            i64_const(FULL_WIDTH_MASK);
+            i64_const(Imm64(FULL_WIDTH_MASK));
             // val_if_false = (1 << bits) - 1   (valid only for 0 <= bits < 64)
-            i64_const(1); local_get(bits_local); i64_shl; i64_const(1); i64_sub;
+            i64_const(Imm64(1)); local_get(Local(bits_local)); i64_shl; i64_const(Imm64(1)); i64_sub;
             // cond
-            local_get(bits_local); i64_const(FULL_WIDTH_BITS); i64_ge_s;
+            local_get(Local(bits_local)); i64_const(Imm64(FULL_WIDTH_BITS)); i64_ge_s;
             select;
         });
     }
@@ -75,22 +76,22 @@ impl FuncCompiler<'_> {
         let a = self.scratch.alloc_f64();
         let b = self.scratch.alloc_f64();
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(a); });
+        wasm!(self.func, { local_set(Local(a)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { local_set(b); });
+        wasm!(self.func, { local_set(Local(b)); });
         wasm!(self.func, {
             // if a != a (a is NaN) { b }
-            local_get(a); local_get(a); f64_ne;
+            local_get(Local(a)); local_get(Local(a)); f64_ne;
             if_f64;
-              local_get(b);
+              local_get(Local(b));
             else_;
               // else if b != b (b is NaN) { a }
-              local_get(b); local_get(b); f64_ne;
+              local_get(Local(b)); local_get(Local(b)); f64_ne;
               if_f64;
-                local_get(a);
+                local_get(Local(a));
               else_;
                 // strict comparison; for max: a < b ? b : a; for min: b < a ? b : a
-                local_get(a); local_get(b);
+                local_get(Local(a)); local_get(Local(b));
         });
         if is_max {
             wasm!(self.func, { f64_lt; }); // a < b
@@ -99,9 +100,9 @@ impl FuncCompiler<'_> {
         }
         wasm!(self.func, {
                 if_f64;
-                  local_get(b);
+                  local_get(Local(b));
                 else_;
-                  local_get(a);
+                  local_get(Local(a));
                 end;
               end;
             end;
@@ -135,10 +136,10 @@ impl FuncCompiler<'_> {
                 let tmp = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(tmp);
-                    local_get(tmp); // x
+                    local_set(Local(tmp));
+                    local_get(Local(tmp)); // x
                     f64_abs; f64_const(0.5); f64_add; f64_floor; // floor(abs(x)+0.5)
-                    local_get(tmp); // x (for sign)
+                    local_get(Local(tmp)); // x (for sign)
                     f64_copysign; // copysign(magnitude, sign)
                 });
                 self.scratch.free_f64(tmp);
@@ -172,13 +173,13 @@ impl FuncCompiler<'_> {
                 let tmp = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(tmp);
+                    local_set(Local(tmp));
                     // if x != x { x (NaN) } else { copysign(1.0, x) }
-                    local_get(tmp); local_get(tmp); f64_ne;
+                    local_get(Local(tmp)); local_get(Local(tmp)); f64_ne;
                     if_f64;
-                      local_get(tmp);
+                      local_get(Local(tmp));
                     else_;
-                      f64_const(1.0); local_get(tmp); f64_copysign;
+                      f64_const(1.0); local_get(Local(tmp)); f64_copysign;
                     end;
                 });
                 self.scratch.free_f64(tmp);
@@ -201,21 +202,21 @@ impl FuncCompiler<'_> {
                 let lo = self.scratch.alloc_f64();
                 let hi = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(n); });
+                wasm!(self.func, { local_set(Local(n)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(lo); });
+                wasm!(self.func, { local_set(Local(lo)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    local_set(hi);
-                    local_get(n); local_get(lo); f64_lt;
+                    local_set(Local(hi));
+                    local_get(Local(n)); local_get(Local(lo)); f64_lt;
                     if_f64;
-                      local_get(lo);
+                      local_get(Local(lo));
                     else_;
-                      local_get(n); local_get(hi); f64_gt;
+                      local_get(Local(n)); local_get(Local(hi)); f64_gt;
                       if_f64;
-                        local_get(hi);
+                        local_get(Local(hi));
                       else_;
-                        local_get(n);
+                        local_get(Local(n));
                       end;
                     end;
                 });
@@ -228,9 +229,9 @@ impl FuncCompiler<'_> {
                 let tmp = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(tmp);
-                    local_get(tmp);
-                    local_get(tmp);
+                    local_set(Local(tmp));
+                    local_get(Local(tmp));
+                    local_get(Local(tmp));
                     f64_ne;
                 });
                 self.scratch.free_f64(tmp);
@@ -275,12 +276,12 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 let s = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i64_const(0); i64_lt_s;
+                    local_set(Local(s));
+                    local_get(Local(s)); i64_const(Imm64(0)); i64_lt_s;
                     if_i64;
-                      i64_const(0); local_get(s); i64_sub;
+                      i64_const(Imm64(0)); local_get(Local(s)); i64_sub;
                     else_;
-                      local_get(s);
+                      local_get(Local(s));
                     end;
                 });
                 self.scratch.free_i64(s);
@@ -291,9 +292,9 @@ impl FuncCompiler<'_> {
                 let a = self.scratch.alloc_i64();
                 let b = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(a); local_set(b);
-                    local_get(b); local_get(a); i64_lt_s;
-                    if_i64; local_get(b); else_; local_get(a); end;
+                    local_set(Local(a)); local_set(Local(b));
+                    local_get(Local(b)); local_get(Local(a)); i64_lt_s;
+                    if_i64; local_get(Local(b)); else_; local_get(Local(a)); end;
                 });
                 self.scratch.free_i64(b);
                 self.scratch.free_i64(a);
@@ -304,9 +305,9 @@ impl FuncCompiler<'_> {
                 let a = self.scratch.alloc_i64();
                 let b = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(a); local_set(b);
-                    local_get(b); local_get(a); i64_gt_s;
-                    if_i64; local_get(b); else_; local_get(a); end;
+                    local_set(Local(a)); local_set(Local(b));
+                    local_get(Local(b)); local_get(Local(a)); i64_gt_s;
+                    if_i64; local_get(Local(b)); else_; local_get(Local(a)); end;
                 });
                 self.scratch.free_i64(b);
                 self.scratch.free_i64(a);
@@ -320,16 +321,16 @@ impl FuncCompiler<'_> {
                 let lo = self.scratch.alloc_i64();
                 let n = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(hi);       // hi
-                    local_set(lo);   // lo
-                    local_set(n);   // n
+                    local_set(Local(hi));       // hi
+                    local_set(Local(lo));   // lo
+                    local_set(Local(n));   // n
                     // min(n, hi)
-                    local_get(n); local_get(hi); i64_lt_s;
-                    if_i64; local_get(n); else_; local_get(hi); end;
+                    local_get(Local(n)); local_get(Local(hi)); i64_lt_s;
+                    if_i64; local_get(Local(n)); else_; local_get(Local(hi)); end;
                     // max(lo, result)
-                    local_set(n); // temp = min(n, hi)
-                    local_get(lo); local_get(n); i64_gt_s;
-                    if_i64; local_get(lo); else_; local_get(n); end;
+                    local_set(Local(n)); // temp = min(n, hi)
+                    local_get(Local(lo)); local_get(Local(n)); i64_gt_s;
+                    if_i64; local_get(Local(lo)); else_; local_get(Local(n)); end;
                 });
                 self.scratch.free_i64(n);
                 self.scratch.free_i64(lo);
@@ -366,15 +367,15 @@ impl FuncCompiler<'_> {
             }
             "bnot" => {
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i64_const(-1); i64_xor; });
+                wasm!(self.func, { i64_const(Imm64(-1)); i64_xor; });
             }
             "to_u32" => {
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i64_const(U32_MASK); i64_and; });
+                wasm!(self.func, { i64_const(Imm64(U32_MASK)); i64_and; });
             }
             "to_u8" => {
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i64_const(LOW_BYTE_MASK_I64); i64_and; });
+                wasm!(self.func, { i64_const(Imm64(LOW_BYTE_MASK_I64)); i64_and; });
             }
             "count_leading_zeros" => {
                 self.emit_expr(&args[0]);
@@ -395,21 +396,21 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(src);
-                    i64_const(0); local_set(dst);
-                    i64_const(0); local_set(i);
+                    local_set(Local(src));
+                    i64_const(Imm64(0)); local_set(Local(dst));
+                    i64_const(Imm64(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                        local_get(i); i64_const(I64_BITS); i64_ge_s; br_if(1);
+                        local_get(Local(i)); i64_const(Imm64(I64_BITS)); i64_ge_s; br_if(1);
                         // dst = (dst << 1) | (src & 1)
-                        local_get(dst); i64_const(1); i64_shl;
-                        local_get(src); i64_const(1); i64_and;
-                        i64_or; local_set(dst);
+                        local_get(Local(dst)); i64_const(Imm64(1)); i64_shl;
+                        local_get(Local(src)); i64_const(Imm64(1)); i64_and;
+                        i64_or; local_set(Local(dst));
                         // src >>= 1
-                        local_get(src); i64_const(1); i64_shr_u; local_set(src);
-                        local_get(i); i64_const(1); i64_add; local_set(i);
+                        local_get(Local(src)); i64_const(Imm64(1)); i64_shr_u; local_set(Local(src));
+                        local_get(Local(i)); i64_const(Imm64(1)); i64_add; local_set(Local(i));
                         br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i64(i);
                 self.scratch.free_i64(dst);
@@ -422,21 +423,21 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(src);
-                    i64_const(0); local_set(dst);
-                    i64_const(0); local_set(i);
+                    local_set(Local(src));
+                    i64_const(Imm64(0)); local_set(Local(dst));
+                    i64_const(Imm64(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                        local_get(i); i64_const(I64_BYTES); i64_ge_s; br_if(1);
+                        local_get(Local(i)); i64_const(Imm64(I64_BYTES)); i64_ge_s; br_if(1);
                         // dst = (dst << 8) | (src & 0xFF)
-                        local_get(dst); i64_const(I64_BYTES); i64_shl;
-                        local_get(src); i64_const(LOW_BYTE_MASK_I64); i64_and;
-                        i64_or; local_set(dst);
+                        local_get(Local(dst)); i64_const(Imm64(I64_BYTES)); i64_shl;
+                        local_get(Local(src)); i64_const(Imm64(LOW_BYTE_MASK_I64)); i64_and;
+                        i64_or; local_set(Local(dst));
                         // src >>= 8
-                        local_get(src); i64_const(I64_BYTES); i64_shr_u; local_set(src);
-                        local_get(i); i64_const(1); i64_add; local_set(i);
+                        local_get(Local(src)); i64_const(Imm64(I64_BYTES)); i64_shr_u; local_set(Local(src));
+                        local_get(Local(i)); i64_const(Imm64(1)); i64_add; local_set(Local(i));
                         br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i64(i);
                 self.scratch.free_i64(dst);
@@ -447,12 +448,12 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 let n = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(n);
-                    local_get(n); i64_eqz;
+                    local_set(Local(n));
+                    local_get(Local(n)); i64_eqz;
                     if_i64;
-                        i64_const(0);
+                        i64_const(Imm64(0));
                     else_;
-                        i64_const(I64_BITS); local_get(n); i64_clz; i64_sub;
+                        i64_const(Imm64(I64_BITS)); local_get(Local(n)); i64_clz; i64_sub;
                     end;
                 });
                 self.scratch.free_i64(n);
@@ -462,12 +463,12 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 let n = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(n);
-                    local_get(n); i64_const(0); i64_le_s;
+                    local_set(Local(n));
+                    local_get(Local(n)); i64_const(Imm64(0)); i64_le_s;
                     if_i64;
-                        i64_const(-1);
+                        i64_const(Imm64(-1));
                     else_;
-                        i64_const(I64_MAX_BIT_IDX); local_get(n); i64_clz; i64_sub;
+                        i64_const(Imm64(I64_MAX_BIT_IDX)); local_get(Local(n)); i64_clz; i64_sub;
                     end;
                 });
                 self.scratch.free_i64(n);
@@ -477,13 +478,13 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 let n = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(n);
-                    local_get(n); i64_const(1); i64_le_s;
+                    local_set(Local(n));
+                    local_get(Local(n)); i64_const(Imm64(1)); i64_le_s;
                     if_i64;
-                        i64_const(0);
+                        i64_const(Imm64(0));
                     else_;
-                        i64_const(I64_BITS);
-                        local_get(n); i64_const(1); i64_sub; i64_clz;
+                        i64_const(Imm64(I64_BITS));
+                        local_get(Local(n)); i64_const(Imm64(1)); i64_sub; i64_clz;
                         i64_sub;
                     end;
                 });
@@ -494,14 +495,14 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 let n = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(n);
-                    local_get(n); i64_const(1); i64_le_s;
+                    local_set(Local(n));
+                    local_get(Local(n)); i64_const(Imm64(1)); i64_le_s;
                     if_i64;
-                        i64_const(1);
+                        i64_const(Imm64(1));
                     else_;
-                        i64_const(1);
-                        i64_const(I64_BITS);
-                        local_get(n); i64_const(1); i64_sub; i64_clz;
+                        i64_const(Imm64(1));
+                        i64_const(Imm64(I64_BITS));
+                        local_get(Local(n)); i64_const(Imm64(1)); i64_sub; i64_clz;
                         i64_sub;
                         i64_shl;
                     end;
@@ -513,13 +514,13 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 let n = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(n);
-                    local_get(n); i64_const(0); i64_le_s;
+                    local_set(Local(n));
+                    local_get(Local(n)); i64_const(Imm64(0)); i64_le_s;
                     if_i64;
-                        i64_const(0);
+                        i64_const(Imm64(0));
                     else_;
-                        i64_const(1);
-                        i64_const(I64_MAX_BIT_IDX); local_get(n); i64_clz; i64_sub;
+                        i64_const(Imm64(1));
+                        i64_const(Imm64(I64_MAX_BIT_IDX)); local_get(Local(n)); i64_clz; i64_sub;
                         i64_shl;
                     end;
                 });
@@ -532,7 +533,7 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[1]);
                 wasm!(self.func, { i64_add; });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { local_set(bits); });
+                wasm!(self.func, { local_set(Local(bits)); });
                 self.emit_wrap_mask(bits);
                 wasm!(self.func, { i64_and; });
                 self.scratch.free_i64(bits);
@@ -544,7 +545,7 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[1]);
                 wasm!(self.func, { i64_mul; });
                 self.emit_expr(&args[2]);
-                wasm!(self.func, { local_set(bits); });
+                wasm!(self.func, { local_set(Local(bits)); });
                 self.emit_wrap_mask(bits);
                 wasm!(self.func, { i64_and; });
                 self.scratch.free_i64(bits);
@@ -559,58 +560,58 @@ impl FuncCompiler<'_> {
                 let n64 = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(n64);
-                    local_get(n64); i64_eqz;
+                    local_set(Local(n64));
+                    local_get(Local(n64)); i64_eqz;
                     if_i32;
-                      i32_const(1); call(self.emitter.rt.string_alloc); local_set(buf);
-                      local_get(buf); i32_const(1); i32_store(0);
-                      local_get(buf); i32_const(1); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
-                      local_get(buf); i32_const(ASCII_ZERO); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
-                      local_get(buf);
+                      i32_const(Imm32(1)); call(self.emitter.rt.string_alloc); local_set(Local(buf));
+                      local_get(Local(buf)); i32_const(Imm32(1)); i32_store(0);
+                      local_get(Local(buf)); i32_const(Imm32(1)); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
+                      local_get(Local(buf)); i32_const(Imm32(ASCII_ZERO)); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
+                      local_get(Local(buf));
                     else_;
                       // Alloc temp buffer for reversed digits
-                      i32_const(HEX_BUF_BYTES); call(self.emitter.rt.alloc); local_set(buf); // buf
-                      i32_const(0); local_set(count); // count
+                      i32_const(Imm32(HEX_BUF_BYTES)); call(self.emitter.rt.alloc); local_set(Local(buf)); // buf
+                      i32_const(Imm32(0)); local_set(Local(count)); // count
                 });
                 wasm!(self.func, {
                       block_empty; loop_empty;
-                        local_get(n64); i64_eqz; br_if(1);
-                        local_get(n64); i64_const(HEX_BASE); i64_rem_u; i32_wrap_i64;
-                        local_set(digit); // digit
-                        local_get(digit); i32_const(DECIMAL_BASE); i32_lt_u;
-                        if_i32; local_get(digit); i32_const(ASCII_ZERO); i32_add;
-                        else_; local_get(digit); i32_const(HEX_LETTER_OFFSET); i32_add; end;
-                        local_set(digit); // char
-                        local_get(buf); local_get(count); i32_add;
-                        local_get(digit); i32_store8(0);
-                        local_get(count); i32_const(1); i32_add; local_set(count);
-                        local_get(n64); i64_const(HEX_BASE); i64_div_u; local_set(n64);
+                        local_get(Local(n64)); i64_eqz; br_if(1);
+                        local_get(Local(n64)); i64_const(Imm64(HEX_BASE)); i64_rem_u; i32_wrap_i64;
+                        local_set(Local(digit)); // digit
+                        local_get(Local(digit)); i32_const(Imm32(DECIMAL_BASE)); i32_lt_u;
+                        if_i32; local_get(Local(digit)); i32_const(Imm32(ASCII_ZERO)); i32_add;
+                        else_; local_get(Local(digit)); i32_const(Imm32(HEX_LETTER_OFFSET)); i32_add; end;
+                        local_set(Local(digit)); // char
+                        local_get(Local(buf)); local_get(Local(count)); i32_add;
+                        local_get(Local(digit)); i32_store8(0);
+                        local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count));
+                        local_get(Local(n64)); i64_const(Imm64(HEX_BASE)); i64_div_u; local_set(Local(n64));
                         br(0);
                       end; end;
                 });
                 wasm!(self.func, {
                       // Alloc result string: [len][cap][data...]
-                      i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32);
-                      local_get(count); i32_add;
-                      call(self.emitter.rt.alloc); local_set(digit);
-                      local_get(digit); local_get(count); i32_store(0); // len
-                      local_get(digit); local_get(count);
+                      i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32));
+                      local_get(Local(count)); i32_add;
+                      call(self.emitter.rt.alloc); local_set(Local(digit));
+                      local_get(Local(digit)); local_get(Local(count)); i32_store(0); // len
+                      local_get(Local(digit)); local_get(Local(count));
                       i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as u32); // cap
                       // Copy reversed
-                      i32_const(0); local_set(idx);
+                      i32_const(Imm32(0)); local_set(Local(idx));
                       block_empty; loop_empty;
-                        local_get(idx); local_get(count); i32_ge_u; br_if(1);
-                        local_get(digit);
-                        i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
-                        i32_add; local_get(idx); i32_add;
-                        local_get(buf);
-                        local_get(count); i32_const(1); i32_sub; local_get(idx); i32_sub;
+                        local_get(Local(idx)); local_get(Local(count)); i32_ge_u; br_if(1);
+                        local_get(Local(digit));
+                        i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
+                        i32_add; local_get(Local(idx)); i32_add;
+                        local_get(Local(buf));
+                        local_get(Local(count)); i32_const(Imm32(1)); i32_sub; local_get(Local(idx)); i32_sub;
                         i32_add; i32_load8_u(0);
                         i32_store8(0);
-                        local_get(idx); i32_const(1); i32_add; local_set(idx);
+                        local_get(Local(idx)); i32_const(Imm32(1)); i32_add; local_set(Local(idx));
                         br(0);
                       end; end;
-                      local_get(digit);
+                      local_get(Local(digit));
                     end;
                 });
                 self.scratch.free_i64(n64);
@@ -660,43 +661,43 @@ impl FuncCompiler<'_> {
                 let mask = self.scratch.alloc_i64();
                 let v = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
                 // n = n % bits (needs bits first)
-                wasm!(self.func, { local_set(n); });
+                wasm!(self.func, { local_set(Local(n)); });
                 self.emit_expr(&args[2]);
                 wasm!(self.func, {
-                    local_set(bits);
+                    local_set(Local(bits));
                     // if bits <= 0 { abort("rotate width must be positive") }
-                    local_get(bits); i64_const(0); i64_le_s;
+                    local_get(Local(bits)); i64_const(Imm64(0)); i64_le_s;
                     if_empty;
-                      i32_const(rot_width_msg); call(div_trap);
+                      i32_const(Imm32(rot_width_msg)); call(div_trap);
                     end;
                 });
                 // mask = wrap_mask(bits)  (u64::MAX for bits >= 64)
                 self.emit_wrap_mask(bits);
                 wasm!(self.func, {
-                    local_set(mask);
+                    local_set(Local(mask));
                     // v = a & mask
-                    local_get(a); local_get(mask); i64_and; local_set(v);
+                    local_get(Local(a)); local_get(Local(mask)); i64_and; local_set(Local(v));
                     // n = n % bits
-                    local_get(n); local_get(bits); i64_rem_s; local_set(n);
+                    local_get(Local(n)); local_get(Local(bits)); i64_rem_s; local_set(Local(n));
                 });
                 if is_left {
                     wasm!(self.func, {
                         // (v << n) | (v >> (bits - n))
-                        local_get(v); local_get(n); i64_shl;
-                        local_get(v); local_get(bits); local_get(n); i64_sub; i64_shr_u;
+                        local_get(Local(v)); local_get(Local(n)); i64_shl;
+                        local_get(Local(v)); local_get(Local(bits)); local_get(Local(n)); i64_sub; i64_shr_u;
                         i64_or;
-                        local_get(mask); i64_and;
+                        local_get(Local(mask)); i64_and;
                     });
                 } else {
                     wasm!(self.func, {
                         // (v >> n) | (v << (bits - n))
-                        local_get(v); local_get(n); i64_shr_u;
-                        local_get(v); local_get(bits); local_get(n); i64_sub; i64_shl;
+                        local_get(Local(v)); local_get(Local(n)); i64_shr_u;
+                        local_get(Local(v)); local_get(Local(bits)); local_get(Local(n)); i64_sub; i64_shl;
                         i64_or;
-                        local_get(mask); i64_and;
+                        local_get(Local(mask)); i64_and;
                     });
                 }
                 self.scratch.free_i64(v);
@@ -756,10 +757,10 @@ impl FuncCompiler<'_> {
                     _ => {
                         let s = self.scratch.alloc_i64();
                         wasm!(self.func, {
-                            local_set(s);
-                            local_get(s); i64_const(0); i64_lt_s;
-                            if_i64; i64_const(0); local_get(s); i64_sub;
-                            else_; local_get(s); end;
+                            local_set(Local(s));
+                            local_get(Local(s)); i64_const(Imm64(0)); i64_lt_s;
+                            if_i64; i64_const(Imm64(0)); local_get(Local(s)); i64_sub;
+                            else_; local_get(Local(s)); end;
                         });
                         self.scratch.free_i64(s);
                     }
@@ -771,9 +772,9 @@ impl FuncCompiler<'_> {
                 let a = self.scratch.alloc_i64();
                 let b = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(a); local_set(b);
-                    local_get(b); local_get(a); i64_gt_s;
-                    if_i64; local_get(b); else_; local_get(a); end;
+                    local_set(Local(a)); local_set(Local(b));
+                    local_get(Local(b)); local_get(Local(a)); i64_gt_s;
+                    if_i64; local_get(Local(b)); else_; local_get(Local(a)); end;
                 });
                 self.scratch.free_i64(b);
                 self.scratch.free_i64(a);
@@ -784,9 +785,9 @@ impl FuncCompiler<'_> {
                 let a = self.scratch.alloc_i64();
                 let b = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(a); local_set(b);
-                    local_get(b); local_get(a); i64_lt_s;
-                    if_i64; local_get(b); else_; local_get(a); end;
+                    local_set(Local(a)); local_set(Local(b));
+                    local_get(Local(b)); local_get(Local(a)); i64_lt_s;
+                    if_i64; local_get(Local(b)); else_; local_get(Local(a)); end;
                 });
                 self.scratch.free_i64(b);
                 self.scratch.free_i64(a);
@@ -804,13 +805,13 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 let s = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i64_const(0); i64_lt_s;
-                    if_i64; i64_const(-1);
+                    local_set(Local(s));
+                    local_get(Local(s)); i64_const(Imm64(0)); i64_lt_s;
+                    if_i64; i64_const(Imm64(-1));
                     else_;
-                      local_get(s); i64_const(0); i64_gt_s;
-                      if_i64; i64_const(1);
-                      else_; i64_const(0);
+                      local_get(Local(s)); i64_const(Imm64(0)); i64_gt_s;
+                      if_i64; i64_const(Imm64(1));
+                      else_; i64_const(Imm64(0));
                       end;
                     end;
                 });
@@ -833,33 +834,33 @@ impl FuncCompiler<'_> {
                 let base = self.scratch.alloc_i64();
                 let result = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(exp);
-                    local_set(base);
+                    local_set(Local(exp));
+                    local_set(Local(base));
                     // if exp < 0 { abort("negative exponent") }
-                    local_get(exp); i64_const(0); i64_lt_s;
+                    local_get(Local(exp)); i64_const(Imm64(0)); i64_lt_s;
                     if_empty;
-                      i32_const(neg_exp_msg); call(div_trap);
+                      i32_const(Imm32(neg_exp_msg)); call(div_trap);
                     end;
-                    i64_const(1); local_set(result);   // result = 1
+                    i64_const(Imm64(1)); local_set(Local(result));   // result = 1
                     // exponentiation by squaring; exp treated as an unsigned count
                     block_empty; loop_empty;
-                      local_get(exp); i64_eqz; br_if(1);          // while exp != 0
+                      local_get(Local(exp)); i64_eqz; br_if(1);          // while exp != 0
                       // if exp & 1 == 1 { result *= base }
-                      local_get(exp); i64_const(1); i64_and; i64_const(1); i64_eq;
+                      local_get(Local(exp)); i64_const(Imm64(1)); i64_and; i64_const(Imm64(1)); i64_eq;
                       if_empty;
-                        local_get(result); local_get(base); i64_mul; local_set(result);
+                        local_get(Local(result)); local_get(Local(base)); i64_mul; local_set(Local(result));
                       end;
                       // exp >>= 1  (logical: exp is a non-negative count here)
-                      local_get(exp); i64_const(1); i64_shr_u; local_set(exp);
+                      local_get(Local(exp)); i64_const(Imm64(1)); i64_shr_u; local_set(Local(exp));
                       // if exp != 0 { base *= base }   (avoid a final useless square)
-                      local_get(exp); i64_eqz;
+                      local_get(Local(exp)); i64_eqz;
                       if_empty;
                       else_;
-                        local_get(base); local_get(base); i64_mul; local_set(base);
+                        local_get(Local(base)); local_get(Local(base)); i64_mul; local_set(Local(base));
                       end;
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i64(result);
                 self.scratch.free_i64(base);
@@ -878,16 +879,16 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i64();
                 let i = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(n); // n
-                    i64_const(1); local_set(result); // result
-                    i64_const(FACTORIAL_START); local_set(i); // i
+                    local_set(Local(n)); // n
+                    i64_const(Imm64(1)); local_set(Local(result)); // result
+                    i64_const(Imm64(FACTORIAL_START)); local_set(Local(i)); // i
                     block_empty; loop_empty;
-                      local_get(i); local_get(n); i64_gt_s; br_if(1);
-                      local_get(result); local_get(i); i64_mul; local_set(result);
-                      local_get(i); i64_const(1); i64_add; local_set(i);
+                      local_get(Local(i)); local_get(Local(n)); i64_gt_s; br_if(1);
+                      local_get(Local(result)); local_get(Local(i)); i64_mul; local_set(Local(result));
+                      local_get(Local(i)); i64_const(Imm64(1)); i64_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i64(i);
                 self.scratch.free_i64(result);
@@ -903,23 +904,23 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i64();
                 let i = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_set(k);       // k
-                    local_set(n);   // n
-                    i64_const(1); local_set(result); // result
-                    i64_const(0); local_set(i); // i
+                    local_set(Local(k));       // k
+                    local_set(Local(n));   // n
+                    i64_const(Imm64(1)); local_set(Local(result)); // result
+                    i64_const(Imm64(0)); local_set(Local(i)); // i
                     block_empty; loop_empty;
-                      local_get(i); local_get(k); i64_ge_s; br_if(1);
+                      local_get(Local(i)); local_get(Local(k)); i64_ge_s; br_if(1);
                       // result = result * (n - i) / (i + 1)
-                      local_get(result);
-                      local_get(n); local_get(i); i64_sub;
+                      local_get(Local(result));
+                      local_get(Local(n)); local_get(Local(i)); i64_sub;
                       i64_mul;
-                      local_get(i); i64_const(1); i64_add;
+                      local_get(Local(i)); i64_const(Imm64(1)); i64_add;
                       i64_div_s;
-                      local_set(result);
-                      local_get(i); i64_const(1); i64_add; local_set(i);
+                      local_set(Local(result));
+                      local_get(Local(i)); i64_const(Imm64(1)); i64_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i64(i);
                 self.scratch.free_i64(result);
@@ -944,40 +945,40 @@ impl FuncCompiler<'_> {
                 let ag = self.scratch.alloc_f64();
                 self.emit_expr(&args[0]);
                 // Lanczos computes Γ(x+1), shift by -1 to get Γ(x)
-                wasm!(self.func, { f64_const(1.0); f64_sub; local_set(x); });
+                wasm!(self.func, { f64_const(1.0); f64_sub; local_set(Local(x)); });
                 let coeffs: [f64; 9] = [
                     0.99999999999980993, 676.5203681218851, -1259.1392167224028,
                     771.32342877765313, -176.61502916214059, 12.507343278686905,
                     -0.13857109526572012, 9.9843695780195716e-6, 1.5056327351493116e-7,
                 ];
-                wasm!(self.func, { f64_const(coeffs[0]); local_set(ag); });
+                wasm!(self.func, { f64_const(coeffs[0]); local_set(Local(ag)); });
                 for (i, &c) in coeffs[1..].iter().enumerate() {
                     wasm!(self.func, {
-                        local_get(ag);
+                        local_get(Local(ag));
                         f64_const(c);
-                        local_get(x); f64_const((i + 1) as f64); f64_add;
+                        local_get(Local(x)); f64_const((i + 1) as f64); f64_add;
                         f64_div;
                         f64_add;
-                        local_set(ag);
+                        local_set(Local(ag));
                     });
                 }
                 wasm!(self.func, {
-                    local_get(x); f64_const(LANCZOS_G_OFFSET); f64_add; local_set(t);
+                    local_get(Local(x)); f64_const(LANCZOS_G_OFFSET); f64_add; local_set(Local(t));
                 });
                 // Reuse ag as final result: ag = ln(ag)
                 wasm!(self.func, {
-                    local_get(ag); call(self.emitter.rt.math_log); local_set(ag);
+                    local_get(Local(ag)); call(self.emitter.rt.math_log); local_set(Local(ag));
                 });
                 // result = 0.5*ln(2π) + (x+0.5)*ln(t) - t + ag
                 // Reuse t slot: compute ln(t) and store back
                 wasm!(self.func, {
                     f64_const(HALF_LN_2PI);
-                    local_get(x); f64_const(0.5); f64_add;
-                    local_get(t); call(self.emitter.rt.math_log);
+                    local_get(Local(x)); f64_const(0.5); f64_add;
+                    local_get(Local(t)); call(self.emitter.rt.math_log);
                     f64_mul;
                     f64_add;
-                    local_get(t); f64_sub;
-                    local_get(ag); f64_add;
+                    local_get(Local(t)); f64_sub;
+                    local_get(Local(ag)); f64_add;
                 });
                 self.scratch.free_f64(ag);
                 self.scratch.free_f64(t);

--- a/crates/almide-codegen/src/emit_wasm/calls_numeric.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_numeric.rs
@@ -5,6 +5,32 @@ use almide_ir::IrExpr;
 use almide_lang::types::Ty;
 use wasm_encoder::Instruction;
 
+// ── Named immediates ─────────────────────────────────────────────────────────
+/// Number of bits in an i64 register.
+const I64_BITS: i64 = 64;
+/// Highest bit index in an i64 (= I64_BITS - 1); used in `63 - clz(n)`.
+const I64_MAX_BIT_IDX: i64 = 63;
+/// Number of bytes in an i64; also the byte_swap loop iteration count.
+const I64_BYTES: i64 = 8;
+/// Base for hexadecimal numeral system.
+const HEX_BASE: i64 = 16;
+/// Mask retaining the low 32 bits of an i64 (u32 range).
+const U32_MASK: i64 = 0xFFFF_FFFF;
+/// Mask retaining the low 8 bits of an i64/i32 (one byte).
+const LOW_BYTE_MASK_I64: i64 = 0xFF;
+/// ASCII code point for '0' (i32); used for digit '0'–'9' in hex output.
+const ASCII_ZERO: i32 = 48;
+/// Offset from a hex digit value (10..=15) to its lowercase ASCII letter
+/// ('a'=97, 97-10=87). Used in `to_hex` for letters a–f.
+const HEX_LETTER_OFFSET: i32 = 87;
+/// Decimal base; used to distinguish digit digits (< 10) from letter digits (>= 10).
+const DECIMAL_BASE: i32 = 10;
+/// Max bytes needed for an i64 hex string (16 hex digits + headroom = 20).
+const HEX_BUF_BYTES: i32 = 20;
+/// Loop start index for `factorial`: multiply from 2 upward.
+const FACTORIAL_START: i64 = 2;
+// ─────────────────────────────────────────────────────────────────────────────
+
 /// Bit width at and above which a `bits`-wide mask saturates to "all ones".
 /// `int.wrap_*` / `int.rotate_*` model an N-bit register; for `bits >= 64` the
 /// register is the full i64, so the mask is `u64::MAX`. This mirrors the native
@@ -344,11 +370,11 @@ impl FuncCompiler<'_> {
             }
             "to_u32" => {
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i64_const(0xFFFFFFFF); i64_and; });
+                wasm!(self.func, { i64_const(U32_MASK); i64_and; });
             }
             "to_u8" => {
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i64_const(0xFF); i64_and; });
+                wasm!(self.func, { i64_const(LOW_BYTE_MASK_I64); i64_and; });
             }
             "count_leading_zeros" => {
                 self.emit_expr(&args[0]);
@@ -373,7 +399,7 @@ impl FuncCompiler<'_> {
                     i64_const(0); local_set(dst);
                     i64_const(0); local_set(i);
                     block_empty; loop_empty;
-                        local_get(i); i64_const(64); i64_ge_s; br_if(1);
+                        local_get(i); i64_const(I64_BITS); i64_ge_s; br_if(1);
                         // dst = (dst << 1) | (src & 1)
                         local_get(dst); i64_const(1); i64_shl;
                         local_get(src); i64_const(1); i64_and;
@@ -400,13 +426,13 @@ impl FuncCompiler<'_> {
                     i64_const(0); local_set(dst);
                     i64_const(0); local_set(i);
                     block_empty; loop_empty;
-                        local_get(i); i64_const(8); i64_ge_s; br_if(1);
+                        local_get(i); i64_const(I64_BYTES); i64_ge_s; br_if(1);
                         // dst = (dst << 8) | (src & 0xFF)
-                        local_get(dst); i64_const(8); i64_shl;
-                        local_get(src); i64_const(0xFF); i64_and;
+                        local_get(dst); i64_const(I64_BYTES); i64_shl;
+                        local_get(src); i64_const(LOW_BYTE_MASK_I64); i64_and;
                         i64_or; local_set(dst);
                         // src >>= 8
-                        local_get(src); i64_const(8); i64_shr_u; local_set(src);
+                        local_get(src); i64_const(I64_BYTES); i64_shr_u; local_set(src);
                         local_get(i); i64_const(1); i64_add; local_set(i);
                         br(0);
                     end; end;
@@ -426,7 +452,7 @@ impl FuncCompiler<'_> {
                     if_i64;
                         i64_const(0);
                     else_;
-                        i64_const(64); local_get(n); i64_clz; i64_sub;
+                        i64_const(I64_BITS); local_get(n); i64_clz; i64_sub;
                     end;
                 });
                 self.scratch.free_i64(n);
@@ -441,7 +467,7 @@ impl FuncCompiler<'_> {
                     if_i64;
                         i64_const(-1);
                     else_;
-                        i64_const(63); local_get(n); i64_clz; i64_sub;
+                        i64_const(I64_MAX_BIT_IDX); local_get(n); i64_clz; i64_sub;
                     end;
                 });
                 self.scratch.free_i64(n);
@@ -456,7 +482,7 @@ impl FuncCompiler<'_> {
                     if_i64;
                         i64_const(0);
                     else_;
-                        i64_const(64);
+                        i64_const(I64_BITS);
                         local_get(n); i64_const(1); i64_sub; i64_clz;
                         i64_sub;
                     end;
@@ -474,7 +500,7 @@ impl FuncCompiler<'_> {
                         i64_const(1);
                     else_;
                         i64_const(1);
-                        i64_const(64);
+                        i64_const(I64_BITS);
                         local_get(n); i64_const(1); i64_sub; i64_clz;
                         i64_sub;
                         i64_shl;
@@ -493,7 +519,7 @@ impl FuncCompiler<'_> {
                         i64_const(0);
                     else_;
                         i64_const(1);
-                        i64_const(63); local_get(n); i64_clz; i64_sub;
+                        i64_const(I64_MAX_BIT_IDX); local_get(n); i64_clz; i64_sub;
                         i64_shl;
                     end;
                 });
@@ -539,26 +565,26 @@ impl FuncCompiler<'_> {
                       i32_const(1); call(self.emitter.rt.string_alloc); local_set(buf);
                       local_get(buf); i32_const(1); i32_store(0);
                       local_get(buf); i32_const(1); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
-                      local_get(buf); i32_const(48); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
+                      local_get(buf); i32_const(ASCII_ZERO); i32_store8(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32);
                       local_get(buf);
                     else_;
                       // Alloc temp buffer for reversed digits
-                      i32_const(20); call(self.emitter.rt.alloc); local_set(buf); // buf
+                      i32_const(HEX_BUF_BYTES); call(self.emitter.rt.alloc); local_set(buf); // buf
                       i32_const(0); local_set(count); // count
                 });
                 wasm!(self.func, {
                       block_empty; loop_empty;
                         local_get(n64); i64_eqz; br_if(1);
-                        local_get(n64); i64_const(16); i64_rem_u; i32_wrap_i64;
+                        local_get(n64); i64_const(HEX_BASE); i64_rem_u; i32_wrap_i64;
                         local_set(digit); // digit
-                        local_get(digit); i32_const(10); i32_lt_u;
-                        if_i32; local_get(digit); i32_const(48); i32_add;
-                        else_; local_get(digit); i32_const(87); i32_add; end;
+                        local_get(digit); i32_const(DECIMAL_BASE); i32_lt_u;
+                        if_i32; local_get(digit); i32_const(ASCII_ZERO); i32_add;
+                        else_; local_get(digit); i32_const(HEX_LETTER_OFFSET); i32_add; end;
                         local_set(digit); // char
                         local_get(buf); local_get(count); i32_add;
                         local_get(digit); i32_store8(0);
                         local_get(count); i32_const(1); i32_add; local_set(count);
-                        local_get(n64); i64_const(16); i64_div_u; local_set(n64);
+                        local_get(n64); i64_const(HEX_BASE); i64_div_u; local_set(n64);
                         br(0);
                       end; end;
                 });
@@ -854,7 +880,7 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     local_set(n); // n
                     i64_const(1); local_set(result); // result
-                    i64_const(2); local_set(i); // i
+                    i64_const(FACTORIAL_START); local_set(i); // i
                     block_empty; loop_empty;
                       local_get(i); local_get(n); i64_gt_s; br_if(1);
                       local_get(result); local_get(i); i64_mul; local_set(result);

--- a/crates/almide-codegen/src/emit_wasm/calls_option.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_option.rs
@@ -1,5 +1,6 @@
 //! Option and Result stdlib call dispatch for WASM codegen.
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use super::FuncCompiler;
 use super::values;
 use almide_ir::IrExpr;
@@ -23,7 +24,7 @@ impl FuncCompiler<'_> {
             "is_some" => {
                 // is_some(opt) → Bool(i32): ptr != 0
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_const(0); i32_ne; });
+                wasm!(self.func, { i32_const(Imm32(0)); i32_ne; });
             }
             "is_none" => {
                 self.emit_expr(&args[0]);
@@ -39,28 +40,28 @@ impl FuncCompiler<'_> {
                 match vt {
                     Some(ValType::I64) => {
                         wasm!(self.func, {
-                            local_set(s);
-                            local_get(s); i32_eqz;
+                            local_set(Local(s));
+                            local_get(Local(s)); i32_eqz;
                             if_i64;
                         });
                         self.emit_expr(&args[1]);
                         wasm!(self.func, {
                             else_;
-                              local_get(s);
+                              local_get(Local(s));
                               i64_load(0);
                             end;
                         });
                     }
                     Some(ValType::F64) => {
                         wasm!(self.func, {
-                            local_set(s);
-                            local_get(s); i32_eqz;
+                            local_set(Local(s));
+                            local_get(Local(s)); i32_eqz;
                             if_f64;
                         });
                         self.emit_expr(&args[1]);
                         wasm!(self.func, {
                             else_;
-                              local_get(s);
+                              local_get(Local(s));
                               f64_load(0);
                             end;
                         });
@@ -68,14 +69,14 @@ impl FuncCompiler<'_> {
                     _ => {
                         // i32 (String, Option, etc.)
                         wasm!(self.func, {
-                            local_set(s);
-                            local_get(s); i32_eqz;
+                            local_set(Local(s));
+                            local_get(Local(s)); i32_eqz;
                             if_i32;
                         });
                         self.emit_expr(&args[1]);
                         wasm!(self.func, {
                             else_;
-                              local_get(s);
+                              local_get(Local(s));
                               i32_load(0);
                             end;
                         });
@@ -91,37 +92,37 @@ impl FuncCompiler<'_> {
                 let s = self.scratch.alloc_i32();
                 // Store opt
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(opt); });
+                wasm!(self.func, { local_set(Local(opt)); });
                 // Store closure
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(opt); i32_eqz; // opt == 0?
+                    local_set(Local(closure));
+                    local_get(Local(opt)); i32_eqz; // opt == 0?
                     if_i32;
-                      i32_const(0); // none
+                      i32_const(Imm32(0)); // none
                     else_;
                 });
                 let out_ty = self.fn_ret_ty(&args[1].ty);
                 let out_size = values::byte_size(&out_ty);
                 wasm!(self.func, {
-                    i32_const(out_size as i32);
+                    i32_const(Imm32(out_size as i32));
                     call(self.emitter.rt.alloc);
-                    local_set(s);
-                    local_get(s);
+                    local_set(Local(s));
+                    local_get(Local(s));
                     // env_ptr
-                    local_get(closure); i32_load(4);
+                    local_get(Local(closure)); i32_load(4);
                     // Load inner value
-                    local_get(opt);
+                    local_get(Local(opt));
                 });
                 self.emit_load_at(&inner_ty, 0);
                 // table_idx
                 wasm!(self.func, {
-                    local_get(closure); i32_load(0);
+                    local_get(Local(closure)); i32_load(0);
                 });
                 self.emit_closure_call(&inner_ty, &out_ty);
                 self.emit_store_at(&out_ty, 0);
                 wasm!(self.func, {
-                      local_get(s);
+                      local_get(Local(s));
                     end;
                 });
                 self.scratch.free_i32(s);
@@ -140,21 +141,21 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 // Store opt
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(opt); });
+                wasm!(self.func, { local_set(Local(opt)); });
                 // Store closure
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(opt); i32_eqz; // opt == 0?
+                    local_set(Local(closure));
+                    local_get(Local(opt)); i32_eqz; // opt == 0?
                     if_i32;
-                      i32_const(0);
+                      i32_const(Imm32(0));
                     else_;
-                      local_get(closure); i32_load(4); // env
+                      local_get(Local(closure)); i32_load(4); // env
                 });
-                wasm!(self.func, { local_get(opt); });
+                wasm!(self.func, { local_get(Local(opt)); });
                 self.emit_load_at(&inner_ty, 0);
                 wasm!(self.func, {
-                    local_get(closure); i32_load(0); // table_idx
+                    local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 // Result is i32 (Option ptr)
                 self.emit_closure_call(&inner_ty, &Ty::Unknown);
@@ -167,15 +168,15 @@ impl FuncCompiler<'_> {
                 let s = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_eqz;
+                    local_set(Local(s));
+                    local_get(Local(s)); i32_eqz;
                     if_i32;
-                      i32_const(0);
+                      i32_const(Imm32(0));
                     else_;
                       // SHARE: the inner Option is borrowed out of the outer box;
                       // it must own a +1 or the let-bound result double-frees it
                       // against the outer's payload Dec (#666). No-op when inner=0.
-                      local_get(s);
+                      local_get(Local(s));
                       i32_load(0); // inner Option ptr
                       call(self.emitter.rt.rc_inc);
                     end;
@@ -190,22 +191,22 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 // Store opt
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(opt); });
+                wasm!(self.func, { local_set(Local(opt)); });
                 // Store closure
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(opt); i32_eqz; // opt == 0?
+                    local_set(Local(closure));
+                    local_get(Local(opt)); i32_eqz; // opt == 0?
                     if_i32;
-                      i32_const(0);
+                      i32_const(Imm32(0));
                     else_;
                       // Call pred(*opt)
-                      local_get(closure); i32_load(4); // env
+                      local_get(Local(closure)); i32_load(4); // env
                 });
-                wasm!(self.func, { local_get(opt); });
+                wasm!(self.func, { local_get(Local(opt)); });
                 self.emit_load_at(&inner_ty, 0);
                 wasm!(self.func, {
-                    local_get(closure); i32_load(0); // table_idx
+                    local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 self.emit_closure_call(&inner_ty, &Ty::Bool);
                 // Result is Bool(i32): if true return opt, else 0.
@@ -215,9 +216,9 @@ impl FuncCompiler<'_> {
                 // double-free it (#666). rc_inc is a no-op on the none(0) branch.
                 wasm!(self.func, {
                       if_i32;
-                        local_get(opt); call(self.emitter.rt.rc_inc);
+                        local_get(Local(opt)); call(self.emitter.rt.rc_inc);
                       else_;
-                        i32_const(0);
+                        i32_const(Imm32(0));
                       end;
                     end;
                 });
@@ -236,33 +237,33 @@ impl FuncCompiler<'_> {
                 let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_eqz;
+                    local_set(Local(s));
+                    local_get(Local(s)); i32_eqz;
                     if_i32;
                       // err(err_msg)
-                      i32_const((4 + err_size) as i32);
+                      i32_const(Imm32((4 + err_size) as i32));
                       call(self.emitter.rt.alloc);
-                      local_set(s2);
-                      local_get(s2); i32_const(1); i32_store(0); // tag=1
-                      local_get(s2);
+                      local_set(Local(s2));
+                      local_get(Local(s2)); i32_const(Imm32(1)); i32_store(0); // tag=1
+                      local_get(Local(s2));
                 });
                 self.emit_expr(&args[1]); // err_msg
                 wasm!(self.func, {
                       i32_store(4);
-                      local_get(s2);
+                      local_get(Local(s2));
                     else_;
                       // ok(*opt)
-                      i32_const(alloc_size as i32);
+                      i32_const(Imm32(alloc_size as i32));
                       call(self.emitter.rt.alloc);
-                      local_set(s2);
-                      local_get(s2); i32_const(0); i32_store(0); // tag=0
-                      local_get(s2);
-                      local_get(s);
+                      local_set(Local(s2));
+                      local_get(Local(s2)); i32_const(Imm32(0)); i32_store(0); // tag=0
+                      local_get(Local(s2));
+                      local_get(Local(s));
                 });
                 self.emit_load_at(&inner_ty, 0);
                 self.emit_store_at(&inner_ty, 4);
                 wasm!(self.func, {
-                      local_get(s2);
+                      local_get(Local(s2));
                     end;
                 });
                 self.scratch.free_i32(s2);
@@ -274,18 +275,18 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 // Store opt
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(opt); });
+                wasm!(self.func, { local_set(Local(opt)); });
                 // Store closure
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(opt); i32_eqz; // opt == 0?
+                    local_set(Local(closure));
+                    local_get(Local(opt)); i32_eqz; // opt == 0?
                     if_i32;
                 });
                 // Call f() — thunk returning Option
                 wasm!(self.func, {
-                    local_get(closure); i32_load(4); // env
-                    local_get(closure); i32_load(0); // table_idx
+                    local_get(Local(closure)); i32_load(4); // env
+                    local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 // call_indirect () → i32
                 let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
@@ -294,7 +295,7 @@ impl FuncCompiler<'_> {
                     else_;
                       // SHARE: the some path returns the INPUT box — own a +1 so the
                       // let-bound result doesn't double-free it with the input (#666).
-                      local_get(opt); call(self.emitter.rt.rc_inc);
+                      local_get(Local(opt)); call(self.emitter.rt.rc_inc);
                     end;
                 });
                 self.scratch.free_i32(closure);
@@ -308,38 +309,38 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 // Store opt
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(opt); });
+                wasm!(self.func, { local_set(Local(opt)); });
                 // Store closure
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(closure); });
+                wasm!(self.func, { local_set(Local(closure)); });
                 match vt {
                     ValType::I64 => {
-                        wasm!(self.func, { local_get(opt); i32_eqz; if_i64; });
+                        wasm!(self.func, { local_get(Local(opt)); i32_eqz; if_i64; });
                         // f()
                         wasm!(self.func, {
-                            local_get(closure); i32_load(4);
-                            local_get(closure); i32_load(0);
+                            local_get(Local(closure)); i32_load(4);
+                            local_get(Local(closure)); i32_load(0);
                         });
                         let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::I64]);
-                        wasm!(self.func, { call_indirect(ti, 0); else_; local_get(opt); i64_load(0); end; });
+                        wasm!(self.func, { call_indirect(ti, 0); else_; local_get(Local(opt)); i64_load(0); end; });
                     }
                     ValType::F64 => {
-                        wasm!(self.func, { local_get(opt); i32_eqz; if_f64; });
+                        wasm!(self.func, { local_get(Local(opt)); i32_eqz; if_f64; });
                         wasm!(self.func, {
-                            local_get(closure); i32_load(4);
-                            local_get(closure); i32_load(0);
+                            local_get(Local(closure)); i32_load(4);
+                            local_get(Local(closure)); i32_load(0);
                         });
                         let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::F64]);
-                        wasm!(self.func, { call_indirect(ti, 0); else_; local_get(opt); f64_load(0); end; });
+                        wasm!(self.func, { call_indirect(ti, 0); else_; local_get(Local(opt)); f64_load(0); end; });
                     }
                     _ => {
-                        wasm!(self.func, { local_get(opt); i32_eqz; if_i32; });
+                        wasm!(self.func, { local_get(Local(opt)); i32_eqz; if_i32; });
                         wasm!(self.func, {
-                            local_get(closure); i32_load(4);
-                            local_get(closure); i32_load(0);
+                            local_get(Local(closure)); i32_load(4);
+                            local_get(Local(closure)); i32_load(0);
                         });
                         let ti = self.emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
-                        wasm!(self.func, { call_indirect(ti, 0); else_; local_get(opt); i32_load(0); end; });
+                        wasm!(self.func, { call_indirect(ti, 0); else_; local_get(Local(opt)); i32_load(0); end; });
                     }
                 }
                 self.scratch.free_i32(closure);
@@ -353,24 +354,24 @@ impl FuncCompiler<'_> {
                 let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_eqz;
+                    local_set(Local(s));
+                    local_get(Local(s)); i32_eqz;
                     if_i32;
                       // empty list: [len=0][cap=0]
-                      i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); call(self.emitter.rt.alloc); local_set(s2);
-                      local_get(s2); i32_const(0); i32_store(0);
-                      local_get(s2);
+                      i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); call(self.emitter.rt.alloc); local_set(Local(s2));
+                      local_get(Local(s2)); i32_const(Imm32(0)); i32_store(0);
+                      local_get(Local(s2));
                     else_;
                       // [len=1, cap=0, elem]
-                      i32_const((self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + elem_size as i32)); call(self.emitter.rt.alloc); local_set(s2);
-                      local_get(s2); i32_const(1); i32_store(0);
-                      local_get(s2);
-                      local_get(s);
+                      i32_const(Imm32((self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32 + elem_size as i32))); call(self.emitter.rt.alloc); local_set(Local(s2));
+                      local_get(Local(s2)); i32_const(Imm32(1)); i32_store(0);
+                      local_get(Local(s2));
+                      local_get(Local(s));
                 });
                 self.emit_load_at(&inner_ty, 0);
                 self.emit_store_at(&inner_ty, self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32 as u32);
                 wasm!(self.func, {
-                      local_get(s2);
+                      local_get(Local(s2));
                     end;
                 });
                 self.scratch.free_i32(s2);
@@ -384,15 +385,15 @@ impl FuncCompiler<'_> {
                 let s_tuple = self.scratch.alloc_i32();
                 let s_some = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(sa); });
+                wasm!(self.func, { local_set(Local(sa)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(sb);
-                    local_get(sa); i32_eqz;
-                    local_get(sb); i32_eqz;
+                    local_set(Local(sb));
+                    local_get(Local(sa)); i32_eqz;
+                    local_get(Local(sb)); i32_eqz;
                     i32_or;
                     if_i32;
-                      i32_const(0);
+                      i32_const(Imm32(0));
                     else_;
                 });
                 // Allocate tuple and wrap in some
@@ -403,24 +404,24 @@ impl FuncCompiler<'_> {
                 let tuple_size = a_size + b_size;
                 // Tuple ptr
                 wasm!(self.func, {
-                    i32_const(tuple_size as i32); call(self.emitter.rt.alloc);
-                    local_set(s_tuple);
-                    local_get(s_tuple);
-                    local_get(sa);
+                    i32_const(Imm32(tuple_size as i32)); call(self.emitter.rt.alloc);
+                    local_set(Local(s_tuple));
+                    local_get(Local(s_tuple));
+                    local_get(Local(sa));
                 });
                 self.emit_load_at(&a_ty, 0);
                 self.emit_store_at(&a_ty, 0);
-                wasm!(self.func, { local_get(s_tuple); local_get(sb); });
+                wasm!(self.func, { local_get(Local(s_tuple)); local_get(Local(sb)); });
                 self.emit_load_at(&b_ty, 0);
                 self.emit_store_at(&b_ty, a_size as u32);
                 // Wrap tuple in Some: alloc ptr-size, store tuple ptr
                 wasm!(self.func, {
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc);
-                    local_set(s_some);
-                    local_get(s_some);
-                    local_get(s_tuple);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc);
+                    local_set(Local(s_some));
+                    local_get(Local(s_some));
+                    local_get(Local(s_tuple));
                     i32_store(0);
-                    local_get(s_some);
+                    local_get(Local(s_some));
                     end;
                 });
                 self.scratch.free_i32(s_some);
@@ -442,7 +443,7 @@ impl FuncCompiler<'_> {
             }
             "is_err" => {
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_load(0); i32_const(0); i32_ne; });
+                wasm!(self.func, { i32_load(0); i32_const(Imm32(0)); i32_ne; });
             }
             "unwrap_or" => {
                 // unwrap_or(result, default) → T
@@ -452,17 +453,17 @@ impl FuncCompiler<'_> {
                 let vt = values::ty_to_valtype(&inner_ty).unwrap_or(ValType::I32);
                 match vt {
                     ValType::I64 => {
-                        wasm!(self.func, { local_set(s); local_get(s); i32_load(0); i32_eqz; if_i64; local_get(s); i64_load(4); else_; });
+                        wasm!(self.func, { local_set(Local(s)); local_get(Local(s)); i32_load(0); i32_eqz; if_i64; local_get(Local(s)); i64_load(4); else_; });
                         self.emit_expr(&args[1]);
                         wasm!(self.func, { end; });
                     }
                     ValType::F64 => {
-                        wasm!(self.func, { local_set(s); local_get(s); i32_load(0); i32_eqz; if_f64; local_get(s); f64_load(4); else_; });
+                        wasm!(self.func, { local_set(Local(s)); local_get(Local(s)); i32_load(0); i32_eqz; if_f64; local_get(Local(s)); f64_load(4); else_; });
                         self.emit_expr(&args[1]);
                         wasm!(self.func, { end; });
                     }
                     _ => {
-                        wasm!(self.func, { local_set(s); local_get(s); i32_load(0); i32_eqz; if_i32; local_get(s); i32_load(4); else_; });
+                        wasm!(self.func, { local_set(Local(s)); local_get(Local(s)); i32_load(0); i32_eqz; if_i32; local_get(Local(s)); i32_load(4); else_; });
                         self.emit_expr(&args[1]);
                         wasm!(self.func, { end; });
                     }
@@ -476,33 +477,33 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 // Store result
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(result); });
+                wasm!(self.func, { local_set(Local(result)); });
                 // Store closure
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(closure); });
+                wasm!(self.func, { local_set(Local(closure)); });
                 self.emit_result_branch_err(result);
                 wasm!(self.func, {
                     if_i32;
                       // SHARE: err path returns the INPUT box — own a +1 so the
                       // let-bound result doesn't double-free it with the input (#666).
-                      local_get(result); call(self.emitter.rt.rc_inc); // return err as-is
+                      local_get(Local(result)); call(self.emitter.rt.rc_inc); // return err as-is
                     else_;
                 });
                 let out_ty = self.fn_ret_ty(&args[1].ty);
                 let s = self.emit_result_alloc_ok(&out_ty);
                 wasm!(self.func, {
-                    local_get(s);
+                    local_get(Local(s));
                     // env
-                    local_get(closure); i32_load(4);
+                    local_get(Local(closure)); i32_load(4);
                     // Load ok value from result
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.emit_load_at(&ok_ty, 4);
                 // table_idx
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 self.emit_closure_call(&ok_ty, &out_ty);
                 self.emit_store_at(&out_ty, 4);
-                wasm!(self.func, { local_get(s); end; });
+                wasm!(self.func, { local_get(Local(s)); end; });
                 self.scratch.free_i32(s);
                 self.scratch.free_i32(closure);
                 self.scratch.free_i32(result);
@@ -514,30 +515,30 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 // Store result
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(result); });
+                wasm!(self.func, { local_set(Local(result)); });
                 // Store closure
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(closure); });
+                wasm!(self.func, { local_set(Local(closure)); });
                 self.emit_result_branch_ok(result);
                 wasm!(self.func, {
                     if_i32;
                       // SHARE: ok path returns the INPUT box — own a +1 so the
                       // let-bound result doesn't double-free it with the input (#666).
-                      local_get(result); call(self.emitter.rt.rc_inc); // return ok as-is
+                      local_get(Local(result)); call(self.emitter.rt.rc_inc); // return ok as-is
                     else_;
                 });
                 let out_ty = self.fn_ret_ty(&args[1].ty);
                 let s = self.emit_result_alloc_err(&out_ty);
                 wasm!(self.func, {
-                    local_get(s);
-                    local_get(closure); i32_load(4); // env
+                    local_get(Local(s));
+                    local_get(Local(closure)); i32_load(4); // env
                 });
-                wasm!(self.func, { local_get(result); });
+                wasm!(self.func, { local_get(Local(result)); });
                 self.emit_load_at(&err_ty, 4);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 self.emit_closure_call(&err_ty, &out_ty);
                 self.emit_store_at(&out_ty, 4);
-                wasm!(self.func, { local_get(s); end; });
+                wasm!(self.func, { local_get(Local(s)); end; });
                 self.scratch.free_i32(s);
                 self.scratch.free_i32(closure);
                 self.scratch.free_i32(result);
@@ -549,22 +550,22 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 // Store result
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(result); });
+                wasm!(self.func, { local_set(Local(result)); });
                 // Store closure
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(closure); });
+                wasm!(self.func, { local_set(Local(closure)); });
                 self.emit_result_branch_err(result);
                 wasm!(self.func, {
                     if_i32;
                       // SHARE: err path returns the INPUT box — own a +1 so the
                       // let-bound result doesn't double-free it with the input (#666).
-                      local_get(result); call(self.emitter.rt.rc_inc); // return err as-is
+                      local_get(Local(result)); call(self.emitter.rt.rc_inc); // return err as-is
                     else_;
-                      local_get(closure); i32_load(4); // env
+                      local_get(Local(closure)); i32_load(4); // env
                 });
-                wasm!(self.func, { local_get(result); });
+                wasm!(self.func, { local_get(Local(result)); });
                 self.emit_load_at(&ok_ty, 4);
-                wasm!(self.func, { local_get(closure); i32_load(0); });
+                wasm!(self.func, { local_get(Local(closure)); i32_load(0); });
                 // Returns Result ptr (i32)
                 self.emit_closure_call(&ok_ty, &Ty::Unknown);
                 wasm!(self.func, { end; });
@@ -579,19 +580,19 @@ impl FuncCompiler<'_> {
                 let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); i32_const(0); i32_ne;
+                    local_set(Local(s));
+                    local_get(Local(s)); i32_load(0); i32_const(Imm32(0)); i32_ne;
                     if_i32;
-                      i32_const(0); // none
+                      i32_const(Imm32(0)); // none
                     else_;
                       // some(ok_value)
-                      i32_const(ok_size as i32); call(self.emitter.rt.alloc); local_set(s2);
-                      local_get(s2);
-                      local_get(s);
+                      i32_const(Imm32(ok_size as i32)); call(self.emitter.rt.alloc); local_set(Local(s2));
+                      local_get(Local(s2));
+                      local_get(Local(s));
                 });
                 self.emit_load_at(&ok_ty, 4);
                 self.emit_store_at(&ok_ty, 0);
-                wasm!(self.func, { local_get(s2); end; });
+                wasm!(self.func, { local_get(Local(s2)); end; });
                 self.scratch.free_i32(s2);
                 self.scratch.free_i32(s);
             }
@@ -602,18 +603,18 @@ impl FuncCompiler<'_> {
                 let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); i32_eqz;
+                    local_set(Local(s));
+                    local_get(Local(s)); i32_load(0); i32_eqz;
                     if_i32;
-                      i32_const(0); // none (was ok)
+                      i32_const(Imm32(0)); // none (was ok)
                     else_;
-                      i32_const(err_size as i32); call(self.emitter.rt.alloc); local_set(s2);
-                      local_get(s2);
-                      local_get(s);
+                      i32_const(Imm32(err_size as i32)); call(self.emitter.rt.alloc); local_set(Local(s2));
+                      local_get(Local(s2));
+                      local_get(Local(s));
                 });
                 self.emit_load_at(&err_ty, 4);
                 self.emit_store_at(&err_ty, 0);
-                wasm!(self.func, { local_get(s2); end; });
+                wasm!(self.func, { local_get(Local(s2)); end; });
                 self.scratch.free_i32(s2);
                 self.scratch.free_i32(s);
             }
@@ -624,22 +625,22 @@ impl FuncCompiler<'_> {
                 let closure = self.scratch.alloc_i32();
                 // Store result
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(result); });
+                wasm!(self.func, { local_set(Local(result)); });
                 // Store closure
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(closure); });
+                wasm!(self.func, { local_set(Local(closure)); });
                 match vt {
                     ValType::I64 => {
-                        wasm!(self.func, { local_get(result); i32_load(0); i32_eqz; if_i64; local_get(result); i64_load(4); else_; });
+                        wasm!(self.func, { local_get(Local(result)); i32_load(0); i32_eqz; if_i64; local_get(Local(result)); i64_load(4); else_; });
                         // f(err)
-                        wasm!(self.func, { local_get(closure); i32_load(4); local_get(result); i32_load(4); local_get(closure); i32_load(0); });
+                        wasm!(self.func, { local_get(Local(closure)); i32_load(4); local_get(Local(result)); i32_load(4); local_get(Local(closure)); i32_load(0); });
                         let err_ty = self.result_err_ty(&args[0].ty);
                         self.emit_closure_call(&err_ty, &ok_ty);
                         wasm!(self.func, { end; });
                     }
                     _ => {
-                        wasm!(self.func, { local_get(result); i32_load(0); i32_eqz; if_i32; local_get(result); i32_load(4); else_; });
-                        wasm!(self.func, { local_get(closure); i32_load(4); local_get(result); i32_load(4); local_get(closure); i32_load(0); });
+                        wasm!(self.func, { local_get(Local(result)); i32_load(0); i32_eqz; if_i32; local_get(Local(result)); i32_load(4); else_; });
+                        wasm!(self.func, { local_get(Local(closure)); i32_load(4); local_get(Local(result)); i32_load(4); local_get(Local(closure)); i32_load(0); });
                         let err_ty = self.result_err_ty(&args[0].ty);
                         self.emit_closure_call(&err_ty, &ok_ty);
                         wasm!(self.func, { end; });
@@ -668,41 +669,41 @@ impl FuncCompiler<'_> {
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(rs);
-                    local_get(rs); i32_load(0); local_set(len);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(len); i32_const(ok_size); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(ok_list);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(len); i32_const(err_size); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(err_list);
-                    i32_const(0); local_set(ok_cnt);
-                    i32_const(0); local_set(err_cnt);
-                    i32_const(0); local_set(i);
+                    local_set(Local(rs));
+                    local_get(Local(rs)); i32_load(0); local_set(Local(len));
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(len)); i32_const(Imm32(ok_size)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(ok_list));
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(len)); i32_const(Imm32(err_size)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(err_list));
+                    i32_const(Imm32(0)); local_set(Local(ok_cnt));
+                    i32_const(Imm32(0)); local_set(Local(err_cnt));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(rs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      i32_load(0); local_set(elem);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(rs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      i32_load(0); local_set(Local(elem));
                 });
                 self.emit_result_sort_into_lists(
                     &ok_ty, &err_ty, ok_size, err_size,
                     ok_list, err_list, ok_cnt, err_cnt, elem,
                 );
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(ok_list); local_get(ok_cnt); i32_store(0);
-                    local_get(err_list); local_get(err_cnt); i32_store(0);
-                    i32_const(TWO_I32_BYTES); call(self.emitter.rt.alloc); local_set(out);
-                    local_get(err_cnt); i32_eqz;
+                    local_get(Local(ok_list)); local_get(Local(ok_cnt)); i32_store(0);
+                    local_get(Local(err_list)); local_get(Local(err_cnt)); i32_store(0);
+                    i32_const(Imm32(TWO_I32_BYTES)); call(self.emitter.rt.alloc); local_set(Local(out));
+                    local_get(Local(err_cnt)); i32_eqz;
                     if_empty;
-                      local_get(out); i32_const(0); i32_store(0);
-                      local_get(out); local_get(ok_list); i32_store(4);
+                      local_get(Local(out)); i32_const(Imm32(0)); i32_store(0);
+                      local_get(Local(out)); local_get(Local(ok_list)); i32_store(4);
                     else_;
-                      local_get(out); i32_const(1); i32_store(0);
-                      local_get(out); local_get(err_list); i32_store(4);
+                      local_get(Local(out)); i32_const(Imm32(1)); i32_store(0);
+                      local_get(Local(out)); local_get(Local(err_list)); i32_store(4);
                     end;
-                    local_get(out);
+                    local_get(Local(out));
                 });
 
                 self.scratch.free_i32(out);
@@ -735,35 +736,35 @@ impl FuncCompiler<'_> {
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(rs);
-                    local_get(rs); i32_load(0); local_set(len);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(len); i32_const(ok_size); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(ok_list);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(len); i32_const(err_size); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(err_list);
-                    i32_const(0); local_set(ok_cnt);
-                    i32_const(0); local_set(err_cnt);
-                    i32_const(0); local_set(i);
+                    local_set(Local(rs));
+                    local_get(Local(rs)); i32_load(0); local_set(Local(len));
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(len)); i32_const(Imm32(ok_size)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(ok_list));
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(len)); i32_const(Imm32(err_size)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(err_list));
+                    i32_const(Imm32(0)); local_set(Local(ok_cnt));
+                    i32_const(Imm32(0)); local_set(Local(err_cnt));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(rs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      i32_load(0); local_set(elem);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(rs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      i32_load(0); local_set(Local(elem));
                 });
                 self.emit_result_sort_into_lists(
                     &ok_ty, &err_ty, ok_size, err_size,
                     ok_list, err_list, ok_cnt, err_cnt, elem,
                 );
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(ok_list); local_get(ok_cnt); i32_store(0);
-                    local_get(err_list); local_get(err_cnt); i32_store(0);
-                    i32_const(TWO_I32_BYTES); call(self.emitter.rt.alloc); local_set(tuple_ptr);
-                    local_get(tuple_ptr); local_get(ok_list); i32_store(0);
-                    local_get(tuple_ptr); local_get(err_list); i32_store(4);
-                    local_get(tuple_ptr);
+                    local_get(Local(ok_list)); local_get(Local(ok_cnt)); i32_store(0);
+                    local_get(Local(err_list)); local_get(Local(err_cnt)); i32_store(0);
+                    i32_const(Imm32(TWO_I32_BYTES)); call(self.emitter.rt.alloc); local_set(Local(tuple_ptr));
+                    local_get(Local(tuple_ptr)); local_get(Local(ok_list)); i32_store(0);
+                    local_get(Local(tuple_ptr)); local_get(Local(err_list)); i32_store(4);
+                    local_get(Local(tuple_ptr));
                 });
 
                 self.scratch.free_i32(tuple_ptr);
@@ -799,28 +800,28 @@ impl FuncCompiler<'_> {
                 let out = self.scratch.alloc_i32();
 
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(xs); });
+                wasm!(self.func, { local_set(Local(xs)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(closure);
-                    local_get(xs); i32_load(0); local_set(len);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(len); i32_const(ok_size); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(ok_list);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(len); i32_const(err_size); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(err_list);
-                    i32_const(0); local_set(ok_cnt);
-                    i32_const(0); local_set(err_cnt);
-                    i32_const(0); local_set(i);
+                    local_set(Local(closure));
+                    local_get(Local(xs)); i32_load(0); local_set(Local(len));
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(len)); i32_const(Imm32(ok_size)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(ok_list));
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(len)); i32_const(Imm32(err_size)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(err_list));
+                    i32_const(Imm32(0)); local_set(Local(ok_cnt));
+                    i32_const(Imm32(0)); local_set(Local(err_cnt));
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                       // Call closure with xs[i]
-                      local_get(closure); i32_load(4); // env
-                      local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(closure)); i32_load(4); // env
+                      local_get(Local(xs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(closure); i32_load(0); // table_idx
+                      local_get(Local(closure)); i32_load(0); // table_idx
                 });
                 // call_indirect: (env, elem) -> Result ptr (i32)
                 {
@@ -830,28 +831,28 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call_indirect(ti, 0); });
                 }
                 wasm!(self.func, {
-                      local_set(res_ptr);
+                      local_set(Local(res_ptr));
                 });
                 self.emit_result_sort_into_lists(
                     &ok_ty, &err_ty, ok_size, err_size,
                     ok_list, err_list, ok_cnt, err_cnt, res_ptr,
                 );
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(ok_list); local_get(ok_cnt); i32_store(0);
-                    local_get(err_list); local_get(err_cnt); i32_store(0);
-                    i32_const(TWO_I32_BYTES); call(self.emitter.rt.alloc); local_set(out);
-                    local_get(err_cnt); i32_eqz;
+                    local_get(Local(ok_list)); local_get(Local(ok_cnt)); i32_store(0);
+                    local_get(Local(err_list)); local_get(Local(err_cnt)); i32_store(0);
+                    i32_const(Imm32(TWO_I32_BYTES)); call(self.emitter.rt.alloc); local_set(Local(out));
+                    local_get(Local(err_cnt)); i32_eqz;
                     if_empty;
-                      local_get(out); i32_const(0); i32_store(0);
-                      local_get(out); local_get(ok_list); i32_store(4);
+                      local_get(Local(out)); i32_const(Imm32(0)); i32_store(0);
+                      local_get(Local(out)); local_get(Local(ok_list)); i32_store(4);
                     else_;
-                      local_get(out); i32_const(1); i32_store(0);
-                      local_get(out); local_get(err_list); i32_store(4);
+                      local_get(Local(out)); i32_const(Imm32(1)); i32_store(0);
+                      local_get(Local(out)); local_get(Local(err_list)); i32_store(4);
                     end;
-                    local_get(out);
+                    local_get(Local(out));
                 });
 
                 self.scratch.free_i32(out);
@@ -879,8 +880,8 @@ impl FuncCompiler<'_> {
         let size = 4 + values::byte_size(ok_ty);
         let s = self.scratch.alloc_i32();
         wasm!(self.func, {
-            i32_const(size as i32); call(self.emitter.rt.alloc); local_set(s);
-            local_get(s); i32_const(0); i32_store(0); // tag=0
+            i32_const(Imm32(size as i32)); call(self.emitter.rt.alloc); local_set(Local(s));
+            local_get(Local(s)); i32_const(Imm32(0)); i32_store(0); // tag=0
         });
         s
     }
@@ -892,8 +893,8 @@ impl FuncCompiler<'_> {
         let size = 4 + values::byte_size(err_ty);
         let s = self.scratch.alloc_i32();
         wasm!(self.func, {
-            i32_const(size as i32); call(self.emitter.rt.alloc); local_set(s);
-            local_get(s); i32_const(1); i32_store(0); // tag=1
+            i32_const(Imm32(size as i32)); call(self.emitter.rt.alloc); local_set(Local(s));
+            local_get(Local(s)); i32_const(Imm32(1)); i32_store(0); // tag=1
         });
         s
     }
@@ -903,7 +904,7 @@ impl FuncCompiler<'_> {
     /// The "then" branch is the ok path; the "else" branch is the err path.
     fn emit_result_branch_ok(&mut self, result_local: u32) {
         wasm!(self.func, {
-            local_get(result_local); i32_load(0); i32_eqz;
+            local_get(Local(result_local)); i32_load(0); i32_eqz;
         });
     }
 
@@ -911,7 +912,7 @@ impl FuncCompiler<'_> {
     /// The "then" branch is the err path; the "else" branch is the ok path.
     fn emit_result_branch_err(&mut self, result_local: u32) {
         wasm!(self.func, {
-            local_get(result_local); i32_load(0); i32_const(0); i32_ne;
+            local_get(Local(result_local)); i32_load(0); i32_const(Imm32(0)); i32_ne;
         });
     }
 
@@ -937,21 +938,21 @@ impl FuncCompiler<'_> {
         self.emit_result_branch_ok(elem);
         wasm!(self.func, {
             if_empty; // tag==0 → ok
-              local_get(ok_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-              local_get(ok_cnt); i32_const(ok_size); i32_mul; i32_add;
-              local_get(elem); i32_const(RESULT_PAYLOAD_OFFSET); i32_add; // Result payload at +4
+              local_get(Local(ok_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+              local_get(Local(ok_cnt)); i32_const(Imm32(ok_size)); i32_mul; i32_add;
+              local_get(Local(elem)); i32_const(Imm32(RESULT_PAYLOAD_OFFSET)); i32_add; // Result payload at +4
         });
         self.emit_elem_copy(ok_ty);
         wasm!(self.func, {
-              local_get(ok_cnt); i32_const(1); i32_add; local_set(ok_cnt);
+              local_get(Local(ok_cnt)); i32_const(Imm32(1)); i32_add; local_set(Local(ok_cnt));
             else_;
-              local_get(err_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-              local_get(err_cnt); i32_const(err_size); i32_mul; i32_add;
-              local_get(elem); i32_const(RESULT_PAYLOAD_OFFSET); i32_add; // Result payload at +4
+              local_get(Local(err_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+              local_get(Local(err_cnt)); i32_const(Imm32(err_size)); i32_mul; i32_add;
+              local_get(Local(elem)); i32_const(Imm32(RESULT_PAYLOAD_OFFSET)); i32_add; // Result payload at +4
         });
         self.emit_elem_copy(err_ty);
         wasm!(self.func, {
-              local_get(err_cnt); i32_const(1); i32_add; local_set(err_cnt);
+              local_get(Local(err_cnt)); i32_const(Imm32(1)); i32_add; local_set(Local(err_cnt));
             end;
         });
     }

--- a/crates/almide-codegen/src/emit_wasm/calls_option.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_option.rs
@@ -6,6 +6,16 @@ use almide_ir::IrExpr;
 use almide_lang::types::Ty;
 use wasm_encoder::ValType;
 
+// ── Immediate constants ──────────────────────────────────────────────────────
+/// Byte width of an i32 / pointer on the WASM heap (used as element stride and
+/// single-pointer allocation size).
+const I32_BYTES: i32 = 4;
+/// Byte size of two consecutive i32 fields (e.g. [tag:i32, ptr:i32] or
+/// [ptr_a:i32, ptr_b:i32]).
+const TWO_I32_BYTES: i32 = 8;
+/// Byte offset of the value payload inside a Result box ([tag:i32][payload…]).
+const RESULT_PAYLOAD_OFFSET: i32 = 4;
+
 impl FuncCompiler<'_> {
     /// Dispatch an option stdlib method call. Returns true if handled.
     pub(super) fn emit_option_call(&mut self, method: &str, args: &[IrExpr]) -> bool {
@@ -405,7 +415,7 @@ impl FuncCompiler<'_> {
                 self.emit_store_at(&b_ty, a_size as u32);
                 // Wrap tuple in Some: alloc ptr-size, store tuple ptr
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc);
                     local_set(s_some);
                     local_get(s_some);
                     local_get(s_tuple);
@@ -670,7 +680,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); local_get(len); i32_ge_u; br_if(1);
                       local_get(rs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0); local_set(elem);
                 });
                 self.emit_result_sort_into_lists(
@@ -683,7 +693,7 @@ impl FuncCompiler<'_> {
                     end; end;
                     local_get(ok_list); local_get(ok_cnt); i32_store(0);
                     local_get(err_list); local_get(err_cnt); i32_store(0);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(out);
+                    i32_const(TWO_I32_BYTES); call(self.emitter.rt.alloc); local_set(out);
                     local_get(err_cnt); i32_eqz;
                     if_empty;
                       local_get(out); i32_const(0); i32_store(0);
@@ -737,7 +747,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); local_get(len); i32_ge_u; br_if(1);
                       local_get(rs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0); local_set(elem);
                 });
                 self.emit_result_sort_into_lists(
@@ -750,7 +760,7 @@ impl FuncCompiler<'_> {
                     end; end;
                     local_get(ok_list); local_get(ok_cnt); i32_store(0);
                     local_get(err_list); local_get(err_cnt); i32_store(0);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(tuple_ptr);
+                    i32_const(TWO_I32_BYTES); call(self.emitter.rt.alloc); local_set(tuple_ptr);
                     local_get(tuple_ptr); local_get(ok_list); i32_store(0);
                     local_get(tuple_ptr); local_get(err_list); i32_store(4);
                     local_get(tuple_ptr);
@@ -832,7 +842,7 @@ impl FuncCompiler<'_> {
                     end; end;
                     local_get(ok_list); local_get(ok_cnt); i32_store(0);
                     local_get(err_list); local_get(err_cnt); i32_store(0);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(out);
+                    i32_const(TWO_I32_BYTES); call(self.emitter.rt.alloc); local_set(out);
                     local_get(err_cnt); i32_eqz;
                     if_empty;
                       local_get(out); i32_const(0); i32_store(0);
@@ -929,7 +939,7 @@ impl FuncCompiler<'_> {
             if_empty; // tag==0 → ok
               local_get(ok_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
               local_get(ok_cnt); i32_const(ok_size); i32_mul; i32_add;
-              local_get(elem); i32_const(4); i32_add; // Result payload at +4
+              local_get(elem); i32_const(RESULT_PAYLOAD_OFFSET); i32_add; // Result payload at +4
         });
         self.emit_elem_copy(ok_ty);
         wasm!(self.func, {
@@ -937,7 +947,7 @@ impl FuncCompiler<'_> {
             else_;
               local_get(err_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
               local_get(err_cnt); i32_const(err_size); i32_mul; i32_add;
-              local_get(elem); i32_const(4); i32_add; // Result payload at +4
+              local_get(elem); i32_const(RESULT_PAYLOAD_OFFSET); i32_add; // Result payload at +4
         });
         self.emit_elem_copy(err_ty);
         wasm!(self.func, {

--- a/crates/almide-codegen/src/emit_wasm/calls_process.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_process.rs
@@ -1,5 +1,6 @@
 //! process module: exit, stdin_lines — WASM codegen dispatch.
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use super::FuncCompiler;
 use almide_ir::IrExpr;
 use almide_lang::types::Ty;
@@ -76,11 +77,11 @@ impl FuncCompiler<'_> {
 
                 // --- Phase 1: read all stdin ---
                 wasm!(self.func, {
-                    i32_const(STDIN_BUF_INIT_CAP); call(self.emitter.rt.alloc); local_set(buf);
-                    i32_const(STDIN_BUF_INIT_CAP); local_set(capacity);
-                    i32_const(0); local_set(len);
-                    i32_const(IOV_BYTES); call(self.emitter.rt.alloc); local_set(iov_ptr);
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(nread_ptr);
+                    i32_const(Imm32(STDIN_BUF_INIT_CAP)); call(self.emitter.rt.alloc); local_set(Local(buf));
+                    i32_const(Imm32(STDIN_BUF_INIT_CAP)); local_set(Local(capacity));
+                    i32_const(Imm32(0)); local_set(Local(len));
+                    i32_const(Imm32(IOV_BYTES)); call(self.emitter.rt.alloc); local_set(Local(iov_ptr));
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc); local_set(Local(nread_ptr));
                 });
 
                 wasm!(self.func, {
@@ -89,41 +90,41 @@ impl FuncCompiler<'_> {
 
                 // Grow if needed
                 wasm!(self.func, {
-                    local_get(capacity); local_get(len); i32_sub;
-                    i32_const(STDIN_BUF_GROW_THRESHOLD); i32_lt_u;
+                    local_get(Local(capacity)); local_get(Local(len)); i32_sub;
+                    i32_const(Imm32(STDIN_BUF_GROW_THRESHOLD)); i32_lt_u;
                     if_empty;
-                      local_get(capacity); i32_const(CAPACITY_DOUBLE); i32_mul; local_set(capacity);
-                      local_get(capacity); call(self.emitter.rt.alloc); local_set(new_buf);
-                      i32_const(0); local_set(copy_i);
+                      local_get(Local(capacity)); i32_const(Imm32(CAPACITY_DOUBLE)); i32_mul; local_set(Local(capacity));
+                      local_get(Local(capacity)); call(self.emitter.rt.alloc); local_set(Local(new_buf));
+                      i32_const(Imm32(0)); local_set(Local(copy_i));
                       block_empty; loop_empty;
-                        local_get(copy_i); local_get(len); i32_ge_u; br_if(1);
-                        local_get(new_buf); local_get(copy_i); i32_add;
-                        local_get(buf); local_get(copy_i); i32_add; i32_load8_u(0);
+                        local_get(Local(copy_i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                        local_get(Local(new_buf)); local_get(Local(copy_i)); i32_add;
+                        local_get(Local(buf)); local_get(Local(copy_i)); i32_add; i32_load8_u(0);
                         i32_store8(0);
-                        local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                        local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                         br(0);
                       end; end;
-                      local_get(new_buf); local_set(buf);
+                      local_get(Local(new_buf)); local_set(Local(buf));
                     end;
                 });
 
                 // Read chunk
                 wasm!(self.func, {
-                    local_get(iov_ptr); local_get(buf); local_get(len); i32_add; i32_store(0);
-                    local_get(iov_ptr); local_get(capacity); local_get(len); i32_sub; i32_store(4);
-                    i32_const(0);
-                    local_get(iov_ptr);
-                    i32_const(1);
-                    local_get(nread_ptr);
+                    local_get(Local(iov_ptr)); local_get(Local(buf)); local_get(Local(len)); i32_add; i32_store(0);
+                    local_get(Local(iov_ptr)); local_get(Local(capacity)); local_get(Local(len)); i32_sub; i32_store(4);
+                    i32_const(Imm32(0));
+                    local_get(Local(iov_ptr));
+                    i32_const(Imm32(1));
+                    local_get(Local(nread_ptr));
                     call(self.emitter.rt.fd_read);
                     drop;
                 });
 
                 wasm!(self.func, {
-                    local_get(nread_ptr); i32_load(0); local_set(nread_val);
-                    local_get(nread_val); i32_eqz;
+                    local_get(Local(nread_ptr)); i32_load(0); local_set(Local(nread_val));
+                    local_get(Local(nread_val)); i32_eqz;
                     br_if(1);
-                    local_get(len); local_get(nread_val); i32_add; local_set(len);
+                    local_get(Local(len)); local_get(Local(nread_val)); i32_add; local_set(Local(len));
                     br(0);
                     end; end;
                 });
@@ -134,155 +135,155 @@ impl FuncCompiler<'_> {
                 // We'll build with a growable array of i32 pointers.
                 wasm!(self.func, {
                     // Initial list capacity: INIT_LINE_LIST_CAP elements (i32 ptrs)
-                    i32_const(INIT_LINE_LIST_CAP); local_set(list_cap);
-                    local_get(list_cap); i32_const(I32_BYTES); i32_mul;
-                    call(self.emitter.rt.alloc); local_set(list_ptr);
-                    i32_const(0); local_set(list_count);
-                    i32_const(0); local_set(scan_i);
-                    i32_const(0); local_set(line_start);
+                    i32_const(Imm32(INIT_LINE_LIST_CAP)); local_set(Local(list_cap));
+                    local_get(Local(list_cap)); i32_const(Imm32(I32_BYTES)); i32_mul;
+                    call(self.emitter.rt.alloc); local_set(Local(list_ptr));
+                    i32_const(Imm32(0)); local_set(Local(list_count));
+                    i32_const(Imm32(0)); local_set(Local(scan_i));
+                    i32_const(Imm32(0)); local_set(Local(line_start));
                 });
 
                 // Scan loop: iterate through buf looking for '\n'
                 wasm!(self.func, {
                     block_empty; loop_empty;
-                      local_get(scan_i); local_get(len); i32_ge_u;
+                      local_get(Local(scan_i)); local_get(Local(len)); i32_ge_u;
                       br_if(1);
                 });
 
                 // Check if buf[scan_i] == '\n'
                 wasm!(self.func, {
-                      local_get(buf); local_get(scan_i); i32_add; i32_load8_u(0);
-                      i32_const(ASCII_NEWLINE); i32_eq;
+                      local_get(Local(buf)); local_get(Local(scan_i)); i32_add; i32_load8_u(0);
+                      i32_const(Imm32(ASCII_NEWLINE)); i32_eq;
                       if_empty;
                 });
 
                 // Found '\n': build string from line_start..scan_i
                 wasm!(self.func, {
-                        local_get(scan_i); local_get(line_start); i32_sub; local_set(line_len);
+                        local_get(Local(scan_i)); local_get(Local(line_start)); i32_sub; local_set(Local(line_len));
                         // Allocate Almide string [len][cap][bytes...]
-                        local_get(line_len); i32_const(string_hdr()); i32_add;
-                        call(self.emitter.rt.alloc); local_set(line_ptr);
-                        local_get(line_ptr); local_get(line_len); i32_store(0);
-                        local_get(line_ptr); i32_const(string_cap_off()); i32_add; local_get(line_len); i32_store(0); // cap = len
+                        local_get(Local(line_len)); i32_const(Imm32(string_hdr())); i32_add;
+                        call(self.emitter.rt.alloc); local_set(Local(line_ptr));
+                        local_get(Local(line_ptr)); local_get(Local(line_len)); i32_store(0);
+                        local_get(Local(line_ptr)); i32_const(Imm32(string_cap_off())); i32_add; local_get(Local(line_len)); i32_store(0); // cap = len
                         // Copy line data
-                        i32_const(0); local_set(copy_i);
+                        i32_const(Imm32(0)); local_set(Local(copy_i));
                         block_empty; loop_empty;
-                          local_get(copy_i); local_get(line_len); i32_ge_u; br_if(1);
-                          local_get(line_ptr); i32_const(string_data_off()); i32_add; local_get(copy_i); i32_add;
-                          local_get(buf); local_get(line_start); i32_add; local_get(copy_i); i32_add;
+                          local_get(Local(copy_i)); local_get(Local(line_len)); i32_ge_u; br_if(1);
+                          local_get(Local(line_ptr)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(copy_i)); i32_add;
+                          local_get(Local(buf)); local_get(Local(line_start)); i32_add; local_get(Local(copy_i)); i32_add;
                           i32_load8_u(0);
                           i32_store8(0);
-                          local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                          local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                           br(0);
                         end; end;
                 });
 
                 // Grow list if needed
                 wasm!(self.func, {
-                        local_get(list_count); local_get(list_cap); i32_ge_u;
+                        local_get(Local(list_count)); local_get(Local(list_cap)); i32_ge_u;
                         if_empty;
-                          local_get(list_cap); i32_const(CAPACITY_DOUBLE); i32_mul; local_set(list_cap);
-                          local_get(list_cap); i32_const(I32_BYTES); i32_mul;
-                          call(self.emitter.rt.alloc); local_set(new_list);
+                          local_get(Local(list_cap)); i32_const(Imm32(CAPACITY_DOUBLE)); i32_mul; local_set(Local(list_cap));
+                          local_get(Local(list_cap)); i32_const(Imm32(I32_BYTES)); i32_mul;
+                          call(self.emitter.rt.alloc); local_set(Local(new_list));
                           // Copy old list ptrs
-                          i32_const(0); local_set(copy_i);
+                          i32_const(Imm32(0)); local_set(Local(copy_i));
                           block_empty; loop_empty;
-                            local_get(copy_i); local_get(list_count); i32_ge_u; br_if(1);
-                            local_get(new_list); local_get(copy_i); i32_const(I32_BYTES); i32_mul; i32_add;
-                            local_get(list_ptr); local_get(copy_i); i32_const(I32_BYTES); i32_mul; i32_add;
+                            local_get(Local(copy_i)); local_get(Local(list_count)); i32_ge_u; br_if(1);
+                            local_get(Local(new_list)); local_get(Local(copy_i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                            local_get(Local(list_ptr)); local_get(Local(copy_i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
                             i32_load(0);
                             i32_store(0);
-                            local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                            local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                             br(0);
                           end; end;
-                          local_get(new_list); local_set(list_ptr);
+                          local_get(Local(new_list)); local_set(Local(list_ptr));
                         end;
                 });
 
                 // Append line_ptr to list
                 wasm!(self.func, {
-                        local_get(list_ptr); local_get(list_count); i32_const(I32_BYTES); i32_mul; i32_add;
-                        local_get(line_ptr); i32_store(0);
-                        local_get(list_count); i32_const(1); i32_add; local_set(list_count);
+                        local_get(Local(list_ptr)); local_get(Local(list_count)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                        local_get(Local(line_ptr)); i32_store(0);
+                        local_get(Local(list_count)); i32_const(Imm32(1)); i32_add; local_set(Local(list_count));
                         // line_start = scan_i + 1
-                        local_get(scan_i); i32_const(1); i32_add; local_set(line_start);
+                        local_get(Local(scan_i)); i32_const(Imm32(1)); i32_add; local_set(Local(line_start));
                       end; // end if '\n'
                 });
 
                 // Advance scan_i
                 wasm!(self.func, {
-                      local_get(scan_i); i32_const(1); i32_add; local_set(scan_i);
+                      local_get(Local(scan_i)); i32_const(Imm32(1)); i32_add; local_set(Local(scan_i));
                       br(0);
                     end; end; // end loop, end block
                 });
 
                 // Handle last line (if no trailing '\n')
                 wasm!(self.func, {
-                    local_get(line_start); local_get(len); i32_lt_u;
+                    local_get(Local(line_start)); local_get(Local(len)); i32_lt_u;
                     if_empty;
-                      local_get(len); local_get(line_start); i32_sub; local_set(line_len);
-                      local_get(line_len); i32_const(string_hdr()); i32_add;
-                      call(self.emitter.rt.alloc); local_set(line_ptr);
-                      local_get(line_ptr); local_get(line_len); i32_store(0);
-                      local_get(line_ptr); i32_const(string_cap_off()); i32_add; local_get(line_len); i32_store(0); // cap = len
-                      i32_const(0); local_set(copy_i);
+                      local_get(Local(len)); local_get(Local(line_start)); i32_sub; local_set(Local(line_len));
+                      local_get(Local(line_len)); i32_const(Imm32(string_hdr())); i32_add;
+                      call(self.emitter.rt.alloc); local_set(Local(line_ptr));
+                      local_get(Local(line_ptr)); local_get(Local(line_len)); i32_store(0);
+                      local_get(Local(line_ptr)); i32_const(Imm32(string_cap_off())); i32_add; local_get(Local(line_len)); i32_store(0); // cap = len
+                      i32_const(Imm32(0)); local_set(Local(copy_i));
                       block_empty; loop_empty;
-                        local_get(copy_i); local_get(line_len); i32_ge_u; br_if(1);
-                        local_get(line_ptr); i32_const(string_data_off()); i32_add; local_get(copy_i); i32_add;
-                        local_get(buf); local_get(line_start); i32_add; local_get(copy_i); i32_add;
+                        local_get(Local(copy_i)); local_get(Local(line_len)); i32_ge_u; br_if(1);
+                        local_get(Local(line_ptr)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(copy_i)); i32_add;
+                        local_get(Local(buf)); local_get(Local(line_start)); i32_add; local_get(Local(copy_i)); i32_add;
                         i32_load8_u(0);
                         i32_store8(0);
-                        local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                        local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                         br(0);
                       end; end;
                 });
 
                 // Grow list if needed for last line
                 wasm!(self.func, {
-                      local_get(list_count); local_get(list_cap); i32_ge_u;
+                      local_get(Local(list_count)); local_get(Local(list_cap)); i32_ge_u;
                       if_empty;
-                        local_get(list_cap); i32_const(CAPACITY_DOUBLE); i32_mul; local_set(list_cap);
-                        local_get(list_cap); i32_const(I32_BYTES); i32_mul;
-                        call(self.emitter.rt.alloc); local_set(new_list);
-                        i32_const(0); local_set(copy_i);
+                        local_get(Local(list_cap)); i32_const(Imm32(CAPACITY_DOUBLE)); i32_mul; local_set(Local(list_cap));
+                        local_get(Local(list_cap)); i32_const(Imm32(I32_BYTES)); i32_mul;
+                        call(self.emitter.rt.alloc); local_set(Local(new_list));
+                        i32_const(Imm32(0)); local_set(Local(copy_i));
                         block_empty; loop_empty;
-                          local_get(copy_i); local_get(list_count); i32_ge_u; br_if(1);
-                          local_get(new_list); local_get(copy_i); i32_const(I32_BYTES); i32_mul; i32_add;
-                          local_get(list_ptr); local_get(copy_i); i32_const(I32_BYTES); i32_mul; i32_add;
+                          local_get(Local(copy_i)); local_get(Local(list_count)); i32_ge_u; br_if(1);
+                          local_get(Local(new_list)); local_get(Local(copy_i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                          local_get(Local(list_ptr)); local_get(Local(copy_i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
                           i32_load(0);
                           i32_store(0);
-                          local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                          local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                           br(0);
                         end; end;
-                        local_get(new_list); local_set(list_ptr);
+                        local_get(Local(new_list)); local_set(Local(list_ptr));
                       end;
                       // Append last line
-                      local_get(list_ptr); local_get(list_count); i32_const(I32_BYTES); i32_mul; i32_add;
-                      local_get(line_ptr); i32_store(0);
-                      local_get(list_count); i32_const(1); i32_add; local_set(list_count);
+                      local_get(Local(list_ptr)); local_get(Local(list_count)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      local_get(Local(line_ptr)); i32_store(0);
+                      local_get(Local(list_count)); i32_const(Imm32(1)); i32_add; local_set(Local(list_count));
                     end; // end if line_start < len
                 });
 
                 // Build final Almide List: [len:i32][cap:i32][elem0:i32][elem1:i32]...
                 // elem_size = I32_BYTES (i32 pointer)
                 wasm!(self.func, {
-                    local_get(list_count); i32_const(I32_BYTES); i32_mul; i32_const(list_hdr()); i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); local_get(list_count); i32_store(0);
-                    local_get(result); i32_const(list_cap_off()); i32_add; local_get(list_count); i32_store(0); // cap = len
+                    local_get(Local(list_count)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_const(Imm32(list_hdr())); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); local_get(Local(list_count)); i32_store(0);
+                    local_get(Local(result)); i32_const(Imm32(list_cap_off())); i32_add; local_get(Local(list_count)); i32_store(0); // cap = len
                     // Copy list_ptr[0..list_count] to result+data_off
-                    i32_const(0); local_set(copy_i);
+                    i32_const(Imm32(0)); local_set(Local(copy_i));
                     block_empty; loop_empty;
-                      local_get(copy_i); local_get(list_count); i32_ge_u; br_if(1);
-                      local_get(result); i32_const(list_data_off()); i32_add;
-                      local_get(copy_i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      local_get(list_ptr); local_get(copy_i); i32_const(I32_BYTES); i32_mul; i32_add;
+                      local_get(Local(copy_i)); local_get(Local(list_count)); i32_ge_u; br_if(1);
+                      local_get(Local(result)); i32_const(Imm32(list_data_off())); i32_add;
+                      local_get(Local(copy_i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      local_get(Local(list_ptr)); local_get(Local(copy_i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
                       i32_load(0);
                       i32_store(0);
-                      local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                      local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
 
                 self.scratch.free_i32(result);
@@ -324,14 +325,14 @@ impl FuncCompiler<'_> {
 
                 // --- Phase 1: discover argc + total argv buffer size ---
                 wasm!(self.func, {
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(argc_ptr);
-                    i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(bufsize_ptr);
-                    local_get(argc_ptr);
-                    local_get(bufsize_ptr);
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc); local_set(Local(argc_ptr));
+                    i32_const(Imm32(I32_BYTES)); call(self.emitter.rt.alloc); local_set(Local(bufsize_ptr));
+                    local_get(Local(argc_ptr));
+                    local_get(Local(bufsize_ptr));
                     call(self.emitter.rt.args_sizes_get);
                     drop; // discard errno
-                    local_get(argc_ptr); i32_load(0); local_set(argc);
-                    local_get(bufsize_ptr); i32_load(0); local_set(buf_size);
+                    local_get(Local(argc_ptr)); i32_load(0); local_set(Local(argc));
+                    local_get(Local(bufsize_ptr)); i32_load(0); local_set(Local(buf_size));
                 });
 
                 // --- Phase 2: alloc the pointer array + the string buffer, fill them ---
@@ -342,59 +343,59 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                     // argv_ptr: argc i32 pointers (+I32_BYTES guard so a zero argc never
                     // yields a degenerate alloc).
-                    local_get(argc); i32_const(I32_BYTES); i32_mul; i32_const(I32_BYTES); i32_add;
-                    call(self.emitter.rt.alloc); local_set(argv_ptr);
-                    local_get(buf_size); i32_const(I32_BYTES); i32_add;
-                    call(self.emitter.rt.alloc); local_set(argv_buf);
-                    local_get(argv_ptr);
-                    local_get(argv_buf);
+                    local_get(Local(argc)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_const(Imm32(I32_BYTES)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(argv_ptr));
+                    local_get(Local(buf_size)); i32_const(Imm32(I32_BYTES)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(argv_buf));
+                    local_get(Local(argv_ptr));
+                    local_get(Local(argv_buf));
                     call(self.emitter.rt.args_get);
                     drop; // discard errno
                 });
 
                 // --- Phase 3: build List[String] = [len][cap][strptr0][strptr1]... ---
                 wasm!(self.func, {
-                    local_get(argc); i32_const(I32_BYTES); i32_mul; i32_const(list_hdr()); i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); local_get(argc); i32_store(0);
-                    local_get(result); i32_const(list_cap_off()); i32_add; local_get(argc); i32_store(0); // cap = len
-                    i32_const(0); local_set(i);
+                    local_get(Local(argc)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_const(Imm32(list_hdr())); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); local_get(Local(argc)); i32_store(0);
+                    local_get(Local(result)); i32_const(Imm32(list_cap_off())); i32_add; local_get(Local(argc)); i32_store(0); // cap = len
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(argc); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(argc)); i32_ge_u; br_if(1);
                       // cstr_ptr = argv_ptr[i]
-                      local_get(argv_ptr); local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      i32_load(0); local_set(cstr_ptr);
+                      local_get(Local(argv_ptr)); local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      i32_load(0); local_set(Local(cstr_ptr));
                       // str_len = strlen(cstr_ptr): scan to NUL
-                      i32_const(0); local_set(str_len);
+                      i32_const(Imm32(0)); local_set(Local(str_len));
                       block_empty; loop_empty;
-                        local_get(cstr_ptr); local_get(str_len); i32_add; i32_load8_u(0);
+                        local_get(Local(cstr_ptr)); local_get(Local(str_len)); i32_add; i32_load8_u(0);
                         i32_eqz; br_if(1);
-                        local_get(str_len); i32_const(1); i32_add; local_set(str_len);
+                        local_get(Local(str_len)); i32_const(Imm32(1)); i32_add; local_set(Local(str_len));
                         br(0);
                       end; end;
                       // alloc Almide string [len][cap][bytes...]
-                      local_get(str_len); i32_const(string_hdr()); i32_add;
-                      call(self.emitter.rt.alloc); local_set(str_ptr);
-                      local_get(str_ptr); local_get(str_len); i32_store(0);
-                      local_get(str_ptr); i32_const(string_cap_off()); i32_add; local_get(str_len); i32_store(0); // cap = len
+                      local_get(Local(str_len)); i32_const(Imm32(string_hdr())); i32_add;
+                      call(self.emitter.rt.alloc); local_set(Local(str_ptr));
+                      local_get(Local(str_ptr)); local_get(Local(str_len)); i32_store(0);
+                      local_get(Local(str_ptr)); i32_const(Imm32(string_cap_off())); i32_add; local_get(Local(str_len)); i32_store(0); // cap = len
                       // copy str_len bytes from cstr_ptr into str_ptr+data_off
-                      i32_const(0); local_set(copy_i);
+                      i32_const(Imm32(0)); local_set(Local(copy_i));
                       block_empty; loop_empty;
-                        local_get(copy_i); local_get(str_len); i32_ge_u; br_if(1);
-                        local_get(str_ptr); i32_const(string_data_off()); i32_add; local_get(copy_i); i32_add;
-                        local_get(cstr_ptr); local_get(copy_i); i32_add; i32_load8_u(0);
+                        local_get(Local(copy_i)); local_get(Local(str_len)); i32_ge_u; br_if(1);
+                        local_get(Local(str_ptr)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(copy_i)); i32_add;
+                        local_get(Local(cstr_ptr)); local_get(Local(copy_i)); i32_add; i32_load8_u(0);
                         i32_store8(0);
-                        local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
+                        local_get(Local(copy_i)); i32_const(Imm32(1)); i32_add; local_set(Local(copy_i));
                         br(0);
                       end; end;
                       // result[data_off + i*I32_BYTES] = str_ptr
-                      local_get(result); i32_const(list_data_off()); i32_add;
-                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
-                      local_get(str_ptr); i32_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(result)); i32_const(Imm32(list_data_off())); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                      local_get(Local(str_ptr)); i32_store(0);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
 
                 self.scratch.free_i32(copy_i);

--- a/crates/almide-codegen/src/emit_wasm/calls_process.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_process.rs
@@ -11,6 +11,33 @@ use super::values;
 use super::rt_string::{string_hdr, string_data_off, string_cap_off, list_hdr, list_data_off, list_cap_off};
 use wasm_encoder::Instruction;
 
+/// Named WASM immediate constants for process-call codegen.
+mod imm {
+    // ── byte widths ────────────────────────────────────────────────────────
+    /// Byte size of an i32 / pointer (pointer stride in List[String] element
+    /// arrays and size of a single i32 out-parameter allocation).
+    pub const I32_BYTES: i32 = 4;
+    /// Byte size of a WASI iovec_t struct ([buf_ptr: i32, buf_len: i32] = 2×4).
+    pub const IOV_BYTES: i32 = 8;
+
+    // ── initial capacities ─────────────────────────────────────────────────
+    /// Initial byte capacity of the stdin read buffer before any growth.
+    pub const STDIN_BUF_INIT_CAP: i32 = 4096;
+    /// Growth threshold: when fewer than this many bytes remain free in the
+    /// read buffer, double the capacity before the next fd_read call.
+    pub const STDIN_BUF_GROW_THRESHOLD: i32 = 4096;
+    /// Initial element capacity of the line-pointer array while scanning
+    /// stdin for newlines.
+    pub const INIT_LINE_LIST_CAP: i32 = 64;
+    /// Multiplicative growth factor applied to buffer / list capacities.
+    pub const CAPACITY_DOUBLE: i32 = 2;
+
+    // ── character codes ────────────────────────────────────────────────────
+    /// ASCII code for the newline character '\n' (0x0A).
+    pub const ASCII_NEWLINE: i32 = 10;
+}
+use imm::*;
+
 impl FuncCompiler<'_> {
     /// process module: exit, stdin_lines
     pub(super) fn emit_process_call(&mut self, func: &str, args: &[IrExpr]) {
@@ -49,11 +76,11 @@ impl FuncCompiler<'_> {
 
                 // --- Phase 1: read all stdin ---
                 wasm!(self.func, {
-                    i32_const(4096); call(self.emitter.rt.alloc); local_set(buf);
-                    i32_const(4096); local_set(capacity);
+                    i32_const(STDIN_BUF_INIT_CAP); call(self.emitter.rt.alloc); local_set(buf);
+                    i32_const(STDIN_BUF_INIT_CAP); local_set(capacity);
                     i32_const(0); local_set(len);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(iov_ptr);
-                    i32_const(4); call(self.emitter.rt.alloc); local_set(nread_ptr);
+                    i32_const(IOV_BYTES); call(self.emitter.rt.alloc); local_set(iov_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(nread_ptr);
                 });
 
                 wasm!(self.func, {
@@ -63,9 +90,9 @@ impl FuncCompiler<'_> {
                 // Grow if needed
                 wasm!(self.func, {
                     local_get(capacity); local_get(len); i32_sub;
-                    i32_const(4096); i32_lt_u;
+                    i32_const(STDIN_BUF_GROW_THRESHOLD); i32_lt_u;
                     if_empty;
-                      local_get(capacity); i32_const(2); i32_mul; local_set(capacity);
+                      local_get(capacity); i32_const(CAPACITY_DOUBLE); i32_mul; local_set(capacity);
                       local_get(capacity); call(self.emitter.rt.alloc); local_set(new_buf);
                       i32_const(0); local_set(copy_i);
                       block_empty; loop_empty;
@@ -106,9 +133,9 @@ impl FuncCompiler<'_> {
                 // Each elem is a ptr to Almide String [len:i32][data:u8...]
                 // We'll build with a growable array of i32 pointers.
                 wasm!(self.func, {
-                    // Initial list capacity: 64 elements (i32 ptrs)
-                    i32_const(64); local_set(list_cap);
-                    local_get(list_cap); i32_const(4); i32_mul;
+                    // Initial list capacity: INIT_LINE_LIST_CAP elements (i32 ptrs)
+                    i32_const(INIT_LINE_LIST_CAP); local_set(list_cap);
+                    local_get(list_cap); i32_const(I32_BYTES); i32_mul;
                     call(self.emitter.rt.alloc); local_set(list_ptr);
                     i32_const(0); local_set(list_count);
                     i32_const(0); local_set(scan_i);
@@ -125,7 +152,7 @@ impl FuncCompiler<'_> {
                 // Check if buf[scan_i] == '\n'
                 wasm!(self.func, {
                       local_get(buf); local_get(scan_i); i32_add; i32_load8_u(0);
-                      i32_const(10); i32_eq;
+                      i32_const(ASCII_NEWLINE); i32_eq;
                       if_empty;
                 });
 
@@ -154,15 +181,15 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                         local_get(list_count); local_get(list_cap); i32_ge_u;
                         if_empty;
-                          local_get(list_cap); i32_const(2); i32_mul; local_set(list_cap);
-                          local_get(list_cap); i32_const(4); i32_mul;
+                          local_get(list_cap); i32_const(CAPACITY_DOUBLE); i32_mul; local_set(list_cap);
+                          local_get(list_cap); i32_const(I32_BYTES); i32_mul;
                           call(self.emitter.rt.alloc); local_set(new_list);
                           // Copy old list ptrs
                           i32_const(0); local_set(copy_i);
                           block_empty; loop_empty;
                             local_get(copy_i); local_get(list_count); i32_ge_u; br_if(1);
-                            local_get(new_list); local_get(copy_i); i32_const(4); i32_mul; i32_add;
-                            local_get(list_ptr); local_get(copy_i); i32_const(4); i32_mul; i32_add;
+                            local_get(new_list); local_get(copy_i); i32_const(I32_BYTES); i32_mul; i32_add;
+                            local_get(list_ptr); local_get(copy_i); i32_const(I32_BYTES); i32_mul; i32_add;
                             i32_load(0);
                             i32_store(0);
                             local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
@@ -174,7 +201,7 @@ impl FuncCompiler<'_> {
 
                 // Append line_ptr to list
                 wasm!(self.func, {
-                        local_get(list_ptr); local_get(list_count); i32_const(4); i32_mul; i32_add;
+                        local_get(list_ptr); local_get(list_count); i32_const(I32_BYTES); i32_mul; i32_add;
                         local_get(line_ptr); i32_store(0);
                         local_get(list_count); i32_const(1); i32_add; local_set(list_count);
                         // line_start = scan_i + 1
@@ -214,14 +241,14 @@ impl FuncCompiler<'_> {
                 wasm!(self.func, {
                       local_get(list_count); local_get(list_cap); i32_ge_u;
                       if_empty;
-                        local_get(list_cap); i32_const(2); i32_mul; local_set(list_cap);
-                        local_get(list_cap); i32_const(4); i32_mul;
+                        local_get(list_cap); i32_const(CAPACITY_DOUBLE); i32_mul; local_set(list_cap);
+                        local_get(list_cap); i32_const(I32_BYTES); i32_mul;
                         call(self.emitter.rt.alloc); local_set(new_list);
                         i32_const(0); local_set(copy_i);
                         block_empty; loop_empty;
                           local_get(copy_i); local_get(list_count); i32_ge_u; br_if(1);
-                          local_get(new_list); local_get(copy_i); i32_const(4); i32_mul; i32_add;
-                          local_get(list_ptr); local_get(copy_i); i32_const(4); i32_mul; i32_add;
+                          local_get(new_list); local_get(copy_i); i32_const(I32_BYTES); i32_mul; i32_add;
+                          local_get(list_ptr); local_get(copy_i); i32_const(I32_BYTES); i32_mul; i32_add;
                           i32_load(0);
                           i32_store(0);
                           local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
@@ -230,16 +257,16 @@ impl FuncCompiler<'_> {
                         local_get(new_list); local_set(list_ptr);
                       end;
                       // Append last line
-                      local_get(list_ptr); local_get(list_count); i32_const(4); i32_mul; i32_add;
+                      local_get(list_ptr); local_get(list_count); i32_const(I32_BYTES); i32_mul; i32_add;
                       local_get(line_ptr); i32_store(0);
                       local_get(list_count); i32_const(1); i32_add; local_set(list_count);
                     end; // end if line_start < len
                 });
 
                 // Build final Almide List: [len:i32][cap:i32][elem0:i32][elem1:i32]...
-                // elem_size = 4 (i32 pointer)
+                // elem_size = I32_BYTES (i32 pointer)
                 wasm!(self.func, {
-                    local_get(list_count); i32_const(4); i32_mul; i32_const(list_hdr()); i32_add;
+                    local_get(list_count); i32_const(I32_BYTES); i32_mul; i32_const(list_hdr()); i32_add;
                     call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); local_get(list_count); i32_store(0);
                     local_get(result); i32_const(list_cap_off()); i32_add; local_get(list_count); i32_store(0); // cap = len
@@ -248,8 +275,8 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(copy_i); local_get(list_count); i32_ge_u; br_if(1);
                       local_get(result); i32_const(list_data_off()); i32_add;
-                      local_get(copy_i); i32_const(4); i32_mul; i32_add;
-                      local_get(list_ptr); local_get(copy_i); i32_const(4); i32_mul; i32_add;
+                      local_get(copy_i); i32_const(I32_BYTES); i32_mul; i32_add;
+                      local_get(list_ptr); local_get(copy_i); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0);
                       i32_store(0);
                       local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
@@ -297,8 +324,8 @@ impl FuncCompiler<'_> {
 
                 // --- Phase 1: discover argc + total argv buffer size ---
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc); local_set(argc_ptr);
-                    i32_const(4); call(self.emitter.rt.alloc); local_set(bufsize_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(argc_ptr);
+                    i32_const(I32_BYTES); call(self.emitter.rt.alloc); local_set(bufsize_ptr);
                     local_get(argc_ptr);
                     local_get(bufsize_ptr);
                     call(self.emitter.rt.args_sizes_get);
@@ -313,11 +340,11 @@ impl FuncCompiler<'_> {
                 // returns a degenerate pointer (argc is always >= 1 in practice, but
                 // stay defensive).
                 wasm!(self.func, {
-                    // argv_ptr: argc i32 pointers (+4 guard so a zero argc never
+                    // argv_ptr: argc i32 pointers (+I32_BYTES guard so a zero argc never
                     // yields a degenerate alloc).
-                    local_get(argc); i32_const(4); i32_mul; i32_const(4); i32_add;
+                    local_get(argc); i32_const(I32_BYTES); i32_mul; i32_const(I32_BYTES); i32_add;
                     call(self.emitter.rt.alloc); local_set(argv_ptr);
-                    local_get(buf_size); i32_const(4); i32_add;
+                    local_get(buf_size); i32_const(I32_BYTES); i32_add;
                     call(self.emitter.rt.alloc); local_set(argv_buf);
                     local_get(argv_ptr);
                     local_get(argv_buf);
@@ -327,7 +354,7 @@ impl FuncCompiler<'_> {
 
                 // --- Phase 3: build List[String] = [len][cap][strptr0][strptr1]... ---
                 wasm!(self.func, {
-                    local_get(argc); i32_const(4); i32_mul; i32_const(list_hdr()); i32_add;
+                    local_get(argc); i32_const(I32_BYTES); i32_mul; i32_const(list_hdr()); i32_add;
                     call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); local_get(argc); i32_store(0);
                     local_get(result); i32_const(list_cap_off()); i32_add; local_get(argc); i32_store(0); // cap = len
@@ -335,7 +362,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); local_get(argc); i32_ge_u; br_if(1);
                       // cstr_ptr = argv_ptr[i]
-                      local_get(argv_ptr); local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(argv_ptr); local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       i32_load(0); local_set(cstr_ptr);
                       // str_len = strlen(cstr_ptr): scan to NUL
                       i32_const(0); local_set(str_len);
@@ -360,9 +387,9 @@ impl FuncCompiler<'_> {
                         local_get(copy_i); i32_const(1); i32_add; local_set(copy_i);
                         br(0);
                       end; end;
-                      // result[data_off + i*4] = str_ptr
+                      // result[data_off + i*I32_BYTES] = str_ptr
                       local_get(result); i32_const(list_data_off()); i32_add;
-                      local_get(i); i32_const(4); i32_mul; i32_add;
+                      local_get(i); i32_const(I32_BYTES); i32_mul; i32_add;
                       local_get(str_ptr); i32_store(0);
                       local_get(i); i32_const(1); i32_add; local_set(i);
                       br(0);

--- a/crates/almide-codegen/src/emit_wasm/calls_random.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_random.rs
@@ -6,6 +6,22 @@ use almide_lang::types::Ty;
 use super::values;
 use wasm_encoder::Instruction;
 
+// ── named immediates ──────────────────────────────────────────────────────────
+/// xorshift64 shift parameters (Marsaglia 2003).
+const XORSHIFT_A: i64 = 13;
+const XORSHIFT_B: i64 = 7;
+const XORSHIFT_C: i64 = 17;
+
+/// WASI `random_get`: entropy bytes to request for one i64 seed.
+const RANDOM_SEED_BYTES: i32 = 8;
+
+/// List memory layout: 4-byte length header preceding element data.
+const LIST_HEADER_BYTES: i32 = 4;
+
+/// Float [0, 1) conversion: right-shift to obtain a 53-bit mantissa.
+const FLOAT_MANTISSA_SHIFT: i64 = 11;
+// ─────────────────────────────────────────────────────────────────────────────
+
 impl FuncCompiler<'_> {
     pub(super) fn emit_random_call(&mut self, func: &str, args: &[IrExpr]) {
         match func {
@@ -24,15 +40,15 @@ impl FuncCompiler<'_> {
                     // If state == 0, initialize with seed
                     local_get(state); i64_eqz;
                     if_empty;
-                      i32_const(0); i32_const(8); call(self.emitter.rt.random_get); drop;
+                      i32_const(0); i32_const(RANDOM_SEED_BYTES); call(self.emitter.rt.random_get); drop;
                       i32_const(0); i64_load(0); local_set(state);
                       local_get(state); i64_eqz;
                       if_empty; i64_const(1); local_set(state); end;
                     end;
                     // xorshift64
-                    local_get(state); local_get(state); i64_const(13); i64_shl; i64_xor; local_set(state);
-                    local_get(state); local_get(state); i64_const(7); i64_shr_u; i64_xor; local_set(state);
-                    local_get(state); local_get(state); i64_const(17); i64_shl; i64_xor; local_set(state);
+                    local_get(state); local_get(state); i64_const(XORSHIFT_A); i64_shl; i64_xor; local_set(state);
+                    local_get(state); local_get(state); i64_const(XORSHIFT_B); i64_shr_u; i64_xor; local_set(state);
+                    local_get(state); local_get(state); i64_const(XORSHIFT_C); i64_shl; i64_xor; local_set(state);
                     // Store back
                     i32_const(0); local_get(state); i64_store(0);
                     // result = min + abs(state) % (max - min + 1)
@@ -55,21 +71,21 @@ impl FuncCompiler<'_> {
                     i32_const(0); i64_load(0); local_set(state);
                     local_get(state); i64_eqz;
                     if_empty;
-                      i32_const(0); i32_const(8); call(self.emitter.rt.random_get); drop;
+                      i32_const(0); i32_const(RANDOM_SEED_BYTES); call(self.emitter.rt.random_get); drop;
                       i32_const(0); i64_load(0); local_set(state);
                       local_get(state); i64_eqz;
                       if_empty; i64_const(1); local_set(state); end;
                     end;
-                    local_get(state); local_get(state); i64_const(13); i64_shl; i64_xor; local_set(state);
-                    local_get(state); local_get(state); i64_const(7); i64_shr_u; i64_xor; local_set(state);
-                    local_get(state); local_get(state); i64_const(17); i64_shl; i64_xor; local_set(state);
+                    local_get(state); local_get(state); i64_const(XORSHIFT_A); i64_shl; i64_xor; local_set(state);
+                    local_get(state); local_get(state); i64_const(XORSHIFT_B); i64_shr_u; i64_xor; local_set(state);
+                    local_get(state); local_get(state); i64_const(XORSHIFT_C); i64_shl; i64_xor; local_set(state);
                     i32_const(0); local_get(state); i64_store(0);
                 });
                 // Convert to float in [0, 1): abs(state) >>> 11 * (1/2^53)
                 wasm!(self.func, {
                     local_get(state); i64_const(0); i64_lt_s;
                     if_i64; i64_const(0); local_get(state); i64_sub; else_; local_get(state); end;
-                    i64_const(11); i64_shr_u;
+                    i64_const(FLOAT_MANTISSA_SHIFT); i64_shr_u;
                     f64_convert_i64_u;
                     f64_const(1.1102230246251565e-16); // 1.0 / 2^53
                     f64_mul;
@@ -96,14 +112,14 @@ impl FuncCompiler<'_> {
                       i32_const(0); i64_load(0); local_set(state);
                       local_get(state); i64_eqz;
                       if_empty;
-                      i32_const(0); i32_const(8); call(self.emitter.rt.random_get); drop;
+                      i32_const(0); i32_const(RANDOM_SEED_BYTES); call(self.emitter.rt.random_get); drop;
                       i32_const(0); i64_load(0); local_set(state);
                       local_get(state); i64_eqz;
                       if_empty; i64_const(1); local_set(state); end;
                     end;
-                      local_get(state); local_get(state); i64_const(13); i64_shl; i64_xor; local_set(state);
-                      local_get(state); local_get(state); i64_const(7); i64_shr_u; i64_xor; local_set(state);
-                      local_get(state); local_get(state); i64_const(17); i64_shl; i64_xor; local_set(state);
+                      local_get(state); local_get(state); i64_const(XORSHIFT_A); i64_shl; i64_xor; local_set(state);
+                      local_get(state); local_get(state); i64_const(XORSHIFT_B); i64_shr_u; i64_xor; local_set(state);
+                      local_get(state); local_get(state); i64_const(XORSHIFT_C); i64_shl; i64_xor; local_set(state);
                       i32_const(0); local_get(state); i64_store(0);
                       // idx = abs(state) % len
                       local_get(state); i64_const(0); i64_lt_s;
@@ -113,7 +129,7 @@ impl FuncCompiler<'_> {
                       // Alloc option box and load elem into it
                       i32_const(es); call(self.emitter.rt.alloc); local_set(option_box);
                       local_get(option_box);
-                      local_get(xs); i32_const(4); i32_add;
+                      local_get(xs); i32_const(LIST_HEADER_BYTES); i32_add;
                       local_get(idx); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
@@ -142,16 +158,16 @@ impl FuncCompiler<'_> {
                     local_set(src);
                     local_get(src); i32_load(0); local_set(len);
                     // Alloc copy
-                    i32_const(4); local_get(len); i32_const(es); i32_mul; i32_add;
+                    i32_const(LIST_HEADER_BYTES); local_get(len); i32_const(es); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(len); i32_store(0);
                     // Copy all elements
                     i32_const(0); local_set(i);
                     block_empty; loop_empty;
                       local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(4); i32_add;
+                      local_get(dst); i32_const(LIST_HEADER_BYTES); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(src); i32_const(4); i32_add;
+                      local_get(src); i32_const(LIST_HEADER_BYTES); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
@@ -164,7 +180,7 @@ impl FuncCompiler<'_> {
                     i32_const(0); i64_load(0); local_set(state);
                     local_get(state); i64_eqz;
                     if_empty;
-                      i32_const(0); i32_const(8); call(self.emitter.rt.random_get); drop;
+                      i32_const(0); i32_const(RANDOM_SEED_BYTES); call(self.emitter.rt.random_get); drop;
                       i32_const(0); i64_load(0); local_set(state);
                       local_get(state); i64_eqz;
                       if_empty; i64_const(1); local_set(state); end;
@@ -172,9 +188,9 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); i32_const(0); i32_le_s; br_if(1);
                       // xorshift
-                      local_get(state); local_get(state); i64_const(13); i64_shl; i64_xor; local_set(state);
-                      local_get(state); local_get(state); i64_const(7); i64_shr_u; i64_xor; local_set(state);
-                      local_get(state); local_get(state); i64_const(17); i64_shl; i64_xor; local_set(state);
+                      local_get(state); local_get(state); i64_const(XORSHIFT_A); i64_shl; i64_xor; local_set(state);
+                      local_get(state); local_get(state); i64_const(XORSHIFT_B); i64_shr_u; i64_xor; local_set(state);
+                      local_get(state); local_get(state); i64_const(XORSHIFT_C); i64_shl; i64_xor; local_set(state);
                       // j = abs(state) % (i + 1)
                       local_get(state);
                       local_get(state); i64_const(0); i64_lt_s;
@@ -184,17 +200,17 @@ impl FuncCompiler<'_> {
                       // swap dst[i] and dst[j] using mem[0..es] as temp
                       // Copy dst[i] to temp
                       i32_const(0);
-                      local_get(dst); i32_const(4); i32_add;
+                      local_get(dst); i32_const(LIST_HEADER_BYTES); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
                       i32_load(0); i32_store(0);
                       // Copy dst[j] to dst[i]
-                      local_get(dst); i32_const(4); i32_add;
+                      local_get(dst); i32_const(LIST_HEADER_BYTES); i32_add;
                       local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(dst); i32_const(4); i32_add;
+                      local_get(dst); i32_const(LIST_HEADER_BYTES); i32_add;
                       local_get(j); i32_const(es); i32_mul; i32_add;
                       i32_load(0); i32_store(0);
                       // Copy temp to dst[j]
-                      local_get(dst); i32_const(4); i32_add;
+                      local_get(dst); i32_const(LIST_HEADER_BYTES); i32_add;
                       local_get(j); i32_const(es); i32_mul; i32_add;
                       i32_const(0); i32_load(0); i32_store(0);
                       local_get(i); i32_const(1); i32_sub; local_set(i);

--- a/crates/almide-codegen/src/emit_wasm/calls_random.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_random.rs
@@ -1,5 +1,6 @@
 //! random module — WASM codegen dispatch.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::FuncCompiler;
 use almide_ir::IrExpr;
 use almide_lang::types::Ty;
@@ -31,32 +32,32 @@ impl FuncCompiler<'_> {
                 let max = self.scratch.alloc_i64();
                 let state = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(min); });
+                wasm!(self.func, { local_set(Local(min)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(max);
+                    local_set(Local(max));
                     // Load PRNG state from mem[0..8]
-                    i32_const(0); i64_load(0); local_set(state);
+                    i32_const(Imm32(0)); i64_load(0); local_set(Local(state));
                     // If state == 0, initialize with seed
-                    local_get(state); i64_eqz;
+                    local_get(Local(state)); i64_eqz;
                     if_empty;
-                      i32_const(0); i32_const(RANDOM_SEED_BYTES); call(self.emitter.rt.random_get); drop;
-                      i32_const(0); i64_load(0); local_set(state);
-                      local_get(state); i64_eqz;
-                      if_empty; i64_const(1); local_set(state); end;
+                      i32_const(Imm32(0)); i32_const(Imm32(RANDOM_SEED_BYTES)); call(self.emitter.rt.random_get); drop;
+                      i32_const(Imm32(0)); i64_load(0); local_set(Local(state));
+                      local_get(Local(state)); i64_eqz;
+                      if_empty; i64_const(Imm64(1)); local_set(Local(state)); end;
                     end;
                     // xorshift64
-                    local_get(state); local_get(state); i64_const(XORSHIFT_A); i64_shl; i64_xor; local_set(state);
-                    local_get(state); local_get(state); i64_const(XORSHIFT_B); i64_shr_u; i64_xor; local_set(state);
-                    local_get(state); local_get(state); i64_const(XORSHIFT_C); i64_shl; i64_xor; local_set(state);
+                    local_get(Local(state)); local_get(Local(state)); i64_const(Imm64(XORSHIFT_A)); i64_shl; i64_xor; local_set(Local(state));
+                    local_get(Local(state)); local_get(Local(state)); i64_const(Imm64(XORSHIFT_B)); i64_shr_u; i64_xor; local_set(Local(state));
+                    local_get(Local(state)); local_get(Local(state)); i64_const(Imm64(XORSHIFT_C)); i64_shl; i64_xor; local_set(Local(state));
                     // Store back
-                    i32_const(0); local_get(state); i64_store(0);
+                    i32_const(Imm32(0)); local_get(Local(state)); i64_store(0);
                     // result = min + abs(state) % (max - min + 1)
-                    local_get(min);
+                    local_get(Local(min));
                     // abs(state)
-                    local_get(state); i64_const(0); i64_lt_s;
-                    if_i64; i64_const(0); local_get(state); i64_sub; else_; local_get(state); end;
-                    local_get(max); local_get(min); i64_sub; i64_const(1); i64_add;
+                    local_get(Local(state)); i64_const(Imm64(0)); i64_lt_s;
+                    if_i64; i64_const(Imm64(0)); local_get(Local(state)); i64_sub; else_; local_get(Local(state)); end;
+                    local_get(Local(max)); local_get(Local(min)); i64_sub; i64_const(Imm64(1)); i64_add;
                     i64_rem_u;
                     i64_add;
                 });
@@ -68,24 +69,24 @@ impl FuncCompiler<'_> {
                 // random.float() → Float in [0.0, 1.0)
                 let state = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    i32_const(0); i64_load(0); local_set(state);
-                    local_get(state); i64_eqz;
+                    i32_const(Imm32(0)); i64_load(0); local_set(Local(state));
+                    local_get(Local(state)); i64_eqz;
                     if_empty;
-                      i32_const(0); i32_const(RANDOM_SEED_BYTES); call(self.emitter.rt.random_get); drop;
-                      i32_const(0); i64_load(0); local_set(state);
-                      local_get(state); i64_eqz;
-                      if_empty; i64_const(1); local_set(state); end;
+                      i32_const(Imm32(0)); i32_const(Imm32(RANDOM_SEED_BYTES)); call(self.emitter.rt.random_get); drop;
+                      i32_const(Imm32(0)); i64_load(0); local_set(Local(state));
+                      local_get(Local(state)); i64_eqz;
+                      if_empty; i64_const(Imm64(1)); local_set(Local(state)); end;
                     end;
-                    local_get(state); local_get(state); i64_const(XORSHIFT_A); i64_shl; i64_xor; local_set(state);
-                    local_get(state); local_get(state); i64_const(XORSHIFT_B); i64_shr_u; i64_xor; local_set(state);
-                    local_get(state); local_get(state); i64_const(XORSHIFT_C); i64_shl; i64_xor; local_set(state);
-                    i32_const(0); local_get(state); i64_store(0);
+                    local_get(Local(state)); local_get(Local(state)); i64_const(Imm64(XORSHIFT_A)); i64_shl; i64_xor; local_set(Local(state));
+                    local_get(Local(state)); local_get(Local(state)); i64_const(Imm64(XORSHIFT_B)); i64_shr_u; i64_xor; local_set(Local(state));
+                    local_get(Local(state)); local_get(Local(state)); i64_const(Imm64(XORSHIFT_C)); i64_shl; i64_xor; local_set(Local(state));
+                    i32_const(Imm32(0)); local_get(Local(state)); i64_store(0);
                 });
                 // Convert to float in [0, 1): abs(state) >>> 11 * (1/2^53)
                 wasm!(self.func, {
-                    local_get(state); i64_const(0); i64_lt_s;
-                    if_i64; i64_const(0); local_get(state); i64_sub; else_; local_get(state); end;
-                    i64_const(FLOAT_MANTISSA_SHIFT); i64_shr_u;
+                    local_get(Local(state)); i64_const(Imm64(0)); i64_lt_s;
+                    if_i64; i64_const(Imm64(0)); local_get(Local(state)); i64_sub; else_; local_get(Local(state)); end;
+                    i64_const(Imm64(FLOAT_MANTISSA_SHIFT)); i64_shr_u;
                     f64_convert_i64_u;
                     f64_const(1.1102230246251565e-16); // 1.0 / 2^53
                     f64_mul;
@@ -103,39 +104,39 @@ impl FuncCompiler<'_> {
 
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(xs);
-                    local_get(xs); i32_load(0); i32_eqz;
+                    local_set(Local(xs));
+                    local_get(Local(xs)); i32_load(0); i32_eqz;
                     if_i32;
-                      i32_const(0); // none (empty list)
+                      i32_const(Imm32(0)); // none (empty list)
                     else_;
                       // PRNG to get random index
-                      i32_const(0); i64_load(0); local_set(state);
-                      local_get(state); i64_eqz;
+                      i32_const(Imm32(0)); i64_load(0); local_set(Local(state));
+                      local_get(Local(state)); i64_eqz;
                       if_empty;
-                      i32_const(0); i32_const(RANDOM_SEED_BYTES); call(self.emitter.rt.random_get); drop;
-                      i32_const(0); i64_load(0); local_set(state);
-                      local_get(state); i64_eqz;
-                      if_empty; i64_const(1); local_set(state); end;
+                      i32_const(Imm32(0)); i32_const(Imm32(RANDOM_SEED_BYTES)); call(self.emitter.rt.random_get); drop;
+                      i32_const(Imm32(0)); i64_load(0); local_set(Local(state));
+                      local_get(Local(state)); i64_eqz;
+                      if_empty; i64_const(Imm64(1)); local_set(Local(state)); end;
                     end;
-                      local_get(state); local_get(state); i64_const(XORSHIFT_A); i64_shl; i64_xor; local_set(state);
-                      local_get(state); local_get(state); i64_const(XORSHIFT_B); i64_shr_u; i64_xor; local_set(state);
-                      local_get(state); local_get(state); i64_const(XORSHIFT_C); i64_shl; i64_xor; local_set(state);
-                      i32_const(0); local_get(state); i64_store(0);
+                      local_get(Local(state)); local_get(Local(state)); i64_const(Imm64(XORSHIFT_A)); i64_shl; i64_xor; local_set(Local(state));
+                      local_get(Local(state)); local_get(Local(state)); i64_const(Imm64(XORSHIFT_B)); i64_shr_u; i64_xor; local_set(Local(state));
+                      local_get(Local(state)); local_get(Local(state)); i64_const(Imm64(XORSHIFT_C)); i64_shl; i64_xor; local_set(Local(state));
+                      i32_const(Imm32(0)); local_get(Local(state)); i64_store(0);
                       // idx = abs(state) % len
-                      local_get(state); i64_const(0); i64_lt_s;
-                      if_i64; i64_const(0); local_get(state); i64_sub; else_; local_get(state); end;
-                      local_get(xs); i32_load(0); i64_extend_i32_u;
-                      i64_rem_u; i32_wrap_i64; local_set(idx);
+                      local_get(Local(state)); i64_const(Imm64(0)); i64_lt_s;
+                      if_i64; i64_const(Imm64(0)); local_get(Local(state)); i64_sub; else_; local_get(Local(state)); end;
+                      local_get(Local(xs)); i32_load(0); i64_extend_i32_u;
+                      i64_rem_u; i32_wrap_i64; local_set(Local(idx));
                       // Alloc option box and load elem into it
-                      i32_const(es); call(self.emitter.rt.alloc); local_set(option_box);
-                      local_get(option_box);
-                      local_get(xs); i32_const(LIST_HEADER_BYTES); i32_add;
-                      local_get(idx); i32_const(es); i32_mul; i32_add;
+                      i32_const(Imm32(es)); call(self.emitter.rt.alloc); local_set(Local(option_box));
+                      local_get(Local(option_box));
+                      local_get(Local(xs)); i32_const(Imm32(LIST_HEADER_BYTES)); i32_add;
+                      local_get(Local(idx)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_store_at(&elem_ty, 0);
                 wasm!(self.func, {
-                      local_get(option_box);
+                      local_get(Local(option_box));
                     end;
                 });
                 self.scratch.free_i64(state);
@@ -155,69 +156,69 @@ impl FuncCompiler<'_> {
                 let state = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(src);
-                    local_get(src); i32_load(0); local_set(len);
+                    local_set(Local(src));
+                    local_get(Local(src)); i32_load(0); local_set(Local(len));
                     // Alloc copy
-                    i32_const(LIST_HEADER_BYTES); local_get(len); i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
+                    i32_const(Imm32(LIST_HEADER_BYTES)); local_get(Local(len)); i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
                     // Copy all elements
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(LIST_HEADER_BYTES); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(src); i32_const(LIST_HEADER_BYTES); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(LIST_HEADER_BYTES)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(src)); i32_const(Imm32(LIST_HEADER_BYTES)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
                     // Fisher-Yates shuffle (backwards)
-                    local_get(len); i32_const(1); i32_sub; local_set(i);
-                    i32_const(0); i64_load(0); local_set(state);
-                    local_get(state); i64_eqz;
+                    local_get(Local(len)); i32_const(Imm32(1)); i32_sub; local_set(Local(i));
+                    i32_const(Imm32(0)); i64_load(0); local_set(Local(state));
+                    local_get(Local(state)); i64_eqz;
                     if_empty;
-                      i32_const(0); i32_const(RANDOM_SEED_BYTES); call(self.emitter.rt.random_get); drop;
-                      i32_const(0); i64_load(0); local_set(state);
-                      local_get(state); i64_eqz;
-                      if_empty; i64_const(1); local_set(state); end;
+                      i32_const(Imm32(0)); i32_const(Imm32(RANDOM_SEED_BYTES)); call(self.emitter.rt.random_get); drop;
+                      i32_const(Imm32(0)); i64_load(0); local_set(Local(state));
+                      local_get(Local(state)); i64_eqz;
+                      if_empty; i64_const(Imm64(1)); local_set(Local(state)); end;
                     end;
                     block_empty; loop_empty;
-                      local_get(i); i32_const(0); i32_le_s; br_if(1);
+                      local_get(Local(i)); i32_const(Imm32(0)); i32_le_s; br_if(1);
                       // xorshift
-                      local_get(state); local_get(state); i64_const(XORSHIFT_A); i64_shl; i64_xor; local_set(state);
-                      local_get(state); local_get(state); i64_const(XORSHIFT_B); i64_shr_u; i64_xor; local_set(state);
-                      local_get(state); local_get(state); i64_const(XORSHIFT_C); i64_shl; i64_xor; local_set(state);
+                      local_get(Local(state)); local_get(Local(state)); i64_const(Imm64(XORSHIFT_A)); i64_shl; i64_xor; local_set(Local(state));
+                      local_get(Local(state)); local_get(Local(state)); i64_const(Imm64(XORSHIFT_B)); i64_shr_u; i64_xor; local_set(Local(state));
+                      local_get(Local(state)); local_get(Local(state)); i64_const(Imm64(XORSHIFT_C)); i64_shl; i64_xor; local_set(Local(state));
                       // j = abs(state) % (i + 1)
-                      local_get(state);
-                      local_get(state); i64_const(0); i64_lt_s;
-                      if_i64; i64_const(0); local_get(state); i64_sub; else_; local_get(state); end;
-                      local_get(i); i32_const(1); i32_add; i64_extend_i32_u;
-                      i64_rem_u; i32_wrap_i64; local_set(j);
+                      local_get(Local(state));
+                      local_get(Local(state)); i64_const(Imm64(0)); i64_lt_s;
+                      if_i64; i64_const(Imm64(0)); local_get(Local(state)); i64_sub; else_; local_get(Local(state)); end;
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; i64_extend_i32_u;
+                      i64_rem_u; i32_wrap_i64; local_set(Local(j));
                       // swap dst[i] and dst[j] using mem[0..es] as temp
                       // Copy dst[i] to temp
-                      i32_const(0);
-                      local_get(dst); i32_const(LIST_HEADER_BYTES); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      i32_const(Imm32(0));
+                      local_get(Local(dst)); i32_const(Imm32(LIST_HEADER_BYTES)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                       i32_load(0); i32_store(0);
                       // Copy dst[j] to dst[i]
-                      local_get(dst); i32_const(LIST_HEADER_BYTES); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(dst); i32_const(LIST_HEADER_BYTES); i32_add;
-                      local_get(j); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(LIST_HEADER_BYTES)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(dst)); i32_const(Imm32(LIST_HEADER_BYTES)); i32_add;
+                      local_get(Local(j)); i32_const(Imm32(es)); i32_mul; i32_add;
                       i32_load(0); i32_store(0);
                       // Copy temp to dst[j]
-                      local_get(dst); i32_const(LIST_HEADER_BYTES); i32_add;
-                      local_get(j); i32_const(es); i32_mul; i32_add;
-                      i32_const(0); i32_load(0); i32_store(0);
-                      local_get(i); i32_const(1); i32_sub; local_set(i);
+                      local_get(Local(dst)); i32_const(Imm32(LIST_HEADER_BYTES)); i32_add;
+                      local_get(Local(j)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      i32_const(Imm32(0)); i32_load(0); i32_store(0);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_sub; local_set(Local(i));
                       br(0);
                     end; end;
-                    i32_const(0); local_get(state); i64_store(0); // save state
-                    local_get(dst);
+                    i32_const(Imm32(0)); local_get(Local(state)); i64_store(0); // save state
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i64(state);
                 self.scratch.free_i32(j);

--- a/crates/almide-codegen/src/emit_wasm/calls_regex.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_regex.rs
@@ -24,6 +24,8 @@ use almide_ir::IrExpr;
 const RX_CAP_BYTES: i32 = 8;
 /// Bytes per list/buffer pointer slot.
 const PTR_BYTES: i32 = 4;
+/// Extra segment slots in the split buffer: trailing segment + one for boundary.
+const SPLIT_SEG_OVERHEAD: i32 = 2;
 
 impl FuncCompiler<'_> {
     /// Dispatch a `regex.*` module call.
@@ -147,7 +149,7 @@ impl FuncCompiler<'_> {
                 local_get(text); local_get(match_start); local_get(end_pos);
                 call(self.emitter.rt.string.slice);
                 local_set(str_ptr);
-                i32_const(4); call(self.emitter.rt.alloc); local_set(opt_ptr);
+                i32_const(PTR_BYTES); call(self.emitter.rt.alloc); local_set(opt_ptr);
                 local_get(opt_ptr); local_get(str_ptr); i32_store(0);
                 local_get(opt_ptr);
             end;
@@ -449,7 +451,7 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
             local_get(text); i32_load(0); local_set(text_len);
             // upper bound on segments: text_len+2
-            local_get(text_len); i32_const(2); i32_add; i32_const(PTR_BYTES); i32_mul;
+            local_get(text_len); i32_const(SPLIT_SEG_OVERHEAD); i32_add; i32_const(PTR_BYTES); i32_mul;
             call(self.emitter.rt.alloc); local_set(buf);
             i32_const(0); local_set(count);
             i32_const(0); local_set(pos);
@@ -607,7 +609,7 @@ impl FuncCompiler<'_> {
                         br(0);
                     end; end;
                     // wrap in Option some
-                    i32_const(4); call(self.emitter.rt.alloc); local_set(opt_ptr);
+                    i32_const(PTR_BYTES); call(self.emitter.rt.alloc); local_set(opt_ptr);
                     local_get(opt_ptr); local_get(list_ptr); i32_store(0);
                     local_get(opt_ptr);
                 end;

--- a/crates/almide-codegen/src/emit_wasm/calls_regex.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_regex.rs
@@ -17,6 +17,7 @@
 //!   regex.split(pattern, text)         → List[String]
 //!   regex.captures(pattern, text)      → Option[List[String]]  (None when ncap==0)
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use super::FuncCompiler;
 use almide_ir::IrExpr;
 
@@ -54,10 +55,10 @@ impl FuncCompiler<'_> {
         let ncap_global = self.emitter.rt.regex.ncap_global;
         let alloc = self.emitter.rt.alloc;
         wasm!(self.func, {
-            local_get(pat); call(compile); local_set(alts);
-            global_get(ncap_global); local_set(ncap);
+            local_get(Local(pat)); call(compile); local_set(Local(alts));
+            global_get(ncap_global); local_set(Local(ncap));
             // caps = alloc(ncap * RX_CAP_BYTES)  (ncap may be 0 → 0-byte alloc, fine)
-            local_get(ncap); i32_const(RX_CAP_BYTES); i32_mul; call(alloc); local_set(caps);
+            local_get(Local(ncap)); i32_const(Imm32(RX_CAP_BYTES)); i32_mul; call(alloc); local_set(Local(caps));
         });
     }
 
@@ -70,14 +71,14 @@ impl FuncCompiler<'_> {
         let ncap = self.scratch.alloc_i32();
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(pat); });
+        wasm!(self.func, { local_set(Local(pat)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { local_set(text); });
+        wasm!(self.func, { local_set(Local(text)); });
         self.emit_compile_pattern(pat, alts, caps, ncap);
         wasm!(self.func, {
-            local_get(alts); local_get(text); i32_const(0); local_get(caps); local_get(ncap);
+            local_get(Local(alts)); local_get(Local(text)); i32_const(Imm32(0)); local_get(Local(caps)); local_get(Local(ncap));
             call(self.emitter.rt.regex.find_at);
-            i32_const(-1); i32_ne;
+            i32_const(Imm32(-1)); i32_ne;
         });
 
         self.scratch.free_i32(ncap);
@@ -98,17 +99,17 @@ impl FuncCompiler<'_> {
         let end_pos = self.scratch.alloc_i32();
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(pat); });
+        wasm!(self.func, { local_set(Local(pat)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { local_set(text); });
+        wasm!(self.func, { local_set(Local(text)); });
         self.emit_compile_pattern(pat, alts, caps, ncap);
         wasm!(self.func, {
-            local_get(alts); local_get(text); i32_const(0); local_get(caps); local_get(ncap);
+            local_get(Local(alts)); local_get(Local(text)); i32_const(Imm32(0)); local_get(Local(caps)); local_get(Local(ncap));
             call(self.emitter.rt.regex.match_alts);
-            local_set(end_pos);
+            local_set(Local(end_pos));
             // full_match = end_pos != -1 && end_pos == byte_len
-            local_get(end_pos); i32_const(-1); i32_ne;
-            local_get(end_pos); local_get(text); i32_load(0); i32_eq;
+            local_get(Local(end_pos)); i32_const(Imm32(-1)); i32_ne;
+            local_get(Local(end_pos)); local_get(Local(text)); i32_load(0); i32_eq;
             i32_and;
         });
 
@@ -133,25 +134,25 @@ impl FuncCompiler<'_> {
         let opt_ptr = self.scratch.alloc_i32();
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(pat); });
+        wasm!(self.func, { local_set(Local(pat)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { local_set(text); });
+        wasm!(self.func, { local_set(Local(text)); });
         self.emit_compile_pattern(pat, alts, caps, ncap);
         wasm!(self.func, {
-            local_get(alts); local_get(text); i32_const(0); local_get(caps); local_get(ncap);
+            local_get(Local(alts)); local_get(Local(text)); i32_const(Imm32(0)); local_get(Local(caps)); local_get(Local(ncap));
             call(self.emitter.rt.regex.find_at);
-            local_set(end_pos);
-            local_get(end_pos); i32_const(-1); i32_eq;
+            local_set(Local(end_pos));
+            local_get(Local(end_pos)); i32_const(Imm32(-1)); i32_eq;
             if_i32;
-                i32_const(0); // none
+                i32_const(Imm32(0)); // none
             else_;
-                global_get(self.emitter.rt.regex.match_start_global); local_set(match_start);
-                local_get(text); local_get(match_start); local_get(end_pos);
+                global_get(self.emitter.rt.regex.match_start_global); local_set(Local(match_start));
+                local_get(Local(text)); local_get(Local(match_start)); local_get(Local(end_pos));
                 call(self.emitter.rt.string.slice);
-                local_set(str_ptr);
-                i32_const(PTR_BYTES); call(self.emitter.rt.alloc); local_set(opt_ptr);
-                local_get(opt_ptr); local_get(str_ptr); i32_store(0);
-                local_get(opt_ptr);
+                local_set(Local(str_ptr));
+                i32_const(Imm32(PTR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(opt_ptr));
+                local_get(Local(opt_ptr)); local_get(Local(str_ptr)); i32_store(0);
+                local_get(Local(opt_ptr));
             end;
         });
 
@@ -190,62 +191,62 @@ impl FuncCompiler<'_> {
         let list_data = self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32;
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(pat); });
+        wasm!(self.func, { local_set(Local(pat)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { local_set(text); });
+        wasm!(self.func, { local_set(Local(text)); });
         self.emit_compile_pattern(pat, alts, caps, ncap);
         wasm!(self.func, {
-            local_get(text); i32_load(0); local_set(text_len);
+            local_get(Local(text)); i32_load(0); local_set(Local(text_len));
             // upper bound: at most text_len+1 matches → buffer of (text_len+1) ptrs
-            local_get(text_len); i32_const(1); i32_add; i32_const(PTR_BYTES); i32_mul;
-            call(self.emitter.rt.alloc); local_set(buf);
-            i32_const(0); local_set(count);
-            i32_const(0); local_set(pos);
+            local_get(Local(text_len)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(PTR_BYTES)); i32_mul;
+            call(self.emitter.rt.alloc); local_set(Local(buf));
+            i32_const(Imm32(0)); local_set(Local(count));
+            i32_const(Imm32(0)); local_set(Local(pos));
 
             block_empty; loop_empty;
-                local_get(pos); local_get(text_len); i32_gt_u; br_if(1);
-                local_get(alts); local_get(text); local_get(pos); local_get(caps); local_get(ncap);
+                local_get(Local(pos)); local_get(Local(text_len)); i32_gt_u; br_if(1);
+                local_get(Local(alts)); local_get(Local(text)); local_get(Local(pos)); local_get(Local(caps)); local_get(Local(ncap));
                 call(self.emitter.rt.regex.find_at);
-                local_set(end_pos);
-                local_get(end_pos); i32_const(-1); i32_eq; br_if(1);
-                global_get(self.emitter.rt.regex.match_start_global); local_set(match_start);
+                local_set(Local(end_pos));
+                local_get(Local(end_pos)); i32_const(Imm32(-1)); i32_eq; br_if(1);
+                global_get(self.emitter.rt.regex.match_start_global); local_set(Local(match_start));
                 // slice the match
-                local_get(text); local_get(match_start); local_get(end_pos);
+                local_get(Local(text)); local_get(Local(match_start)); local_get(Local(end_pos));
                 call(self.emitter.rt.string.slice);
-                local_set(str_ptr);
-                local_get(buf); local_get(count); i32_const(PTR_BYTES); i32_mul; i32_add;
-                local_get(str_ptr); i32_store(0);
-                local_get(count); i32_const(1); i32_add; local_set(count);
+                local_set(Local(str_ptr));
+                local_get(Local(buf)); local_get(Local(count)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add;
+                local_get(Local(str_ptr)); i32_store(0);
+                local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count));
                 // advance: zero-width → +1 scalar width; else → end
-                local_get(end_pos); local_get(match_start); i32_eq;
+                local_get(Local(end_pos)); local_get(Local(match_start)); i32_eq;
                 if_empty;
                     // zero-width: if at end, stop; else advance one scalar
-                    local_get(end_pos); local_get(text_len); i32_ge_u;
+                    local_get(Local(end_pos)); local_get(Local(text_len)); i32_ge_u;
                     if_empty; br(3); end; // break loop
-                    local_get(text); local_get(end_pos);
-                    call(self.emitter.rt.string.utf8_width); local_set(width);
-                    local_get(end_pos); local_get(width); i32_add; local_set(pos);
+                    local_get(Local(text)); local_get(Local(end_pos));
+                    call(self.emitter.rt.string.utf8_width); local_set(Local(width));
+                    local_get(Local(end_pos)); local_get(Local(width)); i32_add; local_set(Local(pos));
                 else_;
-                    local_get(end_pos); local_set(pos);
+                    local_get(Local(end_pos)); local_set(Local(pos));
                 end;
                 br(0);
             end; end;
 
             // build result list
-            local_get(count); i32_const(PTR_BYTES); i32_mul; i32_const(list_hdr); i32_add;
-            call(self.emitter.rt.alloc); local_set(result);
-            local_get(result); local_get(count); i32_store(0);
-            i32_const(0); local_set(pos);
+            local_get(Local(count)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_const(Imm32(list_hdr)); i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(result));
+            local_get(Local(result)); local_get(Local(count)); i32_store(0);
+            i32_const(Imm32(0)); local_set(Local(pos));
             block_empty; loop_empty;
-                local_get(pos); local_get(count); i32_ge_u; br_if(1);
-                local_get(result); i32_const(list_data); i32_add;
-                local_get(pos); i32_const(PTR_BYTES); i32_mul; i32_add;
-                local_get(buf); local_get(pos); i32_const(PTR_BYTES); i32_mul; i32_add; i32_load(0);
+                local_get(Local(pos)); local_get(Local(count)); i32_ge_u; br_if(1);
+                local_get(Local(result)); i32_const(Imm32(list_data)); i32_add;
+                local_get(Local(pos)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add;
+                local_get(Local(buf)); local_get(Local(pos)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add; i32_load(0);
                 i32_store(0);
-                local_get(pos); i32_const(1); i32_add; local_set(pos);
+                local_get(Local(pos)); i32_const(Imm32(1)); i32_add; local_set(Local(pos));
                 br(0);
             end; end;
-            local_get(result);
+            local_get(Local(result));
         });
 
         self.scratch.free_i32(width);
@@ -285,70 +286,70 @@ impl FuncCompiler<'_> {
         let empty_str = self.emitter.intern_string("");
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(pat); });
+        wasm!(self.func, { local_set(Local(pat)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { local_set(text); });
+        wasm!(self.func, { local_set(Local(text)); });
         self.emit_expr(&args[2]);
-        wasm!(self.func, { local_set(repl); });
+        wasm!(self.func, { local_set(Local(repl)); });
         self.emit_compile_pattern(pat, alts, caps, ncap);
         wasm!(self.func, {
-            local_get(text); i32_load(0); local_set(text_len);
-            i32_const(empty_str as i32); local_set(result);
-            i32_const(0); local_set(pos);
+            local_get(Local(text)); i32_load(0); local_set(Local(text_len));
+            i32_const(Imm32(empty_str as i32)); local_set(Local(result));
+            i32_const(Imm32(0)); local_set(Local(pos));
 
             block_empty; loop_empty;
                 // pos > text_len → done
-                local_get(pos); local_get(text_len); i32_gt_u;
+                local_get(Local(pos)); local_get(Local(text_len)); i32_gt_u;
                 if_empty; br(2); end;
 
-                local_get(alts); local_get(text); local_get(pos); local_get(caps); local_get(ncap);
+                local_get(Local(alts)); local_get(Local(text)); local_get(Local(pos)); local_get(Local(caps)); local_get(Local(ncap));
                 call(self.emitter.rt.regex.find_at);
-                local_set(end_pos);
-                local_get(end_pos); i32_const(-1); i32_eq;
+                local_set(Local(end_pos));
+                local_get(Local(end_pos)); i32_const(Imm32(-1)); i32_eq;
                 if_empty;
                     // no more matches: append rest of text and break
-                    local_get(text); local_get(pos); local_get(text_len);
-                    call(self.emitter.rt.string.slice); local_set(segment);
-                    local_get(result); local_get(segment);
-                    call(self.emitter.rt.concat_str); local_set(result);
+                    local_get(Local(text)); local_get(Local(pos)); local_get(Local(text_len));
+                    call(self.emitter.rt.string.slice); local_set(Local(segment));
+                    local_get(Local(result)); local_get(Local(segment));
+                    call(self.emitter.rt.concat_str); local_set(Local(result));
                     br(2);
                 end;
 
-                global_get(self.emitter.rt.regex.match_start_global); local_set(match_start);
+                global_get(self.emitter.rt.regex.match_start_global); local_set(Local(match_start));
                 // append text[pos..match_start]
-                local_get(text); local_get(pos); local_get(match_start);
-                call(self.emitter.rt.string.slice); local_set(segment);
-                local_get(result); local_get(segment);
-                call(self.emitter.rt.concat_str); local_set(result);
+                local_get(Local(text)); local_get(Local(pos)); local_get(Local(match_start));
+                call(self.emitter.rt.string.slice); local_set(Local(segment));
+                local_get(Local(result)); local_get(Local(segment));
+                call(self.emitter.rt.concat_str); local_set(Local(result));
                 // append replacement (verbatim)
-                local_get(result); local_get(repl);
-                call(self.emitter.rt.concat_str); local_set(result);
+                local_get(Local(result)); local_get(Local(repl));
+                call(self.emitter.rt.concat_str); local_set(Local(result));
 
                 // advance: zero-width → emit one scalar of text then +width
-                local_get(end_pos); local_get(match_start); i32_eq;
+                local_get(Local(end_pos)); local_get(Local(match_start)); i32_eq;
                 if_empty;
                     // if end < text_len, append the scalar at `end`
-                    local_get(end_pos); local_get(text_len); i32_lt_u;
+                    local_get(Local(end_pos)); local_get(Local(text_len)); i32_lt_u;
                     if_empty;
-                        local_get(text); local_get(end_pos);
-                        call(self.emitter.rt.string.utf8_width); local_set(width);
-                        local_get(text); local_get(end_pos);
-                        local_get(end_pos); local_get(width); i32_add;
-                        call(self.emitter.rt.string.slice); local_set(segment);
-                        local_get(result); local_get(segment);
-                        call(self.emitter.rt.concat_str); local_set(result);
-                        local_get(end_pos); local_get(width); i32_add; local_set(pos);
+                        local_get(Local(text)); local_get(Local(end_pos));
+                        call(self.emitter.rt.string.utf8_width); local_set(Local(width));
+                        local_get(Local(text)); local_get(Local(end_pos));
+                        local_get(Local(end_pos)); local_get(Local(width)); i32_add;
+                        call(self.emitter.rt.string.slice); local_set(Local(segment));
+                        local_get(Local(result)); local_get(Local(segment));
+                        call(self.emitter.rt.concat_str); local_set(Local(result));
+                        local_get(Local(end_pos)); local_get(Local(width)); i32_add; local_set(Local(pos));
                     else_;
                         // end == text_len: advance past end to terminate
-                        local_get(end_pos); i32_const(1); i32_add; local_set(pos);
+                        local_get(Local(end_pos)); i32_const(Imm32(1)); i32_add; local_set(Local(pos));
                     end;
                 else_;
-                    local_get(end_pos); local_set(pos);
+                    local_get(Local(end_pos)); local_set(Local(pos));
                 end;
                 br(0);
             end; end;
 
-            local_get(result);
+            local_get(Local(result));
         });
 
         self.scratch.free_i32(width);
@@ -381,29 +382,29 @@ impl FuncCompiler<'_> {
         let after = self.scratch.alloc_i32();
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(pat); });
+        wasm!(self.func, { local_set(Local(pat)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { local_set(text); });
+        wasm!(self.func, { local_set(Local(text)); });
         self.emit_expr(&args[2]);
-        wasm!(self.func, { local_set(repl); });
+        wasm!(self.func, { local_set(Local(repl)); });
         self.emit_compile_pattern(pat, alts, caps, ncap);
         wasm!(self.func, {
-            local_get(text); i32_load(0); local_set(text_len);
-            local_get(alts); local_get(text); i32_const(0); local_get(caps); local_get(ncap);
+            local_get(Local(text)); i32_load(0); local_set(Local(text_len));
+            local_get(Local(alts)); local_get(Local(text)); i32_const(Imm32(0)); local_get(Local(caps)); local_get(Local(ncap));
             call(self.emitter.rt.regex.find_at);
-            local_set(end_pos);
-            local_get(end_pos); i32_const(-1); i32_eq;
+            local_set(Local(end_pos));
+            local_get(Local(end_pos)); i32_const(Imm32(-1)); i32_eq;
             if_i32;
-                local_get(text); // no match → text as-is
+                local_get(Local(text)); // no match → text as-is
             else_;
-                global_get(self.emitter.rt.regex.match_start_global); local_set(match_start);
-                local_get(text); i32_const(0); local_get(match_start);
-                call(self.emitter.rt.string.slice); local_set(before);
-                local_get(text); local_get(end_pos); local_get(text_len);
-                call(self.emitter.rt.string.slice); local_set(after);
-                local_get(before); local_get(repl);
+                global_get(self.emitter.rt.regex.match_start_global); local_set(Local(match_start));
+                local_get(Local(text)); i32_const(Imm32(0)); local_get(Local(match_start));
+                call(self.emitter.rt.string.slice); local_set(Local(before));
+                local_get(Local(text)); local_get(Local(end_pos)); local_get(Local(text_len));
+                call(self.emitter.rt.string.slice); local_set(Local(after));
+                local_get(Local(before)); local_get(Local(repl));
                 call(self.emitter.rt.concat_str);
-                local_get(after);
+                local_get(Local(after));
                 call(self.emitter.rt.concat_str);
             end;
         });
@@ -444,53 +445,53 @@ impl FuncCompiler<'_> {
         let list_data = self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32;
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(pat); });
+        wasm!(self.func, { local_set(Local(pat)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { local_set(text); });
+        wasm!(self.func, { local_set(Local(text)); });
         self.emit_compile_pattern(pat, alts, caps, ncap);
         wasm!(self.func, {
-            local_get(text); i32_load(0); local_set(text_len);
+            local_get(Local(text)); i32_load(0); local_set(Local(text_len));
             // upper bound on segments: text_len+2
-            local_get(text_len); i32_const(SPLIT_SEG_OVERHEAD); i32_add; i32_const(PTR_BYTES); i32_mul;
-            call(self.emitter.rt.alloc); local_set(buf);
-            i32_const(0); local_set(count);
-            i32_const(0); local_set(pos);
+            local_get(Local(text_len)); i32_const(Imm32(SPLIT_SEG_OVERHEAD)); i32_add; i32_const(Imm32(PTR_BYTES)); i32_mul;
+            call(self.emitter.rt.alloc); local_set(Local(buf));
+            i32_const(Imm32(0)); local_set(Local(count));
+            i32_const(Imm32(0)); local_set(Local(pos));
 
             block_empty; loop_empty;
-                local_get(pos); local_get(text_len); i32_gt_u; br_if(1);
+                local_get(Local(pos)); local_get(Local(text_len)); i32_gt_u; br_if(1);
 
-                local_get(alts); local_get(text); local_get(pos); local_get(caps); local_get(ncap);
+                local_get(Local(alts)); local_get(Local(text)); local_get(Local(pos)); local_get(Local(caps)); local_get(Local(ncap));
                 call(self.emitter.rt.regex.find_at);
-                local_set(end_pos);
-                local_get(end_pos); i32_const(-1); i32_eq;
+                local_set(Local(end_pos));
+                local_get(Local(end_pos)); i32_const(Imm32(-1)); i32_eq;
                 if_empty;
                     // no more matches: push rest and break
-                    local_get(text); local_get(pos); local_get(text_len);
-                    call(self.emitter.rt.string.slice); local_set(segment);
-                    local_get(buf); local_get(count); i32_const(PTR_BYTES); i32_mul; i32_add;
-                    local_get(segment); i32_store(0);
-                    local_get(count); i32_const(1); i32_add; local_set(count);
+                    local_get(Local(text)); local_get(Local(pos)); local_get(Local(text_len));
+                    call(self.emitter.rt.string.slice); local_set(Local(segment));
+                    local_get(Local(buf)); local_get(Local(count)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add;
+                    local_get(Local(segment)); i32_store(0);
+                    local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count));
                     br(2);
                 end;
 
-                global_get(self.emitter.rt.regex.match_start_global); local_set(match_start);
+                global_get(self.emitter.rt.regex.match_start_global); local_set(Local(match_start));
 
                 // zero-width at current pos: take one scalar, move on
-                local_get(end_pos); local_get(match_start); i32_eq;
-                local_get(match_start); local_get(pos); i32_eq;
+                local_get(Local(end_pos)); local_get(Local(match_start)); i32_eq;
+                local_get(Local(match_start)); local_get(Local(pos)); i32_eq;
                 i32_and;
                 if_empty;
-                    local_get(pos); local_get(text_len); i32_lt_u;
+                    local_get(Local(pos)); local_get(Local(text_len)); i32_lt_u;
                     if_empty;
-                        local_get(text); local_get(pos);
-                        call(self.emitter.rt.string.utf8_width); local_set(width);
-                        local_get(text); local_get(pos);
-                        local_get(pos); local_get(width); i32_add;
-                        call(self.emitter.rt.string.slice); local_set(segment);
-                        local_get(buf); local_get(count); i32_const(PTR_BYTES); i32_mul; i32_add;
-                        local_get(segment); i32_store(0);
-                        local_get(count); i32_const(1); i32_add; local_set(count);
-                        local_get(pos); local_get(width); i32_add; local_set(pos);
+                        local_get(Local(text)); local_get(Local(pos));
+                        call(self.emitter.rt.string.utf8_width); local_set(Local(width));
+                        local_get(Local(text)); local_get(Local(pos));
+                        local_get(Local(pos)); local_get(Local(width)); i32_add;
+                        call(self.emitter.rt.string.slice); local_set(Local(segment));
+                        local_get(Local(buf)); local_get(Local(count)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add;
+                        local_get(Local(segment)); i32_store(0);
+                        local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count));
+                        local_get(Local(pos)); local_get(Local(width)); i32_add; local_set(Local(pos));
                         // continue loop: 2 `if`s deep (if(zerowidth)/if(pos<len)),
                         // loop is the 3rd level → br(2).
                         br(2);
@@ -501,30 +502,30 @@ impl FuncCompiler<'_> {
                 end;
 
                 // normal: push text[pos..match_start], advance to end
-                local_get(text); local_get(pos); local_get(match_start);
-                call(self.emitter.rt.string.slice); local_set(segment);
-                local_get(buf); local_get(count); i32_const(PTR_BYTES); i32_mul; i32_add;
-                local_get(segment); i32_store(0);
-                local_get(count); i32_const(1); i32_add; local_set(count);
-                local_get(end_pos); local_set(pos);
+                local_get(Local(text)); local_get(Local(pos)); local_get(Local(match_start));
+                call(self.emitter.rt.string.slice); local_set(Local(segment));
+                local_get(Local(buf)); local_get(Local(count)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add;
+                local_get(Local(segment)); i32_store(0);
+                local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count));
+                local_get(Local(end_pos)); local_set(Local(pos));
                 br(0);
             end; end;
 
             // build result list
-            local_get(count); i32_const(PTR_BYTES); i32_mul; i32_const(list_hdr); i32_add;
-            call(self.emitter.rt.alloc); local_set(result);
-            local_get(result); local_get(count); i32_store(0);
-            i32_const(0); local_set(pos);
+            local_get(Local(count)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_const(Imm32(list_hdr)); i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(result));
+            local_get(Local(result)); local_get(Local(count)); i32_store(0);
+            i32_const(Imm32(0)); local_set(Local(pos));
             block_empty; loop_empty;
-                local_get(pos); local_get(count); i32_ge_u; br_if(1);
-                local_get(result); i32_const(list_data); i32_add;
-                local_get(pos); i32_const(PTR_BYTES); i32_mul; i32_add;
-                local_get(buf); local_get(pos); i32_const(PTR_BYTES); i32_mul; i32_add; i32_load(0);
+                local_get(Local(pos)); local_get(Local(count)); i32_ge_u; br_if(1);
+                local_get(Local(result)); i32_const(Imm32(list_data)); i32_add;
+                local_get(Local(pos)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add;
+                local_get(Local(buf)); local_get(Local(pos)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add; i32_load(0);
                 i32_store(0);
-                local_get(pos); i32_const(1); i32_add; local_set(pos);
+                local_get(Local(pos)); i32_const(Imm32(1)); i32_add; local_set(Local(pos));
                 br(0);
             end; end;
-            local_get(result);
+            local_get(Local(result));
         });
 
         self.scratch.free_i32(width);
@@ -565,53 +566,53 @@ impl FuncCompiler<'_> {
         let empty_str = self.emitter.intern_string("");
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(pat); });
+        wasm!(self.func, { local_set(Local(pat)); });
         self.emit_expr(&args[1]);
-        wasm!(self.func, { local_set(text); });
+        wasm!(self.func, { local_set(Local(text)); });
         self.emit_compile_pattern(pat, alts, caps, ncap);
         wasm!(self.func, {
             // ncap == 0 → None
-            local_get(ncap); i32_eqz;
+            local_get(Local(ncap)); i32_eqz;
             if_i32;
-                i32_const(0);
+                i32_const(Imm32(0));
             else_;
-                local_get(alts); local_get(text); i32_const(0); local_get(caps); local_get(ncap);
+                local_get(Local(alts)); local_get(Local(text)); i32_const(Imm32(0)); local_get(Local(caps)); local_get(Local(ncap));
                 call(self.emitter.rt.regex.find_at);
-                local_set(end_pos);
-                local_get(end_pos); i32_const(-1); i32_eq;
+                local_set(Local(end_pos));
+                local_get(Local(end_pos)); i32_const(Imm32(-1)); i32_eq;
                 if_i32;
-                    i32_const(0); // None
+                    i32_const(Imm32(0)); // None
                 else_;
                     // build list of ncap strings
-                    local_get(ncap); i32_const(PTR_BYTES); i32_mul; i32_const(list_hdr); i32_add;
-                    call(self.emitter.rt.alloc); local_set(list_ptr);
-                    local_get(list_ptr); local_get(ncap); i32_store(0);
-                    i32_const(0); local_set(i);
+                    local_get(Local(ncap)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_const(Imm32(list_hdr)); i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(list_ptr));
+                    local_get(Local(list_ptr)); local_get(Local(ncap)); i32_store(0);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                        local_get(i); local_get(ncap); i32_ge_u; br_if(1);
-                        local_get(caps); local_get(i); i32_const(RX_CAP_BYTES); i32_mul; i32_add; i32_load(0);
-                        local_set(grp_start);
-                        local_get(caps); local_get(i); i32_const(RX_CAP_BYTES); i32_mul; i32_add; i32_load(4);
-                        local_set(grp_end);
+                        local_get(Local(i)); local_get(Local(ncap)); i32_ge_u; br_if(1);
+                        local_get(Local(caps)); local_get(Local(i)); i32_const(Imm32(RX_CAP_BYTES)); i32_mul; i32_add; i32_load(0);
+                        local_set(Local(grp_start));
+                        local_get(Local(caps)); local_get(Local(i)); i32_const(Imm32(RX_CAP_BYTES)); i32_mul; i32_add; i32_load(4);
+                        local_set(Local(grp_end));
                         // unset (-1) → empty string
-                        local_get(grp_start); i32_const(-1); i32_eq;
+                        local_get(Local(grp_start)); i32_const(Imm32(-1)); i32_eq;
                         if_i32;
-                            i32_const(empty_str as i32);
+                            i32_const(Imm32(empty_str as i32));
                         else_;
-                            local_get(text); local_get(grp_start); local_get(grp_end);
+                            local_get(Local(text)); local_get(Local(grp_start)); local_get(Local(grp_end));
                             call(self.emitter.rt.string.slice);
                         end;
-                        local_set(str_ptr);
-                        local_get(list_ptr); i32_const(list_data); i32_add;
-                        local_get(i); i32_const(PTR_BYTES); i32_mul; i32_add;
-                        local_get(str_ptr); i32_store(0);
-                        local_get(i); i32_const(1); i32_add; local_set(i);
+                        local_set(Local(str_ptr));
+                        local_get(Local(list_ptr)); i32_const(Imm32(list_data)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(PTR_BYTES)); i32_mul; i32_add;
+                        local_get(Local(str_ptr)); i32_store(0);
+                        local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                         br(0);
                     end; end;
                     // wrap in Option some
-                    i32_const(PTR_BYTES); call(self.emitter.rt.alloc); local_set(opt_ptr);
-                    local_get(opt_ptr); local_get(list_ptr); i32_store(0);
-                    local_get(opt_ptr);
+                    i32_const(Imm32(PTR_BYTES)); call(self.emitter.rt.alloc); local_set(Local(opt_ptr));
+                    local_get(Local(opt_ptr)); local_get(Local(list_ptr)); i32_store(0);
+                    local_get(Local(opt_ptr));
                 end;
             end;
         });

--- a/crates/almide-codegen/src/emit_wasm/calls_set.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_set.rs
@@ -3,6 +3,7 @@
 //! Set layout: [len:i32][elem0:K_size][elem1:K_size]...
 //! Essentially a List with unique elements.
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use super::FuncCompiler;
 use super::values;
 use almide_ir::IrExpr;
@@ -15,9 +16,9 @@ impl FuncCompiler<'_> {
             "new" => {
                 let s = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); call(self.emitter.rt.alloc); local_set(s);
-                    local_get(s); i32_const(0); i32_store(0);
-                    local_get(s);
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); call(self.emitter.rt.alloc); local_set(Local(s));
+                    local_get(Local(s)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(s));
                 });
                 self.scratch.free_i32(s);
             }
@@ -40,64 +41,64 @@ impl FuncCompiler<'_> {
                 let xs = self.scratch.alloc_i32();
                 // Start with empty set
                 wasm!(self.func, {
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); call(self.emitter.rt.alloc); local_set(s);
-                    local_get(s); i32_const(0); i32_store(0);
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); call(self.emitter.rt.alloc); local_set(Local(s));
+                    local_get(Local(s)); i32_const(Imm32(0)); i32_store(0);
                 });
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(xs); // xs
-                    i32_const(0); local_set(s1); // i
+                    local_set(Local(xs)); // xs
+                    i32_const(Imm32(0)); local_set(Local(s1)); // i
                     block_empty; loop_empty;
-                      local_get(s1); local_get(xs); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(s1)); local_get(Local(xs)); i32_load(0); i32_ge_u; br_if(1);
                       // Check if elem already in set
-                      i32_const(0); local_set(s2); // j
-                      i32_const(0); local_set(s3); // found
+                      i32_const(Imm32(0)); local_set(Local(s2)); // j
+                      i32_const(Imm32(0)); local_set(Local(s3)); // found
                       block_empty; loop_empty;
-                        local_get(s2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(s2)); local_get(Local(s)); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s1); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s1)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
-                        if_empty; i32_const(1); local_set(s3); br(2); end;
-                        local_get(s2); i32_const(1); i32_add; local_set(s2);
+                        if_empty; i32_const(Imm32(1)); local_set(Local(s3)); br(2); end;
+                        local_get(Local(s2)); i32_const(Imm32(1)); i32_add; local_set(Local(s2));
                         br(0);
                       end; end;
                       // If not found, append
-                      local_get(s3); i32_eqz;
+                      local_get(Local(s3)); i32_eqz;
                       if_empty;
                         // Grow set: alloc new with len+1
-                        i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(s); i32_load(0); i32_const(1); i32_add;
-                        i32_const(es); i32_mul; i32_add;
-                        call(self.emitter.rt.alloc); local_set(s2);
-                        local_get(s2); local_get(s); i32_load(0); i32_const(1); i32_add; i32_store(0);
+                        i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(s)); i32_load(0); i32_const(Imm32(1)); i32_add;
+                        i32_const(Imm32(es)); i32_mul; i32_add;
+                        call(self.emitter.rt.alloc); local_set(Local(s2));
+                        local_get(Local(s2)); local_get(Local(s)); i32_load(0); i32_const(Imm32(1)); i32_add; i32_store(0);
                         // Copy old elements
-                        i32_const(0); local_set(s3);
+                        i32_const(Imm32(0)); local_set(Local(s3));
                         block_empty; loop_empty;
-                          local_get(s3); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                          local_get(s2); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(s3); i32_const(es); i32_mul; i32_add;
-                          local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(s3); i32_const(es); i32_mul; i32_add;
+                          local_get(Local(s3)); local_get(Local(s)); i32_load(0); i32_ge_u; br_if(1);
+                          local_get(Local(s2)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(s3)); i32_const(Imm32(es)); i32_mul; i32_add;
+                          local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(s3)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 // MOVE: from_list grows its OWN accumulator buffer and abandons the
                 // old one — the element references just relocate, no new owner.
                 self.emit_elem_copy(&elem_ty);
                 wasm!(self.func, {
-                          local_get(s3); i32_const(1); i32_add; local_set(s3);
+                          local_get(Local(s3)); i32_const(Imm32(1)); i32_add; local_set(Local(s3));
                           br(0);
                         end; end;
                         // Append new element
-                        local_get(s2); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s); i32_load(0); i32_const(es); i32_mul; i32_add;
-                        local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s1); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s)); i32_load(0); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(xs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s1)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
@@ -105,13 +106,13 @@ impl FuncCompiler<'_> {
                         // were MOVE-copied into s2, so a PLAIN rc_dec reclaims just
                         // this buffer (not the relocated elements). Without it every
                         // grow leaks its previous buffer (O(n) churn per from_list).
-                        local_get(s); call(self.emitter.rt.rc_dec);
-                        local_get(s2); local_set(s);
+                        local_get(Local(s)); call(self.emitter.rt.rc_dec);
+                        local_get(Local(s2)); local_set(Local(s));
                       end;
-                      local_get(s1); i32_const(1); i32_add; local_set(s1);
+                      local_get(Local(s1)); i32_const(Imm32(1)); i32_add; local_set(Local(s1));
                       br(0);
                     end; end;
-                    local_get(s);
+                    local_get(Local(s));
                 });
                 self.scratch.free_i32(xs);
                 self.scratch.free_i32(s3);
@@ -126,25 +127,25 @@ impl FuncCompiler<'_> {
                 let s1 = self.scratch.alloc_i32();
                 let s2 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); });
+                wasm!(self.func, { local_set(Local(s)); });
                 match values::ty_to_valtype(&elem_ty) {
                     Some(ValType::I64) => {
                         let s64 = self.scratch.alloc_i64();
                         self.emit_expr(&args[1]);
                         wasm!(self.func, {
-                            local_set(s64);
-                            i32_const(0); local_set(s1);
-                            i32_const(0); local_set(s2);
+                            local_set(Local(s64));
+                            i32_const(Imm32(0)); local_set(Local(s1));
+                            i32_const(Imm32(0)); local_set(Local(s2));
                             block_empty; loop_empty;
-                              local_get(s1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                              local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                              local_get(s1); i32_const(es); i32_mul; i32_add;
-                              i64_load(0); local_get(s64); i64_eq;
-                              if_empty; i32_const(1); local_set(s2); br(2); end;
-                              local_get(s1); i32_const(1); i32_add; local_set(s1);
+                              local_get(Local(s1)); local_get(Local(s)); i32_load(0); i32_ge_u; br_if(1);
+                              local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                              local_get(Local(s1)); i32_const(Imm32(es)); i32_mul; i32_add;
+                              i64_load(0); local_get(Local(s64)); i64_eq;
+                              if_empty; i32_const(Imm32(1)); local_set(Local(s2)); br(2); end;
+                              local_get(Local(s1)); i32_const(Imm32(1)); i32_add; local_set(Local(s1));
                               br(0);
                             end; end;
-                            local_get(s2);
+                            local_get(Local(s2));
                         });
                         self.scratch.free_i64(s64);
                     }
@@ -152,19 +153,19 @@ impl FuncCompiler<'_> {
                         let sf = self.scratch.alloc(ValType::F64);
                         self.emit_expr(&args[1]);
                         wasm!(self.func, {
-                            local_set(sf);
-                            i32_const(0); local_set(s1);
-                            i32_const(0); local_set(s2);
+                            local_set(Local(sf));
+                            i32_const(Imm32(0)); local_set(Local(s1));
+                            i32_const(Imm32(0)); local_set(Local(s2));
                             block_empty; loop_empty;
-                              local_get(s1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                              local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                              local_get(s1); i32_const(es); i32_mul; i32_add;
-                              f64_load(0); local_get(sf); f64_eq;
-                              if_empty; i32_const(1); local_set(s2); br(2); end;
-                              local_get(s1); i32_const(1); i32_add; local_set(s1);
+                              local_get(Local(s1)); local_get(Local(s)); i32_load(0); i32_ge_u; br_if(1);
+                              local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                              local_get(Local(s1)); i32_const(Imm32(es)); i32_mul; i32_add;
+                              f64_load(0); local_get(Local(sf)); f64_eq;
+                              if_empty; i32_const(Imm32(1)); local_set(Local(s2)); br(2); end;
+                              local_get(Local(s1)); i32_const(Imm32(1)); i32_add; local_set(Local(s1));
                               br(0);
                             end; end;
-                            local_get(s2);
+                            local_get(Local(s2));
                         });
                         self.scratch.free(sf, ValType::F64);
                     }
@@ -172,24 +173,24 @@ impl FuncCompiler<'_> {
                         let s3 = self.scratch.alloc_i32();
                         self.emit_expr(&args[1]);
                         wasm!(self.func, {
-                            local_set(s3);
-                            i32_const(0); local_set(s1);
-                            i32_const(0); local_set(s2);
+                            local_set(Local(s3));
+                            i32_const(Imm32(0)); local_set(Local(s1));
+                            i32_const(Imm32(0)); local_set(Local(s2));
                             block_empty; loop_empty;
-                              local_get(s1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                              local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                              local_get(s1); i32_const(es); i32_mul; i32_add;
-                              i32_load(0); local_get(s3);
+                              local_get(Local(s1)); local_get(Local(s)); i32_load(0); i32_ge_u; br_if(1);
+                              local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                              local_get(Local(s1)); i32_const(Imm32(es)); i32_mul; i32_add;
+                              i32_load(0); local_get(Local(s3));
                         });
                         // Structural eq: String + compound elements compare by value
                         // (deep), matching native set containment.
                         self.emit_eq_typed(&elem_ty);
                         wasm!(self.func, {
-                              if_empty; i32_const(1); local_set(s2); br(2); end;
-                              local_get(s1); i32_const(1); i32_add; local_set(s1);
+                              if_empty; i32_const(Imm32(1)); local_set(Local(s2)); br(2); end;
+                              local_get(Local(s1)); i32_const(Imm32(1)); i32_add; local_set(Local(s1));
                               br(0);
                             end; end;
-                            local_get(s2);
+                            local_get(Local(s2));
                         });
                         self.scratch.free_i32(s3);
                     }
@@ -207,51 +208,51 @@ impl FuncCompiler<'_> {
                 let s2 = self.scratch.alloc_i32();
                 let val = self.scratch.alloc(vt);
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); });
+                wasm!(self.func, { local_set(Local(s)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(val); });
+                wasm!(self.func, { local_set(Local(val)); });
                 wasm!(self.func, {
-                    i32_const(0); local_set(s1); // i
-                    i32_const(0); local_set(s2); // found
+                    i32_const(Imm32(0)); local_set(Local(s1)); // i
+                    i32_const(Imm32(0)); local_set(Local(s2)); // found
                     block_empty; loop_empty;
-                      local_get(s1); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(s1); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(s1)); local_get(Local(s)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(s1)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { local_get(val); });
+                wasm!(self.func, { local_get(Local(val)); });
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
-                      if_empty; i32_const(1); local_set(s2); br(2); end;
-                      local_get(s1); i32_const(1); i32_add; local_set(s1);
+                      if_empty; i32_const(Imm32(1)); local_set(Local(s2)); br(2); end;
+                      local_get(Local(s1)); i32_const(Imm32(1)); i32_add; local_set(Local(s1));
                       br(0);
                     end; end;
-                    local_get(s2);
+                    local_get(Local(s2));
                     // SHARE: dedup hit → the result IS the borrowed input set. Dup it
                     // so the caller's scope-end Dec of both the input and the result
                     // don't double-free the single heap set they now share.
-                    if_i32; local_get(s); call(self.emitter.rt.rc_inc);
+                    if_i32; local_get(Local(s)); call(self.emitter.rt.rc_inc);
                     else_;
-                      i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(s); i32_load(0); i32_const(1); i32_add;
-                      i32_const(es); i32_mul; i32_add;
-                      call(self.emitter.rt.alloc); local_set(s1);
-                      local_get(s1); local_get(s); i32_load(0); i32_const(1); i32_add; i32_store(0);
-                      i32_const(0); local_set(s2);
+                      i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(s)); i32_load(0); i32_const(Imm32(1)); i32_add;
+                      i32_const(Imm32(es)); i32_mul; i32_add;
+                      call(self.emitter.rt.alloc); local_set(Local(s1));
+                      local_get(Local(s1)); local_get(Local(s)); i32_load(0); i32_const(Imm32(1)); i32_add; i32_store(0);
+                      i32_const(Imm32(0)); local_set(Local(s2));
                       block_empty; loop_empty;
-                        local_get(s2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(s1); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
-                        local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(s2)); local_get(Local(s)); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(s1)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s2); i32_const(1); i32_add; local_set(s2);
+                        local_get(Local(s2)); i32_const(Imm32(1)); i32_add; local_set(Local(s2));
                         br(0);
                       end; end;
-                      local_get(s1); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(s); i32_load(0); i32_const(es); i32_mul; i32_add;
-                      local_get(val);
+                      local_get(Local(s1)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(s)); i32_load(0); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(val));
                 });
                 // SHARE: `val` (args[1]) is a borrowed element; the new set takes a
                 // new reference to it, so dup before storing (heap i32 only — rc_inc
@@ -261,7 +262,7 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, { call(self.emitter.rt.rc_inc); });
                 }
                 self.emit_store_at(&elem_ty, 0);
-                wasm!(self.func, { local_get(s1); end; });
+                wasm!(self.func, { local_get(Local(s1)); end; });
                 self.scratch.free(val, vt);
                 self.scratch.free_i32(s2);
                 self.scratch.free_i32(s1);
@@ -278,59 +279,59 @@ impl FuncCompiler<'_> {
                 let val = self.scratch.alloc(vt);
                 let orig = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); });
+                wasm!(self.func, { local_set(Local(s)); });
                 self.emit_expr(&args[1]);
-                wasm!(self.func, { local_set(val); });
+                wasm!(self.func, { local_set(Local(val)); });
                 wasm!(self.func, {
-                    i32_const(-1); local_set(s1); // found_idx
-                    i32_const(0); local_set(s2);
+                    i32_const(Imm32(-1)); local_set(Local(s1)); // found_idx
+                    i32_const(Imm32(0)); local_set(Local(s2));
                     block_empty; loop_empty;
-                      local_get(s2); local_get(s); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(s2); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(s2)); local_get(Local(s)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
-                wasm!(self.func, { local_get(val); });
+                wasm!(self.func, { local_get(Local(val)); });
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
-                      if_empty; local_get(s2); local_set(s1); br(2); end;
-                      local_get(s2); i32_const(1); i32_add; local_set(s2);
+                      if_empty; local_get(Local(s2)); local_set(Local(s1)); br(2); end;
+                      local_get(Local(s2)); i32_const(Imm32(1)); i32_add; local_set(Local(s2));
                       br(0);
                     end; end;
-                    local_get(s1); i32_const(0); i32_lt_s;
+                    local_get(Local(s1)); i32_const(Imm32(0)); i32_lt_s;
                     // SHARE: element absent → the result IS the borrowed input set;
                     // dup so input and result don't double-free the shared heap set.
-                    if_i32; local_get(s); call(self.emitter.rt.rc_inc); // not found
+                    if_i32; local_get(Local(s)); call(self.emitter.rt.rc_inc); // not found
                     else_;
                       // Store original set ptr
-                      local_get(s); local_set(orig);
-                      i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(orig); i32_load(0); i32_const(1); i32_sub;
-                      i32_const(es); i32_mul; i32_add;
-                      call(self.emitter.rt.alloc); local_set(s2);
-                      local_get(s2);
-                      local_get(orig); i32_load(0); i32_const(1); i32_sub;
+                      local_get(Local(s)); local_set(Local(orig));
+                      i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(orig)); i32_load(0); i32_const(Imm32(1)); i32_sub;
+                      i32_const(Imm32(es)); i32_mul; i32_add;
+                      call(self.emitter.rt.alloc); local_set(Local(s2));
+                      local_get(Local(s2));
+                      local_get(Local(orig)); i32_load(0); i32_const(Imm32(1)); i32_sub;
                       i32_store(0);
-                      i32_const(0); local_set(s3); // src_i
-                      i32_const(0); local_set(s);     // dst_i
+                      i32_const(Imm32(0)); local_set(Local(s3)); // src_i
+                      i32_const(Imm32(0)); local_set(Local(s));     // dst_i
                       block_empty; loop_empty;
-                        local_get(s3);
-                        local_get(orig); i32_load(0); // original len
+                        local_get(Local(s3));
+                        local_get(Local(orig)); i32_load(0); // original len
                         i32_ge_u; br_if(1);
-                        local_get(s3); local_get(s1); i32_ne;
+                        local_get(Local(s3)); local_get(Local(s1)); i32_ne;
                         if_empty;
-                          local_get(s2); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(s); i32_const(es); i32_mul; i32_add;
-                          local_get(orig); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(s3); i32_const(es); i32_mul; i32_add;
+                          local_get(Local(s2)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(s)); i32_const(Imm32(es)); i32_mul; i32_add;
+                          local_get(Local(orig)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(s3)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                          local_get(s); i32_const(1); i32_add; local_set(s);
+                          local_get(Local(s)); i32_const(Imm32(1)); i32_add; local_set(Local(s));
                         end;
-                        local_get(s3); i32_const(1); i32_add; local_set(s3);
+                        local_get(Local(s3)); i32_const(Imm32(1)); i32_add; local_set(Local(s3));
                         br(0);
                       end; end;
-                      local_get(s2);
+                      local_get(Local(s2));
                     end;
                 });
                 self.scratch.free_i32(orig);
@@ -351,69 +352,69 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let j = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(b);
+                    local_set(Local(b));
                     // Alloc max size: a.len + b.len
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(a); i32_load(0); local_get(b); i32_load(0); i32_add;
-                    i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(result);
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(a)); i32_load(0); local_get(Local(b)); i32_load(0); i32_add;
+                    i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(result));
                     // Copy all of a first
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(a); i32_load(0); i32_ge_u; br_if(1);
-                      local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
-                      local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(es); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(a)); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(result)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                      local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(a); i32_load(0); local_set(out_count); // out_count = a.len
+                    local_get(Local(a)); i32_load(0); local_set(Local(out_count)); // out_count = a.len
                     // Add elements from b that are not in a
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(b); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(b)); i32_load(0); i32_ge_u; br_if(1);
                       // Check if b[i] is in a
-                      i32_const(0); local_set(j);
+                      i32_const(Imm32(0)); local_set(Local(j));
                       block_empty; loop_empty;
-                        local_get(j); local_get(a); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(j)); local_get(Local(a)); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(j); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(j)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1); // found → break inner loop
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
                       // j >= a.len means NOT found → add b[i]
-                      local_get(j); local_get(a); i32_load(0); i32_ge_u;
+                      local_get(Local(j)); local_get(Local(a)); i32_load(0); i32_ge_u;
                       if_empty;
-                        local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(out_count); i32_const(es); i32_mul; i32_add;
-                        local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(result)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(out_count)); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(out_count); i32_const(1); i32_add; local_set(out_count);
+                        local_get(Local(out_count)); i32_const(Imm32(1)); i32_add; local_set(Local(out_count));
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result); local_get(out_count); i32_store(0);
-                    local_get(result);
+                    local_get(Local(result)); local_get(Local(out_count)); i32_store(0);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(j);
                 self.scratch.free_i32(i);
@@ -444,57 +445,57 @@ impl FuncCompiler<'_> {
                 let b = self.scratch.alloc_i32();
                 // a, b
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(b);
+                    local_set(Local(b));
                     // result = alloc(4 + a.len * es)
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(a); i32_load(0);
-                    i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s);
-                    i32_const(0); local_set(s1); // out_count
-                    i32_const(0); local_set(s2); // i
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(a)); i32_load(0);
+                    i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(s));
+                    i32_const(Imm32(0)); local_set(Local(s1)); // out_count
+                    i32_const(Imm32(0)); local_set(Local(s2)); // i
                     block_empty; loop_empty;
-                      local_get(s2); local_get(a); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(s2)); local_get(Local(a)); i32_load(0); i32_ge_u; br_if(1);
                       // Inner: scan b for a[i]
-                      i32_const(0); local_set(s3); // j
+                      i32_const(Imm32(0)); local_set(Local(s3)); // j
                       block_empty; loop_empty;
-                        local_get(s3); local_get(b); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(s3)); local_get(Local(b)); i32_load(0); i32_ge_u; br_if(1);
                         // Load a[i]
-                        local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
                         // Load b[j]
-                        local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s3); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s3)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1); // found → break out of inner loop
-                        local_get(s3); i32_const(1); i32_add; local_set(s3);
+                        local_get(Local(s3)); i32_const(Imm32(1)); i32_add; local_set(Local(s3));
                         br(0);
                       end; end;
                       // After inner loop: j < b.len means found
-                      local_get(s3); local_get(b); i32_load(0); i32_lt_u;
+                      local_get(Local(s3)); local_get(Local(b)); i32_load(0); i32_lt_u;
                       if_empty;
                         // Copy a[i] to result[out_count]
-                        local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s1); i32_const(es); i32_mul; i32_add;
-                        local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s1)); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s1); i32_const(1); i32_add; local_set(s1);
+                        local_get(Local(s1)); i32_const(Imm32(1)); i32_add; local_set(Local(s1));
                       end;
-                      local_get(s2); i32_const(1); i32_add; local_set(s2);
+                      local_get(Local(s2)); i32_const(Imm32(1)); i32_add; local_set(Local(s2));
                       br(0);
                     end; end;
-                    local_get(s); local_get(s1); i32_store(0);
-                    local_get(s);
+                    local_get(Local(s)); local_get(Local(s1)); i32_store(0);
+                    local_get(Local(s));
                 });
                 self.scratch.free_i32(b);
                 self.scratch.free_i32(a);
@@ -515,52 +516,52 @@ impl FuncCompiler<'_> {
                 let a = self.scratch.alloc_i32();
                 let b = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(b);
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(a); i32_load(0);
-                    i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s);
-                    i32_const(0); local_set(s1);
-                    i32_const(0); local_set(s2);
+                    local_set(Local(b));
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(a)); i32_load(0);
+                    i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(s));
+                    i32_const(Imm32(0)); local_set(Local(s1));
+                    i32_const(Imm32(0)); local_set(Local(s2));
                     block_empty; loop_empty;
-                      local_get(s2); local_get(a); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(s3); // j
+                      local_get(Local(s2)); local_get(Local(a)); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(s3)); // j
                       block_empty; loop_empty;
-                        local_get(s3); local_get(b); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(s3)); local_get(Local(b)); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s3); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s3)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1); // found → break
-                        local_get(s3); i32_const(1); i32_add; local_set(s3);
+                        local_get(Local(s3)); i32_const(Imm32(1)); i32_add; local_set(Local(s3));
                         br(0);
                       end; end;
                       // j >= b.len means NOT found → keep element
-                      local_get(s3); local_get(b); i32_load(0); i32_ge_u;
+                      local_get(Local(s3)); local_get(Local(b)); i32_load(0); i32_ge_u;
                       if_empty;
-                        local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s1); i32_const(es); i32_mul; i32_add;
-                        local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s1)); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s1); i32_const(1); i32_add; local_set(s1);
+                        local_get(Local(s1)); i32_const(Imm32(1)); i32_add; local_set(Local(s1));
                       end;
-                      local_get(s2); i32_const(1); i32_add; local_set(s2);
+                      local_get(Local(s2)); i32_const(Imm32(1)); i32_add; local_set(Local(s2));
                       br(0);
                     end; end;
-                    local_get(s); local_get(s1); i32_store(0);
-                    local_get(s);
+                    local_get(Local(s)); local_get(Local(s1)); i32_store(0);
+                    local_get(Local(s));
                 });
                 self.scratch.free_i32(b);
                 self.scratch.free_i32(a);
@@ -583,95 +584,95 @@ impl FuncCompiler<'_> {
                 let b = self.scratch.alloc_i32();
                 // a, b
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(b);
+                    local_set(Local(b));
                     // result = alloc(4 + (a.len + b.len) * es)
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32);
-                    local_get(a); i32_load(0);
-                    local_get(b); i32_load(0);
-                    i32_add; i32_const(es); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(s);
-                    i32_const(0); local_set(s1); // out_count
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32));
+                    local_get(Local(a)); i32_load(0);
+                    local_get(Local(b)); i32_load(0);
+                    i32_add; i32_const(Imm32(es)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(s));
+                    i32_const(Imm32(0)); local_set(Local(s1)); // out_count
                 });
                 // Pass 1: elements of a not in b
                 wasm!(self.func, {
-                    i32_const(0); local_set(s2);
+                    i32_const(Imm32(0)); local_set(Local(s2));
                     block_empty; loop_empty;
-                      local_get(s2); local_get(a); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(s3);
+                      local_get(Local(s2)); local_get(Local(a)); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(s3));
                       block_empty; loop_empty;
-                        local_get(s3); local_get(b); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(s3)); local_get(Local(b)); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s3); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s3)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1);
-                        local_get(s3); i32_const(1); i32_add; local_set(s3);
+                        local_get(Local(s3)); i32_const(Imm32(1)); i32_add; local_set(Local(s3));
                         br(0);
                       end; end;
-                      local_get(s3); local_get(b); i32_load(0); i32_ge_u;
+                      local_get(Local(s3)); local_get(Local(b)); i32_load(0); i32_ge_u;
                       if_empty;
-                        local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s1); i32_const(es); i32_mul; i32_add;
-                        local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s1)); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s1); i32_const(1); i32_add; local_set(s1);
+                        local_get(Local(s1)); i32_const(Imm32(1)); i32_add; local_set(Local(s1));
                       end;
-                      local_get(s2); i32_const(1); i32_add; local_set(s2);
+                      local_get(Local(s2)); i32_const(Imm32(1)); i32_add; local_set(Local(s2));
                       br(0);
                     end; end;
                 });
                 // Pass 2: elements of b not in a
                 wasm!(self.func, {
-                    i32_const(0); local_set(s2);
+                    i32_const(Imm32(0)); local_set(Local(s2));
                     block_empty; loop_empty;
-                      local_get(s2); local_get(b); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(s3);
+                      local_get(Local(s2)); local_get(Local(b)); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(s3));
                       block_empty; loop_empty;
-                        local_get(s3); local_get(a); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(s3)); local_get(Local(a)); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s3); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s3)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1);
-                        local_get(s3); i32_const(1); i32_add; local_set(s3);
+                        local_get(Local(s3)); i32_const(Imm32(1)); i32_add; local_set(Local(s3));
                         br(0);
                       end; end;
-                      local_get(s3); local_get(a); i32_load(0); i32_ge_u;
+                      local_get(Local(s3)); local_get(Local(a)); i32_load(0); i32_ge_u;
                       if_empty;
-                        local_get(s); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s1); i32_const(es); i32_mul; i32_add;
-                        local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(s)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s1)); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy_owned(&elem_ty);
                 wasm!(self.func, {
-                        local_get(s1); i32_const(1); i32_add; local_set(s1);
+                        local_get(Local(s1)); i32_const(Imm32(1)); i32_add; local_set(Local(s1));
                       end;
-                      local_get(s2); i32_const(1); i32_add; local_set(s2);
+                      local_get(Local(s2)); i32_const(Imm32(1)); i32_add; local_set(Local(s2));
                       br(0);
                     end; end;
-                    local_get(s); local_get(s1); i32_store(0);
-                    local_get(s);
+                    local_get(Local(s)); local_get(Local(s1)); i32_store(0);
+                    local_get(Local(s));
                 });
                 self.scratch.free_i32(b);
                 self.scratch.free_i32(a);
@@ -691,42 +692,42 @@ impl FuncCompiler<'_> {
                 let a = self.scratch.alloc_i32();
                 let b = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(b);
-                    i32_const(1); local_set(s); // result = true
-                    i32_const(0); local_set(s1); // i
+                    local_set(Local(b));
+                    i32_const(Imm32(1)); local_set(Local(s)); // result = true
+                    i32_const(Imm32(0)); local_set(Local(s1)); // i
                     block_empty; loop_empty;
-                      local_get(s1); local_get(a); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(s2); // j
+                      local_get(Local(s1)); local_get(Local(a)); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(s2)); // j
                       block_empty; loop_empty;
-                        local_get(s2); local_get(b); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s1); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(s2)); local_get(Local(b)); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s1)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1); // found → break inner
-                        local_get(s2); i32_const(1); i32_add; local_set(s2);
+                        local_get(Local(s2)); i32_const(Imm32(1)); i32_add; local_set(Local(s2));
                         br(0);
                       end; end;
                       // j >= b.len means NOT found → a[i] not in b → result = false
-                      local_get(s2); local_get(b); i32_load(0); i32_ge_u;
+                      local_get(Local(s2)); local_get(Local(b)); i32_load(0); i32_ge_u;
                       if_empty;
-                        i32_const(0); local_set(s);
+                        i32_const(Imm32(0)); local_set(Local(s));
                         br(2); // break outer
                       end;
-                      local_get(s1); i32_const(1); i32_add; local_set(s1);
+                      local_get(Local(s1)); i32_const(Imm32(1)); i32_add; local_set(Local(s1));
                       br(0);
                     end; end;
-                    local_get(s);
+                    local_get(Local(s));
                 });
                 self.scratch.free_i32(b);
                 self.scratch.free_i32(a);
@@ -745,42 +746,42 @@ impl FuncCompiler<'_> {
                 let a = self.scratch.alloc_i32();
                 let b = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(a); });
+                wasm!(self.func, { local_set(Local(a)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(b);
-                    i32_const(1); local_set(s); // result = true
-                    i32_const(0); local_set(s1); // i
+                    local_set(Local(b));
+                    i32_const(Imm32(1)); local_set(Local(s)); // result = true
+                    i32_const(Imm32(0)); local_set(Local(s1)); // i
                     block_empty; loop_empty;
-                      local_get(s1); local_get(a); i32_load(0); i32_ge_u; br_if(1);
-                      i32_const(0); local_set(s2); // j
+                      local_get(Local(s1)); local_get(Local(a)); i32_load(0); i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(s2)); // j
                       block_empty; loop_empty;
-                        local_get(s2); local_get(b); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s1); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(s2)); local_get(Local(b)); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s1)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 wasm!(self.func, {
-                        local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(s2); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(s2)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&elem_ty, 0);
                 self.emit_set_elem_eq(&elem_ty);
                 wasm!(self.func, {
                         br_if(1); // found → break inner
-                        local_get(s2); i32_const(1); i32_add; local_set(s2);
+                        local_get(Local(s2)); i32_const(Imm32(1)); i32_add; local_set(Local(s2));
                         br(0);
                       end; end;
                       // j < b.len means found → result = false
-                      local_get(s2); local_get(b); i32_load(0); i32_lt_u;
+                      local_get(Local(s2)); local_get(Local(b)); i32_load(0); i32_lt_u;
                       if_empty;
-                        i32_const(0); local_set(s);
+                        i32_const(Imm32(0)); local_set(Local(s));
                         br(2); // break outer
                       end;
-                      local_get(s1); i32_const(1); i32_add; local_set(s1);
+                      local_get(Local(s1)); i32_const(Imm32(1)); i32_add; local_set(Local(s1));
                       br(0);
                     end; end;
-                    local_get(s);
+                    local_get(Local(s));
                 });
                 self.scratch.free_i32(b);
                 self.scratch.free_i32(a);
@@ -809,72 +810,72 @@ impl FuncCompiler<'_> {
                 let j = self.scratch.alloc_i32();
                 let found = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(mapped);
+                    local_set(Local(mapped));
                     // Start with empty set
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(0); i32_store(0);
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
                     // For each element in mapped, insert if not present
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(mapped); i32_load(0); i32_ge_u; br_if(1);
+                      local_get(Local(i)); local_get(Local(mapped)); i32_load(0); i32_ge_u; br_if(1);
                       // Check if mapped[i] already in result
-                      i32_const(0); local_set(j);
-                      i32_const(0); local_set(found);
+                      i32_const(Imm32(0)); local_set(Local(j));
+                      i32_const(Imm32(0)); local_set(Local(found));
                       block_empty; loop_empty;
-                        local_get(j); local_get(result); i32_load(0); i32_ge_u; br_if(1);
-                        local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(j); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(j)); local_get(Local(result)); i32_load(0); i32_ge_u; br_if(1);
+                        local_get(Local(result)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(j)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&result_elem_ty, 0);
                 wasm!(self.func, {
-                        local_get(mapped); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(mapped)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&result_elem_ty, 0);
                 self.emit_set_elem_eq(&result_elem_ty);
                 wasm!(self.func, {
-                        if_empty; i32_const(1); local_set(found); br(2); end;
-                        local_get(j); i32_const(1); i32_add; local_set(j);
+                        if_empty; i32_const(Imm32(1)); local_set(Local(found)); br(2); end;
+                        local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                         br(0);
                       end; end;
-                      local_get(found); i32_eqz;
+                      local_get(Local(found)); i32_eqz;
                       if_empty;
                         // Not found: append to result
-                        i32_const(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32); local_get(result); i32_load(0); i32_const(1); i32_add;
-                        i32_const(es); i32_mul; i32_add;
-                        call(self.emitter.rt.alloc); local_set(j); // new result
-                        local_get(j); local_get(result); i32_load(0); i32_const(1); i32_add; i32_store(0);
+                        i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::LIST) as i32)); local_get(Local(result)); i32_load(0); i32_const(Imm32(1)); i32_add;
+                        i32_const(Imm32(es)); i32_mul; i32_add;
+                        call(self.emitter.rt.alloc); local_set(Local(j)); // new result
+                        local_get(Local(j)); local_get(Local(result)); i32_load(0); i32_const(Imm32(1)); i32_add; i32_store(0);
                         // Copy old elements
-                        i32_const(0); local_set(found);
+                        i32_const(Imm32(0)); local_set(Local(found));
                         block_empty; loop_empty;
-                          local_get(found); local_get(result); i32_load(0); i32_ge_u; br_if(1);
-                          local_get(j); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(found); i32_const(es); i32_mul; i32_add;
-                          local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                          local_get(found); i32_const(es); i32_mul; i32_add;
+                          local_get(Local(found)); local_get(Local(result)); i32_load(0); i32_ge_u; br_if(1);
+                          local_get(Local(j)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(found)); i32_const(Imm32(es)); i32_mul; i32_add;
+                          local_get(Local(result)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(found)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&result_elem_ty);
                 wasm!(self.func, {
-                          local_get(found); i32_const(1); i32_add; local_set(found);
+                          local_get(Local(found)); i32_const(Imm32(1)); i32_add; local_set(Local(found));
                           br(0);
                         end; end;
                         // Copy new element
-                        local_get(j); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(result); i32_load(0); i32_const(es); i32_mul; i32_add;
-                        local_get(mapped); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                        local_get(i); i32_const(es); i32_mul; i32_add;
+                        local_get(Local(j)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(result)); i32_load(0); i32_const(Imm32(es)); i32_mul; i32_add;
+                        local_get(Local(mapped)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
                 });
                 self.emit_elem_copy(&result_elem_ty);
                 wasm!(self.func, {
                         // Free the abandoned old dedup accumulator (elements MOVE-copied
                         // into j); plain rc_dec reclaims just this buffer.
-                        local_get(result); call(self.emitter.rt.rc_dec);
-                        local_get(j); local_set(result);
+                        local_get(Local(result)); call(self.emitter.rt.rc_dec);
+                        local_get(Local(j)); local_set(Local(result));
                       end;
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(result);
+                    local_get(Local(result));
                 });
                 self.scratch.free_i32(found);
                 self.scratch.free_i32(j);

--- a/crates/almide-codegen/src/emit_wasm/calls_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string.rs
@@ -2,6 +2,7 @@
 //!
 //! All `("string", _)` method call handlers live here.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::FuncCompiler;
 use almide_ir::{IrExpr, IrStringPart};
 use almide_lang::types::Ty;
@@ -109,18 +110,18 @@ impl FuncCompiler<'_> {
                 let s0 = self.scratch.alloc_i32();
                 let s1 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s0); });
+                wasm!(self.func, { local_set(Local(s0)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(s1);
-                    local_get(s1); i32_load(0); // prefix.len
-                    local_get(s0); i32_load(0); // s.len
+                    local_set(Local(s1));
+                    local_get(Local(s1)); i32_load(0); // prefix.len
+                    local_get(Local(s0)); i32_load(0); // s.len
                     i32_gt_u;
-                    if_i32; i32_const(0);
+                    if_i32; i32_const(Imm32(0));
                     else_;
-                      local_get(s0); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(s1); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(s1); i32_load(0);
+                      local_get(Local(s0)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(s1)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(s1)); i32_load(0);
                       call(self.emitter.rt.mem_eq);
                     end;
                 });
@@ -131,20 +132,20 @@ impl FuncCompiler<'_> {
                 let s0 = self.scratch.alloc_i32();
                 let s1 = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s0); });
+                wasm!(self.func, { local_set(Local(s0)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(s1);
-                    local_get(s1); i32_load(0);
-                    local_get(s0); i32_load(0);
+                    local_set(Local(s1));
+                    local_get(Local(s1)); i32_load(0);
+                    local_get(Local(s0)); i32_load(0);
                     i32_gt_u;
-                    if_i32; i32_const(0);
+                    if_i32; i32_const(Imm32(0));
                     else_;
-                      local_get(s0); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(s0); i32_load(0); i32_add;
-                      local_get(s1); i32_load(0); i32_sub;
-                      local_get(s1); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                      local_get(s1); i32_load(0);
+                      local_get(Local(s0)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(s0)); i32_load(0); i32_add;
+                      local_get(Local(s1)); i32_load(0); i32_sub;
+                      local_get(Local(s1)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                      local_get(Local(s1)); i32_load(0);
                       call(self.emitter.rt.mem_eq);
                     end;
                 });
@@ -159,36 +160,36 @@ impl FuncCompiler<'_> {
                 let cp = self.scratch.alloc_i32();  // result string ptr
                 let i64v = self.scratch.alloc_i64();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); });
+                wasm!(self.func, { local_set(Local(s)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(i64v);
-                    local_get(i64v); i64_const(0); i64_lt_s;
+                    local_set(Local(i64v));
+                    local_get(Local(i64v)); i64_const(Imm64(0)); i64_lt_s;
                     if_i32;
-                      i32_const(0); // none
+                      i32_const(Imm32(0)); // none
                     else_;
                       // saturate the cp index to i32::MAX; utf8_byte_of_cp maps
                       // any count at/past the end to byte_len → none below.
-                      local_get(i64v); i64_const(CP_SAT_CEIL_I64); i64_gt_s;
+                      local_get(Local(i64v)); i64_const(Imm64(CP_SAT_CEIL_I64)); i64_gt_s;
                       if_i32;
-                        i32_const(CP_SAT_CEIL_I32);
+                        i32_const(Imm32(CP_SAT_CEIL_I32));
                       else_;
-                        local_get(i64v); i32_wrap_i64;
+                        local_get(Local(i64v)); i32_wrap_i64;
                       end;
-                      local_set(i);
-                      local_get(s); local_get(i); call(self.emitter.rt.string.utf8_byte_of_cp); local_set(i);
-                      local_get(i); local_get(s); i32_load(0); i32_ge_u;
+                      local_set(Local(i));
+                      local_get(Local(s)); local_get(Local(i)); call(self.emitter.rt.string.utf8_byte_of_cp); local_set(Local(i));
+                      local_get(Local(i)); local_get(Local(s)); i32_load(0); i32_ge_u;
                       if_i32;
-                        i32_const(0); // none
+                        i32_const(Imm32(0)); // none
                       else_;
                         // cp = slice(s, i, i + width(s, i))
-                        local_get(s); local_get(i);
-                        local_get(i); local_get(s); local_get(i); call(self.emitter.rt.string.utf8_width); i32_add;
-                        call(self.emitter.rt.string.slice); local_set(cp);
+                        local_get(Local(s)); local_get(Local(i));
+                        local_get(Local(i)); local_get(Local(s)); local_get(Local(i)); call(self.emitter.rt.string.utf8_width); i32_add;
+                        call(self.emitter.rt.string.slice); local_set(Local(cp));
                         // wrap in some: alloc ptr, store string ptr
-                        i32_const(OPTION_PTR_BOX_BYTES); call(self.emitter.rt.alloc); local_set(i);
-                        local_get(i); local_get(cp); i32_store(0);
-                        local_get(i);
+                        i32_const(Imm32(OPTION_PTR_BOX_BYTES)); call(self.emitter.rt.alloc); local_set(Local(i));
+                        local_get(Local(i)); local_get(Local(cp)); i32_store(0);
+                        local_get(Local(i));
                       end;
                     end;
                 });
@@ -224,33 +225,33 @@ impl FuncCompiler<'_> {
                 let start_b = self.scratch.alloc_i32();
                 let end_b = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s_ptr); });
+                wasm!(self.func, { local_set(Local(s_ptr)); });
                 self.emit_expr(&args[1]);
                 self.emit_clamp_count_signed_i32(super::calls_list_helpers::ClampHi::Const(STRING_COUNT_HUGE));
                 wasm!(self.func, {
-                    local_set(start_b);
-                    local_get(s_ptr); local_get(start_b);
-                    call(self.emitter.rt.string.utf8_byte_of_cp); local_set(start_b);
+                    local_set(Local(start_b));
+                    local_get(Local(s_ptr)); local_get(Local(start_b));
+                    call(self.emitter.rt.string.utf8_byte_of_cp); local_set(Local(start_b));
                 });
                 if args.len() > 2 {
                     self.emit_expr(&args[2]);
                     self.emit_clamp_count_signed_i32(super::calls_list_helpers::ClampHi::Const(STRING_COUNT_HUGE));
                     wasm!(self.func, {
-                        local_set(end_b);
-                        local_get(s_ptr); local_get(end_b);
-                        call(self.emitter.rt.string.utf8_byte_of_cp); local_set(end_b);
+                        local_set(Local(end_b));
+                        local_get(Local(s_ptr)); local_get(Local(end_b));
+                        call(self.emitter.rt.string.utf8_byte_of_cp); local_set(Local(end_b));
                     });
                 } else {
-                    wasm!(self.func, { local_get(s_ptr); i32_load(0); local_set(end_b); });
+                    wasm!(self.func, { local_get(Local(s_ptr)); i32_load(0); local_set(Local(end_b)); });
                 }
                 wasm!(self.func, {
                     // start >= end → empty string (matches native; also guards
                     // __str_slice against an unsigned `end - start` underflow)
-                    local_get(start_b); local_get(end_b); i32_ge_u;
+                    local_get(Local(start_b)); local_get(Local(end_b)); i32_ge_u;
                     if_i32;
-                        i32_const(0); call(self.emitter.rt.string_alloc);
+                        i32_const(Imm32(0)); call(self.emitter.rt.string_alloc);
                     else_;
-                        local_get(s_ptr); local_get(start_b); local_get(end_b);
+                        local_get(Local(s_ptr)); local_get(Local(start_b)); local_get(Local(end_b));
                         call(self.emitter.rt.string.slice);
                     end;
                 });
@@ -266,20 +267,20 @@ impl FuncCompiler<'_> {
                 let s32 = self.scratch.alloc_i32();
                 let s_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s_ptr); local_get(s_ptr); });
+                wasm!(self.func, { local_set(Local(s_ptr)); local_get(Local(s_ptr)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
                     call(self.emitter.rt.string.index_of);
-                    local_set(s64);
-                    local_get(s64); i64_const(-1i64 as i64); i64_eq;
+                    local_set(Local(s64));
+                    local_get(Local(s64)); i64_const(Imm64(-1i64 as i64)); i64_eq;
                     if_i32;
-                      i32_const(0);
+                      i32_const(Imm32(0));
                     else_;
-                      local_get(s_ptr); local_get(s64); i32_wrap_i64;
-                      call(self.emitter.rt.string.cp_of_byte); local_set(s64);
-                      i32_const(OPTION_INT_BOX_BYTES); call(self.emitter.rt.alloc); local_set(s32);
-                      local_get(s32); local_get(s64); i64_store(0);
-                      local_get(s32);
+                      local_get(Local(s_ptr)); local_get(Local(s64)); i32_wrap_i64;
+                      call(self.emitter.rt.string.cp_of_byte); local_set(Local(s64));
+                      i32_const(Imm32(OPTION_INT_BOX_BYTES)); call(self.emitter.rt.alloc); local_set(Local(s32));
+                      local_get(Local(s32)); local_get(Local(s64)); i64_store(0);
+                      local_get(Local(s32));
                     end;
                 });
                 self.scratch.free_i32(s_ptr);
@@ -292,20 +293,20 @@ impl FuncCompiler<'_> {
                 let s32 = self.scratch.alloc_i32();
                 let s_ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s_ptr); local_get(s_ptr); });
+                wasm!(self.func, { local_set(Local(s_ptr)); local_get(Local(s_ptr)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
                     call(self.emitter.rt.string.last_index_of);
-                    local_set(s64);
-                    local_get(s64); i64_const(-1i64 as i64); i64_eq;
+                    local_set(Local(s64));
+                    local_get(Local(s64)); i64_const(Imm64(-1i64 as i64)); i64_eq;
                     if_i32;
-                      i32_const(0);
+                      i32_const(Imm32(0));
                     else_;
-                      local_get(s_ptr); local_get(s64); i32_wrap_i64;
-                      call(self.emitter.rt.string.cp_of_byte); local_set(s64);
-                      i32_const(OPTION_INT_BOX_BYTES); call(self.emitter.rt.alloc); local_set(s32);
-                      local_get(s32); local_get(s64); i64_store(0);
-                      local_get(s32);
+                      local_get(Local(s_ptr)); local_get(Local(s64)); i32_wrap_i64;
+                      call(self.emitter.rt.string.cp_of_byte); local_set(Local(s64));
+                      i32_const(Imm32(OPTION_INT_BOX_BYTES)); call(self.emitter.rt.alloc); local_set(Local(s32));
+                      local_get(Local(s32)); local_get(Local(s64)); i64_store(0);
+                      local_get(Local(s32));
                     end;
                 });
                 self.scratch.free_i32(s_ptr);
@@ -403,15 +404,15 @@ impl FuncCompiler<'_> {
                 let some = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); i32_eqz;
-                    if_i32; i32_const(0);
+                    local_set(Local(s));
+                    local_get(Local(s)); i32_load(0); i32_eqz;
+                    if_i32; i32_const(Imm32(0));
                     else_;
-                      i32_const(OPTION_INT_BOX_BYTES); call(self.emitter.rt.alloc); local_set(some);
-                      local_get(some);
-                      local_get(s); i32_const(0); call(self.emitter.rt.string.utf8_scalar);
+                      i32_const(Imm32(OPTION_INT_BOX_BYTES)); call(self.emitter.rt.alloc); local_set(Local(some));
+                      local_get(Local(some));
+                      local_get(Local(s)); i32_const(Imm32(0)); call(self.emitter.rt.string.utf8_scalar);
                       i64_store(0);
-                      local_get(some);
+                      local_get(Local(some));
                     end;
                 });
                 self.scratch.free_i32(some);
@@ -426,65 +427,65 @@ impl FuncCompiler<'_> {
                 let data = self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 as u32;
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(cp);
+                    i32_wrap_i64; local_set(Local(cp));
                     // invalid? cp < 0 || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF)
-                    local_get(cp); i32_const(0); i32_lt_s;
-                    local_get(cp); i32_const(UNICODE_MAX_SCALAR); i32_gt_s; i32_or;
-                    local_get(cp); i32_const(UNICODE_SURR_LO); i32_ge_s;
-                    local_get(cp); i32_const(UNICODE_SURR_HI); i32_le_s; i32_and; i32_or;
+                    local_get(Local(cp)); i32_const(Imm32(0)); i32_lt_s;
+                    local_get(Local(cp)); i32_const(Imm32(UNICODE_MAX_SCALAR)); i32_gt_s; i32_or;
+                    local_get(Local(cp)); i32_const(Imm32(UNICODE_SURR_LO)); i32_ge_s;
+                    local_get(Local(cp)); i32_const(Imm32(UNICODE_SURR_HI)); i32_le_s; i32_and; i32_or;
                     if_i32;
                       // invalid → empty string
-                      i32_const(0); call(self.emitter.rt.string_alloc);
+                      i32_const(Imm32(0)); call(self.emitter.rt.string_alloc);
                     else_;
-                      local_get(cp); i32_const(UTF8_1B_LIMIT); i32_lt_s;
+                      local_get(Local(cp)); i32_const(Imm32(UTF8_1B_LIMIT)); i32_lt_s;
                       if_i32;
                         // 1 byte
-                        i32_const(1); call(self.emitter.rt.string_alloc); local_set(r);
-                        local_get(r); local_get(cp); i32_store8(data);
-                        local_get(r);
+                        i32_const(Imm32(1)); call(self.emitter.rt.string_alloc); local_set(Local(r));
+                        local_get(Local(r)); local_get(Local(cp)); i32_store8(data);
+                        local_get(Local(r));
                       else_;
-                        local_get(cp); i32_const(UTF8_2B_LIMIT); i32_lt_s;
+                        local_get(Local(cp)); i32_const(Imm32(UTF8_2B_LIMIT)); i32_lt_s;
                         if_i32;
                           // 2 bytes
-                          i32_const(UTF8_2B_LEN); call(self.emitter.rt.string_alloc); local_set(r);
-                          local_get(r);
-                          i32_const(UTF8_2B_LEAD); local_get(cp); i32_const(UTF8_SHIFT_6); i32_shr_u; i32_or;
+                          i32_const(Imm32(UTF8_2B_LEN)); call(self.emitter.rt.string_alloc); local_set(Local(r));
+                          local_get(Local(r));
+                          i32_const(Imm32(UTF8_2B_LEAD)); local_get(Local(cp)); i32_const(Imm32(UTF8_SHIFT_6)); i32_shr_u; i32_or;
                           i32_store8(data);
-                          local_get(r);
-                          i32_const(UTF8_CONT_PREFIX); local_get(cp); i32_const(UTF8_PAYLOAD_MASK); i32_and; i32_or;
+                          local_get(Local(r));
+                          i32_const(Imm32(UTF8_CONT_PREFIX)); local_get(Local(cp)); i32_const(Imm32(UTF8_PAYLOAD_MASK)); i32_and; i32_or;
                           i32_store8(data + 1);
-                          local_get(r);
+                          local_get(Local(r));
                         else_;
-                          local_get(cp); i32_const(UTF8_3B_LIMIT); i32_lt_s;
+                          local_get(Local(cp)); i32_const(Imm32(UTF8_3B_LIMIT)); i32_lt_s;
                           if_i32;
                             // 3 bytes
-                            i32_const(UTF8_3B_LEN); call(self.emitter.rt.string_alloc); local_set(r);
-                            local_get(r);
-                            i32_const(UTF8_3B_LEAD); local_get(cp); i32_const(UTF8_SHIFT_12); i32_shr_u; i32_or;
+                            i32_const(Imm32(UTF8_3B_LEN)); call(self.emitter.rt.string_alloc); local_set(Local(r));
+                            local_get(Local(r));
+                            i32_const(Imm32(UTF8_3B_LEAD)); local_get(Local(cp)); i32_const(Imm32(UTF8_SHIFT_12)); i32_shr_u; i32_or;
                             i32_store8(data);
-                            local_get(r);
-                            i32_const(UTF8_CONT_PREFIX); local_get(cp); i32_const(UTF8_SHIFT_6); i32_shr_u; i32_const(UTF8_PAYLOAD_MASK); i32_and; i32_or;
+                            local_get(Local(r));
+                            i32_const(Imm32(UTF8_CONT_PREFIX)); local_get(Local(cp)); i32_const(Imm32(UTF8_SHIFT_6)); i32_shr_u; i32_const(Imm32(UTF8_PAYLOAD_MASK)); i32_and; i32_or;
                             i32_store8(data + 1);
-                            local_get(r);
-                            i32_const(UTF8_CONT_PREFIX); local_get(cp); i32_const(UTF8_PAYLOAD_MASK); i32_and; i32_or;
+                            local_get(Local(r));
+                            i32_const(Imm32(UTF8_CONT_PREFIX)); local_get(Local(cp)); i32_const(Imm32(UTF8_PAYLOAD_MASK)); i32_and; i32_or;
                             i32_store8(data + 2);
-                            local_get(r);
+                            local_get(Local(r));
                           else_;
                             // 4 bytes
-                            i32_const(UTF8_4B_LEN); call(self.emitter.rt.string_alloc); local_set(r);
-                            local_get(r);
-                            i32_const(UTF8_4B_LEAD); local_get(cp); i32_const(UTF8_SHIFT_18); i32_shr_u; i32_or;
+                            i32_const(Imm32(UTF8_4B_LEN)); call(self.emitter.rt.string_alloc); local_set(Local(r));
+                            local_get(Local(r));
+                            i32_const(Imm32(UTF8_4B_LEAD)); local_get(Local(cp)); i32_const(Imm32(UTF8_SHIFT_18)); i32_shr_u; i32_or;
                             i32_store8(data);
-                            local_get(r);
-                            i32_const(UTF8_CONT_PREFIX); local_get(cp); i32_const(UTF8_SHIFT_12); i32_shr_u; i32_const(UTF8_PAYLOAD_MASK); i32_and; i32_or;
+                            local_get(Local(r));
+                            i32_const(Imm32(UTF8_CONT_PREFIX)); local_get(Local(cp)); i32_const(Imm32(UTF8_SHIFT_12)); i32_shr_u; i32_const(Imm32(UTF8_PAYLOAD_MASK)); i32_and; i32_or;
                             i32_store8(data + 1);
-                            local_get(r);
-                            i32_const(UTF8_CONT_PREFIX); local_get(cp); i32_const(UTF8_SHIFT_6); i32_shr_u; i32_const(UTF8_PAYLOAD_MASK); i32_and; i32_or;
+                            local_get(Local(r));
+                            i32_const(Imm32(UTF8_CONT_PREFIX)); local_get(Local(cp)); i32_const(Imm32(UTF8_SHIFT_6)); i32_shr_u; i32_const(Imm32(UTF8_PAYLOAD_MASK)); i32_and; i32_or;
                             i32_store8(data + 2);
-                            local_get(r);
-                            i32_const(UTF8_CONT_PREFIX); local_get(cp); i32_const(UTF8_PAYLOAD_MASK); i32_and; i32_or;
+                            local_get(Local(r));
+                            i32_const(Imm32(UTF8_CONT_PREFIX)); local_get(Local(cp)); i32_const(Imm32(UTF8_PAYLOAD_MASK)); i32_and; i32_or;
                             i32_store8(data + 3);
-                            local_get(r);
+                            local_get(Local(r));
                           end;
                         end;
                       end;
@@ -516,18 +517,18 @@ impl FuncCompiler<'_> {
                 let some = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); i32_eqz; // empty?
-                    if_i32; i32_const(0); // none
+                    local_set(Local(s));
+                    local_get(Local(s)); i32_load(0); i32_eqz; // empty?
+                    if_i32; i32_const(Imm32(0)); // none
                     else_;
                       // cp = slice(s, 0, width(s, 0))
-                      local_get(s); i32_const(0);
-                      local_get(s); i32_const(0); call(self.emitter.rt.string.utf8_width);
-                      call(self.emitter.rt.string.slice); local_set(cp);
+                      local_get(Local(s)); i32_const(Imm32(0));
+                      local_get(Local(s)); i32_const(Imm32(0)); call(self.emitter.rt.string.utf8_width);
+                      call(self.emitter.rt.string.slice); local_set(Local(cp));
                       // wrap in some
-                      i32_const(OPTION_PTR_BOX_BYTES); call(self.emitter.rt.alloc); local_set(some);
-                      local_get(some); local_get(cp); i32_store(0);
-                      local_get(some);
+                      i32_const(Imm32(OPTION_PTR_BOX_BYTES)); call(self.emitter.rt.alloc); local_set(Local(some));
+                      local_get(Local(some)); local_get(Local(cp)); i32_store(0);
+                      local_get(Local(some));
                     end;
                 });
                 self.scratch.free_i32(some);
@@ -541,22 +542,22 @@ impl FuncCompiler<'_> {
                 let cp = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(s);
-                    local_get(s); i32_load(0); i32_eqz;
-                    if_i32; i32_const(0);
+                    local_set(Local(s));
+                    local_get(Local(s)); i32_load(0); i32_eqz;
+                    if_i32; i32_const(Imm32(0));
                     else_;
                       // start = byte_of_cp(s, char_count(s) - 1)
-                      local_get(s);
-                      local_get(s); call(self.emitter.rt.string.char_count); i32_wrap_i64;
-                      i32_const(1); i32_sub;
-                      call(self.emitter.rt.string.utf8_byte_of_cp); local_set(start);
+                      local_get(Local(s));
+                      local_get(Local(s)); call(self.emitter.rt.string.char_count); i32_wrap_i64;
+                      i32_const(Imm32(1)); i32_sub;
+                      call(self.emitter.rt.string.utf8_byte_of_cp); local_set(Local(start));
                       // cp = slice(s, start, byte_len)
-                      local_get(s); local_get(start); local_get(s); i32_load(0);
-                      call(self.emitter.rt.string.slice); local_set(cp);
+                      local_get(Local(s)); local_get(Local(start)); local_get(Local(s)); i32_load(0);
+                      call(self.emitter.rt.string.slice); local_set(Local(cp));
                       // wrap in some
-                      i32_const(OPTION_PTR_BOX_BYTES); call(self.emitter.rt.alloc); local_set(start);
-                      local_get(start); local_get(cp); i32_store(0);
-                      local_get(start);
+                      i32_const(Imm32(OPTION_PTR_BOX_BYTES)); call(self.emitter.rt.alloc); local_set(Local(start));
+                      local_get(Local(start)); local_get(Local(cp)); i32_store(0);
+                      local_get(Local(start));
                     end;
                 });
                 self.scratch.free_i32(cp);
@@ -571,7 +572,7 @@ impl FuncCompiler<'_> {
                 let n = self.scratch.alloc_i32();
                 let cp = self.scratch.alloc_i32(); // count - n
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); });
+                wasm!(self.func, { local_set(Local(s)); });
                 self.emit_expr(&args[1]);
                 // Unsigned saturate the i64 COUNT (C-054): native take_end uses
                 // `n as usize >= count → start 0` (whole string). A negative `n`
@@ -581,16 +582,16 @@ impl FuncCompiler<'_> {
                 // `2^32`/`2^32+k` (they wrap to small non-negative counts).
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::Const(STRING_COUNT_HUGE));
                 wasm!(self.func, {
-                    local_set(n);
+                    local_set(Local(n));
                     // cp = char_count(s) - n
-                    local_get(s); call(self.emitter.rt.string.char_count); i32_wrap_i64;
-                    local_get(n); i32_sub; local_set(cp);
+                    local_get(Local(s)); call(self.emitter.rt.string.char_count); i32_wrap_i64;
+                    local_get(Local(n)); i32_sub; local_set(Local(cp));
                     // start_byte = byte_of_cp(s, max(0, cp))
-                    local_get(cp); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(cp); end;
-                    local_get(s);
-                    local_get(s); local_get(cp); call(self.emitter.rt.string.utf8_byte_of_cp);
-                    local_get(s); i32_load(0);
+                    local_get(Local(cp)); i32_const(Imm32(0)); i32_lt_s;
+                    if_empty; i32_const(Imm32(0)); local_set(Local(cp)); end;
+                    local_get(Local(s));
+                    local_get(Local(s)); local_get(Local(cp)); call(self.emitter.rt.string.utf8_byte_of_cp);
+                    local_get(Local(s)); i32_load(0);
                     call(self.emitter.rt.string.slice);
                 });
                 self.scratch.free_i32(cp);
@@ -604,7 +605,7 @@ impl FuncCompiler<'_> {
                 let n = self.scratch.alloc_i32();
                 let cp = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); });
+                wasm!(self.func, { local_set(Local(s)); });
                 self.emit_expr(&args[1]);
                 // Unsigned saturate the i64 COUNT (C-054): native drop_end uses
                 // `n as usize >= count → end 0` (empty). A negative `n` OR any
@@ -612,13 +613,13 @@ impl FuncCompiler<'_> {
                 // sentinel here, so `cp = count - n` underflows to <0 → end 0.
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::Const(STRING_COUNT_HUGE));
                 wasm!(self.func, {
-                    local_set(n);
-                    local_get(s); call(self.emitter.rt.string.char_count); i32_wrap_i64;
-                    local_get(n); i32_sub; local_set(cp); // cp = count - n
-                    local_get(cp); i32_const(0); i32_lt_s;
-                    if_empty; i32_const(0); local_set(cp); end;
-                    local_get(s); i32_const(0);
-                    local_get(s); local_get(cp); call(self.emitter.rt.string.utf8_byte_of_cp);
+                    local_set(Local(n));
+                    local_get(Local(s)); call(self.emitter.rt.string.char_count); i32_wrap_i64;
+                    local_get(Local(n)); i32_sub; local_set(Local(cp)); // cp = count - n
+                    local_get(Local(cp)); i32_const(Imm32(0)); i32_lt_s;
+                    if_empty; i32_const(Imm32(0)); local_set(Local(cp)); end;
+                    local_get(Local(s)); i32_const(Imm32(0));
+                    local_get(Local(s)); local_get(Local(cp)); call(self.emitter.rt.string.utf8_byte_of_cp);
                     call(self.emitter.rt.string.slice);
                 });
                 self.scratch.free_i32(cp);
@@ -631,7 +632,7 @@ impl FuncCompiler<'_> {
                 let s = self.scratch.alloc_i32();
                 let n = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); });
+                wasm!(self.func, { local_set(Local(s)); });
                 self.emit_expr(&args[1]);
                 // Saturate the i64 codepoint COUNT to [0, i32::MAX] BEFORE the
                 // wrap (C-054). Native `take(n as usize)` is UNSIGNED, so a
@@ -644,9 +645,9 @@ impl FuncCompiler<'_> {
                 // clamps to byte_len → whole string.
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::Const(STRING_COUNT_HUGE));
                 wasm!(self.func, {
-                    local_set(n);
-                    local_get(s); i32_const(0);
-                    local_get(s); local_get(n); call(self.emitter.rt.string.utf8_byte_of_cp);
+                    local_set(Local(n));
+                    local_get(Local(s)); i32_const(Imm32(0));
+                    local_get(Local(s)); local_get(Local(n)); call(self.emitter.rt.string.utf8_byte_of_cp);
                     call(self.emitter.rt.string.slice);
                 });
                 self.scratch.free_i32(n);
@@ -658,7 +659,7 @@ impl FuncCompiler<'_> {
                 let s = self.scratch.alloc_i32();
                 let n = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(s); });
+                wasm!(self.func, { local_set(Local(s)); });
                 self.emit_expr(&args[1]);
                 // Unsigned saturate the i64 COUNT (C-054): native
                 // `drop(n as usize)` treats a negative `n` and any `n >= 2^32`
@@ -666,10 +667,10 @@ impl FuncCompiler<'_> {
                 // sentinel; `byte_of_cp` then clamps the start to byte_len.
                 self.emit_clamp_count_to_i32(super::calls_list_helpers::ClampHi::Const(STRING_COUNT_HUGE));
                 wasm!(self.func, {
-                    local_set(n);
-                    local_get(s);
-                    local_get(s); local_get(n); call(self.emitter.rt.string.utf8_byte_of_cp);
-                    local_get(s); i32_load(0);
+                    local_set(Local(n));
+                    local_get(Local(s));
+                    local_get(Local(s)); local_get(Local(n)); call(self.emitter.rt.string.utf8_byte_of_cp);
+                    local_get(Local(s)); i32_load(0);
                     call(self.emitter.rt.string.slice);
                 });
                 self.scratch.free_i32(n);
@@ -693,7 +694,7 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
                     call(self.emitter.rt.string_append);
-                    local_set(new_ptr);
+                    local_set(Local(new_ptr));
                 });
                 // Write the (possibly reallocated) string ptr back into the
                 // local / global / mutable-capture cell.
@@ -706,7 +707,7 @@ impl FuncCompiler<'_> {
                 // writeback is needed — the pointer is unchanged. Mirrors
                 // `list.clear`.
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { i32_const(0); i32_store(0); });
+                wasm!(self.func, { i32_const(Imm32(0)); i32_store(0); });
             }
             _ => return false,
         }
@@ -739,7 +740,7 @@ impl FuncCompiler<'_> {
 
         if parts.is_empty() {
             let empty = self.emitter.intern_string("");
-            wasm!(self.func, { i32_const(empty as i32); });
+            wasm!(self.func, { i32_const(Imm32(empty as i32)); });
             return;
         }
 
@@ -754,46 +755,46 @@ impl FuncCompiler<'_> {
         for part in parts {
             self.emit_string_part(part);
             let local = self.scratch.alloc_i32();
-            wasm!(self.func, { local_set(local); });
+            wasm!(self.func, { local_set(Local(local)); });
             part_locals.push(local);
         }
 
         // Stage 2: total_len = sum(load(part) for each part).
         // String header layout: mem0[ptr + 0] = byte length.
         let total_len_local = self.scratch.alloc_i32();
-        wasm!(self.func, { i32_const(0); local_set(total_len_local); });
+        wasm!(self.func, { i32_const(Imm32(0)); local_set(Local(total_len_local)); });
         for &p in &part_locals {
             wasm!(self.func, {
-                local_get(total_len_local);
-                local_get(p);
+                local_get(Local(total_len_local));
+                local_get(Local(p));
                 i32_load(0);
                 i32_add;
-                local_set(total_len_local);
+                local_set(Local(total_len_local));
             });
         }
 
         // Stage 3: alloc result = [len:i32][cap:i32][data...] with one heap bump.
         let result_local = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_get(total_len_local);
-            i32_const(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32);
+            local_get(Local(total_len_local));
+            i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::STRING) as i32));
             i32_add;
         });
         let alloc_fn = self.emitter.rt.alloc;
         wasm!(self.func, {
             call(alloc_fn);
-            local_set(result_local);
+            local_set(Local(result_local));
         });
         // Write length prefix.
         wasm!(self.func, {
-            local_get(result_local);
-            local_get(total_len_local);
+            local_get(Local(result_local));
+            local_get(Local(total_len_local));
             i32_store(0);
         });
         // Write capacity = total_len.
         wasm!(self.func, {
-            local_get(result_local);
-            local_get(total_len_local);
+            local_get(Local(result_local));
+            local_get(Local(total_len_local));
             i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32);
         });
 
@@ -801,33 +802,33 @@ impl FuncCompiler<'_> {
         // dst starts at result + self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32 and advances by each part's length.
         let dst_local = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_get(result_local);
-            i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
+            local_get(Local(result_local));
+            i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
             i32_add;
-            local_set(dst_local);
+            local_set(Local(dst_local));
         });
         for &p in &part_locals {
             wasm!(self.func, {
                 // memory.copy(dst, src=part+self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32, len=mem0[part])
-                local_get(dst_local);
-                local_get(p);
-                i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
+                local_get(Local(dst_local));
+                local_get(Local(p));
+                i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
                 i32_add;
-                local_get(p);
+                local_get(Local(p));
                 i32_load(0);
                 memory_copy(0, 0);
                 // dst += part length
-                local_get(dst_local);
-                local_get(p);
+                local_get(Local(dst_local));
+                local_get(Local(p));
                 i32_load(0);
                 i32_add;
-                local_set(dst_local);
+                local_set(Local(dst_local));
             });
         }
 
         // Leave the result pointer on the stack as the interp value, then
         // release the scratch locals.
-        wasm!(self.func, { local_get(result_local); });
+        wasm!(self.func, { local_get(Local(result_local)); });
         for p in part_locals {
             self.scratch.free_i32(p);
         }
@@ -841,7 +842,7 @@ impl FuncCompiler<'_> {
         match part {
             IrStringPart::Lit { value } => {
                 let offset = self.emitter.intern_string(value);
-                wasm!(self.func, { i32_const(offset as i32); });
+                wasm!(self.func, { i32_const(Imm32(offset as i32)); });
             }
             IrStringPart::Expr { expr } => {
                 match &expr.ty {
@@ -856,9 +857,9 @@ impl FuncCompiler<'_> {
                         let f = self.emitter.intern_string("false");
                         wasm!(self.func, {
                             if_i32;
-                            i32_const(t as i32);
+                            i32_const(Imm32(t as i32));
                             else_;
-                            i32_const(f as i32);
+                            i32_const(Imm32(f as i32));
                             end;
                         });
                     }

--- a/crates/almide-codegen/src/emit_wasm/calls_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string.rs
@@ -17,6 +17,55 @@ use almide_lang::types::Ty;
 /// is explicit instead of a bare `2147483647` literal.
 const STRING_COUNT_HUGE: i64 = i32::MAX as i64;
 
+// ── Named immediates ────────────────────────────────────────────────────────
+
+/// Saturated codepoint index ceiling as i64 (for `i64_gt_s` guard in `get`).
+/// Same semantic as STRING_COUNT_HUGE; typed i64 to match the i64_const opcode.
+const CP_SAT_CEIL_I64: i64 = 0x7FFF_FFFF;
+/// Saturated codepoint index ceiling as i32 (the wrapped value after `i32_wrap_i64`).
+const CP_SAT_CEIL_I32: i32 = 0x7FFF_FFFF;
+
+/// Heap allocation size for an `Option[String]` / `some(ptr)` box: one i32 pointer.
+const OPTION_PTR_BOX_BYTES: i32 = 4;
+/// Heap allocation size for an `Option[Int]` / `some(Int)` box: one i64 value.
+const OPTION_INT_BOX_BYTES: i32 = 8;
+
+// UTF-8 encoding constants used in `from_codepoint`.
+/// Max valid Unicode scalar value (U+10FFFF).
+const UNICODE_MAX_SCALAR: i32 = 0x10FFFF;
+/// First Unicode surrogate code point (low surrogate range start; invalid in UTF-8).
+const UNICODE_SURR_LO: i32 = 0xD800;
+/// Last Unicode surrogate code point (high surrogate range end; invalid in UTF-8).
+const UNICODE_SURR_HI: i32 = 0xDFFF;
+/// Codepoints strictly below this are encoded as 1 UTF-8 byte (ASCII range < 128).
+const UTF8_1B_LIMIT: i32 = 0x80;
+/// Codepoints strictly below this are encoded as at most 2 UTF-8 bytes (< 2048).
+const UTF8_2B_LIMIT: i32 = 0x800;
+/// Codepoints strictly below this are encoded as at most 3 UTF-8 bytes (< 65536).
+const UTF8_3B_LIMIT: i32 = 0x10000;
+/// Lead byte mask for 2-byte UTF-8 sequences: 110xxxxx.
+const UTF8_2B_LEAD: i32 = 0xC0;
+/// Lead byte mask for 3-byte UTF-8 sequences: 1110xxxx.
+const UTF8_3B_LEAD: i32 = 0xE0;
+/// Lead byte mask for 4-byte UTF-8 sequences: 11110xxx.
+const UTF8_4B_LEAD: i32 = 0xF0;
+/// Continuation byte OR-in prefix for UTF-8 non-lead bytes: 10xxxxxx.
+const UTF8_CONT_PREFIX: i32 = 0x80;
+/// Mask extracting the 6-bit payload from a UTF-8 continuation byte position.
+const UTF8_PAYLOAD_MASK: i32 = 0x3F;
+/// Right-shift to reach the 2nd UTF-8 payload group (bits 6–11).
+const UTF8_SHIFT_6: i32 = 6;
+/// Right-shift to reach the 3rd UTF-8 payload group (bits 12–17).
+const UTF8_SHIFT_12: i32 = 12;
+/// Right-shift to reach the 4th UTF-8 payload group (bits 18–20).
+const UTF8_SHIFT_18: i32 = 18;
+/// Byte length of a 2-byte UTF-8 sequence (used as alloc size for string_alloc).
+const UTF8_2B_LEN: i32 = 2;
+/// Byte length of a 3-byte UTF-8 sequence (used as alloc size for string_alloc).
+const UTF8_3B_LEN: i32 = 3;
+/// Byte length of a 4-byte UTF-8 sequence (used as alloc size for string_alloc).
+const UTF8_4B_LEN: i32 = 4;
+
 impl FuncCompiler<'_> {
     /// Dispatch a string stdlib method call. Returns true if handled.
     pub(super) fn emit_string_call(
@@ -120,9 +169,9 @@ impl FuncCompiler<'_> {
                     else_;
                       // saturate the cp index to i32::MAX; utf8_byte_of_cp maps
                       // any count at/past the end to byte_len → none below.
-                      local_get(i64v); i64_const(0x7FFF_FFFF); i64_gt_s;
+                      local_get(i64v); i64_const(CP_SAT_CEIL_I64); i64_gt_s;
                       if_i32;
-                        i32_const(0x7FFF_FFFF);
+                        i32_const(CP_SAT_CEIL_I32);
                       else_;
                         local_get(i64v); i32_wrap_i64;
                       end;
@@ -137,7 +186,7 @@ impl FuncCompiler<'_> {
                         local_get(i); local_get(s); local_get(i); call(self.emitter.rt.string.utf8_width); i32_add;
                         call(self.emitter.rt.string.slice); local_set(cp);
                         // wrap in some: alloc ptr, store string ptr
-                        i32_const(4); call(self.emitter.rt.alloc); local_set(i);
+                        i32_const(OPTION_PTR_BOX_BYTES); call(self.emitter.rt.alloc); local_set(i);
                         local_get(i); local_get(cp); i32_store(0);
                         local_get(i);
                       end;
@@ -228,7 +277,7 @@ impl FuncCompiler<'_> {
                     else_;
                       local_get(s_ptr); local_get(s64); i32_wrap_i64;
                       call(self.emitter.rt.string.cp_of_byte); local_set(s64);
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(s32);
+                      i32_const(OPTION_INT_BOX_BYTES); call(self.emitter.rt.alloc); local_set(s32);
                       local_get(s32); local_get(s64); i64_store(0);
                       local_get(s32);
                     end;
@@ -254,7 +303,7 @@ impl FuncCompiler<'_> {
                     else_;
                       local_get(s_ptr); local_get(s64); i32_wrap_i64;
                       call(self.emitter.rt.string.cp_of_byte); local_set(s64);
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(s32);
+                      i32_const(OPTION_INT_BOX_BYTES); call(self.emitter.rt.alloc); local_set(s32);
                       local_get(s32); local_get(s64); i64_store(0);
                       local_get(s32);
                     end;
@@ -358,7 +407,7 @@ impl FuncCompiler<'_> {
                     local_get(s); i32_load(0); i32_eqz;
                     if_i32; i32_const(0);
                     else_;
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(some);
+                      i32_const(OPTION_INT_BOX_BYTES); call(self.emitter.rt.alloc); local_set(some);
                       local_get(some);
                       local_get(s); i32_const(0); call(self.emitter.rt.string.utf8_scalar);
                       i64_store(0);
@@ -380,60 +429,60 @@ impl FuncCompiler<'_> {
                     i32_wrap_i64; local_set(cp);
                     // invalid? cp < 0 || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF)
                     local_get(cp); i32_const(0); i32_lt_s;
-                    local_get(cp); i32_const(0x10FFFF); i32_gt_s; i32_or;
-                    local_get(cp); i32_const(0xD800); i32_ge_s;
-                    local_get(cp); i32_const(0xDFFF); i32_le_s; i32_and; i32_or;
+                    local_get(cp); i32_const(UNICODE_MAX_SCALAR); i32_gt_s; i32_or;
+                    local_get(cp); i32_const(UNICODE_SURR_LO); i32_ge_s;
+                    local_get(cp); i32_const(UNICODE_SURR_HI); i32_le_s; i32_and; i32_or;
                     if_i32;
                       // invalid → empty string
                       i32_const(0); call(self.emitter.rt.string_alloc);
                     else_;
-                      local_get(cp); i32_const(0x80); i32_lt_s;
+                      local_get(cp); i32_const(UTF8_1B_LIMIT); i32_lt_s;
                       if_i32;
                         // 1 byte
                         i32_const(1); call(self.emitter.rt.string_alloc); local_set(r);
                         local_get(r); local_get(cp); i32_store8(data);
                         local_get(r);
                       else_;
-                        local_get(cp); i32_const(0x800); i32_lt_s;
+                        local_get(cp); i32_const(UTF8_2B_LIMIT); i32_lt_s;
                         if_i32;
                           // 2 bytes
-                          i32_const(2); call(self.emitter.rt.string_alloc); local_set(r);
+                          i32_const(UTF8_2B_LEN); call(self.emitter.rt.string_alloc); local_set(r);
                           local_get(r);
-                          i32_const(0xC0); local_get(cp); i32_const(6); i32_shr_u; i32_or;
+                          i32_const(UTF8_2B_LEAD); local_get(cp); i32_const(UTF8_SHIFT_6); i32_shr_u; i32_or;
                           i32_store8(data);
                           local_get(r);
-                          i32_const(0x80); local_get(cp); i32_const(0x3F); i32_and; i32_or;
+                          i32_const(UTF8_CONT_PREFIX); local_get(cp); i32_const(UTF8_PAYLOAD_MASK); i32_and; i32_or;
                           i32_store8(data + 1);
                           local_get(r);
                         else_;
-                          local_get(cp); i32_const(0x10000); i32_lt_s;
+                          local_get(cp); i32_const(UTF8_3B_LIMIT); i32_lt_s;
                           if_i32;
                             // 3 bytes
-                            i32_const(3); call(self.emitter.rt.string_alloc); local_set(r);
+                            i32_const(UTF8_3B_LEN); call(self.emitter.rt.string_alloc); local_set(r);
                             local_get(r);
-                            i32_const(0xE0); local_get(cp); i32_const(12); i32_shr_u; i32_or;
+                            i32_const(UTF8_3B_LEAD); local_get(cp); i32_const(UTF8_SHIFT_12); i32_shr_u; i32_or;
                             i32_store8(data);
                             local_get(r);
-                            i32_const(0x80); local_get(cp); i32_const(6); i32_shr_u; i32_const(0x3F); i32_and; i32_or;
+                            i32_const(UTF8_CONT_PREFIX); local_get(cp); i32_const(UTF8_SHIFT_6); i32_shr_u; i32_const(UTF8_PAYLOAD_MASK); i32_and; i32_or;
                             i32_store8(data + 1);
                             local_get(r);
-                            i32_const(0x80); local_get(cp); i32_const(0x3F); i32_and; i32_or;
+                            i32_const(UTF8_CONT_PREFIX); local_get(cp); i32_const(UTF8_PAYLOAD_MASK); i32_and; i32_or;
                             i32_store8(data + 2);
                             local_get(r);
                           else_;
                             // 4 bytes
-                            i32_const(4); call(self.emitter.rt.string_alloc); local_set(r);
+                            i32_const(UTF8_4B_LEN); call(self.emitter.rt.string_alloc); local_set(r);
                             local_get(r);
-                            i32_const(0xF0); local_get(cp); i32_const(18); i32_shr_u; i32_or;
+                            i32_const(UTF8_4B_LEAD); local_get(cp); i32_const(UTF8_SHIFT_18); i32_shr_u; i32_or;
                             i32_store8(data);
                             local_get(r);
-                            i32_const(0x80); local_get(cp); i32_const(12); i32_shr_u; i32_const(0x3F); i32_and; i32_or;
+                            i32_const(UTF8_CONT_PREFIX); local_get(cp); i32_const(UTF8_SHIFT_12); i32_shr_u; i32_const(UTF8_PAYLOAD_MASK); i32_and; i32_or;
                             i32_store8(data + 1);
                             local_get(r);
-                            i32_const(0x80); local_get(cp); i32_const(6); i32_shr_u; i32_const(0x3F); i32_and; i32_or;
+                            i32_const(UTF8_CONT_PREFIX); local_get(cp); i32_const(UTF8_SHIFT_6); i32_shr_u; i32_const(UTF8_PAYLOAD_MASK); i32_and; i32_or;
                             i32_store8(data + 2);
                             local_get(r);
-                            i32_const(0x80); local_get(cp); i32_const(0x3F); i32_and; i32_or;
+                            i32_const(UTF8_CONT_PREFIX); local_get(cp); i32_const(UTF8_PAYLOAD_MASK); i32_and; i32_or;
                             i32_store8(data + 3);
                             local_get(r);
                           end;
@@ -476,7 +525,7 @@ impl FuncCompiler<'_> {
                       local_get(s); i32_const(0); call(self.emitter.rt.string.utf8_width);
                       call(self.emitter.rt.string.slice); local_set(cp);
                       // wrap in some
-                      i32_const(4); call(self.emitter.rt.alloc); local_set(some);
+                      i32_const(OPTION_PTR_BOX_BYTES); call(self.emitter.rt.alloc); local_set(some);
                       local_get(some); local_get(cp); i32_store(0);
                       local_get(some);
                     end;
@@ -505,7 +554,7 @@ impl FuncCompiler<'_> {
                       local_get(s); local_get(start); local_get(s); i32_load(0);
                       call(self.emitter.rt.string.slice); local_set(cp);
                       // wrap in some
-                      i32_const(4); call(self.emitter.rt.alloc); local_set(start);
+                      i32_const(OPTION_PTR_BOX_BYTES); call(self.emitter.rt.alloc); local_set(start);
                       local_get(start); local_get(cp); i32_store(0);
                       local_get(start);
                     end;

--- a/crates/almide-codegen/src/emit_wasm/calls_string_repr.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_string_repr.rs
@@ -20,6 +20,7 @@
 //! pointer on the stack. Strings are joined with `__concat_str` and interned
 //! literal separators (`[`, `, `, `]`, `: `, `some(`, …).
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use super::FuncCompiler;
 use almide_lang::types::Ty;
 use almide_lang::types::constructor::TypeConstructorId;
@@ -62,7 +63,7 @@ impl FuncCompiler<'_> {
                 let t = self.emitter.intern_string("true");
                 let f = self.emitter.intern_string("false");
                 wasm!(self.func, {
-                    if_i32; i32_const(t as i32); else_; i32_const(f as i32); end;
+                    if_i32; i32_const(Imm32(t as i32)); else_; i32_const(Imm32(f as i32)); end;
                 });
             }
             // ── Containers ──
@@ -200,36 +201,36 @@ impl FuncCompiler<'_> {
         let concat = self.emitter.rt.concat_str;
 
         wasm!(self.func, {
-            local_set(lst);
-            local_get(lst); i32_load(0); local_set(len);
+            local_set(Local(lst));
+            local_get(Local(lst)); i32_load(0); local_set(Local(len));
             // Empty → exact literal (`[]`, `[:]` is map-only, `set.from_list([])`).
-            local_get(len); i32_eqz;
+            local_get(Local(len)); i32_eqz;
             if_i32;
-              i32_const(empty_s);
+              i32_const(Imm32(empty_s));
             else_;
-              i32_const(open_s); local_set(acc);
-              i32_const(0); local_set(i);
+              i32_const(Imm32(open_s)); local_set(Local(acc));
+              i32_const(Imm32(0)); local_set(Local(i));
               block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                 // separator before every element except the first
-                local_get(i); i32_eqz;
+                local_get(Local(i)); i32_eqz;
                 if_empty; else_;
-                  local_get(acc); i32_const(sep_s); call(concat); local_set(acc);
+                  local_get(Local(acc)); i32_const(Imm32(sep_s)); call(concat); local_set(Local(acc));
                 end;
                 // acc = acc ++ repr(elem[i])
-                local_get(acc);
+                local_get(Local(acc));
                 // load elem[i] onto stack: addr = lst + data_off + i*elem_size
-                local_get(lst); i32_const(data_off); i32_add;
-                local_get(i); i32_const(elem_size); i32_mul; i32_add;
+                local_get(Local(lst)); i32_const(Imm32(data_off)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(elem_size)); i32_mul; i32_add;
             });
             self.emit_load_at(elem_ty, 0);
             self.emit_repr_value(elem_ty);
             wasm!(self.func, {
-                call(concat); local_set(acc);
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                call(concat); local_set(Local(acc));
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
               end; end;
-              local_get(acc); i32_const(close_s); call(concat);
+              local_get(Local(acc)); i32_const(Imm32(close_s)); call(concat);
             end;
         });
 
@@ -269,49 +270,49 @@ impl FuncCompiler<'_> {
         let concat = self.emitter.rt.concat_str;
 
         wasm!(self.func, {
-            local_set(m);
-            local_get(m); i32_load(0); local_set(len);
-            local_get(m); i32_load(cap_off); local_set(cap);
+            local_set(Local(m));
+            local_get(Local(m)); i32_load(0); local_set(Local(len));
+            local_get(Local(m)); i32_load(cap_off); local_set(Local(cap));
         });
         self.emit_dict_entries_base(m, cap);
         wasm!(self.func, {
-            local_set(eb);
-            local_get(len); i32_eqz;
+            local_set(Local(eb));
+            local_get(Local(len)); i32_eqz;
             if_i32;
-              i32_const(empty_s);
+              i32_const(Imm32(empty_s));
             else_;
-              i32_const(open_s); local_set(acc);
-              i32_const(0); local_set(i);
+              i32_const(Imm32(open_s)); local_set(Local(acc));
+              i32_const(Imm32(0)); local_set(Local(i));
               block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
-                local_get(i); i32_eqz;
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                local_get(Local(i)); i32_eqz;
                 if_empty; else_;
-                  local_get(acc); i32_const(sep_s); call(concat); local_set(acc);
+                  local_get(Local(acc)); i32_const(Imm32(sep_s)); call(concat); local_set(Local(acc));
                 end;
                 // entry = eb + i*es
-                local_get(eb); local_get(i); i32_const(es); i32_mul; i32_add;
-                local_set(entry);
+                local_get(Local(eb)); local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
+                local_set(Local(entry));
                 // acc ++ repr(key)
-                local_get(acc);
-                local_get(entry);
+                local_get(Local(acc));
+                local_get(Local(entry));
         });
         self.emit_load_at(&key_ty, 0);
         self.emit_repr_value(&key_ty);
         wasm!(self.func, {
                 call(concat);
-                i32_const(kv_s); call(concat); local_set(acc);
+                i32_const(Imm32(kv_s)); call(concat); local_set(Local(acc));
                 // acc ++ repr(value)   (value at entry + ks)
-                local_get(acc);
-                local_get(entry); i32_const(ks as i32); i32_add;
+                local_get(Local(acc));
+                local_get(Local(entry)); i32_const(Imm32(ks as i32)); i32_add;
         });
         self.emit_load_at(&val_ty, 0);
         self.emit_repr_value(&val_ty);
         wasm!(self.func, {
-                call(concat); local_set(acc);
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                call(concat); local_set(Local(acc));
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
               end; end;
-              local_get(acc); i32_const(close_s); call(concat);
+              local_get(Local(acc)); i32_const(Imm32(close_s)); call(concat);
             end;
         });
 
@@ -336,24 +337,24 @@ impl FuncCompiler<'_> {
         let concat = self.emitter.rt.concat_str;
 
         wasm!(self.func, {
-            local_set(tp);
-            i32_const(open_s); local_set(acc);
+            local_set(Local(tp));
+            i32_const(Imm32(open_s)); local_set(Local(acc));
         });
         let mut offset = 0u32;
         for (idx, elem_ty) in elems.iter().enumerate() {
             if idx > 0 {
-                wasm!(self.func, { local_get(acc); i32_const(sep_s); call(concat); local_set(acc); });
+                wasm!(self.func, { local_get(Local(acc)); i32_const(Imm32(sep_s)); call(concat); local_set(Local(acc)); });
             }
             wasm!(self.func, {
-                local_get(acc);
-                local_get(tp); i32_const(offset as i32); i32_add;
+                local_get(Local(acc));
+                local_get(Local(tp)); i32_const(Imm32(offset as i32)); i32_add;
             });
             self.emit_load_at(elem_ty, 0);
             self.emit_repr_value(elem_ty);
-            wasm!(self.func, { call(concat); local_set(acc); });
+            wasm!(self.func, { call(concat); local_set(Local(acc)); });
             offset += values::byte_size(elem_ty);
         }
-        wasm!(self.func, { local_get(acc); i32_const(close_s); call(concat); });
+        wasm!(self.func, { local_get(Local(acc)); i32_const(Imm32(close_s)); call(concat); });
 
         self.scratch.free_i32(acc);
         self.scratch.free_i32(tp);
@@ -370,19 +371,19 @@ impl FuncCompiler<'_> {
         let concat = self.emitter.rt.concat_str;
 
         wasm!(self.func, {
-            local_set(opt);
-            local_get(opt); i32_eqz;
+            local_set(Local(opt));
+            local_get(Local(opt)); i32_eqz;
             if_i32;
-              i32_const(none_s);
+              i32_const(Imm32(none_s));
             else_;
-              i32_const(some_s);
-              local_get(opt);
+              i32_const(Imm32(some_s));
+              local_get(Local(opt));
         });
         self.emit_load_at(inner_ty, 0);
         self.emit_repr_value(inner_ty);
         wasm!(self.func, {
               call(concat);
-              i32_const(close_s); call(concat);
+              i32_const(Imm32(close_s)); call(concat);
             end;
         });
 
@@ -400,25 +401,25 @@ impl FuncCompiler<'_> {
         let concat = self.emitter.rt.concat_str;
 
         wasm!(self.func, {
-            local_set(res);
+            local_set(Local(res));
             // tag == 0 → ok branch
-            local_get(res); i32_load(0); i32_eqz;
+            local_get(Local(res)); i32_load(0); i32_eqz;
             if_i32;
-              i32_const(ok_s);
-              local_get(res);
+              i32_const(Imm32(ok_s));
+              local_get(Local(res));
         });
         self.emit_load_at(ok_ty, RESULT_PAYLOAD_OFFSET);
         self.emit_repr_value(ok_ty);
         wasm!(self.func, {
-              call(concat); i32_const(close_s); call(concat);
+              call(concat); i32_const(Imm32(close_s)); call(concat);
             else_;
-              i32_const(err_s);
-              local_get(res);
+              i32_const(Imm32(err_s));
+              local_get(Local(res));
         });
         self.emit_load_at(err_ty, RESULT_PAYLOAD_OFFSET);
         self.emit_repr_value(err_ty);
         wasm!(self.func, {
-              call(concat); i32_const(close_s); call(concat);
+              call(concat); i32_const(Imm32(close_s)); call(concat);
             end;
         });
 
@@ -481,8 +482,8 @@ impl FuncCompiler<'_> {
         let concat = self.emitter.rt.concat_str;
 
         wasm!(self.func, {
-            local_set(rec);
-            i32_const(open_s); local_set(acc);
+            local_set(Local(rec));
+            i32_const(Imm32(open_s)); local_set(Local(acc));
         });
         for (render_idx, &(field_idx, field_off)) in placed.iter().enumerate() {
             let (fname, fty) = &fields[field_idx];
@@ -491,15 +492,15 @@ impl FuncCompiler<'_> {
             let label = format!("{}{}: ", if render_idx > 0 { ", " } else { "" }, fname);
             let label_s = self.emitter.intern_string(&label) as i32;
             wasm!(self.func, {
-                local_get(acc); i32_const(label_s); call(concat); local_set(acc);
-                local_get(acc);
-                local_get(rec); i32_const(field_off as i32); i32_add;
+                local_get(Local(acc)); i32_const(Imm32(label_s)); call(concat); local_set(Local(acc));
+                local_get(Local(acc));
+                local_get(Local(rec)); i32_const(Imm32(field_off as i32)); i32_add;
             });
             self.emit_load_at(fty, 0);
             self.emit_repr_value(fty);
-            wasm!(self.func, { call(concat); local_set(acc); });
+            wasm!(self.func, { call(concat); local_set(Local(acc)); });
         }
-        wasm!(self.func, { local_get(acc); i32_const(close_s); call(concat); });
+        wasm!(self.func, { local_get(Local(acc)); i32_const(Imm32(close_s)); call(concat); });
 
         self.scratch.free_i32(acc);
         self.scratch.free_i32(rec);
@@ -555,8 +556,8 @@ impl FuncCompiler<'_> {
         let val = self.scratch.alloc_i32();
         let tag = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(val);
-            local_get(val); i32_load(0); local_set(tag); // tag @ cell start
+            local_set(Local(val));
+            local_get(Local(val)); i32_load(0); local_set(Local(tag)); // tag @ cell start
         });
 
         let n = cases.len();
@@ -565,7 +566,7 @@ impl FuncCompiler<'_> {
             if !is_last {
                 // if tag == case.tag { <case> } else { …next… }
                 wasm!(self.func, {
-                    local_get(tag); i32_const(case.tag as i32); i32_eq;
+                    local_get(Local(tag)); i32_const(Imm32(case.tag as i32)); i32_eq;
                     if_i32;
                 });
             }
@@ -591,7 +592,7 @@ impl FuncCompiler<'_> {
     fn emit_repr_variant_case(&mut self, val: u32, payload_off: u32, ctor: &str, fields: &[(String, Ty)]) {
         if fields.is_empty() {
             let name_s = self.emitter.intern_string(ctor) as i32;
-            wasm!(self.func, { i32_const(name_s); });
+            wasm!(self.func, { i32_const(Imm32(name_s)); });
             return;
         }
 
@@ -606,7 +607,7 @@ impl FuncCompiler<'_> {
 
         let acc = self.scratch.alloc_i32();
         let concat = self.emitter.rt.concat_str;
-        wasm!(self.func, { i32_const(open_s); local_set(acc); });
+        wasm!(self.func, { i32_const(Imm32(open_s)); local_set(Local(acc)); });
 
         let mut offset = payload_off;
         for (idx, (fname, fty)) in fields.iter().enumerate() {
@@ -618,18 +619,18 @@ impl FuncCompiler<'_> {
             };
             if !label.is_empty() {
                 let label_s = self.emitter.intern_string(&label) as i32;
-                wasm!(self.func, { local_get(acc); i32_const(label_s); call(concat); local_set(acc); });
+                wasm!(self.func, { local_get(Local(acc)); i32_const(Imm32(label_s)); call(concat); local_set(Local(acc)); });
             }
             wasm!(self.func, {
-                local_get(acc);
-                local_get(val); i32_const(offset as i32); i32_add;
+                local_get(Local(acc));
+                local_get(Local(val)); i32_const(Imm32(offset as i32)); i32_add;
             });
             self.emit_load_at(fty, 0);
             self.emit_repr_value(fty);
-            wasm!(self.func, { call(concat); local_set(acc); });
+            wasm!(self.func, { call(concat); local_set(Local(acc)); });
             offset += values::byte_size(fty);
         }
-        wasm!(self.func, { local_get(acc); i32_const(close_s); call(concat); });
+        wasm!(self.func, { local_get(Local(acc)); i32_const(Imm32(close_s)); call(concat); });
         self.scratch.free_i32(acc);
     }
 }

--- a/crates/almide-codegen/src/emit_wasm/calls_value.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_value.rs
@@ -12,6 +12,41 @@
 use super::FuncCompiler;
 use almide_ir::IrExpr;
 
+// ── Value type tags ────────────────────────────────────────────────────────
+// Stored as i32 at offset 0 of every Value heap cell (tagged union).
+// See module-level doc comment for the full tag table.
+const VAL_TAG_INT:    i32 = 2; // Value::Int   — payload: i64 at offset 4
+const VAL_TAG_FLOAT:  i32 = 3; // Value::Float — payload: f64 at offset 4
+const VAL_TAG_STRING: i32 = 4; // Value::Str   — payload: string ptr (i32) at offset 4
+const VAL_TAG_ARRAY:  i32 = 5; // Value::Array — payload: list ptr (i32) at offset 4
+const VAL_TAG_OBJECT: i32 = 6; // Value::Object — payload: pairs-list ptr (i32) at offset 4
+
+// ── Value heap cell allocation sizes (bytes) ───────────────────────────────
+// null / JpRoot:        [tag:i32]                    =  4 bytes
+// bool / str / array / object: [tag:i32][payload:i32] =  8 bytes
+// int / float:          [tag:i32][payload:i64|f64]   = 12 bytes
+const VAL_ALLOC_NULL: i32 = 4;  // tag-only cell
+const VAL_ALLOC_PTR:  i32 = 8;  // tag + one i32 field
+const VAL_ALLOC_I64:  i32 = 12; // tag + one i64/f64 field
+
+// ── JsonPath node allocation size (bytes) ──────────────────────────────────
+// JpField / JpIndex: [tag:i32][parent:i32][name_or_idx:i32] = 12 bytes
+const JP_NODE_ALLOC: i32 = 12;
+
+// ── List element strides (bytes per element in list data arrays) ───────────
+const PTR_STRIDE: i32 = 4; // pointer-sized element (i32 / heap ptr)
+const I64_STRIDE: i32 = 8; // 64-bit element (i64 / f64)
+
+// ── ASCII constants used in key-case transforms ────────────────────────────
+const ASCII_UNDERSCORE:  i32 = 95; // '_'
+const ASCII_UPPER_A:     i32 = 65; // 'A'
+const ASCII_UPPER_Z:     i32 = 90; // 'Z'
+const ASCII_CASE_OFFSET: i32 = 32; // 'a' - 'A': additive distance upper↔lower
+
+// ── Buffer over-allocation factor for snake_case expansion ────────────────
+// Worst case: every char becomes '_' + lowercase → 2× source length.
+const SNAKE_BUF_FACTOR: i32 = 2;
+
 impl FuncCompiler<'_> {
     /// Dispatch a `value.*` module call.
     pub(super) fn emit_value_call(&mut self, func: &str, args: &[IrExpr]) {
@@ -20,7 +55,7 @@ impl FuncCompiler<'_> {
                 // value.null() -> Value: alloc [tag=0], size=4
                 let s = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc); local_set(s);
+                    i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(s);
                     local_get(s); i32_const(0); i32_store(0); // tag = 0 (null)
                     local_get(s);
                 });
@@ -33,7 +68,7 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(val);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(ptr);
+                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(ptr);
                     local_get(ptr); i32_const(1); i32_store(0); // tag = 1 (bool)
                     local_get(ptr); local_get(val); i32_store(4); // payload
                     local_get(ptr);
@@ -48,8 +83,8 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(val);
-                    i32_const(12); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(2); i32_store(0); // tag = 2 (int)
+                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(ptr);
+                    local_get(ptr); i32_const(VAL_TAG_INT); i32_store(0); // tag = 2 (int)
                     local_get(ptr); local_get(val); i64_store(4); // payload
                     local_get(ptr);
                 });
@@ -63,8 +98,8 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(val);
-                    i32_const(12); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(3); i32_store(0); // tag = 3 (float)
+                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(ptr);
+                    local_get(ptr); i32_const(VAL_TAG_FLOAT); i32_store(0); // tag = 3 (float)
                     local_get(ptr); local_get(val); f64_store(4); // payload
                     local_get(ptr);
                 });
@@ -78,8 +113,8 @@ impl FuncCompiler<'_> {
                 self.emit_stored_field(&args[0]);
                 wasm!(self.func, {
                     local_set(val);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(4); i32_store(0); // tag = 4 (string)
+                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(ptr);
+                    local_get(ptr); i32_const(VAL_TAG_STRING); i32_store(0); // tag = 4 (string)
                     local_get(ptr); local_get(val); i32_store(4); // payload = str ptr
                     local_get(ptr);
                 });
@@ -93,8 +128,8 @@ impl FuncCompiler<'_> {
                 self.emit_stored_field(&args[0]);
                 wasm!(self.func, {
                     local_set(val);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(5); i32_store(0); // tag = 5 (array)
+                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(ptr);
+                    local_get(ptr); i32_const(VAL_TAG_ARRAY); i32_store(0); // tag = 5 (array)
                     local_get(ptr); local_get(val); i32_store(4); // payload = list ptr
                     local_get(ptr);
                 });
@@ -108,8 +143,8 @@ impl FuncCompiler<'_> {
                 self.emit_stored_field(&args[0]);
                 wasm!(self.func, {
                     local_set(val);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(6); i32_store(0); // tag = 6 (object)
+                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(ptr);
+                    local_get(ptr); i32_const(VAL_TAG_OBJECT); i32_store(0); // tag = 6 (object)
                     local_get(ptr); local_get(val); i32_store(4); // payload = list ptr
                     local_get(ptr);
                 });
@@ -165,18 +200,18 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(v);
-                    local_get(v); i32_load(0); i32_const(3); i32_eq;
+                    local_get(v); i32_load(0); i32_const(VAL_TAG_FLOAT); i32_eq;
                     if_i32;
-                      i32_const(12); call(self.emitter.rt.alloc); local_set(result);
+                      i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
                       local_get(result); i32_const(0); i32_store(0); // ok
                       local_get(result); local_get(v); f64_load(4); f64_store(4);
                       local_get(result);
                     else_;
                       // #658: a JSON integer is a valid Float — widen Int→f64 so
                       // Codec roundtrips stay total (mirrors native as_float).
-                      local_get(v); i32_load(0); i32_const(2); i32_eq;
+                      local_get(v); i32_load(0); i32_const(VAL_TAG_INT); i32_eq;
                       if_i32;
-                        i32_const(12); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(0); i32_store(0); // ok
                         local_get(result); local_get(v); i64_load(4); f64_convert_i64_s; f64_store(4);
                         local_get(result);
@@ -184,7 +219,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("expected Float");
                 wasm!(self.func, {
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                      i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                       local_get(result); i32_const(1); i32_store(0);
                       local_get(result); i32_const(err_msg as i32); i32_store(4);
                       local_get(result);
@@ -202,9 +237,9 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(v);
-                    local_get(v); i32_load(0); i32_const(5); i32_eq;
+                    local_get(v); i32_load(0); i32_const(VAL_TAG_ARRAY); i32_eq;
                     if_i32;
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                      i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                       local_get(result); i32_const(0); i32_store(0); // ok
                       local_get(result); local_get(v); i32_load(4); i32_store(4);
                       local_get(result);
@@ -212,7 +247,7 @@ impl FuncCompiler<'_> {
                 });
                 let err_msg = self.emitter.intern_string("expected Array");
                 wasm!(self.func, {
-                      i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                      i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                       local_get(result); i32_const(1); i32_store(0);
                       local_get(result); i32_const(err_msg as i32); i32_store(4);
                       local_get(result);
@@ -300,7 +335,7 @@ impl FuncCompiler<'_> {
                 // json.root() → JpRoot: alloc [tag:i32=0], 4 bytes
                 let ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(4); call(self.emitter.rt.alloc); local_set(ptr);
+                    i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(ptr);
                     local_get(ptr); i32_const(0); i32_store(0); // tag = 0 (root)
                     local_get(ptr);
                 });
@@ -316,7 +351,7 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
                     local_set(name);
-                    i32_const(12); call(self.emitter.rt.alloc); local_set(ptr);
+                    i32_const(JP_NODE_ALLOC); call(self.emitter.rt.alloc); local_set(ptr);
                     local_get(ptr); i32_const(1); i32_store(0);  // tag = 1 (field)
                     local_get(ptr); local_get(parent); i32_store(4);  // parent ptr
                     local_get(ptr); local_get(name); i32_store(8);    // field name str
@@ -337,8 +372,8 @@ impl FuncCompiler<'_> {
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
                     i32_wrap_i64; local_set(idx);
-                    i32_const(12); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(2); i32_store(0);  // tag = 2 (index)
+                    i32_const(JP_NODE_ALLOC); call(self.emitter.rt.alloc); local_set(ptr);
+                    local_get(ptr); i32_const(VAL_TAG_INT); i32_store(0);  // tag = 2 (index)
                     local_get(ptr); local_get(parent); i32_store(4);  // parent ptr
                     local_get(ptr); local_get(idx); i32_store(8);     // array index
                     local_get(ptr);
@@ -398,7 +433,7 @@ impl FuncCompiler<'_> {
             local_set(key);
             i32_const(0); local_set(result); // none by default
             // Check tag == 6 (object)
-            local_get(v); i32_load(0); i32_const(6); i32_eq;
+            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_eq;
             if_empty;
               // It's an object: iterate pairs
               local_get(v); i32_load(4); local_set(list);
@@ -407,7 +442,7 @@ impl FuncCompiler<'_> {
               block_empty; loop_empty;
                 local_get(i); local_get(len); i32_ge_u; br_if(1);
                 local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 i32_load(0); local_set(pair_ptr);
                 local_get(pair_ptr); i32_load(0);
                 local_get(key);
@@ -416,7 +451,7 @@ impl FuncCompiler<'_> {
                   // Found: some(value) — alloc Option box with value ptr.
                   // SHARE: the boxed pointer is an interior reference into a
                   // Value tree the caller still owns — dup it.
-                  i32_const(4); call(self.emitter.rt.alloc); local_set(result);
+                  i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(result);
                   local_get(result);
                   local_get(pair_ptr); i32_load(4); call(self.emitter.rt.rc_inc);
                   i32_store(0);
@@ -453,12 +488,12 @@ impl FuncCompiler<'_> {
               // Correct tag: return ok(payload at offset 4). The STRING
               // payload is an interior pointer into the surviving Value —
               // dup it (scalar tags copy by value).
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(0); i32_store(0); // ok
               local_get(result);
               local_get(v); i32_load(4);
         });
-        if expected_tag == 4 || expected_tag == 5 {
+        if expected_tag == VAL_TAG_STRING || expected_tag == VAL_TAG_ARRAY {
             // tags 4 (string) and 5 (array) carry POINTER payloads; bool
             // shares the 4-byte size but is a scalar — key on the TAG.
             wasm!(self.func, { call(self.emitter.rt.rc_inc); });
@@ -471,7 +506,7 @@ impl FuncCompiler<'_> {
         });
         let err_msg = self.emitter.intern_string(&format!("expected {}", type_name));
         wasm!(self.func, {
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(1); i32_store(0); // err
               local_get(result); i32_const(err_msg as i32); i32_store(4);
               local_get(result);
@@ -491,10 +526,10 @@ impl FuncCompiler<'_> {
         self.emit_expr(&args[0]);
         wasm!(self.func, {
             local_set(v);
-            local_get(v); i32_load(0); i32_const(2); i32_eq;
+            local_get(v); i32_load(0); i32_const(VAL_TAG_INT); i32_eq;
             if_i32;
               // tag==2 (int): payload is i64 at offset 4
-              i32_const(12); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(0); i32_store(0); // ok tag
               local_get(result); local_get(v); i64_load(4); i64_store(4); // i64 payload at offset 4
               local_get(result);
@@ -502,7 +537,7 @@ impl FuncCompiler<'_> {
         });
         let err_msg = self.emitter.intern_string("expected Int");
         wasm!(self.func, {
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(1); i32_store(0); // err
               local_get(result); i32_const(err_msg as i32); i32_store(4);
               local_get(result);
@@ -517,12 +552,12 @@ impl FuncCompiler<'_> {
     /// Returns Option[T]: get value by key, check type tag, unwrap payload.
     fn emit_json_get_typed(&mut self, func: &str, args: &[IrExpr]) {
         let expected_tag: i32 = match func {
-            "get_string" => 4,
-            "get_int" => 2,
-            "get_float" => 3,
-            "get_bool" => 1,
-            "get_array" => 5,
-            _ => 4,
+            "get_string" => VAL_TAG_STRING,
+            "get_int"    => VAL_TAG_INT,
+            "get_float"  => VAL_TAG_FLOAT,
+            "get_bool"   => 1,
+            "get_array"  => VAL_TAG_ARRAY,
+            _            => VAL_TAG_STRING,
         };
 
         // First do json.get(v, key) → Option[Value]
@@ -541,7 +576,7 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
             local_set(key);
             i32_const(0); local_set(found_val);
-            local_get(v); i32_load(0); i32_const(6); i32_eq;
+            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_eq;
             if_empty;
               local_get(v); i32_load(4); local_set(list);
               local_get(list); i32_load(0); local_set(len);
@@ -549,7 +584,7 @@ impl FuncCompiler<'_> {
               block_empty; loop_empty;
                 local_get(i); local_get(len); i32_ge_u; br_if(1);
                 local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 i32_load(0); local_set(pair_ptr);
                 local_get(pair_ptr); i32_load(0);
                 local_get(key);
@@ -573,9 +608,9 @@ impl FuncCompiler<'_> {
         // Return Option[T]: some = alloc box with payload, none = 0.
         // For all types, we alloc a box and copy the payload.
         let payload_size: u32 = match func {
-            "get_int" => 8,    // i64
-            "get_float" => 8,  // f64
-            _ => 4,            // i32 (string ptr, bool, list ptr)
+            "get_int"   => I64_STRIDE as u32,  // i64
+            "get_float" => I64_STRIDE as u32,  // f64
+            _           => PTR_STRIDE as u32,  // i32 (string ptr, bool, list ptr)
         };
         let option_box = self.scratch.alloc_i32();
         wasm!(self.func, {
@@ -615,17 +650,17 @@ impl FuncCompiler<'_> {
     /// (json module returns Option, value module returns Result — handled separately)
     fn emit_json_as_typed(&mut self, func: &str, args: &[IrExpr]) {
         let expected_tag: i32 = match func {
-            "as_string" => 4,
-            "as_int" => 2,
-            "as_float" => 3,
-            "as_bool" => 1,
-            "as_array" => 5,
-            _ => 4,
+            "as_string" => VAL_TAG_STRING,
+            "as_int"    => VAL_TAG_INT,
+            "as_float"  => VAL_TAG_FLOAT,
+            "as_bool"   => 1,
+            "as_array"  => VAL_TAG_ARRAY,
+            _           => VAL_TAG_STRING,
         };
         let payload_size: u32 = match func {
-            "as_int" => 8,
-            "as_float" => 8,
-            _ => 4,
+            "as_int"   => I64_STRIDE as u32,
+            "as_float" => I64_STRIDE as u32,
+            _          => PTR_STRIDE as u32,
         };
         // #658: json.as_float widens a JSON Int to Float, matching the native
         // almide_json_as_float oracle (a JSON number is type-agnostic).
@@ -652,9 +687,9 @@ impl FuncCompiler<'_> {
         });
         if coerce_int {
             wasm!(self.func, {
-              local_get(v); i32_load(0); i32_const(2); i32_eq;
+              local_get(v); i32_load(0); i32_const(VAL_TAG_INT); i32_eq;
               if_i32;
-                i32_const(8); call(self.emitter.rt.alloc); local_set(option_box);
+                i32_const(I64_STRIDE); call(self.emitter.rt.alloc); local_set(option_box);
                 local_get(option_box); local_get(v); i64_load(4); f64_convert_i64_s; f64_store(0);
                 local_get(option_box);
               else_;
@@ -682,12 +717,12 @@ impl FuncCompiler<'_> {
         self.emit_expr(&args[0]);
         wasm!(self.func, {
             local_set(v);
-            local_get(v); i32_load(0); i32_const(6); i32_eq;
+            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_eq;
             if_i32;
               local_get(v); i32_load(4); local_set(list);
               local_get(list); i32_load(0); local_set(len);
               // Alloc result list
-              i32_const(4); local_get(len); i32_const(4); i32_mul; i32_add;
+              i32_const(VAL_ALLOC_NULL); local_get(len); i32_const(PTR_STRIDE); i32_mul; i32_add;
               call(self.emitter.rt.alloc); local_set(result);
               local_get(result); local_get(len); i32_store(0);
               i32_const(0); local_set(i);
@@ -695,9 +730,9 @@ impl FuncCompiler<'_> {
                 local_get(i); local_get(len); i32_ge_u; br_if(1);
                 // result[i] = pair[i].key
                 local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 i32_load(0); // pair ptr
                 i32_load(0); // key string ptr
                 i32_store(0); // store in result
@@ -707,7 +742,7 @@ impl FuncCompiler<'_> {
               local_get(result);
             else_;
               // Not an object: return empty list
-              i32_const(4); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(0); i32_store(0);
               local_get(result);
             end;
@@ -735,12 +770,12 @@ impl FuncCompiler<'_> {
         self.emit_expr(&args[1]);
         wasm!(self.func, {
             local_set(key);
-            local_get(v); i32_load(0); i32_const(6); i32_ne;
+            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_ne;
             if_i32;
         });
         let err_msg = self.emitter.intern_string("expected Object");
         wasm!(self.func, {
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(1); i32_store(0);
               local_get(result); i32_const(err_msg as i32); i32_store(4);
               local_get(result);
@@ -752,13 +787,13 @@ impl FuncCompiler<'_> {
               block_empty; loop_empty;
                 local_get(i); local_get(len); i32_ge_u; br_if(1);
                 local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 i32_load(0); local_set(pair_ptr);
                 local_get(pair_ptr); i32_load(0);
                 local_get(key);
                 call(self.emitter.rt.string.eq);
                 if_empty;
-                  i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                  i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                   local_get(result); i32_const(0); i32_store(0);
                   local_get(result); local_get(pair_ptr); i32_load(4); i32_store(4);
                   br(2);
@@ -776,7 +811,7 @@ impl FuncCompiler<'_> {
         let mf_prefix = self.emitter.intern_string("missing field '");
         let mf_suffix = self.emitter.intern_string("'");
         wasm!(self.func, {
-                i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                 local_get(result); i32_const(1); i32_store(0);
                 local_get(result);
                   i32_const(mf_prefix as i32); local_get(key); call(self.emitter.rt.concat_str);
@@ -809,12 +844,12 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
             local_set(v);
             // Must be object (tag 6) with at least 1 pair
-            local_get(v); i32_load(0); i32_const(6); i32_ne;
+            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_ne;
             if_i32;
         });
         let err_msg = self.emitter.intern_string("not a tagged variant");
         wasm!(self.func, {
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(1); i32_store(0);
               local_get(result); i32_const(err_msg as i32); i32_store(4);
               local_get(result);
@@ -823,12 +858,12 @@ impl FuncCompiler<'_> {
               local_get(v); i32_load(4); local_set(list); // pairs list
               local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add; i32_load(0); local_set(pair_ptr); // first pair tuple
               // Build tuple (tag_name: String, payload: Value)
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); local_get(pair_ptr); i32_load(0); i32_store(0); // tag name string
               local_get(result); local_get(pair_ptr); i32_load(4); i32_store(4); // payload value
               // Build ok(tuple)
               local_get(result); local_set(pair_ptr); // save tuple ptr
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(0); i32_store(0); // tag = ok
               local_get(result); local_get(pair_ptr); i32_store(4);
               local_get(result);
@@ -866,13 +901,13 @@ impl FuncCompiler<'_> {
         self.emit_expr(&args[0]);
         wasm!(self.func, {
             local_set(v);
-            local_get(v); i32_load(0); i32_const(6); i32_ne;
+            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_ne;
             if_i32; local_get(v); // not object → return as-is
             else_;
               local_get(v); i32_load(4); local_set(old_list);
               local_get(old_list); i32_load(0); local_set(len);
               // Alloc new pairs list
-              i32_const(4); local_get(len); i32_const(4); i32_mul; i32_add;
+              i32_const(VAL_ALLOC_NULL); local_get(len); i32_const(PTR_STRIDE); i32_mul; i32_add;
               call(self.emitter.rt.alloc); local_set(new_list);
               local_get(new_list); local_get(len); i32_store(0);
               i32_const(0); local_set(i);
@@ -880,13 +915,13 @@ impl FuncCompiler<'_> {
                 local_get(i); local_get(len); i32_ge_u; br_if(1);
                 // Get old pair
                 local_get(old_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 i32_load(0); local_set(old_pair);
                 local_get(old_pair); i32_load(0); local_set(old_key);
                 // Transform key
                 local_get(old_key); i32_load(0); local_set(src_len); // key string len
                 // Alloc dst buffer (max 2x src_len for snake_case expansion)
-                i32_const(4); local_get(src_len); i32_const(2); i32_mul; i32_add;
+                i32_const(VAL_ALLOC_NULL); local_get(src_len); i32_const(SNAKE_BUF_FACTOR); i32_mul; i32_add;
                 call(self.emitter.rt.alloc); local_set(dst_buf);
                 i32_const(0); local_set(j); // src index
                 i32_const(0); local_set(dst_pos); // dst index
@@ -899,7 +934,7 @@ impl FuncCompiler<'_> {
                   local_get(j); local_get(src_len); i32_ge_u; br_if(1);
                   local_get(old_key); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(j); i32_add; i32_load8_u(0);
                   local_set(ch);
-                  local_get(ch); i32_const(95); i32_eq; // '_'
+                  local_get(ch); i32_const(ASCII_UNDERSCORE); i32_eq; // '_'
                   if_empty;
                     // Skip underscore, capitalize next char
                     local_get(j); i32_const(1); i32_add; local_set(j);
@@ -907,7 +942,7 @@ impl FuncCompiler<'_> {
                     if_empty;
                       local_get(dst_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(dst_pos); i32_add;
                       local_get(old_key); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(j); i32_add; i32_load8_u(0);
-                      i32_const(32); i32_sub; // to uppercase
+                      i32_const(ASCII_CASE_OFFSET); i32_sub; // to uppercase
                       i32_store8(0);
                       local_get(dst_pos); i32_const(1); i32_add; local_set(dst_pos);
                     end;
@@ -930,16 +965,16 @@ impl FuncCompiler<'_> {
                   local_get(old_key); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(j); i32_add; i32_load8_u(0);
                   local_set(ch);
                   // Check if uppercase (A=65..Z=90)
-                  local_get(ch); i32_const(65); i32_ge_u;
-                  local_get(ch); i32_const(90); i32_le_u;
+                  local_get(ch); i32_const(ASCII_UPPER_A); i32_ge_u;
+                  local_get(ch); i32_const(ASCII_UPPER_Z); i32_le_u;
                   i32_and;
                   if_empty;
                     // Insert underscore then lowercase char
                     local_get(dst_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(dst_pos); i32_add;
-                    i32_const(95); i32_store8(0); // '_'
+                    i32_const(ASCII_UNDERSCORE); i32_store8(0); // '_'
                     local_get(dst_pos); i32_const(1); i32_add; local_set(dst_pos);
                     local_get(dst_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(dst_pos); i32_add;
-                    local_get(ch); i32_const(32); i32_add; // to lowercase
+                    local_get(ch); i32_const(ASCII_CASE_OFFSET); i32_add; // to lowercase
                     i32_store8(0);
                     local_get(dst_pos); i32_const(1); i32_add; local_set(dst_pos);
                   else_;
@@ -958,19 +993,19 @@ impl FuncCompiler<'_> {
                 local_get(dst_buf); local_get(dst_pos); i32_store(0);
                 local_get(dst_buf); local_set(new_key);
                 // Build new pair (new_key, old_value)
-                i32_const(8); call(self.emitter.rt.alloc); local_set(new_pair);
+                i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(new_pair);
                 local_get(new_pair); local_get(new_key); i32_store(0);
                 local_get(new_pair); local_get(old_pair); i32_load(4); i32_store(4);
                 // Store in new list
                 local_get(new_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 local_get(new_pair); i32_store(0);
                 local_get(i); i32_const(1); i32_add; local_set(i);
                 br(0);
               end; end;
               // Build new Value object
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(6); i32_store(0); // tag = object
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
+              local_get(result); i32_const(VAL_TAG_OBJECT); i32_store(0); // tag = object
               local_get(result); local_get(new_list); i32_store(4);
               local_get(result);
             end;
@@ -1015,7 +1050,7 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
             local_set(keys);
             // Not an object? return as-is
-            local_get(v); i32_load(0); i32_const(6); i32_ne;
+            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_ne;
             if_i32; local_get(v);
             else_;
               local_get(v); i32_load(4); local_set(old_list);
@@ -1027,7 +1062,7 @@ impl FuncCompiler<'_> {
               block_empty; loop_empty;
                 local_get(i); local_get(old_len); i32_ge_u; br_if(1);
                 local_get(old_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 i32_load(0); local_set(pair_ptr);
                 // Check if key is in keys list
                 i32_const(0); local_set(found);
@@ -1036,7 +1071,7 @@ impl FuncCompiler<'_> {
                   local_get(j); local_get(keys_len); i32_ge_u; br_if(1);
                   local_get(pair_ptr); i32_load(0);
                   local_get(keys); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                  local_get(j); i32_const(4); i32_mul; i32_add;
+                  local_get(j); i32_const(PTR_STRIDE); i32_mul; i32_add;
                   i32_load(0);
                   call(self.emitter.rt.string.eq);
                   if_empty;
@@ -1064,7 +1099,7 @@ impl FuncCompiler<'_> {
                 br(0);
               end; end;
               // Alloc new list
-              i32_const(4); local_get(count); i32_const(4); i32_mul; i32_add;
+              i32_const(VAL_ALLOC_NULL); local_get(count); i32_const(PTR_STRIDE); i32_mul; i32_add;
               call(self.emitter.rt.alloc); local_set(new_list);
               local_get(new_list); local_get(count); i32_store(0);
               // Second pass: copy matching pairs
@@ -1073,7 +1108,7 @@ impl FuncCompiler<'_> {
               block_empty; loop_empty;
                 local_get(i); local_get(old_len); i32_ge_u; br_if(1);
                 local_get(old_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 i32_load(0); local_set(pair_ptr);
                 i32_const(0); local_set(found);
                 i32_const(0); local_set(j);
@@ -1081,7 +1116,7 @@ impl FuncCompiler<'_> {
                   local_get(j); local_get(keys_len); i32_ge_u; br_if(1);
                   local_get(pair_ptr); i32_load(0);
                   local_get(keys); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                  local_get(j); i32_const(4); i32_mul; i32_add;
+                  local_get(j); i32_const(PTR_STRIDE); i32_mul; i32_add;
                   i32_load(0);
                   call(self.emitter.rt.string.eq);
                   if_empty;
@@ -1100,7 +1135,7 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
                 if_empty;
                   local_get(new_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                  local_get(count); i32_const(4); i32_mul; i32_add;
+                  local_get(count); i32_const(PTR_STRIDE); i32_mul; i32_add;
                   local_get(pair_ptr); i32_store(0);
                   local_get(count); i32_const(1); i32_add; local_set(count);
                 end;
@@ -1108,8 +1143,8 @@ impl FuncCompiler<'_> {
                 br(0);
               end; end;
               // Build result object
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(6); i32_store(0);
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
+              local_get(result); i32_const(VAL_TAG_OBJECT); i32_store(0);
               local_get(result); local_get(new_list); i32_store(4);
               local_get(result);
             end;
@@ -1156,7 +1191,7 @@ impl FuncCompiler<'_> {
             local_get(a_list); i32_load(0); local_set(a_len);
             local_get(b_list); i32_load(0); local_set(b_len);
             // Max possible pairs = a_len + b_len
-            i32_const(4); local_get(a_len); local_get(b_len); i32_add; i32_const(4); i32_mul; i32_add;
+            i32_const(VAL_ALLOC_NULL); local_get(a_len); local_get(b_len); i32_add; i32_const(PTR_STRIDE); i32_mul; i32_add;
             call(self.emitter.rt.alloc); local_set(new_list);
             i32_const(0); local_set(count);
             // Copy all from a that are NOT in b
@@ -1164,7 +1199,7 @@ impl FuncCompiler<'_> {
             block_empty; loop_empty;
               local_get(i); local_get(a_len); i32_ge_u; br_if(1);
               local_get(a_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-              local_get(i); i32_const(4); i32_mul; i32_add;
+              local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
               i32_load(0); local_set(pair_ptr);
               // Check if key exists in b
               i32_const(0); local_set(found);
@@ -1173,7 +1208,7 @@ impl FuncCompiler<'_> {
                 local_get(j); local_get(b_len); i32_ge_u; br_if(1);
                 local_get(pair_ptr); i32_load(0);
                 local_get(b_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(j); i32_const(4); i32_mul; i32_add;
+                local_get(j); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 i32_load(0); i32_load(0); // b pair key
                 call(self.emitter.rt.string.eq);
                 if_empty; i32_const(1); local_set(found); br(2); end;
@@ -1183,7 +1218,7 @@ impl FuncCompiler<'_> {
               local_get(found); i32_eqz;
               if_empty;
                 local_get(new_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(count); i32_const(4); i32_mul; i32_add;
+                local_get(count); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 local_get(pair_ptr); i32_store(0);
                 local_get(count); i32_const(1); i32_add; local_set(count);
               end;
@@ -1195,9 +1230,9 @@ impl FuncCompiler<'_> {
             block_empty; loop_empty;
               local_get(i); local_get(b_len); i32_ge_u; br_if(1);
               local_get(new_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-              local_get(count); i32_const(4); i32_mul; i32_add;
+              local_get(count); i32_const(PTR_STRIDE); i32_mul; i32_add;
               local_get(b_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-              local_get(i); i32_const(4); i32_mul; i32_add;
+              local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
               i32_load(0); i32_store(0);
               local_get(count); i32_const(1); i32_add; local_set(count);
               local_get(i); i32_const(1); i32_add; local_set(i);
@@ -1206,8 +1241,8 @@ impl FuncCompiler<'_> {
             // Set actual count
             local_get(new_list); local_get(count); i32_store(0);
             // Build result
-            i32_const(8); call(self.emitter.rt.alloc); local_set(result);
-            local_get(result); i32_const(6); i32_store(0);
+            i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
+            local_get(result); i32_const(VAL_TAG_OBJECT); i32_store(0);
             local_get(result); local_get(new_list); i32_store(4);
             local_get(result);
         });
@@ -1263,31 +1298,31 @@ impl FuncCompiler<'_> {
         match suffix {
             "string" => {
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(4); i32_store(0); // tag = string
+                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); i32_const(VAL_TAG_STRING); i32_store(0); // tag = string
                     local_get(result); local_get(opt); i32_load(0); i32_store(4); // payload at offset 0
                     local_get(result);
                 });
             }
             "int" => {
                 wasm!(self.func, {
-                    i32_const(12); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(2); i32_store(0); // tag = int
+                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); i32_const(VAL_TAG_INT); i32_store(0); // tag = int
                     local_get(result); local_get(opt); i64_load(0); i64_store(4); // payload at offset 0
                     local_get(result);
                 });
             }
             "float" => {
                 wasm!(self.func, {
-                    i32_const(12); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(3); i32_store(0); // tag = float
+                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); i32_const(VAL_TAG_FLOAT); i32_store(0); // tag = float
                     local_get(result); local_get(opt); f64_load(0); f64_store(4); // payload at offset 0
                     local_get(result);
                 });
             }
             "bool" => {
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); i32_const(1); i32_store(0); // tag = bool
                     local_get(result); local_get(opt); i32_load(0); i32_store(4); // payload at offset 0
                     local_get(result);
@@ -1302,14 +1337,14 @@ impl FuncCompiler<'_> {
                 if let Some(&func_idx) = self.emitter.func_map.get(encode_name.as_str()) {
                     wasm!(self.func, { call(func_idx); });
                 } else {
-                    wasm!(self.func, { drop; i32_const(4); call(self.emitter.rt.alloc); local_set(result); local_get(result); i32_const(0); i32_store(0); local_get(result); });
+                    wasm!(self.func, { drop; i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(result); local_get(result); i32_const(0); i32_store(0); local_get(result); });
                 }
             }
         }
         wasm!(self.func, {
             else_;
               // None: return value.null
-              i32_const(4); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(0); i32_store(0); // tag = null
               local_get(result);
             end;
@@ -1338,12 +1373,12 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
             local_set(key);
             // v must be object
-            local_get(v); i32_load(0); i32_const(6); i32_ne;
+            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_ne;
             if_i32;
         });
         let err_msg = self.emitter.intern_string("expected Object");
         wasm!(self.func, {
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(1); i32_store(0); // err
               local_get(result); i32_const(err_msg as i32); i32_store(4);
               local_get(result);
@@ -1355,7 +1390,7 @@ impl FuncCompiler<'_> {
               block_empty; loop_empty;
                 local_get(i); local_get(len); i32_ge_u; br_if(1);
                 local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 i32_load(0); local_set(pair_ptr);
                 local_get(pair_ptr); i32_load(0);
                 local_get(key);
@@ -1386,7 +1421,7 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
                 // Option None = pointer 0
                 // Wrap in ok Result: [tag=0][payload=0]
-                i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                 local_get(result); i32_const(0); i32_store(0); // Result ok
                 local_get(result); i32_const(0); i32_store(4); // Option None = 0
                 local_get(result);
@@ -1400,20 +1435,20 @@ impl FuncCompiler<'_> {
                 // Value tag 4 = string, payload i32 at +4
                 // Option[String] Some = heap ptr → [string_ptr:i32] (no tag, ptr != 0 = Some)
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(4); i32_ne;
+                    local_get(found); i32_load(0); i32_const(VAL_TAG_STRING); i32_ne;
                     if_i32;
                 });
                 let type_err = self.emitter.intern_string("expected Str");
                 wasm!(self.func, {
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(1); i32_store(0);
                         local_get(result); i32_const(type_err as i32); i32_store(4);
                         local_get(result);
                     else_;
                         // Some: alloc payload only (no tag)
-                        i32_const(4); call(self.emitter.rt.alloc); local_set(some_opt);
+                        i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(some_opt);
                         local_get(some_opt); local_get(found); i32_load(4); i32_store(0); // string ptr
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(0); i32_store(0); // ok
                         local_get(result); local_get(some_opt); i32_store(4);
                         local_get(result);
@@ -1422,19 +1457,19 @@ impl FuncCompiler<'_> {
             }
             "int" => {
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(2); i32_ne;
+                    local_get(found); i32_load(0); i32_const(VAL_TAG_INT); i32_ne;
                     if_i32;
                 });
                 let type_err = self.emitter.intern_string("expected Int");
                 wasm!(self.func, {
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(1); i32_store(0);
                         local_get(result); i32_const(type_err as i32); i32_store(4);
                         local_get(result);
                     else_;
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(some_opt);
+                        i32_const(I64_STRIDE); call(self.emitter.rt.alloc); local_set(some_opt);
                         local_get(some_opt); local_get(found); i64_load(4); i64_store(0); // i64 payload
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(0); i32_store(0);
                         local_get(result); local_get(some_opt); i32_store(4);
                         local_get(result);
@@ -1445,25 +1480,25 @@ impl FuncCompiler<'_> {
                 // #658: accept both Float (tag 3) and Int (tag 2, widened to f64).
                 let type_err = self.emitter.intern_string("expected Float");
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(3); i32_eq;
+                    local_get(found); i32_load(0); i32_const(VAL_TAG_FLOAT); i32_eq;
                     if_i32;
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(some_opt);
+                        i32_const(I64_STRIDE); call(self.emitter.rt.alloc); local_set(some_opt);
                         local_get(some_opt); local_get(found); f64_load(4); f64_store(0);
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(0); i32_store(0);
                         local_get(result); local_get(some_opt); i32_store(4);
                         local_get(result);
                     else_;
-                      local_get(found); i32_load(0); i32_const(2); i32_eq;
+                      local_get(found); i32_load(0); i32_const(VAL_TAG_INT); i32_eq;
                       if_i32;
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(some_opt);
+                        i32_const(I64_STRIDE); call(self.emitter.rt.alloc); local_set(some_opt);
                         local_get(some_opt); local_get(found); i64_load(4); f64_convert_i64_s; f64_store(0);
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(0); i32_store(0);
                         local_get(result); local_get(some_opt); i32_store(4);
                         local_get(result);
                       else_;
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(1); i32_store(0);
                         local_get(result); i32_const(type_err as i32); i32_store(4);
                         local_get(result);
@@ -1478,14 +1513,14 @@ impl FuncCompiler<'_> {
                 });
                 let type_err = self.emitter.intern_string("expected Bool");
                 wasm!(self.func, {
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(1); i32_store(0);
                         local_get(result); i32_const(type_err as i32); i32_store(4);
                         local_get(result);
                     else_;
-                        i32_const(4); call(self.emitter.rt.alloc); local_set(some_opt);
+                        i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(some_opt);
                         local_get(some_opt); local_get(found); i32_load(4); i32_store(0);
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(0); i32_store(0);
                         local_get(result); local_get(some_opt); i32_store(4);
                         local_get(result);
@@ -1508,9 +1543,9 @@ impl FuncCompiler<'_> {
                           // (no tag — matches the encode/primitive layout). Storing a
                           // spurious tag here made the re-encode read `1` as the
                           // payload pointer → garbage (新②).
-                          i32_const(4); call(self.emitter.rt.alloc); local_set(some_opt);
+                          i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(some_opt);
                           local_get(some_opt); local_get(decode_result); i32_load(4); i32_store(0);
-                          i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                          i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                           local_get(result); i32_const(0); i32_store(0);
                           local_get(result); local_get(some_opt); i32_store(4);
                           local_get(result);
@@ -1566,12 +1601,12 @@ impl FuncCompiler<'_> {
         self.emit_expr(&args[2]); // default value
         wasm!(self.func, {
             local_set(default_local);
-            local_get(v); i32_load(0); i32_const(6); i32_ne;
+            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_ne;
             if_i32;
         });
         let err_msg = self.emitter.intern_string("expected Object");
         wasm!(self.func, {
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(1); i32_store(0);
               local_get(result); i32_const(err_msg as i32); i32_store(4);
               local_get(result);
@@ -1583,7 +1618,7 @@ impl FuncCompiler<'_> {
               block_empty; loop_empty;
                 local_get(i); local_get(len); i32_ge_u; br_if(1);
                 local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 i32_load(0); local_set(pair_ptr);
                 local_get(pair_ptr); i32_load(0);
                 local_get(key);
@@ -1608,7 +1643,7 @@ impl FuncCompiler<'_> {
         match suffix {
             "string" | "bool" => {
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); i32_const(0); i32_store(0);
                     local_get(result); local_get(default_local); i32_store(4);
                     local_get(result);
@@ -1616,7 +1651,7 @@ impl FuncCompiler<'_> {
             }
             "int" => {
                 wasm!(self.func, {
-                    i32_const(12); call(self.emitter.rt.alloc); local_set(result);
+                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); i32_const(0); i32_store(0);
                     local_get(result); local_get(default_local); i64_store(4);
                     local_get(result);
@@ -1624,7 +1659,7 @@ impl FuncCompiler<'_> {
             }
             "float" => {
                 wasm!(self.func, {
-                    i32_const(12); call(self.emitter.rt.alloc); local_set(result);
+                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); i32_const(0); i32_store(0);
                     local_get(result); local_get(default_local); f64_store(4);
                     local_get(result);
@@ -1632,7 +1667,7 @@ impl FuncCompiler<'_> {
             }
             _ => {
                 wasm!(self.func, {
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); i32_const(0); i32_store(0);
                     local_get(result); local_get(default_local); i32_store(4);
                     local_get(result);
@@ -1646,17 +1681,17 @@ impl FuncCompiler<'_> {
         match suffix {
             "string" => {
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(4); i32_ne;
+                    local_get(found); i32_load(0); i32_const(VAL_TAG_STRING); i32_ne;
                     if_i32;
                 });
                 let te = self.emitter.intern_string("expected Str");
                 wasm!(self.func, {
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(1); i32_store(0);
                         local_get(result); i32_const(te as i32); i32_store(4);
                         local_get(result);
                     else_;
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(0); i32_store(0);
                         local_get(result); local_get(found); i32_load(4); i32_store(4);
                         local_get(result);
@@ -1665,17 +1700,17 @@ impl FuncCompiler<'_> {
             }
             "int" => {
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(2); i32_ne;
+                    local_get(found); i32_load(0); i32_const(VAL_TAG_INT); i32_ne;
                     if_i32;
                 });
                 let te = self.emitter.intern_string("expected Int");
                 wasm!(self.func, {
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(1); i32_store(0);
                         local_get(result); i32_const(te as i32); i32_store(4);
                         local_get(result);
                     else_;
-                        i32_const(12); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(0); i32_store(0);
                         local_get(result); local_get(found); i64_load(4); i64_store(4);
                         local_get(result);
@@ -1686,21 +1721,21 @@ impl FuncCompiler<'_> {
                 // #658: widen a JSON Int (tag 2) to Float, like native as_float.
                 let te = self.emitter.intern_string("expected Float");
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(3); i32_eq;
+                    local_get(found); i32_load(0); i32_const(VAL_TAG_FLOAT); i32_eq;
                     if_i32;
-                        i32_const(12); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(0); i32_store(0);
                         local_get(result); local_get(found); f64_load(4); f64_store(4);
                         local_get(result);
                     else_;
-                      local_get(found); i32_load(0); i32_const(2); i32_eq;
+                      local_get(found); i32_load(0); i32_const(VAL_TAG_INT); i32_eq;
                       if_i32;
-                        i32_const(12); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(0); i32_store(0);
                         local_get(result); local_get(found); i64_load(4); f64_convert_i64_s; f64_store(4);
                         local_get(result);
                       else_;
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(1); i32_store(0);
                         local_get(result); i32_const(te as i32); i32_store(4);
                         local_get(result);
@@ -1715,12 +1750,12 @@ impl FuncCompiler<'_> {
                 });
                 let te = self.emitter.intern_string("expected Bool");
                 wasm!(self.func, {
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(1); i32_store(0);
                         local_get(result); i32_const(te as i32); i32_store(4);
                         local_get(result);
                     else_;
-                        i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                         local_get(result); i32_const(0); i32_store(0);
                         local_get(result); local_get(found); i32_load(4); i32_store(4);
                         local_get(result);
@@ -1769,7 +1804,7 @@ impl FuncCompiler<'_> {
             local_set(xs);
             local_get(xs); i32_load(0); local_set(len);
             // Alloc value list: [len:i32][ptr0][ptr1]...
-            i32_const(4); local_get(len); i32_const(4); i32_mul; i32_add;
+            i32_const(VAL_ALLOC_NULL); local_get(len); i32_const(PTR_STRIDE); i32_mul; i32_add;
             call(self.emitter.rt.alloc); local_set(val_list);
             local_get(val_list); local_get(len); i32_store(0);
             i32_const(0); local_set(i);
@@ -1784,10 +1819,10 @@ impl FuncCompiler<'_> {
             "string" => {
                 wasm!(self.func, {
                     local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(4); i32_mul; i32_add;
+                    local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                     i32_load(0); local_set(elem);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(4); i32_store(0); // string tag
+                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); i32_const(VAL_TAG_STRING); i32_store(0); // string tag
                     local_get(result); local_get(elem); i32_store(4);
                 });
             }
@@ -1795,10 +1830,10 @@ impl FuncCompiler<'_> {
                 let elem64 = self.scratch.alloc_i64();
                 wasm!(self.func, {
                     local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(8); i32_mul; i32_add;
+                    local_get(i); i32_const(I64_STRIDE); i32_mul; i32_add;
                     i64_load(0); local_set(elem64);
-                    i32_const(12); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(2); i32_store(0); // int tag
+                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); i32_const(VAL_TAG_INT); i32_store(0); // int tag
                     local_get(result); local_get(elem64); i64_store(4);
                 });
                 self.scratch.free_i64(elem64);
@@ -1807,10 +1842,10 @@ impl FuncCompiler<'_> {
                 let elem_f = self.scratch.alloc_f64();
                 wasm!(self.func, {
                     local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(8); i32_mul; i32_add;
+                    local_get(i); i32_const(I64_STRIDE); i32_mul; i32_add;
                     f64_load(0); local_set(elem_f);
-                    i32_const(12); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(3); i32_store(0); // float tag
+                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
+                    local_get(result); i32_const(VAL_TAG_FLOAT); i32_store(0); // float tag
                     local_get(result); local_get(elem_f); f64_store(4);
                 });
                 self.scratch.free_f64(elem_f);
@@ -1818,9 +1853,9 @@ impl FuncCompiler<'_> {
             "bool" => {
                 wasm!(self.func, {
                     local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(4); i32_mul; i32_add;
+                    local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                     i32_load(0); local_set(elem);
-                    i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
                     local_get(result); i32_const(1); i32_store(0); // bool tag
                     local_get(result); local_get(elem); i32_store(4);
                 });
@@ -1829,7 +1864,7 @@ impl FuncCompiler<'_> {
                 // Named type: call Type.encode(elem)
                 wasm!(self.func, {
                     local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(4); i32_mul; i32_add;
+                    local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                     i32_load(0);
                 });
                 let encode_name = format!("{}.encode", suffix);
@@ -1843,14 +1878,14 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
               // Store value in val_list
               local_get(val_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-              local_get(i); i32_const(4); i32_mul; i32_add;
+              local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
               local_get(result); i32_store(0);
               local_get(i); i32_const(1); i32_add; local_set(i);
               br(0);
             end; end;
             // Wrap in Value array: [tag=5][list_ptr]
-            i32_const(8); call(self.emitter.rt.alloc); local_set(result);
-            local_get(result); i32_const(5); i32_store(0); // array tag
+            i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
+            local_get(result); i32_const(VAL_TAG_ARRAY); i32_store(0); // array tag
             local_get(result); local_get(val_list); i32_store(4);
             local_get(result);
         });
@@ -1877,15 +1912,15 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
             local_set(v);
             // Must be array (tag 5)
-            local_get(v); i32_load(0); i32_const(5); i32_ne;
+            local_get(v); i32_load(0); i32_const(VAL_TAG_ARRAY); i32_ne;
             if_i32;
         });
         let err_msg = self.emitter.intern_string("expected Array");
         let elem_size: u32 = match suffix {
-            "int" | "float" => 8, _ => 4,
+            "int" | "float" => I64_STRIDE as u32, _ => PTR_STRIDE as u32,
         };
         wasm!(self.func, {
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(1); i32_store(0);
               local_get(result); i32_const(err_msg as i32); i32_store(4);
               local_get(result);
@@ -1893,7 +1928,7 @@ impl FuncCompiler<'_> {
               local_get(v); i32_load(4); local_set(arr_list);
               local_get(arr_list); i32_load(0); local_set(len);
               // Alloc output list
-              i32_const(4); local_get(len); i32_const(elem_size as i32); i32_mul; i32_add;
+              i32_const(VAL_ALLOC_NULL); local_get(len); i32_const(elem_size as i32); i32_mul; i32_add;
               call(self.emitter.rt.alloc); local_set(out_list);
               local_get(out_list); local_get(len); i32_store(0);
               i32_const(0); local_set(i);
@@ -1901,7 +1936,7 @@ impl FuncCompiler<'_> {
                 local_get(i); local_get(len); i32_ge_u; br_if(1);
                 // Get Value element from array
                 local_get(arr_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(4); i32_mul; i32_add;
+                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                 i32_load(0); local_set(elem_val);
         });
         // Extract typed value from Value element
@@ -1909,7 +1944,7 @@ impl FuncCompiler<'_> {
             "string" => {
                 wasm!(self.func, {
                     local_get(out_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(4); i32_mul; i32_add;
+                    local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                     local_get(elem_val); i32_load(4); // string ptr from Value
                     i32_store(0);
                 });
@@ -1917,7 +1952,7 @@ impl FuncCompiler<'_> {
             "int" => {
                 wasm!(self.func, {
                     local_get(out_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(8); i32_mul; i32_add;
+                    local_get(i); i32_const(I64_STRIDE); i32_mul; i32_add;
                     local_get(elem_val); i64_load(4); // i64 from Value
                     i64_store(0);
                 });
@@ -1925,7 +1960,7 @@ impl FuncCompiler<'_> {
             "float" => {
                 wasm!(self.func, {
                     local_get(out_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(8); i32_mul; i32_add;
+                    local_get(i); i32_const(I64_STRIDE); i32_mul; i32_add;
                     local_get(elem_val); f64_load(4);
                     f64_store(0);
                 });
@@ -1933,7 +1968,7 @@ impl FuncCompiler<'_> {
             "bool" => {
                 wasm!(self.func, {
                     local_get(out_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(4); i32_mul; i32_add;
+                    local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                     local_get(elem_val); i32_load(4); // bool (0/1)
                     i32_store(0);
                 });
@@ -1946,7 +1981,7 @@ impl FuncCompiler<'_> {
                     wasm!(self.func, {
                         local_get(elem_val); call(func_idx); local_set(dr);
                         local_get(out_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                        local_get(i); i32_const(4); i32_mul; i32_add;
+                        local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                         local_get(dr); i32_load(4); // ok payload (pointer)
                         i32_store(0);
                     });
@@ -1954,7 +1989,7 @@ impl FuncCompiler<'_> {
                 } else {
                     wasm!(self.func, {
                         local_get(out_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                        local_get(i); i32_const(4); i32_mul; i32_add;
+                        local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
                         local_get(elem_val);
                         i32_store(0);
                     });
@@ -1966,7 +2001,7 @@ impl FuncCompiler<'_> {
                 br(0);
               end; end;
               // Wrap in ok Result
-              i32_const(8); call(self.emitter.rt.alloc); local_set(result);
+              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
               local_get(result); i32_const(0); i32_store(0);
               local_get(result); local_get(out_list); i32_store(4);
               local_get(result);

--- a/crates/almide-codegen/src/emit_wasm/calls_value.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_value.rs
@@ -9,6 +9,7 @@
 //!   [tag:i32=5][payload:i32 (list ptr -> List[Value])] = array
 //!   [tag:i32=6][payload:i32 (list ptr -> List[(String, Value)])] = object
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use super::FuncCompiler;
 use almide_ir::IrExpr;
 
@@ -55,9 +56,9 @@ impl FuncCompiler<'_> {
                 // value.null() -> Value: alloc [tag=0], size=4
                 let s = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(s);
-                    local_get(s); i32_const(0); i32_store(0); // tag = 0 (null)
-                    local_get(s);
+                    i32_const(Imm32(VAL_ALLOC_NULL)); call(self.emitter.rt.alloc); local_set(Local(s));
+                    local_get(Local(s)); i32_const(Imm32(0)); i32_store(0); // tag = 0 (null)
+                    local_get(Local(s));
                 });
                 self.scratch.free_i32(s);
             }
@@ -67,11 +68,11 @@ impl FuncCompiler<'_> {
                 let ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(val);
-                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(1); i32_store(0); // tag = 1 (bool)
-                    local_get(ptr); local_get(val); i32_store(4); // payload
-                    local_get(ptr);
+                    local_set(Local(val));
+                    i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(ptr));
+                    local_get(Local(ptr)); i32_const(Imm32(1)); i32_store(0); // tag = 1 (bool)
+                    local_get(Local(ptr)); local_get(Local(val)); i32_store(4); // payload
+                    local_get(Local(ptr));
                 });
                 self.scratch.free_i32(ptr);
                 self.scratch.free_i32(val);
@@ -82,11 +83,11 @@ impl FuncCompiler<'_> {
                 let ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(val);
-                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(VAL_TAG_INT); i32_store(0); // tag = 2 (int)
-                    local_get(ptr); local_get(val); i64_store(4); // payload
-                    local_get(ptr);
+                    local_set(Local(val));
+                    i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(ptr));
+                    local_get(Local(ptr)); i32_const(Imm32(VAL_TAG_INT)); i32_store(0); // tag = 2 (int)
+                    local_get(Local(ptr)); local_get(Local(val)); i64_store(4); // payload
+                    local_get(Local(ptr));
                 });
                 self.scratch.free_i32(ptr);
                 self.scratch.free_i64(val);
@@ -97,11 +98,11 @@ impl FuncCompiler<'_> {
                 let ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(val);
-                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(VAL_TAG_FLOAT); i32_store(0); // tag = 3 (float)
-                    local_get(ptr); local_get(val); f64_store(4); // payload
-                    local_get(ptr);
+                    local_set(Local(val));
+                    i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(ptr));
+                    local_get(Local(ptr)); i32_const(Imm32(VAL_TAG_FLOAT)); i32_store(0); // tag = 3 (float)
+                    local_get(Local(ptr)); local_get(Local(val)); f64_store(4); // payload
+                    local_get(Local(ptr));
                 });
                 self.scratch.free_i32(ptr);
                 self.scratch.free_f64(val);
@@ -112,11 +113,11 @@ impl FuncCompiler<'_> {
                 let ptr = self.scratch.alloc_i32();
                 self.emit_stored_field(&args[0]);
                 wasm!(self.func, {
-                    local_set(val);
-                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(VAL_TAG_STRING); i32_store(0); // tag = 4 (string)
-                    local_get(ptr); local_get(val); i32_store(4); // payload = str ptr
-                    local_get(ptr);
+                    local_set(Local(val));
+                    i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(ptr));
+                    local_get(Local(ptr)); i32_const(Imm32(VAL_TAG_STRING)); i32_store(0); // tag = 4 (string)
+                    local_get(Local(ptr)); local_get(Local(val)); i32_store(4); // payload = str ptr
+                    local_get(Local(ptr));
                 });
                 self.scratch.free_i32(ptr);
                 self.scratch.free_i32(val);
@@ -127,11 +128,11 @@ impl FuncCompiler<'_> {
                 let ptr = self.scratch.alloc_i32();
                 self.emit_stored_field(&args[0]);
                 wasm!(self.func, {
-                    local_set(val);
-                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(VAL_TAG_ARRAY); i32_store(0); // tag = 5 (array)
-                    local_get(ptr); local_get(val); i32_store(4); // payload = list ptr
-                    local_get(ptr);
+                    local_set(Local(val));
+                    i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(ptr));
+                    local_get(Local(ptr)); i32_const(Imm32(VAL_TAG_ARRAY)); i32_store(0); // tag = 5 (array)
+                    local_get(Local(ptr)); local_get(Local(val)); i32_store(4); // payload = list ptr
+                    local_get(Local(ptr));
                 });
                 self.scratch.free_i32(ptr);
                 self.scratch.free_i32(val);
@@ -142,11 +143,11 @@ impl FuncCompiler<'_> {
                 let ptr = self.scratch.alloc_i32();
                 self.emit_stored_field(&args[0]);
                 wasm!(self.func, {
-                    local_set(val);
-                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(VAL_TAG_OBJECT); i32_store(0); // tag = 6 (object)
-                    local_get(ptr); local_get(val); i32_store(4); // payload = list ptr
-                    local_get(ptr);
+                    local_set(Local(val));
+                    i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(ptr));
+                    local_get(Local(ptr)); i32_const(Imm32(VAL_TAG_OBJECT)); i32_store(0); // tag = 6 (object)
+                    local_get(Local(ptr)); local_get(Local(val)); i32_store(4); // payload = list ptr
+                    local_get(Local(ptr));
                 });
                 self.scratch.free_i32(ptr);
                 self.scratch.free_i32(val);
@@ -199,30 +200,30 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(v);
-                    local_get(v); i32_load(0); i32_const(VAL_TAG_FLOAT); i32_eq;
+                    local_set(Local(v));
+                    local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_FLOAT)); i32_eq;
                     if_i32;
-                      i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
-                      local_get(result); i32_const(0); i32_store(0); // ok
-                      local_get(result); local_get(v); f64_load(4); f64_store(4);
-                      local_get(result);
+                      i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(result));
+                      local_get(Local(result)); i32_const(Imm32(0)); i32_store(0); // ok
+                      local_get(Local(result)); local_get(Local(v)); f64_load(4); f64_store(4);
+                      local_get(Local(result));
                     else_;
                       // #658: a JSON integer is a valid Float — widen Int→f64 so
                       // Codec roundtrips stay total (mirrors native as_float).
-                      local_get(v); i32_load(0); i32_const(VAL_TAG_INT); i32_eq;
+                      local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_INT)); i32_eq;
                       if_i32;
-                        i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(0); i32_store(0); // ok
-                        local_get(result); local_get(v); i64_load(4); f64_convert_i64_s; f64_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(0)); i32_store(0); // ok
+                        local_get(Local(result)); local_get(Local(v)); i64_load(4); f64_convert_i64_s; f64_store(4);
+                        local_get(Local(result));
                       else_;
                 });
                 let err_msg = self.emitter.intern_string("expected Float");
                 wasm!(self.func, {
-                      i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                      local_get(result); i32_const(1); i32_store(0);
-                      local_get(result); i32_const(err_msg as i32); i32_store(4);
-                      local_get(result);
+                      i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                      local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                      local_get(Local(result)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                      local_get(Local(result));
                       end;
                     end;
                 });
@@ -236,21 +237,21 @@ impl FuncCompiler<'_> {
                 let result = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    local_set(v);
-                    local_get(v); i32_load(0); i32_const(VAL_TAG_ARRAY); i32_eq;
+                    local_set(Local(v));
+                    local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_ARRAY)); i32_eq;
                     if_i32;
-                      i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                      local_get(result); i32_const(0); i32_store(0); // ok
-                      local_get(result); local_get(v); i32_load(4); i32_store(4);
-                      local_get(result);
+                      i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                      local_get(Local(result)); i32_const(Imm32(0)); i32_store(0); // ok
+                      local_get(Local(result)); local_get(Local(v)); i32_load(4); i32_store(4);
+                      local_get(Local(result));
                     else_;
                 });
                 let err_msg = self.emitter.intern_string("expected Array");
                 wasm!(self.func, {
-                      i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                      local_get(result); i32_const(1); i32_store(0);
-                      local_get(result); i32_const(err_msg as i32); i32_store(4);
-                      local_get(result);
+                      i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                      local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                      local_get(Local(result)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+                      local_get(Local(result));
                     end;
                 });
                 self.scratch.free_i32(result);
@@ -326,7 +327,7 @@ impl FuncCompiler<'_> {
                 // exactly one, matching native.
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
-                    i32_const(0);
+                    i32_const(Imm32(0));
                     call(self.emitter.rt.json_stringify_pretty);
                 });
             }
@@ -335,9 +336,9 @@ impl FuncCompiler<'_> {
                 // json.root() → JpRoot: alloc [tag:i32=0], 4 bytes
                 let ptr = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(0); i32_store(0); // tag = 0 (root)
-                    local_get(ptr);
+                    i32_const(Imm32(VAL_ALLOC_NULL)); call(self.emitter.rt.alloc); local_set(Local(ptr));
+                    local_get(Local(ptr)); i32_const(Imm32(0)); i32_store(0); // tag = 0 (root)
+                    local_get(Local(ptr));
                 });
                 self.scratch.free_i32(ptr);
             }
@@ -347,15 +348,15 @@ impl FuncCompiler<'_> {
                 let name = self.scratch.alloc_i32();
                 let ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(parent); });
+                wasm!(self.func, { local_set(Local(parent)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    local_set(name);
-                    i32_const(JP_NODE_ALLOC); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(1); i32_store(0);  // tag = 1 (field)
-                    local_get(ptr); local_get(parent); i32_store(4);  // parent ptr
-                    local_get(ptr); local_get(name); i32_store(8);    // field name str
-                    local_get(ptr);
+                    local_set(Local(name));
+                    i32_const(Imm32(JP_NODE_ALLOC)); call(self.emitter.rt.alloc); local_set(Local(ptr));
+                    local_get(Local(ptr)); i32_const(Imm32(1)); i32_store(0);  // tag = 1 (field)
+                    local_get(Local(ptr)); local_get(Local(parent)); i32_store(4);  // parent ptr
+                    local_get(Local(ptr)); local_get(Local(name)); i32_store(8);    // field name str
+                    local_get(Local(ptr));
                 });
                 self.scratch.free_i32(ptr);
                 self.scratch.free_i32(name);
@@ -368,15 +369,15 @@ impl FuncCompiler<'_> {
                 let idx = self.scratch.alloc_i32();
                 let ptr = self.scratch.alloc_i32();
                 self.emit_expr(&args[0]);
-                wasm!(self.func, { local_set(parent); });
+                wasm!(self.func, { local_set(Local(parent)); });
                 self.emit_expr(&args[1]);
                 wasm!(self.func, {
-                    i32_wrap_i64; local_set(idx);
-                    i32_const(JP_NODE_ALLOC); call(self.emitter.rt.alloc); local_set(ptr);
-                    local_get(ptr); i32_const(VAL_TAG_INT); i32_store(0);  // tag = 2 (index)
-                    local_get(ptr); local_get(parent); i32_store(4);  // parent ptr
-                    local_get(ptr); local_get(idx); i32_store(8);     // array index
-                    local_get(ptr);
+                    i32_wrap_i64; local_set(Local(idx));
+                    i32_const(Imm32(JP_NODE_ALLOC)); call(self.emitter.rt.alloc); local_set(Local(ptr));
+                    local_get(Local(ptr)); i32_const(Imm32(VAL_TAG_INT)); i32_store(0);  // tag = 2 (index)
+                    local_get(Local(ptr)); local_get(Local(parent)); i32_store(4);  // parent ptr
+                    local_get(Local(ptr)); local_get(Local(idx)); i32_store(8);     // array index
+                    local_get(Local(ptr));
                 });
                 self.scratch.free_i32(ptr);
                 self.scratch.free_i32(idx);
@@ -427,41 +428,41 @@ impl FuncCompiler<'_> {
         let result = self.scratch.alloc_i32();
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(v); });
+        wasm!(self.func, { local_set(Local(v)); });
         self.emit_expr(&args[1]);
         wasm!(self.func, {
-            local_set(key);
-            i32_const(0); local_set(result); // none by default
+            local_set(Local(key));
+            i32_const(Imm32(0)); local_set(Local(result)); // none by default
             // Check tag == 6 (object)
-            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_eq;
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_OBJECT)); i32_eq;
             if_empty;
               // It's an object: iterate pairs
-              local_get(v); i32_load(4); local_set(list);
-              local_get(list); i32_load(0); local_set(len);
-              i32_const(0); local_set(i);
+              local_get(Local(v)); i32_load(4); local_set(Local(list));
+              local_get(Local(list)); i32_load(0); local_set(Local(len));
+              i32_const(Imm32(0)); local_set(Local(i));
               block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
-                local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                i32_load(0); local_set(pair_ptr);
-                local_get(pair_ptr); i32_load(0);
-                local_get(key);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                local_get(Local(list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                i32_load(0); local_set(Local(pair_ptr));
+                local_get(Local(pair_ptr)); i32_load(0);
+                local_get(Local(key));
                 call(self.emitter.rt.string.eq);
                 if_empty;
                   // Found: some(value) — alloc Option box with value ptr.
                   // SHARE: the boxed pointer is an interior reference into a
                   // Value tree the caller still owns — dup it.
-                  i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(result);
-                  local_get(result);
-                  local_get(pair_ptr); i32_load(4); call(self.emitter.rt.rc_inc);
+                  i32_const(Imm32(VAL_ALLOC_NULL)); call(self.emitter.rt.alloc); local_set(Local(result));
+                  local_get(Local(result));
+                  local_get(Local(pair_ptr)); i32_load(4); call(self.emitter.rt.rc_inc);
                   i32_store(0);
                   br(2);
                 end;
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
               end; end;
             end;
-            local_get(result); // 0 = none, or some ptr
+            local_get(Local(result)); // 0 = none, or some ptr
         });
 
         self.scratch.free_i32(result);
@@ -482,16 +483,16 @@ impl FuncCompiler<'_> {
 
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(v);
-            local_get(v); i32_load(0); i32_const(expected_tag); i32_eq;
+            local_set(Local(v));
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(expected_tag)); i32_eq;
             if_i32;
               // Correct tag: return ok(payload at offset 4). The STRING
               // payload is an interior pointer into the surviving Value —
               // dup it (scalar tags copy by value).
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(0); i32_store(0); // ok
-              local_get(result);
-              local_get(v); i32_load(4);
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(0)); i32_store(0); // ok
+              local_get(Local(result));
+              local_get(Local(v)); i32_load(4);
         });
         if expected_tag == VAL_TAG_STRING || expected_tag == VAL_TAG_ARRAY {
             // tags 4 (string) and 5 (array) carry POINTER payloads; bool
@@ -500,16 +501,16 @@ impl FuncCompiler<'_> {
         }
         wasm!(self.func, {
               i32_store(4);
-              local_get(result);
+              local_get(Local(result));
             else_;
               // Wrong tag: return err("expected <type>")
         });
         let err_msg = self.emitter.intern_string(&format!("expected {}", type_name));
         wasm!(self.func, {
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(1); i32_store(0); // err
-              local_get(result); i32_const(err_msg as i32); i32_store(4);
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(1)); i32_store(0); // err
+              local_get(Local(result)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+              local_get(Local(result));
             end;
         });
 
@@ -525,22 +526,22 @@ impl FuncCompiler<'_> {
 
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(v);
-            local_get(v); i32_load(0); i32_const(VAL_TAG_INT); i32_eq;
+            local_set(Local(v));
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_INT)); i32_eq;
             if_i32;
               // tag==2 (int): payload is i64 at offset 4
-              i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(0); i32_store(0); // ok tag
-              local_get(result); local_get(v); i64_load(4); i64_store(4); // i64 payload at offset 4
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(0)); i32_store(0); // ok tag
+              local_get(Local(result)); local_get(Local(v)); i64_load(4); i64_store(4); // i64 payload at offset 4
+              local_get(Local(result));
             else_;
         });
         let err_msg = self.emitter.intern_string("expected Int");
         wasm!(self.func, {
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(1); i32_store(0); // err
-              local_get(result); i32_const(err_msg as i32); i32_store(4);
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(1)); i32_store(0); // err
+              local_get(Local(result)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+              local_get(Local(result));
             end;
         });
 
@@ -571,34 +572,34 @@ impl FuncCompiler<'_> {
         let found_val = self.scratch.alloc_i32();
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(v); });
+        wasm!(self.func, { local_set(Local(v)); });
         self.emit_expr(&args[1]);
         wasm!(self.func, {
-            local_set(key);
-            i32_const(0); local_set(found_val);
-            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_eq;
+            local_set(Local(key));
+            i32_const(Imm32(0)); local_set(Local(found_val));
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_OBJECT)); i32_eq;
             if_empty;
-              local_get(v); i32_load(4); local_set(list);
-              local_get(list); i32_load(0); local_set(len);
-              i32_const(0); local_set(i);
+              local_get(Local(v)); i32_load(4); local_set(Local(list));
+              local_get(Local(list)); i32_load(0); local_set(Local(len));
+              i32_const(Imm32(0)); local_set(Local(i));
               block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
-                local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                i32_load(0); local_set(pair_ptr);
-                local_get(pair_ptr); i32_load(0);
-                local_get(key);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                local_get(Local(list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                i32_load(0); local_set(Local(pair_ptr));
+                local_get(Local(pair_ptr)); i32_load(0);
+                local_get(Local(key));
                 call(self.emitter.rt.string.eq);
                 if_empty;
                   // Found key. Check tag.
-                  local_get(pair_ptr); i32_load(4); local_set(found_val); // value ptr
-                  local_get(found_val); i32_load(0); i32_const(expected_tag); i32_ne;
+                  local_get(Local(pair_ptr)); i32_load(4); local_set(Local(found_val)); // value ptr
+                  local_get(Local(found_val)); i32_load(0); i32_const(Imm32(expected_tag)); i32_ne;
                   if_empty;
-                    i32_const(0); local_set(found_val); // wrong type → none
+                    i32_const(Imm32(0)); local_set(Local(found_val)); // wrong type → none
                   end;
                   br(2);
                 end;
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
               end; end;
             end;
@@ -614,12 +615,12 @@ impl FuncCompiler<'_> {
         };
         let option_box = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_get(found_val); i32_eqz;
-            if_i32; i32_const(0); // none
+            local_get(Local(found_val)); i32_eqz;
+            if_i32; i32_const(Imm32(0)); // none
             else_;
-              i32_const(payload_size as i32); call(self.emitter.rt.alloc); local_set(option_box);
-              local_get(option_box);
-              local_get(found_val);
+              i32_const(Imm32(payload_size as i32)); call(self.emitter.rt.alloc); local_set(Local(option_box));
+              local_get(Local(option_box));
+              local_get(Local(found_val));
         });
         // Copy payload from Value offset 4 to option box offset 0.
         // get_string/get_array box an INTERIOR POINTER into the surviving
@@ -632,7 +633,7 @@ impl FuncCompiler<'_> {
             _ => { wasm!(self.func, { i32_load(4); i32_store(0); }); }
         }
         wasm!(self.func, {
-              local_get(option_box);
+              local_get(Local(option_box));
             end;
         });
         self.scratch.free_i32(option_box);
@@ -669,35 +670,35 @@ impl FuncCompiler<'_> {
         let option_box = self.scratch.alloc_i32();
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(v);
-            local_get(v); i32_load(0); i32_const(expected_tag); i32_eq;
+            local_set(Local(v));
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(expected_tag)); i32_eq;
             if_i32;
               // Matching tag: alloc option box, copy payload
-              i32_const(payload_size as i32); call(self.emitter.rt.alloc); local_set(option_box);
-              local_get(option_box);
-              local_get(v);
+              i32_const(Imm32(payload_size as i32)); call(self.emitter.rt.alloc); local_set(Local(option_box));
+              local_get(Local(option_box));
+              local_get(Local(v));
         });
         match payload_size {
             8 => { wasm!(self.func, { i64_load(4); i64_store(0); }); }
             _ => { wasm!(self.func, { i32_load(4); i32_store(0); }); }
         }
         wasm!(self.func, {
-              local_get(option_box);
+              local_get(Local(option_box));
             else_;
         });
         if coerce_int {
             wasm!(self.func, {
-              local_get(v); i32_load(0); i32_const(VAL_TAG_INT); i32_eq;
+              local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_INT)); i32_eq;
               if_i32;
-                i32_const(I64_STRIDE); call(self.emitter.rt.alloc); local_set(option_box);
-                local_get(option_box); local_get(v); i64_load(4); f64_convert_i64_s; f64_store(0);
-                local_get(option_box);
+                i32_const(Imm32(I64_STRIDE)); call(self.emitter.rt.alloc); local_set(Local(option_box));
+                local_get(Local(option_box)); local_get(Local(v)); i64_load(4); f64_convert_i64_s; f64_store(0);
+                local_get(Local(option_box));
               else_;
-                i32_const(0); // none
+                i32_const(Imm32(0)); // none
               end;
             });
         } else {
-            wasm!(self.func, { i32_const(0); }); // none
+            wasm!(self.func, { i32_const(Imm32(0)); }); // none
         }
         wasm!(self.func, {
             end;
@@ -716,35 +717,35 @@ impl FuncCompiler<'_> {
 
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(v);
-            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_eq;
+            local_set(Local(v));
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_OBJECT)); i32_eq;
             if_i32;
-              local_get(v); i32_load(4); local_set(list);
-              local_get(list); i32_load(0); local_set(len);
+              local_get(Local(v)); i32_load(4); local_set(Local(list));
+              local_get(Local(list)); i32_load(0); local_set(Local(len));
               // Alloc result list
-              i32_const(VAL_ALLOC_NULL); local_get(len); i32_const(PTR_STRIDE); i32_mul; i32_add;
-              call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); local_get(len); i32_store(0);
-              i32_const(0); local_set(i);
+              i32_const(Imm32(VAL_ALLOC_NULL)); local_get(Local(len)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+              call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); local_get(Local(len)); i32_store(0);
+              i32_const(Imm32(0)); local_set(Local(i));
               block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                 // result[i] = pair[i].key
-                local_get(result); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
+                local_get(Local(result)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                local_get(Local(list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
                 i32_load(0); // pair ptr
                 i32_load(0); // key string ptr
                 i32_store(0); // store in result
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
               end; end;
-              local_get(result);
+              local_get(Local(result));
             else_;
               // Not an object: return empty list
-              i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(0); i32_store(0);
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_NULL)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+              local_get(Local(result));
             end;
         });
 
@@ -766,42 +767,42 @@ impl FuncCompiler<'_> {
         let result = self.scratch.alloc_i32();
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(v); });
+        wasm!(self.func, { local_set(Local(v)); });
         self.emit_expr(&args[1]);
         wasm!(self.func, {
-            local_set(key);
-            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_ne;
+            local_set(Local(key));
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_OBJECT)); i32_ne;
             if_i32;
         });
         let err_msg = self.emitter.intern_string("expected Object");
         wasm!(self.func, {
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(1); i32_store(0);
-              local_get(result); i32_const(err_msg as i32); i32_store(4);
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+              local_get(Local(result)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+              local_get(Local(result));
             else_;
-              local_get(v); i32_load(4); local_set(list);
-              local_get(list); i32_load(0); local_set(len);
-              i32_const(0); local_set(i);
-              i32_const(0); local_set(result);
+              local_get(Local(v)); i32_load(4); local_set(Local(list));
+              local_get(Local(list)); i32_load(0); local_set(Local(len));
+              i32_const(Imm32(0)); local_set(Local(i));
+              i32_const(Imm32(0)); local_set(Local(result));
               block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
-                local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                i32_load(0); local_set(pair_ptr);
-                local_get(pair_ptr); i32_load(0);
-                local_get(key);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                local_get(Local(list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                i32_load(0); local_set(Local(pair_ptr));
+                local_get(Local(pair_ptr)); i32_load(0);
+                local_get(Local(key));
                 call(self.emitter.rt.string.eq);
                 if_empty;
-                  i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                  local_get(result); i32_const(0); i32_store(0);
-                  local_get(result); local_get(pair_ptr); i32_load(4); i32_store(4);
+                  i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                  local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                  local_get(Local(result)); local_get(Local(pair_ptr)); i32_load(4); i32_store(4);
                   br(2);
                 end;
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
               end; end;
-              local_get(result); i32_eqz;
+              local_get(Local(result)); i32_eqz;
               if_empty;
         });
         // Mirror the native oracle's `format!("missing field '{}'", key)` exactly
@@ -811,14 +812,14 @@ impl FuncCompiler<'_> {
         let mf_prefix = self.emitter.intern_string("missing field '");
         let mf_suffix = self.emitter.intern_string("'");
         wasm!(self.func, {
-                i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                local_get(result); i32_const(1); i32_store(0);
-                local_get(result);
-                  i32_const(mf_prefix as i32); local_get(key); call(self.emitter.rt.concat_str);
-                  i32_const(mf_suffix as i32); call(self.emitter.rt.concat_str);
+                i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                local_get(Local(result));
+                  i32_const(Imm32(mf_prefix as i32)); local_get(Local(key)); call(self.emitter.rt.concat_str);
+                  i32_const(Imm32(mf_suffix as i32)); call(self.emitter.rt.concat_str);
                 i32_store(4);
               end;
-              local_get(result);
+              local_get(Local(result));
             end;
         });
 
@@ -842,31 +843,31 @@ impl FuncCompiler<'_> {
 
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(v);
+            local_set(Local(v));
             // Must be object (tag 6) with at least 1 pair
-            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_ne;
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_OBJECT)); i32_ne;
             if_i32;
         });
         let err_msg = self.emitter.intern_string("not a tagged variant");
         wasm!(self.func, {
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(1); i32_store(0);
-              local_get(result); i32_const(err_msg as i32); i32_store(4);
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+              local_get(Local(result)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+              local_get(Local(result));
             else_;
               // Get first pair: key = tag name, value = payload
-              local_get(v); i32_load(4); local_set(list); // pairs list
-              local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add; i32_load(0); local_set(pair_ptr); // first pair tuple
+              local_get(Local(v)); i32_load(4); local_set(Local(list)); // pairs list
+              local_get(Local(list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add; i32_load(0); local_set(Local(pair_ptr)); // first pair tuple
               // Build tuple (tag_name: String, payload: Value)
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); local_get(pair_ptr); i32_load(0); i32_store(0); // tag name string
-              local_get(result); local_get(pair_ptr); i32_load(4); i32_store(4); // payload value
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); local_get(Local(pair_ptr)); i32_load(0); i32_store(0); // tag name string
+              local_get(Local(result)); local_get(Local(pair_ptr)); i32_load(4); i32_store(4); // payload value
               // Build ok(tuple)
-              local_get(result); local_set(pair_ptr); // save tuple ptr
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(0); i32_store(0); // tag = ok
-              local_get(result); local_get(pair_ptr); i32_store(4);
-              local_get(result);
+              local_get(Local(result)); local_set(Local(pair_ptr)); // save tuple ptr
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(0)); i32_store(0); // tag = ok
+              local_get(Local(result)); local_get(Local(pair_ptr)); i32_store(4);
+              local_get(Local(result));
             end;
         });
 
@@ -900,60 +901,60 @@ impl FuncCompiler<'_> {
 
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(v);
-            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_ne;
-            if_i32; local_get(v); // not object → return as-is
+            local_set(Local(v));
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_OBJECT)); i32_ne;
+            if_i32; local_get(Local(v)); // not object → return as-is
             else_;
-              local_get(v); i32_load(4); local_set(old_list);
-              local_get(old_list); i32_load(0); local_set(len);
+              local_get(Local(v)); i32_load(4); local_set(Local(old_list));
+              local_get(Local(old_list)); i32_load(0); local_set(Local(len));
               // Alloc new pairs list
-              i32_const(VAL_ALLOC_NULL); local_get(len); i32_const(PTR_STRIDE); i32_mul; i32_add;
-              call(self.emitter.rt.alloc); local_set(new_list);
-              local_get(new_list); local_get(len); i32_store(0);
-              i32_const(0); local_set(i);
+              i32_const(Imm32(VAL_ALLOC_NULL)); local_get(Local(len)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+              call(self.emitter.rt.alloc); local_set(Local(new_list));
+              local_get(Local(new_list)); local_get(Local(len)); i32_store(0);
+              i32_const(Imm32(0)); local_set(Local(i));
               block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                 // Get old pair
-                local_get(old_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                i32_load(0); local_set(old_pair);
-                local_get(old_pair); i32_load(0); local_set(old_key);
+                local_get(Local(old_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                i32_load(0); local_set(Local(old_pair));
+                local_get(Local(old_pair)); i32_load(0); local_set(Local(old_key));
                 // Transform key
-                local_get(old_key); i32_load(0); local_set(src_len); // key string len
+                local_get(Local(old_key)); i32_load(0); local_set(Local(src_len)); // key string len
                 // Alloc dst buffer (max 2x src_len for snake_case expansion)
-                i32_const(VAL_ALLOC_NULL); local_get(src_len); i32_const(SNAKE_BUF_FACTOR); i32_mul; i32_add;
-                call(self.emitter.rt.alloc); local_set(dst_buf);
-                i32_const(0); local_set(j); // src index
-                i32_const(0); local_set(dst_pos); // dst index
+                i32_const(Imm32(VAL_ALLOC_NULL)); local_get(Local(src_len)); i32_const(Imm32(SNAKE_BUF_FACTOR)); i32_mul; i32_add;
+                call(self.emitter.rt.alloc); local_set(Local(dst_buf));
+                i32_const(Imm32(0)); local_set(Local(j)); // src index
+                i32_const(Imm32(0)); local_set(Local(dst_pos)); // dst index
         });
 
         if to_camel {
             // snake_case → camelCase: skip '_', capitalize next
             wasm!(self.func, {
                 block_empty; loop_empty;
-                  local_get(j); local_get(src_len); i32_ge_u; br_if(1);
-                  local_get(old_key); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(j); i32_add; i32_load8_u(0);
-                  local_set(ch);
-                  local_get(ch); i32_const(ASCII_UNDERSCORE); i32_eq; // '_'
+                  local_get(Local(j)); local_get(Local(src_len)); i32_ge_u; br_if(1);
+                  local_get(Local(old_key)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(j)); i32_add; i32_load8_u(0);
+                  local_set(Local(ch));
+                  local_get(Local(ch)); i32_const(Imm32(ASCII_UNDERSCORE)); i32_eq; // '_'
                   if_empty;
                     // Skip underscore, capitalize next char
-                    local_get(j); i32_const(1); i32_add; local_set(j);
-                    local_get(j); local_get(src_len); i32_lt_u;
+                    local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
+                    local_get(Local(j)); local_get(Local(src_len)); i32_lt_u;
                     if_empty;
-                      local_get(dst_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(dst_pos); i32_add;
-                      local_get(old_key); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(j); i32_add; i32_load8_u(0);
-                      i32_const(ASCII_CASE_OFFSET); i32_sub; // to uppercase
+                      local_get(Local(dst_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(dst_pos)); i32_add;
+                      local_get(Local(old_key)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(j)); i32_add; i32_load8_u(0);
+                      i32_const(Imm32(ASCII_CASE_OFFSET)); i32_sub; // to uppercase
                       i32_store8(0);
-                      local_get(dst_pos); i32_const(1); i32_add; local_set(dst_pos);
+                      local_get(Local(dst_pos)); i32_const(Imm32(1)); i32_add; local_set(Local(dst_pos));
                     end;
                   else_;
                     // Copy char as-is
-                    local_get(dst_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(dst_pos); i32_add;
-                    local_get(ch);
+                    local_get(Local(dst_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(dst_pos)); i32_add;
+                    local_get(Local(ch));
                     i32_store8(0);
-                    local_get(dst_pos); i32_const(1); i32_add; local_set(dst_pos);
+                    local_get(Local(dst_pos)); i32_const(Imm32(1)); i32_add; local_set(Local(dst_pos));
                   end;
-                  local_get(j); i32_const(1); i32_add; local_set(j);
+                  local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                   br(0);
                 end; end;
             });
@@ -961,28 +962,28 @@ impl FuncCompiler<'_> {
             // camelCase → snake_case: insert '_' before uppercase, lowercase
             wasm!(self.func, {
                 block_empty; loop_empty;
-                  local_get(j); local_get(src_len); i32_ge_u; br_if(1);
-                  local_get(old_key); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(j); i32_add; i32_load8_u(0);
-                  local_set(ch);
+                  local_get(Local(j)); local_get(Local(src_len)); i32_ge_u; br_if(1);
+                  local_get(Local(old_key)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(j)); i32_add; i32_load8_u(0);
+                  local_set(Local(ch));
                   // Check if uppercase (A=65..Z=90)
-                  local_get(ch); i32_const(ASCII_UPPER_A); i32_ge_u;
-                  local_get(ch); i32_const(ASCII_UPPER_Z); i32_le_u;
+                  local_get(Local(ch)); i32_const(Imm32(ASCII_UPPER_A)); i32_ge_u;
+                  local_get(Local(ch)); i32_const(Imm32(ASCII_UPPER_Z)); i32_le_u;
                   i32_and;
                   if_empty;
                     // Insert underscore then lowercase char
-                    local_get(dst_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(dst_pos); i32_add;
-                    i32_const(ASCII_UNDERSCORE); i32_store8(0); // '_'
-                    local_get(dst_pos); i32_const(1); i32_add; local_set(dst_pos);
-                    local_get(dst_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(dst_pos); i32_add;
-                    local_get(ch); i32_const(ASCII_CASE_OFFSET); i32_add; // to lowercase
+                    local_get(Local(dst_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(dst_pos)); i32_add;
+                    i32_const(Imm32(ASCII_UNDERSCORE)); i32_store8(0); // '_'
+                    local_get(Local(dst_pos)); i32_const(Imm32(1)); i32_add; local_set(Local(dst_pos));
+                    local_get(Local(dst_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(dst_pos)); i32_add;
+                    local_get(Local(ch)); i32_const(Imm32(ASCII_CASE_OFFSET)); i32_add; // to lowercase
                     i32_store8(0);
-                    local_get(dst_pos); i32_const(1); i32_add; local_set(dst_pos);
+                    local_get(Local(dst_pos)); i32_const(Imm32(1)); i32_add; local_set(Local(dst_pos));
                   else_;
-                    local_get(dst_buf); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add; local_get(dst_pos); i32_add;
-                    local_get(ch); i32_store8(0);
-                    local_get(dst_pos); i32_const(1); i32_add; local_set(dst_pos);
+                    local_get(Local(dst_buf)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add; local_get(Local(dst_pos)); i32_add;
+                    local_get(Local(ch)); i32_store8(0);
+                    local_get(Local(dst_pos)); i32_const(Imm32(1)); i32_add; local_set(Local(dst_pos));
                   end;
-                  local_get(j); i32_const(1); i32_add; local_set(j);
+                  local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                   br(0);
                 end; end;
             });
@@ -990,24 +991,24 @@ impl FuncCompiler<'_> {
 
         wasm!(self.func, {
                 // Set dst string length
-                local_get(dst_buf); local_get(dst_pos); i32_store(0);
-                local_get(dst_buf); local_set(new_key);
+                local_get(Local(dst_buf)); local_get(Local(dst_pos)); i32_store(0);
+                local_get(Local(dst_buf)); local_set(Local(new_key));
                 // Build new pair (new_key, old_value)
-                i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(new_pair);
-                local_get(new_pair); local_get(new_key); i32_store(0);
-                local_get(new_pair); local_get(old_pair); i32_load(4); i32_store(4);
+                i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(new_pair));
+                local_get(Local(new_pair)); local_get(Local(new_key)); i32_store(0);
+                local_get(Local(new_pair)); local_get(Local(old_pair)); i32_load(4); i32_store(4);
                 // Store in new list
-                local_get(new_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                local_get(new_pair); i32_store(0);
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(new_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                local_get(Local(new_pair)); i32_store(0);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
               end; end;
               // Build new Value object
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(VAL_TAG_OBJECT); i32_store(0); // tag = object
-              local_get(result); local_get(new_list); i32_store(4);
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(VAL_TAG_OBJECT)); i32_store(0); // tag = object
+              local_get(Local(result)); local_get(Local(new_list)); i32_store(4);
+              local_get(Local(result));
             end;
         });
 
@@ -1045,108 +1046,108 @@ impl FuncCompiler<'_> {
         let result = self.scratch.alloc_i32();
 
         self.emit_expr(&args[0]); // v: Value (object)
-        wasm!(self.func, { local_set(v); });
+        wasm!(self.func, { local_set(Local(v)); });
         self.emit_expr(&args[1]); // keys: List[String]
         wasm!(self.func, {
-            local_set(keys);
+            local_set(Local(keys));
             // Not an object? return as-is
-            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_ne;
-            if_i32; local_get(v);
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_OBJECT)); i32_ne;
+            if_i32; local_get(Local(v));
             else_;
-              local_get(v); i32_load(4); local_set(old_list);
-              local_get(old_list); i32_load(0); local_set(old_len);
-              local_get(keys); i32_load(0); local_set(keys_len);
+              local_get(Local(v)); i32_load(4); local_set(Local(old_list));
+              local_get(Local(old_list)); i32_load(0); local_set(Local(old_len));
+              local_get(Local(keys)); i32_load(0); local_set(Local(keys_len));
               // First pass: count matching pairs
-              i32_const(0); local_set(count);
-              i32_const(0); local_set(i);
+              i32_const(Imm32(0)); local_set(Local(count));
+              i32_const(Imm32(0)); local_set(Local(i));
               block_empty; loop_empty;
-                local_get(i); local_get(old_len); i32_ge_u; br_if(1);
-                local_get(old_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                i32_load(0); local_set(pair_ptr);
+                local_get(Local(i)); local_get(Local(old_len)); i32_ge_u; br_if(1);
+                local_get(Local(old_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                i32_load(0); local_set(Local(pair_ptr));
                 // Check if key is in keys list
-                i32_const(0); local_set(found);
-                i32_const(0); local_set(j);
+                i32_const(Imm32(0)); local_set(Local(found));
+                i32_const(Imm32(0)); local_set(Local(j));
                 block_empty; loop_empty;
-                  local_get(j); local_get(keys_len); i32_ge_u; br_if(1);
-                  local_get(pair_ptr); i32_load(0);
-                  local_get(keys); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                  local_get(j); i32_const(PTR_STRIDE); i32_mul; i32_add;
+                  local_get(Local(j)); local_get(Local(keys_len)); i32_ge_u; br_if(1);
+                  local_get(Local(pair_ptr)); i32_load(0);
+                  local_get(Local(keys)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                  local_get(Local(j)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
                   i32_load(0);
                   call(self.emitter.rt.string.eq);
                   if_empty;
-                    i32_const(1); local_set(found);
+                    i32_const(Imm32(1)); local_set(Local(found));
                     br(2);
                   end;
-                  local_get(j); i32_const(1); i32_add; local_set(j);
+                  local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                   br(0);
                 end; end;
         });
         // pick: include if found, omit: include if NOT found
         if is_pick {
             wasm!(self.func, {
-                local_get(found);
-                if_empty; local_get(count); i32_const(1); i32_add; local_set(count); end;
+                local_get(Local(found));
+                if_empty; local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count)); end;
             });
         } else {
             wasm!(self.func, {
-                local_get(found); i32_eqz;
-                if_empty; local_get(count); i32_const(1); i32_add; local_set(count); end;
+                local_get(Local(found)); i32_eqz;
+                if_empty; local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count)); end;
             });
         }
         wasm!(self.func, {
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
               end; end;
               // Alloc new list
-              i32_const(VAL_ALLOC_NULL); local_get(count); i32_const(PTR_STRIDE); i32_mul; i32_add;
-              call(self.emitter.rt.alloc); local_set(new_list);
-              local_get(new_list); local_get(count); i32_store(0);
+              i32_const(Imm32(VAL_ALLOC_NULL)); local_get(Local(count)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+              call(self.emitter.rt.alloc); local_set(Local(new_list));
+              local_get(Local(new_list)); local_get(Local(count)); i32_store(0);
               // Second pass: copy matching pairs
-              i32_const(0); local_set(i);
-              i32_const(0); local_set(count); // reuse as write index
+              i32_const(Imm32(0)); local_set(Local(i));
+              i32_const(Imm32(0)); local_set(Local(count)); // reuse as write index
               block_empty; loop_empty;
-                local_get(i); local_get(old_len); i32_ge_u; br_if(1);
-                local_get(old_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                i32_load(0); local_set(pair_ptr);
-                i32_const(0); local_set(found);
-                i32_const(0); local_set(j);
+                local_get(Local(i)); local_get(Local(old_len)); i32_ge_u; br_if(1);
+                local_get(Local(old_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                i32_load(0); local_set(Local(pair_ptr));
+                i32_const(Imm32(0)); local_set(Local(found));
+                i32_const(Imm32(0)); local_set(Local(j));
                 block_empty; loop_empty;
-                  local_get(j); local_get(keys_len); i32_ge_u; br_if(1);
-                  local_get(pair_ptr); i32_load(0);
-                  local_get(keys); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                  local_get(j); i32_const(PTR_STRIDE); i32_mul; i32_add;
+                  local_get(Local(j)); local_get(Local(keys_len)); i32_ge_u; br_if(1);
+                  local_get(Local(pair_ptr)); i32_load(0);
+                  local_get(Local(keys)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                  local_get(Local(j)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
                   i32_load(0);
                   call(self.emitter.rt.string.eq);
                   if_empty;
-                    i32_const(1); local_set(found);
+                    i32_const(Imm32(1)); local_set(Local(found));
                     br(2);
                   end;
-                  local_get(j); i32_const(1); i32_add; local_set(j);
+                  local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                   br(0);
                 end; end;
         });
         if is_pick {
-            wasm!(self.func, { local_get(found); });
+            wasm!(self.func, { local_get(Local(found)); });
         } else {
-            wasm!(self.func, { local_get(found); i32_eqz; });
+            wasm!(self.func, { local_get(Local(found)); i32_eqz; });
         }
         wasm!(self.func, {
                 if_empty;
-                  local_get(new_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                  local_get(count); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                  local_get(pair_ptr); i32_store(0);
-                  local_get(count); i32_const(1); i32_add; local_set(count);
+                  local_get(Local(new_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                  local_get(Local(count)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                  local_get(Local(pair_ptr)); i32_store(0);
+                  local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count));
                 end;
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
               end; end;
               // Build result object
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(VAL_TAG_OBJECT); i32_store(0);
-              local_get(result); local_get(new_list); i32_store(4);
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(VAL_TAG_OBJECT)); i32_store(0);
+              local_get(Local(result)); local_get(Local(new_list)); i32_store(4);
+              local_get(Local(result));
             end;
         });
 
@@ -1182,69 +1183,69 @@ impl FuncCompiler<'_> {
         let result = self.scratch.alloc_i32();
 
         self.emit_expr(&args[0]);
-        wasm!(self.func, { local_set(a); });
+        wasm!(self.func, { local_set(Local(a)); });
         self.emit_expr(&args[1]);
         wasm!(self.func, {
-            local_set(b);
-            local_get(a); i32_load(4); local_set(a_list);
-            local_get(b); i32_load(4); local_set(b_list);
-            local_get(a_list); i32_load(0); local_set(a_len);
-            local_get(b_list); i32_load(0); local_set(b_len);
+            local_set(Local(b));
+            local_get(Local(a)); i32_load(4); local_set(Local(a_list));
+            local_get(Local(b)); i32_load(4); local_set(Local(b_list));
+            local_get(Local(a_list)); i32_load(0); local_set(Local(a_len));
+            local_get(Local(b_list)); i32_load(0); local_set(Local(b_len));
             // Max possible pairs = a_len + b_len
-            i32_const(VAL_ALLOC_NULL); local_get(a_len); local_get(b_len); i32_add; i32_const(PTR_STRIDE); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(new_list);
-            i32_const(0); local_set(count);
+            i32_const(Imm32(VAL_ALLOC_NULL)); local_get(Local(a_len)); local_get(Local(b_len)); i32_add; i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(new_list));
+            i32_const(Imm32(0)); local_set(Local(count));
             // Copy all from a that are NOT in b
-            i32_const(0); local_set(i);
+            i32_const(Imm32(0)); local_set(Local(i));
             block_empty; loop_empty;
-              local_get(i); local_get(a_len); i32_ge_u; br_if(1);
-              local_get(a_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-              local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-              i32_load(0); local_set(pair_ptr);
+              local_get(Local(i)); local_get(Local(a_len)); i32_ge_u; br_if(1);
+              local_get(Local(a_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+              local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+              i32_load(0); local_set(Local(pair_ptr));
               // Check if key exists in b
-              i32_const(0); local_set(found);
-              i32_const(0); local_set(j);
+              i32_const(Imm32(0)); local_set(Local(found));
+              i32_const(Imm32(0)); local_set(Local(j));
               block_empty; loop_empty;
-                local_get(j); local_get(b_len); i32_ge_u; br_if(1);
-                local_get(pair_ptr); i32_load(0);
-                local_get(b_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(j); i32_const(PTR_STRIDE); i32_mul; i32_add;
+                local_get(Local(j)); local_get(Local(b_len)); i32_ge_u; br_if(1);
+                local_get(Local(pair_ptr)); i32_load(0);
+                local_get(Local(b_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                local_get(Local(j)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
                 i32_load(0); i32_load(0); // b pair key
                 call(self.emitter.rt.string.eq);
-                if_empty; i32_const(1); local_set(found); br(2); end;
-                local_get(j); i32_const(1); i32_add; local_set(j);
+                if_empty; i32_const(Imm32(1)); local_set(Local(found)); br(2); end;
+                local_get(Local(j)); i32_const(Imm32(1)); i32_add; local_set(Local(j));
                 br(0);
               end; end;
-              local_get(found); i32_eqz;
+              local_get(Local(found)); i32_eqz;
               if_empty;
-                local_get(new_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(count); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                local_get(pair_ptr); i32_store(0);
-                local_get(count); i32_const(1); i32_add; local_set(count);
+                local_get(Local(new_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                local_get(Local(count)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                local_get(Local(pair_ptr)); i32_store(0);
+                local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count));
               end;
-              local_get(i); i32_const(1); i32_add; local_set(i);
+              local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
               br(0);
             end; end;
             // Copy all from b
-            i32_const(0); local_set(i);
+            i32_const(Imm32(0)); local_set(Local(i));
             block_empty; loop_empty;
-              local_get(i); local_get(b_len); i32_ge_u; br_if(1);
-              local_get(new_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-              local_get(count); i32_const(PTR_STRIDE); i32_mul; i32_add;
-              local_get(b_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-              local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
+              local_get(Local(i)); local_get(Local(b_len)); i32_ge_u; br_if(1);
+              local_get(Local(new_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+              local_get(Local(count)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+              local_get(Local(b_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+              local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
               i32_load(0); i32_store(0);
-              local_get(count); i32_const(1); i32_add; local_set(count);
-              local_get(i); i32_const(1); i32_add; local_set(i);
+              local_get(Local(count)); i32_const(Imm32(1)); i32_add; local_set(Local(count));
+              local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
               br(0);
             end; end;
             // Set actual count
-            local_get(new_list); local_get(count); i32_store(0);
+            local_get(Local(new_list)); local_get(Local(count)); i32_store(0);
             // Build result
-            i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-            local_get(result); i32_const(VAL_TAG_OBJECT); i32_store(0);
-            local_get(result); local_get(new_list); i32_store(4);
-            local_get(result);
+            i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+            local_get(Local(result)); i32_const(Imm32(VAL_TAG_OBJECT)); i32_store(0);
+            local_get(Local(result)); local_get(Local(new_list)); i32_store(4);
+            local_get(Local(result));
         });
 
         self.scratch.free_i32(result);
@@ -1289,64 +1290,64 @@ impl FuncCompiler<'_> {
         let result = self.scratch.alloc_i32();
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(opt);
+            local_set(Local(opt));
             // Option layout: ptr==0 → None, ptr!=0 → Some (payload at offset 0, no tag)
-            local_get(opt); i32_const(0); i32_ne;
+            local_get(Local(opt)); i32_const(Imm32(0)); i32_ne;
             if_i32;
         });
         // Some: wrap payload as Value
         match suffix {
             "string" => {
                 wasm!(self.func, {
-                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(VAL_TAG_STRING); i32_store(0); // tag = string
-                    local_get(result); local_get(opt); i32_load(0); i32_store(4); // payload at offset 0
-                    local_get(result);
+                    i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(VAL_TAG_STRING)); i32_store(0); // tag = string
+                    local_get(Local(result)); local_get(Local(opt)); i32_load(0); i32_store(4); // payload at offset 0
+                    local_get(Local(result));
                 });
             }
             "int" => {
                 wasm!(self.func, {
-                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(VAL_TAG_INT); i32_store(0); // tag = int
-                    local_get(result); local_get(opt); i64_load(0); i64_store(4); // payload at offset 0
-                    local_get(result);
+                    i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(VAL_TAG_INT)); i32_store(0); // tag = int
+                    local_get(Local(result)); local_get(Local(opt)); i64_load(0); i64_store(4); // payload at offset 0
+                    local_get(Local(result));
                 });
             }
             "float" => {
                 wasm!(self.func, {
-                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(VAL_TAG_FLOAT); i32_store(0); // tag = float
-                    local_get(result); local_get(opt); f64_load(0); f64_store(4); // payload at offset 0
-                    local_get(result);
+                    i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(VAL_TAG_FLOAT)); i32_store(0); // tag = float
+                    local_get(Local(result)); local_get(Local(opt)); f64_load(0); f64_store(4); // payload at offset 0
+                    local_get(Local(result));
                 });
             }
             "bool" => {
                 wasm!(self.func, {
-                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(1); i32_store(0); // tag = bool
-                    local_get(result); local_get(opt); i32_load(0); i32_store(4); // payload at offset 0
-                    local_get(result);
+                    i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(1)); i32_store(0); // tag = bool
+                    local_get(Local(result)); local_get(Local(opt)); i32_load(0); i32_store(4); // payload at offset 0
+                    local_get(Local(result));
                 });
             }
             _ => {
                 // Named type: payload is a pointer at offset 0
                 wasm!(self.func, {
-                    local_get(opt); i32_load(0);
+                    local_get(Local(opt)); i32_load(0);
                 });
                 let encode_name = format!("{}.encode", suffix);
                 if let Some(&func_idx) = self.emitter.func_map.get(encode_name.as_str()) {
                     wasm!(self.func, { call(func_idx); });
                 } else {
-                    wasm!(self.func, { drop; i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(result); local_get(result); i32_const(0); i32_store(0); local_get(result); });
+                    wasm!(self.func, { drop; i32_const(Imm32(VAL_ALLOC_NULL)); call(self.emitter.rt.alloc); local_set(Local(result)); local_get(Local(result)); i32_const(Imm32(0)); i32_store(0); local_get(Local(result)); });
                 }
             }
         }
         wasm!(self.func, {
             else_;
               // None: return value.null
-              i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(0); i32_store(0); // tag = null
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_NULL)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(0)); i32_store(0); // tag = null
+              local_get(Local(result));
             end;
         });
         self.scratch.free_i32(result);
@@ -1368,49 +1369,49 @@ impl FuncCompiler<'_> {
         let result = self.scratch.alloc_i32();
 
         self.emit_expr(&args[0]); // v: Value
-        wasm!(self.func, { local_set(v); });
+        wasm!(self.func, { local_set(Local(v)); });
         self.emit_expr(&args[1]); // key: String
         wasm!(self.func, {
-            local_set(key);
+            local_set(Local(key));
             // v must be object
-            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_ne;
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_OBJECT)); i32_ne;
             if_i32;
         });
         let err_msg = self.emitter.intern_string("expected Object");
         wasm!(self.func, {
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(1); i32_store(0); // err
-              local_get(result); i32_const(err_msg as i32); i32_store(4);
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(1)); i32_store(0); // err
+              local_get(Local(result)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+              local_get(Local(result));
             else_;
-              local_get(v); i32_load(4); local_set(list);
-              local_get(list); i32_load(0); local_set(len);
-              i32_const(0); local_set(i);
-              i32_const(0); local_set(found); // 0 = not found
+              local_get(Local(v)); i32_load(4); local_set(Local(list));
+              local_get(Local(list)); i32_load(0); local_set(Local(len));
+              i32_const(Imm32(0)); local_set(Local(i));
+              i32_const(Imm32(0)); local_set(Local(found)); // 0 = not found
               block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
-                local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                i32_load(0); local_set(pair_ptr);
-                local_get(pair_ptr); i32_load(0);
-                local_get(key);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                local_get(Local(list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                i32_load(0); local_set(Local(pair_ptr));
+                local_get(Local(pair_ptr)); i32_load(0);
+                local_get(Local(key));
                 call(self.emitter.rt.string.eq);
                 if_empty;
-                  local_get(pair_ptr); i32_load(4); local_set(found); // found = value ptr
+                  local_get(Local(pair_ptr)); i32_load(4); local_set(Local(found)); // found = value ptr
                   br(2);
                 end;
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
               end; end;
               // found == 0 → missing → ok(None)
               // found != 0 && tag == 0 (null) → ok(None)
               // found != 0 && tag != 0 → ok(Some(as_T(found)?))
               // Use nested if to avoid loading from null pointer
-              local_get(found); i32_eqz;
+              local_get(Local(found)); i32_eqz;
               if_i32;
-                i32_const(1); // use_none = true
+                i32_const(Imm32(1)); // use_none = true
               else_;
-                local_get(found); i32_load(0); i32_eqz; // tag == null?
+                local_get(Local(found)); i32_load(0); i32_eqz; // tag == null?
               end;
               if_i32;
                 // Missing or null → ok(None)
@@ -1421,10 +1422,10 @@ impl FuncCompiler<'_> {
         wasm!(self.func, {
                 // Option None = pointer 0
                 // Wrap in ok Result: [tag=0][payload=0]
-                i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                local_get(result); i32_const(0); i32_store(0); // Result ok
-                local_get(result); i32_const(0); i32_store(4); // Option None = 0
-                local_get(result);
+                i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                local_get(Local(result)); i32_const(Imm32(0)); i32_store(0); // Result ok
+                local_get(Local(result)); i32_const(Imm32(0)); i32_store(4); // Option None = 0
+                local_get(Local(result));
               else_;
                 // Found value with non-null type → extract and wrap in Some
         });
@@ -1435,44 +1436,44 @@ impl FuncCompiler<'_> {
                 // Value tag 4 = string, payload i32 at +4
                 // Option[String] Some = heap ptr → [string_ptr:i32] (no tag, ptr != 0 = Some)
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(VAL_TAG_STRING); i32_ne;
+                    local_get(Local(found)); i32_load(0); i32_const(Imm32(VAL_TAG_STRING)); i32_ne;
                     if_i32;
                 });
                 let type_err = self.emitter.intern_string("expected Str");
                 wasm!(self.func, {
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(1); i32_store(0);
-                        local_get(result); i32_const(type_err as i32); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                        local_get(Local(result)); i32_const(Imm32(type_err as i32)); i32_store(4);
+                        local_get(Local(result));
                     else_;
                         // Some: alloc payload only (no tag)
-                        i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(some_opt);
-                        local_get(some_opt); local_get(found); i32_load(4); i32_store(0); // string ptr
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(0); i32_store(0); // ok
-                        local_get(result); local_get(some_opt); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_NULL)); call(self.emitter.rt.alloc); local_set(Local(some_opt));
+                        local_get(Local(some_opt)); local_get(Local(found)); i32_load(4); i32_store(0); // string ptr
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(0)); i32_store(0); // ok
+                        local_get(Local(result)); local_get(Local(some_opt)); i32_store(4);
+                        local_get(Local(result));
                     end;
                 });
             }
             "int" => {
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(VAL_TAG_INT); i32_ne;
+                    local_get(Local(found)); i32_load(0); i32_const(Imm32(VAL_TAG_INT)); i32_ne;
                     if_i32;
                 });
                 let type_err = self.emitter.intern_string("expected Int");
                 wasm!(self.func, {
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(1); i32_store(0);
-                        local_get(result); i32_const(type_err as i32); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                        local_get(Local(result)); i32_const(Imm32(type_err as i32)); i32_store(4);
+                        local_get(Local(result));
                     else_;
-                        i32_const(I64_STRIDE); call(self.emitter.rt.alloc); local_set(some_opt);
-                        local_get(some_opt); local_get(found); i64_load(4); i64_store(0); // i64 payload
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(0); i32_store(0);
-                        local_get(result); local_get(some_opt); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(I64_STRIDE)); call(self.emitter.rt.alloc); local_set(Local(some_opt));
+                        local_get(Local(some_opt)); local_get(Local(found)); i64_load(4); i64_store(0); // i64 payload
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                        local_get(Local(result)); local_get(Local(some_opt)); i32_store(4);
+                        local_get(Local(result));
                     end;
                 });
             }
@@ -1480,77 +1481,77 @@ impl FuncCompiler<'_> {
                 // #658: accept both Float (tag 3) and Int (tag 2, widened to f64).
                 let type_err = self.emitter.intern_string("expected Float");
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(VAL_TAG_FLOAT); i32_eq;
+                    local_get(Local(found)); i32_load(0); i32_const(Imm32(VAL_TAG_FLOAT)); i32_eq;
                     if_i32;
-                        i32_const(I64_STRIDE); call(self.emitter.rt.alloc); local_set(some_opt);
-                        local_get(some_opt); local_get(found); f64_load(4); f64_store(0);
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(0); i32_store(0);
-                        local_get(result); local_get(some_opt); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(I64_STRIDE)); call(self.emitter.rt.alloc); local_set(Local(some_opt));
+                        local_get(Local(some_opt)); local_get(Local(found)); f64_load(4); f64_store(0);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                        local_get(Local(result)); local_get(Local(some_opt)); i32_store(4);
+                        local_get(Local(result));
                     else_;
-                      local_get(found); i32_load(0); i32_const(VAL_TAG_INT); i32_eq;
+                      local_get(Local(found)); i32_load(0); i32_const(Imm32(VAL_TAG_INT)); i32_eq;
                       if_i32;
-                        i32_const(I64_STRIDE); call(self.emitter.rt.alloc); local_set(some_opt);
-                        local_get(some_opt); local_get(found); i64_load(4); f64_convert_i64_s; f64_store(0);
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(0); i32_store(0);
-                        local_get(result); local_get(some_opt); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(I64_STRIDE)); call(self.emitter.rt.alloc); local_set(Local(some_opt));
+                        local_get(Local(some_opt)); local_get(Local(found)); i64_load(4); f64_convert_i64_s; f64_store(0);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                        local_get(Local(result)); local_get(Local(some_opt)); i32_store(4);
+                        local_get(Local(result));
                       else_;
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(1); i32_store(0);
-                        local_get(result); i32_const(type_err as i32); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                        local_get(Local(result)); i32_const(Imm32(type_err as i32)); i32_store(4);
+                        local_get(Local(result));
                       end;
                     end;
                 });
             }
             "bool" => {
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(1); i32_ne;
+                    local_get(Local(found)); i32_load(0); i32_const(Imm32(1)); i32_ne;
                     if_i32;
                 });
                 let type_err = self.emitter.intern_string("expected Bool");
                 wasm!(self.func, {
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(1); i32_store(0);
-                        local_get(result); i32_const(type_err as i32); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                        local_get(Local(result)); i32_const(Imm32(type_err as i32)); i32_store(4);
+                        local_get(Local(result));
                     else_;
-                        i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(some_opt);
-                        local_get(some_opt); local_get(found); i32_load(4); i32_store(0);
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(0); i32_store(0);
-                        local_get(result); local_get(some_opt); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_NULL)); call(self.emitter.rt.alloc); local_set(Local(some_opt));
+                        local_get(Local(some_opt)); local_get(Local(found)); i32_load(4); i32_store(0);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                        local_get(Local(result)); local_get(Local(some_opt)); i32_store(4);
+                        local_get(Local(result));
                     end;
                 });
             }
             _ => {
                 // Named type: call Type.decode(found_value)
-                wasm!(self.func, { local_get(found); });
+                wasm!(self.func, { local_get(Local(found)); });
                 let decode_name = format!("{}.decode", suffix);
                 if let Some(&func_idx) = self.emitter.func_map.get(decode_name.as_str()) {
                     // Type.decode returns Result[T, String]
                     // On ok, wrap in Some; on err, propagate
                     let decode_result = self.scratch.alloc_i32();
                     wasm!(self.func, {
-                        call(func_idx); local_set(decode_result);
-                        local_get(decode_result); i32_load(0); i32_const(0); i32_eq;
+                        call(func_idx); local_set(Local(decode_result));
+                        local_get(Local(decode_result)); i32_load(0); i32_const(Imm32(0)); i32_eq;
                         if_i32;
                           // Option Some = a block whose offset 0 IS the payload ptr
                           // (no tag — matches the encode/primitive layout). Storing a
                           // spurious tag here made the re-encode read `1` as the
                           // payload pointer → garbage (新②).
-                          i32_const(VAL_ALLOC_NULL); call(self.emitter.rt.alloc); local_set(some_opt);
-                          local_get(some_opt); local_get(decode_result); i32_load(4); i32_store(0);
-                          i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                          local_get(result); i32_const(0); i32_store(0);
-                          local_get(result); local_get(some_opt); i32_store(4);
-                          local_get(result);
+                          i32_const(Imm32(VAL_ALLOC_NULL)); call(self.emitter.rt.alloc); local_set(Local(some_opt));
+                          local_get(Local(some_opt)); local_get(Local(decode_result)); i32_load(4); i32_store(0);
+                          i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                          local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                          local_get(Local(result)); local_get(Local(some_opt)); i32_store(4);
+                          local_get(Local(result));
                         else_;
-                          local_get(decode_result); // propagate err
+                          local_get(Local(decode_result)); // propagate err
                         end;
                     });
                     self.scratch.free_i32(decode_result);
@@ -1595,47 +1596,47 @@ impl FuncCompiler<'_> {
         };
 
         self.emit_expr(&args[0]); // v
-        wasm!(self.func, { local_set(v); });
+        wasm!(self.func, { local_set(Local(v)); });
         self.emit_expr(&args[1]); // key
-        wasm!(self.func, { local_set(key); });
+        wasm!(self.func, { local_set(Local(key)); });
         self.emit_expr(&args[2]); // default value
         wasm!(self.func, {
-            local_set(default_local);
-            local_get(v); i32_load(0); i32_const(VAL_TAG_OBJECT); i32_ne;
+            local_set(Local(default_local));
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_OBJECT)); i32_ne;
             if_i32;
         });
         let err_msg = self.emitter.intern_string("expected Object");
         wasm!(self.func, {
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(1); i32_store(0);
-              local_get(result); i32_const(err_msg as i32); i32_store(4);
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+              local_get(Local(result)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+              local_get(Local(result));
             else_;
-              local_get(v); i32_load(4); local_set(list);
-              local_get(list); i32_load(0); local_set(len);
-              i32_const(0); local_set(i);
-              i32_const(0); local_set(found);
+              local_get(Local(v)); i32_load(4); local_set(Local(list));
+              local_get(Local(list)); i32_load(0); local_set(Local(len));
+              i32_const(Imm32(0)); local_set(Local(i));
+              i32_const(Imm32(0)); local_set(Local(found));
               block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
-                local_get(list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                i32_load(0); local_set(pair_ptr);
-                local_get(pair_ptr); i32_load(0);
-                local_get(key);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                local_get(Local(list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                i32_load(0); local_set(Local(pair_ptr));
+                local_get(Local(pair_ptr)); i32_load(0);
+                local_get(Local(key));
                 call(self.emitter.rt.string.eq);
                 if_empty;
-                  local_get(pair_ptr); i32_load(4); local_set(found);
+                  local_get(Local(pair_ptr)); i32_load(4); local_set(Local(found));
                   br(2);
                 end;
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
               end; end;
               // found==0 or null → use default
-              local_get(found); i32_eqz;
+              local_get(Local(found)); i32_eqz;
               if_i32;
-                i32_const(1);
+                i32_const(Imm32(1));
               else_;
-                local_get(found); i32_load(0); i32_eqz;
+                local_get(Local(found)); i32_load(0); i32_eqz;
               end;
               if_i32;
         });
@@ -1643,34 +1644,34 @@ impl FuncCompiler<'_> {
         match suffix {
             "string" | "bool" => {
                 wasm!(self.func, {
-                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(0); i32_store(0);
-                    local_get(result); local_get(default_local); i32_store(4);
-                    local_get(result);
+                    i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result)); local_get(Local(default_local)); i32_store(4);
+                    local_get(Local(result));
                 });
             }
             "int" => {
                 wasm!(self.func, {
-                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(0); i32_store(0);
-                    local_get(result); local_get(default_local); i64_store(4);
-                    local_get(result);
+                    i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result)); local_get(Local(default_local)); i64_store(4);
+                    local_get(Local(result));
                 });
             }
             "float" => {
                 wasm!(self.func, {
-                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(0); i32_store(0);
-                    local_get(result); local_get(default_local); f64_store(4);
-                    local_get(result);
+                    i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result)); local_get(Local(default_local)); f64_store(4);
+                    local_get(Local(result));
                 });
             }
             _ => {
                 wasm!(self.func, {
-                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(0); i32_store(0);
-                    local_get(result); local_get(default_local); i32_store(4);
-                    local_get(result);
+                    i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                    local_get(Local(result)); local_get(Local(default_local)); i32_store(4);
+                    local_get(Local(result));
                 });
             }
         }
@@ -1681,39 +1682,39 @@ impl FuncCompiler<'_> {
         match suffix {
             "string" => {
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(VAL_TAG_STRING); i32_ne;
+                    local_get(Local(found)); i32_load(0); i32_const(Imm32(VAL_TAG_STRING)); i32_ne;
                     if_i32;
                 });
                 let te = self.emitter.intern_string("expected Str");
                 wasm!(self.func, {
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(1); i32_store(0);
-                        local_get(result); i32_const(te as i32); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                        local_get(Local(result)); i32_const(Imm32(te as i32)); i32_store(4);
+                        local_get(Local(result));
                     else_;
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(0); i32_store(0);
-                        local_get(result); local_get(found); i32_load(4); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                        local_get(Local(result)); local_get(Local(found)); i32_load(4); i32_store(4);
+                        local_get(Local(result));
                     end;
                 });
             }
             "int" => {
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(VAL_TAG_INT); i32_ne;
+                    local_get(Local(found)); i32_load(0); i32_const(Imm32(VAL_TAG_INT)); i32_ne;
                     if_i32;
                 });
                 let te = self.emitter.intern_string("expected Int");
                 wasm!(self.func, {
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(1); i32_store(0);
-                        local_get(result); i32_const(te as i32); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                        local_get(Local(result)); i32_const(Imm32(te as i32)); i32_store(4);
+                        local_get(Local(result));
                     else_;
-                        i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(0); i32_store(0);
-                        local_get(result); local_get(found); i64_load(4); i64_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                        local_get(Local(result)); local_get(Local(found)); i64_load(4); i64_store(4);
+                        local_get(Local(result));
                     end;
                 });
             }
@@ -1721,44 +1722,44 @@ impl FuncCompiler<'_> {
                 // #658: widen a JSON Int (tag 2) to Float, like native as_float.
                 let te = self.emitter.intern_string("expected Float");
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(VAL_TAG_FLOAT); i32_eq;
+                    local_get(Local(found)); i32_load(0); i32_const(Imm32(VAL_TAG_FLOAT)); i32_eq;
                     if_i32;
-                        i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(0); i32_store(0);
-                        local_get(result); local_get(found); f64_load(4); f64_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                        local_get(Local(result)); local_get(Local(found)); f64_load(4); f64_store(4);
+                        local_get(Local(result));
                     else_;
-                      local_get(found); i32_load(0); i32_const(VAL_TAG_INT); i32_eq;
+                      local_get(Local(found)); i32_load(0); i32_const(Imm32(VAL_TAG_INT)); i32_eq;
                       if_i32;
-                        i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(0); i32_store(0);
-                        local_get(result); local_get(found); i64_load(4); f64_convert_i64_s; f64_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                        local_get(Local(result)); local_get(Local(found)); i64_load(4); f64_convert_i64_s; f64_store(4);
+                        local_get(Local(result));
                       else_;
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(1); i32_store(0);
-                        local_get(result); i32_const(te as i32); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                        local_get(Local(result)); i32_const(Imm32(te as i32)); i32_store(4);
+                        local_get(Local(result));
                       end;
                     end;
                 });
             }
             "bool" => {
                 wasm!(self.func, {
-                    local_get(found); i32_load(0); i32_const(1); i32_ne;
+                    local_get(Local(found)); i32_load(0); i32_const(Imm32(1)); i32_ne;
                     if_i32;
                 });
                 let te = self.emitter.intern_string("expected Bool");
                 wasm!(self.func, {
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(1); i32_store(0);
-                        local_get(result); i32_const(te as i32); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+                        local_get(Local(result)); i32_const(Imm32(te as i32)); i32_store(4);
+                        local_get(Local(result));
                     else_;
-                        i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                        local_get(result); i32_const(0); i32_store(0);
-                        local_get(result); local_get(found); i32_load(4); i32_store(4);
-                        local_get(result);
+                        i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                        local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+                        local_get(Local(result)); local_get(Local(found)); i32_load(4); i32_store(4);
+                        local_get(Local(result));
                     end;
                 });
             }
@@ -1801,15 +1802,15 @@ impl FuncCompiler<'_> {
 
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(xs);
-            local_get(xs); i32_load(0); local_set(len);
+            local_set(Local(xs));
+            local_get(Local(xs)); i32_load(0); local_set(Local(len));
             // Alloc value list: [len:i32][ptr0][ptr1]...
-            i32_const(VAL_ALLOC_NULL); local_get(len); i32_const(PTR_STRIDE); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(val_list);
-            local_get(val_list); local_get(len); i32_store(0);
-            i32_const(0); local_set(i);
+            i32_const(Imm32(VAL_ALLOC_NULL)); local_get(Local(len)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+            call(self.emitter.rt.alloc); local_set(Local(val_list));
+            local_get(Local(val_list)); local_get(Local(len)); i32_store(0);
+            i32_const(Imm32(0)); local_set(Local(i));
             block_empty; loop_empty;
-              local_get(i); local_get(len); i32_ge_u; br_if(1);
+              local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
         });
         // Read element from source list
         let _elem_stride = match suffix {
@@ -1818,76 +1819,76 @@ impl FuncCompiler<'_> {
         match suffix {
             "string" => {
                 wasm!(self.func, {
-                    local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                    i32_load(0); local_set(elem);
-                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(VAL_TAG_STRING); i32_store(0); // string tag
-                    local_get(result); local_get(elem); i32_store(4);
+                    local_get(Local(xs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                    local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                    i32_load(0); local_set(Local(elem));
+                    i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(VAL_TAG_STRING)); i32_store(0); // string tag
+                    local_get(Local(result)); local_get(Local(elem)); i32_store(4);
                 });
             }
             "int" => {
                 let elem64 = self.scratch.alloc_i64();
                 wasm!(self.func, {
-                    local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(I64_STRIDE); i32_mul; i32_add;
-                    i64_load(0); local_set(elem64);
-                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(VAL_TAG_INT); i32_store(0); // int tag
-                    local_get(result); local_get(elem64); i64_store(4);
+                    local_get(Local(xs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                    local_get(Local(i)); i32_const(Imm32(I64_STRIDE)); i32_mul; i32_add;
+                    i64_load(0); local_set(Local(elem64));
+                    i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(VAL_TAG_INT)); i32_store(0); // int tag
+                    local_get(Local(result)); local_get(Local(elem64)); i64_store(4);
                 });
                 self.scratch.free_i64(elem64);
             }
             "float" => {
                 let elem_f = self.scratch.alloc_f64();
                 wasm!(self.func, {
-                    local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(I64_STRIDE); i32_mul; i32_add;
-                    f64_load(0); local_set(elem_f);
-                    i32_const(VAL_ALLOC_I64); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(VAL_TAG_FLOAT); i32_store(0); // float tag
-                    local_get(result); local_get(elem_f); f64_store(4);
+                    local_get(Local(xs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                    local_get(Local(i)); i32_const(Imm32(I64_STRIDE)); i32_mul; i32_add;
+                    f64_load(0); local_set(Local(elem_f));
+                    i32_const(Imm32(VAL_ALLOC_I64)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(VAL_TAG_FLOAT)); i32_store(0); // float tag
+                    local_get(Local(result)); local_get(Local(elem_f)); f64_store(4);
                 });
                 self.scratch.free_f64(elem_f);
             }
             "bool" => {
                 wasm!(self.func, {
-                    local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                    i32_load(0); local_set(elem);
-                    i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-                    local_get(result); i32_const(1); i32_store(0); // bool tag
-                    local_get(result); local_get(elem); i32_store(4);
+                    local_get(Local(xs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                    local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                    i32_load(0); local_set(Local(elem));
+                    i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+                    local_get(Local(result)); i32_const(Imm32(1)); i32_store(0); // bool tag
+                    local_get(Local(result)); local_get(Local(elem)); i32_store(4);
                 });
             }
             _ => {
                 // Named type: call Type.encode(elem)
                 wasm!(self.func, {
-                    local_get(xs); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
+                    local_get(Local(xs)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                    local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
                     i32_load(0);
                 });
                 let encode_name = format!("{}.encode", suffix);
                 if let Some(&func_idx) = self.emitter.func_map.get(encode_name.as_str()) {
-                    wasm!(self.func, { call(func_idx); local_set(result); });
+                    wasm!(self.func, { call(func_idx); local_set(Local(result)); });
                 } else {
-                    wasm!(self.func, { local_set(result); }); // passthrough ptr
+                    wasm!(self.func, { local_set(Local(result)); }); // passthrough ptr
                 }
             }
         }
         wasm!(self.func, {
               // Store value in val_list
-              local_get(val_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-              local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-              local_get(result); i32_store(0);
-              local_get(i); i32_const(1); i32_add; local_set(i);
+              local_get(Local(val_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+              local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+              local_get(Local(result)); i32_store(0);
+              local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
               br(0);
             end; end;
             // Wrap in Value array: [tag=5][list_ptr]
-            i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-            local_get(result); i32_const(VAL_TAG_ARRAY); i32_store(0); // array tag
-            local_get(result); local_get(val_list); i32_store(4);
-            local_get(result);
+            i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+            local_get(Local(result)); i32_const(Imm32(VAL_TAG_ARRAY)); i32_store(0); // array tag
+            local_get(Local(result)); local_get(Local(val_list)); i32_store(4);
+            local_get(Local(result));
         });
 
         self.scratch.free_i32(result);
@@ -1910,9 +1911,9 @@ impl FuncCompiler<'_> {
 
         self.emit_expr(&args[0]);
         wasm!(self.func, {
-            local_set(v);
+            local_set(Local(v));
             // Must be array (tag 5)
-            local_get(v); i32_load(0); i32_const(VAL_TAG_ARRAY); i32_ne;
+            local_get(Local(v)); i32_load(0); i32_const(Imm32(VAL_TAG_ARRAY)); i32_ne;
             if_i32;
         });
         let err_msg = self.emitter.intern_string("expected Array");
@@ -1920,56 +1921,56 @@ impl FuncCompiler<'_> {
             "int" | "float" => I64_STRIDE as u32, _ => PTR_STRIDE as u32,
         };
         wasm!(self.func, {
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(1); i32_store(0);
-              local_get(result); i32_const(err_msg as i32); i32_store(4);
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(1)); i32_store(0);
+              local_get(Local(result)); i32_const(Imm32(err_msg as i32)); i32_store(4);
+              local_get(Local(result));
             else_;
-              local_get(v); i32_load(4); local_set(arr_list);
-              local_get(arr_list); i32_load(0); local_set(len);
+              local_get(Local(v)); i32_load(4); local_set(Local(arr_list));
+              local_get(Local(arr_list)); i32_load(0); local_set(Local(len));
               // Alloc output list
-              i32_const(VAL_ALLOC_NULL); local_get(len); i32_const(elem_size as i32); i32_mul; i32_add;
-              call(self.emitter.rt.alloc); local_set(out_list);
-              local_get(out_list); local_get(len); i32_store(0);
-              i32_const(0); local_set(i);
+              i32_const(Imm32(VAL_ALLOC_NULL)); local_get(Local(len)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
+              call(self.emitter.rt.alloc); local_set(Local(out_list));
+              local_get(Local(out_list)); local_get(Local(len)); i32_store(0);
+              i32_const(Imm32(0)); local_set(Local(i));
               block_empty; loop_empty;
-                local_get(i); local_get(len); i32_ge_u; br_if(1);
+                local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
                 // Get Value element from array
-                local_get(arr_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                i32_load(0); local_set(elem_val);
+                local_get(Local(arr_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                i32_load(0); local_set(Local(elem_val));
         });
         // Extract typed value from Value element
         match suffix {
             "string" => {
                 wasm!(self.func, {
-                    local_get(out_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                    local_get(elem_val); i32_load(4); // string ptr from Value
+                    local_get(Local(out_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                    local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                    local_get(Local(elem_val)); i32_load(4); // string ptr from Value
                     i32_store(0);
                 });
             }
             "int" => {
                 wasm!(self.func, {
-                    local_get(out_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(I64_STRIDE); i32_mul; i32_add;
-                    local_get(elem_val); i64_load(4); // i64 from Value
+                    local_get(Local(out_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                    local_get(Local(i)); i32_const(Imm32(I64_STRIDE)); i32_mul; i32_add;
+                    local_get(Local(elem_val)); i64_load(4); // i64 from Value
                     i64_store(0);
                 });
             }
             "float" => {
                 wasm!(self.func, {
-                    local_get(out_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(I64_STRIDE); i32_mul; i32_add;
-                    local_get(elem_val); f64_load(4);
+                    local_get(Local(out_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                    local_get(Local(i)); i32_const(Imm32(I64_STRIDE)); i32_mul; i32_add;
+                    local_get(Local(elem_val)); f64_load(4);
                     f64_store(0);
                 });
             }
             "bool" => {
                 wasm!(self.func, {
-                    local_get(out_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                    local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                    local_get(elem_val); i32_load(4); // bool (0/1)
+                    local_get(Local(out_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                    local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                    local_get(Local(elem_val)); i32_load(4); // bool (0/1)
                     i32_store(0);
                 });
             }
@@ -1979,32 +1980,32 @@ impl FuncCompiler<'_> {
                 if let Some(&func_idx) = self.emitter.func_map.get(decode_name.as_str()) {
                     let dr = self.scratch.alloc_i32();
                     wasm!(self.func, {
-                        local_get(elem_val); call(func_idx); local_set(dr);
-                        local_get(out_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                        local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                        local_get(dr); i32_load(4); // ok payload (pointer)
+                        local_get(Local(elem_val)); call(func_idx); local_set(Local(dr));
+                        local_get(Local(out_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                        local_get(Local(dr)); i32_load(4); // ok payload (pointer)
                         i32_store(0);
                     });
                     self.scratch.free_i32(dr);
                 } else {
                     wasm!(self.func, {
-                        local_get(out_list); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32); i32_add;
-                        local_get(i); i32_const(PTR_STRIDE); i32_mul; i32_add;
-                        local_get(elem_val);
+                        local_get(Local(out_list)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::TAGS) as i32)); i32_add;
+                        local_get(Local(i)); i32_const(Imm32(PTR_STRIDE)); i32_mul; i32_add;
+                        local_get(Local(elem_val));
                         i32_store(0);
                     });
                 }
             }
         }
         wasm!(self.func, {
-                local_get(i); i32_const(1); i32_add; local_set(i);
+                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                 br(0);
               end; end;
               // Wrap in ok Result
-              i32_const(VAL_ALLOC_PTR); call(self.emitter.rt.alloc); local_set(result);
-              local_get(result); i32_const(0); i32_store(0);
-              local_get(result); local_get(out_list); i32_store(4);
-              local_get(result);
+              i32_const(Imm32(VAL_ALLOC_PTR)); call(self.emitter.rt.alloc); local_set(Local(result));
+              local_get(Local(result)); i32_const(Imm32(0)); i32_store(0);
+              local_get(Local(result)); local_get(Local(out_list)); i32_store(4);
+              local_get(Local(result));
             end;
         });
 

--- a/crates/almide-codegen/src/emit_wasm/closures.rs
+++ b/crates/almide-codegen/src/emit_wasm/closures.rs
@@ -5,6 +5,7 @@
 
 use std::collections::{HashMap, HashSet};
 use wasm_encoder::ValType;
+use crate::emit_wasm::engine::Local;
 
 use almide_ir::{IrExpr, IrExprKind, IrProgram, IrStmtKind, VarId};
 use almide_ir::visit::{IrVisitor, walk_expr, walk_stmt};
@@ -307,15 +308,15 @@ pub(super) fn compile_lambda_bodies(
                 // Mutable capture: env stores cell ptr (i32). Load as i32.
                 let cap_local = var_map[&vid.0];
                 let offset = ci as u32 * 8;
-                wasm_func.instruction(&wasm_encoder::Instruction::LocalGet(0));
+                wasm!(wasm_func, { local_get(Local(0)); });
                 wasm_func.instruction(&wasm_encoder::Instruction::I32Load(
                     wasm_encoder::MemArg { offset: offset as u64, align: 2, memory_index: 0 }
                 ));
-                wasm_func.instruction(&wasm_encoder::Instruction::LocalSet(cap_local));
+                wasm!(wasm_func, { local_set(Local(cap_local)); });
             } else if let Some(vt) = values::ty_to_valtype(ty) {
                 let cap_local = var_map[&vid.0];
                 let offset = ci as u32 * 8;
-                wasm_func.instruction(&wasm_encoder::Instruction::LocalGet(0));
+                wasm!(wasm_func, { local_get(Local(0)); });
                 match vt {
                     ValType::I64 => {
                         wasm_func.instruction(&wasm_encoder::Instruction::I64Load(
@@ -333,7 +334,7 @@ pub(super) fn compile_lambda_bodies(
                         ));
                     }
                 }
-                wasm_func.instruction(&wasm_encoder::Instruction::LocalSet(cap_local));
+                wasm!(wasm_func, { local_set(Local(cap_local)); });
             }
         }
 
@@ -375,7 +376,7 @@ pub(super) fn compile_lambda_bodies(
                 let mut f = super::TrackedFunction::new([]);
                 // Skip env (local 0), pass remaining params to original
                 for i in 0..orig_params.len() {
-                    f.instruction(&wasm_encoder::Instruction::LocalGet((i + 1) as u32));
+                    wasm!(f, { local_get(Local((i + 1) as u32)); });
                 }
                 f.instruction(&wasm_encoder::Instruction::Call(orig_func_idx));
                 f.instruction(&wasm_encoder::Instruction::End);

--- a/crates/almide-codegen/src/emit_wasm/collections.rs
+++ b/crates/almide-codegen/src/emit_wasm/collections.rs
@@ -1,5 +1,6 @@
 //! Collection construction and access emission — records, lists, tuples, maps.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use almide_ir::{IrExpr, IrExprKind};
 use almide_lang::types::Ty;
 use super::FuncCompiler;
@@ -52,18 +53,18 @@ impl FuncCompiler<'_> {
 
         // Allocate
         wasm!(self.func, {
-            i32_const(total_size as i32);
+            i32_const(Imm32(total_size as i32));
             call(self.emitter.rt.alloc);
         });
 
         let scratch = self.scratch.alloc_i32();
-        wasm!(self.func, { local_set(scratch); });
+        wasm!(self.func, { local_set(Local(scratch)); });
 
         // Write tag if variant
         if let Some(tag_val) = tag {
             wasm!(self.func, {
-                local_get(scratch);
-                i32_const(tag_val as i32);
+                local_get(Local(scratch));
+                i32_const(Imm32(tag_val as i32));
                 i32_store(0);
             });
         }
@@ -102,7 +103,7 @@ impl FuncCompiler<'_> {
             // Emit in type-definition order
             for (field_name, field_ty) in &type_fields {
                 if let Some(expr) = explicit_map.get(field_name.as_str()) {
-                    wasm!(self.func, { local_get(scratch); });
+                    wasm!(self.func, { local_get(Local(scratch)); });
                     self.emit_stored_field(expr);
                     let store_ty = if expr.ty.is_unresolved() {
                         field_ty
@@ -113,7 +114,7 @@ impl FuncCompiler<'_> {
                     offset += values::byte_size(store_ty);
                 } else if let Some(ctor_name) = name {
                     if let Some(default_expr) = self.emitter.default_fields.get(&(ctor_name.to_string(), field_name.clone())) {
-                        wasm!(self.func, { local_get(scratch); });
+                        wasm!(self.func, { local_get(Local(scratch)); });
                         let default_expr = default_expr.clone();
                         let dt = match (&default_expr.ty, &default_expr.kind) {
                             (Ty::Unknown, almide_ir::IrExprKind::LitInt { .. }) => Ty::Int,
@@ -137,7 +138,7 @@ impl FuncCompiler<'_> {
             // No type info: emit explicit fields only
             for (_, field_expr) in fields {
                 let field_size = values::byte_size(&field_expr.ty);
-                wasm!(self.func, { local_get(scratch); });
+                wasm!(self.func, { local_get(Local(scratch)); });
                 self.emit_stored_field(field_expr);
                 self.emit_store_at(&field_expr.ty, offset);
                 offset += field_size;
@@ -145,7 +146,7 @@ impl FuncCompiler<'_> {
         }
 
         self.scratch.free_i32(scratch);
-        wasm!(self.func, { local_get(scratch); });
+        wasm!(self.func, { local_get(Local(scratch)); });
     }
 
     /// Look up variant tag for a constructor name within a variant type.
@@ -171,40 +172,40 @@ impl FuncCompiler<'_> {
 
         // Allocate new record
         wasm!(self.func, {
-            i32_const(total_size as i32);
+            i32_const(Imm32(total_size as i32));
             call(self.emitter.rt.alloc);
         });
         let result_scratch = self.scratch.alloc_i32();
-        wasm!(self.func, { local_set(result_scratch); });
+        wasm!(self.func, { local_set(Local(result_scratch)); });
 
         // Evaluate base and store ptr
         self.emit_expr(base);
         let base_scratch = self.scratch.alloc_i32();
-        wasm!(self.func, { local_set(base_scratch); });
+        wasm!(self.func, { local_set(Local(base_scratch)); });
 
         // Copy all bytes from base to result (including tag if variant)
         let counter = self.scratch.alloc_i64();
         wasm!(self.func, {
-            i64_const(0);
-            local_set(counter);
+            i64_const(Imm64(0));
+            local_set(Local(counter));
             block_empty;
             loop_empty;
         });
         // break if counter >= total_size
         wasm!(self.func, {
-            local_get(counter);
-            i64_const(total_size as i64);
+            local_get(Local(counter));
+            i64_const(Imm64(total_size as i64));
             i64_ge_u;
             br_if(1);
         });
         // dst[i] = src[i]
         wasm!(self.func, {
-            local_get(result_scratch);
-            local_get(counter);
+            local_get(Local(result_scratch));
+            local_get(Local(counter));
             i32_wrap_i64;
             i32_add;
-            local_get(base_scratch);
-            local_get(counter);
+            local_get(Local(base_scratch));
+            local_get(Local(counter));
             i32_wrap_i64;
             i32_add;
             i32_load8_u(0);
@@ -212,10 +213,10 @@ impl FuncCompiler<'_> {
         });
         // counter++
         wasm!(self.func, {
-            local_get(counter);
-            i64_const(1);
+            local_get(Local(counter));
+            i64_const(Imm64(1));
             i64_add;
-            local_set(counter);
+            local_set(Local(counter));
             br(0);
             end;
             end;
@@ -229,7 +230,7 @@ impl FuncCompiler<'_> {
             // whereas the record layout is authoritative.
             if let Some((offset, field_ty)) = values::field_offset(&all_fields, field_name) {
                 let total_offset = tag_offset + offset;
-                wasm!(self.func, { local_get(result_scratch); });
+                wasm!(self.func, { local_get(Local(result_scratch)); });
                 self.emit_expr(field_expr);
                 self.emit_store_at(&field_ty, total_offset);
             }
@@ -239,7 +240,7 @@ impl FuncCompiler<'_> {
         self.scratch.free_i64(counter);
         self.scratch.free_i32(base_scratch);
         self.scratch.free_i32(result_scratch);
-        wasm!(self.func, { local_get(result_scratch); });
+        wasm!(self.func, { local_get(Local(result_scratch)); });
     }
 
     /// Emit a list literal: allocate [len:i32][cap:i32][elem0][elem1]...
@@ -254,37 +255,37 @@ impl FuncCompiler<'_> {
         let total = 8 + n * elem_size;
 
         wasm!(self.func, {
-            i32_const(total as i32);
+            i32_const(Imm32(total as i32));
             call(self.emitter.rt.alloc);
         });
 
         let scratch = self.scratch.alloc_i32();
-        wasm!(self.func, { local_set(scratch); });
+        wasm!(self.func, { local_set(Local(scratch)); });
 
         // Store length
         wasm!(self.func, {
-            local_get(scratch);
-            i32_const(n as i32);
+            local_get(Local(scratch));
+            i32_const(Imm32(n as i32));
             i32_store(0);
         });
 
         // Store capacity = len (exact fit)
         wasm!(self.func, {
-            local_get(scratch);
-            i32_const(n as i32);
+            local_get(Local(scratch));
+            i32_const(Imm32(n as i32));
             i32_store(4);
         });
 
         // Store each element
         for (i, elem) in elements.iter().enumerate() {
             let offset = 8 + (i as u32) * elem_size;
-            wasm!(self.func, { local_get(scratch); });
+            wasm!(self.func, { local_get(Local(scratch)); });
             self.emit_stored_field(elem);
             self.emit_store_at(&elem.ty, offset);
         }
 
         self.scratch.free_i32(scratch);
-        wasm!(self.func, { local_get(scratch); });
+        wasm!(self.func, { local_get(Local(scratch)); });
     }
 
     /// Emit index access: list_ptr + 8 + index * elem_size
@@ -298,7 +299,7 @@ impl FuncCompiler<'_> {
         // ptr → local (needed for both the bounds check's len load and the address)
         self.emit_expr(object);
         let ptr = self.scratch.alloc_i32();
-        wasm!(self.func, { local_set(ptr); });
+        wasm!(self.func, { local_set(Local(ptr)); });
 
         // index → i32 local, BOUNDS-CHECKED on the FULL i64 first (#554/C-072).
         // The prior code did `i32_wrap_i64` BEFORE the u32 compare, so an index
@@ -315,28 +316,28 @@ impl FuncCompiler<'_> {
             // Constant index: the bound is dynamic (len), so still guard, but the
             // index itself fits i32 once we know it is non-negative and < 2^31.
             let idx64 = self.scratch.alloc_i64();
-            wasm!(self.func, { i64_const(v); local_set(idx64); });
+            wasm!(self.func, { i64_const(Imm64(v)); local_set(Local(idx64)); });
             self.emit_index_bound_guard(idx64, ptr, oob_msg, div_trap);
-            wasm!(self.func, { local_get(idx64); i32_wrap_i64; local_set(idx); });
+            wasm!(self.func, { local_get(Local(idx64)); i32_wrap_i64; local_set(Local(idx)); });
             self.scratch.free_i64(idx64);
         } else {
             let idx64 = self.scratch.alloc_i64();
             self.emit_expr(index);
             if matches!(&index.ty, Ty::Int) {
-                wasm!(self.func, { local_set(idx64); });
+                wasm!(self.func, { local_set(Local(idx64)); });
             } else {
                 // narrow-int index already i32 on the stack — widen to i64
-                wasm!(self.func, { i64_extend_i32_s; local_set(idx64); });
+                wasm!(self.func, { i64_extend_i32_s; local_set(Local(idx64)); });
             }
             self.emit_index_bound_guard(idx64, ptr, oob_msg, div_trap);
-            wasm!(self.func, { local_get(idx64); i32_wrap_i64; local_set(idx); });
+            wasm!(self.func, { local_get(Local(idx64)); i32_wrap_i64; local_set(Local(idx)); });
             self.scratch.free_i64(idx64);
         }
 
         // addr = ptr + data_off + idx * elem_size
-        wasm!(self.func, { local_get(ptr); i32_const(data_off as i32); i32_add; local_get(idx); });
+        wasm!(self.func, { local_get(Local(ptr)); i32_const(Imm32(data_off as i32)); i32_add; local_get(Local(idx)); });
         if elem_size > 1 {
-            wasm!(self.func, { i32_const(elem_size as i32); i32_mul; });
+            wasm!(self.func, { i32_const(Imm32(elem_size as i32)); i32_mul; });
         }
         wasm!(self.func, { i32_add; });
 
@@ -367,12 +368,12 @@ impl FuncCompiler<'_> {
         let total_size = values::record_size(&element_types);
 
         wasm!(self.func, {
-            i32_const(total_size as i32);
+            i32_const(Imm32(total_size as i32));
             call(self.emitter.rt.alloc);
         });
 
         let scratch = self.scratch.alloc_i32();
-        wasm!(self.func, { local_set(scratch); });
+        wasm!(self.func, { local_set(Local(scratch)); });
 
         let mut offset = 0u32;
         for elem in elements {
@@ -389,14 +390,14 @@ impl FuncCompiler<'_> {
                 elem.ty.clone()
             };
             let size = values::byte_size(&elem_ty);
-            wasm!(self.func, { local_get(scratch); });
+            wasm!(self.func, { local_get(Local(scratch)); });
             self.emit_stored_field(elem);
             self.emit_store_at(&elem_ty, offset);
             offset += size;
         }
 
         self.scratch.free_i32(scratch);
-        wasm!(self.func, { local_get(scratch); });
+        wasm!(self.func, { local_get(Local(scratch)); });
     }
 
     /// Emit a tuple index access: load from tuple pointer + element offset.

--- a/crates/almide-codegen/src/emit_wasm/control.rs
+++ b/crates/almide-codegen/src/emit_wasm/control.rs
@@ -1,5 +1,6 @@
 //! Control flow emission — for-in loops and match expressions.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use almide_ir::{IrExpr, IrExprKind, IrMatchArm, IrPattern, IrStmt};
 use almide_lang::types::Ty;
 use wasm_encoder::{Instruction, ValType};
@@ -17,7 +18,7 @@ impl FuncCompiler<'_> {
 
                 // Initialize loop variable to start
                 self.emit_expr(start);
-                wasm!(self.func, { local_set(loop_var); });
+                wasm!(self.func, { local_set(Local(loop_var)); });
 
                 // block $break { loop $loop { check; block $continue { body }; i++; br $loop } }
                 wasm!(self.func, { block_empty; });
@@ -27,7 +28,7 @@ impl FuncCompiler<'_> {
                 let loop_guard = self.depth_push();
 
                 // Break condition
-                wasm!(self.func, { local_get(loop_var); });
+                wasm!(self.func, { local_get(Local(loop_var)); });
                 self.emit_expr(end);
                 if *inclusive {
                     wasm!(self.func, { i64_gt_s; });
@@ -53,10 +54,10 @@ impl FuncCompiler<'_> {
 
                 // Increment: var += 1 (always runs, even after continue)
                 wasm!(self.func, {
-                    local_get(loop_var);
-                    i64_const(1);
+                    local_get(Local(loop_var));
+                    i64_const(Imm64(1));
                     i64_add;
-                    local_set(loop_var);
+                    local_set(Local(loop_var));
                 });
 
                 // Loop back
@@ -93,8 +94,8 @@ impl FuncCompiler<'_> {
         let entry_size = values::byte_size(&elem_ty);
 
         self.emit_expr(iterable);
-        wasm!(self.func, { local_set(list_scratch); });
-        wasm!(self.func, { i32_const(0); local_set(idx_scratch); });
+        wasm!(self.func, { local_set(Local(list_scratch)); });
+        wasm!(self.func, { i32_const(Imm32(0)); local_set(Local(idx_scratch)); });
 
         // block $break { loop $loop { ... } }
         wasm!(self.func, { block_empty; });
@@ -104,24 +105,24 @@ impl FuncCompiler<'_> {
 
         // Break if idx >= len
         wasm!(self.func, {
-            local_get(idx_scratch);
-            local_get(list_scratch); i32_load(0);
+            local_get(Local(idx_scratch));
+            local_get(Local(list_scratch)); i32_load(0);
             i32_ge_u;
             br_if(self.depth - break_guard.saved() - 1);
         });
 
         // Load element from data[idx]
         wasm!(self.func, {
-            local_get(list_scratch);
-            i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32);
+            local_get(Local(list_scratch));
+            i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32));
             i32_add;
-            local_get(idx_scratch);
-            i32_const(entry_size as i32);
+            local_get(Local(idx_scratch));
+            i32_const(Imm32(entry_size as i32));
             i32_mul;
             i32_add;
         });
         self.emit_load_at(&elem_ty, 0);
-        wasm!(self.func, { local_set(loop_var); });
+        wasm!(self.func, { local_set(Local(loop_var)); });
 
         // Tuple destructure (for list of tuples)
         if let Some(tuple_vars) = var_tuple {
@@ -132,9 +133,9 @@ impl FuncCompiler<'_> {
                 for (i, &tv) in tuple_vars.iter().enumerate() {
                     let ft = elem_types.get(i).cloned().unwrap_or(Ty::Int);
                     if let Some(&local_idx) = self.var_map.get(&tv.0) {
-                        wasm!(self.func, { local_get(loop_var); });
+                        wasm!(self.func, { local_get(Local(loop_var)); });
                         self.emit_load_at(&ft, field_offset);
-                        wasm!(self.func, { local_set(local_idx); });
+                        wasm!(self.func, { local_set(Local(local_idx)); });
                     }
                     field_offset += values::byte_size(&ft);
                 }
@@ -154,7 +155,7 @@ impl FuncCompiler<'_> {
 
         // idx++; br $loop
         wasm!(self.func, {
-            local_get(idx_scratch); i32_const(1); i32_add; local_set(idx_scratch);
+            local_get(Local(idx_scratch)); i32_const(Imm32(1)); i32_add; local_set(Local(idx_scratch));
         });
         wasm!(self.func, { br(self.depth - loop_guard.saved() - 1); });
 
@@ -191,12 +192,12 @@ impl FuncCompiler<'_> {
 
         self.emit_expr(iterable);
         wasm!(self.func, {
-            local_set(m);
-            local_get(m); i32_load(0); local_set(len);
-            local_get(m); i32_load(map_cap_off); local_set(cap);
+            local_set(Local(m));
+            local_get(Local(m)); i32_load(0); local_set(Local(len));
+            local_get(Local(m)); i32_load(map_cap_off); local_set(Local(cap));
         });
         self.emit_dict_entries_base(m, cap);
-        wasm!(self.func, { local_set(eb); i32_const(0); local_set(idx); });
+        wasm!(self.func, { local_set(Local(eb)); i32_const(Imm32(0)); local_set(Local(idx)); });
 
         // block $break { loop $loop { ... } }
         wasm!(self.func, { block_empty; });
@@ -206,7 +207,7 @@ impl FuncCompiler<'_> {
 
         // Break if idx >= len (dense entries are all occupied — no tag skip)
         wasm!(self.func, {
-            local_get(idx); local_get(len); i32_ge_u;
+            local_get(Local(idx)); local_get(Local(len)); i32_ge_u;
             br_if(self.depth - break_guard.saved() - 1);
         });
 
@@ -215,21 +216,21 @@ impl FuncCompiler<'_> {
             // Load key
             if let Some(&k_local) = tuple_vars.first().and_then(|tv| self.var_map.get(&tv.0)) {
                 wasm!(self.func, {
-                    local_get(eb);
-                    local_get(idx); i32_const(entry_size as i32); i32_mul; i32_add;
+                    local_get(Local(eb));
+                    local_get(Local(idx)); i32_const(Imm32(entry_size as i32)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&key_ty, 0);
-                wasm!(self.func, { local_set(k_local); });
+                wasm!(self.func, { local_set(Local(k_local)); });
             }
 
             // Load value
             if let Some(&v_local) = tuple_vars.get(1).and_then(|tv| self.var_map.get(&tv.0)) {
                 wasm!(self.func, {
-                    local_get(eb);
-                    local_get(idx); i32_const(entry_size as i32); i32_mul; i32_add;
+                    local_get(Local(eb));
+                    local_get(Local(idx)); i32_const(Imm32(entry_size as i32)); i32_mul; i32_add;
                 });
                 self.emit_load_at(&val_ty, key_size);
-                wasm!(self.func, { local_set(v_local); });
+                wasm!(self.func, { local_set(Local(v_local)); });
             }
         }
 
@@ -246,7 +247,7 @@ impl FuncCompiler<'_> {
 
         // idx++; br $loop
         wasm!(self.func, {
-            local_get(idx); i32_const(1); i32_add; local_set(idx);
+            local_get(Local(idx)); i32_const(Imm32(1)); i32_add; local_set(Local(idx));
         });
         wasm!(self.func, { br(self.depth - loop_guard.saved() - 1); });
 
@@ -346,7 +347,7 @@ impl FuncCompiler<'_> {
             self.scratch.alloc_i32()
         };
 
-        wasm!(self.func, { local_set(scratch); });
+        wasm!(self.func, { local_set(Local(scratch)); });
 
         self.emit_match_arms(arms, scratch, &subject_ty, result_ty, 0);
 
@@ -426,8 +427,8 @@ impl FuncCompiler<'_> {
                     // Only bind if types match, or var type is Unknown (trust subject)
                     if var_vt == subj_vt || matches!(var_ty, Ty::Unknown) {
                         wasm!(self.func, {
-                            local_get(scratch);
-                            local_set(local_idx);
+                            local_get(Local(scratch));
+                            local_set(Local(local_idx));
                         });
                     }
                 }
@@ -454,7 +455,7 @@ impl FuncCompiler<'_> {
             // Literal: compare subject to literal, if-else
             IrPattern::Literal { expr: lit_expr } => {
                 // Push subject
-                wasm!(self.func, { local_get(scratch); });
+                wasm!(self.func, { local_get(Local(scratch)); });
                 // Push literal
                 self.emit_expr(lit_expr);
                 // Compare
@@ -490,9 +491,9 @@ impl FuncCompiler<'_> {
                 let tag_result = self.find_variant_tag_by_ctor(ctor_name, subject_ty);
                 if let Some(tag_val) = tag_result {
                     wasm!(self.func, {
-                        local_get(scratch);
+                        local_get(Local(scratch));
                         i32_load(0);
-                        i32_const(tag_val as i32);
+                        i32_const(Imm32(tag_val as i32));
                         i32_eq;
                     });
 
@@ -624,8 +625,8 @@ impl FuncCompiler<'_> {
             IrPattern::Some { inner } => {
                 // some(x) is a non-null pointer. Check ptr != 0, then bind inner.
                 wasm!(self.func, {
-                    local_get(scratch);
-                    i32_const(0);
+                    local_get(Local(scratch));
+                    i32_const(Imm32(0));
                     i32_ne;
                 });
                 let bt = values::block_type(result_ty);
@@ -659,7 +660,7 @@ impl FuncCompiler<'_> {
             IrPattern::None => {
                 // None is represented as i32 0
                 wasm!(self.func, {
-                    local_get(scratch);
+                    local_get(Local(scratch));
                     i32_eqz;
                 });
                 let bt = values::block_type(result_ty);
@@ -684,9 +685,9 @@ impl FuncCompiler<'_> {
                 if let Some(tag_val) = tag {
                     // Load tag from subject pointer
                     wasm!(self.func, {
-                        local_get(scratch);
+                        local_get(Local(scratch));
                         i32_load(0);
-                        i32_const(tag_val as i32);
+                        i32_const(Imm32(tag_val as i32));
                         i32_eq;
                     });
 
@@ -706,9 +707,9 @@ impl FuncCompiler<'_> {
                                 self.find_var_by_field(&pf.name, &case_fields).copied()
                             };
                             if let Some(idx) = local_idx {
-                                wasm!(self.func, { local_get(scratch); });
+                                wasm!(self.func, { local_get(Local(scratch)); });
                                 self.emit_load_at(&fty, total_offset);
-                                wasm!(self.func, { local_set(idx); });
+                                wasm!(self.func, { local_set(Local(idx)); });
                             }
                         }
                     }
@@ -739,9 +740,9 @@ impl FuncCompiler<'_> {
                                 self.find_var_by_field(&pf.name, &case_fields).copied()
                             };
                             if let Some(idx) = local_idx {
-                                wasm!(self.func, { local_get(scratch); });
+                                wasm!(self.func, { local_get(Local(scratch)); });
                                 self.emit_load_at(&fty, foff);
-                                wasm!(self.func, { local_set(idx); });
+                                wasm!(self.func, { local_set(Local(idx)); });
                             }
                         }
                     }
@@ -754,7 +755,7 @@ impl FuncCompiler<'_> {
             IrPattern::Ok { inner } => {
                 // Result ok = tag 0. Check tag, then bind value.
                 wasm!(self.func, {
-                    local_get(scratch);
+                    local_get(Local(scratch));
                     i32_load(0);
                     i32_eqz;
                 });
@@ -784,9 +785,9 @@ impl FuncCompiler<'_> {
             // Err(e) pattern (Result)
             IrPattern::Err { inner } => {
                 wasm!(self.func, {
-                    local_get(scratch);
+                    local_get(Local(scratch));
                     i32_load(0);
-                    i32_const(0);
+                    i32_const(Imm32(0));
                     i32_ne;
                 });
                 let bt = values::block_type(result_ty);
@@ -829,7 +830,7 @@ impl FuncCompiler<'_> {
                         for (i, elem_pat) in elements.iter().enumerate() {
                             let ft = elem_types.get(i).cloned().unwrap_or(Ty::Int);
                             if let IrPattern::Literal { expr: lit_expr } = elem_pat {
-                                wasm!(self.func, { local_get(scratch); });
+                                wasm!(self.func, { local_get(Local(scratch)); });
                                 self.emit_load_at(&ft, offset);
                                 self.emit_expr(lit_expr);
                                 match &ft {
@@ -869,13 +870,13 @@ impl FuncCompiler<'_> {
                             match elem_pat {
                                 IrPattern::Some { .. } => {
                                     // Option: check ptr != 0
-                                    wasm!(self.func, { local_get(scratch); });
+                                    wasm!(self.func, { local_get(Local(scratch)); });
                                     self.emit_load_at(&ft, offset);
-                                    wasm!(self.func, { i32_const(0); i32_ne; });
+                                    wasm!(self.func, { i32_const(Imm32(0)); i32_ne; });
                                     cond_count += 1;
                                 }
                                 IrPattern::None => {
-                                    wasm!(self.func, { local_get(scratch); });
+                                    wasm!(self.func, { local_get(Local(scratch)); });
                                     self.emit_load_at(&ft, offset);
                                     wasm!(self.func, { i32_eqz; });
                                     cond_count += 1;
@@ -888,10 +889,10 @@ impl FuncCompiler<'_> {
                                     // condition operand → the `If` had nothing on the stack.)
                                     if let Some(tag_val) = self.find_variant_tag_by_ctor(ctor_name, &ft) {
                                         wasm!(self.func, {
-                                            local_get(scratch);
+                                            local_get(Local(scratch));
                                             i32_load(offset);
                                             i32_load(0);
-                                            i32_const(tag_val as i32);
+                                            i32_const(Imm32(tag_val as i32));
                                             i32_eq;
                                         });
                                         cond_count += 1;
@@ -911,7 +912,7 @@ impl FuncCompiler<'_> {
                         // then matches unconditionally (the safe direction, and the
                         // bind loop below still runs).
                         if cond_count == 0 {
-                            wasm!(self.func, { i32_const(1); });
+                            wasm!(self.func, { i32_const(Imm32(1)); });
                         }
                         let bt = values::block_type(result_ty);
                         self.func.instruction(&Instruction::If(bt));
@@ -924,9 +925,9 @@ impl FuncCompiler<'_> {
                             match elem_pat {
                                 IrPattern::Bind { var, .. } => {
                                     if let Some(&local_idx) = self.var_map.get(&var.0) {
-                                        wasm!(self.func, { local_get(scratch); });
+                                        wasm!(self.func, { local_get(Local(scratch)); });
                                         self.emit_load_at(&ft, offset2);
-                                        wasm!(self.func, { local_set(local_idx); });
+                                        wasm!(self.func, { local_set(Local(local_idx)); });
                                     }
                                 }
                                 IrPattern::Some { inner } => {
@@ -938,10 +939,10 @@ impl FuncCompiler<'_> {
                                             } else { Ty::Int };
                                             // Load option ptr from tuple
                                             let opt_scratch = self.scratch.alloc_i32();
-                                            wasm!(self.func, { local_get(scratch); i32_load(offset2); local_set(opt_scratch); });
-                                            wasm!(self.func, { local_get(opt_scratch); });
+                                            wasm!(self.func, { local_get(Local(scratch)); i32_load(offset2); local_set(Local(opt_scratch)); });
+                                            wasm!(self.func, { local_get(Local(opt_scratch)); });
                                             self.emit_load_at(&inner_ty, 0);
-                                            wasm!(self.func, { local_set(local_idx); });
+                                            wasm!(self.func, { local_set(Local(local_idx)); });
                                             self.scratch.free_i32(opt_scratch);
                                         }
                                     }
@@ -953,7 +954,7 @@ impl FuncCompiler<'_> {
                                     if !args.is_empty() {
                                         let ctor_fields = self.emitter.fields_of(ctor_name);
                                         let var_scratch = self.scratch.alloc_i32();
-                                        wasm!(self.func, { local_get(scratch); i32_load(offset2); local_set(var_scratch); });
+                                        wasm!(self.func, { local_get(Local(scratch)); i32_load(offset2); local_set(Local(var_scratch)); });
                                         let mut field_offset = 4u32; // skip tag
                                         for (arg_idx, arg_pat) in args.iter().enumerate() {
                                             let field_ty = ctor_fields.get(arg_idx)
@@ -961,9 +962,9 @@ impl FuncCompiler<'_> {
                                                 .unwrap_or(Ty::Int);
                                             if let IrPattern::Bind { var, .. } = arg_pat {
                                                 if let Some(&local_idx) = self.var_map.get(&var.0) {
-                                                    wasm!(self.func, { local_get(var_scratch); });
+                                                    wasm!(self.func, { local_get(Local(var_scratch)); });
                                                     self.emit_load_at(&field_ty, field_offset);
-                                                    wasm!(self.func, { local_set(local_idx); });
+                                                    wasm!(self.func, { local_set(Local(local_idx)); });
                                                 }
                                             }
                                             field_offset += values::byte_size(&field_ty);
@@ -995,9 +996,9 @@ impl FuncCompiler<'_> {
                         let ft = elem_types.get(i).cloned().unwrap_or(Ty::Int);
                         if let IrPattern::Bind { var, .. } = elem_pat {
                             if let Some(&local_idx) = self.var_map.get(&var.0) {
-                                wasm!(self.func, { local_get(scratch); });
+                                wasm!(self.func, { local_get(Local(scratch)); });
                                 self.emit_load_at(&ft, offset);
-                                wasm!(self.func, { local_set(local_idx); });
+                                wasm!(self.func, { local_set(Local(local_idx)); });
                             }
                         }
                         offset += values::byte_size(&ft);
@@ -1061,7 +1062,7 @@ impl FuncCompiler<'_> {
     fn emit_arg_tests(&mut self, ctor_local: u32, field_offset: u32, field_ty: &Ty, pat: &IrPattern) -> u32 {
         match pat {
             IrPattern::Literal { expr } => {
-                wasm!(self.func, { local_get(ctor_local); });
+                wasm!(self.func, { local_get(Local(ctor_local)); });
                 self.emit_load_at(field_ty, field_offset);
                 self.emit_expr(expr);
                 self.emit_eq_typed(field_ty);
@@ -1069,10 +1070,10 @@ impl FuncCompiler<'_> {
             }
             IrPattern::Constructor { name, args } => {
                 let inner = self.scratch.alloc_i32();
-                wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); local_set(inner); });
+                wasm!(self.func, { local_get(Local(ctor_local)); i32_load(field_offset); local_set(Local(inner)); });
                 let mut count = 0;
                 if let Some(tag) = self.find_variant_tag_by_ctor(name, field_ty) {
-                    wasm!(self.func, { local_get(inner); i32_load(0); i32_const(tag as i32); i32_eq; });
+                    wasm!(self.func, { local_get(Local(inner)); i32_load(0); i32_const(Imm32(tag as i32)); i32_eq; });
                     count += 1;
                 }
                 let inner_fields = self.emitter.fields_of(name);
@@ -1086,11 +1087,11 @@ impl FuncCompiler<'_> {
                 count
             }
             IrPattern::Some { .. } => {
-                wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); i32_const(0); i32_ne; });
+                wasm!(self.func, { local_get(Local(ctor_local)); i32_load(field_offset); i32_const(Imm32(0)); i32_ne; });
                 1
             }
             IrPattern::None => {
-                wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); i32_eqz; });
+                wasm!(self.func, { local_get(Local(ctor_local)); i32_load(field_offset); i32_eqz; });
                 1
             }
             // A variant-RECORD ctor arg (`Held(Circle { r })`) — the inner
@@ -1098,7 +1099,7 @@ impl FuncCompiler<'_> {
             // tested (Circle vs Square) exactly like a tuple-payload ctor.
             IrPattern::RecordPattern { name, .. } => {
                 if let Some(tag) = self.find_variant_tag_by_ctor(name, field_ty) {
-                    wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); i32_load(0); i32_const(tag as i32); i32_eq; });
+                    wasm!(self.func, { local_get(Local(ctor_local)); i32_load(field_offset); i32_load(0); i32_const(Imm32(tag as i32)); i32_eq; });
                     1
                 } else { 0 }
             }
@@ -1117,14 +1118,14 @@ impl FuncCompiler<'_> {
                     let load_ty = if pat_ty.is_unresolved()
                         || matches!(pat_ty, Ty::Named(n, a) if a.is_empty() && n.len() <= 2)
                     { field_ty } else { pat_ty };
-                    wasm!(self.func, { local_get(ctor_local); });
+                    wasm!(self.func, { local_get(Local(ctor_local)); });
                     self.emit_load_at(load_ty, field_offset);
-                    wasm!(self.func, { local_set(local_idx); });
+                    wasm!(self.func, { local_set(Local(local_idx)); });
                 }
             }
             IrPattern::Constructor { name, args } => {
                 let inner = self.scratch.alloc_i32();
-                wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); local_set(inner); });
+                wasm!(self.func, { local_get(Local(ctor_local)); i32_load(field_offset); local_set(Local(inner)); });
                 let inner_fields = self.emitter.fields_of(name);
                 let mut off = 4u32;
                 for (i, ap) in args.iter().enumerate() {
@@ -1137,7 +1138,7 @@ impl FuncCompiler<'_> {
             IrPattern::Some { inner: inner_pat } => {
                 // Some payload is at offset 0 of the inner pointer.
                 let inner = self.scratch.alloc_i32();
-                wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); local_set(inner); });
+                wasm!(self.func, { local_get(Local(ctor_local)); i32_load(field_offset); local_set(Local(inner)); });
                 let payload_ty = match field_ty {
                     Ty::Applied(_, a) => a.first().cloned().unwrap_or(Ty::Int),
                     _ => Ty::Int,
@@ -1151,7 +1152,7 @@ impl FuncCompiler<'_> {
                 // tag; resolve the ctor's fields for the offsets (mirrors the
                 // top-level RecordPattern arm).
                 let rec = self.scratch.alloc_i32();
-                wasm!(self.func, { local_get(ctor_local); i32_load(field_offset); local_set(rec); });
+                wasm!(self.func, { local_get(Local(ctor_local)); i32_load(field_offset); local_set(Local(rec)); });
                 let is_variant = self.find_variant_tag_by_ctor(name, field_ty).is_some();
                 let tag_off = if is_variant { 4u32 } else { 0u32 };
                 let rec_fields = if is_variant {
@@ -1165,17 +1166,17 @@ impl FuncCompiler<'_> {
                         match &pf.pattern {
                             Some(IrPattern::Bind { var, .. }) => {
                                 if let Some(&local_idx) = self.var_map.get(&var.0) {
-                                    wasm!(self.func, { local_get(rec); });
+                                    wasm!(self.func, { local_get(Local(rec)); });
                                     self.emit_load_at(&fty, total);
-                                    wasm!(self.func, { local_set(local_idx); });
+                                    wasm!(self.func, { local_set(Local(local_idx)); });
                                 }
                             }
                             Some(inner_pat) => self.bind_arg(rec, total, &fty, inner_pat),
                             None => {
                                 if let Some(&local_idx) = self.find_var_by_field(&pf.name, &rec_fields) {
-                                    wasm!(self.func, { local_get(rec); });
+                                    wasm!(self.func, { local_get(Local(rec)); });
                                     self.emit_load_at(&fty, total);
-                                    wasm!(self.func, { local_set(local_idx); });
+                                    wasm!(self.func, { local_set(Local(local_idx)); });
                                 }
                             }
                         }
@@ -1204,9 +1205,9 @@ impl FuncCompiler<'_> {
         match inner {
             IrPattern::Bind { var, .. } => {
                 if let Some(&local_idx) = self.var_map.get(&var.0) {
-                    wasm!(self.func, { local_get(container_scratch); });
+                    wasm!(self.func, { local_get(Local(container_scratch)); });
                     self.emit_load_at(inner_ty, inner_offset);
-                    wasm!(self.func, { local_set(local_idx); });
+                    wasm!(self.func, { local_set(Local(local_idx)); });
                 }
                 false // caller emits body
             }
@@ -1223,7 +1224,7 @@ impl FuncCompiler<'_> {
             // the literal with the shared type-directed equality, then emit the
             // body only on a match.
             IrPattern::Literal { expr: lit_expr } => {
-                wasm!(self.func, { local_get(container_scratch); });
+                wasm!(self.func, { local_get(Local(container_scratch)); });
                 self.emit_load_at(inner_ty, inner_offset);
                 self.emit_expr(lit_expr);
                 let inner_ty_c = inner_ty.clone();
@@ -1243,9 +1244,9 @@ impl FuncCompiler<'_> {
                 // Inner value is a tuple pointer
                 let inner_scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_get(container_scratch);
+                    local_get(Local(container_scratch));
                     i32_load(inner_offset);
-                    local_set(inner_scratch);
+                    local_set(Local(inner_scratch));
                 });
                 if let Ty::Tuple(elem_types) = inner_ty {
                     let mut offset = 0u32;
@@ -1253,9 +1254,9 @@ impl FuncCompiler<'_> {
                         let ety = elem_types.get(i).cloned().unwrap_or(Ty::Int);
                         if let IrPattern::Bind { var, .. } = elem_pat {
                             if let Some(&local_idx) = self.var_map.get(&var.0) {
-                                wasm!(self.func, { local_get(inner_scratch); });
+                                wasm!(self.func, { local_get(Local(inner_scratch)); });
                                 self.emit_load_at(&ety, offset);
-                                wasm!(self.func, { local_set(local_idx); });
+                                wasm!(self.func, { local_set(Local(local_idx)); });
                             }
                         }
                         offset += values::byte_size(&ety);
@@ -1268,16 +1269,16 @@ impl FuncCompiler<'_> {
                 // Inner value is a variant pointer — need conditional tag check
                 let inner_scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_get(container_scratch);
+                    local_get(Local(container_scratch));
                     i32_load(inner_offset);
-                    local_set(inner_scratch);
+                    local_set(Local(inner_scratch));
                 });
                 let tag = self.find_variant_tag_by_ctor(ctor_name, inner_ty);
                 if let Some(tag_val) = tag {
                     wasm!(self.func, {
-                        local_get(inner_scratch);
+                        local_get(Local(inner_scratch));
                         i32_load(0);
-                        i32_const(tag_val as i32);
+                        i32_const(Imm32(tag_val as i32));
                         i32_eq;
                     });
                     let bt = values::block_type(result_ty);
@@ -1317,9 +1318,9 @@ impl FuncCompiler<'_> {
                                 let load_ty = if pat_ty.is_unresolved()
                                     || matches!(pat_ty, Ty::Named(n, a) if a.is_empty() && n.len() <= 2)
                                 { &field_ty } else { pat_ty };
-                                wasm!(self.func, { local_get(inner_scratch); });
+                                wasm!(self.func, { local_get(Local(inner_scratch)); });
                                 self.emit_load_at(load_ty, field_offset);
-                                wasm!(self.func, { local_set(local_idx); });
+                                wasm!(self.func, { local_set(Local(local_idx)); });
                             }
                         }
                         field_offset += values::byte_size(&field_ty);
@@ -1343,13 +1344,13 @@ impl FuncCompiler<'_> {
                 // Nested Some: load inner ptr, check non-null
                 let inner_scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_get(container_scratch);
+                    local_get(Local(container_scratch));
                     i32_load(inner_offset);
-                    local_set(inner_scratch);
+                    local_set(Local(inner_scratch));
                 });
                 wasm!(self.func, {
-                    local_get(inner_scratch);
-                    i32_const(0);
+                    local_get(Local(inner_scratch));
+                    i32_const(Imm32(0));
                     i32_ne;
                 });
                 let nested_ty = if let Ty::Applied(_, args) = inner_ty {
@@ -1377,11 +1378,11 @@ impl FuncCompiler<'_> {
                 // Nested None: check inner ptr == 0
                 let inner_scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_get(container_scratch);
+                    local_get(Local(container_scratch));
                     i32_load(inner_offset);
-                    local_set(inner_scratch);
+                    local_set(Local(inner_scratch));
                 });
-                wasm!(self.func, { local_get(inner_scratch); i32_eqz; });
+                wasm!(self.func, { local_get(Local(inner_scratch)); i32_eqz; });
                 let bt = values::block_type(result_ty);
                 self.func.instruction(&Instruction::If(bt));
                 let none_guard = self.depth_push();
@@ -1398,12 +1399,12 @@ impl FuncCompiler<'_> {
                 // Nested Ok: load inner, check tag == 0
                 let inner_scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_get(container_scratch);
+                    local_get(Local(container_scratch));
                     i32_load(inner_offset);
-                    local_set(inner_scratch);
+                    local_set(Local(inner_scratch));
                 });
                 wasm!(self.func, {
-                    local_get(inner_scratch);
+                    local_get(Local(inner_scratch));
                     i32_load(0);
                     i32_eqz;
                 });
@@ -1432,14 +1433,14 @@ impl FuncCompiler<'_> {
                 // Nested Err: load inner, check tag != 0
                 let inner_scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_get(container_scratch);
+                    local_get(Local(container_scratch));
                     i32_load(inner_offset);
-                    local_set(inner_scratch);
+                    local_set(Local(inner_scratch));
                 });
                 wasm!(self.func, {
-                    local_get(inner_scratch);
+                    local_get(Local(inner_scratch));
                     i32_load(0);
-                    i32_const(0);
+                    i32_const(Imm32(0));
                     i32_ne;
                 });
                 let nested_ty = if let Ty::Applied(_, args) = inner_ty {
@@ -1467,16 +1468,16 @@ impl FuncCompiler<'_> {
                 // Inner variant with record payload (e.g., ok(Parsed { value, rest }))
                 let inner_scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_get(container_scratch);
+                    local_get(Local(container_scratch));
                     i32_load(inner_offset);
-                    local_set(inner_scratch);
+                    local_set(Local(inner_scratch));
                 });
                 let tag = self.find_variant_tag_by_ctor(ctor_name, inner_ty);
                 if let Some(tag_val) = tag {
                     wasm!(self.func, {
-                        local_get(inner_scratch);
+                        local_get(Local(inner_scratch));
                         i32_load(0);
-                        i32_const(tag_val as i32);
+                        i32_const(Imm32(tag_val as i32));
                         i32_eq;
                     });
                     let bt = values::block_type(result_ty);
@@ -1493,9 +1494,9 @@ impl FuncCompiler<'_> {
                                 self.find_var_by_field(&pf.name, &case_fields).copied()
                             };
                             if let Some(idx) = local_idx {
-                                wasm!(self.func, { local_get(inner_scratch); });
+                                wasm!(self.func, { local_get(Local(inner_scratch)); });
                                 self.emit_load_at(&fty, total_offset);
-                                wasm!(self.func, { local_set(idx); });
+                                wasm!(self.func, { local_set(Local(idx)); });
                             }
                         }
                     }
@@ -1516,9 +1517,9 @@ impl FuncCompiler<'_> {
                                 self.find_var_by_field(&pf.name, &record_fields).copied()
                             };
                             if let Some(idx) = local_idx {
-                                wasm!(self.func, { local_get(inner_scratch); });
+                                wasm!(self.func, { local_get(Local(inner_scratch)); });
                                 self.emit_load_at(&fty, inner_offset + foff);
-                                wasm!(self.func, { local_set(idx); });
+                                wasm!(self.func, { local_set(Local(idx)); });
                             }
                         }
                     }

--- a/crates/almide-codegen/src/emit_wasm/dce.rs
+++ b/crates/almide-codegen/src/emit_wasm/dce.rs
@@ -609,6 +609,27 @@ mod tests {
     use super::*;
     use wasm_encoder::Instruction;
 
+    // ── Named constants for test immediates ──────────────────────────
+    /// Byte count used in 8-byte memory copy/fill test fixtures.
+    const MEM_OP_BYTES_8: i32 = 8;
+    /// Byte count used in 4-byte memory copy/fill test fixtures.
+    const MEM_OP_BYTES_4: i32 = 4;
+    /// Byte count used in 16-byte memory copy/fill test fixtures.
+    const MEM_OP_BYTES_16: i32 = 16;
+    /// Arbitrary sentinel i32 constant that is obviously not a call index,
+    /// used to verify the scanner stays in sync through numeric constants.
+    const TEST_CONST_999: i32 = 999;
+    /// Recognisable "no calls" test constant pushed as an i32.const operand.
+    const TEST_CONST_42: i32 = 42;
+    /// Second addend in the arithmetic instruction coverage test (1 + 2).
+    const TEST_ADDEND: i32 = 2;
+    /// Large i64 value (48-bit max) used to stress the i64.const LEB128 scanner.
+    const TEST_I64_LARGE: i64 = 0x7FFF_FFFF_FFFF;
+    /// i32 maximum value; used as a wide constant in instruction-family coverage.
+    const I32_MAX_VAL: i32 = 0x7FFF_FFFF;
+    /// i64 maximum value; used as a wide constant in instruction-family coverage.
+    const I64_MAX_VAL: i64 = 0x7FFF_FFFF_FFFF_FFFF;
+
     /// Build a Function with given instructions and extract its call targets.
     fn calls_in(instrs: &[Instruction]) -> Vec<u32> {
         let mut f = Function::new([]);
@@ -649,7 +670,7 @@ mod tests {
         let targets = calls_in(&[
             Instruction::I32Const(0),
             Instruction::I32Const(0),
-            Instruction::I32Const(8),
+            Instruction::I32Const(MEM_OP_BYTES_8),
             Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 },
             Instruction::Call(99),
         ]);
@@ -661,7 +682,7 @@ mod tests {
         let targets = calls_in(&[
             Instruction::I32Const(0),
             Instruction::I32Const(0),
-            Instruction::I32Const(8),
+            Instruction::I32Const(MEM_OP_BYTES_8),
             Instruction::MemoryFill(0),
             Instruction::Call(77),
         ]);
@@ -674,12 +695,12 @@ mod tests {
             Instruction::Call(10),
             Instruction::I32Const(0),
             Instruction::I32Const(0),
-            Instruction::I32Const(4),
+            Instruction::I32Const(MEM_OP_BYTES_4),
             Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 },
             Instruction::Call(20),
             Instruction::I32Const(0),
             Instruction::I32Const(0),
-            Instruction::I32Const(4),
+            Instruction::I32Const(MEM_OP_BYTES_4),
             Instruction::MemoryFill(0),
             Instruction::Call(30),
         ]);
@@ -694,7 +715,7 @@ mod tests {
         for _ in 0..10 {
             instrs.push(Instruction::I32Const(0));
             instrs.push(Instruction::I32Const(0));
-            instrs.push(Instruction::I32Const(16));
+            instrs.push(Instruction::I32Const(MEM_OP_BYTES_16));
             instrs.push(Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
         }
         instrs.push(Instruction::Call(55));
@@ -733,7 +754,7 @@ mod tests {
     #[test]
     fn call_after_i64_const() {
         let targets = calls_in(&[
-            Instruction::I64Const(0x7FFF_FFFF_FFFF),
+            Instruction::I64Const(TEST_I64_LARGE),
             Instruction::Drop,
             Instruction::Call(88),
         ]);
@@ -782,8 +803,8 @@ mod tests {
     fn exhaustive_instruction_coverage() {
         let mut f = Function::new([(1, wasm_encoder::ValType::I32)]);
         // Numeric constants
-        f.instruction(&Instruction::I32Const(999));
-        f.instruction(&Instruction::I64Const(0x7FFF_FFFF_FFFF));
+        f.instruction(&Instruction::I32Const(TEST_CONST_999));
+        f.instruction(&Instruction::I64Const(TEST_I64_LARGE));
         f.instruction(&Instruction::F64Const(3.14_f64.into()));
         f.instruction(&Instruction::Drop);
         f.instruction(&Instruction::Drop);
@@ -806,11 +827,11 @@ mod tests {
         // 0xFC prefix: bulk memory
         f.instruction(&Instruction::I32Const(0));
         f.instruction(&Instruction::I32Const(0));
-        f.instruction(&Instruction::I32Const(4));
+        f.instruction(&Instruction::I32Const(MEM_OP_BYTES_4));
         f.instruction(&Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
         f.instruction(&Instruction::I32Const(0));
         f.instruction(&Instruction::I32Const(0));
-        f.instruction(&Instruction::I32Const(4));
+        f.instruction(&Instruction::I32Const(MEM_OP_BYTES_4));
         f.instruction(&Instruction::MemoryFill(0));
         // Control flow: block, br, br_if, if
         f.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
@@ -931,7 +952,7 @@ mod tests {
     #[test]
     fn cross_validate_no_calls() {
         let mut tf = TrackedFunction::new([]);
-        tf.instruction(&Instruction::I32Const(42));
+        tf.instruction(&Instruction::I32Const(TEST_CONST_42));
         tf.instruction(&Instruction::Drop);
         tf.instruction(&Instruction::End);
         assert_tracked_matches_wasmparser(&tf);
@@ -942,12 +963,12 @@ mod tests {
         let mut tf = TrackedFunction::new([]);
         tf.instruction(&Instruction::I32Const(0));
         tf.instruction(&Instruction::I32Const(0));
-        tf.instruction(&Instruction::I32Const(8));
+        tf.instruction(&Instruction::I32Const(MEM_OP_BYTES_8));
         tf.instruction(&Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
         tf.instruction(&Instruction::Call(99));
         tf.instruction(&Instruction::I32Const(0));
         tf.instruction(&Instruction::I32Const(0));
-        tf.instruction(&Instruction::I32Const(4));
+        tf.instruction(&Instruction::I32Const(MEM_OP_BYTES_4));
         tf.instruction(&Instruction::MemoryFill(0));
         tf.instruction(&Instruction::Call(100));
         tf.instruction(&Instruction::End);
@@ -984,9 +1005,9 @@ mod tests {
     fn cross_validate_all_instruction_families() {
         let mut tf = TrackedFunction::new([(1, wasm_encoder::ValType::I32)]);
         // Constants
-        tf.instruction(&Instruction::I32Const(0x7FFFFFFF));
+        tf.instruction(&Instruction::I32Const(I32_MAX_VAL));
         tf.instruction(&Instruction::Drop);
-        tf.instruction(&Instruction::I64Const(0x7FFFFFFFFFFFFFFF));
+        tf.instruction(&Instruction::I64Const(I64_MAX_VAL));
         tf.instruction(&Instruction::Drop);
         tf.instruction(&Instruction::F64Const(f64::MAX.into()));
         tf.instruction(&Instruction::Drop);
@@ -1012,18 +1033,18 @@ mod tests {
         // Bulk memory (0xFC)
         tf.instruction(&Instruction::I32Const(0));
         tf.instruction(&Instruction::I32Const(0));
-        tf.instruction(&Instruction::I32Const(16));
+        tf.instruction(&Instruction::I32Const(MEM_OP_BYTES_16));
         tf.instruction(&Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
         tf.instruction(&Instruction::I32Const(0));
         tf.instruction(&Instruction::I32Const(0));
-        tf.instruction(&Instruction::I32Const(16));
+        tf.instruction(&Instruction::I32Const(MEM_OP_BYTES_16));
         tf.instruction(&Instruction::MemoryFill(0));
         // br_table
         tf.instruction(&Instruction::I32Const(0));
         tf.instruction(&Instruction::BrTable(std::borrow::Cow::Borrowed(&[0, 0, 0]), 0));
         // Numeric ops
         tf.instruction(&Instruction::I32Const(1));
-        tf.instruction(&Instruction::I32Const(2));
+        tf.instruction(&Instruction::I32Const(TEST_ADDEND));
         tf.instruction(&Instruction::I32Add);
         tf.instruction(&Instruction::Drop);
         // Call — THE target we must find
@@ -1043,7 +1064,7 @@ mod tests {
             tf.instruction(&Instruction::Call(i));
             tf.instruction(&Instruction::I32Const(0));
             tf.instruction(&Instruction::I32Const(0));
-            tf.instruction(&Instruction::I32Const(4));
+            tf.instruction(&Instruction::I32Const(MEM_OP_BYTES_4));
             tf.instruction(&Instruction::MemoryCopy { src_mem: 0, dst_mem: 0 });
         }
         tf.instruction(&Instruction::End);

--- a/crates/almide-codegen/src/emit_wasm/engine/builder.rs
+++ b/crates/almide-codegen/src/emit_wasm/engine/builder.rs
@@ -18,6 +18,32 @@ fn ma(offset: u32, ty: MemType) -> wasm_encoder::MemArg {
     wasm_encoder::MemArg { offset: offset as u64, align: ty.align_exp(), memory_index: 0 }
 }
 
+// ── ValueObjects for WASM numeric operands ───────────────────────────────
+// A raw integer can NEVER be passed where one of these is expected — that is a
+// compile error — so a bare "magic number" cannot reach a builder/macro call.
+// The number lives only inside the explicit `Local(n)` / `Imm32(n)` constructor
+// (typically a named const), making every operand intentional and greppable.
+
+/// A WASM local-variable index.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Local(pub u32);
+/// A 32-bit WASM immediate constant value.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Imm32(pub i32);
+/// A 64-bit WASM immediate constant value.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Imm64(pub i64);
+
+impl Local {
+    #[inline] pub const fn idx(self) -> u32 { self.0 }
+}
+impl Imm32 {
+    #[inline] pub const fn val(self) -> i32 { self.0 }
+}
+impl Imm64 {
+    #[inline] pub const fn val(self) -> i64 { self.0 }
+}
+
 impl<'a> WasmBuilder<'a> {
     pub fn new(f: &'a mut TrackedFunction, reg: &'a LayoutRegistry) -> Self {
         Self { f, reg }
@@ -46,15 +72,15 @@ impl<'a> WasmBuilder<'a> {
     /// Element address. Stack: `[base, index] → [addr]`
     pub fn elem_addr(&mut self, layout: LayoutId, field: FieldId, stride: u32) -> &mut Self {
         let off = self.reg.fixed_offset(layout, field);
-        self.i32c(stride as i32).mul().add();
-        if off != 0 { self.i32c(off as i32).add(); }
+        self.i32c(Imm32(stride as i32)).mul().add();
+        if off != 0 { self.i32c(Imm32(off as i32)).add(); }
         self
     }
 
     /// Compute field address (not load value). Stack: `[base] → [base + offset]`
     pub fn field_addr(&mut self, layout: LayoutId, field: FieldId) -> &mut Self {
         let off = self.reg.fixed_offset(layout, field);
-        if off != 0 { self.i32c(off as i32).add(); }
+        if off != 0 { self.i32c(Imm32(off as i32)).add(); }
         self
     }
 
@@ -63,14 +89,14 @@ impl<'a> WasmBuilder<'a> {
         let mf = self.reg.field(layout, field);
         match &mf.offset {
             FieldOffset::Fixed(n) => {
-                if *n != 0 { self.i32c(*n as i32).add(); }
+                if *n != 0 { self.i32c(Imm32(*n as i32)).add(); }
             }
             FieldOffset::AfterDynamic { base, size_field } => {
                 let size_off = self.reg.fixed_offset(layout, *size_field);
                 let size_ty = self.reg.field(layout, *size_field).ty;
-                self.tee(temp).emit_load(size_off, size_ty);
-                self.get(temp).add();
-                if *base != 0 { self.i32c(*base as i32).add(); }
+                self.tee(Local(temp)).emit_load(size_off, size_ty);
+                self.get(Local(temp)).add();
+                if *base != 0 { self.i32c(Imm32(*base as i32)).add(); }
             }
         }
         self
@@ -115,18 +141,18 @@ impl<'a> WasmBuilder<'a> {
         let data_off = self.reg.fixed_offset(LIST, list::DATA);
         let len_ty = self.reg.field(LIST, list::LEN).ty;
 
-        self.i32c(0).set(idx);
+        self.i32c(Imm32(0)).set(Local(idx));
         self.block(|w| { w.loop_(|w| {
-            w.get(idx).get(list).emit_load(len_off, len_ty);
+            w.get(Local(idx)).get(Local(list)).emit_load(len_off, len_ty);
             w.ge_u().br_if(1);
 
-            w.get(list).i32c(data_off as i32).add();
-            w.get(idx).i32c(stride as i32).mul().add();
-            w.set(elem);
+            w.get(Local(list)).i32c(Imm32(data_off as i32)).add();
+            w.get(Local(idx)).i32c(Imm32(stride as i32)).mul().add();
+            w.set(Local(elem));
 
             body(w);
 
-            w.get(idx).i32c(1).add().set(idx);
+            w.get(Local(idx)).i32c(Imm32(1)).add().set(Local(idx));
             w.br(0);
         }); });
     }
@@ -145,23 +171,23 @@ impl<'a> WasmBuilder<'a> {
         let tags_off = self.reg.fixed_offset(SWISS_MAP, map::TAGS);
 
         // Dense entries base = map + header + cap + cap*INDEX_SLOT_SIZE (after tags + index).
-        self.get(map).emit_load(cap_off, cap_ty).set(cap_l);
-        self.get(map).i32c(tags_off as i32).add()
-            .get(cap_l).add()
-            .get(cap_l).i32c(map::INDEX_SLOT_SIZE as i32).mul().add()
-            .set(eb);
+        self.get(Local(map)).emit_load(cap_off, cap_ty).set(Local(cap_l));
+        self.get(Local(map)).i32c(Imm32(tags_off as i32)).add()
+            .get(Local(cap_l)).add()
+            .get(Local(cap_l)).i32c(Imm32(map::INDEX_SLOT_SIZE as i32)).mul().add()
+            .set(Local(eb));
         // Reuse cap_l to hold the len bound (cap only needed for the base above).
-        self.get(map).emit_load(len_off, len_ty).set(cap_l);
-        self.i32c(0).set(idx);
+        self.get(Local(map)).emit_load(len_off, len_ty).set(Local(cap_l));
+        self.i32c(Imm32(0)).set(Local(idx));
 
         self.block(|w| { w.loop_(|w| {
-            w.get(idx).get(cap_l).ge_u().br_if(1);
+            w.get(Local(idx)).get(Local(cap_l)).ge_u().br_if(1);
 
-            w.get(eb).get(idx).i32c(entry_stride as i32).mul().add().set(entry);
+            w.get(Local(eb)).get(Local(idx)).i32c(Imm32(entry_stride as i32)).mul().add().set(Local(entry));
 
             body(w);
 
-            w.get(idx).i32c(1).add().set(idx);
+            w.get(Local(idx)).i32c(Imm32(1)).add().set(Local(idx));
             w.br(0);
         }); });
     }
@@ -181,10 +207,10 @@ impl<'a> WasmBuilder<'a> {
         let cap_off = self.reg.fixed_offset(layout, FieldId(1)); // CAP is always field 1
         let cap_ty = self.reg.field(layout, FieldId(1)).ty;
 
-        self.get(len).i32c(stride as i32).mul().i32c(hdr as i32).add();
-        self.call(alloc_fn).tee(out);
-        self.get(len).emit_store(len_off, len_ty);
-        self.get(out).get(len).emit_store(cap_off, cap_ty);
+        self.get(Local(len)).i32c(Imm32(stride as i32)).mul().i32c(Imm32(hdr as i32)).add();
+        self.call(alloc_fn).tee(Local(out));
+        self.get(Local(len)).emit_store(len_off, len_ty);
+        self.get(Local(out)).get(Local(len)).emit_store(cap_off, cap_ty);
     }
 
     // ════════════════════════════════════════════════════════════════
@@ -192,19 +218,19 @@ impl<'a> WasmBuilder<'a> {
     // ════════════════════════════════════════════════════════════════
 
     pub fn rc_inc(&mut self, ptr: u32, fn_idx: u32) -> &mut Self {
-        self.get(ptr).call(fn_idx)
+        self.get(Local(ptr)).call(fn_idx)
     }
 
     pub fn rc_dec(&mut self, ptr: u32, fn_idx: u32) -> &mut Self {
-        self.get(ptr).call(fn_idx)
+        self.get(Local(ptr)).call(fn_idx)
     }
 
     /// COW check: if rc > 1, clone.
     pub fn cow_check(&mut self, ptr: u32, clone: impl FnOnce(&mut Self)) {
         let neg = self.reg.alloc_header_neg_offset(alloc::RC);
         let rc_ty = self.reg.field(ALLOC_HEADER, alloc::RC).ty;
-        self.get(ptr).i32c(neg as i32).sub().emit_load(0, rc_ty);
-        self.i32c(1).gt_u();
+        self.get(Local(ptr)).i32c(Imm32(neg as i32)).sub().emit_load(0, rc_ty);
+        self.i32c(Imm32(1)).gt_u();
         self.if_void(clone, |_| {});
     }
 
@@ -240,15 +266,15 @@ impl<'a> WasmBuilder<'a> {
     pub fn raw(&mut self, i: Instruction<'_>) -> &mut Self { self.f.instruction(&i); self }
 
     // locals / globals
-    pub fn get(&mut self, l: u32) -> &mut Self { self.f.instruction(&Instruction::LocalGet(l)); self }
-    pub fn set(&mut self, l: u32) -> &mut Self { self.f.instruction(&Instruction::LocalSet(l)); self }
-    pub fn tee(&mut self, l: u32) -> &mut Self { self.f.instruction(&Instruction::LocalTee(l)); self }
+    pub fn get(&mut self, l: Local) -> &mut Self { self.f.instruction(&Instruction::LocalGet(l.idx())); self }
+    pub fn set(&mut self, l: Local) -> &mut Self { self.f.instruction(&Instruction::LocalSet(l.idx())); self }
+    pub fn tee(&mut self, l: Local) -> &mut Self { self.f.instruction(&Instruction::LocalTee(l.idx())); self }
     pub fn gget(&mut self, g: u32) -> &mut Self { self.f.instruction(&Instruction::GlobalGet(g)); self }
     pub fn gset(&mut self, g: u32) -> &mut Self { self.f.instruction(&Instruction::GlobalSet(g)); self }
 
     // constants
-    pub fn i32c(&mut self, v: i32) -> &mut Self { self.f.instruction(&Instruction::I32Const(v)); self }
-    pub fn i64c(&mut self, v: i64) -> &mut Self { self.f.instruction(&Instruction::I64Const(v)); self }
+    pub fn i32c(&mut self, v: Imm32) -> &mut Self { self.f.instruction(&Instruction::I32Const(v.val())); self }
+    pub fn i64c(&mut self, v: Imm64) -> &mut Self { self.f.instruction(&Instruction::I64Const(v.val())); self }
     pub fn f64c(&mut self, v: f64) -> &mut Self { self.f.instruction(&Instruction::F64Const(v.into())); self }
 
     // i32 ops
@@ -300,9 +326,9 @@ mod tests {
         let mut f = func();
         let mut w = WasmBuilder::new(&mut f, &reg);
         // String LEN @ 0, align=2; CAP @ 4, align=2; DATA @ 8, align=0
-        w.get(0).field_load(STRING, string::LEN);
-        w.get(0).field_load(STRING, string::CAP);
-        w.get(0).field_load(STRING, string::DATA);
+        w.get(Local(0)).field_load(STRING, string::LEN);
+        w.get(Local(0)).field_load(STRING, string::CAP);
+        w.get(Local(0)).field_load(STRING, string::DATA);
     }
 
     #[test]
@@ -327,7 +353,7 @@ mod tests {
         let reg = LayoutRegistry::new();
         let mut f = func();
         let mut w = WasmBuilder::new(&mut f, &reg);
-        w.list_foreach(0, 1, 2, 4, |w| { w.get(1).emit_load(0, MemType::I32).drop_(); });
+        w.list_foreach(0, 1, 2, 4, |w| { w.get(Local(1)).emit_load(0, MemType::I32).drop_(); });
     }
 
     #[test]
@@ -335,7 +361,7 @@ mod tests {
         let reg = LayoutRegistry::new();
         let mut f = func();
         let mut w = WasmBuilder::new(&mut f, &reg);
-        w.map_foreach(0, 1, 2, 3, 4, 8, |w| { w.get(1).emit_load(0, MemType::I32).drop_(); });
+        w.map_foreach(0, 1, 2, 3, 4, 8, |w| { w.get(Local(1)).emit_load(0, MemType::I32).drop_(); });
     }
 
     #[test]
@@ -343,7 +369,7 @@ mod tests {
         let reg = LayoutRegistry::new();
         let mut f = func();
         let mut w = WasmBuilder::new(&mut f, &reg);
-        w.get(0).dyn_field_addr(1, SWISS_MAP, map::ENTRIES);
+        w.get(Local(0)).dyn_field_addr(1, SWISS_MAP, map::ENTRIES);
     }
 
     // ── Perceus integration tests ──
@@ -356,7 +382,7 @@ mod tests {
         let rc_dec_fn = 12;
         // Typed RcDec for List[String]: iterate elements, rc_dec each
         w.list_foreach(0, 1, 2, MemType::I32.byte_size(), |w| {
-            w.get(1).emit_load(0, MemType::I32); // load element ptr
+            w.get(Local(1)).emit_load(0, MemType::I32); // load element ptr
             w.call(rc_dec_fn);
         });
         w.rc_dec(0, rc_dec_fn);
@@ -369,7 +395,7 @@ mod tests {
         let mut w = WasmBuilder::new(&mut f, &reg);
         let rc_dec_fn = 12;
         // Load env_ptr from closure pair, then rc_dec it
-        w.get(0).field_load(CLOSURE_PAIR, closure::ENV_PTR);
+        w.get(Local(0)).field_load(CLOSURE_PAIR, closure::ENV_PTR);
         w.call(rc_dec_fn);
         w.rc_dec(0, rc_dec_fn);
     }
@@ -381,9 +407,9 @@ mod tests {
         let mut w = WasmBuilder::new(&mut f, &reg);
         let rc_dec_fn = 12;
         // Option[String]: if tag == Some(1), dec the payload
-        w.get(0).field_load(OPTION, tagged::TAG);
+        w.get(Local(0)).field_load(OPTION, tagged::TAG);
         w.if_void(|w| {
-            w.get(0).field_load(OPTION, tagged::PAYLOAD);
+            w.get(Local(0)).field_load(OPTION, tagged::PAYLOAD);
             w.call(rc_dec_fn);
         }, |_| {});
         w.rc_dec(0, rc_dec_fn);
@@ -395,8 +421,8 @@ mod tests {
         let mut f = func();
         let mut w = WasmBuilder::new(&mut f, &reg);
         // Load variant tag via layout, no hardcoded 0 offset
-        w.get(0).field_load(VARIANT, tagged::TAG);
-        w.i32c(1).eq(); // check if tag == 1
+        w.get(Local(0)).field_load(VARIANT, tagged::TAG);
+        w.i32c(Imm32(1)).eq(); // check if tag == 1
         w.drop_();
     }
 
@@ -409,9 +435,9 @@ mod tests {
         let entry_stride = 8; // key:i32 + val:i32
         // Map[String, String]: iterate entries, dec both key and val
         w.map_foreach(0, 1, 2, 3, 4, entry_stride, |w| {
-            w.get(1).emit_load(0, MemType::I32).call(rc_dec_fn); // key
+            w.get(Local(1)).emit_load(0, MemType::I32).call(rc_dec_fn); // key
             let val_off = MemType::I32.byte_size();
-            w.get(1).emit_load(val_off, MemType::I32).call(rc_dec_fn); // val
+            w.get(Local(1)).emit_load(val_off, MemType::I32).call(rc_dec_fn); // val
         });
         w.rc_dec(0, rc_dec_fn);
     }

--- a/crates/almide-codegen/src/emit_wasm/engine/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/engine/mod.rs
@@ -27,4 +27,5 @@ pub mod builder;
 
 pub use layout::LayoutRegistry;
 pub use builder::WasmBuilder;
+pub use builder::{Imm32, Imm64, Local};
 pub use ir::verify_func_stack;

--- a/crates/almide-codegen/src/emit_wasm/equality.rs
+++ b/crates/almide-codegen/src/emit_wasm/equality.rs
@@ -5,6 +5,10 @@
 use std::collections::HashMap;
 use std::collections::BTreeMap;
 
+// Named constants for raw WASM immediate values used in this module.
+/// Position of the sign bit in an i64 (used by the f64 total-order key transform).
+const I64_SIGN_BIT_POS: i64 = 63;
+
 use super::FuncCompiler;
 use super::VariantCase;
 use super::values;
@@ -981,7 +985,7 @@ impl FuncCompiler<'_> {
             i64_reinterpret_f64; local_set(bits);
             local_get(bits);
             // mask = (bits >>_s 63) >>_u 1
-            local_get(bits); i64_const(63); i64_shr_s; i64_const(1); i64_shr_u;
+            local_get(bits); i64_const(I64_SIGN_BIT_POS); i64_shr_s; i64_const(1); i64_shr_u;
             i64_xor;
         });
         self.scratch.free_i64(bits);

--- a/crates/almide-codegen/src/emit_wasm/equality.rs
+++ b/crates/almide-codegen/src/emit_wasm/equality.rs
@@ -2,6 +2,7 @@
 //!
 //! Type-aware recursive equality for List, Option, Result, Tuple, Record, Variant.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use std::collections::HashMap;
 use std::collections::BTreeMap;
 
@@ -69,7 +70,7 @@ impl FuncCompiler<'_> {
                 if self.is_value_type(&elem_ty) {
                     let elem_size = values::byte_size(&elem_ty);
                     wasm!(self.func, {
-                        i32_const(elem_size as i32);
+                        i32_const(Imm32(elem_size as i32));
                         call(self.emitter.rt.list_eq);
                     });
                 } else {
@@ -108,7 +109,7 @@ impl FuncCompiler<'_> {
             Ty::Tuple(elems) => {
                 if elems.iter().all(|t| self.is_value_type(t)) {
                     let size: u32 = elems.iter().map(|t| values::byte_size(t)).sum();
-                    wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
+                    wasm!(self.func, { i32_const(Imm32(size as i32)); call(self.emitter.rt.mem_eq); });
                 } else {
                     self.emit_tuple_eq_deep(elems);
                 }
@@ -118,7 +119,7 @@ impl FuncCompiler<'_> {
                 let string_fields: Vec<(String, Ty)> = fields.iter().map(|(n, t)| (n.to_string(), t.clone())).collect();
                 if fields.iter().all(|(_, t)| self.is_value_type(t)) {
                     let size = values::record_size(&string_fields);
-                    wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
+                    wasm!(self.func, { i32_const(Imm32(size as i32)); call(self.emitter.rt.mem_eq); });
                 } else {
                     // Field-by-field deep equality
                     self.emit_record_eq_deep(&string_fields);
@@ -141,7 +142,7 @@ impl FuncCompiler<'_> {
                             .map(|c| values::record_size(&c.fields))
                             .max().unwrap_or(0);
                         let size = 4 + max_payload;
-                        wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
+                        wasm!(self.func, { i32_const(Imm32(size as i32)); call(self.emitter.rt.mem_eq); });
                     }
                 } else {
                     let fields = self.emitter.record_fields.get(name.as_str()).cloned().unwrap_or_default();
@@ -150,7 +151,7 @@ impl FuncCompiler<'_> {
                     } else {
                         let size = values::record_size(&fields);
                         if size > 0 {
-                            wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
+                            wasm!(self.func, { i32_const(Imm32(size as i32)); call(self.emitter.rt.mem_eq); });
                         } else {
                             wasm!(self.func, { i32_eq; });
                         }
@@ -193,7 +194,7 @@ impl FuncCompiler<'_> {
                         })
                         .max().unwrap_or(0);
                     let size = 4 + max_payload;
-                    wasm!(self.func, { i32_const(size as i32); call(self.emitter.rt.mem_eq); });
+                    wasm!(self.func, { i32_const(Imm32(size as i32)); call(self.emitter.rt.mem_eq); });
                 }
             }
 
@@ -254,32 +255,32 @@ impl FuncCompiler<'_> {
         let matched = self.scratch.alloc_i32();
         let elem_size = values::byte_size(elem_ty);
         wasm!(self.func, {
-            local_set(b); // b
-            local_set(a); // a
+            local_set(Local(b)); // b
+            local_set(Local(a)); // a
             // Same pointer → true
-            local_get(a); local_get(b); i32_eq;
-            if_i32; i32_const(1);
+            local_get(Local(a)); local_get(Local(b)); i32_eq;
+            if_i32; i32_const(Imm32(1));
             else_;
               // Different lengths → false
-              local_get(a); i32_load(0);
-              local_get(b); i32_load(0);
+              local_get(Local(a)); i32_load(0);
+              local_get(Local(b)); i32_load(0);
               i32_ne;
-              if_i32; i32_const(0);
+              if_i32; i32_const(Imm32(0));
               else_;
                 // Compare element by element
-                i32_const(0); local_set(i); // i
-                i32_const(1); local_set(matched); // 1 until a mismatch is found
+                i32_const(Imm32(0)); local_set(Local(i)); // i
+                i32_const(Imm32(1)); local_set(Local(matched)); // 1 until a mismatch is found
                 block_empty; loop_empty;
-                  local_get(i); local_get(a); i32_load(0); i32_ge_u; br_if(1);
+                  local_get(Local(i)); local_get(Local(a)); i32_load(0); i32_ge_u; br_if(1);
                   // Load a[i]
-                  local_get(a); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                  local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
+                  local_get(Local(a)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                  local_get(Local(i)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
         });
         self.emit_load_at(elem_ty, 0);
         // Load b[i]
         wasm!(self.func, {
-                  local_get(b); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                  local_get(i); i32_const(elem_size as i32); i32_mul; i32_add;
+                  local_get(Local(b)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                  local_get(Local(i)); i32_const(Imm32(elem_size as i32)); i32_mul; i32_add;
         });
         self.emit_load_at(elem_ty, 0);
         // Compare elements (recursive)
@@ -292,12 +293,12 @@ impl FuncCompiler<'_> {
                     // (NOT `return_` — that returned 0 from the ENCLOSING function,
                     // corrupting its contract whenever a List/Tuple/Record of
                     // unequal heap elements like String was compared.)
-                    i32_const(0); local_set(matched); br(2);
+                    i32_const(Imm32(0)); local_set(Local(matched)); br(2);
                   end;
-                  local_get(i); i32_const(1); i32_add; local_set(i);
+                  local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                   br(0);
                 end; end;
-                local_get(matched);
+                local_get(Local(matched));
               end;
             end;
         });
@@ -338,91 +339,91 @@ impl FuncCompiler<'_> {
         let found = self.scratch.alloc_i32();
 
         wasm!(self.func, {
-            local_set(b);
-            local_set(a);
+            local_set(Local(b));
+            local_set(Local(a));
             // Same pointer → equal.
-            local_get(a); local_get(b); i32_eq;
-            if_i32; i32_const(1);
+            local_get(Local(a)); local_get(Local(b)); i32_eq;
+            if_i32; i32_const(Imm32(1));
             else_;
               // Different size → not equal.
-              local_get(a); i32_load(0); local_get(b); i32_load(0); i32_ne;
-              if_i32; i32_const(0);
+              local_get(Local(a)); i32_load(0); local_get(Local(b)); i32_load(0); i32_ne;
+              if_i32; i32_const(Imm32(0));
               else_;
-                i32_const(1); local_set(result);
-                local_get(a); i32_load(0); local_set(alen);
-                local_get(a); i32_load(map_cap_off); local_set(acap);
+                i32_const(Imm32(1)); local_set(Local(result));
+                local_get(Local(a)); i32_load(0); local_set(Local(alen));
+                local_get(Local(a)); i32_load(map_cap_off); local_set(Local(acap));
         });
         self.emit_dict_entries_base(a, acap);
         wasm!(self.func, {
-                local_set(aeb);
-                i32_const(0); local_set(ai);
+                local_set(Local(aeb));
+                i32_const(Imm32(0)); local_set(Local(ai));
                 block_empty; loop_empty;                                  // [A] a-exit, [B] a-loop
-                  local_get(ai); local_get(alen); i32_ge_u; br_if(1);     // done iterating a (dense)
+                  local_get(Local(ai)); local_get(Local(alen)); i32_ge_u; br_if(1);     // done iterating a (dense)
                   // Load this dense entry's key into the search-key register.
-                  local_get(aeb); local_get(ai); i32_const(es as i32); i32_mul; i32_add;
+                  local_get(Local(aeb)); local_get(Local(ai)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         self.emit_key_load(key_ty, 0);
         self.emit_search_key_store(key_ty, sk32, sk64);
         // Probe b for the key.
         wasm!(self.func, {
-                  i32_const(0); local_set(found);
-                  local_get(b); i32_load(map_cap_off); local_set(bcap);
-                  local_get(bcap); i32_eqz;
+                  i32_const(Imm32(0)); local_set(Local(found));
+                  local_get(Local(b)); i32_load(map_cap_off); local_set(Local(bcap));
+                  local_get(Local(bcap)); i32_eqz;
                   if_empty; else_;                                        // [D] bcap==0 guard
         });
         self.emit_dict_index_base(b, bcap);
-        wasm!(self.func, { local_set(bib); });
+        wasm!(self.func, { local_set(Local(bib)); });
         self.emit_dict_entries_base(b, bcap);
-        wasm!(self.func, { local_set(beb); });
+        wasm!(self.func, { local_set(Local(beb)); });
         self.emit_search_key_load(key_ty, sk32, sk64);
         self.emit_hash_key(key_ty);
         self.emit_h1_h2(bcap, bidx, h2);
         wasm!(self.func, {
                     block_empty; loop_empty;                             // [E] probe-block, [F] probe-loop
-                      local_get(b); i32_const(map_tags_off); i32_add; local_get(bidx); i32_add; i32_load8_u(0); local_set(tg);
-                      local_get(tg); i32_eqz; br_if(1);                  // empty slot → key absent
-                      local_get(tg); local_get(h2); i32_eq;
+                      local_get(Local(b)); i32_const(Imm32(map_tags_off)); i32_add; local_get(Local(bidx)); i32_add; i32_load8_u(0); local_set(Local(tg));
+                      local_get(Local(tg)); i32_eqz; br_if(1);                  // empty slot → key absent
+                      local_get(Local(tg)); local_get(Local(h2)); i32_eq;
                       if_empty;                                          // [G] tag matches
                         // bei = index[bidx] - 1 (1-based pointer into dense entries)
-                        local_get(bib); local_get(bidx); i32_const(lm::INDEX_SLOT_SIZE as i32); i32_mul; i32_add;
-                        i32_load(0); i32_const(1); i32_sub; local_set(bei);
-                        local_get(beb); local_get(bei); i32_const(es as i32); i32_mul; i32_add;
+                        local_get(Local(bib)); local_get(Local(bidx)); i32_const(Imm32(lm::INDEX_SLOT_SIZE as i32)); i32_mul; i32_add;
+                        i32_load(0); i32_const(Imm32(1)); i32_sub; local_set(Local(bei));
+                        local_get(Local(beb)); local_get(Local(bei)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         self.emit_key_load(key_ty, 0);
         self.emit_search_key_load(key_ty, sk32, sk64);
         self.emit_key_eq(key_ty);
         wasm!(self.func, {
-                        if_empty; i32_const(1); local_set(found); br(3); end;   // found → exit probe-block
+                        if_empty; i32_const(Imm32(1)); local_set(Local(found)); br(3); end;   // found → exit probe-block
                       end;
-                      local_get(bidx); i32_const(1); i32_add;
-                      local_get(bcap); i32_const(1); i32_sub; i32_and;
-                      local_set(bidx); br(0);
+                      local_get(Local(bidx)); i32_const(Imm32(1)); i32_add;
+                      local_get(Local(bcap)); i32_const(Imm32(1)); i32_sub; i32_and;
+                      local_set(Local(bidx)); br(0);
                     end; end;                                            // close F, E
                   end;                                                   // close D
                   // Key absent → maps differ.
-                  local_get(found); i32_eqz;
-                  if_empty; i32_const(0); local_set(result); br(2); end; // exit a-loop+block
+                  local_get(Local(found)); i32_eqz;
+                  if_empty; i32_const(Imm32(0)); local_set(Local(result)); br(2); end; // exit a-loop+block
         });
         // Compare the values (skip for valueless maps).
         if vs > 0 {
             wasm!(self.func, {
-                  local_get(aeb); local_get(ai); i32_const(es as i32); i32_mul; i32_add; i32_const(ks as i32); i32_add;
+                  local_get(Local(aeb)); local_get(Local(ai)); i32_const(Imm32(es as i32)); i32_mul; i32_add; i32_const(Imm32(ks as i32)); i32_add;
             });
             self.emit_load_at(val_ty, 0);
             wasm!(self.func, {
-                  local_get(beb); local_get(bei); i32_const(es as i32); i32_mul; i32_add; i32_const(ks as i32); i32_add;
+                  local_get(Local(beb)); local_get(Local(bei)); i32_const(Imm32(es as i32)); i32_mul; i32_add; i32_const(Imm32(ks as i32)); i32_add;
             });
             self.emit_load_at(val_ty, 0);
             self.emit_eq_typed(val_ty);
             wasm!(self.func, {
                   i32_eqz;
-                  if_empty; i32_const(0); local_set(result); br(2); end; // values differ → exit
+                  if_empty; i32_const(Imm32(0)); local_set(Local(result)); br(2); end; // values differ → exit
             });
         }
         wasm!(self.func, {
-                  local_get(ai); i32_const(1); i32_add; local_set(ai); br(0);
+                  local_get(Local(ai)); i32_const(Imm32(1)); i32_add; local_set(Local(ai)); br(0);
                 end; end;                                                // close B, A
-                local_get(result);
+                local_get(Local(result));
               end;                                                       // close size-if
             end;                                                         // close sameptr-if
         });
@@ -463,41 +464,41 @@ impl FuncCompiler<'_> {
         let ea = self.scratch.alloc(ea_vt);
 
         wasm!(self.func, {
-            local_set(b);
-            local_set(a);
-            local_get(a); local_get(b); i32_eq;
-            if_i32; i32_const(1);
+            local_set(Local(b));
+            local_set(Local(a));
+            local_get(Local(a)); local_get(Local(b)); i32_eq;
+            if_i32; i32_const(Imm32(1));
             else_;
-              local_get(a); i32_load(0); local_get(b); i32_load(0); i32_ne;
-              if_i32; i32_const(0);
+              local_get(Local(a)); i32_load(0); local_get(Local(b)); i32_load(0); i32_ne;
+              if_i32; i32_const(Imm32(0));
               else_;
-                i32_const(1); local_set(result);
-                i32_const(0); local_set(ai);
+                i32_const(Imm32(1)); local_set(Local(result));
+                i32_const(Imm32(0)); local_set(Local(ai));
                 block_empty; loop_empty;                                 // [A] exit, [B] a-loop
-                  local_get(ai); local_get(a); i32_load(0); i32_ge_u; br_if(1);
-                  local_get(a); i32_const(data_off); i32_add; local_get(ai); i32_const(es as i32); i32_mul; i32_add;
+                  local_get(Local(ai)); local_get(Local(a)); i32_load(0); i32_ge_u; br_if(1);
+                  local_get(Local(a)); i32_const(Imm32(data_off)); i32_add; local_get(Local(ai)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         self.emit_load_at(elem_ty, 0);
         wasm!(self.func, {
-                  local_set(ea);
-                  i32_const(0); local_set(found);
-                  i32_const(0); local_set(bj);
+                  local_set(Local(ea));
+                  i32_const(Imm32(0)); local_set(Local(found));
+                  i32_const(Imm32(0)); local_set(Local(bj));
                   block_empty; loop_empty;                               // [C] scan-block, [D] scan-loop
-                    local_get(bj); local_get(b); i32_load(0); i32_ge_u; br_if(1);
-                    local_get(b); i32_const(data_off); i32_add; local_get(bj); i32_const(es as i32); i32_mul; i32_add;
+                    local_get(Local(bj)); local_get(Local(b)); i32_load(0); i32_ge_u; br_if(1);
+                    local_get(Local(b)); i32_const(Imm32(data_off)); i32_add; local_get(Local(bj)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         self.emit_load_at(elem_ty, 0);
-        wasm!(self.func, { local_get(ea); });
+        wasm!(self.func, { local_get(Local(ea)); });
         self.emit_eq_typed(elem_ty);
         wasm!(self.func, {
-                    if_empty; i32_const(1); local_set(found); br(2); end; // found → exit scan-block
-                    local_get(bj); i32_const(1); i32_add; local_set(bj); br(0);
+                    if_empty; i32_const(Imm32(1)); local_set(Local(found)); br(2); end; // found → exit scan-block
+                    local_get(Local(bj)); i32_const(Imm32(1)); i32_add; local_set(Local(bj)); br(0);
                   end; end;                                              // close D, C
-                  local_get(found); i32_eqz;
-                  if_empty; i32_const(0); local_set(result); br(2); end; // absent → exit a-loop+block
-                  local_get(ai); i32_const(1); i32_add; local_set(ai); br(0);
+                  local_get(Local(found)); i32_eqz;
+                  if_empty; i32_const(Imm32(0)); local_set(Local(result)); br(2); end; // absent → exit a-loop+block
+                  local_get(Local(ai)); i32_const(Imm32(1)); i32_add; local_set(Local(ai)); br(0);
                 end; end;                                                // close B, A
-                local_get(result);
+                local_get(Local(result));
               end;
             end;
         });
@@ -515,21 +516,21 @@ impl FuncCompiler<'_> {
         let a = self.scratch.alloc_i32();
         let b = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(b); // b
-            local_set(a); // a
+            local_set(Local(b)); // b
+            local_set(Local(a)); // a
             // Both none → true
-            local_get(a); i32_eqz; local_get(b); i32_eqz; i32_and;
-            if_i32; i32_const(1);
+            local_get(Local(a)); i32_eqz; local_get(Local(b)); i32_eqz; i32_and;
+            if_i32; i32_const(Imm32(1));
             else_;
               // One none → false
-              local_get(a); i32_eqz; local_get(b); i32_eqz; i32_or;
-              if_i32; i32_const(0);
+              local_get(Local(a)); i32_eqz; local_get(Local(b)); i32_eqz; i32_or;
+              if_i32; i32_const(Imm32(0));
               else_;
                 // Both some: compare inner values
-                local_get(a);
+                local_get(Local(a));
         });
         self.emit_load_at(inner_ty, 0);
-        wasm!(self.func, { local_get(b); });
+        wasm!(self.func, { local_get(Local(b)); });
         self.emit_load_at(inner_ty, 0);
         let inner_clone = inner_ty.clone();
         self.emit_eq_typed(&inner_clone);
@@ -546,25 +547,25 @@ impl FuncCompiler<'_> {
         let a = self.scratch.alloc_i32();
         let b = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(b); // b
-            local_set(a); // a
+            local_set(Local(b)); // b
+            local_set(Local(a)); // a
             // Tags must match
-            local_get(a); i32_load(0);
-            local_get(b); i32_load(0);
+            local_get(Local(a)); i32_load(0);
+            local_get(Local(b)); i32_load(0);
             i32_ne;
-            if_i32; i32_const(0);
+            if_i32; i32_const(Imm32(0));
             else_;
               // Same tag. If tag==0 (ok): compare ok values
-              local_get(a); i32_load(0); i32_eqz;
+              local_get(Local(a)); i32_load(0); i32_eqz;
               if_i32;
         });
         // Ty::Unit has no representation — skip loading and treat as equal.
         if matches!(ok_ty, Ty::Unit) {
-            wasm!(self.func, { i32_const(1); });
+            wasm!(self.func, { i32_const(Imm32(1)); });
         } else {
-            wasm!(self.func, { local_get(a); });
+            wasm!(self.func, { local_get(Local(a)); });
             self.emit_load_at(ok_ty, 4);
-            wasm!(self.func, { local_get(b); });
+            wasm!(self.func, { local_get(Local(b)); });
             self.emit_load_at(ok_ty, 4);
             let ok_clone = ok_ty.clone();
             self.emit_eq_typed(&ok_clone);
@@ -574,11 +575,11 @@ impl FuncCompiler<'_> {
                 // tag==1 (err): compare err values
         });
         if matches!(err_ty, Ty::Unit) {
-            wasm!(self.func, { i32_const(1); });
+            wasm!(self.func, { i32_const(Imm32(1)); });
         } else {
-            wasm!(self.func, { local_get(a); });
+            wasm!(self.func, { local_get(Local(a)); });
             self.emit_load_at(err_ty, 4);
-            wasm!(self.func, { local_get(b); });
+            wasm!(self.func, { local_get(Local(b)); });
             self.emit_load_at(err_ty, 4);
             let err_clone = err_ty.clone();
             self.emit_eq_typed(&err_clone);
@@ -596,22 +597,22 @@ impl FuncCompiler<'_> {
         let a = self.scratch.alloc_i32();
         let b = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(b); // b
-            local_set(a); // a
+            local_set(Local(b)); // b
+            local_set(Local(a)); // a
         });
         // AND every field's deep eq. NOT a `return_` short-circuit — that returned
         // from the ENCLOSING function and corrupted its contract on a mismatch
         // (e.g. a tuple with an unequal String element). Equality has no side
         // effects, so evaluating all fields and AND-ing is equivalent and safe.
         if elems.is_empty() {
-            wasm!(self.func, { i32_const(1); });
+            wasm!(self.func, { i32_const(Imm32(1)); });
         }
         let mut offset: u32 = 0;
         for (i, elem_ty) in elems.iter().enumerate() {
             let elem_size = values::byte_size(elem_ty);
-            wasm!(self.func, { local_get(a); });
+            wasm!(self.func, { local_get(Local(a)); });
             self.emit_load_at(elem_ty, offset);
-            wasm!(self.func, { local_get(b); });
+            wasm!(self.func, { local_get(Local(b)); });
             self.emit_load_at(elem_ty, offset);
             let elem_clone = elem_ty.clone();
             self.emit_eq_typed(&elem_clone);
@@ -629,20 +630,20 @@ impl FuncCompiler<'_> {
         let a = self.scratch.alloc_i32();
         let b = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(b);
-            local_set(a);
+            local_set(Local(b));
+            local_set(Local(a));
         });
         // AND every field's deep eq (see emit_tuple_eq_deep — `return_` corrupted
         // the enclosing function on a mismatch).
         if fields.is_empty() {
-            wasm!(self.func, { i32_const(1); });
+            wasm!(self.func, { i32_const(Imm32(1)); });
         }
         let mut offset: u32 = 0;
         for (i, (_, field_ty)) in fields.iter().enumerate() {
             let field_size = values::byte_size(field_ty);
-            wasm!(self.func, { local_get(a); });
+            wasm!(self.func, { local_get(Local(a)); });
             self.emit_load_at(field_ty, offset);
-            wasm!(self.func, { local_get(b); });
+            wasm!(self.func, { local_get(Local(b)); });
             self.emit_load_at(field_ty, offset);
             let field_clone = field_ty.clone();
             self.emit_eq_typed(&field_clone);
@@ -661,19 +662,19 @@ impl FuncCompiler<'_> {
         let a = self.scratch.alloc_i32();
         let b = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(b);
-            local_set(a);
+            local_set(Local(b));
+            local_set(Local(a));
             // tags equal? → if so compute payload eq, else 0. (No `return_`: it
             // returned 0 from the ENCLOSING function and corrupted its contract.)
-            local_get(a); i32_load(0);
-            local_get(b); i32_load(0);
+            local_get(Local(a)); i32_load(0);
+            local_get(Local(b)); i32_load(0);
             i32_eq;
             if_i32;
         });
 
         if cases.is_empty() || cases.iter().all(|c| c.fields.is_empty()) {
             // All unit variants — tags matched, so equal
-            wasm!(self.func, { i32_const(1); });
+            wasm!(self.func, { i32_const(Imm32(1)); });
         } else {
             // Compare payload fields based on tag
             // For simplicity: compare each field at its offset, starting after tag (offset 4)
@@ -685,9 +686,9 @@ impl FuncCompiler<'_> {
                 let mut offset = 4u32;
                 for (i, (_, field_ty)) in case.fields.iter().enumerate() {
                     let field_size = values::byte_size(field_ty);
-                    wasm!(self.func, { local_get(a); });
+                    wasm!(self.func, { local_get(Local(a)); });
                     self.emit_load_at(field_ty, offset);
-                    wasm!(self.func, { local_get(b); });
+                    wasm!(self.func, { local_get(Local(b)); });
                     self.emit_load_at(field_ty, offset);
                     let ft = field_ty.clone();
                     self.emit_eq_typed(&ft);
@@ -697,17 +698,17 @@ impl FuncCompiler<'_> {
                     offset += field_size;
                 }
                 if case.fields.is_empty() {
-                    wasm!(self.func, { i32_const(1); });
+                    wasm!(self.func, { i32_const(Imm32(1)); });
                 }
             } else {
-                wasm!(self.func, { i32_const(1); });
+                wasm!(self.func, { i32_const(Imm32(1)); });
             }
         }
 
         // Close the tags-equal `if_i32`: tags differ → not equal.
         wasm!(self.func, {
             else_;
-            i32_const(0);
+            i32_const(Imm32(0));
             end;
         });
 
@@ -760,16 +761,16 @@ impl FuncCompiler<'_> {
                 });
             }
             (Ty::String, CmpKind::Lt) => {
-                wasm!(self.func, { call(self.emitter.rt.string.cmp); i32_const(0); i32_lt_s; });
+                wasm!(self.func, { call(self.emitter.rt.string.cmp); i32_const(Imm32(0)); i32_lt_s; });
             }
             (Ty::String, CmpKind::Gt) => {
-                wasm!(self.func, { call(self.emitter.rt.string.cmp); i32_const(0); i32_gt_s; });
+                wasm!(self.func, { call(self.emitter.rt.string.cmp); i32_const(Imm32(0)); i32_gt_s; });
             }
             (Ty::String, CmpKind::Lte) => {
-                wasm!(self.func, { call(self.emitter.rt.string.cmp); i32_const(0); i32_le_s; });
+                wasm!(self.func, { call(self.emitter.rt.string.cmp); i32_const(Imm32(0)); i32_le_s; });
             }
             (Ty::String, CmpKind::Gte) => {
-                wasm!(self.func, { call(self.emitter.rt.string.cmp); i32_const(0); i32_ge_s; });
+                wasm!(self.func, { call(self.emitter.rt.string.cmp); i32_const(Imm32(0)); i32_ge_s; });
             }
             // Variant (enum-like) comparison: each value is a pointer to a heap
             // block whose first i32 is the discriminant tag. For `Ord`-derived
@@ -783,10 +784,10 @@ impl FuncCompiler<'_> {
                 let right = self.scratch.alloc_i32();
                 let left = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(right);
-                    local_set(left);
-                    local_get(left); i32_load(0);
-                    local_get(right); i32_load(0);
+                    local_set(Local(right));
+                    local_set(Local(left));
+                    local_get(Local(left)); i32_load(0);
+                    local_get(Local(right)); i32_load(0);
                 });
                 match cmp_kind {
                     CmpKind::Lt => { wasm!(self.func, { i32_lt_u; }); }
@@ -905,11 +906,11 @@ impl FuncCompiler<'_> {
                 let b = self.scratch.alloc_i32();
                 let a = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(b); local_set(a);
-                    local_get(a); i32_load(0);
-                    local_get(b); i32_load(0); i32_gt_u;
-                    local_get(a); i32_load(0);
-                    local_get(b); i32_load(0); i32_lt_u;
+                    local_set(Local(b)); local_set(Local(a));
+                    local_get(Local(a)); i32_load(0);
+                    local_get(Local(b)); i32_load(0); i32_gt_u;
+                    local_get(Local(a)); i32_load(0);
+                    local_get(Local(b)); i32_load(0); i32_lt_u;
                     i32_sub;
                 });
                 self.scratch.free_i32(a);
@@ -930,12 +931,12 @@ impl FuncCompiler<'_> {
         let vt = values::ty_to_valtype(ty).unwrap_or(ValType::I32);
         let b = self.scratch.alloc(vt);
         let a = self.scratch.alloc(vt);
-        wasm!(self.func, { local_set(b); local_set(a); });
+        wasm!(self.func, { local_set(Local(b)); local_set(Local(a)); });
         // (a > b)
-        wasm!(self.func, { local_get(a); local_get(b); });
+        wasm!(self.func, { local_get(Local(a)); local_get(Local(b)); });
         self.emit_cmp_instruction(ty, CmpKind::Gt);
         // (a < b)
-        wasm!(self.func, { local_get(a); local_get(b); });
+        wasm!(self.func, { local_get(Local(a)); local_get(Local(b)); });
         self.emit_cmp_instruction(ty, CmpKind::Lt);
         // sign = (a>b) - (a<b)  ∈ {-1, 0, 1}
         wasm!(self.func, { i32_sub; });
@@ -961,13 +962,13 @@ impl FuncCompiler<'_> {
         let ka = self.scratch.alloc_i64();
         // [a, b] → key(b) into kb, key(a) into ka.
         self.emit_f64_total_order_key();
-        wasm!(self.func, { local_set(kb); });
+        wasm!(self.func, { local_set(Local(kb)); });
         self.emit_f64_total_order_key();
-        wasm!(self.func, { local_set(ka); });
+        wasm!(self.func, { local_set(Local(ka)); });
         // sign = (ka > kb) - (ka < kb)
         wasm!(self.func, {
-            local_get(ka); local_get(kb); i64_gt_s;
-            local_get(ka); local_get(kb); i64_lt_s;
+            local_get(Local(ka)); local_get(Local(kb)); i64_gt_s;
+            local_get(Local(ka)); local_get(Local(kb)); i64_lt_s;
             i32_sub;
         });
         self.scratch.free_i64(ka);
@@ -982,10 +983,10 @@ impl FuncCompiler<'_> {
     pub(super) fn emit_f64_total_order_key(&mut self) {
         let bits = self.scratch.alloc_i64();
         wasm!(self.func, {
-            i64_reinterpret_f64; local_set(bits);
-            local_get(bits);
+            i64_reinterpret_f64; local_set(Local(bits));
+            local_get(Local(bits));
             // mask = (bits >>_s 63) >>_u 1
-            local_get(bits); i64_const(I64_SIGN_BIT_POS); i64_shr_s; i64_const(1); i64_shr_u;
+            local_get(Local(bits)); i64_const(Imm64(I64_SIGN_BIT_POS)); i64_shr_s; i64_const(Imm64(1)); i64_shr_u;
             i64_xor;
         });
         self.scratch.free_i64(bits);
@@ -997,22 +998,22 @@ impl FuncCompiler<'_> {
         let b = self.scratch.alloc_i32();
         let a = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(b); local_set(a);
+            local_set(Local(b)); local_set(Local(a));
             // a == none?
-            local_get(a); i32_eqz;
+            local_get(Local(a)); i32_eqz;
             if_i32;
               // a none: none < some, none == none
-              local_get(b); i32_eqz; if_i32; i32_const(0); else_; i32_const(-1); end;
+              local_get(Local(b)); i32_eqz; if_i32; i32_const(Imm32(0)); else_; i32_const(Imm32(-1)); end;
             else_;
               // a some
-              local_get(b); i32_eqz;
-              if_i32; i32_const(1); // some > none
+              local_get(Local(b)); i32_eqz;
+              if_i32; i32_const(Imm32(1)); // some > none
               else_;
                 // both some: recurse on inner (loaded at offset 0)
-                local_get(a);
+                local_get(Local(a));
         });
         self.emit_load_at(inner_ty, 0);
-        wasm!(self.func, { local_get(b); });
+        wasm!(self.func, { local_get(Local(b)); });
         self.emit_load_at(inner_ty, 0);
         let inner = inner_ty.clone();
         self.emit_ord_cmp3(&inner);
@@ -1031,29 +1032,29 @@ impl FuncCompiler<'_> {
         let b = self.scratch.alloc_i32();
         let a = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(b); local_set(a);
+            local_set(Local(b)); local_set(Local(a));
             // tags differ → order by tag (ok=0 < err=1)
-            local_get(a); i32_load(0);
-            local_get(b); i32_load(0);
+            local_get(Local(a)); i32_load(0);
+            local_get(Local(b)); i32_load(0);
             i32_ne;
             if_i32;
-              local_get(a); i32_load(0);
-              local_get(b); i32_load(0); i32_gt_u;
-              local_get(a); i32_load(0);
-              local_get(b); i32_load(0); i32_lt_u;
+              local_get(Local(a)); i32_load(0);
+              local_get(Local(b)); i32_load(0); i32_gt_u;
+              local_get(Local(a)); i32_load(0);
+              local_get(Local(b)); i32_load(0); i32_lt_u;
               i32_sub;
             else_;
               // same tag: recurse on the matching payload
-              local_get(a); i32_load(0); i32_eqz;
+              local_get(Local(a)); i32_load(0); i32_eqz;
               if_i32;
         });
         // ok payload at offset 4
         if matches!(ok_ty, Ty::Unit) {
-            wasm!(self.func, { i32_const(0); });
+            wasm!(self.func, { i32_const(Imm32(0)); });
         } else {
-            wasm!(self.func, { local_get(a); });
+            wasm!(self.func, { local_get(Local(a)); });
             self.emit_load_at(ok_ty, 4);
-            wasm!(self.func, { local_get(b); });
+            wasm!(self.func, { local_get(Local(b)); });
             self.emit_load_at(ok_ty, 4);
             let ok = ok_ty.clone();
             self.emit_ord_cmp3(&ok);
@@ -1061,11 +1062,11 @@ impl FuncCompiler<'_> {
         wasm!(self.func, { else_; });
         // err payload at offset 4
         if matches!(err_ty, Ty::Unit) {
-            wasm!(self.func, { i32_const(0); });
+            wasm!(self.func, { i32_const(Imm32(0)); });
         } else {
-            wasm!(self.func, { local_get(a); });
+            wasm!(self.func, { local_get(Local(a)); });
             self.emit_load_at(err_ty, 4);
-            wasm!(self.func, { local_get(b); });
+            wasm!(self.func, { local_get(Local(b)); });
             self.emit_load_at(err_ty, 4);
             let err = err_ty.clone();
             self.emit_ord_cmp3(&err);
@@ -1084,25 +1085,25 @@ impl FuncCompiler<'_> {
         let res = self.scratch.alloc_i32();
         let b = self.scratch.alloc_i32();
         let a = self.scratch.alloc_i32();
-        wasm!(self.func, { local_set(b); local_set(a); i32_const(0); local_set(res); });
+        wasm!(self.func, { local_set(Local(b)); local_set(Local(a)); i32_const(Imm32(0)); local_set(Local(res)); });
         let mut offset = 0u32;
         // A single block we break out of on the first non-equal field.
         wasm!(self.func, { block_empty; });
         for (i, ety) in elems.iter().enumerate() {
-            wasm!(self.func, { local_get(a); });
+            wasm!(self.func, { local_get(Local(a)); });
             self.emit_load_at(ety, offset);
-            wasm!(self.func, { local_get(b); });
+            wasm!(self.func, { local_get(Local(b)); });
             self.emit_load_at(ety, offset);
             let ety_c = ety.clone();
             self.emit_ord_cmp3(&ety_c);
-            wasm!(self.func, { local_set(res); });
+            wasm!(self.func, { local_set(Local(res)); });
             // if res != 0, break (last field need not test — falls through).
             if i + 1 < elems.len() {
-                wasm!(self.func, { local_get(res); br_if(0); });
+                wasm!(self.func, { local_get(Local(res)); br_if(0); });
             }
             offset += values::byte_size(ety);
         }
-        wasm!(self.func, { end; local_get(res); });
+        wasm!(self.func, { end; local_get(Local(res)); });
         self.scratch.free_i32(a);
         self.scratch.free_i32(b);
         self.scratch.free_i32(res);
@@ -1123,39 +1124,39 @@ impl FuncCompiler<'_> {
         let b = self.scratch.alloc_i32();
         let a = self.scratch.alloc_i32();
         wasm!(self.func, {
-            local_set(b); local_set(a);
-            i32_const(0); local_set(res);
-            local_get(a); i32_load(0); local_set(alen);
-            local_get(b); i32_load(0); local_set(blen);
-            local_get(alen); local_get(blen); i32_lt_u;
-            if_i32; local_get(alen); else_; local_get(blen); end;
-            local_set(minlen);
-            i32_const(0); local_set(i);
+            local_set(Local(b)); local_set(Local(a));
+            i32_const(Imm32(0)); local_set(Local(res));
+            local_get(Local(a)); i32_load(0); local_set(Local(alen));
+            local_get(Local(b)); i32_load(0); local_set(Local(blen));
+            local_get(Local(alen)); local_get(Local(blen)); i32_lt_u;
+            if_i32; local_get(Local(alen)); else_; local_get(Local(blen)); end;
+            local_set(Local(minlen));
+            i32_const(Imm32(0)); local_set(Local(i));
             block_empty; loop_empty;                                  // [A] exit, [B] loop
-              local_get(i); local_get(minlen); i32_ge_u; br_if(1);    // i >= minlen → break
-              local_get(a); i32_const(data_off); i32_add; local_get(i); i32_const(es); i32_mul; i32_add;
+              local_get(Local(i)); local_get(Local(minlen)); i32_ge_u; br_if(1);    // i >= minlen → break
+              local_get(Local(a)); i32_const(Imm32(data_off)); i32_add; local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
         });
         self.emit_load_at(elem_ty, 0);
         wasm!(self.func, {
-              local_get(b); i32_const(data_off); i32_add; local_get(i); i32_const(es); i32_mul; i32_add;
+              local_get(Local(b)); i32_const(Imm32(data_off)); i32_add; local_get(Local(i)); i32_const(Imm32(es)); i32_mul; i32_add;
         });
         self.emit_load_at(elem_ty, 0);
         let elem_c = elem_ty.clone();
         self.emit_ord_cmp3(&elem_c);
         wasm!(self.func, {
-              local_set(res);
-              local_get(res); br_if(1);                               // non-equal element → break with res
-              local_get(i); i32_const(1); i32_add; local_set(i);
+              local_set(Local(res));
+              local_get(Local(res)); br_if(1);                               // non-equal element → break with res
+              local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
               br(0);
             end; end;                                                 // close B, A
             // Common prefix equal: order by length (sign(alen - blen)).
-            local_get(res); i32_eqz;
+            local_get(Local(res)); i32_eqz;
             if_i32;
-              local_get(alen); local_get(blen); i32_gt_u;
-              local_get(alen); local_get(blen); i32_lt_u;
+              local_get(Local(alen)); local_get(Local(blen)); i32_gt_u;
+              local_get(Local(alen)); local_get(Local(blen)); i32_lt_u;
               i32_sub;
             else_;
-              local_get(res);
+              local_get(Local(res));
             end;
         });
         self.scratch.free_i32(a);

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -1,5 +1,6 @@
 //! IrExpr → WASM instruction emission.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use almide_ir::{BinOp, IrExpr, IrExprKind, UnOp};
 use almide_lang::types::Ty;
 use wasm_encoder::{Instruction, ValType};
@@ -113,10 +114,10 @@ impl FuncCompiler<'_> {
                 match &expr.ty {
                     Ty::Int8 | Ty::Int16 | Ty::Int32
                     | Ty::UInt8 | Ty::UInt16 | Ty::UInt32 => {
-                        wasm!(self.func, { i32_const(*value as i32); });
+                        wasm!(self.func, { i32_const(Imm32(*value as i32)); });
                     }
                     _ => {
-                        wasm!(self.func, { i64_const(*value); });
+                        wasm!(self.func, { i64_const(Imm64(*value)); });
                     }
                 }
             }
@@ -130,11 +131,11 @@ impl FuncCompiler<'_> {
                 }
             }
             IrExprKind::LitBool { value } => {
-                wasm!(self.func, { i32_const(*value as i32); });
+                wasm!(self.func, { i32_const(Imm32(*value as i32)); });
             }
             IrExprKind::LitStr { value } => {
                 let offset = self.emitter.intern_string(value);
-                wasm!(self.func, { i32_const(offset as i32); });
+                wasm!(self.func, { i32_const(Imm32(offset as i32)); });
             }
             IrExprKind::Unit => {
                 // Unit produces no value on the stack
@@ -159,10 +160,10 @@ impl FuncCompiler<'_> {
                 if let Some(&local_idx) = self.var_map.get(&id.0) {
                     if self.emitter.mutable_captures.contains(&id.0) {
                         // Mutable capture: local holds cell ptr, deref to get value
-                        wasm!(self.func, { local_get(local_idx); });
+                        wasm!(self.func, { local_get(Local(local_idx)); });
                         self.emit_load_at(&expr.ty, 0);
                     } else {
-                        wasm!(self.func, { local_get(local_idx); });
+                        wasm!(self.func, { local_get(Local(local_idx)); });
                     }
                 } else if let Some(&(global_idx, _)) = {
                     // Name-based lookup FIRST: cross-module synthetic Vars
@@ -210,7 +211,7 @@ impl FuncCompiler<'_> {
                             .map(|(_, lidx)| *lidx)
                     } else { None };
                     if let Some(local_idx) = found {
-                        wasm!(self.func, { local_get(local_idx); });
+                        wasm!(self.func, { local_get(Local(local_idx)); });
                     } else {
                         // A module-origin var that reached this point missed
                         // every global key — that is a compiler bug, and the
@@ -228,9 +229,9 @@ impl FuncCompiler<'_> {
                         }
                         // Truly not in scope — push typed zero
                         match values::ty_to_valtype(&expr.ty) {
-                            Some(ValType::I64) => { wasm!(self.func, { i64_const(0); }); }
+                            Some(ValType::I64) => { wasm!(self.func, { i64_const(Imm64(0)); }); }
                             Some(ValType::F64) => { wasm!(self.func, { f64_const(0.0); }); }
-                            Some(ValType::I32) => { wasm!(self.func, { i32_const(0); }); }
+                            Some(ValType::I32) => { wasm!(self.func, { i32_const(Imm32(0)); }); }
                             _ => {}
                         }
                     }
@@ -256,10 +257,10 @@ impl FuncCompiler<'_> {
             IrExprKind::EnvLoad { env_var, index } => {
                 let offset = (*index) * 8;
                 if let Some(&local_idx) = self.var_map.get(&env_var.0) {
-                    wasm!(self.func, { local_get(local_idx); });
+                    wasm!(self.func, { local_get(Local(local_idx)); });
                 } else {
                     // env_var should be local 0 in lifted functions (first param)
-                    wasm!(self.func, { local_get(0); });
+                    wasm!(self.func, { local_get(Local(0)); });
                 }
                 // Load value from env at offset
                 match super::values::ty_to_valtype(&expr.ty) {
@@ -290,7 +291,7 @@ impl FuncCompiler<'_> {
             IrExprKind::UnOp { op, operand } => {
                 match op {
                     UnOp::NegInt => {
-                        wasm!(self.func, { i64_const(0); });
+                        wasm!(self.func, { i64_const(Imm64(0)); });
                         self.emit_expr(operand);
                         wasm!(self.func, { i64_sub; });
                     }
@@ -394,7 +395,7 @@ impl FuncCompiler<'_> {
 
                 // Save heap at iteration start
                 if let Some(sl) = iter_scope_local {
-                    wasm!(self.func, { global_get(self.emitter.heap_ptr_global); local_set(sl); });
+                    wasm!(self.func, { global_get(self.emitter.heap_ptr_global); local_set(Local(sl)); });
                 }
 
                 // body
@@ -408,8 +409,8 @@ impl FuncCompiler<'_> {
                 // so forgetting them wholesale is the only sound option.
                 if let Some(sl) = iter_scope_local {
                     wasm!(self.func, {
-                        local_get(sl); global_set(self.emitter.heap_ptr_global);
-                        i32_const(0); global_set(self.emitter.free_list_global);
+                        local_get(Local(sl)); global_set(self.emitter.heap_ptr_global);
+                        i32_const(Imm32(0)); global_set(self.emitter.free_list_global);
                     });
                 }
 
@@ -577,12 +578,12 @@ impl FuncCompiler<'_> {
                 // Empty hash map: [len=0][cap=0]
                 let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(self.emitter.layout_reg.header_size(super::engine::layout::SWISS_MAP) as i32);
+                    i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::SWISS_MAP) as i32));
                     call(self.emitter.rt.alloc);
-                    local_set(scratch);
-                    local_get(scratch); i32_const(0); i32_store(0); // len = 0
-                    local_get(scratch); i32_const(0); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::CAP)); // cap = 0
-                    local_get(scratch);
+                    local_set(Local(scratch));
+                    local_get(Local(scratch)); i32_const(Imm32(0)); i32_store(0); // len = 0
+                    local_get(Local(scratch)); i32_const(Imm32(0)); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::CAP)); // cap = 0
+                    local_get(Local(scratch));
                 });
                 self.scratch.free_i32(scratch);
             }
@@ -594,12 +595,12 @@ impl FuncCompiler<'_> {
                     // Empty map
                     let scratch = self.scratch.alloc_i32();
                     wasm!(self.func, {
-                        i32_const(self.emitter.layout_reg.header_size(super::engine::layout::SWISS_MAP) as i32);
+                        i32_const(Imm32(self.emitter.layout_reg.header_size(super::engine::layout::SWISS_MAP) as i32));
                         call(self.emitter.rt.alloc);
-                        local_set(scratch);
-                        local_get(scratch); i32_const(0); i32_store(0);
-                        local_get(scratch); i32_const(0); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::CAP));
-                        local_get(scratch);
+                        local_set(Local(scratch));
+                        local_get(Local(scratch)); i32_const(Imm32(0)); i32_store(0);
+                        local_get(Local(scratch)); i32_const(Imm32(0)); i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::SWISS_MAP, super::engine::layout::map::CAP));
+                        local_get(Local(scratch));
                     });
                     self.scratch.free_i32(scratch);
                 } else {
@@ -619,24 +620,24 @@ impl FuncCompiler<'_> {
                     let ib = self.scratch.alloc_i32();
                     let eb = self.scratch.alloc_i32();
                     let tmp = self.scratch.alloc_i32();
-                    wasm!(self.func, { i32_const(cap as i32); local_set(cap_local); });
+                    wasm!(self.func, { i32_const(Imm32(cap as i32)); local_set(Local(cap_local)); });
                     self.emit_dict_alloc(map, cap_local, es);
                     self.emit_dict_index_base(map, cap_local);
-                    wasm!(self.func, { local_set(ib); });
+                    wasm!(self.func, { local_set(Local(ib)); });
                     self.emit_dict_entries_base(map, cap_local);
-                    wasm!(self.func, { local_set(eb); });
+                    wasm!(self.func, { local_set(Local(eb)); });
 
                     for (key, val) in entries {
                         // Materialize the (key, val) into a temp entry buffer.
-                        wasm!(self.func, { i32_const(es as i32); call(self.emitter.rt.alloc); local_set(tmp); local_get(tmp); });
+                        wasm!(self.func, { i32_const(Imm32(es as i32)); call(self.emitter.rt.alloc); local_set(Local(tmp)); local_get(Local(tmp)); });
                         self.emit_expr(key);
                         self.emit_key_store(&key_ty, 0);
-                        wasm!(self.func, { local_get(tmp); i32_const(ks as i32); i32_add; });
+                        wasm!(self.func, { local_get(Local(tmp)); i32_const(Imm32(ks as i32)); i32_add; });
                         self.emit_expr(val);
                         self.emit_store_at(&val.ty, 0);
                         self.emit_dict_put_entry(map, cap_local, ib, eb, tmp, es, ks, vs, &key_ty, &val_ty);
                     }
-                    wasm!(self.func, { local_get(map); });
+                    wasm!(self.func, { local_get(Local(map)); });
                     self.scratch.free_i32(tmp);
                     self.scratch.free_i32(eb);
                     self.scratch.free_i32(ib);
@@ -658,18 +659,18 @@ impl FuncCompiler<'_> {
                 let inner_size = values::byte_size(&inner_ty);
                 let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const(inner_size as i32);
+                    i32_const(Imm32(inner_size as i32));
                     call(self.emitter.rt.alloc);
-                    local_set(scratch);
-                    local_get(scratch);
+                    local_set(Local(scratch));
+                    local_get(Local(scratch));
                 });
                 self.emit_stored_field(inner);
                 self.emit_store_at(&inner_ty, 0);
-                wasm!(self.func, { local_get(scratch); });
+                wasm!(self.func, { local_get(Local(scratch)); });
                 self.scratch.free_i32(scratch);
             }
             IrExprKind::OptionNone => {
-                wasm!(self.func, { i32_const(0); });
+                wasm!(self.func, { i32_const(Imm32(0)); });
             }
 
             // ── Result ok/err ──
@@ -682,23 +683,23 @@ impl FuncCompiler<'_> {
                 let inner_size = values::byte_size(&inner_ty);
                 let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const((4 + inner_size) as i32);
+                    i32_const(Imm32((4 + inner_size) as i32));
                     call(self.emitter.rt.alloc);
-                    local_set(scratch);
+                    local_set(Local(scratch));
                     // tag = 0
-                    local_get(scratch);
-                    i32_const(0);
+                    local_get(Local(scratch));
+                    i32_const(Imm32(0));
                     i32_store(0);
                 });
                 if values::ty_to_valtype(&inner_ty).is_some() {
-                    wasm!(self.func, { local_get(scratch); });
+                    wasm!(self.func, { local_get(Local(scratch)); });
                     self.emit_stored_field(inner);
                     self.emit_store_at(&inner_ty, 4);
                 } else {
                     // Unit or zero-sized: still emit for side effects
                     self.emit_expr(inner);
                 }
-                wasm!(self.func, { local_get(scratch); });
+                wasm!(self.func, { local_get(Local(scratch)); });
                 self.scratch.free_i32(scratch);
             }
             IrExprKind::ResultErr { expr: inner } => {
@@ -709,23 +710,23 @@ impl FuncCompiler<'_> {
                 let inner_size = values::byte_size(&inner_ty);
                 let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    i32_const((4 + inner_size) as i32);
+                    i32_const(Imm32((4 + inner_size) as i32));
                     call(self.emitter.rt.alloc);
-                    local_set(scratch);
+                    local_set(Local(scratch));
                     // tag = 1
-                    local_get(scratch);
-                    i32_const(1);
+                    local_get(Local(scratch));
+                    i32_const(Imm32(1));
                     i32_store(0);
                 });
                 if values::ty_to_valtype(&inner_ty).is_some() {
-                    wasm!(self.func, { local_get(scratch); });
+                    wasm!(self.func, { local_get(Local(scratch)); });
                     self.emit_stored_field(inner);
                     self.emit_store_at(&inner_ty, 4);
                 } else {
                     // Unit or zero-sized: still emit for side effects
                     self.emit_expr(inner);
                 }
-                wasm!(self.func, { local_get(scratch); });
+                wasm!(self.func, { local_get(Local(scratch)); });
                 self.scratch.free_i32(scratch);
             }
 
@@ -737,10 +738,10 @@ impl FuncCompiler<'_> {
                     if let Ty::Applied(almide_lang::types::constructor::TypeConstructorId::Result, _) = &exprs[0].ty {
                         let scratch = self.scratch.alloc_i32();
                         wasm!(self.func, {
-                            local_set(scratch);
-                            local_get(scratch); i32_load(0); i32_const(0); i32_ne;
-                            if_empty; local_get(scratch); return_; end;
-                            local_get(scratch);
+                            local_set(Local(scratch));
+                            local_get(Local(scratch)); i32_load(0); i32_const(Imm32(0)); i32_ne;
+                            if_empty; local_get(Local(scratch)); return_; end;
+                            local_get(Local(scratch));
                         });
                         self.emit_load_at(&expr.ty, 4);
                         self.scratch.free_i32(scratch);
@@ -756,9 +757,9 @@ impl FuncCompiler<'_> {
                     let total_size: u32 = elem_types.iter().map(|t| values::byte_size(t)).sum();
                     let tuple_scratch = self.scratch.alloc_i32();
                     wasm!(self.func, {
-                        i32_const(total_size as i32);
+                        i32_const(Imm32(total_size as i32));
                         call(self.emitter.rt.alloc);
-                        local_set(tuple_scratch);
+                        local_set(Local(tuple_scratch));
                     });
                     let mut offset = 0u32;
                     for (i, e) in exprs.iter().enumerate() {
@@ -771,24 +772,24 @@ impl FuncCompiler<'_> {
                             self.emit_expr(e);
                             let res_scratch = self.scratch.alloc_i32();
                             wasm!(self.func, {
-                                local_set(res_scratch);
-                                local_get(res_scratch); i32_load(0); i32_const(0); i32_ne;
-                                if_empty; local_get(res_scratch); return_; end;
-                                local_get(tuple_scratch);
-                                local_get(res_scratch);
+                                local_set(Local(res_scratch));
+                                local_get(Local(res_scratch)); i32_load(0); i32_const(Imm32(0)); i32_ne;
+                                if_empty; local_get(Local(res_scratch)); return_; end;
+                                local_get(Local(tuple_scratch));
+                                local_get(Local(res_scratch));
                             });
                             self.emit_load_at(&elem_ty, 4);
                             self.emit_store_at(&elem_ty, offset);
                             self.scratch.free_i32(res_scratch);
                         } else {
                             // Non-Result: push tuple_ptr, emit expr, store
-                            wasm!(self.func, { local_get(tuple_scratch); });
+                            wasm!(self.func, { local_get(Local(tuple_scratch)); });
                             self.emit_expr(e);
                             self.emit_store_at(&elem_ty, offset);
                         }
                         offset += elem_size;
                     }
-                    wasm!(self.func, { local_get(tuple_scratch); });
+                    wasm!(self.func, { local_get(Local(tuple_scratch)); });
                     self.scratch.free_i32(tuple_scratch);
                 }
             }
@@ -801,21 +802,21 @@ impl FuncCompiler<'_> {
                 self.emit_expr(inner);
                 let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(scratch);
+                    local_set(Local(scratch));
                     // Check tag
-                    local_get(scratch);
+                    local_get(Local(scratch));
                     i32_load(0);
-                    i32_const(0);
+                    i32_const(Imm32(0));
                     i32_ne;
                     if_empty;
                     // Err: return the Result ptr
-                    local_get(scratch);
+                    local_get(Local(scratch));
                     return_;
                     end;
                 });
                 // Ok: load the unwrapped value (skip for Unit — nothing to load)
                 if !matches!(&expr.ty, Ty::Unit) {
-                    wasm!(self.func, { local_get(scratch); });
+                    wasm!(self.func, { local_get(Local(scratch)); });
                     self.emit_load_at(&expr.ty, 4);
                 }
                 self.scratch.free_i32(scratch);
@@ -832,49 +833,49 @@ impl FuncCompiler<'_> {
                     let none_str = self.emitter.intern_string("none") as i32;
                     let alloc = self.emitter.rt.alloc;
                     wasm!(self.func, {
-                        local_set(scratch);
-                        local_get(scratch);
+                        local_set(Local(scratch));
+                        local_get(Local(scratch));
                         i32_eqz;
                         if_empty;
                         // None → return `err("none")` so the unwrap propagates a real
                         // Err Result, matching native's `.ok_or("none")?`. (Previously
                         // returned a null ptr `0`, which the caller mis-read as `Ok`
                         // tag → silent success / exit 0 on wasm.)
-                        i32_const(ERR_STRING_BOX_BYTES); // [tag:i32@0][String ptr@4]
+                        i32_const(Imm32(ERR_STRING_BOX_BYTES)); // [tag:i32@0][String ptr@4]
                         call(alloc);
-                        local_set(err_ptr);
-                        local_get(err_ptr);
-                        i32_const(1);          // tag = 1 (Err)
+                        local_set(Local(err_ptr));
+                        local_get(Local(err_ptr));
+                        i32_const(Imm32(1));          // tag = 1 (Err)
                         i32_store(0);
-                        local_get(err_ptr);
-                        i32_const(none_str);   // err payload = "none"
+                        local_get(Local(err_ptr));
+                        i32_const(Imm32(none_str));   // err payload = "none"
                         i32_store(4);
-                        local_get(err_ptr);
+                        local_get(Local(err_ptr));
                         return_;
                         end;
                     });
                     self.scratch.free_i32(err_ptr);
                     // Some: load payload from ptr
                     if !matches!(&expr.ty, Ty::Unit) {
-                        wasm!(self.func, { local_get(scratch); });
+                        wasm!(self.func, { local_get(Local(scratch)); });
                         self.emit_load_at(&expr.ty, 0);
                     }
                 } else {
                     // Result: [tag:i32, payload]. tag==0 → Ok, tag!=0 → Err
                     wasm!(self.func, {
-                        local_set(scratch);
-                        local_get(scratch);
+                        local_set(Local(scratch));
+                        local_get(Local(scratch));
                         i32_load(0);
-                        i32_const(0);
+                        i32_const(Imm32(0));
                         i32_ne;
                         if_empty;
                         // Err path: propagate the Result pointer (early return)
-                        local_get(scratch);
+                        local_get(Local(scratch));
                         return_;
                         end;
                     });
                     if !matches!(&expr.ty, Ty::Unit) {
-                        wasm!(self.func, { local_get(scratch); });
+                        wasm!(self.func, { local_get(Local(scratch)); });
                         self.emit_load_at(&expr.ty, 4);
                     }
                 }
@@ -890,25 +891,25 @@ impl FuncCompiler<'_> {
                 if is_option {
                     // Option: ptr==0 → fallback, ptr!=0 → load payload from ptr
                     wasm!(self.func, {
-                        local_set(scratch);
-                        local_get(scratch);
+                        local_set(Local(scratch));
+                        local_get(Local(scratch));
                         i32_eqz;
                     });
                     self.func.instruction(&Instruction::If(bt));
                     self.emit_expr(fallback);
-                    wasm!(self.func, { else_; local_get(scratch); });
+                    wasm!(self.func, { else_; local_get(Local(scratch)); });
                     self.emit_load_at(&expr.ty, 0);
                     wasm!(self.func, { end; });
                 } else {
                     // Result: tag==0 → ok (load payload at +4), tag!=0 → fallback
                     wasm!(self.func, {
-                        local_set(scratch);
-                        local_get(scratch);
+                        local_set(Local(scratch));
+                        local_get(Local(scratch));
                         i32_load(0);
                         i32_eqz;
                     });
                     self.func.instruction(&Instruction::If(bt));
-                    wasm!(self.func, { local_get(scratch); });
+                    wasm!(self.func, { local_get(Local(scratch)); });
                     self.emit_load_at(&expr.ty, 4);
                     wasm!(self.func, { else_; });
                     self.emit_expr(fallback);
@@ -927,8 +928,8 @@ impl FuncCompiler<'_> {
                     self.emit_expr(inner);
                     let scratch = self.scratch.alloc_i32();
                     wasm!(self.func, {
-                        local_set(scratch);
-                        local_get(scratch);
+                        local_set(Local(scratch));
+                        local_get(Local(scratch));
                         i32_load(0);
                         i32_eqz;
                         if_i32;
@@ -938,26 +939,26 @@ impl FuncCompiler<'_> {
                     let inner_size = values::byte_size(&inner_ty);
                     if inner_size > 0 {
                         wasm!(self.func, {
-                            i32_const(inner_size as i32);
+                            i32_const(Imm32(inner_size as i32));
                             call(self.emitter.rt.alloc);
                         });
                         let some_scratch = self.scratch.alloc_i32();
-                        wasm!(self.func, { local_tee(some_scratch); });
-                        wasm!(self.func, { local_get(scratch); });
+                        wasm!(self.func, { local_tee(Local(some_scratch)); });
+                        wasm!(self.func, { local_get(Local(scratch)); });
                         self.emit_load_at(&inner_ty, 4);
                         self.emit_store_at(&inner_ty, 0);
-                        wasm!(self.func, { local_get(some_scratch); });
+                        wasm!(self.func, { local_get(Local(some_scratch)); });
                         self.scratch.free_i32(some_scratch);
                     } else {
                         // Unit payload — Some is just a non-zero ptr
                         wasm!(self.func, {
-                            i32_const(1);
+                            i32_const(Imm32(1));
                         });
                     }
                     wasm!(self.func, {
                         else_;
                         // Err: return 0 (None)
-                        i32_const(0);
+                        i32_const(Imm32(0));
                         end;
                     });
                     self.scratch.free_i32(scratch);
@@ -977,19 +978,19 @@ impl FuncCompiler<'_> {
                 self.emit_expr(inner);
                 let scratch = self.scratch.alloc_i32();
                 wasm!(self.func, {
-                    local_set(scratch);
-                    local_get(scratch);
+                    local_set(Local(scratch));
+                    local_get(Local(scratch));
                     i32_eqz;
                     if_i32;
                     // None path → propagate None (ptr=0)
-                    i32_const(0);
+                    i32_const(Imm32(0));
                     else_;
                 });
                 // Some path: dereference Some wrapper to get the actual record pointer
                 let payload_ty = inner.ty.option_inner().unwrap_or_else(|| inner.ty.clone());
                 let payload_size = values::byte_size(&payload_ty);
                 if payload_size > 0 {
-                    wasm!(self.func, { local_get(scratch); i32_load(0); local_set(scratch); });
+                    wasm!(self.func, { local_get(Local(scratch)); i32_load(0); local_set(Local(scratch)); });
                 }
                 let fields = self.extract_record_fields(&payload_ty);
                 let tag_offset = self.variant_tag_offset(&payload_ty);
@@ -998,16 +999,16 @@ impl FuncCompiler<'_> {
                     let field_size = values::byte_size(&field_ty);
                     if field_size > 0 {
                         // Allocate Some wrapper for the field value
-                        wasm!(self.func, { i32_const(field_size as i32); call(self.emitter.rt.alloc); });
+                        wasm!(self.func, { i32_const(Imm32(field_size as i32)); call(self.emitter.rt.alloc); });
                         let some_ptr = self.scratch.alloc_i32();
-                        wasm!(self.func, { local_tee(some_ptr); local_get(scratch); });
+                        wasm!(self.func, { local_tee(Local(some_ptr)); local_get(Local(scratch)); });
                         self.emit_load_at(&field_ty, total_offset);
                         self.emit_store_at(&field_ty, 0);
-                        wasm!(self.func, { local_get(some_ptr); });
+                        wasm!(self.func, { local_get(Local(some_ptr)); });
                         self.scratch.free_i32(some_ptr);
                     } else {
                         // Unit field → Some is just a non-zero ptr
-                        wasm!(self.func, { i32_const(1); });
+                        wasm!(self.func, { i32_const(Imm32(1)); });
                     }
                 } else {
                     wasm!(self.func, { unreachable; });
@@ -1026,48 +1027,48 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let i = self.scratch.alloc_i32();
                 self.emit_expr(start);
-                wasm!(self.func, { local_set(s); });
+                wasm!(self.func, { local_set(Local(s)); });
                 self.emit_expr(end);
-                wasm!(self.func, { local_set(e); });
+                wasm!(self.func, { local_set(Local(e)); });
                 // len = max(0, end - start [+ 1 if inclusive])
                 wasm!(self.func, {
-                    local_get(e); local_get(s); i64_sub;
+                    local_get(Local(e)); local_get(Local(s)); i64_sub;
                 });
                 if *inclusive {
-                    wasm!(self.func, { i64_const(1); i64_add; });
+                    wasm!(self.func, { i64_const(Imm64(1)); i64_add; });
                 }
                 wasm!(self.func, {
-                    i64_const(0); i64_gt_s;
+                    i64_const(Imm64(0)); i64_gt_s;
                     if_i32;
-                      local_get(e); local_get(s); i64_sub;
+                      local_get(Local(e)); local_get(Local(s)); i64_sub;
                 });
                 if *inclusive {
-                    wasm!(self.func, { i64_const(1); i64_add; });
+                    wasm!(self.func, { i64_const(Imm64(1)); i64_add; });
                 }
                 wasm!(self.func, {
                       i32_wrap_i64;
                     else_;
-                      i32_const(0);
+                      i32_const(Imm32(0));
                     end;
-                    local_set(len);
+                    local_set(Local(len));
                     // alloc: LIST_HDR_BYTES + len * INT_ELEM_BYTES (header: [len:i32][cap:i32])
-                    i32_const(LIST_HDR_BYTES); local_get(len); i32_const(INT_ELEM_BYTES); i32_mul; i32_add;
-                    call(self.emitter.rt.alloc); local_set(dst);
-                    local_get(dst); local_get(len); i32_store(0);
-                    local_get(dst); local_get(len); i32_store(4); // cap = len
+                    i32_const(Imm32(LIST_HDR_BYTES)); local_get(Local(len)); i32_const(Imm32(INT_ELEM_BYTES)); i32_mul; i32_add;
+                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(0);
+                    local_get(Local(dst)); local_get(Local(len)); i32_store(4); // cap = len
                     // fill elements
-                    i32_const(0); local_set(i);
+                    i32_const(Imm32(0)); local_set(Local(i));
                     block_empty; loop_empty;
-                      local_get(i); local_get(len); i32_ge_u; br_if(1);
-                      local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(INT_ELEM_BYTES); i32_mul; i32_add;
+                      local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
+                      local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                      local_get(Local(i)); i32_const(Imm32(INT_ELEM_BYTES)); i32_mul; i32_add;
                       // value = start + i
-                      local_get(s); local_get(i); i64_extend_i32_u; i64_add;
+                      local_get(Local(s)); local_get(Local(i)); i64_extend_i32_u; i64_add;
                       i64_store(0);
-                      local_get(i); i32_const(1); i32_add; local_set(i);
+                      local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
                       br(0);
                     end; end;
-                    local_get(dst);
+                    local_get(Local(dst));
                 });
                 self.scratch.free_i32(i);
                 self.scratch.free_i32(dst);
@@ -1209,7 +1210,7 @@ impl FuncCompiler<'_> {
                     .or_else(|| Self::extract_mod_pow2_eq_zero(right, left));
                 if let Some((mod_expr, mask)) = modint_zero {
                     self.emit_expr(mod_expr);
-                    wasm!(self.func, { i64_const(mask); i64_and; i64_eqz; });
+                    wasm!(self.func, { i64_const(Imm64(mask)); i64_and; i64_eqz; });
                 } else {
                     self.emit_eq(left, right, false);
                 }
@@ -1220,7 +1221,7 @@ impl FuncCompiler<'_> {
                     .or_else(|| Self::extract_mod_pow2_eq_zero(right, left));
                 if let Some((mod_expr, mask)) = modint_zero {
                     self.emit_expr(mod_expr);
-                    wasm!(self.func, { i64_const(mask); i64_and; i64_const(0); i64_ne; });
+                    wasm!(self.func, { i64_const(Imm64(mask)); i64_and; i64_const(Imm64(0)); i64_ne; });
                 } else {
                     self.emit_eq(left, right, true);
                 }
@@ -1286,7 +1287,7 @@ impl FuncCompiler<'_> {
                     .or_else(|| var_elem(right))
                     .unwrap_or(8);
                 wasm!(self.func, {
-                    i32_const(elem_size as i32);
+                    i32_const(Imm32(elem_size as i32));
                     call(self.emitter.rt.concat_list);
                 });
                 // SHARE dup: __concat_list bulk-copies BOTH inputs' element
@@ -1316,18 +1317,18 @@ impl FuncCompiler<'_> {
                     let len = self.scratch.alloc_i32();
                     let data_off = super::rt_string::list_data_off();
                     wasm!(self.func, {
-                        local_set(res);
-                        local_get(res); i32_load(0); local_set(len);
-                        i32_const(0); local_set(idx);
+                        local_set(Local(res));
+                        local_get(Local(res)); i32_load(0); local_set(Local(len));
+                        i32_const(Imm32(0)); local_set(Local(idx));
                         block_empty; loop_empty;
-                            local_get(idx); local_get(len); i32_ge_u; br_if(1);
-                            local_get(res); i32_const(data_off); i32_add;
-                            local_get(idx); i32_const(I32_BYTES); i32_mul; i32_add;
+                            local_get(Local(idx)); local_get(Local(len)); i32_ge_u; br_if(1);
+                            local_get(Local(res)); i32_const(Imm32(data_off)); i32_add;
+                            local_get(Local(idx)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
                             i32_load(0); call(self.emitter.rt.rc_inc); drop;
-                            local_get(idx); i32_const(1); i32_add; local_set(idx);
+                            local_get(Local(idx)); i32_const(Imm32(1)); i32_add; local_set(Local(idx));
                             br(0);
                         end; end;
-                        local_get(res);
+                        local_get(Local(res));
                     });
                     self.scratch.free_i32(len);
                     self.scratch.free_i32(idx);
@@ -1364,27 +1365,27 @@ impl FuncCompiler<'_> {
                 let counter_s = self.scratch.alloc_i32();
                 wasm!(self.func, {
                     i32_wrap_i64;
-                    local_set(counter_s);
-                    local_set(base_s);
-                    i64_const(1);
-                    local_set(result_s);
+                    local_set(Local(counter_s));
+                    local_set(Local(base_s));
+                    i64_const(Imm64(1));
+                    local_set(Local(result_s));
                     block_empty;
                     loop_empty;
-                    local_get(counter_s);
+                    local_get(Local(counter_s));
                     i32_eqz;
                     br_if(1);
-                    local_get(result_s);
-                    local_get(base_s);
+                    local_get(Local(result_s));
+                    local_get(Local(base_s));
                     i64_mul;
-                    local_set(result_s);
-                    local_get(counter_s);
-                    i32_const(1);
+                    local_set(Local(result_s));
+                    local_get(Local(counter_s));
+                    i32_const(Imm32(1));
                     i32_sub;
-                    local_set(counter_s);
+                    local_set(Local(counter_s));
                     br(0);
                     end;
                     end;
-                    local_get(result_s);
+                    local_get(Local(result_s));
                 });
                 self.scratch.free_i32(counter_s);
                 self.scratch.free_i64(result_s);
@@ -1438,37 +1439,37 @@ impl FuncCompiler<'_> {
             let la = self.scratch.alloc_i32();
             let rb = self.scratch.alloc_i32();
             self.emit_expr(left);
-            wasm!(self.func, { local_set(la); });
+            wasm!(self.func, { local_set(Local(la)); });
             self.emit_expr(right);
-            wasm!(self.func, { local_set(rb); });
+            wasm!(self.func, { local_set(Local(rb)); });
 
             // if rb == 0 { div_trap("division by zero") }
             wasm!(self.func, {
-                local_get(rb);
+                local_get(Local(rb));
                 i32_eqz;
                 if_empty;
-                i32_const(div_by_zero_msg);
+                i32_const(Imm32(div_by_zero_msg));
                 call(div_trap);
                 end;
             });
             // Signed overflow: if la == width_min && rb == -1 { div_trap("integer overflow") }
             if !is_unsigned_int {
                 wasm!(self.func, {
-                    local_get(la);
-                    i32_const(width_min as i32);
+                    local_get(Local(la));
+                    i32_const(Imm32(width_min as i32));
                     i32_eq;
-                    local_get(rb);
-                    i32_const(NEG_ONE as i32);
+                    local_get(Local(rb));
+                    i32_const(Imm32(NEG_ONE as i32));
                     i32_eq;
                     i32_and;
                     if_empty;
-                    i32_const(overflow_msg);
+                    i32_const(Imm32(overflow_msg));
                     call(div_trap);
                     end;
                 });
             }
             // The checked operands are now safe — run the raw op.
-            wasm!(self.func, { local_get(la); local_get(rb); });
+            wasm!(self.func, { local_get(Local(la)); local_get(Local(rb)); });
             let instr = match (is_mod, is_unsigned_int) {
                 (false, true) => wasm_encoder::Instruction::I32DivU,
                 (false, false) => wasm_encoder::Instruction::I32DivS,
@@ -1482,36 +1483,36 @@ impl FuncCompiler<'_> {
             let la = self.scratch.alloc_i64();
             let rb = self.scratch.alloc_i64();
             self.emit_expr(left);
-            wasm!(self.func, { local_set(la); });
+            wasm!(self.func, { local_set(Local(la)); });
             self.emit_expr(right);
-            wasm!(self.func, { local_set(rb); });
+            wasm!(self.func, { local_set(Local(rb)); });
 
             // if rb == 0 { div_trap("division by zero") }
             wasm!(self.func, {
-                local_get(rb);
+                local_get(Local(rb));
                 i64_eqz;
                 if_empty;
-                i32_const(div_by_zero_msg);
+                i32_const(Imm32(div_by_zero_msg));
                 call(div_trap);
                 end;
             });
             // Signed overflow: if la == i64::MIN && rb == -1 { div_trap("integer overflow") }
             if !is_unsigned_int {
                 wasm!(self.func, {
-                    local_get(la);
-                    i64_const(width_min);
+                    local_get(Local(la));
+                    i64_const(Imm64(width_min));
                     i64_eq;
-                    local_get(rb);
-                    i64_const(NEG_ONE);
+                    local_get(Local(rb));
+                    i64_const(Imm64(NEG_ONE));
                     i64_eq;
                     i32_and;
                     if_empty;
-                    i32_const(overflow_msg);
+                    i32_const(Imm32(overflow_msg));
                     call(div_trap);
                     end;
                 });
             }
-            wasm!(self.func, { local_get(la); local_get(rb); });
+            wasm!(self.func, { local_get(Local(la)); local_get(Local(rb)); });
             let instr = match (is_mod, is_unsigned_int) {
                 (false, true) => wasm_encoder::Instruction::I64DivU,
                 (false, false) => wasm_encoder::Instruction::I64DivS,
@@ -1763,11 +1764,11 @@ impl FuncCompiler<'_> {
 
         // Hoist: load len and cap from string header
         wasm!(self.func, {
-            local_get(str_local); local_tee(s);
-            i32_load(0); local_set(len);
-            local_get(s);
+            local_get(Local(str_local)); local_tee(Local(s));
+            i32_load(0); local_set(Local(len));
+            local_get(Local(s));
             i32_load(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32);
-            local_set(cap);
+            local_set(Local(cap));
             // Loop
             block_empty; loop_empty;
         });
@@ -1784,51 +1785,51 @@ impl FuncCompiler<'_> {
 
         // Fast path: len < cap → inline byte store (NO memory read for len/cap)
         wasm!(self.func, {
-            local_get(len); local_get(cap); i32_lt_u;
+            local_get(Local(len)); local_get(Local(cap)); i32_lt_u;
             if_empty;
-              local_get(s);
-              i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
+              local_get(Local(s));
+              i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
               i32_add;
-              local_get(len); i32_add;
-              i32_const(byte_val as i32);
+              local_get(Local(len)); i32_add;
+              i32_const(Imm32(byte_val as i32));
               i32_store8(0);
-              local_get(len); i32_const(1); i32_add; local_set(len);
+              local_get(Local(len)); i32_const(Imm32(1)); i32_add; local_set(Local(len));
             else_;
               // Slow: write len back, grow, reload s/cap
-              local_get(s); local_get(len); i32_store(0);
+              local_get(Local(s)); local_get(Local(len)); i32_store(0);
               // new_cap = max(cap*2, STRING_GROW_MIN_CAP)
-              local_get(cap); i32_const(1); i32_shl; local_tee(cap);
-              i32_const(STRING_GROW_MIN_CAP); i32_lt_u;
-              if_empty; i32_const(STRING_GROW_MIN_CAP); local_set(cap); end;
+              local_get(Local(cap)); i32_const(Imm32(1)); i32_shl; local_tee(Local(cap));
+              i32_const(Imm32(STRING_GROW_MIN_CAP)); i32_lt_u;
+              if_empty; i32_const(Imm32(STRING_GROW_MIN_CAP)); local_set(Local(cap)); end;
               // Alloc
-              local_get(cap);
-              i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
+              local_get(Local(cap));
+              i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
               i32_add;
-              call(self.emitter.rt.alloc); local_tee(s);
+              call(self.emitter.rt.alloc); local_tee(Local(s));
               // Copy old data
-              i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-              local_get(str_local);
-              i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-              local_get(len);
+              i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+              local_get(Local(str_local));
+              i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+              local_get(Local(len));
               memory_copy;
               // Write cap
-              local_get(s); local_get(cap);
+              local_get(Local(s)); local_get(Local(cap));
               i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32);
               // Update str local
-              local_get(s); local_set(str_local);
+              local_get(Local(s)); local_set(Local(str_local));
               // Write byte
-              local_get(s);
-              i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
+              local_get(Local(s));
+              i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
               i32_add;
-              local_get(len); i32_add;
-              i32_const(byte_val as i32);
+              local_get(Local(len)); i32_add;
+              i32_const(Imm32(byte_val as i32));
               i32_store8(0);
-              local_get(len); i32_const(1); i32_add; local_set(len);
+              local_get(Local(len)); i32_const(Imm32(1)); i32_add; local_set(Local(len));
             end;
             // i++
-            local_get(counter_local);
-            i64_const(1); i64_add;
-            local_set(counter_local);
+            local_get(Local(counter_local));
+            i64_const(Imm64(1)); i64_add;
+            local_set(Local(counter_local));
         });
 
         // Continue
@@ -1840,7 +1841,7 @@ impl FuncCompiler<'_> {
 
         // Write final len back to memory
         wasm!(self.func, {
-            local_get(s); local_get(len); i32_store(0);
+            local_get(Local(s)); local_get(Local(len)); i32_store(0);
         });
 
         self.scratch.free_i32(cap);

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -9,6 +9,33 @@ use super::values;
 use super::wasm_macro::wasm;
 use crate::pass_closure_conversion::is_inplace_mutator;
 
+// ── Named immediates used in WASM instruction arguments ──────────────────────
+// Every const below is the EXACT value it replaces; the byte-identity gate
+// enforces that substituting the name back to its literal produces bit-for-bit
+// identical output.
+mod imm {
+    /// Byte size of the boxed `Err(String)` allocation emitted by `!` (unwrap)
+    /// when propagating `None` as an error: `[tag:i32 @ 0][String ptr:i32 @ 4]`.
+    pub(super) const ERR_STRING_BOX_BYTES: i32 = 8;
+
+    /// Byte width of the list header: `[len:i32][cap:i32]` = 8 bytes.
+    /// Used when manually computing a list allocation size (e.g. Range→List).
+    pub(super) const LIST_HDR_BYTES: i32 = 8;
+
+    /// Byte stride per `Int` element (i64, 8 bytes) in a `List[Int]` body.
+    /// Used in Range→List materialization to size the alloc and stride the fill loop.
+    pub(super) const INT_ELEM_BYTES: i32 = 8;
+
+    /// Byte width of an i32 / heap pointer value (4 bytes).
+    /// Used as the element stride when iterating over `List[HeapType]` pointer slots.
+    pub(super) const I32_BYTES: i32 = 4;
+
+    /// Minimum byte capacity of a string buffer after the slow-growth path doubles
+    /// from zero: `max(cap * 2, STRING_GROW_MIN_CAP)`.
+    pub(super) const STRING_GROW_MIN_CAP: i32 = 16;
+}
+use imm::*;
+
 #[derive(Clone, Copy)]
 pub(super) enum CmpKind {
     Lt,
@@ -813,7 +840,7 @@ impl FuncCompiler<'_> {
                         // Err Result, matching native's `.ok_or("none")?`. (Previously
                         // returned a null ptr `0`, which the caller mis-read as `Ok`
                         // tag → silent success / exit 0 on wasm.)
-                        i32_const(8);          // [tag:i32@0][String ptr@4]
+                        i32_const(ERR_STRING_BOX_BYTES); // [tag:i32@0][String ptr@4]
                         call(alloc);
                         local_set(err_ptr);
                         local_get(err_ptr);
@@ -1023,8 +1050,8 @@ impl FuncCompiler<'_> {
                       i32_const(0);
                     end;
                     local_set(len);
-                    // alloc: 8 + len * 8 (header: [len:i32][cap:i32])
-                    i32_const(8); local_get(len); i32_const(8); i32_mul; i32_add;
+                    // alloc: LIST_HDR_BYTES + len * INT_ELEM_BYTES (header: [len:i32][cap:i32])
+                    i32_const(LIST_HDR_BYTES); local_get(len); i32_const(INT_ELEM_BYTES); i32_mul; i32_add;
                     call(self.emitter.rt.alloc); local_set(dst);
                     local_get(dst); local_get(len); i32_store(0);
                     local_get(dst); local_get(len); i32_store(4); // cap = len
@@ -1033,7 +1060,7 @@ impl FuncCompiler<'_> {
                     block_empty; loop_empty;
                       local_get(i); local_get(len); i32_ge_u; br_if(1);
                       local_get(dst); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                      local_get(i); i32_const(8); i32_mul; i32_add;
+                      local_get(i); i32_const(INT_ELEM_BYTES); i32_mul; i32_add;
                       // value = start + i
                       local_get(s); local_get(i); i64_extend_i32_u; i64_add;
                       i64_store(0);
@@ -1295,7 +1322,7 @@ impl FuncCompiler<'_> {
                         block_empty; loop_empty;
                             local_get(idx); local_get(len); i32_ge_u; br_if(1);
                             local_get(res); i32_const(data_off); i32_add;
-                            local_get(idx); i32_const(4); i32_mul; i32_add;
+                            local_get(idx); i32_const(I32_BYTES); i32_mul; i32_add;
                             i32_load(0); call(self.emitter.rt.rc_inc); drop;
                             local_get(idx); i32_const(1); i32_add; local_set(idx);
                             br(0);
@@ -1769,10 +1796,10 @@ impl FuncCompiler<'_> {
             else_;
               // Slow: write len back, grow, reload s/cap
               local_get(s); local_get(len); i32_store(0);
-              // new_cap = max(cap*2, 16)
+              // new_cap = max(cap*2, STRING_GROW_MIN_CAP)
               local_get(cap); i32_const(1); i32_shl; local_tee(cap);
-              i32_const(16); i32_lt_u;
-              if_empty; i32_const(16); local_set(cap); end;
+              i32_const(STRING_GROW_MIN_CAP); i32_lt_u;
+              if_empty; i32_const(STRING_GROW_MIN_CAP); local_set(cap); end;
               // Alloc
               local_get(cap);
               i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);

--- a/crates/almide-codegen/src/emit_wasm/list_layout.rs
+++ b/crates/almide-codegen/src/emit_wasm/list_layout.rs
@@ -3,6 +3,7 @@
 //! Legacy constants kept for backward compatibility during migration.
 //! New code should use `engine::LayoutRegistry` via `WasmBuilder`.
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use super::FuncCompiler;
 
 // ── Legacy constants (used by existing code not yet migrated) ──
@@ -30,15 +31,15 @@ impl FuncCompiler<'_> {
     pub fn emit_list_data_addr(&mut self, list_local: u32) {
         use super::engine::{WasmBuilder, layout::{LIST, list}};
         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-        w.get(list_local).field_addr(LIST, list::DATA);
+        w.get(Local(list_local)).field_addr(LIST, list::DATA);
     }
 
     /// List element address. Stack: `[] → [elem_ptr]`
     pub fn emit_list_elem_addr(&mut self, list_local: u32, idx_local: u32, elem_size: u32) {
         use super::engine::{WasmBuilder, layout::{LIST, list}};
         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-        w.get(list_local).field_addr(LIST, list::DATA);
-        w.get(idx_local).i32c(elem_size as i32).mul().add();
+        w.get(Local(list_local)).field_addr(LIST, list::DATA);
+        w.get(Local(idx_local)).i32c(Imm32(elem_size as i32)).mul().add();
     }
 
     /// Allocate list for `len_local` elements. Returns scratch local with ptr.
@@ -58,8 +59,8 @@ impl FuncCompiler<'_> {
         let alloc_fn = self.emitter.rt.alloc;
         let hdr = self.emitter.layout_reg.header_size(LIST);
         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-        w.i32c(hdr as i32).call(alloc_fn).tee(dst);
-        w.i32c(0).field_store(LIST, list::LEN);
+        w.i32c(Imm32(hdr as i32)).call(alloc_fn).tee(Local(dst));
+        w.i32c(Imm32(0)).field_store(LIST, list::LEN);
         dst
     }
 
@@ -67,7 +68,7 @@ impl FuncCompiler<'_> {
     pub fn emit_list_len(&mut self, list_local: u32) {
         use super::engine::{WasmBuilder, layout::{LIST, list}};
         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-        w.get(list_local).field_load(LIST, list::LEN);
+        w.get(Local(list_local)).field_load(LIST, list::LEN);
     }
 
     // ── Compact-ordered-dict tag helpers (the tags array is unchanged from the old layout) ──
@@ -76,7 +77,7 @@ impl FuncCompiler<'_> {
     pub fn emit_swiss_tag_load(&mut self, map: u32, idx: u32) {
         use super::engine::{WasmBuilder, layout::{SWISS_MAP, map as m, MemType}};
         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-        w.get(map).field_addr(SWISS_MAP, m::TAGS).get(idx).add();
+        w.get(Local(map)).field_addr(SWISS_MAP, m::TAGS).get(Local(idx)).add();
         w.emit_load(0, MemType::U8);
     }
 
@@ -84,10 +85,10 @@ impl FuncCompiler<'_> {
     pub fn emit_swiss_tag_store(&mut self, map: u32, idx: u32) {
         use super::engine::{WasmBuilder, layout::{SWISS_MAP, map as m, MemType}};
         let tmp = self.scratch.alloc_i32();
-        wasm!(self.func, { local_set(tmp); }); // save tag from stack
+        wasm!(self.func, { local_set(Local(tmp)); }); // save tag from stack
         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-        w.get(map).field_addr(SWISS_MAP, m::TAGS).get(idx).add();
-        w.get(tmp).emit_store(0, MemType::U8);
+        w.get(Local(map)).field_addr(SWISS_MAP, m::TAGS).get(Local(idx)).add();
+        w.get(Local(tmp)).emit_store(0, MemType::U8);
         self.scratch.free_i32(tmp);
     }
 
@@ -95,14 +96,14 @@ impl FuncCompiler<'_> {
     pub fn emit_map_len(&mut self, map: u32) {
         use super::engine::{WasmBuilder, layout::{SWISS_MAP, map as m}};
         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-        w.get(map).field_load(SWISS_MAP, m::LEN);
+        w.get(Local(map)).field_load(SWISS_MAP, m::LEN);
     }
 
     /// Store map length. Stack: `[] → []`. `len_local` has the value.
     pub fn emit_map_store_len(&mut self, map: u32, len_local: u32) {
         use super::engine::{WasmBuilder, layout::{SWISS_MAP, map as m}};
         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-        w.get(map).get(len_local).field_store(SWISS_MAP, m::LEN);
+        w.get(Local(map)).get(Local(len_local)).field_store(SWISS_MAP, m::LEN);
     }
 
     /// Allocate empty map (len=0, cap=0). Returns scratch local.
@@ -112,9 +113,9 @@ impl FuncCompiler<'_> {
         let hdr = self.emitter.layout_reg.header_size(SWISS_MAP);
         let alloc_fn = self.emitter.rt.alloc;
         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-        w.i32c(hdr as i32).call(alloc_fn).tee(dst);
-        w.i32c(0).field_store(SWISS_MAP, m::LEN);
-        w.get(dst).i32c(0).field_store(SWISS_MAP, m::CAP);
+        w.i32c(Imm32(hdr as i32)).call(alloc_fn).tee(Local(dst));
+        w.i32c(Imm32(0)).field_store(SWISS_MAP, m::LEN);
+        w.get(Local(dst)).i32c(Imm32(0)).field_store(SWISS_MAP, m::CAP);
         dst
     }
 
@@ -129,9 +130,9 @@ impl FuncCompiler<'_> {
         // total = hdr + cap + cap * entry_stride
         let total = hdr + cap_val + cap_val * entry_stride;
         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-        w.i32c(total as i32).call(alloc_fn).tee(dst);
-        w.i32c(0).field_store(SWISS_MAP, m::LEN);
-        w.get(dst).i32c(cap_val as i32).field_store(SWISS_MAP, m::CAP);
+        w.i32c(Imm32(total as i32)).call(alloc_fn).tee(Local(dst));
+        w.i32c(Imm32(0)).field_store(SWISS_MAP, m::LEN);
+        w.get(Local(dst)).i32c(Imm32(cap_val as i32)).field_store(SWISS_MAP, m::CAP);
         dst
     }
 }

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -93,6 +93,17 @@ const SCRATCH_ITOA: u32 = 16;
 /// data section DCE can distinguish string offsets from character codes.
 const NEWLINE_OFFSET: u32 = 4096;
 
+// IOV (iovec) scratch layout used by WASI fd_write in compile_main_runner.
+// Mirrors the identically-named constants in runtime.rs (which are module-private).
+/// Byte offset of the `len` field inside one iovec record (4 bytes past `buf`).
+const IOV_LEN_OFF: i32 = 4;
+/// Byte offset at which fd_write writes its `nwritten` result (just past one iovec).
+const NWRITTEN_OFF: i32 = 8;
+
+// WASI file-descriptor numbers.
+/// Standard error file descriptor (fd 2), used to write the unhandled-error message.
+const FD_STDERR: i32 = 2;
+
 /// Wrapper around `wasm_encoder::Function` that automatically records
 /// `call` targets as instructions are emitted. Used by `FuncCompiler`
 /// so DCE gets a type-safe call graph without bytecode scanning.
@@ -2327,15 +2338,15 @@ fn compile_main_runner(emitter: &mut WasmEmitter, main_idx: u32, drop_count: usi
     f.instruction(&Ins::I32Const(data_off));
     f.instruction(&Ins::I32Add);
     f.instruction(&Ins::I32Store(m(0)));
-    f.instruction(&Ins::I32Const(4));
+    f.instruction(&Ins::I32Const(IOV_LEN_OFF));
     f.instruction(&Ins::LocalGet(1));
     f.instruction(&Ins::I32Load(m(0)));
     f.instruction(&Ins::I32Store(m(0)));
-    //   fd_write(fd=2 stderr, iovs=0, iovs_len=1, nwritten=8)
-    f.instruction(&Ins::I32Const(2));
+    //   fd_write(fd=2 stderr, iovs=0, iovs_len=1, nwritten=NWRITTEN_OFF)
+    f.instruction(&Ins::I32Const(FD_STDERR));
     f.instruction(&Ins::I32Const(0));
     f.instruction(&Ins::I32Const(1));
-    f.instruction(&Ins::I32Const(8));
+    f.instruction(&Ins::I32Const(NWRITTEN_OFF));
     f.instruction(&Ins::Call(fd_write));
     f.instruction(&Ins::Drop);
     f.instruction(&Ins::I32Const(1));

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -12,6 +12,7 @@
 //!   [49..N)     String literal data ([len:i32][data:u8...] per string)
 //!   [N..)       Heap (bump allocator, grows upward)
 
+use crate::emit_wasm::engine::{Imm32, Local};
 #[macro_use]
 mod wasm_macro;
 
@@ -947,12 +948,12 @@ impl FuncCompiler<'_> {
         };
         if self.emitter.mutable_captures.contains(&id) {
             if let Some(&local_idx) = self.var_map.get(&id) {
-                wasm!(self.func, { local_get(local_idx); local_get(new_ptr); i32_store(0); });
+                wasm!(self.func, { local_get(Local(local_idx)); local_get(Local(new_ptr)); i32_store(0); });
             }
         } else if let Some(&local_idx) = self.var_map.get(&id) {
-            wasm!(self.func, { local_get(new_ptr); local_set(local_idx); });
+            wasm!(self.func, { local_get(Local(new_ptr)); local_set(Local(local_idx)); });
         } else if let Some((global_idx, _)) = self.lookup_global(almide_ir::VarId(id)) {
-            wasm!(self.func, { local_get(new_ptr); global_set(global_idx); });
+            wasm!(self.func, { local_get(Local(new_ptr)); global_set(global_idx); });
         } else {
             // #525 (A6): silently SKIPPING the write-back leaves the var
             // holding a stale pre-realloc pointer — this fn's own doc calls
@@ -980,7 +981,7 @@ impl FuncCompiler<'_> {
         if self.emitter.mutable_captures.contains(&id) { return; }
         let Some(&local_idx) = self.var_map.get(&id) else { return };
         let cow_check = self.emitter.rt.cow_check;
-        wasm!(self.func, { local_get(local_idx); call(cow_check); local_set(local_idx); });
+        wasm!(self.func, { local_get(Local(local_idx)); call(cow_check); local_set(Local(local_idx)); });
     }
 }
 
@@ -2265,7 +2266,7 @@ fn compile_test_runner(emitter: &mut WasmEmitter, tests: &[(u32, String)], init_
     for (func_idx, test_name) in tests {
         // Print test name
         let name_str = emitter.intern_string(&format!("test: {} ... ", test_name));
-        f.instruction(&wasm_encoder::Instruction::I32Const(name_str as i32));
+        wasm!(f, { i32_const(Imm32(name_str as i32)); });
         f.instruction(&wasm_encoder::Instruction::Call(emitter.rt.println_str));
 
         // Call the test function (it will trap on assert_eq failure)
@@ -2273,7 +2274,7 @@ fn compile_test_runner(emitter: &mut WasmEmitter, tests: &[(u32, String)], init_
 
         // If we get here, test passed
         let pass_str = emitter.intern_string("ok");
-        f.instruction(&wasm_encoder::Instruction::I32Const(pass_str as i32));
+        wasm!(f, { i32_const(Imm32(pass_str as i32)); });
         f.instruction(&wasm_encoder::Instruction::Call(emitter.rt.println_str));
     }
 
@@ -2446,21 +2447,21 @@ fn compile_variant_eq_funcs(emitter: &mut WasmEmitter, var_table: &almide_ir::Va
 
             // Compare tags
             wasm!(compiler.func, {
-                local_get(0); i32_load(0);
-                local_get(1); i32_load(0);
+                local_get(Local(0)); i32_load(0);
+                local_get(Local(1)); i32_load(0);
                 i32_ne;
-                if_empty; i32_const(0); return_; end;
+                if_empty; i32_const(Imm32(0)); return_; end;
             });
 
             // Branch on tag for each case
             let non_empty: Vec<_> = cases.iter().filter(|c| !c.fields.is_empty()).collect();
             if non_empty.is_empty() {
-                wasm!(compiler.func, { i32_const(1); });
+                wasm!(compiler.func, { i32_const(Imm32(1)); });
             } else {
                 for case in &non_empty {
                     wasm!(compiler.func, {
-                        local_get(0); i32_load(0);
-                        i32_const(case.tag as i32);
+                        local_get(Local(0)); i32_load(0);
+                        i32_const(Imm32(case.tag as i32));
                         i32_eq;
                         if_i32;
                     });
@@ -2468,9 +2469,9 @@ fn compile_variant_eq_funcs(emitter: &mut WasmEmitter, var_table: &almide_ir::Va
                     let mut offset = 4u32;
                     for (fi, (_, field_ty)) in case.fields.iter().enumerate() {
                         let field_size = values::byte_size(field_ty);
-                        wasm!(compiler.func, { local_get(0); });
+                        wasm!(compiler.func, { local_get(Local(0)); });
                         compiler.emit_load_at(field_ty, offset);
-                        wasm!(compiler.func, { local_get(1); });
+                        wasm!(compiler.func, { local_get(Local(1)); });
                         compiler.emit_load_at(field_ty, offset);
                         let ft = field_ty.clone();
                         compiler.emit_eq_typed(&ft);
@@ -2481,7 +2482,7 @@ fn compile_variant_eq_funcs(emitter: &mut WasmEmitter, var_table: &almide_ir::Va
                     }
                     wasm!(compiler.func, { else_; });
                 }
-                wasm!(compiler.func, { i32_const(1); }); // default: unit case → equal
+                wasm!(compiler.func, { i32_const(Imm32(1)); }); // default: unit case → equal
                 for _ in 0..non_empty.len() {
                     wasm!(compiler.func, { end; });
                 }
@@ -2805,7 +2806,7 @@ fn compile_repr_funcs(emitter: &mut WasmEmitter, var_table: &almide_ir::VarTable
 
             // Push the value pointer (param 0); the walk consumes it from the
             // stack and leaves the result string pointer (the return value).
-            wasm!(compiler.func, { local_get(0); });
+            wasm!(compiler.func, { local_get(Local(0)); });
             if is_variant {
                 compiler.emit_repr_variant(&ty);
             } else {

--- a/crates/almide-codegen/src/emit_wasm/rt_dec2flt.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_dec2flt.rs
@@ -14,6 +14,7 @@
 //! (handling subnormals and overflow→inf). Proven byte-identical to
 //! `str::parse::<f64>()` over 2.55M fuzzed + boundary inputs.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::{CompiledFunc, WasmEmitter};
 use super::rt_dragon::{BN_HDR, BN_STRIDE, NLIMBS};
 use wasm_encoder::ValType;
@@ -113,7 +114,7 @@ pub fn compile_helpers(emitter: &mut WasmEmitter) {
 /// Emit `return (-1)^neg · 0.0` reading `neg` from `neg_local`.
 fn emit_signed_zero_return(f: &mut Function, neg_local: u32) {
     wasm!(f, {
-        local_get(neg_local); if_f64; f64_const(-0.0); else_; f64_const(0.0); end;
+        local_get(Local(neg_local)); if_f64; f64_const(-0.0); else_; f64_const(0.0); end;
         return_;
     });
 }
@@ -121,18 +122,18 @@ fn emit_signed_zero_return(f: &mut Function, neg_local: u32) {
 /// Set the sign bit of the f64 in `bits_local` when `neg_local` is non-zero.
 fn emit_apply_sign(f: &mut Function, bits_local: u32, neg_local: u32) {
     wasm!(f, {
-        local_get(neg_local);
+        local_get(Local(neg_local));
         if_empty;
-          local_get(bits_local); i64_const(1); i64_const(SIGN_BIT); i64_shl; i64_or; local_set(bits_local);
+          local_get(Local(bits_local)); i64_const(Imm64(1)); i64_const(Imm64(SIGN_BIT)); i64_shl; i64_or; local_set(Local(bits_local));
         end;
     });
 }
 
 /// Emit `return (-1)^neg · inf`, using `bits_local` as scratch.
 fn emit_signed_inf_return(f: &mut Function, bits_local: u32, neg_local: u32) {
-    wasm!(f, { i64_const(INF_BITS); local_set(bits_local); });
+    wasm!(f, { i64_const(Imm64(INF_BITS)); local_set(Local(bits_local)); });
     emit_apply_sign(f, bits_local, neg_local);
-    wasm!(f, { local_get(bits_local); f64_reinterpret_i64; return_; });
+    wasm!(f, { local_get(Local(bits_local)); f64_reinterpret_i64; return_; });
 }
 
 /// `__bn_add_small(p, a)`: p += a (a: u32). Carry-propagates; appends a limb if needed.
@@ -141,27 +142,27 @@ fn compile_bn_add_small(emitter: &mut WasmEmitter) {
     // params: 0=p, 1=a | locals: 2=len, 3=i, 4=carry, 5=addr, 6=limb, 7=sum
     let mut f = Function::new([(6, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);   // len
-        i32_const(0); local_set(3);                 // i
-        local_get(1); local_set(4);                 // carry = a
+        local_get(Local(0)); i32_load(0); local_set(Local(2));   // len
+        i32_const(Imm32(0)); local_set(Local(3));                 // i
+        local_get(Local(1)); local_set(Local(4));                 // carry = a
         block_empty; loop_empty;
-          local_get(4); i32_eqz; br_if(1);          // carry == 0 → done
-          local_get(3); local_get(2); i32_ge_u; br_if(1); // i >= len → extend below
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(LIMB_BYTES); i32_mul; i32_add; local_set(5); // &limb[i]
-          local_get(5); i32_load(0); local_set(6);  // limb
-          local_get(6); local_get(4); i32_add; local_set(7); // sum (wraps)
-          local_get(5); local_get(7); i32_store(0);
-          local_get(7); local_get(6); i32_lt_u; local_set(4); // carry = unsigned overflow
-          local_get(3); i32_const(1); i32_add; local_set(3);
+          local_get(Local(4)); i32_eqz; br_if(1);          // carry == 0 → done
+          local_get(Local(3)); local_get(Local(2)); i32_ge_u; br_if(1); // i >= len → extend below
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(3)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add; local_set(Local(5)); // &limb[i]
+          local_get(Local(5)); i32_load(0); local_set(Local(6));  // limb
+          local_get(Local(6)); local_get(Local(4)); i32_add; local_set(Local(7)); // sum (wraps)
+          local_get(Local(5)); local_get(Local(7)); i32_store(0);
+          local_get(Local(7)); local_get(Local(6)); i32_lt_u; local_set(Local(4)); // carry = unsigned overflow
+          local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(3));
           br(0);
         end; end;
         // leftover carry → append a new limb
-        local_get(4); i32_eqz;
+        local_get(Local(4)); i32_eqz;
         if_empty;
         else_;
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(2); i32_const(LIMB_BYTES); i32_mul; i32_add;
-          local_get(4); i32_store(0);
-          local_get(0); local_get(2); i32_const(1); i32_add; i32_store(0);
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(2)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
+          local_get(Local(4)); i32_store(0);
+          local_get(Local(0)); local_get(Local(2)); i32_const(Imm32(1)); i32_add; i32_store(0);
         end;
         end;
     });
@@ -174,24 +175,24 @@ fn compile_bn_bit_len(emitter: &mut WasmEmitter) {
     // params: 0=p | locals: 1=i, 2=limb
     let mut f = Function::new([(2, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);    // i = len
+        local_get(Local(0)); i32_load(0); local_set(Local(1));    // i = len
         block_empty; loop_empty;
-          local_get(1); i32_eqz; br_if(1);          // i == 0 → 0
-          local_get(1); i32_const(1); i32_sub; local_set(1); // i--
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(1); i32_const(LIMB_BYTES); i32_mul; i32_add;
-          i32_load(0); local_set(2);                // limb
-          local_get(2); i32_eqz;
+          local_get(Local(1)); i32_eqz; br_if(1);          // i == 0 → 0
+          local_get(Local(1)); i32_const(Imm32(1)); i32_sub; local_set(Local(1)); // i--
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(1)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
+          i32_load(0); local_set(Local(2));                // limb
+          local_get(Local(2)); i32_eqz;
           if_empty;
           else_;
             // i*LIMB_BITS + (LIMB_BITS - clz(limb))  — bit index of the top set bit
-            local_get(1); i32_const(LIMB_BITS); i32_mul;
-            i32_const(LIMB_BITS); local_get(2); i32_clz; i32_sub;
+            local_get(Local(1)); i32_const(Imm32(LIMB_BITS)); i32_mul;
+            i32_const(Imm32(LIMB_BITS)); local_get(Local(2)); i32_clz; i32_sub;
             i32_add;
             return_;
           end;
           br(0);
         end; end;
-        i32_const(0);
+        i32_const(Imm32(0));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.decfloat.bn_bit_len, type_idx, f));
@@ -239,19 +240,19 @@ fn compile_dec2flt(emitter: &mut WasmEmitter) {
 
     // scratch = alloc(SCRATCH_SLOTS · BN_STRIDE); compute slot pointers.
     wasm!(f, {
-        i32_const(stride * SCRATCH_SLOTS); call(alloc); local_set(BASE);
-        local_get(BASE); i32_const(slot(SLOT_NUM)); i32_add; local_set(NUM);
-        local_get(BASE); i32_const(slot(SLOT_DEN)); i32_add; local_set(DEN);
-        local_get(BASE); i32_const(slot(SLOT_U)); i32_add; local_set(U);
-        local_get(BASE); i32_const(slot(SLOT_D)); i32_add; local_set(D);
-        local_get(BASE); i32_const(slot(SLOT_SHIFTED)); i32_add; local_set(SHIFTED);
-        local_get(BASE); i32_const(slot(SLOT_TWOREM)); i32_add; local_set(TWOREM);
+        i32_const(Imm32(stride * SCRATCH_SLOTS)); call(alloc); local_set(Local(BASE));
+        local_get(Local(BASE)); i32_const(Imm32(slot(SLOT_NUM))); i32_add; local_set(Local(NUM));
+        local_get(Local(BASE)); i32_const(Imm32(slot(SLOT_DEN))); i32_add; local_set(Local(DEN));
+        local_get(Local(BASE)); i32_const(Imm32(slot(SLOT_U))); i32_add; local_set(Local(U));
+        local_get(Local(BASE)); i32_const(Imm32(slot(SLOT_D))); i32_add; local_set(Local(D));
+        local_get(Local(BASE)); i32_const(Imm32(slot(SLOT_SHIFTED))); i32_add; local_set(Local(SHIFTED));
+        local_get(Local(BASE)); i32_const(Imm32(slot(SLOT_TWOREM))); i32_add; local_set(Local(TWOREM));
     });
 
     // Zero significand → ±0.
     wasm!(f, {
-        local_get(SIG); i32_load(0); i32_const(1); i32_eq;
-        local_get(SIG); i32_const(hdr); i32_add; i32_load(0); i32_eqz;
+        local_get(Local(SIG)); i32_load(0); i32_const(Imm32(1)); i32_eq;
+        local_get(Local(SIG)); i32_const(Imm32(hdr)); i32_add; i32_load(0); i32_eqz;
         i32_and;
         if_empty;
     });
@@ -260,9 +261,9 @@ fn compile_dec2flt(emitter: &mut WasmEmitter) {
 
     // num = sig ; den = 1.
     wasm!(f, {
-        local_get(NUM); local_get(SIG); call(d_copy);
-        local_get(DEN); i32_const(1); i32_store(0);
-        local_get(DEN); i32_const(hdr); i32_add; i32_const(1); i32_store(0);
+        local_get(Local(NUM)); local_get(Local(SIG)); call(d_copy);
+        local_get(Local(DEN)); i32_const(Imm32(1)); i32_store(0);
+        local_get(Local(DEN)); i32_const(Imm32(hdr)); i32_add; i32_const(Imm32(1)); i32_store(0);
     });
 
     // Scale: exp10 >= 0 → num *= 10^exp10 ; else den *= 10^(-exp10) (×10, |exp10| times).
@@ -270,33 +271,33 @@ fn compile_dec2flt(emitter: &mut WasmEmitter) {
     // is astronomically large → ±inf; if den would, it is astronomically small → ±0.
     // This also bounds huge exponents ("1e999999" → inf) without an unbounded loop.
     wasm!(f, {
-        local_get(EXP10); i32_const(0); i32_ge_s;
+        local_get(Local(EXP10)); i32_const(Imm32(0)); i32_ge_s;
         if_empty;
-          local_get(EXP10); local_set(E);
+          local_get(Local(EXP10)); local_set(Local(E));
           block_empty; loop_empty;
-            local_get(E); i32_eqz; br_if(1);
-            local_get(NUM); call(bn_blen); i32_const(BN_OVERFLOW_GUARD_BITS); i32_gt_s;
+            local_get(Local(E)); i32_eqz; br_if(1);
+            local_get(Local(NUM)); call(bn_blen); i32_const(Imm32(BN_OVERFLOW_GUARD_BITS)); i32_gt_s;
             if_empty;
     });
     emit_signed_inf_return(&mut f, BITS, NEG);
     wasm!(f, {
             end;
-            local_get(NUM); i32_const(DECIMAL_BASE); call(d_mul);
-            local_get(E); i32_const(1); i32_sub; local_set(E);
+            local_get(Local(NUM)); i32_const(Imm32(DECIMAL_BASE)); call(d_mul);
+            local_get(Local(E)); i32_const(Imm32(1)); i32_sub; local_set(Local(E));
             br(0);
           end; end;
         else_;
-          i32_const(0); local_get(EXP10); i32_sub; local_set(E);
+          i32_const(Imm32(0)); local_get(Local(EXP10)); i32_sub; local_set(Local(E));
           block_empty; loop_empty;
-            local_get(E); i32_eqz; br_if(1);
-            local_get(DEN); call(bn_blen); i32_const(BN_OVERFLOW_GUARD_BITS); i32_gt_s;
+            local_get(Local(E)); i32_eqz; br_if(1);
+            local_get(Local(DEN)); call(bn_blen); i32_const(Imm32(BN_OVERFLOW_GUARD_BITS)); i32_gt_s;
             if_empty;
     });
     emit_signed_zero_return(&mut f, NEG);
     wasm!(f, {
             end;
-            local_get(DEN); i32_const(DECIMAL_BASE); call(d_mul);
-            local_get(E); i32_const(1); i32_sub; local_set(E);
+            local_get(Local(DEN)); i32_const(Imm32(DECIMAL_BASE)); call(d_mul);
+            local_get(Local(E)); i32_const(Imm32(1)); i32_sub; local_set(Local(E));
             br(0);
           end; end;
         end;
@@ -304,117 +305,117 @@ fn compile_dec2flt(emitter: &mut WasmEmitter) {
 
     // e2 = bit_len(num) - bit_len(den).
     wasm!(f, {
-        local_get(NUM); call(bn_blen);
-        local_get(DEN); call(bn_blen);
-        i32_sub; local_set(E2);
+        local_get(Local(NUM)); call(bn_blen);
+        local_get(Local(DEN)); call(bn_blen);
+        i32_sub; local_set(Local(E2));
     });
 
     // ── AlgorithmM outer loop ──
     wasm!(f, {
         block_empty; loop_empty;
           // prec = MANT_BITS ; shift = e2 - MANT_FIELD_BITS
-          i32_const(MANT_BITS); local_set(PREC);
-          local_get(E2); i32_const(MANT_FIELD_BITS); i32_sub; local_set(SHIFT);
+          i32_const(Imm32(MANT_BITS)); local_set(Local(PREC));
+          local_get(Local(E2)); i32_const(Imm32(MANT_FIELD_BITS)); i32_sub; local_set(Local(SHIFT));
           // Subnormal: if shift < MIN_SUBNORMAL_SHIFT, pin shift and shrink precision.
-          local_get(SHIFT); i32_const(MIN_SUBNORMAL_SHIFT); i32_lt_s;
+          local_get(Local(SHIFT)); i32_const(Imm32(MIN_SUBNORMAL_SHIFT)); i32_lt_s;
           if_empty;
-            i32_const(MANT_BITS);
-            i32_const(MIN_SUBNORMAL_SHIFT); local_get(SHIFT); i32_sub;   // (MIN_SUBNORMAL_SHIFT - shift)
-            i32_sub; local_set(PREC);
-            i32_const(MIN_SUBNORMAL_SHIFT); local_set(SHIFT);
-            local_get(PREC); i32_const(0); i32_le_s;
-            if_empty; i32_const(0); local_set(PREC); end;
+            i32_const(Imm32(MANT_BITS));
+            i32_const(Imm32(MIN_SUBNORMAL_SHIFT)); local_get(Local(SHIFT)); i32_sub;   // (MIN_SUBNORMAL_SHIFT - shift)
+            i32_sub; local_set(Local(PREC));
+            i32_const(Imm32(MIN_SUBNORMAL_SHIFT)); local_set(Local(SHIFT));
+            local_get(Local(PREC)); i32_const(Imm32(0)); i32_le_s;
+            if_empty; i32_const(Imm32(0)); local_set(Local(PREC)); end;
           end;
           // u = num ; d = den ; scale by 2^shift
-          local_get(U); local_get(NUM); call(d_copy);
-          local_get(D); local_get(DEN); call(d_copy);
-          local_get(SHIFT); i32_const(0); i32_ge_s;
+          local_get(Local(U)); local_get(Local(NUM)); call(d_copy);
+          local_get(Local(D)); local_get(Local(DEN)); call(d_copy);
+          local_get(Local(SHIFT)); i32_const(Imm32(0)); i32_ge_s;
           if_empty;
-            local_get(D); local_get(SHIFT); call(d_shl);          // d <<= shift
+            local_get(Local(D)); local_get(Local(SHIFT)); call(d_shl);          // d <<= shift
           else_;
-            local_get(U); i32_const(0); local_get(SHIFT); i32_sub; call(d_shl); // u <<= -shift
+            local_get(Local(U)); i32_const(Imm32(0)); local_get(Local(SHIFT)); i32_sub; call(d_shl); // u <<= -shift
           end;
           // maxbits = max(prec + ROUND_GUARD_BITS, 1)
-          local_get(PREC); i32_const(ROUND_GUARD_BITS); i32_add; local_set(MAXBITS);
-          local_get(MAXBITS); i32_const(1); i32_lt_s;
-          if_empty; i32_const(1); local_set(MAXBITS); end;
+          local_get(Local(PREC)); i32_const(Imm32(ROUND_GUARD_BITS)); i32_add; local_set(Local(MAXBITS));
+          local_get(Local(MAXBITS)); i32_const(Imm32(1)); i32_lt_s;
+          if_empty; i32_const(Imm32(1)); local_set(Local(MAXBITS)); end;
           // m = 0 ; bit-by-bit long division (U holds the remainder)
-          i64_const(0); local_set(M);
-          local_get(MAXBITS); local_set(BIT);
+          i64_const(Imm64(0)); local_set(Local(M));
+          local_get(Local(MAXBITS)); local_set(Local(BIT));
           block_empty; loop_empty;
-            local_get(BIT); i32_eqz; br_if(1);
-            local_get(BIT); i32_const(1); i32_sub; local_set(BIT);
-            local_get(SHIFTED); local_get(D); call(d_copy);          // shifted = d
-            local_get(SHIFTED); local_get(BIT); call(d_shl);         // shifted <<= bit
-            local_get(U); local_get(SHIFTED); call(d_cmp); i32_const(0); i32_ge_s; // u >= shifted ?
+            local_get(Local(BIT)); i32_eqz; br_if(1);
+            local_get(Local(BIT)); i32_const(Imm32(1)); i32_sub; local_set(Local(BIT));
+            local_get(Local(SHIFTED)); local_get(Local(D)); call(d_copy);          // shifted = d
+            local_get(Local(SHIFTED)); local_get(Local(BIT)); call(d_shl);         // shifted <<= bit
+            local_get(Local(U)); local_get(Local(SHIFTED)); call(d_cmp); i32_const(Imm32(0)); i32_ge_s; // u >= shifted ?
             if_empty;
-              local_get(U); local_get(SHIFTED); call(d_sub);         // u -= shifted
-              local_get(M); i64_const(1); local_get(BIT); i64_extend_i32_u; i64_shl; i64_or; local_set(M); // m |= 1<<bit
+              local_get(Local(U)); local_get(Local(SHIFTED)); call(d_sub);         // u -= shifted
+              local_get(Local(M)); i64_const(Imm64(1)); local_get(Local(BIT)); i64_extend_i32_u; i64_shl; i64_or; local_set(Local(M)); // m |= 1<<bit
             end;
             br(0);
           end; end;
           // width correction for normals: keep m in [2^(MANT_BITS-1), 2^MANT_BITS)
-          local_get(PREC); i32_const(MANT_BITS); i32_eq;
+          local_get(Local(PREC)); i32_const(Imm32(MANT_BITS)); i32_eq;
           if_empty;
-            local_get(M); i64_const(SIGNIFICAND_LIMIT); i64_ge_u;            // m >= 2^53
-            if_empty; local_get(E2); i32_const(1); i32_add; local_set(E2); br(2); end;
-            local_get(M); i64_const(SIGNIFICAND_MSB); i64_lt_u;             // m < 2^52
-            local_get(E2); i32_const(MIN_NORMAL_EXP); i32_gt_s; i32_and;
-            if_empty; local_get(E2); i32_const(1); i32_sub; local_set(E2); br(2); end;
+            local_get(Local(M)); i64_const(Imm64(SIGNIFICAND_LIMIT)); i64_ge_u;            // m >= 2^53
+            if_empty; local_get(Local(E2)); i32_const(Imm32(1)); i32_add; local_set(Local(E2)); br(2); end;
+            local_get(Local(M)); i64_const(Imm64(SIGNIFICAND_MSB)); i64_lt_u;             // m < 2^52
+            local_get(Local(E2)); i32_const(Imm32(MIN_NORMAL_EXP)); i32_gt_s; i32_and;
+            if_empty; local_get(Local(E2)); i32_const(Imm32(1)); i32_sub; local_set(Local(E2)); br(2); end;
           end;
           // round half-even: two_rem = U<<1. Round up iff 2·rem > den, or 2·rem ==
           // den AND (the dropped-digit sticky bit is set OR m is odd). The sticky
           // bit breaks an otherwise-exact half-way tie upward (truncated input).
-          local_get(TWOREM); local_get(U); call(d_copy);
-          local_get(TWOREM); i32_const(1); call(d_shl);
-          local_get(TWOREM); local_get(D); call(d_cmp); local_set(C);
-          local_get(C); i32_const(0); i32_gt_s;          // 2·rem > den
-          local_get(C); i32_eqz;                          // 2·rem == den (tie)
-          local_get(STICKY);                              // sticky ...
-          local_get(M); i64_const(1); i64_and; i64_const(1); i64_eq;  // ... OR m odd
+          local_get(Local(TWOREM)); local_get(Local(U)); call(d_copy);
+          local_get(Local(TWOREM)); i32_const(Imm32(1)); call(d_shl);
+          local_get(Local(TWOREM)); local_get(Local(D)); call(d_cmp); local_set(Local(C));
+          local_get(Local(C)); i32_const(Imm32(0)); i32_gt_s;          // 2·rem > den
+          local_get(Local(C)); i32_eqz;                          // 2·rem == den (tie)
+          local_get(Local(STICKY));                              // sticky ...
+          local_get(Local(M)); i64_const(Imm64(1)); i64_and; i64_const(Imm64(1)); i64_eq;  // ... OR m odd
           i32_or;
           i32_and;
           i32_or;
-          if_empty; local_get(M); i64_const(1); i64_add; local_set(M); end;
+          if_empty; local_get(Local(M)); i64_const(Imm64(1)); i64_add; local_set(Local(M)); end;
           // m == 2^MANT_BITS after rounding (normal) → renormalize
-          local_get(PREC); i32_const(MANT_BITS); i32_eq;
-          local_get(M); i64_const(SIGNIFICAND_LIMIT); i64_eq;
+          local_get(Local(PREC)); i32_const(Imm32(MANT_BITS)); i32_eq;
+          local_get(Local(M)); i64_const(Imm64(SIGNIFICAND_LIMIT)); i64_eq;
           i32_and;
           if_empty;
-            local_get(M); i64_const(1); i64_shr_u; local_set(M);
-            local_get(E2); i32_const(1); i32_add; local_set(E2);
-            local_get(SHIFT); i32_const(1); i32_add; local_set(SHIFT);
+            local_get(Local(M)); i64_const(Imm64(1)); i64_shr_u; local_set(Local(M));
+            local_get(Local(E2)); i32_const(Imm32(1)); i32_add; local_set(Local(E2));
+            local_get(Local(SHIFT)); i32_const(Imm32(1)); i32_add; local_set(Local(SHIFT));
           end;
           // ── assemble f64 from (m, shift) ──
           // m == 0 → ±0
-          local_get(M); i64_eqz;
+          local_get(Local(M)); i64_eqz;
           if_empty;
     });
     emit_signed_zero_return(&mut f, NEG);
     wasm!(f, {
           end;
           // bits = (m >= 2^MANT_FIELD_BITS) ? normal : subnormal
-          local_get(M); i64_const(SIGNIFICAND_MSB); i64_ge_u;
+          local_get(Local(M)); i64_const(Imm64(SIGNIFICAND_MSB)); i64_ge_u;
           if_empty;
             // normal: exp_field = shift + EXP_FIELD_BIAS
-            local_get(SHIFT); i32_const(EXP_FIELD_BIAS); i32_add; local_set(EXP_FIELD);
-            local_get(EXP_FIELD); i32_const(INF_EXP_FIELD); i32_ge_s;
+            local_get(Local(SHIFT)); i32_const(Imm32(EXP_FIELD_BIAS)); i32_add; local_set(Local(EXP_FIELD));
+            local_get(Local(EXP_FIELD)); i32_const(Imm32(INF_EXP_FIELD)); i32_ge_s;
             if_empty;
     });
     emit_signed_inf_return(&mut f, BITS, NEG);
     wasm!(f, {
             end;
-            local_get(EXP_FIELD); i64_extend_i32_u; i64_const(MANT_FIELD_BITS as i64); i64_shl;
-            local_get(M); i64_const(MANTISSA_MASK); i64_and;
-            i64_or; local_set(BITS);
+            local_get(Local(EXP_FIELD)); i64_extend_i32_u; i64_const(Imm64(MANT_FIELD_BITS as i64)); i64_shl;
+            local_get(Local(M)); i64_const(Imm64(MANTISSA_MASK)); i64_and;
+            i64_or; local_set(Local(BITS));
           else_;
             // subnormal: exponent field is 0, the whole value is in the mantissa.
-            local_get(M); local_set(BITS);
+            local_get(Local(M)); local_set(Local(BITS));
           end;
     });
     emit_apply_sign(&mut f, BITS, NEG);
     wasm!(f, {
-          local_get(BITS); f64_reinterpret_i64; return_;
+          local_get(Local(BITS)); f64_reinterpret_i64; return_;
         end; end;
         // unreachable (the loop always returns)
         f64_const(0.0);

--- a/crates/almide-codegen/src/emit_wasm/rt_dragon.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_dragon.rs
@@ -23,6 +23,7 @@
 //! buffer. No `i64_trunc` of the value is ever performed, so arbitrary
 //! magnitude is handled without traps.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::{CompiledFunc, WasmEmitter};
 use super::rt_string::{string_data_off, string_hdr, string_cap_off};
 use wasm_encoder::ValType;
@@ -163,19 +164,19 @@ fn compile_norm(emitter: &mut WasmEmitter) {
     // param 0 = p ; local 1 = len
     let mut f = Function::new([(1, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
+        local_get(Local(0)); i32_load(0); local_set(Local(1));
         block_empty; loop_empty;
           // while len > 1 && limb[len-1] == 0 { len-- }
-          local_get(1); i32_const(1); i32_le_u; br_if(1);
+          local_get(Local(1)); i32_const(Imm32(1)); i32_le_u; br_if(1);
           // limb[len-1] at p + BN_HDR + (len-1)*4
-          local_get(0); i32_const(BN_HDR as i32); i32_add;
-          local_get(1); i32_const(1); i32_sub; i32_const(LIMB_BYTES); i32_mul; i32_add;
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add;
+          local_get(Local(1)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
           i32_load(0);
           br_if(1); // nonzero -> stop
-          local_get(1); i32_const(1); i32_sub; local_set(1);
+          local_get(Local(1)); i32_const(Imm32(1)); i32_sub; local_set(Local(1));
           br(0);
         end; end;
-        local_get(0); local_get(1); i32_store(0);
+        local_get(Local(0)); local_get(Local(1)); i32_store(0);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.norm, type_idx, f));
@@ -189,38 +190,38 @@ fn compile_mul_small(emitter: &mut WasmEmitter) {
         (1, ValType::I32), (1, ValType::I32), (1, ValType::I64), (1, ValType::I64),
     ]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        i32_const(0); local_set(3);
-        i64_const(0); local_set(4);
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        i32_const(Imm32(0)); local_set(Local(3));
+        i64_const(Imm64(0)); local_set(Local(4));
         block_empty; loop_empty;
-          local_get(3); local_get(2); i32_ge_u; br_if(1);
+          local_get(Local(3)); local_get(Local(2)); i32_ge_u; br_if(1);
           // prod = limb[i] * m + carry
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(LIMB_BYTES); i32_mul; i32_add;
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(3)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
           i32_load(0); i64_extend_i32_u;
-          local_get(1); i64_extend_i32_u;
+          local_get(Local(1)); i64_extend_i32_u;
           i64_mul;
-          local_get(4); i64_add;
-          local_set(5);
+          local_get(Local(4)); i64_add;
+          local_set(Local(5));
           // limb[i] = prod & 0xFFFFFFFF
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(LIMB_BYTES); i32_mul; i32_add;
-          local_get(5); i32_wrap_i64;
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(3)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
+          local_get(Local(5)); i32_wrap_i64;
           i32_store(0);
           // carry = prod >> 32
-          local_get(5); i64_const(LIMB_BITS_I64); i64_shr_u; local_set(4);
-          local_get(3); i32_const(1); i32_add; local_set(3);
+          local_get(Local(5)); i64_const(Imm64(LIMB_BITS_I64)); i64_shr_u; local_set(Local(4));
+          local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(3));
           br(0);
         end; end;
         // emit remaining carry limbs
         block_empty; loop_empty;
-          local_get(4); i64_eqz; br_if(1);
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(2); i32_const(LIMB_BYTES); i32_mul; i32_add;
-          local_get(4); i32_wrap_i64;
+          local_get(Local(4)); i64_eqz; br_if(1);
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(2)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
+          local_get(Local(4)); i32_wrap_i64;
           i32_store(0);
-          local_get(2); i32_const(1); i32_add; local_set(2);
-          local_get(4); i64_const(LIMB_BITS_I64); i64_shr_u; local_set(4);
+          local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
+          local_get(Local(4)); i64_const(Imm64(LIMB_BITS_I64)); i64_shr_u; local_set(Local(4));
           br(0);
         end; end;
-        local_get(0); local_get(2); i32_store(0);
+        local_get(Local(0)); local_get(Local(2)); i32_store(0);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.mul_small, type_idx, f));
@@ -234,31 +235,31 @@ fn compile_cmp(emitter: &mut WasmEmitter) {
         (1, ValType::I32), (1, ValType::I32), (1, ValType::I32), (1, ValType::I32), (1, ValType::I32),
     ]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(1); i32_load(0); local_set(3);
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(1)); i32_load(0); local_set(Local(3));
         // different lengths -> longer is larger
-        local_get(2); local_get(3); i32_ne;
+        local_get(Local(2)); local_get(Local(3)); i32_ne;
         if_empty;
-          local_get(2); local_get(3); i32_lt_u;
-          if_i32; i32_const(-1); else_; i32_const(1); end;
+          local_get(Local(2)); local_get(Local(3)); i32_lt_u;
+          if_i32; i32_const(Imm32(-1)); else_; i32_const(Imm32(1)); end;
           return_;
         end;
         // equal lengths: compare from MSD down
-        local_get(2); local_set(4); // i = len
+        local_get(Local(2)); local_set(Local(4)); // i = len
         block_empty; loop_empty;
-          local_get(4); i32_eqz; br_if(1);
-          local_get(4); i32_const(1); i32_sub; local_set(4);
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); local_set(5);
-          local_get(1); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); local_set(6);
-          local_get(5); local_get(6); i32_ne;
+          local_get(Local(4)); i32_eqz; br_if(1);
+          local_get(Local(4)); i32_const(Imm32(1)); i32_sub; local_set(Local(4));
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(4)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add; i32_load(0); local_set(Local(5));
+          local_get(Local(1)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(4)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add; i32_load(0); local_set(Local(6));
+          local_get(Local(5)); local_get(Local(6)); i32_ne;
           if_empty;
-            local_get(5); local_get(6); i32_lt_u;
-            if_i32; i32_const(-1); else_; i32_const(1); end;
+            local_get(Local(5)); local_get(Local(6)); i32_lt_u;
+            if_i32; i32_const(Imm32(-1)); else_; i32_const(Imm32(1)); end;
             return_;
           end;
           br(0);
         end; end;
-        i32_const(0);
+        i32_const(Imm32(0));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.cmp, type_idx, f));
@@ -273,42 +274,42 @@ fn compile_add(emitter: &mut WasmEmitter) {
         (1, ValType::I64), (1, ValType::I64),
     ]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(1); i32_load(0); local_set(3);
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(1)); i32_load(0); local_set(Local(3));
         // n = max(ld, ls)
-        local_get(2); local_get(3); i32_ge_u;
-        if_i32; local_get(2); else_; local_get(3); end;
-        local_set(4);
-        i32_const(0); local_set(5);
-        i64_const(0); local_set(6);
+        local_get(Local(2)); local_get(Local(3)); i32_ge_u;
+        if_i32; local_get(Local(2)); else_; local_get(Local(3)); end;
+        local_set(Local(4));
+        i32_const(Imm32(0)); local_set(Local(5));
+        i64_const(Imm64(0)); local_set(Local(6));
         block_empty; loop_empty;
-          local_get(5); local_get(4); i32_ge_u; br_if(1);
+          local_get(Local(5)); local_get(Local(4)); i32_ge_u; br_if(1);
           // a = (i < ld) ? dst.limb[i] : 0
-          local_get(5); local_get(2); i32_lt_u;
+          local_get(Local(5)); local_get(Local(2)); i32_lt_u;
           if_i64;
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
-          else_; i64_const(0); end;
+            local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(5)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
+          else_; i64_const(Imm64(0)); end;
           // b = (i < ls) ? src.limb[i] : 0
-          local_get(5); local_get(3); i32_lt_u;
+          local_get(Local(5)); local_get(Local(3)); i32_lt_u;
           if_i64;
-            local_get(1); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
-          else_; i64_const(0); end;
-          i64_add; local_get(6); i64_add; local_set(7);
+            local_get(Local(1)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(5)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
+          else_; i64_const(Imm64(0)); end;
+          i64_add; local_get(Local(6)); i64_add; local_set(Local(7));
           // dst.limb[i] = sum & 0xFFFFFFFF
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add;
-          local_get(7); i32_wrap_i64; i32_store(0);
-          local_get(7); i64_const(LIMB_BITS_I64); i64_shr_u; local_set(6);
-          local_get(5); i32_const(1); i32_add; local_set(5);
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(5)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
+          local_get(Local(7)); i32_wrap_i64; i32_store(0);
+          local_get(Local(7)); i64_const(Imm64(LIMB_BITS_I64)); i64_shr_u; local_set(Local(6));
+          local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5));
           br(0);
         end; end;
         // final carry
-        local_get(6); i64_eqz; i32_eqz;
+        local_get(Local(6)); i64_eqz; i32_eqz;
         if_empty;
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(LIMB_BYTES); i32_mul; i32_add;
-          local_get(6); i32_wrap_i64; i32_store(0);
-          local_get(4); i32_const(1); i32_add; local_set(4);
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(4)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
+          local_get(Local(6)); i32_wrap_i64; i32_store(0);
+          local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
         end;
-        local_get(0); local_get(4); i32_store(0);
+        local_get(Local(0)); local_get(Local(4)); i32_store(0);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.add, type_idx, f));
@@ -323,33 +324,33 @@ fn compile_sub(emitter: &mut WasmEmitter) {
         (1, ValType::I64), (1, ValType::I64),
     ]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(1); i32_load(0); local_set(3);
-        i32_const(0); local_set(4);
-        i64_const(0); local_set(5);
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(1)); i32_load(0); local_set(Local(3));
+        i32_const(Imm32(0)); local_set(Local(4));
+        i64_const(Imm64(0)); local_set(Local(5));
         block_empty; loop_empty;
-          local_get(4); local_get(2); i32_ge_u; br_if(1);
+          local_get(Local(4)); local_get(Local(2)); i32_ge_u; br_if(1);
           // diff = dst.limb[i] - (i<ls? src.limb[i] : 0) - borrow
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
-          local_get(4); local_get(3); i32_lt_u;
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(4)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
+          local_get(Local(4)); local_get(Local(3)); i32_lt_u;
           if_i64;
-            local_get(1); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
-          else_; i64_const(0); end;
-          i64_sub; local_get(5); i64_sub; local_set(6);
+            local_get(Local(1)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(4)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
+          else_; i64_const(Imm64(0)); end;
+          i64_sub; local_get(Local(5)); i64_sub; local_set(Local(6));
           // if diff < 0 (high bit set since we extended u32): diff += 2^32, borrow=1
-          local_get(6); i64_const(0); i64_lt_s;
+          local_get(Local(6)); i64_const(Imm64(0)); i64_lt_s;
           if_empty;
-            local_get(6); i64_const(CARRY_WRAP); i64_add; local_set(6);
-            i64_const(1); local_set(5);
+            local_get(Local(6)); i64_const(Imm64(CARRY_WRAP)); i64_add; local_set(Local(6));
+            i64_const(Imm64(1)); local_set(Local(5));
           else_;
-            i64_const(0); local_set(5);
+            i64_const(Imm64(0)); local_set(Local(5));
           end;
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(LIMB_BYTES); i32_mul; i32_add;
-          local_get(6); i32_wrap_i64; i32_store(0);
-          local_get(4); i32_const(1); i32_add; local_set(4);
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(4)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
+          local_get(Local(6)); i32_wrap_i64; i32_store(0);
+          local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
           br(0);
         end; end;
-        local_get(0); call(emitter.rt.dragon.norm);
+        local_get(Local(0)); call(emitter.rt.dragon.norm);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.sub, type_idx, f));
@@ -364,59 +365,59 @@ fn compile_shl(emitter: &mut WasmEmitter) {
         (1, ValType::I32), (1, ValType::I32), (1, ValType::I32),
     ]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(1); i32_const(LIMB_BITS_I32); i32_div_u; local_set(3); // limb_shift
-        local_get(1); i32_const(LIMB_BITS_I32); i32_rem_u; local_set(4); // bit_shift
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(1)); i32_const(Imm32(LIMB_BITS_I32)); i32_div_u; local_set(Local(3)); // limb_shift
+        local_get(Local(1)); i32_const(Imm32(LIMB_BITS_I32)); i32_rem_u; local_set(Local(4)); // bit_shift
         // limb shift: move limbs up by limb_shift, zero the low ones
-        local_get(3); i32_eqz; i32_eqz;
+        local_get(Local(3)); i32_eqz; i32_eqz;
         if_empty;
           // i = len; while i>0 { i--; limb[i+ls] = limb[i] }
-          local_get(2); local_set(5);
+          local_get(Local(2)); local_set(Local(5));
           block_empty; loop_empty;
-            local_get(5); i32_eqz; br_if(1);
-            local_get(5); i32_const(1); i32_sub; local_set(5);
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); local_get(3); i32_add; i32_const(LIMB_BYTES); i32_mul; i32_add;
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0);
+            local_get(Local(5)); i32_eqz; br_if(1);
+            local_get(Local(5)); i32_const(Imm32(1)); i32_sub; local_set(Local(5));
+            local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(5)); local_get(Local(3)); i32_add; i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
+            local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(5)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add; i32_load(0);
             i32_store(0);
             br(0);
           end; end;
           // zero low limb_shift limbs
-          i32_const(0); local_set(5);
+          i32_const(Imm32(0)); local_set(Local(5));
           block_empty; loop_empty;
-            local_get(5); local_get(3); i32_ge_u; br_if(1);
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add;
-            i32_const(0); i32_store(0);
-            local_get(5); i32_const(1); i32_add; local_set(5);
+            local_get(Local(5)); local_get(Local(3)); i32_ge_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(5)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
+            i32_const(Imm32(0)); i32_store(0);
+            local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5));
             br(0);
           end; end;
-          local_get(2); local_get(3); i32_add; local_set(2);
+          local_get(Local(2)); local_get(Local(3)); i32_add; local_set(Local(2));
         end;
         // bit shift within limbs
-        local_get(4); i32_eqz; i32_eqz;
+        local_get(Local(4)); i32_eqz; i32_eqz;
         if_empty;
-          i32_const(0); local_set(6); // carry
-          local_get(3); local_set(5); // i = limb_shift
+          i32_const(Imm32(0)); local_set(Local(6)); // carry
+          local_get(Local(3)); local_set(Local(5)); // i = limb_shift
           block_empty; loop_empty;
-            local_get(5); local_get(2); i32_ge_u; br_if(1);
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); local_set(7);
+            local_get(Local(5)); local_get(Local(2)); i32_ge_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(5)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add; i32_load(0); local_set(Local(7));
             // limb[i] = (v << bit_shift) | carry
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add;
-            local_get(7); local_get(4); i32_shl; local_get(6); i32_or;
+            local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(5)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
+            local_get(Local(7)); local_get(Local(4)); i32_shl; local_get(Local(6)); i32_or;
             i32_store(0);
             // carry = v >> (32 - bit_shift)
-            local_get(7); i32_const(LIMB_BITS_I32); local_get(4); i32_sub; i32_shr_u; local_set(6);
-            local_get(5); i32_const(1); i32_add; local_set(5);
+            local_get(Local(7)); i32_const(Imm32(LIMB_BITS_I32)); local_get(Local(4)); i32_sub; i32_shr_u; local_set(Local(6));
+            local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5));
             br(0);
           end; end;
-          local_get(6); i32_eqz; i32_eqz;
+          local_get(Local(6)); i32_eqz; i32_eqz;
           if_empty;
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(2); i32_const(LIMB_BYTES); i32_mul; i32_add;
-            local_get(6); i32_store(0);
-            local_get(2); i32_const(1); i32_add; local_set(2);
+            local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(2)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
+            local_get(Local(6)); i32_store(0);
+            local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
           end;
         end;
-        local_get(0); local_get(2); i32_store(0);
-        local_get(0); call(emitter.rt.dragon.norm);
+        local_get(Local(0)); local_get(Local(2)); i32_store(0);
+        local_get(Local(0)); call(emitter.rt.dragon.norm);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.dragon.shl, type_idx, f));
@@ -428,15 +429,15 @@ fn compile_copy(emitter: &mut WasmEmitter) {
     // params: 0=dst, 1=src | local 2=len, 3=i
     let mut f = Function::new([(1, ValType::I32), (1, ValType::I32)]);
     wasm!(f, {
-        local_get(1); i32_load(0); local_set(2);
-        local_get(0); local_get(2); i32_store(0);
-        i32_const(0); local_set(3);
+        local_get(Local(1)); i32_load(0); local_set(Local(2));
+        local_get(Local(0)); local_get(Local(2)); i32_store(0);
+        i32_const(Imm32(0)); local_set(Local(3));
         block_empty; loop_empty;
-          local_get(3); local_get(2); i32_ge_u; br_if(1);
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(LIMB_BYTES); i32_mul; i32_add;
-          local_get(1); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0);
+          local_get(Local(3)); local_get(Local(2)); i32_ge_u; br_if(1);
+          local_get(Local(0)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(3)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add;
+          local_get(Local(1)); i32_const(Imm32(BN_HDR as i32)); i32_add; local_get(Local(3)); i32_const(Imm32(LIMB_BYTES)); i32_mul; i32_add; i32_load(0);
           i32_store(0);
-          local_get(3); i32_const(1); i32_add; local_set(3);
+          local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(3));
           br(0);
         end; end;
         end;
@@ -508,7 +509,7 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     // ── Special cases: NaN / inf / zero ──
     // bits = reinterpret(x); exp field; mant field.
     wasm!(f, {
-        local_get(0); i64_reinterpret_f64; local_set(2);
+        local_get(Local(0)); i64_reinterpret_f64; local_set(Local(2));
     });
     // NaN: exp==0x7FF && mant!=0  → "NaN"
     let s_nan = emitter.intern_string("NaN");
@@ -518,66 +519,66 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     let s_nzero = emitter.intern_string("-0.0");
     wasm!(f, {
         // exp = (bits >> 52) & 0x7FF
-        local_get(2); i64_const(F64_MANTISSA_BITS); i64_shr_u; i32_wrap_i64; i32_const(F64_EXP_MASK); i32_and; local_set(3);
+        local_get(Local(2)); i64_const(Imm64(F64_MANTISSA_BITS)); i64_shr_u; i32_wrap_i64; i32_const(Imm32(F64_EXP_MASK)); i32_and; local_set(Local(3));
         // raw_mant = bits & 0xF_FFFF_FFFF_FFFF
-        local_get(2); i64_const(F64_MANT_MASK); i64_and; local_set(4);
+        local_get(Local(2)); i64_const(Imm64(F64_MANT_MASK)); i64_and; local_set(Local(4));
         // if exp == 0x7FF: NaN or inf
-        local_get(3); i32_const(F64_EXP_MASK); i32_eq;
+        local_get(Local(3)); i32_const(Imm32(F64_EXP_MASK)); i32_eq;
         if_empty;
-          local_get(4); i64_eqz; i32_eqz;
+          local_get(Local(4)); i64_eqz; i32_eqz;
           if_empty;
-            i32_const(s_nan as i32); return_;
+            i32_const(Imm32(s_nan as i32)); return_;
           end;
           // inf: sign bit
-          local_get(2); i64_const(0); i64_lt_s;
-          if_i32; i32_const(s_ninf as i32); else_; i32_const(s_inf as i32); end;
+          local_get(Local(2)); i64_const(Imm64(0)); i64_lt_s;
+          if_i32; i32_const(Imm32(s_ninf as i32)); else_; i32_const(Imm32(s_inf as i32)); end;
           return_;
         end;
     });
     // zero: x == 0.0 (covers +0 and -0). Sign from bit 63.
     wasm!(f, {
-        local_get(0); f64_const(0.0); f64_eq;
+        local_get(Local(0)); f64_const(0.0); f64_eq;
         if_empty;
-          local_get(2); i64_const(0); i64_lt_s;
-          if_i32; i32_const(s_nzero as i32); else_; i32_const(s_zero as i32); end;
+          local_get(Local(2)); i64_const(Imm64(0)); i64_lt_s;
+          if_i32; i32_const(Imm32(s_nzero as i32)); else_; i32_const(Imm32(s_zero as i32)); end;
           return_;
         end;
     });
 
     // neg = sign bit
     wasm!(f, {
-        local_get(2); i64_const(0); i64_lt_s; local_set(11);
+        local_get(Local(2)); i64_const(Imm64(0)); i64_lt_s; local_set(Local(11));
     });
 
     // Work with |x|: clear sign bit.
     wasm!(f, {
-        local_get(2); i64_const(F64_ABS_MASK); i64_and; local_set(2);
+        local_get(Local(2)); i64_const(Imm64(F64_ABS_MASK)); i64_and; local_set(Local(2));
         // re-extract exp/mant from |bits| (exp/mant already sign-independent, but recompute mant cleanly)
-        local_get(2); i64_const(F64_MANTISSA_BITS); i64_shr_u; i32_wrap_i64; i32_const(F64_EXP_MASK); i32_and; local_set(3);
-        local_get(2); i64_const(F64_MANT_MASK); i64_and; local_set(4);
+        local_get(Local(2)); i64_const(Imm64(F64_MANTISSA_BITS)); i64_shr_u; i32_wrap_i64; i32_const(Imm32(F64_EXP_MASK)); i32_and; local_set(Local(3));
+        local_get(Local(2)); i64_const(Imm64(F64_MANT_MASK)); i64_and; local_set(Local(4));
     });
 
     // Decompose: if exp==0 (subnormal): f=raw_mant, e=-1074
     //            else:                  f=raw_mant + 2^52, e=exp-1075
     wasm!(f, {
-        local_get(3); i32_eqz;
+        local_get(Local(3)); i32_eqz;
         if_empty;
-          local_get(4); local_set(5);
-          i32_const(F64_SUBNORMAL_EXP); local_set(6);
+          local_get(Local(4)); local_set(Local(5));
+          i32_const(Imm32(F64_SUBNORMAL_EXP)); local_set(Local(6));
         else_;
-          local_get(4); i64_const(F64_IMPLICIT_BIT); i64_add; local_set(5);
-          local_get(3); i32_const(F64_EXP_BIAS_OFFSET); i32_sub; local_set(6);
+          local_get(Local(4)); i64_const(Imm64(F64_IMPLICIT_BIT)); i64_add; local_set(Local(5));
+          local_get(Local(3)); i32_const(Imm32(F64_EXP_BIAS_OFFSET)); i32_sub; local_set(Local(6));
         end;
         // even = (f & 1) == 0
-        local_get(5); i64_const(1); i64_and; i64_eqz; local_set(8);
+        local_get(Local(5)); i64_const(Imm64(1)); i64_and; i64_eqz; local_set(Local(8));
         // low_bnd = raw_mant == 0 && exp > 1
-        local_get(4); i64_eqz; local_get(3); i32_const(1); i32_gt_s; i32_and; local_set(9);
+        local_get(Local(4)); i64_eqz; local_get(Local(3)); i32_const(Imm32(1)); i32_gt_s; i32_and; local_set(Local(9));
     });
 
     // Allocate scratch block.
     wasm!(f, {
-        i32_const(SCRATCH_BYTES as i32); call(emitter.rt.alloc); local_set(1);
-        local_get(1); i32_const(OFF_DIGITS as i32); i32_add; local_set(20);
+        i32_const(Imm32(SCRATCH_BYTES as i32)); call(emitter.rt.alloc); local_set(Local(1));
+        local_get(Local(1)); i32_const(Imm32(OFF_DIGITS as i32)); i32_add; local_set(Local(20));
     });
 
     // ── Initialize R, S, MP, MM as bignums set to f and 1 ──
@@ -588,7 +589,7 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     if true {
         // e >= 0 branch vs e < 0 branch
         wasm!(f, {
-            local_get(6); i32_const(0); i32_ge_s;
+            local_get(Local(6)); i32_const(Imm32(0)); i32_ge_s;
             if_empty;
         });
         // R = f << (e+1); S = 2; MP = 2^e; MM = 2^e
@@ -613,7 +614,7 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     }
     // low boundary: MP <<= 1; R <<= 1; S <<= 1
     wasm!(f, {
-        local_get(9);
+        local_get(Local(9));
         if_empty;
     });
     dr.shl_const(&mut f, OFF_MP, 1);
@@ -626,40 +627,40 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     // The fixup loops below correct any off-by-one in this estimate, so its
     // only requirement is to be close — exactness is not needed.
     wasm!(f, {
-        local_get(5); f64_convert_i64_u;
+        local_get(Local(5)); f64_convert_i64_u;
         call(emitter.rt.math_log10);
-        local_get(6); f64_convert_i32_s; f64_const(LOG10_2); f64_mul;
+        local_get(Local(6)); f64_convert_i32_s; f64_const(LOG10_2); f64_mul;
         f64_add;
         f64_ceil;
         // k = (i32) ceil(approx). k is in [-324, 309]; trunc-toward-zero is safe.
     });
     f.instruction(&wasm_encoder::Instruction::I32TruncF64S);
-    wasm!(f, { local_set(7); });
+    wasm!(f, { local_set(Local(7)); });
 
     // ── Scale: if k>=0 S *= 10^k else R,MP,MM *= 10^(-k) ──
     // loop k times
     wasm!(f, {
-        local_get(7); i32_const(0); i32_ge_s;
+        local_get(Local(7)); i32_const(Imm32(0)); i32_ge_s;
         if_empty;
-          i32_const(0); local_set(16);
+          i32_const(Imm32(0)); local_set(Local(16));
           block_empty; loop_empty;
-            local_get(16); local_get(7); i32_ge_s; br_if(1);
+            local_get(Local(16)); local_get(Local(7)); i32_ge_s; br_if(1);
     });
     dr.mul10(&mut f, OFF_S);
     wasm!(f, {
-            local_get(16); i32_const(1); i32_add; local_set(16);
+            local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
             br(0);
           end; end;
         else_;
-          i32_const(0); local_set(16);
+          i32_const(Imm32(0)); local_set(Local(16));
           block_empty; loop_empty;
-            local_get(16); i32_const(0); local_get(7); i32_sub; i32_ge_s; br_if(1);
+            local_get(Local(16)); i32_const(Imm32(0)); local_get(Local(7)); i32_sub; i32_ge_s; br_if(1);
     });
     dr.mul10(&mut f, OFF_R);
     dr.mul10(&mut f, OFF_MP);
     dr.mul10(&mut f, OFF_MM);
     wasm!(f, {
-            local_get(16); i32_const(1); i32_add; local_set(16);
+            local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
             br(0);
           end; end;
         end;
@@ -680,7 +681,7 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     });
     dr.mul10(&mut f, OFF_S);
     wasm!(f, {
-        local_get(7); i32_const(1); i32_add; local_set(7);
+        local_get(Local(7)); i32_const(Imm32(1)); i32_add; local_set(Local(7));
         br(0);
         end; end;
     });
@@ -703,14 +704,14 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     dr.mul10(&mut f, OFF_MP);
     dr.mul10(&mut f, OFF_MM);
     wasm!(f, {
-        local_get(7); i32_const(1); i32_sub; local_set(7);
+        local_get(Local(7)); i32_const(Imm32(1)); i32_sub; local_set(Local(7));
         br(0);
         end; end;
     });
 
     // ── Digit generation loop ──
     wasm!(f, {
-        i32_const(0); local_set(10); // dlen = 0
+        i32_const(Imm32(0)); local_set(Local(10)); // dlen = 0
         block_empty; loop_empty;     // [outer block (1)] [loop (0)]
     });
     dr.mul10(&mut f, OFF_R);
@@ -718,37 +719,37 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     dr.mul10(&mut f, OFF_MM);
     // d = 0; while cmp(R,S) >= 0 { R -= S; d++ }
     wasm!(f, {
-        i32_const(0); local_set(12);
+        i32_const(Imm32(0)); local_set(Local(12));
         block_empty; loop_empty;
     });
     dr.cmp(&mut f, OFF_R, OFF_S);
     wasm!(f, {
-          i32_const(0); i32_lt_s; br_if(1); // c < 0 -> stop
+          i32_const(Imm32(0)); i32_lt_s; br_if(1); // c < 0 -> stop
     });
     dr.sub(&mut f, OFF_R, OFF_S);
     wasm!(f, {
-          local_get(12); i32_const(1); i32_add; local_set(12);
+          local_get(Local(12)); i32_const(Imm32(1)); i32_add; local_set(Local(12));
           br(0);
         end; end;
     });
     // low_t = even ? cmp(R,MM)<=0 : cmp(R,MM)<0
     dr.cmp_set(&mut f, OFF_R, OFF_MM);
     dr.pred_le_lt(&mut f);
-    wasm!(f, { local_set(13); });
+    wasm!(f, { local_set(Local(13)); });
     // high_t = even ? cmp(R+MP,S)>=0 : cmp(R+MP,S)>0
     dr.copy(&mut f, OFF_TMP, OFF_R);
     dr.add(&mut f, OFF_TMP, OFF_MP);
     dr.cmp_set(&mut f, OFF_TMP, OFF_S);
     dr.pred_ge_gt(&mut f);
-    wasm!(f, { local_set(14); });
+    wasm!(f, { local_set(Local(14)); });
     // if !low_t && !high_t: emit d, continue
     wasm!(f, {
-        local_get(13); i32_eqz; local_get(14); i32_eqz; i32_and;
+        local_get(Local(13)); i32_eqz; local_get(Local(14)); i32_eqz; i32_and;
         if_empty;
           // digits[dlen] = '0'+d ; dlen++
-          local_get(20); local_get(10); i32_add;
-          local_get(12); i32_const(ASCII_ZERO); i32_add; i32_store8(0);
-          local_get(10); i32_const(1); i32_add; local_set(10);
+          local_get(Local(20)); local_get(Local(10)); i32_add;
+          local_get(Local(12)); i32_const(Imm32(ASCII_ZERO)); i32_add; i32_store8(0);
+          local_get(Local(10)); i32_const(Imm32(1)); i32_add; local_set(Local(10));
           br(1); // continue outer loop
         end;
     });
@@ -757,13 +758,13 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     // elif high_t && !low_t: round_up=1
     // else: round_up = (2R cmp S) >= 0
     wasm!(f, {
-        local_get(13); local_get(14); i32_eqz; i32_and;
+        local_get(Local(13)); local_get(Local(14)); i32_eqz; i32_and;
         if_empty;
-          i32_const(0); local_set(15);
+          i32_const(Imm32(0)); local_set(Local(15));
         else_;
-          local_get(14); local_get(13); i32_eqz; i32_and;
+          local_get(Local(14)); local_get(Local(13)); i32_eqz; i32_and;
           if_empty;
-            i32_const(1); local_set(15);
+            i32_const(Imm32(1)); local_set(Local(15));
           else_;
     });
     // 2R cmp S
@@ -771,51 +772,51 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     dr.shl_const(&mut f, OFF_TMP, 1);
     dr.cmp(&mut f, OFF_TMP, OFF_S);
     wasm!(f, {
-            i32_const(0); i32_ge_s; local_set(15);
+            i32_const(Imm32(0)); i32_ge_s; local_set(Local(15));
           end;
         end;
     });
     // digits[dlen] = '0'+d ; dlen++
     wasm!(f, {
-        local_get(20); local_get(10); i32_add;
-        local_get(12); i32_const(ASCII_ZERO); i32_add; i32_store8(0);
-        local_get(10); i32_const(1); i32_add; local_set(10);
+        local_get(Local(20)); local_get(Local(10)); i32_add;
+        local_get(Local(12)); i32_const(Imm32(ASCII_ZERO)); i32_add; i32_store8(0);
+        local_get(Local(10)); i32_const(Imm32(1)); i32_add; local_set(Local(10));
     });
     // if round_up: propagate carry from the last digit
     wasm!(f, {
-        local_get(15);
+        local_get(Local(15));
         if_empty;
           // i = dlen
-          local_get(10); local_set(22);
+          local_get(Local(10)); local_set(Local(22));
           block_empty; loop_empty;
             // if i == 0: prepend '1', k++, break
-            local_get(22); i32_eqz;
+            local_get(Local(22)); i32_eqz;
             if_empty;
               // shift digits right by 1: memmove digits[0..dlen] -> digits[1..dlen+1]
     });
     // memory.copy(dst=dp+1, src=dp, len=dlen)
     wasm!(f, {
-              local_get(20); i32_const(1); i32_add;
-              local_get(20);
-              local_get(10);
+              local_get(Local(20)); i32_const(Imm32(1)); i32_add;
+              local_get(Local(20));
+              local_get(Local(10));
               memory_copy;
-              local_get(20); i32_const(ASCII_ONE); i32_store8(0); // '1'
-              local_get(10); i32_const(1); i32_add; local_set(10);
-              local_get(7); i32_const(1); i32_add; local_set(7);
+              local_get(Local(20)); i32_const(Imm32(ASCII_ONE)); i32_store8(0); // '1'
+              local_get(Local(10)); i32_const(Imm32(1)); i32_add; local_set(Local(10));
+              local_get(Local(7)); i32_const(Imm32(1)); i32_add; local_set(Local(7));
               br(2); // break carry loop
             end;
             // i--
-            local_get(22); i32_const(1); i32_sub; local_set(22);
+            local_get(Local(22)); i32_const(Imm32(1)); i32_sub; local_set(Local(22));
             // if digits[i] == '9': set '0', continue loop; else digits[i]++, break.
             // Depths from inside this if/else: if-block=0, loop=1, block=2.
-            local_get(20); local_get(22); i32_add; i32_load8_u(0);
-            i32_const(ASCII_NINE); i32_eq; // '9'
+            local_get(Local(20)); local_get(Local(22)); i32_add; i32_load8_u(0);
+            i32_const(Imm32(ASCII_NINE)); i32_eq; // '9'
             if_empty;
-              local_get(20); local_get(22); i32_add; i32_const(ASCII_ZERO); i32_store8(0);
+              local_get(Local(20)); local_get(Local(22)); i32_add; i32_const(Imm32(ASCII_ZERO)); i32_store8(0);
               br(1); // continue carry loop
             else_;
-              local_get(20); local_get(22); i32_add;
-              local_get(20); local_get(22); i32_add; i32_load8_u(0); i32_const(1); i32_add;
+              local_get(Local(20)); local_get(Local(22)); i32_add;
+              local_get(Local(20)); local_get(Local(22)); i32_add; i32_load8_u(0); i32_const(Imm32(1)); i32_add;
               i32_store8(0);
               br(2); // break carry loop
             end;
@@ -838,146 +839,146 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     // result buffer: string header then data. We compute total data len, alloc,
     // then write characters sequentially using a cursor.
     wasm!(f, {
-        local_get(10); local_set(21); // m = dlen (alias)
+        local_get(Local(10)); local_set(Local(21)); // m = dlen (alias)
     });
 
     // Compute out_len into local 19.
     wasm!(f, {
         // start with neg
-        local_get(11);
+        local_get(Local(11));
         // + branch
-        local_get(7); i32_const(0); i32_le_s;
+        local_get(Local(7)); i32_const(Imm32(0)); i32_le_s;
         if_i32;
           // 2 + (-k) + m
-          i32_const(ZERO_DOT_LEN); i32_const(0); local_get(7); i32_sub; i32_add; local_get(21); i32_add;
+          i32_const(Imm32(ZERO_DOT_LEN)); i32_const(Imm32(0)); local_get(Local(7)); i32_sub; i32_add; local_get(Local(21)); i32_add;
         else_;
-          local_get(7); local_get(21); i32_ge_s;
+          local_get(Local(7)); local_get(Local(21)); i32_ge_s;
           if_i32;
             // m + (k-m) + 2  == k + 2
-            local_get(7); i32_const(ZERO_DOT_LEN); i32_add;
+            local_get(Local(7)); i32_const(Imm32(ZERO_DOT_LEN)); i32_add;
           else_;
             // m + 1
-            local_get(21); i32_const(1); i32_add;
+            local_get(Local(21)); i32_const(Imm32(1)); i32_add;
           end;
         end;
         i32_add;
-        local_set(19);
+        local_set(Local(19));
     });
 
     // Alloc string: header + out_len, set len & cap.
     wasm!(f, {
-        local_get(19); i32_const(string_hdr() as i32); i32_add;
-        call(emitter.rt.alloc); local_set(18);
-        local_get(18); local_get(19); i32_store(0);
-        local_get(18); local_get(19); i32_store(string_cap_off() as u32, 0);
+        local_get(Local(19)); i32_const(Imm32(string_hdr() as i32)); i32_add;
+        call(emitter.rt.alloc); local_set(Local(18));
+        local_get(Local(18)); local_get(Local(19)); i32_store(0);
+        local_get(Local(18)); local_get(Local(19)); i32_store(string_cap_off() as u32, 0);
     });
 
     // Write characters. Use local 16 as write cursor (byte offset from data start),
     // local 22 as a scratch index.
     wasm!(f, {
-        i32_const(0); local_set(16); // cursor
+        i32_const(Imm32(0)); local_set(Local(16)); // cursor
         // sign
-        local_get(11);
+        local_get(Local(11));
         if_empty;
-          local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-          i32_const(ASCII_MINUS); i32_store8(0); // '-'
-          local_get(16); i32_const(1); i32_add; local_set(16);
+          local_get(Local(18)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(16)); i32_add;
+          i32_const(Imm32(ASCII_MINUS)); i32_store8(0); // '-'
+          local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
         end;
     });
 
     // Branch on k.
     wasm!(f, {
-        local_get(7); i32_const(0); i32_le_s;
+        local_get(Local(7)); i32_const(Imm32(0)); i32_le_s;
         if_empty;
           // "0." then (-k) zeros then digits
-          local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-          i32_const(ASCII_ZERO); i32_store8(0); // '0'
-          local_get(16); i32_const(1); i32_add; local_set(16);
-          local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-          i32_const(ASCII_DOT); i32_store8(0); // '.'
-          local_get(16); i32_const(1); i32_add; local_set(16);
+          local_get(Local(18)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(16)); i32_add;
+          i32_const(Imm32(ASCII_ZERO)); i32_store8(0); // '0'
+          local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
+          local_get(Local(18)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(16)); i32_add;
+          i32_const(Imm32(ASCII_DOT)); i32_store8(0); // '.'
+          local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
           // (-k) zeros
-          i32_const(0); local_set(22);
+          i32_const(Imm32(0)); local_set(Local(22));
           block_empty; loop_empty;
-            local_get(22); i32_const(0); local_get(7); i32_sub; i32_ge_s; br_if(1);
-            local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-            i32_const(ASCII_ZERO); i32_store8(0);
-            local_get(16); i32_const(1); i32_add; local_set(16);
-            local_get(22); i32_const(1); i32_add; local_set(22);
+            local_get(Local(22)); i32_const(Imm32(0)); local_get(Local(7)); i32_sub; i32_ge_s; br_if(1);
+            local_get(Local(18)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(16)); i32_add;
+            i32_const(Imm32(ASCII_ZERO)); i32_store8(0);
+            local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
+            local_get(Local(22)); i32_const(Imm32(1)); i32_add; local_set(Local(22));
             br(0);
           end; end;
           // digits
-          i32_const(0); local_set(22);
+          i32_const(Imm32(0)); local_set(Local(22));
           block_empty; loop_empty;
-            local_get(22); local_get(21); i32_ge_s; br_if(1);
-            local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-            local_get(20); local_get(22); i32_add; i32_load8_u(0);
+            local_get(Local(22)); local_get(Local(21)); i32_ge_s; br_if(1);
+            local_get(Local(18)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(16)); i32_add;
+            local_get(Local(20)); local_get(Local(22)); i32_add; i32_load8_u(0);
             i32_store8(0);
-            local_get(16); i32_const(1); i32_add; local_set(16);
-            local_get(22); i32_const(1); i32_add; local_set(22);
+            local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
+            local_get(Local(22)); i32_const(Imm32(1)); i32_add; local_set(Local(22));
             br(0);
           end; end;
         else_;
-          local_get(7); local_get(21); i32_ge_s;
+          local_get(Local(7)); local_get(Local(21)); i32_ge_s;
           if_empty;
             // digits then (k-m) zeros then ".0"
-            i32_const(0); local_set(22);
+            i32_const(Imm32(0)); local_set(Local(22));
             block_empty; loop_empty;
-              local_get(22); local_get(21); i32_ge_s; br_if(1);
-              local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-              local_get(20); local_get(22); i32_add; i32_load8_u(0);
+              local_get(Local(22)); local_get(Local(21)); i32_ge_s; br_if(1);
+              local_get(Local(18)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(16)); i32_add;
+              local_get(Local(20)); local_get(Local(22)); i32_add; i32_load8_u(0);
               i32_store8(0);
-              local_get(16); i32_const(1); i32_add; local_set(16);
-              local_get(22); i32_const(1); i32_add; local_set(22);
+              local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
+              local_get(Local(22)); i32_const(Imm32(1)); i32_add; local_set(Local(22));
               br(0);
             end; end;
             // (k - m) zeros
-            i32_const(0); local_set(22);
+            i32_const(Imm32(0)); local_set(Local(22));
             block_empty; loop_empty;
-              local_get(22); local_get(7); local_get(21); i32_sub; i32_ge_s; br_if(1);
-              local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-              i32_const(ASCII_ZERO); i32_store8(0);
-              local_get(16); i32_const(1); i32_add; local_set(16);
-              local_get(22); i32_const(1); i32_add; local_set(22);
+              local_get(Local(22)); local_get(Local(7)); local_get(Local(21)); i32_sub; i32_ge_s; br_if(1);
+              local_get(Local(18)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(16)); i32_add;
+              i32_const(Imm32(ASCII_ZERO)); i32_store8(0);
+              local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
+              local_get(Local(22)); i32_const(Imm32(1)); i32_add; local_set(Local(22));
               br(0);
             end; end;
             // ".0"
-            local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-            i32_const(ASCII_DOT); i32_store8(0);
-            local_get(16); i32_const(1); i32_add; local_set(16);
-            local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-            i32_const(ASCII_ZERO); i32_store8(0);
-            local_get(16); i32_const(1); i32_add; local_set(16);
+            local_get(Local(18)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(16)); i32_add;
+            i32_const(Imm32(ASCII_DOT)); i32_store8(0);
+            local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
+            local_get(Local(18)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(16)); i32_add;
+            i32_const(Imm32(ASCII_ZERO)); i32_store8(0);
+            local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
           else_;
             // digits[0..k] "." digits[k..m]
-            i32_const(0); local_set(22);
+            i32_const(Imm32(0)); local_set(Local(22));
             block_empty; loop_empty;
-              local_get(22); local_get(7); i32_ge_s; br_if(1);
-              local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-              local_get(20); local_get(22); i32_add; i32_load8_u(0);
+              local_get(Local(22)); local_get(Local(7)); i32_ge_s; br_if(1);
+              local_get(Local(18)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(16)); i32_add;
+              local_get(Local(20)); local_get(Local(22)); i32_add; i32_load8_u(0);
               i32_store8(0);
-              local_get(16); i32_const(1); i32_add; local_set(16);
-              local_get(22); i32_const(1); i32_add; local_set(22);
+              local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
+              local_get(Local(22)); i32_const(Imm32(1)); i32_add; local_set(Local(22));
               br(0);
             end; end;
-            local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-            i32_const(ASCII_DOT); i32_store8(0);
-            local_get(16); i32_const(1); i32_add; local_set(16);
+            local_get(Local(18)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(16)); i32_add;
+            i32_const(Imm32(ASCII_DOT)); i32_store8(0);
+            local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
             // digits[k..m]  (continue from local 22 = k)
             block_empty; loop_empty;
-              local_get(22); local_get(21); i32_ge_s; br_if(1);
-              local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-              local_get(20); local_get(22); i32_add; i32_load8_u(0);
+              local_get(Local(22)); local_get(Local(21)); i32_ge_s; br_if(1);
+              local_get(Local(18)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(16)); i32_add;
+              local_get(Local(20)); local_get(Local(22)); i32_add; i32_load8_u(0);
               i32_store8(0);
-              local_get(16); i32_const(1); i32_add; local_set(16);
-              local_get(22); i32_const(1); i32_add; local_set(22);
+              local_get(Local(16)); i32_const(Imm32(1)); i32_add; local_set(Local(16));
+              local_get(Local(22)); i32_const(Imm32(1)); i32_add; local_set(Local(22));
               br(0);
             end; end;
           end;
         end;
     });
 
-    wasm!(f, { local_get(18); end; });
+    wasm!(f, { local_get(Local(18)); end; });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.float_to_string, type_idx, f));
 }
 
@@ -1064,54 +1065,54 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
 
     // bits = reinterpret(f); n = clamp(decimals, 0, ..)
     wasm!(f, {
-        local_get(0); i64_reinterpret_f64; local_set(BITS);
-        local_get(1); i32_wrap_i64; local_set(N);
-        local_get(N); i32_const(0); i32_lt_s; if_empty; i32_const(0); local_set(N); end;
+        local_get(Local(0)); i64_reinterpret_f64; local_set(Local(BITS));
+        local_get(Local(1)); i32_wrap_i64; local_set(Local(N));
+        local_get(Local(N)); i32_const(Imm32(0)); i32_lt_s; if_empty; i32_const(Imm32(0)); local_set(Local(N)); end;
     });
 
     // NaN / inf special cases (raw exp == 0x7FF).
     wasm!(f, {
-        local_get(BITS); i64_const(F64_MANTISSA_BITS); i64_shr_u; i32_wrap_i64; i32_const(F64_EXP_MASK); i32_and; local_set(RAW_EXP);
-        local_get(BITS); i64_const(F64_MANT_MASK); i64_and; local_set(RAW_MANT);
-        local_get(RAW_EXP); i32_const(F64_EXP_MASK); i32_eq;
+        local_get(Local(BITS)); i64_const(Imm64(F64_MANTISSA_BITS)); i64_shr_u; i32_wrap_i64; i32_const(Imm32(F64_EXP_MASK)); i32_and; local_set(Local(RAW_EXP));
+        local_get(Local(BITS)); i64_const(Imm64(F64_MANT_MASK)); i64_and; local_set(Local(RAW_MANT));
+        local_get(Local(RAW_EXP)); i32_const(Imm32(F64_EXP_MASK)); i32_eq;
         if_empty;
-            local_get(RAW_MANT); i64_eqz; i32_eqz;
-            if_empty; i32_const(s_nan as i32); return_; end;
-            local_get(BITS); i64_const(0); i64_lt_s;
-            if_i32; i32_const(s_ninf as i32); else_; i32_const(s_inf as i32); end;
+            local_get(Local(RAW_MANT)); i64_eqz; i32_eqz;
+            if_empty; i32_const(Imm32(s_nan as i32)); return_; end;
+            local_get(Local(BITS)); i64_const(Imm64(0)); i64_lt_s;
+            if_i32; i32_const(Imm32(s_ninf as i32)); else_; i32_const(Imm32(s_inf as i32)); end;
             return_;
         end;
     });
 
     // neg = sign bit; work with |f| bits.
     wasm!(f, {
-        local_get(BITS); i64_const(0); i64_lt_s; local_set(NEG);
-        local_get(BITS); i64_const(F64_ABS_MASK); i64_and; local_set(BITS);
-        local_get(BITS); i64_const(F64_MANTISSA_BITS); i64_shr_u; i32_wrap_i64; i32_const(F64_EXP_MASK); i32_and; local_set(RAW_EXP);
-        local_get(BITS); i64_const(F64_MANT_MASK); i64_and; local_set(RAW_MANT);
+        local_get(Local(BITS)); i64_const(Imm64(0)); i64_lt_s; local_set(Local(NEG));
+        local_get(Local(BITS)); i64_const(Imm64(F64_ABS_MASK)); i64_and; local_set(Local(BITS));
+        local_get(Local(BITS)); i64_const(Imm64(F64_MANTISSA_BITS)); i64_shr_u; i32_wrap_i64; i32_const(Imm32(F64_EXP_MASK)); i32_and; local_set(Local(RAW_EXP));
+        local_get(Local(BITS)); i64_const(Imm64(F64_MANT_MASK)); i64_and; local_set(Local(RAW_MANT));
     });
 
     // Decompose: subnormal (raw_exp==0): mant=raw_mant, e=-1074; else mant=raw_mant+2^52, e=raw_exp-1075.
     wasm!(f, {
-        local_get(RAW_EXP); i32_eqz;
+        local_get(Local(RAW_EXP)); i32_eqz;
         if_empty;
-            local_get(RAW_MANT); local_set(MANT);
-            i32_const(F64_SUBNORMAL_EXP); local_set(E);
+            local_get(Local(RAW_MANT)); local_set(Local(MANT));
+            i32_const(Imm32(F64_SUBNORMAL_EXP)); local_set(Local(E));
         else_;
-            local_get(RAW_MANT); i64_const(F64_IMPLICIT_BIT); i64_add; local_set(MANT);
-            local_get(RAW_EXP); i32_const(F64_EXP_BIAS_OFFSET); i32_sub; local_set(E);
+            local_get(Local(RAW_MANT)); i64_const(Imm64(F64_IMPLICIT_BIT)); i64_add; local_set(Local(MANT));
+            local_get(Local(RAW_EXP)); i32_const(Imm32(F64_EXP_BIAS_OFFSET)); i32_sub; local_set(Local(E));
         end;
     });
 
     // Allocate the Dragon4 scratch block (we use only R, S, TMP).
     wasm!(f, {
-        i32_const(SCRATCH_BYTES as i32); call(emitter.rt.alloc); local_set(BASE);
+        i32_const(Imm32(SCRATCH_BYTES as i32)); call(emitter.rt.alloc); local_set(Local(BASE));
         // Digit buffer: up to ~310 integer digits + n fraction digits + slack (for a
         // round-up carry that prepends one leading digit). The generation loop stops
         // producing significant digits once R hits 0, so n only sizes the buffer.
-        i32_const(MAX_INT_DIGITS); local_get(N); i32_add; i32_const(DIGIT_BUF_SLACK); i32_add; call(emitter.rt.alloc); local_set(DP);
-        i32_const(0); local_set(DLEN);
-        i32_const(0); local_set(K);
+        i32_const(Imm32(MAX_INT_DIGITS)); local_get(Local(N)); i32_add; i32_const(Imm32(DIGIT_BUF_SLACK)); i32_add; call(emitter.rt.alloc); local_set(Local(DP));
+        i32_const(Imm32(0)); local_set(Local(DLEN));
+        i32_const(Imm32(0)); local_set(Local(K));
     });
     // base must be in local 1 for DragonRefs.ptr; alias via a copy is impossible
     // (ptr() hardcodes local_get(1)). So we keep base in BASE and patch ptr via a
@@ -1124,43 +1125,43 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
     set_bn_u64(&mut f, BASE, OFF_R, MANT);
     set_bn_small(&mut f, BASE, OFF_S, 1);
     wasm!(f, {
-        local_get(E); i32_const(0); i32_ge_s;
+        local_get(Local(E)); i32_const(Imm32(0)); i32_ge_s;
         if_empty;
             // e >= 0: R <<= e ; S = 1
-            local_get(BASE); i32_const(OFF_R as i32); i32_add; local_get(E); call(dr.shl);
+            local_get(Local(BASE)); i32_const(Imm32(OFF_R as i32)); i32_add; local_get(Local(E)); call(dr.shl);
         else_;
             // e < 0: S <<= (-e)
-            local_get(BASE); i32_const(OFF_S as i32); i32_add; i32_const(0); local_get(E); i32_sub; call(dr.shl);
+            local_get(Local(BASE)); i32_const(Imm32(OFF_S as i32)); i32_add; i32_const(Imm32(0)); local_get(Local(E)); i32_sub; call(dr.shl);
         end;
     });
 
     // ── Position: scale so value/10^k ∈ [0.1, 1), tracking k ──
     // if value == 0 (mant == 0): k stays 0, R stays 0 → all digits zero.
     wasm!(f, {
-        local_get(MANT); i64_eqz; i32_eqz;
+        local_get(Local(MANT)); i64_eqz; i32_eqz;
         if_empty;
             // value >= 1 ?  cmp(R, S) >= 0
-            local_get(BASE); i32_const(OFF_R as i32); i32_add; local_get(BASE); i32_const(OFF_S as i32); i32_add; call(dr.cmp);
-            i32_const(0); i32_ge_s;
+            local_get(Local(BASE)); i32_const(Imm32(OFF_R as i32)); i32_add; local_get(Local(BASE)); i32_const(Imm32(OFF_S as i32)); i32_add; call(dr.cmp);
+            i32_const(Imm32(0)); i32_ge_s;
             if_empty;
                 // while cmp(R, S) >= 0 { S *= 10; k++ }
                 block_empty; loop_empty;
-                    local_get(BASE); i32_const(OFF_R as i32); i32_add; local_get(BASE); i32_const(OFF_S as i32); i32_add; call(dr.cmp);
-                    i32_const(0); i32_lt_s; br_if(1);
-                    local_get(BASE); i32_const(OFF_S as i32); i32_add; i32_const(DECIMAL_BASE); call(dr.mul_small);
-                    local_get(K); i32_const(1); i32_add; local_set(K);
+                    local_get(Local(BASE)); i32_const(Imm32(OFF_R as i32)); i32_add; local_get(Local(BASE)); i32_const(Imm32(OFF_S as i32)); i32_add; call(dr.cmp);
+                    i32_const(Imm32(0)); i32_lt_s; br_if(1);
+                    local_get(Local(BASE)); i32_const(Imm32(OFF_S as i32)); i32_add; i32_const(Imm32(DECIMAL_BASE)); call(dr.mul_small);
+                    local_get(Local(K)); i32_const(Imm32(1)); i32_add; local_set(Local(K));
                     br(0);
                 end; end;
             else_;
                 // while cmp(R*10, S) < 0 { R *= 10; k-- }
                 block_empty; loop_empty;
                     // TMP = R; TMP *= 10; cmp(TMP, S) >= 0 → stop
-                    local_get(BASE); i32_const(OFF_TMP as i32); i32_add; local_get(BASE); i32_const(OFF_R as i32); i32_add; call(dr.copy);
-                    local_get(BASE); i32_const(OFF_TMP as i32); i32_add; i32_const(DECIMAL_BASE); call(dr.mul_small);
-                    local_get(BASE); i32_const(OFF_TMP as i32); i32_add; local_get(BASE); i32_const(OFF_S as i32); i32_add; call(dr.cmp);
-                    i32_const(0); i32_ge_s; br_if(1);
-                    local_get(BASE); i32_const(OFF_R as i32); i32_add; i32_const(DECIMAL_BASE); call(dr.mul_small);
-                    local_get(K); i32_const(1); i32_sub; local_set(K);
+                    local_get(Local(BASE)); i32_const(Imm32(OFF_TMP as i32)); i32_add; local_get(Local(BASE)); i32_const(Imm32(OFF_R as i32)); i32_add; call(dr.copy);
+                    local_get(Local(BASE)); i32_const(Imm32(OFF_TMP as i32)); i32_add; i32_const(Imm32(DECIMAL_BASE)); call(dr.mul_small);
+                    local_get(Local(BASE)); i32_const(Imm32(OFF_TMP as i32)); i32_add; local_get(Local(BASE)); i32_const(Imm32(OFF_S as i32)); i32_add; call(dr.cmp);
+                    i32_const(Imm32(0)); i32_ge_s; br_if(1);
+                    local_get(Local(BASE)); i32_const(Imm32(OFF_R as i32)); i32_add; i32_const(Imm32(DECIMAL_BASE)); call(dr.mul_small);
+                    local_get(Local(K)); i32_const(Imm32(1)); i32_sub; local_set(Local(K));
                     br(0);
                 end; end;
             end;
@@ -1175,12 +1176,12 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
     //   start = max(-k,0)    leading-zero slots before the first significant digit
     //                        (only when k<=0; = total - max(cnt,0)).
     wasm!(f, {
-        local_get(K); local_get(N); i32_add; local_set(CNT);
-        local_get(K); i32_const(0); i32_gt_s; if_i32; local_get(K); else_; i32_const(0); end;
-        local_get(N); i32_add; local_set(TOTAL);
-        i32_const(0); local_get(K); i32_sub; i32_const(0); i32_gt_s;
-        if_i32; i32_const(0); local_get(K); i32_sub; else_; i32_const(0); end;
-        local_set(START);
+        local_get(Local(K)); local_get(Local(N)); i32_add; local_set(Local(CNT));
+        local_get(Local(K)); i32_const(Imm32(0)); i32_gt_s; if_i32; local_get(Local(K)); else_; i32_const(Imm32(0)); end;
+        local_get(Local(N)); i32_add; local_set(Local(TOTAL));
+        i32_const(Imm32(0)); local_get(Local(K)); i32_sub; i32_const(Imm32(0)); i32_gt_s;
+        if_i32; i32_const(Imm32(0)); local_get(Local(K)); i32_sub; else_; i32_const(Imm32(0)); end;
+        local_set(Local(START));
     });
 
     // ── Generate `total` digit slots ──
@@ -1188,39 +1189,39 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
     //   R != 0        : R*=10; d = floor(R/S) via repeated subtraction; R -= d*S
     //   R == 0        : the exact expansion has ended → digit 0 (no bignum work)
     wasm!(f, {
-        i32_const(0); local_set(DLEN);
-        i32_const(0); local_set(I);
+        i32_const(Imm32(0)); local_set(Local(DLEN));
+        i32_const(Imm32(0)); local_set(Local(I));
         block_empty; loop_empty;
-            local_get(I); local_get(TOTAL); i32_ge_s; br_if(1);
-            local_get(I); local_get(START); i32_lt_s;
+            local_get(Local(I)); local_get(Local(TOTAL)); i32_ge_s; br_if(1);
+            local_get(Local(I)); local_get(Local(START)); i32_lt_s;
             if_empty;
                 // leading-zero slot (only when k <= 0): digit is 0, no bignum work.
-                i32_const(0); local_set(D);
+                i32_const(Imm32(0)); local_set(Local(D));
             else_;
                 // Once R has been driven to 0, the EXACT expansion has ended and every
                 // remaining digit is 0 — skip the bignum work. R is zero iff its len is
                 // 1 and limb0 is 0. (This replaces a digit-count cap: it is exact and
                 // bounds the work to the real expansion regardless of how large N is.)
-                local_get(BASE); i32_const(OFF_R as i32); i32_add; i32_load(0); i32_const(1); i32_eq;
-                local_get(BASE); i32_const((OFF_R + BN_HDR) as i32); i32_add; i32_load(0); i32_eqz;
+                local_get(Local(BASE)); i32_const(Imm32(OFF_R as i32)); i32_add; i32_load(0); i32_const(Imm32(1)); i32_eq;
+                local_get(Local(BASE)); i32_const(Imm32((OFF_R + BN_HDR) as i32)); i32_add; i32_load(0); i32_eqz;
                 i32_and;
                 if_empty;
-                    i32_const(0); local_set(D);
+                    i32_const(Imm32(0)); local_set(Local(D));
                 else_;
-                    local_get(BASE); i32_const(OFF_R as i32); i32_add; i32_const(DECIMAL_BASE); call(dr.mul_small);
-                    i32_const(0); local_set(D);
+                    local_get(Local(BASE)); i32_const(Imm32(OFF_R as i32)); i32_add; i32_const(Imm32(DECIMAL_BASE)); call(dr.mul_small);
+                    i32_const(Imm32(0)); local_set(Local(D));
                     block_empty; loop_empty;
-                        local_get(BASE); i32_const(OFF_R as i32); i32_add; local_get(BASE); i32_const(OFF_S as i32); i32_add; call(dr.cmp);
-                        i32_const(0); i32_lt_s; br_if(1);
-                        local_get(BASE); i32_const(OFF_R as i32); i32_add; local_get(BASE); i32_const(OFF_S as i32); i32_add; call(dr.sub);
-                        local_get(D); i32_const(1); i32_add; local_set(D);
+                        local_get(Local(BASE)); i32_const(Imm32(OFF_R as i32)); i32_add; local_get(Local(BASE)); i32_const(Imm32(OFF_S as i32)); i32_add; call(dr.cmp);
+                        i32_const(Imm32(0)); i32_lt_s; br_if(1);
+                        local_get(Local(BASE)); i32_const(Imm32(OFF_R as i32)); i32_add; local_get(Local(BASE)); i32_const(Imm32(OFF_S as i32)); i32_add; call(dr.sub);
+                        local_get(Local(D)); i32_const(Imm32(1)); i32_add; local_set(Local(D));
                         br(0);
                     end; end;
                 end;
             end;
-            local_get(DP); local_get(DLEN); i32_add; local_get(D); i32_const(ASCII_ZERO); i32_add; i32_store8(0);
-            local_get(DLEN); i32_const(1); i32_add; local_set(DLEN);
-            local_get(I); i32_const(1); i32_add; local_set(I);
+            local_get(Local(DP)); local_get(Local(DLEN)); i32_add; local_get(Local(D)); i32_const(Imm32(ASCII_ZERO)); i32_add; i32_store8(0);
+            local_get(Local(DLEN)); i32_const(Imm32(1)); i32_add; local_set(Local(DLEN));
+            local_get(Local(I)); i32_const(Imm32(1)); i32_add; local_set(Local(I));
             br(0);
         end; end;
     });
@@ -1231,38 +1232,38 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
     // comparison is taken at position -n. (When cnt > 0, R is already the residue
     // below -n and -cnt <= 0, so no scaling.) Tie breaks to even via the last slot.
     wasm!(f, {
-        local_get(CNT); i32_const(0); i32_lt_s;
+        local_get(Local(CNT)); i32_const(Imm32(0)); i32_lt_s;
         if_empty;
             // S *= 10, (-cnt) times.
-            i32_const(0); local_set(I);
+            i32_const(Imm32(0)); local_set(Local(I));
             block_empty; loop_empty;
-                local_get(I); i32_const(0); local_get(CNT); i32_sub; i32_ge_s; br_if(1);
-                local_get(BASE); i32_const(OFF_S as i32); i32_add; i32_const(DECIMAL_BASE); call(dr.mul_small);
-                local_get(I); i32_const(1); i32_add; local_set(I);
+                local_get(Local(I)); i32_const(Imm32(0)); local_get(Local(CNT)); i32_sub; i32_ge_s; br_if(1);
+                local_get(Local(BASE)); i32_const(Imm32(OFF_S as i32)); i32_add; i32_const(Imm32(DECIMAL_BASE)); call(dr.mul_small);
+                local_get(Local(I)); i32_const(Imm32(1)); i32_add; local_set(Local(I));
                 br(0);
             end; end;
         end;
         // TMP = 2R; cmp(TMP, S).
-        local_get(BASE); i32_const(OFF_TMP as i32); i32_add; local_get(BASE); i32_const(OFF_R as i32); i32_add; call(dr.copy);
-        local_get(BASE); i32_const(OFF_TMP as i32); i32_add; i32_const(1); call(dr.shl);
-        local_get(BASE); i32_const(OFF_TMP as i32); i32_add; local_get(BASE); i32_const(OFF_S as i32); i32_add; call(dr.cmp);
-        local_set(D);
-        i32_const(0); local_set(ROUND);
-        local_get(D); i32_const(0); i32_gt_s;
+        local_get(Local(BASE)); i32_const(Imm32(OFF_TMP as i32)); i32_add; local_get(Local(BASE)); i32_const(Imm32(OFF_R as i32)); i32_add; call(dr.copy);
+        local_get(Local(BASE)); i32_const(Imm32(OFF_TMP as i32)); i32_add; i32_const(Imm32(1)); call(dr.shl);
+        local_get(Local(BASE)); i32_const(Imm32(OFF_TMP as i32)); i32_add; local_get(Local(BASE)); i32_const(Imm32(OFF_S as i32)); i32_add; call(dr.cmp);
+        local_set(Local(D));
+        i32_const(Imm32(0)); local_set(Local(ROUND));
+        local_get(Local(D)); i32_const(Imm32(0)); i32_gt_s;
         if_empty;
-            i32_const(1); local_set(ROUND);                  // 2R > S → up
+            i32_const(Imm32(1)); local_set(Local(ROUND));                  // 2R > S → up
         else_;
-            local_get(D); i32_eqz;
+            local_get(Local(D)); i32_eqz;
             if_empty;
                 // exact half: round to even — up iff the last slot's digit is odd.
                 // (total >= n >= 0; when total == 0, n == 0 and k <= 0, the units digit
                 // is the implicit '0' → even → keep.)
-                local_get(TOTAL); i32_eqz;
+                local_get(Local(TOTAL)); i32_eqz;
                 if_empty;
-                    i32_const(0); local_set(ROUND);
+                    i32_const(Imm32(0)); local_set(Local(ROUND));
                 else_;
-                    local_get(DP); local_get(TOTAL); i32_const(1); i32_sub; i32_add; i32_load8_u(0);
-                    i32_const(1); i32_and; local_set(ROUND);
+                    local_get(Local(DP)); local_get(Local(TOTAL)); i32_const(Imm32(1)); i32_sub; i32_add; i32_load8_u(0);
+                    i32_const(Imm32(1)); i32_and; local_set(Local(ROUND));
                 end;
             end;
         end;
@@ -1270,28 +1271,28 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
 
     // ── Apply round-up carry over digits[0..total]; overflow prepends '1', k++. ──
     wasm!(f, {
-        local_get(ROUND);
+        local_get(Local(ROUND));
         if_empty;
-            local_get(TOTAL); local_set(I);
+            local_get(Local(TOTAL)); local_set(Local(I));
             block_empty; loop_empty;
-                local_get(I); i32_eqz;
+                local_get(Local(I)); i32_eqz;
                 if_empty;
                     // carry out of the most-significant slot: shift right by 1, set
                     // digits[0]='1', total++, k++ (a new leading integer digit).
-                    local_get(DP); i32_const(1); i32_add; local_get(DP); local_get(TOTAL); memory_copy;
-                    local_get(DP); i32_const(ASCII_ONE); i32_store8(0);
-                    local_get(TOTAL); i32_const(1); i32_add; local_set(TOTAL);
-                    local_get(K); i32_const(1); i32_add; local_set(K);
+                    local_get(Local(DP)); i32_const(Imm32(1)); i32_add; local_get(Local(DP)); local_get(Local(TOTAL)); memory_copy;
+                    local_get(Local(DP)); i32_const(Imm32(ASCII_ONE)); i32_store8(0);
+                    local_get(Local(TOTAL)); i32_const(Imm32(1)); i32_add; local_set(Local(TOTAL));
+                    local_get(Local(K)); i32_const(Imm32(1)); i32_add; local_set(Local(K));
                     br(2);
                 end;
-                local_get(I); i32_const(1); i32_sub; local_set(I);
-                local_get(DP); local_get(I); i32_add; i32_load8_u(0); i32_const(ASCII_NINE); i32_eq;
+                local_get(Local(I)); i32_const(Imm32(1)); i32_sub; local_set(Local(I));
+                local_get(Local(DP)); local_get(Local(I)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_NINE)); i32_eq;
                 if_empty;
-                    local_get(DP); local_get(I); i32_add; i32_const(ASCII_ZERO); i32_store8(0);
+                    local_get(Local(DP)); local_get(Local(I)); i32_add; i32_const(Imm32(ASCII_ZERO)); i32_store8(0);
                     br(1);
                 else_;
-                    local_get(DP); local_get(I); i32_add;
-                    local_get(DP); local_get(I); i32_add; i32_load8_u(0); i32_const(1); i32_add;
+                    local_get(Local(DP)); local_get(Local(I)); i32_add;
+                    local_get(Local(DP)); local_get(Local(I)); i32_add; i32_load8_u(0); i32_const(Imm32(1)); i32_add;
                     i32_store8(0);
                     br(2);
                 end;
@@ -1309,97 +1310,97 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
     // Note dlen == (k>0 ? k : 0) + n after carry handling.
     wasm!(f, {
         // out_len = neg + body
-        local_get(NEG);
-        local_get(K); i32_const(0); i32_le_s;
+        local_get(Local(NEG));
+        local_get(Local(K)); i32_const(Imm32(0)); i32_le_s;
         if_i32;
             // 2 ("0.") + (-k) + (k+n) == 2 + n ; but if n==0 then k<=0 means value<1 rounded:
             // Rust prints "0" with no point when n==0 and value<1 (e.g. 0.5@0="0").
-            local_get(N); i32_eqz;
+            local_get(Local(N)); i32_eqz;
             if_i32;
-                i32_const(1);                 // just "0"
+                i32_const(Imm32(1));                 // just "0"
             else_;
-                i32_const(ZERO_DOT_LEN); local_get(N); i32_add;   // "0." + n frac
+                i32_const(Imm32(ZERO_DOT_LEN)); local_get(Local(N)); i32_add;   // "0." + n frac
             end;
         else_;
-            local_get(N); i32_eqz;
+            local_get(Local(N)); i32_eqz;
             if_i32;
-                local_get(K);                 // k integer digits
+                local_get(Local(K));                 // k integer digits
             else_;
-                local_get(K); i32_const(1); i32_add; local_get(N); i32_add;  // k + "." + n
+                local_get(Local(K)); i32_const(Imm32(1)); i32_add; local_get(Local(N)); i32_add;  // k + "." + n
             end;
         end;
-        i32_add; local_set(OUT_LEN);
+        i32_add; local_set(Local(OUT_LEN));
     });
 
     // alloc string [len][cap][data...]
     wasm!(f, {
-        local_get(OUT_LEN); i32_const(string_hdr() as i32); i32_add;
-        call(emitter.rt.alloc); local_set(RESULT);
-        local_get(RESULT); local_get(OUT_LEN); i32_store(0);
-        local_get(RESULT); local_get(OUT_LEN); i32_store(string_cap_off() as u32, 0);
-        i32_const(0); local_set(CURSOR);
+        local_get(Local(OUT_LEN)); i32_const(Imm32(string_hdr() as i32)); i32_add;
+        call(emitter.rt.alloc); local_set(Local(RESULT));
+        local_get(Local(RESULT)); local_get(Local(OUT_LEN)); i32_store(0);
+        local_get(Local(RESULT)); local_get(Local(OUT_LEN)); i32_store(string_cap_off() as u32, 0);
+        i32_const(Imm32(0)); local_set(Local(CURSOR));
         // sign
-        local_get(NEG);
+        local_get(Local(NEG));
         if_empty;
-            local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add; i32_const(ASCII_MINUS); i32_store8(0);
-            local_get(CURSOR); i32_const(1); i32_add; local_set(CURSOR);
+            local_get(Local(RESULT)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(CURSOR)); i32_add; i32_const(Imm32(ASCII_MINUS)); i32_store8(0);
+            local_get(Local(CURSOR)); i32_const(Imm32(1)); i32_add; local_set(Local(CURSOR));
         end;
     });
 
     // branch on k
     wasm!(f, {
-        local_get(K); i32_const(0); i32_le_s;
+        local_get(Local(K)); i32_const(Imm32(0)); i32_le_s;
         if_empty;
             // value < 1 (after rounding). If n == 0 → just "0".
-            local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add; i32_const(ASCII_ZERO); i32_store8(0);
-            local_get(CURSOR); i32_const(1); i32_add; local_set(CURSOR);
-            local_get(N); i32_eqz;
+            local_get(Local(RESULT)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(CURSOR)); i32_add; i32_const(Imm32(ASCII_ZERO)); i32_store8(0);
+            local_get(Local(CURSOR)); i32_const(Imm32(1)); i32_add; local_set(Local(CURSOR));
+            local_get(Local(N)); i32_eqz;
             if_empty;
                 // done: just "0"
             else_;
                 // '.' then all `total`(==n) fraction digits — the leading zeros are
                 // already materialized in the buffer, so this is a straight copy.
-                local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add; i32_const(ASCII_DOT); i32_store8(0);
-                local_get(CURSOR); i32_const(1); i32_add; local_set(CURSOR);
-                i32_const(0); local_set(I);
+                local_get(Local(RESULT)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(CURSOR)); i32_add; i32_const(Imm32(ASCII_DOT)); i32_store8(0);
+                local_get(Local(CURSOR)); i32_const(Imm32(1)); i32_add; local_set(Local(CURSOR));
+                i32_const(Imm32(0)); local_set(Local(I));
                 block_empty; loop_empty;
-                    local_get(I); local_get(TOTAL); i32_ge_s; br_if(1);
-                    local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add;
-                    local_get(DP); local_get(I); i32_add; i32_load8_u(0); i32_store8(0);
-                    local_get(CURSOR); i32_const(1); i32_add; local_set(CURSOR);
-                    local_get(I); i32_const(1); i32_add; local_set(I);
+                    local_get(Local(I)); local_get(Local(TOTAL)); i32_ge_s; br_if(1);
+                    local_get(Local(RESULT)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(CURSOR)); i32_add;
+                    local_get(Local(DP)); local_get(Local(I)); i32_add; i32_load8_u(0); i32_store8(0);
+                    local_get(Local(CURSOR)); i32_const(Imm32(1)); i32_add; local_set(Local(CURSOR));
+                    local_get(Local(I)); i32_const(Imm32(1)); i32_add; local_set(Local(I));
                     br(0);
                 end; end;
             end;
         else_;
             // value >= 1: k integer digits = digits[0..k], then (n>0) "." + digits[k..k+n]
-            i32_const(0); local_set(I);
+            i32_const(Imm32(0)); local_set(Local(I));
             block_empty; loop_empty;
-                local_get(I); local_get(K); i32_ge_s; br_if(1);
-                local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add;
-                local_get(DP); local_get(I); i32_add; i32_load8_u(0); i32_store8(0);
-                local_get(CURSOR); i32_const(1); i32_add; local_set(CURSOR);
-                local_get(I); i32_const(1); i32_add; local_set(I);
+                local_get(Local(I)); local_get(Local(K)); i32_ge_s; br_if(1);
+                local_get(Local(RESULT)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(CURSOR)); i32_add;
+                local_get(Local(DP)); local_get(Local(I)); i32_add; i32_load8_u(0); i32_store8(0);
+                local_get(Local(CURSOR)); i32_const(Imm32(1)); i32_add; local_set(Local(CURSOR));
+                local_get(Local(I)); i32_const(Imm32(1)); i32_add; local_set(Local(I));
                 br(0);
             end; end;
-            local_get(N); i32_eqz;
+            local_get(Local(N)); i32_eqz;
             if_empty; else_;
-                local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add; i32_const(ASCII_DOT); i32_store8(0);
-                local_get(CURSOR); i32_const(1); i32_add; local_set(CURSOR);
+                local_get(Local(RESULT)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(CURSOR)); i32_add; i32_const(Imm32(ASCII_DOT)); i32_store8(0);
+                local_get(Local(CURSOR)); i32_const(Imm32(1)); i32_add; local_set(Local(CURSOR));
                 // digits[k .. total]  (I continues from k)
                 block_empty; loop_empty;
-                    local_get(I); local_get(TOTAL); i32_ge_s; br_if(1);
-                    local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add;
-                    local_get(DP); local_get(I); i32_add; i32_load8_u(0); i32_store8(0);
-                    local_get(CURSOR); i32_const(1); i32_add; local_set(CURSOR);
-                    local_get(I); i32_const(1); i32_add; local_set(I);
+                    local_get(Local(I)); local_get(Local(TOTAL)); i32_ge_s; br_if(1);
+                    local_get(Local(RESULT)); i32_const(Imm32(string_data_off() as i32)); i32_add; local_get(Local(CURSOR)); i32_add;
+                    local_get(Local(DP)); local_get(Local(I)); i32_add; i32_load8_u(0); i32_store8(0);
+                    local_get(Local(CURSOR)); i32_const(Imm32(1)); i32_add; local_set(Local(CURSOR));
+                    local_get(Local(I)); i32_const(Imm32(1)); i32_add; local_set(Local(I));
                     br(0);
                 end; end;
             end;
         end;
     });
 
-    wasm!(f, { local_get(RESULT); end; });
+    wasm!(f, { local_get(Local(RESULT)); end; });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.float_to_fixed, type_idx, f));
 }
 
@@ -1408,18 +1409,18 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
 /// OTHER than 1 (to_fixed keeps it in BASE because local 1 is its `decimals` param).
 fn set_bn_u64(f: &mut Function, base: u32, off: u32, loc: u32) {
     wasm!(f, {
-        local_get(base); i32_const((off + BN_HDR) as i32); i32_add; local_get(loc); i32_wrap_i64; i32_store(0);
-        local_get(base); i32_const((off + BN_HDR + 4) as i32); i32_add; local_get(loc); i64_const(LIMB_BITS_I64); i64_shr_u; i32_wrap_i64; i32_store(0);
-        local_get(base); i32_const(off as i32); i32_add;
-        local_get(loc); i64_const(LIMB_BITS_I64); i64_shr_u; i64_eqz; if_i32; i32_const(1); else_; i32_const(BN_TWO_LIMBS); end;
+        local_get(Local(base)); i32_const(Imm32((off + BN_HDR) as i32)); i32_add; local_get(Local(loc)); i32_wrap_i64; i32_store(0);
+        local_get(Local(base)); i32_const(Imm32((off + BN_HDR + 4) as i32)); i32_add; local_get(Local(loc)); i64_const(Imm64(LIMB_BITS_I64)); i64_shr_u; i32_wrap_i64; i32_store(0);
+        local_get(Local(base)); i32_const(Imm32(off as i32)); i32_add;
+        local_get(Local(loc)); i64_const(Imm64(LIMB_BITS_I64)); i64_shr_u; i64_eqz; if_i32; i32_const(Imm32(1)); else_; i32_const(Imm32(BN_TWO_LIMBS)); end;
         i32_store(0);
     });
 }
 /// Set bignum at (base+off) to a small u32 constant (1 limb).
 fn set_bn_small(f: &mut Function, base: u32, off: u32, v: u32) {
     wasm!(f, {
-        local_get(base); i32_const(off as i32); i32_add; i32_const(1); i32_store(0);
-        local_get(base); i32_const((off + BN_HDR) as i32); i32_add; i32_const(v as i32); i32_store(0);
+        local_get(Local(base)); i32_const(Imm32(off as i32)); i32_add; i32_const(Imm32(1)); i32_store(0);
+        local_get(Local(base)); i32_const(Imm32((off + BN_HDR) as i32)); i32_add; i32_const(Imm32(v as i32)); i32_store(0);
     });
 }
 
@@ -1446,30 +1447,30 @@ impl DragonRefs {
     }
     // base ptr is in local 1; absolute ptr of bignum at offset `off` = base + off.
     fn ptr(&self, f: &mut Function, off: u32) {
-        wasm!(f, { local_get(1); i32_const(off as i32); i32_add; });
+        wasm!(f, { local_get(Local(1)); i32_const(Imm32(off as i32)); i32_add; });
     }
     /// bignum[off] = the i64 in local `loc` (split into two u32 limbs).
     fn set_u64(&self, f: &mut Function, off: u32, loc: u32) {
         // len: if hi != 0 -> 2 else 1
         wasm!(f, {
             // limb0 = (val & 0xFFFFFFFF)
-            local_get(1); i32_const((off + BN_HDR) as i32); i32_add;
-            local_get(loc); i32_wrap_i64; i32_store(0);
+            local_get(Local(1)); i32_const(Imm32((off + BN_HDR) as i32)); i32_add;
+            local_get(Local(loc)); i32_wrap_i64; i32_store(0);
             // limb1 = (val >> 32)
-            local_get(1); i32_const((off + BN_HDR + 4) as i32); i32_add;
-            local_get(loc); i64_const(LIMB_BITS_I64); i64_shr_u; i32_wrap_i64; i32_store(0);
+            local_get(Local(1)); i32_const(Imm32((off + BN_HDR + 4) as i32)); i32_add;
+            local_get(Local(loc)); i64_const(Imm64(LIMB_BITS_I64)); i64_shr_u; i32_wrap_i64; i32_store(0);
             // len = (hi != 0) ? 2 : 1
-            local_get(1); i32_const(off as i32); i32_add;
-            local_get(loc); i64_const(LIMB_BITS_I64); i64_shr_u; i64_eqz;
-            if_i32; i32_const(1); else_; i32_const(BN_TWO_LIMBS); end;
+            local_get(Local(1)); i32_const(Imm32(off as i32)); i32_add;
+            local_get(Local(loc)); i64_const(Imm64(LIMB_BITS_I64)); i64_shr_u; i64_eqz;
+            if_i32; i32_const(Imm32(1)); else_; i32_const(Imm32(BN_TWO_LIMBS)); end;
             i32_store(0);
         });
     }
     /// bignum[off] = small constant (1 limb).
     fn set_small(&self, f: &mut Function, off: u32, v: u32) {
         wasm!(f, {
-            local_get(1); i32_const(off as i32); i32_add; i32_const(1); i32_store(0); // len = 1
-            local_get(1); i32_const((off + BN_HDR) as i32); i32_add; i32_const(v as i32); i32_store(0);
+            local_get(Local(1)); i32_const(Imm32(off as i32)); i32_add; i32_const(Imm32(1)); i32_store(0); // len = 1
+            local_get(Local(1)); i32_const(Imm32((off + BN_HDR) as i32)); i32_add; i32_const(Imm32(v as i32)); i32_store(0);
         });
     }
     fn copy(&self, f: &mut Function, dst: u32, src: u32) {
@@ -1491,15 +1492,15 @@ impl DragonRefs {
     /// cmp(a, b) and store the -1/0/1 result into local 23 (`cmp_tmp`).
     fn cmp_set(&self, f: &mut Function, a: u32, b: u32) {
         self.cmp(f, a, b);
-        wasm!(f, { local_set(23); });
+        wasm!(f, { local_set(Local(23)); });
     }
     /// Push the boolean `even ? (cmp_tmp >= 0) : (cmp_tmp > 0)`.
     /// (Used where the rounding interval is closed for even mantissas: the
     /// "upper" predicate.)  = (c > 0) | (even & (c == 0)).
     fn pred_ge_gt(&self, f: &mut Function) {
         wasm!(f, {
-            local_get(23); i32_const(0); i32_gt_s;
-            local_get(8); local_get(23); i32_eqz; i32_and;
+            local_get(Local(23)); i32_const(Imm32(0)); i32_gt_s;
+            local_get(Local(8)); local_get(Local(23)); i32_eqz; i32_and;
             i32_or;
         });
     }
@@ -1507,34 +1508,34 @@ impl DragonRefs {
     /// (The "lower" predicate.)  = (c < 0) | (even & (c == 0)).
     fn pred_le_lt(&self, f: &mut Function) {
         wasm!(f, {
-            local_get(23); i32_const(0); i32_lt_s;
-            local_get(8); local_get(23); i32_eqz; i32_and;
+            local_get(Local(23)); i32_const(Imm32(0)); i32_lt_s;
+            local_get(Local(8)); local_get(Local(23)); i32_eqz; i32_and;
             i32_or;
         });
     }
     fn mul10(&self, f: &mut Function, off: u32) {
         self.ptr(f, off);
-        wasm!(f, { i32_const(DECIMAL_BASE); call(self.mul_small); });
+        wasm!(f, { i32_const(Imm32(DECIMAL_BASE)); call(self.mul_small); });
     }
     /// shl by a constant bit count.
     fn shl_const(&self, f: &mut Function, off: u32, bits: u32) {
         self.ptr(f, off);
-        wasm!(f, { i32_const(bits as i32); call(self.shl); });
+        wasm!(f, { i32_const(Imm32(bits as i32)); call(self.shl); });
     }
     /// shl by the value in local `loc` (an i32).
     fn shl_local(&self, f: &mut Function, off: u32, loc: u32) {
         self.ptr(f, off);
-        wasm!(f, { local_get(loc); call(self.shl); });
+        wasm!(f, { local_get(Local(loc)); call(self.shl); });
     }
     /// shl by (local + imm).
     fn shl_imm_local(&self, f: &mut Function, off: u32, loc: u32, imm: i32) {
         self.ptr(f, off);
-        wasm!(f, { local_get(loc); i32_const(imm); i32_add; call(self.shl); });
+        wasm!(f, { local_get(Local(loc)); i32_const(Imm32(imm)); i32_add; call(self.shl); });
     }
     /// shl by (1 - local).
     fn shl_one_minus_e(&self, f: &mut Function, off: u32, loc: u32) {
         self.ptr(f, off);
-        wasm!(f, { i32_const(1); local_get(loc); i32_sub; call(self.shl); });
+        wasm!(f, { i32_const(Imm32(1)); local_get(Local(loc)); i32_sub; call(self.shl); });
     }
 }
 

--- a/crates/almide-codegen/src/emit_wasm/rt_dragon.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_dragon.rs
@@ -71,6 +71,51 @@ pub struct DragonRuntime {
     pub copy: u32,
 }
 
+// ── Numeric / IEEE-754 constants used in WASM emission ──
+/// Bits per u32 limb, as i64 (used with i64_shr_u / i64_const).
+const LIMB_BITS_I64: i64 = 32;
+/// Bits per u32 limb, as i32 (used with i32_div_u / i32_rem_u / carry-shift subtract).
+const LIMB_BITS_I32: i32 = 32;
+/// Byte size of one u32 limb (stride = `limb_index * LIMB_BYTES`).
+const LIMB_BYTES: i32 = 4;
+/// 2^32: added to a negative borrow difference to wrap it into the unsigned range.
+const CARRY_WRAP: i64 = 0x1_0000_0000;
+
+/// 11-bit mask for the f64 exponent field (`(bits >> 52) & F64_EXP_MASK`).
+const F64_EXP_MASK: i32 = 0x7FF;
+/// Number of mantissa bits in an f64 (used to shift bits into the exponent position).
+const F64_MANTISSA_BITS: i64 = 52;
+/// Mask for the 52 mantissa bits of an f64.
+const F64_MANT_MASK: i64 = 0x000F_FFFF_FFFF_FFFF;
+/// Mask to clear the sign bit of an f64 raw bit pattern (= i64::MAX).
+const F64_ABS_MASK: i64 = 0x7FFF_FFFF_FFFF_FFFF;
+/// The implicit leading `1` bit that normal f64 values have (2^52 = 0x10_0000_0000_0000).
+const F64_IMPLICIT_BIT: i64 = 0x10_0000_0000_0000;
+/// Binary exponent assigned to subnormal f64 values (`e = -1074`).
+const F64_SUBNORMAL_EXP: i32 = -1074;
+/// Bias subtracted from the raw f64 exponent to get the effective binary exponent for normals.
+/// Effective `e = raw_exp - F64_EXP_BIAS_OFFSET`.
+const F64_EXP_BIAS_OFFSET: i32 = 1075;
+
+/// Decimal base used in digit extraction (`R *= 10`, `d = floor(R/S)`).
+const DECIMAL_BASE: i32 = 10;
+/// Upper bound on integer-part digit count in the `to_fixed` digit buffer (covers up to 10^309).
+const MAX_INT_DIGITS: i32 = 340;
+/// Extra slack bytes appended to `MAX_INT_DIGITS + n` when allocating the `to_fixed` digit buffer.
+const DIGIT_BUF_SLACK: i32 = 8;
+
+// ── ASCII character codes ──
+const ASCII_ZERO: i32  = 48; // '0'
+const ASCII_ONE: i32   = 49; // '1'
+const ASCII_DOT: i32   = 46; // '.'
+const ASCII_MINUS: i32 = 45; // '-'
+const ASCII_NINE: i32  = 57; // '9'
+
+/// Byte length of the two-character prefix/suffix "0." or ".0".
+const ZERO_DOT_LEN: i32 = 2;
+/// Bignum `len` field value when the value occupies exactly two u32 limbs.
+const BN_TWO_LIMBS: i32 = 2;
+
 /// Register all Dragon4 helper signatures. Call from `register_runtime_functions`.
 pub fn register(emitter: &mut WasmEmitter) {
     let p_void = emitter.register_type(vec![ValType::I32], vec![]);
@@ -124,7 +169,7 @@ fn compile_norm(emitter: &mut WasmEmitter) {
           local_get(1); i32_const(1); i32_le_u; br_if(1);
           // limb[len-1] at p + BN_HDR + (len-1)*4
           local_get(0); i32_const(BN_HDR as i32); i32_add;
-          local_get(1); i32_const(1); i32_sub; i32_const(4); i32_mul; i32_add;
+          local_get(1); i32_const(1); i32_sub; i32_const(LIMB_BYTES); i32_mul; i32_add;
           i32_load(0);
           br_if(1); // nonzero -> stop
           local_get(1); i32_const(1); i32_sub; local_set(1);
@@ -150,29 +195,29 @@ fn compile_mul_small(emitter: &mut WasmEmitter) {
         block_empty; loop_empty;
           local_get(3); local_get(2); i32_ge_u; br_if(1);
           // prod = limb[i] * m + carry
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(4); i32_mul; i32_add;
+          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(LIMB_BYTES); i32_mul; i32_add;
           i32_load(0); i64_extend_i32_u;
           local_get(1); i64_extend_i32_u;
           i64_mul;
           local_get(4); i64_add;
           local_set(5);
           // limb[i] = prod & 0xFFFFFFFF
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(4); i32_mul; i32_add;
+          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(LIMB_BYTES); i32_mul; i32_add;
           local_get(5); i32_wrap_i64;
           i32_store(0);
           // carry = prod >> 32
-          local_get(5); i64_const(32); i64_shr_u; local_set(4);
+          local_get(5); i64_const(LIMB_BITS_I64); i64_shr_u; local_set(4);
           local_get(3); i32_const(1); i32_add; local_set(3);
           br(0);
         end; end;
         // emit remaining carry limbs
         block_empty; loop_empty;
           local_get(4); i64_eqz; br_if(1);
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(2); i32_const(4); i32_mul; i32_add;
+          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(2); i32_const(LIMB_BYTES); i32_mul; i32_add;
           local_get(4); i32_wrap_i64;
           i32_store(0);
           local_get(2); i32_const(1); i32_add; local_set(2);
-          local_get(4); i64_const(32); i64_shr_u; local_set(4);
+          local_get(4); i64_const(LIMB_BITS_I64); i64_shr_u; local_set(4);
           br(0);
         end; end;
         local_get(0); local_get(2); i32_store(0);
@@ -203,8 +248,8 @@ fn compile_cmp(emitter: &mut WasmEmitter) {
         block_empty; loop_empty;
           local_get(4); i32_eqz; br_if(1);
           local_get(4); i32_const(1); i32_sub; local_set(4);
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(4); i32_mul; i32_add; i32_load(0); local_set(5);
-          local_get(1); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(4); i32_mul; i32_add; i32_load(0); local_set(6);
+          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); local_set(5);
+          local_get(1); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); local_set(6);
           local_get(5); local_get(6); i32_ne;
           if_empty;
             local_get(5); local_get(6); i32_lt_u;
@@ -241,25 +286,25 @@ fn compile_add(emitter: &mut WasmEmitter) {
           // a = (i < ld) ? dst.limb[i] : 0
           local_get(5); local_get(2); i32_lt_u;
           if_i64;
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(4); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
+            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
           else_; i64_const(0); end;
           // b = (i < ls) ? src.limb[i] : 0
           local_get(5); local_get(3); i32_lt_u;
           if_i64;
-            local_get(1); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(4); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
+            local_get(1); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
           else_; i64_const(0); end;
           i64_add; local_get(6); i64_add; local_set(7);
           // dst.limb[i] = sum & 0xFFFFFFFF
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(4); i32_mul; i32_add;
+          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add;
           local_get(7); i32_wrap_i64; i32_store(0);
-          local_get(7); i64_const(32); i64_shr_u; local_set(6);
+          local_get(7); i64_const(LIMB_BITS_I64); i64_shr_u; local_set(6);
           local_get(5); i32_const(1); i32_add; local_set(5);
           br(0);
         end; end;
         // final carry
         local_get(6); i64_eqz; i32_eqz;
         if_empty;
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(4); i32_mul; i32_add;
+          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(LIMB_BYTES); i32_mul; i32_add;
           local_get(6); i32_wrap_i64; i32_store(0);
           local_get(4); i32_const(1); i32_add; local_set(4);
         end;
@@ -285,21 +330,21 @@ fn compile_sub(emitter: &mut WasmEmitter) {
         block_empty; loop_empty;
           local_get(4); local_get(2); i32_ge_u; br_if(1);
           // diff = dst.limb[i] - (i<ls? src.limb[i] : 0) - borrow
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(4); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
+          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
           local_get(4); local_get(3); i32_lt_u;
           if_i64;
-            local_get(1); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(4); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
+            local_get(1); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); i64_extend_i32_u;
           else_; i64_const(0); end;
           i64_sub; local_get(5); i64_sub; local_set(6);
           // if diff < 0 (high bit set since we extended u32): diff += 2^32, borrow=1
           local_get(6); i64_const(0); i64_lt_s;
           if_empty;
-            local_get(6); i64_const(0x1_0000_0000); i64_add; local_set(6);
+            local_get(6); i64_const(CARRY_WRAP); i64_add; local_set(6);
             i64_const(1); local_set(5);
           else_;
             i64_const(0); local_set(5);
           end;
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(4); i32_mul; i32_add;
+          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(4); i32_const(LIMB_BYTES); i32_mul; i32_add;
           local_get(6); i32_wrap_i64; i32_store(0);
           local_get(4); i32_const(1); i32_add; local_set(4);
           br(0);
@@ -320,8 +365,8 @@ fn compile_shl(emitter: &mut WasmEmitter) {
     ]);
     wasm!(f, {
         local_get(0); i32_load(0); local_set(2);
-        local_get(1); i32_const(32); i32_div_u; local_set(3); // limb_shift
-        local_get(1); i32_const(32); i32_rem_u; local_set(4); // bit_shift
+        local_get(1); i32_const(LIMB_BITS_I32); i32_div_u; local_set(3); // limb_shift
+        local_get(1); i32_const(LIMB_BITS_I32); i32_rem_u; local_set(4); // bit_shift
         // limb shift: move limbs up by limb_shift, zero the low ones
         local_get(3); i32_eqz; i32_eqz;
         if_empty;
@@ -330,8 +375,8 @@ fn compile_shl(emitter: &mut WasmEmitter) {
           block_empty; loop_empty;
             local_get(5); i32_eqz; br_if(1);
             local_get(5); i32_const(1); i32_sub; local_set(5);
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); local_get(3); i32_add; i32_const(4); i32_mul; i32_add;
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(4); i32_mul; i32_add; i32_load(0);
+            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); local_get(3); i32_add; i32_const(LIMB_BYTES); i32_mul; i32_add;
+            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0);
             i32_store(0);
             br(0);
           end; end;
@@ -339,7 +384,7 @@ fn compile_shl(emitter: &mut WasmEmitter) {
           i32_const(0); local_set(5);
           block_empty; loop_empty;
             local_get(5); local_get(3); i32_ge_u; br_if(1);
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(4); i32_mul; i32_add;
+            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add;
             i32_const(0); i32_store(0);
             local_get(5); i32_const(1); i32_add; local_set(5);
             br(0);
@@ -353,19 +398,19 @@ fn compile_shl(emitter: &mut WasmEmitter) {
           local_get(3); local_set(5); // i = limb_shift
           block_empty; loop_empty;
             local_get(5); local_get(2); i32_ge_u; br_if(1);
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(4); i32_mul; i32_add; i32_load(0); local_set(7);
+            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0); local_set(7);
             // limb[i] = (v << bit_shift) | carry
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(4); i32_mul; i32_add;
+            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(5); i32_const(LIMB_BYTES); i32_mul; i32_add;
             local_get(7); local_get(4); i32_shl; local_get(6); i32_or;
             i32_store(0);
             // carry = v >> (32 - bit_shift)
-            local_get(7); i32_const(32); local_get(4); i32_sub; i32_shr_u; local_set(6);
+            local_get(7); i32_const(LIMB_BITS_I32); local_get(4); i32_sub; i32_shr_u; local_set(6);
             local_get(5); i32_const(1); i32_add; local_set(5);
             br(0);
           end; end;
           local_get(6); i32_eqz; i32_eqz;
           if_empty;
-            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(2); i32_const(4); i32_mul; i32_add;
+            local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(2); i32_const(LIMB_BYTES); i32_mul; i32_add;
             local_get(6); i32_store(0);
             local_get(2); i32_const(1); i32_add; local_set(2);
           end;
@@ -388,8 +433,8 @@ fn compile_copy(emitter: &mut WasmEmitter) {
         i32_const(0); local_set(3);
         block_empty; loop_empty;
           local_get(3); local_get(2); i32_ge_u; br_if(1);
-          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(4); i32_mul; i32_add;
-          local_get(1); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(4); i32_mul; i32_add; i32_load(0);
+          local_get(0); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(LIMB_BYTES); i32_mul; i32_add;
+          local_get(1); i32_const(BN_HDR as i32); i32_add; local_get(3); i32_const(LIMB_BYTES); i32_mul; i32_add; i32_load(0);
           i32_store(0);
           local_get(3); i32_const(1); i32_add; local_set(3);
           br(0);
@@ -473,11 +518,11 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     let s_nzero = emitter.intern_string("-0.0");
     wasm!(f, {
         // exp = (bits >> 52) & 0x7FF
-        local_get(2); i64_const(52); i64_shr_u; i32_wrap_i64; i32_const(0x7FF); i32_and; local_set(3);
+        local_get(2); i64_const(F64_MANTISSA_BITS); i64_shr_u; i32_wrap_i64; i32_const(F64_EXP_MASK); i32_and; local_set(3);
         // raw_mant = bits & 0xF_FFFF_FFFF_FFFF
-        local_get(2); i64_const(0x000F_FFFF_FFFF_FFFF); i64_and; local_set(4);
+        local_get(2); i64_const(F64_MANT_MASK); i64_and; local_set(4);
         // if exp == 0x7FF: NaN or inf
-        local_get(3); i32_const(0x7FF); i32_eq;
+        local_get(3); i32_const(F64_EXP_MASK); i32_eq;
         if_empty;
           local_get(4); i64_eqz; i32_eqz;
           if_empty;
@@ -506,10 +551,10 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
 
     // Work with |x|: clear sign bit.
     wasm!(f, {
-        local_get(2); i64_const(0x7FFF_FFFF_FFFF_FFFF); i64_and; local_set(2);
+        local_get(2); i64_const(F64_ABS_MASK); i64_and; local_set(2);
         // re-extract exp/mant from |bits| (exp/mant already sign-independent, but recompute mant cleanly)
-        local_get(2); i64_const(52); i64_shr_u; i32_wrap_i64; i32_const(0x7FF); i32_and; local_set(3);
-        local_get(2); i64_const(0x000F_FFFF_FFFF_FFFF); i64_and; local_set(4);
+        local_get(2); i64_const(F64_MANTISSA_BITS); i64_shr_u; i32_wrap_i64; i32_const(F64_EXP_MASK); i32_and; local_set(3);
+        local_get(2); i64_const(F64_MANT_MASK); i64_and; local_set(4);
     });
 
     // Decompose: if exp==0 (subnormal): f=raw_mant, e=-1074
@@ -518,10 +563,10 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
         local_get(3); i32_eqz;
         if_empty;
           local_get(4); local_set(5);
-          i32_const(-1074); local_set(6);
+          i32_const(F64_SUBNORMAL_EXP); local_set(6);
         else_;
-          local_get(4); i64_const(0x10_0000_0000_0000); i64_add; local_set(5);
-          local_get(3); i32_const(1075); i32_sub; local_set(6);
+          local_get(4); i64_const(F64_IMPLICIT_BIT); i64_add; local_set(5);
+          local_get(3); i32_const(F64_EXP_BIAS_OFFSET); i32_sub; local_set(6);
         end;
         // even = (f & 1) == 0
         local_get(5); i64_const(1); i64_and; i64_eqz; local_set(8);
@@ -702,7 +747,7 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
         if_empty;
           // digits[dlen] = '0'+d ; dlen++
           local_get(20); local_get(10); i32_add;
-          local_get(12); i32_const(48); i32_add; i32_store8(0);
+          local_get(12); i32_const(ASCII_ZERO); i32_add; i32_store8(0);
           local_get(10); i32_const(1); i32_add; local_set(10);
           br(1); // continue outer loop
         end;
@@ -733,7 +778,7 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
     // digits[dlen] = '0'+d ; dlen++
     wasm!(f, {
         local_get(20); local_get(10); i32_add;
-        local_get(12); i32_const(48); i32_add; i32_store8(0);
+        local_get(12); i32_const(ASCII_ZERO); i32_add; i32_store8(0);
         local_get(10); i32_const(1); i32_add; local_set(10);
     });
     // if round_up: propagate carry from the last digit
@@ -754,7 +799,7 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
               local_get(20);
               local_get(10);
               memory_copy;
-              local_get(20); i32_const(49); i32_store8(0); // '1'
+              local_get(20); i32_const(ASCII_ONE); i32_store8(0); // '1'
               local_get(10); i32_const(1); i32_add; local_set(10);
               local_get(7); i32_const(1); i32_add; local_set(7);
               br(2); // break carry loop
@@ -764,9 +809,9 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
             // if digits[i] == '9': set '0', continue loop; else digits[i]++, break.
             // Depths from inside this if/else: if-block=0, loop=1, block=2.
             local_get(20); local_get(22); i32_add; i32_load8_u(0);
-            i32_const(57); i32_eq; // '9'
+            i32_const(ASCII_NINE); i32_eq; // '9'
             if_empty;
-              local_get(20); local_get(22); i32_add; i32_const(48); i32_store8(0);
+              local_get(20); local_get(22); i32_add; i32_const(ASCII_ZERO); i32_store8(0);
               br(1); // continue carry loop
             else_;
               local_get(20); local_get(22); i32_add;
@@ -804,12 +849,12 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
         local_get(7); i32_const(0); i32_le_s;
         if_i32;
           // 2 + (-k) + m
-          i32_const(2); i32_const(0); local_get(7); i32_sub; i32_add; local_get(21); i32_add;
+          i32_const(ZERO_DOT_LEN); i32_const(0); local_get(7); i32_sub; i32_add; local_get(21); i32_add;
         else_;
           local_get(7); local_get(21); i32_ge_s;
           if_i32;
             // m + (k-m) + 2  == k + 2
-            local_get(7); i32_const(2); i32_add;
+            local_get(7); i32_const(ZERO_DOT_LEN); i32_add;
           else_;
             // m + 1
             local_get(21); i32_const(1); i32_add;
@@ -835,7 +880,7 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
         local_get(11);
         if_empty;
           local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-          i32_const(45); i32_store8(0); // '-'
+          i32_const(ASCII_MINUS); i32_store8(0); // '-'
           local_get(16); i32_const(1); i32_add; local_set(16);
         end;
     });
@@ -846,17 +891,17 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
         if_empty;
           // "0." then (-k) zeros then digits
           local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-          i32_const(48); i32_store8(0); // '0'
+          i32_const(ASCII_ZERO); i32_store8(0); // '0'
           local_get(16); i32_const(1); i32_add; local_set(16);
           local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-          i32_const(46); i32_store8(0); // '.'
+          i32_const(ASCII_DOT); i32_store8(0); // '.'
           local_get(16); i32_const(1); i32_add; local_set(16);
           // (-k) zeros
           i32_const(0); local_set(22);
           block_empty; loop_empty;
             local_get(22); i32_const(0); local_get(7); i32_sub; i32_ge_s; br_if(1);
             local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-            i32_const(48); i32_store8(0);
+            i32_const(ASCII_ZERO); i32_store8(0);
             local_get(16); i32_const(1); i32_add; local_set(16);
             local_get(22); i32_const(1); i32_add; local_set(22);
             br(0);
@@ -891,17 +936,17 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
             block_empty; loop_empty;
               local_get(22); local_get(7); local_get(21); i32_sub; i32_ge_s; br_if(1);
               local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-              i32_const(48); i32_store8(0);
+              i32_const(ASCII_ZERO); i32_store8(0);
               local_get(16); i32_const(1); i32_add; local_set(16);
               local_get(22); i32_const(1); i32_add; local_set(22);
               br(0);
             end; end;
             // ".0"
             local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-            i32_const(46); i32_store8(0);
+            i32_const(ASCII_DOT); i32_store8(0);
             local_get(16); i32_const(1); i32_add; local_set(16);
             local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-            i32_const(48); i32_store8(0);
+            i32_const(ASCII_ZERO); i32_store8(0);
             local_get(16); i32_const(1); i32_add; local_set(16);
           else_;
             // digits[0..k] "." digits[k..m]
@@ -916,7 +961,7 @@ fn compile_float_to_string(emitter: &mut WasmEmitter) {
               br(0);
             end; end;
             local_get(18); i32_const(string_data_off() as i32); i32_add; local_get(16); i32_add;
-            i32_const(46); i32_store8(0);
+            i32_const(ASCII_DOT); i32_store8(0);
             local_get(16); i32_const(1); i32_add; local_set(16);
             // digits[k..m]  (continue from local 22 = k)
             block_empty; loop_empty;
@@ -1026,9 +1071,9 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
 
     // NaN / inf special cases (raw exp == 0x7FF).
     wasm!(f, {
-        local_get(BITS); i64_const(52); i64_shr_u; i32_wrap_i64; i32_const(0x7FF); i32_and; local_set(RAW_EXP);
-        local_get(BITS); i64_const(0x000F_FFFF_FFFF_FFFF); i64_and; local_set(RAW_MANT);
-        local_get(RAW_EXP); i32_const(0x7FF); i32_eq;
+        local_get(BITS); i64_const(F64_MANTISSA_BITS); i64_shr_u; i32_wrap_i64; i32_const(F64_EXP_MASK); i32_and; local_set(RAW_EXP);
+        local_get(BITS); i64_const(F64_MANT_MASK); i64_and; local_set(RAW_MANT);
+        local_get(RAW_EXP); i32_const(F64_EXP_MASK); i32_eq;
         if_empty;
             local_get(RAW_MANT); i64_eqz; i32_eqz;
             if_empty; i32_const(s_nan as i32); return_; end;
@@ -1041,9 +1086,9 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
     // neg = sign bit; work with |f| bits.
     wasm!(f, {
         local_get(BITS); i64_const(0); i64_lt_s; local_set(NEG);
-        local_get(BITS); i64_const(0x7FFF_FFFF_FFFF_FFFF); i64_and; local_set(BITS);
-        local_get(BITS); i64_const(52); i64_shr_u; i32_wrap_i64; i32_const(0x7FF); i32_and; local_set(RAW_EXP);
-        local_get(BITS); i64_const(0x000F_FFFF_FFFF_FFFF); i64_and; local_set(RAW_MANT);
+        local_get(BITS); i64_const(F64_ABS_MASK); i64_and; local_set(BITS);
+        local_get(BITS); i64_const(F64_MANTISSA_BITS); i64_shr_u; i32_wrap_i64; i32_const(F64_EXP_MASK); i32_and; local_set(RAW_EXP);
+        local_get(BITS); i64_const(F64_MANT_MASK); i64_and; local_set(RAW_MANT);
     });
 
     // Decompose: subnormal (raw_exp==0): mant=raw_mant, e=-1074; else mant=raw_mant+2^52, e=raw_exp-1075.
@@ -1051,10 +1096,10 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
         local_get(RAW_EXP); i32_eqz;
         if_empty;
             local_get(RAW_MANT); local_set(MANT);
-            i32_const(-1074); local_set(E);
+            i32_const(F64_SUBNORMAL_EXP); local_set(E);
         else_;
-            local_get(RAW_MANT); i64_const(0x10_0000_0000_0000); i64_add; local_set(MANT);
-            local_get(RAW_EXP); i32_const(1075); i32_sub; local_set(E);
+            local_get(RAW_MANT); i64_const(F64_IMPLICIT_BIT); i64_add; local_set(MANT);
+            local_get(RAW_EXP); i32_const(F64_EXP_BIAS_OFFSET); i32_sub; local_set(E);
         end;
     });
 
@@ -1064,7 +1109,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
         // Digit buffer: up to ~310 integer digits + n fraction digits + slack (for a
         // round-up carry that prepends one leading digit). The generation loop stops
         // producing significant digits once R hits 0, so n only sizes the buffer.
-        i32_const(340); local_get(N); i32_add; i32_const(8); i32_add; call(emitter.rt.alloc); local_set(DP);
+        i32_const(MAX_INT_DIGITS); local_get(N); i32_add; i32_const(DIGIT_BUF_SLACK); i32_add; call(emitter.rt.alloc); local_set(DP);
         i32_const(0); local_set(DLEN);
         i32_const(0); local_set(K);
     });
@@ -1102,7 +1147,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
                 block_empty; loop_empty;
                     local_get(BASE); i32_const(OFF_R as i32); i32_add; local_get(BASE); i32_const(OFF_S as i32); i32_add; call(dr.cmp);
                     i32_const(0); i32_lt_s; br_if(1);
-                    local_get(BASE); i32_const(OFF_S as i32); i32_add; i32_const(10); call(dr.mul_small);
+                    local_get(BASE); i32_const(OFF_S as i32); i32_add; i32_const(DECIMAL_BASE); call(dr.mul_small);
                     local_get(K); i32_const(1); i32_add; local_set(K);
                     br(0);
                 end; end;
@@ -1111,10 +1156,10 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
                 block_empty; loop_empty;
                     // TMP = R; TMP *= 10; cmp(TMP, S) >= 0 → stop
                     local_get(BASE); i32_const(OFF_TMP as i32); i32_add; local_get(BASE); i32_const(OFF_R as i32); i32_add; call(dr.copy);
-                    local_get(BASE); i32_const(OFF_TMP as i32); i32_add; i32_const(10); call(dr.mul_small);
+                    local_get(BASE); i32_const(OFF_TMP as i32); i32_add; i32_const(DECIMAL_BASE); call(dr.mul_small);
                     local_get(BASE); i32_const(OFF_TMP as i32); i32_add; local_get(BASE); i32_const(OFF_S as i32); i32_add; call(dr.cmp);
                     i32_const(0); i32_ge_s; br_if(1);
-                    local_get(BASE); i32_const(OFF_R as i32); i32_add; i32_const(10); call(dr.mul_small);
+                    local_get(BASE); i32_const(OFF_R as i32); i32_add; i32_const(DECIMAL_BASE); call(dr.mul_small);
                     local_get(K); i32_const(1); i32_sub; local_set(K);
                     br(0);
                 end; end;
@@ -1162,7 +1207,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
                 if_empty;
                     i32_const(0); local_set(D);
                 else_;
-                    local_get(BASE); i32_const(OFF_R as i32); i32_add; i32_const(10); call(dr.mul_small);
+                    local_get(BASE); i32_const(OFF_R as i32); i32_add; i32_const(DECIMAL_BASE); call(dr.mul_small);
                     i32_const(0); local_set(D);
                     block_empty; loop_empty;
                         local_get(BASE); i32_const(OFF_R as i32); i32_add; local_get(BASE); i32_const(OFF_S as i32); i32_add; call(dr.cmp);
@@ -1173,7 +1218,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
                     end; end;
                 end;
             end;
-            local_get(DP); local_get(DLEN); i32_add; local_get(D); i32_const(48); i32_add; i32_store8(0);
+            local_get(DP); local_get(DLEN); i32_add; local_get(D); i32_const(ASCII_ZERO); i32_add; i32_store8(0);
             local_get(DLEN); i32_const(1); i32_add; local_set(DLEN);
             local_get(I); i32_const(1); i32_add; local_set(I);
             br(0);
@@ -1192,7 +1237,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
             i32_const(0); local_set(I);
             block_empty; loop_empty;
                 local_get(I); i32_const(0); local_get(CNT); i32_sub; i32_ge_s; br_if(1);
-                local_get(BASE); i32_const(OFF_S as i32); i32_add; i32_const(10); call(dr.mul_small);
+                local_get(BASE); i32_const(OFF_S as i32); i32_add; i32_const(DECIMAL_BASE); call(dr.mul_small);
                 local_get(I); i32_const(1); i32_add; local_set(I);
                 br(0);
             end; end;
@@ -1234,15 +1279,15 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
                     // carry out of the most-significant slot: shift right by 1, set
                     // digits[0]='1', total++, k++ (a new leading integer digit).
                     local_get(DP); i32_const(1); i32_add; local_get(DP); local_get(TOTAL); memory_copy;
-                    local_get(DP); i32_const(49); i32_store8(0);
+                    local_get(DP); i32_const(ASCII_ONE); i32_store8(0);
                     local_get(TOTAL); i32_const(1); i32_add; local_set(TOTAL);
                     local_get(K); i32_const(1); i32_add; local_set(K);
                     br(2);
                 end;
                 local_get(I); i32_const(1); i32_sub; local_set(I);
-                local_get(DP); local_get(I); i32_add; i32_load8_u(0); i32_const(57); i32_eq;
+                local_get(DP); local_get(I); i32_add; i32_load8_u(0); i32_const(ASCII_NINE); i32_eq;
                 if_empty;
-                    local_get(DP); local_get(I); i32_add; i32_const(48); i32_store8(0);
+                    local_get(DP); local_get(I); i32_add; i32_const(ASCII_ZERO); i32_store8(0);
                     br(1);
                 else_;
                     local_get(DP); local_get(I); i32_add;
@@ -1273,7 +1318,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
             if_i32;
                 i32_const(1);                 // just "0"
             else_;
-                i32_const(2); local_get(N); i32_add;   // "0." + n frac
+                i32_const(ZERO_DOT_LEN); local_get(N); i32_add;   // "0." + n frac
             end;
         else_;
             local_get(N); i32_eqz;
@@ -1296,7 +1341,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
         // sign
         local_get(NEG);
         if_empty;
-            local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add; i32_const(45); i32_store8(0);
+            local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add; i32_const(ASCII_MINUS); i32_store8(0);
             local_get(CURSOR); i32_const(1); i32_add; local_set(CURSOR);
         end;
     });
@@ -1306,7 +1351,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
         local_get(K); i32_const(0); i32_le_s;
         if_empty;
             // value < 1 (after rounding). If n == 0 → just "0".
-            local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add; i32_const(48); i32_store8(0);
+            local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add; i32_const(ASCII_ZERO); i32_store8(0);
             local_get(CURSOR); i32_const(1); i32_add; local_set(CURSOR);
             local_get(N); i32_eqz;
             if_empty;
@@ -1314,7 +1359,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
             else_;
                 // '.' then all `total`(==n) fraction digits — the leading zeros are
                 // already materialized in the buffer, so this is a straight copy.
-                local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add; i32_const(46); i32_store8(0);
+                local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add; i32_const(ASCII_DOT); i32_store8(0);
                 local_get(CURSOR); i32_const(1); i32_add; local_set(CURSOR);
                 i32_const(0); local_set(I);
                 block_empty; loop_empty;
@@ -1339,7 +1384,7 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
             end; end;
             local_get(N); i32_eqz;
             if_empty; else_;
-                local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add; i32_const(46); i32_store8(0);
+                local_get(RESULT); i32_const(string_data_off() as i32); i32_add; local_get(CURSOR); i32_add; i32_const(ASCII_DOT); i32_store8(0);
                 local_get(CURSOR); i32_const(1); i32_add; local_set(CURSOR);
                 // digits[k .. total]  (I continues from k)
                 block_empty; loop_empty;
@@ -1364,9 +1409,9 @@ pub(super) fn compile_float_to_fixed(emitter: &mut WasmEmitter) {
 fn set_bn_u64(f: &mut Function, base: u32, off: u32, loc: u32) {
     wasm!(f, {
         local_get(base); i32_const((off + BN_HDR) as i32); i32_add; local_get(loc); i32_wrap_i64; i32_store(0);
-        local_get(base); i32_const((off + BN_HDR + 4) as i32); i32_add; local_get(loc); i64_const(32); i64_shr_u; i32_wrap_i64; i32_store(0);
+        local_get(base); i32_const((off + BN_HDR + 4) as i32); i32_add; local_get(loc); i64_const(LIMB_BITS_I64); i64_shr_u; i32_wrap_i64; i32_store(0);
         local_get(base); i32_const(off as i32); i32_add;
-        local_get(loc); i64_const(32); i64_shr_u; i64_eqz; if_i32; i32_const(1); else_; i32_const(2); end;
+        local_get(loc); i64_const(LIMB_BITS_I64); i64_shr_u; i64_eqz; if_i32; i32_const(1); else_; i32_const(BN_TWO_LIMBS); end;
         i32_store(0);
     });
 }
@@ -1412,11 +1457,11 @@ impl DragonRefs {
             local_get(loc); i32_wrap_i64; i32_store(0);
             // limb1 = (val >> 32)
             local_get(1); i32_const((off + BN_HDR + 4) as i32); i32_add;
-            local_get(loc); i64_const(32); i64_shr_u; i32_wrap_i64; i32_store(0);
+            local_get(loc); i64_const(LIMB_BITS_I64); i64_shr_u; i32_wrap_i64; i32_store(0);
             // len = (hi != 0) ? 2 : 1
             local_get(1); i32_const(off as i32); i32_add;
-            local_get(loc); i64_const(32); i64_shr_u; i64_eqz;
-            if_i32; i32_const(1); else_; i32_const(2); end;
+            local_get(loc); i64_const(LIMB_BITS_I64); i64_shr_u; i64_eqz;
+            if_i32; i32_const(1); else_; i32_const(BN_TWO_LIMBS); end;
             i32_store(0);
         });
     }
@@ -1469,7 +1514,7 @@ impl DragonRefs {
     }
     fn mul10(&self, f: &mut Function, off: u32) {
         self.ptr(f, off);
-        wasm!(f, { i32_const(10); call(self.mul_small); });
+        wasm!(f, { i32_const(DECIMAL_BASE); call(self.mul_small); });
     }
     /// shl by a constant bit count.
     fn shl_const(&self, f: &mut Function, off: u32, bits: u32) {

--- a/crates/almide-codegen/src/emit_wasm/rt_encoding.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_encoding.rs
@@ -11,6 +11,7 @@
 //!   hex alphabet (lower):      0..9 → '0'+i, 10..15 → 'a'+(i-10)
 //!   hex alphabet (upper):      0..9 → '0'+i, 10..15 → 'A'+(i-10)
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use super::{CompiledFunc, WasmEmitter};
 use wasm_encoder::{ValType};
 use super::TrackedFunction as Function;
@@ -126,145 +127,145 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
 
     // byte_len = buf_ptr[0]
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
+        local_get(Local(0)); i32_load(0); local_set(Local(1));
     });
 
     // groups of 3 → 4 chars, padded: out_len = ceil(byte_len / 3) * 4.
     wasm!(f, {
-        local_get(1); i32_const(B64_GROUP_BYTES - 1); i32_add;
-        i32_const(B64_GROUP_BYTES); i32_div_u;
-        i32_const(B64_GROUP_CHARS); i32_mul;
-        local_set(2);
+        local_get(Local(1)); i32_const(Imm32(B64_GROUP_BYTES - 1)); i32_add;
+        i32_const(Imm32(B64_GROUP_BYTES)); i32_div_u;
+        i32_const(Imm32(B64_GROUP_CHARS)); i32_mul;
+        local_set(Local(2));
     });
 
     // out_ptr = string_alloc(out_len): writes the len AND cap header fields
     // (the previous code called raw alloc and left len=0 → empty output).
     wasm!(f, {
-        local_get(2); call(emitter.rt.string_alloc); local_set(3);
-        i32_const(0); local_set(4); // i = 0
-        i32_const(0); local_set(5); // j = 0
+        local_get(Local(2)); call(emitter.rt.string_alloc); local_set(Local(3));
+        i32_const(Imm32(0)); local_set(Local(4)); // i = 0
+        i32_const(Imm32(0)); local_set(Local(5)); // j = 0
     });
 
     // Main loop: process 3 input bytes → 4 output chars
     wasm!(f, {
         block_empty; loop_empty;
-            local_get(4); i32_const(B64_GROUP_BYTES); i32_add; local_get(1); i32_gt_u; br_if(1);
+            local_get(Local(4)); i32_const(Imm32(B64_GROUP_BYTES)); i32_add; local_get(Local(1)); i32_gt_u; br_if(1);
             // Load 3 bytes b0, b1, b2
-            local_get(0); i32_const(data_off); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(6);
-            local_get(0); i32_const(data_off + 1); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(7);
-            local_get(0); i32_const(data_off + 2); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(8);
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(6));
+            local_get(Local(0)); i32_const(Imm32(data_off + 1)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(7));
+            local_get(Local(0)); i32_const(Imm32(data_off + 2)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(8));
             // c0 = alphabet[b0 >> 2]
-            local_get(6); i32_const(B64_UPPER_SHIFT); i32_shr_u; local_set(9);
+            local_get(Local(6)); i32_const(Imm32(B64_UPPER_SHIFT)); i32_shr_u; local_set(Local(9));
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
-            local_set(9);
-            local_get(3); i32_const(data_off); i32_add; local_get(5); i32_add;
-            local_get(9);
+            local_set(Local(9));
+            local_get(Local(3)); i32_const(Imm32(data_off)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(9));
             i32_store8(0);
             // c1 = alphabet[((b0 & 3) << 4) | (b1 >> 4)]
-            local_get(6); i32_const(B64_LOW2_MASK); i32_and; i32_const(B64_MID_SHIFT); i32_shl;
-            local_get(7); i32_const(B64_MID_SHIFT); i32_shr_u;
-            i32_or; local_set(9);
+            local_get(Local(6)); i32_const(Imm32(B64_LOW2_MASK)); i32_and; i32_const(Imm32(B64_MID_SHIFT)); i32_shl;
+            local_get(Local(7)); i32_const(Imm32(B64_MID_SHIFT)); i32_shr_u;
+            i32_or; local_set(Local(9));
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
-            local_set(9);
-            local_get(3); i32_const(data_off + 1); i32_add; local_get(5); i32_add;
-            local_get(9);
+            local_set(Local(9));
+            local_get(Local(3)); i32_const(Imm32(data_off + 1)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(9));
             i32_store8(0);
             // c2 = alphabet[((b1 & 0xF) << 2) | (b2 >> 6)]
-            local_get(7); i32_const(B64_LOW4_MASK); i32_and; i32_const(B64_UPPER_SHIFT); i32_shl;
-            local_get(8); i32_const(B64_LOWER_SHIFT); i32_shr_u;
-            i32_or; local_set(9);
+            local_get(Local(7)); i32_const(Imm32(B64_LOW4_MASK)); i32_and; i32_const(Imm32(B64_UPPER_SHIFT)); i32_shl;
+            local_get(Local(8)); i32_const(Imm32(B64_LOWER_SHIFT)); i32_shr_u;
+            i32_or; local_set(Local(9));
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
-            local_set(9);
-            local_get(3); i32_const(data_off + 2); i32_add; local_get(5); i32_add;
-            local_get(9);
+            local_set(Local(9));
+            local_get(Local(3)); i32_const(Imm32(data_off + 2)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(9));
             i32_store8(0);
             // c3 = alphabet[b2 & 0x3F]
-            local_get(8); i32_const(B64_6BIT_MASK); i32_and; local_set(9);
+            local_get(Local(8)); i32_const(Imm32(B64_6BIT_MASK)); i32_and; local_set(Local(9));
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
-            local_set(9);
-            local_get(3); i32_const(data_off + 3); i32_add; local_get(5); i32_add;
-            local_get(9);
+            local_set(Local(9));
+            local_get(Local(3)); i32_const(Imm32(data_off + 3)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(9));
             i32_store8(0);
-            local_get(4); i32_const(B64_GROUP_BYTES); i32_add; local_set(4);
-            local_get(5); i32_const(B64_GROUP_CHARS); i32_add; local_set(5);
+            local_get(Local(4)); i32_const(Imm32(B64_GROUP_BYTES)); i32_add; local_set(Local(4));
+            local_get(Local(5)); i32_const(Imm32(B64_GROUP_CHARS)); i32_add; local_set(Local(5));
             br(0);
         end; end;
     });
 
     // Tail: handle rem 1 or 2 bytes
     wasm!(f, {
-        local_get(1); local_get(4); i32_sub; // rem
-        local_set(9); // reuse local 9 as rem
-        local_get(9); i32_const(1); i32_eq;
+        local_get(Local(1)); local_get(Local(4)); i32_sub; // rem
+        local_set(Local(9)); // reuse local 9 as rem
+        local_get(Local(9)); i32_const(Imm32(1)); i32_eq;
         if_empty;
             // 1 byte: 2 output chars + 2 '=' padding
-            local_get(0); i32_const(data_off); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(6);
-            local_get(6); i32_const(B64_UPPER_SHIFT); i32_shr_u; local_set(9);
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(6));
+            local_get(Local(6)); i32_const(Imm32(B64_UPPER_SHIFT)); i32_shr_u; local_set(Local(9));
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
-            local_set(9);
-            local_get(3); i32_const(data_off); i32_add; local_get(5); i32_add;
-            local_get(9);
+            local_set(Local(9));
+            local_get(Local(3)); i32_const(Imm32(data_off)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(9));
             i32_store8(0);
-            local_get(6); i32_const(B64_LOW2_MASK); i32_and; i32_const(B64_MID_SHIFT); i32_shl; local_set(9);
+            local_get(Local(6)); i32_const(Imm32(B64_LOW2_MASK)); i32_and; i32_const(Imm32(B64_MID_SHIFT)); i32_shl; local_set(Local(9));
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
-            local_set(9);
-            local_get(3); i32_const(data_off + 1); i32_add; local_get(5); i32_add;
-            local_get(9);
+            local_set(Local(9));
+            local_get(Local(3)); i32_const(Imm32(data_off + 1)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(9));
             i32_store8(0);
             // padding '=' '='
-            local_get(3); i32_const(data_off + 2); i32_add; local_get(5); i32_add;
-            i32_const(B64_PAD); i32_store8(0);
-            local_get(3); i32_const(data_off + 3); i32_add; local_get(5); i32_add;
-            i32_const(B64_PAD); i32_store8(0);
+            local_get(Local(3)); i32_const(Imm32(data_off + 2)); i32_add; local_get(Local(5)); i32_add;
+            i32_const(Imm32(B64_PAD)); i32_store8(0);
+            local_get(Local(3)); i32_const(Imm32(data_off + 3)); i32_add; local_get(Local(5)); i32_add;
+            i32_const(Imm32(B64_PAD)); i32_store8(0);
         end;
-        local_get(1); local_get(4); i32_sub;
-        i32_const(B64_GROUP_BYTES - 1); i32_eq;
+        local_get(Local(1)); local_get(Local(4)); i32_sub;
+        i32_const(Imm32(B64_GROUP_BYTES - 1)); i32_eq;
         if_empty;
             // 2 bytes: 3 output chars + 1 '=' padding
-            local_get(0); i32_const(data_off); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(6);
-            local_get(0); i32_const(data_off + 1); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(7);
-            local_get(6); i32_const(B64_UPPER_SHIFT); i32_shr_u; local_set(9);
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(6));
+            local_get(Local(0)); i32_const(Imm32(data_off + 1)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(7));
+            local_get(Local(6)); i32_const(Imm32(B64_UPPER_SHIFT)); i32_shr_u; local_set(Local(9));
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
-            local_set(9);
-            local_get(3); i32_const(data_off); i32_add; local_get(5); i32_add;
-            local_get(9);
+            local_set(Local(9));
+            local_get(Local(3)); i32_const(Imm32(data_off)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(9));
             i32_store8(0);
-            local_get(6); i32_const(B64_LOW2_MASK); i32_and; i32_const(B64_MID_SHIFT); i32_shl;
-            local_get(7); i32_const(B64_MID_SHIFT); i32_shr_u;
-            i32_or; local_set(9);
+            local_get(Local(6)); i32_const(Imm32(B64_LOW2_MASK)); i32_and; i32_const(Imm32(B64_MID_SHIFT)); i32_shl;
+            local_get(Local(7)); i32_const(Imm32(B64_MID_SHIFT)); i32_shr_u;
+            i32_or; local_set(Local(9));
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
-            local_set(9);
-            local_get(3); i32_const(data_off + 1); i32_add; local_get(5); i32_add;
-            local_get(9);
+            local_set(Local(9));
+            local_get(Local(3)); i32_const(Imm32(data_off + 1)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(9));
             i32_store8(0);
-            local_get(7); i32_const(B64_LOW4_MASK); i32_and; i32_const(B64_UPPER_SHIFT); i32_shl; local_set(9);
+            local_get(Local(7)); i32_const(Imm32(B64_LOW4_MASK)); i32_and; i32_const(Imm32(B64_UPPER_SHIFT)); i32_shl; local_set(Local(9));
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
-            local_set(9);
-            local_get(3); i32_const(data_off + 2); i32_add; local_get(5); i32_add;
-            local_get(9);
+            local_set(Local(9));
+            local_get(Local(3)); i32_const(Imm32(data_off + 2)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(9));
             i32_store8(0);
-            local_get(3); i32_const(data_off + 3); i32_add; local_get(5); i32_add;
-            i32_const(B64_PAD); i32_store8(0);
+            local_get(Local(3)); i32_const(Imm32(data_off + 3)); i32_add; local_get(Local(5)); i32_add;
+            i32_const(Imm32(B64_PAD)); i32_store8(0);
         end;
-        local_get(3);
+        local_get(Local(3));
         end; // end function
     });
 
@@ -277,23 +278,23 @@ fn emit_b64_alphabet_lookup(f: &mut Function, idx_local: u32, url_safe: bool) {
     let plus_or_dash: i32 = if url_safe { 45 } else { 43 };   // '-' or '+'
     let slash_or_under: i32 = if url_safe { 95 } else { 47 }; // '_' or '/'
     wasm!(f, {
-        local_get(idx_local); i32_const(B64_UPPERCASE_COUNT); i32_lt_u;
+        local_get(Local(idx_local)); i32_const(Imm32(B64_UPPERCASE_COUNT)); i32_lt_u;
         if_i32;
-            i32_const(ASCII_UPPER_A); local_get(idx_local); i32_add; // 'A'+i
+            i32_const(Imm32(ASCII_UPPER_A)); local_get(Local(idx_local)); i32_add; // 'A'+i
         else_;
-            local_get(idx_local); i32_const(B64_DIGIT_START_IDX); i32_lt_u;
+            local_get(Local(idx_local)); i32_const(Imm32(B64_DIGIT_START_IDX)); i32_lt_u;
             if_i32;
-                i32_const(B64_LOWER_ALPHA_OFFSET); local_get(idx_local); i32_add; // 'a'-26 = 71
+                i32_const(Imm32(B64_LOWER_ALPHA_OFFSET)); local_get(Local(idx_local)); i32_add; // 'a'-26 = 71
             else_;
-                local_get(idx_local); i32_const(B64_IDX_PLUS_OR_DASH); i32_lt_u;
+                local_get(Local(idx_local)); i32_const(Imm32(B64_IDX_PLUS_OR_DASH)); i32_lt_u;
                 if_i32;
-                    i32_const(B64_DIGIT_OFFSET); local_get(idx_local); i32_add; // '0'-52 = -4 (256-52=204 mod 256)
+                    i32_const(Imm32(B64_DIGIT_OFFSET)); local_get(Local(idx_local)); i32_add; // '0'-52 = -4 (256-52=204 mod 256)
                 else_;
-                    local_get(idx_local); i32_const(B64_IDX_PLUS_OR_DASH); i32_eq;
+                    local_get(Local(idx_local)); i32_const(Imm32(B64_IDX_PLUS_OR_DASH)); i32_eq;
                     if_i32;
-                        i32_const(plus_or_dash);
+                        i32_const(Imm32(plus_or_dash));
                     else_;
-                        i32_const(slash_or_under);
+                        i32_const(Imm32(slash_or_under));
                     end;
                 end;
             end;
@@ -344,16 +345,16 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
     // Emit an `err(<interned constant>)` return.
     let emit_err_const = |f: &mut Function, err_ptr: u32| {
         wasm!(f, {
-            i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(10);
-            local_get(10); i32_const(1); i32_store(0);
-            local_get(10); i32_const(err_ptr as i32); i32_store(4);
-            local_get(10); return_;
+            i32_const(Imm32(RESULT_CELL_BYTES)); call(emitter.rt.alloc); local_set(Local(10));
+            local_get(Local(10)); i32_const(Imm32(1)); i32_store(0);
+            local_get(Local(10)); i32_const(Imm32(err_ptr as i32)); i32_store(4);
+            local_get(Local(10)); return_;
         });
     };
     // Emit `if (a|b|... == invalid) return err(char)`.
     let emit_invalid_guard = |f: &mut Function, slots: &[u32]| {
         for (k, &slot) in slots.iter().enumerate() {
-            wasm!(f, { local_get(slot); i32_const(invalid); i32_eq; });
+            wasm!(f, { local_get(Local(slot)); i32_const(Imm32(invalid)); i32_eq; });
             if k > 0 { wasm!(f, { i32_or; }); }
         }
         wasm!(f, { if_empty; });
@@ -362,76 +363,76 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
     };
 
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
-        local_get(1); local_set(2);
+        local_get(Local(0)); i32_load(0); local_set(Local(1));
+        local_get(Local(1)); local_set(Local(2));
         // Strip trailing '=': last body char is at str_ptr + data_off + (end-1).
         block_empty; loop_empty;
-            local_get(2); i32_eqz; br_if(1);
-            local_get(0); i32_const(data_off); i32_add; local_get(2); i32_add; i32_const(1); i32_sub;
-            i32_load8_u(0); i32_const(B64_PAD); i32_ne; br_if(1);
-            local_get(2); i32_const(1); i32_sub; local_set(2);
+            local_get(Local(2)); i32_eqz; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; local_get(Local(2)); i32_add; i32_const(Imm32(1)); i32_sub;
+            i32_load8_u(0); i32_const(Imm32(B64_PAD)); i32_ne; br_if(1);
+            local_get(Local(2)); i32_const(Imm32(1)); i32_sub; local_set(Local(2));
             br(0);
         end; end;
     });
 
     // body_len % 4 == 1 → "invalid base64 length: <orig_len>"
     wasm!(f, {
-        local_get(2); i32_const(B64_GROUP_CHARS - 1); i32_and; i32_const(1); i32_eq;
+        local_get(Local(2)); i32_const(Imm32(B64_GROUP_CHARS - 1)); i32_and; i32_const(Imm32(1)); i32_eq;
         if_empty;
           // msg = "invalid base64 length: " + int_to_string(str_len)
-          i32_const(err_len_prefix as i32);
-          local_get(1); i64_extend_i32_u; call(itoa);
-          call(concat); local_set(11);
-          i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(10);
-          local_get(10); i32_const(1); i32_store(0);
-          local_get(10); local_get(11); i32_store(4);
-          local_get(10); return_;
+          i32_const(Imm32(err_len_prefix as i32));
+          local_get(Local(1)); i64_extend_i32_u; call(itoa);
+          call(concat); local_set(Local(11));
+          i32_const(Imm32(RESULT_CELL_BYTES)); call(emitter.rt.alloc); local_set(Local(10));
+          local_get(Local(10)); i32_const(Imm32(1)); i32_store(0);
+          local_get(Local(10)); local_get(Local(11)); i32_store(4);
+          local_get(Local(10)); return_;
         end;
     });
 
     wasm!(f, {
         // alloc output: max possible = body_len * 3 / 4
-        local_get(2); i32_const(B64_GROUP_BYTES); i32_mul; i32_const(B64_GROUP_CHARS); i32_div_u;
-        i32_const(string_hdr()); i32_add;
-        call(emitter.rt.alloc); local_set(3);
-        i32_const(0); local_set(4);
-        i32_const(0); local_set(5);
+        local_get(Local(2)); i32_const(Imm32(B64_GROUP_BYTES)); i32_mul; i32_const(Imm32(B64_GROUP_CHARS)); i32_div_u;
+        i32_const(Imm32(string_hdr())); i32_add;
+        call(emitter.rt.alloc); local_set(Local(3));
+        i32_const(Imm32(0)); local_set(Local(4));
+        i32_const(Imm32(0)); local_set(Local(5));
     });
 
     // Main 4-char loop
     wasm!(f, {
         block_empty; loop_empty;
-            local_get(4); i32_const(B64_GROUP_CHARS); i32_add; local_get(2); i32_gt_u; br_if(1);
-            local_get(0); i32_const(data_off); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(6);
-            local_get(0); i32_const(data_off + 1); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(7);
-            local_get(0); i32_const(data_off + 2); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(8);
-            local_get(0); i32_const(data_off + 3); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(9);
-            local_get(6);
+            local_get(Local(4)); i32_const(Imm32(B64_GROUP_CHARS)); i32_add; local_get(Local(2)); i32_gt_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(6));
+            local_get(Local(0)); i32_const(Imm32(data_off + 1)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(7));
+            local_get(Local(0)); i32_const(Imm32(data_off + 2)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(8));
+            local_get(Local(0)); i32_const(Imm32(data_off + 3)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(9));
+            local_get(Local(6));
     });
     emit_b64_decode_char(&mut f);
-    wasm!(f, { local_set(6); local_get(7); });
+    wasm!(f, { local_set(Local(6)); local_get(Local(7)); });
     emit_b64_decode_char(&mut f);
-    wasm!(f, { local_set(7); local_get(8); });
+    wasm!(f, { local_set(Local(7)); local_get(Local(8)); });
     emit_b64_decode_char(&mut f);
-    wasm!(f, { local_set(8); local_get(9); });
+    wasm!(f, { local_set(Local(8)); local_get(Local(9)); });
     emit_b64_decode_char(&mut f);
-    wasm!(f, { local_set(9); });
+    wasm!(f, { local_set(Local(9)); });
     emit_invalid_guard(&mut f, &[6, 7, 8, 9]);
     wasm!(f, {
             // decode 3 bytes
-            local_get(3); i32_const(data_off); i32_add; local_get(5); i32_add;
-            local_get(6); i32_const(B64_UPPER_SHIFT); i32_shl; local_get(7); i32_const(B64_MID_SHIFT); i32_shr_u; i32_or;
+            local_get(Local(3)); i32_const(Imm32(data_off)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(6)); i32_const(Imm32(B64_UPPER_SHIFT)); i32_shl; local_get(Local(7)); i32_const(Imm32(B64_MID_SHIFT)); i32_shr_u; i32_or;
             i32_store8(0);
-            local_get(3); i32_const(data_off + 1); i32_add; local_get(5); i32_add;
-            local_get(7); i32_const(B64_LOW4_MASK); i32_and; i32_const(B64_MID_SHIFT); i32_shl;
-            local_get(8); i32_const(B64_UPPER_SHIFT); i32_shr_u; i32_or;
+            local_get(Local(3)); i32_const(Imm32(data_off + 1)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(7)); i32_const(Imm32(B64_LOW4_MASK)); i32_and; i32_const(Imm32(B64_MID_SHIFT)); i32_shl;
+            local_get(Local(8)); i32_const(Imm32(B64_UPPER_SHIFT)); i32_shr_u; i32_or;
             i32_store8(0);
-            local_get(3); i32_const(data_off + 2); i32_add; local_get(5); i32_add;
-            local_get(8); i32_const(B64_LOW2_MASK); i32_and; i32_const(B64_LOWER_SHIFT); i32_shl;
-            local_get(9); i32_or;
+            local_get(Local(3)); i32_const(Imm32(data_off + 2)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(8)); i32_const(Imm32(B64_LOW2_MASK)); i32_and; i32_const(Imm32(B64_LOWER_SHIFT)); i32_shl;
+            local_get(Local(9)); i32_or;
             i32_store8(0);
-            local_get(4); i32_const(B64_GROUP_CHARS); i32_add; local_set(4);
-            local_get(5); i32_const(B64_GROUP_BYTES); i32_add; local_set(5);
+            local_get(Local(4)); i32_const(Imm32(B64_GROUP_CHARS)); i32_add; local_set(Local(4));
+            local_get(Local(5)); i32_const(Imm32(B64_GROUP_BYTES)); i32_add; local_set(Local(5));
             br(0);
         end; end;
     });
@@ -439,61 +440,61 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
     // Tail: rem == 2 → 1 byte, rem == 3 → 2 bytes, rem == 0 → done.
     // (rem == 1 was rejected by the length check above.)
     wasm!(f, {
-        local_get(2); local_get(4); i32_sub;
-        i32_const(B64_GROUP_BYTES - 1); i32_eq;
+        local_get(Local(2)); local_get(Local(4)); i32_sub;
+        i32_const(Imm32(B64_GROUP_BYTES - 1)); i32_eq;
         if_empty;
-            local_get(0); i32_const(data_off); i32_add; local_get(4); i32_add; i32_load8_u(0);
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0);
     });
     emit_b64_decode_char(&mut f);
     wasm!(f, {
-            local_set(6);
-            local_get(0); i32_const(data_off + 1); i32_add; local_get(4); i32_add; i32_load8_u(0);
+            local_set(Local(6));
+            local_get(Local(0)); i32_const(Imm32(data_off + 1)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0);
     });
     emit_b64_decode_char(&mut f);
-    wasm!(f, { local_set(7); });
+    wasm!(f, { local_set(Local(7)); });
     emit_invalid_guard(&mut f, &[6, 7]);
     wasm!(f, {
-            local_get(3); i32_const(data_off); i32_add; local_get(5); i32_add;
-            local_get(6); i32_const(B64_UPPER_SHIFT); i32_shl; local_get(7); i32_const(B64_MID_SHIFT); i32_shr_u; i32_or;
+            local_get(Local(3)); i32_const(Imm32(data_off)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(6)); i32_const(Imm32(B64_UPPER_SHIFT)); i32_shl; local_get(Local(7)); i32_const(Imm32(B64_MID_SHIFT)); i32_shr_u; i32_or;
             i32_store8(0);
-            local_get(5); i32_const(1); i32_add; local_set(5);
+            local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5));
         end;
-        local_get(2); local_get(4); i32_sub;
-        i32_const(B64_GROUP_BYTES); i32_eq;
+        local_get(Local(2)); local_get(Local(4)); i32_sub;
+        i32_const(Imm32(B64_GROUP_BYTES)); i32_eq;
         if_empty;
-            local_get(0); i32_const(data_off); i32_add; local_get(4); i32_add; i32_load8_u(0);
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0);
     });
     emit_b64_decode_char(&mut f);
     wasm!(f, {
-            local_set(6);
-            local_get(0); i32_const(data_off + 1); i32_add; local_get(4); i32_add; i32_load8_u(0);
+            local_set(Local(6));
+            local_get(Local(0)); i32_const(Imm32(data_off + 1)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0);
     });
     emit_b64_decode_char(&mut f);
     wasm!(f, {
-            local_set(7);
-            local_get(0); i32_const(data_off + 2); i32_add; local_get(4); i32_add; i32_load8_u(0);
+            local_set(Local(7));
+            local_get(Local(0)); i32_const(Imm32(data_off + 2)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0);
     });
     emit_b64_decode_char(&mut f);
-    wasm!(f, { local_set(8); });
+    wasm!(f, { local_set(Local(8)); });
     emit_invalid_guard(&mut f, &[6, 7, 8]);
     wasm!(f, {
-            local_get(3); i32_const(data_off); i32_add; local_get(5); i32_add;
-            local_get(6); i32_const(B64_UPPER_SHIFT); i32_shl; local_get(7); i32_const(B64_MID_SHIFT); i32_shr_u; i32_or;
+            local_get(Local(3)); i32_const(Imm32(data_off)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(6)); i32_const(Imm32(B64_UPPER_SHIFT)); i32_shl; local_get(Local(7)); i32_const(Imm32(B64_MID_SHIFT)); i32_shr_u; i32_or;
             i32_store8(0);
-            local_get(3); i32_const(data_off + 1); i32_add; local_get(5); i32_add;
-            local_get(7); i32_const(B64_LOW4_MASK); i32_and; i32_const(B64_MID_SHIFT); i32_shl;
-            local_get(8); i32_const(B64_UPPER_SHIFT); i32_shr_u; i32_or;
+            local_get(Local(3)); i32_const(Imm32(data_off + 1)); i32_add; local_get(Local(5)); i32_add;
+            local_get(Local(7)); i32_const(Imm32(B64_LOW4_MASK)); i32_and; i32_const(Imm32(B64_MID_SHIFT)); i32_shl;
+            local_get(Local(8)); i32_const(Imm32(B64_UPPER_SHIFT)); i32_shr_u; i32_or;
             i32_store8(0);
-            local_get(5); i32_const(B64_GROUP_BYTES - 1); i32_add; local_set(5);
+            local_get(Local(5)); i32_const(Imm32(B64_GROUP_BYTES - 1)); i32_add; local_set(Local(5));
         end;
         // Set actual output length + cap on the bytes header
-        local_get(3); local_get(5); i32_store(0);
-        local_get(3); local_get(5); i32_store(string_cap_off() as u32);
+        local_get(Local(3)); local_get(Local(5)); i32_store(0);
+        local_get(Local(3)); local_get(Local(5)); i32_store(string_cap_off() as u32);
         // Wrap in Result::ok
-        i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(10);
-        local_get(10); i32_const(0); i32_store(0);
-        local_get(10); local_get(3); i32_store(4);
-        local_get(10);
+        i32_const(Imm32(RESULT_CELL_BYTES)); call(emitter.rt.alloc); local_set(Local(10));
+        local_get(Local(10)); i32_const(Imm32(0)); i32_store(0);
+        local_get(Local(10)); local_get(Local(3)); i32_store(4);
+        local_get(Local(10));
         end; // end function
     });
 
@@ -505,34 +506,34 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
 /// must declare local 11 to be free.
 fn emit_b64_decode_char(f: &mut Function) {
     wasm!(f, {
-        local_tee(11);
-        i32_const(ASCII_UPPER_A); i32_ge_u;
-        local_get(11); i32_const(ASCII_UPPER_Z); i32_le_u; i32_and;
+        local_tee(Local(11));
+        i32_const(Imm32(ASCII_UPPER_A)); i32_ge_u;
+        local_get(Local(11)); i32_const(Imm32(ASCII_UPPER_Z)); i32_le_u; i32_and;
         if_i32;
-            local_get(11); i32_const(ASCII_UPPER_A); i32_sub;
+            local_get(Local(11)); i32_const(Imm32(ASCII_UPPER_A)); i32_sub;
         else_;
-            local_get(11); i32_const(ASCII_LOWER_A); i32_ge_u;
-            local_get(11); i32_const(ASCII_LOWER_Z); i32_le_u; i32_and;
+            local_get(Local(11)); i32_const(Imm32(ASCII_LOWER_A)); i32_ge_u;
+            local_get(Local(11)); i32_const(Imm32(ASCII_LOWER_Z)); i32_le_u; i32_and;
             if_i32;
-                local_get(11); i32_const(B64_LOWER_ALPHA_OFFSET); i32_sub; // 97 - 26 = 71
+                local_get(Local(11)); i32_const(Imm32(B64_LOWER_ALPHA_OFFSET)); i32_sub; // 97 - 26 = 71
             else_;
-                local_get(11); i32_const(ASCII_ZERO); i32_ge_u;
-                local_get(11); i32_const(ASCII_NINE); i32_le_u; i32_and;
+                local_get(Local(11)); i32_const(Imm32(ASCII_ZERO)); i32_ge_u;
+                local_get(Local(11)); i32_const(Imm32(ASCII_NINE)); i32_le_u; i32_and;
                 if_i32;
                     // '0'..'9' (48..57) → values 52..61: value = char - 48 + 52 = char + 4.
-                    local_get(11); i32_const(B64_MID_SHIFT); i32_add;
+                    local_get(Local(11)); i32_const(Imm32(B64_MID_SHIFT)); i32_add;
                 else_;
-                    local_get(11); i32_const(ASCII_PLUS); i32_eq;
-                    local_get(11); i32_const(ASCII_MINUS); i32_eq; i32_or;
+                    local_get(Local(11)); i32_const(Imm32(ASCII_PLUS)); i32_eq;
+                    local_get(Local(11)); i32_const(Imm32(ASCII_MINUS)); i32_eq; i32_or;
                     if_i32;
-                        i32_const(B64_IDX_PLUS_OR_DASH);
+                        i32_const(Imm32(B64_IDX_PLUS_OR_DASH));
                     else_;
-                        local_get(11); i32_const(ASCII_SLASH); i32_eq;
-                        local_get(11); i32_const(ASCII_UNDERSCORE); i32_eq; i32_or;
+                        local_get(Local(11)); i32_const(Imm32(ASCII_SLASH)); i32_eq;
+                        local_get(Local(11)); i32_const(Imm32(ASCII_UNDERSCORE)); i32_eq; i32_or;
                         if_i32;
-                            i32_const(B64_6BIT_MASK);
+                            i32_const(Imm32(B64_6BIT_MASK));
                         else_;
-                            i32_const(INVALID_CHAR_SENTINEL);
+                            i32_const(Imm32(INVALID_CHAR_SENTINEL));
                         end;
                     end;
                 end;
@@ -555,36 +556,36 @@ pub(super) fn compile_hex_encode(emitter: &mut WasmEmitter, upper: bool) {
         (1, ValType::I32),  // 6: nibble
     ]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
-        local_get(1); i32_const(HEX_CHARS_PER_BYTE); i32_mul; local_set(2);
-        local_get(2); call(emitter.rt.string_alloc); local_set(3);
+        local_get(Local(0)); i32_load(0); local_set(Local(1));
+        local_get(Local(1)); i32_const(Imm32(HEX_CHARS_PER_BYTE)); i32_mul; local_set(Local(2));
+        local_get(Local(2)); call(emitter.rt.string_alloc); local_set(Local(3));
         // len+cap already written by string_alloc
-        i32_const(0); local_set(4);
+        i32_const(Imm32(0)); local_set(Local(4));
         block_empty; loop_empty;
-            local_get(4); local_get(1); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(5);
+            local_get(Local(4)); local_get(Local(1)); i32_ge_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(5));
             // hi nibble
-            local_get(5); i32_const(HEX_NIBBLE_SHIFT); i32_shr_u; local_set(6);
+            local_get(Local(5)); i32_const(Imm32(HEX_NIBBLE_SHIFT)); i32_shr_u; local_set(Local(6));
     });
     emit_hex_nibble_to_char(&mut f, 6, alpha_offset);
     wasm!(f, {
-            local_set(6); // reuse 6 as char
-            local_get(3); i32_const(string_data_off()); i32_add; local_get(4); i32_const(HEX_CHARS_PER_BYTE); i32_mul; i32_add;
-            local_get(6);
+            local_set(Local(6)); // reuse 6 as char
+            local_get(Local(3)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(4)); i32_const(Imm32(HEX_CHARS_PER_BYTE)); i32_mul; i32_add;
+            local_get(Local(6));
             i32_store8(0);
             // lo nibble
-            local_get(5); i32_const(HEX_LOW_NIBBLE_MASK); i32_and; local_set(6);
+            local_get(Local(5)); i32_const(Imm32(HEX_LOW_NIBBLE_MASK)); i32_and; local_set(Local(6));
     });
     emit_hex_nibble_to_char(&mut f, 6, alpha_offset);
     wasm!(f, {
-            local_set(6);
-            local_get(3); i32_const(string_data_off() + 1); i32_add; local_get(4); i32_const(HEX_CHARS_PER_BYTE); i32_mul; i32_add;
-            local_get(6);
+            local_set(Local(6));
+            local_get(Local(3)); i32_const(Imm32(string_data_off() + 1)); i32_add; local_get(Local(4)); i32_const(Imm32(HEX_CHARS_PER_BYTE)); i32_mul; i32_add;
+            local_get(Local(6));
             i32_store8(0);
-            local_get(4); i32_const(1); i32_add; local_set(4);
+            local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
             br(0);
         end; end;
-        local_get(3);
+        local_get(Local(3));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
@@ -592,11 +593,11 @@ pub(super) fn compile_hex_encode(emitter: &mut WasmEmitter, upper: bool) {
 
 fn emit_hex_nibble_to_char(f: &mut Function, nibble_local: u32, alpha_offset: i32) {
     wasm!(f, {
-        local_get(nibble_local); i32_const(HEX_DIGIT_THRESHOLD); i32_lt_u;
+        local_get(Local(nibble_local)); i32_const(Imm32(HEX_DIGIT_THRESHOLD)); i32_lt_u;
         if_i32;
-            i32_const(ASCII_ZERO); local_get(nibble_local); i32_add;
+            i32_const(Imm32(ASCII_ZERO)); local_get(Local(nibble_local)); i32_add;
         else_;
-            i32_const(alpha_offset); local_get(nibble_local); i32_add;
+            i32_const(Imm32(alpha_offset)); local_get(Local(nibble_local)); i32_add;
         end;
     });
 }
@@ -628,68 +629,68 @@ pub(super) fn compile_hex_decode(emitter: &mut WasmEmitter) {
     ]);
 
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
+        local_get(Local(0)); i32_load(0); local_set(Local(1));
         // odd length → "hex string has odd length: <str_len>"
-        local_get(1); i32_const(1); i32_and;
+        local_get(Local(1)); i32_const(Imm32(1)); i32_and;
         if_empty;
-            i32_const(err_odd_prefix as i32);
-            local_get(1); i64_extend_i32_u; call(itoa);
-            call(concat); local_set(9);
-            i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(7);
-            local_get(7); i32_const(1); i32_store(0);
-            local_get(7); local_get(9); i32_store(4);
-            local_get(7); return_;
+            i32_const(Imm32(err_odd_prefix as i32));
+            local_get(Local(1)); i64_extend_i32_u; call(itoa);
+            call(concat); local_set(Local(9));
+            i32_const(Imm32(RESULT_CELL_BYTES)); call(emitter.rt.alloc); local_set(Local(7));
+            local_get(Local(7)); i32_const(Imm32(1)); i32_store(0);
+            local_get(Local(7)); local_get(Local(9)); i32_store(4);
+            local_get(Local(7)); return_;
         end;
-        local_get(1); i32_const(1); i32_shr_u; local_set(2);
-        local_get(2); call(emitter.rt.string_alloc); local_set(3);
+        local_get(Local(1)); i32_const(Imm32(1)); i32_shr_u; local_set(Local(2));
+        local_get(Local(2)); call(emitter.rt.string_alloc); local_set(Local(3));
         // len+cap already written by string_alloc
-        i32_const(0); local_set(4);
+        i32_const(Imm32(0)); local_set(Local(4));
         block_empty; loop_empty;
-            local_get(4); local_get(2); i32_ge_u; br_if(1);
-            local_get(0); i32_const(data_off); i32_add; local_get(4); i32_const(HEX_CHARS_PER_BYTE); i32_mul; i32_add;
+            local_get(Local(4)); local_get(Local(2)); i32_ge_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; local_get(Local(4)); i32_const(Imm32(HEX_CHARS_PER_BYTE)); i32_mul; i32_add;
             i32_load8_u(0);
     });
     emit_hex_char_to_nibble(&mut f);
-    wasm!(f, { local_set(5); });
+    wasm!(f, { local_set(Local(5)); });
     // hi invalid → "invalid hex char at <2*pair>"
     wasm!(f, {
-            local_get(5); i32_const(invalid); i32_eq;
+            local_get(Local(5)); i32_const(Imm32(invalid)); i32_eq;
             if_empty;
-                i32_const(err_char_prefix as i32);
-                local_get(4); i32_const(HEX_CHARS_PER_BYTE); i32_mul; i64_extend_i32_u; call(itoa);
-                call(concat); local_set(9);
-                i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(7);
-                local_get(7); i32_const(1); i32_store(0);
-                local_get(7); local_get(9); i32_store(4);
-                local_get(7); return_;
+                i32_const(Imm32(err_char_prefix as i32));
+                local_get(Local(4)); i32_const(Imm32(HEX_CHARS_PER_BYTE)); i32_mul; i64_extend_i32_u; call(itoa);
+                call(concat); local_set(Local(9));
+                i32_const(Imm32(RESULT_CELL_BYTES)); call(emitter.rt.alloc); local_set(Local(7));
+                local_get(Local(7)); i32_const(Imm32(1)); i32_store(0);
+                local_get(Local(7)); local_get(Local(9)); i32_store(4);
+                local_get(Local(7)); return_;
             end;
-            local_get(0); i32_const(data_off + 1); i32_add; local_get(4); i32_const(HEX_CHARS_PER_BYTE); i32_mul; i32_add;
+            local_get(Local(0)); i32_const(Imm32(data_off + 1)); i32_add; local_get(Local(4)); i32_const(Imm32(HEX_CHARS_PER_BYTE)); i32_mul; i32_add;
             i32_load8_u(0);
     });
     emit_hex_char_to_nibble(&mut f);
-    wasm!(f, { local_set(6); });
+    wasm!(f, { local_set(Local(6)); });
     // lo invalid → "invalid hex char at <2*pair + 1>"
     wasm!(f, {
-            local_get(6); i32_const(invalid); i32_eq;
+            local_get(Local(6)); i32_const(Imm32(invalid)); i32_eq;
             if_empty;
-                i32_const(err_char_prefix as i32);
-                local_get(4); i32_const(HEX_CHARS_PER_BYTE); i32_mul; i32_const(1); i32_add; i64_extend_i32_u; call(itoa);
-                call(concat); local_set(9);
-                i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(7);
-                local_get(7); i32_const(1); i32_store(0);
-                local_get(7); local_get(9); i32_store(4);
-                local_get(7); return_;
+                i32_const(Imm32(err_char_prefix as i32));
+                local_get(Local(4)); i32_const(Imm32(HEX_CHARS_PER_BYTE)); i32_mul; i32_const(Imm32(1)); i32_add; i64_extend_i32_u; call(itoa);
+                call(concat); local_set(Local(9));
+                i32_const(Imm32(RESULT_CELL_BYTES)); call(emitter.rt.alloc); local_set(Local(7));
+                local_get(Local(7)); i32_const(Imm32(1)); i32_store(0);
+                local_get(Local(7)); local_get(Local(9)); i32_store(4);
+                local_get(Local(7)); return_;
             end;
-            local_get(3); i32_const(data_off); i32_add; local_get(4); i32_add;
-            local_get(5); i32_const(HEX_NIBBLE_SHIFT); i32_shl; local_get(6); i32_or;
+            local_get(Local(3)); i32_const(Imm32(data_off)); i32_add; local_get(Local(4)); i32_add;
+            local_get(Local(5)); i32_const(Imm32(HEX_NIBBLE_SHIFT)); i32_shl; local_get(Local(6)); i32_or;
             i32_store8(0);
-            local_get(4); i32_const(1); i32_add; local_set(4);
+            local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
             br(0);
         end; end;
-        i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(7);
-        local_get(7); i32_const(0); i32_store(0);
-        local_get(7); local_get(3); i32_store(4);
-        local_get(7);
+        i32_const(Imm32(RESULT_CELL_BYTES)); call(emitter.rt.alloc); local_set(Local(7));
+        local_get(Local(7)); i32_const(Imm32(0)); i32_store(0);
+        local_get(Local(7)); local_get(Local(3)); i32_store(4);
+        local_get(Local(7));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.hex_decode, type_idx, f));
@@ -698,23 +699,23 @@ pub(super) fn compile_hex_decode(emitter: &mut WasmEmitter) {
 fn emit_hex_char_to_nibble(f: &mut Function) {
     // Pops i32 (char), pushes i32 (0..15 or 255). Uses local 8 as scratch.
     wasm!(f, {
-        local_tee(8);
-        i32_const(ASCII_ZERO); i32_ge_u;
-        local_get(8); i32_const(ASCII_NINE); i32_le_u; i32_and;
+        local_tee(Local(8));
+        i32_const(Imm32(ASCII_ZERO)); i32_ge_u;
+        local_get(Local(8)); i32_const(Imm32(ASCII_NINE)); i32_le_u; i32_and;
         if_i32;
-            local_get(8); i32_const(ASCII_ZERO); i32_sub;
+            local_get(Local(8)); i32_const(Imm32(ASCII_ZERO)); i32_sub;
         else_;
-            local_get(8); i32_const(ASCII_LOWER_A); i32_ge_u;
-            local_get(8); i32_const(ASCII_LOWER_F); i32_le_u; i32_and;
+            local_get(Local(8)); i32_const(Imm32(ASCII_LOWER_A)); i32_ge_u;
+            local_get(Local(8)); i32_const(Imm32(ASCII_LOWER_F)); i32_le_u; i32_and;
             if_i32;
-                local_get(8); i32_const(HEX_LOWER_A_OFFSET); i32_sub; // 'a' - 10
+                local_get(Local(8)); i32_const(Imm32(HEX_LOWER_A_OFFSET)); i32_sub; // 'a' - 10
             else_;
-                local_get(8); i32_const(ASCII_UPPER_A); i32_ge_u;
-                local_get(8); i32_const(ASCII_UPPER_F); i32_le_u; i32_and;
+                local_get(Local(8)); i32_const(Imm32(ASCII_UPPER_A)); i32_ge_u;
+                local_get(Local(8)); i32_const(Imm32(ASCII_UPPER_F)); i32_le_u; i32_and;
                 if_i32;
-                    local_get(8); i32_const(HEX_UPPER_A_OFFSET); i32_sub; // 'A' - 10
+                    local_get(Local(8)); i32_const(Imm32(HEX_UPPER_A_OFFSET)); i32_sub; // 'A' - 10
                 else_;
-                    i32_const(INVALID_CHAR_SENTINEL);
+                    i32_const(Imm32(INVALID_CHAR_SENTINEL));
                 end;
             end;
         end;

--- a/crates/almide-codegen/src/emit_wasm/rt_encoding.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_encoding.rs
@@ -19,6 +19,81 @@ use super::rt_string::{string_data_off, string_hdr, string_cap_off};
 /// ASCII '=' — Base64 padding byte (RFC 4648).
 const B64_PAD: i32 = 61;
 
+// ── Encoding constants ────────────────────────────────────────────────────────
+
+/// Number of raw bytes in one base64 group (3 bytes → 4 chars).
+const B64_GROUP_BYTES: i32 = 3;
+/// Number of base64 characters per group (3 bytes → 4 chars).
+const B64_GROUP_CHARS: i32 = 4;
+/// Bit shift to extract the uppermost 6-bit sextet: `b >> 2`.
+const B64_UPPER_SHIFT: i32 = 2;
+/// Bit shift for the cross-byte middle join in base64 packing: 4-bit boundary.
+const B64_MID_SHIFT: i32 = 4;
+/// Bit shift for the lower 6-bit sextet of a 3-byte group: `b >> 6`.
+const B64_LOWER_SHIFT: i32 = 6;
+/// Bitmask for the lower 2 bits of a byte (`0b11`), used in base64 bit extraction.
+const B64_LOW2_MASK: i32 = 3;
+/// Bitmask for the lower 4 bits of a byte (`0xF`), used in base64 bit extraction.
+const B64_LOW4_MASK: i32 = 15;
+/// Bitmask for a full 6-bit sextet (`0x3F`), applied to the last byte of a group.
+const B64_6BIT_MASK: i32 = 63;
+/// Alphabet index where the numeric digits ('0'..'9') begin in the base64 table.
+const B64_DIGIT_START_IDX: i32 = 52;
+/// Arithmetic offset for digit indices 52..61: `'0' - 52 = -4`.
+const B64_DIGIT_OFFSET: i32 = -4;
+/// Number of uppercase letters A-Z represented in the base64 alphabet.
+const B64_UPPERCASE_COUNT: i32 = 26;
+/// Alphabet index of the '+' / '-' character (std / url-safe base64).
+const B64_IDX_PLUS_OR_DASH: i32 = 62;
+/// Offset used when encoding/decoding lowercase base64 letters: `'a' - 26 = 71`.
+const B64_LOWER_ALPHA_OFFSET: i32 = 71;
+/// Sentinel value returned by the char-to-value helpers for an invalid character.
+const INVALID_CHAR_SENTINEL: i32 = 255;
+/// Byte size of a Result cell: `[tag:i32][value:i32]` = 8 bytes.
+const RESULT_CELL_BYTES: i32 = 8;
+
+// ── ASCII character codes ─────────────────────────────────────────────────────
+
+/// ASCII code of 'A' (0x41 = 65).
+const ASCII_UPPER_A: i32 = 65;
+/// ASCII code of 'Z' (0x5A = 90).
+const ASCII_UPPER_Z: i32 = 90;
+/// ASCII code of 'F' (0x46 = 70), upper bound of uppercase hex digits.
+const ASCII_UPPER_F: i32 = 70;
+/// ASCII code of 'a' (0x61 = 97).
+const ASCII_LOWER_A: i32 = 97;
+/// ASCII code of 'z' (0x7A = 122).
+const ASCII_LOWER_Z: i32 = 122;
+/// ASCII code of 'f' (0x66 = 102), upper bound of lowercase hex digits.
+const ASCII_LOWER_F: i32 = 102;
+/// ASCII code of '0' (0x30 = 48).
+const ASCII_ZERO: i32 = 48;
+/// ASCII code of '9' (0x39 = 57).
+const ASCII_NINE: i32 = 57;
+/// ASCII code of '+' (0x2B = 43), standard base64 char at index 62.
+const ASCII_PLUS: i32 = 43;
+/// ASCII code of '-' (0x2D = 45), url-safe base64 char at index 62.
+const ASCII_MINUS: i32 = 45;
+/// ASCII code of '/' (0x2F = 47), standard base64 char at index 63.
+const ASCII_SLASH: i32 = 47;
+/// ASCII code of '_' (0x5F = 95), url-safe base64 char at index 63.
+const ASCII_UNDERSCORE: i32 = 95;
+
+// ── Hex encoding constants ────────────────────────────────────────────────────
+
+/// Number of hex characters per encoded byte (2 nibbles).
+const HEX_CHARS_PER_BYTE: i32 = 2;
+/// Bit shift to isolate the high nibble of a byte: `b >> 4`.
+const HEX_NIBBLE_SHIFT: i32 = 4;
+/// Bitmask to isolate the low nibble of a byte (`0xF`).
+const HEX_LOW_NIBBLE_MASK: i32 = 15;
+/// Nibble values 0-9 map to ASCII digits; 10-15 use a letter offset.
+const HEX_DIGIT_THRESHOLD: i32 = 10;
+/// Offset for lowercase hex letter encoding: `'a' - 10 = 87`.
+const HEX_LOWER_A_OFFSET: i32 = 87;
+/// Offset for uppercase hex letter encoding: `'A' - 10 = 55`.
+const HEX_UPPER_A_OFFSET: i32 = 55;
+
 /// __base64_encode(buf_ptr) -> string_ptr.
 ///
 /// Mirrors the native oracle `runtime/rs/src/base64.rs::encode_with`: both the
@@ -56,9 +131,9 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
 
     // groups of 3 → 4 chars, padded: out_len = ceil(byte_len / 3) * 4.
     wasm!(f, {
-        local_get(1); i32_const(2); i32_add;
-        i32_const(3); i32_div_u;
-        i32_const(4); i32_mul;
+        local_get(1); i32_const(B64_GROUP_BYTES - 1); i32_add;
+        i32_const(B64_GROUP_BYTES); i32_div_u;
+        i32_const(B64_GROUP_CHARS); i32_mul;
         local_set(2);
     });
 
@@ -73,13 +148,13 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
     // Main loop: process 3 input bytes → 4 output chars
     wasm!(f, {
         block_empty; loop_empty;
-            local_get(4); i32_const(3); i32_add; local_get(1); i32_gt_u; br_if(1);
+            local_get(4); i32_const(B64_GROUP_BYTES); i32_add; local_get(1); i32_gt_u; br_if(1);
             // Load 3 bytes b0, b1, b2
             local_get(0); i32_const(data_off); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(6);
             local_get(0); i32_const(data_off + 1); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(7);
             local_get(0); i32_const(data_off + 2); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(8);
             // c0 = alphabet[b0 >> 2]
-            local_get(6); i32_const(2); i32_shr_u; local_set(9);
+            local_get(6); i32_const(B64_UPPER_SHIFT); i32_shr_u; local_set(9);
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
@@ -88,8 +163,8 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
             local_get(9);
             i32_store8(0);
             // c1 = alphabet[((b0 & 3) << 4) | (b1 >> 4)]
-            local_get(6); i32_const(3); i32_and; i32_const(4); i32_shl;
-            local_get(7); i32_const(4); i32_shr_u;
+            local_get(6); i32_const(B64_LOW2_MASK); i32_and; i32_const(B64_MID_SHIFT); i32_shl;
+            local_get(7); i32_const(B64_MID_SHIFT); i32_shr_u;
             i32_or; local_set(9);
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
@@ -99,8 +174,8 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
             local_get(9);
             i32_store8(0);
             // c2 = alphabet[((b1 & 0xF) << 2) | (b2 >> 6)]
-            local_get(7); i32_const(15); i32_and; i32_const(2); i32_shl;
-            local_get(8); i32_const(6); i32_shr_u;
+            local_get(7); i32_const(B64_LOW4_MASK); i32_and; i32_const(B64_UPPER_SHIFT); i32_shl;
+            local_get(8); i32_const(B64_LOWER_SHIFT); i32_shr_u;
             i32_or; local_set(9);
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
@@ -110,7 +185,7 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
             local_get(9);
             i32_store8(0);
             // c3 = alphabet[b2 & 0x3F]
-            local_get(8); i32_const(63); i32_and; local_set(9);
+            local_get(8); i32_const(B64_6BIT_MASK); i32_and; local_set(9);
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
@@ -118,8 +193,8 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
             local_get(3); i32_const(data_off + 3); i32_add; local_get(5); i32_add;
             local_get(9);
             i32_store8(0);
-            local_get(4); i32_const(3); i32_add; local_set(4);
-            local_get(5); i32_const(4); i32_add; local_set(5);
+            local_get(4); i32_const(B64_GROUP_BYTES); i32_add; local_set(4);
+            local_get(5); i32_const(B64_GROUP_CHARS); i32_add; local_set(5);
             br(0);
         end; end;
     });
@@ -132,7 +207,7 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
         if_empty;
             // 1 byte: 2 output chars + 2 '=' padding
             local_get(0); i32_const(data_off); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(6);
-            local_get(6); i32_const(2); i32_shr_u; local_set(9);
+            local_get(6); i32_const(B64_UPPER_SHIFT); i32_shr_u; local_set(9);
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
@@ -140,7 +215,7 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
             local_get(3); i32_const(data_off); i32_add; local_get(5); i32_add;
             local_get(9);
             i32_store8(0);
-            local_get(6); i32_const(3); i32_and; i32_const(4); i32_shl; local_set(9);
+            local_get(6); i32_const(B64_LOW2_MASK); i32_and; i32_const(B64_MID_SHIFT); i32_shl; local_set(9);
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
@@ -155,12 +230,12 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
             i32_const(B64_PAD); i32_store8(0);
         end;
         local_get(1); local_get(4); i32_sub;
-        i32_const(2); i32_eq;
+        i32_const(B64_GROUP_BYTES - 1); i32_eq;
         if_empty;
             // 2 bytes: 3 output chars + 1 '=' padding
             local_get(0); i32_const(data_off); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(6);
             local_get(0); i32_const(data_off + 1); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(7);
-            local_get(6); i32_const(2); i32_shr_u; local_set(9);
+            local_get(6); i32_const(B64_UPPER_SHIFT); i32_shr_u; local_set(9);
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
@@ -168,8 +243,8 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
             local_get(3); i32_const(data_off); i32_add; local_get(5); i32_add;
             local_get(9);
             i32_store8(0);
-            local_get(6); i32_const(3); i32_and; i32_const(4); i32_shl;
-            local_get(7); i32_const(4); i32_shr_u;
+            local_get(6); i32_const(B64_LOW2_MASK); i32_and; i32_const(B64_MID_SHIFT); i32_shl;
+            local_get(7); i32_const(B64_MID_SHIFT); i32_shr_u;
             i32_or; local_set(9);
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
@@ -178,7 +253,7 @@ pub(super) fn compile_base64_encode(emitter: &mut WasmEmitter, url_safe: bool) {
             local_get(3); i32_const(data_off + 1); i32_add; local_get(5); i32_add;
             local_get(9);
             i32_store8(0);
-            local_get(7); i32_const(15); i32_and; i32_const(2); i32_shl; local_set(9);
+            local_get(7); i32_const(B64_LOW4_MASK); i32_and; i32_const(B64_UPPER_SHIFT); i32_shl; local_set(9);
     });
     emit_b64_alphabet_lookup(&mut f, 9, url_safe);
     wasm!(f, {
@@ -202,19 +277,19 @@ fn emit_b64_alphabet_lookup(f: &mut Function, idx_local: u32, url_safe: bool) {
     let plus_or_dash: i32 = if url_safe { 45 } else { 43 };   // '-' or '+'
     let slash_or_under: i32 = if url_safe { 95 } else { 47 }; // '_' or '/'
     wasm!(f, {
-        local_get(idx_local); i32_const(26); i32_lt_u;
+        local_get(idx_local); i32_const(B64_UPPERCASE_COUNT); i32_lt_u;
         if_i32;
-            i32_const(65); local_get(idx_local); i32_add; // 'A'+i
+            i32_const(ASCII_UPPER_A); local_get(idx_local); i32_add; // 'A'+i
         else_;
-            local_get(idx_local); i32_const(52); i32_lt_u;
+            local_get(idx_local); i32_const(B64_DIGIT_START_IDX); i32_lt_u;
             if_i32;
-                i32_const(71); local_get(idx_local); i32_add; // 'a'-26 = 71
+                i32_const(B64_LOWER_ALPHA_OFFSET); local_get(idx_local); i32_add; // 'a'-26 = 71
             else_;
-                local_get(idx_local); i32_const(62); i32_lt_u;
+                local_get(idx_local); i32_const(B64_IDX_PLUS_OR_DASH); i32_lt_u;
                 if_i32;
-                    i32_const(-4); local_get(idx_local); i32_add; // '0'-52 = -4 (256-52=204 mod 256)
+                    i32_const(B64_DIGIT_OFFSET); local_get(idx_local); i32_add; // '0'-52 = -4 (256-52=204 mod 256)
                 else_;
-                    local_get(idx_local); i32_const(62); i32_eq;
+                    local_get(idx_local); i32_const(B64_IDX_PLUS_OR_DASH); i32_eq;
                     if_i32;
                         i32_const(plus_or_dash);
                     else_;
@@ -269,7 +344,7 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
     // Emit an `err(<interned constant>)` return.
     let emit_err_const = |f: &mut Function, err_ptr: u32| {
         wasm!(f, {
-            i32_const(8); call(emitter.rt.alloc); local_set(10);
+            i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(10);
             local_get(10); i32_const(1); i32_store(0);
             local_get(10); i32_const(err_ptr as i32); i32_store(4);
             local_get(10); return_;
@@ -301,13 +376,13 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
 
     // body_len % 4 == 1 → "invalid base64 length: <orig_len>"
     wasm!(f, {
-        local_get(2); i32_const(3); i32_and; i32_const(1); i32_eq;
+        local_get(2); i32_const(B64_GROUP_CHARS - 1); i32_and; i32_const(1); i32_eq;
         if_empty;
           // msg = "invalid base64 length: " + int_to_string(str_len)
           i32_const(err_len_prefix as i32);
           local_get(1); i64_extend_i32_u; call(itoa);
           call(concat); local_set(11);
-          i32_const(8); call(emitter.rt.alloc); local_set(10);
+          i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(10);
           local_get(10); i32_const(1); i32_store(0);
           local_get(10); local_get(11); i32_store(4);
           local_get(10); return_;
@@ -316,7 +391,7 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
 
     wasm!(f, {
         // alloc output: max possible = body_len * 3 / 4
-        local_get(2); i32_const(3); i32_mul; i32_const(4); i32_div_u;
+        local_get(2); i32_const(B64_GROUP_BYTES); i32_mul; i32_const(B64_GROUP_CHARS); i32_div_u;
         i32_const(string_hdr()); i32_add;
         call(emitter.rt.alloc); local_set(3);
         i32_const(0); local_set(4);
@@ -326,7 +401,7 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
     // Main 4-char loop
     wasm!(f, {
         block_empty; loop_empty;
-            local_get(4); i32_const(4); i32_add; local_get(2); i32_gt_u; br_if(1);
+            local_get(4); i32_const(B64_GROUP_CHARS); i32_add; local_get(2); i32_gt_u; br_if(1);
             local_get(0); i32_const(data_off); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(6);
             local_get(0); i32_const(data_off + 1); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(7);
             local_get(0); i32_const(data_off + 2); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(8);
@@ -345,18 +420,18 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
     wasm!(f, {
             // decode 3 bytes
             local_get(3); i32_const(data_off); i32_add; local_get(5); i32_add;
-            local_get(6); i32_const(2); i32_shl; local_get(7); i32_const(4); i32_shr_u; i32_or;
+            local_get(6); i32_const(B64_UPPER_SHIFT); i32_shl; local_get(7); i32_const(B64_MID_SHIFT); i32_shr_u; i32_or;
             i32_store8(0);
             local_get(3); i32_const(data_off + 1); i32_add; local_get(5); i32_add;
-            local_get(7); i32_const(15); i32_and; i32_const(4); i32_shl;
-            local_get(8); i32_const(2); i32_shr_u; i32_or;
+            local_get(7); i32_const(B64_LOW4_MASK); i32_and; i32_const(B64_MID_SHIFT); i32_shl;
+            local_get(8); i32_const(B64_UPPER_SHIFT); i32_shr_u; i32_or;
             i32_store8(0);
             local_get(3); i32_const(data_off + 2); i32_add; local_get(5); i32_add;
-            local_get(8); i32_const(3); i32_and; i32_const(6); i32_shl;
+            local_get(8); i32_const(B64_LOW2_MASK); i32_and; i32_const(B64_LOWER_SHIFT); i32_shl;
             local_get(9); i32_or;
             i32_store8(0);
-            local_get(4); i32_const(4); i32_add; local_set(4);
-            local_get(5); i32_const(3); i32_add; local_set(5);
+            local_get(4); i32_const(B64_GROUP_CHARS); i32_add; local_set(4);
+            local_get(5); i32_const(B64_GROUP_BYTES); i32_add; local_set(5);
             br(0);
         end; end;
     });
@@ -365,7 +440,7 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
     // (rem == 1 was rejected by the length check above.)
     wasm!(f, {
         local_get(2); local_get(4); i32_sub;
-        i32_const(2); i32_eq;
+        i32_const(B64_GROUP_BYTES - 1); i32_eq;
         if_empty;
             local_get(0); i32_const(data_off); i32_add; local_get(4); i32_add; i32_load8_u(0);
     });
@@ -379,12 +454,12 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
     emit_invalid_guard(&mut f, &[6, 7]);
     wasm!(f, {
             local_get(3); i32_const(data_off); i32_add; local_get(5); i32_add;
-            local_get(6); i32_const(2); i32_shl; local_get(7); i32_const(4); i32_shr_u; i32_or;
+            local_get(6); i32_const(B64_UPPER_SHIFT); i32_shl; local_get(7); i32_const(B64_MID_SHIFT); i32_shr_u; i32_or;
             i32_store8(0);
             local_get(5); i32_const(1); i32_add; local_set(5);
         end;
         local_get(2); local_get(4); i32_sub;
-        i32_const(3); i32_eq;
+        i32_const(B64_GROUP_BYTES); i32_eq;
         if_empty;
             local_get(0); i32_const(data_off); i32_add; local_get(4); i32_add; i32_load8_u(0);
     });
@@ -403,19 +478,19 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
     emit_invalid_guard(&mut f, &[6, 7, 8]);
     wasm!(f, {
             local_get(3); i32_const(data_off); i32_add; local_get(5); i32_add;
-            local_get(6); i32_const(2); i32_shl; local_get(7); i32_const(4); i32_shr_u; i32_or;
+            local_get(6); i32_const(B64_UPPER_SHIFT); i32_shl; local_get(7); i32_const(B64_MID_SHIFT); i32_shr_u; i32_or;
             i32_store8(0);
             local_get(3); i32_const(data_off + 1); i32_add; local_get(5); i32_add;
-            local_get(7); i32_const(15); i32_and; i32_const(4); i32_shl;
-            local_get(8); i32_const(2); i32_shr_u; i32_or;
+            local_get(7); i32_const(B64_LOW4_MASK); i32_and; i32_const(B64_MID_SHIFT); i32_shl;
+            local_get(8); i32_const(B64_UPPER_SHIFT); i32_shr_u; i32_or;
             i32_store8(0);
-            local_get(5); i32_const(2); i32_add; local_set(5);
+            local_get(5); i32_const(B64_GROUP_BYTES - 1); i32_add; local_set(5);
         end;
         // Set actual output length + cap on the bytes header
         local_get(3); local_get(5); i32_store(0);
         local_get(3); local_get(5); i32_store(string_cap_off() as u32);
         // Wrap in Result::ok
-        i32_const(8); call(emitter.rt.alloc); local_set(10);
+        i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(10);
         local_get(10); i32_const(0); i32_store(0);
         local_get(10); local_get(3); i32_store(4);
         local_get(10);
@@ -431,33 +506,33 @@ pub(super) fn compile_base64_decode(emitter: &mut WasmEmitter, _url_safe: bool) 
 fn emit_b64_decode_char(f: &mut Function) {
     wasm!(f, {
         local_tee(11);
-        i32_const(65); i32_ge_u;
-        local_get(11); i32_const(90); i32_le_u; i32_and;
+        i32_const(ASCII_UPPER_A); i32_ge_u;
+        local_get(11); i32_const(ASCII_UPPER_Z); i32_le_u; i32_and;
         if_i32;
-            local_get(11); i32_const(65); i32_sub;
+            local_get(11); i32_const(ASCII_UPPER_A); i32_sub;
         else_;
-            local_get(11); i32_const(97); i32_ge_u;
-            local_get(11); i32_const(122); i32_le_u; i32_and;
+            local_get(11); i32_const(ASCII_LOWER_A); i32_ge_u;
+            local_get(11); i32_const(ASCII_LOWER_Z); i32_le_u; i32_and;
             if_i32;
-                local_get(11); i32_const(71); i32_sub; // 97 - 26 = 71
+                local_get(11); i32_const(B64_LOWER_ALPHA_OFFSET); i32_sub; // 97 - 26 = 71
             else_;
-                local_get(11); i32_const(48); i32_ge_u;
-                local_get(11); i32_const(57); i32_le_u; i32_and;
+                local_get(11); i32_const(ASCII_ZERO); i32_ge_u;
+                local_get(11); i32_const(ASCII_NINE); i32_le_u; i32_and;
                 if_i32;
                     // '0'..'9' (48..57) → values 52..61: value = char - 48 + 52 = char + 4.
-                    local_get(11); i32_const(4); i32_add;
+                    local_get(11); i32_const(B64_MID_SHIFT); i32_add;
                 else_;
-                    local_get(11); i32_const(43); i32_eq;
-                    local_get(11); i32_const(45); i32_eq; i32_or;
+                    local_get(11); i32_const(ASCII_PLUS); i32_eq;
+                    local_get(11); i32_const(ASCII_MINUS); i32_eq; i32_or;
                     if_i32;
-                        i32_const(62);
+                        i32_const(B64_IDX_PLUS_OR_DASH);
                     else_;
-                        local_get(11); i32_const(47); i32_eq;
-                        local_get(11); i32_const(95); i32_eq; i32_or;
+                        local_get(11); i32_const(ASCII_SLASH); i32_eq;
+                        local_get(11); i32_const(ASCII_UNDERSCORE); i32_eq; i32_or;
                         if_i32;
-                            i32_const(63);
+                            i32_const(B64_6BIT_MASK);
                         else_;
-                            i32_const(255);
+                            i32_const(INVALID_CHAR_SENTINEL);
                         end;
                     end;
                 end;
@@ -481,7 +556,7 @@ pub(super) fn compile_hex_encode(emitter: &mut WasmEmitter, upper: bool) {
     ]);
     wasm!(f, {
         local_get(0); i32_load(0); local_set(1);
-        local_get(1); i32_const(2); i32_mul; local_set(2);
+        local_get(1); i32_const(HEX_CHARS_PER_BYTE); i32_mul; local_set(2);
         local_get(2); call(emitter.rt.string_alloc); local_set(3);
         // len+cap already written by string_alloc
         i32_const(0); local_set(4);
@@ -489,21 +564,21 @@ pub(super) fn compile_hex_encode(emitter: &mut WasmEmitter, upper: bool) {
             local_get(4); local_get(1); i32_ge_u; br_if(1);
             local_get(0); i32_const(string_data_off()); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(5);
             // hi nibble
-            local_get(5); i32_const(4); i32_shr_u; local_set(6);
+            local_get(5); i32_const(HEX_NIBBLE_SHIFT); i32_shr_u; local_set(6);
     });
     emit_hex_nibble_to_char(&mut f, 6, alpha_offset);
     wasm!(f, {
             local_set(6); // reuse 6 as char
-            local_get(3); i32_const(string_data_off()); i32_add; local_get(4); i32_const(2); i32_mul; i32_add;
+            local_get(3); i32_const(string_data_off()); i32_add; local_get(4); i32_const(HEX_CHARS_PER_BYTE); i32_mul; i32_add;
             local_get(6);
             i32_store8(0);
             // lo nibble
-            local_get(5); i32_const(15); i32_and; local_set(6);
+            local_get(5); i32_const(HEX_LOW_NIBBLE_MASK); i32_and; local_set(6);
     });
     emit_hex_nibble_to_char(&mut f, 6, alpha_offset);
     wasm!(f, {
             local_set(6);
-            local_get(3); i32_const(string_data_off() + 1); i32_add; local_get(4); i32_const(2); i32_mul; i32_add;
+            local_get(3); i32_const(string_data_off() + 1); i32_add; local_get(4); i32_const(HEX_CHARS_PER_BYTE); i32_mul; i32_add;
             local_get(6);
             i32_store8(0);
             local_get(4); i32_const(1); i32_add; local_set(4);
@@ -517,9 +592,9 @@ pub(super) fn compile_hex_encode(emitter: &mut WasmEmitter, upper: bool) {
 
 fn emit_hex_nibble_to_char(f: &mut Function, nibble_local: u32, alpha_offset: i32) {
     wasm!(f, {
-        local_get(nibble_local); i32_const(10); i32_lt_u;
+        local_get(nibble_local); i32_const(HEX_DIGIT_THRESHOLD); i32_lt_u;
         if_i32;
-            i32_const(48); local_get(nibble_local); i32_add;
+            i32_const(ASCII_ZERO); local_get(nibble_local); i32_add;
         else_;
             i32_const(alpha_offset); local_get(nibble_local); i32_add;
         end;
@@ -560,7 +635,7 @@ pub(super) fn compile_hex_decode(emitter: &mut WasmEmitter) {
             i32_const(err_odd_prefix as i32);
             local_get(1); i64_extend_i32_u; call(itoa);
             call(concat); local_set(9);
-            i32_const(8); call(emitter.rt.alloc); local_set(7);
+            i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(7);
             local_get(7); i32_const(1); i32_store(0);
             local_get(7); local_get(9); i32_store(4);
             local_get(7); return_;
@@ -571,7 +646,7 @@ pub(super) fn compile_hex_decode(emitter: &mut WasmEmitter) {
         i32_const(0); local_set(4);
         block_empty; loop_empty;
             local_get(4); local_get(2); i32_ge_u; br_if(1);
-            local_get(0); i32_const(data_off); i32_add; local_get(4); i32_const(2); i32_mul; i32_add;
+            local_get(0); i32_const(data_off); i32_add; local_get(4); i32_const(HEX_CHARS_PER_BYTE); i32_mul; i32_add;
             i32_load8_u(0);
     });
     emit_hex_char_to_nibble(&mut f);
@@ -581,14 +656,14 @@ pub(super) fn compile_hex_decode(emitter: &mut WasmEmitter) {
             local_get(5); i32_const(invalid); i32_eq;
             if_empty;
                 i32_const(err_char_prefix as i32);
-                local_get(4); i32_const(2); i32_mul; i64_extend_i32_u; call(itoa);
+                local_get(4); i32_const(HEX_CHARS_PER_BYTE); i32_mul; i64_extend_i32_u; call(itoa);
                 call(concat); local_set(9);
-                i32_const(8); call(emitter.rt.alloc); local_set(7);
+                i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(7);
                 local_get(7); i32_const(1); i32_store(0);
                 local_get(7); local_get(9); i32_store(4);
                 local_get(7); return_;
             end;
-            local_get(0); i32_const(data_off + 1); i32_add; local_get(4); i32_const(2); i32_mul; i32_add;
+            local_get(0); i32_const(data_off + 1); i32_add; local_get(4); i32_const(HEX_CHARS_PER_BYTE); i32_mul; i32_add;
             i32_load8_u(0);
     });
     emit_hex_char_to_nibble(&mut f);
@@ -598,20 +673,20 @@ pub(super) fn compile_hex_decode(emitter: &mut WasmEmitter) {
             local_get(6); i32_const(invalid); i32_eq;
             if_empty;
                 i32_const(err_char_prefix as i32);
-                local_get(4); i32_const(2); i32_mul; i32_const(1); i32_add; i64_extend_i32_u; call(itoa);
+                local_get(4); i32_const(HEX_CHARS_PER_BYTE); i32_mul; i32_const(1); i32_add; i64_extend_i32_u; call(itoa);
                 call(concat); local_set(9);
-                i32_const(8); call(emitter.rt.alloc); local_set(7);
+                i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(7);
                 local_get(7); i32_const(1); i32_store(0);
                 local_get(7); local_get(9); i32_store(4);
                 local_get(7); return_;
             end;
             local_get(3); i32_const(data_off); i32_add; local_get(4); i32_add;
-            local_get(5); i32_const(4); i32_shl; local_get(6); i32_or;
+            local_get(5); i32_const(HEX_NIBBLE_SHIFT); i32_shl; local_get(6); i32_or;
             i32_store8(0);
             local_get(4); i32_const(1); i32_add; local_set(4);
             br(0);
         end; end;
-        i32_const(8); call(emitter.rt.alloc); local_set(7);
+        i32_const(RESULT_CELL_BYTES); call(emitter.rt.alloc); local_set(7);
         local_get(7); i32_const(0); i32_store(0);
         local_get(7); local_get(3); i32_store(4);
         local_get(7);
@@ -624,22 +699,22 @@ fn emit_hex_char_to_nibble(f: &mut Function) {
     // Pops i32 (char), pushes i32 (0..15 or 255). Uses local 8 as scratch.
     wasm!(f, {
         local_tee(8);
-        i32_const(48); i32_ge_u;
-        local_get(8); i32_const(57); i32_le_u; i32_and;
+        i32_const(ASCII_ZERO); i32_ge_u;
+        local_get(8); i32_const(ASCII_NINE); i32_le_u; i32_and;
         if_i32;
-            local_get(8); i32_const(48); i32_sub;
+            local_get(8); i32_const(ASCII_ZERO); i32_sub;
         else_;
-            local_get(8); i32_const(97); i32_ge_u;
-            local_get(8); i32_const(102); i32_le_u; i32_and;
+            local_get(8); i32_const(ASCII_LOWER_A); i32_ge_u;
+            local_get(8); i32_const(ASCII_LOWER_F); i32_le_u; i32_and;
             if_i32;
-                local_get(8); i32_const(87); i32_sub; // 'a' - 10
+                local_get(8); i32_const(HEX_LOWER_A_OFFSET); i32_sub; // 'a' - 10
             else_;
-                local_get(8); i32_const(65); i32_ge_u;
-                local_get(8); i32_const(70); i32_le_u; i32_and;
+                local_get(8); i32_const(ASCII_UPPER_A); i32_ge_u;
+                local_get(8); i32_const(ASCII_UPPER_F); i32_le_u; i32_and;
                 if_i32;
-                    local_get(8); i32_const(55); i32_sub; // 'A' - 10
+                    local_get(8); i32_const(HEX_UPPER_A_OFFSET); i32_sub; // 'A' - 10
                 else_;
-                    i32_const(255);
+                    i32_const(INVALID_CHAR_SENTINEL);
                 end;
             end;
         end;

--- a/crates/almide-codegen/src/emit_wasm/rt_float_display.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_float_display.rs
@@ -17,6 +17,7 @@
 //! it returns the driver's string pointer unchanged. Output uses the standard
 //! `[len:i32][cap:i32][data:u8...]` string layout.
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use super::{CompiledFunc, WasmEmitter};
 use wasm_encoder::ValType;
 use super::TrackedFunction as Function;
@@ -65,37 +66,37 @@ pub(super) fn compile(emitter: &mut WasmEmitter) {
     const I: u32 = 5;
 
     wasm!(f, {
-        local_get(F); call(to_string); local_set(SRC);
-        local_get(SRC); i32_load(0); local_set(LEN);
+        local_get(Local(F)); call(to_string); local_set(Local(SRC));
+        local_get(Local(SRC)); i32_load(0); local_set(Local(LEN));
         // Keep the driver's string verbatim unless it ends in exactly `.0`:
         //   len >= 2  &&  data[len-2] == '.'  &&  data[len-1] == '0'
-        local_get(LEN); i32_const(DOT_ZERO_LEN); i32_ge_s;
-        local_get(SRC); i32_const(data_off); i32_add;
-          local_get(LEN); i32_add; i32_const(DOT_ZERO_LEN); i32_sub;
-          i32_load8_u(0); i32_const(BYTE_DOT); i32_eq;
+        local_get(Local(LEN)); i32_const(Imm32(DOT_ZERO_LEN)); i32_ge_s;
+        local_get(Local(SRC)); i32_const(Imm32(data_off)); i32_add;
+          local_get(Local(LEN)); i32_add; i32_const(Imm32(DOT_ZERO_LEN)); i32_sub;
+          i32_load8_u(0); i32_const(Imm32(BYTE_DOT)); i32_eq;
         i32_and;
-        local_get(SRC); i32_const(data_off); i32_add;
-          local_get(LEN); i32_add; i32_const(1); i32_sub;
-          i32_load8_u(0); i32_const(BYTE_ZERO); i32_eq;
+        local_get(Local(SRC)); i32_const(Imm32(data_off)); i32_add;
+          local_get(Local(LEN)); i32_add; i32_const(Imm32(1)); i32_sub;
+          i32_load8_u(0); i32_const(Imm32(BYTE_ZERO)); i32_eq;
         i32_and;
         if_i32;
           // out_len = len - 2; allocate header + out_len, copy the prefix bytes.
-          local_get(LEN); i32_const(DOT_ZERO_LEN); i32_sub; local_set(OUT_LEN);
-          local_get(OUT_LEN); i32_const(hdr); i32_add; call(alloc); local_set(OUT);
-          local_get(OUT); local_get(OUT_LEN); i32_store(0);
-          local_get(OUT); local_get(OUT_LEN); i32_store(cap_off, 0);
-          i32_const(0); local_set(I);
+          local_get(Local(LEN)); i32_const(Imm32(DOT_ZERO_LEN)); i32_sub; local_set(Local(OUT_LEN));
+          local_get(Local(OUT_LEN)); i32_const(Imm32(hdr)); i32_add; call(alloc); local_set(Local(OUT));
+          local_get(Local(OUT)); local_get(Local(OUT_LEN)); i32_store(0);
+          local_get(Local(OUT)); local_get(Local(OUT_LEN)); i32_store(cap_off, 0);
+          i32_const(Imm32(0)); local_set(Local(I));
           block_empty; loop_empty;
-            local_get(I); local_get(OUT_LEN); i32_ge_u; br_if(1);
-            local_get(OUT); i32_const(data_off); i32_add; local_get(I); i32_add;
-            local_get(SRC); i32_const(data_off); i32_add; local_get(I); i32_add;
+            local_get(Local(I)); local_get(Local(OUT_LEN)); i32_ge_u; br_if(1);
+            local_get(Local(OUT)); i32_const(Imm32(data_off)); i32_add; local_get(Local(I)); i32_add;
+            local_get(Local(SRC)); i32_const(Imm32(data_off)); i32_add; local_get(Local(I)); i32_add;
             i32_load8_u(0); i32_store8(0);
-            local_get(I); i32_const(1); i32_add; local_set(I);
+            local_get(Local(I)); i32_const(Imm32(1)); i32_add; local_set(Local(I));
             br(0);
           end; end;
-          local_get(OUT);
+          local_get(Local(OUT));
         else_;
-          local_get(SRC);
+          local_get(Local(SRC));
         end;
         end;
     });

--- a/crates/almide-codegen/src/emit_wasm/rt_libm.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_libm.rs
@@ -170,6 +170,101 @@ const TY_BYTES: i32 = 3 * 8;
 // IEEE-754 binary64 helpers as named consts (so the bit math reads as IEEE-754).
 const HI_SHIFT: i64 = 32;          // high word = bits >> 32
 
+// ── IEEE-754 binary64 bit-field positions and masks ──────────────────────────
+const F64_MANTISSA_BITS: i64 = 52;             // mantissa width; also exponent shift
+const F64_MANTISSA_BITS_I32: i32 = 52;         // i32 form for i32_const
+const F64_SIGN_BIT: i64 = 63;                  // sign bit position in raw i64
+const F64_EXP_MASK: i64 = 0x7ff;               // 11-bit exponent field mask (i64)
+const F64_EXP_MASK_I32: i32 = 0x7ff;           // i32 form (after i32_wrap_i64)
+const F64_EXP_BIAS: i32 = 0x3ff;               // exponent bias = 1023
+const F64_MANTISSA_MASK: i64 = 0x000f_ffff_ffff_ffff; // 52 low-order mantissa bits
+const F64_ABS_MASK_HI: i32 = 0x7fffffff;       // strip sign from high i32 word
+const I32_SIGN_BIT: i32 = 31;                  // sign bit position in i32
+const F64_EXP_SHIFT: i32 = 20;                 // exponent field offset in high 32-bit word
+const F64_EXP_ONE_HI: i32 = 0x00100000;        // bit 20; minimum normal high-word bit
+const F64_MANTISSA_HI_MASK: i32 = 0x000fffff;  // lower 20 mantissa bits of high word
+const F64_ONE_HI: i32 = 0x3ff00000;            // high word of 1.0
+const F64_HALF_HI: i32 = 0x3fe00000;           // high word of 0.5
+const F64_INF_NAN_HI: i32 = 0x7ff00000;        // high word with exponent = 0x7ff
+const LOW_WORD_BITS: i64 = 0xffffffff;          // mask for low 32 bits of i64 repr
+
+// ── array element strides ─────────────────────────────────────────────────────
+const I32_BYTES: i32 = 4;  // i32 element stride in memory
+const F64_BYTES: i32 = 8;  // f64 element stride in memory
+
+// ── scalbn clamping thresholds ────────────────────────────────────────────────
+const F64_MIN_EXP: i32 = -1022;        // minimum normal binary64 exponent
+const SCALBN_SUBNORM_STEP: i32 = 969;  // = 1022 - 53; subnormal recovery step
+
+// ── rem_pio2 ix-range thresholds (high word of |x|) ──────────────────────────
+const RP2_5PI4_HI: i32 = 0x400f6a7a;   // |x| ~ 5π/4
+const RP2_FRAC_MASK: i32 = 0xfffff;    // 20-bit fractional check mask
+const RP2_PI_FRAC: i32 = 0x921fb;      // π/2 fractional bits (exact-multiple check)
+const RP2_3PI4_HI: i32 = 0x4002d97c;   // |x| ~ 3π/4 small-case split
+const RP2_9PI4_HI: i32 = 0x401c463b;   // |x| ~ 9π/4
+const RP2_7PI4_HI: i32 = 0x4015fdbc;   // |x| ~ 7π/4
+const RP2_2PI_HI: i32 = 0x4012d97c;    // |x| ~ 2π
+const RP2_3PI2_HI: i32 = 0x401921fb;   // |x| ~ 3π/2 + ε
+const RP2_LARGE_HI: i32 = 0x413921fb;  // ix threshold → switch to rem_pio2_large
+
+// ── rem_pio2 medium-case exponent-difference thresholds ──────────────────────
+const MEDIUM_EX_EY_THRESH_1: i32 = 16; // first refinement: ex - ey > 16
+const MEDIUM_EX_EY_THRESH_2: i32 = 49; // second refinement: ex - ey > 49
+
+// ── rem_pio2_large (2/pi table, 24-bit chunks) ────────────────────────────────
+const IPIO2_CHUNK_BITS: i32 = 24;          // bits per 2/pi table chunk
+const IPIO2_CHUNK_M1: i32 = 23;            // IPIO2_CHUNK_BITS - 1
+const IPIO2_E0_ADJUST: i32 = 3;            // jv = (e0 - 3) / 24
+const IPIO2_CARRY_BASE: i32 = 0x1000000;   // 2^24; base for carry arithmetic
+const IPIO2_24BIT_MASK: i32 = 0xffffff;    // 2^24 - 1
+const IPIO2_23BIT_MASK: i32 = 0x7fffff;    // 2^23 - 1 (q0 == 1 trim)
+const IPIO2_22BIT_MASK: i32 = 0x3fffff;    // 2^22 - 1 (q0 == 2 trim)
+// Normalisation step that strips the top 12 bits of the raw mantissa to build tx[].
+const RPL_NORM_STRIP: i64 = 12;
+// Exponent that gives 2^0 in the 24-bit chunk representation: (0x3ff + 23) << 52.
+const RPL_EXPO_BIAS: i64 = 0x3ff + 23;     // = 1046
+const TX_SPLIT_COUNT: i32 = 2;             // tx[0..=2]: loop fills indices 0..TX_SPLIT_COUNT
+const TX_LAST_OFFSET: i32 = 16;            // byte offset of tx[2] = 2 * F64_BYTES
+const REM_PIO2_N_MASK: i32 = 7;            // result octant: n & 7
+
+// ── INIT_JK table values (prec → jk) ─────────────────────────────────────────
+const JK_DOUBLE: i32 = 4;      // jk for double precision (prec = 1)
+const JK_EXTENDED: i32 = 6;    // jk for extended precision (prec = 3)
+const PREC_DOUBLE_MAX: i32 = 2; // prec in {0,1,2} → jk = JK_DOUBLE
+
+// ── IH (half-integer rounding) state ─────────────────────────────────────────
+const IH_HALFWAY: i32 = 2;     // ih == 2 means z was >= 0.5 (round-up branch)
+
+// ── k_tan (k_tan.c) high-word threshold ──────────────────────────────────────
+const KTAN_BIG_HI: i32 = 0x3FE59428; // |x| threshold above which k_tan uses π/4 reduction
+
+// ── exp (e_exp.c) high-word thresholds ───────────────────────────────────────
+const EXP_OVERFLOW_HI: i32 = 0x4086232b;   // |x| >= 709.78...
+const EXP_HALF_LN2_HI: i32 = 0x3fd62e42;   // high word of 0.5 * ln2
+const EXP_LN2_SMALL_HI: i32 = 0x3ff0a2b2;  // |x| >= sqrt(2)/2 → full reduction
+const EXP_TINY_HI: i32 = 0x3e300000;       // 2^-28; below this 1+x suffices
+
+// ── log/log2/log10 (e_log.c) ─────────────────────────────────────────────────
+const LOG_SUBNORM_SCALE: i32 = 54;         // k -= 54; x *= 2^54 for subnormals
+const LOG_SQRT2_HI: i32 = 0x3fe6a09e;     // high word of √2/2 (interval basis)
+
+// ── pow (e_pow.c) high-word thresholds ───────────────────────────────────────
+const POW_YINT_LARGE_HI: i32 = 0x43400000;     // |y| >= 2^53 → even integer
+const POW_BELOW_ONE_HI: i32 = 0x3fefffff;       // largest high word < 1.0
+const POW_TWO_HI: i32 = 0x40000000;             // high word of 2.0
+const POW_HUGE_EXP_HI: i32 = 0x41e00000;        // |y| > 2^31 (large-y fast-path)
+const POW_HUGE64_EXP_HI: i32 = 0x43f00000;      // |y| > 2^64 (must over/underflow)
+const POW_SUBNORM_SCALE: i32 = 53;              // n -= 53 when ax is subnormal
+const POW_KK0_THRESH: i32 = 0x3988E;            // interval kk == 0 upper bound
+const POW_KK1_THRESH: i32 = 0xBB67A;            // interval kk == 1 upper bound
+const POW_T_H_BASE: i32 = 0x20000000;           // bit 29 seed in t_h high-word build
+const POW_T_H_HALF: i32 = 0x00080000;           // half-ULP correction in t_h build
+const POW_KK_BIT_SHIFT: i32 = 18;               // kk shifts into bit 18 of t_h
+const POW_Z_OVERFLOW_HI: i32 = 0x40900000;      // z >= 1024 → overflow
+const POW_Z_UNDERFLOW_HI: i32 = 0x4090cc00;     // |z| near 1075 → underflow
+const POW_Z_UNDERFLOW_NEG: i32 = 0xc090cc00_u32 as i32; // negative counterpart
+const YISINT_EVEN: i32 = 2;  // yisint: 2 = even integer exponent, 1 = odd (derived as EVEN - (j&1))
+
 
 pub fn register(emitter: &mut WasmEmitter) {
     let f64_f64 = emitter.register_type(vec![ValType::F64], vec![ValType::F64]);
@@ -223,21 +318,21 @@ fn compile_floor(emitter: &mut WasmEmitter) {
     wasm!(f, {
         local_get(0); i64_reinterpret_f64; local_set(1);              // ui = x.to_bits()
         // e = ((ui >> 52) & 0x7ff) - 0x3ff
-        local_get(1); i64_const(52); i64_shr_u; i64_const(0x7ff); i64_and;
-        i32_wrap_i64; i32_const(0x3ff); i32_sub; local_set(2);
+        local_get(1); i64_const(F64_MANTISSA_BITS); i64_shr_u; i64_const(F64_EXP_MASK); i64_and;
+        i32_wrap_i64; i32_const(F64_EXP_BIAS); i32_sub; local_set(2);
         // if e >= 52 { return x }
-        local_get(2); i32_const(52); i32_ge_s;
+        local_get(2); i32_const(F64_MANTISSA_BITS_I32); i32_ge_s;
         if_empty; local_get(0); return_; end;
         // if e >= 0
         local_get(2); i32_const(0); i32_ge_s;
         if_f64;
             // m = 0x000f_ffff_ffff_ffff >> e
-            i64_const(0x000f_ffff_ffff_ffff); local_get(2); i64_extend_i32_s; i64_shr_u; local_set(3);
+            i64_const(F64_MANTISSA_MASK); local_get(2); i64_extend_i32_s; i64_shr_u; local_set(3);
             // if ui & m == 0 { return x }
             local_get(1); local_get(3); i64_and; i64_eqz;
             if_empty; local_get(0); return_; end;
             // if (ui >> 63) != 0 { ui += m }
-            local_get(1); i64_const(63); i64_shr_u; i64_eqz;
+            local_get(1); i64_const(F64_SIGN_BIT); i64_shr_u; i64_eqz;
             if_empty; else_;
                 local_get(1); local_get(3); i64_add; local_set(1);
             end;
@@ -247,7 +342,7 @@ fn compile_floor(emitter: &mut WasmEmitter) {
         else_;
             // |x| < 1
             // if (ui >> 63) == 0 { 0.0 } else if (ui << 1) != 0 { -1.0 } else { x }
-            local_get(1); i64_const(63); i64_shr_u; i64_eqz;
+            local_get(1); i64_const(F64_SIGN_BIT); i64_shr_u; i64_eqz;
             if_f64;
                 f64_const(0.0);
             else_;
@@ -277,30 +372,30 @@ fn compile_scalbn(emitter: &mut WasmEmitter) {
     });
     // if n > 1023
     wasm!(f, {
-        local_get(1); i32_const(1023); i32_gt_s;
+        local_get(1); i32_const(F64_EXP_BIAS); i32_gt_s;
         if_empty;
             local_get(0); local_get(2); f64_mul; local_set(0);
-            local_get(1); i32_const(1023); i32_sub; local_set(1);
-            local_get(1); i32_const(1023); i32_gt_s;
+            local_get(1); i32_const(F64_EXP_BIAS); i32_sub; local_set(1);
+            local_get(1); i32_const(F64_EXP_BIAS); i32_gt_s;
             if_empty;
                 local_get(0); local_get(2); f64_mul; local_set(0);
-                local_get(1); i32_const(1023); i32_sub; local_set(1);
-                local_get(1); i32_const(1023); i32_gt_s;
-                if_empty; i32_const(1023); local_set(1); end;
+                local_get(1); i32_const(F64_EXP_BIAS); i32_sub; local_set(1);
+                local_get(1); i32_const(F64_EXP_BIAS); i32_gt_s;
+                if_empty; i32_const(F64_EXP_BIAS); local_set(1); end;
             end;
         else_;
             // if n < -1022
-            local_get(1); i32_const(-1022); i32_lt_s;
+            local_get(1); i32_const(F64_MIN_EXP); i32_lt_s;
             if_empty;
                 // add = -(-1022) - 53 = 1022 - 53 = 969
                 local_get(0); local_get(4); f64_mul; local_set(0);
-                local_get(1); i32_const(969); i32_add; local_set(1);
-                local_get(1); i32_const(-1022); i32_lt_s;
+                local_get(1); i32_const(SCALBN_SUBNORM_STEP); i32_add; local_set(1);
+                local_get(1); i32_const(F64_MIN_EXP); i32_lt_s;
                 if_empty;
                     local_get(0); local_get(4); f64_mul; local_set(0);
-                    local_get(1); i32_const(969); i32_add; local_set(1);
-                    local_get(1); i32_const(-1022); i32_lt_s;
-                    if_empty; i32_const(-1022); local_set(1); end;
+                    local_get(1); i32_const(SCALBN_SUBNORM_STEP); i32_add; local_set(1);
+                    local_get(1); i32_const(F64_MIN_EXP); i32_lt_s;
+                    if_empty; i32_const(F64_MIN_EXP); local_set(1); end;
                 end;
             end;
         end;
@@ -308,7 +403,7 @@ fn compile_scalbn(emitter: &mut WasmEmitter) {
     // scale = bits((1023 + n) << 52) ; return x * scale
     wasm!(f, {
         local_get(0);
-        i32_const(1023); local_get(1); i32_add; i64_extend_i32_s; i64_const(52); i64_shl;
+        i32_const(F64_EXP_BIAS); local_get(1); i32_add; i64_extend_i32_s; i64_const(F64_MANTISSA_BITS); i64_shl;
         f64_reinterpret_i64;
         f64_mul;
         end;
@@ -428,9 +523,9 @@ fn compile_k_tan(emitter: &mut WasmEmitter) {
         // hx = (to_bits(x) >> 32) as u32
         local_get(X); i64_reinterpret_f64; i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; local_set(HX);
         // big = (hx & 0x7fffffff) >= 0x3FE59428
-        local_get(HX); i32_const(0x7fffffff); i32_and; i32_const(0x3FE59428); i32_ge_u; local_set(BIG);
+        local_get(HX); i32_const(F64_ABS_MASK_HI); i32_and; i32_const(KTAN_BIG_HI); i32_ge_u; local_set(BIG);
         // sign = hx >> 31  (logical)
-        local_get(HX); i32_const(31); i32_shr_u; local_set(SIGN);
+        local_get(HX); i32_const(I32_SIGN_BIT); i32_shr_u; local_set(SIGN);
         // if big { if sign { x=-x; y=-y } x=(PIO4-x)+(PIO4_LO-y); y=0 }
         local_get(BIG);
         if_empty;
@@ -503,13 +598,13 @@ fn compile_k_tan(emitter: &mut WasmEmitter) {
         local_get(ODD); i32_eqz;
         if_empty; local_get(W); return_; end;
         // w0 = zero_low_word(w)
-        local_get(W); i64_reinterpret_f64; i64_const(-4294967296); i64_and; f64_reinterpret_i64; local_set(W0); // !0xFFFFFFFF == 0xFFFFFFFF00000000 = -4294967296
+        local_get(W); i64_reinterpret_f64; i64_const(LOW_WORD_MASK); i64_and; f64_reinterpret_i64; local_set(W0); // !0xFFFFFFFF == 0xFFFFFFFF00000000 = LOW_WORD_MASK
         // v = r - (w0 - x)
         local_get(R); local_get(W0); local_get(X); f64_sub; f64_sub; local_set(V);
         // a = -1.0 / w
         f64_const(-1.0); local_get(W); f64_div; local_set(A);
         // a0 = zero_low_word(a)
-        local_get(A); i64_reinterpret_f64; i64_const(-4294967296); i64_and; f64_reinterpret_i64; local_set(A0);
+        local_get(A); i64_reinterpret_f64; i64_const(LOW_WORD_MASK); i64_and; f64_reinterpret_i64; local_set(A0);
         // return a0 + a*(1 + a0*w0 + a0*v)
         local_get(A0);
         local_get(A);
@@ -573,10 +668,10 @@ fn emit_medium(f: &mut Function) {
         // y0 = r - w
         local_get(RP_R); local_get(RP_W); f64_sub; local_set(RP_Y0);
         // ey = (to_bits(y0) >> 52) & 0x7ff ; ex = ix >> 20
-        local_get(RP_Y0); i64_reinterpret_f64; i64_const(52); i64_shr_u; i32_wrap_i64; i32_const(0x7ff); i32_and; local_set(RP_EY);
-        local_get(RP_IX); i32_const(20); i32_shr_u; local_set(RP_EX);
+        local_get(RP_Y0); i64_reinterpret_f64; i64_const(F64_MANTISSA_BITS); i64_shr_u; i32_wrap_i64; i32_const(F64_EXP_MASK_I32); i32_and; local_set(RP_EY);
+        local_get(RP_IX); i32_const(F64_EXP_SHIFT); i32_shr_u; local_set(RP_EX);
         // if ex - ey > 16
-        local_get(RP_EX); local_get(RP_EY); i32_sub; i32_const(16); i32_gt_s;
+        local_get(RP_EX); local_get(RP_EY); i32_sub; i32_const(MEDIUM_EX_EY_THRESH_1); i32_gt_s;
         if_empty;
             // t = r; w = f_n*PIO2_2; r = t - w; w = f_n*PIO2_2T - ((t - r) - w); y0 = r - w
             local_get(RP_R); local_set(RP_T);
@@ -587,9 +682,9 @@ fn emit_medium(f: &mut Function) {
             f64_sub; local_set(RP_W);
             local_get(RP_R); local_get(RP_W); f64_sub; local_set(RP_Y0);
             // ey = (to_bits(y0) >> 52) & 0x7ff
-            local_get(RP_Y0); i64_reinterpret_f64; i64_const(52); i64_shr_u; i32_wrap_i64; i32_const(0x7ff); i32_and; local_set(RP_EY);
+            local_get(RP_Y0); i64_reinterpret_f64; i64_const(F64_MANTISSA_BITS); i64_shr_u; i32_wrap_i64; i32_const(F64_EXP_MASK_I32); i32_and; local_set(RP_EY);
             // if ex - ey > 49
-            local_get(RP_EX); local_get(RP_EY); i32_sub; i32_const(49); i32_gt_s;
+            local_get(RP_EX); local_get(RP_EY); i32_sub; i32_const(MEDIUM_EX_EY_THRESH_2); i32_gt_s;
             if_empty;
                 local_get(RP_R); local_set(RP_T);
                 local_get(RP_FN); f64_const(PIO2_3); f64_mul; local_set(RP_W);
@@ -670,20 +765,20 @@ fn compile_rem_pio2(emitter: &mut WasmEmitter) {
     ]);
     wasm!(f, {
         // sign = (to_bits(x) >> 63) as i32
-        local_get(RP_X); i64_reinterpret_f64; i64_const(63); i64_shr_u; i32_wrap_i64; local_set(RP_SIGN);
+        local_get(RP_X); i64_reinterpret_f64; i64_const(F64_SIGN_BIT); i64_shr_u; i32_wrap_i64; local_set(RP_SIGN);
         // ix = (to_bits(x) >> 32) as u32 & 0x7fffffff
-        local_get(RP_X); i64_reinterpret_f64; i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; i32_const(0x7fffffff); i32_and; local_set(RP_IX);
+        local_get(RP_X); i64_reinterpret_f64; i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; i32_const(F64_ABS_MASK_HI); i32_and; local_set(RP_IX);
     });
 
     // if ix <= 0x400f6a7a  (|x| ~<= 5pi/4)
-    wasm!(f, { local_get(RP_IX); i32_const(0x400f6a7a); i32_le_u; if_empty; });
+    wasm!(f, { local_get(RP_IX); i32_const(RP2_5PI4_HI); i32_le_u; if_empty; });
     // if (ix & 0xfffff) == 0x921fb { medium; return n }
-    wasm!(f, { local_get(RP_IX); i32_const(0xfffff); i32_and; i32_const(0x921fb); i32_eq; if_empty; });
+    wasm!(f, { local_get(RP_IX); i32_const(RP2_FRAC_MASK); i32_and; i32_const(RP2_PI_FRAC); i32_eq; if_empty; });
     emit_medium(&mut f);
     wasm!(f, { local_get(RP_N); return_; });
     wasm!(f, { end; }); // end the 0x921fb if
     // if ix <= 0x4002d97c { small(1) } else { small(2) }
-    wasm!(f, { local_get(RP_IX); i32_const(0x4002d97c); i32_le_u; if_empty; });
+    wasm!(f, { local_get(RP_IX); i32_const(RP2_3PI4_HI); i32_le_u; if_empty; });
     emit_small(&mut f, 1);
     wasm!(f, { local_get(RP_N); return_; });
     wasm!(f, { else_; });
@@ -693,11 +788,11 @@ fn compile_rem_pio2(emitter: &mut WasmEmitter) {
     wasm!(f, { end; });   // end 5pi/4 outer
 
     // if ix <= 0x401c463b  (|x| ~<= 9pi/4)
-    wasm!(f, { local_get(RP_IX); i32_const(0x401c463b); i32_le_u; if_empty; });
+    wasm!(f, { local_get(RP_IX); i32_const(RP2_9PI4_HI); i32_le_u; if_empty; });
         // if ix <= 0x4015fdbc (|x| ~<= 7pi/4)
-        wasm!(f, { local_get(RP_IX); i32_const(0x4015fdbc); i32_le_u; if_empty; });
+        wasm!(f, { local_get(RP_IX); i32_const(RP2_7PI4_HI); i32_le_u; if_empty; });
             // if ix == 0x4012d97c { medium }
-            wasm!(f, { local_get(RP_IX); i32_const(0x4012d97c); i32_eq; if_empty; });
+            wasm!(f, { local_get(RP_IX); i32_const(RP2_2PI_HI); i32_eq; if_empty; });
             emit_medium(&mut f);
             wasm!(f, { local_get(RP_N); return_; });
             wasm!(f, { end; });
@@ -705,7 +800,7 @@ fn compile_rem_pio2(emitter: &mut WasmEmitter) {
             wasm!(f, { local_get(RP_N); return_; });
         wasm!(f, { else_; });
             // if ix == 0x401921fb { medium }
-            wasm!(f, { local_get(RP_IX); i32_const(0x401921fb); i32_eq; if_empty; });
+            wasm!(f, { local_get(RP_IX); i32_const(RP2_3PI2_HI); i32_eq; if_empty; });
             emit_medium(&mut f);
             wasm!(f, { local_get(RP_N); return_; });
             wasm!(f, { end; });
@@ -715,13 +810,13 @@ fn compile_rem_pio2(emitter: &mut WasmEmitter) {
     wasm!(f, { end; }); // end 9pi/4 outer
 
     // if ix < 0x413921fb { medium }
-    wasm!(f, { local_get(RP_IX); i32_const(0x413921fb); i32_lt_u; if_empty; });
+    wasm!(f, { local_get(RP_IX); i32_const(RP2_LARGE_HI); i32_lt_u; if_empty; });
     emit_medium(&mut f);
     wasm!(f, { local_get(RP_N); return_; });
     wasm!(f, { end; });
 
     // if ix >= 0x7ff00000 { y0 = x - x; y1 = y0; return 0 }
-    wasm!(f, { local_get(RP_IX); i32_const(0x7ff00000); i32_ge_u; if_empty;
+    wasm!(f, { local_get(RP_IX); i32_const(F64_INF_NAN_HI); i32_ge_u; if_empty;
         local_get(RP_X); local_get(RP_X); f64_sub; local_set(RP_Y0);
         local_get(RP_Y0); local_set(RP_Y1);
     });
@@ -736,34 +831,34 @@ fn compile_rem_pio2(emitter: &mut WasmEmitter) {
         // ui = to_bits(x); ui &= (!1) >> 12; ui |= (0x3ff+23) << 52; z = from_bits(ui)
         local_get(RP_X); i64_reinterpret_f64;
         i64_const(-1); i64_const(1); i64_const(-1); i64_xor; i64_and; // (!1)
-        i64_const(12); i64_shr_u;
+        i64_const(RPL_NORM_STRIP); i64_shr_u;
         i64_and;
-        i64_const(0x3ff + 23); i64_const(52); i64_shl; i64_or;
+        i64_const(RPL_EXPO_BIAS); i64_const(F64_MANTISSA_BITS); i64_shl; i64_or;
         local_set(RP_UI);
         local_get(RP_UI); f64_reinterpret_i64; local_set(RP_Z);
         // for i in 0..2 { tx[i] = z as i32 as f64; z = (z - tx[i]) * 2^24 }
         i32_const(0); local_set(RP_I);
         block_empty; loop_empty;
-            local_get(RP_I); i32_const(2); i32_ge_s; br_if(1);
+            local_get(RP_I); i32_const(TX_SPLIT_COUNT); i32_ge_s; br_if(1);
             // tx[i] = (z as i32) as f64
-            local_get(RP_TXP); local_get(RP_I); i32_const(8); i32_mul; i32_add;
+            local_get(RP_TXP); local_get(RP_I); i32_const(F64_BYTES); i32_mul; i32_add;
             local_get(RP_Z); i64_trunc_f64_s; i32_wrap_i64; f64_convert_i32_s;
             f64_store(0);
             // z = (z - tx[i]) * 2^24
             local_get(RP_Z);
-            local_get(RP_TXP); local_get(RP_I); i32_const(8); i32_mul; i32_add; f64_load(0);
+            local_get(RP_TXP); local_get(RP_I); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
             f64_sub;
             i64_const(x1p24_bits); f64_reinterpret_i64; f64_mul; local_set(RP_Z);
             local_get(RP_I); i32_const(1); i32_add; local_set(RP_I);
             br(0);
         end; end;
         // tx[2] = z
-        local_get(RP_TXP); i32_const(16); i32_add; local_get(RP_Z); f64_store(0);
+        local_get(RP_TXP); i32_const(TX_LAST_OFFSET); i32_add; local_get(RP_Z); f64_store(0);
         // i = 2; while i != 0 && tx[i] == 0 { i -= 1 }
-        i32_const(2); local_set(RP_I);
+        i32_const(TX_SPLIT_COUNT); local_set(RP_I);
         block_empty; loop_empty;
             local_get(RP_I); i32_eqz; br_if(1);
-            local_get(RP_TXP); local_get(RP_I); i32_const(8); i32_mul; i32_add; f64_load(0);
+            local_get(RP_TXP); local_get(RP_I); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
             f64_const(0.0); f64_ne; br_if(1);
             local_get(RP_I); i32_const(1); i32_sub; local_set(RP_I);
             br(0);
@@ -772,7 +867,7 @@ fn compile_rem_pio2(emitter: &mut WasmEmitter) {
         local_get(RP_TXP);
         local_get(RP_I); i32_const(1); i32_add;        // nx = i+1
         local_get(RP_TYP);
-        local_get(RP_IX); i32_const(20); i32_shr_s; i32_const(0x3ff + 23); i32_sub; // e0
+        local_get(RP_IX); i32_const(F64_EXP_SHIFT); i32_shr_s; i32_const(0x3ff + 23); i32_sub; // e0
         i32_const(1);                                   // prec
         call(rpl); local_set(RP_N);
         // y0 = ty[0]; y1 = ty[1]
@@ -858,18 +953,18 @@ fn compile_rem_pio2_large(emitter: &mut WasmEmitter) {
     wasm!(f, {
         // INIT_JK is a compile-time const; read via select chain on prec (0..3)
         // jk = match prec {0=>3,1=>4,2=>4,_=>6}
-        local_get(PREC); i32_const(0); i32_eq; if_i32; i32_const(3); else_;
-          local_get(PREC); i32_const(2); i32_le_u; if_i32; i32_const(4); else_; i32_const(6); end;
+        local_get(PREC); i32_const(0); i32_eq; if_i32; i32_const(IPIO2_E0_ADJUST); else_;
+          local_get(PREC); i32_const(PREC_DOUBLE_MAX); i32_le_u; if_i32; i32_const(JK_DOUBLE); else_; i32_const(JK_EXTENDED); end;
         end;
         local_set(JK);
         local_get(JK); local_set(JP);
         // jx = nx - 1
         local_get(NX); i32_const(1); i32_sub; local_set(JX);
         // jv = (e0 - 3) / 24 ; if jv < 0 { jv = 0 }
-        local_get(E0); i32_const(3); i32_sub; i32_const(24); i32_div_s; local_set(JV);
+        local_get(E0); i32_const(IPIO2_E0_ADJUST); i32_sub; i32_const(IPIO2_CHUNK_BITS); i32_div_s; local_set(JV);
         local_get(JV); i32_const(0); i32_lt_s; if_empty; i32_const(0); local_set(JV); end;
         // q0 = e0 - 24*(jv+1)
-        local_get(E0); i32_const(24); local_get(JV); i32_const(1); i32_add; i32_mul; i32_sub; local_set(Q0);
+        local_get(E0); i32_const(IPIO2_CHUNK_BITS); local_get(JV); i32_const(1); i32_add; i32_mul; i32_sub; local_set(Q0);
     });
 
     // set up f[0..=jx+jk]: j = jv - jx ; for i in 0..=m { f[i] = j<0?0:IPIO2[j]; j++ }
@@ -881,14 +976,14 @@ fn compile_rem_pio2_large(emitter: &mut WasmEmitter) {
         block_empty; loop_empty;
             local_get(II); local_get(M); i32_gt_s; br_if(1);
             // f[i] address
-            local_get(FA); local_get(II); i32_const(8); i32_mul; i32_add;
+            local_get(FA); local_get(II); i32_const(F64_BYTES); i32_mul; i32_add;
             // value = j<0 ? 0.0 : IPIO2[j] as f64
             local_get(JTMP); i32_const(0); i32_lt_s;
             if_f64;
                 f64_const(0.0);
             else_;
                 // IPIO2[j] : i32 at ipio2 + j*4
-                i32_const(ipio2); local_get(JTMP); i32_const(4); i32_mul; i32_add; i32_load(0);
+                i32_const(ipio2); local_get(JTMP); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
                 f64_convert_i32_s;
             end;
             f64_store(0);
@@ -909,14 +1004,14 @@ fn compile_rem_pio2_large(emitter: &mut WasmEmitter) {
                 local_get(JJ); local_get(JX); i32_gt_s; br_if(1);
                 local_get(FW);
                 // x[j]
-                local_get(XP); local_get(JJ); i32_const(8); i32_mul; i32_add; f64_load(0);
+                local_get(XP); local_get(JJ); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                 // f[jx+i-j]
-                local_get(FA); local_get(JX); local_get(II); i32_add; local_get(JJ); i32_sub; i32_const(8); i32_mul; i32_add; f64_load(0);
+                local_get(FA); local_get(JX); local_get(II); i32_add; local_get(JJ); i32_sub; i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                 f64_mul; f64_add; local_set(FW);
                 local_get(JJ); i32_const(1); i32_add; local_set(JJ);
                 br(0);
             end; end;
-            local_get(QA); local_get(II); i32_const(8); i32_mul; i32_add; local_get(FW); f64_store(0);
+            local_get(QA); local_get(II); i32_const(F64_BYTES); i32_mul; i32_add; local_get(FW); f64_store(0);
             local_get(II); i32_const(1); i32_add; local_set(II);
             br(0);
         end; end;
@@ -954,15 +1049,15 @@ fn emit_rpl_recompute_and_finalize(
     wasm!(f, {
         block_empty; loop_empty;
         i32_const(0); local_set(II);
-        local_get(QA); local_get(JZ); i32_const(8); i32_mul; i32_add; f64_load(0); local_set(Z);
+        local_get(QA); local_get(JZ); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0); local_set(Z);
         local_get(JZ); local_set(JJ);
         block_empty; loop_empty;
             local_get(JJ); i32_const(1); i32_lt_s; br_if(1);
             i64_const(x1p_24_bits); f64_reinterpret_i64; local_get(Z); f64_mul; i64_trunc_f64_s; i32_wrap_i64; f64_convert_i32_s; local_set(FW);
-            local_get(IQ); local_get(II); i32_const(4); i32_mul; i32_add;
+            local_get(IQ); local_get(II); i32_const(I32_BYTES); i32_mul; i32_add;
             local_get(Z); i64_const(x1p24_bits); f64_reinterpret_i64; local_get(FW); f64_mul; f64_sub; i64_trunc_f64_s; i32_wrap_i64;
             i32_store(0);
-            local_get(QA); local_get(JJ); i32_const(1); i32_sub; i32_const(8); i32_mul; i32_add; f64_load(0); local_get(FW); f64_add; local_set(Z);
+            local_get(QA); local_get(JJ); i32_const(1); i32_sub; i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0); local_get(FW); f64_add; local_set(Z);
             local_get(II); i32_const(1); i32_add; local_set(II);
             local_get(JJ); i32_const(1); i32_sub; local_set(JJ);
             br(0);
@@ -978,22 +1073,22 @@ fn emit_rpl_recompute_and_finalize(
         i32_const(0); local_set(IH);
         local_get(Q0); i32_const(0); i32_gt_s;
         if_empty;
-            local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(4); i32_mul; i32_add; i32_load(0);
-            i32_const(24); local_get(Q0); i32_sub; i32_shr_s; local_set(II);
+            local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
+            i32_const(IPIO2_CHUNK_BITS); local_get(Q0); i32_sub; i32_shr_s; local_set(II);
             local_get(N); local_get(II); i32_add; local_set(N);
-            local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(4); i32_mul; i32_add; local_tee(TMP1);
+            local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; local_tee(TMP1);
             local_get(TMP1); i32_load(0);
-            local_get(II); i32_const(24); local_get(Q0); i32_sub; i32_shl; i32_sub;
+            local_get(II); i32_const(IPIO2_CHUNK_BITS); local_get(Q0); i32_sub; i32_shl; i32_sub;
             i32_store(0);
-            local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(4); i32_mul; i32_add; i32_load(0);
-            i32_const(23); local_get(Q0); i32_sub; i32_shr_s; local_set(IH);
+            local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
+            i32_const(IPIO2_CHUNK_M1); local_get(Q0); i32_sub; i32_shr_s; local_set(IH);
         else_;
             local_get(Q0); i32_eqz;
             if_empty;
-                local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(4); i32_mul; i32_add; i32_load(0);
-                i32_const(23); i32_shr_s; local_set(IH);
+                local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
+                i32_const(IPIO2_CHUNK_M1); i32_shr_s; local_set(IH);
             else_;
-                local_get(Z); f64_const(0.5); f64_ge; if_empty; i32_const(2); local_set(IH); end;
+                local_get(Z); f64_const(0.5); f64_ge; if_empty; i32_const(IH_HALFWAY); local_set(IH); end;
             end;
         end;
 
@@ -1004,16 +1099,16 @@ fn emit_rpl_recompute_and_finalize(
             i32_const(0); local_set(II);
             block_empty; loop_empty;
                 local_get(II); local_get(JZ); i32_ge_s; br_if(1);
-                local_get(IQ); local_get(II); i32_const(4); i32_mul; i32_add; i32_load(0); local_set(JJ);
+                local_get(IQ); local_get(II); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0); local_set(JJ);
                 local_get(CARRY); i32_eqz;
                 if_empty;
                     local_get(JJ); i32_eqz;
                     if_empty; else_;
                         i32_const(1); local_set(CARRY);
-                        local_get(IQ); local_get(II); i32_const(4); i32_mul; i32_add; i32_const(0x1000000); local_get(JJ); i32_sub; i32_store(0);
+                        local_get(IQ); local_get(II); i32_const(I32_BYTES); i32_mul; i32_add; i32_const(IPIO2_CARRY_BASE); local_get(JJ); i32_sub; i32_store(0);
                     end;
                 else_;
-                    local_get(IQ); local_get(II); i32_const(4); i32_mul; i32_add; i32_const(0xffffff); local_get(JJ); i32_sub; i32_store(0);
+                    local_get(IQ); local_get(II); i32_const(I32_BYTES); i32_mul; i32_add; i32_const(IPIO2_24BIT_MASK); local_get(JJ); i32_sub; i32_store(0);
                 end;
                 local_get(II); i32_const(1); i32_add; local_set(II);
                 br(0);
@@ -1022,17 +1117,17 @@ fn emit_rpl_recompute_and_finalize(
             if_empty;
                 local_get(Q0); i32_const(1); i32_eq;
                 if_empty;
-                    local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(4); i32_mul; i32_add; local_tee(TMP1);
-                    local_get(TMP1); i32_load(0); i32_const(0x7fffff); i32_and; i32_store(0);
+                    local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; local_tee(TMP1);
+                    local_get(TMP1); i32_load(0); i32_const(IPIO2_23BIT_MASK); i32_and; i32_store(0);
                 else_;
-                    local_get(Q0); i32_const(2); i32_eq;
+                    local_get(Q0); i32_const(IH_HALFWAY); i32_eq;
                     if_empty;
-                        local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(4); i32_mul; i32_add; local_tee(TMP1);
-                        local_get(TMP1); i32_load(0); i32_const(0x3fffff); i32_and; i32_store(0);
+                        local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; local_tee(TMP1);
+                        local_get(TMP1); i32_load(0); i32_const(IPIO2_22BIT_MASK); i32_and; i32_store(0);
                     end;
                 end;
             end;
-            local_get(IH); i32_const(2); i32_eq;
+            local_get(IH); i32_const(IH_HALFWAY); i32_eq;
             if_empty;
                 f64_const(1.0); local_get(Z); f64_sub; local_set(Z);
                 local_get(CARRY); i32_eqz;
@@ -1048,7 +1143,7 @@ fn emit_rpl_recompute_and_finalize(
             local_get(JZ); i32_const(1); i32_sub; local_set(II);
             block_empty; loop_empty;
                 local_get(II); local_get(JK); i32_lt_s; br_if(1);
-                local_get(JJ); local_get(IQ); local_get(II); i32_const(4); i32_mul; i32_add; i32_load(0); i32_or; local_set(JJ);
+                local_get(JJ); local_get(IQ); local_get(II); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0); i32_or; local_set(JJ);
                 local_get(II); i32_const(1); i32_sub; local_set(II);
                 br(0);
             end; end;
@@ -1056,7 +1151,7 @@ fn emit_rpl_recompute_and_finalize(
             if_empty;
                 i32_const(1); local_set(KK);
                 block_empty; loop_empty;
-                    local_get(IQ); local_get(JK); local_get(KK); i32_sub; i32_const(4); i32_mul; i32_add; i32_load(0);
+                    local_get(IQ); local_get(JK); local_get(KK); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
                     br_if(1);
                     local_get(KK); i32_const(1); i32_add; local_set(KK);
                     br(0);
@@ -1064,21 +1159,21 @@ fn emit_rpl_recompute_and_finalize(
                 local_get(JZ); i32_const(1); i32_add; local_set(II);
                 block_empty; loop_empty;
                     local_get(II); local_get(JZ); local_get(KK); i32_add; i32_gt_s; br_if(1);
-                    local_get(FA); local_get(JX); local_get(II); i32_add; i32_const(8); i32_mul; i32_add;
-                    i32_const(ipio2); local_get(JV); local_get(II); i32_add; i32_const(4); i32_mul; i32_add; i32_load(0); f64_convert_i32_s;
+                    local_get(FA); local_get(JX); local_get(II); i32_add; i32_const(F64_BYTES); i32_mul; i32_add;
+                    i32_const(ipio2); local_get(JV); local_get(II); i32_add; i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0); f64_convert_i32_s;
                     f64_store(0);
                     f64_const(0.0); local_set(FW);
                     i32_const(0); local_set(JJ);
                     block_empty; loop_empty;
                         local_get(JJ); local_get(JX); i32_gt_s; br_if(1);
                         local_get(FW);
-                        local_get(XP); local_get(JJ); i32_const(8); i32_mul; i32_add; f64_load(0);
-                        local_get(FA); local_get(JX); local_get(II); i32_add; local_get(JJ); i32_sub; i32_const(8); i32_mul; i32_add; f64_load(0);
+                        local_get(XP); local_get(JJ); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
+                        local_get(FA); local_get(JX); local_get(II); i32_add; local_get(JJ); i32_sub; i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                         f64_mul; f64_add; local_set(FW);
                         local_get(JJ); i32_const(1); i32_add; local_set(JJ);
                         br(0);
                     end; end;
-                    local_get(QA); local_get(II); i32_const(8); i32_mul; i32_add; local_get(FW); f64_store(0);
+                    local_get(QA); local_get(II); i32_const(F64_BYTES); i32_mul; i32_add; local_get(FW); f64_store(0);
                     local_get(II); i32_const(1); i32_add; local_set(II);
                     br(0);
                 end; end;
@@ -1100,11 +1195,11 @@ fn emit_rpl_recompute_and_finalize(
         local_get(Z); f64_const(0.0); f64_eq;
         if_empty;
             local_get(JZ); i32_const(1); i32_sub; local_set(JZ);
-            local_get(Q0); i32_const(24); i32_sub; local_set(Q0);
+            local_get(Q0); i32_const(IPIO2_CHUNK_BITS); i32_sub; local_set(Q0);
             block_empty; loop_empty;
-                local_get(IQ); local_get(JZ); i32_const(4); i32_mul; i32_add; i32_load(0); br_if(1);
+                local_get(IQ); local_get(JZ); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0); br_if(1);
                 local_get(JZ); i32_const(1); i32_sub; local_set(JZ);
-                local_get(Q0); i32_const(24); i32_sub; local_set(Q0);
+                local_get(Q0); i32_const(IPIO2_CHUNK_BITS); i32_sub; local_set(Q0);
                 br(0);
             end; end;
         else_;
@@ -1112,13 +1207,13 @@ fn emit_rpl_recompute_and_finalize(
             local_get(Z); i64_const(x1p24_bits); f64_reinterpret_i64; f64_ge;
             if_empty;
                 i64_const(x1p_24_bits); f64_reinterpret_i64; local_get(Z); f64_mul; i64_trunc_f64_s; i32_wrap_i64; f64_convert_i32_s; local_set(FW);
-                local_get(IQ); local_get(JZ); i32_const(4); i32_mul; i32_add;
+                local_get(IQ); local_get(JZ); i32_const(I32_BYTES); i32_mul; i32_add;
                 local_get(Z); i64_const(x1p24_bits); f64_reinterpret_i64; local_get(FW); f64_mul; f64_sub; i64_trunc_f64_s; i32_wrap_i64; i32_store(0);
                 local_get(JZ); i32_const(1); i32_add; local_set(JZ);
-                local_get(Q0); i32_const(24); i32_add; local_set(Q0);
-                local_get(IQ); local_get(JZ); i32_const(4); i32_mul; i32_add; local_get(FW); i64_trunc_f64_s; i32_wrap_i64; i32_store(0);
+                local_get(Q0); i32_const(IPIO2_CHUNK_BITS); i32_add; local_set(Q0);
+                local_get(IQ); local_get(JZ); i32_const(I32_BYTES); i32_mul; i32_add; local_get(FW); i64_trunc_f64_s; i32_wrap_i64; i32_store(0);
             else_;
-                local_get(IQ); local_get(JZ); i32_const(4); i32_mul; i32_add; local_get(Z); i64_trunc_f64_s; i32_wrap_i64; i32_store(0);
+                local_get(IQ); local_get(JZ); i32_const(I32_BYTES); i32_mul; i32_add; local_get(Z); i64_trunc_f64_s; i32_wrap_i64; i32_store(0);
             end;
         end;
     });
@@ -1129,8 +1224,8 @@ fn emit_rpl_recompute_and_finalize(
         local_get(JZ); local_set(II);
         block_empty; loop_empty;
             local_get(II); i32_const(0); i32_lt_s; br_if(1);
-            local_get(QA); local_get(II); i32_const(8); i32_mul; i32_add;
-            local_get(FW); local_get(IQ); local_get(II); i32_const(4); i32_mul; i32_add; i32_load(0); f64_convert_i32_s; f64_mul;
+            local_get(QA); local_get(II); i32_const(F64_BYTES); i32_mul; i32_add;
+            local_get(FW); local_get(IQ); local_get(II); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0); f64_convert_i32_s; f64_mul;
             f64_store(0);
             local_get(FW); i64_const(x1p_24_bits); f64_reinterpret_i64; f64_mul; local_set(FW);
             local_get(II); i32_const(1); i32_sub; local_set(II);
@@ -1149,13 +1244,13 @@ fn emit_rpl_recompute_and_finalize(
                 local_get(KK); local_get(JP); i32_gt_s; br_if(1);
                 local_get(KK); local_get(JZ); local_get(II); i32_sub; i32_gt_s; br_if(1);
                 local_get(FW);
-                i32_const(pio2); local_get(KK); i32_const(8); i32_mul; i32_add; f64_load(0);
-                local_get(QA); local_get(II); local_get(KK); i32_add; i32_const(8); i32_mul; i32_add; f64_load(0);
+                i32_const(pio2); local_get(KK); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
+                local_get(QA); local_get(II); local_get(KK); i32_add; i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
                 f64_mul; f64_add; local_set(FW);
                 local_get(KK); i32_const(1); i32_add; local_set(KK);
                 br(0);
             end; end;
-            local_get(FQA); local_get(JZ); local_get(II); i32_sub; i32_const(8); i32_mul; i32_add; local_get(FW); f64_store(0);
+            local_get(FQA); local_get(JZ); local_get(II); i32_sub; i32_const(F64_BYTES); i32_mul; i32_add; local_get(FW); f64_store(0);
             local_get(II); i32_const(1); i32_sub; local_set(II);
             br(0);
         end; end;
@@ -1167,7 +1262,7 @@ fn emit_rpl_recompute_and_finalize(
         local_get(JZ); local_set(II);
         block_empty; loop_empty;
             local_get(II); i32_const(0); i32_lt_s; br_if(1);
-            local_get(FW); local_get(FQA); local_get(II); i32_const(8); i32_mul; i32_add; f64_load(0); f64_add; local_set(FW);
+            local_get(FW); local_get(FQA); local_get(II); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0); f64_add; local_set(FW);
             local_get(II); i32_const(1); i32_sub; local_set(II);
             br(0);
         end; end;
@@ -1178,14 +1273,14 @@ fn emit_rpl_recompute_and_finalize(
         i32_const(1); local_set(II);
         block_empty; loop_empty;
             local_get(II); local_get(JZ); i32_gt_s; br_if(1);
-            local_get(FW); local_get(FQA); local_get(II); i32_const(8); i32_mul; i32_add; f64_load(0); f64_add; local_set(FW);
+            local_get(FW); local_get(FQA); local_get(II); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0); f64_add; local_set(FW);
             local_get(II); i32_const(1); i32_add; local_set(II);
             br(0);
         end; end;
         local_get(YP);
         local_get(IH); i32_eqz; if_f64; local_get(FW); else_; local_get(FW); f64_neg; end;
         f64_store(8);
-        local_get(N); i32_const(7); i32_and;
+        local_get(N); i32_const(REM_PIO2_N_MASK); i32_and;
         end;
     });
 }
@@ -1237,11 +1332,11 @@ fn compile_exp(emitter: &mut WasmEmitter) {
     wasm!(f, {
         // hx = (to_bits(x) >> 32); sign = hx >> 31; hx &= 0x7fffffff
         local_get(X); i64_reinterpret_f64; i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; local_set(HX);
-        local_get(HX); i32_const(31); i32_shr_u; local_set(SIGN);
-        local_get(HX); i32_const(0x7fffffff); i32_and; local_set(HX);
+        local_get(HX); i32_const(I32_SIGN_BIT); i32_shr_u; local_set(SIGN);
+        local_get(HX); i32_const(F64_ABS_MASK_HI); i32_and; local_set(HX);
 
         // special cases: if hx >= 0x4086232b
-        local_get(HX); i32_const(0x4086232b); i32_ge_u;
+        local_get(HX); i32_const(EXP_OVERFLOW_HI); i32_ge_u;
         if_empty;
             // if x.is_nan() return x  (x != x)
             local_get(X); local_get(X); f64_ne;
@@ -1262,10 +1357,10 @@ fn compile_exp(emitter: &mut WasmEmitter) {
         end;
 
         // argument reduction
-        local_get(HX); i32_const(0x3fd62e42); i32_gt_u;
+        local_get(HX); i32_const(EXP_HALF_LN2_HI); i32_gt_u;
         if_empty;
             // |x| > 0.5 ln2
-            local_get(HX); i32_const(0x3ff0a2b2); i32_ge_u;
+            local_get(HX); i32_const(EXP_LN2_SMALL_HI); i32_ge_u;
             if_empty;
                 // k = (INVLN2*x + HALF[sign]) as i32   (HALF = [0.5, -0.5])
                 local_get(X); f64_const(EXP_INVLN2); f64_mul;
@@ -1280,7 +1375,7 @@ fn compile_exp(emitter: &mut WasmEmitter) {
             local_get(K); f64_convert_i32_s; f64_const(EXP_LN2LO); f64_mul; local_set(LO);
             local_get(HI); local_get(LO); f64_sub; local_set(X);
         else_;
-            local_get(HX); i32_const(0x3e300000); i32_gt_u;
+            local_get(HX); i32_const(EXP_TINY_HI); i32_gt_u;
             if_empty;
                 // |x| > 2^-28: k=0; hi=x; lo=0
                 i32_const(0); local_set(K);
@@ -1364,8 +1459,8 @@ fn emit_log_reduce(f: &mut Function) {
         local_get(LG_UI); i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; local_set(LG_HX);
         i32_const(0); local_set(LG_K);
         // if hx < 0x00100000 || (hx >> 31) != 0
-        local_get(LG_HX); i32_const(0x00100000); i32_lt_u;
-        local_get(LG_HX); i32_const(31); i32_shr_u; i32_const(0); i32_ne;
+        local_get(LG_HX); i32_const(F64_EXP_ONE_HI); i32_lt_u;
+        local_get(LG_HX); i32_const(I32_SIGN_BIT); i32_shr_u; i32_const(0); i32_ne;
         i32_or;
         if_empty;
             // if (ui << 1) == 0 { return -1/(x*x) }   log(+-0) = -inf
@@ -1374,22 +1469,22 @@ fn emit_log_reduce(f: &mut Function) {
                 f64_const(-1.0); local_get(LG_X); local_get(LG_X); f64_mul; f64_div; return_;
             end;
             // if (hx >> 31) != 0 { return (x-x)/0 }   log(-#) = NaN
-            local_get(LG_HX); i32_const(31); i32_shr_u; i32_const(0); i32_ne;
+            local_get(LG_HX); i32_const(I32_SIGN_BIT); i32_shr_u; i32_const(0); i32_ne;
             if_empty;
                 local_get(LG_X); local_get(LG_X); f64_sub; f64_const(0.0); f64_div; return_;
             end;
             // subnormal: k -= 54; x *= 2^54; ui = to_bits(x); hx = ui >> 32
-            local_get(LG_K); i32_const(54); i32_sub; local_set(LG_K);
+            local_get(LG_K); i32_const(LOG_SUBNORM_SCALE); i32_sub; local_set(LG_K);
             local_get(LG_X); f64_const(x1p54); f64_mul; local_set(LG_X);
             local_get(LG_X); i64_reinterpret_f64; local_set(LG_UI);
             local_get(LG_UI); i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; local_set(LG_HX);
         else_;
             // else if hx >= 0x7ff00000 { return x }
-            local_get(LG_HX); i32_const(0x7ff00000); i32_ge_u;
+            local_get(LG_HX); i32_const(F64_INF_NAN_HI); i32_ge_u;
             if_empty; local_get(LG_X); return_; end;
             // else if hx == 0x3ff00000 && (ui << 32) == 0 { return 0 }
-            local_get(LG_HX); i32_const(0x3ff00000); i32_eq;
-            local_get(LG_UI); i64_const(32); i64_shl; i64_eqz;
+            local_get(LG_HX); i32_const(F64_ONE_HI); i32_eq;
+            local_get(LG_UI); i64_const(HI_SHIFT); i64_shl; i64_eqz;
             i32_and;
             if_empty; f64_const(0.0); return_; end;
         end;
@@ -1398,12 +1493,12 @@ fn emit_log_reduce(f: &mut Function) {
         // hx += 0x3ff00000 - 0x3fe6a09e
         local_get(LG_HX); i32_const(0x3ff00000 - 0x3fe6a09e); i32_add; local_set(LG_HX);
         // k += (hx >> 20) - 0x3ff
-        local_get(LG_K); local_get(LG_HX); i32_const(20); i32_shr_u; i32_const(0x3ff); i32_sub; i32_add; local_set(LG_K);
+        local_get(LG_K); local_get(LG_HX); i32_const(F64_EXP_SHIFT); i32_shr_u; i32_const(F64_EXP_BIAS); i32_sub; i32_add; local_set(LG_K);
         // hx = (hx & 0x000fffff) + 0x3fe6a09e
-        local_get(LG_HX); i32_const(0x000fffff); i32_and; i32_const(0x3fe6a09e); i32_add; local_set(LG_HX);
+        local_get(LG_HX); i32_const(F64_MANTISSA_HI_MASK); i32_and; i32_const(LOG_SQRT2_HI); i32_add; local_set(LG_HX);
         // ui = (hx << 32) | (ui & 0xffffffff); x = from_bits(ui)
         local_get(LG_HX); i64_extend_i32_u; i64_const(HI_SHIFT); i64_shl;
-        local_get(LG_UI); i64_const(0xffffffff); i64_and;
+        local_get(LG_UI); i64_const(LOW_WORD_BITS); i64_and;
         i64_or; local_set(LG_UI);
         local_get(LG_UI); f64_reinterpret_i64; local_set(LG_X);
 
@@ -1604,51 +1699,51 @@ fn compile_pow(emitter: &mut WasmEmitter) {
         local_get(PW_Y); i64_reinterpret_f64; i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; local_set(PW_HY);
         local_get(PW_Y); i64_reinterpret_f64; i32_wrap_i64; local_set(PW_LY);
         // ix = hx & 0x7fffffff; iy = hy & 0x7fffffff
-        local_get(PW_HX); i32_const(0x7fffffff); i32_and; local_set(PW_IX);
-        local_get(PW_HY); i32_const(0x7fffffff); i32_and; local_set(PW_IY);
+        local_get(PW_HX); i32_const(F64_ABS_MASK_HI); i32_and; local_set(PW_IX);
+        local_get(PW_HY); i32_const(F64_ABS_MASK_HI); i32_and; local_set(PW_IY);
 
         // x**0 = 1 (even if x is NaN): if (iy | ly) == 0 return 1
         local_get(PW_IY); local_get(PW_LY); i32_or; i32_eqz;
         if_empty; f64_const(1.0); return_; end;
         // 1**y = 1: if hx == 0x3ff00000 && lx == 0 return 1
-        local_get(PW_HX); i32_const(0x3ff00000); i32_eq; local_get(PW_LX); i32_eqz; i32_and;
+        local_get(PW_HX); i32_const(F64_ONE_HI); i32_eq; local_get(PW_LX); i32_eqz; i32_and;
         if_empty; f64_const(1.0); return_; end;
         // NaN if either arg is NaN:
         //   ix > 0x7ff00000 || (ix==0x7ff00000 && lx!=0) || iy > 0x7ff00000 || (iy==0x7ff00000 && ly!=0)
-        local_get(PW_IX); i32_const(0x7ff00000); i32_gt_s;
-        local_get(PW_IX); i32_const(0x7ff00000); i32_eq; local_get(PW_LX); i32_const(0); i32_ne; i32_and; i32_or;
-        local_get(PW_IY); i32_const(0x7ff00000); i32_gt_s; i32_or;
-        local_get(PW_IY); i32_const(0x7ff00000); i32_eq; local_get(PW_LY); i32_const(0); i32_ne; i32_and; i32_or;
+        local_get(PW_IX); i32_const(F64_INF_NAN_HI); i32_gt_s;
+        local_get(PW_IX); i32_const(F64_INF_NAN_HI); i32_eq; local_get(PW_LX); i32_const(0); i32_ne; i32_and; i32_or;
+        local_get(PW_IY); i32_const(F64_INF_NAN_HI); i32_gt_s; i32_or;
+        local_get(PW_IY); i32_const(F64_INF_NAN_HI); i32_eq; local_get(PW_LY); i32_const(0); i32_ne; i32_and; i32_or;
         if_empty; local_get(PW_X); local_get(PW_Y); f64_add; return_; end;
 
         // yisint: 0 not int, 1 odd int, 2 even int (only matters when x < 0)
         i32_const(0); local_set(PW_YISINT);
         local_get(PW_HX); i32_const(0); i32_lt_s;
         if_empty;
-            local_get(PW_IY); i32_const(0x43400000); i32_ge_s;
+            local_get(PW_IY); i32_const(POW_YINT_LARGE_HI); i32_ge_s;
             if_empty;
-                i32_const(2); local_set(PW_YISINT); // even integer y
+                i32_const(YISINT_EVEN); local_set(PW_YISINT); // even integer y
             else_;
-                local_get(PW_IY); i32_const(0x3ff00000); i32_ge_s;
+                local_get(PW_IY); i32_const(F64_ONE_HI); i32_ge_s;
                 if_empty;
                     // k = (iy >> 20) - 0x3ff
-                    local_get(PW_IY); i32_const(20); i32_shr_s; i32_const(0x3ff); i32_sub; local_set(PW_K);
-                    local_get(PW_K); i32_const(20); i32_gt_s;
+                    local_get(PW_IY); i32_const(F64_EXP_SHIFT); i32_shr_s; i32_const(F64_EXP_BIAS); i32_sub; local_set(PW_K);
+                    local_get(PW_K); i32_const(F64_EXP_SHIFT); i32_gt_s;
                     if_empty;
                         // j = (ly >> (52 - k)) ; if (j << (52-k)) == ly { yisint = 2 - (j&1) }
-                        local_get(PW_LY); i32_const(52); local_get(PW_K); i32_sub; i32_shr_u; local_set(PW_J);
-                        local_get(PW_J); i32_const(52); local_get(PW_K); i32_sub; i32_shl; local_get(PW_LY); i32_eq;
+                        local_get(PW_LY); i32_const(F64_MANTISSA_BITS_I32); local_get(PW_K); i32_sub; i32_shr_u; local_set(PW_J);
+                        local_get(PW_J); i32_const(F64_MANTISSA_BITS_I32); local_get(PW_K); i32_sub; i32_shl; local_get(PW_LY); i32_eq;
                         if_empty;
-                            i32_const(2); local_get(PW_J); i32_const(1); i32_and; i32_sub; local_set(PW_YISINT);
+                            i32_const(YISINT_EVEN); local_get(PW_J); i32_const(1); i32_and; i32_sub; local_set(PW_YISINT);
                         end;
                     else_;
                         local_get(PW_LY); i32_eqz;
                         if_empty;
                             // j = iy >> (20 - k); if (j << (20-k)) == iy { yisint = 2 - (j&1) }
-                            local_get(PW_IY); i32_const(20); local_get(PW_K); i32_sub; i32_shr_s; local_set(PW_J);
-                            local_get(PW_J); i32_const(20); local_get(PW_K); i32_sub; i32_shl; local_get(PW_IY); i32_eq;
+                            local_get(PW_IY); i32_const(F64_EXP_SHIFT); local_get(PW_K); i32_sub; i32_shr_s; local_set(PW_J);
+                            local_get(PW_J); i32_const(F64_EXP_SHIFT); local_get(PW_K); i32_sub; i32_shl; local_get(PW_IY); i32_eq;
                             if_empty;
-                                i32_const(2); local_get(PW_J); i32_const(1); i32_and; i32_sub; local_set(PW_YISINT);
+                                i32_const(YISINT_EVEN); local_get(PW_J); i32_const(1); i32_and; i32_sub; local_set(PW_YISINT);
                             end;
                         end;
                     end;
@@ -1660,15 +1755,15 @@ fn compile_pow(emitter: &mut WasmEmitter) {
         local_get(PW_LY); i32_eqz;
         if_empty;
             // y is +-inf
-            local_get(PW_IY); i32_const(0x7ff00000); i32_eq;
+            local_get(PW_IY); i32_const(F64_INF_NAN_HI); i32_eq;
             if_empty;
                 // if ((ix - 0x3ff00000) | lx) == 0  -> (-1)**+-inf = 1
-                local_get(PW_IX); i32_const(0x3ff00000); i32_sub; local_get(PW_LX); i32_or; i32_eqz;
+                local_get(PW_IX); i32_const(F64_ONE_HI); i32_sub; local_get(PW_LX); i32_or; i32_eqz;
                 if_f64;
                     f64_const(1.0);
                 else_;
                     // elif ix >= 0x3ff00000  -> (|x|>1)**+-inf = inf,0
-                    local_get(PW_IX); i32_const(0x3ff00000); i32_ge_s;
+                    local_get(PW_IX); i32_const(F64_ONE_HI); i32_ge_s;
                     if_f64;
                         local_get(PW_HY); i32_const(0); i32_ge_s; if_f64; local_get(PW_Y); else_; f64_const(0.0); end;
                     else_;
@@ -1679,17 +1774,17 @@ fn compile_pow(emitter: &mut WasmEmitter) {
                 return_;
             end;
             // y is +-1
-            local_get(PW_IY); i32_const(0x3ff00000); i32_eq;
+            local_get(PW_IY); i32_const(F64_ONE_HI); i32_eq;
             if_empty;
                 local_get(PW_HY); i32_const(0); i32_ge_s;
                 if_f64; local_get(PW_X); else_; f64_const(1.0); local_get(PW_X); f64_div; end;
                 return_;
             end;
             // y is 2
-            local_get(PW_HY); i32_const(0x40000000); i32_eq;
+            local_get(PW_HY); i32_const(POW_TWO_HI); i32_eq;
             if_empty; local_get(PW_X); local_get(PW_X); f64_mul; return_; end;
             // y is 0.5 and x >= +0
-            local_get(PW_HY); i32_const(0x3fe00000); i32_eq;
+            local_get(PW_HY); i32_const(F64_HALF_HI); i32_eq;
             if_empty;
                 local_get(PW_HX); i32_const(0); i32_ge_s;
                 if_empty; local_get(PW_X); f64_sqrt; return_; end;
@@ -1702,9 +1797,9 @@ fn compile_pow(emitter: &mut WasmEmitter) {
         local_get(PW_LX); i32_eqz;
         if_empty;
             // x is +-0,+-inf,+-1
-            local_get(PW_IX); i32_const(0x7ff00000); i32_eq;
+            local_get(PW_IX); i32_const(F64_INF_NAN_HI); i32_eq;
             local_get(PW_IX); i32_eqz; i32_or;
-            local_get(PW_IX); i32_const(0x3ff00000); i32_eq; i32_or;
+            local_get(PW_IX); i32_const(F64_ONE_HI); i32_eq; i32_or;
             if_empty;
                 // z = ax
                 local_get(PW_AX); local_set(PW_Z);
@@ -1715,7 +1810,7 @@ fn compile_pow(emitter: &mut WasmEmitter) {
                 local_get(PW_HX); i32_const(0); i32_lt_s;
                 if_empty;
                     // if ((ix-0x3ff00000)|yisint)==0 { z = (z-z)/(z-z) }  (-1)**non-int = NaN
-                    local_get(PW_IX); i32_const(0x3ff00000); i32_sub; local_get(PW_YISINT); i32_or; i32_eqz;
+                    local_get(PW_IX); i32_const(F64_ONE_HI); i32_sub; local_get(PW_YISINT); i32_or; i32_eqz;
                     if_empty;
                         local_get(PW_Z); local_get(PW_Z); f64_sub; local_get(PW_Z); local_get(PW_Z); f64_sub; f64_div; local_set(PW_Z);
                     else_;
@@ -1742,20 +1837,20 @@ fn compile_pow(emitter: &mut WasmEmitter) {
         end;
 
         // |y| is HUGE: if iy > 0x41e00000
-        local_get(PW_IY); i32_const(0x41e00000); i32_gt_s;
+        local_get(PW_IY); i32_const(POW_HUGE_EXP_HI); i32_gt_s;
         if_empty;
             // if iy > 0x43f00000  (|y| > 2^64, must o/uflow)
-            local_get(PW_IY); i32_const(0x43f00000); i32_gt_s;
+            local_get(PW_IY); i32_const(POW_HUGE64_EXP_HI); i32_gt_s;
             if_empty;
                 // if ix <= 0x3fefffff { return hy<0 ? HUGE*HUGE : TINY*TINY }
-                local_get(PW_IX); i32_const(0x3fefffff); i32_le_s;
+                local_get(PW_IX); i32_const(POW_BELOW_ONE_HI); i32_le_s;
                 if_empty;
                     local_get(PW_HY); i32_const(0); i32_lt_s;
                     if_f64; f64_const(POW_HUGE); f64_const(POW_HUGE); f64_mul; else_; f64_const(POW_TINY); f64_const(POW_TINY); f64_mul; end;
                     return_;
                 end;
                 // if ix >= 0x3ff00000 { return hy>0 ? HUGE*HUGE : TINY*TINY }
-                local_get(PW_IX); i32_const(0x3ff00000); i32_ge_s;
+                local_get(PW_IX); i32_const(F64_ONE_HI); i32_ge_s;
                 if_empty;
                     local_get(PW_HY); i32_const(0); i32_gt_s;
                     if_f64; f64_const(POW_HUGE); f64_const(POW_HUGE); f64_mul; else_; f64_const(POW_TINY); f64_const(POW_TINY); f64_mul; end;
@@ -1763,13 +1858,13 @@ fn compile_pow(emitter: &mut WasmEmitter) {
                 end;
             end;
             // over/underflow if x not close to one
-            local_get(PW_IX); i32_const(0x3fefffff); i32_lt_s;
+            local_get(PW_IX); i32_const(POW_BELOW_ONE_HI); i32_lt_s;
             if_empty;
                 local_get(PW_HY); i32_const(0); i32_lt_s;
                 if_f64; local_get(PW_S); f64_const(POW_HUGE); f64_mul; f64_const(POW_HUGE); f64_mul; else_; local_get(PW_S); f64_const(POW_TINY); f64_mul; f64_const(POW_TINY); f64_mul; end;
                 return_;
             end;
-            local_get(PW_IX); i32_const(0x3ff00000); i32_gt_s;
+            local_get(PW_IX); i32_const(F64_ONE_HI); i32_gt_s;
             if_empty;
                 local_get(PW_HY); i32_const(0); i32_gt_s;
                 if_f64; local_get(PW_S); f64_const(POW_HUGE); f64_mul; f64_const(POW_HUGE); f64_mul; else_; local_get(PW_S); f64_const(POW_TINY); f64_mul; f64_const(POW_TINY); f64_mul; end;
@@ -1801,10 +1896,10 @@ fn compile_pow(emitter: &mut WasmEmitter) {
             // n = 0
             i32_const(0); local_set(PW_N);
             // if ix < 0x00100000 { ax *= 2^53; n -= 53; ix = get_high_word(ax) }
-            local_get(PW_IX); i32_const(0x00100000); i32_lt_s;
+            local_get(PW_IX); i32_const(F64_EXP_ONE_HI); i32_lt_s;
             if_empty;
                 local_get(PW_AX); f64_const(POW_TWO53); f64_mul; local_set(PW_AX);
-                local_get(PW_N); i32_const(53); i32_sub; local_set(PW_N);
+                local_get(PW_N); i32_const(POW_SUBNORM_SCALE); i32_sub; local_set(PW_N);
                 local_get(PW_AX);
     });
     emit_high_word(&mut f);
@@ -1812,26 +1907,26 @@ fn compile_pow(emitter: &mut WasmEmitter) {
                 local_set(PW_IX);
             end;
             // n += (ix >> 20) - 0x3ff; j = ix & 0x000fffff
-            local_get(PW_N); local_get(PW_IX); i32_const(20); i32_shr_s; i32_const(0x3ff); i32_sub; i32_add; local_set(PW_N);
-            local_get(PW_IX); i32_const(0x000fffff); i32_and; local_set(PW_J);
+            local_get(PW_N); local_get(PW_IX); i32_const(F64_EXP_SHIFT); i32_shr_s; i32_const(F64_EXP_BIAS); i32_sub; i32_add; local_set(PW_N);
+            local_get(PW_IX); i32_const(F64_MANTISSA_HI_MASK); i32_and; local_set(PW_J);
             // ix = j | 0x3ff00000
-            local_get(PW_J); i32_const(0x3ff00000); i32_or; local_set(PW_IX);
+            local_get(PW_J); i32_const(F64_ONE_HI); i32_or; local_set(PW_IX);
             // determine interval kk:  j<=0x3988E -> 0; j<0xBB67A -> 1; else { 0; n++; ix-=0x00100000 }
-            local_get(PW_J); i32_const(0x3988E); i32_le_s;
+            local_get(PW_J); i32_const(POW_KK0_THRESH); i32_le_s;
             if_empty;
                 i32_const(0); local_set(PW_KK);
             else_;
-                local_get(PW_J); i32_const(0xBB67A); i32_lt_s;
+                local_get(PW_J); i32_const(POW_KK1_THRESH); i32_lt_s;
                 if_empty;
                     i32_const(1); local_set(PW_KK);
                 else_;
                     i32_const(0); local_set(PW_KK);
                     local_get(PW_N); i32_const(1); i32_add; local_set(PW_N);
-                    local_get(PW_IX); i32_const(0x00100000); i32_sub; local_set(PW_IX);
+                    local_get(PW_IX); i32_const(F64_EXP_ONE_HI); i32_sub; local_set(PW_IX);
                 end;
             end;
             // ax = with_set_high_word(ax, ix)
-            local_get(PW_AX); i64_reinterpret_f64; i64_const(0xffffffff); i64_and;
+            local_get(PW_AX); i64_reinterpret_f64; i64_const(LOW_WORD_BITS); i64_and;
             local_get(PW_IX); i64_extend_i32_u; i64_const(HI_SHIFT); i64_shl;
             i64_or; f64_reinterpret_i64; local_set(PW_AX);
 
@@ -1846,9 +1941,9 @@ fn compile_pow(emitter: &mut WasmEmitter) {
     wasm!(f, {
             local_set(PW_S_H);
             // t_h = with_set_high_word(0.0, ((ix>>1)|0x20000000) + 0x00080000 + (kk<<18))
-            local_get(PW_IX); i32_const(1); i32_shr_u; i32_const(0x20000000); i32_or;
-            i32_const(0x00080000); i32_add;
-            local_get(PW_KK); i32_const(18); i32_shl; i32_add;
+            local_get(PW_IX); i32_const(1); i32_shr_u; i32_const(POW_T_H_BASE); i32_or;
+            i32_const(POW_T_H_HALF); i32_add;
+            local_get(PW_KK); i32_const(POW_KK_BIT_SHIFT); i32_shl; i32_add;
     });
     emit_from_high_word(&mut f);
     wasm!(f, {
@@ -1939,20 +2034,20 @@ fn compile_pow(emitter: &mut WasmEmitter) {
         local_get(PW_Z); i64_reinterpret_f64; i32_wrap_i64; local_set(PW_I);
 
         // if j >= 0x40900000  (z >= 1024)
-        local_get(PW_J); i32_const(0x40900000); i32_ge_s;
+        local_get(PW_J); i32_const(POW_Z_OVERFLOW_HI); i32_ge_s;
         if_empty;
             // if (j - 0x40900000) | i != 0  (z > 1024) -> overflow
-            local_get(PW_J); i32_const(0x40900000); i32_sub; local_get(PW_I); i32_or; i32_const(0); i32_ne;
+            local_get(PW_J); i32_const(POW_Z_OVERFLOW_HI); i32_sub; local_get(PW_I); i32_or; i32_const(0); i32_ne;
             if_empty; local_get(PW_S); f64_const(POW_HUGE); f64_mul; f64_const(POW_HUGE); f64_mul; return_; end;
             // if p_l + OVT > z - p_h -> overflow
             local_get(PW_P_L); f64_const(POW_OVT); f64_add; local_get(PW_Z); local_get(PW_P_H); f64_sub; f64_gt;
             if_empty; local_get(PW_S); f64_const(POW_HUGE); f64_mul; f64_const(POW_HUGE); f64_mul; return_; end;
         else_;
             // else if (j & 0x7fffffff) >= 0x4090cc00  (z <= -1075)
-            local_get(PW_J); i32_const(0x7fffffff); i32_and; i32_const(0x4090cc00); i32_ge_s;
+            local_get(PW_J); i32_const(F64_ABS_MASK_HI); i32_and; i32_const(POW_Z_UNDERFLOW_HI); i32_ge_s;
             if_empty;
                 // if (((j as u32) - 0xc090cc00) | (i as u32)) != 0  (z < -1075) -> underflow
-                local_get(PW_J); i32_const(0xc090cc00_u32 as i32); i32_sub; local_get(PW_I); i32_or; i32_const(0); i32_ne;
+                local_get(PW_J); i32_const(POW_Z_UNDERFLOW_NEG); i32_sub; local_get(PW_I); i32_or; i32_const(0); i32_ne;
                 if_empty; local_get(PW_S); f64_const(POW_TINY); f64_mul; f64_const(POW_TINY); f64_mul; return_; end;
                 // if p_l <= z - p_h -> underflow
                 local_get(PW_P_L); local_get(PW_Z); local_get(PW_P_H); f64_sub; f64_le;
@@ -1961,24 +2056,24 @@ fn compile_pow(emitter: &mut WasmEmitter) {
         end;
 
         // compute 2**(p_h+p_l): i = j & 0x7fffffff; k = (i>>20) - 0x3ff; n = 0
-        local_get(PW_J); i32_const(0x7fffffff); i32_and; local_set(PW_I);
-        local_get(PW_I); i32_const(20); i32_shr_s; i32_const(0x3ff); i32_sub; local_set(PW_K);
+        local_get(PW_J); i32_const(F64_ABS_MASK_HI); i32_and; local_set(PW_I);
+        local_get(PW_I); i32_const(F64_EXP_SHIFT); i32_shr_s; i32_const(F64_EXP_BIAS); i32_sub; local_set(PW_K);
         i32_const(0); local_set(PW_N);
         // if i > 0x3fe00000  (|z| > 0.5)
-        local_get(PW_I); i32_const(0x3fe00000); i32_gt_s;
+        local_get(PW_I); i32_const(F64_HALF_HI); i32_gt_s;
         if_empty;
             // n = j + (0x00100000 >> (k+1))
-            local_get(PW_J); i32_const(0x00100000); local_get(PW_K); i32_const(1); i32_add; i32_shr_s; i32_add; local_set(PW_N);
+            local_get(PW_J); i32_const(F64_EXP_ONE_HI); local_get(PW_K); i32_const(1); i32_add; i32_shr_s; i32_add; local_set(PW_N);
             // k = ((n & 0x7fffffff) >> 20) - 0x3ff
-            local_get(PW_N); i32_const(0x7fffffff); i32_and; i32_const(20); i32_shr_s; i32_const(0x3ff); i32_sub; local_set(PW_K);
+            local_get(PW_N); i32_const(F64_ABS_MASK_HI); i32_and; i32_const(F64_EXP_SHIFT); i32_shr_s; i32_const(F64_EXP_BIAS); i32_sub; local_set(PW_K);
             // t = with_set_high_word(0.0, (n & !(0x000fffff >> k)))
-            local_get(PW_N); i32_const(0x000fffff); local_get(PW_K); i32_shr_s; i32_const(-1); i32_xor; i32_and;
+            local_get(PW_N); i32_const(F64_MANTISSA_HI_MASK); local_get(PW_K); i32_shr_s; i32_const(-1); i32_xor; i32_and;
     });
     emit_from_high_word(&mut f);
     wasm!(f, {
             local_set(PW_T);
             // n = ((n & 0x000fffff) | 0x00100000) >> (20 - k)
-            local_get(PW_N); i32_const(0x000fffff); i32_and; i32_const(0x00100000); i32_or; i32_const(20); local_get(PW_K); i32_sub; i32_shr_s; local_set(PW_N);
+            local_get(PW_N); i32_const(F64_MANTISSA_HI_MASK); i32_and; i32_const(F64_EXP_ONE_HI); i32_or; i32_const(F64_EXP_SHIFT); local_get(PW_K); i32_sub; i32_shr_s; local_set(PW_N);
             // if j < 0 { n = -n }
             local_get(PW_J); i32_const(0); i32_lt_s;
             if_empty; i32_const(0); local_get(PW_N); i32_sub; local_set(PW_N); end;
@@ -2024,13 +2119,13 @@ fn compile_pow(emitter: &mut WasmEmitter) {
     });
     emit_high_word(&mut f);
     wasm!(f, {
-        local_get(PW_N); i32_const(20); i32_shl; i32_add; local_set(PW_J);
+        local_get(PW_N); i32_const(F64_EXP_SHIFT); i32_shl; i32_add; local_set(PW_J);
         // if (j >> 20) <= 0 { z = scalbn(z, n) } else { z = with_set_high_word(z, j) }
-        local_get(PW_J); i32_const(20); i32_shr_s; i32_const(0); i32_le_s;
+        local_get(PW_J); i32_const(F64_EXP_SHIFT); i32_shr_s; i32_const(0); i32_le_s;
         if_empty;
             local_get(PW_Z); local_get(PW_N); call(scalbn); local_set(PW_Z);
         else_;
-            local_get(PW_Z); i64_reinterpret_f64; i64_const(0xffffffff); i64_and;
+            local_get(PW_Z); i64_reinterpret_f64; i64_const(LOW_WORD_BITS); i64_and;
             local_get(PW_J); i64_extend_i32_u; i64_const(HI_SHIFT); i64_shl;
             i64_or; f64_reinterpret_i64; local_set(PW_Z);
         end;

--- a/crates/almide-codegen/src/emit_wasm/rt_libm.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_libm.rs
@@ -22,6 +22,7 @@
 //!   __libm_floor, __libm_scalbn, __libm_rem_pio2_large, __libm_rem_pio2,
 //!   __libm_k_sin, __libm_k_cos, __libm_k_tan, __math_sin, __math_cos, __math_tan.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::{CompiledFunc, WasmEmitter};
 use wasm_encoder::ValType;
 use super::TrackedFunction as Function;
@@ -316,38 +317,38 @@ fn compile_floor(emitter: &mut WasmEmitter) {
     // param 0=f64 x. locals: 1=i64 ui, 2=i32 e, 3=i64 m
     let mut f = Function::new([(1, ValType::I64), (1, ValType::I32), (1, ValType::I64)]);
     wasm!(f, {
-        local_get(0); i64_reinterpret_f64; local_set(1);              // ui = x.to_bits()
+        local_get(Local(0)); i64_reinterpret_f64; local_set(Local(1));              // ui = x.to_bits()
         // e = ((ui >> 52) & 0x7ff) - 0x3ff
-        local_get(1); i64_const(F64_MANTISSA_BITS); i64_shr_u; i64_const(F64_EXP_MASK); i64_and;
-        i32_wrap_i64; i32_const(F64_EXP_BIAS); i32_sub; local_set(2);
+        local_get(Local(1)); i64_const(Imm64(F64_MANTISSA_BITS)); i64_shr_u; i64_const(Imm64(F64_EXP_MASK)); i64_and;
+        i32_wrap_i64; i32_const(Imm32(F64_EXP_BIAS)); i32_sub; local_set(Local(2));
         // if e >= 52 { return x }
-        local_get(2); i32_const(F64_MANTISSA_BITS_I32); i32_ge_s;
-        if_empty; local_get(0); return_; end;
+        local_get(Local(2)); i32_const(Imm32(F64_MANTISSA_BITS_I32)); i32_ge_s;
+        if_empty; local_get(Local(0)); return_; end;
         // if e >= 0
-        local_get(2); i32_const(0); i32_ge_s;
+        local_get(Local(2)); i32_const(Imm32(0)); i32_ge_s;
         if_f64;
             // m = 0x000f_ffff_ffff_ffff >> e
-            i64_const(F64_MANTISSA_MASK); local_get(2); i64_extend_i32_s; i64_shr_u; local_set(3);
+            i64_const(Imm64(F64_MANTISSA_MASK)); local_get(Local(2)); i64_extend_i32_s; i64_shr_u; local_set(Local(3));
             // if ui & m == 0 { return x }
-            local_get(1); local_get(3); i64_and; i64_eqz;
-            if_empty; local_get(0); return_; end;
+            local_get(Local(1)); local_get(Local(3)); i64_and; i64_eqz;
+            if_empty; local_get(Local(0)); return_; end;
             // if (ui >> 63) != 0 { ui += m }
-            local_get(1); i64_const(F64_SIGN_BIT); i64_shr_u; i64_eqz;
+            local_get(Local(1)); i64_const(Imm64(F64_SIGN_BIT)); i64_shr_u; i64_eqz;
             if_empty; else_;
-                local_get(1); local_get(3); i64_add; local_set(1);
+                local_get(Local(1)); local_get(Local(3)); i64_add; local_set(Local(1));
             end;
             // ui &= !m
-            local_get(1); local_get(3); i64_const(-1); i64_xor; i64_and; local_set(1);
-            local_get(1); f64_reinterpret_i64;
+            local_get(Local(1)); local_get(Local(3)); i64_const(Imm64(-1)); i64_xor; i64_and; local_set(Local(1));
+            local_get(Local(1)); f64_reinterpret_i64;
         else_;
             // |x| < 1
             // if (ui >> 63) == 0 { 0.0 } else if (ui << 1) != 0 { -1.0 } else { x }
-            local_get(1); i64_const(F64_SIGN_BIT); i64_shr_u; i64_eqz;
+            local_get(Local(1)); i64_const(Imm64(F64_SIGN_BIT)); i64_shr_u; i64_eqz;
             if_f64;
                 f64_const(0.0);
             else_;
-                local_get(1); i64_const(1); i64_shl; i64_eqz;
-                if_f64; local_get(0); else_; f64_const(-1.0); end;
+                local_get(Local(1)); i64_const(Imm64(1)); i64_shl; i64_eqz;
+                if_f64; local_get(Local(0)); else_; f64_const(-1.0); end;
             end;
         end;
         end;
@@ -365,45 +366,45 @@ fn compile_scalbn(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(3, ValType::F64)]);
     // f_exp_max = 2^1023 = bits (1023<<1)<<52 = 2046<<52
     wasm!(f, {
-        i64_const((2046i64) << 52); f64_reinterpret_i64; local_set(2);
-        i64_const(1i64 << 52); f64_reinterpret_i64; local_set(3);     // f_exp_min = 2^-1022
+        i64_const(Imm64((2046i64) << 52)); f64_reinterpret_i64; local_set(Local(2));
+        i64_const(Imm64(1i64 << 52)); f64_reinterpret_i64; local_set(Local(3));     // f_exp_min = 2^-1022
         // mul = f_exp_min * 2^53 ; 2^53 bits = (53+1023)<<52 = 1076<<52
-        local_get(3); i64_const((1076i64) << 52); f64_reinterpret_i64; f64_mul; local_set(4);
+        local_get(Local(3)); i64_const(Imm64((1076i64) << 52)); f64_reinterpret_i64; f64_mul; local_set(Local(4));
     });
     // if n > 1023
     wasm!(f, {
-        local_get(1); i32_const(F64_EXP_BIAS); i32_gt_s;
+        local_get(Local(1)); i32_const(Imm32(F64_EXP_BIAS)); i32_gt_s;
         if_empty;
-            local_get(0); local_get(2); f64_mul; local_set(0);
-            local_get(1); i32_const(F64_EXP_BIAS); i32_sub; local_set(1);
-            local_get(1); i32_const(F64_EXP_BIAS); i32_gt_s;
+            local_get(Local(0)); local_get(Local(2)); f64_mul; local_set(Local(0));
+            local_get(Local(1)); i32_const(Imm32(F64_EXP_BIAS)); i32_sub; local_set(Local(1));
+            local_get(Local(1)); i32_const(Imm32(F64_EXP_BIAS)); i32_gt_s;
             if_empty;
-                local_get(0); local_get(2); f64_mul; local_set(0);
-                local_get(1); i32_const(F64_EXP_BIAS); i32_sub; local_set(1);
-                local_get(1); i32_const(F64_EXP_BIAS); i32_gt_s;
-                if_empty; i32_const(F64_EXP_BIAS); local_set(1); end;
+                local_get(Local(0)); local_get(Local(2)); f64_mul; local_set(Local(0));
+                local_get(Local(1)); i32_const(Imm32(F64_EXP_BIAS)); i32_sub; local_set(Local(1));
+                local_get(Local(1)); i32_const(Imm32(F64_EXP_BIAS)); i32_gt_s;
+                if_empty; i32_const(Imm32(F64_EXP_BIAS)); local_set(Local(1)); end;
             end;
         else_;
             // if n < -1022
-            local_get(1); i32_const(F64_MIN_EXP); i32_lt_s;
+            local_get(Local(1)); i32_const(Imm32(F64_MIN_EXP)); i32_lt_s;
             if_empty;
                 // add = -(-1022) - 53 = 1022 - 53 = 969
-                local_get(0); local_get(4); f64_mul; local_set(0);
-                local_get(1); i32_const(SCALBN_SUBNORM_STEP); i32_add; local_set(1);
-                local_get(1); i32_const(F64_MIN_EXP); i32_lt_s;
+                local_get(Local(0)); local_get(Local(4)); f64_mul; local_set(Local(0));
+                local_get(Local(1)); i32_const(Imm32(SCALBN_SUBNORM_STEP)); i32_add; local_set(Local(1));
+                local_get(Local(1)); i32_const(Imm32(F64_MIN_EXP)); i32_lt_s;
                 if_empty;
-                    local_get(0); local_get(4); f64_mul; local_set(0);
-                    local_get(1); i32_const(SCALBN_SUBNORM_STEP); i32_add; local_set(1);
-                    local_get(1); i32_const(F64_MIN_EXP); i32_lt_s;
-                    if_empty; i32_const(F64_MIN_EXP); local_set(1); end;
+                    local_get(Local(0)); local_get(Local(4)); f64_mul; local_set(Local(0));
+                    local_get(Local(1)); i32_const(Imm32(SCALBN_SUBNORM_STEP)); i32_add; local_set(Local(1));
+                    local_get(Local(1)); i32_const(Imm32(F64_MIN_EXP)); i32_lt_s;
+                    if_empty; i32_const(Imm32(F64_MIN_EXP)); local_set(Local(1)); end;
                 end;
             end;
         end;
     });
     // scale = bits((1023 + n) << 52) ; return x * scale
     wasm!(f, {
-        local_get(0);
-        i32_const(F64_EXP_BIAS); local_get(1); i32_add; i64_extend_i32_s; i64_const(F64_MANTISSA_BITS); i64_shl;
+        local_get(Local(0));
+        i32_const(Imm32(F64_EXP_BIAS)); local_get(Local(1)); i32_add; i64_extend_i32_s; i64_const(Imm64(F64_MANTISSA_BITS)); i64_shl;
         f64_reinterpret_i64;
         f64_mul;
         end;
@@ -451,28 +452,28 @@ fn compile_k_sin(emitter: &mut WasmEmitter) {
     // params: 0=x, 1=y, 2=iy. locals: 3=z, 4=w, 5=r, 6=v
     let mut f = Function::new([(4, ValType::F64)]);
     wasm!(f, {
-        local_get(0); local_get(0); f64_mul; local_set(3);           // z = x*x
-        local_get(3); local_get(3); f64_mul; local_set(4);           // w = z*z
+        local_get(Local(0)); local_get(Local(0)); f64_mul; local_set(Local(3));           // z = x*x
+        local_get(Local(3)); local_get(Local(3)); f64_mul; local_set(Local(4));           // w = z*z
         // r = S2 + z*(S3 + z*S4) + z*w*(S5 + z*S6)
         f64_const(S2);
-        local_get(3); f64_const(S3); local_get(3); f64_const(S4); f64_mul; f64_add; f64_mul;
+        local_get(Local(3)); f64_const(S3); local_get(Local(3)); f64_const(S4); f64_mul; f64_add; f64_mul;
         f64_add;
-        local_get(3); local_get(4); f64_mul; f64_const(S5); local_get(3); f64_const(S6); f64_mul; f64_add; f64_mul;
-        f64_add; local_set(5);
-        local_get(3); local_get(0); f64_mul; local_set(6);           // v = z*x
+        local_get(Local(3)); local_get(Local(4)); f64_mul; f64_const(S5); local_get(Local(3)); f64_const(S6); f64_mul; f64_add; f64_mul;
+        f64_add; local_set(Local(5));
+        local_get(Local(3)); local_get(Local(0)); f64_mul; local_set(Local(6));           // v = z*x
         // if iy == 0
-        local_get(2); i32_eqz;
+        local_get(Local(2)); i32_eqz;
         if_f64;
             // x + v*(S1 + z*r)
-            local_get(0);
-            local_get(6); f64_const(S1); local_get(3); local_get(5); f64_mul; f64_add; f64_mul;
+            local_get(Local(0));
+            local_get(Local(6)); f64_const(S1); local_get(Local(3)); local_get(Local(5)); f64_mul; f64_add; f64_mul;
             f64_add;
         else_;
             // x - ((z*(0.5*y - v*r) - y) - v*S1)
-            local_get(0);
-            local_get(3); f64_const(0.5); local_get(1); f64_mul; local_get(6); local_get(5); f64_mul; f64_sub; f64_mul;
-            local_get(1); f64_sub;
-            local_get(6); f64_const(S1); f64_mul; f64_sub;
+            local_get(Local(0));
+            local_get(Local(3)); f64_const(0.5); local_get(Local(1)); f64_mul; local_get(Local(6)); local_get(Local(5)); f64_mul; f64_sub; f64_mul;
+            local_get(Local(1)); f64_sub;
+            local_get(Local(6)); f64_const(S1); f64_mul; f64_sub;
             f64_sub;
         end;
         end;
@@ -488,18 +489,18 @@ fn compile_k_cos(emitter: &mut WasmEmitter) {
     // params: 0=x, 1=y. locals: 2=z, 3=w(z*z then reused as 1-hz), 4=r, 5=hz, 6=w2(=1-hz)
     let mut f = Function::new([(5, ValType::F64)]);
     wasm!(f, {
-        local_get(0); local_get(0); f64_mul; local_set(2);           // z = x*x
-        local_get(2); local_get(2); f64_mul; local_set(3);           // w = z*z
+        local_get(Local(0)); local_get(Local(0)); f64_mul; local_set(Local(2));           // z = x*x
+        local_get(Local(2)); local_get(Local(2)); f64_mul; local_set(Local(3));           // w = z*z
         // r = z*(C1 + z*(C2 + z*C3)) + w*w*(C4 + z*(C5 + z*C6))
-        local_get(2); f64_const(C1); local_get(2); f64_const(C2); local_get(2); f64_const(C3); f64_mul; f64_add; f64_mul; f64_add; f64_mul;
-        local_get(3); local_get(3); f64_mul; f64_const(C4); local_get(2); f64_const(C5); local_get(2); f64_const(C6); f64_mul; f64_add; f64_mul; f64_add; f64_mul;
-        f64_add; local_set(4);
-        local_get(2); f64_const(0.5); f64_mul; local_set(5);         // hz = 0.5*z
-        f64_const(1.0); local_get(5); f64_sub; local_set(6);         // w2 = 1 - hz
+        local_get(Local(2)); f64_const(C1); local_get(Local(2)); f64_const(C2); local_get(Local(2)); f64_const(C3); f64_mul; f64_add; f64_mul; f64_add; f64_mul;
+        local_get(Local(3)); local_get(Local(3)); f64_mul; f64_const(C4); local_get(Local(2)); f64_const(C5); local_get(Local(2)); f64_const(C6); f64_mul; f64_add; f64_mul; f64_add; f64_mul;
+        f64_add; local_set(Local(4));
+        local_get(Local(2)); f64_const(0.5); f64_mul; local_set(Local(5));         // hz = 0.5*z
+        f64_const(1.0); local_get(Local(5)); f64_sub; local_set(Local(6));         // w2 = 1 - hz
         // return w2 + (((1 - w2) - hz) + (z*r - x*y))
-        local_get(6);
-        f64_const(1.0); local_get(6); f64_sub; local_get(5); f64_sub;
-        local_get(2); local_get(4); f64_mul; local_get(0); local_get(1); f64_mul; f64_sub;
+        local_get(Local(6));
+        f64_const(1.0); local_get(Local(6)); f64_sub; local_get(Local(5)); f64_sub;
+        local_get(Local(2)); local_get(Local(4)); f64_mul; local_get(Local(0)); local_get(Local(1)); f64_mul; f64_sub;
         f64_add;
         f64_add;
         end;
@@ -521,94 +522,94 @@ fn compile_k_tan(emitter: &mut WasmEmitter) {
     const HX: u32 = 12; const BIG: u32 = 13; const SIGN: u32 = 14;
     wasm!(f, {
         // hx = (to_bits(x) >> 32) as u32
-        local_get(X); i64_reinterpret_f64; i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; local_set(HX);
+        local_get(Local(X)); i64_reinterpret_f64; i64_const(Imm64(HI_SHIFT)); i64_shr_u; i32_wrap_i64; local_set(Local(HX));
         // big = (hx & 0x7fffffff) >= 0x3FE59428
-        local_get(HX); i32_const(F64_ABS_MASK_HI); i32_and; i32_const(KTAN_BIG_HI); i32_ge_u; local_set(BIG);
+        local_get(Local(HX)); i32_const(Imm32(F64_ABS_MASK_HI)); i32_and; i32_const(Imm32(KTAN_BIG_HI)); i32_ge_u; local_set(Local(BIG));
         // sign = hx >> 31  (logical)
-        local_get(HX); i32_const(I32_SIGN_BIT); i32_shr_u; local_set(SIGN);
+        local_get(Local(HX)); i32_const(Imm32(I32_SIGN_BIT)); i32_shr_u; local_set(Local(SIGN));
         // if big { if sign { x=-x; y=-y } x=(PIO4-x)+(PIO4_LO-y); y=0 }
-        local_get(BIG);
+        local_get(Local(BIG));
         if_empty;
-            local_get(SIGN);
+            local_get(Local(SIGN));
             if_empty;
-                local_get(X); f64_neg; local_set(X);
-                local_get(Y); f64_neg; local_set(Y);
+                local_get(Local(X)); f64_neg; local_set(Local(X));
+                local_get(Local(Y)); f64_neg; local_set(Local(Y));
             end;
-            f64_const(PIO4); local_get(X); f64_sub;
-            f64_const(PIO4_LO); local_get(Y); f64_sub;
-            f64_add; local_set(X);
-            f64_const(0.0); local_set(Y);
+            f64_const(PIO4); local_get(Local(X)); f64_sub;
+            f64_const(PIO4_LO); local_get(Local(Y)); f64_sub;
+            f64_add; local_set(Local(X));
+            f64_const(0.0); local_set(Local(Y));
         end;
         // z = x*x; w = z*z
-        local_get(X); local_get(X); f64_mul; local_set(Z);
-        local_get(Z); local_get(Z); f64_mul; local_set(W);
+        local_get(Local(X)); local_get(Local(X)); f64_mul; local_set(Local(Z));
+        local_get(Local(Z)); local_get(Local(Z)); f64_mul; local_set(Local(W));
         // r = T1 + w*(T3 + w*(T5 + w*(T7 + w*(T9 + w*T11))))
         f64_const(T1);
-        local_get(W); f64_const(T3);
-        local_get(W); f64_const(T5);
-        local_get(W); f64_const(T7);
-        local_get(W); f64_const(T9);
-        local_get(W); f64_const(T11); f64_mul; f64_add;
+        local_get(Local(W)); f64_const(T3);
+        local_get(Local(W)); f64_const(T5);
+        local_get(Local(W)); f64_const(T7);
+        local_get(Local(W)); f64_const(T9);
+        local_get(Local(W)); f64_const(T11); f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul; f64_add;
-        f64_mul; f64_add; local_set(R);
+        f64_mul; f64_add; local_set(Local(R));
         // v = z*(T2 + w*(T4 + w*(T6 + w*(T8 + w*(T10 + w*T12)))))
-        local_get(Z);
+        local_get(Local(Z));
         f64_const(T2);
-        local_get(W); f64_const(T4);
-        local_get(W); f64_const(T6);
-        local_get(W); f64_const(T8);
-        local_get(W); f64_const(T10);
-        local_get(W); f64_const(T12); f64_mul; f64_add;
+        local_get(Local(W)); f64_const(T4);
+        local_get(Local(W)); f64_const(T6);
+        local_get(Local(W)); f64_const(T8);
+        local_get(Local(W)); f64_const(T10);
+        local_get(Local(W)); f64_const(T12); f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul; f64_add;
-        f64_mul; local_set(V);
+        f64_mul; local_set(Local(V));
         // s = z*x
-        local_get(Z); local_get(X); f64_mul; local_set(S);
+        local_get(Local(Z)); local_get(Local(X)); f64_mul; local_set(Local(S));
         // r = y + z*(s*(r+v) + y) + s*T0
-        local_get(Y);
-        local_get(Z); local_get(S); local_get(R); local_get(V); f64_add; f64_mul; local_get(Y); f64_add; f64_mul;
+        local_get(Local(Y));
+        local_get(Local(Z)); local_get(Local(S)); local_get(Local(R)); local_get(Local(V)); f64_add; f64_mul; local_get(Local(Y)); f64_add; f64_mul;
         f64_add;
-        local_get(S); f64_const(T0); f64_mul;
-        f64_add; local_set(R);
+        local_get(Local(S)); f64_const(T0); f64_mul;
+        f64_add; local_set(Local(R));
         // w = x + r
-        local_get(X); local_get(R); f64_add; local_set(W);
+        local_get(Local(X)); local_get(Local(R)); f64_add; local_set(Local(W));
         // if big { ... return ±v }
-        local_get(BIG);
+        local_get(Local(BIG));
         if_empty;
             // s = 1 - 2*odd
-            f64_const(1.0); f64_const(2.0); local_get(ODD); f64_convert_i32_s; f64_mul; f64_sub; local_set(S);
+            f64_const(1.0); f64_const(2.0); local_get(Local(ODD)); f64_convert_i32_s; f64_mul; f64_sub; local_set(Local(S));
             // v = s - 2*(x + (r - w*w/(w+s)))
-            local_get(S);
+            local_get(Local(S));
             f64_const(2.0);
-            local_get(X);
-            local_get(R); local_get(W); local_get(W); f64_mul; local_get(W); local_get(S); f64_add; f64_div; f64_sub;
+            local_get(Local(X));
+            local_get(Local(R)); local_get(Local(W)); local_get(Local(W)); f64_mul; local_get(Local(W)); local_get(Local(S)); f64_add; f64_div; f64_sub;
             f64_add;
             f64_mul;
-            f64_sub; local_set(V);
+            f64_sub; local_set(Local(V));
             // return sign ? -v : v
-            local_get(SIGN);
-            if_f64; local_get(V); f64_neg; else_; local_get(V); end;
+            local_get(Local(SIGN));
+            if_f64; local_get(Local(V)); f64_neg; else_; local_get(Local(V)); end;
             return_;
         end;
         // if odd == 0 { return w }
-        local_get(ODD); i32_eqz;
-        if_empty; local_get(W); return_; end;
+        local_get(Local(ODD)); i32_eqz;
+        if_empty; local_get(Local(W)); return_; end;
         // w0 = zero_low_word(w)
-        local_get(W); i64_reinterpret_f64; i64_const(LOW_WORD_MASK); i64_and; f64_reinterpret_i64; local_set(W0); // !0xFFFFFFFF == 0xFFFFFFFF00000000 = LOW_WORD_MASK
+        local_get(Local(W)); i64_reinterpret_f64; i64_const(Imm64(LOW_WORD_MASK)); i64_and; f64_reinterpret_i64; local_set(Local(W0)); // !0xFFFFFFFF == 0xFFFFFFFF00000000 = LOW_WORD_MASK
         // v = r - (w0 - x)
-        local_get(R); local_get(W0); local_get(X); f64_sub; f64_sub; local_set(V);
+        local_get(Local(R)); local_get(Local(W0)); local_get(Local(X)); f64_sub; f64_sub; local_set(Local(V));
         // a = -1.0 / w
-        f64_const(-1.0); local_get(W); f64_div; local_set(A);
+        f64_const(-1.0); local_get(Local(W)); f64_div; local_set(Local(A));
         // a0 = zero_low_word(a)
-        local_get(A); i64_reinterpret_f64; i64_const(LOW_WORD_MASK); i64_and; f64_reinterpret_i64; local_set(A0);
+        local_get(Local(A)); i64_reinterpret_f64; i64_const(Imm64(LOW_WORD_MASK)); i64_and; f64_reinterpret_i64; local_set(Local(A0));
         // return a0 + a*(1 + a0*w0 + a0*v)
-        local_get(A0);
-        local_get(A);
-        f64_const(1.0); local_get(A0); local_get(W0); f64_mul; f64_add; local_get(A0); local_get(V); f64_mul; f64_add;
+        local_get(Local(A0));
+        local_get(Local(A));
+        f64_const(1.0); local_get(Local(A0)); local_get(Local(W0)); f64_mul; f64_add; local_get(Local(A0)); local_get(Local(V)); f64_mul; f64_add;
         f64_mul;
         f64_add;
         end;
@@ -657,46 +658,46 @@ const RP_I: u32 = 19;       // i32 loop i
 fn emit_medium(f: &mut Function) {
     wasm!(f, {
         // f_n = (x*INV_PIO2 + TO_INT) - TO_INT
-        local_get(RP_X); f64_const(INV_PIO2); f64_mul; f64_const(TO_INT); f64_add;
-        f64_const(TO_INT); f64_sub; local_set(RP_FN);
+        local_get(Local(RP_X)); f64_const(INV_PIO2); f64_mul; f64_const(TO_INT); f64_add;
+        f64_const(TO_INT); f64_sub; local_set(Local(RP_FN));
         // n = f_n as i32
-        local_get(RP_FN); i64_trunc_f64_s; i32_wrap_i64; local_set(RP_N);
+        local_get(Local(RP_FN)); i64_trunc_f64_s; i32_wrap_i64; local_set(Local(RP_N));
         // r = x - f_n*PIO2_1
-        local_get(RP_X); local_get(RP_FN); f64_const(PIO2_1); f64_mul; f64_sub; local_set(RP_R);
+        local_get(Local(RP_X)); local_get(Local(RP_FN)); f64_const(PIO2_1); f64_mul; f64_sub; local_set(Local(RP_R));
         // w = f_n*PIO2_1T
-        local_get(RP_FN); f64_const(PIO2_1T); f64_mul; local_set(RP_W);
+        local_get(Local(RP_FN)); f64_const(PIO2_1T); f64_mul; local_set(Local(RP_W));
         // y0 = r - w
-        local_get(RP_R); local_get(RP_W); f64_sub; local_set(RP_Y0);
+        local_get(Local(RP_R)); local_get(Local(RP_W)); f64_sub; local_set(Local(RP_Y0));
         // ey = (to_bits(y0) >> 52) & 0x7ff ; ex = ix >> 20
-        local_get(RP_Y0); i64_reinterpret_f64; i64_const(F64_MANTISSA_BITS); i64_shr_u; i32_wrap_i64; i32_const(F64_EXP_MASK_I32); i32_and; local_set(RP_EY);
-        local_get(RP_IX); i32_const(F64_EXP_SHIFT); i32_shr_u; local_set(RP_EX);
+        local_get(Local(RP_Y0)); i64_reinterpret_f64; i64_const(Imm64(F64_MANTISSA_BITS)); i64_shr_u; i32_wrap_i64; i32_const(Imm32(F64_EXP_MASK_I32)); i32_and; local_set(Local(RP_EY));
+        local_get(Local(RP_IX)); i32_const(Imm32(F64_EXP_SHIFT)); i32_shr_u; local_set(Local(RP_EX));
         // if ex - ey > 16
-        local_get(RP_EX); local_get(RP_EY); i32_sub; i32_const(MEDIUM_EX_EY_THRESH_1); i32_gt_s;
+        local_get(Local(RP_EX)); local_get(Local(RP_EY)); i32_sub; i32_const(Imm32(MEDIUM_EX_EY_THRESH_1)); i32_gt_s;
         if_empty;
             // t = r; w = f_n*PIO2_2; r = t - w; w = f_n*PIO2_2T - ((t - r) - w); y0 = r - w
-            local_get(RP_R); local_set(RP_T);
-            local_get(RP_FN); f64_const(PIO2_2); f64_mul; local_set(RP_W);
-            local_get(RP_T); local_get(RP_W); f64_sub; local_set(RP_R);
-            local_get(RP_FN); f64_const(PIO2_2T); f64_mul;
-            local_get(RP_T); local_get(RP_R); f64_sub; local_get(RP_W); f64_sub;
-            f64_sub; local_set(RP_W);
-            local_get(RP_R); local_get(RP_W); f64_sub; local_set(RP_Y0);
+            local_get(Local(RP_R)); local_set(Local(RP_T));
+            local_get(Local(RP_FN)); f64_const(PIO2_2); f64_mul; local_set(Local(RP_W));
+            local_get(Local(RP_T)); local_get(Local(RP_W)); f64_sub; local_set(Local(RP_R));
+            local_get(Local(RP_FN)); f64_const(PIO2_2T); f64_mul;
+            local_get(Local(RP_T)); local_get(Local(RP_R)); f64_sub; local_get(Local(RP_W)); f64_sub;
+            f64_sub; local_set(Local(RP_W));
+            local_get(Local(RP_R)); local_get(Local(RP_W)); f64_sub; local_set(Local(RP_Y0));
             // ey = (to_bits(y0) >> 52) & 0x7ff
-            local_get(RP_Y0); i64_reinterpret_f64; i64_const(F64_MANTISSA_BITS); i64_shr_u; i32_wrap_i64; i32_const(F64_EXP_MASK_I32); i32_and; local_set(RP_EY);
+            local_get(Local(RP_Y0)); i64_reinterpret_f64; i64_const(Imm64(F64_MANTISSA_BITS)); i64_shr_u; i32_wrap_i64; i32_const(Imm32(F64_EXP_MASK_I32)); i32_and; local_set(Local(RP_EY));
             // if ex - ey > 49
-            local_get(RP_EX); local_get(RP_EY); i32_sub; i32_const(MEDIUM_EX_EY_THRESH_2); i32_gt_s;
+            local_get(Local(RP_EX)); local_get(Local(RP_EY)); i32_sub; i32_const(Imm32(MEDIUM_EX_EY_THRESH_2)); i32_gt_s;
             if_empty;
-                local_get(RP_R); local_set(RP_T);
-                local_get(RP_FN); f64_const(PIO2_3); f64_mul; local_set(RP_W);
-                local_get(RP_T); local_get(RP_W); f64_sub; local_set(RP_R);
-                local_get(RP_FN); f64_const(PIO2_3T); f64_mul;
-                local_get(RP_T); local_get(RP_R); f64_sub; local_get(RP_W); f64_sub;
-                f64_sub; local_set(RP_W);
-                local_get(RP_R); local_get(RP_W); f64_sub; local_set(RP_Y0);
+                local_get(Local(RP_R)); local_set(Local(RP_T));
+                local_get(Local(RP_FN)); f64_const(PIO2_3); f64_mul; local_set(Local(RP_W));
+                local_get(Local(RP_T)); local_get(Local(RP_W)); f64_sub; local_set(Local(RP_R));
+                local_get(Local(RP_FN)); f64_const(PIO2_3T); f64_mul;
+                local_get(Local(RP_T)); local_get(Local(RP_R)); f64_sub; local_get(Local(RP_W)); f64_sub;
+                f64_sub; local_set(Local(RP_W));
+                local_get(Local(RP_R)); local_get(Local(RP_W)); f64_sub; local_set(Local(RP_Y0));
             end;
         end;
         // y1 = (r - y0) - w
-        local_get(RP_R); local_get(RP_Y0); f64_sub; local_get(RP_W); f64_sub; local_set(RP_Y1);
+        local_get(Local(RP_R)); local_get(Local(RP_Y0)); f64_sub; local_get(Local(RP_W)); f64_sub; local_set(Local(RP_Y1));
     });
     emit_store_y(f);
 }
@@ -704,8 +705,8 @@ fn emit_medium(f: &mut Function) {
 /// Store RP_Y0 / RP_Y1 to y_ptr[0], y_ptr[1].
 fn emit_store_y(f: &mut Function) {
     wasm!(f, {
-        local_get(RP_YP); local_get(RP_Y0); f64_store(0);
-        local_get(RP_YP); local_get(RP_Y1); f64_store(8);
+        local_get(Local(RP_YP)); local_get(Local(RP_Y0)); f64_store(0);
+        local_get(Local(RP_YP)); local_get(Local(RP_Y1)); f64_store(8);
     });
 }
 
@@ -716,18 +717,18 @@ fn emit_store_y(f: &mut Function) {
 fn emit_small(f: &mut Function, k: i32) {
     let kf = k as f64;
     wasm!(f, {
-        local_get(RP_SIGN); i32_eqz;
+        local_get(Local(RP_SIGN)); i32_eqz;
         if_empty;
             // positive
-            local_get(RP_X); f64_const(kf); f64_const(PIO2_1); f64_mul; f64_sub; local_set(RP_Z);
-            local_get(RP_Z); f64_const(kf); f64_const(PIO2_1T); f64_mul; f64_sub; local_set(RP_Y0);
-            local_get(RP_Z); local_get(RP_Y0); f64_sub; f64_const(kf); f64_const(PIO2_1T); f64_mul; f64_sub; local_set(RP_Y1);
-            i32_const(k); local_set(RP_N);
+            local_get(Local(RP_X)); f64_const(kf); f64_const(PIO2_1); f64_mul; f64_sub; local_set(Local(RP_Z));
+            local_get(Local(RP_Z)); f64_const(kf); f64_const(PIO2_1T); f64_mul; f64_sub; local_set(Local(RP_Y0));
+            local_get(Local(RP_Z)); local_get(Local(RP_Y0)); f64_sub; f64_const(kf); f64_const(PIO2_1T); f64_mul; f64_sub; local_set(Local(RP_Y1));
+            i32_const(Imm32(k)); local_set(Local(RP_N));
         else_;
-            local_get(RP_X); f64_const(kf); f64_const(PIO2_1); f64_mul; f64_add; local_set(RP_Z);
-            local_get(RP_Z); f64_const(kf); f64_const(PIO2_1T); f64_mul; f64_add; local_set(RP_Y0);
-            local_get(RP_Z); local_get(RP_Y0); f64_sub; f64_const(kf); f64_const(PIO2_1T); f64_mul; f64_add; local_set(RP_Y1);
-            i32_const(-k); local_set(RP_N);
+            local_get(Local(RP_X)); f64_const(kf); f64_const(PIO2_1); f64_mul; f64_add; local_set(Local(RP_Z));
+            local_get(Local(RP_Z)); f64_const(kf); f64_const(PIO2_1T); f64_mul; f64_add; local_set(Local(RP_Y0));
+            local_get(Local(RP_Z)); local_get(Local(RP_Y0)); f64_sub; f64_const(kf); f64_const(PIO2_1T); f64_mul; f64_add; local_set(Local(RP_Y1));
+            i32_const(Imm32(-k)); local_set(Local(RP_N));
         end;
     });
     emit_store_y(f);
@@ -765,124 +766,124 @@ fn compile_rem_pio2(emitter: &mut WasmEmitter) {
     ]);
     wasm!(f, {
         // sign = (to_bits(x) >> 63) as i32
-        local_get(RP_X); i64_reinterpret_f64; i64_const(F64_SIGN_BIT); i64_shr_u; i32_wrap_i64; local_set(RP_SIGN);
+        local_get(Local(RP_X)); i64_reinterpret_f64; i64_const(Imm64(F64_SIGN_BIT)); i64_shr_u; i32_wrap_i64; local_set(Local(RP_SIGN));
         // ix = (to_bits(x) >> 32) as u32 & 0x7fffffff
-        local_get(RP_X); i64_reinterpret_f64; i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; i32_const(F64_ABS_MASK_HI); i32_and; local_set(RP_IX);
+        local_get(Local(RP_X)); i64_reinterpret_f64; i64_const(Imm64(HI_SHIFT)); i64_shr_u; i32_wrap_i64; i32_const(Imm32(F64_ABS_MASK_HI)); i32_and; local_set(Local(RP_IX));
     });
 
     // if ix <= 0x400f6a7a  (|x| ~<= 5pi/4)
-    wasm!(f, { local_get(RP_IX); i32_const(RP2_5PI4_HI); i32_le_u; if_empty; });
+    wasm!(f, { local_get(Local(RP_IX)); i32_const(Imm32(RP2_5PI4_HI)); i32_le_u; if_empty; });
     // if (ix & 0xfffff) == 0x921fb { medium; return n }
-    wasm!(f, { local_get(RP_IX); i32_const(RP2_FRAC_MASK); i32_and; i32_const(RP2_PI_FRAC); i32_eq; if_empty; });
+    wasm!(f, { local_get(Local(RP_IX)); i32_const(Imm32(RP2_FRAC_MASK)); i32_and; i32_const(Imm32(RP2_PI_FRAC)); i32_eq; if_empty; });
     emit_medium(&mut f);
-    wasm!(f, { local_get(RP_N); return_; });
+    wasm!(f, { local_get(Local(RP_N)); return_; });
     wasm!(f, { end; }); // end the 0x921fb if
     // if ix <= 0x4002d97c { small(1) } else { small(2) }
-    wasm!(f, { local_get(RP_IX); i32_const(RP2_3PI4_HI); i32_le_u; if_empty; });
+    wasm!(f, { local_get(Local(RP_IX)); i32_const(Imm32(RP2_3PI4_HI)); i32_le_u; if_empty; });
     emit_small(&mut f, 1);
-    wasm!(f, { local_get(RP_N); return_; });
+    wasm!(f, { local_get(Local(RP_N)); return_; });
     wasm!(f, { else_; });
     emit_small(&mut f, 2);
-    wasm!(f, { local_get(RP_N); return_; });
+    wasm!(f, { local_get(Local(RP_N)); return_; });
     wasm!(f, { end; });   // end 3pi/4 split
     wasm!(f, { end; });   // end 5pi/4 outer
 
     // if ix <= 0x401c463b  (|x| ~<= 9pi/4)
-    wasm!(f, { local_get(RP_IX); i32_const(RP2_9PI4_HI); i32_le_u; if_empty; });
+    wasm!(f, { local_get(Local(RP_IX)); i32_const(Imm32(RP2_9PI4_HI)); i32_le_u; if_empty; });
         // if ix <= 0x4015fdbc (|x| ~<= 7pi/4)
-        wasm!(f, { local_get(RP_IX); i32_const(RP2_7PI4_HI); i32_le_u; if_empty; });
+        wasm!(f, { local_get(Local(RP_IX)); i32_const(Imm32(RP2_7PI4_HI)); i32_le_u; if_empty; });
             // if ix == 0x4012d97c { medium }
-            wasm!(f, { local_get(RP_IX); i32_const(RP2_2PI_HI); i32_eq; if_empty; });
+            wasm!(f, { local_get(Local(RP_IX)); i32_const(Imm32(RP2_2PI_HI)); i32_eq; if_empty; });
             emit_medium(&mut f);
-            wasm!(f, { local_get(RP_N); return_; });
+            wasm!(f, { local_get(Local(RP_N)); return_; });
             wasm!(f, { end; });
             emit_small(&mut f, 3);
-            wasm!(f, { local_get(RP_N); return_; });
+            wasm!(f, { local_get(Local(RP_N)); return_; });
         wasm!(f, { else_; });
             // if ix == 0x401921fb { medium }
-            wasm!(f, { local_get(RP_IX); i32_const(RP2_3PI2_HI); i32_eq; if_empty; });
+            wasm!(f, { local_get(Local(RP_IX)); i32_const(Imm32(RP2_3PI2_HI)); i32_eq; if_empty; });
             emit_medium(&mut f);
-            wasm!(f, { local_get(RP_N); return_; });
+            wasm!(f, { local_get(Local(RP_N)); return_; });
             wasm!(f, { end; });
             emit_small(&mut f, 4);
-            wasm!(f, { local_get(RP_N); return_; });
+            wasm!(f, { local_get(Local(RP_N)); return_; });
         wasm!(f, { end; }); // end 7pi/4 split
     wasm!(f, { end; }); // end 9pi/4 outer
 
     // if ix < 0x413921fb { medium }
-    wasm!(f, { local_get(RP_IX); i32_const(RP2_LARGE_HI); i32_lt_u; if_empty; });
+    wasm!(f, { local_get(Local(RP_IX)); i32_const(Imm32(RP2_LARGE_HI)); i32_lt_u; if_empty; });
     emit_medium(&mut f);
-    wasm!(f, { local_get(RP_N); return_; });
+    wasm!(f, { local_get(Local(RP_N)); return_; });
     wasm!(f, { end; });
 
     // if ix >= 0x7ff00000 { y0 = x - x; y1 = y0; return 0 }
-    wasm!(f, { local_get(RP_IX); i32_const(F64_INF_NAN_HI); i32_ge_u; if_empty;
-        local_get(RP_X); local_get(RP_X); f64_sub; local_set(RP_Y0);
-        local_get(RP_Y0); local_set(RP_Y1);
+    wasm!(f, { local_get(Local(RP_IX)); i32_const(Imm32(F64_INF_NAN_HI)); i32_ge_u; if_empty;
+        local_get(Local(RP_X)); local_get(Local(RP_X)); f64_sub; local_set(Local(RP_Y0));
+        local_get(Local(RP_Y0)); local_set(Local(RP_Y1));
     });
     emit_store_y(&mut f);
-    wasm!(f, { i32_const(0); return_; end; });
+    wasm!(f, { i32_const(Imm32(0)); return_; end; });
 
     // ── large path ──
     // alloc tx(24) + ty(24). RP_TXP = tx, RP_TYP = ty.
     wasm!(f, {
-        i32_const(TX_BYTES + TY_BYTES); call(alloc); local_set(RP_TXP);
-        local_get(RP_TXP); i32_const(TX_BYTES); i32_add; local_set(RP_TYP);
+        i32_const(Imm32(TX_BYTES + TY_BYTES)); call(alloc); local_set(Local(RP_TXP));
+        local_get(Local(RP_TXP)); i32_const(Imm32(TX_BYTES)); i32_add; local_set(Local(RP_TYP));
         // ui = to_bits(x); ui &= (!1) >> 12; ui |= (0x3ff+23) << 52; z = from_bits(ui)
-        local_get(RP_X); i64_reinterpret_f64;
-        i64_const(-1); i64_const(1); i64_const(-1); i64_xor; i64_and; // (!1)
-        i64_const(RPL_NORM_STRIP); i64_shr_u;
+        local_get(Local(RP_X)); i64_reinterpret_f64;
+        i64_const(Imm64(-1)); i64_const(Imm64(1)); i64_const(Imm64(-1)); i64_xor; i64_and; // (!1)
+        i64_const(Imm64(RPL_NORM_STRIP)); i64_shr_u;
         i64_and;
-        i64_const(RPL_EXPO_BIAS); i64_const(F64_MANTISSA_BITS); i64_shl; i64_or;
-        local_set(RP_UI);
-        local_get(RP_UI); f64_reinterpret_i64; local_set(RP_Z);
+        i64_const(Imm64(RPL_EXPO_BIAS)); i64_const(Imm64(F64_MANTISSA_BITS)); i64_shl; i64_or;
+        local_set(Local(RP_UI));
+        local_get(Local(RP_UI)); f64_reinterpret_i64; local_set(Local(RP_Z));
         // for i in 0..2 { tx[i] = z as i32 as f64; z = (z - tx[i]) * 2^24 }
-        i32_const(0); local_set(RP_I);
+        i32_const(Imm32(0)); local_set(Local(RP_I));
         block_empty; loop_empty;
-            local_get(RP_I); i32_const(TX_SPLIT_COUNT); i32_ge_s; br_if(1);
+            local_get(Local(RP_I)); i32_const(Imm32(TX_SPLIT_COUNT)); i32_ge_s; br_if(1);
             // tx[i] = (z as i32) as f64
-            local_get(RP_TXP); local_get(RP_I); i32_const(F64_BYTES); i32_mul; i32_add;
-            local_get(RP_Z); i64_trunc_f64_s; i32_wrap_i64; f64_convert_i32_s;
+            local_get(Local(RP_TXP)); local_get(Local(RP_I)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+            local_get(Local(RP_Z)); i64_trunc_f64_s; i32_wrap_i64; f64_convert_i32_s;
             f64_store(0);
             // z = (z - tx[i]) * 2^24
-            local_get(RP_Z);
-            local_get(RP_TXP); local_get(RP_I); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
+            local_get(Local(RP_Z));
+            local_get(Local(RP_TXP)); local_get(Local(RP_I)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
             f64_sub;
-            i64_const(x1p24_bits); f64_reinterpret_i64; f64_mul; local_set(RP_Z);
-            local_get(RP_I); i32_const(1); i32_add; local_set(RP_I);
+            i64_const(Imm64(x1p24_bits)); f64_reinterpret_i64; f64_mul; local_set(Local(RP_Z));
+            local_get(Local(RP_I)); i32_const(Imm32(1)); i32_add; local_set(Local(RP_I));
             br(0);
         end; end;
         // tx[2] = z
-        local_get(RP_TXP); i32_const(TX_LAST_OFFSET); i32_add; local_get(RP_Z); f64_store(0);
+        local_get(Local(RP_TXP)); i32_const(Imm32(TX_LAST_OFFSET)); i32_add; local_get(Local(RP_Z)); f64_store(0);
         // i = 2; while i != 0 && tx[i] == 0 { i -= 1 }
-        i32_const(TX_SPLIT_COUNT); local_set(RP_I);
+        i32_const(Imm32(TX_SPLIT_COUNT)); local_set(Local(RP_I));
         block_empty; loop_empty;
-            local_get(RP_I); i32_eqz; br_if(1);
-            local_get(RP_TXP); local_get(RP_I); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
+            local_get(Local(RP_I)); i32_eqz; br_if(1);
+            local_get(Local(RP_TXP)); local_get(Local(RP_I)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
             f64_const(0.0); f64_ne; br_if(1);
-            local_get(RP_I); i32_const(1); i32_sub; local_set(RP_I);
+            local_get(Local(RP_I)); i32_const(Imm32(1)); i32_sub; local_set(Local(RP_I));
             br(0);
         end; end;
         // jx = i  (nx-1 form); n = rem_pio2_large(tx, i+1, ty, (ix>>20)-(0x3ff+23), 1)
-        local_get(RP_TXP);
-        local_get(RP_I); i32_const(1); i32_add;        // nx = i+1
-        local_get(RP_TYP);
-        local_get(RP_IX); i32_const(F64_EXP_SHIFT); i32_shr_s; i32_const(0x3ff + 23); i32_sub; // e0
-        i32_const(1);                                   // prec
-        call(rpl); local_set(RP_N);
+        local_get(Local(RP_TXP));
+        local_get(Local(RP_I)); i32_const(Imm32(1)); i32_add;        // nx = i+1
+        local_get(Local(RP_TYP));
+        local_get(Local(RP_IX)); i32_const(Imm32(F64_EXP_SHIFT)); i32_shr_s; i32_const(Imm32(0x3ff + 23)); i32_sub; // e0
+        i32_const(Imm32(1));                                   // prec
+        call(rpl); local_set(Local(RP_N));
         // y0 = ty[0]; y1 = ty[1]
-        local_get(RP_TYP); f64_load(0); local_set(RP_Y0);
-        local_get(RP_TYP); f64_load(8); local_set(RP_Y1);
+        local_get(Local(RP_TYP)); f64_load(0); local_set(Local(RP_Y0));
+        local_get(Local(RP_TYP)); f64_load(8); local_set(Local(RP_Y1));
         // if sign != 0 { n = -n; y0 = -y0; y1 = -y1 }
-        local_get(RP_SIGN);
+        local_get(Local(RP_SIGN));
         if_empty;
-            i32_const(0); local_get(RP_N); i32_sub; local_set(RP_N);
-            local_get(RP_Y0); f64_neg; local_set(RP_Y0);
-            local_get(RP_Y1); f64_neg; local_set(RP_Y1);
+            i32_const(Imm32(0)); local_get(Local(RP_N)); i32_sub; local_set(Local(RP_N));
+            local_get(Local(RP_Y0)); f64_neg; local_set(Local(RP_Y0));
+            local_get(Local(RP_Y1)); f64_neg; local_set(Local(RP_Y1));
         end;
     });
     emit_store_y(&mut f);
-    wasm!(f, { local_get(RP_N); end; });
+    wasm!(f, { local_get(Local(RP_N)); end; });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.rem_pio2, type_idx, f));
 }
 
@@ -940,83 +941,83 @@ fn compile_rem_pio2_large(emitter: &mut WasmEmitter) {
     // Helper closures to compute element addresses are inlined as wasm sequences.
     // Allocate scratch + zero it (f/q/fq/iq start at 0 in Rust).
     wasm!(f, {
-        i32_const(SCRATCH_BYTES); call(alloc); local_set(SCR);
-        local_get(SCR); i32_const(IQ_OFF); i32_add; local_set(IQ);
-        local_get(SCR); i32_const(F_OFF); i32_add; local_set(FA);
-        local_get(SCR); i32_const(Q_OFF); i32_add; local_set(QA);
-        local_get(SCR); i32_const(FQ_OFF); i32_add; local_set(FQA);
+        i32_const(Imm32(SCRATCH_BYTES)); call(alloc); local_set(Local(SCR));
+        local_get(Local(SCR)); i32_const(Imm32(IQ_OFF)); i32_add; local_set(Local(IQ));
+        local_get(Local(SCR)); i32_const(Imm32(F_OFF)); i32_add; local_set(Local(FA));
+        local_get(Local(SCR)); i32_const(Imm32(Q_OFF)); i32_add; local_set(Local(QA));
+        local_get(Local(SCR)); i32_const(Imm32(FQ_OFF)); i32_add; local_set(Local(FQA));
         // memory.fill(SCR, 0, SCRATCH_BYTES)
-        local_get(SCR); i32_const(0); i32_const(SCRATCH_BYTES); memory_fill;
+        local_get(Local(SCR)); i32_const(Imm32(0)); i32_const(Imm32(SCRATCH_BYTES)); memory_fill;
     });
 
     // jk = INIT_JK[prec]; jp = jk  (prec is always 1 for trig → 4; emit the table read)
     wasm!(f, {
         // INIT_JK is a compile-time const; read via select chain on prec (0..3)
         // jk = match prec {0=>3,1=>4,2=>4,_=>6}
-        local_get(PREC); i32_const(0); i32_eq; if_i32; i32_const(IPIO2_E0_ADJUST); else_;
-          local_get(PREC); i32_const(PREC_DOUBLE_MAX); i32_le_u; if_i32; i32_const(JK_DOUBLE); else_; i32_const(JK_EXTENDED); end;
+        local_get(Local(PREC)); i32_const(Imm32(0)); i32_eq; if_i32; i32_const(Imm32(IPIO2_E0_ADJUST)); else_;
+          local_get(Local(PREC)); i32_const(Imm32(PREC_DOUBLE_MAX)); i32_le_u; if_i32; i32_const(Imm32(JK_DOUBLE)); else_; i32_const(Imm32(JK_EXTENDED)); end;
         end;
-        local_set(JK);
-        local_get(JK); local_set(JP);
+        local_set(Local(JK));
+        local_get(Local(JK)); local_set(Local(JP));
         // jx = nx - 1
-        local_get(NX); i32_const(1); i32_sub; local_set(JX);
+        local_get(Local(NX)); i32_const(Imm32(1)); i32_sub; local_set(Local(JX));
         // jv = (e0 - 3) / 24 ; if jv < 0 { jv = 0 }
-        local_get(E0); i32_const(IPIO2_E0_ADJUST); i32_sub; i32_const(IPIO2_CHUNK_BITS); i32_div_s; local_set(JV);
-        local_get(JV); i32_const(0); i32_lt_s; if_empty; i32_const(0); local_set(JV); end;
+        local_get(Local(E0)); i32_const(Imm32(IPIO2_E0_ADJUST)); i32_sub; i32_const(Imm32(IPIO2_CHUNK_BITS)); i32_div_s; local_set(Local(JV));
+        local_get(Local(JV)); i32_const(Imm32(0)); i32_lt_s; if_empty; i32_const(Imm32(0)); local_set(Local(JV)); end;
         // q0 = e0 - 24*(jv+1)
-        local_get(E0); i32_const(IPIO2_CHUNK_BITS); local_get(JV); i32_const(1); i32_add; i32_mul; i32_sub; local_set(Q0);
+        local_get(Local(E0)); i32_const(Imm32(IPIO2_CHUNK_BITS)); local_get(Local(JV)); i32_const(Imm32(1)); i32_add; i32_mul; i32_sub; local_set(Local(Q0));
     });
 
     // set up f[0..=jx+jk]: j = jv - jx ; for i in 0..=m { f[i] = j<0?0:IPIO2[j]; j++ }
     // use JTMP as j, M as m, II as i
     wasm!(f, {
-        local_get(JV); local_get(JX); i32_sub; local_set(JTMP); // j
-        local_get(JX); local_get(JK); i32_add; local_set(M);
-        i32_const(0); local_set(II);
+        local_get(Local(JV)); local_get(Local(JX)); i32_sub; local_set(Local(JTMP)); // j
+        local_get(Local(JX)); local_get(Local(JK)); i32_add; local_set(Local(M));
+        i32_const(Imm32(0)); local_set(Local(II));
         block_empty; loop_empty;
-            local_get(II); local_get(M); i32_gt_s; br_if(1);
+            local_get(Local(II)); local_get(Local(M)); i32_gt_s; br_if(1);
             // f[i] address
-            local_get(FA); local_get(II); i32_const(F64_BYTES); i32_mul; i32_add;
+            local_get(Local(FA)); local_get(Local(II)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
             // value = j<0 ? 0.0 : IPIO2[j] as f64
-            local_get(JTMP); i32_const(0); i32_lt_s;
+            local_get(Local(JTMP)); i32_const(Imm32(0)); i32_lt_s;
             if_f64;
                 f64_const(0.0);
             else_;
                 // IPIO2[j] : i32 at ipio2 + j*4
-                i32_const(ipio2); local_get(JTMP); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
+                i32_const(Imm32(ipio2)); local_get(Local(JTMP)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_load(0);
                 f64_convert_i32_s;
             end;
             f64_store(0);
-            local_get(JTMP); i32_const(1); i32_add; local_set(JTMP);
-            local_get(II); i32_const(1); i32_add; local_set(II);
+            local_get(Local(JTMP)); i32_const(Imm32(1)); i32_add; local_set(Local(JTMP));
+            local_get(Local(II)); i32_const(Imm32(1)); i32_add; local_set(Local(II));
             br(0);
         end; end;
     });
 
     // compute q[0..=jk]: for i { fw=0; for j in 0..=jx { fw += x[j]*f[jx+i-j] } ; q[i]=fw }
     wasm!(f, {
-        i32_const(0); local_set(II);
+        i32_const(Imm32(0)); local_set(Local(II));
         block_empty; loop_empty;
-            local_get(II); local_get(JK); i32_gt_s; br_if(1);
-            f64_const(0.0); local_set(FW);
-            i32_const(0); local_set(JJ);
+            local_get(Local(II)); local_get(Local(JK)); i32_gt_s; br_if(1);
+            f64_const(0.0); local_set(Local(FW));
+            i32_const(Imm32(0)); local_set(Local(JJ));
             block_empty; loop_empty;
-                local_get(JJ); local_get(JX); i32_gt_s; br_if(1);
-                local_get(FW);
+                local_get(Local(JJ)); local_get(Local(JX)); i32_gt_s; br_if(1);
+                local_get(Local(FW));
                 // x[j]
-                local_get(XP); local_get(JJ); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
+                local_get(Local(XP)); local_get(Local(JJ)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
                 // f[jx+i-j]
-                local_get(FA); local_get(JX); local_get(II); i32_add; local_get(JJ); i32_sub; i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                f64_mul; f64_add; local_set(FW);
-                local_get(JJ); i32_const(1); i32_add; local_set(JJ);
+                local_get(Local(FA)); local_get(Local(JX)); local_get(Local(II)); i32_add; local_get(Local(JJ)); i32_sub; i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                f64_mul; f64_add; local_set(Local(FW));
+                local_get(Local(JJ)); i32_const(Imm32(1)); i32_add; local_set(Local(JJ));
                 br(0);
             end; end;
-            local_get(QA); local_get(II); i32_const(F64_BYTES); i32_mul; i32_add; local_get(FW); f64_store(0);
-            local_get(II); i32_const(1); i32_add; local_set(II);
+            local_get(Local(QA)); local_get(Local(II)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; local_get(Local(FW)); f64_store(0);
+            local_get(Local(II)); i32_const(Imm32(1)); i32_add; local_set(Local(II));
             br(0);
         end; end;
         // jz = jk
-        local_get(JK); local_set(JZ);
+        local_get(Local(JK)); local_set(Local(JZ));
     });
     emit_rpl_recompute_and_finalize(
         &mut f, scalbn, floor, ipio2, pio2, x1p24_bits, x1p_24_bits,
@@ -1048,136 +1049,136 @@ fn emit_rpl_recompute_and_finalize(
     // ── 'recompute loop ── block(exit) wraps loop(restart).
     wasm!(f, {
         block_empty; loop_empty;
-        i32_const(0); local_set(II);
-        local_get(QA); local_get(JZ); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0); local_set(Z);
-        local_get(JZ); local_set(JJ);
+        i32_const(Imm32(0)); local_set(Local(II));
+        local_get(Local(QA)); local_get(Local(JZ)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0); local_set(Local(Z));
+        local_get(Local(JZ)); local_set(Local(JJ));
         block_empty; loop_empty;
-            local_get(JJ); i32_const(1); i32_lt_s; br_if(1);
-            i64_const(x1p_24_bits); f64_reinterpret_i64; local_get(Z); f64_mul; i64_trunc_f64_s; i32_wrap_i64; f64_convert_i32_s; local_set(FW);
-            local_get(IQ); local_get(II); i32_const(I32_BYTES); i32_mul; i32_add;
-            local_get(Z); i64_const(x1p24_bits); f64_reinterpret_i64; local_get(FW); f64_mul; f64_sub; i64_trunc_f64_s; i32_wrap_i64;
+            local_get(Local(JJ)); i32_const(Imm32(1)); i32_lt_s; br_if(1);
+            i64_const(Imm64(x1p_24_bits)); f64_reinterpret_i64; local_get(Local(Z)); f64_mul; i64_trunc_f64_s; i32_wrap_i64; f64_convert_i32_s; local_set(Local(FW));
+            local_get(Local(IQ)); local_get(Local(II)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+            local_get(Local(Z)); i64_const(Imm64(x1p24_bits)); f64_reinterpret_i64; local_get(Local(FW)); f64_mul; f64_sub; i64_trunc_f64_s; i32_wrap_i64;
             i32_store(0);
-            local_get(QA); local_get(JJ); i32_const(1); i32_sub; i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0); local_get(FW); f64_add; local_set(Z);
-            local_get(II); i32_const(1); i32_add; local_set(II);
-            local_get(JJ); i32_const(1); i32_sub; local_set(JJ);
+            local_get(Local(QA)); local_get(Local(JJ)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0); local_get(Local(FW)); f64_add; local_set(Local(Z));
+            local_get(Local(II)); i32_const(Imm32(1)); i32_add; local_set(Local(II));
+            local_get(Local(JJ)); i32_const(Imm32(1)); i32_sub; local_set(Local(JJ));
             br(0);
         end; end;
 
         // z = scalbn(z, q0); z -= 8*floor(z*0.125); n = z as i32; z -= n as f64
-        local_get(Z); local_get(Q0); call(scalbn); local_set(Z);
-        local_get(Z);
-        f64_const(8.0); local_get(Z); f64_const(0.125); f64_mul; call(floor); f64_mul;
-        f64_sub; local_set(Z);
-        local_get(Z); i64_trunc_f64_s; i32_wrap_i64; local_set(N);
-        local_get(Z); local_get(N); f64_convert_i32_s; f64_sub; local_set(Z);
-        i32_const(0); local_set(IH);
-        local_get(Q0); i32_const(0); i32_gt_s;
+        local_get(Local(Z)); local_get(Local(Q0)); call(scalbn); local_set(Local(Z));
+        local_get(Local(Z));
+        f64_const(8.0); local_get(Local(Z)); f64_const(0.125); f64_mul; call(floor); f64_mul;
+        f64_sub; local_set(Local(Z));
+        local_get(Local(Z)); i64_trunc_f64_s; i32_wrap_i64; local_set(Local(N));
+        local_get(Local(Z)); local_get(Local(N)); f64_convert_i32_s; f64_sub; local_set(Local(Z));
+        i32_const(Imm32(0)); local_set(Local(IH));
+        local_get(Local(Q0)); i32_const(Imm32(0)); i32_gt_s;
         if_empty;
-            local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
-            i32_const(IPIO2_CHUNK_BITS); local_get(Q0); i32_sub; i32_shr_s; local_set(II);
-            local_get(N); local_get(II); i32_add; local_set(N);
-            local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; local_tee(TMP1);
-            local_get(TMP1); i32_load(0);
-            local_get(II); i32_const(IPIO2_CHUNK_BITS); local_get(Q0); i32_sub; i32_shl; i32_sub;
+            local_get(Local(IQ)); local_get(Local(JZ)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_load(0);
+            i32_const(Imm32(IPIO2_CHUNK_BITS)); local_get(Local(Q0)); i32_sub; i32_shr_s; local_set(Local(II));
+            local_get(Local(N)); local_get(Local(II)); i32_add; local_set(Local(N));
+            local_get(Local(IQ)); local_get(Local(JZ)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; local_tee(Local(TMP1));
+            local_get(Local(TMP1)); i32_load(0);
+            local_get(Local(II)); i32_const(Imm32(IPIO2_CHUNK_BITS)); local_get(Local(Q0)); i32_sub; i32_shl; i32_sub;
             i32_store(0);
-            local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
-            i32_const(IPIO2_CHUNK_M1); local_get(Q0); i32_sub; i32_shr_s; local_set(IH);
+            local_get(Local(IQ)); local_get(Local(JZ)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_load(0);
+            i32_const(Imm32(IPIO2_CHUNK_M1)); local_get(Local(Q0)); i32_sub; i32_shr_s; local_set(Local(IH));
         else_;
-            local_get(Q0); i32_eqz;
+            local_get(Local(Q0)); i32_eqz;
             if_empty;
-                local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
-                i32_const(IPIO2_CHUNK_M1); i32_shr_s; local_set(IH);
+                local_get(Local(IQ)); local_get(Local(JZ)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_load(0);
+                i32_const(Imm32(IPIO2_CHUNK_M1)); i32_shr_s; local_set(Local(IH));
             else_;
-                local_get(Z); f64_const(0.5); f64_ge; if_empty; i32_const(IH_HALFWAY); local_set(IH); end;
+                local_get(Local(Z)); f64_const(0.5); f64_ge; if_empty; i32_const(Imm32(IH_HALFWAY)); local_set(Local(IH)); end;
             end;
         end;
 
-        local_get(IH); i32_const(0); i32_gt_s;
+        local_get(Local(IH)); i32_const(Imm32(0)); i32_gt_s;
         if_empty;
-            local_get(N); i32_const(1); i32_add; local_set(N);
-            i32_const(0); local_set(CARRY);
-            i32_const(0); local_set(II);
+            local_get(Local(N)); i32_const(Imm32(1)); i32_add; local_set(Local(N));
+            i32_const(Imm32(0)); local_set(Local(CARRY));
+            i32_const(Imm32(0)); local_set(Local(II));
             block_empty; loop_empty;
-                local_get(II); local_get(JZ); i32_ge_s; br_if(1);
-                local_get(IQ); local_get(II); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0); local_set(JJ);
-                local_get(CARRY); i32_eqz;
+                local_get(Local(II)); local_get(Local(JZ)); i32_ge_s; br_if(1);
+                local_get(Local(IQ)); local_get(Local(II)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_load(0); local_set(Local(JJ));
+                local_get(Local(CARRY)); i32_eqz;
                 if_empty;
-                    local_get(JJ); i32_eqz;
+                    local_get(Local(JJ)); i32_eqz;
                     if_empty; else_;
-                        i32_const(1); local_set(CARRY);
-                        local_get(IQ); local_get(II); i32_const(I32_BYTES); i32_mul; i32_add; i32_const(IPIO2_CARRY_BASE); local_get(JJ); i32_sub; i32_store(0);
+                        i32_const(Imm32(1)); local_set(Local(CARRY));
+                        local_get(Local(IQ)); local_get(Local(II)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_const(Imm32(IPIO2_CARRY_BASE)); local_get(Local(JJ)); i32_sub; i32_store(0);
                     end;
                 else_;
-                    local_get(IQ); local_get(II); i32_const(I32_BYTES); i32_mul; i32_add; i32_const(IPIO2_24BIT_MASK); local_get(JJ); i32_sub; i32_store(0);
+                    local_get(Local(IQ)); local_get(Local(II)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_const(Imm32(IPIO2_24BIT_MASK)); local_get(Local(JJ)); i32_sub; i32_store(0);
                 end;
-                local_get(II); i32_const(1); i32_add; local_set(II);
+                local_get(Local(II)); i32_const(Imm32(1)); i32_add; local_set(Local(II));
                 br(0);
             end; end;
-            local_get(Q0); i32_const(0); i32_gt_s;
+            local_get(Local(Q0)); i32_const(Imm32(0)); i32_gt_s;
             if_empty;
-                local_get(Q0); i32_const(1); i32_eq;
+                local_get(Local(Q0)); i32_const(Imm32(1)); i32_eq;
                 if_empty;
-                    local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; local_tee(TMP1);
-                    local_get(TMP1); i32_load(0); i32_const(IPIO2_23BIT_MASK); i32_and; i32_store(0);
+                    local_get(Local(IQ)); local_get(Local(JZ)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; local_tee(Local(TMP1));
+                    local_get(Local(TMP1)); i32_load(0); i32_const(Imm32(IPIO2_23BIT_MASK)); i32_and; i32_store(0);
                 else_;
-                    local_get(Q0); i32_const(IH_HALFWAY); i32_eq;
+                    local_get(Local(Q0)); i32_const(Imm32(IH_HALFWAY)); i32_eq;
                     if_empty;
-                        local_get(IQ); local_get(JZ); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; local_tee(TMP1);
-                        local_get(TMP1); i32_load(0); i32_const(IPIO2_22BIT_MASK); i32_and; i32_store(0);
+                        local_get(Local(IQ)); local_get(Local(JZ)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; local_tee(Local(TMP1));
+                        local_get(Local(TMP1)); i32_load(0); i32_const(Imm32(IPIO2_22BIT_MASK)); i32_and; i32_store(0);
                     end;
                 end;
             end;
-            local_get(IH); i32_const(IH_HALFWAY); i32_eq;
+            local_get(Local(IH)); i32_const(Imm32(IH_HALFWAY)); i32_eq;
             if_empty;
-                f64_const(1.0); local_get(Z); f64_sub; local_set(Z);
-                local_get(CARRY); i32_eqz;
+                f64_const(1.0); local_get(Local(Z)); f64_sub; local_set(Local(Z));
+                local_get(Local(CARRY)); i32_eqz;
                 if_empty; else_;
-                    local_get(Z); f64_const(1.0); local_get(Q0); call(scalbn); f64_sub; local_set(Z);
+                    local_get(Local(Z)); f64_const(1.0); local_get(Local(Q0)); call(scalbn); f64_sub; local_set(Local(Z));
                 end;
             end;
         end;
 
-        local_get(Z); f64_const(0.0); f64_eq;
+        local_get(Local(Z)); f64_const(0.0); f64_eq;
         if_empty;
-            i32_const(0); local_set(JJ);
-            local_get(JZ); i32_const(1); i32_sub; local_set(II);
+            i32_const(Imm32(0)); local_set(Local(JJ));
+            local_get(Local(JZ)); i32_const(Imm32(1)); i32_sub; local_set(Local(II));
             block_empty; loop_empty;
-                local_get(II); local_get(JK); i32_lt_s; br_if(1);
-                local_get(JJ); local_get(IQ); local_get(II); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0); i32_or; local_set(JJ);
-                local_get(II); i32_const(1); i32_sub; local_set(II);
+                local_get(Local(II)); local_get(Local(JK)); i32_lt_s; br_if(1);
+                local_get(Local(JJ)); local_get(Local(IQ)); local_get(Local(II)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_load(0); i32_or; local_set(Local(JJ));
+                local_get(Local(II)); i32_const(Imm32(1)); i32_sub; local_set(Local(II));
                 br(0);
             end; end;
-            local_get(JJ); i32_eqz;
+            local_get(Local(JJ)); i32_eqz;
             if_empty;
-                i32_const(1); local_set(KK);
+                i32_const(Imm32(1)); local_set(Local(KK));
                 block_empty; loop_empty;
-                    local_get(IQ); local_get(JK); local_get(KK); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
+                    local_get(Local(IQ)); local_get(Local(JK)); local_get(Local(KK)); i32_sub; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_load(0);
                     br_if(1);
-                    local_get(KK); i32_const(1); i32_add; local_set(KK);
+                    local_get(Local(KK)); i32_const(Imm32(1)); i32_add; local_set(Local(KK));
                     br(0);
                 end; end;
-                local_get(JZ); i32_const(1); i32_add; local_set(II);
+                local_get(Local(JZ)); i32_const(Imm32(1)); i32_add; local_set(Local(II));
                 block_empty; loop_empty;
-                    local_get(II); local_get(JZ); local_get(KK); i32_add; i32_gt_s; br_if(1);
-                    local_get(FA); local_get(JX); local_get(II); i32_add; i32_const(F64_BYTES); i32_mul; i32_add;
-                    i32_const(ipio2); local_get(JV); local_get(II); i32_add; i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0); f64_convert_i32_s;
+                    local_get(Local(II)); local_get(Local(JZ)); local_get(Local(KK)); i32_add; i32_gt_s; br_if(1);
+                    local_get(Local(FA)); local_get(Local(JX)); local_get(Local(II)); i32_add; i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                    i32_const(Imm32(ipio2)); local_get(Local(JV)); local_get(Local(II)); i32_add; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_load(0); f64_convert_i32_s;
                     f64_store(0);
-                    f64_const(0.0); local_set(FW);
-                    i32_const(0); local_set(JJ);
+                    f64_const(0.0); local_set(Local(FW));
+                    i32_const(Imm32(0)); local_set(Local(JJ));
                     block_empty; loop_empty;
-                        local_get(JJ); local_get(JX); i32_gt_s; br_if(1);
-                        local_get(FW);
-                        local_get(XP); local_get(JJ); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                        local_get(FA); local_get(JX); local_get(II); i32_add; local_get(JJ); i32_sub; i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                        f64_mul; f64_add; local_set(FW);
-                        local_get(JJ); i32_const(1); i32_add; local_set(JJ);
+                        local_get(Local(JJ)); local_get(Local(JX)); i32_gt_s; br_if(1);
+                        local_get(Local(FW));
+                        local_get(Local(XP)); local_get(Local(JJ)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                        local_get(Local(FA)); local_get(Local(JX)); local_get(Local(II)); i32_add; local_get(Local(JJ)); i32_sub; i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                        f64_mul; f64_add; local_set(Local(FW));
+                        local_get(Local(JJ)); i32_const(Imm32(1)); i32_add; local_set(Local(JJ));
                         br(0);
                     end; end;
-                    local_get(QA); local_get(II); i32_const(F64_BYTES); i32_mul; i32_add; local_get(FW); f64_store(0);
-                    local_get(II); i32_const(1); i32_add; local_set(II);
+                    local_get(Local(QA)); local_get(Local(II)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; local_get(Local(FW)); f64_store(0);
+                    local_get(Local(II)); i32_const(Imm32(1)); i32_add; local_set(Local(II));
                     br(0);
                 end; end;
-                local_get(JZ); local_get(KK); i32_add; local_set(JZ);
+                local_get(Local(JZ)); local_get(Local(KK)); i32_add; local_set(Local(JZ));
                 // continue 'recompute: branch to the main loop header. Depth 0 = the
                 // inner `if j==0`, 1 = the outer `if z==0`, 2 = the 'recompute loop.
                 // (`if` blocks DO count as branch-target labels — a `br(1)` here would
@@ -1192,95 +1193,95 @@ fn emit_rpl_recompute_and_finalize(
 
     // ── chop off zero terms / break z into 24-bit ──
     wasm!(f, {
-        local_get(Z); f64_const(0.0); f64_eq;
+        local_get(Local(Z)); f64_const(0.0); f64_eq;
         if_empty;
-            local_get(JZ); i32_const(1); i32_sub; local_set(JZ);
-            local_get(Q0); i32_const(IPIO2_CHUNK_BITS); i32_sub; local_set(Q0);
+            local_get(Local(JZ)); i32_const(Imm32(1)); i32_sub; local_set(Local(JZ));
+            local_get(Local(Q0)); i32_const(Imm32(IPIO2_CHUNK_BITS)); i32_sub; local_set(Local(Q0));
             block_empty; loop_empty;
-                local_get(IQ); local_get(JZ); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0); br_if(1);
-                local_get(JZ); i32_const(1); i32_sub; local_set(JZ);
-                local_get(Q0); i32_const(IPIO2_CHUNK_BITS); i32_sub; local_set(Q0);
+                local_get(Local(IQ)); local_get(Local(JZ)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_load(0); br_if(1);
+                local_get(Local(JZ)); i32_const(Imm32(1)); i32_sub; local_set(Local(JZ));
+                local_get(Local(Q0)); i32_const(Imm32(IPIO2_CHUNK_BITS)); i32_sub; local_set(Local(Q0));
                 br(0);
             end; end;
         else_;
-            local_get(Z); i32_const(0); local_get(Q0); i32_sub; call(scalbn); local_set(Z);
-            local_get(Z); i64_const(x1p24_bits); f64_reinterpret_i64; f64_ge;
+            local_get(Local(Z)); i32_const(Imm32(0)); local_get(Local(Q0)); i32_sub; call(scalbn); local_set(Local(Z));
+            local_get(Local(Z)); i64_const(Imm64(x1p24_bits)); f64_reinterpret_i64; f64_ge;
             if_empty;
-                i64_const(x1p_24_bits); f64_reinterpret_i64; local_get(Z); f64_mul; i64_trunc_f64_s; i32_wrap_i64; f64_convert_i32_s; local_set(FW);
-                local_get(IQ); local_get(JZ); i32_const(I32_BYTES); i32_mul; i32_add;
-                local_get(Z); i64_const(x1p24_bits); f64_reinterpret_i64; local_get(FW); f64_mul; f64_sub; i64_trunc_f64_s; i32_wrap_i64; i32_store(0);
-                local_get(JZ); i32_const(1); i32_add; local_set(JZ);
-                local_get(Q0); i32_const(IPIO2_CHUNK_BITS); i32_add; local_set(Q0);
-                local_get(IQ); local_get(JZ); i32_const(I32_BYTES); i32_mul; i32_add; local_get(FW); i64_trunc_f64_s; i32_wrap_i64; i32_store(0);
+                i64_const(Imm64(x1p_24_bits)); f64_reinterpret_i64; local_get(Local(Z)); f64_mul; i64_trunc_f64_s; i32_wrap_i64; f64_convert_i32_s; local_set(Local(FW));
+                local_get(Local(IQ)); local_get(Local(JZ)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                local_get(Local(Z)); i64_const(Imm64(x1p24_bits)); f64_reinterpret_i64; local_get(Local(FW)); f64_mul; f64_sub; i64_trunc_f64_s; i32_wrap_i64; i32_store(0);
+                local_get(Local(JZ)); i32_const(Imm32(1)); i32_add; local_set(Local(JZ));
+                local_get(Local(Q0)); i32_const(Imm32(IPIO2_CHUNK_BITS)); i32_add; local_set(Local(Q0));
+                local_get(Local(IQ)); local_get(Local(JZ)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; local_get(Local(FW)); i64_trunc_f64_s; i32_wrap_i64; i32_store(0);
             else_;
-                local_get(IQ); local_get(JZ); i32_const(I32_BYTES); i32_mul; i32_add; local_get(Z); i64_trunc_f64_s; i32_wrap_i64; i32_store(0);
+                local_get(Local(IQ)); local_get(Local(JZ)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; local_get(Local(Z)); i64_trunc_f64_s; i32_wrap_i64; i32_store(0);
             end;
         end;
     });
 
     // ── convert integer "bit" chunk to f64 ──
     wasm!(f, {
-        f64_const(1.0); local_get(Q0); call(scalbn); local_set(FW);
-        local_get(JZ); local_set(II);
+        f64_const(1.0); local_get(Local(Q0)); call(scalbn); local_set(Local(FW));
+        local_get(Local(JZ)); local_set(Local(II));
         block_empty; loop_empty;
-            local_get(II); i32_const(0); i32_lt_s; br_if(1);
-            local_get(QA); local_get(II); i32_const(F64_BYTES); i32_mul; i32_add;
-            local_get(FW); local_get(IQ); local_get(II); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0); f64_convert_i32_s; f64_mul;
+            local_get(Local(II)); i32_const(Imm32(0)); i32_lt_s; br_if(1);
+            local_get(Local(QA)); local_get(Local(II)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+            local_get(Local(FW)); local_get(Local(IQ)); local_get(Local(II)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_load(0); f64_convert_i32_s; f64_mul;
             f64_store(0);
-            local_get(FW); i64_const(x1p_24_bits); f64_reinterpret_i64; f64_mul; local_set(FW);
-            local_get(II); i32_const(1); i32_sub; local_set(II);
+            local_get(Local(FW)); i64_const(Imm64(x1p_24_bits)); f64_reinterpret_i64; f64_mul; local_set(Local(FW));
+            local_get(Local(II)); i32_const(Imm32(1)); i32_sub; local_set(Local(II));
             br(0);
         end; end;
     });
 
     // ── PIO2[0..=jp]*q[jz..0] → fq ──
     wasm!(f, {
-        local_get(JZ); local_set(II);
+        local_get(Local(JZ)); local_set(Local(II));
         block_empty; loop_empty;
-            local_get(II); i32_const(0); i32_lt_s; br_if(1);
-            f64_const(0.0); local_set(FW);
-            i32_const(0); local_set(KK);
+            local_get(Local(II)); i32_const(Imm32(0)); i32_lt_s; br_if(1);
+            f64_const(0.0); local_set(Local(FW));
+            i32_const(Imm32(0)); local_set(Local(KK));
             block_empty; loop_empty;
-                local_get(KK); local_get(JP); i32_gt_s; br_if(1);
-                local_get(KK); local_get(JZ); local_get(II); i32_sub; i32_gt_s; br_if(1);
-                local_get(FW);
-                i32_const(pio2); local_get(KK); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                local_get(QA); local_get(II); local_get(KK); i32_add; i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0);
-                f64_mul; f64_add; local_set(FW);
-                local_get(KK); i32_const(1); i32_add; local_set(KK);
+                local_get(Local(KK)); local_get(Local(JP)); i32_gt_s; br_if(1);
+                local_get(Local(KK)); local_get(Local(JZ)); local_get(Local(II)); i32_sub; i32_gt_s; br_if(1);
+                local_get(Local(FW));
+                i32_const(Imm32(pio2)); local_get(Local(KK)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                local_get(Local(QA)); local_get(Local(II)); local_get(Local(KK)); i32_add; i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0);
+                f64_mul; f64_add; local_set(Local(FW));
+                local_get(Local(KK)); i32_const(Imm32(1)); i32_add; local_set(Local(KK));
                 br(0);
             end; end;
-            local_get(FQA); local_get(JZ); local_get(II); i32_sub; i32_const(F64_BYTES); i32_mul; i32_add; local_get(FW); f64_store(0);
-            local_get(II); i32_const(1); i32_sub; local_set(II);
+            local_get(Local(FQA)); local_get(Local(JZ)); local_get(Local(II)); i32_sub; i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; local_get(Local(FW)); f64_store(0);
+            local_get(Local(II)); i32_const(Imm32(1)); i32_sub; local_set(Local(II));
             br(0);
         end; end;
     });
 
     // ── compress fq[] into y[] (prec 1: y[0],y[1]) ──
     wasm!(f, {
-        f64_const(0.0); local_set(FW);
-        local_get(JZ); local_set(II);
+        f64_const(0.0); local_set(Local(FW));
+        local_get(Local(JZ)); local_set(Local(II));
         block_empty; loop_empty;
-            local_get(II); i32_const(0); i32_lt_s; br_if(1);
-            local_get(FW); local_get(FQA); local_get(II); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0); f64_add; local_set(FW);
-            local_get(II); i32_const(1); i32_sub; local_set(II);
+            local_get(Local(II)); i32_const(Imm32(0)); i32_lt_s; br_if(1);
+            local_get(Local(FW)); local_get(Local(FQA)); local_get(Local(II)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0); f64_add; local_set(Local(FW));
+            local_get(Local(II)); i32_const(Imm32(1)); i32_sub; local_set(Local(II));
             br(0);
         end; end;
-        local_get(YP);
-        local_get(IH); i32_eqz; if_f64; local_get(FW); else_; local_get(FW); f64_neg; end;
+        local_get(Local(YP));
+        local_get(Local(IH)); i32_eqz; if_f64; local_get(Local(FW)); else_; local_get(Local(FW)); f64_neg; end;
         f64_store(0);
-        local_get(FQA); f64_load(0); local_get(FW); f64_sub; local_set(FW);
-        i32_const(1); local_set(II);
+        local_get(Local(FQA)); f64_load(0); local_get(Local(FW)); f64_sub; local_set(Local(FW));
+        i32_const(Imm32(1)); local_set(Local(II));
         block_empty; loop_empty;
-            local_get(II); local_get(JZ); i32_gt_s; br_if(1);
-            local_get(FW); local_get(FQA); local_get(II); i32_const(F64_BYTES); i32_mul; i32_add; f64_load(0); f64_add; local_set(FW);
-            local_get(II); i32_const(1); i32_add; local_set(II);
+            local_get(Local(II)); local_get(Local(JZ)); i32_gt_s; br_if(1);
+            local_get(Local(FW)); local_get(Local(FQA)); local_get(Local(II)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; f64_load(0); f64_add; local_set(Local(FW));
+            local_get(Local(II)); i32_const(Imm32(1)); i32_add; local_set(Local(II));
             br(0);
         end; end;
-        local_get(YP);
-        local_get(IH); i32_eqz; if_f64; local_get(FW); else_; local_get(FW); f64_neg; end;
+        local_get(Local(YP));
+        local_get(Local(IH)); i32_eqz; if_f64; local_get(Local(FW)); else_; local_get(Local(FW)); f64_neg; end;
         f64_store(8);
-        local_get(N); i32_const(REM_PIO2_N_MASK); i32_and;
+        local_get(Local(N)); i32_const(Imm32(REM_PIO2_N_MASK)); i32_and;
         end;
     });
 }
@@ -1331,90 +1332,90 @@ fn compile_exp(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(3, ValType::I32), (5, ValType::F64)]);
     wasm!(f, {
         // hx = (to_bits(x) >> 32); sign = hx >> 31; hx &= 0x7fffffff
-        local_get(X); i64_reinterpret_f64; i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; local_set(HX);
-        local_get(HX); i32_const(I32_SIGN_BIT); i32_shr_u; local_set(SIGN);
-        local_get(HX); i32_const(F64_ABS_MASK_HI); i32_and; local_set(HX);
+        local_get(Local(X)); i64_reinterpret_f64; i64_const(Imm64(HI_SHIFT)); i64_shr_u; i32_wrap_i64; local_set(Local(HX));
+        local_get(Local(HX)); i32_const(Imm32(I32_SIGN_BIT)); i32_shr_u; local_set(Local(SIGN));
+        local_get(Local(HX)); i32_const(Imm32(F64_ABS_MASK_HI)); i32_and; local_set(Local(HX));
 
         // special cases: if hx >= 0x4086232b
-        local_get(HX); i32_const(EXP_OVERFLOW_HI); i32_ge_u;
+        local_get(Local(HX)); i32_const(Imm32(EXP_OVERFLOW_HI)); i32_ge_u;
         if_empty;
             // if x.is_nan() return x  (x != x)
-            local_get(X); local_get(X); f64_ne;
-            if_empty; local_get(X); return_; end;
+            local_get(Local(X)); local_get(Local(X)); f64_ne;
+            if_empty; local_get(Local(X)); return_; end;
             // if x > 709.782712893383973096 { x *= 2^1023; return x }  (overflow)
-            local_get(X); f64_const(709.782712893383973096); f64_gt;
+            local_get(Local(X)); f64_const(709.782712893383973096); f64_gt;
             if_empty;
-                local_get(X); f64_const(x1p1023); f64_mul; return_;
+                local_get(Local(X)); f64_const(x1p1023); f64_mul; return_;
             end;
             // if x < -708.39641853226410622 { force_eval(-2^-149/x); if x < -745.13321910194110842 return 0 }
-            local_get(X); f64_const(-708.39641853226410622); f64_lt;
+            local_get(Local(X)); f64_const(-708.39641853226410622); f64_lt;
             if_empty;
                 // unobservable underflow-flag computation; drop the f32 result.
-                f64_const(x1p_149); f64_neg; local_get(X); f64_div; f32_demote_f64; drop;
-                local_get(X); f64_const(-745.13321910194110842); f64_lt;
+                f64_const(x1p_149); f64_neg; local_get(Local(X)); f64_div; f32_demote_f64; drop;
+                local_get(Local(X)); f64_const(-745.13321910194110842); f64_lt;
                 if_empty; f64_const(0.0); return_; end;
             end;
         end;
 
         // argument reduction
-        local_get(HX); i32_const(EXP_HALF_LN2_HI); i32_gt_u;
+        local_get(Local(HX)); i32_const(Imm32(EXP_HALF_LN2_HI)); i32_gt_u;
         if_empty;
             // |x| > 0.5 ln2
-            local_get(HX); i32_const(EXP_LN2_SMALL_HI); i32_ge_u;
+            local_get(Local(HX)); i32_const(Imm32(EXP_LN2_SMALL_HI)); i32_ge_u;
             if_empty;
                 // k = (INVLN2*x + HALF[sign]) as i32   (HALF = [0.5, -0.5])
-                local_get(X); f64_const(EXP_INVLN2); f64_mul;
-                local_get(SIGN); if_f64; f64_const(-0.5); else_; f64_const(0.5); end;
-                f64_add; i32_trunc_f64_s; local_set(K);
+                local_get(Local(X)); f64_const(EXP_INVLN2); f64_mul;
+                local_get(Local(SIGN)); if_f64; f64_const(-0.5); else_; f64_const(0.5); end;
+                f64_add; i32_trunc_f64_s; local_set(Local(K));
             else_;
                 // k = 1 - sign - sign
-                i32_const(1); local_get(SIGN); i32_sub; local_get(SIGN); i32_sub; local_set(K);
+                i32_const(Imm32(1)); local_get(Local(SIGN)); i32_sub; local_get(Local(SIGN)); i32_sub; local_set(Local(K));
             end;
             // hi = x - k*LN2HI; lo = k*LN2LO; x = hi - lo
-            local_get(X); local_get(K); f64_convert_i32_s; f64_const(EXP_LN2HI); f64_mul; f64_sub; local_set(HI);
-            local_get(K); f64_convert_i32_s; f64_const(EXP_LN2LO); f64_mul; local_set(LO);
-            local_get(HI); local_get(LO); f64_sub; local_set(X);
+            local_get(Local(X)); local_get(Local(K)); f64_convert_i32_s; f64_const(EXP_LN2HI); f64_mul; f64_sub; local_set(Local(HI));
+            local_get(Local(K)); f64_convert_i32_s; f64_const(EXP_LN2LO); f64_mul; local_set(Local(LO));
+            local_get(Local(HI)); local_get(Local(LO)); f64_sub; local_set(Local(X));
         else_;
-            local_get(HX); i32_const(EXP_TINY_HI); i32_gt_u;
+            local_get(Local(HX)); i32_const(Imm32(EXP_TINY_HI)); i32_gt_u;
             if_empty;
                 // |x| > 2^-28: k=0; hi=x; lo=0
-                i32_const(0); local_set(K);
-                local_get(X); local_set(HI);
-                f64_const(0.0); local_set(LO);
+                i32_const(Imm32(0)); local_set(Local(K));
+                local_get(Local(X)); local_set(Local(HI));
+                f64_const(0.0); local_set(Local(LO));
             else_;
                 // inexact if x!=0; return 1 + x
-                f64_const(x1p1023); local_get(X); f64_add; drop;
-                f64_const(1.0); local_get(X); f64_add; return_;
+                f64_const(x1p1023); local_get(Local(X)); f64_add; drop;
+                f64_const(1.0); local_get(Local(X)); f64_add; return_;
             end;
         end;
 
         // primary range: xx = x*x;
-        local_get(X); local_get(X); f64_mul; local_set(XX);
+        local_get(Local(X)); local_get(Local(X)); f64_mul; local_set(Local(XX));
         // c = x - xx*(P1 + xx*(P2 + xx*(P3 + xx*(P4 + xx*P5))))
-        local_get(X);
-        local_get(XX);
+        local_get(Local(X));
+        local_get(Local(XX));
         f64_const(EXP_P1);
-        local_get(XX); f64_const(EXP_P2);
-        local_get(XX); f64_const(EXP_P3);
-        local_get(XX); f64_const(EXP_P4);
-        local_get(XX); f64_const(EXP_P5); f64_mul; f64_add;
+        local_get(Local(XX)); f64_const(EXP_P2);
+        local_get(Local(XX)); f64_const(EXP_P3);
+        local_get(Local(XX)); f64_const(EXP_P4);
+        local_get(Local(XX)); f64_const(EXP_P5); f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul;
-        f64_sub; local_set(C);
+        f64_sub; local_set(Local(C));
         // y = 1 + (x*c/(2-c) - lo + hi)
         f64_const(1.0);
-        local_get(X); local_get(C); f64_mul; f64_const(2.0); local_get(C); f64_sub; f64_div;
-        local_get(LO); f64_sub;
-        local_get(HI); f64_add;
-        f64_add; local_set(Y);
+        local_get(Local(X)); local_get(Local(C)); f64_mul; f64_const(2.0); local_get(Local(C)); f64_sub; f64_div;
+        local_get(Local(LO)); f64_sub;
+        local_get(Local(HI)); f64_add;
+        f64_add; local_set(Local(Y));
         // if k==0 { y } else { scalbn(y, k) }
-        local_get(K); i32_eqz;
+        local_get(Local(K)); i32_eqz;
         if_f64;
-            local_get(Y);
+            local_get(Local(Y));
         else_;
-            local_get(Y); local_get(K); call(scalbn);
+            local_get(Local(Y)); local_get(Local(K)); call(scalbn);
         end;
         end;
     });
@@ -1455,74 +1456,74 @@ fn emit_log_reduce(f: &mut Function) {
     let x1p54 = f64::from_bits(0x4350000000000000); // 2^54
     wasm!(f, {
         // ui = to_bits(x); hx = ui >> 32; k = 0
-        local_get(LG_X); i64_reinterpret_f64; local_set(LG_UI);
-        local_get(LG_UI); i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; local_set(LG_HX);
-        i32_const(0); local_set(LG_K);
+        local_get(Local(LG_X)); i64_reinterpret_f64; local_set(Local(LG_UI));
+        local_get(Local(LG_UI)); i64_const(Imm64(HI_SHIFT)); i64_shr_u; i32_wrap_i64; local_set(Local(LG_HX));
+        i32_const(Imm32(0)); local_set(Local(LG_K));
         // if hx < 0x00100000 || (hx >> 31) != 0
-        local_get(LG_HX); i32_const(F64_EXP_ONE_HI); i32_lt_u;
-        local_get(LG_HX); i32_const(I32_SIGN_BIT); i32_shr_u; i32_const(0); i32_ne;
+        local_get(Local(LG_HX)); i32_const(Imm32(F64_EXP_ONE_HI)); i32_lt_u;
+        local_get(Local(LG_HX)); i32_const(Imm32(I32_SIGN_BIT)); i32_shr_u; i32_const(Imm32(0)); i32_ne;
         i32_or;
         if_empty;
             // if (ui << 1) == 0 { return -1/(x*x) }   log(+-0) = -inf
-            local_get(LG_UI); i64_const(1); i64_shl; i64_eqz;
+            local_get(Local(LG_UI)); i64_const(Imm64(1)); i64_shl; i64_eqz;
             if_empty;
-                f64_const(-1.0); local_get(LG_X); local_get(LG_X); f64_mul; f64_div; return_;
+                f64_const(-1.0); local_get(Local(LG_X)); local_get(Local(LG_X)); f64_mul; f64_div; return_;
             end;
             // if (hx >> 31) != 0 { return (x-x)/0 }   log(-#) = NaN
-            local_get(LG_HX); i32_const(I32_SIGN_BIT); i32_shr_u; i32_const(0); i32_ne;
+            local_get(Local(LG_HX)); i32_const(Imm32(I32_SIGN_BIT)); i32_shr_u; i32_const(Imm32(0)); i32_ne;
             if_empty;
-                local_get(LG_X); local_get(LG_X); f64_sub; f64_const(0.0); f64_div; return_;
+                local_get(Local(LG_X)); local_get(Local(LG_X)); f64_sub; f64_const(0.0); f64_div; return_;
             end;
             // subnormal: k -= 54; x *= 2^54; ui = to_bits(x); hx = ui >> 32
-            local_get(LG_K); i32_const(LOG_SUBNORM_SCALE); i32_sub; local_set(LG_K);
-            local_get(LG_X); f64_const(x1p54); f64_mul; local_set(LG_X);
-            local_get(LG_X); i64_reinterpret_f64; local_set(LG_UI);
-            local_get(LG_UI); i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; local_set(LG_HX);
+            local_get(Local(LG_K)); i32_const(Imm32(LOG_SUBNORM_SCALE)); i32_sub; local_set(Local(LG_K));
+            local_get(Local(LG_X)); f64_const(x1p54); f64_mul; local_set(Local(LG_X));
+            local_get(Local(LG_X)); i64_reinterpret_f64; local_set(Local(LG_UI));
+            local_get(Local(LG_UI)); i64_const(Imm64(HI_SHIFT)); i64_shr_u; i32_wrap_i64; local_set(Local(LG_HX));
         else_;
             // else if hx >= 0x7ff00000 { return x }
-            local_get(LG_HX); i32_const(F64_INF_NAN_HI); i32_ge_u;
-            if_empty; local_get(LG_X); return_; end;
+            local_get(Local(LG_HX)); i32_const(Imm32(F64_INF_NAN_HI)); i32_ge_u;
+            if_empty; local_get(Local(LG_X)); return_; end;
             // else if hx == 0x3ff00000 && (ui << 32) == 0 { return 0 }
-            local_get(LG_HX); i32_const(F64_ONE_HI); i32_eq;
-            local_get(LG_UI); i64_const(HI_SHIFT); i64_shl; i64_eqz;
+            local_get(Local(LG_HX)); i32_const(Imm32(F64_ONE_HI)); i32_eq;
+            local_get(Local(LG_UI)); i64_const(Imm64(HI_SHIFT)); i64_shl; i64_eqz;
             i32_and;
             if_empty; f64_const(0.0); return_; end;
         end;
 
         // reduce x into [sqrt(2)/2, sqrt(2)]
         // hx += 0x3ff00000 - 0x3fe6a09e
-        local_get(LG_HX); i32_const(0x3ff00000 - 0x3fe6a09e); i32_add; local_set(LG_HX);
+        local_get(Local(LG_HX)); i32_const(Imm32(0x3ff00000 - 0x3fe6a09e)); i32_add; local_set(Local(LG_HX));
         // k += (hx >> 20) - 0x3ff
-        local_get(LG_K); local_get(LG_HX); i32_const(F64_EXP_SHIFT); i32_shr_u; i32_const(F64_EXP_BIAS); i32_sub; i32_add; local_set(LG_K);
+        local_get(Local(LG_K)); local_get(Local(LG_HX)); i32_const(Imm32(F64_EXP_SHIFT)); i32_shr_u; i32_const(Imm32(F64_EXP_BIAS)); i32_sub; i32_add; local_set(Local(LG_K));
         // hx = (hx & 0x000fffff) + 0x3fe6a09e
-        local_get(LG_HX); i32_const(F64_MANTISSA_HI_MASK); i32_and; i32_const(LOG_SQRT2_HI); i32_add; local_set(LG_HX);
+        local_get(Local(LG_HX)); i32_const(Imm32(F64_MANTISSA_HI_MASK)); i32_and; i32_const(Imm32(LOG_SQRT2_HI)); i32_add; local_set(Local(LG_HX));
         // ui = (hx << 32) | (ui & 0xffffffff); x = from_bits(ui)
-        local_get(LG_HX); i64_extend_i32_u; i64_const(HI_SHIFT); i64_shl;
-        local_get(LG_UI); i64_const(LOW_WORD_BITS); i64_and;
-        i64_or; local_set(LG_UI);
-        local_get(LG_UI); f64_reinterpret_i64; local_set(LG_X);
+        local_get(Local(LG_HX)); i64_extend_i32_u; i64_const(Imm64(HI_SHIFT)); i64_shl;
+        local_get(Local(LG_UI)); i64_const(Imm64(LOW_WORD_BITS)); i64_and;
+        i64_or; local_set(Local(LG_UI));
+        local_get(Local(LG_UI)); f64_reinterpret_i64; local_set(Local(LG_X));
 
         // f = x - 1; hfsq = 0.5*f*f; s = f/(2+f); z = s*s; w = z*z
-        local_get(LG_X); f64_const(1.0); f64_sub; local_set(LG_F);
-        f64_const(0.5); local_get(LG_F); f64_mul; local_get(LG_F); f64_mul; local_set(LG_HFSQ);
-        local_get(LG_F); f64_const(2.0); local_get(LG_F); f64_add; f64_div; local_set(LG_S);
-        local_get(LG_S); local_get(LG_S); f64_mul; local_set(LG_Z);
-        local_get(LG_Z); local_get(LG_Z); f64_mul; local_set(LG_W);
+        local_get(Local(LG_X)); f64_const(1.0); f64_sub; local_set(Local(LG_F));
+        f64_const(0.5); local_get(Local(LG_F)); f64_mul; local_get(Local(LG_F)); f64_mul; local_set(Local(LG_HFSQ));
+        local_get(Local(LG_F)); f64_const(2.0); local_get(Local(LG_F)); f64_add; f64_div; local_set(Local(LG_S));
+        local_get(Local(LG_S)); local_get(Local(LG_S)); f64_mul; local_set(Local(LG_Z));
+        local_get(Local(LG_Z)); local_get(Local(LG_Z)); f64_mul; local_set(Local(LG_W));
         // t1 = w*(LG2 + w*(LG4 + w*LG6)); t2 = z*(LG1 + w*(LG3 + w*(LG5 + w*LG7))); r = t2 + t1
         // compute r directly: r = t2 + t1
-        local_get(LG_Z); f64_const(LG1);
-        local_get(LG_W); f64_const(LG3);
-        local_get(LG_W); f64_const(LG5);
-        local_get(LG_W); f64_const(LG7); f64_mul; f64_add;
+        local_get(Local(LG_Z)); f64_const(LG1);
+        local_get(Local(LG_W)); f64_const(LG3);
+        local_get(Local(LG_W)); f64_const(LG5);
+        local_get(Local(LG_W)); f64_const(LG7); f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul;                                  // t2
-        local_get(LG_W); f64_const(LG2);
-        local_get(LG_W); f64_const(LG4);
-        local_get(LG_W); f64_const(LG6); f64_mul; f64_add;
+        local_get(Local(LG_W)); f64_const(LG2);
+        local_get(Local(LG_W)); f64_const(LG4);
+        local_get(Local(LG_W)); f64_const(LG6); f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul;                                  // t1
-        f64_add; local_set(LG_R);
+        f64_add; local_set(Local(LG_R));
     });
 }
 
@@ -1535,11 +1536,11 @@ fn compile_log(emitter: &mut WasmEmitter) {
     emit_log_reduce(&mut f);
     wasm!(f, {
         // dk = k; return s*(hfsq+r) + dk*LN2_LO - hfsq + f + dk*LN2_HI
-        local_get(LG_S); local_get(LG_HFSQ); local_get(LG_R); f64_add; f64_mul;
-        local_get(LG_K); f64_convert_i32_s; f64_const(LOG_LN2_LO); f64_mul; f64_add;
-        local_get(LG_HFSQ); f64_sub;
-        local_get(LG_F); f64_add;
-        local_get(LG_K); f64_convert_i32_s; f64_const(LOG_LN2_HI); f64_mul; f64_add;
+        local_get(Local(LG_S)); local_get(Local(LG_HFSQ)); local_get(Local(LG_R)); f64_add; f64_mul;
+        local_get(Local(LG_K)); f64_convert_i32_s; f64_const(LOG_LN2_LO); f64_mul; f64_add;
+        local_get(Local(LG_HFSQ)); f64_sub;
+        local_get(Local(LG_F)); f64_add;
+        local_get(Local(LG_K)); f64_convert_i32_s; f64_const(LOG_LN2_HI); f64_mul; f64_add;
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.log, type_idx, f));
@@ -1564,23 +1565,23 @@ fn compile_log2(emitter: &mut WasmEmitter) {
     emit_log_reduce(&mut f);
     wasm!(f, {
         // hi = f - hfsq; ui = to_bits(hi) & 0xFFFFFFFF00000000; hi = from_bits(ui)
-        local_get(LG_F); local_get(LG_HFSQ); f64_sub; local_set(LG_HI);
-        local_get(LG_HI); i64_reinterpret_f64; i64_const(LOW_WORD_MASK); i64_and; f64_reinterpret_i64; local_set(LG_HI);
+        local_get(Local(LG_F)); local_get(Local(LG_HFSQ)); f64_sub; local_set(Local(LG_HI));
+        local_get(Local(LG_HI)); i64_reinterpret_f64; i64_const(Imm64(LOW_WORD_MASK)); i64_and; f64_reinterpret_i64; local_set(Local(LG_HI));
         // lo = f - hi - hfsq + s*(hfsq + r)
-        local_get(LG_F); local_get(LG_HI); f64_sub; local_get(LG_HFSQ); f64_sub;
-        local_get(LG_S); local_get(LG_HFSQ); local_get(LG_R); f64_add; f64_mul;
-        f64_add; local_set(LG_LO);
+        local_get(Local(LG_F)); local_get(Local(LG_HI)); f64_sub; local_get(Local(LG_HFSQ)); f64_sub;
+        local_get(Local(LG_S)); local_get(Local(LG_HFSQ)); local_get(Local(LG_R)); f64_add; f64_mul;
+        f64_add; local_set(Local(LG_LO));
         // val_hi = hi*IVLN2HI; val_lo = (lo+hi)*IVLN2LO + lo*IVLN2HI
-        local_get(LG_HI); f64_const(IVLN2HI); f64_mul; local_set(LG_VH);
-        local_get(LG_LO); local_get(LG_HI); f64_add; f64_const(IVLN2LO); f64_mul;
-        local_get(LG_LO); f64_const(IVLN2HI); f64_mul; f64_add; local_set(LG_VL);
+        local_get(Local(LG_HI)); f64_const(IVLN2HI); f64_mul; local_set(Local(LG_VH));
+        local_get(Local(LG_LO)); local_get(Local(LG_HI)); f64_add; f64_const(IVLN2LO); f64_mul;
+        local_get(Local(LG_LO)); f64_const(IVLN2HI); f64_mul; f64_add; local_set(Local(LG_VL));
         // y = k; w = y + val_hi; val_lo += (y - w) + val_hi; val_hi = w
-        local_get(LG_K); f64_convert_i32_s; local_set(LG_Y);
-        local_get(LG_Y); local_get(LG_VH); f64_add; local_set(LG_W);
-        local_get(LG_VL); local_get(LG_Y); local_get(LG_W); f64_sub; local_get(LG_VH); f64_add; f64_add; local_set(LG_VL);
-        local_get(LG_W); local_set(LG_VH);
+        local_get(Local(LG_K)); f64_convert_i32_s; local_set(Local(LG_Y));
+        local_get(Local(LG_Y)); local_get(Local(LG_VH)); f64_add; local_set(Local(LG_W));
+        local_get(Local(LG_VL)); local_get(Local(LG_Y)); local_get(Local(LG_W)); f64_sub; local_get(Local(LG_VH)); f64_add; f64_add; local_set(Local(LG_VL));
+        local_get(Local(LG_W)); local_set(Local(LG_VH));
         // return val_lo + val_hi
-        local_get(LG_VL); local_get(LG_VH); f64_add;
+        local_get(Local(LG_VL)); local_get(Local(LG_VH)); f64_add;
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.log2, type_idx, f));
@@ -1599,24 +1600,24 @@ fn compile_log10(emitter: &mut WasmEmitter) {
     emit_log_reduce(&mut f);
     wasm!(f, {
         // hi = f - hfsq; zero low word
-        local_get(LG_F); local_get(LG_HFSQ); f64_sub; local_set(LG_HI);
-        local_get(LG_HI); i64_reinterpret_f64; i64_const(LOW_WORD_MASK); i64_and; f64_reinterpret_i64; local_set(LG_HI);
+        local_get(Local(LG_F)); local_get(Local(LG_HFSQ)); f64_sub; local_set(Local(LG_HI));
+        local_get(Local(LG_HI)); i64_reinterpret_f64; i64_const(Imm64(LOW_WORD_MASK)); i64_and; f64_reinterpret_i64; local_set(Local(LG_HI));
         // lo = f - hi - hfsq + s*(hfsq + r)
-        local_get(LG_F); local_get(LG_HI); f64_sub; local_get(LG_HFSQ); f64_sub;
-        local_get(LG_S); local_get(LG_HFSQ); local_get(LG_R); f64_add; f64_mul;
-        f64_add; local_set(LG_LO);
+        local_get(Local(LG_F)); local_get(Local(LG_HI)); f64_sub; local_get(Local(LG_HFSQ)); f64_sub;
+        local_get(Local(LG_S)); local_get(Local(LG_HFSQ)); local_get(Local(LG_R)); f64_add; f64_mul;
+        f64_add; local_set(Local(LG_LO));
         // val_hi = hi*IVLN10HI; dk = k; y = dk*LOG10_2HI
-        local_get(LG_HI); f64_const(IVLN10HI); f64_mul; local_set(LG_VH);
-        local_get(LG_K); f64_convert_i32_s; f64_const(LOG10_2HI); f64_mul; local_set(LG_Y);
+        local_get(Local(LG_HI)); f64_const(IVLN10HI); f64_mul; local_set(Local(LG_VH));
+        local_get(Local(LG_K)); f64_convert_i32_s; f64_const(LOG10_2HI); f64_mul; local_set(Local(LG_Y));
         // val_lo = dk*LOG10_2LO + (lo+hi)*IVLN10LO + lo*IVLN10HI
-        local_get(LG_K); f64_convert_i32_s; f64_const(LOG10_2LO); f64_mul;
-        local_get(LG_LO); local_get(LG_HI); f64_add; f64_const(IVLN10LO); f64_mul; f64_add;
-        local_get(LG_LO); f64_const(IVLN10HI); f64_mul; f64_add; local_set(LG_VL);
+        local_get(Local(LG_K)); f64_convert_i32_s; f64_const(LOG10_2LO); f64_mul;
+        local_get(Local(LG_LO)); local_get(Local(LG_HI)); f64_add; f64_const(IVLN10LO); f64_mul; f64_add;
+        local_get(Local(LG_LO)); f64_const(IVLN10HI); f64_mul; f64_add; local_set(Local(LG_VL));
         // w = y + val_hi; val_lo += (y - w) + val_hi; val_hi = w
-        local_get(LG_Y); local_get(LG_VH); f64_add; local_set(LG_W);
-        local_get(LG_VL); local_get(LG_Y); local_get(LG_W); f64_sub; local_get(LG_VH); f64_add; f64_add; local_set(LG_VL);
-        local_get(LG_W); local_set(LG_VH);
-        local_get(LG_VL); local_get(LG_VH); f64_add;
+        local_get(Local(LG_Y)); local_get(Local(LG_VH)); f64_add; local_set(Local(LG_W));
+        local_get(Local(LG_VL)); local_get(Local(LG_Y)); local_get(Local(LG_W)); f64_sub; local_get(Local(LG_VH)); f64_add; f64_add; local_set(Local(LG_VL));
+        local_get(Local(LG_W)); local_set(Local(LG_VH));
+        local_get(Local(LG_VL)); local_get(Local(LG_VH)); f64_add;
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.libm.log10, type_idx, f));
@@ -1669,15 +1670,15 @@ const PW_T: u32 = 34;
 
 /// Push `with_set_low_word(<f64 on stack>, 0)` (zero the low 32-bit word).
 fn emit_zero_low_word(f: &mut Function) {
-    wasm!(f, { i64_reinterpret_f64; i64_const(LOW_WORD_MASK); i64_and; f64_reinterpret_i64; });
+    wasm!(f, { i64_reinterpret_f64; i64_const(Imm64(LOW_WORD_MASK)); i64_and; f64_reinterpret_i64; });
 }
 /// Push `get_high_word(<f64 on stack>)` as i32.
 fn emit_high_word(f: &mut Function) {
-    wasm!(f, { i64_reinterpret_f64; i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; });
+    wasm!(f, { i64_reinterpret_f64; i64_const(Imm64(HI_SHIFT)); i64_shr_u; i32_wrap_i64; });
 }
 /// Push `with_set_high_word(0.0, <i32 hi on stack>)`  = from_bits((hi as u64)<<32).
 fn emit_from_high_word(f: &mut Function) {
-    wasm!(f, { i64_extend_i32_u; i64_const(HI_SHIFT); i64_shl; f64_reinterpret_i64; });
+    wasm!(f, { i64_extend_i32_u; i64_const(Imm64(HI_SHIFT)); i64_shl; f64_reinterpret_i64; });
 }
 
 // ───────────────────────────── __libm_pow ──────────────────────────────
@@ -1694,56 +1695,56 @@ fn compile_pow(emitter: &mut WasmEmitter) {
 
     wasm!(f, {
         // hx = (to_bits(x) >> 32) as i32; lx = to_bits(x) as u32
-        local_get(PW_X); i64_reinterpret_f64; i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; local_set(PW_HX);
-        local_get(PW_X); i64_reinterpret_f64; i32_wrap_i64; local_set(PW_LX);
-        local_get(PW_Y); i64_reinterpret_f64; i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; local_set(PW_HY);
-        local_get(PW_Y); i64_reinterpret_f64; i32_wrap_i64; local_set(PW_LY);
+        local_get(Local(PW_X)); i64_reinterpret_f64; i64_const(Imm64(HI_SHIFT)); i64_shr_u; i32_wrap_i64; local_set(Local(PW_HX));
+        local_get(Local(PW_X)); i64_reinterpret_f64; i32_wrap_i64; local_set(Local(PW_LX));
+        local_get(Local(PW_Y)); i64_reinterpret_f64; i64_const(Imm64(HI_SHIFT)); i64_shr_u; i32_wrap_i64; local_set(Local(PW_HY));
+        local_get(Local(PW_Y)); i64_reinterpret_f64; i32_wrap_i64; local_set(Local(PW_LY));
         // ix = hx & 0x7fffffff; iy = hy & 0x7fffffff
-        local_get(PW_HX); i32_const(F64_ABS_MASK_HI); i32_and; local_set(PW_IX);
-        local_get(PW_HY); i32_const(F64_ABS_MASK_HI); i32_and; local_set(PW_IY);
+        local_get(Local(PW_HX)); i32_const(Imm32(F64_ABS_MASK_HI)); i32_and; local_set(Local(PW_IX));
+        local_get(Local(PW_HY)); i32_const(Imm32(F64_ABS_MASK_HI)); i32_and; local_set(Local(PW_IY));
 
         // x**0 = 1 (even if x is NaN): if (iy | ly) == 0 return 1
-        local_get(PW_IY); local_get(PW_LY); i32_or; i32_eqz;
+        local_get(Local(PW_IY)); local_get(Local(PW_LY)); i32_or; i32_eqz;
         if_empty; f64_const(1.0); return_; end;
         // 1**y = 1: if hx == 0x3ff00000 && lx == 0 return 1
-        local_get(PW_HX); i32_const(F64_ONE_HI); i32_eq; local_get(PW_LX); i32_eqz; i32_and;
+        local_get(Local(PW_HX)); i32_const(Imm32(F64_ONE_HI)); i32_eq; local_get(Local(PW_LX)); i32_eqz; i32_and;
         if_empty; f64_const(1.0); return_; end;
         // NaN if either arg is NaN:
         //   ix > 0x7ff00000 || (ix==0x7ff00000 && lx!=0) || iy > 0x7ff00000 || (iy==0x7ff00000 && ly!=0)
-        local_get(PW_IX); i32_const(F64_INF_NAN_HI); i32_gt_s;
-        local_get(PW_IX); i32_const(F64_INF_NAN_HI); i32_eq; local_get(PW_LX); i32_const(0); i32_ne; i32_and; i32_or;
-        local_get(PW_IY); i32_const(F64_INF_NAN_HI); i32_gt_s; i32_or;
-        local_get(PW_IY); i32_const(F64_INF_NAN_HI); i32_eq; local_get(PW_LY); i32_const(0); i32_ne; i32_and; i32_or;
-        if_empty; local_get(PW_X); local_get(PW_Y); f64_add; return_; end;
+        local_get(Local(PW_IX)); i32_const(Imm32(F64_INF_NAN_HI)); i32_gt_s;
+        local_get(Local(PW_IX)); i32_const(Imm32(F64_INF_NAN_HI)); i32_eq; local_get(Local(PW_LX)); i32_const(Imm32(0)); i32_ne; i32_and; i32_or;
+        local_get(Local(PW_IY)); i32_const(Imm32(F64_INF_NAN_HI)); i32_gt_s; i32_or;
+        local_get(Local(PW_IY)); i32_const(Imm32(F64_INF_NAN_HI)); i32_eq; local_get(Local(PW_LY)); i32_const(Imm32(0)); i32_ne; i32_and; i32_or;
+        if_empty; local_get(Local(PW_X)); local_get(Local(PW_Y)); f64_add; return_; end;
 
         // yisint: 0 not int, 1 odd int, 2 even int (only matters when x < 0)
-        i32_const(0); local_set(PW_YISINT);
-        local_get(PW_HX); i32_const(0); i32_lt_s;
+        i32_const(Imm32(0)); local_set(Local(PW_YISINT));
+        local_get(Local(PW_HX)); i32_const(Imm32(0)); i32_lt_s;
         if_empty;
-            local_get(PW_IY); i32_const(POW_YINT_LARGE_HI); i32_ge_s;
+            local_get(Local(PW_IY)); i32_const(Imm32(POW_YINT_LARGE_HI)); i32_ge_s;
             if_empty;
-                i32_const(YISINT_EVEN); local_set(PW_YISINT); // even integer y
+                i32_const(Imm32(YISINT_EVEN)); local_set(Local(PW_YISINT)); // even integer y
             else_;
-                local_get(PW_IY); i32_const(F64_ONE_HI); i32_ge_s;
+                local_get(Local(PW_IY)); i32_const(Imm32(F64_ONE_HI)); i32_ge_s;
                 if_empty;
                     // k = (iy >> 20) - 0x3ff
-                    local_get(PW_IY); i32_const(F64_EXP_SHIFT); i32_shr_s; i32_const(F64_EXP_BIAS); i32_sub; local_set(PW_K);
-                    local_get(PW_K); i32_const(F64_EXP_SHIFT); i32_gt_s;
+                    local_get(Local(PW_IY)); i32_const(Imm32(F64_EXP_SHIFT)); i32_shr_s; i32_const(Imm32(F64_EXP_BIAS)); i32_sub; local_set(Local(PW_K));
+                    local_get(Local(PW_K)); i32_const(Imm32(F64_EXP_SHIFT)); i32_gt_s;
                     if_empty;
                         // j = (ly >> (52 - k)) ; if (j << (52-k)) == ly { yisint = 2 - (j&1) }
-                        local_get(PW_LY); i32_const(F64_MANTISSA_BITS_I32); local_get(PW_K); i32_sub; i32_shr_u; local_set(PW_J);
-                        local_get(PW_J); i32_const(F64_MANTISSA_BITS_I32); local_get(PW_K); i32_sub; i32_shl; local_get(PW_LY); i32_eq;
+                        local_get(Local(PW_LY)); i32_const(Imm32(F64_MANTISSA_BITS_I32)); local_get(Local(PW_K)); i32_sub; i32_shr_u; local_set(Local(PW_J));
+                        local_get(Local(PW_J)); i32_const(Imm32(F64_MANTISSA_BITS_I32)); local_get(Local(PW_K)); i32_sub; i32_shl; local_get(Local(PW_LY)); i32_eq;
                         if_empty;
-                            i32_const(YISINT_EVEN); local_get(PW_J); i32_const(1); i32_and; i32_sub; local_set(PW_YISINT);
+                            i32_const(Imm32(YISINT_EVEN)); local_get(Local(PW_J)); i32_const(Imm32(1)); i32_and; i32_sub; local_set(Local(PW_YISINT));
                         end;
                     else_;
-                        local_get(PW_LY); i32_eqz;
+                        local_get(Local(PW_LY)); i32_eqz;
                         if_empty;
                             // j = iy >> (20 - k); if (j << (20-k)) == iy { yisint = 2 - (j&1) }
-                            local_get(PW_IY); i32_const(F64_EXP_SHIFT); local_get(PW_K); i32_sub; i32_shr_s; local_set(PW_J);
-                            local_get(PW_J); i32_const(F64_EXP_SHIFT); local_get(PW_K); i32_sub; i32_shl; local_get(PW_IY); i32_eq;
+                            local_get(Local(PW_IY)); i32_const(Imm32(F64_EXP_SHIFT)); local_get(Local(PW_K)); i32_sub; i32_shr_s; local_set(Local(PW_J));
+                            local_get(Local(PW_J)); i32_const(Imm32(F64_EXP_SHIFT)); local_get(Local(PW_K)); i32_sub; i32_shl; local_get(Local(PW_IY)); i32_eq;
                             if_empty;
-                                i32_const(YISINT_EVEN); local_get(PW_J); i32_const(1); i32_and; i32_sub; local_set(PW_YISINT);
+                                i32_const(Imm32(YISINT_EVEN)); local_get(Local(PW_J)); i32_const(Imm32(1)); i32_and; i32_sub; local_set(Local(PW_YISINT));
                             end;
                         end;
                     end;
@@ -1752,385 +1753,385 @@ fn compile_pow(emitter: &mut WasmEmitter) {
         end;
 
         // special value of y: if ly == 0
-        local_get(PW_LY); i32_eqz;
+        local_get(Local(PW_LY)); i32_eqz;
         if_empty;
             // y is +-inf
-            local_get(PW_IY); i32_const(F64_INF_NAN_HI); i32_eq;
+            local_get(Local(PW_IY)); i32_const(Imm32(F64_INF_NAN_HI)); i32_eq;
             if_empty;
                 // if ((ix - 0x3ff00000) | lx) == 0  -> (-1)**+-inf = 1
-                local_get(PW_IX); i32_const(F64_ONE_HI); i32_sub; local_get(PW_LX); i32_or; i32_eqz;
+                local_get(Local(PW_IX)); i32_const(Imm32(F64_ONE_HI)); i32_sub; local_get(Local(PW_LX)); i32_or; i32_eqz;
                 if_f64;
                     f64_const(1.0);
                 else_;
                     // elif ix >= 0x3ff00000  -> (|x|>1)**+-inf = inf,0
-                    local_get(PW_IX); i32_const(F64_ONE_HI); i32_ge_s;
+                    local_get(Local(PW_IX)); i32_const(Imm32(F64_ONE_HI)); i32_ge_s;
                     if_f64;
-                        local_get(PW_HY); i32_const(0); i32_ge_s; if_f64; local_get(PW_Y); else_; f64_const(0.0); end;
+                        local_get(Local(PW_HY)); i32_const(Imm32(0)); i32_ge_s; if_f64; local_get(Local(PW_Y)); else_; f64_const(0.0); end;
                     else_;
                         // (|x|<1)**+-inf = 0,inf
-                        local_get(PW_HY); i32_const(0); i32_ge_s; if_f64; f64_const(0.0); else_; local_get(PW_Y); f64_neg; end;
+                        local_get(Local(PW_HY)); i32_const(Imm32(0)); i32_ge_s; if_f64; f64_const(0.0); else_; local_get(Local(PW_Y)); f64_neg; end;
                     end;
                 end;
                 return_;
             end;
             // y is +-1
-            local_get(PW_IY); i32_const(F64_ONE_HI); i32_eq;
+            local_get(Local(PW_IY)); i32_const(Imm32(F64_ONE_HI)); i32_eq;
             if_empty;
-                local_get(PW_HY); i32_const(0); i32_ge_s;
-                if_f64; local_get(PW_X); else_; f64_const(1.0); local_get(PW_X); f64_div; end;
+                local_get(Local(PW_HY)); i32_const(Imm32(0)); i32_ge_s;
+                if_f64; local_get(Local(PW_X)); else_; f64_const(1.0); local_get(Local(PW_X)); f64_div; end;
                 return_;
             end;
             // y is 2
-            local_get(PW_HY); i32_const(POW_TWO_HI); i32_eq;
-            if_empty; local_get(PW_X); local_get(PW_X); f64_mul; return_; end;
+            local_get(Local(PW_HY)); i32_const(Imm32(POW_TWO_HI)); i32_eq;
+            if_empty; local_get(Local(PW_X)); local_get(Local(PW_X)); f64_mul; return_; end;
             // y is 0.5 and x >= +0
-            local_get(PW_HY); i32_const(F64_HALF_HI); i32_eq;
+            local_get(Local(PW_HY)); i32_const(Imm32(F64_HALF_HI)); i32_eq;
             if_empty;
-                local_get(PW_HX); i32_const(0); i32_ge_s;
-                if_empty; local_get(PW_X); f64_sqrt; return_; end;
+                local_get(Local(PW_HX)); i32_const(Imm32(0)); i32_ge_s;
+                if_empty; local_get(Local(PW_X)); f64_sqrt; return_; end;
             end;
         end;
 
         // ax = |x|
-        local_get(PW_X); f64_abs; local_set(PW_AX);
+        local_get(Local(PW_X)); f64_abs; local_set(Local(PW_AX));
         // special value of x: if lx == 0
-        local_get(PW_LX); i32_eqz;
+        local_get(Local(PW_LX)); i32_eqz;
         if_empty;
             // x is +-0,+-inf,+-1
-            local_get(PW_IX); i32_const(F64_INF_NAN_HI); i32_eq;
-            local_get(PW_IX); i32_eqz; i32_or;
-            local_get(PW_IX); i32_const(F64_ONE_HI); i32_eq; i32_or;
+            local_get(Local(PW_IX)); i32_const(Imm32(F64_INF_NAN_HI)); i32_eq;
+            local_get(Local(PW_IX)); i32_eqz; i32_or;
+            local_get(Local(PW_IX)); i32_const(Imm32(F64_ONE_HI)); i32_eq; i32_or;
             if_empty;
                 // z = ax
-                local_get(PW_AX); local_set(PW_Z);
+                local_get(Local(PW_AX)); local_set(Local(PW_Z));
                 // if hy < 0 { z = 1/z }
-                local_get(PW_HY); i32_const(0); i32_lt_s;
-                if_empty; f64_const(1.0); local_get(PW_Z); f64_div; local_set(PW_Z); end;
+                local_get(Local(PW_HY)); i32_const(Imm32(0)); i32_lt_s;
+                if_empty; f64_const(1.0); local_get(Local(PW_Z)); f64_div; local_set(Local(PW_Z)); end;
                 // if hx < 0
-                local_get(PW_HX); i32_const(0); i32_lt_s;
+                local_get(Local(PW_HX)); i32_const(Imm32(0)); i32_lt_s;
                 if_empty;
                     // if ((ix-0x3ff00000)|yisint)==0 { z = (z-z)/(z-z) }  (-1)**non-int = NaN
-                    local_get(PW_IX); i32_const(F64_ONE_HI); i32_sub; local_get(PW_YISINT); i32_or; i32_eqz;
+                    local_get(Local(PW_IX)); i32_const(Imm32(F64_ONE_HI)); i32_sub; local_get(Local(PW_YISINT)); i32_or; i32_eqz;
                     if_empty;
-                        local_get(PW_Z); local_get(PW_Z); f64_sub; local_get(PW_Z); local_get(PW_Z); f64_sub; f64_div; local_set(PW_Z);
+                        local_get(Local(PW_Z)); local_get(Local(PW_Z)); f64_sub; local_get(Local(PW_Z)); local_get(Local(PW_Z)); f64_sub; f64_div; local_set(Local(PW_Z));
                     else_;
                         // elif yisint == 1 { z = -z }
-                        local_get(PW_YISINT); i32_const(1); i32_eq;
-                        if_empty; local_get(PW_Z); f64_neg; local_set(PW_Z); end;
+                        local_get(Local(PW_YISINT)); i32_const(Imm32(1)); i32_eq;
+                        if_empty; local_get(Local(PW_Z)); f64_neg; local_set(Local(PW_Z)); end;
                     end;
                 end;
-                local_get(PW_Z); return_;
+                local_get(Local(PW_Z)); return_;
             end;
         end;
 
         // s = sign of result
-        f64_const(1.0); local_set(PW_S);
-        local_get(PW_HX); i32_const(0); i32_lt_s;
+        f64_const(1.0); local_set(Local(PW_S));
+        local_get(Local(PW_HX)); i32_const(Imm32(0)); i32_lt_s;
         if_empty;
-            local_get(PW_YISINT); i32_eqz;
+            local_get(Local(PW_YISINT)); i32_eqz;
             if_empty;
                 // (x<0)**(non-int) = NaN
-                local_get(PW_X); local_get(PW_X); f64_sub; local_get(PW_X); local_get(PW_X); f64_sub; f64_div; return_;
+                local_get(Local(PW_X)); local_get(Local(PW_X)); f64_sub; local_get(Local(PW_X)); local_get(Local(PW_X)); f64_sub; f64_div; return_;
             end;
-            local_get(PW_YISINT); i32_const(1); i32_eq;
-            if_empty; f64_const(-1.0); local_set(PW_S); end;
+            local_get(Local(PW_YISINT)); i32_const(Imm32(1)); i32_eq;
+            if_empty; f64_const(-1.0); local_set(Local(PW_S)); end;
         end;
 
         // |y| is HUGE: if iy > 0x41e00000
-        local_get(PW_IY); i32_const(POW_HUGE_EXP_HI); i32_gt_s;
+        local_get(Local(PW_IY)); i32_const(Imm32(POW_HUGE_EXP_HI)); i32_gt_s;
         if_empty;
             // if iy > 0x43f00000  (|y| > 2^64, must o/uflow)
-            local_get(PW_IY); i32_const(POW_HUGE64_EXP_HI); i32_gt_s;
+            local_get(Local(PW_IY)); i32_const(Imm32(POW_HUGE64_EXP_HI)); i32_gt_s;
             if_empty;
                 // if ix <= 0x3fefffff { return hy<0 ? HUGE*HUGE : TINY*TINY }
-                local_get(PW_IX); i32_const(POW_BELOW_ONE_HI); i32_le_s;
+                local_get(Local(PW_IX)); i32_const(Imm32(POW_BELOW_ONE_HI)); i32_le_s;
                 if_empty;
-                    local_get(PW_HY); i32_const(0); i32_lt_s;
+                    local_get(Local(PW_HY)); i32_const(Imm32(0)); i32_lt_s;
                     if_f64; f64_const(POW_HUGE); f64_const(POW_HUGE); f64_mul; else_; f64_const(POW_TINY); f64_const(POW_TINY); f64_mul; end;
                     return_;
                 end;
                 // if ix >= 0x3ff00000 { return hy>0 ? HUGE*HUGE : TINY*TINY }
-                local_get(PW_IX); i32_const(F64_ONE_HI); i32_ge_s;
+                local_get(Local(PW_IX)); i32_const(Imm32(F64_ONE_HI)); i32_ge_s;
                 if_empty;
-                    local_get(PW_HY); i32_const(0); i32_gt_s;
+                    local_get(Local(PW_HY)); i32_const(Imm32(0)); i32_gt_s;
                     if_f64; f64_const(POW_HUGE); f64_const(POW_HUGE); f64_mul; else_; f64_const(POW_TINY); f64_const(POW_TINY); f64_mul; end;
                     return_;
                 end;
             end;
             // over/underflow if x not close to one
-            local_get(PW_IX); i32_const(POW_BELOW_ONE_HI); i32_lt_s;
+            local_get(Local(PW_IX)); i32_const(Imm32(POW_BELOW_ONE_HI)); i32_lt_s;
             if_empty;
-                local_get(PW_HY); i32_const(0); i32_lt_s;
-                if_f64; local_get(PW_S); f64_const(POW_HUGE); f64_mul; f64_const(POW_HUGE); f64_mul; else_; local_get(PW_S); f64_const(POW_TINY); f64_mul; f64_const(POW_TINY); f64_mul; end;
+                local_get(Local(PW_HY)); i32_const(Imm32(0)); i32_lt_s;
+                if_f64; local_get(Local(PW_S)); f64_const(POW_HUGE); f64_mul; f64_const(POW_HUGE); f64_mul; else_; local_get(Local(PW_S)); f64_const(POW_TINY); f64_mul; f64_const(POW_TINY); f64_mul; end;
                 return_;
             end;
-            local_get(PW_IX); i32_const(F64_ONE_HI); i32_gt_s;
+            local_get(Local(PW_IX)); i32_const(Imm32(F64_ONE_HI)); i32_gt_s;
             if_empty;
-                local_get(PW_HY); i32_const(0); i32_gt_s;
-                if_f64; local_get(PW_S); f64_const(POW_HUGE); f64_mul; f64_const(POW_HUGE); f64_mul; else_; local_get(PW_S); f64_const(POW_TINY); f64_mul; f64_const(POW_TINY); f64_mul; end;
+                local_get(Local(PW_HY)); i32_const(Imm32(0)); i32_gt_s;
+                if_f64; local_get(Local(PW_S)); f64_const(POW_HUGE); f64_mul; f64_const(POW_HUGE); f64_mul; else_; local_get(Local(PW_S)); f64_const(POW_TINY); f64_mul; f64_const(POW_TINY); f64_mul; end;
                 return_;
             end;
             // |1-x| is TINY <= 2^-20: log(x) by x-x^2/2+x^3/3-x^4/4
             // t = ax - 1
-            local_get(PW_AX); f64_const(1.0); f64_sub; local_set(PW_T);
+            local_get(Local(PW_AX)); f64_const(1.0); f64_sub; local_set(Local(PW_T));
             // w = (t*t)*(0.5 - t*(1/3 - t*0.25))
-            local_get(PW_T); local_get(PW_T); f64_mul;
-            f64_const(0.5); local_get(PW_T); f64_const(POW_ONE_THIRD); local_get(PW_T); f64_const(0.25); f64_mul; f64_sub; f64_mul; f64_sub;
-            f64_mul; local_set(PW_W);
+            local_get(Local(PW_T)); local_get(Local(PW_T)); f64_mul;
+            f64_const(0.5); local_get(Local(PW_T)); f64_const(POW_ONE_THIRD); local_get(Local(PW_T)); f64_const(0.25); f64_mul; f64_sub; f64_mul; f64_sub;
+            f64_mul; local_set(Local(PW_W));
             // u = IVLN2_H * t
-            local_get(PW_T); f64_const(POW_IVLN2_H); f64_mul; local_set(PW_U);
+            local_get(Local(PW_T)); f64_const(POW_IVLN2_H); f64_mul; local_set(Local(PW_U));
             // v = t*IVLN2_L - w*IVLN2
-            local_get(PW_T); f64_const(POW_IVLN2_L); f64_mul; local_get(PW_W); f64_const(POW_IVLN2); f64_mul; f64_sub; local_set(PW_V);
+            local_get(Local(PW_T)); f64_const(POW_IVLN2_L); f64_mul; local_get(Local(PW_W)); f64_const(POW_IVLN2); f64_mul; f64_sub; local_set(Local(PW_V));
             // t1 = with_set_low_word(u+v, 0); t2 = v - (t1 - u)
-            local_get(PW_U); local_get(PW_V); f64_add;
+            local_get(Local(PW_U)); local_get(Local(PW_V)); f64_add;
         });
         emit_zero_low_word(&mut f);
         wasm!(f, {
-            local_set(PW_T1);
-            local_get(PW_V); local_get(PW_T1); local_get(PW_U); f64_sub; f64_sub; local_set(PW_T2);
+            local_set(Local(PW_T1));
+            local_get(Local(PW_V)); local_get(Local(PW_T1)); local_get(Local(PW_U)); f64_sub; f64_sub; local_set(Local(PW_T2));
         });
 
     // ── else: main log path (|y| not HUGE) ──
     wasm!(f, {
         else_;
             // n = 0
-            i32_const(0); local_set(PW_N);
+            i32_const(Imm32(0)); local_set(Local(PW_N));
             // if ix < 0x00100000 { ax *= 2^53; n -= 53; ix = get_high_word(ax) }
-            local_get(PW_IX); i32_const(F64_EXP_ONE_HI); i32_lt_s;
+            local_get(Local(PW_IX)); i32_const(Imm32(F64_EXP_ONE_HI)); i32_lt_s;
             if_empty;
-                local_get(PW_AX); f64_const(POW_TWO53); f64_mul; local_set(PW_AX);
-                local_get(PW_N); i32_const(POW_SUBNORM_SCALE); i32_sub; local_set(PW_N);
-                local_get(PW_AX);
+                local_get(Local(PW_AX)); f64_const(POW_TWO53); f64_mul; local_set(Local(PW_AX));
+                local_get(Local(PW_N)); i32_const(Imm32(POW_SUBNORM_SCALE)); i32_sub; local_set(Local(PW_N));
+                local_get(Local(PW_AX));
     });
     emit_high_word(&mut f);
     wasm!(f, {
-                local_set(PW_IX);
+                local_set(Local(PW_IX));
             end;
             // n += (ix >> 20) - 0x3ff; j = ix & 0x000fffff
-            local_get(PW_N); local_get(PW_IX); i32_const(F64_EXP_SHIFT); i32_shr_s; i32_const(F64_EXP_BIAS); i32_sub; i32_add; local_set(PW_N);
-            local_get(PW_IX); i32_const(F64_MANTISSA_HI_MASK); i32_and; local_set(PW_J);
+            local_get(Local(PW_N)); local_get(Local(PW_IX)); i32_const(Imm32(F64_EXP_SHIFT)); i32_shr_s; i32_const(Imm32(F64_EXP_BIAS)); i32_sub; i32_add; local_set(Local(PW_N));
+            local_get(Local(PW_IX)); i32_const(Imm32(F64_MANTISSA_HI_MASK)); i32_and; local_set(Local(PW_J));
             // ix = j | 0x3ff00000
-            local_get(PW_J); i32_const(F64_ONE_HI); i32_or; local_set(PW_IX);
+            local_get(Local(PW_J)); i32_const(Imm32(F64_ONE_HI)); i32_or; local_set(Local(PW_IX));
             // determine interval kk:  j<=0x3988E -> 0; j<0xBB67A -> 1; else { 0; n++; ix-=0x00100000 }
-            local_get(PW_J); i32_const(POW_KK0_THRESH); i32_le_s;
+            local_get(Local(PW_J)); i32_const(Imm32(POW_KK0_THRESH)); i32_le_s;
             if_empty;
-                i32_const(0); local_set(PW_KK);
+                i32_const(Imm32(0)); local_set(Local(PW_KK));
             else_;
-                local_get(PW_J); i32_const(POW_KK1_THRESH); i32_lt_s;
+                local_get(Local(PW_J)); i32_const(Imm32(POW_KK1_THRESH)); i32_lt_s;
                 if_empty;
-                    i32_const(1); local_set(PW_KK);
+                    i32_const(Imm32(1)); local_set(Local(PW_KK));
                 else_;
-                    i32_const(0); local_set(PW_KK);
-                    local_get(PW_N); i32_const(1); i32_add; local_set(PW_N);
-                    local_get(PW_IX); i32_const(F64_EXP_ONE_HI); i32_sub; local_set(PW_IX);
+                    i32_const(Imm32(0)); local_set(Local(PW_KK));
+                    local_get(Local(PW_N)); i32_const(Imm32(1)); i32_add; local_set(Local(PW_N));
+                    local_get(Local(PW_IX)); i32_const(Imm32(F64_EXP_ONE_HI)); i32_sub; local_set(Local(PW_IX));
                 end;
             end;
             // ax = with_set_high_word(ax, ix)
-            local_get(PW_AX); i64_reinterpret_f64; i64_const(LOW_WORD_BITS); i64_and;
-            local_get(PW_IX); i64_extend_i32_u; i64_const(HI_SHIFT); i64_shl;
-            i64_or; f64_reinterpret_i64; local_set(PW_AX);
+            local_get(Local(PW_AX)); i64_reinterpret_f64; i64_const(Imm64(LOW_WORD_BITS)); i64_and;
+            local_get(Local(PW_IX)); i64_extend_i32_u; i64_const(Imm64(HI_SHIFT)); i64_shl;
+            i64_or; f64_reinterpret_i64; local_set(Local(PW_AX));
 
             // bp[kk]: kk==0 -> 1.0 ; kk==1 -> 1.5
             // u = ax - bp[kk]; v = 1/(ax + bp[kk]); ss = u*v; s_h = with_set_low_word(ss,0)
-            local_get(PW_AX); local_get(PW_KK); if_f64; f64_const(1.5); else_; f64_const(1.0); end; f64_sub; local_set(PW_U);
-            f64_const(1.0); local_get(PW_AX); local_get(PW_KK); if_f64; f64_const(1.5); else_; f64_const(1.0); end; f64_add; f64_div; local_set(PW_V);
-            local_get(PW_U); local_get(PW_V); f64_mul; local_set(PW_SS);
-            local_get(PW_SS);
+            local_get(Local(PW_AX)); local_get(Local(PW_KK)); if_f64; f64_const(1.5); else_; f64_const(1.0); end; f64_sub; local_set(Local(PW_U));
+            f64_const(1.0); local_get(Local(PW_AX)); local_get(Local(PW_KK)); if_f64; f64_const(1.5); else_; f64_const(1.0); end; f64_add; f64_div; local_set(Local(PW_V));
+            local_get(Local(PW_U)); local_get(Local(PW_V)); f64_mul; local_set(Local(PW_SS));
+            local_get(Local(PW_SS));
     });
     emit_zero_low_word(&mut f);
     wasm!(f, {
-            local_set(PW_S_H);
+            local_set(Local(PW_S_H));
             // t_h = with_set_high_word(0.0, ((ix>>1)|0x20000000) + 0x00080000 + (kk<<18))
-            local_get(PW_IX); i32_const(1); i32_shr_u; i32_const(POW_T_H_BASE); i32_or;
-            i32_const(POW_T_H_HALF); i32_add;
-            local_get(PW_KK); i32_const(POW_KK_BIT_SHIFT); i32_shl; i32_add;
+            local_get(Local(PW_IX)); i32_const(Imm32(1)); i32_shr_u; i32_const(Imm32(POW_T_H_BASE)); i32_or;
+            i32_const(Imm32(POW_T_H_HALF)); i32_add;
+            local_get(Local(PW_KK)); i32_const(Imm32(POW_KK_BIT_SHIFT)); i32_shl; i32_add;
     });
     emit_from_high_word(&mut f);
     wasm!(f, {
-            local_set(PW_T_H);
+            local_set(Local(PW_T_H));
             // t_l = ax - (t_h - bp[kk])
-            local_get(PW_AX); local_get(PW_T_H); local_get(PW_KK); if_f64; f64_const(1.5); else_; f64_const(1.0); end; f64_sub; f64_sub; local_set(PW_T_L);
+            local_get(Local(PW_AX)); local_get(Local(PW_T_H)); local_get(Local(PW_KK)); if_f64; f64_const(1.5); else_; f64_const(1.0); end; f64_sub; f64_sub; local_set(Local(PW_T_L));
             // s_l = v*((u - s_h*t_h) - s_h*t_l)
-            local_get(PW_V);
-            local_get(PW_U); local_get(PW_S_H); local_get(PW_T_H); f64_mul; f64_sub;
-            local_get(PW_S_H); local_get(PW_T_L); f64_mul; f64_sub;
-            f64_mul; local_set(PW_S_L);
+            local_get(Local(PW_V));
+            local_get(Local(PW_U)); local_get(Local(PW_S_H)); local_get(Local(PW_T_H)); f64_mul; f64_sub;
+            local_get(Local(PW_S_H)); local_get(Local(PW_T_L)); f64_mul; f64_sub;
+            f64_mul; local_set(Local(PW_S_L));
 
             // s2 = ss*ss; r = s2*s2*(L1+s2*(L2+s2*(L3+s2*(L4+s2*(L5+s2*L6)))))
-            local_get(PW_SS); local_get(PW_SS); f64_mul; local_set(PW_S2);
-            local_get(PW_S2); local_get(PW_S2); f64_mul;
+            local_get(Local(PW_SS)); local_get(Local(PW_SS)); f64_mul; local_set(Local(PW_S2));
+            local_get(Local(PW_S2)); local_get(Local(PW_S2)); f64_mul;
             f64_const(POW_L1);
-            local_get(PW_S2); f64_const(POW_L2);
-            local_get(PW_S2); f64_const(POW_L3);
-            local_get(PW_S2); f64_const(POW_L4);
-            local_get(PW_S2); f64_const(POW_L5);
-            local_get(PW_S2); f64_const(POW_L6); f64_mul; f64_add;
+            local_get(Local(PW_S2)); f64_const(POW_L2);
+            local_get(Local(PW_S2)); f64_const(POW_L3);
+            local_get(Local(PW_S2)); f64_const(POW_L4);
+            local_get(Local(PW_S2)); f64_const(POW_L5);
+            local_get(Local(PW_S2)); f64_const(POW_L6); f64_mul; f64_add;
             f64_mul; f64_add;
             f64_mul; f64_add;
             f64_mul; f64_add;
             f64_mul; f64_add;
-            f64_mul; local_set(PW_R);
+            f64_mul; local_set(Local(PW_R));
             // r += s_l*(s_h + ss)
-            local_get(PW_R); local_get(PW_S_L); local_get(PW_S_H); local_get(PW_SS); f64_add; f64_mul; f64_add; local_set(PW_R);
+            local_get(Local(PW_R)); local_get(Local(PW_S_L)); local_get(Local(PW_S_H)); local_get(Local(PW_SS)); f64_add; f64_mul; f64_add; local_set(Local(PW_R));
             // s2 = s_h*s_h
-            local_get(PW_S_H); local_get(PW_S_H); f64_mul; local_set(PW_S2);
+            local_get(Local(PW_S_H)); local_get(Local(PW_S_H)); f64_mul; local_set(Local(PW_S2));
             // t_h = with_set_low_word(3 + s2 + r, 0)
-            f64_const(3.0); local_get(PW_S2); f64_add; local_get(PW_R); f64_add;
+            f64_const(3.0); local_get(Local(PW_S2)); f64_add; local_get(Local(PW_R)); f64_add;
     });
     emit_zero_low_word(&mut f);
     wasm!(f, {
-            local_set(PW_T_H);
+            local_set(Local(PW_T_H));
             // t_l = r - ((t_h - 3) - s2)
-            local_get(PW_R); local_get(PW_T_H); f64_const(3.0); f64_sub; local_get(PW_S2); f64_sub; f64_sub; local_set(PW_T_L);
+            local_get(Local(PW_R)); local_get(Local(PW_T_H)); f64_const(3.0); f64_sub; local_get(Local(PW_S2)); f64_sub; f64_sub; local_set(Local(PW_T_L));
             // u = s_h*t_h; v = s_l*t_h + t_l*ss
-            local_get(PW_S_H); local_get(PW_T_H); f64_mul; local_set(PW_U);
-            local_get(PW_S_L); local_get(PW_T_H); f64_mul; local_get(PW_T_L); local_get(PW_SS); f64_mul; f64_add; local_set(PW_V);
+            local_get(Local(PW_S_H)); local_get(Local(PW_T_H)); f64_mul; local_set(Local(PW_U));
+            local_get(Local(PW_S_L)); local_get(Local(PW_T_H)); f64_mul; local_get(Local(PW_T_L)); local_get(Local(PW_SS)); f64_mul; f64_add; local_set(Local(PW_V));
             // p_h = with_set_low_word(u+v, 0); p_l = v - (p_h - u)
-            local_get(PW_U); local_get(PW_V); f64_add;
+            local_get(Local(PW_U)); local_get(Local(PW_V)); f64_add;
     });
     emit_zero_low_word(&mut f);
     wasm!(f, {
-            local_set(PW_P_H);
-            local_get(PW_V); local_get(PW_P_H); local_get(PW_U); f64_sub; f64_sub; local_set(PW_P_L);
+            local_set(Local(PW_P_H));
+            local_get(Local(PW_V)); local_get(Local(PW_P_H)); local_get(Local(PW_U)); f64_sub; f64_sub; local_set(Local(PW_P_L));
             // z_h = CP_H*p_h; z_l = CP_L*p_h + p_l*CP + dp_l[kk]
-            f64_const(POW_CP_H); local_get(PW_P_H); f64_mul; local_set(PW_Z_H);
-            f64_const(POW_CP_L); local_get(PW_P_H); f64_mul;
-            local_get(PW_P_L); f64_const(POW_CP); f64_mul; f64_add;
-            local_get(PW_KK); if_f64; f64_const(POW_DP_L1); else_; f64_const(0.0); end; f64_add;
-            local_set(PW_Z_L);
+            f64_const(POW_CP_H); local_get(Local(PW_P_H)); f64_mul; local_set(Local(PW_Z_H));
+            f64_const(POW_CP_L); local_get(Local(PW_P_H)); f64_mul;
+            local_get(Local(PW_P_L)); f64_const(POW_CP); f64_mul; f64_add;
+            local_get(Local(PW_KK)); if_f64; f64_const(POW_DP_L1); else_; f64_const(0.0); end; f64_add;
+            local_set(Local(PW_Z_L));
             // t = n; t1 = with_set_low_word((z_h+z_l)+dp_h[kk]+t, 0)
-            local_get(PW_N); f64_convert_i32_s; local_set(PW_T);
-            local_get(PW_Z_H); local_get(PW_Z_L); f64_add;
-            local_get(PW_KK); if_f64; f64_const(POW_DP_H1); else_; f64_const(0.0); end; f64_add;
-            local_get(PW_T); f64_add;
+            local_get(Local(PW_N)); f64_convert_i32_s; local_set(Local(PW_T));
+            local_get(Local(PW_Z_H)); local_get(Local(PW_Z_L)); f64_add;
+            local_get(Local(PW_KK)); if_f64; f64_const(POW_DP_H1); else_; f64_const(0.0); end; f64_add;
+            local_get(Local(PW_T)); f64_add;
     });
     emit_zero_low_word(&mut f);
     wasm!(f, {
-            local_set(PW_T1);
+            local_set(Local(PW_T1));
             // t2 = z_l - (((t1 - t) - dp_h[kk]) - z_h)
-            local_get(PW_Z_L);
-            local_get(PW_T1); local_get(PW_T); f64_sub;
-            local_get(PW_KK); if_f64; f64_const(POW_DP_H1); else_; f64_const(0.0); end; f64_sub;
-            local_get(PW_Z_H); f64_sub;
-            f64_sub; local_set(PW_T2);
+            local_get(Local(PW_Z_L));
+            local_get(Local(PW_T1)); local_get(Local(PW_T)); f64_sub;
+            local_get(Local(PW_KK)); if_f64; f64_const(POW_DP_H1); else_; f64_const(0.0); end; f64_sub;
+            local_get(Local(PW_Z_H)); f64_sub;
+            f64_sub; local_set(Local(PW_T2));
         end; // end of HUGE if/else
     });
 
     // ── combine: (y1+y2)*(t1+t2), overflow/underflow, 2**(p_h+p_l) ──
     wasm!(f, {
         // y1 = with_set_low_word(y, 0)
-        local_get(PW_Y);
+        local_get(Local(PW_Y));
     });
     emit_zero_low_word(&mut f);
     wasm!(f, {
-        local_set(PW_Y1);
+        local_set(Local(PW_Y1));
         // p_l = (y - y1)*t1 + y*t2 ; p_h = y1*t1 ; z = p_l + p_h
-        local_get(PW_Y); local_get(PW_Y1); f64_sub; local_get(PW_T1); f64_mul;
-        local_get(PW_Y); local_get(PW_T2); f64_mul; f64_add; local_set(PW_P_L);
-        local_get(PW_Y1); local_get(PW_T1); f64_mul; local_set(PW_P_H);
-        local_get(PW_P_L); local_get(PW_P_H); f64_add; local_set(PW_Z);
+        local_get(Local(PW_Y)); local_get(Local(PW_Y1)); f64_sub; local_get(Local(PW_T1)); f64_mul;
+        local_get(Local(PW_Y)); local_get(Local(PW_T2)); f64_mul; f64_add; local_set(Local(PW_P_L));
+        local_get(Local(PW_Y1)); local_get(Local(PW_T1)); f64_mul; local_set(Local(PW_P_H));
+        local_get(Local(PW_P_L)); local_get(Local(PW_P_H)); f64_add; local_set(Local(PW_Z));
         // j = (z.bits >> 32) as i32 ; i = z.bits as i32
-        local_get(PW_Z); i64_reinterpret_f64; i64_const(HI_SHIFT); i64_shr_u; i32_wrap_i64; local_set(PW_J);
-        local_get(PW_Z); i64_reinterpret_f64; i32_wrap_i64; local_set(PW_I);
+        local_get(Local(PW_Z)); i64_reinterpret_f64; i64_const(Imm64(HI_SHIFT)); i64_shr_u; i32_wrap_i64; local_set(Local(PW_J));
+        local_get(Local(PW_Z)); i64_reinterpret_f64; i32_wrap_i64; local_set(Local(PW_I));
 
         // if j >= 0x40900000  (z >= 1024)
-        local_get(PW_J); i32_const(POW_Z_OVERFLOW_HI); i32_ge_s;
+        local_get(Local(PW_J)); i32_const(Imm32(POW_Z_OVERFLOW_HI)); i32_ge_s;
         if_empty;
             // if (j - 0x40900000) | i != 0  (z > 1024) -> overflow
-            local_get(PW_J); i32_const(POW_Z_OVERFLOW_HI); i32_sub; local_get(PW_I); i32_or; i32_const(0); i32_ne;
-            if_empty; local_get(PW_S); f64_const(POW_HUGE); f64_mul; f64_const(POW_HUGE); f64_mul; return_; end;
+            local_get(Local(PW_J)); i32_const(Imm32(POW_Z_OVERFLOW_HI)); i32_sub; local_get(Local(PW_I)); i32_or; i32_const(Imm32(0)); i32_ne;
+            if_empty; local_get(Local(PW_S)); f64_const(POW_HUGE); f64_mul; f64_const(POW_HUGE); f64_mul; return_; end;
             // if p_l + OVT > z - p_h -> overflow
-            local_get(PW_P_L); f64_const(POW_OVT); f64_add; local_get(PW_Z); local_get(PW_P_H); f64_sub; f64_gt;
-            if_empty; local_get(PW_S); f64_const(POW_HUGE); f64_mul; f64_const(POW_HUGE); f64_mul; return_; end;
+            local_get(Local(PW_P_L)); f64_const(POW_OVT); f64_add; local_get(Local(PW_Z)); local_get(Local(PW_P_H)); f64_sub; f64_gt;
+            if_empty; local_get(Local(PW_S)); f64_const(POW_HUGE); f64_mul; f64_const(POW_HUGE); f64_mul; return_; end;
         else_;
             // else if (j & 0x7fffffff) >= 0x4090cc00  (z <= -1075)
-            local_get(PW_J); i32_const(F64_ABS_MASK_HI); i32_and; i32_const(POW_Z_UNDERFLOW_HI); i32_ge_s;
+            local_get(Local(PW_J)); i32_const(Imm32(F64_ABS_MASK_HI)); i32_and; i32_const(Imm32(POW_Z_UNDERFLOW_HI)); i32_ge_s;
             if_empty;
                 // if (((j as u32) - 0xc090cc00) | (i as u32)) != 0  (z < -1075) -> underflow
-                local_get(PW_J); i32_const(POW_Z_UNDERFLOW_NEG); i32_sub; local_get(PW_I); i32_or; i32_const(0); i32_ne;
-                if_empty; local_get(PW_S); f64_const(POW_TINY); f64_mul; f64_const(POW_TINY); f64_mul; return_; end;
+                local_get(Local(PW_J)); i32_const(Imm32(POW_Z_UNDERFLOW_NEG)); i32_sub; local_get(Local(PW_I)); i32_or; i32_const(Imm32(0)); i32_ne;
+                if_empty; local_get(Local(PW_S)); f64_const(POW_TINY); f64_mul; f64_const(POW_TINY); f64_mul; return_; end;
                 // if p_l <= z - p_h -> underflow
-                local_get(PW_P_L); local_get(PW_Z); local_get(PW_P_H); f64_sub; f64_le;
-                if_empty; local_get(PW_S); f64_const(POW_TINY); f64_mul; f64_const(POW_TINY); f64_mul; return_; end;
+                local_get(Local(PW_P_L)); local_get(Local(PW_Z)); local_get(Local(PW_P_H)); f64_sub; f64_le;
+                if_empty; local_get(Local(PW_S)); f64_const(POW_TINY); f64_mul; f64_const(POW_TINY); f64_mul; return_; end;
             end;
         end;
 
         // compute 2**(p_h+p_l): i = j & 0x7fffffff; k = (i>>20) - 0x3ff; n = 0
-        local_get(PW_J); i32_const(F64_ABS_MASK_HI); i32_and; local_set(PW_I);
-        local_get(PW_I); i32_const(F64_EXP_SHIFT); i32_shr_s; i32_const(F64_EXP_BIAS); i32_sub; local_set(PW_K);
-        i32_const(0); local_set(PW_N);
+        local_get(Local(PW_J)); i32_const(Imm32(F64_ABS_MASK_HI)); i32_and; local_set(Local(PW_I));
+        local_get(Local(PW_I)); i32_const(Imm32(F64_EXP_SHIFT)); i32_shr_s; i32_const(Imm32(F64_EXP_BIAS)); i32_sub; local_set(Local(PW_K));
+        i32_const(Imm32(0)); local_set(Local(PW_N));
         // if i > 0x3fe00000  (|z| > 0.5)
-        local_get(PW_I); i32_const(F64_HALF_HI); i32_gt_s;
+        local_get(Local(PW_I)); i32_const(Imm32(F64_HALF_HI)); i32_gt_s;
         if_empty;
             // n = j + (0x00100000 >> (k+1))
-            local_get(PW_J); i32_const(F64_EXP_ONE_HI); local_get(PW_K); i32_const(1); i32_add; i32_shr_s; i32_add; local_set(PW_N);
+            local_get(Local(PW_J)); i32_const(Imm32(F64_EXP_ONE_HI)); local_get(Local(PW_K)); i32_const(Imm32(1)); i32_add; i32_shr_s; i32_add; local_set(Local(PW_N));
             // k = ((n & 0x7fffffff) >> 20) - 0x3ff
-            local_get(PW_N); i32_const(F64_ABS_MASK_HI); i32_and; i32_const(F64_EXP_SHIFT); i32_shr_s; i32_const(F64_EXP_BIAS); i32_sub; local_set(PW_K);
+            local_get(Local(PW_N)); i32_const(Imm32(F64_ABS_MASK_HI)); i32_and; i32_const(Imm32(F64_EXP_SHIFT)); i32_shr_s; i32_const(Imm32(F64_EXP_BIAS)); i32_sub; local_set(Local(PW_K));
             // t = with_set_high_word(0.0, (n & !(0x000fffff >> k)))
-            local_get(PW_N); i32_const(F64_MANTISSA_HI_MASK); local_get(PW_K); i32_shr_s; i32_const(-1); i32_xor; i32_and;
+            local_get(Local(PW_N)); i32_const(Imm32(F64_MANTISSA_HI_MASK)); local_get(Local(PW_K)); i32_shr_s; i32_const(Imm32(-1)); i32_xor; i32_and;
     });
     emit_from_high_word(&mut f);
     wasm!(f, {
-            local_set(PW_T);
+            local_set(Local(PW_T));
             // n = ((n & 0x000fffff) | 0x00100000) >> (20 - k)
-            local_get(PW_N); i32_const(F64_MANTISSA_HI_MASK); i32_and; i32_const(F64_EXP_ONE_HI); i32_or; i32_const(F64_EXP_SHIFT); local_get(PW_K); i32_sub; i32_shr_s; local_set(PW_N);
+            local_get(Local(PW_N)); i32_const(Imm32(F64_MANTISSA_HI_MASK)); i32_and; i32_const(Imm32(F64_EXP_ONE_HI)); i32_or; i32_const(Imm32(F64_EXP_SHIFT)); local_get(Local(PW_K)); i32_sub; i32_shr_s; local_set(Local(PW_N));
             // if j < 0 { n = -n }
-            local_get(PW_J); i32_const(0); i32_lt_s;
-            if_empty; i32_const(0); local_get(PW_N); i32_sub; local_set(PW_N); end;
+            local_get(Local(PW_J)); i32_const(Imm32(0)); i32_lt_s;
+            if_empty; i32_const(Imm32(0)); local_get(Local(PW_N)); i32_sub; local_set(Local(PW_N)); end;
             // p_h -= t
-            local_get(PW_P_H); local_get(PW_T); f64_sub; local_set(PW_P_H);
+            local_get(Local(PW_P_H)); local_get(Local(PW_T)); f64_sub; local_set(Local(PW_P_H));
         end;
 
         // t = with_set_low_word(p_l + p_h, 0)
-        local_get(PW_P_L); local_get(PW_P_H); f64_add;
+        local_get(Local(PW_P_L)); local_get(Local(PW_P_H)); f64_add;
     });
     emit_zero_low_word(&mut f);
     wasm!(f, {
-        local_set(PW_T);
+        local_set(Local(PW_T));
         // u = t*LG2_H; v = (p_l - (t - p_h))*LG2 + t*LG2_L
-        local_get(PW_T); f64_const(POW_LG2_H); f64_mul; local_set(PW_U);
-        local_get(PW_P_L); local_get(PW_T); local_get(PW_P_H); f64_sub; f64_sub; f64_const(POW_LG2); f64_mul;
-        local_get(PW_T); f64_const(POW_LG2_L); f64_mul; f64_add; local_set(PW_V);
+        local_get(Local(PW_T)); f64_const(POW_LG2_H); f64_mul; local_set(Local(PW_U));
+        local_get(Local(PW_P_L)); local_get(Local(PW_T)); local_get(Local(PW_P_H)); f64_sub; f64_sub; f64_const(POW_LG2); f64_mul;
+        local_get(Local(PW_T)); f64_const(POW_LG2_L); f64_mul; f64_add; local_set(Local(PW_V));
         // z = u + v; w = v - (z - u); t = z*z
-        local_get(PW_U); local_get(PW_V); f64_add; local_set(PW_Z);
-        local_get(PW_V); local_get(PW_Z); local_get(PW_U); f64_sub; f64_sub; local_set(PW_W);
-        local_get(PW_Z); local_get(PW_Z); f64_mul; local_set(PW_T);
+        local_get(Local(PW_U)); local_get(Local(PW_V)); f64_add; local_set(Local(PW_Z));
+        local_get(Local(PW_V)); local_get(Local(PW_Z)); local_get(Local(PW_U)); f64_sub; f64_sub; local_set(Local(PW_W));
+        local_get(Local(PW_Z)); local_get(Local(PW_Z)); f64_mul; local_set(Local(PW_T));
         // t1 = z - t*(P1 + t*(P2 + t*(P3 + t*(P4 + t*P5))))
-        local_get(PW_Z);
-        local_get(PW_T);
+        local_get(Local(PW_Z));
+        local_get(Local(PW_T));
         f64_const(POW_P1);
-        local_get(PW_T); f64_const(POW_P2);
-        local_get(PW_T); f64_const(POW_P3);
-        local_get(PW_T); f64_const(POW_P4);
-        local_get(PW_T); f64_const(POW_P5); f64_mul; f64_add;
+        local_get(Local(PW_T)); f64_const(POW_P2);
+        local_get(Local(PW_T)); f64_const(POW_P3);
+        local_get(Local(PW_T)); f64_const(POW_P4);
+        local_get(Local(PW_T)); f64_const(POW_P5); f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul; f64_add;
         f64_mul;
-        f64_sub; local_set(PW_T1);
+        f64_sub; local_set(Local(PW_T1));
         // r = (z*t1)/(t1 - 2) - (w + z*w)
-        local_get(PW_Z); local_get(PW_T1); f64_mul; local_get(PW_T1); f64_const(2.0); f64_sub; f64_div;
-        local_get(PW_W); local_get(PW_Z); local_get(PW_W); f64_mul; f64_add;
-        f64_sub; local_set(PW_R);
+        local_get(Local(PW_Z)); local_get(Local(PW_T1)); f64_mul; local_get(Local(PW_T1)); f64_const(2.0); f64_sub; f64_div;
+        local_get(Local(PW_W)); local_get(Local(PW_Z)); local_get(Local(PW_W)); f64_mul; f64_add;
+        f64_sub; local_set(Local(PW_R));
         // z = 1 - (r - z)
-        f64_const(1.0); local_get(PW_R); local_get(PW_Z); f64_sub; f64_sub; local_set(PW_Z);
+        f64_const(1.0); local_get(Local(PW_R)); local_get(Local(PW_Z)); f64_sub; f64_sub; local_set(Local(PW_Z));
         // j = get_high_word(z); j += n << 20
-        local_get(PW_Z);
+        local_get(Local(PW_Z));
     });
     emit_high_word(&mut f);
     wasm!(f, {
-        local_get(PW_N); i32_const(F64_EXP_SHIFT); i32_shl; i32_add; local_set(PW_J);
+        local_get(Local(PW_N)); i32_const(Imm32(F64_EXP_SHIFT)); i32_shl; i32_add; local_set(Local(PW_J));
         // if (j >> 20) <= 0 { z = scalbn(z, n) } else { z = with_set_high_word(z, j) }
-        local_get(PW_J); i32_const(F64_EXP_SHIFT); i32_shr_s; i32_const(0); i32_le_s;
+        local_get(Local(PW_J)); i32_const(Imm32(F64_EXP_SHIFT)); i32_shr_s; i32_const(Imm32(0)); i32_le_s;
         if_empty;
-            local_get(PW_Z); local_get(PW_N); call(scalbn); local_set(PW_Z);
+            local_get(Local(PW_Z)); local_get(Local(PW_N)); call(scalbn); local_set(Local(PW_Z));
         else_;
-            local_get(PW_Z); i64_reinterpret_f64; i64_const(LOW_WORD_BITS); i64_and;
-            local_get(PW_J); i64_extend_i32_u; i64_const(HI_SHIFT); i64_shl;
-            i64_or; f64_reinterpret_i64; local_set(PW_Z);
+            local_get(Local(PW_Z)); i64_reinterpret_f64; i64_const(Imm64(LOW_WORD_BITS)); i64_and;
+            local_get(Local(PW_J)); i64_extend_i32_u; i64_const(Imm64(HI_SHIFT)); i64_shl;
+            i64_or; f64_reinterpret_i64; local_set(Local(PW_Z));
         end;
         // return s * z
-        local_get(PW_S); local_get(PW_Z); f64_mul;
+        local_get(Local(PW_S)); local_get(Local(PW_Z)); f64_mul;
         end;
     });
 

--- a/crates/almide-codegen/src/emit_wasm/rt_numeric.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_numeric.rs
@@ -6,6 +6,67 @@ use super::{CompiledFunc, WasmEmitter};
 use wasm_encoder::{Instruction, ValType};
 use super::TrackedFunction as Function;
 
+// ---------------------------------------------------------------------------
+// Named immediates — every raw literal in a constant-emitting call goes here.
+// ---------------------------------------------------------------------------
+mod imm {
+    // Result/allocation sizes
+    /// Bytes for a Result[T, E] heap cell: [tag:i32=4][value/err:i64=8].
+    pub(super) const RESULT_ALLOC_BYTES: i32 = 12;
+    /// Bytes for the rem_pio2 two-f64 output buffer [y0:f64=8][y1:f64=8].
+    pub(super) const REM_PIO2_OUT_BYTES: i32 = 16;
+
+    // Hex prefix
+    /// Number of bytes in the "0x" prefix that from_str_radix strips.
+    pub(super) const HEX_PREFIX_LEN: i32 = 2;
+
+    // ASCII character codes
+    pub(super) const ASCII_PLUS: i32  = 43;   // '+'
+    pub(super) const ASCII_MINUS: i32 = 45;   // '-'
+    pub(super) const ASCII_DOT: i32   = 46;   // '.'
+    pub(super) const ASCII_ZERO: i32  = 48;   // '0'
+    pub(super) const ASCII_NINE: i32  = 57;   // '9'
+    pub(super) const ASCII_UPPER_E: i32 = 69; // 'E'
+    pub(super) const ASCII_UPPER_A: i32 = 65; // 'A'
+    pub(super) const ASCII_UPPER_F: i32 = 70; // 'F'
+    pub(super) const ASCII_LOWER_A: i32 = 97; // 'a'
+    pub(super) const ASCII_LOWER_E: i32 = 101; // 'e'
+    pub(super) const ASCII_LOWER_F: i32 = 102; // 'f'
+    pub(super) const ASCII_LOWER_X: i32 = 120; // 'x' (in "0x" prefix)
+    /// Subtract from a lowercase hex letter ('a'..'f') to get its digit value (10..15).
+    pub(super) const ASCII_LOWER_A_HEX_OFFSET: i32 = 87; // 'a' - 10
+    /// Subtract from an uppercase hex letter ('A'..'F') to get its digit value (10..15).
+    pub(super) const ASCII_UPPER_A_HEX_OFFSET: i32 = 55; // 'A' - 10
+    /// OR-mask to ASCII-lowercase a byte: 'A' | 0x20 == 'a'.
+    pub(super) const ASCII_LOWERCASE_MASK: i32 = 0x20;
+
+    // IEEE-754 / f64 bit-level constants
+    /// Right-shift count to extract the high 32-bit word from an i64 reinterpretation of f64.
+    pub(super) const F64_HIGH_WORD_SHIFT: i64 = 32;
+    /// Mask to clear the sign bit in the high 32-bit word of f64 (|x| extraction).
+    pub(super) const F64_ABS_HIGH_WORD_MASK: i32 = 0x7fff_ffff;
+    /// High-word value when f64 is ±infinity (exponent all-ones, mantissa zero).
+    pub(super) const F64_INF_HIGH_WORD: i32 = 0x7ff0_0000;
+    /// f64 sign bit (set to negate via i64_or).
+    pub(super) const F64_SIGN_BIT: i64 = 0x8000_0000_0000_0000_u64 as i64;
+
+    // libm small/tiny argument thresholds (high-word of |x|, hex)
+    /// π/4 ≈ 0x3fe921fb: upper bound of the "small argument" fast path for sin/cos/tan.
+    pub(super) const LIBM_SMALL_ARG: i32   = 0x3fe9_21fb;
+    /// sin tiny-arg threshold (below → return x): |x| < 2^{-26}.
+    pub(super) const LIBM_SIN_TINY_ARG: i32 = 0x3e50_0000;
+    /// cos tiny-arg threshold (below → return 1): different exponent from sin.
+    pub(super) const LIBM_COS_TINY_ARG: i32 = 0x3e46_a09e;
+    /// tan tiny-arg threshold (below → return x): |x| < 2^{-27.5}.
+    pub(super) const LIBM_TAN_TINY_ARG: i32 = 0x3e40_0000;
+
+    // Trig quadrant dispatch (n & 3 == ?)
+    /// Bitmask to extract the 2-bit quadrant from rem_pio2's integer result.
+    pub(super) const QUAD_MASK: i32 = 3;
+    /// Quadrant index 2: negate the primary kernel output (-sin or -cos).
+    pub(super) const QUAD_NEG: i32 = 2;
+}
+
 /// __int_from_hex(s: i32) -> i32
 ///
 /// Byte-for-byte mirror of the native oracle (runtime/rs/src/int.rs):
@@ -55,7 +116,7 @@ pub(super) fn compile_int_from_hex(emitter: &mut WasmEmitter) {
     // Emit an `err(<interned string>)` return: alloc [tag=1][str_ptr] and return.
     let emit_err = |f: &mut Function, err_str: u32| {
         wasm!(f, {
-            i32_const(12); call(alloc); local_set(6);
+            i32_const(imm::RESULT_ALLOC_BYTES); call(alloc); local_set(6);
             local_get(6); i32_const(1); i32_store(0);
             local_get(6); i32_const(err_str as i32); i32_store(4);
             local_get(6);
@@ -84,19 +145,19 @@ pub(super) fn compile_int_from_hex(emitter: &mut WasmEmitter) {
     wasm!(f, {
         block_empty; loop_empty;
           // need at least 2 chars remaining
-          local_get(3); local_get(2); i32_sub; i32_const(2); i32_lt_s; br_if(1);
+          local_get(3); local_get(2); i32_sub; i32_const(imm::HEX_PREFIX_LEN); i32_lt_s; br_if(1);
     });
     load_byte(&mut f, 2, 5);
     wasm!(f, {
-          local_get(5); i32_const(48); i32_ne; br_if(1);   // s[i] != '0'
+          local_get(5); i32_const(imm::ASCII_ZERO); i32_ne; br_if(1);   // s[i] != '0'
     });
     // s[i+1] == 'x' (lowercase only)
     wasm!(f, { i32_const(0); local_set(5); }); // reuse byte; compute s[i+1]
     wasm!(f, {
           local_get(0); i32_const(data_off); i32_add; local_get(2); i32_add; i32_const(1); i32_add;
           i32_load8_u(0); local_set(5);
-          local_get(5); i32_const(120); i32_ne; br_if(1);   // s[i+1] != 'x'
-          local_get(2); i32_const(2); i32_add; local_set(2); // i += 2
+          local_get(5); i32_const(imm::ASCII_LOWER_X); i32_ne; br_if(1);   // s[i+1] != 'x'
+          local_get(2); i32_const(imm::HEX_PREFIX_LEN); i32_add; local_set(2); // i += 2
           br(0);
         end; end;
     });
@@ -110,12 +171,12 @@ pub(super) fn compile_int_from_hex(emitter: &mut WasmEmitter) {
     wasm!(f, { i32_const(0); local_set(4); }); // is_neg = 0
     load_byte(&mut f, 2, 5);
     wasm!(f, {
-        local_get(5); i32_const(45); i32_eq; // '-'
+        local_get(5); i32_const(imm::ASCII_MINUS); i32_eq; // '-'
         if_empty;
           i32_const(1); local_set(4);
           local_get(2); i32_const(1); i32_add; local_set(2);
         else_;
-          local_get(5); i32_const(43); i32_eq; // '+'
+          local_get(5); i32_const(imm::ASCII_PLUS); i32_eq; // '+'
           if_empty;
             local_get(2); i32_const(1); i32_add; local_set(2);
           end;
@@ -144,20 +205,20 @@ pub(super) fn compile_int_from_hex(emitter: &mut WasmEmitter) {
     // Classify hex digit: '0'-'9' → 0-9, 'a'-'f' → 10-15, 'A'-'F' → 10-15, else -1.
     wasm!(f, {
         i32_const(-1); local_set(8);
-        local_get(5); i32_const(48); i32_ge_u;
-        local_get(5); i32_const(57); i32_le_u; i32_and;
+        local_get(5); i32_const(imm::ASCII_ZERO); i32_ge_u;
+        local_get(5); i32_const(imm::ASCII_NINE); i32_le_u; i32_and;
         if_empty;
-          local_get(5); i32_const(48); i32_sub; local_set(8);
+          local_get(5); i32_const(imm::ASCII_ZERO); i32_sub; local_set(8);
         else_;
-          local_get(5); i32_const(97); i32_ge_u;
-          local_get(5); i32_const(102); i32_le_u; i32_and;
+          local_get(5); i32_const(imm::ASCII_LOWER_A); i32_ge_u;
+          local_get(5); i32_const(imm::ASCII_LOWER_F); i32_le_u; i32_and;
           if_empty;
-            local_get(5); i32_const(87); i32_sub; local_set(8); // 'a'-87 = 10
+            local_get(5); i32_const(imm::ASCII_LOWER_A_HEX_OFFSET); i32_sub; local_set(8); // 'a'-87 = 10
           else_;
-            local_get(5); i32_const(65); i32_ge_u;
-            local_get(5); i32_const(70); i32_le_u; i32_and;
+            local_get(5); i32_const(imm::ASCII_UPPER_A); i32_ge_u;
+            local_get(5); i32_const(imm::ASCII_UPPER_F); i32_le_u; i32_and;
             if_empty;
-              local_get(5); i32_const(55); i32_sub; local_set(8); // 'A'-55 = 10
+              local_get(5); i32_const(imm::ASCII_UPPER_A_HEX_OFFSET); i32_sub; local_set(8); // 'A'-55 = 10
             end;
           end;
         end;
@@ -214,7 +275,7 @@ pub(super) fn compile_int_from_hex(emitter: &mut WasmEmitter) {
 
     // Return ok(value): alloc [tag=0][value:i64]
     wasm!(f, {
-        i32_const(12); call(alloc); local_set(6);
+        i32_const(imm::RESULT_ALLOC_BYTES); call(alloc); local_set(6);
         local_get(6); i32_const(0); i32_store(0);
         local_get(6); local_get(7); i64_store(4);
         local_get(6);
@@ -338,12 +399,12 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
     // Optional leading sign at data[i].
     wasm!(f, {
         local_get(11); local_get(2); i32_add; i32_load8_u(0); local_set(5);
-        local_get(5); i32_const(45); i32_eq;   // '-'
+        local_get(5); i32_const(imm::ASCII_MINUS); i32_eq;   // '-'
         if_empty;
           i32_const(1); local_set(4);
           local_get(2); i32_const(1); i32_add; local_set(2);
         else_;
-          local_get(5); i32_const(43); i32_eq; // '+'
+          local_get(5); i32_const(imm::ASCII_PLUS); i32_eq; // '+'
           if_empty;
             local_get(2); i32_const(1); i32_add; local_set(2);
           end;
@@ -384,7 +445,7 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
           local_get(11); local_get(2); i32_add; i32_load8_u(0); local_set(5);
 
           // '.' -> set has_dot (err on second dot)
-          local_get(5); i32_const(46); i32_eq;
+          local_get(5); i32_const(imm::ASCII_DOT); i32_eq;
           if_empty;
             local_get(8); if_empty;
     });
@@ -397,8 +458,8 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
           end;
 
           // 'e' / 'E' -> exponent: mark and break out of mantissa loop
-          local_get(5); i32_const(101); i32_eq;   // 'e'
-          local_get(5); i32_const(69); i32_eq;     // 'E'
+          local_get(5); i32_const(imm::ASCII_LOWER_E); i32_eq;   // 'e'
+          local_get(5); i32_const(imm::ASCII_UPPER_E); i32_eq;   // 'E'
           i32_or;
           if_empty;
             i32_const(1); local_set(16);
@@ -407,8 +468,8 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
           end;
 
           // digit '0'..'9' ?
-          local_get(5); i32_const(48); i32_lt_u;
-          local_get(5); i32_const(57); i32_gt_u;
+          local_get(5); i32_const(imm::ASCII_ZERO); i32_lt_u;
+          local_get(5); i32_const(imm::ASCII_NINE); i32_gt_u;
           i32_or;
           if_empty;
     });
@@ -418,7 +479,7 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
 
           local_get(9); i32_const(1); i32_add; local_set(9);   // digit_count++ (all digits)
           // started |= (digit != 0) — leading zeros carry no significance.
-          local_get(19); local_get(5); i32_const(48); i32_ne; i32_or; local_set(19);
+          local_get(19); local_get(5); i32_const(imm::ASCII_ZERO); i32_ne; i32_or; local_set(19);
           local_get(19); i32_eqz;
           if_empty;
             // Leading zero: it only advances the fractional scale (frac_count),
@@ -433,11 +494,11 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
             local_get(20); i32_const(super::rt_dec2flt::SIG_DIGIT_CAP); i32_lt_u;
             if_empty;
               local_get(17); i32_const(super::rt_dec2flt::DECIMAL_BASE); call(mul_small);
-              local_get(17); local_get(5); i32_const(48); i32_sub; call(bn_add_small);
+              local_get(17); local_get(5); i32_const(imm::ASCII_ZERO); i32_sub; call(bn_add_small);
               local_get(20); i32_const(1); i32_add; local_set(20);   // sig_digits++
               local_get(8); if_empty; local_get(18); i32_const(1); i32_add; local_set(18); end;
             else_;
-              local_get(21); local_get(5); i32_const(48); i32_ne; i32_or; local_set(21);
+              local_get(21); local_get(5); i32_const(imm::ASCII_ZERO); i32_ne; i32_or; local_set(21);
             end;
           end;
 
@@ -467,12 +528,12 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
     wasm!(f, {
           end;
           local_get(11); local_get(2); i32_add; i32_load8_u(0); local_set(5);
-          local_get(5); i32_const(45); i32_eq;   // '-'
+          local_get(5); i32_const(imm::ASCII_MINUS); i32_eq;   // '-'
           if_empty;
             i32_const(1); local_set(12);
             local_get(2); i32_const(1); i32_add; local_set(2);
           else_;
-            local_get(5); i32_const(43); i32_eq; // '+'
+            local_get(5); i32_const(imm::ASCII_PLUS); i32_eq; // '+'
             if_empty;
               local_get(2); i32_const(1); i32_add; local_set(2);
             end;
@@ -482,8 +543,8 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
           block_empty; loop_empty;
             local_get(2); local_get(10); i32_ge_u; br_if(1);
             local_get(11); local_get(2); i32_add; i32_load8_u(0); local_set(5);
-            local_get(5); i32_const(48); i32_lt_u;
-            local_get(5); i32_const(57); i32_gt_u;
+            local_get(5); i32_const(imm::ASCII_ZERO); i32_lt_u;
+            local_get(5); i32_const(imm::ASCII_NINE); i32_gt_u;
             i32_or;
             if_empty;
     });
@@ -494,8 +555,8 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
             // huge exponent can't wrap the i32 accumulator (see clamp definition).
             local_get(13); i32_const(exp_magnitude_clamp); i32_lt_u;
             if_empty;
-              local_get(13); i32_const(10); i32_mul;
-              local_get(5); i32_const(48); i32_sub; i32_add; local_set(13);
+              local_get(13); i32_const(super::rt_dec2flt::DECIMAL_BASE); i32_mul;
+              local_get(5); i32_const(imm::ASCII_ZERO); i32_sub; i32_add; local_set(13);
             end;
             local_get(14); i32_const(1); i32_add; local_set(14);
             local_get(2); i32_const(1); i32_add; local_set(2);
@@ -533,7 +594,7 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
         local_set(14);
         local_get(4); local_get(17); local_get(14); local_get(21); call(dec2flt); local_set(3);
         // Return ok(result): alloc 12 bytes [tag=0][f64]
-        i32_const(12); call(emitter.rt.alloc); local_set(6);
+        i32_const(imm::RESULT_ALLOC_BYTES); call(emitter.rt.alloc); local_set(6);
         local_get(6); i32_const(0); i32_store(0);
         local_get(6); local_get(3); f64_store(4);
         local_get(6);
@@ -558,7 +619,7 @@ fn emit_kw_match(f: &mut Function, kw: &[u8], i_local: u32, end_local: u32, base
         wasm!(f, {
             local_get(base_local); local_get(i_local); i32_add;
             i32_const(k as i32); i32_add; i32_load8_u(0);
-            i32_const(0x20); i32_or;            // ASCII lowercase
+            i32_const(imm::ASCII_LOWERCASE_MASK); i32_or;  // ASCII lowercase
             i32_const(lower); i32_eq;
             i32_and;
         });
@@ -568,7 +629,7 @@ fn emit_kw_match(f: &mut Function, kw: &[u8], i_local: u32, end_local: u32, base
 /// Emit the err return for float_parse: alloc [tag=1][str_ptr] and return.
 fn emit_float_parse_err(f: &mut Function, emitter: &WasmEmitter, err_str: u32) {
     wasm!(f, {
-        i32_const(12); call(emitter.rt.alloc); local_set(6);
+        i32_const(imm::RESULT_ALLOC_BYTES); call(emitter.rt.alloc); local_set(6);
         local_get(6); i32_const(1); i32_store(0);          // tag = 1 (err)
         local_get(6); i32_const(err_str as i32); i32_store(4); // err string
         local_get(6);
@@ -582,13 +643,13 @@ fn emit_float_parse_err(f: &mut Function, emitter: &WasmEmitter, err_str: u32) {
 fn emit_float_parse_ok_special(f: &mut Function, emitter: &WasmEmitter, value: f64) {
     let pos_bits = (value.to_bits() & 0x7FFF_FFFF_FFFF_FFFF) as i64; // magnitude bits
     wasm!(f, {
-        i32_const(12); call(emitter.rt.alloc); local_set(6);
+        i32_const(imm::RESULT_ALLOC_BYTES); call(emitter.rt.alloc); local_set(6);
         local_get(6); i32_const(0); i32_store(0);          // tag = 0 (ok)
         local_get(6);
         i64_const(pos_bits);
         local_get(4);
         if_i64;
-          i64_const(0x8000000000000000_u64 as i64);
+          i64_const(imm::F64_SIGN_BIT);
         else_;
           i64_const(0);
         end;
@@ -641,32 +702,32 @@ pub(super) fn compile_math_sin(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(2, ValType::I32), (1, ValType::I32), (2, ValType::F64)]);
     wasm!(f, {
         // ix = (to_bits(x) >> 32) & 0x7fffffff
-        local_get(0); i64_reinterpret_f64; i64_const(32); i64_shr_u; i32_wrap_i64; i32_const(0x7fffffff); i32_and; local_set(1);
+        local_get(0); i64_reinterpret_f64; i64_const(imm::F64_HIGH_WORD_SHIFT); i64_shr_u; i32_wrap_i64; i32_const(imm::F64_ABS_HIGH_WORD_MASK); i32_and; local_set(1);
         // if ix <= 0x3fe921fb { if ix < 0x3e500000 { return x } return k_sin(x,0,0) }
-        local_get(1); i32_const(0x3fe921fb); i32_le_u;
+        local_get(1); i32_const(imm::LIBM_SMALL_ARG); i32_le_u;
         if_empty;
-            local_get(1); i32_const(0x3e500000); i32_lt_u;
+            local_get(1); i32_const(imm::LIBM_SIN_TINY_ARG); i32_lt_u;
             if_empty; local_get(0); return_; end;
             local_get(0); f64_const(0.0); i32_const(0); call(k_sin); return_;
         end;
         // if ix >= 0x7ff00000 { return x - x }
-        local_get(1); i32_const(0x7ff00000); i32_ge_u;
+        local_get(1); i32_const(imm::F64_INF_HIGH_WORD); i32_ge_u;
         if_empty; local_get(0); local_get(0); f64_sub; return_; end;
         // n = rem_pio2(x, yp); y0=y[0]; y1=y[1]
-        i32_const(16); call(alloc); local_set(3);
+        i32_const(imm::REM_PIO2_OUT_BYTES); call(alloc); local_set(3);
         local_get(0); local_get(3); call(rem_pio2); local_set(2);
         local_get(3); f64_load(0); local_set(4);
         local_get(3); f64_load(8); local_set(5);
         // match n & 3 { 0=>k_sin(y0,y1,1) 1=>k_cos(y0,y1) 2=>-k_sin(y0,y1,1) _=>-k_cos(y0,y1) }
-        local_get(2); i32_const(3); i32_and; i32_const(0); i32_eq;
+        local_get(2); i32_const(imm::QUAD_MASK); i32_and; i32_const(0); i32_eq;
         if_f64;
             local_get(4); local_get(5); i32_const(1); call(k_sin);
         else_;
-            local_get(2); i32_const(3); i32_and; i32_const(1); i32_eq;
+            local_get(2); i32_const(imm::QUAD_MASK); i32_and; i32_const(1); i32_eq;
             if_f64;
                 local_get(4); local_get(5); call(k_cos);
             else_;
-                local_get(2); i32_const(3); i32_and; i32_const(2); i32_eq;
+                local_get(2); i32_const(imm::QUAD_MASK); i32_and; i32_const(imm::QUAD_NEG); i32_eq;
                 if_f64;
                     local_get(4); local_get(5); i32_const(1); call(k_sin); f64_neg;
                 else_;
@@ -690,33 +751,33 @@ pub(super) fn compile_math_cos(emitter: &mut WasmEmitter) {
     // params: 0=x. locals: 1=i32 ix, 2=i32 n, 3=i32 yp, 4=f64 y0, 5=f64 y1
     let mut f = Function::new([(2, ValType::I32), (1, ValType::I32), (2, ValType::F64)]);
     wasm!(f, {
-        local_get(0); i64_reinterpret_f64; i64_const(32); i64_shr_u; i32_wrap_i64; i32_const(0x7fffffff); i32_and; local_set(1);
+        local_get(0); i64_reinterpret_f64; i64_const(imm::F64_HIGH_WORD_SHIFT); i64_shr_u; i32_wrap_i64; i32_const(imm::F64_ABS_HIGH_WORD_MASK); i32_and; local_set(1);
         // if ix <= 0x3fe921fb { if ix < 0x3e46a09e { if (x as i32)==0 { return 1.0 } } return k_cos(x,0) }
-        local_get(1); i32_const(0x3fe921fb); i32_le_u;
+        local_get(1); i32_const(imm::LIBM_SMALL_ARG); i32_le_u;
         if_empty;
-            local_get(1); i32_const(0x3e46a09e); i32_lt_u;
+            local_get(1); i32_const(imm::LIBM_COS_TINY_ARG); i32_lt_u;
             if_empty;
                 local_get(0); i32_trunc_f64_s; i32_eqz;
                 if_empty; f64_const(1.0); return_; end;
             end;
             local_get(0); f64_const(0.0); call(k_cos); return_;
         end;
-        local_get(1); i32_const(0x7ff00000); i32_ge_u;
+        local_get(1); i32_const(imm::F64_INF_HIGH_WORD); i32_ge_u;
         if_empty; local_get(0); local_get(0); f64_sub; return_; end;
-        i32_const(16); call(alloc); local_set(3);
+        i32_const(imm::REM_PIO2_OUT_BYTES); call(alloc); local_set(3);
         local_get(0); local_get(3); call(rem_pio2); local_set(2);
         local_get(3); f64_load(0); local_set(4);
         local_get(3); f64_load(8); local_set(5);
         // match n & 3 { 0=>k_cos 1=>-k_sin 2=>-k_cos _=>k_sin }
-        local_get(2); i32_const(3); i32_and; i32_const(0); i32_eq;
+        local_get(2); i32_const(imm::QUAD_MASK); i32_and; i32_const(0); i32_eq;
         if_f64;
             local_get(4); local_get(5); call(k_cos);
         else_;
-            local_get(2); i32_const(3); i32_and; i32_const(1); i32_eq;
+            local_get(2); i32_const(imm::QUAD_MASK); i32_and; i32_const(1); i32_eq;
             if_f64;
                 local_get(4); local_get(5); i32_const(1); call(k_sin); f64_neg;
             else_;
-                local_get(2); i32_const(3); i32_and; i32_const(2); i32_eq;
+                local_get(2); i32_const(imm::QUAD_MASK); i32_and; i32_const(imm::QUAD_NEG); i32_eq;
                 if_f64;
                     local_get(4); local_get(5); call(k_cos); f64_neg;
                 else_;
@@ -739,17 +800,17 @@ pub(super) fn compile_math_tan(emitter: &mut WasmEmitter) {
     // params: 0=x. locals: 1=i32 ix, 2=i32 n, 3=i32 yp, 4=f64 y0, 5=f64 y1
     let mut f = Function::new([(2, ValType::I32), (1, ValType::I32), (2, ValType::F64)]);
     wasm!(f, {
-        local_get(0); i64_reinterpret_f64; i64_const(32); i64_shr_u; i32_wrap_i64; i32_const(0x7fffffff); i32_and; local_set(1);
+        local_get(0); i64_reinterpret_f64; i64_const(imm::F64_HIGH_WORD_SHIFT); i64_shr_u; i32_wrap_i64; i32_const(imm::F64_ABS_HIGH_WORD_MASK); i32_and; local_set(1);
         // if ix <= 0x3fe921fb { if ix < 0x3e400000 { return x } return k_tan(x,0,0) }
-        local_get(1); i32_const(0x3fe921fb); i32_le_u;
+        local_get(1); i32_const(imm::LIBM_SMALL_ARG); i32_le_u;
         if_empty;
-            local_get(1); i32_const(0x3e400000); i32_lt_u;
+            local_get(1); i32_const(imm::LIBM_TAN_TINY_ARG); i32_lt_u;
             if_empty; local_get(0); return_; end;
             local_get(0); f64_const(0.0); i32_const(0); call(k_tan); return_;
         end;
-        local_get(1); i32_const(0x7ff00000); i32_ge_u;
+        local_get(1); i32_const(imm::F64_INF_HIGH_WORD); i32_ge_u;
         if_empty; local_get(0); local_get(0); f64_sub; return_; end;
-        i32_const(16); call(alloc); local_set(3);
+        i32_const(imm::REM_PIO2_OUT_BYTES); call(alloc); local_set(3);
         local_get(0); local_get(3); call(rem_pio2); local_set(2);
         local_get(3); f64_load(0); local_set(4);
         local_get(3); f64_load(8); local_set(5);

--- a/crates/almide-codegen/src/emit_wasm/rt_numeric.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_numeric.rs
@@ -2,6 +2,7 @@
 //!
 //! Called from `compile_runtime()` in runtime.rs.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::{CompiledFunc, WasmEmitter};
 use wasm_encoder::{Instruction, ValType};
 use super::TrackedFunction as Function;
@@ -116,144 +117,144 @@ pub(super) fn compile_int_from_hex(emitter: &mut WasmEmitter) {
     // Emit an `err(<interned string>)` return: alloc [tag=1][str_ptr] and return.
     let emit_err = |f: &mut Function, err_str: u32| {
         wasm!(f, {
-            i32_const(imm::RESULT_ALLOC_BYTES); call(alloc); local_set(6);
-            local_get(6); i32_const(1); i32_store(0);
-            local_get(6); i32_const(err_str as i32); i32_store(4);
-            local_get(6);
+            i32_const(Imm32(imm::RESULT_ALLOC_BYTES)); call(alloc); local_set(Local(6));
+            local_get(Local(6)); i32_const(Imm32(1)); i32_store(0);
+            local_get(Local(6)); i32_const(Imm32(err_str as i32)); i32_store(4);
+            local_get(Local(6));
             return_;
         });
     };
     // Emit `byte = s[data_off + idx_local]`.
     let load_byte = |f: &mut Function, idx_local: u32, dst: u32| {
         wasm!(f, {
-            local_get(0); i32_const(data_off); i32_add;
-            local_get(idx_local); i32_add;
-            i32_load8_u(0); local_set(dst);
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add;
+            local_get(Local(idx_local)); i32_add;
+            i32_load8_u(0); local_set(Local(dst));
         });
     };
 
     // len = s.len
-    wasm!(f, { local_get(0); i32_load(0); local_set(1); });
+    wasm!(f, { local_get(Local(0)); i32_load(0); local_set(Local(1)); });
 
     // Trim leading + trailing Unicode whitespace (s.trim()).
-    wasm!(f, { i32_const(0); local_set(2); });
+    wasm!(f, { i32_const(Imm32(0)); local_set(Local(2)); });
     super::rt_string::emit_trim_forward(&mut f, emitter, 2, 1);
-    wasm!(f, { local_get(1); local_set(3); });
+    wasm!(f, { local_get(Local(1)); local_set(Local(3)); });
     super::rt_string::emit_trim_backward(&mut f, emitter, 3, 2, 11);
 
     // Strip a lowercase "0x" prefix REPEATEDLY: while (end-i >= 2 && s[i]=='0' && s[i+1]=='x') i += 2.
     wasm!(f, {
         block_empty; loop_empty;
           // need at least 2 chars remaining
-          local_get(3); local_get(2); i32_sub; i32_const(imm::HEX_PREFIX_LEN); i32_lt_s; br_if(1);
+          local_get(Local(3)); local_get(Local(2)); i32_sub; i32_const(Imm32(imm::HEX_PREFIX_LEN)); i32_lt_s; br_if(1);
     });
     load_byte(&mut f, 2, 5);
     wasm!(f, {
-          local_get(5); i32_const(imm::ASCII_ZERO); i32_ne; br_if(1);   // s[i] != '0'
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_ZERO)); i32_ne; br_if(1);   // s[i] != '0'
     });
     // s[i+1] == 'x' (lowercase only)
-    wasm!(f, { i32_const(0); local_set(5); }); // reuse byte; compute s[i+1]
+    wasm!(f, { i32_const(Imm32(0)); local_set(Local(5)); }); // reuse byte; compute s[i+1]
     wasm!(f, {
-          local_get(0); i32_const(data_off); i32_add; local_get(2); i32_add; i32_const(1); i32_add;
-          i32_load8_u(0); local_set(5);
-          local_get(5); i32_const(imm::ASCII_LOWER_X); i32_ne; br_if(1);   // s[i+1] != 'x'
-          local_get(2); i32_const(imm::HEX_PREFIX_LEN); i32_add; local_set(2); // i += 2
+          local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; local_get(Local(2)); i32_add; i32_const(Imm32(1)); i32_add;
+          i32_load8_u(0); local_set(Local(5));
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_LOWER_X)); i32_ne; br_if(1);   // s[i+1] != 'x'
+          local_get(Local(2)); i32_const(Imm32(imm::HEX_PREFIX_LEN)); i32_add; local_set(Local(2)); // i += 2
           br(0);
         end; end;
     });
 
     // Empty after trim + strip → "cannot parse integer from empty string"
-    wasm!(f, { local_get(2); local_get(3); i32_ge_u; if_empty; });
+    wasm!(f, { local_get(Local(2)); local_get(Local(3)); i32_ge_u; if_empty; });
     emit_err(&mut f, err_empty);
     wasm!(f, { end; });
 
     // Optional single leading sign (from_str_radix accepts +/-).
-    wasm!(f, { i32_const(0); local_set(4); }); // is_neg = 0
+    wasm!(f, { i32_const(Imm32(0)); local_set(Local(4)); }); // is_neg = 0
     load_byte(&mut f, 2, 5);
     wasm!(f, {
-        local_get(5); i32_const(imm::ASCII_MINUS); i32_eq; // '-'
+        local_get(Local(5)); i32_const(Imm32(imm::ASCII_MINUS)); i32_eq; // '-'
         if_empty;
-          i32_const(1); local_set(4);
-          local_get(2); i32_const(1); i32_add; local_set(2);
+          i32_const(Imm32(1)); local_set(Local(4));
+          local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
         else_;
-          local_get(5); i32_const(imm::ASCII_PLUS); i32_eq; // '+'
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_PLUS)); i32_eq; // '+'
           if_empty;
-            local_get(2); i32_const(1); i32_add; local_set(2);
+            local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
           end;
         end;
     });
 
     // No digits after sign → "invalid digit found in string"
-    wasm!(f, { local_get(2); local_get(3); i32_ge_u; if_empty; });
+    wasm!(f, { local_get(Local(2)); local_get(Local(3)); i32_ge_u; if_empty; });
     emit_err(&mut f, err_digit);
     wasm!(f, { end; });
 
     // limit = is_neg ? |i64::MIN| : i64::MAX  (u64 semantics)
     wasm!(f, {
-        local_get(4);
-        if_empty; i64_const(i64::MIN); local_set(9);
-        else_; i64_const(i64::MAX); local_set(9); end;
-        i64_const(0); local_set(7);   // acc = 0
+        local_get(Local(4));
+        if_empty; i64_const(Imm64(i64::MIN)); local_set(Local(9));
+        else_; i64_const(Imm64(i64::MAX)); local_set(Local(9)); end;
+        i64_const(Imm64(0)); local_set(Local(7));   // acc = 0
     });
 
     // Main parse loop: while i < end
     wasm!(f, { block_empty; loop_empty;
-        local_get(2); local_get(3); i32_ge_u; br_if(1);
+        local_get(Local(2)); local_get(Local(3)); i32_ge_u; br_if(1);
     });
     load_byte(&mut f, 2, 5);
 
     // Classify hex digit: '0'-'9' → 0-9, 'a'-'f' → 10-15, 'A'-'F' → 10-15, else -1.
     wasm!(f, {
-        i32_const(-1); local_set(8);
-        local_get(5); i32_const(imm::ASCII_ZERO); i32_ge_u;
-        local_get(5); i32_const(imm::ASCII_NINE); i32_le_u; i32_and;
+        i32_const(Imm32(-1)); local_set(Local(8));
+        local_get(Local(5)); i32_const(Imm32(imm::ASCII_ZERO)); i32_ge_u;
+        local_get(Local(5)); i32_const(Imm32(imm::ASCII_NINE)); i32_le_u; i32_and;
         if_empty;
-          local_get(5); i32_const(imm::ASCII_ZERO); i32_sub; local_set(8);
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_ZERO)); i32_sub; local_set(Local(8));
         else_;
-          local_get(5); i32_const(imm::ASCII_LOWER_A); i32_ge_u;
-          local_get(5); i32_const(imm::ASCII_LOWER_F); i32_le_u; i32_and;
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_LOWER_A)); i32_ge_u;
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_LOWER_F)); i32_le_u; i32_and;
           if_empty;
-            local_get(5); i32_const(imm::ASCII_LOWER_A_HEX_OFFSET); i32_sub; local_set(8); // 'a'-87 = 10
+            local_get(Local(5)); i32_const(Imm32(imm::ASCII_LOWER_A_HEX_OFFSET)); i32_sub; local_set(Local(8)); // 'a'-87 = 10
           else_;
-            local_get(5); i32_const(imm::ASCII_UPPER_A); i32_ge_u;
-            local_get(5); i32_const(imm::ASCII_UPPER_F); i32_le_u; i32_and;
+            local_get(Local(5)); i32_const(Imm32(imm::ASCII_UPPER_A)); i32_ge_u;
+            local_get(Local(5)); i32_const(Imm32(imm::ASCII_UPPER_F)); i32_le_u; i32_and;
             if_empty;
-              local_get(5); i32_const(imm::ASCII_UPPER_A_HEX_OFFSET); i32_sub; local_set(8); // 'A'-55 = 10
+              local_get(Local(5)); i32_const(Imm32(imm::ASCII_UPPER_A_HEX_OFFSET)); i32_sub; local_set(Local(8)); // 'A'-55 = 10
             end;
           end;
         end;
     });
 
     // Invalid digit → "invalid digit found in string"
-    wasm!(f, { local_get(8); i32_const(-1); i32_eq; if_empty; });
+    wasm!(f, { local_get(Local(8)); i32_const(Imm32(-1)); i32_eq; if_empty; });
     emit_err(&mut f, err_digit);
     wasm!(f, { end; });
 
     // d (i64) → tmp
-    wasm!(f, { local_get(8); i64_extend_i32_u; local_set(10); });
+    wasm!(f, { local_get(Local(8)); i64_extend_i32_u; local_set(Local(10)); });
 
     // Overflow step 1: acc > limit/RADIX → overflow.
     wasm!(f, {
-        local_get(9); i64_const(RADIX); i64_div_u;
-        local_get(7); i64_ge_u; i32_eqz;
+        local_get(Local(9)); i64_const(Imm64(RADIX)); i64_div_u;
+        local_get(Local(7)); i64_ge_u; i32_eqz;
         if_empty;
     });
-    wasm!(f, { local_get(4); if_empty; });
+    wasm!(f, { local_get(Local(4)); if_empty; });
     emit_err(&mut f, err_small);
     wasm!(f, { else_; });
     emit_err(&mut f, err_large);
     wasm!(f, { end; end; });
 
     // acc = acc * RADIX
-    wasm!(f, { local_get(7); i64_const(RADIX); i64_mul; local_set(7); });
+    wasm!(f, { local_get(Local(7)); i64_const(Imm64(RADIX)); i64_mul; local_set(Local(7)); });
 
     // Overflow step 2: acc > limit - d → overflow.
     wasm!(f, {
-        local_get(9); local_get(10); i64_sub;
-        local_get(7); i64_ge_u; i32_eqz;
+        local_get(Local(9)); local_get(Local(10)); i64_sub;
+        local_get(Local(7)); i64_ge_u; i32_eqz;
         if_empty;
     });
-    wasm!(f, { local_get(4); if_empty; });
+    wasm!(f, { local_get(Local(4)); if_empty; });
     emit_err(&mut f, err_small);
     wasm!(f, { else_; });
     emit_err(&mut f, err_large);
@@ -261,24 +262,24 @@ pub(super) fn compile_int_from_hex(emitter: &mut WasmEmitter) {
 
     // acc = acc + d; i++
     wasm!(f, {
-        local_get(7); local_get(10); i64_add; local_set(7);
-        local_get(2); i32_const(1); i32_add; local_set(2);
+        local_get(Local(7)); local_get(Local(10)); i64_add; local_set(Local(7));
+        local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
         br(0);
         end; end;
     });
 
     // Materialize signed value: negative → 0 - acc (wraps to i64::MIN at 2^63).
     wasm!(f, {
-        local_get(4);
-        if_empty; i64_const(0); local_get(7); i64_sub; local_set(7); end;
+        local_get(Local(4));
+        if_empty; i64_const(Imm64(0)); local_get(Local(7)); i64_sub; local_set(Local(7)); end;
     });
 
     // Return ok(value): alloc [tag=0][value:i64]
     wasm!(f, {
-        i32_const(imm::RESULT_ALLOC_BYTES); call(alloc); local_set(6);
-        local_get(6); i32_const(0); i32_store(0);
-        local_get(6); local_get(7); i64_store(4);
-        local_get(6);
+        i32_const(Imm32(imm::RESULT_ALLOC_BYTES)); call(alloc); local_set(Local(6));
+        local_get(Local(6)); i32_const(Imm32(0)); i32_store(0);
+        local_get(Local(6)); local_get(Local(7)); i64_store(4);
+        local_get(Local(6));
         end;
     });
 
@@ -354,32 +355,32 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
 
     // len = s.len ; data_base = s + DATA_OFFSET
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
-        local_get(0); i32_const(data_off); i32_add; local_set(11);
+        local_get(Local(0)); i32_load(0); local_set(Local(1));
+        local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; local_set(Local(11));
     });
 
     // Initialize: i = 0, end = len, defaults.
     wasm!(f, {
-        i32_const(0); local_set(2);
-        local_get(1); local_set(10);
-        f64_const(0.0); local_set(3);
-        i32_const(0); local_set(4);
-        f64_const(1.0); local_set(7);
-        i32_const(0); local_set(8);
-        i32_const(0); local_set(9);
-        i32_const(0); local_set(12);
-        i32_const(0); local_set(13);
-        i32_const(0); local_set(14);
-        i32_const(0); local_set(16);
+        i32_const(Imm32(0)); local_set(Local(2));
+        local_get(Local(1)); local_set(Local(10));
+        f64_const(0.0); local_set(Local(3));
+        i32_const(Imm32(0)); local_set(Local(4));
+        f64_const(1.0); local_set(Local(7));
+        i32_const(Imm32(0)); local_set(Local(8));
+        i32_const(Imm32(0)); local_set(Local(9));
+        i32_const(Imm32(0)); local_set(Local(12));
+        i32_const(Imm32(0)); local_set(Local(13));
+        i32_const(Imm32(0)); local_set(Local(14));
+        i32_const(Imm32(0)); local_set(Local(16));
         // Significand bignum (len=1, limb0=0) — built digit by digit, then handed
         // to __dec2flt for correctly-rounded scaling. frac_count = fractional digits.
-        i32_const(sig_stride); call(emitter.rt.alloc); local_set(17);
-        local_get(17); i32_const(1); i32_store(0);
-        local_get(17); i32_const(sig_hdr); i32_add; i32_const(0); i32_store(0);
-        i32_const(0); local_set(18);
-        i32_const(0); local_set(19);   // started
-        i32_const(0); local_set(20);   // sig_digits
-        i32_const(0); local_set(21);   // sticky
+        i32_const(Imm32(sig_stride)); call(emitter.rt.alloc); local_set(Local(17));
+        local_get(Local(17)); i32_const(Imm32(1)); i32_store(0);
+        local_get(Local(17)); i32_const(Imm32(sig_hdr)); i32_add; i32_const(Imm32(0)); i32_store(0);
+        i32_const(Imm32(0)); local_set(Local(18));
+        i32_const(Imm32(0)); local_set(Local(19));   // started
+        i32_const(Imm32(0)); local_set(Local(20));   // sig_digits
+        i32_const(Imm32(0)); local_set(Local(21));   // sticky
     });
 
     // Trim leading + trailing Unicode whitespace (matches native s.trim().parse),
@@ -390,7 +391,7 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
 
     // Empty after trim -> "cannot parse float from empty string"
     wasm!(f, {
-        local_get(2); local_get(10); i32_ge_u;
+        local_get(Local(2)); local_get(Local(10)); i32_ge_u;
         if_empty;
     });
     emit_float_parse_err(&mut f, emitter, empty_err);
@@ -398,22 +399,22 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
 
     // Optional leading sign at data[i].
     wasm!(f, {
-        local_get(11); local_get(2); i32_add; i32_load8_u(0); local_set(5);
-        local_get(5); i32_const(imm::ASCII_MINUS); i32_eq;   // '-'
+        local_get(Local(11)); local_get(Local(2)); i32_add; i32_load8_u(0); local_set(Local(5));
+        local_get(Local(5)); i32_const(Imm32(imm::ASCII_MINUS)); i32_eq;   // '-'
         if_empty;
-          i32_const(1); local_set(4);
-          local_get(2); i32_const(1); i32_add; local_set(2);
+          i32_const(Imm32(1)); local_set(Local(4));
+          local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
         else_;
-          local_get(5); i32_const(imm::ASCII_PLUS); i32_eq; // '+'
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_PLUS)); i32_eq; // '+'
           if_empty;
-            local_get(2); i32_const(1); i32_add; local_set(2);
+            local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
           end;
         end;
     });
 
     // After the sign, the body [i, end) must be non-empty (rejects "+", "-").
     wasm!(f, {
-        local_get(2); local_get(10); i32_ge_u;
+        local_get(Local(2)); local_get(Local(10)); i32_ge_u;
         if_empty;
     });
     emit_float_parse_err(&mut f, emitter, invalid_err);
@@ -441,35 +442,35 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
     // --- Decimal mantissa: scan [i, end). On 'e'/'E' break to exponent. ---
     wasm!(f, {
         block_empty; loop_empty;
-          local_get(2); local_get(10); i32_ge_u; br_if(1);
-          local_get(11); local_get(2); i32_add; i32_load8_u(0); local_set(5);
+          local_get(Local(2)); local_get(Local(10)); i32_ge_u; br_if(1);
+          local_get(Local(11)); local_get(Local(2)); i32_add; i32_load8_u(0); local_set(Local(5));
 
           // '.' -> set has_dot (err on second dot)
-          local_get(5); i32_const(imm::ASCII_DOT); i32_eq;
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_DOT)); i32_eq;
           if_empty;
-            local_get(8); if_empty;
+            local_get(Local(8)); if_empty;
     });
     emit_float_parse_err(&mut f, emitter, invalid_err);
     wasm!(f, {
             end;
-            i32_const(1); local_set(8);
-            local_get(2); i32_const(1); i32_add; local_set(2);
+            i32_const(Imm32(1)); local_set(Local(8));
+            local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
             br(1);
           end;
 
           // 'e' / 'E' -> exponent: mark and break out of mantissa loop
-          local_get(5); i32_const(imm::ASCII_LOWER_E); i32_eq;   // 'e'
-          local_get(5); i32_const(imm::ASCII_UPPER_E); i32_eq;   // 'E'
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_LOWER_E)); i32_eq;   // 'e'
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_UPPER_E)); i32_eq;   // 'E'
           i32_or;
           if_empty;
-            i32_const(1); local_set(16);
-            local_get(2); i32_const(1); i32_add; local_set(2);
+            i32_const(Imm32(1)); local_set(Local(16));
+            local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
             br(2);                                  // exit loop+block
           end;
 
           // digit '0'..'9' ?
-          local_get(5); i32_const(imm::ASCII_ZERO); i32_lt_u;
-          local_get(5); i32_const(imm::ASCII_NINE); i32_gt_u;
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_ZERO)); i32_lt_u;
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_NINE)); i32_gt_u;
           i32_or;
           if_empty;
     });
@@ -477,39 +478,39 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
     wasm!(f, {
           end;
 
-          local_get(9); i32_const(1); i32_add; local_set(9);   // digit_count++ (all digits)
+          local_get(Local(9)); i32_const(Imm32(1)); i32_add; local_set(Local(9));   // digit_count++ (all digits)
           // started |= (digit != 0) — leading zeros carry no significance.
-          local_get(19); local_get(5); i32_const(imm::ASCII_ZERO); i32_ne; i32_or; local_set(19);
-          local_get(19); i32_eqz;
+          local_get(Local(19)); local_get(Local(5)); i32_const(Imm32(imm::ASCII_ZERO)); i32_ne; i32_or; local_set(Local(19));
+          local_get(Local(19)); i32_eqz;
           if_empty;
             // Leading zero: it only advances the fractional scale (frac_count),
             // never the significand or the precision budget. So a flat decimal
             // like "0.000…0123" keeps full precision for its real digits.
-            local_get(8); if_empty; local_get(18); i32_const(1); i32_add; local_set(18); end;
+            local_get(Local(8)); if_empty; local_get(Local(18)); i32_const(Imm32(1)); i32_add; local_set(Local(18)); end;
           else_;
             // Significant digit. Accumulate sig = sig*10 + digit while under the
             // precision cap (keeps the bignum within NLIMBS); track the exact
             // decimal exponent via frac_count. Past the cap, drop the digit but
             // OR a non-zero value into `sticky` so __dec2flt can break a tie.
-            local_get(20); i32_const(super::rt_dec2flt::SIG_DIGIT_CAP); i32_lt_u;
+            local_get(Local(20)); i32_const(Imm32(super::rt_dec2flt::SIG_DIGIT_CAP)); i32_lt_u;
             if_empty;
-              local_get(17); i32_const(super::rt_dec2flt::DECIMAL_BASE); call(mul_small);
-              local_get(17); local_get(5); i32_const(imm::ASCII_ZERO); i32_sub; call(bn_add_small);
-              local_get(20); i32_const(1); i32_add; local_set(20);   // sig_digits++
-              local_get(8); if_empty; local_get(18); i32_const(1); i32_add; local_set(18); end;
+              local_get(Local(17)); i32_const(Imm32(super::rt_dec2flt::DECIMAL_BASE)); call(mul_small);
+              local_get(Local(17)); local_get(Local(5)); i32_const(Imm32(imm::ASCII_ZERO)); i32_sub; call(bn_add_small);
+              local_get(Local(20)); i32_const(Imm32(1)); i32_add; local_set(Local(20));   // sig_digits++
+              local_get(Local(8)); if_empty; local_get(Local(18)); i32_const(Imm32(1)); i32_add; local_set(Local(18)); end;
             else_;
-              local_get(21); local_get(5); i32_const(imm::ASCII_ZERO); i32_ne; i32_or; local_set(21);
+              local_get(Local(21)); local_get(Local(5)); i32_const(Imm32(imm::ASCII_ZERO)); i32_ne; i32_or; local_set(Local(21));
             end;
           end;
 
-          local_get(2); i32_const(1); i32_add; local_set(2);
+          local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
           br(0);
         end; end;
     });
 
     // Need at least one mantissa digit (rejects ".", "e3", ".e1").
     wasm!(f, {
-        local_get(9); i32_eqz;
+        local_get(Local(9)); i32_eqz;
         if_empty;
     });
     emit_float_parse_err(&mut f, emitter, invalid_err);
@@ -517,34 +518,34 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
 
     // --- Exponent (only if we saw 'e'/'E') ---
     wasm!(f, {
-        local_get(16);
+        local_get(Local(16));
         if_empty;
           // Optional exponent sign at data[i].
-          local_get(2); local_get(10); i32_ge_u;
+          local_get(Local(2)); local_get(Local(10)); i32_ge_u;
           if_empty;
     });
     // "1e" with no exponent body -> invalid.
     emit_float_parse_err(&mut f, emitter, invalid_err);
     wasm!(f, {
           end;
-          local_get(11); local_get(2); i32_add; i32_load8_u(0); local_set(5);
-          local_get(5); i32_const(imm::ASCII_MINUS); i32_eq;   // '-'
+          local_get(Local(11)); local_get(Local(2)); i32_add; i32_load8_u(0); local_set(Local(5));
+          local_get(Local(5)); i32_const(Imm32(imm::ASCII_MINUS)); i32_eq;   // '-'
           if_empty;
-            i32_const(1); local_set(12);
-            local_get(2); i32_const(1); i32_add; local_set(2);
+            i32_const(Imm32(1)); local_set(Local(12));
+            local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
           else_;
-            local_get(5); i32_const(imm::ASCII_PLUS); i32_eq; // '+'
+            local_get(Local(5)); i32_const(Imm32(imm::ASCII_PLUS)); i32_eq; // '+'
             if_empty;
-              local_get(2); i32_const(1); i32_add; local_set(2);
+              local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
             end;
           end;
 
           // Exponent digit loop.
           block_empty; loop_empty;
-            local_get(2); local_get(10); i32_ge_u; br_if(1);
-            local_get(11); local_get(2); i32_add; i32_load8_u(0); local_set(5);
-            local_get(5); i32_const(imm::ASCII_ZERO); i32_lt_u;
-            local_get(5); i32_const(imm::ASCII_NINE); i32_gt_u;
+            local_get(Local(2)); local_get(Local(10)); i32_ge_u; br_if(1);
+            local_get(Local(11)); local_get(Local(2)); i32_add; i32_load8_u(0); local_set(Local(5));
+            local_get(Local(5)); i32_const(Imm32(imm::ASCII_ZERO)); i32_lt_u;
+            local_get(Local(5)); i32_const(Imm32(imm::ASCII_NINE)); i32_gt_u;
             i32_or;
             if_empty;
     });
@@ -553,17 +554,17 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
             end;
             // exp_val = exp_val*10 + digit, saturating at exp_magnitude_clamp so a
             // huge exponent can't wrap the i32 accumulator (see clamp definition).
-            local_get(13); i32_const(exp_magnitude_clamp); i32_lt_u;
+            local_get(Local(13)); i32_const(Imm32(exp_magnitude_clamp)); i32_lt_u;
             if_empty;
-              local_get(13); i32_const(super::rt_dec2flt::DECIMAL_BASE); i32_mul;
-              local_get(5); i32_const(imm::ASCII_ZERO); i32_sub; i32_add; local_set(13);
+              local_get(Local(13)); i32_const(Imm32(super::rt_dec2flt::DECIMAL_BASE)); i32_mul;
+              local_get(Local(5)); i32_const(Imm32(imm::ASCII_ZERO)); i32_sub; i32_add; local_set(Local(13));
             end;
-            local_get(14); i32_const(1); i32_add; local_set(14);
-            local_get(2); i32_const(1); i32_add; local_set(2);
+            local_get(Local(14)); i32_const(Imm32(1)); i32_add; local_set(Local(14));
+            local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
             br(0);
           end; end;
           // Exponent must have >= 1 digit ("1e+" -> invalid).
-          local_get(14); i32_eqz;
+          local_get(Local(14)); i32_eqz;
           if_empty;
     });
     emit_float_parse_err(&mut f, emitter, invalid_err);
@@ -574,7 +575,7 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
 
     // i must now equal end — no trailing garbage.
     wasm!(f, {
-        local_get(2); local_get(10); i32_lt_u;
+        local_get(Local(2)); local_get(Local(10)); i32_lt_u;
         if_empty;
     });
     emit_float_parse_err(&mut f, emitter, invalid_err);
@@ -584,20 +585,20 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
     // decimal exponent to __dec2flt for the correctly-rounded f64 (Clinger
     // AlgorithmM, exact big-integer arithmetic); __dec2flt applies the sign.
     wasm!(f, {
-        local_get(12);                          // exp_neg
+        local_get(Local(12));                          // exp_neg
         if_i32;
-          i32_const(0); local_get(13); i32_sub; // -exp_val
+          i32_const(Imm32(0)); local_get(Local(13)); i32_sub; // -exp_val
         else_;
-          local_get(13);                        // exp_val
+          local_get(Local(13));                        // exp_val
         end;
-        local_get(18); i32_sub;                 // - frac_count → exp10
-        local_set(14);
-        local_get(4); local_get(17); local_get(14); local_get(21); call(dec2flt); local_set(3);
+        local_get(Local(18)); i32_sub;                 // - frac_count → exp10
+        local_set(Local(14));
+        local_get(Local(4)); local_get(Local(17)); local_get(Local(14)); local_get(Local(21)); call(dec2flt); local_set(Local(3));
         // Return ok(result): alloc 12 bytes [tag=0][f64]
-        i32_const(imm::RESULT_ALLOC_BYTES); call(emitter.rt.alloc); local_set(6);
-        local_get(6); i32_const(0); i32_store(0);
-        local_get(6); local_get(3); f64_store(4);
-        local_get(6);
+        i32_const(Imm32(imm::RESULT_ALLOC_BYTES)); call(emitter.rt.alloc); local_set(Local(6));
+        local_get(Local(6)); i32_const(Imm32(0)); i32_store(0);
+        local_get(Local(6)); local_get(Local(3)); f64_store(4);
+        local_get(Local(6));
         end;
     });
 
@@ -610,17 +611,17 @@ pub(super) fn compile_float_parse(emitter: &mut WasmEmitter) {
 fn emit_kw_match(f: &mut Function, kw: &[u8], i_local: u32, end_local: u32, base_local: u32) {
     // result = (end - i) == kw.len()
     wasm!(f, {
-        local_get(end_local); local_get(i_local); i32_sub;
-        i32_const(kw.len() as i32); i32_eq;
+        local_get(Local(end_local)); local_get(Local(i_local)); i32_sub;
+        i32_const(Imm32(kw.len() as i32)); i32_eq;
     });
     // AND each byte matches (lowercased). Stack holds the running i32 result.
     for (k, &c) in kw.iter().enumerate() {
         let lower = (c | 0x20) as i32;
         wasm!(f, {
-            local_get(base_local); local_get(i_local); i32_add;
-            i32_const(k as i32); i32_add; i32_load8_u(0);
-            i32_const(imm::ASCII_LOWERCASE_MASK); i32_or;  // ASCII lowercase
-            i32_const(lower); i32_eq;
+            local_get(Local(base_local)); local_get(Local(i_local)); i32_add;
+            i32_const(Imm32(k as i32)); i32_add; i32_load8_u(0);
+            i32_const(Imm32(imm::ASCII_LOWERCASE_MASK)); i32_or;  // ASCII lowercase
+            i32_const(Imm32(lower)); i32_eq;
             i32_and;
         });
     }
@@ -629,10 +630,10 @@ fn emit_kw_match(f: &mut Function, kw: &[u8], i_local: u32, end_local: u32, base
 /// Emit the err return for float_parse: alloc [tag=1][str_ptr] and return.
 fn emit_float_parse_err(f: &mut Function, emitter: &WasmEmitter, err_str: u32) {
     wasm!(f, {
-        i32_const(imm::RESULT_ALLOC_BYTES); call(emitter.rt.alloc); local_set(6);
-        local_get(6); i32_const(1); i32_store(0);          // tag = 1 (err)
-        local_get(6); i32_const(err_str as i32); i32_store(4); // err string
-        local_get(6);
+        i32_const(Imm32(imm::RESULT_ALLOC_BYTES)); call(emitter.rt.alloc); local_set(Local(6));
+        local_get(Local(6)); i32_const(Imm32(1)); i32_store(0);          // tag = 1 (err)
+        local_get(Local(6)); i32_const(Imm32(err_str as i32)); i32_store(4); // err string
+        local_get(Local(6));
         return_;
     });
 }
@@ -643,20 +644,20 @@ fn emit_float_parse_err(f: &mut Function, emitter: &WasmEmitter, err_str: u32) {
 fn emit_float_parse_ok_special(f: &mut Function, emitter: &WasmEmitter, value: f64) {
     let pos_bits = (value.to_bits() & 0x7FFF_FFFF_FFFF_FFFF) as i64; // magnitude bits
     wasm!(f, {
-        i32_const(imm::RESULT_ALLOC_BYTES); call(emitter.rt.alloc); local_set(6);
-        local_get(6); i32_const(0); i32_store(0);          // tag = 0 (ok)
-        local_get(6);
-        i64_const(pos_bits);
-        local_get(4);
+        i32_const(Imm32(imm::RESULT_ALLOC_BYTES)); call(emitter.rt.alloc); local_set(Local(6));
+        local_get(Local(6)); i32_const(Imm32(0)); i32_store(0);          // tag = 0 (ok)
+        local_get(Local(6));
+        i64_const(Imm64(pos_bits));
+        local_get(Local(4));
         if_i64;
-          i64_const(imm::F64_SIGN_BIT);
+          i64_const(Imm64(imm::F64_SIGN_BIT));
         else_;
-          i64_const(0);
+          i64_const(Imm64(0));
         end;
         i64_or;
         f64_reinterpret_i64;
         f64_store(4);
-        local_get(6);
+        local_get(Local(6));
         return_;
     });
 }
@@ -681,7 +682,7 @@ pub(super) fn compile_float_pow(emitter: &mut WasmEmitter) {
     let libm_pow = emitter.rt.libm.pow;
     let mut f = Function::new([]);
     wasm!(f, {
-        local_get(0); local_get(1); call(libm_pow);
+        local_get(Local(0)); local_get(Local(1)); call(libm_pow);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.float_pow, type_idx, f));
@@ -702,36 +703,36 @@ pub(super) fn compile_math_sin(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(2, ValType::I32), (1, ValType::I32), (2, ValType::F64)]);
     wasm!(f, {
         // ix = (to_bits(x) >> 32) & 0x7fffffff
-        local_get(0); i64_reinterpret_f64; i64_const(imm::F64_HIGH_WORD_SHIFT); i64_shr_u; i32_wrap_i64; i32_const(imm::F64_ABS_HIGH_WORD_MASK); i32_and; local_set(1);
+        local_get(Local(0)); i64_reinterpret_f64; i64_const(Imm64(imm::F64_HIGH_WORD_SHIFT)); i64_shr_u; i32_wrap_i64; i32_const(Imm32(imm::F64_ABS_HIGH_WORD_MASK)); i32_and; local_set(Local(1));
         // if ix <= 0x3fe921fb { if ix < 0x3e500000 { return x } return k_sin(x,0,0) }
-        local_get(1); i32_const(imm::LIBM_SMALL_ARG); i32_le_u;
+        local_get(Local(1)); i32_const(Imm32(imm::LIBM_SMALL_ARG)); i32_le_u;
         if_empty;
-            local_get(1); i32_const(imm::LIBM_SIN_TINY_ARG); i32_lt_u;
-            if_empty; local_get(0); return_; end;
-            local_get(0); f64_const(0.0); i32_const(0); call(k_sin); return_;
+            local_get(Local(1)); i32_const(Imm32(imm::LIBM_SIN_TINY_ARG)); i32_lt_u;
+            if_empty; local_get(Local(0)); return_; end;
+            local_get(Local(0)); f64_const(0.0); i32_const(Imm32(0)); call(k_sin); return_;
         end;
         // if ix >= 0x7ff00000 { return x - x }
-        local_get(1); i32_const(imm::F64_INF_HIGH_WORD); i32_ge_u;
-        if_empty; local_get(0); local_get(0); f64_sub; return_; end;
+        local_get(Local(1)); i32_const(Imm32(imm::F64_INF_HIGH_WORD)); i32_ge_u;
+        if_empty; local_get(Local(0)); local_get(Local(0)); f64_sub; return_; end;
         // n = rem_pio2(x, yp); y0=y[0]; y1=y[1]
-        i32_const(imm::REM_PIO2_OUT_BYTES); call(alloc); local_set(3);
-        local_get(0); local_get(3); call(rem_pio2); local_set(2);
-        local_get(3); f64_load(0); local_set(4);
-        local_get(3); f64_load(8); local_set(5);
+        i32_const(Imm32(imm::REM_PIO2_OUT_BYTES)); call(alloc); local_set(Local(3));
+        local_get(Local(0)); local_get(Local(3)); call(rem_pio2); local_set(Local(2));
+        local_get(Local(3)); f64_load(0); local_set(Local(4));
+        local_get(Local(3)); f64_load(8); local_set(Local(5));
         // match n & 3 { 0=>k_sin(y0,y1,1) 1=>k_cos(y0,y1) 2=>-k_sin(y0,y1,1) _=>-k_cos(y0,y1) }
-        local_get(2); i32_const(imm::QUAD_MASK); i32_and; i32_const(0); i32_eq;
+        local_get(Local(2)); i32_const(Imm32(imm::QUAD_MASK)); i32_and; i32_const(Imm32(0)); i32_eq;
         if_f64;
-            local_get(4); local_get(5); i32_const(1); call(k_sin);
+            local_get(Local(4)); local_get(Local(5)); i32_const(Imm32(1)); call(k_sin);
         else_;
-            local_get(2); i32_const(imm::QUAD_MASK); i32_and; i32_const(1); i32_eq;
+            local_get(Local(2)); i32_const(Imm32(imm::QUAD_MASK)); i32_and; i32_const(Imm32(1)); i32_eq;
             if_f64;
-                local_get(4); local_get(5); call(k_cos);
+                local_get(Local(4)); local_get(Local(5)); call(k_cos);
             else_;
-                local_get(2); i32_const(imm::QUAD_MASK); i32_and; i32_const(imm::QUAD_NEG); i32_eq;
+                local_get(Local(2)); i32_const(Imm32(imm::QUAD_MASK)); i32_and; i32_const(Imm32(imm::QUAD_NEG)); i32_eq;
                 if_f64;
-                    local_get(4); local_get(5); i32_const(1); call(k_sin); f64_neg;
+                    local_get(Local(4)); local_get(Local(5)); i32_const(Imm32(1)); call(k_sin); f64_neg;
                 else_;
-                    local_get(4); local_get(5); call(k_cos); f64_neg;
+                    local_get(Local(4)); local_get(Local(5)); call(k_cos); f64_neg;
                 end;
             end;
         end;
@@ -751,37 +752,37 @@ pub(super) fn compile_math_cos(emitter: &mut WasmEmitter) {
     // params: 0=x. locals: 1=i32 ix, 2=i32 n, 3=i32 yp, 4=f64 y0, 5=f64 y1
     let mut f = Function::new([(2, ValType::I32), (1, ValType::I32), (2, ValType::F64)]);
     wasm!(f, {
-        local_get(0); i64_reinterpret_f64; i64_const(imm::F64_HIGH_WORD_SHIFT); i64_shr_u; i32_wrap_i64; i32_const(imm::F64_ABS_HIGH_WORD_MASK); i32_and; local_set(1);
+        local_get(Local(0)); i64_reinterpret_f64; i64_const(Imm64(imm::F64_HIGH_WORD_SHIFT)); i64_shr_u; i32_wrap_i64; i32_const(Imm32(imm::F64_ABS_HIGH_WORD_MASK)); i32_and; local_set(Local(1));
         // if ix <= 0x3fe921fb { if ix < 0x3e46a09e { if (x as i32)==0 { return 1.0 } } return k_cos(x,0) }
-        local_get(1); i32_const(imm::LIBM_SMALL_ARG); i32_le_u;
+        local_get(Local(1)); i32_const(Imm32(imm::LIBM_SMALL_ARG)); i32_le_u;
         if_empty;
-            local_get(1); i32_const(imm::LIBM_COS_TINY_ARG); i32_lt_u;
+            local_get(Local(1)); i32_const(Imm32(imm::LIBM_COS_TINY_ARG)); i32_lt_u;
             if_empty;
-                local_get(0); i32_trunc_f64_s; i32_eqz;
+                local_get(Local(0)); i32_trunc_f64_s; i32_eqz;
                 if_empty; f64_const(1.0); return_; end;
             end;
-            local_get(0); f64_const(0.0); call(k_cos); return_;
+            local_get(Local(0)); f64_const(0.0); call(k_cos); return_;
         end;
-        local_get(1); i32_const(imm::F64_INF_HIGH_WORD); i32_ge_u;
-        if_empty; local_get(0); local_get(0); f64_sub; return_; end;
-        i32_const(imm::REM_PIO2_OUT_BYTES); call(alloc); local_set(3);
-        local_get(0); local_get(3); call(rem_pio2); local_set(2);
-        local_get(3); f64_load(0); local_set(4);
-        local_get(3); f64_load(8); local_set(5);
+        local_get(Local(1)); i32_const(Imm32(imm::F64_INF_HIGH_WORD)); i32_ge_u;
+        if_empty; local_get(Local(0)); local_get(Local(0)); f64_sub; return_; end;
+        i32_const(Imm32(imm::REM_PIO2_OUT_BYTES)); call(alloc); local_set(Local(3));
+        local_get(Local(0)); local_get(Local(3)); call(rem_pio2); local_set(Local(2));
+        local_get(Local(3)); f64_load(0); local_set(Local(4));
+        local_get(Local(3)); f64_load(8); local_set(Local(5));
         // match n & 3 { 0=>k_cos 1=>-k_sin 2=>-k_cos _=>k_sin }
-        local_get(2); i32_const(imm::QUAD_MASK); i32_and; i32_const(0); i32_eq;
+        local_get(Local(2)); i32_const(Imm32(imm::QUAD_MASK)); i32_and; i32_const(Imm32(0)); i32_eq;
         if_f64;
-            local_get(4); local_get(5); call(k_cos);
+            local_get(Local(4)); local_get(Local(5)); call(k_cos);
         else_;
-            local_get(2); i32_const(imm::QUAD_MASK); i32_and; i32_const(1); i32_eq;
+            local_get(Local(2)); i32_const(Imm32(imm::QUAD_MASK)); i32_and; i32_const(Imm32(1)); i32_eq;
             if_f64;
-                local_get(4); local_get(5); i32_const(1); call(k_sin); f64_neg;
+                local_get(Local(4)); local_get(Local(5)); i32_const(Imm32(1)); call(k_sin); f64_neg;
             else_;
-                local_get(2); i32_const(imm::QUAD_MASK); i32_and; i32_const(imm::QUAD_NEG); i32_eq;
+                local_get(Local(2)); i32_const(Imm32(imm::QUAD_MASK)); i32_and; i32_const(Imm32(imm::QUAD_NEG)); i32_eq;
                 if_f64;
-                    local_get(4); local_get(5); call(k_cos); f64_neg;
+                    local_get(Local(4)); local_get(Local(5)); call(k_cos); f64_neg;
                 else_;
-                    local_get(4); local_get(5); i32_const(1); call(k_sin);
+                    local_get(Local(4)); local_get(Local(5)); i32_const(Imm32(1)); call(k_sin);
                 end;
             end;
         end;
@@ -800,22 +801,22 @@ pub(super) fn compile_math_tan(emitter: &mut WasmEmitter) {
     // params: 0=x. locals: 1=i32 ix, 2=i32 n, 3=i32 yp, 4=f64 y0, 5=f64 y1
     let mut f = Function::new([(2, ValType::I32), (1, ValType::I32), (2, ValType::F64)]);
     wasm!(f, {
-        local_get(0); i64_reinterpret_f64; i64_const(imm::F64_HIGH_WORD_SHIFT); i64_shr_u; i32_wrap_i64; i32_const(imm::F64_ABS_HIGH_WORD_MASK); i32_and; local_set(1);
+        local_get(Local(0)); i64_reinterpret_f64; i64_const(Imm64(imm::F64_HIGH_WORD_SHIFT)); i64_shr_u; i32_wrap_i64; i32_const(Imm32(imm::F64_ABS_HIGH_WORD_MASK)); i32_and; local_set(Local(1));
         // if ix <= 0x3fe921fb { if ix < 0x3e400000 { return x } return k_tan(x,0,0) }
-        local_get(1); i32_const(imm::LIBM_SMALL_ARG); i32_le_u;
+        local_get(Local(1)); i32_const(Imm32(imm::LIBM_SMALL_ARG)); i32_le_u;
         if_empty;
-            local_get(1); i32_const(imm::LIBM_TAN_TINY_ARG); i32_lt_u;
-            if_empty; local_get(0); return_; end;
-            local_get(0); f64_const(0.0); i32_const(0); call(k_tan); return_;
+            local_get(Local(1)); i32_const(Imm32(imm::LIBM_TAN_TINY_ARG)); i32_lt_u;
+            if_empty; local_get(Local(0)); return_; end;
+            local_get(Local(0)); f64_const(0.0); i32_const(Imm32(0)); call(k_tan); return_;
         end;
-        local_get(1); i32_const(imm::F64_INF_HIGH_WORD); i32_ge_u;
-        if_empty; local_get(0); local_get(0); f64_sub; return_; end;
-        i32_const(imm::REM_PIO2_OUT_BYTES); call(alloc); local_set(3);
-        local_get(0); local_get(3); call(rem_pio2); local_set(2);
-        local_get(3); f64_load(0); local_set(4);
-        local_get(3); f64_load(8); local_set(5);
+        local_get(Local(1)); i32_const(Imm32(imm::F64_INF_HIGH_WORD)); i32_ge_u;
+        if_empty; local_get(Local(0)); local_get(Local(0)); f64_sub; return_; end;
+        i32_const(Imm32(imm::REM_PIO2_OUT_BYTES)); call(alloc); local_set(Local(3));
+        local_get(Local(0)); local_get(Local(3)); call(rem_pio2); local_set(Local(2));
+        local_get(Local(3)); f64_load(0); local_set(Local(4));
+        local_get(Local(3)); f64_load(8); local_set(Local(5));
         // k_tan(y0, y1, n & 1)
-        local_get(4); local_get(5); local_get(2); i32_const(1); i32_and; call(k_tan);
+        local_get(Local(4)); local_get(Local(5)); local_get(Local(2)); i32_const(Imm32(1)); i32_and; call(k_tan);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.math_tan, type_idx, f));
@@ -832,7 +833,7 @@ pub(super) fn compile_math_log(emitter: &mut WasmEmitter) {
     let libm_log = emitter.rt.libm.log;
     let mut f = Function::new([]);
     wasm!(f, {
-        local_get(0); call(libm_log);
+        local_get(Local(0)); call(libm_log);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.math_log, type_idx, f));
@@ -847,7 +848,7 @@ pub(super) fn compile_math_log10(emitter: &mut WasmEmitter) {
     let libm_log10 = emitter.rt.libm.log10;
     let mut f = Function::new([]);
     wasm!(f, {
-        local_get(0); call(libm_log10);
+        local_get(Local(0)); call(libm_log10);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.math_log10, type_idx, f));
@@ -861,7 +862,7 @@ pub(super) fn compile_math_log2(emitter: &mut WasmEmitter) {
     let libm_log2 = emitter.rt.libm.log2;
     let mut f = Function::new([]);
     wasm!(f, {
-        local_get(0); call(libm_log2);
+        local_get(Local(0)); call(libm_log2);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.math_log2, type_idx, f));
@@ -878,7 +879,7 @@ pub(super) fn compile_math_exp(emitter: &mut WasmEmitter) {
     let libm_exp = emitter.rt.libm.exp;
     let mut f = Function::new([]);
     wasm!(f, {
-        local_get(0); call(libm_exp);
+        local_get(Local(0)); call(libm_exp);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.math_exp, type_idx, f));

--- a/crates/almide-codegen/src/emit_wasm/rt_regex.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_regex.rs
@@ -44,6 +44,7 @@
 //! stack" (`rx_save_sp_global`) carved from the same arena: a branch pushes a
 //! `ncap*2`-word copy and restores by copying back on failure.
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use super::{CompiledFunc, WasmEmitter};
 use wasm_encoder::ValType;
 use super::TrackedFunction as Function;
@@ -253,7 +254,7 @@ pub(super) fn compile(emitter: &mut WasmEmitter) {
 fn emit_node_alloc(f: &mut Function, arena_sp: u32, n: i32) {
     wasm!(f, {
         global_get(arena_sp);                              // base (result)
-        global_get(arena_sp); i32_const(n * RX_WORD); i32_add; global_set(arena_sp);
+        global_get(arena_sp); i32_const(Imm32(n * RX_WORD)); i32_add; global_set(arena_sp);
     });
 }
 
@@ -271,22 +272,22 @@ fn compile_compile(emitter: &mut WasmEmitter) {
     let ncap = emitter.rt.regex.ncap_global;
 
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
+        local_get(Local(0)); i32_load(0); local_set(Local(1));
         // arena_words = pat_byte_len * PER_BYTE + SLACK
-        local_get(1); i32_const(RX_ARENA_WORDS_PER_BYTE); i32_mul;
-        i32_const(RX_ARENA_SLACK_WORDS); i32_add; local_set(3);
+        local_get(Local(1)); i32_const(Imm32(RX_ARENA_WORDS_PER_BYTE)); i32_mul;
+        i32_const(Imm32(RX_ARENA_SLACK_WORDS)); i32_add; local_set(Local(3));
         // arena_base = alloc(arena_words * 4)
-        local_get(3); i32_const(RX_WORD); i32_mul; call(alloc); local_set(2);
+        local_get(Local(3)); i32_const(Imm32(RX_WORD)); i32_mul; call(alloc); local_set(Local(2));
         // node region grows up from arena_base; save stack grows up from the
         // node/save split point so the two bump cursors never collide.
-        local_get(2); global_set(arena_sp);
-        local_get(3); i32_const(RX_ARENA_NODE_SHIFT); i32_shr_u; local_set(4); // node_words = arena_words/2
-        local_get(2); local_get(4); i32_const(RX_WORD); i32_mul; i32_add; global_set(save_sp);
+        local_get(Local(2)); global_set(arena_sp);
+        local_get(Local(3)); i32_const(Imm32(RX_ARENA_NODE_SHIFT)); i32_shr_u; local_set(Local(4)); // node_words = arena_words/2
+        local_get(Local(2)); local_get(Local(4)); i32_const(Imm32(RX_WORD)); i32_mul; i32_add; global_set(save_sp);
         // reset parser state
-        i32_const(0); global_set(parse_pos);
-        i32_const(0); global_set(ncap);
+        i32_const(Imm32(0)); global_set(parse_pos);
+        i32_const(Imm32(0)); global_set(ncap);
         // alts = parse_alts(pat, in_group=0)
-        local_get(0); i32_const(0); call(parse_alts);
+        local_get(Local(0)); i32_const(Imm32(0)); call(parse_alts);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.compile, type_idx, f));
@@ -306,29 +307,29 @@ fn compile_parse_alts(emitter: &mut WasmEmitter) {
     let parse_pos = emitter.rt.regex.parse_pos_global;
     let data_off = string_data_off();
 
-    wasm!(f, { local_get(0); i32_load(0); local_set(2); });
+    wasm!(f, { local_get(Local(0)); i32_load(0); local_set(Local(2)); });
     // Alts header
     emit_node_alloc(&mut f, arena_sp, RX_ALTS_WORDS);
-    wasm!(f, { local_set(3); });
+    wasm!(f, { local_set(Local(3)); });
     // First Seq (native starts with one empty alt). cur_seq head=null, next=null
     emit_node_alloc(&mut f, arena_sp, RX_SEQ_WORDS);
     wasm!(f, {
-        local_set(4); // cur_seq
-        local_get(4); i32_const(RX_SEQ_HEAD_OFF); i32_add; i32_const(RX_NULL); i32_store(0);
-        local_get(4); i32_const(RX_SEQ_NEXT_OFF); i32_add; i32_const(RX_NULL); i32_store(0);
-        local_get(3); i32_const(RX_ALTS_HEAD_OFF); i32_add; local_get(4); i32_store(0);
-        local_get(4); local_set(5); // last_seq = cur_seq
-        i32_const(RX_NULL); local_set(6); // cur_piece_tail = null
+        local_set(Local(4)); // cur_seq
+        local_get(Local(4)); i32_const(Imm32(RX_SEQ_HEAD_OFF)); i32_add; i32_const(Imm32(RX_NULL)); i32_store(0);
+        local_get(Local(4)); i32_const(Imm32(RX_SEQ_NEXT_OFF)); i32_add; i32_const(Imm32(RX_NULL)); i32_store(0);
+        local_get(Local(3)); i32_const(Imm32(RX_ALTS_HEAD_OFF)); i32_add; local_get(Local(4)); i32_store(0);
+        local_get(Local(4)); local_set(Local(5)); // last_seq = cur_seq
+        i32_const(Imm32(RX_NULL)); local_set(Local(6)); // cur_piece_tail = null
     });
     // Main loop
     wasm!(f, { block_empty; loop_empty; });
-    wasm!(f, { global_get(parse_pos); local_get(2); i32_ge_u; br_if(1); });
+    wasm!(f, { global_get(parse_pos); local_get(Local(2)); i32_ge_u; br_if(1); });
     wasm!(f, {
-        local_get(0); i32_const(data_off); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0); local_set(7);
+        local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0); local_set(Local(7));
     });
     // if in_group && ch==')' break
     wasm!(f, {
-        local_get(1); local_get(7); i32_const(ASCII_RPAREN); i32_eq; i32_and;
+        local_get(Local(1)); local_get(Local(7)); i32_const(Imm32(ASCII_RPAREN)); i32_eq; i32_and;
         if_empty; br(2); end;
     });
     // if ch=='|' : pos++, start a new (possibly empty) Seq; else parse a piece.
@@ -338,37 +339,37 @@ fn compile_parse_alts(emitter: &mut WasmEmitter) {
     // an atom to a freshly-started empty trailing arm (`a|`). Native mirrors this
     // as `if '|' { … continue } else { push piece }` in rx_parse_alts.
     wasm!(f, {
-        local_get(7); i32_const(ASCII_PIPE); i32_eq;
+        local_get(Local(7)); i32_const(Imm32(ASCII_PIPE)); i32_eq;
         if_empty;
-            global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos);
+            global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos);
     });
     emit_node_alloc(&mut f, arena_sp, RX_SEQ_WORDS);
     wasm!(f, {
-            local_set(9); // new_seq
-            local_get(9); i32_const(RX_SEQ_HEAD_OFF); i32_add; i32_const(RX_NULL); i32_store(0);
-            local_get(9); i32_const(RX_SEQ_NEXT_OFF); i32_add; i32_const(RX_NULL); i32_store(0);
+            local_set(Local(9)); // new_seq
+            local_get(Local(9)); i32_const(Imm32(RX_SEQ_HEAD_OFF)); i32_add; i32_const(Imm32(RX_NULL)); i32_store(0);
+            local_get(Local(9)); i32_const(Imm32(RX_SEQ_NEXT_OFF)); i32_add; i32_const(Imm32(RX_NULL)); i32_store(0);
             // last_seq.next = new_seq
-            local_get(5); i32_const(RX_SEQ_NEXT_OFF); i32_add; local_get(9); i32_store(0);
-            local_get(9); local_set(5); // last_seq = new_seq
-            local_get(9); local_set(4); // cur_seq = new_seq
-            i32_const(RX_NULL); local_set(6); // reset piece tail
+            local_get(Local(5)); i32_const(Imm32(RX_SEQ_NEXT_OFF)); i32_add; local_get(Local(9)); i32_store(0);
+            local_get(Local(9)); local_set(Local(5)); // last_seq = new_seq
+            local_get(Local(9)); local_set(Local(4)); // cur_seq = new_seq
+            i32_const(Imm32(RX_NULL)); local_set(Local(6)); // reset piece tail
         else_;
             // piece = parse_piece(pat); append to cur_seq's piece list
-            local_get(0); call(parse_piece); local_set(8);
-            local_get(8); i32_const(RX_PIECE_NEXT_OFF); i32_add; i32_const(RX_NULL); i32_store(0);
+            local_get(Local(0)); call(parse_piece); local_set(Local(8));
+            local_get(Local(8)); i32_const(Imm32(RX_PIECE_NEXT_OFF)); i32_add; i32_const(Imm32(RX_NULL)); i32_store(0);
             // if cur_piece_tail==null: cur_seq.head = piece; else tail.next = piece
-            local_get(6); i32_eqz;
+            local_get(Local(6)); i32_eqz;
             if_empty;
-                local_get(4); i32_const(RX_SEQ_HEAD_OFF); i32_add; local_get(8); i32_store(0);
+                local_get(Local(4)); i32_const(Imm32(RX_SEQ_HEAD_OFF)); i32_add; local_get(Local(8)); i32_store(0);
             else_;
-                local_get(6); i32_const(RX_PIECE_NEXT_OFF); i32_add; local_get(8); i32_store(0);
+                local_get(Local(6)); i32_const(Imm32(RX_PIECE_NEXT_OFF)); i32_add; local_get(Local(8)); i32_store(0);
             end;
-            local_get(8); local_set(6); // tail = piece
+            local_get(Local(8)); local_set(Local(6)); // tail = piece
         end;
         br(0); // continue loop (loop level, outside the '|' if)
     });
     wasm!(f, { end; end; }); // end loop, block
-    wasm!(f, { local_get(3); end; });
+    wasm!(f, { local_get(Local(3)); end; });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.parse_alts, type_idx, f));
 }
 
@@ -384,38 +385,38 @@ fn compile_parse_piece(emitter: &mut WasmEmitter) {
     let data_off = string_data_off();
 
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(0); call(parse_atom); local_set(1);
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(0)); call(parse_atom); local_set(Local(1));
         // default (min=1, max=1)
-        local_get(1); i32_const(RX_PIECE_MIN_OFF); i32_add; i32_const(1); i32_store(0);
-        local_get(1); i32_const(RX_PIECE_MAX_OFF); i32_add; i32_const(1); i32_store(0);
+        local_get(Local(1)); i32_const(Imm32(RX_PIECE_MIN_OFF)); i32_add; i32_const(Imm32(1)); i32_store(0);
+        local_get(Local(1)); i32_const(Imm32(RX_PIECE_MAX_OFF)); i32_add; i32_const(Imm32(1)); i32_store(0);
         // quantifier?
-        global_get(parse_pos); local_get(2); i32_lt_u;
+        global_get(parse_pos); local_get(Local(2)); i32_lt_u;
         if_empty;
-            local_get(0); i32_const(data_off); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0); local_set(3);
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0); local_set(Local(3));
             // '*' => (0, None)
-            local_get(3); i32_const(ASCII_STAR); i32_eq;
+            local_get(Local(3)); i32_const(Imm32(ASCII_STAR)); i32_eq;
             if_empty;
-                local_get(1); i32_const(RX_PIECE_MIN_OFF); i32_add; i32_const(0); i32_store(0);
-                local_get(1); i32_const(RX_PIECE_MAX_OFF); i32_add; i32_const(RX_MAX_UNBOUNDED); i32_store(0);
-                global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos);
+                local_get(Local(1)); i32_const(Imm32(RX_PIECE_MIN_OFF)); i32_add; i32_const(Imm32(0)); i32_store(0);
+                local_get(Local(1)); i32_const(Imm32(RX_PIECE_MAX_OFF)); i32_add; i32_const(Imm32(RX_MAX_UNBOUNDED)); i32_store(0);
+                global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos);
             else_;
-                local_get(3); i32_const(ASCII_PLUS); i32_eq;
+                local_get(Local(3)); i32_const(Imm32(ASCII_PLUS)); i32_eq;
                 if_empty;
-                    local_get(1); i32_const(RX_PIECE_MIN_OFF); i32_add; i32_const(1); i32_store(0);
-                    local_get(1); i32_const(RX_PIECE_MAX_OFF); i32_add; i32_const(RX_MAX_UNBOUNDED); i32_store(0);
-                    global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos);
+                    local_get(Local(1)); i32_const(Imm32(RX_PIECE_MIN_OFF)); i32_add; i32_const(Imm32(1)); i32_store(0);
+                    local_get(Local(1)); i32_const(Imm32(RX_PIECE_MAX_OFF)); i32_add; i32_const(Imm32(RX_MAX_UNBOUNDED)); i32_store(0);
+                    global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos);
                 else_;
-                    local_get(3); i32_const(ASCII_QUESTION); i32_eq;
+                    local_get(Local(3)); i32_const(Imm32(ASCII_QUESTION)); i32_eq;
                     if_empty;
-                        local_get(1); i32_const(RX_PIECE_MIN_OFF); i32_add; i32_const(0); i32_store(0);
-                        local_get(1); i32_const(RX_PIECE_MAX_OFF); i32_add; i32_const(1); i32_store(0);
-                        global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos);
+                        local_get(Local(1)); i32_const(Imm32(RX_PIECE_MIN_OFF)); i32_add; i32_const(Imm32(0)); i32_store(0);
+                        local_get(Local(1)); i32_const(Imm32(RX_PIECE_MAX_OFF)); i32_add; i32_const(Imm32(1)); i32_store(0);
+                        global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos);
                     end;
                 end;
             end;
         end;
-        local_get(1);
+        local_get(Local(1));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.parse_piece, type_idx, f));
@@ -439,84 +440,84 @@ fn compile_parse_atom(emitter: &mut WasmEmitter) {
     let data_off = string_data_off();
 
     emit_node_alloc(&mut f, arena_sp, RX_PIECE_WORDS);
-    wasm!(f, { local_set(1); });
+    wasm!(f, { local_set(Local(1)); });
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(7);
-        local_get(0); i32_const(data_off); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0); local_set(6);
+        local_get(Local(0)); i32_load(0); local_set(Local(7));
+        local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0); local_set(Local(6));
     });
     // '.' => Dot
     wasm!(f, {
-        local_get(6); i32_const(ASCII_DOT); i32_eq;
+        local_get(Local(6)); i32_const(Imm32(ASCII_DOT)); i32_eq;
         if_empty;
-            local_get(1); i32_const(RX_PIECE_KIND_OFF); i32_add; i32_const(RX_KIND_DOT); i32_store(0);
-            global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos);
-            local_get(1); return_;
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_KIND_OFF)); i32_add; i32_const(Imm32(RX_KIND_DOT)); i32_store(0);
+            global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos);
+            local_get(Local(1)); return_;
         end;
     });
     // '^' => AnchorStart
     wasm!(f, {
-        local_get(6); i32_const(ASCII_CARET); i32_eq;
+        local_get(Local(6)); i32_const(Imm32(ASCII_CARET)); i32_eq;
         if_empty;
-            local_get(1); i32_const(RX_PIECE_KIND_OFF); i32_add; i32_const(RX_KIND_ANCHOR_START); i32_store(0);
-            global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos);
-            local_get(1); return_;
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_KIND_OFF)); i32_add; i32_const(Imm32(RX_KIND_ANCHOR_START)); i32_store(0);
+            global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos);
+            local_get(Local(1)); return_;
         end;
     });
     // '$' => AnchorEnd
     wasm!(f, {
-        local_get(6); i32_const(ASCII_DOLLAR); i32_eq;
+        local_get(Local(6)); i32_const(Imm32(ASCII_DOLLAR)); i32_eq;
         if_empty;
-            local_get(1); i32_const(RX_PIECE_KIND_OFF); i32_add; i32_const(RX_KIND_ANCHOR_END); i32_store(0);
-            global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos);
-            local_get(1); return_;
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_KIND_OFF)); i32_add; i32_const(Imm32(RX_KIND_ANCHOR_END)); i32_store(0);
+            global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos);
+            local_get(Local(1)); return_;
         end;
     });
     // '\\' => escape
     wasm!(f, {
-        local_get(6); i32_const(ASCII_BACKSLASH); i32_eq;
+        local_get(Local(6)); i32_const(Imm32(ASCII_BACKSLASH)); i32_eq;
         if_empty;
-            global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos);
-            local_get(0); local_get(1); call(parse_escape);
-            local_get(1); return_;
+            global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos);
+            local_get(Local(0)); local_get(Local(1)); call(parse_escape);
+            local_get(Local(1)); return_;
         end;
     });
     // '[' => class
     wasm!(f, {
-        local_get(6); i32_const(ASCII_LBRACKET); i32_eq;
+        local_get(Local(6)); i32_const(Imm32(ASCII_LBRACKET)); i32_eq;
         if_empty;
-            global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos);
-            local_get(0); local_get(1); call(parse_class);
-            local_get(1); return_;
+            global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos);
+            local_get(Local(0)); local_get(Local(1)); call(parse_class);
+            local_get(Local(1)); return_;
         end;
     });
     // '(' => group: ncap++, ci, recurse alts(in_group=1), consume ')'
     wasm!(f, {
-        local_get(6); i32_const(ASCII_LPAREN); i32_eq;
+        local_get(Local(6)); i32_const(Imm32(ASCII_LPAREN)); i32_eq;
         if_empty;
-            global_get(ncap); i32_const(1); i32_add; local_tee(4); global_set(ncap); // ci = ++ncap
-            global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); // consume '('
-            local_get(0); i32_const(1); call(parse_alts); local_set(5);
+            global_get(ncap); i32_const(Imm32(1)); i32_add; local_tee(Local(4)); global_set(ncap); // ci = ++ncap
+            global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); // consume '('
+            local_get(Local(0)); i32_const(Imm32(1)); call(parse_alts); local_set(Local(5));
             // consume ')' if present
-            global_get(parse_pos); local_get(7); i32_lt_u;
+            global_get(parse_pos); local_get(Local(7)); i32_lt_u;
             if_empty;
-                local_get(0); i32_const(data_off); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0);
-                i32_const(ASCII_RPAREN); i32_eq;
-                if_empty; global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); end;
+                local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0);
+                i32_const(Imm32(ASCII_RPAREN)); i32_eq;
+                if_empty; global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); end;
             end;
-            local_get(1); i32_const(RX_PIECE_KIND_OFF); i32_add; i32_const(RX_KIND_GROUP); i32_store(0);
-            local_get(1); i32_const(RX_PIECE_X_OFF); i32_add; local_get(5); i32_store(0);
-            local_get(1); i32_const(RX_PIECE_Z_OFF); i32_add; local_get(4); i32_store(0);
-            local_get(1); return_;
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_KIND_OFF)); i32_add; i32_const(Imm32(RX_KIND_GROUP)); i32_store(0);
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_X_OFF)); i32_add; local_get(Local(5)); i32_store(0);
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_Z_OFF)); i32_add; local_get(Local(4)); i32_store(0);
+            local_get(Local(1)); return_;
         end;
     });
     // else: literal scalar (decode by UTF-8, advance by width)
     wasm!(f, {
-        local_get(0); global_get(parse_pos); call(utf8_scalar); i32_wrap_i64; local_set(2);
-        local_get(0); global_get(parse_pos); call(utf8_width); local_set(3);
-        local_get(1); i32_const(RX_PIECE_KIND_OFF); i32_add; i32_const(RX_KIND_LIT); i32_store(0);
-        local_get(1); i32_const(RX_PIECE_X_OFF); i32_add; local_get(2); i32_store(0);
-        global_get(parse_pos); local_get(3); i32_add; global_set(parse_pos);
-        local_get(1);
+        local_get(Local(0)); global_get(parse_pos); call(utf8_scalar); i32_wrap_i64; local_set(Local(2));
+        local_get(Local(0)); global_get(parse_pos); call(utf8_width); local_set(Local(3));
+        local_get(Local(1)); i32_const(Imm32(RX_PIECE_KIND_OFF)); i32_add; i32_const(Imm32(RX_KIND_LIT)); i32_store(0);
+        local_get(Local(1)); i32_const(Imm32(RX_PIECE_X_OFF)); i32_add; local_get(Local(2)); i32_store(0);
+        global_get(parse_pos); local_get(Local(3)); i32_add; global_set(parse_pos);
+        local_get(Local(1));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.parse_atom, type_idx, f));
@@ -536,66 +537,66 @@ fn compile_parse_escape(emitter: &mut WasmEmitter) {
     let data_off = string_data_off();
 
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
         // if pos >= pat_len → Lit('\\')
-        global_get(parse_pos); local_get(2); i32_ge_u;
+        global_get(parse_pos); local_get(Local(2)); i32_ge_u;
         if_empty;
-            local_get(1); i32_const(RX_PIECE_KIND_OFF); i32_add; i32_const(RX_KIND_LIT); i32_store(0);
-            local_get(1); i32_const(RX_PIECE_X_OFF); i32_add; i32_const(ASCII_BACKSLASH); i32_store(0);
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_KIND_OFF)); i32_add; i32_const(Imm32(RX_KIND_LIT)); i32_store(0);
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_X_OFF)); i32_add; i32_const(Imm32(ASCII_BACKSLASH)); i32_store(0);
             return_;
         end;
-        local_get(0); i32_const(data_off); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0); local_set(3);
+        local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0); local_set(Local(3));
     });
 
     // \d / \D
-    wasm!(f, { local_get(3); i32_const(ASCII_LOWER_D); i32_eq; if_empty; });
+    wasm!(f, { local_get(Local(3)); i32_const(Imm32(ASCII_LOWER_D)); i32_eq; if_empty; });
     emit_class_digit(&mut f, arena_sp, 1, 4, 0);
-    wasm!(f, { global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); return_; end; });
-    wasm!(f, { local_get(3); i32_const(ASCII_UPPER_D); i32_eq; if_empty; });
+    wasm!(f, { global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); return_; end; });
+    wasm!(f, { local_get(Local(3)); i32_const(Imm32(ASCII_UPPER_D)); i32_eq; if_empty; });
     emit_class_digit(&mut f, arena_sp, 1, 4, 1);
-    wasm!(f, { global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); return_; end; });
+    wasm!(f, { global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); return_; end; });
     // \w / \W
-    wasm!(f, { local_get(3); i32_const(ASCII_LOWER_W); i32_eq; if_empty; });
+    wasm!(f, { local_get(Local(3)); i32_const(Imm32(ASCII_LOWER_W)); i32_eq; if_empty; });
     emit_class_word(&mut f, arena_sp, 1, 4, 0);
-    wasm!(f, { global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); return_; end; });
-    wasm!(f, { local_get(3); i32_const(ASCII_UPPER_W); i32_eq; if_empty; });
+    wasm!(f, { global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); return_; end; });
+    wasm!(f, { local_get(Local(3)); i32_const(Imm32(ASCII_UPPER_W)); i32_eq; if_empty; });
     emit_class_word(&mut f, arena_sp, 1, 4, 1);
-    wasm!(f, { global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); return_; end; });
+    wasm!(f, { global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); return_; end; });
     // \s / \S
-    wasm!(f, { local_get(3); i32_const(ASCII_LOWER_S); i32_eq; if_empty; });
+    wasm!(f, { local_get(Local(3)); i32_const(Imm32(ASCII_LOWER_S)); i32_eq; if_empty; });
     emit_class_space(&mut f, arena_sp, 1, 4, 0);
-    wasm!(f, { global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); return_; end; });
-    wasm!(f, { local_get(3); i32_const(ASCII_UPPER_S); i32_eq; if_empty; });
+    wasm!(f, { global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); return_; end; });
+    wasm!(f, { local_get(Local(3)); i32_const(Imm32(ASCII_UPPER_S)); i32_eq; if_empty; });
     emit_class_space(&mut f, arena_sp, 1, 4, 1);
-    wasm!(f, { global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); return_; end; });
+    wasm!(f, { global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); return_; end; });
     // \n \t \r → control Lit
     wasm!(f, {
-        local_get(3); i32_const(ASCII_LOWER_N); i32_eq;
+        local_get(Local(3)); i32_const(Imm32(ASCII_LOWER_N)); i32_eq;
         if_empty;
-            local_get(1); i32_const(RX_PIECE_KIND_OFF); i32_add; i32_const(RX_KIND_LIT); i32_store(0);
-            local_get(1); i32_const(RX_PIECE_X_OFF); i32_add; i32_const(ASCII_NEWLINE); i32_store(0);
-            global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); return_;
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_KIND_OFF)); i32_add; i32_const(Imm32(RX_KIND_LIT)); i32_store(0);
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_X_OFF)); i32_add; i32_const(Imm32(ASCII_NEWLINE)); i32_store(0);
+            global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); return_;
         end;
-        local_get(3); i32_const(ASCII_LOWER_T); i32_eq;
+        local_get(Local(3)); i32_const(Imm32(ASCII_LOWER_T)); i32_eq;
         if_empty;
-            local_get(1); i32_const(RX_PIECE_KIND_OFF); i32_add; i32_const(RX_KIND_LIT); i32_store(0);
-            local_get(1); i32_const(RX_PIECE_X_OFF); i32_add; i32_const(ASCII_TAB); i32_store(0);
-            global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); return_;
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_KIND_OFF)); i32_add; i32_const(Imm32(RX_KIND_LIT)); i32_store(0);
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_X_OFF)); i32_add; i32_const(Imm32(ASCII_TAB)); i32_store(0);
+            global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); return_;
         end;
-        local_get(3); i32_const(ASCII_LOWER_R); i32_eq;
+        local_get(Local(3)); i32_const(Imm32(ASCII_LOWER_R)); i32_eq;
         if_empty;
-            local_get(1); i32_const(RX_PIECE_KIND_OFF); i32_add; i32_const(RX_KIND_LIT); i32_store(0);
-            local_get(1); i32_const(RX_PIECE_X_OFF); i32_add; i32_const(ASCII_CR); i32_store(0);
-            global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); return_;
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_KIND_OFF)); i32_add; i32_const(Imm32(RX_KIND_LIT)); i32_store(0);
+            local_get(Local(1)); i32_const(Imm32(RX_PIECE_X_OFF)); i32_add; i32_const(Imm32(ASCII_CR)); i32_store(0);
+            global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); return_;
         end;
     });
     // default → Lit(escaped scalar), advance by width
     wasm!(f, {
-        local_get(0); global_get(parse_pos); call(utf8_scalar); i32_wrap_i64; local_set(3);
-        local_get(0); global_get(parse_pos); call(utf8_width); local_set(5);
-        local_get(1); i32_const(RX_PIECE_KIND_OFF); i32_add; i32_const(RX_KIND_LIT); i32_store(0);
-        local_get(1); i32_const(RX_PIECE_X_OFF); i32_add; local_get(3); i32_store(0);
-        global_get(parse_pos); local_get(5); i32_add; global_set(parse_pos);
+        local_get(Local(0)); global_get(parse_pos); call(utf8_scalar); i32_wrap_i64; local_set(Local(3));
+        local_get(Local(0)); global_get(parse_pos); call(utf8_width); local_set(Local(5));
+        local_get(Local(1)); i32_const(Imm32(RX_PIECE_KIND_OFF)); i32_add; i32_const(Imm32(RX_KIND_LIT)); i32_store(0);
+        local_get(Local(1)); i32_const(Imm32(RX_PIECE_X_OFF)); i32_add; local_get(Local(3)); i32_store(0);
+        global_get(parse_pos); local_get(Local(5)); i32_add; global_set(parse_pos);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.parse_escape, type_idx, f));
@@ -610,13 +611,13 @@ fn emit_class_const(
     fill: impl Fn(&mut Function, u32),
 ) {
     emit_node_alloc(f, arena_sp, RX_RANGE_WORDS * nranges);
-    wasm!(f, { local_set(rp); });
+    wasm!(f, { local_set(Local(rp)); });
     fill(f, rp);
     wasm!(f, {
-        local_get(piece); i32_const(RX_PIECE_KIND_OFF); i32_add; i32_const(RX_KIND_CLASS); i32_store(0);
-        local_get(piece); i32_const(RX_PIECE_X_OFF); i32_add; local_get(rp); i32_store(0);
-        local_get(piece); i32_const(RX_PIECE_Y_OFF); i32_add; i32_const(nranges); i32_store(0);
-        local_get(piece); i32_const(RX_PIECE_Z_OFF); i32_add; i32_const(negated); i32_store(0);
+        local_get(Local(piece)); i32_const(Imm32(RX_PIECE_KIND_OFF)); i32_add; i32_const(Imm32(RX_KIND_CLASS)); i32_store(0);
+        local_get(Local(piece)); i32_const(Imm32(RX_PIECE_X_OFF)); i32_add; local_get(Local(rp)); i32_store(0);
+        local_get(Local(piece)); i32_const(Imm32(RX_PIECE_Y_OFF)); i32_add; i32_const(Imm32(nranges)); i32_store(0);
+        local_get(Local(piece)); i32_const(Imm32(RX_PIECE_Z_OFF)); i32_add; i32_const(Imm32(negated)); i32_store(0);
     });
 }
 
@@ -624,8 +625,8 @@ fn emit_class_const(
 fn emit_store_range(f: &mut Function, rp: u32, index: i32, lo: i32, hi: i32) {
     let base = index * RX_RANGE_WORDS * RX_WORD;
     wasm!(f, {
-        local_get(rp); i32_const(base + RX_RANGE_LO_OFF); i32_add; i32_const(lo); i32_store(0);
-        local_get(rp); i32_const(base + RX_RANGE_HI_OFF); i32_add; i32_const(hi); i32_store(0);
+        local_get(Local(rp)); i32_const(Imm32(base + RX_RANGE_LO_OFF)); i32_add; i32_const(Imm32(lo)); i32_store(0);
+        local_get(Local(rp)); i32_const(Imm32(base + RX_RANGE_HI_OFF)); i32_add; i32_const(Imm32(hi)); i32_store(0);
     });
 }
 
@@ -670,65 +671,65 @@ fn compile_parse_class(emitter: &mut WasmEmitter) {
     let data_off = string_data_off();
 
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        i32_const(0); local_set(3); // neg
-        i32_const(0); local_set(5); // nranges
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        i32_const(Imm32(0)); local_set(Local(3)); // neg
+        i32_const(Imm32(0)); local_set(Local(5)); // nranges
         // leading '^' => negated
-        global_get(parse_pos); local_get(2); i32_lt_u;
+        global_get(parse_pos); local_get(Local(2)); i32_lt_u;
         if_empty;
-            local_get(0); i32_const(data_off); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0);
-            i32_const(ASCII_CARET); i32_eq;
-            if_empty; i32_const(1); local_set(3); global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); end;
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0);
+            i32_const(Imm32(ASCII_CARET)); i32_eq;
+            if_empty; i32_const(Imm32(1)); local_set(Local(3)); global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); end;
         end;
         // ranges grow contiguously from here
-        global_get(arena_sp); local_set(4);
+        global_get(arena_sp); local_set(Local(4));
     });
 
     // Loop: while pos < pat_len && pat[pos] != ']'
     wasm!(f, { block_empty; loop_empty; });
-    wasm!(f, { global_get(parse_pos); local_get(2); i32_ge_u; br_if(1); });
+    wasm!(f, { global_get(parse_pos); local_get(Local(2)); i32_ge_u; br_if(1); });
     wasm!(f, {
-        local_get(0); i32_const(data_off); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0); local_set(6);
-        local_get(6); i32_const(ASCII_RBRACKET); i32_eq; br_if(1);
+        local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0); local_set(Local(6));
+        local_get(Local(6)); i32_const(Imm32(ASCII_RBRACKET)); i32_eq; br_if(1);
     });
 
     // Escape inside class: '\' and pos+1 < pat_len
     wasm!(f, {
-        local_get(6); i32_const(ASCII_BACKSLASH); i32_eq;
-        global_get(parse_pos); i32_const(1); i32_add; local_get(2); i32_lt_u;
+        local_get(Local(6)); i32_const(Imm32(ASCII_BACKSLASH)); i32_eq;
+        global_get(parse_pos); i32_const(Imm32(1)); i32_add; local_get(Local(2)); i32_lt_u;
         i32_and;
         if_empty;
-            local_get(0); i32_const(data_off); i32_add; global_get(parse_pos); i32_const(1); i32_add; i32_add; i32_load8_u(0); local_set(7);
-            global_get(parse_pos); i32_const(RX_ESCAPE_LEN); i32_add; global_set(parse_pos);
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; global_get(parse_pos); i32_const(Imm32(1)); i32_add; i32_add; i32_load8_u(0); local_set(Local(7));
+            global_get(parse_pos); i32_const(Imm32(RX_ESCAPE_LEN)); i32_add; global_set(parse_pos);
     });
     // Each `\X` sub-branch sits inside its own `if(escape)` → `if(\X)`; the loop
     // is two structured-control levels out, so `br(2)` continues the class loop.
     // The default branch (no inner `if`) is one level inside `if(escape)`, so it
     // uses `br(1)`.
     // \d
-    wasm!(f, { local_get(7); i32_const(ASCII_LOWER_D); i32_eq; if_empty; });
+    wasm!(f, { local_get(Local(7)); i32_const(Imm32(ASCII_LOWER_D)); i32_eq; if_empty; });
     emit_push_pair_const(&mut f, arena_sp, 4, 5, RX_DIGIT_LO, RX_DIGIT_HI);
     wasm!(f, { br(2); end; });
     // \w
-    wasm!(f, { local_get(7); i32_const(ASCII_LOWER_W); i32_eq; if_empty; });
+    wasm!(f, { local_get(Local(7)); i32_const(Imm32(ASCII_LOWER_W)); i32_eq; if_empty; });
     emit_push_pair_const(&mut f, arena_sp, 4, 5, RX_LOWER_LO, RX_LOWER_HI);
     emit_push_pair_const(&mut f, arena_sp, 4, 5, RX_UPPER_LO, RX_UPPER_HI);
     emit_push_pair_const(&mut f, arena_sp, 4, 5, RX_DIGIT_LO, RX_DIGIT_HI);
     emit_push_pair_const(&mut f, arena_sp, 4, 5, RX_UNDERSCORE, RX_UNDERSCORE);
     wasm!(f, { br(2); end; });
     // \s
-    wasm!(f, { local_get(7); i32_const(ASCII_LOWER_S); i32_eq; if_empty; });
+    wasm!(f, { local_get(Local(7)); i32_const(Imm32(ASCII_LOWER_S)); i32_eq; if_empty; });
     emit_push_pair_const(&mut f, arena_sp, 4, 5, ASCII_SPACE, ASCII_SPACE);
     emit_push_pair_const(&mut f, arena_sp, 4, 5, ASCII_TAB, ASCII_TAB);
     emit_push_pair_const(&mut f, arena_sp, 4, 5, ASCII_NEWLINE, ASCII_NEWLINE);
     emit_push_pair_const(&mut f, arena_sp, 4, 5, ASCII_CR, ASCII_CR);
     wasm!(f, { br(2); end; });
     // \n
-    wasm!(f, { local_get(7); i32_const(ASCII_LOWER_N); i32_eq; if_empty; });
+    wasm!(f, { local_get(Local(7)); i32_const(Imm32(ASCII_LOWER_N)); i32_eq; if_empty; });
     emit_push_pair_const(&mut f, arena_sp, 4, 5, ASCII_NEWLINE, ASCII_NEWLINE);
     wasm!(f, { br(2); end; });
     // \t
-    wasm!(f, { local_get(7); i32_const(ASCII_LOWER_T); i32_eq; if_empty; });
+    wasm!(f, { local_get(Local(7)); i32_const(Imm32(ASCII_LOWER_T)); i32_eq; if_empty; });
     emit_push_pair_const(&mut f, arena_sp, 4, 5, ASCII_TAB, ASCII_TAB);
     wasm!(f, { br(2); end; });
     // default (incl \D \S \W \r): literal esc byte → (esc, esc)
@@ -738,27 +739,27 @@ fn compile_parse_class(emitter: &mut WasmEmitter) {
 
     // Non-escape: decode scalar (lo), advance by width
     wasm!(f, {
-        local_get(0); global_get(parse_pos); call(utf8_scalar); i32_wrap_i64; local_set(10);
-        local_get(0); global_get(parse_pos); call(utf8_width); local_set(9);
-        global_get(parse_pos); local_get(9); i32_add; global_set(parse_pos);
+        local_get(Local(0)); global_get(parse_pos); call(utf8_scalar); i32_wrap_i64; local_set(Local(10));
+        local_get(Local(0)); global_get(parse_pos); call(utf8_width); local_set(Local(9));
+        global_get(parse_pos); local_get(Local(9)); i32_add; global_set(parse_pos);
     });
     // range a-b: '-' at pos && byte after '-' exists && != ']'
     wasm!(f, {
-        global_get(parse_pos); local_get(2); i32_lt_u;
+        global_get(parse_pos); local_get(Local(2)); i32_lt_u;
         if_empty;
-            local_get(0); i32_const(data_off); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0);
-            i32_const(ASCII_DASH); i32_eq;
-            global_get(parse_pos); i32_const(1); i32_add; local_get(2); i32_lt_u;
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; global_get(parse_pos); i32_add; i32_load8_u(0);
+            i32_const(Imm32(ASCII_DASH)); i32_eq;
+            global_get(parse_pos); i32_const(Imm32(1)); i32_add; local_get(Local(2)); i32_lt_u;
             i32_and;
             if_empty;
-                local_get(0); i32_const(data_off); i32_add; global_get(parse_pos); i32_const(1); i32_add; i32_add; i32_load8_u(0);
-                i32_const(ASCII_RBRACKET); i32_ne;
+                local_get(Local(0)); i32_const(Imm32(data_off)); i32_add; global_get(parse_pos); i32_const(Imm32(1)); i32_add; i32_add; i32_load8_u(0);
+                i32_const(Imm32(ASCII_RBRACKET)); i32_ne;
                 if_empty;
                     // consume '-', decode end scalar (hi)
-                    global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos);
-                    local_get(0); global_get(parse_pos); call(utf8_scalar); i32_wrap_i64; local_set(8);
-                    local_get(0); global_get(parse_pos); call(utf8_width); local_set(9);
-                    global_get(parse_pos); local_get(9); i32_add; global_set(parse_pos);
+                    global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos);
+                    local_get(Local(0)); global_get(parse_pos); call(utf8_scalar); i32_wrap_i64; local_set(Local(8));
+                    local_get(Local(0)); global_get(parse_pos); call(utf8_width); local_set(Local(9));
+                    global_get(parse_pos); local_get(Local(9)); i32_add; global_set(parse_pos);
     });
     emit_push_pair_local(&mut f, arena_sp, 4, 5, 10, 8); // (lo, hi)
     wasm!(f, {
@@ -776,15 +777,15 @@ fn compile_parse_class(emitter: &mut WasmEmitter) {
 
     // skip closing ']'
     wasm!(f, {
-        global_get(parse_pos); local_get(2); i32_lt_u;
-        if_empty; global_get(parse_pos); i32_const(1); i32_add; global_set(parse_pos); end;
+        global_get(parse_pos); local_get(Local(2)); i32_lt_u;
+        if_empty; global_get(parse_pos); i32_const(Imm32(1)); i32_add; global_set(parse_pos); end;
     });
     // write CLASS node
     wasm!(f, {
-        local_get(1); i32_const(RX_PIECE_KIND_OFF); i32_add; i32_const(RX_KIND_CLASS); i32_store(0);
-        local_get(1); i32_const(RX_PIECE_X_OFF); i32_add; local_get(4); i32_store(0);
-        local_get(1); i32_const(RX_PIECE_Y_OFF); i32_add; local_get(5); i32_store(0);
-        local_get(1); i32_const(RX_PIECE_Z_OFF); i32_add; local_get(3); i32_store(0);
+        local_get(Local(1)); i32_const(Imm32(RX_PIECE_KIND_OFF)); i32_add; i32_const(Imm32(RX_KIND_CLASS)); i32_store(0);
+        local_get(Local(1)); i32_const(Imm32(RX_PIECE_X_OFF)); i32_add; local_get(Local(4)); i32_store(0);
+        local_get(Local(1)); i32_const(Imm32(RX_PIECE_Y_OFF)); i32_add; local_get(Local(5)); i32_store(0);
+        local_get(Local(1)); i32_const(Imm32(RX_PIECE_Z_OFF)); i32_add; local_get(Local(3)); i32_store(0);
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.parse_class, type_idx, f));
@@ -796,11 +797,11 @@ fn emit_push_pair_const(f: &mut Function, arena_sp: u32, ranges_base: u32, nrang
     emit_node_alloc(f, arena_sp, RX_RANGE_WORDS);
     wasm!(f, { drop; }); // base already known via ranges_base + nranges
     wasm!(f, {
-        local_get(ranges_base); local_get(nranges); i32_const(RX_RANGE_WORDS * RX_WORD); i32_mul; i32_add;
-        i32_const(lo); i32_store(RX_RANGE_LO_OFF);
-        local_get(ranges_base); local_get(nranges); i32_const(RX_RANGE_WORDS * RX_WORD); i32_mul; i32_add;
-        i32_const(hi); i32_store(RX_RANGE_HI_OFF);
-        local_get(nranges); i32_const(1); i32_add; local_set(nranges);
+        local_get(Local(ranges_base)); local_get(Local(nranges)); i32_const(Imm32(RX_RANGE_WORDS * RX_WORD)); i32_mul; i32_add;
+        i32_const(Imm32(lo)); i32_store(RX_RANGE_LO_OFF);
+        local_get(Local(ranges_base)); local_get(Local(nranges)); i32_const(Imm32(RX_RANGE_WORDS * RX_WORD)); i32_mul; i32_add;
+        i32_const(Imm32(hi)); i32_store(RX_RANGE_HI_OFF);
+        local_get(Local(nranges)); i32_const(Imm32(1)); i32_add; local_set(Local(nranges));
     });
 }
 
@@ -809,11 +810,11 @@ fn emit_push_pair_local(f: &mut Function, arena_sp: u32, ranges_base: u32, nrang
     emit_node_alloc(f, arena_sp, RX_RANGE_WORDS);
     wasm!(f, { drop; });
     wasm!(f, {
-        local_get(ranges_base); local_get(nranges); i32_const(RX_RANGE_WORDS * RX_WORD); i32_mul; i32_add;
-        local_get(lo_l); i32_store(RX_RANGE_LO_OFF);
-        local_get(ranges_base); local_get(nranges); i32_const(RX_RANGE_WORDS * RX_WORD); i32_mul; i32_add;
-        local_get(hi_l); i32_store(RX_RANGE_HI_OFF);
-        local_get(nranges); i32_const(1); i32_add; local_set(nranges);
+        local_get(Local(ranges_base)); local_get(Local(nranges)); i32_const(Imm32(RX_RANGE_WORDS * RX_WORD)); i32_mul; i32_add;
+        local_get(Local(lo_l)); i32_store(RX_RANGE_LO_OFF);
+        local_get(Local(ranges_base)); local_get(Local(nranges)); i32_const(Imm32(RX_RANGE_WORDS * RX_WORD)); i32_mul; i32_add;
+        local_get(Local(hi_l)); i32_store(RX_RANGE_HI_OFF);
+        local_get(Local(nranges)); i32_const(Imm32(1)); i32_add; local_set(Local(nranges));
     });
 }
 
@@ -829,45 +830,45 @@ fn compile_node_matches(emitter: &mut WasmEmitter) {
     // locals: 2=kind, 3=ranges, 4=nranges, 5=neg, 6=i, 7=hit, 8=lo, 9=hi
     let mut f = Function::new([(8, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2); // kind
+        local_get(Local(0)); i32_load(0); local_set(Local(2)); // kind
         // Lit
-        local_get(2); i32_const(RX_KIND_LIT); i32_eq;
+        local_get(Local(2)); i32_const(Imm32(RX_KIND_LIT)); i32_eq;
         if_empty;
-            local_get(1); local_get(0); i32_const(RX_PIECE_X_OFF); i32_add; i32_load(0); i32_eq;
+            local_get(Local(1)); local_get(Local(0)); i32_const(Imm32(RX_PIECE_X_OFF)); i32_add; i32_load(0); i32_eq;
             return_;
         end;
         // Dot
-        local_get(2); i32_const(RX_KIND_DOT); i32_eq;
+        local_get(Local(2)); i32_const(Imm32(RX_KIND_DOT)); i32_eq;
         if_empty;
-            local_get(1); i32_const(ASCII_NEWLINE); i32_ne;
+            local_get(Local(1)); i32_const(Imm32(ASCII_NEWLINE)); i32_ne;
             return_;
         end;
         // Class
-        local_get(2); i32_const(RX_KIND_CLASS); i32_eq;
+        local_get(Local(2)); i32_const(Imm32(RX_KIND_CLASS)); i32_eq;
         if_empty;
-            local_get(0); i32_const(RX_PIECE_X_OFF); i32_add; i32_load(0); local_set(3);
-            local_get(0); i32_const(RX_PIECE_Y_OFF); i32_add; i32_load(0); local_set(4);
-            local_get(0); i32_const(RX_PIECE_Z_OFF); i32_add; i32_load(0); local_set(5);
-            i32_const(0); local_set(7); // hit
-            i32_const(0); local_set(6); // i
+            local_get(Local(0)); i32_const(Imm32(RX_PIECE_X_OFF)); i32_add; i32_load(0); local_set(Local(3));
+            local_get(Local(0)); i32_const(Imm32(RX_PIECE_Y_OFF)); i32_add; i32_load(0); local_set(Local(4));
+            local_get(Local(0)); i32_const(Imm32(RX_PIECE_Z_OFF)); i32_add; i32_load(0); local_set(Local(5));
+            i32_const(Imm32(0)); local_set(Local(7)); // hit
+            i32_const(Imm32(0)); local_set(Local(6)); // i
             block_empty; loop_empty;
-                local_get(6); local_get(4); i32_ge_u; br_if(1);
-                local_get(3); local_get(6); i32_const(RX_RANGE_WORDS * RX_WORD); i32_mul; i32_add; i32_load(RX_RANGE_LO_OFF); local_set(8);
-                local_get(3); local_get(6); i32_const(RX_RANGE_WORDS * RX_WORD); i32_mul; i32_add; i32_load(RX_RANGE_HI_OFF); local_set(9);
+                local_get(Local(6)); local_get(Local(4)); i32_ge_u; br_if(1);
+                local_get(Local(3)); local_get(Local(6)); i32_const(Imm32(RX_RANGE_WORDS * RX_WORD)); i32_mul; i32_add; i32_load(RX_RANGE_LO_OFF); local_set(Local(8));
+                local_get(Local(3)); local_get(Local(6)); i32_const(Imm32(RX_RANGE_WORDS * RX_WORD)); i32_mul; i32_add; i32_load(RX_RANGE_HI_OFF); local_set(Local(9));
                 // lo <= scalar <= hi (signed; scalars are non-negative)
-                local_get(1); local_get(8); i32_ge_s;
-                local_get(1); local_get(9); i32_le_s;
+                local_get(Local(1)); local_get(Local(8)); i32_ge_s;
+                local_get(Local(1)); local_get(Local(9)); i32_le_s;
                 i32_and;
-                if_empty; i32_const(1); local_set(7); br(2); end;
-                local_get(6); i32_const(1); i32_add; local_set(6);
+                if_empty; i32_const(Imm32(1)); local_set(Local(7)); br(2); end;
+                local_get(Local(6)); i32_const(Imm32(1)); i32_add; local_set(Local(6));
                 br(0);
             end; end;
             // hit XOR neg
-            local_get(7); local_get(5); i32_ne;
+            local_get(Local(7)); local_get(Local(5)); i32_ne;
             return_;
         end;
         // anchors / group never reach node_matches
-        i32_const(0);
+        i32_const(Imm32(0));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.node_matches, type_idx, f));
@@ -887,46 +888,46 @@ fn compile_match_one(emitter: &mut WasmEmitter) {
     let utf8_width = emitter.rt.string.utf8_width;
 
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(5); // kind
-        local_get(1); i32_load(0); local_set(6); // text_len bytes
+        local_get(Local(0)); i32_load(0); local_set(Local(5)); // kind
+        local_get(Local(1)); i32_load(0); local_set(Local(6)); // text_len bytes
     });
     // Group
     wasm!(f, {
-        local_get(5); i32_const(RX_KIND_GROUP); i32_eq;
+        local_get(Local(5)); i32_const(Imm32(RX_KIND_GROUP)); i32_eq;
         if_empty;
-            local_get(2); local_set(12); // start = p
-            local_get(0); i32_const(RX_PIECE_X_OFF); i32_add; i32_load(0); local_set(9); // inner alts
-            local_get(9); local_get(1); local_get(2); local_get(3); local_get(4);
+            local_get(Local(2)); local_set(Local(12)); // start = p
+            local_get(Local(0)); i32_const(Imm32(RX_PIECE_X_OFF)); i32_add; i32_load(0); local_set(Local(9)); // inner alts
+            local_get(Local(9)); local_get(Local(1)); local_get(Local(2)); local_get(Local(3)); local_get(Local(4));
             call(match_alts);
-            local_set(10);
-            local_get(10); i32_const(RX_NO_MATCH); i32_eq;
-            if_empty; i32_const(RX_NO_MATCH); return_; end;
+            local_set(Local(10));
+            local_get(Local(10)); i32_const(Imm32(RX_NO_MATCH)); i32_eq;
+            if_empty; i32_const(Imm32(RX_NO_MATCH)); return_; end;
             // caps[ci-1] = (start,end) when ci>0
-            local_get(0); i32_const(RX_PIECE_Z_OFF); i32_add; i32_load(0); local_set(11);
-            local_get(11); i32_const(0); i32_gt_u;
+            local_get(Local(0)); i32_const(Imm32(RX_PIECE_Z_OFF)); i32_add; i32_load(0); local_set(Local(11));
+            local_get(Local(11)); i32_const(Imm32(0)); i32_gt_u;
             if_empty;
-                local_get(3); local_get(11); i32_const(1); i32_sub; i32_const(RX_CAP_BYTES); i32_mul; i32_add;
-                local_get(12); i32_store(RX_CAP_START_OFF);
-                local_get(3); local_get(11); i32_const(1); i32_sub; i32_const(RX_CAP_BYTES); i32_mul; i32_add;
-                local_get(10); i32_store(RX_CAP_END_OFF);
+                local_get(Local(3)); local_get(Local(11)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(RX_CAP_BYTES)); i32_mul; i32_add;
+                local_get(Local(12)); i32_store(RX_CAP_START_OFF);
+                local_get(Local(3)); local_get(Local(11)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(RX_CAP_BYTES)); i32_mul; i32_add;
+                local_get(Local(10)); i32_store(RX_CAP_END_OFF);
             end;
-            local_get(10); local_get(2); i32_sub; return_; // bytes consumed
+            local_get(Local(10)); local_get(Local(2)); i32_sub; return_; // bytes consumed
         end;
     });
     // Lit / Dot / Class: one scalar at p
     wasm!(f, {
-        local_get(2); local_get(6); i32_ge_u;
-        if_empty; i32_const(RX_NO_MATCH); return_; end;
-        local_get(1); local_get(2); call(utf8_scalar); i32_wrap_i64; local_set(7);
-        local_get(0); local_get(7); call(node_matches);
+        local_get(Local(2)); local_get(Local(6)); i32_ge_u;
+        if_empty; i32_const(Imm32(RX_NO_MATCH)); return_; end;
+        local_get(Local(1)); local_get(Local(2)); call(utf8_scalar); i32_wrap_i64; local_set(Local(7));
+        local_get(Local(0)); local_get(Local(7)); call(node_matches);
         if_empty;
-            local_get(1); local_get(2); call(utf8_width); local_set(8);
-            local_get(8); return_;
+            local_get(Local(1)); local_get(Local(2)); call(utf8_width); local_set(Local(8));
+            local_get(Local(8)); return_;
         else_;
-            i32_const(RX_NO_MATCH); return_;
+            i32_const(Imm32(RX_NO_MATCH)); return_;
         end;
     });
-    wasm!(f, { i32_const(RX_NO_MATCH); end; });
+    wasm!(f, { i32_const(Imm32(RX_NO_MATCH)); end; });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.match_one, type_idx, f));
 }
 
@@ -944,39 +945,39 @@ fn compile_match_rep(emitter: &mut WasmEmitter) {
     let save_sp = emitter.rt.regex.save_sp_global;
 
     wasm!(f, {
-        local_get(0); i32_const(RX_PIECE_MAX_OFF); i32_add; i32_load(0); local_set(6);
-        local_get(0); i32_const(RX_PIECE_MIN_OFF); i32_add; i32_load(0); local_set(7);
+        local_get(Local(0)); i32_const(Imm32(RX_PIECE_MAX_OFF)); i32_add; i32_load(0); local_set(Local(6));
+        local_get(Local(0)); i32_const(Imm32(RX_PIECE_MIN_OFF)); i32_add; i32_load(0); local_set(Local(7));
         // at_max = max != UNBOUNDED && count >= max
-        i32_const(0); local_set(8);
-        local_get(6); i32_const(RX_MAX_UNBOUNDED); i32_ne;
-        if_empty; local_get(5); local_get(6); i32_ge_u; local_set(8); end;
+        i32_const(Imm32(0)); local_set(Local(8));
+        local_get(Local(6)); i32_const(Imm32(RX_MAX_UNBOUNDED)); i32_ne;
+        if_empty; local_get(Local(5)); local_get(Local(6)); i32_ge_u; local_set(Local(8)); end;
     });
     // greedy: if !at_max try one more
-    wasm!(f, { local_get(8); i32_eqz; if_empty; });
+    wasm!(f, { local_get(Local(8)); i32_eqz; if_empty; });
     emit_caps_push(&mut f, save_sp, 3, 4, 11);
     wasm!(f, {
-            local_get(0); local_get(1); local_get(2); local_get(3); local_get(4);
+            local_get(Local(0)); local_get(Local(1)); local_get(Local(2)); local_get(Local(3)); local_get(Local(4));
             call(match_one);
-            local_set(9);
-            local_get(9); i32_const(RX_NO_MATCH); i32_ne;
+            local_set(Local(9));
+            local_get(Local(9)); i32_const(Imm32(RX_NO_MATCH)); i32_ne;
             if_empty;
                 // zero-width guard: consumed>0 || count==0
-                local_get(9); i32_const(0); i32_gt_u;
-                local_get(5); i32_eqz;
+                local_get(Local(9)); i32_const(Imm32(0)); i32_gt_u;
+                local_get(Local(5)); i32_eqz;
                 i32_or;
                 if_empty;
-                    local_get(0); local_get(1);
-                    local_get(2); local_get(9); i32_add; // p+consumed
-                    local_get(3); local_get(4);
-                    local_get(5); i32_const(1); i32_add; // count+1
+                    local_get(Local(0)); local_get(Local(1));
+                    local_get(Local(2)); local_get(Local(9)); i32_add; // p+consumed
+                    local_get(Local(3)); local_get(Local(4));
+                    local_get(Local(5)); i32_const(Imm32(1)); i32_add; // count+1
                     call(match_rep);
-                    local_set(10);
-                    local_get(10); i32_const(RX_NO_MATCH); i32_ne;
+                    local_set(Local(10));
+                    local_get(Local(10)); i32_const(Imm32(RX_NO_MATCH)); i32_ne;
                     if_empty;
     });
     emit_caps_pop_discard(&mut f, save_sp, 11);
     wasm!(f, {
-                        local_get(10); return_;
+                        local_get(Local(10)); return_;
                     end;
                 end;
             end;
@@ -985,14 +986,14 @@ fn compile_match_rep(emitter: &mut WasmEmitter) {
     wasm!(f, { end; }); // end !at_max
     // if count >= min: match rest of seq (piece.next)
     wasm!(f, {
-        local_get(5); local_get(7); i32_ge_u;
+        local_get(Local(5)); local_get(Local(7)); i32_ge_u;
         if_empty;
-            local_get(0); i32_const(RX_PIECE_NEXT_OFF); i32_add; i32_load(0); local_set(12);
-            local_get(12); local_get(1); local_get(2); local_get(3); local_get(4);
+            local_get(Local(0)); i32_const(Imm32(RX_PIECE_NEXT_OFF)); i32_add; i32_load(0); local_set(Local(12));
+            local_get(Local(12)); local_get(Local(1)); local_get(Local(2)); local_get(Local(3)); local_get(Local(4));
             call(match_seq);
             return_;
         end;
-        i32_const(RX_NO_MATCH);
+        i32_const(Imm32(RX_NO_MATCH));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.match_rep, type_idx, f));
@@ -1011,35 +1012,35 @@ fn compile_match_seq(emitter: &mut WasmEmitter) {
 
     wasm!(f, {
         // piece == null => success (return p)
-        local_get(0); i32_eqz;
-        if_empty; local_get(2); return_; end;
-        local_get(0); i32_load(0); local_set(5); // kind
-        local_get(1); i32_load(0); local_set(6); // text_len bytes
-        local_get(0); i32_const(RX_PIECE_NEXT_OFF); i32_add; i32_load(0); local_set(7); // next
+        local_get(Local(0)); i32_eqz;
+        if_empty; local_get(Local(2)); return_; end;
+        local_get(Local(0)); i32_load(0); local_set(Local(5)); // kind
+        local_get(Local(1)); i32_load(0); local_set(Local(6)); // text_len bytes
+        local_get(Local(0)); i32_const(Imm32(RX_PIECE_NEXT_OFF)); i32_add; i32_load(0); local_set(Local(7)); // next
         // AnchorStart: p==0
-        local_get(5); i32_const(RX_KIND_ANCHOR_START); i32_eq;
+        local_get(Local(5)); i32_const(Imm32(RX_KIND_ANCHOR_START)); i32_eq;
         if_empty;
-            local_get(2); i32_eqz;
+            local_get(Local(2)); i32_eqz;
             if_empty;
-                local_get(7); local_get(1); local_get(2); local_get(3); local_get(4);
+                local_get(Local(7)); local_get(Local(1)); local_get(Local(2)); local_get(Local(3)); local_get(Local(4));
                 call(match_seq); return_;
             else_;
-                i32_const(RX_NO_MATCH); return_;
+                i32_const(Imm32(RX_NO_MATCH)); return_;
             end;
         end;
         // AnchorEnd: p==text_len(bytes)
-        local_get(5); i32_const(RX_KIND_ANCHOR_END); i32_eq;
+        local_get(Local(5)); i32_const(Imm32(RX_KIND_ANCHOR_END)); i32_eq;
         if_empty;
-            local_get(2); local_get(6); i32_eq;
+            local_get(Local(2)); local_get(Local(6)); i32_eq;
             if_empty;
-                local_get(7); local_get(1); local_get(2); local_get(3); local_get(4);
+                local_get(Local(7)); local_get(Local(1)); local_get(Local(2)); local_get(Local(3)); local_get(Local(4));
                 call(match_seq); return_;
             else_;
-                i32_const(RX_NO_MATCH); return_;
+                i32_const(Imm32(RX_NO_MATCH)); return_;
             end;
         end;
         // else: rep over this piece, count=0
-        local_get(0); local_get(1); local_get(2); local_get(3); local_get(4); i32_const(0);
+        local_get(Local(0)); local_get(Local(1)); local_get(Local(2)); local_get(Local(3)); local_get(Local(4)); i32_const(Imm32(0));
         call(match_rep);
         end;
     });
@@ -1057,30 +1058,30 @@ fn compile_match_alts(emitter: &mut WasmEmitter) {
     let save_sp = emitter.rt.regex.save_sp_global;
 
     wasm!(f, {
-        local_get(0); i32_const(RX_ALTS_HEAD_OFF); i32_add; i32_load(0); local_set(5); // first seq
+        local_get(Local(0)); i32_const(Imm32(RX_ALTS_HEAD_OFF)); i32_add; i32_load(0); local_set(Local(5)); // first seq
         block_empty; loop_empty;
-            local_get(5); i32_eqz; br_if(1); // no more alts → fail
-            local_get(5); i32_const(RX_SEQ_HEAD_OFF); i32_add; i32_load(0); local_set(8); // head piece
+            local_get(Local(5)); i32_eqz; br_if(1); // no more alts → fail
+            local_get(Local(5)); i32_const(Imm32(RX_SEQ_HEAD_OFF)); i32_add; i32_load(0); local_set(Local(8)); // head piece
     });
     emit_caps_push(&mut f, save_sp, 3, 4, 7);
     wasm!(f, {
-            local_get(8); local_get(1); local_get(2); local_get(3); local_get(4);
+            local_get(Local(8)); local_get(Local(1)); local_get(Local(2)); local_get(Local(3)); local_get(Local(4));
             call(match_seq);
-            local_set(6);
-            local_get(6); i32_const(RX_NO_MATCH); i32_ne;
+            local_set(Local(6));
+            local_get(Local(6)); i32_const(Imm32(RX_NO_MATCH)); i32_ne;
             if_empty;
     });
     emit_caps_pop_discard(&mut f, save_sp, 7);
     wasm!(f, {
-                local_get(6); return_;
+                local_get(Local(6)); return_;
             end;
     });
     emit_caps_restore(&mut f, save_sp, 3, 4, 7);
     wasm!(f, {
-            local_get(5); i32_const(RX_SEQ_NEXT_OFF); i32_add; i32_load(0); local_set(5); // next alt
+            local_get(Local(5)); i32_const(Imm32(RX_SEQ_NEXT_OFF)); i32_add; i32_load(0); local_set(Local(5)); // next alt
             br(0);
         end; end;
-        i32_const(RX_NO_MATCH);
+        i32_const(Imm32(RX_NO_MATCH));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.match_alts, type_idx, f));
@@ -1101,29 +1102,29 @@ fn compile_find_at(emitter: &mut WasmEmitter) {
     let utf8_width = emitter.rt.string.utf8_width;
 
     wasm!(f, {
-        local_get(1); i32_load(0); local_set(5); // text_len bytes
-        local_get(2); local_set(6); // i = start
+        local_get(Local(1)); i32_load(0); local_set(Local(5)); // text_len bytes
+        local_get(Local(2)); local_set(Local(6)); // i = start
         block_empty; loop_empty;
-            local_get(6); local_get(5); i32_gt_u; br_if(1); // i > len → stop
+            local_get(Local(6)); local_get(Local(5)); i32_gt_u; br_if(1); // i > len → stop
     });
     emit_caps_reset(&mut f, 3, 4, 8);
     wasm!(f, {
-            local_get(0); local_get(1); local_get(6); local_get(3); local_get(4);
+            local_get(Local(0)); local_get(Local(1)); local_get(Local(6)); local_get(Local(3)); local_get(Local(4));
             call(match_alts);
-            local_set(7);
-            local_get(7); i32_const(RX_NO_MATCH); i32_ne;
+            local_set(Local(7));
+            local_get(Local(7)); i32_const(Imm32(RX_NO_MATCH)); i32_ne;
             if_empty;
-                local_get(6); global_set(match_start);
-                local_get(7); return_;
+                local_get(Local(6)); global_set(match_start);
+                local_get(Local(7)); return_;
             end;
             // advance i by one scalar width; if i==len, no more positions.
-            local_get(6); local_get(5); i32_ge_u;
-            if_empty; i32_const(RX_NO_MATCH); return_; end;
-            local_get(1); local_get(6); call(utf8_width); local_set(9);
-            local_get(6); local_get(9); i32_add; local_set(6);
+            local_get(Local(6)); local_get(Local(5)); i32_ge_u;
+            if_empty; i32_const(Imm32(RX_NO_MATCH)); return_; end;
+            local_get(Local(1)); local_get(Local(6)); call(utf8_width); local_set(Local(9));
+            local_get(Local(6)); local_get(Local(9)); i32_add; local_set(Local(6));
             br(0);
         end; end;
-        i32_const(RX_NO_MATCH);
+        i32_const(Imm32(RX_NO_MATCH));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.regex.find_at, type_idx, f));
@@ -1137,10 +1138,10 @@ fn compile_find_at(emitter: &mut WasmEmitter) {
 /// base into `save_local`. Bumps `save_sp` by ncap × RX_CAP_BYTES.
 fn emit_caps_push(f: &mut Function, save_sp: u32, caps: u32, ncap: u32, save_local: u32) {
     wasm!(f, {
-        global_get(save_sp); local_set(save_local);
-        global_get(save_sp); local_get(ncap); i32_const(RX_CAP_BYTES); i32_mul; i32_add; global_set(save_sp);
+        global_get(save_sp); local_set(Local(save_local));
+        global_get(save_sp); local_get(Local(ncap)); i32_const(Imm32(RX_CAP_BYTES)); i32_mul; i32_add; global_set(save_sp);
         // memory_copy(dst=save_base, src=caps, n=ncap*RX_CAP_BYTES)
-        local_get(save_local); local_get(caps); local_get(ncap); i32_const(RX_CAP_BYTES); i32_mul;
+        local_get(Local(save_local)); local_get(Local(caps)); local_get(Local(ncap)); i32_const(Imm32(RX_CAP_BYTES)); i32_mul;
         memory_copy;
     });
 }
@@ -1148,28 +1149,28 @@ fn emit_caps_push(f: &mut Function, save_sp: u32, caps: u32, ncap: u32, save_loc
 /// Restore `caps` from the saved copy at `save_local`, then pop (rewind save_sp).
 fn emit_caps_restore(f: &mut Function, save_sp: u32, caps: u32, ncap: u32, save_local: u32) {
     wasm!(f, {
-        local_get(caps); local_get(save_local); local_get(ncap); i32_const(RX_CAP_BYTES); i32_mul;
+        local_get(Local(caps)); local_get(Local(save_local)); local_get(Local(ncap)); i32_const(Imm32(RX_CAP_BYTES)); i32_mul;
         memory_copy;
-        local_get(save_local); global_set(save_sp);
+        local_get(Local(save_local)); global_set(save_sp);
     });
 }
 
 /// Discard the saved copy at `save_local` (success path): rewind save_sp.
 fn emit_caps_pop_discard(f: &mut Function, save_sp: u32, save_local: u32) {
-    wasm!(f, { local_get(save_local); global_set(save_sp); });
+    wasm!(f, { local_get(Local(save_local)); global_set(save_sp); });
 }
 
 /// Reset all caps slots to UNSET (-1). `i` is a scratch loop local.
 fn emit_caps_reset(f: &mut Function, caps: u32, ncap: u32, i: u32) {
     wasm!(f, {
-        i32_const(0); local_set(i);
+        i32_const(Imm32(0)); local_set(Local(i));
         block_empty; loop_empty;
-            local_get(i); local_get(ncap); i32_ge_u; br_if(1);
-            local_get(caps); local_get(i); i32_const(RX_CAP_BYTES); i32_mul; i32_add;
-            i32_const(RX_CAP_UNSET); i32_store(RX_CAP_START_OFF);
-            local_get(caps); local_get(i); i32_const(RX_CAP_BYTES); i32_mul; i32_add;
-            i32_const(RX_CAP_UNSET); i32_store(RX_CAP_END_OFF);
-            local_get(i); i32_const(1); i32_add; local_set(i);
+            local_get(Local(i)); local_get(Local(ncap)); i32_ge_u; br_if(1);
+            local_get(Local(caps)); local_get(Local(i)); i32_const(Imm32(RX_CAP_BYTES)); i32_mul; i32_add;
+            i32_const(Imm32(RX_CAP_UNSET)); i32_store(RX_CAP_START_OFF);
+            local_get(Local(caps)); local_get(Local(i)); i32_const(Imm32(RX_CAP_BYTES)); i32_mul; i32_add;
+            i32_const(Imm32(RX_CAP_UNSET)); i32_store(RX_CAP_END_OFF);
+            local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i));
             br(0);
         end; end;
     });

--- a/crates/almide-codegen/src/emit_wasm/rt_regex.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_regex.rs
@@ -144,6 +144,8 @@ const RX_ARENA_SLACK_WORDS: i32 = 512;
 /// Fraction of the arena handed to the node graph; the rest is the save stack.
 /// Nodes are bounded by O(pattern); the save stack by O(depth × ncap).
 const RX_ARENA_NODE_SHIFT: i32 = 1; // node region = arena/2, save region = arena/2
+/// Bytes consumed by a two-character escape sequence (`\` + escape char).
+const RX_ESCAPE_LEN: i32 = 2;
 
 /// Regex-related runtime function indices.
 #[derive(Default, Clone)]
@@ -697,7 +699,7 @@ fn compile_parse_class(emitter: &mut WasmEmitter) {
         i32_and;
         if_empty;
             local_get(0); i32_const(data_off); i32_add; global_get(parse_pos); i32_const(1); i32_add; i32_add; i32_load8_u(0); local_set(7);
-            global_get(parse_pos); i32_const(2); i32_add; global_set(parse_pos);
+            global_get(parse_pos); i32_const(RX_ESCAPE_LEN); i32_add; global_set(parse_pos);
     });
     // Each `\X` sub-branch sits inside its own `if(escape)` → `if(\X)`; the loop
     // is two structured-control levels out, so `br(2)` continues the class loop.

--- a/crates/almide-codegen/src/emit_wasm/rt_repr.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_repr.rs
@@ -13,6 +13,7 @@
 //!   `\\ \" \n \r \t`  (every other byte is copied verbatim).
 //! Output (and input) use the standard `[len:i32][cap:i32][data:u8...]` layout.
 
+use crate::emit_wasm::engine::{Imm32, Local};
 use super::{CompiledFunc, WasmEmitter};
 use wasm_encoder::ValType;
 use super::TrackedFunction as Function;
@@ -73,77 +74,77 @@ pub(super) fn compile(emitter: &mut WasmEmitter) {
     const ESC: u32 = 7;
 
     wasm!(f, {
-        local_get(S); i32_load(0); local_set(IN_LEN);
+        local_get(Local(S)); i32_load(0); local_set(Local(IN_LEN));
         // ── Pass 1: out_len = sum over bytes (escapable → 2, else → 1) ──
-        i32_const(0); local_set(OUT_LEN);
-        i32_const(0); local_set(I);
+        i32_const(Imm32(0)); local_set(Local(OUT_LEN));
+        i32_const(Imm32(0)); local_set(Local(I));
         block_empty; loop_empty;
-          local_get(I); local_get(IN_LEN); i32_ge_u; br_if(1);
-          local_get(S); i32_const(data_off); i32_add; local_get(I); i32_add;
-          i32_load8_u(0); local_set(B);
+          local_get(Local(I)); local_get(Local(IN_LEN)); i32_ge_u; br_if(1);
+          local_get(Local(S)); i32_const(Imm32(data_off)); i32_add; local_get(Local(I)); i32_add;
+          i32_load8_u(0); local_set(Local(B));
           // escapable = b==\\ || b=='"' || b=='\n' || b=='\r' || b=='\t'
-          local_get(OUT_LEN);
-          local_get(B); i32_const(BYTE_BACKSLASH); i32_eq;
-          local_get(B); i32_const(BYTE_QUOTE); i32_eq; i32_or;
-          local_get(B); i32_const(BYTE_NL); i32_eq; i32_or;
-          local_get(B); i32_const(BYTE_CR); i32_eq; i32_or;
-          local_get(B); i32_const(BYTE_TAB); i32_eq; i32_or;
+          local_get(Local(OUT_LEN));
+          local_get(Local(B)); i32_const(Imm32(BYTE_BACKSLASH)); i32_eq;
+          local_get(Local(B)); i32_const(Imm32(BYTE_QUOTE)); i32_eq; i32_or;
+          local_get(Local(B)); i32_const(Imm32(BYTE_NL)); i32_eq; i32_or;
+          local_get(Local(B)); i32_const(Imm32(BYTE_CR)); i32_eq; i32_or;
+          local_get(Local(B)); i32_const(Imm32(BYTE_TAB)); i32_eq; i32_or;
           // escapable ? 2 : 1  →  1 + escapable
-          i32_const(1); i32_add;
-          i32_add; local_set(OUT_LEN);
-          local_get(I); i32_const(1); i32_add; local_set(I);
+          i32_const(Imm32(1)); i32_add;
+          i32_add; local_set(Local(OUT_LEN));
+          local_get(Local(I)); i32_const(Imm32(1)); i32_add; local_set(Local(I));
           br(0);
         end; end;
         // ── Allocate result: header + quotes + escaped bytes ──
-        local_get(OUT_LEN); i32_const(QUOTE_LEN); i32_add; i32_const(hdr); i32_add;
-        call(alloc); local_set(OUT);
+        local_get(Local(OUT_LEN)); i32_const(Imm32(QUOTE_LEN)); i32_add; i32_const(Imm32(hdr)); i32_add;
+        call(alloc); local_set(Local(OUT));
         // len = cap = out_len + 2  (write both header words like __string_alloc)
-        local_get(OUT); local_get(OUT_LEN); i32_const(QUOTE_LEN); i32_add; i32_store(0);
-        local_get(OUT); local_get(OUT_LEN); i32_const(QUOTE_LEN); i32_add; i32_store(cap_off, 0);
+        local_get(Local(OUT)); local_get(Local(OUT_LEN)); i32_const(Imm32(QUOTE_LEN)); i32_add; i32_store(0);
+        local_get(Local(OUT)); local_get(Local(OUT_LEN)); i32_const(Imm32(QUOTE_LEN)); i32_add; i32_store(cap_off, 0);
         // w = out + DATA; write opening quote.
-        local_get(OUT); i32_const(data_off); i32_add; local_set(W);
-        local_get(W); i32_const(BYTE_QUOTE); i32_store8(0);
-        local_get(W); i32_const(1); i32_add; local_set(W);
+        local_get(Local(OUT)); i32_const(Imm32(data_off)); i32_add; local_set(Local(W));
+        local_get(Local(W)); i32_const(Imm32(BYTE_QUOTE)); i32_store8(0);
+        local_get(Local(W)); i32_const(Imm32(1)); i32_add; local_set(Local(W));
         // ── Pass 2: copy/escape each byte ──
-        i32_const(0); local_set(I);
+        i32_const(Imm32(0)); local_set(Local(I));
         block_empty; loop_empty;
-          local_get(I); local_get(IN_LEN); i32_ge_u; br_if(1);
-          local_get(S); i32_const(data_off); i32_add; local_get(I); i32_add;
-          i32_load8_u(0); local_set(B);
+          local_get(Local(I)); local_get(Local(IN_LEN)); i32_ge_u; br_if(1);
+          local_get(Local(S)); i32_const(Imm32(data_off)); i32_add; local_get(Local(I)); i32_add;
+          i32_load8_u(0); local_set(Local(B));
           // esc = post-backslash char, or 0 if this byte is copied verbatim.
           //   \\ , "  → the literal byte itself (a backslash precedes it)
           //   \n      → 'n' , \r → 'r' , \t → 't'
-          i32_const(0); local_set(ESC);
-          local_get(B); i32_const(BYTE_BACKSLASH); i32_eq;
-          local_get(B); i32_const(BYTE_QUOTE); i32_eq; i32_or;
+          i32_const(Imm32(0)); local_set(Local(ESC));
+          local_get(Local(B)); i32_const(Imm32(BYTE_BACKSLASH)); i32_eq;
+          local_get(Local(B)); i32_const(Imm32(BYTE_QUOTE)); i32_eq; i32_or;
           if_empty;
-            local_get(B); local_set(ESC);          // self-quoting: \\ , \"
+            local_get(Local(B)); local_set(Local(ESC));          // self-quoting: \\ , \"
           else_;
-            local_get(B); i32_const(BYTE_NL); i32_eq;
-            if_empty; i32_const(CHAR_N); local_set(ESC); end;
-            local_get(B); i32_const(BYTE_CR); i32_eq;
-            if_empty; i32_const(CHAR_R); local_set(ESC); end;
-            local_get(B); i32_const(BYTE_TAB); i32_eq;
-            if_empty; i32_const(CHAR_T); local_set(ESC); end;
+            local_get(Local(B)); i32_const(Imm32(BYTE_NL)); i32_eq;
+            if_empty; i32_const(Imm32(CHAR_N)); local_set(Local(ESC)); end;
+            local_get(Local(B)); i32_const(Imm32(BYTE_CR)); i32_eq;
+            if_empty; i32_const(Imm32(CHAR_R)); local_set(Local(ESC)); end;
+            local_get(Local(B)); i32_const(Imm32(BYTE_TAB)); i32_eq;
+            if_empty; i32_const(Imm32(CHAR_T)); local_set(Local(ESC)); end;
           end;
           // esc == 0 → copy byte verbatim; esc != 0 → write '\\' then esc.
-          local_get(ESC); i32_eqz;
+          local_get(Local(ESC)); i32_eqz;
           if_empty;
             // verbatim byte (esc == 0)
-            local_get(W); local_get(B); i32_store8(0);
-            local_get(W); i32_const(1); i32_add; local_set(W);
+            local_get(Local(W)); local_get(Local(B)); i32_store8(0);
+            local_get(Local(W)); i32_const(Imm32(1)); i32_add; local_set(Local(W));
           else_;
             // escaped pair: backslash + esc char
-            local_get(W); i32_const(BYTE_BACKSLASH); i32_store8(0);
-            local_get(W); i32_const(1); i32_add; local_get(ESC); i32_store8(0);
-            local_get(W); i32_const(QUOTE_LEN); i32_add; local_set(W);
+            local_get(Local(W)); i32_const(Imm32(BYTE_BACKSLASH)); i32_store8(0);
+            local_get(Local(W)); i32_const(Imm32(1)); i32_add; local_get(Local(ESC)); i32_store8(0);
+            local_get(Local(W)); i32_const(Imm32(QUOTE_LEN)); i32_add; local_set(Local(W));
           end;
-          local_get(I); i32_const(1); i32_add; local_set(I);
+          local_get(Local(I)); i32_const(Imm32(1)); i32_add; local_set(Local(I));
           br(0);
         end; end;
         // closing quote
-        local_get(W); i32_const(BYTE_QUOTE); i32_store8(0);
-        local_get(OUT);
+        local_get(Local(W)); i32_const(Imm32(BYTE_QUOTE)); i32_store8(0);
+        local_get(Local(OUT));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -2,6 +2,70 @@
 //!
 //! All `__str_*` runtime function registration and compilation lives here.
 
+// ── WASM immediate constants ──
+// UTF-8 byte classification boundaries (lead-byte ranges and continuation mask).
+// These mirror the Rust-level CONT_MASK/CONT_TAG consts defined later in the file,
+// but as i32 for use in WASM i32_const() immediates.
+const UTF8_CONT_TAG_IMM: i32  = 0x80; // 1000_0000: continuation byte tag / ASCII upper bound
+const UTF8_CONT_MASK_IMM: i32 = 0xC0; // 1100_0000: mask to isolate top-2 bits of any byte
+const UTF8_3B_LEAD_MIN: i32   = 0xE0; // 1110_0000: minimum value of a 3-byte sequence lead byte
+const UTF8_4B_LEAD_MIN: i32   = 0xF0; // 1111_0000: minimum value of a 4-byte sequence lead byte
+// Widths of UTF-8 multi-byte sequences.
+const UTF8_W2: i32 = 2; // 2-byte sequence width
+const UTF8_W3: i32 = 3; // 3-byte sequence width
+const UTF8_W4: i32 = 4; // 4-byte sequence width
+// Data-bit masks for lead bytes (strip the fixed lead bits, keep payload).
+const UTF8_2B_DATA_MASK: i32 = 0x1F; // 0001_1111: 5 data bits from a 2-byte lead
+const UTF8_3B_DATA_MASK: i32 = 0x0F; // 0000_1111: 4 data bits from a 3-byte lead
+const UTF8_4B_DATA_MASK: i32 = 0x07; // 0000_0111: 3 data bits from a 4-byte lead
+const UTF8_CONT_DATA_MASK: i32 = 0x3F; // 0011_1111: 6 data bits from a continuation byte
+// Bit-shift amounts for UTF-8 scalar decoding/encoding.
+const UTF8_CONT_BITS: i64 = 6; // bits of data carried by each continuation byte (i64 for i64_shl)
+const UTF8_W2_LEAD_SHIFT: i32 = 6;  // shift right to isolate lead bits of a 2-byte sequence
+const UTF8_W3_LEAD_SHIFT: i32 = 12; // shift right to isolate lead bits of a 3-byte sequence
+const UTF8_W4_LEAD_SHIFT: i32 = 18; // shift right to isolate lead bits of a 4-byte sequence
+// UTF-8 encoding thresholds: scalar >= these values need ≥3 / ≥4 bytes.
+const UTF8_3B_MIN_SCALAR: i32 = 0x800;   // 2048
+const UTF8_4B_MIN_SCALAR: i32 = 0x10000; // 65536
+// Tags ORed into the lead byte during encoding (same values as the *_LEAD_MIN thresholds).
+const UTF8_2B_LEAD_TAG: i32 = 0xC0; // == UTF8_CONT_MASK_IMM
+const UTF8_3B_LEAD_TAG: i32 = 0xE0; // == UTF8_3B_LEAD_MIN
+const UTF8_4B_LEAD_TAG: i32 = 0xF0; // == UTF8_4B_LEAD_MIN
+// Binary-search: key array uses 4-byte (i32) entries; index * 4 == index << 2.
+const KEY_ENTRY_SHIFT: i32 = 2; // log2(4): index → byte-offset left-shift for i32 key arrays
+// I32 pointer slot size in list data (each list element is a 4-byte i32 pointer).
+const LIST_SLOT_BYTES: i32 = 4;
+// I64 element slot size used by to_bytes (each byte stored as a full i64 value).
+const LIST_I64_SLOT_BYTES: i32 = 8;
+// Byte size of a (String, Int) tuple allocated by run_length_encode: i32 ptr @0 + i64 @4.
+const RLE_TUPLE_BYTES: i32 = 12;
+// ASCII character values used in case-folding logic.
+const ASCII_LOWER_A: i32 = 0x61; // 'a'
+const ASCII_LOWER_Z: i32 = 0x7A; // 'z'
+const ASCII_UPPER_A: i32 = 0x41; // 'A'
+const ASCII_UPPER_Z: i32 = 0x5A; // 'Z'
+const ASCII_CASE_DELTA: i32 = 32; // difference between 'A' and 'a' (uppercase ↔ lowercase)
+// Line-break byte values used by compile_lines.
+const ASCII_LF: i32 = 10; // '\n'
+const ASCII_CR: i32 = 13; // '\r'
+// Greek sigma codepoints (Final_Sigma rule in lowercasing).
+const SIGMA_UPPER: i32 = 0x03A3; // Σ
+const SIGMA_LOWER: i32 = 0x03C3; // σ
+const SIGMA_FINAL: i32 = 0x03C2; // ς
+// Internal sentinel used in compile_str_capitalize: means "ASCII byte, identity-mapped".
+const ASCII_ID_SENTINEL: i32 = -2;
+// Encoded result of `classify_packed(1, 1)` for single-byte valid sequences, used in
+// compile_utf8_classify. Computed from the classify_packed fn but written explicitly
+// here as a named const so the WASM immediate is self-describing.
+// classify_packed(consumed=1, valid=1) = (1 << 1) | 1 = 3.
+const CLASSIFY_ASCII: i32 = classify_packed(1, 1); // 3
+// classify_packed(consumed=1, valid=0) = (1 << 1) | 0 = 2.
+const CLASSIFY_INVALID_LEAD: i32 = classify_packed(1, 0); // 2
+// Lowercase Σ produces 2 UTF-8 bytes (ς/σ are U+03C2/U+03C3, both 2 bytes).
+const SIGMA_LOWER_UTF8_LEN: i32 = 2;
+// Extra slots allocated when split(""): one leading "" + one trailing "".
+const SPLIT_EMPTY_DELIM_EXTRA_SLOTS: i32 = 2;
+
 use super::{CompiledFunc, WasmEmitter};
 use wasm_encoder::{ValType};
 use super::TrackedFunction as Function;
@@ -246,17 +310,17 @@ fn compile_utf8_width(emitter: &mut WasmEmitter) {
         local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
         i32_load8_u(0); local_set(3);
         // width by lead-byte class
-        local_get(3); i32_const(0x80); i32_lt_u;
+        local_get(3); i32_const(UTF8_CONT_TAG_IMM); i32_lt_u;
         if_i32; i32_const(1);
         else_;
-          local_get(3); i32_const(0xF0); i32_ge_u;
-          if_i32; i32_const(4);
+          local_get(3); i32_const(UTF8_4B_LEAD_MIN); i32_ge_u;
+          if_i32; i32_const(UTF8_W4);
           else_;
-            local_get(3); i32_const(0xE0); i32_ge_u;
-            if_i32; i32_const(3);
+            local_get(3); i32_const(UTF8_3B_LEAD_MIN); i32_ge_u;
+            if_i32; i32_const(UTF8_W3);
             else_;
-              local_get(3); i32_const(0xC0); i32_ge_u;
-              if_i32; i32_const(2);
+              local_get(3); i32_const(UTF8_CONT_MASK_IMM); i32_ge_u;
+              if_i32; i32_const(UTF8_W2);
               else_; i32_const(1); // continuation byte as lead → 1
               end;
             end;
@@ -296,11 +360,11 @@ fn compile_utf8_scalar(emitter: &mut WasmEmitter) {
           local_get(3); i64_extend_i32_u;
         else_;
           // mask lead bits: 2→0x1F, 3→0x0F, 4→0x07
-          local_get(2); i32_const(2); i32_eq;
-          if_i32; i32_const(0x1F);
+          local_get(2); i32_const(UTF8_W2); i32_eq;
+          if_i32; i32_const(UTF8_2B_DATA_MASK);
           else_;
-            local_get(2); i32_const(3); i32_eq;
-            if_i32; i32_const(0x0F); else_; i32_const(0x07); end;
+            local_get(2); i32_const(UTF8_W3); i32_eq;
+            if_i32; i32_const(UTF8_3B_DATA_MASK); else_; i32_const(UTF8_4B_DATA_MASK); end;
           end;
           local_get(3); i32_and; i64_extend_i32_u; local_set(4); // scalar = b0 & mask
           // fold in (width-1) continuation bytes
@@ -309,8 +373,8 @@ fn compile_utf8_scalar(emitter: &mut WasmEmitter) {
             local_get(5); local_get(2); i32_ge_u; br_if(1);
             local_get(0); i32_const(string_data_off()); i32_add;
             local_get(1); i32_add; local_get(5); i32_add;
-            i32_load8_u(0); i32_const(0x3F); i32_and; local_set(6); // cont = byte & 0x3F
-            local_get(4); i64_const(6); i64_shl;
+            i32_load8_u(0); i32_const(UTF8_CONT_DATA_MASK); i32_and; local_set(6); // cont = byte & 0x3F
+            local_get(4); i64_const(UTF8_CONT_BITS); i64_shl;
             local_get(6); i64_extend_i32_u; i64_or; local_set(4);   // scalar = (scalar<<6) | cont
             local_get(5); i32_const(1); i32_add; local_set(5);
             br(0);
@@ -341,7 +405,7 @@ fn compile_utf8_snap(emitter: &mut WasmEmitter) {
           local_get(3); i32_eqz; br_if(1);
           local_get(3); local_get(2); i32_ge_u; br_if(1);       // i == blen is a boundary
           local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; i32_load8_u(0);
-          i32_const(0xC0); i32_and; i32_const(0x80); i32_ne; br_if(1); // not continuation → boundary
+          i32_const(UTF8_CONT_MASK_IMM); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_ne; br_if(1); // not continuation → boundary
           local_get(3); i32_const(1); i32_sub; local_set(3);
           br(0);
         end; end;
@@ -397,8 +461,8 @@ fn compile_char_count(emitter: &mut WasmEmitter) {
           local_get(0); i32_const(string_data_off()); i32_add;
           local_get(2); i32_add; i32_load8_u(0);
           // if (byte & 0xC0) != 0x80 then count++
-          i32_const(0xC0); i32_and;
-          i32_const(0x80); i32_ne;
+          i32_const(UTF8_CONT_MASK_IMM); i32_and;
+          i32_const(UTF8_CONT_TAG_IMM); i32_ne;
           if_empty;
             local_get(3); i32_const(1); i32_add; local_set(3);
           end;
@@ -432,8 +496,8 @@ fn compile_cp_of_byte(emitter: &mut WasmEmitter) {
           local_get(3); local_get(2); i32_ge_u; br_if(1);
           local_get(0); i32_const(string_data_off()); i32_add;
           local_get(3); i32_add; i32_load8_u(0);
-          i32_const(0xC0); i32_and;
-          i32_const(0x80); i32_ne;
+          i32_const(UTF8_CONT_MASK_IMM); i32_and;
+          i32_const(UTF8_CONT_TAG_IMM); i32_ne;
           if_empty;
             local_get(4); i32_const(1); i32_add; local_set(4);
           end;
@@ -657,7 +721,7 @@ pub(super) fn emit_trim_backward(f: &mut Function, emitter: &WasmEmitter, end_lo
           local_get(end_local); i32_const(1); i32_sub; local_set(q_local);
           block_empty; loop_empty;
             local_get(0); i32_const(do_); i32_add; local_get(q_local); i32_add; i32_load8_u(0);
-            i32_const(0xC0); i32_and; i32_const(0x80); i32_ne; br_if(1);   // lead byte → stop
+            i32_const(UTF8_CONT_MASK_IMM); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_ne; br_if(1);   // lead byte → stop
             local_get(q_local); i32_eqz; br_if(1);
             local_get(q_local); i32_const(1); i32_sub; local_set(q_local);
             br(0);
@@ -948,7 +1012,7 @@ fn compile_split(emitter: &mut WasmEmitter) {
         if_empty;
           // result list: [len = char_count + 2][slot ptrs…]. Worst case (all
           // ASCII) char_count == blen, so blen + 2 slots is always enough.
-          i32_const(list_hdr()); local_get(3); i32_const(2); i32_add; i32_const(4); i32_mul; i32_add;
+          i32_const(list_hdr()); local_get(3); i32_const(SPLIT_EMPTY_DELIM_EXTRA_SLOTS); i32_add; i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
           call(emitter.rt.alloc); local_set(7);
           // slot[0] = "" (leading empty)
           local_get(7); i32_const(list_data_off()); i32_add;
@@ -959,7 +1023,7 @@ fn compile_split(emitter: &mut WasmEmitter) {
             local_get(8); local_get(3); i32_ge_u; br_if(1);
             local_get(0); local_get(8); call(emitter.rt.string.utf8_width); local_set(9); // width
             // slot[slot] = slice(s, in_off, in_off + width)  (one codepoint)
-            local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(4); i32_mul; i32_add;
+            local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
             local_get(0); local_get(8); local_get(8); local_get(9); i32_add;
             call(emitter.rt.string.slice); i32_store(0);
             local_get(8); local_get(9); i32_add; local_set(8);     // in_off += width
@@ -967,7 +1031,7 @@ fn compile_split(emitter: &mut WasmEmitter) {
             br(0);
           end; end;
           // slot[slot] = "" (trailing empty)
-          local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(4); i32_mul; i32_add;
+          local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
           i32_const(0); call(emitter.rt.string_alloc); i32_store(0);
           // result.len = slot + 1  (== char_count + 2)
           local_get(7); local_get(6); i32_const(1); i32_add; i32_store(0);
@@ -975,7 +1039,7 @@ fn compile_split(emitter: &mut WasmEmitter) {
         end;
         // Non-empty delimiter. A delimiter of length d_len>=1 can match at most
         // blen times, so blen + 1 segments is the upper bound on the slot count.
-        i32_const(list_hdr()); local_get(3); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+        i32_const(list_hdr()); local_get(3); i32_const(1); i32_add; i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
         call(emitter.rt.alloc); local_set(7);
         i32_const(0); local_set(4); // seg_start = 0
         i32_const(0); local_set(5); // i = 0 (scan position)
@@ -990,7 +1054,7 @@ fn compile_split(emitter: &mut WasmEmitter) {
           call(emitter.rt.mem_eq);
           if_empty;
             // emit segment slice(s, seg_start, i)
-            local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(4); i32_mul; i32_add;
+            local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
             local_get(0); local_get(4); local_get(5); call(emitter.rt.string.slice); i32_store(0);
             local_get(6); i32_const(1); i32_add; local_set(6);     // slot += 1
             local_get(5); local_get(2); i32_add; local_set(5);     // i += d_len
@@ -1001,7 +1065,7 @@ fn compile_split(emitter: &mut WasmEmitter) {
           br(0);
         end; end;
         // trailing segment slice(s, seg_start, blen)
-        local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(4); i32_mul; i32_add;
+        local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
         local_get(0); local_get(4); local_get(3); call(emitter.rt.string.slice); i32_store(0);
         local_get(6); i32_const(1); i32_add; local_set(6);         // slot += 1
         local_get(7); local_get(6); i32_store(0);                  // result.len = slot
@@ -1039,7 +1103,7 @@ fn compile_join(emitter: &mut WasmEmitter) {
             // result = concat(result, list[i])
             local_get(4);
             local_get(0); i32_const(list_data_off()); i32_add;
-            local_get(3); i32_const(4); i32_mul; i32_add; i32_load(0);
+            local_get(3); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add; i32_load(0);
             call(emitter.rt.concat_str); local_set(4);
             local_get(3); i32_const(1); i32_add; local_set(3);
             br(0);
@@ -1224,7 +1288,7 @@ fn compile_chars(emitter: &mut WasmEmitter) {
     wasm!(f, {
         local_get(0); i32_load(0); local_set(1);                 // blen
         // worst-case slots = blen (all-ASCII); fewer codepoints just leave gaps
-        i32_const(list_hdr()); local_get(1); i32_const(4); i32_mul; i32_add;
+        i32_const(list_hdr()); local_get(1); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
         call(emitter.rt.alloc); local_set(2);
         i32_const(0); local_set(3);                              // in_off = 0
         i32_const(0); local_set(6);                              // j = 0 (codepoint index)
@@ -1243,7 +1307,7 @@ fn compile_chars(emitter: &mut WasmEmitter) {
             br(0);
           end; end;
           // result.data[j] = str
-          local_get(2); i32_const(list_data_off()); i32_add; local_get(6); i32_const(4); i32_mul; i32_add;
+          local_get(2); i32_const(list_data_off()); i32_add; local_get(6); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
           local_get(4); i32_store(0);
           local_get(3); local_get(5); i32_add; local_set(3);     // in_off += width
           local_get(6); i32_const(1); i32_add; local_set(6);     // j += 1
@@ -1294,7 +1358,7 @@ fn compile_run_length_encode(emitter: &mut WasmEmitter) {
           br(0);
         end; end;
         // ── Allocate the result list: [len=nr][nr * ptr] ──
-        i32_const(list_hdr()); local_get(2); i32_const(4); i32_mul; i32_add;
+        i32_const(list_hdr()); local_get(2); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
         call(emitter.rt.alloc); local_set(5);
         local_get(5); local_get(2); i32_store(0);
         // ── Pass 2: emit one (codepoint-string, count) tuple per run ──
@@ -1319,11 +1383,11 @@ fn compile_run_length_encode(emitter: &mut WasmEmitter) {
           local_get(0); local_get(10); local_get(10); local_get(11); i32_add;
           call(emitter.rt.string.slice); local_set(8);
           // tup = [strp @0][cnt:i64 @4]
-          i32_const(12); call(emitter.rt.alloc); local_set(9);
+          i32_const(RLE_TUPLE_BYTES); call(emitter.rt.alloc); local_set(9);
           local_get(9); local_get(8); i32_store(0);
           local_get(9); local_get(7); i64_extend_i32_u; i64_store(4);
           // result.data[j] = tup
-          local_get(5); i32_const(list_data_off()); i32_add; local_get(6); i32_const(4); i32_mul; i32_add;
+          local_get(5); i32_const(list_data_off()); i32_add; local_get(6); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
           local_get(9); i32_store(0);
           local_get(6); i32_const(1); i32_add; local_set(6);     // j += 1
           br(0);
@@ -1348,7 +1412,7 @@ fn compile_lines(emitter: &mut WasmEmitter) {
         // (empty input falls through naturally: the loop body never runs, the
         // trailing-line guard is false, and result.len stays 0 -> empty list.)
         // result: header + (blen + 1) slots (upper bound on the line count).
-        i32_const(list_hdr()); local_get(1); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+        i32_const(list_hdr()); local_get(1); i32_const(1); i32_add; i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
         call(emitter.rt.alloc); local_set(2);
         i32_const(0); local_set(3); // cur
         i32_const(0); local_set(4); // i
@@ -1357,20 +1421,20 @@ fn compile_lines(emitter: &mut WasmEmitter) {
           local_get(4); local_get(1); i32_ge_u; br_if(1); // i >= blen -> done scanning
           // if byte[i] == '\n'
           local_get(0); i32_const(dat); i32_add; local_get(4); i32_add; i32_load8_u(0);
-          i32_const(10); i32_eq;
+          i32_const(ASCII_LF); i32_eq;
           if_empty;
             // line_end = i; strip a trailing '\r' (byte[i-1] == 13 when i > cur)
             local_get(4); local_set(6);
             local_get(4); local_get(3); i32_gt_u;
             if_empty;
               local_get(0); i32_const(dat); i32_add; local_get(4); i32_const(1); i32_sub; i32_add; i32_load8_u(0);
-              i32_const(13); i32_eq;
+              i32_const(ASCII_CR); i32_eq;
               if_empty;
                 local_get(4); i32_const(1); i32_sub; local_set(6);
               end;
             end;
             // slot[slot] = slice(s, cur, line_end)
-            local_get(2); i32_const(list_data_off()); i32_add; local_get(5); i32_const(4); i32_mul; i32_add;
+            local_get(2); i32_const(list_data_off()); i32_add; local_get(5); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
             local_get(0); local_get(3); local_get(6); call(emitter.rt.string.slice);
             i32_store(0);
             local_get(5); i32_const(1); i32_add; local_set(5); // slot++
@@ -1382,7 +1446,7 @@ fn compile_lines(emitter: &mut WasmEmitter) {
         // trailing non-empty line (input did NOT end at a '\n')
         local_get(3); local_get(1); i32_lt_u;
         if_empty;
-          local_get(2); i32_const(list_data_off()); i32_add; local_get(5); i32_const(4); i32_mul; i32_add;
+          local_get(2); i32_const(list_data_off()); i32_add; local_get(5); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
           local_get(0); local_get(3); local_get(1); call(emitter.rt.string.slice);
           i32_store(0);
           local_get(5); i32_const(1); i32_add; local_set(5);
@@ -1477,7 +1541,7 @@ fn compile_utf8_classify(emitter: &mut WasmEmitter) {
     wasm!(f, {
         local_get(BUF); local_get(I); i32_add; i32_load8_u(0); local_set(B0);
         local_get(B0); i32_const(ASCII_MAX); i32_le_u;
-        if_empty; i32_const(classify_packed(1, 1)); return_; end;   // ASCII: 1 byte, valid
+        if_empty; i32_const(CLASSIFY_ASCII); return_; end;   // ASCII: 1 byte, valid
         i32_const(0); local_set(WIDTH);
     });
     // Lead-byte width + 2nd-byte range, generated from the derived groups.
@@ -1494,7 +1558,7 @@ fn compile_utf8_classify(emitter: &mut WasmEmitter) {
     }
     wasm!(f, {
         local_get(WIDTH); i32_eqz;
-        if_empty; i32_const(classify_packed(1, 0)); return_; end;   // invalid lead: 1-byte subpart
+        if_empty; i32_const(CLASSIFY_INVALID_LEAD); return_; end;   // invalid lead: 1-byte subpart
         // Validate continuation bytes: 2nd in [lo2,hi2]; 3rd/4th are plain continuations.
         // On the first failure the maximal subpart ends, so `consumed < width`.
         i32_const(1); local_set(CONSUMED);
@@ -1554,7 +1618,7 @@ fn compile_from_bytes(emitter: &mut WasmEmitter) {
         block_empty; loop_empty;
           local_get(I); local_get(N); i32_ge_u; br_if(1);
           local_get(BUF); local_get(I); i32_add;
-          local_get(LIST); i32_const(list_data_off()); i32_add; local_get(I); i32_const(8); i32_mul; i32_add;
+          local_get(LIST); i32_const(list_data_off()); i32_add; local_get(I); i32_const(LIST_I64_SLOT_BYTES); i32_mul; i32_add;
           i64_load(0); i32_wrap_i64; i32_store8(0);
           local_get(I); i32_const(1); i32_add; local_set(I);
           br(0);
@@ -1605,13 +1669,13 @@ fn compile_to_bytes(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(1, ValType::I32), (1, ValType::I32), (1, ValType::I32)]);
     wasm!(f, {
         local_get(0); i32_load(0); local_set(1);
-        i32_const(list_hdr()); local_get(1); i32_const(8); i32_mul; i32_add;
+        i32_const(list_hdr()); local_get(1); i32_const(LIST_I64_SLOT_BYTES); i32_mul; i32_add;
         call(emitter.rt.alloc); local_set(2);
         local_get(2); local_get(1); i32_store(0);
         i32_const(0); local_set(3);
         block_empty; loop_empty;
           local_get(3); local_get(1); i32_ge_u; br_if(1);
-          local_get(2); i32_const(list_data_off()); i32_add; local_get(3); i32_const(8); i32_mul; i32_add;
+          local_get(2); i32_const(list_data_off()); i32_add; local_get(3); i32_const(LIST_I64_SLOT_BYTES); i32_mul; i32_add;
           local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add;
           i32_load8_u(0); i64_extend_i32_u; i64_store(0);
           local_get(3); i32_const(1); i32_add; local_set(3);
@@ -1640,29 +1704,29 @@ fn compile_utf8_emit_scalar(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(1, ValType::I32)]);
     wasm!(f, {
         local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add; local_set(3);
-        local_get(2); i32_const(0x80); i32_lt_u;
+        local_get(2); i32_const(UTF8_CONT_TAG_IMM); i32_lt_u;
         if_i32;
           local_get(3); local_get(2); i32_store8(0);
           local_get(1); i32_const(1); i32_add;
         else_;
-          local_get(2); i32_const(0x800); i32_lt_u;
+          local_get(2); i32_const(UTF8_3B_MIN_SCALAR); i32_lt_u;
           if_i32;
-            local_get(3); local_get(2); i32_const(6); i32_shr_u; i32_const(0xC0); i32_or; i32_store8(0);
-            local_get(3); local_get(2); i32_const(0x3F); i32_and; i32_const(0x80); i32_or; i32_store8(1);
-            local_get(1); i32_const(2); i32_add;
+            local_get(3); local_get(2); i32_const(UTF8_W2_LEAD_SHIFT); i32_shr_u; i32_const(UTF8_2B_LEAD_TAG); i32_or; i32_store8(0);
+            local_get(3); local_get(2); i32_const(UTF8_CONT_DATA_MASK); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_or; i32_store8(1);
+            local_get(1); i32_const(UTF8_W2); i32_add;
           else_;
-            local_get(2); i32_const(0x10000); i32_lt_u;
+            local_get(2); i32_const(UTF8_4B_MIN_SCALAR); i32_lt_u;
             if_i32;
-              local_get(3); local_get(2); i32_const(12); i32_shr_u; i32_const(0xE0); i32_or; i32_store8(0);
-              local_get(3); local_get(2); i32_const(6); i32_shr_u; i32_const(0x3F); i32_and; i32_const(0x80); i32_or; i32_store8(1);
-              local_get(3); local_get(2); i32_const(0x3F); i32_and; i32_const(0x80); i32_or; i32_store8(2);
-              local_get(1); i32_const(3); i32_add;
+              local_get(3); local_get(2); i32_const(UTF8_W3_LEAD_SHIFT); i32_shr_u; i32_const(UTF8_3B_LEAD_TAG); i32_or; i32_store8(0);
+              local_get(3); local_get(2); i32_const(UTF8_W2_LEAD_SHIFT); i32_shr_u; i32_const(UTF8_CONT_DATA_MASK); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_or; i32_store8(1);
+              local_get(3); local_get(2); i32_const(UTF8_CONT_DATA_MASK); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_or; i32_store8(2);
+              local_get(1); i32_const(UTF8_W3); i32_add;
             else_;
-              local_get(3); local_get(2); i32_const(18); i32_shr_u; i32_const(0xF0); i32_or; i32_store8(0);
-              local_get(3); local_get(2); i32_const(12); i32_shr_u; i32_const(0x3F); i32_and; i32_const(0x80); i32_or; i32_store8(1);
-              local_get(3); local_get(2); i32_const(6); i32_shr_u; i32_const(0x3F); i32_and; i32_const(0x80); i32_or; i32_store8(2);
-              local_get(3); local_get(2); i32_const(0x3F); i32_and; i32_const(0x80); i32_or; i32_store8(3);
-              local_get(1); i32_const(4); i32_add;
+              local_get(3); local_get(2); i32_const(UTF8_W4_LEAD_SHIFT); i32_shr_u; i32_const(UTF8_4B_LEAD_TAG); i32_or; i32_store8(0);
+              local_get(3); local_get(2); i32_const(UTF8_W3_LEAD_SHIFT); i32_shr_u; i32_const(UTF8_CONT_DATA_MASK); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_or; i32_store8(1);
+              local_get(3); local_get(2); i32_const(UTF8_W2_LEAD_SHIFT); i32_shr_u; i32_const(UTF8_CONT_DATA_MASK); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_or; i32_store8(2);
+              local_get(3); local_get(2); i32_const(UTF8_CONT_DATA_MASK); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_or; i32_store8(3);
+              local_get(1); i32_const(UTF8_W4); i32_add;
             end;
           end;
         end;
@@ -1697,10 +1761,10 @@ fn compile_case_map_lookup(emitter: &mut WasmEmitter) {
               local_get(5); local_get(6); i32_ge_u;
               if_empty; i32_const(-1); return_; end;
               local_get(5); local_get(6); i32_add; i32_const(1); i32_shr_u; local_set(7);
-              local_get(2); local_get(7); i32_const(2); i32_shl; i32_add; i32_load(0); local_set(8);
+              local_get(2); local_get(7); i32_const(KEY_ENTRY_SHIFT); i32_shl; i32_add; i32_load(0); local_set(8);
               local_get(8); local_get(1); i32_eq;
               if_empty;
-                local_get(4); local_get(7); i32_const(2); i32_shl; i32_add; i32_load(0); return_;
+                local_get(4); local_get(7); i32_const(KEY_ENTRY_SHIFT); i32_shl; i32_add; i32_load(0); return_;
               end;
               local_get(8); local_get(1); i32_lt_u;
               if_empty;
@@ -1741,7 +1805,7 @@ fn compile_set_member(emitter: &mut WasmEmitter) {
               local_get(4); local_get(5); i32_ge_u;
               if_empty; i32_const(0); return_; end;
               local_get(4); local_get(5); i32_add; i32_const(1); i32_shr_u; local_set(6);
-              local_get(2); local_get(6); i32_const(2); i32_shl; i32_add; i32_load(0); local_set(7);
+              local_get(2); local_get(6); i32_const(KEY_ENTRY_SHIFT); i32_shl; i32_add; i32_load(0); local_set(7);
               local_get(7); local_get(1); i32_eq;
               if_empty; i32_const(1); return_; end;
               local_get(7); local_get(1); i32_lt_u;
@@ -1794,7 +1858,7 @@ fn compile_final_sigma(emitter: &mut WasmEmitter) {
           block_empty; loop_empty;
             local_get(6); i32_eqz; br_if(1);                   // q == 0 → stop
             local_get(0); i32_const(do_); i32_add; local_get(6); i32_add; i32_load8_u(0);
-            i32_const(0xC0); i32_and; i32_const(0x80); i32_eq; // continuation byte?
+            i32_const(UTF8_CONT_MASK_IMM); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_eq; // continuation byte?
             i32_eqz; br_if(1);                                 // not continuation → stop (lead byte)
             local_get(6); i32_const(1); i32_sub; local_set(6);
             br(0);
@@ -1826,7 +1890,7 @@ fn compile_final_sigma(emitter: &mut WasmEmitter) {
           br(0);
         end; end;
         local_get(3); local_get(4); i32_eqz; i32_and;
-        if_i32; i32_const(0x03C2); else_; i32_const(0x03C3); end;
+        if_i32; i32_const(SIGMA_FINAL); else_; i32_const(SIGMA_LOWER); end;
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.final_sigma, type_idx, f));
@@ -1859,16 +1923,16 @@ fn compile_str_case_map(emitter: &mut WasmEmitter) {
         block_empty; loop_empty;
           local_get(4); local_get(2); i32_ge_u; br_if(1);
           local_get(0); i32_const(do_); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(5);
-          local_get(5); i32_const(0x80); i32_lt_u;
+          local_get(5); i32_const(UTF8_CONT_TAG_IMM); i32_lt_u;
           if_empty;
             local_get(3); i32_const(1); i32_add; local_set(3);
             local_get(4); i32_const(1); i32_add; local_set(4);
           else_;
             local_get(0); local_get(4); call(uw); local_set(6);
             local_get(0); local_get(4); call(us); i32_wrap_i64; local_set(7);
-            local_get(1); i32_eqz; local_get(7); i32_const(0x03A3); i32_eq; i32_and;
+            local_get(1); i32_eqz; local_get(7); i32_const(SIGMA_UPPER); i32_eq; i32_and;
             if_empty;
-              local_get(3); i32_const(2); i32_add; local_set(3);
+              local_get(3); i32_const(SIGMA_LOWER_UTF8_LEN); i32_add; local_set(3);
             else_;
               local_get(13); local_get(7); call(lk); local_set(8);
               local_get(8); i32_const(-1); i32_eq;
@@ -1892,15 +1956,15 @@ fn compile_str_case_map(emitter: &mut WasmEmitter) {
         block_empty; loop_empty;
           local_get(4); local_get(2); i32_ge_u; br_if(1);
           local_get(0); i32_const(do_); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(5);
-          local_get(5); i32_const(0x80); i32_lt_u;
+          local_get(5); i32_const(UTF8_CONT_TAG_IMM); i32_lt_u;
           if_empty;
             local_get(1);
             if_i32;
-              local_get(5); i32_const(0x61); i32_ge_u; local_get(5); i32_const(0x7A); i32_le_u; i32_and;
-              if_i32; local_get(5); i32_const(32); i32_sub; else_; local_get(5); end;
+              local_get(5); i32_const(ASCII_LOWER_A); i32_ge_u; local_get(5); i32_const(ASCII_LOWER_Z); i32_le_u; i32_and;
+              if_i32; local_get(5); i32_const(ASCII_CASE_DELTA); i32_sub; else_; local_get(5); end;
             else_;
-              local_get(5); i32_const(0x41); i32_ge_u; local_get(5); i32_const(0x5A); i32_le_u; i32_and;
-              if_i32; local_get(5); i32_const(32); i32_add; else_; local_get(5); end;
+              local_get(5); i32_const(ASCII_UPPER_A); i32_ge_u; local_get(5); i32_const(ASCII_UPPER_Z); i32_le_u; i32_and;
+              if_i32; local_get(5); i32_const(ASCII_CASE_DELTA); i32_add; else_; local_get(5); end;
             end;
             local_set(12);
             local_get(9); i32_const(do_); i32_add; local_get(10); i32_add; local_get(12); i32_store8(0);
@@ -1909,7 +1973,7 @@ fn compile_str_case_map(emitter: &mut WasmEmitter) {
           else_;
             local_get(0); local_get(4); call(uw); local_set(6);
             local_get(0); local_get(4); call(us); i32_wrap_i64; local_set(7);
-            local_get(1); i32_eqz; local_get(7); i32_const(0x03A3); i32_eq; i32_and;
+            local_get(1); i32_eqz; local_get(7); i32_const(SIGMA_UPPER); i32_eq; i32_and;
             if_empty;
               local_get(9); local_get(10);
               local_get(0); local_get(4); call(fsig);
@@ -1961,13 +2025,13 @@ fn compile_str_capitalize(emitter: &mut WasmEmitter) {
         local_get(2); i32_eqz; if_empty; local_get(0); return_; end;
         local_get(0); i32_const(do_); i32_add; i32_load8_u(0); local_set(5);
         local_get(0); i32_const(0); call(uw); local_set(3);
-        local_get(5); i32_const(0x80); i32_lt_u;
+        local_get(5); i32_const(UTF8_CONT_TAG_IMM); i32_lt_u;
         if_empty;
           i32_const(1); local_set(7);
-          local_get(5); i32_const(0x61); i32_ge_u; local_get(5); i32_const(0x7A); i32_le_u; i32_and;
-          if_i32; local_get(5); i32_const(32); i32_sub; else_; local_get(5); end;
+          local_get(5); i32_const(ASCII_LOWER_A); i32_ge_u; local_get(5); i32_const(ASCII_LOWER_Z); i32_le_u; i32_and;
+          if_i32; local_get(5); i32_const(ASCII_CASE_DELTA); i32_sub; else_; local_get(5); end;
           local_set(10);
-          i32_const(-2); local_set(6);
+          i32_const(ASCII_ID_SENTINEL); local_set(6);
         else_;
           local_get(0); i32_const(0); call(us); i32_wrap_i64; local_set(4);
           i32_const(0); local_get(4); call(lk); local_set(6);
@@ -1980,7 +2044,7 @@ fn compile_str_capitalize(emitter: &mut WasmEmitter) {
         local_get(9); local_get(8); i32_store(0);
         local_get(9); local_get(8); i32_store(capo, 0);
         // head
-        local_get(6); i32_const(-2); i32_eq;
+        local_get(6); i32_const(ASCII_ID_SENTINEL); i32_eq;
         if_empty;
           local_get(9); i32_const(do_); i32_add; local_get(10); i32_store8(0);
         else_;

--- a/crates/almide-codegen/src/emit_wasm/rt_string.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string.rs
@@ -6,6 +6,7 @@
 // UTF-8 byte classification boundaries (lead-byte ranges and continuation mask).
 // These mirror the Rust-level CONT_MASK/CONT_TAG consts defined later in the file,
 // but as i32 for use in WASM i32_const() immediates.
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 const UTF8_CONT_TAG_IMM: i32  = 0x80; // 1000_0000: continuation byte tag / ASCII upper bound
 const UTF8_CONT_MASK_IMM: i32 = 0xC0; // 1100_0000: mask to isolate top-2 bits of any byte
 const UTF8_3B_LEAD_MIN: i32   = 0xE0; // 1110_0000: minimum value of a 3-byte sequence lead byte
@@ -305,34 +306,34 @@ fn compile_utf8_width(emitter: &mut WasmEmitter) {
     // params: 0=s, 1=byte_i | locals: 2=blen, 3=b0, 4=width
     let mut f = Function::new([(3, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);                 // blen = *s
+        local_get(Local(0)); i32_load(0); local_set(Local(2));                 // blen = *s
         // b0 = s[data + byte_i]
-        local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-        i32_load8_u(0); local_set(3);
+        local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+        i32_load8_u(0); local_set(Local(3));
         // width by lead-byte class
-        local_get(3); i32_const(UTF8_CONT_TAG_IMM); i32_lt_u;
-        if_i32; i32_const(1);
+        local_get(Local(3)); i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_lt_u;
+        if_i32; i32_const(Imm32(1));
         else_;
-          local_get(3); i32_const(UTF8_4B_LEAD_MIN); i32_ge_u;
-          if_i32; i32_const(UTF8_W4);
+          local_get(Local(3)); i32_const(Imm32(UTF8_4B_LEAD_MIN)); i32_ge_u;
+          if_i32; i32_const(Imm32(UTF8_W4));
           else_;
-            local_get(3); i32_const(UTF8_3B_LEAD_MIN); i32_ge_u;
-            if_i32; i32_const(UTF8_W3);
+            local_get(Local(3)); i32_const(Imm32(UTF8_3B_LEAD_MIN)); i32_ge_u;
+            if_i32; i32_const(Imm32(UTF8_W3));
             else_;
-              local_get(3); i32_const(UTF8_CONT_MASK_IMM); i32_ge_u;
-              if_i32; i32_const(UTF8_W2);
-              else_; i32_const(1); // continuation byte as lead → 1
+              local_get(Local(3)); i32_const(Imm32(UTF8_CONT_MASK_IMM)); i32_ge_u;
+              if_i32; i32_const(Imm32(UTF8_W2));
+              else_; i32_const(Imm32(1)); // continuation byte as lead → 1
               end;
             end;
           end;
         end;
-        local_set(4);
+        local_set(Local(4));
         // clamp width to remaining bytes: if byte_i + width > blen → blen - byte_i
-        local_get(1); local_get(4); i32_add; local_get(2); i32_gt_u;
+        local_get(Local(1)); local_get(Local(4)); i32_add; local_get(Local(2)); i32_gt_u;
         if_i32;
-          local_get(2); local_get(1); i32_sub;
+          local_get(Local(2)); local_get(Local(1)); i32_sub;
         else_;
-          local_get(4);
+          local_get(Local(4));
         end;
         end;
     });
@@ -351,35 +352,35 @@ fn compile_utf8_scalar(emitter: &mut WasmEmitter) {
         (1, ValType::I32), (1, ValType::I32),
     ]);
     wasm!(f, {
-        local_get(0); local_get(1); call(emitter.rt.string.utf8_width); local_set(2);
-        local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-        i32_load8_u(0); local_set(3);                            // b0
+        local_get(Local(0)); local_get(Local(1)); call(emitter.rt.string.utf8_width); local_set(Local(2));
+        local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+        i32_load8_u(0); local_set(Local(3));                            // b0
         // width 1 → scalar = b0 (ASCII or fallback)
-        local_get(2); i32_const(1); i32_eq;
+        local_get(Local(2)); i32_const(Imm32(1)); i32_eq;
         if_i64;
-          local_get(3); i64_extend_i32_u;
+          local_get(Local(3)); i64_extend_i32_u;
         else_;
           // mask lead bits: 2→0x1F, 3→0x0F, 4→0x07
-          local_get(2); i32_const(UTF8_W2); i32_eq;
-          if_i32; i32_const(UTF8_2B_DATA_MASK);
+          local_get(Local(2)); i32_const(Imm32(UTF8_W2)); i32_eq;
+          if_i32; i32_const(Imm32(UTF8_2B_DATA_MASK));
           else_;
-            local_get(2); i32_const(UTF8_W3); i32_eq;
-            if_i32; i32_const(UTF8_3B_DATA_MASK); else_; i32_const(UTF8_4B_DATA_MASK); end;
+            local_get(Local(2)); i32_const(Imm32(UTF8_W3)); i32_eq;
+            if_i32; i32_const(Imm32(UTF8_3B_DATA_MASK)); else_; i32_const(Imm32(UTF8_4B_DATA_MASK)); end;
           end;
-          local_get(3); i32_and; i64_extend_i32_u; local_set(4); // scalar = b0 & mask
+          local_get(Local(3)); i32_and; i64_extend_i32_u; local_set(Local(4)); // scalar = b0 & mask
           // fold in (width-1) continuation bytes
-          i32_const(1); local_set(5);                            // k = 1
+          i32_const(Imm32(1)); local_set(Local(5));                            // k = 1
           block_empty; loop_empty;
-            local_get(5); local_get(2); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add;
-            local_get(1); i32_add; local_get(5); i32_add;
-            i32_load8_u(0); i32_const(UTF8_CONT_DATA_MASK); i32_and; local_set(6); // cont = byte & 0x3F
-            local_get(4); i64_const(UTF8_CONT_BITS); i64_shl;
-            local_get(6); i64_extend_i32_u; i64_or; local_set(4);   // scalar = (scalar<<6) | cont
-            local_get(5); i32_const(1); i32_add; local_set(5);
+            local_get(Local(5)); local_get(Local(2)); i32_ge_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add;
+            local_get(Local(1)); i32_add; local_get(Local(5)); i32_add;
+            i32_load8_u(0); i32_const(Imm32(UTF8_CONT_DATA_MASK)); i32_and; local_set(Local(6)); // cont = byte & 0x3F
+            local_get(Local(4)); i64_const(Imm64(UTF8_CONT_BITS)); i64_shl;
+            local_get(Local(6)); i64_extend_i32_u; i64_or; local_set(Local(4));   // scalar = (scalar<<6) | cont
+            local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5));
             br(0);
           end; end;
-          local_get(4);
+          local_get(Local(4));
         end;
         end;
     });
@@ -395,21 +396,21 @@ fn compile_utf8_snap(emitter: &mut WasmEmitter) {
     // params: 0=s, 1=byte_i | locals: 2=blen, 3=i, 4=byte
     let mut f = Function::new([(3, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);                 // blen
+        local_get(Local(0)); i32_load(0); local_set(Local(2));                 // blen
         // i = min(byte_i, blen)
-        local_get(1); local_get(2); i32_lt_u;
-        if_i32; local_get(1); else_; local_get(2); end;
-        local_set(3);
+        local_get(Local(1)); local_get(Local(2)); i32_lt_u;
+        if_i32; local_get(Local(1)); else_; local_get(Local(2)); end;
+        local_set(Local(3));
         block_empty; loop_empty;
           // stop at 0 or at a non-continuation byte
-          local_get(3); i32_eqz; br_if(1);
-          local_get(3); local_get(2); i32_ge_u; br_if(1);       // i == blen is a boundary
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; i32_load8_u(0);
-          i32_const(UTF8_CONT_MASK_IMM); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_ne; br_if(1); // not continuation → boundary
-          local_get(3); i32_const(1); i32_sub; local_set(3);
+          local_get(Local(3)); i32_eqz; br_if(1);
+          local_get(Local(3)); local_get(Local(2)); i32_ge_u; br_if(1);       // i == blen is a boundary
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(3)); i32_add; i32_load8_u(0);
+          i32_const(Imm32(UTF8_CONT_MASK_IMM)); i32_and; i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_ne; br_if(1); // not continuation → boundary
+          local_get(Local(3)); i32_const(Imm32(1)); i32_sub; local_set(Local(3));
           br(0);
         end; end;
-        local_get(3);
+        local_get(Local(3));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.utf8_snap, type_idx, f));
@@ -423,21 +424,21 @@ fn compile_utf8_byte_of_cp(emitter: &mut WasmEmitter) {
     // params: 0=s, 1=n | locals: 2=blen, 3=off, 4=cp
     let mut f = Function::new([(3, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);                 // blen
-        i32_const(0); local_set(3);                              // off = 0
-        i32_const(0); local_set(4);                              // cp = 0
+        local_get(Local(0)); i32_load(0); local_set(Local(2));                 // blen
+        i32_const(Imm32(0)); local_set(Local(3));                              // off = 0
+        i32_const(Imm32(0)); local_set(Local(4));                              // cp = 0
         block_empty; loop_empty;
           // stop when we've passed n codepoints or run out of bytes
-          local_get(4); local_get(1); i32_ge_s; br_if(1);
-          local_get(3); local_get(2); i32_ge_u; br_if(1);
+          local_get(Local(4)); local_get(Local(1)); i32_ge_s; br_if(1);
+          local_get(Local(3)); local_get(Local(2)); i32_ge_u; br_if(1);
           // off += width(off)
-          local_get(3);
-          local_get(0); local_get(3); call(emitter.rt.string.utf8_width);
-          i32_add; local_set(3);
-          local_get(4); i32_const(1); i32_add; local_set(4);
+          local_get(Local(3));
+          local_get(Local(0)); local_get(Local(3)); call(emitter.rt.string.utf8_width);
+          i32_add; local_set(Local(3));
+          local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
           br(0);
         end; end;
-        local_get(3);
+        local_get(Local(3));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.utf8_byte_of_cp, type_idx, f));
@@ -451,25 +452,25 @@ fn compile_char_count(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(3, ValType::I32)]);
     wasm!(f, {
         // byte_len = *s
-        local_get(0); i32_load(0); local_set(1);
+        local_get(Local(0)); i32_load(0); local_set(Local(1));
         // i = 0, count = 0
-        i32_const(0); local_set(2);
-        i32_const(0); local_set(3);
+        i32_const(Imm32(0)); local_set(Local(2));
+        i32_const(Imm32(0)); local_set(Local(3));
         block_empty; loop_empty;
-          local_get(2); local_get(1); i32_ge_u; br_if(1);
+          local_get(Local(2)); local_get(Local(1)); i32_ge_u; br_if(1);
           // byte = s[string_data_off() + i]
-          local_get(0); i32_const(string_data_off()); i32_add;
-          local_get(2); i32_add; i32_load8_u(0);
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(2)); i32_add; i32_load8_u(0);
           // if (byte & 0xC0) != 0x80 then count++
-          i32_const(UTF8_CONT_MASK_IMM); i32_and;
-          i32_const(UTF8_CONT_TAG_IMM); i32_ne;
+          i32_const(Imm32(UTF8_CONT_MASK_IMM)); i32_and;
+          i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_ne;
           if_empty;
-            local_get(3); i32_const(1); i32_add; local_set(3);
+            local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(3));
           end;
-          local_get(2); i32_const(1); i32_add; local_set(2);
+          local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
           br(0);
         end; end;
-        local_get(3); i64_extend_i32_u;
+        local_get(Local(3)); i64_extend_i32_u;
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.char_count, type_idx, f));
@@ -485,26 +486,26 @@ fn compile_cp_of_byte(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(3, ValType::I32)]);
     wasm!(f, {
         // limit = min(byte, byte_len)
-        local_get(0); i32_load(0); local_set(2);
-        local_get(1); local_get(2); i32_lt_u;
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(1)); local_get(Local(2)); i32_lt_u;
         if_empty;
-          local_get(1); local_set(2);
+          local_get(Local(1)); local_set(Local(2));
         end;
-        i32_const(0); local_set(3);
-        i32_const(0); local_set(4);
+        i32_const(Imm32(0)); local_set(Local(3));
+        i32_const(Imm32(0)); local_set(Local(4));
         block_empty; loop_empty;
-          local_get(3); local_get(2); i32_ge_u; br_if(1);
-          local_get(0); i32_const(string_data_off()); i32_add;
-          local_get(3); i32_add; i32_load8_u(0);
-          i32_const(UTF8_CONT_MASK_IMM); i32_and;
-          i32_const(UTF8_CONT_TAG_IMM); i32_ne;
+          local_get(Local(3)); local_get(Local(2)); i32_ge_u; br_if(1);
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(3)); i32_add; i32_load8_u(0);
+          i32_const(Imm32(UTF8_CONT_MASK_IMM)); i32_and;
+          i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_ne;
           if_empty;
-            local_get(4); i32_const(1); i32_add; local_set(4);
+            local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
           end;
-          local_get(3); i32_const(1); i32_add; local_set(3);
+          local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(3));
           br(0);
         end; end;
-        local_get(4); i64_extend_i32_u;
+        local_get(Local(4)); i64_extend_i32_u;
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.cp_of_byte, type_idx, f));
@@ -517,30 +518,30 @@ fn compile_eq(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(1, ValType::I32), (1, ValType::I32)]);
     // Same pointer → 1
     wasm!(f, {
-        local_get(0); local_get(1); i32_eq;
-        if_empty; i32_const(1); return_; end;
+        local_get(Local(0)); local_get(Local(1)); i32_eq;
+        if_empty; i32_const(Imm32(1)); return_; end;
     });
     // Length mismatch → 0
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(2); local_get(1); i32_load(0); i32_ne;
-        if_empty; i32_const(0); return_; end;
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(2)); local_get(Local(1)); i32_load(0); i32_ne;
+        if_empty; i32_const(Imm32(0)); return_; end;
     });
     // Byte-by-byte compare
     wasm!(f, {
-        i32_const(0); local_set(3);
+        i32_const(Imm32(0)); local_set(Local(3));
         block_empty; loop_empty;
-          local_get(3); local_get(2); i32_ge_u;
-          if_empty; i32_const(1); return_; end;
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; i32_load8_u(0);
-          local_get(1); i32_const(string_data_off()); i32_add; local_get(3); i32_add; i32_load8_u(0);
+          local_get(Local(3)); local_get(Local(2)); i32_ge_u;
+          if_empty; i32_const(Imm32(1)); return_; end;
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(3)); i32_add; i32_load8_u(0);
+          local_get(Local(1)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(3)); i32_add; i32_load8_u(0);
           i32_ne;
-          if_empty; i32_const(0); return_; end;
-          local_get(3); i32_const(1); i32_add; local_set(3);
+          if_empty; i32_const(Imm32(0)); return_; end;
+          local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(3));
           br(0);
         end; end;
     });
-    wasm!(f, { i32_const(0); end; });
+    wasm!(f, { i32_const(Imm32(0)); end; });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.eq, type_idx, f));
 }
 
@@ -551,28 +552,28 @@ fn compile_contains(emitter: &mut WasmEmitter) {
         (1, ValType::I32), (1, ValType::I32),
     ]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2); // h_len
-        local_get(1); i32_load(0); local_set(3); // n_len
+        local_get(Local(0)); i32_load(0); local_set(Local(2)); // h_len
+        local_get(Local(1)); i32_load(0); local_set(Local(3)); // n_len
         // empty needle → true
-        local_get(3); i32_eqz;
-        if_empty; i32_const(1); return_; end;
+        local_get(Local(3)); i32_eqz;
+        if_empty; i32_const(Imm32(1)); return_; end;
         // n_len > h_len → false
-        local_get(3); local_get(2); i32_gt_u;
-        if_empty; i32_const(0); return_; end;
-        i32_const(0); local_set(4); // i=0
+        local_get(Local(3)); local_get(Local(2)); i32_gt_u;
+        if_empty; i32_const(Imm32(0)); return_; end;
+        i32_const(Imm32(0)); local_set(Local(4)); // i=0
         block_empty; loop_empty;
-          local_get(4); local_get(2); local_get(3); i32_sub; i32_const(1); i32_add;
+          local_get(Local(4)); local_get(Local(2)); local_get(Local(3)); i32_sub; i32_const(Imm32(1)); i32_add;
           i32_ge_u; br_if(1);
           // compare h[string_data_off()+i..] with n[string_data_off()..n_len]
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(4); i32_add;
-          local_get(1); i32_const(string_data_off()); i32_add;
-          local_get(3);
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(4)); i32_add;
+          local_get(Local(1)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(3));
           call(emitter.rt.mem_eq);
-          if_empty; i32_const(1); return_; end;
-          local_get(4); i32_const(1); i32_add; local_set(4);
+          if_empty; i32_const(Imm32(1)); return_; end;
+          local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
           br(0);
         end; end;
-        i32_const(0); end;
+        i32_const(Imm32(0)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.contains, type_idx, f));
 }
@@ -672,14 +673,14 @@ mod utf8_lossy_tests {
 fn compile_is_unicode_ws(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.is_unicode_ws];
     let mut f = Function::new([]);
-    wasm!(f, { i32_const(0); }); // running OR accumulator
+    wasm!(f, { i32_const(Imm32(0)); }); // running OR accumulator
     for (lo, hi) in whitespace_ranges() {
         if lo == hi {
-            wasm!(f, { local_get(0); i32_const(lo as i32); i32_eq; i32_or; });
+            wasm!(f, { local_get(Local(0)); i32_const(Imm32(lo as i32)); i32_eq; i32_or; });
         } else {
             wasm!(f, {
-                local_get(0); i32_const(lo as i32); i32_ge_u;
-                local_get(0); i32_const(hi as i32); i32_le_u;
+                local_get(Local(0)); i32_const(Imm32(lo as i32)); i32_ge_u;
+                local_get(Local(0)); i32_const(Imm32(hi as i32)); i32_le_u;
                 i32_and; i32_or;
             });
         }
@@ -698,9 +699,9 @@ pub(super) fn emit_trim_forward(f: &mut Function, emitter: &WasmEmitter, pos_loc
     let isws = emitter.rt.string.is_unicode_ws;
     wasm!(f, {
         block_empty; loop_empty;
-          local_get(pos_local); local_get(end_local); i32_ge_u; br_if(1);
-          local_get(0); local_get(pos_local); call(us); i32_wrap_i64; call(isws); i32_eqz; br_if(1);
-          local_get(0); local_get(pos_local); call(uw); local_get(pos_local); i32_add; local_set(pos_local);
+          local_get(Local(pos_local)); local_get(Local(end_local)); i32_ge_u; br_if(1);
+          local_get(Local(0)); local_get(Local(pos_local)); call(us); i32_wrap_i64; call(isws); i32_eqz; br_if(1);
+          local_get(Local(0)); local_get(Local(pos_local)); call(uw); local_get(Local(pos_local)); i32_add; local_set(Local(pos_local));
           br(0);
         end; end;
     });
@@ -716,18 +717,18 @@ pub(super) fn emit_trim_backward(f: &mut Function, emitter: &WasmEmitter, end_lo
     let do_ = string_data_off();
     wasm!(f, {
         block_empty; loop_empty;
-          local_get(end_local); local_get(floor_local); i32_le_u; br_if(1);
+          local_get(Local(end_local)); local_get(Local(floor_local)); i32_le_u; br_if(1);
           // q = end-1; step back over continuation bytes (0b10xxxxxx) to the lead byte.
-          local_get(end_local); i32_const(1); i32_sub; local_set(q_local);
+          local_get(Local(end_local)); i32_const(Imm32(1)); i32_sub; local_set(Local(q_local));
           block_empty; loop_empty;
-            local_get(0); i32_const(do_); i32_add; local_get(q_local); i32_add; i32_load8_u(0);
-            i32_const(UTF8_CONT_MASK_IMM); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_ne; br_if(1);   // lead byte → stop
-            local_get(q_local); i32_eqz; br_if(1);
-            local_get(q_local); i32_const(1); i32_sub; local_set(q_local);
+            local_get(Local(0)); i32_const(Imm32(do_)); i32_add; local_get(Local(q_local)); i32_add; i32_load8_u(0);
+            i32_const(Imm32(UTF8_CONT_MASK_IMM)); i32_and; i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_ne; br_if(1);   // lead byte → stop
+            local_get(Local(q_local)); i32_eqz; br_if(1);
+            local_get(Local(q_local)); i32_const(Imm32(1)); i32_sub; local_set(Local(q_local));
             br(0);
           end; end;
-          local_get(0); local_get(q_local); call(us); i32_wrap_i64; call(isws); i32_eqz; br_if(1);
-          local_get(q_local); local_set(end_local);
+          local_get(Local(0)); local_get(Local(q_local)); call(us); i32_wrap_i64; call(isws); i32_eqz; br_if(1);
+          local_get(Local(q_local)); local_set(Local(end_local));
           br(0);
         end; end;
     });
@@ -742,14 +743,14 @@ fn compile_trim(emitter: &mut WasmEmitter) {
     const Q: u32 = 4; // scratch for the backward walk
     let mut f = Function::new([(4, ValType::I32)]);
     wasm!(f, {
-        local_get(S); i32_load(0); local_set(LEN);
-        i32_const(0); local_set(START);
-        local_get(LEN); local_set(END);
+        local_get(Local(S)); i32_load(0); local_set(Local(LEN));
+        i32_const(Imm32(0)); local_set(Local(START));
+        local_get(Local(LEN)); local_set(Local(END));
     });
     emit_trim_forward(&mut f, emitter, START, LEN);
     emit_trim_backward(&mut f, emitter, END, START, Q);
     wasm!(f, {
-        local_get(S); local_get(START); local_get(END);
+        local_get(Local(S)); local_get(Local(START)); local_get(Local(END));
         call(emitter.rt.string.slice);
         end;
     });
@@ -762,18 +763,18 @@ fn compile_slice(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.slice];
     let mut f = Function::new([(1, ValType::I32), (1, ValType::I32)]);
     wasm!(f, {
-        local_get(2); local_get(1); i32_sub;
-        call(emitter.rt.string_alloc); local_set(3);
-        i32_const(0); local_set(4);
+        local_get(Local(2)); local_get(Local(1)); i32_sub;
+        call(emitter.rt.string_alloc); local_set(Local(3));
+        i32_const(Imm32(0)); local_set(Local(4));
         block_empty; loop_empty;
-          local_get(4); local_get(2); local_get(1); i32_sub; i32_ge_u; br_if(1);
-          local_get(3); i32_const(string_data_off()); i32_add; local_get(4); i32_add;
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add; local_get(4); i32_add;
+          local_get(Local(4)); local_get(Local(2)); local_get(Local(1)); i32_sub; i32_ge_u; br_if(1);
+          local_get(Local(3)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(4)); i32_add;
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add; local_get(Local(4)); i32_add;
           i32_load8_u(0); i32_store8(0);
-          local_get(4); i32_const(1); i32_add; local_set(4);
+          local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
           br(0);
         end; end;
-        local_get(3); end;
+        local_get(Local(3)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.slice, type_idx, f));
 }
@@ -786,30 +787,30 @@ fn compile_reverse(emitter: &mut WasmEmitter) {
     // params: 0=s | locals: 1=blen, 2=result, 3=in_off, 4=out_off, 5=width, 6=k
     let mut f = Function::new([(6, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);                 // blen
-        local_get(1); call(emitter.rt.string_alloc); local_set(2);
-        i32_const(0); local_set(3);                              // in_off = 0
-        local_get(1); local_set(4);                              // out_off = blen (write end-first)
+        local_get(Local(0)); i32_load(0); local_set(Local(1));                 // blen
+        local_get(Local(1)); call(emitter.rt.string_alloc); local_set(Local(2));
+        i32_const(Imm32(0)); local_set(Local(3));                              // in_off = 0
+        local_get(Local(1)); local_set(Local(4));                              // out_off = blen (write end-first)
         block_empty; loop_empty;
-          local_get(3); local_get(1); i32_ge_u; br_if(1);
+          local_get(Local(3)); local_get(Local(1)); i32_ge_u; br_if(1);
           // width of codepoint at in_off
-          local_get(0); local_get(3); call(emitter.rt.string.utf8_width); local_set(5);
+          local_get(Local(0)); local_get(Local(3)); call(emitter.rt.string.utf8_width); local_set(Local(5));
           // out_off -= width (start of this codepoint in the output)
-          local_get(4); local_get(5); i32_sub; local_set(4);
+          local_get(Local(4)); local_get(Local(5)); i32_sub; local_set(Local(4));
           // copy width bytes forward: out[out_off + k] = in[in_off + k]
-          i32_const(0); local_set(6);
+          i32_const(Imm32(0)); local_set(Local(6));
           block_empty; loop_empty;
-            local_get(6); local_get(5); i32_ge_u; br_if(1);
-            local_get(2); i32_const(string_data_off()); i32_add; local_get(4); i32_add; local_get(6); i32_add;
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; local_get(6); i32_add;
+            local_get(Local(6)); local_get(Local(5)); i32_ge_u; br_if(1);
+            local_get(Local(2)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(4)); i32_add; local_get(Local(6)); i32_add;
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(3)); i32_add; local_get(Local(6)); i32_add;
             i32_load8_u(0); i32_store8(0);
-            local_get(6); i32_const(1); i32_add; local_set(6);
+            local_get(Local(6)); i32_const(Imm32(1)); i32_add; local_set(Local(6));
             br(0);
           end; end;
-          local_get(3); local_get(5); i32_add; local_set(3);     // in_off += width
+          local_get(Local(3)); local_get(Local(5)); i32_add; local_set(Local(3));     // in_off += width
           br(0);
         end; end;
-        local_get(2); end;
+        local_get(Local(2)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.reverse, type_idx, f));
 }
@@ -818,19 +819,19 @@ fn compile_repeat(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.repeat];
     let mut f = Function::new([(1, ValType::I32), (1, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_get(1); i32_mul; local_set(2);
-        local_get(2); call(emitter.rt.string_alloc); local_set(3);
-        i32_const(0); local_set(2); // reuse as offset
+        local_get(Local(0)); i32_load(0); local_get(Local(1)); i32_mul; local_set(Local(2));
+        local_get(Local(2)); call(emitter.rt.string_alloc); local_set(Local(3));
+        i32_const(Imm32(0)); local_set(Local(2)); // reuse as offset
         block_empty; loop_empty;
-          local_get(2); local_get(0); i32_load(0); local_get(1); i32_mul; i32_ge_u; br_if(1);
-          local_get(3); i32_const(string_data_off()); i32_add; local_get(2); i32_add;
-          local_get(0); i32_const(string_data_off()); i32_add;
-          local_get(2); local_get(0); i32_load(0); i32_rem_u;
+          local_get(Local(2)); local_get(Local(0)); i32_load(0); local_get(Local(1)); i32_mul; i32_ge_u; br_if(1);
+          local_get(Local(3)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(2)); i32_add;
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(2)); local_get(Local(0)); i32_load(0); i32_rem_u;
           i32_add; i32_load8_u(0); i32_store8(0);
-          local_get(2); i32_const(1); i32_add; local_set(2);
+          local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
           br(0);
         end; end;
-        local_get(3); end;
+        local_get(Local(3)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.repeat, type_idx, f));
 }
@@ -842,31 +843,31 @@ fn compile_index_of(emitter: &mut WasmEmitter) {
         (1, ValType::I32), (1, ValType::I32), (1, ValType::I32), (1, ValType::I64),
     ]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(1); i32_load(0); local_set(3);
-        i64_const(-1); local_set(5); // result = -1 (not found)
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(1)); i32_load(0); local_set(Local(3));
+        i64_const(Imm64(-1)); local_set(Local(5)); // result = -1 (not found)
         // empty needle → 0
-        local_get(3); i32_eqz;
-        if_empty; i64_const(0); local_set(5); i64_const(0); return_; end;
+        local_get(Local(3)); i32_eqz;
+        if_empty; i64_const(Imm64(0)); local_set(Local(5)); i64_const(Imm64(0)); return_; end;
         // n_len > s_len → -1
-        local_get(3); local_get(2); i32_gt_u;
-        if_empty; i64_const(-1); return_; end;
+        local_get(Local(3)); local_get(Local(2)); i32_gt_u;
+        if_empty; i64_const(Imm64(-1)); return_; end;
         // Scan
-        i32_const(0); local_set(4);
+        i32_const(Imm32(0)); local_set(Local(4));
         block_empty; loop_empty;
-          local_get(4); local_get(2); local_get(3); i32_sub; i32_const(1); i32_add;
+          local_get(Local(4)); local_get(Local(2)); local_get(Local(3)); i32_sub; i32_const(Imm32(1)); i32_add;
           i32_ge_u; br_if(1);
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(4); i32_add;
-          local_get(1); i32_const(string_data_off()); i32_add;
-          local_get(3);
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(4)); i32_add;
+          local_get(Local(1)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(3));
           call(emitter.rt.mem_eq);
           if_empty;
-            local_get(4); i64_extend_i32_u; return_;
+            local_get(Local(4)); i64_extend_i32_u; return_;
           end;
-          local_get(4); i32_const(1); i32_add; local_set(4);
+          local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
           br(0);
         end; end;
-        i64_const(-1); end;
+        i64_const(Imm64(-1)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.index_of, type_idx, f));
 }
@@ -888,100 +889,100 @@ fn compile_replace(emitter: &mut WasmEmitter) {
     ]);
     let dat = string_data_off();
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(3); // blen
-        local_get(1); i32_load(0); local_set(4); // fl
-        local_get(2); i32_load(0); local_set(5); // tl
+        local_get(Local(0)); i32_load(0); local_set(Local(3)); // blen
+        local_get(Local(1)); i32_load(0); local_set(Local(4)); // fl
+        local_get(Local(2)); i32_load(0); local_set(Local(5)); // tl
         // Empty `from`: insert `to` before every codepoint plus one at the end.
         // result_len = blen + (char_count + 1) * tl. Count codepoints first.
-        local_get(4); i32_eqz;
+        local_get(Local(4)); i32_eqz;
         if_empty;
           // cnt = codepoint count (scan widths)
-          i32_const(0); local_set(6); // i = 0 (byte offset)
-          i32_const(0); local_set(7); // cnt = 0 (codepoints)
+          i32_const(Imm32(0)); local_set(Local(6)); // i = 0 (byte offset)
+          i32_const(Imm32(0)); local_set(Local(7)); // cnt = 0 (codepoints)
           block_empty; loop_empty;
-            local_get(6); local_get(3); i32_ge_u; br_if(1);
-            local_get(0); local_get(6); call(emitter.rt.string.utf8_width);
-            local_get(6); i32_add; local_set(6);
-            local_get(7); i32_const(1); i32_add; local_set(7);
+            local_get(Local(6)); local_get(Local(3)); i32_ge_u; br_if(1);
+            local_get(Local(0)); local_get(Local(6)); call(emitter.rt.string.utf8_width);
+            local_get(Local(6)); i32_add; local_set(Local(6));
+            local_get(Local(7)); i32_const(Imm32(1)); i32_add; local_set(Local(7));
             br(0);
           end; end;
           // result = string_alloc(blen + (cnt + 1) * tl)
-          local_get(3); local_get(7); i32_const(1); i32_add; local_get(5); i32_mul; i32_add;
-          call(emitter.rt.string_alloc); local_set(8);
-          i32_const(0); local_set(9); // out = 0
+          local_get(Local(3)); local_get(Local(7)); i32_const(Imm32(1)); i32_add; local_get(Local(5)); i32_mul; i32_add;
+          call(emitter.rt.string_alloc); local_set(Local(8));
+          i32_const(Imm32(0)); local_set(Local(9)); // out = 0
           // leading `to`: result[out..] = to
-          local_get(8); i32_const(dat); i32_add; local_get(9); i32_add;
-          local_get(2); i32_const(dat); i32_add; local_get(5); memory_copy;
-          local_get(9); local_get(5); i32_add; local_set(9);
-          i32_const(0); local_set(6); // i = 0
+          local_get(Local(8)); i32_const(Imm32(dat)); i32_add; local_get(Local(9)); i32_add;
+          local_get(Local(2)); i32_const(Imm32(dat)); i32_add; local_get(Local(5)); memory_copy;
+          local_get(Local(9)); local_get(Local(5)); i32_add; local_set(Local(9));
+          i32_const(Imm32(0)); local_set(Local(6)); // i = 0
           block_empty; loop_empty;
-            local_get(6); local_get(3); i32_ge_u; br_if(1);
-            local_get(0); local_get(6); call(emitter.rt.string.utf8_width); local_set(10); // width
+            local_get(Local(6)); local_get(Local(3)); i32_ge_u; br_if(1);
+            local_get(Local(0)); local_get(Local(6)); call(emitter.rt.string.utf8_width); local_set(Local(10)); // width
             // copy one codepoint: result[out..] = s[i .. i+width]
-            local_get(8); i32_const(dat); i32_add; local_get(9); i32_add;
-            local_get(0); i32_const(dat); i32_add; local_get(6); i32_add;
-            local_get(10); memory_copy;
-            local_get(9); local_get(10); i32_add; local_set(9); // out += width
-            local_get(6); local_get(10); i32_add; local_set(6); // i += width
+            local_get(Local(8)); i32_const(Imm32(dat)); i32_add; local_get(Local(9)); i32_add;
+            local_get(Local(0)); i32_const(Imm32(dat)); i32_add; local_get(Local(6)); i32_add;
+            local_get(Local(10)); memory_copy;
+            local_get(Local(9)); local_get(Local(10)); i32_add; local_set(Local(9)); // out += width
+            local_get(Local(6)); local_get(Local(10)); i32_add; local_set(Local(6)); // i += width
             // `to` after this codepoint
-            local_get(8); i32_const(dat); i32_add; local_get(9); i32_add;
-            local_get(2); i32_const(dat); i32_add; local_get(5); memory_copy;
-            local_get(9); local_get(5); i32_add; local_set(9);
+            local_get(Local(8)); i32_const(Imm32(dat)); i32_add; local_get(Local(9)); i32_add;
+            local_get(Local(2)); i32_const(Imm32(dat)); i32_add; local_get(Local(5)); memory_copy;
+            local_get(Local(9)); local_get(Local(5)); i32_add; local_set(Local(9));
             br(0);
           end; end;
-          local_get(8); return_;
+          local_get(Local(8)); return_;
         end;
         // Non-empty `from`. Pass 1: count occurrences.
-        i32_const(0); local_set(6); // i = 0
-        i32_const(0); local_set(7); // cnt = 0
+        i32_const(Imm32(0)); local_set(Local(6)); // i = 0
+        i32_const(Imm32(0)); local_set(Local(7)); // cnt = 0
         block_empty; loop_empty;
-          local_get(6); local_get(4); i32_add; local_get(3); i32_gt_u; br_if(1);
-          local_get(0); i32_const(dat); i32_add; local_get(6); i32_add;
-          local_get(1); i32_const(dat); i32_add;
-          local_get(4); call(emitter.rt.mem_eq);
+          local_get(Local(6)); local_get(Local(4)); i32_add; local_get(Local(3)); i32_gt_u; br_if(1);
+          local_get(Local(0)); i32_const(Imm32(dat)); i32_add; local_get(Local(6)); i32_add;
+          local_get(Local(1)); i32_const(Imm32(dat)); i32_add;
+          local_get(Local(4)); call(emitter.rt.mem_eq);
           if_empty;
-            local_get(7); i32_const(1); i32_add; local_set(7); // cnt += 1
-            local_get(6); local_get(4); i32_add; local_set(6); // i += fl
+            local_get(Local(7)); i32_const(Imm32(1)); i32_add; local_set(Local(7)); // cnt += 1
+            local_get(Local(6)); local_get(Local(4)); i32_add; local_set(Local(6)); // i += fl
           else_;
-            local_get(6); i32_const(1); i32_add; local_set(6); // i += 1
+            local_get(Local(6)); i32_const(Imm32(1)); i32_add; local_set(Local(6)); // i += 1
           end;
           br(0);
         end; end;
         // No occurrences → return s unchanged.
-        local_get(7); i32_eqz;
-        if_empty; local_get(0); return_; end;
+        local_get(Local(7)); i32_eqz;
+        if_empty; local_get(Local(0)); return_; end;
         // result = string_alloc(blen + cnt * (tl - fl))
-        local_get(3); local_get(7); local_get(5); local_get(4); i32_sub; i32_mul; i32_add;
-        call(emitter.rt.string_alloc); local_set(8);
+        local_get(Local(3)); local_get(Local(7)); local_get(Local(5)); local_get(Local(4)); i32_sub; i32_mul; i32_add;
+        call(emitter.rt.string_alloc); local_set(Local(8));
         // Pass 2: build result.
-        i32_const(0); local_set(6); // i = 0 (read off into s)
-        i32_const(0); local_set(9); // out = 0 (write off into result)
+        i32_const(Imm32(0)); local_set(Local(6)); // i = 0 (read off into s)
+        i32_const(Imm32(0)); local_set(Local(9)); // out = 0 (write off into result)
         block_empty; loop_empty;
-          local_get(6); local_get(3); i32_ge_u; br_if(1);
+          local_get(Local(6)); local_get(Local(3)); i32_ge_u; br_if(1);
           // match at i (only when a full `from` still fits)?
-          local_get(6); local_get(4); i32_add; local_get(3); i32_le_u;
+          local_get(Local(6)); local_get(Local(4)); i32_add; local_get(Local(3)); i32_le_u;
           if_empty;
-            local_get(0); i32_const(dat); i32_add; local_get(6); i32_add;
-            local_get(1); i32_const(dat); i32_add;
-            local_get(4); call(emitter.rt.mem_eq);
+            local_get(Local(0)); i32_const(Imm32(dat)); i32_add; local_get(Local(6)); i32_add;
+            local_get(Local(1)); i32_const(Imm32(dat)); i32_add;
+            local_get(Local(4)); call(emitter.rt.mem_eq);
             if_empty;
               // copy `to`, advance i by fl, out by tl
-              local_get(8); i32_const(dat); i32_add; local_get(9); i32_add;
-              local_get(2); i32_const(dat); i32_add; local_get(5); memory_copy;
-              local_get(9); local_get(5); i32_add; local_set(9);
-              local_get(6); local_get(4); i32_add; local_set(6);
+              local_get(Local(8)); i32_const(Imm32(dat)); i32_add; local_get(Local(9)); i32_add;
+              local_get(Local(2)); i32_const(Imm32(dat)); i32_add; local_get(Local(5)); memory_copy;
+              local_get(Local(9)); local_get(Local(5)); i32_add; local_set(Local(9));
+              local_get(Local(6)); local_get(Local(4)); i32_add; local_set(Local(6));
               br(2); // continue outer loop
             end;
           end;
           // copy one byte verbatim
-          local_get(8); i32_const(dat); i32_add; local_get(9); i32_add;
-          local_get(0); i32_const(dat); i32_add; local_get(6); i32_add;
+          local_get(Local(8)); i32_const(Imm32(dat)); i32_add; local_get(Local(9)); i32_add;
+          local_get(Local(0)); i32_const(Imm32(dat)); i32_add; local_get(Local(6)); i32_add;
           i32_load8_u(0); i32_store8(0);
-          local_get(9); i32_const(1); i32_add; local_set(9);
-          local_get(6); i32_const(1); i32_add; local_set(6);
+          local_get(Local(9)); i32_const(Imm32(1)); i32_add; local_set(Local(9));
+          local_get(Local(6)); i32_const(Imm32(1)); i32_add; local_set(Local(6));
           br(0);
         end; end;
-        local_get(8); end;
+        local_get(Local(8)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.replace, type_idx, f));
 }
@@ -1003,73 +1004,73 @@ fn compile_split(emitter: &mut WasmEmitter) {
         (2, ValType::I32),
     ]);
     wasm!(f, {
-        local_get(1); i32_load(0); local_set(2); // d_len
-        local_get(0); i32_load(0); local_set(3); // blen
+        local_get(Local(1)); i32_load(0); local_set(Local(2)); // d_len
+        local_get(Local(0)); i32_load(0); local_set(Local(3)); // blen
         // Empty delimiter: split per CODEPOINT with a leading + trailing empty
         // string — native `s.split("")` yields ["", c0, c1, …, ""] (and ["", ""]
         // for ""). Slots = char_count + 2.
-        local_get(2); i32_eqz;
+        local_get(Local(2)); i32_eqz;
         if_empty;
           // result list: [len = char_count + 2][slot ptrs…]. Worst case (all
           // ASCII) char_count == blen, so blen + 2 slots is always enough.
-          i32_const(list_hdr()); local_get(3); i32_const(SPLIT_EMPTY_DELIM_EXTRA_SLOTS); i32_add; i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-          call(emitter.rt.alloc); local_set(7);
+          i32_const(Imm32(list_hdr())); local_get(Local(3)); i32_const(Imm32(SPLIT_EMPTY_DELIM_EXTRA_SLOTS)); i32_add; i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+          call(emitter.rt.alloc); local_set(Local(7));
           // slot[0] = "" (leading empty)
-          local_get(7); i32_const(list_data_off()); i32_add;
-          i32_const(0); call(emitter.rt.string_alloc); i32_store(0);
-          i32_const(0); local_set(8);                              // in_off = 0
-          i32_const(1); local_set(6);                              // slot = 1 (after leading "")
+          local_get(Local(7)); i32_const(Imm32(list_data_off())); i32_add;
+          i32_const(Imm32(0)); call(emitter.rt.string_alloc); i32_store(0);
+          i32_const(Imm32(0)); local_set(Local(8));                              // in_off = 0
+          i32_const(Imm32(1)); local_set(Local(6));                              // slot = 1 (after leading "")
           block_empty; loop_empty;
-            local_get(8); local_get(3); i32_ge_u; br_if(1);
-            local_get(0); local_get(8); call(emitter.rt.string.utf8_width); local_set(9); // width
+            local_get(Local(8)); local_get(Local(3)); i32_ge_u; br_if(1);
+            local_get(Local(0)); local_get(Local(8)); call(emitter.rt.string.utf8_width); local_set(Local(9)); // width
             // slot[slot] = slice(s, in_off, in_off + width)  (one codepoint)
-            local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-            local_get(0); local_get(8); local_get(8); local_get(9); i32_add;
+            local_get(Local(7)); i32_const(Imm32(list_data_off())); i32_add; local_get(Local(6)); i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+            local_get(Local(0)); local_get(Local(8)); local_get(Local(8)); local_get(Local(9)); i32_add;
             call(emitter.rt.string.slice); i32_store(0);
-            local_get(8); local_get(9); i32_add; local_set(8);     // in_off += width
-            local_get(6); i32_const(1); i32_add; local_set(6);     // slot += 1
+            local_get(Local(8)); local_get(Local(9)); i32_add; local_set(Local(8));     // in_off += width
+            local_get(Local(6)); i32_const(Imm32(1)); i32_add; local_set(Local(6));     // slot += 1
             br(0);
           end; end;
           // slot[slot] = "" (trailing empty)
-          local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-          i32_const(0); call(emitter.rt.string_alloc); i32_store(0);
+          local_get(Local(7)); i32_const(Imm32(list_data_off())); i32_add; local_get(Local(6)); i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+          i32_const(Imm32(0)); call(emitter.rt.string_alloc); i32_store(0);
           // result.len = slot + 1  (== char_count + 2)
-          local_get(7); local_get(6); i32_const(1); i32_add; i32_store(0);
-          local_get(7); return_;
+          local_get(Local(7)); local_get(Local(6)); i32_const(Imm32(1)); i32_add; i32_store(0);
+          local_get(Local(7)); return_;
         end;
         // Non-empty delimiter. A delimiter of length d_len>=1 can match at most
         // blen times, so blen + 1 segments is the upper bound on the slot count.
-        i32_const(list_hdr()); local_get(3); i32_const(1); i32_add; i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-        call(emitter.rt.alloc); local_set(7);
-        i32_const(0); local_set(4); // seg_start = 0
-        i32_const(0); local_set(5); // i = 0 (scan position)
-        i32_const(0); local_set(6); // slot = 0
+        i32_const(Imm32(list_hdr())); local_get(Local(3)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+        call(emitter.rt.alloc); local_set(Local(7));
+        i32_const(Imm32(0)); local_set(Local(4)); // seg_start = 0
+        i32_const(Imm32(0)); local_set(Local(5)); // i = 0 (scan position)
+        i32_const(Imm32(0)); local_set(Local(6)); // slot = 0
         block_empty; loop_empty;
           // stop scanning once a full delimiter can no longer fit: i > blen - d_len.
-          local_get(5); local_get(2); i32_add; local_get(3); i32_gt_u; br_if(1);
+          local_get(Local(5)); local_get(Local(2)); i32_add; local_get(Local(3)); i32_gt_u; br_if(1);
           // if mem_eq(s_data + i, delim_data, d_len)
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add;
-          local_get(1); i32_const(string_data_off()); i32_add;
-          local_get(2);
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(5)); i32_add;
+          local_get(Local(1)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(2));
           call(emitter.rt.mem_eq);
           if_empty;
             // emit segment slice(s, seg_start, i)
-            local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-            local_get(0); local_get(4); local_get(5); call(emitter.rt.string.slice); i32_store(0);
-            local_get(6); i32_const(1); i32_add; local_set(6);     // slot += 1
-            local_get(5); local_get(2); i32_add; local_set(5);     // i += d_len
-            local_get(5); local_set(4);                            // seg_start = i
+            local_get(Local(7)); i32_const(Imm32(list_data_off())); i32_add; local_get(Local(6)); i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+            local_get(Local(0)); local_get(Local(4)); local_get(Local(5)); call(emitter.rt.string.slice); i32_store(0);
+            local_get(Local(6)); i32_const(Imm32(1)); i32_add; local_set(Local(6));     // slot += 1
+            local_get(Local(5)); local_get(Local(2)); i32_add; local_set(Local(5));     // i += d_len
+            local_get(Local(5)); local_set(Local(4));                            // seg_start = i
           else_;
-            local_get(5); i32_const(1); i32_add; local_set(5);     // i += 1
+            local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5));     // i += 1
           end;
           br(0);
         end; end;
         // trailing segment slice(s, seg_start, blen)
-        local_get(7); i32_const(list_data_off()); i32_add; local_get(6); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-        local_get(0); local_get(4); local_get(3); call(emitter.rt.string.slice); i32_store(0);
-        local_get(6); i32_const(1); i32_add; local_set(6);         // slot += 1
-        local_get(7); local_get(6); i32_store(0);                  // result.len = slot
-        local_get(7); end;
+        local_get(Local(7)); i32_const(Imm32(list_data_off())); i32_add; local_get(Local(6)); i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+        local_get(Local(0)); local_get(Local(4)); local_get(Local(3)); call(emitter.rt.string.slice); i32_store(0);
+        local_get(Local(6)); i32_const(Imm32(1)); i32_add; local_set(Local(6));         // slot += 1
+        local_get(Local(7)); local_get(Local(6)); i32_store(0);                  // result.len = slot
+        local_get(Local(7)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.split, type_idx, f));
 }
@@ -1078,37 +1079,37 @@ fn compile_join(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.join];
     let mut f = Function::new([(1, ValType::I32), (1, ValType::I32), (1, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2); // len
-        local_get(2); i32_eqz;
+        local_get(Local(0)); i32_load(0); local_set(Local(2)); // len
+        local_get(Local(2)); i32_eqz;
         if_i32;
           // empty list → empty string
-          i32_const(0); call(emitter.rt.string_alloc);
+          i32_const(Imm32(0)); call(emitter.rt.string_alloc);
         else_;
           // result = list[0]
-          local_get(0); i32_const(list_data_off()); i32_add; i32_load(0); local_set(4);
+          local_get(Local(0)); i32_const(Imm32(list_data_off())); i32_add; i32_load(0); local_set(Local(4));
           // Singleton SHARE dup: for len==1 the loop never runs and the
           // ELEMENT POINTER itself is returned — an alias into a list the
           // caller still owns and will deep-Dec. Inc it (no-op for
           // data-section strings; len>=2 results are fresh via concat, an
           // unconditional inc would leak elem0 once per join).
-          local_get(2); i32_const(1); i32_eq;
+          local_get(Local(2)); i32_const(Imm32(1)); i32_eq;
           if_empty;
-            local_get(4); call(emitter.rt.rc_inc); drop;
+            local_get(Local(4)); call(emitter.rt.rc_inc); drop;
           end;
-          i32_const(1); local_set(3); // i=1
+          i32_const(Imm32(1)); local_set(Local(3)); // i=1
           block_empty; loop_empty;
-            local_get(3); local_get(2); i32_ge_u; br_if(1);
+            local_get(Local(3)); local_get(Local(2)); i32_ge_u; br_if(1);
             // result = concat(result, sep)
-            local_get(4); local_get(1); call(emitter.rt.concat_str); local_set(4);
+            local_get(Local(4)); local_get(Local(1)); call(emitter.rt.concat_str); local_set(Local(4));
             // result = concat(result, list[i])
-            local_get(4);
-            local_get(0); i32_const(list_data_off()); i32_add;
-            local_get(3); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add; i32_load(0);
-            call(emitter.rt.concat_str); local_set(4);
-            local_get(3); i32_const(1); i32_add; local_set(3);
+            local_get(Local(4));
+            local_get(Local(0)); i32_const(Imm32(list_data_off())); i32_add;
+            local_get(Local(3)); i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add; i32_load(0);
+            call(emitter.rt.concat_str); local_set(Local(4));
+            local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(3));
             br(0);
           end; end;
-          local_get(4);
+          local_get(Local(4));
         end;
         end;
     });
@@ -1122,25 +1123,25 @@ fn compile_count(emitter: &mut WasmEmitter) {
         (1, ValType::I32), (1, ValType::I32),
     ]);
     wasm!(f, {
-        i64_const(0); local_set(2); // count
-        i32_const(0); local_set(4); // pos
-        local_get(1); i32_load(0); local_set(5); // sub_len
-        local_get(5); i32_eqz;
+        i64_const(Imm64(0)); local_set(Local(2)); // count
+        i32_const(Imm32(0)); local_set(Local(4)); // pos
+        local_get(Local(1)); i32_load(0); local_set(Local(5)); // sub_len
+        local_get(Local(5)); i32_eqz;
         // Empty pattern: native `s.matches("").count()` == s.chars().count() + 1
         // (one empty match at every char boundary, including the end).
-        if_i64; local_get(0); call(emitter.rt.string.char_count); i64_const(1); i64_add;
+        if_i64; local_get(Local(0)); call(emitter.rt.string.char_count); i64_const(Imm64(1)); i64_add;
         else_;
           block_empty; loop_empty;
-            local_get(0); local_get(4); local_get(0); i32_load(0);
-            call(emitter.rt.string.slice); local_set(6);
-            local_get(6); local_get(1); call(emitter.rt.string.index_of); local_set(3);
-            local_get(3); i64_const(-1); i64_eq; br_if(1);
-            local_get(2); i64_const(1); i64_add; local_set(2);
-            local_get(4); local_get(3); i32_wrap_i64; i32_add;
-            local_get(5); i32_add; local_set(4);
+            local_get(Local(0)); local_get(Local(4)); local_get(Local(0)); i32_load(0);
+            call(emitter.rt.string.slice); local_set(Local(6));
+            local_get(Local(6)); local_get(Local(1)); call(emitter.rt.string.index_of); local_set(Local(3));
+            local_get(Local(3)); i64_const(Imm64(-1)); i64_eq; br_if(1);
+            local_get(Local(2)); i64_const(Imm64(1)); i64_add; local_set(Local(2));
+            local_get(Local(4)); local_get(Local(3)); i32_wrap_i64; i32_add;
+            local_get(Local(5)); i32_add; local_set(Local(4));
             br(0);
           end; end;
-          local_get(2);
+          local_get(Local(2));
         end;
         end;
     });
@@ -1156,16 +1157,16 @@ fn compile_count(emitter: &mut WasmEmitter) {
 fn emit_pad_first_cp(emitter: &mut WasmEmitter, f: &mut Function, pad_local: u32, out_local: u32) {
     // width of first codepoint (0 if pad empty)
     wasm!(*f, {
-        local_get(pad_local); i32_load(0); i32_eqz;
+        local_get(Local(pad_local)); i32_load(0); i32_eqz;
         if_i32;
-          i32_const(0); call(emitter.rt.string_alloc);
+          i32_const(Imm32(0)); call(emitter.rt.string_alloc);
         else_;
           // unit = slice(pad, 0, width(pad, 0))
-          local_get(pad_local); i32_const(0);
-          local_get(pad_local); i32_const(0); call(emitter.rt.string.utf8_width);
+          local_get(Local(pad_local)); i32_const(Imm32(0));
+          local_get(Local(pad_local)); i32_const(Imm32(0)); call(emitter.rt.string.utf8_width);
           call(emitter.rt.string.slice);
         end;
-        local_set(out_local);
+        local_set(Local(out_local));
     });
 }
 
@@ -1176,16 +1177,16 @@ fn compile_pad_start(emitter: &mut WasmEmitter) {
     // params: 0=s, 1=width, 2=pad | locals: 3=count, 4=n, 5=unit, 6=fill
     let mut f = Function::new([(4, ValType::I32)]);
     wasm!(f, {
-        local_get(0); call(emitter.rt.string.char_count); i32_wrap_i64; local_set(3);
-        local_get(3); local_get(1); i32_ge_u;
-        if_i32; local_get(0);
+        local_get(Local(0)); call(emitter.rt.string.char_count); i32_wrap_i64; local_set(Local(3));
+        local_get(Local(3)); local_get(Local(1)); i32_ge_u;
+        if_i32; local_get(Local(0));
         else_;
-          local_get(1); local_get(3); i32_sub; local_set(4);    // n = width - count
+          local_get(Local(1)); local_get(Local(3)); i32_sub; local_set(Local(4));    // n = width - count
     });
     emit_pad_first_cp(emitter, &mut f, 2, 5);                    // unit (local 5)
     wasm!(f, {
-          local_get(5); local_get(4); call(emitter.rt.string.repeat); local_set(6);
-          local_get(6); local_get(0); call(emitter.rt.concat_str);
+          local_get(Local(5)); local_get(Local(4)); call(emitter.rt.string.repeat); local_set(Local(6));
+          local_get(Local(6)); local_get(Local(0)); call(emitter.rt.concat_str);
         end;
         end;
     });
@@ -1197,16 +1198,16 @@ fn compile_pad_end(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.pad_end];
     let mut f = Function::new([(4, ValType::I32)]);
     wasm!(f, {
-        local_get(0); call(emitter.rt.string.char_count); i32_wrap_i64; local_set(3);
-        local_get(3); local_get(1); i32_ge_u;
-        if_i32; local_get(0);
+        local_get(Local(0)); call(emitter.rt.string.char_count); i32_wrap_i64; local_set(Local(3));
+        local_get(Local(3)); local_get(Local(1)); i32_ge_u;
+        if_i32; local_get(Local(0));
         else_;
-          local_get(1); local_get(3); i32_sub; local_set(4);
+          local_get(Local(1)); local_get(Local(3)); i32_sub; local_set(Local(4));
     });
     emit_pad_first_cp(emitter, &mut f, 2, 5);
     wasm!(f, {
-          local_get(5); local_get(4); call(emitter.rt.string.repeat); local_set(6);
-          local_get(0); local_get(6); call(emitter.rt.concat_str);
+          local_get(Local(5)); local_get(Local(4)); call(emitter.rt.string.repeat); local_set(Local(6));
+          local_get(Local(0)); local_get(Local(6)); call(emitter.rt.concat_str);
         end;
         end;
     });
@@ -1220,12 +1221,12 @@ fn compile_trim_start(emitter: &mut WasmEmitter) {
     const START: u32 = 2;
     let mut f = Function::new([(2, ValType::I32)]);
     wasm!(f, {
-        local_get(S); i32_load(0); local_set(LEN);
-        i32_const(0); local_set(START);
+        local_get(Local(S)); i32_load(0); local_set(Local(LEN));
+        i32_const(Imm32(0)); local_set(Local(START));
     });
     emit_trim_forward(&mut f, emitter, START, LEN);
     wasm!(f, {
-        local_get(S); local_get(START); local_get(LEN);
+        local_get(Local(S)); local_get(Local(START)); local_get(Local(LEN));
         call(emitter.rt.string.slice);
         end;
     });
@@ -1240,12 +1241,12 @@ fn compile_trim_end(emitter: &mut WasmEmitter) {
     const FLOOR: u32 = 3; // 0 — never trim below the start
     let mut f = Function::new([(3, ValType::I32)]);
     wasm!(f, {
-        local_get(S); i32_load(0); local_set(END);
-        i32_const(0); local_set(FLOOR);
+        local_get(Local(S)); i32_load(0); local_set(Local(END));
+        i32_const(Imm32(0)); local_set(Local(FLOOR));
     });
     emit_trim_backward(&mut f, emitter, END, FLOOR, Q);
     wasm!(f, {
-        local_get(S); i32_const(0); local_get(END);
+        local_get(Local(S)); i32_const(Imm32(0)); local_get(Local(END));
         call(emitter.rt.string.slice);
         end;
     });
@@ -1264,7 +1265,7 @@ fn compile_to_upper(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.to_upper];
     let map = emitter.rt.string.str_case_map;
     let mut f = Function::new([]);
-    wasm!(f, { local_get(0); i32_const(1); call(map); end; });
+    wasm!(f, { local_get(Local(0)); i32_const(Imm32(1)); call(map); end; });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.to_upper, type_idx, f));
 }
 
@@ -1272,7 +1273,7 @@ fn compile_to_lower(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.to_lower];
     let map = emitter.rt.string.str_case_map;
     let mut f = Function::new([]);
-    wasm!(f, { local_get(0); i32_const(0); call(map); end; });
+    wasm!(f, { local_get(Local(0)); i32_const(Imm32(0)); call(map); end; });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.to_lower, type_idx, f));
 }
 
@@ -1286,35 +1287,35 @@ fn compile_chars(emitter: &mut WasmEmitter) {
     // params: 0=s | locals: 1=blen, 2=result, 3=in_off, 4=str, 5=width, 6=j, 7=k
     let mut f = Function::new([(7, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);                 // blen
+        local_get(Local(0)); i32_load(0); local_set(Local(1));                 // blen
         // worst-case slots = blen (all-ASCII); fewer codepoints just leave gaps
-        i32_const(list_hdr()); local_get(1); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-        call(emitter.rt.alloc); local_set(2);
-        i32_const(0); local_set(3);                              // in_off = 0
-        i32_const(0); local_set(6);                              // j = 0 (codepoint index)
+        i32_const(Imm32(list_hdr())); local_get(Local(1)); i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+        call(emitter.rt.alloc); local_set(Local(2));
+        i32_const(Imm32(0)); local_set(Local(3));                              // in_off = 0
+        i32_const(Imm32(0)); local_set(Local(6));                              // j = 0 (codepoint index)
         block_empty; loop_empty;
-          local_get(3); local_get(1); i32_ge_u; br_if(1);
-          local_get(0); local_get(3); call(emitter.rt.string.utf8_width); local_set(5);
+          local_get(Local(3)); local_get(Local(1)); i32_ge_u; br_if(1);
+          local_get(Local(0)); local_get(Local(3)); call(emitter.rt.string.utf8_width); local_set(Local(5));
           // str = alloc(width); copy width bytes
-          local_get(5); call(emitter.rt.string_alloc); local_set(4);
-          i32_const(0); local_set(7);
+          local_get(Local(5)); call(emitter.rt.string_alloc); local_set(Local(4));
+          i32_const(Imm32(0)); local_set(Local(7));
           block_empty; loop_empty;
-            local_get(7); local_get(5); i32_ge_u; br_if(1);
-            local_get(4); i32_const(string_data_off()); i32_add; local_get(7); i32_add;
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add; local_get(7); i32_add;
+            local_get(Local(7)); local_get(Local(5)); i32_ge_u; br_if(1);
+            local_get(Local(4)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(7)); i32_add;
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(3)); i32_add; local_get(Local(7)); i32_add;
             i32_load8_u(0); i32_store8(0);
-            local_get(7); i32_const(1); i32_add; local_set(7);
+            local_get(Local(7)); i32_const(Imm32(1)); i32_add; local_set(Local(7));
             br(0);
           end; end;
           // result.data[j] = str
-          local_get(2); i32_const(list_data_off()); i32_add; local_get(6); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-          local_get(4); i32_store(0);
-          local_get(3); local_get(5); i32_add; local_set(3);     // in_off += width
-          local_get(6); i32_const(1); i32_add; local_set(6);     // j += 1
+          local_get(Local(2)); i32_const(Imm32(list_data_off())); i32_add; local_get(Local(6)); i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+          local_get(Local(4)); i32_store(0);
+          local_get(Local(3)); local_get(Local(5)); i32_add; local_set(Local(3));     // in_off += width
+          local_get(Local(6)); i32_const(Imm32(1)); i32_add; local_set(Local(6));     // j += 1
           br(0);
         end; end;
-        local_get(2); local_get(6); i32_store(0);                // result.len = j
-        local_get(2); end;
+        local_get(Local(2)); local_get(Local(6)); i32_store(0);                // result.len = j
+        local_get(Local(2)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.chars, type_idx, f));
 }
@@ -1339,60 +1340,60 @@ fn compile_run_length_encode(emitter: &mut WasmEmitter) {
         (2, ValType::I32),  // 10=run_start 11=width
     ]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);                 // blen = *s
+        local_get(Local(0)); i32_load(0); local_set(Local(1));                 // blen = *s
         // ── Pass 1: count maximal runs (by codepoint scalar) into nr ──
-        i32_const(0); local_set(2);                              // nr = 0
-        i32_const(0); local_set(3);                              // i = 0 (byte offset)
+        i32_const(Imm32(0)); local_set(Local(2));                              // nr = 0
+        i32_const(Imm32(0)); local_set(Local(3));                              // i = 0 (byte offset)
         block_empty; loop_empty;
-          local_get(3); local_get(1); i32_ge_u; br_if(1);
-          local_get(0); local_get(3); call(emitter.rt.string.utf8_scalar); local_set(4); // cur scalar
-          local_get(2); i32_const(1); i32_add; local_set(2);     // nr += 1
-          local_get(0); local_get(3); call(emitter.rt.string.utf8_width); local_get(3); i32_add; local_set(3); // i += width
+          local_get(Local(3)); local_get(Local(1)); i32_ge_u; br_if(1);
+          local_get(Local(0)); local_get(Local(3)); call(emitter.rt.string.utf8_scalar); local_set(Local(4)); // cur scalar
+          local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));     // nr += 1
+          local_get(Local(0)); local_get(Local(3)); call(emitter.rt.string.utf8_width); local_get(Local(3)); i32_add; local_set(Local(3)); // i += width
           block_empty; loop_empty;                               // skip equal codepoints
-            local_get(3); local_get(1); i32_ge_u; br_if(1);
-            local_get(0); local_get(3); call(emitter.rt.string.utf8_scalar);
-            local_get(4); i64_ne; br_if(1);
-            local_get(0); local_get(3); call(emitter.rt.string.utf8_width); local_get(3); i32_add; local_set(3);
+            local_get(Local(3)); local_get(Local(1)); i32_ge_u; br_if(1);
+            local_get(Local(0)); local_get(Local(3)); call(emitter.rt.string.utf8_scalar);
+            local_get(Local(4)); i64_ne; br_if(1);
+            local_get(Local(0)); local_get(Local(3)); call(emitter.rt.string.utf8_width); local_get(Local(3)); i32_add; local_set(Local(3));
             br(0);
           end; end;
           br(0);
         end; end;
         // ── Allocate the result list: [len=nr][nr * ptr] ──
-        i32_const(list_hdr()); local_get(2); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-        call(emitter.rt.alloc); local_set(5);
-        local_get(5); local_get(2); i32_store(0);
+        i32_const(Imm32(list_hdr())); local_get(Local(2)); i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+        call(emitter.rt.alloc); local_set(Local(5));
+        local_get(Local(5)); local_get(Local(2)); i32_store(0);
         // ── Pass 2: emit one (codepoint-string, count) tuple per run ──
-        i32_const(0); local_set(3);                              // i = 0
-        i32_const(0); local_set(6);                              // j = 0
+        i32_const(Imm32(0)); local_set(Local(3));                              // i = 0
+        i32_const(Imm32(0)); local_set(Local(6));                              // j = 0
         block_empty; loop_empty;
-          local_get(3); local_get(1); i32_ge_u; br_if(1);
-          local_get(3); local_set(10);                           // run_start = i
-          local_get(0); local_get(3); call(emitter.rt.string.utf8_scalar); local_set(4); // cur scalar
-          local_get(0); local_get(3); call(emitter.rt.string.utf8_width); local_set(11); // width
-          i32_const(1); local_set(7);                            // cnt = 1
-          local_get(3); local_get(11); i32_add; local_set(3);    // i += width
+          local_get(Local(3)); local_get(Local(1)); i32_ge_u; br_if(1);
+          local_get(Local(3)); local_set(Local(10));                           // run_start = i
+          local_get(Local(0)); local_get(Local(3)); call(emitter.rt.string.utf8_scalar); local_set(Local(4)); // cur scalar
+          local_get(Local(0)); local_get(Local(3)); call(emitter.rt.string.utf8_width); local_set(Local(11)); // width
+          i32_const(Imm32(1)); local_set(Local(7));                            // cnt = 1
+          local_get(Local(3)); local_get(Local(11)); i32_add; local_set(Local(3));    // i += width
           block_empty; loop_empty;
-            local_get(3); local_get(1); i32_ge_u; br_if(1);
-            local_get(0); local_get(3); call(emitter.rt.string.utf8_scalar);
-            local_get(4); i64_ne; br_if(1);
-            local_get(7); i32_const(1); i32_add; local_set(7);   // cnt += 1
-            local_get(0); local_get(3); call(emitter.rt.string.utf8_width); local_get(3); i32_add; local_set(3); // i += width
+            local_get(Local(3)); local_get(Local(1)); i32_ge_u; br_if(1);
+            local_get(Local(0)); local_get(Local(3)); call(emitter.rt.string.utf8_scalar);
+            local_get(Local(4)); i64_ne; br_if(1);
+            local_get(Local(7)); i32_const(Imm32(1)); i32_add; local_set(Local(7));   // cnt += 1
+            local_get(Local(0)); local_get(Local(3)); call(emitter.rt.string.utf8_width); local_get(Local(3)); i32_add; local_set(Local(3)); // i += width
             br(0);
           end; end;
           // strp = slice(s, run_start, run_start + width): the whole codepoint
-          local_get(0); local_get(10); local_get(10); local_get(11); i32_add;
-          call(emitter.rt.string.slice); local_set(8);
+          local_get(Local(0)); local_get(Local(10)); local_get(Local(10)); local_get(Local(11)); i32_add;
+          call(emitter.rt.string.slice); local_set(Local(8));
           // tup = [strp @0][cnt:i64 @4]
-          i32_const(RLE_TUPLE_BYTES); call(emitter.rt.alloc); local_set(9);
-          local_get(9); local_get(8); i32_store(0);
-          local_get(9); local_get(7); i64_extend_i32_u; i64_store(4);
+          i32_const(Imm32(RLE_TUPLE_BYTES)); call(emitter.rt.alloc); local_set(Local(9));
+          local_get(Local(9)); local_get(Local(8)); i32_store(0);
+          local_get(Local(9)); local_get(Local(7)); i64_extend_i32_u; i64_store(4);
           // result.data[j] = tup
-          local_get(5); i32_const(list_data_off()); i32_add; local_get(6); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-          local_get(9); i32_store(0);
-          local_get(6); i32_const(1); i32_add; local_set(6);     // j += 1
+          local_get(Local(5)); i32_const(Imm32(list_data_off())); i32_add; local_get(Local(6)); i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+          local_get(Local(9)); i32_store(0);
+          local_get(Local(6)); i32_const(Imm32(1)); i32_add; local_set(Local(6));     // j += 1
           br(0);
         end; end;
-        local_get(5); end;
+        local_get(Local(5)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.run_length_encode, type_idx, f));
 }
@@ -1408,51 +1409,51 @@ fn compile_lines(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(6, ValType::I32)]);
     let dat = string_data_off() as i32;
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1); // blen
+        local_get(Local(0)); i32_load(0); local_set(Local(1)); // blen
         // (empty input falls through naturally: the loop body never runs, the
         // trailing-line guard is false, and result.len stays 0 -> empty list.)
         // result: header + (blen + 1) slots (upper bound on the line count).
-        i32_const(list_hdr()); local_get(1); i32_const(1); i32_add; i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-        call(emitter.rt.alloc); local_set(2);
-        i32_const(0); local_set(3); // cur
-        i32_const(0); local_set(4); // i
-        i32_const(0); local_set(5); // slot
+        i32_const(Imm32(list_hdr())); local_get(Local(1)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+        call(emitter.rt.alloc); local_set(Local(2));
+        i32_const(Imm32(0)); local_set(Local(3)); // cur
+        i32_const(Imm32(0)); local_set(Local(4)); // i
+        i32_const(Imm32(0)); local_set(Local(5)); // slot
         block_empty; loop_empty;
-          local_get(4); local_get(1); i32_ge_u; br_if(1); // i >= blen -> done scanning
+          local_get(Local(4)); local_get(Local(1)); i32_ge_u; br_if(1); // i >= blen -> done scanning
           // if byte[i] == '\n'
-          local_get(0); i32_const(dat); i32_add; local_get(4); i32_add; i32_load8_u(0);
-          i32_const(ASCII_LF); i32_eq;
+          local_get(Local(0)); i32_const(Imm32(dat)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0);
+          i32_const(Imm32(ASCII_LF)); i32_eq;
           if_empty;
             // line_end = i; strip a trailing '\r' (byte[i-1] == 13 when i > cur)
-            local_get(4); local_set(6);
-            local_get(4); local_get(3); i32_gt_u;
+            local_get(Local(4)); local_set(Local(6));
+            local_get(Local(4)); local_get(Local(3)); i32_gt_u;
             if_empty;
-              local_get(0); i32_const(dat); i32_add; local_get(4); i32_const(1); i32_sub; i32_add; i32_load8_u(0);
-              i32_const(ASCII_CR); i32_eq;
+              local_get(Local(0)); i32_const(Imm32(dat)); i32_add; local_get(Local(4)); i32_const(Imm32(1)); i32_sub; i32_add; i32_load8_u(0);
+              i32_const(Imm32(ASCII_CR)); i32_eq;
               if_empty;
-                local_get(4); i32_const(1); i32_sub; local_set(6);
+                local_get(Local(4)); i32_const(Imm32(1)); i32_sub; local_set(Local(6));
               end;
             end;
             // slot[slot] = slice(s, cur, line_end)
-            local_get(2); i32_const(list_data_off()); i32_add; local_get(5); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-            local_get(0); local_get(3); local_get(6); call(emitter.rt.string.slice);
+            local_get(Local(2)); i32_const(Imm32(list_data_off())); i32_add; local_get(Local(5)); i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+            local_get(Local(0)); local_get(Local(3)); local_get(Local(6)); call(emitter.rt.string.slice);
             i32_store(0);
-            local_get(5); i32_const(1); i32_add; local_set(5); // slot++
-            local_get(4); i32_const(1); i32_add; local_set(3); // cur = i + 1
+            local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5)); // slot++
+            local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(3)); // cur = i + 1
           end;
-          local_get(4); i32_const(1); i32_add; local_set(4); // i++
+          local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4)); // i++
           br(0);
         end; end;
         // trailing non-empty line (input did NOT end at a '\n')
-        local_get(3); local_get(1); i32_lt_u;
+        local_get(Local(3)); local_get(Local(1)); i32_lt_u;
         if_empty;
-          local_get(2); i32_const(list_data_off()); i32_add; local_get(5); i32_const(LIST_SLOT_BYTES); i32_mul; i32_add;
-          local_get(0); local_get(3); local_get(1); call(emitter.rt.string.slice);
+          local_get(Local(2)); i32_const(Imm32(list_data_off())); i32_add; local_get(Local(5)); i32_const(Imm32(LIST_SLOT_BYTES)); i32_mul; i32_add;
+          local_get(Local(0)); local_get(Local(3)); local_get(Local(1)); call(emitter.rt.string.slice);
           i32_store(0);
-          local_get(5); i32_const(1); i32_add; local_set(5);
+          local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5));
         end;
-        local_get(2); local_get(5); i32_store(0); // result.len = slot
-        local_get(2);
+        local_get(Local(2)); local_get(Local(5)); i32_store(0); // result.len = slot
+        local_get(Local(2));
         end; // close the function body
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.lines, type_idx, f));
@@ -1539,49 +1540,49 @@ fn compile_utf8_classify(emitter: &mut WasmEmitter) {
     const BK: u32 = 9;
     let mut f = Function::new([(7, ValType::I32)]);
     wasm!(f, {
-        local_get(BUF); local_get(I); i32_add; i32_load8_u(0); local_set(B0);
-        local_get(B0); i32_const(ASCII_MAX); i32_le_u;
-        if_empty; i32_const(CLASSIFY_ASCII); return_; end;   // ASCII: 1 byte, valid
-        i32_const(0); local_set(WIDTH);
+        local_get(Local(BUF)); local_get(Local(I)); i32_add; i32_load8_u(0); local_set(Local(B0));
+        local_get(Local(B0)); i32_const(Imm32(ASCII_MAX)); i32_le_u;
+        if_empty; i32_const(Imm32(CLASSIFY_ASCII)); return_; end;   // ASCII: 1 byte, valid
+        i32_const(Imm32(0)); local_set(Local(WIDTH));
     });
     // Lead-byte width + 2nd-byte range, generated from the derived groups.
     for (lead_lo, lead_hi, width, lo2, hi2) in groups {
         wasm!(f, {
-            local_get(B0); i32_const(*lead_lo as i32); i32_ge_u;
-            local_get(B0); i32_const(*lead_hi as i32); i32_le_u; i32_and;
+            local_get(Local(B0)); i32_const(Imm32(*lead_lo as i32)); i32_ge_u;
+            local_get(Local(B0)); i32_const(Imm32(*lead_hi as i32)); i32_le_u; i32_and;
             if_empty;
-              i32_const(*width as i32); local_set(WIDTH);
-              i32_const(*lo2 as i32); local_set(LO2);
-              i32_const(*hi2 as i32); local_set(HI2);
+              i32_const(Imm32(*width as i32)); local_set(Local(WIDTH));
+              i32_const(Imm32(*lo2 as i32)); local_set(Local(LO2));
+              i32_const(Imm32(*hi2 as i32)); local_set(Local(HI2));
             end;
         });
     }
     wasm!(f, {
-        local_get(WIDTH); i32_eqz;
-        if_empty; i32_const(CLASSIFY_INVALID_LEAD); return_; end;   // invalid lead: 1-byte subpart
+        local_get(Local(WIDTH)); i32_eqz;
+        if_empty; i32_const(Imm32(CLASSIFY_INVALID_LEAD)); return_; end;   // invalid lead: 1-byte subpart
         // Validate continuation bytes: 2nd in [lo2,hi2]; 3rd/4th are plain continuations.
         // On the first failure the maximal subpart ends, so `consumed < width`.
-        i32_const(1); local_set(CONSUMED);
-        i32_const(1); local_set(K);
+        i32_const(Imm32(1)); local_set(Local(CONSUMED));
+        i32_const(Imm32(1)); local_set(Local(K));
         block_empty; loop_empty;
-          local_get(K); local_get(WIDTH); i32_ge_u; br_if(1);             // matched all → valid
-          local_get(I); local_get(K); i32_add; local_get(N); i32_ge_u; br_if(1);   // truncated
-          local_get(BUF); local_get(I); i32_add; local_get(K); i32_add; i32_load8_u(0); local_set(BK);
+          local_get(Local(K)); local_get(Local(WIDTH)); i32_ge_u; br_if(1);             // matched all → valid
+          local_get(Local(I)); local_get(Local(K)); i32_add; local_get(Local(N)); i32_ge_u; br_if(1);   // truncated
+          local_get(Local(BUF)); local_get(Local(I)); i32_add; local_get(Local(K)); i32_add; i32_load8_u(0); local_set(Local(BK));
           // valid = (k == 1) ? lo2 <= bk <= hi2 : bk is a continuation byte
-          local_get(K); i32_const(1); i32_eq;
+          local_get(Local(K)); i32_const(Imm32(1)); i32_eq;
           if_i32;
-            local_get(BK); local_get(LO2); i32_ge_u; local_get(BK); local_get(HI2); i32_le_u; i32_and;
+            local_get(Local(BK)); local_get(Local(LO2)); i32_ge_u; local_get(Local(BK)); local_get(Local(HI2)); i32_le_u; i32_and;
           else_;
-            local_get(BK); i32_const(CONT_MASK); i32_and; i32_const(CONT_TAG); i32_eq;
+            local_get(Local(BK)); i32_const(Imm32(CONT_MASK)); i32_and; i32_const(Imm32(CONT_TAG)); i32_eq;
           end;
           i32_eqz; br_if(1);
-          local_get(CONSUMED); i32_const(1); i32_add; local_set(CONSUMED);
-          local_get(K); i32_const(1); i32_add; local_set(K);
+          local_get(Local(CONSUMED)); i32_const(Imm32(1)); i32_add; local_set(Local(CONSUMED));
+          local_get(Local(K)); i32_const(Imm32(1)); i32_add; local_set(Local(K));
           br(0);
         end; end;
         // classify_packed(consumed, consumed == width)
-        local_get(CONSUMED); i32_const(1); i32_shl;
-        local_get(CONSUMED); local_get(WIDTH); i32_eq;
+        local_get(Local(CONSUMED)); i32_const(Imm32(1)); i32_shl;
+        local_get(Local(CONSUMED)); local_get(Local(WIDTH)); i32_eq;
         i32_or;
         end;
     });
@@ -1612,54 +1613,54 @@ fn compile_from_bytes(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(8, ValType::I32)]);
     wasm!(f, {
         // n = list length; copy elements (truncated to bytes) into a scratch buffer.
-        local_get(LIST); i32_load(0); local_set(N);
-        local_get(N); call(alloc); local_set(BUF);
-        i32_const(0); local_set(I);
+        local_get(Local(LIST)); i32_load(0); local_set(Local(N));
+        local_get(Local(N)); call(alloc); local_set(Local(BUF));
+        i32_const(Imm32(0)); local_set(Local(I));
         block_empty; loop_empty;
-          local_get(I); local_get(N); i32_ge_u; br_if(1);
-          local_get(BUF); local_get(I); i32_add;
-          local_get(LIST); i32_const(list_data_off()); i32_add; local_get(I); i32_const(LIST_I64_SLOT_BYTES); i32_mul; i32_add;
+          local_get(Local(I)); local_get(Local(N)); i32_ge_u; br_if(1);
+          local_get(Local(BUF)); local_get(Local(I)); i32_add;
+          local_get(Local(LIST)); i32_const(Imm32(list_data_off())); i32_add; local_get(Local(I)); i32_const(Imm32(LIST_I64_SLOT_BYTES)); i32_mul; i32_add;
           i64_load(0); i32_wrap_i64; i32_store8(0);
-          local_get(I); i32_const(1); i32_add; local_set(I);
+          local_get(Local(I)); i32_const(Imm32(1)); i32_add; local_set(Local(I));
           br(0);
         end; end;
         // PASS 1: output byte length (valid run = consumed bytes; invalid = one U+FFFD).
-        i32_const(0); local_set(TOTAL);
-        i32_const(0); local_set(I);
+        i32_const(Imm32(0)); local_set(Local(TOTAL));
+        i32_const(Imm32(0)); local_set(Local(I));
         block_empty; loop_empty;
-          local_get(I); local_get(N); i32_ge_u; br_if(1);
-          local_get(BUF); local_get(I); local_get(N); call(classify); local_set(R);
-          local_get(R); i32_const(1); i32_shr_u; local_set(CONSUMED);   // R >> 1
-          local_get(R); i32_const(1); i32_and;                          // valid bit
-          if_i32; local_get(CONSUMED); else_; i32_const(fffd_len); end;
-          local_get(TOTAL); i32_add; local_set(TOTAL);
-          local_get(I); local_get(CONSUMED); i32_add; local_set(I);
+          local_get(Local(I)); local_get(Local(N)); i32_ge_u; br_if(1);
+          local_get(Local(BUF)); local_get(Local(I)); local_get(Local(N)); call(classify); local_set(Local(R));
+          local_get(Local(R)); i32_const(Imm32(1)); i32_shr_u; local_set(Local(CONSUMED));   // R >> 1
+          local_get(Local(R)); i32_const(Imm32(1)); i32_and;                          // valid bit
+          if_i32; local_get(Local(CONSUMED)); else_; i32_const(Imm32(fffd_len)); end;
+          local_get(Local(TOTAL)); i32_add; local_set(Local(TOTAL));
+          local_get(Local(I)); local_get(Local(CONSUMED)); i32_add; local_set(Local(I));
           br(0);
         end; end;
         // alloc the output string.
-        i32_const(string_hdr()); local_get(TOTAL); i32_add; call(alloc); local_set(OUT);
-        local_get(OUT); local_get(TOTAL); i32_store(0);
+        i32_const(Imm32(string_hdr())); local_get(Local(TOTAL)); i32_add; call(alloc); local_set(Local(OUT));
+        local_get(Local(OUT)); local_get(Local(TOTAL)); i32_store(0);
         // PASS 2: fill (copy valid bytes, emit U+FFFD for each invalid subpart).
-        i32_const(0); local_set(WOFF);
-        i32_const(0); local_set(I);
+        i32_const(Imm32(0)); local_set(Local(WOFF));
+        i32_const(Imm32(0)); local_set(Local(I));
         block_empty; loop_empty;
-          local_get(I); local_get(N); i32_ge_u; br_if(1);
-          local_get(BUF); local_get(I); local_get(N); call(classify); local_set(R);
-          local_get(R); i32_const(1); i32_shr_u; local_set(CONSUMED);
-          local_get(R); i32_const(1); i32_and;
+          local_get(Local(I)); local_get(Local(N)); i32_ge_u; br_if(1);
+          local_get(Local(BUF)); local_get(Local(I)); local_get(Local(N)); call(classify); local_set(Local(R));
+          local_get(Local(R)); i32_const(Imm32(1)); i32_shr_u; local_set(Local(CONSUMED));
+          local_get(Local(R)); i32_const(Imm32(1)); i32_and;
           if_empty;
-            local_get(OUT); i32_const(do_); i32_add; local_get(WOFF); i32_add;
-            local_get(BUF); local_get(I); i32_add;
-            local_get(CONSUMED);
+            local_get(Local(OUT)); i32_const(Imm32(do_)); i32_add; local_get(Local(WOFF)); i32_add;
+            local_get(Local(BUF)); local_get(Local(I)); i32_add;
+            local_get(Local(CONSUMED));
             memory_copy;
-            local_get(WOFF); local_get(CONSUMED); i32_add; local_set(WOFF);
+            local_get(Local(WOFF)); local_get(Local(CONSUMED)); i32_add; local_set(Local(WOFF));
           else_;
-            local_get(OUT); local_get(WOFF); i32_const(REPLACEMENT_SCALAR); call(emit_scalar); local_set(WOFF);
+            local_get(Local(OUT)); local_get(Local(WOFF)); i32_const(Imm32(REPLACEMENT_SCALAR)); call(emit_scalar); local_set(Local(WOFF));
           end;
-          local_get(I); local_get(CONSUMED); i32_add; local_set(I);
+          local_get(Local(I)); local_get(Local(CONSUMED)); i32_add; local_set(Local(I));
           br(0);
         end; end;
-        local_get(OUT); end;
+        local_get(Local(OUT)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.from_bytes, type_idx, f));
 }
@@ -1668,20 +1669,20 @@ fn compile_to_bytes(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.string.to_bytes];
     let mut f = Function::new([(1, ValType::I32), (1, ValType::I32), (1, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
-        i32_const(list_hdr()); local_get(1); i32_const(LIST_I64_SLOT_BYTES); i32_mul; i32_add;
-        call(emitter.rt.alloc); local_set(2);
-        local_get(2); local_get(1); i32_store(0);
-        i32_const(0); local_set(3);
+        local_get(Local(0)); i32_load(0); local_set(Local(1));
+        i32_const(Imm32(list_hdr())); local_get(Local(1)); i32_const(Imm32(LIST_I64_SLOT_BYTES)); i32_mul; i32_add;
+        call(emitter.rt.alloc); local_set(Local(2));
+        local_get(Local(2)); local_get(Local(1)); i32_store(0);
+        i32_const(Imm32(0)); local_set(Local(3));
         block_empty; loop_empty;
-          local_get(3); local_get(1); i32_ge_u; br_if(1);
-          local_get(2); i32_const(list_data_off()); i32_add; local_get(3); i32_const(LIST_I64_SLOT_BYTES); i32_mul; i32_add;
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(3); i32_add;
+          local_get(Local(3)); local_get(Local(1)); i32_ge_u; br_if(1);
+          local_get(Local(2)); i32_const(Imm32(list_data_off())); i32_add; local_get(Local(3)); i32_const(Imm32(LIST_I64_SLOT_BYTES)); i32_mul; i32_add;
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(3)); i32_add;
           i32_load8_u(0); i64_extend_i32_u; i64_store(0);
-          local_get(3); i32_const(1); i32_add; local_set(3);
+          local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(3));
           br(0);
         end; end;
-        local_get(2); end;
+        local_get(Local(2)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.to_bytes, type_idx, f));
 }
@@ -1703,30 +1704,30 @@ fn compile_utf8_emit_scalar(emitter: &mut WasmEmitter) {
     // params: 0=dst, 1=byte_off, 2=scalar | local: 3=addr
     let mut f = Function::new([(1, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add; local_set(3);
-        local_get(2); i32_const(UTF8_CONT_TAG_IMM); i32_lt_u;
+        local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add; local_set(Local(3));
+        local_get(Local(2)); i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_lt_u;
         if_i32;
-          local_get(3); local_get(2); i32_store8(0);
-          local_get(1); i32_const(1); i32_add;
+          local_get(Local(3)); local_get(Local(2)); i32_store8(0);
+          local_get(Local(1)); i32_const(Imm32(1)); i32_add;
         else_;
-          local_get(2); i32_const(UTF8_3B_MIN_SCALAR); i32_lt_u;
+          local_get(Local(2)); i32_const(Imm32(UTF8_3B_MIN_SCALAR)); i32_lt_u;
           if_i32;
-            local_get(3); local_get(2); i32_const(UTF8_W2_LEAD_SHIFT); i32_shr_u; i32_const(UTF8_2B_LEAD_TAG); i32_or; i32_store8(0);
-            local_get(3); local_get(2); i32_const(UTF8_CONT_DATA_MASK); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_or; i32_store8(1);
-            local_get(1); i32_const(UTF8_W2); i32_add;
+            local_get(Local(3)); local_get(Local(2)); i32_const(Imm32(UTF8_W2_LEAD_SHIFT)); i32_shr_u; i32_const(Imm32(UTF8_2B_LEAD_TAG)); i32_or; i32_store8(0);
+            local_get(Local(3)); local_get(Local(2)); i32_const(Imm32(UTF8_CONT_DATA_MASK)); i32_and; i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_or; i32_store8(1);
+            local_get(Local(1)); i32_const(Imm32(UTF8_W2)); i32_add;
           else_;
-            local_get(2); i32_const(UTF8_4B_MIN_SCALAR); i32_lt_u;
+            local_get(Local(2)); i32_const(Imm32(UTF8_4B_MIN_SCALAR)); i32_lt_u;
             if_i32;
-              local_get(3); local_get(2); i32_const(UTF8_W3_LEAD_SHIFT); i32_shr_u; i32_const(UTF8_3B_LEAD_TAG); i32_or; i32_store8(0);
-              local_get(3); local_get(2); i32_const(UTF8_W2_LEAD_SHIFT); i32_shr_u; i32_const(UTF8_CONT_DATA_MASK); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_or; i32_store8(1);
-              local_get(3); local_get(2); i32_const(UTF8_CONT_DATA_MASK); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_or; i32_store8(2);
-              local_get(1); i32_const(UTF8_W3); i32_add;
+              local_get(Local(3)); local_get(Local(2)); i32_const(Imm32(UTF8_W3_LEAD_SHIFT)); i32_shr_u; i32_const(Imm32(UTF8_3B_LEAD_TAG)); i32_or; i32_store8(0);
+              local_get(Local(3)); local_get(Local(2)); i32_const(Imm32(UTF8_W2_LEAD_SHIFT)); i32_shr_u; i32_const(Imm32(UTF8_CONT_DATA_MASK)); i32_and; i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_or; i32_store8(1);
+              local_get(Local(3)); local_get(Local(2)); i32_const(Imm32(UTF8_CONT_DATA_MASK)); i32_and; i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_or; i32_store8(2);
+              local_get(Local(1)); i32_const(Imm32(UTF8_W3)); i32_add;
             else_;
-              local_get(3); local_get(2); i32_const(UTF8_W4_LEAD_SHIFT); i32_shr_u; i32_const(UTF8_4B_LEAD_TAG); i32_or; i32_store8(0);
-              local_get(3); local_get(2); i32_const(UTF8_W3_LEAD_SHIFT); i32_shr_u; i32_const(UTF8_CONT_DATA_MASK); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_or; i32_store8(1);
-              local_get(3); local_get(2); i32_const(UTF8_W2_LEAD_SHIFT); i32_shr_u; i32_const(UTF8_CONT_DATA_MASK); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_or; i32_store8(2);
-              local_get(3); local_get(2); i32_const(UTF8_CONT_DATA_MASK); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_or; i32_store8(3);
-              local_get(1); i32_const(UTF8_W4); i32_add;
+              local_get(Local(3)); local_get(Local(2)); i32_const(Imm32(UTF8_W4_LEAD_SHIFT)); i32_shr_u; i32_const(Imm32(UTF8_4B_LEAD_TAG)); i32_or; i32_store8(0);
+              local_get(Local(3)); local_get(Local(2)); i32_const(Imm32(UTF8_W3_LEAD_SHIFT)); i32_shr_u; i32_const(Imm32(UTF8_CONT_DATA_MASK)); i32_and; i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_or; i32_store8(1);
+              local_get(Local(3)); local_get(Local(2)); i32_const(Imm32(UTF8_W2_LEAD_SHIFT)); i32_shr_u; i32_const(Imm32(UTF8_CONT_DATA_MASK)); i32_and; i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_or; i32_store8(2);
+              local_get(Local(3)); local_get(Local(2)); i32_const(Imm32(UTF8_CONT_DATA_MASK)); i32_and; i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_or; i32_store8(3);
+              local_get(Local(1)); i32_const(Imm32(UTF8_W4)); i32_add;
             end;
           end;
         end;
@@ -1745,40 +1746,40 @@ fn compile_case_map_lookup(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(7, ValType::I32)]);
     if let Some(ct) = emitter.case_tables {
         wasm!(f, {
-            local_get(0); i32_eqz;
+            local_get(Local(0)); i32_eqz;
             if_empty;
-              i32_const(ct.upper_keys as i32); local_set(2);
-              i32_const(ct.upper_n as i32); local_set(3);
-              i32_const(ct.upper_offs as i32); local_set(4);
+              i32_const(Imm32(ct.upper_keys as i32)); local_set(Local(2));
+              i32_const(Imm32(ct.upper_n as i32)); local_set(Local(3));
+              i32_const(Imm32(ct.upper_offs as i32)); local_set(Local(4));
             else_;
-              i32_const(ct.lower_keys as i32); local_set(2);
-              i32_const(ct.lower_n as i32); local_set(3);
-              i32_const(ct.lower_offs as i32); local_set(4);
+              i32_const(Imm32(ct.lower_keys as i32)); local_set(Local(2));
+              i32_const(Imm32(ct.lower_n as i32)); local_set(Local(3));
+              i32_const(Imm32(ct.lower_offs as i32)); local_set(Local(4));
             end;
-            i32_const(0); local_set(5);
-            local_get(3); local_set(6);
+            i32_const(Imm32(0)); local_set(Local(5));
+            local_get(Local(3)); local_set(Local(6));
             block_empty; loop_empty;
-              local_get(5); local_get(6); i32_ge_u;
-              if_empty; i32_const(-1); return_; end;
-              local_get(5); local_get(6); i32_add; i32_const(1); i32_shr_u; local_set(7);
-              local_get(2); local_get(7); i32_const(KEY_ENTRY_SHIFT); i32_shl; i32_add; i32_load(0); local_set(8);
-              local_get(8); local_get(1); i32_eq;
+              local_get(Local(5)); local_get(Local(6)); i32_ge_u;
+              if_empty; i32_const(Imm32(-1)); return_; end;
+              local_get(Local(5)); local_get(Local(6)); i32_add; i32_const(Imm32(1)); i32_shr_u; local_set(Local(7));
+              local_get(Local(2)); local_get(Local(7)); i32_const(Imm32(KEY_ENTRY_SHIFT)); i32_shl; i32_add; i32_load(0); local_set(Local(8));
+              local_get(Local(8)); local_get(Local(1)); i32_eq;
               if_empty;
-                local_get(4); local_get(7); i32_const(KEY_ENTRY_SHIFT); i32_shl; i32_add; i32_load(0); return_;
+                local_get(Local(4)); local_get(Local(7)); i32_const(Imm32(KEY_ENTRY_SHIFT)); i32_shl; i32_add; i32_load(0); return_;
               end;
-              local_get(8); local_get(1); i32_lt_u;
+              local_get(Local(8)); local_get(Local(1)); i32_lt_u;
               if_empty;
-                local_get(7); i32_const(1); i32_add; local_set(5);
+                local_get(Local(7)); i32_const(Imm32(1)); i32_add; local_set(Local(5));
               else_;
-                local_get(7); local_set(6);
+                local_get(Local(7)); local_set(Local(6));
               end;
               br(0);
             end; end;
-            i32_const(-1);
+            i32_const(Imm32(-1));
             end;
         });
     } else {
-        wasm!(f, { i32_const(-1); end; });
+        wasm!(f, { i32_const(Imm32(-1)); end; });
     }
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.case_map_lookup, type_idx, f));
 }
@@ -1791,36 +1792,36 @@ fn compile_set_member(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(6, ValType::I32)]);
     if let Some(ct) = emitter.case_tables {
         wasm!(f, {
-            local_get(0); i32_eqz;
+            local_get(Local(0)); i32_eqz;
             if_empty;
-              i32_const(ct.cased as i32); local_set(2);
-              i32_const(ct.cased_n as i32); local_set(3);
+              i32_const(Imm32(ct.cased as i32)); local_set(Local(2));
+              i32_const(Imm32(ct.cased_n as i32)); local_set(Local(3));
             else_;
-              i32_const(ct.ci as i32); local_set(2);
-              i32_const(ct.ci_n as i32); local_set(3);
+              i32_const(Imm32(ct.ci as i32)); local_set(Local(2));
+              i32_const(Imm32(ct.ci_n as i32)); local_set(Local(3));
             end;
-            i32_const(0); local_set(4);
-            local_get(3); local_set(5);
+            i32_const(Imm32(0)); local_set(Local(4));
+            local_get(Local(3)); local_set(Local(5));
             block_empty; loop_empty;
-              local_get(4); local_get(5); i32_ge_u;
-              if_empty; i32_const(0); return_; end;
-              local_get(4); local_get(5); i32_add; i32_const(1); i32_shr_u; local_set(6);
-              local_get(2); local_get(6); i32_const(KEY_ENTRY_SHIFT); i32_shl; i32_add; i32_load(0); local_set(7);
-              local_get(7); local_get(1); i32_eq;
-              if_empty; i32_const(1); return_; end;
-              local_get(7); local_get(1); i32_lt_u;
+              local_get(Local(4)); local_get(Local(5)); i32_ge_u;
+              if_empty; i32_const(Imm32(0)); return_; end;
+              local_get(Local(4)); local_get(Local(5)); i32_add; i32_const(Imm32(1)); i32_shr_u; local_set(Local(6));
+              local_get(Local(2)); local_get(Local(6)); i32_const(Imm32(KEY_ENTRY_SHIFT)); i32_shl; i32_add; i32_load(0); local_set(Local(7));
+              local_get(Local(7)); local_get(Local(1)); i32_eq;
+              if_empty; i32_const(Imm32(1)); return_; end;
+              local_get(Local(7)); local_get(Local(1)); i32_lt_u;
               if_empty;
-                local_get(6); i32_const(1); i32_add; local_set(4);
+                local_get(Local(6)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
               else_;
-                local_get(6); local_set(5);
+                local_get(Local(6)); local_set(Local(5));
               end;
               br(0);
             end; end;
-            i32_const(0);
+            i32_const(Imm32(0));
             end;
         });
     } else {
-        wasm!(f, { i32_const(0); end; });
+        wasm!(f, { i32_const(Imm32(0)); end; });
     }
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.set_member, type_idx, f));
 }
@@ -1843,54 +1844,54 @@ fn compile_final_sigma(emitter: &mut WasmEmitter) {
     let setm = emitter.rt.string.set_member;
     let do_ = string_data_off();
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        i32_const(0); local_set(3);   // before
-        i32_const(0); local_set(4);   // after
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        i32_const(Imm32(0)); local_set(Local(3));   // before
+        i32_const(Imm32(0)); local_set(Local(4));   // after
         // Before: step BACKWARD from byte_off over codepoints, skipping
         // Case_Ignorable; the first non-ignorable char's Cased-ness is `before`.
-        local_get(1); local_set(5);   // p = byte_off
-        i32_const(0); local_set(8);   // done
+        local_get(Local(1)); local_set(Local(5));   // p = byte_off
+        i32_const(Imm32(0)); local_set(Local(8));   // done
         block_empty; loop_empty;
-          local_get(8); br_if(1);            // done → break
-          local_get(5); i32_eqz; br_if(1);   // p == 0 → break (before stays 0)
+          local_get(Local(8)); br_if(1);            // done → break
+          local_get(Local(5)); i32_eqz; br_if(1);   // p == 0 → break (before stays 0)
           // q = p-1; skip UTF-8 continuation bytes (0b10xxxxxx) back to a lead byte.
-          local_get(5); i32_const(1); i32_sub; local_set(6);
+          local_get(Local(5)); i32_const(Imm32(1)); i32_sub; local_set(Local(6));
           block_empty; loop_empty;
-            local_get(6); i32_eqz; br_if(1);                   // q == 0 → stop
-            local_get(0); i32_const(do_); i32_add; local_get(6); i32_add; i32_load8_u(0);
-            i32_const(UTF8_CONT_MASK_IMM); i32_and; i32_const(UTF8_CONT_TAG_IMM); i32_eq; // continuation byte?
+            local_get(Local(6)); i32_eqz; br_if(1);                   // q == 0 → stop
+            local_get(Local(0)); i32_const(Imm32(do_)); i32_add; local_get(Local(6)); i32_add; i32_load8_u(0);
+            i32_const(Imm32(UTF8_CONT_MASK_IMM)); i32_and; i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_eq; // continuation byte?
             i32_eqz; br_if(1);                                 // not continuation → stop (lead byte)
-            local_get(6); i32_const(1); i32_sub; local_set(6);
+            local_get(Local(6)); i32_const(Imm32(1)); i32_sub; local_set(Local(6));
             br(0);
           end; end;
-          local_get(0); local_get(6); call(us); i32_wrap_i64; local_set(7);
-          i32_const(1); local_get(7); call(setm); i32_eqz;     // not Case_Ignorable
+          local_get(Local(0)); local_get(Local(6)); call(us); i32_wrap_i64; local_set(Local(7));
+          i32_const(Imm32(1)); local_get(Local(7)); call(setm); i32_eqz;     // not Case_Ignorable
           if_empty;
-            i32_const(0); local_get(7); call(setm); local_set(3);  // before = Cased(sc)
-            i32_const(1); local_set(8);
+            i32_const(Imm32(0)); local_get(Local(7)); call(setm); local_set(Local(3));  // before = Cased(sc)
+            i32_const(Imm32(1)); local_set(Local(8));
           else_;
-            local_get(6); local_set(5);                            // p = q (keep scanning back)
+            local_get(Local(6)); local_set(Local(5));                            // p = q (keep scanning back)
           end;
           br(0);
         end; end;
         // After: first non-CI scalar at/after byte_off + width(Σ).
-        local_get(1); local_get(0); local_get(1); call(uw); i32_add; local_set(5);
-        i32_const(0); local_set(8);
+        local_get(Local(1)); local_get(Local(0)); local_get(Local(1)); call(uw); i32_add; local_set(Local(5));
+        i32_const(Imm32(0)); local_set(Local(8));
         block_empty; loop_empty;
-          local_get(5); local_get(2); i32_ge_u; br_if(1);
-          local_get(8); br_if(1);
-          local_get(0); local_get(5); call(uw); local_set(6);
-          local_get(0); local_get(5); call(us); i32_wrap_i64; local_set(7);
-          i32_const(1); local_get(7); call(setm); i32_eqz;
+          local_get(Local(5)); local_get(Local(2)); i32_ge_u; br_if(1);
+          local_get(Local(8)); br_if(1);
+          local_get(Local(0)); local_get(Local(5)); call(uw); local_set(Local(6));
+          local_get(Local(0)); local_get(Local(5)); call(us); i32_wrap_i64; local_set(Local(7));
+          i32_const(Imm32(1)); local_get(Local(7)); call(setm); i32_eqz;
           if_empty;
-            i32_const(0); local_get(7); call(setm); local_set(4);
-            i32_const(1); local_set(8);
+            i32_const(Imm32(0)); local_get(Local(7)); call(setm); local_set(Local(4));
+            i32_const(Imm32(1)); local_set(Local(8));
           end;
-          local_get(5); local_get(6); i32_add; local_set(5);
+          local_get(Local(5)); local_get(Local(6)); i32_add; local_set(Local(5));
           br(0);
         end; end;
-        local_get(3); local_get(4); i32_eqz; i32_and;
-        if_i32; i32_const(SIGMA_FINAL); else_; i32_const(SIGMA_LOWER); end;
+        local_get(Local(3)); local_get(Local(4)); i32_eqz; i32_and;
+        if_i32; i32_const(Imm32(SIGMA_FINAL)); else_; i32_const(Imm32(SIGMA_LOWER)); end;
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.final_sigma, type_idx, f));
@@ -1915,92 +1916,92 @@ fn compile_str_case_map(emitter: &mut WasmEmitter) {
     let hdr = string_hdr();
     let capo = string_cap_off() as u32;
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(1); i32_eqz; local_set(13);   // msel = is_upper==0 ? 1 : 0
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(1)); i32_eqz; local_set(Local(13));   // msel = is_upper==0 ? 1 : 0
         // PASS 1: total output bytes
-        i32_const(0); local_set(3);
-        i32_const(0); local_set(4);
+        i32_const(Imm32(0)); local_set(Local(3));
+        i32_const(Imm32(0)); local_set(Local(4));
         block_empty; loop_empty;
-          local_get(4); local_get(2); i32_ge_u; br_if(1);
-          local_get(0); i32_const(do_); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(5);
-          local_get(5); i32_const(UTF8_CONT_TAG_IMM); i32_lt_u;
+          local_get(Local(4)); local_get(Local(2)); i32_ge_u; br_if(1);
+          local_get(Local(0)); i32_const(Imm32(do_)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(5));
+          local_get(Local(5)); i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_lt_u;
           if_empty;
-            local_get(3); i32_const(1); i32_add; local_set(3);
-            local_get(4); i32_const(1); i32_add; local_set(4);
+            local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(3));
+            local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
           else_;
-            local_get(0); local_get(4); call(uw); local_set(6);
-            local_get(0); local_get(4); call(us); i32_wrap_i64; local_set(7);
-            local_get(1); i32_eqz; local_get(7); i32_const(SIGMA_UPPER); i32_eq; i32_and;
+            local_get(Local(0)); local_get(Local(4)); call(uw); local_set(Local(6));
+            local_get(Local(0)); local_get(Local(4)); call(us); i32_wrap_i64; local_set(Local(7));
+            local_get(Local(1)); i32_eqz; local_get(Local(7)); i32_const(Imm32(SIGMA_UPPER)); i32_eq; i32_and;
             if_empty;
-              local_get(3); i32_const(SIGMA_LOWER_UTF8_LEN); i32_add; local_set(3);
+              local_get(Local(3)); i32_const(Imm32(SIGMA_LOWER_UTF8_LEN)); i32_add; local_set(Local(3));
             else_;
-              local_get(13); local_get(7); call(lk); local_set(8);
-              local_get(8); i32_const(-1); i32_eq;
+              local_get(Local(13)); local_get(Local(7)); call(lk); local_set(Local(8));
+              local_get(Local(8)); i32_const(Imm32(-1)); i32_eq;
               if_empty;
-                local_get(3); local_get(6); i32_add; local_set(3);
+                local_get(Local(3)); local_get(Local(6)); i32_add; local_set(Local(3));
               else_;
-                local_get(3); local_get(8); i32_load8_u(0); i32_add; local_set(3);
+                local_get(Local(3)); local_get(Local(8)); i32_load8_u(0); i32_add; local_set(Local(3));
               end;
             end;
-            local_get(4); local_get(6); i32_add; local_set(4);
+            local_get(Local(4)); local_get(Local(6)); i32_add; local_set(Local(4));
           end;
           br(0);
         end; end;
         // ALLOC exact-size output
-        i32_const(hdr); local_get(3); i32_add; call(alloc); local_set(9);
-        local_get(9); local_get(3); i32_store(0);
-        local_get(9); local_get(3); i32_store(capo, 0);
+        i32_const(Imm32(hdr)); local_get(Local(3)); i32_add; call(alloc); local_set(Local(9));
+        local_get(Local(9)); local_get(Local(3)); i32_store(0);
+        local_get(Local(9)); local_get(Local(3)); i32_store(capo, 0);
         // PASS 2: fill
-        i32_const(0); local_set(10);
-        i32_const(0); local_set(4);
+        i32_const(Imm32(0)); local_set(Local(10));
+        i32_const(Imm32(0)); local_set(Local(4));
         block_empty; loop_empty;
-          local_get(4); local_get(2); i32_ge_u; br_if(1);
-          local_get(0); i32_const(do_); i32_add; local_get(4); i32_add; i32_load8_u(0); local_set(5);
-          local_get(5); i32_const(UTF8_CONT_TAG_IMM); i32_lt_u;
+          local_get(Local(4)); local_get(Local(2)); i32_ge_u; br_if(1);
+          local_get(Local(0)); i32_const(Imm32(do_)); i32_add; local_get(Local(4)); i32_add; i32_load8_u(0); local_set(Local(5));
+          local_get(Local(5)); i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_lt_u;
           if_empty;
-            local_get(1);
+            local_get(Local(1));
             if_i32;
-              local_get(5); i32_const(ASCII_LOWER_A); i32_ge_u; local_get(5); i32_const(ASCII_LOWER_Z); i32_le_u; i32_and;
-              if_i32; local_get(5); i32_const(ASCII_CASE_DELTA); i32_sub; else_; local_get(5); end;
+              local_get(Local(5)); i32_const(Imm32(ASCII_LOWER_A)); i32_ge_u; local_get(Local(5)); i32_const(Imm32(ASCII_LOWER_Z)); i32_le_u; i32_and;
+              if_i32; local_get(Local(5)); i32_const(Imm32(ASCII_CASE_DELTA)); i32_sub; else_; local_get(Local(5)); end;
             else_;
-              local_get(5); i32_const(ASCII_UPPER_A); i32_ge_u; local_get(5); i32_const(ASCII_UPPER_Z); i32_le_u; i32_and;
-              if_i32; local_get(5); i32_const(ASCII_CASE_DELTA); i32_add; else_; local_get(5); end;
+              local_get(Local(5)); i32_const(Imm32(ASCII_UPPER_A)); i32_ge_u; local_get(Local(5)); i32_const(Imm32(ASCII_UPPER_Z)); i32_le_u; i32_and;
+              if_i32; local_get(Local(5)); i32_const(Imm32(ASCII_CASE_DELTA)); i32_add; else_; local_get(Local(5)); end;
             end;
-            local_set(12);
-            local_get(9); i32_const(do_); i32_add; local_get(10); i32_add; local_get(12); i32_store8(0);
-            local_get(10); i32_const(1); i32_add; local_set(10);
-            local_get(4); i32_const(1); i32_add; local_set(4);
+            local_set(Local(12));
+            local_get(Local(9)); i32_const(Imm32(do_)); i32_add; local_get(Local(10)); i32_add; local_get(Local(12)); i32_store8(0);
+            local_get(Local(10)); i32_const(Imm32(1)); i32_add; local_set(Local(10));
+            local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
           else_;
-            local_get(0); local_get(4); call(uw); local_set(6);
-            local_get(0); local_get(4); call(us); i32_wrap_i64; local_set(7);
-            local_get(1); i32_eqz; local_get(7); i32_const(SIGMA_UPPER); i32_eq; i32_and;
+            local_get(Local(0)); local_get(Local(4)); call(uw); local_set(Local(6));
+            local_get(Local(0)); local_get(Local(4)); call(us); i32_wrap_i64; local_set(Local(7));
+            local_get(Local(1)); i32_eqz; local_get(Local(7)); i32_const(Imm32(SIGMA_UPPER)); i32_eq; i32_and;
             if_empty;
-              local_get(9); local_get(10);
-              local_get(0); local_get(4); call(fsig);
-              call(em); local_set(10);
+              local_get(Local(9)); local_get(Local(10));
+              local_get(Local(0)); local_get(Local(4)); call(fsig);
+              call(em); local_set(Local(10));
             else_;
-              local_get(13); local_get(7); call(lk); local_set(8);
-              local_get(8); i32_const(-1); i32_eq;
+              local_get(Local(13)); local_get(Local(7)); call(lk); local_set(Local(8));
+              local_get(Local(8)); i32_const(Imm32(-1)); i32_eq;
               if_empty;
-                local_get(9); i32_const(do_); i32_add; local_get(10); i32_add;
-                local_get(0); i32_const(do_); i32_add; local_get(4); i32_add;
-                local_get(6);
+                local_get(Local(9)); i32_const(Imm32(do_)); i32_add; local_get(Local(10)); i32_add;
+                local_get(Local(0)); i32_const(Imm32(do_)); i32_add; local_get(Local(4)); i32_add;
+                local_get(Local(6));
                 memory_copy;
-                local_get(10); local_get(6); i32_add; local_set(10);
+                local_get(Local(10)); local_get(Local(6)); i32_add; local_set(Local(10));
               else_;
-                local_get(8); i32_load8_u(0); local_set(11);
-                local_get(9); i32_const(do_); i32_add; local_get(10); i32_add;
-                local_get(8); i32_const(1); i32_add;
-                local_get(11);
+                local_get(Local(8)); i32_load8_u(0); local_set(Local(11));
+                local_get(Local(9)); i32_const(Imm32(do_)); i32_add; local_get(Local(10)); i32_add;
+                local_get(Local(8)); i32_const(Imm32(1)); i32_add;
+                local_get(Local(11));
                 memory_copy;
-                local_get(10); local_get(11); i32_add; local_set(10);
+                local_get(Local(10)); local_get(Local(11)); i32_add; local_set(Local(10));
               end;
             end;
-            local_get(4); local_get(6); i32_add; local_set(4);
+            local_get(Local(4)); local_get(Local(6)); i32_add; local_set(Local(4));
           end;
           br(0);
         end; end;
-        local_get(9); end;
+        local_get(Local(9)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.str_case_map, type_idx, f));
 }
@@ -2021,52 +2022,52 @@ fn compile_str_capitalize(emitter: &mut WasmEmitter) {
     let hdr = string_hdr();
     let capo = string_cap_off() as u32;
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(2); i32_eqz; if_empty; local_get(0); return_; end;
-        local_get(0); i32_const(do_); i32_add; i32_load8_u(0); local_set(5);
-        local_get(0); i32_const(0); call(uw); local_set(3);
-        local_get(5); i32_const(UTF8_CONT_TAG_IMM); i32_lt_u;
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(2)); i32_eqz; if_empty; local_get(Local(0)); return_; end;
+        local_get(Local(0)); i32_const(Imm32(do_)); i32_add; i32_load8_u(0); local_set(Local(5));
+        local_get(Local(0)); i32_const(Imm32(0)); call(uw); local_set(Local(3));
+        local_get(Local(5)); i32_const(Imm32(UTF8_CONT_TAG_IMM)); i32_lt_u;
         if_empty;
-          i32_const(1); local_set(7);
-          local_get(5); i32_const(ASCII_LOWER_A); i32_ge_u; local_get(5); i32_const(ASCII_LOWER_Z); i32_le_u; i32_and;
-          if_i32; local_get(5); i32_const(ASCII_CASE_DELTA); i32_sub; else_; local_get(5); end;
-          local_set(10);
-          i32_const(ASCII_ID_SENTINEL); local_set(6);
+          i32_const(Imm32(1)); local_set(Local(7));
+          local_get(Local(5)); i32_const(Imm32(ASCII_LOWER_A)); i32_ge_u; local_get(Local(5)); i32_const(Imm32(ASCII_LOWER_Z)); i32_le_u; i32_and;
+          if_i32; local_get(Local(5)); i32_const(Imm32(ASCII_CASE_DELTA)); i32_sub; else_; local_get(Local(5)); end;
+          local_set(Local(10));
+          i32_const(Imm32(ASCII_ID_SENTINEL)); local_set(Local(6));
         else_;
-          local_get(0); i32_const(0); call(us); i32_wrap_i64; local_set(4);
-          i32_const(0); local_get(4); call(lk); local_set(6);
-          local_get(6); i32_const(-1); i32_eq;
-          if_empty; local_get(3); local_set(7);
-          else_; local_get(6); i32_load8_u(0); local_set(7); end;
+          local_get(Local(0)); i32_const(Imm32(0)); call(us); i32_wrap_i64; local_set(Local(4));
+          i32_const(Imm32(0)); local_get(Local(4)); call(lk); local_set(Local(6));
+          local_get(Local(6)); i32_const(Imm32(-1)); i32_eq;
+          if_empty; local_get(Local(3)); local_set(Local(7));
+          else_; local_get(Local(6)); i32_load8_u(0); local_set(Local(7)); end;
         end;
-        local_get(7); local_get(2); i32_add; local_get(3); i32_sub; local_set(8);
-        i32_const(hdr); local_get(8); i32_add; call(alloc); local_set(9);
-        local_get(9); local_get(8); i32_store(0);
-        local_get(9); local_get(8); i32_store(capo, 0);
+        local_get(Local(7)); local_get(Local(2)); i32_add; local_get(Local(3)); i32_sub; local_set(Local(8));
+        i32_const(Imm32(hdr)); local_get(Local(8)); i32_add; call(alloc); local_set(Local(9));
+        local_get(Local(9)); local_get(Local(8)); i32_store(0);
+        local_get(Local(9)); local_get(Local(8)); i32_store(capo, 0);
         // head
-        local_get(6); i32_const(ASCII_ID_SENTINEL); i32_eq;
+        local_get(Local(6)); i32_const(Imm32(ASCII_ID_SENTINEL)); i32_eq;
         if_empty;
-          local_get(9); i32_const(do_); i32_add; local_get(10); i32_store8(0);
+          local_get(Local(9)); i32_const(Imm32(do_)); i32_add; local_get(Local(10)); i32_store8(0);
         else_;
-          local_get(6); i32_const(-1); i32_eq;
+          local_get(Local(6)); i32_const(Imm32(-1)); i32_eq;
           if_empty;
-            local_get(9); i32_const(do_); i32_add;
-            local_get(0); i32_const(do_); i32_add;
-            local_get(3);
+            local_get(Local(9)); i32_const(Imm32(do_)); i32_add;
+            local_get(Local(0)); i32_const(Imm32(do_)); i32_add;
+            local_get(Local(3));
             memory_copy;
           else_;
-            local_get(9); i32_const(do_); i32_add;
-            local_get(6); i32_const(1); i32_add;
-            local_get(7);
+            local_get(Local(9)); i32_const(Imm32(do_)); i32_add;
+            local_get(Local(6)); i32_const(Imm32(1)); i32_add;
+            local_get(Local(7));
             memory_copy;
           end;
         end;
         // tail (verbatim): blen - w0 bytes from s data+w0 to out data+hlen
-        local_get(9); i32_const(do_); i32_add; local_get(7); i32_add;
-        local_get(0); i32_const(do_); i32_add; local_get(3); i32_add;
-        local_get(2); local_get(3); i32_sub;
+        local_get(Local(9)); i32_const(Imm32(do_)); i32_add; local_get(Local(7)); i32_add;
+        local_get(Local(0)); i32_const(Imm32(do_)); i32_add; local_get(Local(3)); i32_add;
+        local_get(Local(2)); local_get(Local(3)); i32_sub;
         memory_copy;
-        local_get(9); end;
+        local_get(Local(9)); end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string.capitalize, type_idx, f));
 }

--- a/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
@@ -3,6 +3,12 @@
 //! Split from rt_string.rs for file size. These are all standalone compile_* functions
 //! called from `compile()` in rt_string.rs.
 
+// ── Named constants ──────────────────────────────────────────────────────────
+/// Byte width of an i32 / WASM pointer (used when allocating a single-pointer
+/// Option wrapper via `alloc`).
+const I32_BYTES: i32 = 4;
+// ─────────────────────────────────────────────────────────────────────────────
+
 use super::{CompiledFunc, WasmEmitter};
 use wasm_encoder::{ValType};
 use super::TrackedFunction as Function;
@@ -90,7 +96,7 @@ pub(super) fn compile_strip_prefix(emitter: &mut WasmEmitter) {
             // some(slice): wrap string ptr in Option (alloc 4 bytes, store ptr)
             local_get(0); local_get(3); local_get(2);
             call(emitter.rt.string.slice); local_set(4);
-            i32_const(4); call(emitter.rt.alloc);
+            i32_const(I32_BYTES); call(emitter.rt.alloc);
             local_tee(3); // reuse local 3
             local_get(4); i32_store(0);
             local_get(3);
@@ -120,7 +126,7 @@ pub(super) fn compile_strip_suffix(emitter: &mut WasmEmitter) {
           if_i32;
             local_get(0); i32_const(0); local_get(2); local_get(3); i32_sub;
             call(emitter.rt.string.slice); local_set(4);
-            i32_const(4); call(emitter.rt.alloc);
+            i32_const(I32_BYTES); call(emitter.rt.alloc);
             local_tee(3);
             local_get(4); i32_store(0);
             local_get(3);

--- a/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_string_extra.rs
@@ -6,6 +6,7 @@
 // ── Named constants ──────────────────────────────────────────────────────────
 /// Byte width of an i32 / WASM pointer (used when allocating a single-pointer
 /// Option wrapper via `alloc`).
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 const I32_BYTES: i32 = 4;
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -24,18 +25,18 @@ pub(super) fn compile_replace_first(emitter: &mut WasmEmitter) {
         (1, ValType::I32), (1, ValType::I32),
     ]);
     wasm!(f, {
-        local_get(0); local_get(1); call(emitter.rt.string.index_of); local_set(3);
-        local_get(3); i64_const(-1); i64_eq;
-        if_i32; local_get(0);
+        local_get(Local(0)); local_get(Local(1)); call(emitter.rt.string.index_of); local_set(Local(3));
+        local_get(Local(3)); i64_const(Imm64(-1)); i64_eq;
+        if_i32; local_get(Local(0));
         else_;
-          local_get(3); i32_wrap_i64; local_set(4);
-          local_get(1); i32_load(0); local_set(5);
-          local_get(0); i32_const(0); local_get(4);
-          call(emitter.rt.string.slice); local_set(6);
-          local_get(0); local_get(4); local_get(5); i32_add; local_get(0); i32_load(0);
-          call(emitter.rt.string.slice); local_set(7);
-          local_get(6); local_get(2); call(emitter.rt.concat_str);
-          local_get(7); call(emitter.rt.concat_str);
+          local_get(Local(3)); i32_wrap_i64; local_set(Local(4));
+          local_get(Local(1)); i32_load(0); local_set(Local(5));
+          local_get(Local(0)); i32_const(Imm32(0)); local_get(Local(4));
+          call(emitter.rt.string.slice); local_set(Local(6));
+          local_get(Local(0)); local_get(Local(4)); local_get(Local(5)); i32_add; local_get(Local(0)); i32_load(0);
+          call(emitter.rt.string.slice); local_set(Local(7));
+          local_get(Local(6)); local_get(Local(2)); call(emitter.rt.concat_str);
+          local_get(Local(7)); call(emitter.rt.concat_str);
         end;
         end;
     });
@@ -49,29 +50,29 @@ pub(super) fn compile_last_index_of(emitter: &mut WasmEmitter) {
         (1, ValType::I32), (1, ValType::I32), (1, ValType::I64),
     ]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(1); i32_load(0); local_set(3);
-        i64_const(-1); local_set(7);
-        local_get(3); i32_eqz;
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(1)); i32_load(0); local_set(Local(3));
+        i64_const(Imm64(-1)); local_set(Local(7));
+        local_get(Local(3)); i32_eqz;
         // Empty pattern: native `s.rfind("")` == Some(s.len()) — the BYTE length
         // (local 2). The Some sentinel is any non-negative i64; None is -1.
-        if_i64; local_get(2); i64_extend_i32_u;
+        if_i64; local_get(Local(2)); i64_extend_i32_u;
         else_;
-          i32_const(0); local_set(4);
+          i32_const(Imm32(0)); local_set(Local(4));
           block_empty; loop_empty;
-            local_get(4); local_get(2); local_get(3); i32_sub; i32_const(1); i32_add;
+            local_get(Local(4)); local_get(Local(2)); local_get(Local(3)); i32_sub; i32_const(Imm32(1)); i32_add;
             i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(4); i32_add;
-            local_get(1); i32_const(string_data_off()); i32_add;
-            local_get(3);
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(4)); i32_add;
+            local_get(Local(1)); i32_const(Imm32(string_data_off())); i32_add;
+            local_get(Local(3));
             call(emitter.rt.mem_eq);
             if_empty;
-              local_get(4); i64_extend_i32_u; local_set(7);
+              local_get(Local(4)); i64_extend_i32_u; local_set(Local(7));
             end;
-            local_get(4); i32_const(1); i32_add; local_set(4);
+            local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
             br(0);
           end; end;
-          local_get(7);
+          local_get(Local(7));
         end;
         end;
     });
@@ -83,25 +84,25 @@ pub(super) fn compile_strip_prefix(emitter: &mut WasmEmitter) {
     // params: 0=s, 1=prefix | locals: 2=s_len, 3=p_len, 4=result_str
     let mut f = Function::new([(1, ValType::I32), (1, ValType::I32), (1, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(1); i32_load(0); local_set(3);
-        local_get(3); local_get(2); i32_gt_u;
-        if_i32; i32_const(0); // none
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(1)); i32_load(0); local_set(Local(3));
+        local_get(Local(3)); local_get(Local(2)); i32_gt_u;
+        if_i32; i32_const(Imm32(0)); // none
         else_;
-          local_get(0); i32_const(string_data_off()); i32_add;
-          local_get(1); i32_const(string_data_off()); i32_add;
-          local_get(3);
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(1)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(3));
           call(emitter.rt.mem_eq);
           if_i32;
             // some(slice): wrap string ptr in Option (alloc 4 bytes, store ptr)
-            local_get(0); local_get(3); local_get(2);
-            call(emitter.rt.string.slice); local_set(4);
-            i32_const(I32_BYTES); call(emitter.rt.alloc);
-            local_tee(3); // reuse local 3
-            local_get(4); i32_store(0);
-            local_get(3);
+            local_get(Local(0)); local_get(Local(3)); local_get(Local(2));
+            call(emitter.rt.string.slice); local_set(Local(4));
+            i32_const(Imm32(I32_BYTES)); call(emitter.rt.alloc);
+            local_tee(Local(3)); // reuse local 3
+            local_get(Local(4)); i32_store(0);
+            local_get(Local(3));
           else_;
-            i32_const(0);
+            i32_const(Imm32(0));
           end;
         end;
         end;
@@ -114,24 +115,24 @@ pub(super) fn compile_strip_suffix(emitter: &mut WasmEmitter) {
     // params: 0=s, 1=suffix | locals: 2=s_len, 3=p_len, 4=result_str
     let mut f = Function::new([(1, ValType::I32), (1, ValType::I32), (1, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(1); i32_load(0); local_set(3);
-        local_get(3); local_get(2); i32_gt_u;
-        if_i32; i32_const(0);
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(1)); i32_load(0); local_set(Local(3));
+        local_get(Local(3)); local_get(Local(2)); i32_gt_u;
+        if_i32; i32_const(Imm32(0));
         else_;
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(2); i32_add; local_get(3); i32_sub;
-          local_get(1); i32_const(string_data_off()); i32_add;
-          local_get(3);
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(2)); i32_add; local_get(Local(3)); i32_sub;
+          local_get(Local(1)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(3));
           call(emitter.rt.mem_eq);
           if_i32;
-            local_get(0); i32_const(0); local_get(2); local_get(3); i32_sub;
-            call(emitter.rt.string.slice); local_set(4);
-            i32_const(I32_BYTES); call(emitter.rt.alloc);
-            local_tee(3);
-            local_get(4); i32_store(0);
-            local_get(3);
+            local_get(Local(0)); i32_const(Imm32(0)); local_get(Local(2)); local_get(Local(3)); i32_sub;
+            call(emitter.rt.string.slice); local_set(Local(4));
+            i32_const(Imm32(I32_BYTES)); call(emitter.rt.alloc);
+            local_tee(Local(3));
+            local_get(Local(4)); i32_store(0);
+            local_get(Local(3));
           else_;
-            i32_const(0);
+            i32_const(Imm32(0));
           end;
         end;
         end;
@@ -147,24 +148,24 @@ pub(super) fn compile_byte_predicate_range(emitter: &mut WasmEmitter, func_idx: 
     let type_idx = emitter.func_type_indices[&func_idx];
     let mut f = Function::new([(1, ValType::I32), (1, ValType::I32)]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
-        local_get(1); i32_eqz;
-        if_i32; i32_const(0);
+        local_get(Local(0)); i32_load(0); local_set(Local(1));
+        local_get(Local(1)); i32_eqz;
+        if_i32; i32_const(Imm32(0));
         else_;
-          i32_const(0); local_set(2);
+          i32_const(Imm32(0)); local_set(Local(2));
           block_empty; loop_empty;
-            local_get(2); local_get(1); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(2); i32_add; i32_load8_u(0);
-            local_tee(1);
-            i32_const(lo); i32_lt_u;
-            local_get(1); i32_const(hi); i32_gt_u;
+            local_get(Local(2)); local_get(Local(1)); i32_ge_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(2)); i32_add; i32_load8_u(0);
+            local_tee(Local(1));
+            i32_const(Imm32(lo)); i32_lt_u;
+            local_get(Local(1)); i32_const(Imm32(hi)); i32_gt_u;
             i32_or;
             br_if(1);
-            local_get(0); i32_load(0); local_set(1); // restore len
-            local_get(2); i32_const(1); i32_add; local_set(2);
+            local_get(Local(0)); i32_load(0); local_set(Local(1)); // restore len
+            local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
             br(0);
           end; end;
-          local_get(2); local_get(0); i32_load(0); i32_eq;
+          local_get(Local(2)); local_get(Local(0)); i32_load(0); i32_eq;
         end;
         end;
     });
@@ -217,37 +218,37 @@ pub(super) fn compile_prop_membership(emitter: &mut WasmEmitter) {
         // NOT be recognized, so `data_off` is added at RUNTIME below.
         wasm!(f, {
             // data_base = table_off + data_off (pointer to the first [lo,hi] pair)
-            i32_const(table_off as i32); i32_const(data_off); i32_add; local_set(6);
+            i32_const(Imm32(table_off as i32)); i32_const(Imm32(data_off)); i32_add; local_set(Local(6));
             // lo = 0; hi = pair_count = table_len >> entry_shift
-            i32_const(0); local_set(1);
-            i32_const(table_off as i32); i32_load(0); i32_const(entry_shift); i32_shr_u; local_set(2);
+            i32_const(Imm32(0)); local_set(Local(1));
+            i32_const(Imm32(table_off as i32)); i32_load(0); i32_const(Imm32(entry_shift)); i32_shr_u; local_set(Local(2));
             block_empty; loop_empty;
               // while lo < hi
-              local_get(1); local_get(2); i32_ge_u; br_if(1);
+              local_get(Local(1)); local_get(Local(2)); i32_ge_u; br_if(1);
               // mid = (lo + hi) / 2
-              local_get(1); local_get(2); i32_add; i32_const(1); i32_shr_u; local_set(3);
+              local_get(Local(1)); local_get(Local(2)); i32_add; i32_const(Imm32(1)); i32_shr_u; local_set(Local(3));
               // mid_ptr = data_base + mid * RANGE_ENTRY_BYTES
-              local_get(6);
-              local_get(3); i32_const(RANGE_ENTRY_BYTES as i32); i32_mul; i32_add; local_set(4);
+              local_get(Local(6));
+              local_get(Local(3)); i32_const(Imm32(RANGE_ENTRY_BYTES as i32)); i32_mul; i32_add; local_set(Local(4));
               // range_lo = *mid_ptr
-              local_get(4); i32_load(0); local_set(5);
+              local_get(Local(4)); i32_load(0); local_set(Local(5));
               // if scalar < range_lo → search left (hi = mid)
-              local_get(0); local_get(5); i32_lt_u;
+              local_get(Local(0)); local_get(Local(5)); i32_lt_u;
               if_empty;
-                local_get(3); local_set(2);
+                local_get(Local(3)); local_set(Local(2));
               else_;
                 // if scalar <= range_hi → hit
-                local_get(0); local_get(4); i32_load(hi_off); i32_le_u;
+                local_get(Local(0)); local_get(Local(4)); i32_load(hi_off); i32_le_u;
                 if_empty;
-                  i32_const(1); return_;
+                  i32_const(Imm32(1)); return_;
                 else_;
                   // scalar > range_hi → search right (lo = mid + 1)
-                  local_get(3); i32_const(1); i32_add; local_set(1);
+                  local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
                 end;
               end;
               br(0);
             end; end;
-            i32_const(0); // not found
+            i32_const(Imm32(0)); // not found
             end;
         });
         emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
@@ -279,21 +280,21 @@ fn compile_all_codepoints_predicate(emitter: &mut WasmEmitter, func_idx: u32, pr
     const I: u32 = 2;     // byte index
     let mut f = Function::new([(2, ValType::I32)]);
     wasm!(f, {
-        local_get(S); i32_load(0); local_set(BLEN);
-        local_get(BLEN); i32_eqz;
-        if_i32; i32_const(0);                                   // empty → false
+        local_get(Local(S)); i32_load(0); local_set(Local(BLEN));
+        local_get(Local(BLEN)); i32_eqz;
+        if_i32; i32_const(Imm32(0));                                   // empty → false
         else_;
-          i32_const(0); local_set(I);
+          i32_const(Imm32(0)); local_set(Local(I));
           block_empty; loop_empty;
-            local_get(I); local_get(BLEN); i32_ge_u; br_if(1);  // walked all → true
+            local_get(Local(I)); local_get(Local(BLEN)); i32_ge_u; br_if(1);  // walked all → true
             // scalar = utf8_scalar(s, i); fail if not a member
-            local_get(S); local_get(I); call(us); i32_wrap_i64; call(prop_idx); i32_eqz;
-            if_empty; i32_const(0); return_; end;
+            local_get(Local(S)); local_get(Local(I)); call(us); i32_wrap_i64; call(prop_idx); i32_eqz;
+            if_empty; i32_const(Imm32(0)); return_; end;
             // i += utf8_width(s, i)
-            local_get(S); local_get(I); call(uw); local_get(I); i32_add; local_set(I);
+            local_get(Local(S)); local_get(Local(I)); call(uw); local_get(Local(I)); i32_add; local_set(Local(I));
             br(0);
           end; end;
-          i32_const(1);
+          i32_const(Imm32(1));
         end;
         end;
     });
@@ -316,16 +317,16 @@ pub(super) fn compile_is_whitespace(emitter: &mut WasmEmitter) {
     const I: u32 = 2;
     let mut f = Function::new([(2, ValType::I32)]);
     wasm!(f, {
-        local_get(S); i32_load(0); local_set(BLEN);
-        i32_const(0); local_set(I);
+        local_get(Local(S)); i32_load(0); local_set(Local(BLEN));
+        i32_const(Imm32(0)); local_set(Local(I));
         block_empty; loop_empty;
-          local_get(I); local_get(BLEN); i32_ge_u; br_if(1);   // end (incl. empty) → all WS
-          local_get(S); local_get(I); call(us); i32_wrap_i64; call(isws); i32_eqz;
-          if_empty; i32_const(0); return_; end;                // a non-WS codepoint → false
-          local_get(S); local_get(I); call(uw); local_get(I); i32_add; local_set(I);
+          local_get(Local(I)); local_get(Local(BLEN)); i32_ge_u; br_if(1);   // end (incl. empty) → all WS
+          local_get(Local(S)); local_get(Local(I)); call(us); i32_wrap_i64; call(isws); i32_eqz;
+          if_empty; i32_const(Imm32(0)); return_; end;                // a non-WS codepoint → false
+          local_get(Local(S)); local_get(Local(I)); call(uw); local_get(Local(I)); i32_add; local_set(Local(I));
           br(0);
         end; end;
-        i32_const(1);
+        i32_const(Imm32(1));
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
@@ -365,31 +366,31 @@ fn compile_case_predicate(emitter: &mut WasmEmitter, func_idx: u32, case_prop_id
     const ALL_OK: u32 = 5;
     let mut f = Function::new([(5, ValType::I32)]);
     wasm!(f, {
-        local_get(S); i32_load(0); local_set(BLEN);
-        local_get(BLEN); i32_eqz;
-        if_i32; i32_const(0);                                   // empty → false
+        local_get(Local(S)); i32_load(0); local_set(Local(BLEN));
+        local_get(Local(BLEN)); i32_eqz;
+        if_i32; i32_const(Imm32(0));                                   // empty → false
         else_;
-          i32_const(0); local_set(I);
-          i32_const(0); local_set(ANY_ALPHA);                   // any_alpha = false
-          i32_const(1); local_set(ALL_OK);                      // all_ok = true
+          i32_const(Imm32(0)); local_set(Local(I));
+          i32_const(Imm32(0)); local_set(Local(ANY_ALPHA));                   // any_alpha = false
+          i32_const(Imm32(1)); local_set(Local(ALL_OK));                      // all_ok = true
           block_empty; loop_empty;
-            local_get(I); local_get(BLEN); i32_ge_u; br_if(1);
-            local_get(S); local_get(I); call(us); i32_wrap_i64; local_set(SCALAR);
+            local_get(Local(I)); local_get(Local(BLEN)); i32_ge_u; br_if(1);
+            local_get(Local(S)); local_get(Local(I)); call(us); i32_wrap_i64; local_set(Local(SCALAR));
             // if is_alphabetic(scalar)
-            local_get(SCALAR); call(prop_alpha);
+            local_get(Local(SCALAR)); call(prop_alpha);
             if_empty;
-              i32_const(1); local_set(ANY_ALPHA);               // any_alpha = true
+              i32_const(Imm32(1)); local_set(Local(ANY_ALPHA));               // any_alpha = true
               // if NOT case_prop(scalar) → all_ok = false
-              local_get(SCALAR); call(case_prop_idx); i32_eqz;
+              local_get(Local(SCALAR)); call(case_prop_idx); i32_eqz;
               if_empty;
-                i32_const(0); local_set(ALL_OK);
+                i32_const(Imm32(0)); local_set(Local(ALL_OK));
               end;
             end;
             // i += utf8_width(s, i)
-            local_get(S); local_get(I); call(uw); local_get(I); i32_add; local_set(I);
+            local_get(Local(S)); local_get(Local(I)); call(uw); local_get(Local(I)); i32_add; local_set(Local(I));
             br(0);
           end; end;
-          local_get(ANY_ALPHA); local_get(ALL_OK); i32_and;
+          local_get(Local(ANY_ALPHA)); local_get(Local(ALL_OK)); i32_and;
         end;
         end;
     });

--- a/crates/almide-codegen/src/emit_wasm/rt_value.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_value.rs
@@ -14,12 +14,92 @@ use super::TrackedFunction as Function;
 // Value heap tags (see `compile_value_stringify`): 0=null, 1=bool, 2=int,
 // 3=float, 4=string, 5=array, 6=object. Only the container tags matter for the
 // path walkers; the rest are "scalar" and never index/field into.
+const VTAG_INT: i32 = 2;
+const VTAG_FLOAT: i32 = 3;
+const VTAG_STRING: i32 = 4;
 const VTAG_ARRAY: i32 = 5;
 const VTAG_OBJECT: i32 = 6;
 
 /// Size in bytes of a heap value box: `[tag:i32][payload:i32]`. The payload is
 /// the inline scalar (bool/int), or a pointer (string/array/object pairs-list).
 const VALUE_BOX_SIZE: i32 = 8;
+
+// JsonPath segment tags: 0=Root, 1=Field, 2=Index.
+const JP_FIELD_TAG: i32 = 1;
+const JP_INDEX_TAG: i32 = 2;
+
+// Memory sizes and strides.
+/// Byte width of an i32 / heap pointer.
+const I32_BYTES: i32 = 4;
+/// Allocation size of a parse-result struct: [value:i32][new_pos:i32][err_flag:i32].
+const PARSE_RESULT_SIZE: i32 = 12;
+/// Initial element capacity for growable array/object parse buffers.
+const INIT_CAPACITY: i32 = 64;
+/// Initial byte allocation for growable buffers: list_hdr() + INIT_CAPACITY * I32_BYTES.
+const INIT_BUF_BYTES: i32 = 264;
+
+// ASCII character codes used in the JSON parser and string escape decoder.
+const ASCII_BS: i32 = 8;        // backspace (\b)
+const ASCII_HT: i32 = 9;        // horizontal tab (\t)
+const ASCII_LF: i32 = 10;       // line feed (\n)
+const ASCII_FF: i32 = 12;       // form feed (\f)
+const ASCII_CR: i32 = 13;       // carriage return (\r)
+const ASCII_SPACE: i32 = 32;    // space
+const ASCII_DQUOTE: i32 = 34;   // '"'
+const ASCII_PLUS: i32 = 43;     // '+'
+const ASCII_COMMA: i32 = 44;    // ','
+const ASCII_MINUS: i32 = 45;    // '-'
+const ASCII_DOT: i32 = 46;      // '.'
+const ASCII_ZERO: i32 = 48;     // '0'
+const ASCII_NINE: i32 = 57;     // '9'
+const ASCII_COLON: i32 = 58;    // ':'
+const ASCII_E_UPPER: i32 = 69;  // 'E'
+const ASCII_LBRACKET: i32 = 91; // '['
+const ASCII_BACKSLASH: i32 = 92;// '\\'
+const ASCII_RBRACKET: i32 = 93; // ']'
+const ASCII_A_LOWER: i32 = 97;  // 'a'
+const ASCII_B: i32 = 98;        // 'b'
+const ASCII_F_LOWER: i32 = 102; // 'f'
+const ASCII_L: i32 = 108;       // 'l'
+const ASCII_N: i32 = 110;       // 'n'
+const ASCII_R: i32 = 114;       // 'r'
+const ASCII_S: i32 = 115;       // 's'
+const ASCII_T: i32 = 116;       // 't'
+const ASCII_U: i32 = 117;       // 'u'
+const ASCII_LBRACE: i32 = 123;  // '{'
+const ASCII_RBRACE: i32 = 125;  // '}'
+const ASCII_E_LOWER: i32 = 101; // 'e'
+
+// Bit mask used to fold uppercase A-F → a-f: byte | ASCII_LOWER_BIT.
+const ASCII_LOWER_BIT: i32 = 32; // 0x20
+// Bias for hex-digit decoding of a-f/A-F: (byte | ASCII_LOWER_BIT) - HEX_ALPHA_BIAS = 10..15.
+const HEX_ALPHA_BIAS: i32 = 87;  // 'a' - 10
+// Shift applied to a hex nibble when accumulating a 4-hex-digit codepoint.
+const HEX_NIBBLE_SHIFT: i32 = 4;
+
+// JSON keyword lengths (ASCII chars consumed after matching the first character).
+const JSON_KW4_LOOKAHEAD: i32 = 3; // need 3 more chars for a 4-char keyword (null/true)
+const JSON_KW4_LEN: i32 = 4;       // advance pos past "null" or "true" (4 chars)
+const JSON_KW5_LOOKAHEAD: i32 = 4; // need 4 more chars for "false" (alse)
+const JSON_FALSE_LEN: i32 = 5;     // advance pos past "false" (5 chars)
+
+// Unicode / surrogate-pair constants.
+const SURR_HIGH_START: i32 = 0xD800;  // first high surrogate
+const SURR_HIGH_END: i32 = 0xDBFF;    // last  high surrogate
+const SURR_LOW_START: i32 = 0xDC00;   // first low surrogate
+const SURR_LOW_END: i32 = 0xDFFF;     // last  low surrogate
+const SURR_HIGH_SHIFT: i32 = 10;      // high-surrogate left-shift in astral codepoint formula
+const SURR_PAIR_BASE: i32 = 0x10000;  // codepoint base added in astral formula
+const UNICODE_ESCAPE_LEN: i32 = 5;    // chars consumed for first  \uXXXX: 'u' + 4 hex
+const UNICODE_ESCAPE_PAIR_ADV: i32 = 6; // chars consumed for second \uYYYY: '\' + 'u' + 4 hex
+
+// UTF-8 encoding thresholds (exclusive upper bounds per byte-count).
+const UTF8_1BYTE_MAX: i32 = 0x80;     // codepoints < 0x80 encode as 1 byte
+const UTF8_2BYTE_MAX: i32 = 0x800;    // codepoints < 0x800 encode as 2 bytes
+const UTF8_3BYTE_MAX: i32 = 0x10000;  // codepoints < 0x10000 encode as 3 bytes
+
+// Decimal radix used in i64 digit-accumulation loops (integer and float mantissa).
+const DECIMAL_RADIX: i64 = 10;
 
 /// Emit in-place negative-index normalization, mirroring the native oracle
 /// `if i < 0 { len as i64 + i }` (runtime/rs/src/json.rs get/set/remove paths):
@@ -201,7 +281,7 @@ fn compile_value_stringify(emitter: &mut WasmEmitter) {
 
     // Tag 2: int
     wasm!(f, {
-        local_get(1); i32_const(2); i32_eq;
+        local_get(1); i32_const(VTAG_INT); i32_eq;
         if_empty;
           local_get(0); i64_load(4); call(itoa); return_;
         end;
@@ -209,7 +289,7 @@ fn compile_value_stringify(emitter: &mut WasmEmitter) {
 
     // Tag 3: float
     wasm!(f, {
-        local_get(1); i32_const(3); i32_eq;
+        local_get(1); i32_const(VTAG_FLOAT); i32_eq;
         if_empty;
           local_get(0); f64_load(4); call(fdisp); return_;
         end;
@@ -218,7 +298,7 @@ fn compile_value_stringify(emitter: &mut WasmEmitter) {
     // Tag 4: string -> "\"" + escape(s) + "\""
     let escape_fn = emitter.rt.json_escape_string;
     wasm!(f, {
-        local_get(1); i32_const(4); i32_eq;
+        local_get(1); i32_const(VTAG_STRING); i32_eq;
         if_empty;
           i32_const(quote_str as i32);
           local_get(0); i32_load(4); call(escape_fn);
@@ -231,7 +311,7 @@ fn compile_value_stringify(emitter: &mut WasmEmitter) {
 
     // Tag 5: array
     wasm!(f, {
-        local_get(1); i32_const(5); i32_eq;
+        local_get(1); i32_const(VTAG_ARRAY); i32_eq;
         if_empty;
           local_get(0); i32_load(4); local_set(3);
           local_get(3); i32_load(0); local_set(4);
@@ -244,7 +324,7 @@ fn compile_value_stringify(emitter: &mut WasmEmitter) {
           block_empty; loop_empty;
             local_get(5); local_get(4); i32_ge_u; br_if(1);
             local_get(3); i32_const(list_data_off()); i32_add;
-            local_get(5); i32_const(4); i32_mul; i32_add;
+            local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
             i32_load(0); call(stringify_fn); local_set(6);
             local_get(5); i32_const(0); i32_gt_u;
             if_empty;
@@ -260,7 +340,7 @@ fn compile_value_stringify(emitter: &mut WasmEmitter) {
 
     // Tag 6: object
     wasm!(f, {
-        local_get(1); i32_const(6); i32_eq;
+        local_get(1); i32_const(VTAG_OBJECT); i32_eq;
         if_empty;
           local_get(0); i32_load(4); local_set(3);
           local_get(3); i32_load(0); local_set(4);
@@ -274,7 +354,7 @@ fn compile_value_stringify(emitter: &mut WasmEmitter) {
             local_get(5); local_get(4); i32_ge_u; br_if(1);
             // Load tuple pointer: list[8 + i*4] (each list elem is an i32 ptr)
             local_get(3); i32_const(list_data_off()); i32_add;
-            local_get(5); i32_const(4); i32_mul; i32_add;
+            local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
             i32_load(0); // dereference to get tuple ptr
             local_set(6);
             local_get(5); i32_const(0); i32_gt_u;
@@ -345,7 +425,7 @@ fn compile_json_stringify_pretty(emitter: &mut WasmEmitter) {
     // Scalars (tag <= 4): delegate to __value_stringify (byte-identical to
     // compact; native pretty also emits the same scalar text).
     wasm!(f, {
-        local_get(2); i32_const(5); i32_lt_u;
+        local_get(2); i32_const(VTAG_ARRAY); i32_lt_u;
         if_empty;
           local_get(0); call(stringify_fn); return_;
         end;
@@ -359,7 +439,7 @@ fn compile_json_stringify_pretty(emitter: &mut WasmEmitter) {
 
     // Tag 5: array.
     wasm!(f, {
-        local_get(2); i32_const(5); i32_eq;
+        local_get(2); i32_const(VTAG_ARRAY); i32_eq;
         if_empty;
           local_get(0); i32_load(4); local_set(6);
           local_get(6); i32_load(0); local_set(7);
@@ -381,7 +461,7 @@ fn compile_json_stringify_pretty(emitter: &mut WasmEmitter) {
             local_get(3); local_get(5); call(concat); local_set(3);
             // result += pretty(elem, depth+1)
             local_get(6); i32_const(list_data_off()); i32_add;
-            local_get(8); i32_const(4); i32_mul; i32_add;
+            local_get(8); i32_const(I32_BYTES); i32_mul; i32_add;
             i32_load(0);
             local_get(1); i32_const(1); i32_add;
             call(pretty_fn); local_set(9);
@@ -398,7 +478,7 @@ fn compile_json_stringify_pretty(emitter: &mut WasmEmitter) {
 
     // Tag 6: object.
     wasm!(f, {
-        local_get(2); i32_const(6); i32_eq;
+        local_get(2); i32_const(VTAG_OBJECT); i32_eq;
         if_empty;
           local_get(0); i32_load(4); local_set(6);
           local_get(6); i32_load(0); local_set(7);
@@ -412,7 +492,7 @@ fn compile_json_stringify_pretty(emitter: &mut WasmEmitter) {
             local_get(8); local_get(7); i32_ge_u; br_if(1);
             // load tuple ptr [key_str_ptr][value_ptr]
             local_get(6); i32_const(list_data_off()); i32_add;
-            local_get(8); i32_const(4); i32_mul; i32_add;
+            local_get(8); i32_const(I32_BYTES); i32_mul; i32_add;
             i32_load(0); local_set(9);
             local_get(8); i32_const(0); i32_gt_u;
             if_empty;
@@ -459,12 +539,12 @@ fn compile_json_parse(emitter: &mut WasmEmitter) {
         local_get(0); i32_const(0); call(parse_at_fn); local_set(1);
         local_get(1); i32_load(8);
         if_i32;
-          i32_const(8); call(alloc); local_set(2);
+          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(2);
           local_get(2); i32_const(1); i32_store(0);
           local_get(2); local_get(1); i32_load(0); i32_store(4);
           local_get(2);
         else_;
-          i32_const(8); call(alloc); local_set(2);
+          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(2);
           local_get(2); i32_const(0); i32_store(0);
           local_get(2); local_get(1); i32_load(0); i32_store(4);
           local_get(2);
@@ -509,7 +589,7 @@ fn compile_json_parse_at(emitter: &mut WasmEmitter) {
 
     // Allocate result struct (12 bytes)
     wasm!(f, {
-        i32_const(12); call(alloc); local_set(2);
+        i32_const(PARSE_RESULT_SIZE); call(alloc); local_set(2);
         local_get(0); i32_load(0); local_set(3);
     });
 
@@ -535,21 +615,21 @@ fn compile_json_parse_at(emitter: &mut WasmEmitter) {
 
     // ── null: check n,u,l,l ──
     wasm!(f, {
-        local_get(4); i32_const(110); i32_eq; // 'n'
+        local_get(4); i32_const(ASCII_N); i32_eq; // 'n'
         if_empty;
           // Validate remaining chars: u(117), l(108), l(108)
-          local_get(1); i32_const(3); i32_add; local_get(3); i32_lt_u; // need 3 more chars
-          local_get(0); i32_const(string_data_off() + 1); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(117); i32_eq;
+          local_get(1); i32_const(JSON_KW4_LOOKAHEAD); i32_add; local_get(3); i32_lt_u; // need 3 more chars
+          local_get(0); i32_const(string_data_off() + 1); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_U); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 2); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(108); i32_eq;
+          local_get(0); i32_const(string_data_off() + 2); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_L); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 3); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(108); i32_eq;
+          local_get(0); i32_const(string_data_off() + 3); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_L); i32_eq;
           i32_and;
     });
     wasm!(f, {
           if_empty;
-            local_get(1); i32_const(4); i32_add; local_set(1);
-            i32_const(4); call(alloc); local_set(6);
+            local_get(1); i32_const(JSON_KW4_LEN); i32_add; local_set(1);
+            i32_const(I32_BYTES); call(alloc); local_set(6);
             local_get(6); i32_const(0); i32_store(0);
             local_get(2); local_get(6); i32_store(0);
             local_get(2); local_get(1); i32_store(4);
@@ -561,20 +641,20 @@ fn compile_json_parse_at(emitter: &mut WasmEmitter) {
 
     // ── true: check t,r,u,e ──
     wasm!(f, {
-        local_get(4); i32_const(116); i32_eq; // 't'
+        local_get(4); i32_const(ASCII_T); i32_eq; // 't'
         if_empty;
-          local_get(1); i32_const(3); i32_add; local_get(3); i32_lt_u;
-          local_get(0); i32_const(string_data_off() + 1); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(114); i32_eq;
+          local_get(1); i32_const(JSON_KW4_LOOKAHEAD); i32_add; local_get(3); i32_lt_u;
+          local_get(0); i32_const(string_data_off() + 1); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_R); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 2); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(117); i32_eq;
+          local_get(0); i32_const(string_data_off() + 2); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_U); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 3); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(101); i32_eq;
+          local_get(0); i32_const(string_data_off() + 3); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_E_LOWER); i32_eq;
           i32_and;
     });
     wasm!(f, {
           if_empty;
-            local_get(1); i32_const(4); i32_add; local_set(1);
-            i32_const(8); call(alloc); local_set(6);
+            local_get(1); i32_const(JSON_KW4_LEN); i32_add; local_set(1);
+            i32_const(VALUE_BOX_SIZE); call(alloc); local_set(6);
             local_get(6); i32_const(1); i32_store(0);
             local_get(6); i32_const(1); i32_store(4);
             local_get(2); local_get(6); i32_store(0);
@@ -587,22 +667,22 @@ fn compile_json_parse_at(emitter: &mut WasmEmitter) {
 
     // ── false: check f,a,l,s,e ──
     wasm!(f, {
-        local_get(4); i32_const(102); i32_eq; // 'f'
+        local_get(4); i32_const(ASCII_F_LOWER); i32_eq; // 'f'
         if_empty;
-          local_get(1); i32_const(4); i32_add; local_get(3); i32_lt_u;
-          local_get(0); i32_const(string_data_off() + 1); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(97); i32_eq;
+          local_get(1); i32_const(JSON_KW5_LOOKAHEAD); i32_add; local_get(3); i32_lt_u;
+          local_get(0); i32_const(string_data_off() + 1); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_A_LOWER); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 2); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(108); i32_eq;
+          local_get(0); i32_const(string_data_off() + 2); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_L); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 3); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(115); i32_eq;
+          local_get(0); i32_const(string_data_off() + 3); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_S); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 4); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(101); i32_eq;
+          local_get(0); i32_const(string_data_off() + 4); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_E_LOWER); i32_eq;
           i32_and;
     });
     wasm!(f, {
           if_empty;
-            local_get(1); i32_const(5); i32_add; local_set(1);
-            i32_const(8); call(alloc); local_set(6);
+            local_get(1); i32_const(JSON_FALSE_LEN); i32_add; local_set(1);
+            i32_const(VALUE_BOX_SIZE); call(alloc); local_set(6);
             local_get(6); i32_const(1); i32_store(0);
             local_get(6); i32_const(0); i32_store(4);
             local_get(2); local_get(6); i32_store(0);
@@ -650,8 +730,8 @@ fn emit_parse_exponent(f: &mut Function) {
         if_empty;
           local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
           i32_load8_u(0); local_set(4);
-          local_get(4); i32_const(101); i32_eq; // 'e'
-          local_get(4); i32_const(69); i32_eq;  // 'E'
+          local_get(4); i32_const(ASCII_E_LOWER); i32_eq; // 'e'
+          local_get(4); i32_const(ASCII_E_UPPER); i32_eq;  // 'E'
           i32_or;
           if_empty;
             local_get(1); i32_const(1); i32_add; local_set(1);
@@ -661,12 +741,12 @@ fn emit_parse_exponent(f: &mut Function) {
             if_empty;
               local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
               i32_load8_u(0); local_set(4);
-              local_get(4); i32_const(45); i32_eq; // '-'
+              local_get(4); i32_const(ASCII_MINUS); i32_eq; // '-'
               if_empty;
                 i32_const(-1); local_set(7);
                 local_get(1); i32_const(1); i32_add; local_set(1);
               else_;
-                local_get(4); i32_const(43); i32_eq; // '+'
+                local_get(4); i32_const(ASCII_PLUS); i32_eq; // '+'
                 if_empty;
                   local_get(1); i32_const(1); i32_add; local_set(1);
                 end;
@@ -680,10 +760,10 @@ fn emit_parse_exponent(f: &mut Function) {
               local_get(1); local_get(3); i32_ge_u; br_if(1);
               local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
               i32_load8_u(0); local_set(4);
-              local_get(4); i32_const(48); i32_lt_u; br_if(1);
-              local_get(4); i32_const(57); i32_gt_u; br_if(1);
-              local_get(12); i64_const(10); i64_mul;
-              local_get(4); i32_const(48); i32_sub; i64_extend_i32_u;
+              local_get(4); i32_const(ASCII_ZERO); i32_lt_u; br_if(1);
+              local_get(4); i32_const(ASCII_NINE); i32_gt_u; br_if(1);
+              local_get(12); i64_const(DECIMAL_RADIX); i64_mul;
+              local_get(4); i32_const(ASCII_ZERO); i32_sub; i64_extend_i32_u;
               i64_add; local_set(12);
               local_get(1); i32_const(1); i32_add; local_set(1);
               br(0);
@@ -719,10 +799,10 @@ fn emit_skip_ws(f: &mut Function) {
           local_get(1); local_get(3); i32_ge_u; br_if(1);
           local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
           i32_load8_u(0); local_set(4);
-          local_get(4); i32_const(32); i32_eq;
-          local_get(4); i32_const(9); i32_eq; i32_or;
-          local_get(4); i32_const(10); i32_eq; i32_or;
-          local_get(4); i32_const(13); i32_eq; i32_or;
+          local_get(4); i32_const(ASCII_SPACE); i32_eq;
+          local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
+          local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
+          local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
           i32_eqz; br_if(1);
           local_get(1); i32_const(1); i32_add; local_set(1);
           br(0);
@@ -741,13 +821,13 @@ fn emit_parse_hex4(f: &mut Function, off0: i32, target: u32) {
             local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add; local_get(8); i32_add; i32_const(k); i32_add;
             i32_load8_u(0); local_set(11);
             // digit = byte < ':' ? byte - '0' : (byte | 0x20) - ('a' - 10)
-            local_get(11); i32_const(58); i32_lt_u;
+            local_get(11); i32_const(ASCII_COLON); i32_lt_u;
             if_i32;
-              local_get(11); i32_const(48); i32_sub;
+              local_get(11); i32_const(ASCII_ZERO); i32_sub;
             else_;
-              local_get(11); i32_const(32); i32_or; i32_const(87); i32_sub;
+              local_get(11); i32_const(ASCII_LOWER_BIT); i32_or; i32_const(HEX_ALPHA_BIAS); i32_sub;
             end;
-            local_get(target); i32_const(4); i32_shl; i32_add; local_set(target);
+            local_get(target); i32_const(HEX_NIBBLE_SHIFT); i32_shl; i32_add; local_set(target);
         });
     }
 }
@@ -773,45 +853,45 @@ fn emit_utf8_byte(f: &mut Function, shift: i32, mask: i32, high: i32) {
 /// `u`. Mirrors serde_json's `\u` decoding. #651.
 fn emit_unicode_escape_branch(f: &mut Function) {
     wasm!(f, {
-        local_get(4); i32_const(117); i32_eq; // 'u'
+        local_get(4); i32_const(ASCII_U); i32_eq; // 'u'
         if_empty;
     });
     // codepoint (local 10) from the 4 hex following the `u`.
     emit_parse_hex4(f, 1, 10);
-    wasm!(f, { local_get(8); i32_const(5); i32_add; local_set(8); }); // consumed `u` + 4 hex
+    wasm!(f, { local_get(8); i32_const(UNICODE_ESCAPE_LEN); i32_add; local_set(8); }); // consumed `u` + 4 hex
     // Surrogate pair: a high surrogate (D800..DBFF) immediately followed by a
     // "\uYYYY" low surrogate (DC00..DFFF) forms one astral codepoint.
     wasm!(f, {
-        local_get(10); i32_const(0xD800); i32_ge_u;
-        local_get(10); i32_const(0xDBFF); i32_le_u;
+        local_get(10); i32_const(SURR_HIGH_START); i32_ge_u;
+        local_get(10); i32_const(SURR_HIGH_END); i32_le_u;
         i32_and;
         if_empty;
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add; local_get(8); i32_add; i32_load8_u(0); i32_const(92); i32_eq;
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add; local_get(8); i32_add; i32_const(1); i32_add; i32_load8_u(0); i32_const(117); i32_eq;
+          local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add; local_get(8); i32_add; i32_load8_u(0); i32_const(ASCII_BACKSLASH); i32_eq;
+          local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add; local_get(8); i32_add; i32_const(1); i32_add; i32_load8_u(0); i32_const(ASCII_U); i32_eq;
           i32_and;
           if_empty;
     });
     emit_parse_hex4(f, 2, 14); // low surrogate → local 14
     wasm!(f, {
-            local_get(14); i32_const(0xDC00); i32_ge_u;
-            local_get(14); i32_const(0xDFFF); i32_le_u;
+            local_get(14); i32_const(SURR_LOW_START); i32_ge_u;
+            local_get(14); i32_const(SURR_LOW_END); i32_le_u;
             i32_and;
             if_empty;
-              local_get(10); i32_const(0xD800); i32_sub; i32_const(10); i32_shl;
-              local_get(14); i32_const(0xDC00); i32_sub; i32_add;
-              i32_const(0x10000); i32_add; local_set(10);
-              local_get(8); i32_const(6); i32_add; local_set(8); // consumed "\uYYYY"
+              local_get(10); i32_const(SURR_HIGH_START); i32_sub; i32_const(SURR_HIGH_SHIFT); i32_shl;
+              local_get(14); i32_const(SURR_LOW_START); i32_sub; i32_add;
+              i32_const(SURR_PAIR_BASE); i32_add; local_set(10);
+              local_get(8); i32_const(UNICODE_ESCAPE_PAIR_ADV); i32_add; local_set(8); // consumed "\uYYYY"
             end;
           end;
         end;
     });
     // UTF-8 encode cp(10): 1 byte (<0x80), 2 (<0x800), 3 (<0x10000), else 4.
-    wasm!(f, { local_get(10); i32_const(0x80); i32_lt_u; if_empty; });
+    wasm!(f, { local_get(10); i32_const(UTF8_1BYTE_MAX); i32_lt_u; if_empty; });
     emit_utf8_byte(f, 0, 0x7F, 0x00);
-    wasm!(f, { else_; local_get(10); i32_const(0x800); i32_lt_u; if_empty; });
+    wasm!(f, { else_; local_get(10); i32_const(UTF8_2BYTE_MAX); i32_lt_u; if_empty; });
     emit_utf8_byte(f, 6, 0x1F, 0xC0);
     emit_utf8_byte(f, 0, 0x3F, 0x80);
-    wasm!(f, { else_; local_get(10); i32_const(0x10000); i32_lt_u; if_empty; });
+    wasm!(f, { else_; local_get(10); i32_const(UTF8_3BYTE_MAX); i32_lt_u; if_empty; });
     emit_utf8_byte(f, 12, 0x0F, 0xE0);
     emit_utf8_byte(f, 6, 0x3F, 0x80);
     emit_utf8_byte(f, 0, 0x3F, 0x80);
@@ -831,7 +911,7 @@ fn emit_unicode_escape_branch(f: &mut Function) {
 /// Uses locals: 0=str_ptr, 1=pos, 2=result_ptr, 3=str_len, 4=ch, 5=start, 6=value_ptr, 7=tmp, 9=count
 fn emit_parse_string(f: &mut Function, alloc: u32, string_alloc: u32) {
     wasm!(f, {
-        local_get(4); i32_const(34); i32_eq;
+        local_get(4); i32_const(ASCII_DQUOTE); i32_eq;
         if_empty;
           local_get(1); i32_const(1); i32_add; local_set(1);
           local_get(1); local_set(5);
@@ -842,8 +922,8 @@ fn emit_parse_string(f: &mut Function, alloc: u32, string_alloc: u32) {
             local_get(1); local_get(3); i32_ge_u; br_if(1);
             local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
             i32_load8_u(0); local_set(7);
-            local_get(7); i32_const(34); i32_eq; br_if(1);
-            local_get(7); i32_const(92); i32_eq;
+            local_get(7); i32_const(ASCII_DQUOTE); i32_eq; br_if(1);
+            local_get(7); i32_const(ASCII_BACKSLASH); i32_eq;
             if_empty;
               local_get(1); i32_const(1); i32_add; local_set(1);
             end;
@@ -869,7 +949,7 @@ fn emit_parse_string(f: &mut Function, alloc: u32, string_alloc: u32) {
             local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add; local_get(8); i32_add;
             i32_load8_u(0); local_set(4);
             // if byte == 0x5C (backslash): decode next byte
-            local_get(4); i32_const(92); i32_eq;
+            local_get(4); i32_const(ASCII_BACKSLASH); i32_eq;
             if_empty;
               // advance read past backslash
               local_get(8); i32_const(1); i32_add; local_set(8);
@@ -886,11 +966,11 @@ fn emit_parse_string(f: &mut Function, alloc: u32, string_alloc: u32) {
               // Decoded values (8,9,10,12,13) and idempotent ones (34,47,92) don't
               // collide with the source codes for other escapes (110,116,114,98,102),
               // so a sequential pass is safe.
-              local_get(4); i32_const(110); i32_eq; if_empty; i32_const(10); local_set(4); end;  // n
-              local_get(4); i32_const(116); i32_eq; if_empty; i32_const(9);  local_set(4); end;  // t
-              local_get(4); i32_const(114); i32_eq; if_empty; i32_const(13); local_set(4); end;  // r
-              local_get(4); i32_const(98);  i32_eq; if_empty; i32_const(8);  local_set(4); end;  // b
-              local_get(4); i32_const(102); i32_eq; if_empty; i32_const(12); local_set(4); end;  // f
+              local_get(4); i32_const(ASCII_N); i32_eq; if_empty; i32_const(ASCII_LF); local_set(4); end;  // n
+              local_get(4); i32_const(ASCII_T); i32_eq; if_empty; i32_const(ASCII_HT);  local_set(4); end;  // t
+              local_get(4); i32_const(ASCII_R); i32_eq; if_empty; i32_const(ASCII_CR); local_set(4); end;  // r
+              local_get(4); i32_const(ASCII_B);  i32_eq; if_empty; i32_const(ASCII_BS);  local_set(4); end;  // b
+              local_get(4); i32_const(ASCII_F_LOWER); i32_eq; if_empty; i32_const(ASCII_FF); local_set(4); end;  // f
               // ", \, /  decode to themselves — no rewrite needed.
             end;
             // out[out_base + write_off] = byte
@@ -906,8 +986,8 @@ fn emit_parse_string(f: &mut Function, alloc: u32, string_alloc: u32) {
     wasm!(f, {
           local_get(6); local_get(9); i32_store(0);
           local_get(1); i32_const(1); i32_add; local_set(1);
-          i32_const(8); call(alloc); local_set(7);
-          local_get(7); i32_const(4); i32_store(0);
+          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(7);
+          local_get(7); i32_const(VTAG_STRING); i32_store(0);
           local_get(7); local_get(6); i32_store(4);
           local_get(2); local_get(7); i32_store(0);
           local_get(2); local_get(1); i32_store(4);
@@ -922,9 +1002,9 @@ fn emit_parse_string(f: &mut Function, alloc: u32, string_alloc: u32) {
 fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: u32) {
     // Check if number
     wasm!(f, {
-        local_get(4); i32_const(45); i32_eq;
-        local_get(4); i32_const(48); i32_ge_u;
-        local_get(4); i32_const(57); i32_le_u;
+        local_get(4); i32_const(ASCII_MINUS); i32_eq;
+        local_get(4); i32_const(ASCII_ZERO); i32_ge_u;
+        local_get(4); i32_const(ASCII_NINE); i32_le_u;
         i32_and; i32_or;
         if_empty;
           // Save the token start (incl. a leading '-') so a float token can be
@@ -932,7 +1012,7 @@ fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: 
           local_get(1); local_set(5);
           i32_const(1); local_set(11);
           i64_const(0); local_set(12);
-          local_get(4); i32_const(45); i32_eq;
+          local_get(4); i32_const(ASCII_MINUS); i32_eq;
           if_empty;
             i32_const(-1); local_set(11);
             local_get(1); i32_const(1); i32_add; local_set(1);
@@ -944,10 +1024,10 @@ fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: 
             local_get(1); local_get(3); i32_ge_u; br_if(1);
             local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
             i32_load8_u(0); local_set(4);
-            local_get(4); i32_const(48); i32_lt_u; br_if(1);
-            local_get(4); i32_const(57); i32_gt_u; br_if(1);
-            local_get(12); i64_const(10); i64_mul;
-            local_get(4); i32_const(48); i32_sub; i64_extend_i32_u;
+            local_get(4); i32_const(ASCII_ZERO); i32_lt_u; br_if(1);
+            local_get(4); i32_const(ASCII_NINE); i32_gt_u; br_if(1);
+            local_get(12); i64_const(DECIMAL_RADIX); i64_mul;
+            local_get(4); i32_const(ASCII_ZERO); i32_sub; i64_extend_i32_u;
             i64_add; local_set(12);
             local_get(1); i32_const(1); i32_add; local_set(1);
             br(0);
@@ -958,7 +1038,7 @@ fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: 
           local_get(1); local_get(3); i32_lt_u;
           if_empty;
             local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); i32_const(46); i32_eq;
+            i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
             if_empty;
               local_get(1); i32_const(1); i32_add; local_set(1);
               f64_const(1.0); local_set(13);
@@ -969,10 +1049,10 @@ fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: 
                 local_get(1); local_get(3); i32_ge_u; br_if(1);
                 local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
                 i32_load8_u(0); local_set(4);
-                local_get(4); i32_const(48); i32_lt_u; br_if(1);
-                local_get(4); i32_const(57); i32_gt_u; br_if(1);
-                local_get(12); i64_const(10); i64_mul;
-                local_get(4); i32_const(48); i32_sub; i64_extend_i32_u;
+                local_get(4); i32_const(ASCII_ZERO); i32_lt_u; br_if(1);
+                local_get(4); i32_const(ASCII_NINE); i32_gt_u; br_if(1);
+                local_get(12); i64_const(DECIMAL_RADIX); i64_mul;
+                local_get(4); i32_const(ASCII_ZERO); i32_sub; i64_extend_i32_u;
                 i64_add; local_set(12);
                 local_get(13); f64_const(10.0); f64_mul; local_set(13);
                 local_get(1); i32_const(1); i32_add; local_set(1);
@@ -989,8 +1069,8 @@ fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: 
               drop;
               local_get(0); local_get(5); local_get(1); call(str_slice);
               call(float_parse); local_set(7); // Result[Float, String] ptr; valid JSON ⇒ ok
-              i32_const(12); call(alloc); local_set(6);
-              local_get(6); i32_const(3); i32_store(0);
+              i32_const(PARSE_RESULT_SIZE); call(alloc); local_set(6);
+              local_get(6); i32_const(VTAG_FLOAT); i32_store(0);
               local_get(6); local_get(7); f64_load(4); f64_store(4);
               local_get(2); local_get(6); i32_store(0);
               local_get(2); local_get(1); i32_store(4);
@@ -1006,8 +1086,8 @@ fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: 
           if_empty;
             local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
             i32_load8_u(0); local_set(4);
-            local_get(4); i32_const(101); i32_eq; // 'e'
-            local_get(4); i32_const(69); i32_eq;  // 'E'
+            local_get(4); i32_const(ASCII_E_LOWER); i32_eq; // 'e'
+            local_get(4); i32_const(ASCII_E_UPPER); i32_eq;  // 'E'
             i32_or;
             if_empty;
               // Integer mantissa with an exponent suffix → a float. Re-parse the
@@ -1018,8 +1098,8 @@ fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: 
               drop;
               local_get(0); local_get(5); local_get(1); call(str_slice);
               call(float_parse); local_set(7);
-              i32_const(12); call(alloc); local_set(6);
-              local_get(6); i32_const(3); i32_store(0);
+              i32_const(PARSE_RESULT_SIZE); call(alloc); local_set(6);
+              local_get(6); i32_const(VTAG_FLOAT); i32_store(0);
               local_get(6); local_get(7); f64_load(4); f64_store(4);
               local_get(2); local_get(6); i32_store(0);
               local_get(2); local_get(1); i32_store(4);
@@ -1030,8 +1110,8 @@ fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: 
     });
     // Build int Value (no exponent)
     wasm!(f, {
-          i32_const(12); call(alloc); local_set(6);
-          local_get(6); i32_const(2); i32_store(0);
+          i32_const(PARSE_RESULT_SIZE); call(alloc); local_set(6);
+          local_get(6); i32_const(VTAG_INT); i32_store(0);
           local_get(6);
           local_get(11); i64_extend_i32_s; local_get(12); i64_mul;
           i64_store(4);
@@ -1046,7 +1126,7 @@ fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: 
 /// Parse JSON array.
 fn emit_parse_array(f: &mut Function, alloc: u32, parse_at_fn: u32) {
     wasm!(f, {
-        local_get(4); i32_const(91); i32_eq;
+        local_get(4); i32_const(ASCII_LBRACKET); i32_eq;
         if_empty;
           local_get(1); i32_const(1); i32_add; local_set(1);
     });
@@ -1056,10 +1136,10 @@ fn emit_parse_array(f: &mut Function, alloc: u32, parse_at_fn: u32) {
             local_get(1); local_get(3); i32_ge_u; br_if(1);
             local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
             i32_load8_u(0); local_set(4);
-            local_get(4); i32_const(32); i32_eq;
-            local_get(4); i32_const(9); i32_eq; i32_or;
-            local_get(4); i32_const(10); i32_eq; i32_or;
-            local_get(4); i32_const(13); i32_eq; i32_or;
+            local_get(4); i32_const(ASCII_SPACE); i32_eq;
+            local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
+            local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
+            local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
             i32_eqz; br_if(1);
             local_get(1); i32_const(1); i32_add; local_set(1);
             br(0);
@@ -1070,13 +1150,13 @@ fn emit_parse_array(f: &mut Function, alloc: u32, parse_at_fn: u32) {
           local_get(1); local_get(3); i32_lt_u;
           if_empty;
             local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); i32_const(93); i32_eq;
+            i32_load8_u(0); i32_const(ASCII_RBRACKET); i32_eq;
             if_empty;
               local_get(1); i32_const(1); i32_add; local_set(1);
               i32_const(list_hdr()); call(alloc); local_set(8);
               local_get(8); i32_const(0); i32_store(0);
-              i32_const(8); call(alloc); local_set(6);
-              local_get(6); i32_const(5); i32_store(0);
+              i32_const(VALUE_BOX_SIZE); call(alloc); local_set(6);
+              local_get(6); i32_const(VTAG_ARRAY); i32_store(0);
               local_get(6); local_get(8); i32_store(4);
               local_get(2); local_get(6); i32_store(0);
               local_get(2); local_get(1); i32_store(4);
@@ -1087,8 +1167,8 @@ fn emit_parse_array(f: &mut Function, alloc: u32, parse_at_fn: u32) {
     });
     // Parse elements — growable buffer (local 14 = capacity)
     wasm!(f, {
-          i32_const(64); local_set(14); // initial capacity
-          i32_const(264); call(alloc); local_set(8); // 8 + 64*4
+          i32_const(INIT_CAPACITY); local_set(14); // initial capacity
+          i32_const(INIT_BUF_BYTES); call(alloc); local_set(8); // list_hdr + INIT_CAPACITY*4
           i32_const(0); local_set(9); // count = 0
           block_empty; loop_empty;
             local_get(0); local_get(1);
@@ -1107,16 +1187,16 @@ fn emit_parse_array(f: &mut Function, alloc: u32, parse_at_fn: u32) {
             if_empty;
               local_get(8); local_set(15); // save old buf
               local_get(14); i32_const(1); i32_shl; local_set(14); // cap *= 2
-              i32_const(list_hdr()); local_get(14); i32_const(4); i32_mul; i32_add;
+              i32_const(list_hdr()); local_get(14); i32_const(I32_BYTES); i32_mul; i32_add;
               call(alloc); local_set(8); // new buf → local 8
               local_get(8); local_get(15);
-              i32_const(list_hdr()); local_get(9); i32_const(4); i32_mul; i32_add;
+              i32_const(list_hdr()); local_get(9); i32_const(I32_BYTES); i32_mul; i32_add;
               memory_copy;
             end;
     });
     wasm!(f, {
             local_get(8); i32_const(list_data_off()); i32_add;
-            local_get(9); i32_const(4); i32_mul; i32_add;
+            local_get(9); i32_const(I32_BYTES); i32_mul; i32_add;
             local_get(10); i32_load(0); i32_store(0);
             local_get(10); i32_load(4); local_set(1);
             local_get(9); i32_const(1); i32_add; local_set(9);
@@ -1127,10 +1207,10 @@ fn emit_parse_array(f: &mut Function, alloc: u32, parse_at_fn: u32) {
               local_get(1); local_get(3); i32_ge_u; br_if(1);
               local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
               i32_load8_u(0); local_set(4);
-              local_get(4); i32_const(32); i32_eq;
-              local_get(4); i32_const(9); i32_eq; i32_or;
-              local_get(4); i32_const(10); i32_eq; i32_or;
-              local_get(4); i32_const(13); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_SPACE); i32_eq;
+              local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
               i32_eqz; br_if(1);
               local_get(1); i32_const(1); i32_add; local_set(1);
               br(0);
@@ -1141,12 +1221,12 @@ fn emit_parse_array(f: &mut Function, alloc: u32, parse_at_fn: u32) {
             local_get(1); local_get(3); i32_ge_u; br_if(1);
             local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
             i32_load8_u(0); local_set(4);
-            local_get(4); i32_const(93); i32_eq;
+            local_get(4); i32_const(ASCII_RBRACKET); i32_eq;
             if_empty;
               local_get(1); i32_const(1); i32_add; local_set(1);
               br(2);
             end;
-            local_get(4); i32_const(44); i32_eq;
+            local_get(4); i32_const(ASCII_COMMA); i32_eq;
             if_empty;
               local_get(1); i32_const(1); i32_add; local_set(1);
             end;
@@ -1156,8 +1236,8 @@ fn emit_parse_array(f: &mut Function, alloc: u32, parse_at_fn: u32) {
     // Build result
     wasm!(f, {
           local_get(8); local_get(9); i32_store(0);
-          i32_const(8); call(alloc); local_set(6);
-          local_get(6); i32_const(5); i32_store(0);
+          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(6);
+          local_get(6); i32_const(VTAG_ARRAY); i32_store(0);
           local_get(6); local_get(8); i32_store(4);
           local_get(2); local_get(6); i32_store(0);
           local_get(2); local_get(1); i32_store(4);
@@ -1170,7 +1250,7 @@ fn emit_parse_array(f: &mut Function, alloc: u32, parse_at_fn: u32) {
 /// Parse JSON object.
 fn emit_parse_object(f: &mut Function, alloc: u32, parse_at_fn: u32) {
     wasm!(f, {
-        local_get(4); i32_const(123); i32_eq;
+        local_get(4); i32_const(ASCII_LBRACE); i32_eq;
         if_empty;
           local_get(1); i32_const(1); i32_add; local_set(1);
     });
@@ -1180,10 +1260,10 @@ fn emit_parse_object(f: &mut Function, alloc: u32, parse_at_fn: u32) {
             local_get(1); local_get(3); i32_ge_u; br_if(1);
             local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
             i32_load8_u(0); local_set(4);
-            local_get(4); i32_const(32); i32_eq;
-            local_get(4); i32_const(9); i32_eq; i32_or;
-            local_get(4); i32_const(10); i32_eq; i32_or;
-            local_get(4); i32_const(13); i32_eq; i32_or;
+            local_get(4); i32_const(ASCII_SPACE); i32_eq;
+            local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
+            local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
+            local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
             i32_eqz; br_if(1);
             local_get(1); i32_const(1); i32_add; local_set(1);
             br(0);
@@ -1194,13 +1274,13 @@ fn emit_parse_object(f: &mut Function, alloc: u32, parse_at_fn: u32) {
           local_get(1); local_get(3); i32_lt_u;
           if_empty;
             local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); i32_const(125); i32_eq;
+            i32_load8_u(0); i32_const(ASCII_RBRACE); i32_eq;
             if_empty;
               local_get(1); i32_const(1); i32_add; local_set(1);
               i32_const(list_hdr()); call(alloc); local_set(8);
               local_get(8); i32_const(0); i32_store(0);
-              i32_const(8); call(alloc); local_set(6);
-              local_get(6); i32_const(6); i32_store(0);
+              i32_const(VALUE_BOX_SIZE); call(alloc); local_set(6);
+              local_get(6); i32_const(VTAG_OBJECT); i32_store(0);
               local_get(6); local_get(8); i32_store(4);
               local_get(2); local_get(6); i32_store(0);
               local_get(2); local_get(1); i32_store(4);
@@ -1211,8 +1291,8 @@ fn emit_parse_object(f: &mut Function, alloc: u32, parse_at_fn: u32) {
     });
     // Parse key-value pairs — growable buffer (local 14 = capacity)
     wasm!(f, {
-          i32_const(64); local_set(14); // initial capacity
-          i32_const(264); call(alloc); local_set(8); // 8 + 64*4
+          i32_const(INIT_CAPACITY); local_set(14); // initial capacity
+          i32_const(INIT_BUF_BYTES); call(alloc); local_set(8); // list_hdr + INIT_CAPACITY*4
           i32_const(0); local_set(9);
           block_empty; loop_empty;
     });
@@ -1222,10 +1302,10 @@ fn emit_parse_object(f: &mut Function, alloc: u32, parse_at_fn: u32) {
               local_get(1); local_get(3); i32_ge_u; br_if(1);
               local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
               i32_load8_u(0); local_set(4);
-              local_get(4); i32_const(32); i32_eq;
-              local_get(4); i32_const(9); i32_eq; i32_or;
-              local_get(4); i32_const(10); i32_eq; i32_or;
-              local_get(4); i32_const(13); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_SPACE); i32_eq;
+              local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
               i32_eqz; br_if(1);
               local_get(1); i32_const(1); i32_add; local_set(1);
               br(0);
@@ -1251,11 +1331,11 @@ fn emit_parse_object(f: &mut Function, alloc: u32, parse_at_fn: u32) {
               local_get(1); local_get(3); i32_ge_u; br_if(1);
               local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
               i32_load8_u(0); local_set(4);
-              local_get(4); i32_const(32); i32_eq;
-              local_get(4); i32_const(9); i32_eq; i32_or;
-              local_get(4); i32_const(10); i32_eq; i32_or;
-              local_get(4); i32_const(13); i32_eq; i32_or;
-              local_get(4); i32_const(58); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_SPACE); i32_eq;
+              local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_COLON); i32_eq; i32_or;
               i32_eqz; br_if(1);
               local_get(1); i32_const(1); i32_add; local_set(1);
               br(0);
@@ -1279,22 +1359,22 @@ fn emit_parse_object(f: &mut Function, alloc: u32, parse_at_fn: u32) {
             if_empty;
               local_get(8); local_set(15); // save old buf
               local_get(14); i32_const(1); i32_shl; local_set(14); // cap *= 2
-              i32_const(list_hdr()); local_get(14); i32_const(4); i32_mul; i32_add;
+              i32_const(list_hdr()); local_get(14); i32_const(I32_BYTES); i32_mul; i32_add;
               call(alloc); local_set(8); // new buf
               local_get(8); local_get(15);
-              i32_const(list_hdr()); local_get(9); i32_const(4); i32_mul; i32_add;
+              i32_const(list_hdr()); local_get(9); i32_const(I32_BYTES); i32_mul; i32_add;
               memory_copy;
             end;
     });
     // Allocate tuple (key_str_ptr, value_ptr) and store pointer in list
     wasm!(f, {
-            // Allocate 8-byte tuple: [key_str_ptr: i32][value_ptr: i32]
-            i32_const(8); call(alloc); local_set(5); // reuse local 5 as tuple_ptr
+            // Allocate VALUE_BOX_SIZE tuple: [key_str_ptr: i32][value_ptr: i32]
+            i32_const(VALUE_BOX_SIZE); call(alloc); local_set(5); // reuse local 5 as tuple_ptr
             local_get(5); local_get(7); i32_store(0); // key
             local_get(5); local_get(10); i32_load(0); i32_store(4); // value
             // Store tuple pointer in list at position count
             local_get(8); i32_const(list_data_off()); i32_add;
-            local_get(9); i32_const(4); i32_mul; i32_add;
+            local_get(9); i32_const(I32_BYTES); i32_mul; i32_add;
             local_get(5); i32_store(0);
             local_get(10); i32_load(4); local_set(1);
             local_get(9); i32_const(1); i32_add; local_set(9);
@@ -1305,10 +1385,10 @@ fn emit_parse_object(f: &mut Function, alloc: u32, parse_at_fn: u32) {
               local_get(1); local_get(3); i32_ge_u; br_if(1);
               local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
               i32_load8_u(0); local_set(4);
-              local_get(4); i32_const(32); i32_eq;
-              local_get(4); i32_const(9); i32_eq; i32_or;
-              local_get(4); i32_const(10); i32_eq; i32_or;
-              local_get(4); i32_const(13); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_SPACE); i32_eq;
+              local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
+              local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
               i32_eqz; br_if(1);
               local_get(1); i32_const(1); i32_add; local_set(1);
               br(0);
@@ -1319,12 +1399,12 @@ fn emit_parse_object(f: &mut Function, alloc: u32, parse_at_fn: u32) {
             local_get(1); local_get(3); i32_ge_u; br_if(1);
             local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
             i32_load8_u(0); local_set(4);
-            local_get(4); i32_const(125); i32_eq;
+            local_get(4); i32_const(ASCII_RBRACE); i32_eq;
             if_empty;
               local_get(1); i32_const(1); i32_add; local_set(1);
               br(2);
             end;
-            local_get(4); i32_const(44); i32_eq;
+            local_get(4); i32_const(ASCII_COMMA); i32_eq;
             if_empty;
               local_get(1); i32_const(1); i32_add; local_set(1);
             end;
@@ -1334,8 +1414,8 @@ fn emit_parse_object(f: &mut Function, alloc: u32, parse_at_fn: u32) {
     // Build object result
     wasm!(f, {
           local_get(8); local_get(9); i32_store(0);
-          i32_const(8); call(alloc); local_set(6);
-          local_get(6); i32_const(6); i32_store(0);
+          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(6);
+          local_get(6); i32_const(VTAG_OBJECT); i32_store(0);
           local_get(6); local_get(8); i32_store(4);
           local_get(2); local_get(6); i32_store(0);
           local_get(2); local_get(1); i32_store(4);
@@ -1385,24 +1465,24 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
     });
 
     // --- Phase 2: Allocate segments array and fill in reverse ---
-    // segs_arr = alloc(seg_count * 4), each slot is a path node ptr.
+    // segs_arr = alloc(seg_count * I32_BYTES), each slot is a path node ptr.
     wasm!(f, {
         local_get(2); i32_eqz;
         if_empty;
           // Empty path → return some(value): alloc option box.
           // SHARE: the box holds a second reference to the input tree.
-          i32_const(4); call(alloc); local_set(13);
+          i32_const(I32_BYTES); call(alloc); local_set(13);
           local_get(13); local_get(0); call(emitter.rt.rc_inc); i32_store(0);
           local_get(13);
           return_;
         end;
-        local_get(2); i32_const(4); i32_mul; call(alloc); local_set(4); // segs_arr
+        local_get(2); i32_const(I32_BYTES); i32_mul; call(alloc); local_set(4); // segs_arr
         local_get(2); local_set(5); // i = seg_count (fill from end)
         local_get(1); local_set(3); // cur_path = path (start from leaf)
         block_empty; loop_empty;
           local_get(3); i32_load(0); i32_eqz; br_if(1); // root → done
           local_get(5); i32_const(1); i32_sub; local_set(5); // i--
-          local_get(4); local_get(5); i32_const(4); i32_mul; i32_add;
+          local_get(4); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
           local_get(3); i32_store(0); // segs_arr[i] = cur_path
           local_get(3); i32_load(4); local_set(3); // cur_path = parent
           br(0);
@@ -1417,17 +1497,17 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
         block_empty; loop_empty;
           local_get(5); local_get(2); i32_ge_u; br_if(1); // i >= seg_count → done
           // Load segment
-          local_get(4); local_get(5); i32_const(4); i32_mul; i32_add;
+          local_get(4); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
           i32_load(0); local_set(6); // seg_ptr
           local_get(6); i32_load(0); local_set(7); // seg_tag
     });
 
     // --- Field segment (tag=1) ---
     wasm!(f, {
-          local_get(7); i32_const(1); i32_eq;
+          local_get(7); i32_const(JP_FIELD_TAG); i32_eq;
           if_empty;
             // cur_val must be object (tag=6)
-            local_get(8); i32_load(0); i32_const(6); i32_ne;
+            local_get(8); i32_load(0); i32_const(VTAG_OBJECT); i32_ne;
             if_empty; i32_const(0); return_; end; // not object → none
             local_get(8); i32_load(4); local_set(9); // list (pairs)
             local_get(9); i32_load(0); local_set(10); // len
@@ -1436,7 +1516,7 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
             block_empty; loop_empty;
               local_get(11); local_get(10); i32_ge_u; br_if(1);
               local_get(9); i32_const(list_data_off()); i32_add;
-              local_get(11); i32_const(4); i32_mul; i32_add;
+              local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
               i32_load(0); local_set(12); // pair_ptr
               local_get(12); i32_load(0); // pair key
               local_get(6); i32_load(8); // segment field name
@@ -1456,7 +1536,7 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
 
     // --- Index segment (tag=2) ---
     wasm!(f, {
-          local_get(7); i32_const(2); i32_eq;
+          local_get(7); i32_const(JP_INDEX_TAG); i32_eq;
           if_empty;
             // cur_val must be array (tag=5)
             local_get(8); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
@@ -1474,7 +1554,7 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
             if_empty; i32_const(0); return_; end; // out of bounds → none
             // cur_val = list[index]
             local_get(9); i32_const(list_data_off()); i32_add;
-            local_get(11); i32_const(4); i32_mul; i32_add;
+            local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
             i32_load(0); local_set(8);
           end;
     });
@@ -1489,7 +1569,7 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
     // --- Return some(cur_val): alloc Option box ---
     // SHARE: cur_val is an interior pointer into the surviving input tree.
     wasm!(f, {
-        i32_const(4); call(alloc); local_set(13);
+        i32_const(I32_BYTES); call(alloc); local_set(13);
         local_get(13); local_get(8); call(emitter.rt.rc_inc); i32_store(0);
         local_get(13);
         end;
@@ -1536,19 +1616,19 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
         local_get(3); i32_eqz;
         if_empty;
           // Empty path → ok(new_val)
-          i32_const(8); call(alloc); local_set(14);
+          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(14);
           local_get(14); i32_const(0); i32_store(0);
           local_get(14); local_get(2); i32_store(4);
           local_get(14);
           return_;
         end;
-        local_get(3); i32_const(4); i32_mul; call(alloc); local_set(5);
+        local_get(3); i32_const(I32_BYTES); i32_mul; call(alloc); local_set(5);
         local_get(3); local_set(6);
         local_get(1); local_set(4);
         block_empty; loop_empty;
           local_get(4); i32_load(0); i32_eqz; br_if(1);
           local_get(6); i32_const(1); i32_sub; local_set(6);
-          local_get(5); local_get(6); i32_const(4); i32_mul; i32_add;
+          local_get(5); local_get(6); i32_const(I32_BYTES); i32_mul; i32_add;
           local_get(4); i32_store(0);
           local_get(4); i32_load(4); local_set(4);
           br(0);
@@ -1556,19 +1636,19 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
     });
 
     // --- Phase 3: Walk forward saving values at each depth ---
-    // val_stack = alloc((seg_count+1) * 4): val_stack[d] = value at depth d
+    // val_stack = alloc((seg_count+1) * I32_BYTES): val_stack[d] = value at depth d
     wasm!(f, {
-        local_get(3); i32_const(1); i32_add; i32_const(4); i32_mul;
+        local_get(3); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul;
         call(alloc); local_set(16); // val_stack
         local_get(16); local_get(0); i32_store(0); // val_stack[0] = value
         i32_const(0); local_set(6); // depth = 0
         block_empty; loop_empty;
           local_get(6); local_get(3); i32_const(1); i32_sub; i32_ge_u; br_if(1); // depth >= seg_count-1 → done
-          local_get(5); local_get(6); i32_const(4); i32_mul; i32_add;
+          local_get(5); local_get(6); i32_const(I32_BYTES); i32_mul; i32_add;
           i32_load(0); local_set(7); // seg_ptr = segs_arr[depth]
           local_get(7); i32_load(0); local_set(8); // seg_tag
           // Load cur_val from val_stack[depth]
-          local_get(16); local_get(6); i32_const(4); i32_mul; i32_add;
+          local_get(16); local_get(6); i32_const(I32_BYTES); i32_mul; i32_add;
           i32_load(0); local_set(9);
     });
 
@@ -1583,7 +1663,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
     // never an Err. The prior `path error: expected object` Err diverged: native
     // autovivifies here instead of failing.
     wasm!(f, {
-          local_get(8); i32_const(1); i32_eq;
+          local_get(8); i32_const(JP_FIELD_TAG); i32_eq;
           if_empty;
             i32_const(0); local_set(17); // found = 0
             // Only scan pairs when cur_val is actually an object; otherwise it
@@ -1596,13 +1676,13 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
               block_empty; loop_empty;
                 local_get(12); local_get(11); i32_ge_u; br_if(1);
                 local_get(10); i32_const(list_data_off()); i32_add;
-                local_get(12); i32_const(4); i32_mul; i32_add;
+                local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
                 i32_load(0); local_set(13); // pair
                 local_get(13); i32_load(0);
                 local_get(7); i32_load(8);
                 call(str_eq);
                 if_empty;
-                  local_get(16); local_get(6); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+                  local_get(16); local_get(6); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul; i32_add;
                   local_get(13); i32_load(4); i32_store(0);
                   i32_const(1); local_set(17);
                   br(2);
@@ -1618,7 +1698,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
     });
     emit_make_empty_object(&mut f, 17, alloc);
     wasm!(f, {
-              local_get(16); local_get(6); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+              local_get(16); local_get(6); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul; i32_add;
               local_get(17); i32_store(0);
             end;
           end;
@@ -1639,12 +1719,12 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
         // val_stack[depth+1] = {}  (don't-care value; rebuild discards it here)
         emit_make_empty_object(f, 17, alloc);
         wasm!(f, {
-            local_get(16); local_get(6); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+            local_get(16); local_get(6); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul; i32_add;
             local_get(17); i32_store(0);
         });
     };
     wasm!(f, {
-          local_get(8); i32_const(2); i32_eq;
+          local_get(8); i32_const(JP_INDEX_TAG); i32_eq;
           if_empty;
             local_get(9); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
             if_empty;
@@ -1666,9 +1746,9 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
     emit_index_noop_placeholder(&mut f);
     wasm!(f, {
             else_;
-            local_get(16); local_get(6); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+            local_get(16); local_get(6); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul; i32_add;
             local_get(10); i32_const(list_data_off()); i32_add;
-            local_get(18); i32_const(4); i32_mul; i32_add;
+            local_get(18); i32_const(I32_BYTES); i32_mul; i32_add;
             i32_load(0); i32_store(0);
             end;
             end;
@@ -1689,17 +1769,17 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
         local_get(3); i32_const(1); i32_sub; local_set(6); // depth = seg_count - 1
         block_empty; loop_empty;
           local_get(6); i32_const(0); i32_lt_s; br_if(1);
-          local_get(5); local_get(6); i32_const(4); i32_mul; i32_add;
+          local_get(5); local_get(6); i32_const(I32_BYTES); i32_mul; i32_add;
           i32_load(0); local_set(7); // seg
           local_get(7); i32_load(0); local_set(8); // seg_tag
           // orig_val at this depth
-          local_get(16); local_get(6); i32_const(4); i32_mul; i32_add;
+          local_get(16); local_get(6); i32_const(I32_BYTES); i32_mul; i32_add;
           i32_load(0); local_set(14);
     });
 
     // Rebuild for field segment
     wasm!(f, {
-          local_get(8); i32_const(1); i32_eq;
+          local_get(8); i32_const(JP_FIELD_TAG); i32_eq;
           if_empty;
             local_get(14); i32_load(0); i32_const(VTAG_OBJECT); i32_eq;
             if_empty;
@@ -1712,7 +1792,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
               block_empty; loop_empty;
                 local_get(12); local_get(11); i32_ge_u; br_if(1);
                 local_get(10); i32_const(list_data_off()); i32_add;
-                local_get(12); i32_const(4); i32_mul; i32_add;
+                local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
                 i32_load(0); local_set(13);
                 local_get(13); i32_load(0);
                 local_get(7); i32_load(8);
@@ -1724,7 +1804,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
               // new_len = old_len + (found ? 0 : 1)
               local_get(11); local_get(17); i32_eqz; i32_add; local_set(18);
               // Alloc new pairs list
-              i32_const(list_data_off()); local_get(18); i32_const(4); i32_mul; i32_add;
+              i32_const(list_data_off()); local_get(18); i32_const(I32_BYTES); i32_mul; i32_add;
               call(alloc); local_set(15);
               local_get(15); local_get(18); i32_store(0);
               // Copy, replacing match
@@ -1732,7 +1812,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
               block_empty; loop_empty;
                 local_get(12); local_get(11); i32_ge_u; br_if(1);
                 local_get(10); i32_const(list_data_off()); i32_add;
-                local_get(12); i32_const(4); i32_mul; i32_add;
+                local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
                 i32_load(0); local_set(13);
                 local_get(13); i32_load(0);
                 local_get(7); i32_load(8);
@@ -1740,16 +1820,16 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
                 if_empty;
                   // Replace value — the kept KEY string is shared from the
                   // old pair the source tree still owns: dup.
-                  i32_const(8); call(alloc); local_set(17);
+                  i32_const(VALUE_BOX_SIZE); call(alloc); local_set(17);
                   local_get(17); local_get(13); i32_load(0); call(emitter.rt.rc_inc); i32_store(0);
                   local_get(17); local_get(9); i32_store(4);
                   local_get(15); i32_const(list_data_off()); i32_add;
-                  local_get(12); i32_const(4); i32_mul; i32_add;
+                  local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
                   local_get(17); i32_store(0);
                 else_;
                   // Unchanged pair: shared between old and new object — dup.
                   local_get(15); i32_const(list_data_off()); i32_add;
-                  local_get(12); i32_const(4); i32_mul; i32_add;
+                  local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
                   local_get(13); call(emitter.rt.rc_inc); i32_store(0);
                 end;
                 local_get(12); i32_const(1); i32_add; local_set(12);
@@ -1758,11 +1838,11 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
               // Append new pair if key was not found
               local_get(18); local_get(11); i32_gt_u;
               if_empty;
-                i32_const(8); call(alloc); local_set(17);
+                i32_const(VALUE_BOX_SIZE); call(alloc); local_set(17);
                 local_get(17); local_get(7); i32_load(8); call(emitter.rt.rc_inc); i32_store(0);
                 local_get(17); local_get(9); i32_store(4);
                 local_get(15); i32_const(list_data_off()); i32_add;
-                local_get(11); i32_const(4); i32_mul; i32_add;
+                local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
                 local_get(17); i32_store(0);
               end;
               // Build object
@@ -1773,7 +1853,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
               // Not an object → AUTOVIVIFY: replace it with a fresh single-key
               // object {seg_key: cur_built}, mirroring native `set_at_steps`
               // Field-over-non-object (json.rs:288).
-              i32_const(list_hdr() + 4); call(alloc); local_set(15); // pairs list: 1 slot
+              i32_const(list_hdr() + I32_BYTES); call(alloc); local_set(15); // pairs list: 1 slot
               local_get(15); i32_const(1); i32_store(0);
               i32_const(VALUE_BOX_SIZE); call(alloc); local_set(17); // pair [key][val]
               local_get(17); local_get(7); i32_load(8); call(emitter.rt.rc_inc); i32_store(0);
@@ -1791,7 +1871,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
     // So when orig is not an array OR the (normalized) index is OOB, keep the
     // original value as the rebuilt node instead of fabricating an array.
     wasm!(f, {
-          local_get(8); i32_const(2); i32_eq;
+          local_get(8); i32_const(JP_INDEX_TAG); i32_eq;
           if_empty;
             // Non-array → no-op: cur_built = orig_val.
             local_get(14); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
@@ -1812,27 +1892,27 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
                 local_get(14); call(emitter.rt.rc_inc); local_set(9);
               else_;
                 // Clone list replacing at idx
-                i32_const(list_hdr()); local_get(11); i32_const(4); i32_mul; i32_add;
+                i32_const(list_hdr()); local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
                 call(alloc); local_set(15);
                 local_get(15); local_get(11); i32_store(0);
                 i32_const(0); local_set(12);
                 block_empty; loop_empty;
                   local_get(12); local_get(11); i32_ge_u; br_if(1);
                   local_get(15); i32_const(list_data_off()); i32_add;
-                  local_get(12); i32_const(4); i32_mul; i32_add;
+                  local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
                   local_get(12); local_get(18); i32_eq;
                   if_i32; local_get(9);
                   else_;
                     // Unchanged element: shared between old and new array — dup.
                     local_get(10); i32_const(list_data_off()); i32_add;
-                    local_get(12); i32_const(4); i32_mul; i32_add;
+                    local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
                     i32_load(0); call(emitter.rt.rc_inc);
                   end;
                   i32_store(0);
                   local_get(12); i32_const(1); i32_add; local_set(12);
                   br(0);
                 end; end;
-                i32_const(8); call(alloc); local_set(9);
+                i32_const(VALUE_BOX_SIZE); call(alloc); local_set(9);
                 local_get(9); i32_const(VTAG_ARRAY); i32_store(0);
                 local_get(9); local_get(15); i32_store(4);
               end;
@@ -1849,7 +1929,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
 
     // Return ok(result)
     wasm!(f, {
-        i32_const(8); call(alloc); local_set(14);
+        i32_const(VALUE_BOX_SIZE); call(alloc); local_set(14);
         local_get(14); i32_const(0); i32_store(0);
         local_get(14); local_get(9); i32_store(4);
         local_get(14);
@@ -1890,18 +1970,18 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
         local_get(2); i32_eqz;
         if_empty;
           // Empty path → return null (removing root itself)
-          i32_const(4); call(alloc); local_set(16);
+          i32_const(I32_BYTES); call(alloc); local_set(16);
           local_get(16); i32_const(0); i32_store(0);
           local_get(16);
           return_;
         end;
-        local_get(2); i32_const(4); i32_mul; call(alloc); local_set(4);
+        local_get(2); i32_const(I32_BYTES); i32_mul; call(alloc); local_set(4);
         local_get(2); local_set(5);
         local_get(1); local_set(3);
         block_empty; loop_empty;
           local_get(3); i32_load(0); i32_eqz; br_if(1);
           local_get(5); i32_const(1); i32_sub; local_set(5);
-          local_get(4); local_get(5); i32_const(4); i32_mul; i32_add;
+          local_get(4); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
           local_get(3); i32_store(0);
           local_get(3); i32_load(4); local_set(3);
           br(0);
@@ -1910,23 +1990,23 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
 
     // --- Phase 3: Walk forward saving values at each depth (all but last) ---
     wasm!(f, {
-        local_get(2); i32_const(4); i32_mul; call(alloc); local_set(14); // val_stack
+        local_get(2); i32_const(I32_BYTES); i32_mul; call(alloc); local_set(14); // val_stack
         local_get(14); local_get(0); i32_store(0); // val_stack[0] = value
         i32_const(0); local_set(5); // depth = 0
         block_empty; loop_empty;
           local_get(5); local_get(2); i32_const(1); i32_sub; i32_ge_u; br_if(1);
-          local_get(4); local_get(5); i32_const(4); i32_mul; i32_add;
+          local_get(4); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
           i32_load(0); local_set(6);
           local_get(6); i32_load(0); local_set(7);
-          local_get(14); local_get(5); i32_const(4); i32_mul; i32_add;
+          local_get(14); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
           i32_load(0); local_set(8);
     });
 
     // Navigate field for walk
     wasm!(f, {
-          local_get(7); i32_const(1); i32_eq;
+          local_get(7); i32_const(JP_FIELD_TAG); i32_eq;
           if_empty;
-            local_get(8); i32_load(0); i32_const(6); i32_ne;
+            local_get(8); i32_load(0); i32_const(VTAG_OBJECT); i32_ne;
             if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end;
             local_get(8); i32_load(4); local_set(9);
             local_get(9); i32_load(0); local_set(10);
@@ -1935,13 +2015,13 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
             block_empty; loop_empty;
               local_get(11); local_get(10); i32_ge_u; br_if(1);
               local_get(9); i32_const(list_data_off()); i32_add;
-              local_get(11); i32_const(4); i32_mul; i32_add;
+              local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
               i32_load(0); local_set(12);
               local_get(12); i32_load(0);
               local_get(6); i32_load(8);
               call(str_eq);
               if_empty;
-                local_get(14); local_get(5); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+                local_get(14); local_get(5); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul; i32_add;
                 local_get(12); i32_load(4); i32_store(0);
                 i32_const(1); local_set(13);
                 br(2);
@@ -1956,7 +2036,7 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
 
     // Navigate index for walk
     wasm!(f, {
-          local_get(7); i32_const(2); i32_eq;
+          local_get(7); i32_const(JP_INDEX_TAG); i32_eq;
           if_empty;
             local_get(8); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
             if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end; // non-array → no-op (orig)
@@ -1970,9 +2050,9 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
             local_get(17); local_get(10); i32_ge_s;
             i32_or;
             if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end; // OOB → no-op (orig)
-            local_get(14); local_get(5); i32_const(1); i32_add; i32_const(4); i32_mul; i32_add;
+            local_get(14); local_get(5); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul; i32_add;
             local_get(9); i32_const(list_data_off()); i32_add;
-            local_get(17); i32_const(4); i32_mul; i32_add;
+            local_get(17); i32_const(I32_BYTES); i32_mul; i32_add;
             i32_load(0); i32_store(0);
           end;
     });
@@ -1986,30 +2066,30 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
     // --- Phase 4: Remove at the last segment ---
     // Load last segment and value at that depth
     wasm!(f, {
-        local_get(4); local_get(2); i32_const(1); i32_sub; i32_const(4); i32_mul; i32_add;
+        local_get(4); local_get(2); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add;
         i32_load(0); local_set(6);
         local_get(6); i32_load(0); local_set(7);
-        local_get(14); local_get(2); i32_const(1); i32_sub; i32_const(4); i32_mul; i32_add;
+        local_get(14); local_get(2); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add;
         i32_load(0); local_set(8);
     });
 
     // Remove field from object
     wasm!(f, {
-        local_get(7); i32_const(1); i32_eq;
+        local_get(7); i32_const(JP_FIELD_TAG); i32_eq;
         if_empty;
-          local_get(8); i32_load(0); i32_const(6); i32_ne;
+          local_get(8); i32_load(0); i32_const(VTAG_OBJECT); i32_ne;
           if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end;
           local_get(8); i32_load(4); local_set(9);
           local_get(9); i32_load(0); local_set(10);
           // Alloc new list (worst case same size)
-          i32_const(list_data_off()); local_get(10); i32_const(4); i32_mul; i32_add;
+          i32_const(list_data_off()); local_get(10); i32_const(I32_BYTES); i32_mul; i32_add;
           call(alloc); local_set(15);
           i32_const(0); local_set(11); // src
           i32_const(0); local_set(18); // dst
           block_empty; loop_empty;
             local_get(11); local_get(10); i32_ge_u; br_if(1);
             local_get(9); i32_const(list_data_off()); i32_add;
-            local_get(11); i32_const(4); i32_mul; i32_add;
+            local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
             i32_load(0); local_set(12);
             local_get(12); i32_load(0);
             local_get(6); i32_load(8);
@@ -2018,7 +2098,7 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
             if_empty;
               // Surviving pair: shared with the source object — dup.
               local_get(15); i32_const(list_data_off()); i32_add;
-              local_get(18); i32_const(4); i32_mul; i32_add;
+              local_get(18); i32_const(I32_BYTES); i32_mul; i32_add;
               local_get(12); call(emitter.rt.rc_inc); i32_store(0);
               local_get(18); i32_const(1); i32_add; local_set(18);
             end;
@@ -2026,15 +2106,15 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
             br(0);
           end; end;
           local_get(15); local_get(18); i32_store(0); // set actual len
-          i32_const(8); call(alloc); local_set(16);
-          local_get(16); i32_const(6); i32_store(0);
+          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(16);
+          local_get(16); i32_const(VTAG_OBJECT); i32_store(0);
           local_get(16); local_get(15); i32_store(4);
         end;
     });
 
     // Remove index from array
     wasm!(f, {
-        local_get(7); i32_const(2); i32_eq;
+        local_get(7); i32_const(JP_INDEX_TAG); i32_eq;
         if_empty;
           local_get(8); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
           if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end; // non-array → no-op (orig)
@@ -2050,7 +2130,7 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
           if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end; // OOB → no-op (orig)
           // Alloc new list (len - 1)
           local_get(10); i32_const(1); i32_sub; local_set(13);
-          i32_const(list_hdr()); local_get(13); i32_const(4); i32_mul; i32_add;
+          i32_const(list_hdr()); local_get(13); i32_const(I32_BYTES); i32_mul; i32_add;
           call(alloc); local_set(15);
           local_get(15); local_get(13); i32_store(0);
           i32_const(0); local_set(11); // src
@@ -2060,16 +2140,16 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
             local_get(11); local_get(17); i32_ne;
             if_empty;
               local_get(15); i32_const(list_data_off()); i32_add;
-              local_get(18); i32_const(4); i32_mul; i32_add;
+              local_get(18); i32_const(I32_BYTES); i32_mul; i32_add;
               local_get(9); i32_const(list_data_off()); i32_add;
-              local_get(11); i32_const(4); i32_mul; i32_add;
+              local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
               i32_load(0); i32_store(0);
               local_get(18); i32_const(1); i32_add; local_set(18);
             end;
             local_get(11); i32_const(1); i32_add; local_set(11);
             br(0);
           end; end;
-          i32_const(8); call(alloc); local_set(16);
+          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(16);
           local_get(16); i32_const(VTAG_ARRAY); i32_store(0);
           local_get(16); local_get(15); i32_store(4);
         end;
@@ -2078,51 +2158,51 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
     // --- Phase 5: Rebuild upward from seg_count-2 to 0 ---
     // cur_built is in local 16
     wasm!(f, {
-        local_get(2); i32_const(2); i32_sub; local_set(5); // depth = seg_count - 2
+        local_get(2); i32_const(JP_INDEX_TAG); i32_sub; local_set(5); // depth = seg_count - 2
         block_empty; loop_empty;
           local_get(5); i32_const(0); i32_lt_s; br_if(1);
-          local_get(4); local_get(5); i32_const(4); i32_mul; i32_add;
+          local_get(4); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
           i32_load(0); local_set(6);
           local_get(6); i32_load(0); local_set(7);
-          local_get(14); local_get(5); i32_const(4); i32_mul; i32_add;
+          local_get(14); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
           i32_load(0); local_set(8); // orig val
     });
 
     // Rebuild field
     wasm!(f, {
-          local_get(7); i32_const(1); i32_eq;
+          local_get(7); i32_const(JP_FIELD_TAG); i32_eq;
           if_empty;
             local_get(8); i32_load(4); local_set(9);
             local_get(9); i32_load(0); local_set(10);
-            i32_const(list_data_off()); local_get(10); i32_const(4); i32_mul; i32_add;
+            i32_const(list_data_off()); local_get(10); i32_const(I32_BYTES); i32_mul; i32_add;
             call(alloc); local_set(15);
             local_get(15); local_get(10); i32_store(0);
             i32_const(0); local_set(11);
             block_empty; loop_empty;
               local_get(11); local_get(10); i32_ge_u; br_if(1);
               local_get(9); i32_const(list_data_off()); i32_add;
-              local_get(11); i32_const(4); i32_mul; i32_add;
+              local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
               i32_load(0); local_set(12);
               local_get(12); i32_load(0);
               local_get(6); i32_load(8);
               call(str_eq);
               if_empty;
-                i32_const(8); call(alloc); local_set(13);
+                i32_const(VALUE_BOX_SIZE); call(alloc); local_set(13);
                 local_get(13); local_get(12); i32_load(0); call(emitter.rt.rc_inc); i32_store(0);
                 local_get(13); local_get(16); i32_store(4);
                 local_get(15); i32_const(list_data_off()); i32_add;
-                local_get(11); i32_const(4); i32_mul; i32_add;
+                local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
                 local_get(13); call(emitter.rt.rc_inc); i32_store(0);
               else_;
                 local_get(15); i32_const(list_data_off()); i32_add;
-                local_get(11); i32_const(4); i32_mul; i32_add;
+                local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
                 local_get(12); call(emitter.rt.rc_inc); i32_store(0);
               end;
               local_get(11); i32_const(1); i32_add; local_set(11);
               br(0);
             end; end;
-            i32_const(8); call(alloc); local_set(16);
-            local_get(16); i32_const(6); i32_store(0);
+            i32_const(VALUE_BOX_SIZE); call(alloc); local_set(16);
+            local_get(16); i32_const(VTAG_OBJECT); i32_store(0);
             local_get(16); local_get(15); i32_store(4);
           end;
     });
@@ -2132,7 +2212,7 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
     // a non-array here is a defensive no-op; the normalization mirrors the
     // forward walk so a negative intermediate index targets the same slot.
     wasm!(f, {
-          local_get(7); i32_const(2); i32_eq;
+          local_get(7); i32_const(JP_INDEX_TAG); i32_eq;
           if_empty;
             local_get(8); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
             if_empty;
@@ -2144,27 +2224,27 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
     });
     emit_normalize_neg_index(&mut f, 17, 10);
     wasm!(f, {
-              i32_const(list_hdr()); local_get(10); i32_const(4); i32_mul; i32_add;
+              i32_const(list_hdr()); local_get(10); i32_const(I32_BYTES); i32_mul; i32_add;
               call(alloc); local_set(15);
               local_get(15); local_get(10); i32_store(0);
               i32_const(0); local_set(11);
               block_empty; loop_empty;
                 local_get(11); local_get(10); i32_ge_u; br_if(1);
                 local_get(15); i32_const(list_data_off()); i32_add;
-                local_get(11); i32_const(4); i32_mul; i32_add;
+                local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
                 local_get(11); local_get(17); i32_eq;
                 if_i32; local_get(16);
                 else_;
                   // Unchanged element: shared between old and new array — dup.
                   local_get(9); i32_const(list_data_off()); i32_add;
-                  local_get(11); i32_const(4); i32_mul; i32_add;
+                  local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
                   i32_load(0); call(emitter.rt.rc_inc);
                 end;
                 i32_store(0);
                 local_get(11); i32_const(1); i32_add; local_set(11);
                 br(0);
               end; end;
-              i32_const(8); call(alloc); local_set(16);
+              i32_const(VALUE_BOX_SIZE); call(alloc); local_set(16);
               local_get(16); i32_const(VTAG_ARRAY); i32_store(0);
               local_get(16); local_get(15); i32_store(4);
             end;

--- a/crates/almide-codegen/src/emit_wasm/rt_value.rs
+++ b/crates/almide-codegen/src/emit_wasm/rt_value.rs
@@ -6,6 +6,7 @@
 //! __json_parse(s: i32) -> i32 (Result[Value, String] ptr)
 //!   Minimal recursive descent JSON parser.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::{CompiledFunc, WasmEmitter};
 use super::rt_string::{string_data_off, string_hdr, string_cap_off, list_data_off, list_hdr};
 use wasm_encoder::{ValType};
@@ -108,9 +109,9 @@ const DECIMAL_RADIX: i64 = 10;
 /// (e.g. -5 over len 3), so an out-of-range normalized index stays a no-op.
 fn emit_normalize_neg_index(f: &mut Function, idx_local: u32, len_local: u32) {
     wasm!(f, {
-        local_get(idx_local); i32_const(0); i32_lt_s;
+        local_get(Local(idx_local)); i32_const(Imm32(0)); i32_lt_s;
         if_empty;
-          local_get(idx_local); local_get(len_local); i32_add; local_set(idx_local);
+          local_get(Local(idx_local)); local_get(Local(len_local)); i32_add; local_set(Local(idx_local));
         end;
     });
 }
@@ -133,11 +134,11 @@ fn emit_make_empty_object(f: &mut Function, dst_local: u32, alloc: u32) {
     // scratch local 15 holds the pairs list while we build the value box; both
     // 15 and dst are clobbered deterministically here.
     wasm!(f, {
-        i32_const(list_hdr()); call(alloc); local_set(15); // empty pairs list
-        local_get(15); i32_const(0); i32_store(0);          // len = 0
-        i32_const(VALUE_BOX_SIZE); call(alloc); local_set(dst_local);
-        local_get(dst_local); i32_const(VTAG_OBJECT); i32_store(0);
-        local_get(dst_local); local_get(15); i32_store(4);
+        i32_const(Imm32(list_hdr())); call(alloc); local_set(Local(15)); // empty pairs list
+        local_get(Local(15)); i32_const(Imm32(0)); i32_store(0);          // len = 0
+        i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(dst_local));
+        local_get(Local(dst_local)); i32_const(Imm32(VTAG_OBJECT)); i32_store(0);
+        local_get(Local(dst_local)); local_get(Local(15)); i32_store(4);
     });
 }
 
@@ -216,14 +217,14 @@ fn compile_json_escape_string(emitter: &mut WasmEmitter) {
     // Order matters: backslash first to avoid double-escaping
     // local 0 = input, local 1 = result
     let mut f = Function::new([(1, ValType::I32)]);
-    wasm!(f, { local_get(0); local_set(1); });
+    wasm!(f, { local_get(Local(0)); local_set(Local(1)); });
     // Replace \ first (before others to avoid double-escaping)
-    wasm!(f, { local_get(1); i32_const(backslash_char as i32); i32_const(esc_backslash as i32); call(replace); local_set(1); });
-    wasm!(f, { local_get(1); i32_const(quote_char as i32); i32_const(esc_quote as i32); call(replace); local_set(1); });
-    wasm!(f, { local_get(1); i32_const(newline_char as i32); i32_const(esc_newline as i32); call(replace); local_set(1); });
-    wasm!(f, { local_get(1); i32_const(tab_char as i32); i32_const(esc_tab as i32); call(replace); local_set(1); });
-    wasm!(f, { local_get(1); i32_const(cr_char as i32); i32_const(esc_cr as i32); call(replace); local_set(1); });
-    wasm!(f, { local_get(1); end; });
+    wasm!(f, { local_get(Local(1)); i32_const(Imm32(backslash_char as i32)); i32_const(Imm32(esc_backslash as i32)); call(replace); local_set(Local(1)); });
+    wasm!(f, { local_get(Local(1)); i32_const(Imm32(quote_char as i32)); i32_const(Imm32(esc_quote as i32)); call(replace); local_set(Local(1)); });
+    wasm!(f, { local_get(Local(1)); i32_const(Imm32(newline_char as i32)); i32_const(Imm32(esc_newline as i32)); call(replace); local_set(Local(1)); });
+    wasm!(f, { local_get(Local(1)); i32_const(Imm32(tab_char as i32)); i32_const(Imm32(esc_tab as i32)); call(replace); local_set(Local(1)); });
+    wasm!(f, { local_get(Local(1)); i32_const(Imm32(cr_char as i32)); i32_const(Imm32(esc_cr as i32)); call(replace); local_set(Local(1)); });
+    wasm!(f, { local_get(Local(1)); end; });
 
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.json_escape_string, type_idx, f));
 }
@@ -260,50 +261,50 @@ fn compile_value_stringify(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(7, ValType::I32)]);
 
     // Load tag
-    wasm!(f, { local_get(0); i32_load(0); local_set(1); });
+    wasm!(f, { local_get(Local(0)); i32_load(0); local_set(Local(1)); });
 
     // Tag 0: null
     wasm!(f, {
-        local_get(1); i32_eqz;
-        if_empty; i32_const(null_str as i32); return_; end;
+        local_get(Local(1)); i32_eqz;
+        if_empty; i32_const(Imm32(null_str as i32)); return_; end;
     });
 
     // Tag 1: bool
     wasm!(f, {
-        local_get(1); i32_const(1); i32_eq;
+        local_get(Local(1)); i32_const(Imm32(1)); i32_eq;
         if_empty;
-          local_get(0); i32_load(4);
-          if_i32; i32_const(true_str as i32);
-          else_; i32_const(false_str as i32); end;
+          local_get(Local(0)); i32_load(4);
+          if_i32; i32_const(Imm32(true_str as i32));
+          else_; i32_const(Imm32(false_str as i32)); end;
           return_;
         end;
     });
 
     // Tag 2: int
     wasm!(f, {
-        local_get(1); i32_const(VTAG_INT); i32_eq;
+        local_get(Local(1)); i32_const(Imm32(VTAG_INT)); i32_eq;
         if_empty;
-          local_get(0); i64_load(4); call(itoa); return_;
+          local_get(Local(0)); i64_load(4); call(itoa); return_;
         end;
     });
 
     // Tag 3: float
     wasm!(f, {
-        local_get(1); i32_const(VTAG_FLOAT); i32_eq;
+        local_get(Local(1)); i32_const(Imm32(VTAG_FLOAT)); i32_eq;
         if_empty;
-          local_get(0); f64_load(4); call(fdisp); return_;
+          local_get(Local(0)); f64_load(4); call(fdisp); return_;
         end;
     });
 
     // Tag 4: string -> "\"" + escape(s) + "\""
     let escape_fn = emitter.rt.json_escape_string;
     wasm!(f, {
-        local_get(1); i32_const(VTAG_STRING); i32_eq;
+        local_get(Local(1)); i32_const(Imm32(VTAG_STRING)); i32_eq;
         if_empty;
-          i32_const(quote_str as i32);
-          local_get(0); i32_load(4); call(escape_fn);
+          i32_const(Imm32(quote_str as i32));
+          local_get(Local(0)); i32_load(4); call(escape_fn);
           call(concat);
-          i32_const(quote_str as i32);
+          i32_const(Imm32(quote_str as i32));
           call(concat);
           return_;
         end;
@@ -311,76 +312,76 @@ fn compile_value_stringify(emitter: &mut WasmEmitter) {
 
     // Tag 5: array
     wasm!(f, {
-        local_get(1); i32_const(VTAG_ARRAY); i32_eq;
+        local_get(Local(1)); i32_const(Imm32(VTAG_ARRAY)); i32_eq;
         if_empty;
-          local_get(0); i32_load(4); local_set(3);
-          local_get(3); i32_load(0); local_set(4);
-          local_get(4); i32_eqz;
-          if_empty; i32_const(empty_arr_str as i32); return_; end;
-          i32_const(open_bracket as i32); local_set(2);
-          i32_const(0); local_set(5);
+          local_get(Local(0)); i32_load(4); local_set(Local(3));
+          local_get(Local(3)); i32_load(0); local_set(Local(4));
+          local_get(Local(4)); i32_eqz;
+          if_empty; i32_const(Imm32(empty_arr_str as i32)); return_; end;
+          i32_const(Imm32(open_bracket as i32)); local_set(Local(2));
+          i32_const(Imm32(0)); local_set(Local(5));
     });
     wasm!(f, {
           block_empty; loop_empty;
-            local_get(5); local_get(4); i32_ge_u; br_if(1);
-            local_get(3); i32_const(list_data_off()); i32_add;
-            local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
-            i32_load(0); call(stringify_fn); local_set(6);
-            local_get(5); i32_const(0); i32_gt_u;
+            local_get(Local(5)); local_get(Local(4)); i32_ge_u; br_if(1);
+            local_get(Local(3)); i32_const(Imm32(list_data_off())); i32_add;
+            local_get(Local(5)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+            i32_load(0); call(stringify_fn); local_set(Local(6));
+            local_get(Local(5)); i32_const(Imm32(0)); i32_gt_u;
             if_empty;
-              local_get(2); i32_const(comma_str as i32); call(concat); local_set(2);
+              local_get(Local(2)); i32_const(Imm32(comma_str as i32)); call(concat); local_set(Local(2));
             end;
-            local_get(2); local_get(6); call(concat); local_set(2);
-            local_get(5); i32_const(1); i32_add; local_set(5);
+            local_get(Local(2)); local_get(Local(6)); call(concat); local_set(Local(2));
+            local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5));
             br(0);
           end; end;
-          local_get(2); i32_const(close_bracket as i32); call(concat); return_;
+          local_get(Local(2)); i32_const(Imm32(close_bracket as i32)); call(concat); return_;
         end;
     });
 
     // Tag 6: object
     wasm!(f, {
-        local_get(1); i32_const(VTAG_OBJECT); i32_eq;
+        local_get(Local(1)); i32_const(Imm32(VTAG_OBJECT)); i32_eq;
         if_empty;
-          local_get(0); i32_load(4); local_set(3);
-          local_get(3); i32_load(0); local_set(4);
-          local_get(4); i32_eqz;
-          if_empty; i32_const(empty_obj_str as i32); return_; end;
-          i32_const(open_brace as i32); local_set(2);
-          i32_const(0); local_set(5);
+          local_get(Local(0)); i32_load(4); local_set(Local(3));
+          local_get(Local(3)); i32_load(0); local_set(Local(4));
+          local_get(Local(4)); i32_eqz;
+          if_empty; i32_const(Imm32(empty_obj_str as i32)); return_; end;
+          i32_const(Imm32(open_brace as i32)); local_set(Local(2));
+          i32_const(Imm32(0)); local_set(Local(5));
     });
     wasm!(f, {
           block_empty; loop_empty;
-            local_get(5); local_get(4); i32_ge_u; br_if(1);
+            local_get(Local(5)); local_get(Local(4)); i32_ge_u; br_if(1);
             // Load tuple pointer: list[8 + i*4] (each list elem is an i32 ptr)
-            local_get(3); i32_const(list_data_off()); i32_add;
-            local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
+            local_get(Local(3)); i32_const(Imm32(list_data_off())); i32_add;
+            local_get(Local(5)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
             i32_load(0); // dereference to get tuple ptr
-            local_set(6);
-            local_get(5); i32_const(0); i32_gt_u;
+            local_set(Local(6));
+            local_get(Local(5)); i32_const(Imm32(0)); i32_gt_u;
             if_empty;
-              local_get(2); i32_const(comma_str as i32); call(concat); local_set(2);
+              local_get(Local(2)); i32_const(Imm32(comma_str as i32)); call(concat); local_set(Local(2));
             end;
     });
     wasm!(f, {
             // tuple layout: [key_str_ptr: i32][value_ptr: i32]
-            i32_const(quote_str as i32);
-            local_get(6); i32_load(0); // key string ptr
+            i32_const(Imm32(quote_str as i32));
+            local_get(Local(6)); i32_load(0); // key string ptr
             call(concat);
-            i32_const(quote_str as i32); call(concat);
-            i32_const(colon_str as i32); call(concat);
-            local_get(6); i32_load(4); call(stringify_fn); // value ptr
-            call(concat); local_set(7);
-            local_get(2); local_get(7); call(concat); local_set(2);
-            local_get(5); i32_const(1); i32_add; local_set(5);
+            i32_const(Imm32(quote_str as i32)); call(concat);
+            i32_const(Imm32(colon_str as i32)); call(concat);
+            local_get(Local(6)); i32_load(4); call(stringify_fn); // value ptr
+            call(concat); local_set(Local(7));
+            local_get(Local(2)); local_get(Local(7)); call(concat); local_set(Local(2));
+            local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5));
             br(0);
           end; end;
-          local_get(2); i32_const(close_brace as i32); call(concat); return_;
+          local_get(Local(2)); i32_const(Imm32(close_brace as i32)); call(concat); return_;
         end;
     });
 
     // Fallback
-    wasm!(f, { i32_const(null_str as i32); end; });
+    wasm!(f, { i32_const(Imm32(null_str as i32)); end; });
 
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.value_stringify, type_idx, f));
 }
@@ -420,107 +421,107 @@ fn compile_json_stringify_pretty(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(9, ValType::I32)]);
 
     // Load tag.
-    wasm!(f, { local_get(0); i32_load(0); local_set(2); });
+    wasm!(f, { local_get(Local(0)); i32_load(0); local_set(Local(2)); });
 
     // Scalars (tag <= 4): delegate to __value_stringify (byte-identical to
     // compact; native pretty also emits the same scalar text).
     wasm!(f, {
-        local_get(2); i32_const(VTAG_ARRAY); i32_lt_u;
+        local_get(Local(2)); i32_const(Imm32(VTAG_ARRAY)); i32_lt_u;
         if_empty;
-          local_get(0); call(stringify_fn); return_;
+          local_get(Local(0)); call(stringify_fn); return_;
         end;
     });
 
     // Build indentation strings: ind = "  ".repeat(depth), ind1 = "  ".repeat(depth+1).
     wasm!(f, {
-        i32_const(two_sp as i32); local_get(1); call(repeat); local_set(4);
-        i32_const(two_sp as i32); local_get(1); i32_const(1); i32_add; call(repeat); local_set(5);
+        i32_const(Imm32(two_sp as i32)); local_get(Local(1)); call(repeat); local_set(Local(4));
+        i32_const(Imm32(two_sp as i32)); local_get(Local(1)); i32_const(Imm32(1)); i32_add; call(repeat); local_set(Local(5));
     });
 
     // Tag 5: array.
     wasm!(f, {
-        local_get(2); i32_const(VTAG_ARRAY); i32_eq;
+        local_get(Local(2)); i32_const(Imm32(VTAG_ARRAY)); i32_eq;
         if_empty;
-          local_get(0); i32_load(4); local_set(6);
-          local_get(6); i32_load(0); local_set(7);
-          local_get(7); i32_eqz;
-          if_empty; i32_const(empty_arr_str as i32); return_; end;
+          local_get(Local(0)); i32_load(4); local_set(Local(6));
+          local_get(Local(6)); i32_load(0); local_set(Local(7));
+          local_get(Local(7)); i32_eqz;
+          if_empty; i32_const(Imm32(empty_arr_str as i32)); return_; end;
           // result = "[\n"
-          i32_const(open_bracket as i32); i32_const(nl_str as i32); call(concat); local_set(3);
-          i32_const(0); local_set(8);
+          i32_const(Imm32(open_bracket as i32)); i32_const(Imm32(nl_str as i32)); call(concat); local_set(Local(3));
+          i32_const(Imm32(0)); local_set(Local(8));
     });
     wasm!(f, {
           block_empty; loop_empty;
-            local_get(8); local_get(7); i32_ge_u; br_if(1);
+            local_get(Local(8)); local_get(Local(7)); i32_ge_u; br_if(1);
             // separator before all but the first element
-            local_get(8); i32_const(0); i32_gt_u;
+            local_get(Local(8)); i32_const(Imm32(0)); i32_gt_u;
             if_empty;
-              local_get(3); i32_const(comma_nl as i32); call(concat); local_set(3);
+              local_get(Local(3)); i32_const(Imm32(comma_nl as i32)); call(concat); local_set(Local(3));
             end;
             // result += ind1
-            local_get(3); local_get(5); call(concat); local_set(3);
+            local_get(Local(3)); local_get(Local(5)); call(concat); local_set(Local(3));
             // result += pretty(elem, depth+1)
-            local_get(6); i32_const(list_data_off()); i32_add;
-            local_get(8); i32_const(I32_BYTES); i32_mul; i32_add;
+            local_get(Local(6)); i32_const(Imm32(list_data_off())); i32_add;
+            local_get(Local(8)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
             i32_load(0);
-            local_get(1); i32_const(1); i32_add;
-            call(pretty_fn); local_set(9);
-            local_get(3); local_get(9); call(concat); local_set(3);
-            local_get(8); i32_const(1); i32_add; local_set(8);
+            local_get(Local(1)); i32_const(Imm32(1)); i32_add;
+            call(pretty_fn); local_set(Local(9));
+            local_get(Local(3)); local_get(Local(9)); call(concat); local_set(Local(3));
+            local_get(Local(8)); i32_const(Imm32(1)); i32_add; local_set(Local(8));
             br(0);
           end; end;
           // result += "\n" + ind + "]"
-          local_get(3); i32_const(nl_str as i32); call(concat); local_set(3);
-          local_get(3); local_get(4); call(concat); local_set(3);
-          local_get(3); i32_const(close_bracket as i32); call(concat); return_;
+          local_get(Local(3)); i32_const(Imm32(nl_str as i32)); call(concat); local_set(Local(3));
+          local_get(Local(3)); local_get(Local(4)); call(concat); local_set(Local(3));
+          local_get(Local(3)); i32_const(Imm32(close_bracket as i32)); call(concat); return_;
         end;
     });
 
     // Tag 6: object.
     wasm!(f, {
-        local_get(2); i32_const(VTAG_OBJECT); i32_eq;
+        local_get(Local(2)); i32_const(Imm32(VTAG_OBJECT)); i32_eq;
         if_empty;
-          local_get(0); i32_load(4); local_set(6);
-          local_get(6); i32_load(0); local_set(7);
-          local_get(7); i32_eqz;
-          if_empty; i32_const(empty_obj_str as i32); return_; end;
-          i32_const(open_brace as i32); i32_const(nl_str as i32); call(concat); local_set(3);
-          i32_const(0); local_set(8);
+          local_get(Local(0)); i32_load(4); local_set(Local(6));
+          local_get(Local(6)); i32_load(0); local_set(Local(7));
+          local_get(Local(7)); i32_eqz;
+          if_empty; i32_const(Imm32(empty_obj_str as i32)); return_; end;
+          i32_const(Imm32(open_brace as i32)); i32_const(Imm32(nl_str as i32)); call(concat); local_set(Local(3));
+          i32_const(Imm32(0)); local_set(Local(8));
     });
     wasm!(f, {
           block_empty; loop_empty;
-            local_get(8); local_get(7); i32_ge_u; br_if(1);
+            local_get(Local(8)); local_get(Local(7)); i32_ge_u; br_if(1);
             // load tuple ptr [key_str_ptr][value_ptr]
-            local_get(6); i32_const(list_data_off()); i32_add;
-            local_get(8); i32_const(I32_BYTES); i32_mul; i32_add;
-            i32_load(0); local_set(9);
-            local_get(8); i32_const(0); i32_gt_u;
+            local_get(Local(6)); i32_const(Imm32(list_data_off())); i32_add;
+            local_get(Local(8)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+            i32_load(0); local_set(Local(9));
+            local_get(Local(8)); i32_const(Imm32(0)); i32_gt_u;
             if_empty;
-              local_get(3); i32_const(comma_nl as i32); call(concat); local_set(3);
+              local_get(Local(3)); i32_const(Imm32(comma_nl as i32)); call(concat); local_set(Local(3));
             end;
             // result += ind1
-            local_get(3); local_get(5); call(concat); local_set(3);
+            local_get(Local(3)); local_get(Local(5)); call(concat); local_set(Local(3));
             // result += "\"" + escape(key) + "\"" + ": "
-            local_get(3); i32_const(quote_str as i32); call(concat);
-            local_get(9); i32_load(0); call(escape_fn); call(concat);
-            i32_const(quote_str as i32); call(concat);
-            i32_const(colon_sp as i32); call(concat); local_set(3);
+            local_get(Local(3)); i32_const(Imm32(quote_str as i32)); call(concat);
+            local_get(Local(9)); i32_load(0); call(escape_fn); call(concat);
+            i32_const(Imm32(quote_str as i32)); call(concat);
+            i32_const(Imm32(colon_sp as i32)); call(concat); local_set(Local(3));
             // result += pretty(value, depth+1)
-            local_get(9); i32_load(4);
-            local_get(1); i32_const(1); i32_add;
-            call(pretty_fn); local_set(10);
-            local_get(3); local_get(10); call(concat); local_set(3);
-            local_get(8); i32_const(1); i32_add; local_set(8);
+            local_get(Local(9)); i32_load(4);
+            local_get(Local(1)); i32_const(Imm32(1)); i32_add;
+            call(pretty_fn); local_set(Local(10));
+            local_get(Local(3)); local_get(Local(10)); call(concat); local_set(Local(3));
+            local_get(Local(8)); i32_const(Imm32(1)); i32_add; local_set(Local(8));
             br(0);
           end; end;
-          local_get(3); i32_const(nl_str as i32); call(concat); local_set(3);
-          local_get(3); local_get(4); call(concat); local_set(3);
-          local_get(3); i32_const(close_brace as i32); call(concat); return_;
+          local_get(Local(3)); i32_const(Imm32(nl_str as i32)); call(concat); local_set(Local(3));
+          local_get(Local(3)); local_get(Local(4)); call(concat); local_set(Local(3));
+          local_get(Local(3)); i32_const(Imm32(close_brace as i32)); call(concat); return_;
         end;
     });
 
     // Fallback (unreachable for valid Value tags): delegate to compact.
-    wasm!(f, { local_get(0); call(stringify_fn); end; });
+    wasm!(f, { local_get(Local(0)); call(stringify_fn); end; });
 
     emitter.add_compiled(CompiledFunc::tracked(type_idx, f));
 }
@@ -536,18 +537,18 @@ fn compile_json_parse(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(2, ValType::I32)]);
 
     wasm!(f, {
-        local_get(0); i32_const(0); call(parse_at_fn); local_set(1);
-        local_get(1); i32_load(8);
+        local_get(Local(0)); i32_const(Imm32(0)); call(parse_at_fn); local_set(Local(1));
+        local_get(Local(1)); i32_load(8);
         if_i32;
-          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(2);
-          local_get(2); i32_const(1); i32_store(0);
-          local_get(2); local_get(1); i32_load(0); i32_store(4);
-          local_get(2);
+          i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(2));
+          local_get(Local(2)); i32_const(Imm32(1)); i32_store(0);
+          local_get(Local(2)); local_get(Local(1)); i32_load(0); i32_store(4);
+          local_get(Local(2));
         else_;
-          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(2);
-          local_get(2); i32_const(0); i32_store(0);
-          local_get(2); local_get(1); i32_load(0); i32_store(4);
-          local_get(2);
+          i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(2));
+          local_get(Local(2)); i32_const(Imm32(0)); i32_store(0);
+          local_get(Local(2)); local_get(Local(1)); i32_load(0); i32_store(4);
+          local_get(Local(2));
         end;
         end;
     });
@@ -589,8 +590,8 @@ fn compile_json_parse_at(emitter: &mut WasmEmitter) {
 
     // Allocate result struct (12 bytes)
     wasm!(f, {
-        i32_const(PARSE_RESULT_SIZE); call(alloc); local_set(2);
-        local_get(0); i32_load(0); local_set(3);
+        i32_const(Imm32(PARSE_RESULT_SIZE)); call(alloc); local_set(Local(2));
+        local_get(Local(0)); i32_load(0); local_set(Local(3));
     });
 
     // Skip whitespace
@@ -598,97 +599,97 @@ fn compile_json_parse_at(emitter: &mut WasmEmitter) {
 
     // Check EOF
     wasm!(f, {
-        local_get(1); local_get(3); i32_ge_u;
+        local_get(Local(1)); local_get(Local(3)); i32_ge_u;
         if_empty;
-          local_get(2); i32_const(err_eof as i32); i32_store(0);
-          local_get(2); i32_const(0); i32_store(4);
-          local_get(2); i32_const(1); i32_store(8);
-          local_get(2); return_;
+          local_get(Local(2)); i32_const(Imm32(err_eof as i32)); i32_store(0);
+          local_get(Local(2)); i32_const(Imm32(0)); i32_store(4);
+          local_get(Local(2)); i32_const(Imm32(1)); i32_store(8);
+          local_get(Local(2)); return_;
         end;
     });
 
     // Load current char
     wasm!(f, {
-        local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-        i32_load8_u(0); local_set(4);
+        local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+        i32_load8_u(0); local_set(Local(4));
     });
 
     // ── null: check n,u,l,l ──
     wasm!(f, {
-        local_get(4); i32_const(ASCII_N); i32_eq; // 'n'
+        local_get(Local(4)); i32_const(Imm32(ASCII_N)); i32_eq; // 'n'
         if_empty;
           // Validate remaining chars: u(117), l(108), l(108)
-          local_get(1); i32_const(JSON_KW4_LOOKAHEAD); i32_add; local_get(3); i32_lt_u; // need 3 more chars
-          local_get(0); i32_const(string_data_off() + 1); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_U); i32_eq;
+          local_get(Local(1)); i32_const(Imm32(JSON_KW4_LOOKAHEAD)); i32_add; local_get(Local(3)); i32_lt_u; // need 3 more chars
+          local_get(Local(0)); i32_const(Imm32(string_data_off() + 1)); i32_add; local_get(Local(1)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_U)); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 2); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_L); i32_eq;
+          local_get(Local(0)); i32_const(Imm32(string_data_off() + 2)); i32_add; local_get(Local(1)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_L)); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 3); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_L); i32_eq;
+          local_get(Local(0)); i32_const(Imm32(string_data_off() + 3)); i32_add; local_get(Local(1)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_L)); i32_eq;
           i32_and;
     });
     wasm!(f, {
           if_empty;
-            local_get(1); i32_const(JSON_KW4_LEN); i32_add; local_set(1);
-            i32_const(I32_BYTES); call(alloc); local_set(6);
-            local_get(6); i32_const(0); i32_store(0);
-            local_get(2); local_get(6); i32_store(0);
-            local_get(2); local_get(1); i32_store(4);
-            local_get(2); i32_const(0); i32_store(8);
-            local_get(2); return_;
+            local_get(Local(1)); i32_const(Imm32(JSON_KW4_LEN)); i32_add; local_set(Local(1));
+            i32_const(Imm32(I32_BYTES)); call(alloc); local_set(Local(6));
+            local_get(Local(6)); i32_const(Imm32(0)); i32_store(0);
+            local_get(Local(2)); local_get(Local(6)); i32_store(0);
+            local_get(Local(2)); local_get(Local(1)); i32_store(4);
+            local_get(Local(2)); i32_const(Imm32(0)); i32_store(8);
+            local_get(Local(2)); return_;
           end;
         end;
     });
 
     // ── true: check t,r,u,e ──
     wasm!(f, {
-        local_get(4); i32_const(ASCII_T); i32_eq; // 't'
+        local_get(Local(4)); i32_const(Imm32(ASCII_T)); i32_eq; // 't'
         if_empty;
-          local_get(1); i32_const(JSON_KW4_LOOKAHEAD); i32_add; local_get(3); i32_lt_u;
-          local_get(0); i32_const(string_data_off() + 1); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_R); i32_eq;
+          local_get(Local(1)); i32_const(Imm32(JSON_KW4_LOOKAHEAD)); i32_add; local_get(Local(3)); i32_lt_u;
+          local_get(Local(0)); i32_const(Imm32(string_data_off() + 1)); i32_add; local_get(Local(1)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_R)); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 2); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_U); i32_eq;
+          local_get(Local(0)); i32_const(Imm32(string_data_off() + 2)); i32_add; local_get(Local(1)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_U)); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 3); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_E_LOWER); i32_eq;
+          local_get(Local(0)); i32_const(Imm32(string_data_off() + 3)); i32_add; local_get(Local(1)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_E_LOWER)); i32_eq;
           i32_and;
     });
     wasm!(f, {
           if_empty;
-            local_get(1); i32_const(JSON_KW4_LEN); i32_add; local_set(1);
-            i32_const(VALUE_BOX_SIZE); call(alloc); local_set(6);
-            local_get(6); i32_const(1); i32_store(0);
-            local_get(6); i32_const(1); i32_store(4);
-            local_get(2); local_get(6); i32_store(0);
-            local_get(2); local_get(1); i32_store(4);
-            local_get(2); i32_const(0); i32_store(8);
-            local_get(2); return_;
+            local_get(Local(1)); i32_const(Imm32(JSON_KW4_LEN)); i32_add; local_set(Local(1));
+            i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(6));
+            local_get(Local(6)); i32_const(Imm32(1)); i32_store(0);
+            local_get(Local(6)); i32_const(Imm32(1)); i32_store(4);
+            local_get(Local(2)); local_get(Local(6)); i32_store(0);
+            local_get(Local(2)); local_get(Local(1)); i32_store(4);
+            local_get(Local(2)); i32_const(Imm32(0)); i32_store(8);
+            local_get(Local(2)); return_;
           end;
         end;
     });
 
     // ── false: check f,a,l,s,e ──
     wasm!(f, {
-        local_get(4); i32_const(ASCII_F_LOWER); i32_eq; // 'f'
+        local_get(Local(4)); i32_const(Imm32(ASCII_F_LOWER)); i32_eq; // 'f'
         if_empty;
-          local_get(1); i32_const(JSON_KW5_LOOKAHEAD); i32_add; local_get(3); i32_lt_u;
-          local_get(0); i32_const(string_data_off() + 1); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_A_LOWER); i32_eq;
+          local_get(Local(1)); i32_const(Imm32(JSON_KW5_LOOKAHEAD)); i32_add; local_get(Local(3)); i32_lt_u;
+          local_get(Local(0)); i32_const(Imm32(string_data_off() + 1)); i32_add; local_get(Local(1)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_A_LOWER)); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 2); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_L); i32_eq;
+          local_get(Local(0)); i32_const(Imm32(string_data_off() + 2)); i32_add; local_get(Local(1)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_L)); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 3); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_S); i32_eq;
+          local_get(Local(0)); i32_const(Imm32(string_data_off() + 3)); i32_add; local_get(Local(1)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_S)); i32_eq;
           i32_and;
-          local_get(0); i32_const(string_data_off() + 4); i32_add; local_get(1); i32_add; i32_load8_u(0); i32_const(ASCII_E_LOWER); i32_eq;
+          local_get(Local(0)); i32_const(Imm32(string_data_off() + 4)); i32_add; local_get(Local(1)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_E_LOWER)); i32_eq;
           i32_and;
     });
     wasm!(f, {
           if_empty;
-            local_get(1); i32_const(JSON_FALSE_LEN); i32_add; local_set(1);
-            i32_const(VALUE_BOX_SIZE); call(alloc); local_set(6);
-            local_get(6); i32_const(1); i32_store(0);
-            local_get(6); i32_const(0); i32_store(4);
-            local_get(2); local_get(6); i32_store(0);
-            local_get(2); local_get(1); i32_store(4);
-            local_get(2); i32_const(0); i32_store(8);
-            local_get(2); return_;
+            local_get(Local(1)); i32_const(Imm32(JSON_FALSE_LEN)); i32_add; local_set(Local(1));
+            i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(6));
+            local_get(Local(6)); i32_const(Imm32(1)); i32_store(0);
+            local_get(Local(6)); i32_const(Imm32(0)); i32_store(4);
+            local_get(Local(2)); local_get(Local(6)); i32_store(0);
+            local_get(Local(2)); local_get(Local(1)); i32_store(4);
+            local_get(Local(2)); i32_const(Imm32(0)); i32_store(8);
+            local_get(Local(2)); return_;
           end;
         end;
     });
@@ -707,10 +708,10 @@ fn compile_json_parse_at(emitter: &mut WasmEmitter) {
 
     // Fallback: error
     wasm!(f, {
-        local_get(2); i32_const(err_msg as i32); i32_store(0);
-        local_get(2); i32_const(0); i32_store(4);
-        local_get(2); i32_const(1); i32_store(8);
-        local_get(2);
+        local_get(Local(2)); i32_const(Imm32(err_msg as i32)); i32_store(0);
+        local_get(Local(2)); i32_const(Imm32(0)); i32_store(4);
+        local_get(Local(2)); i32_const(Imm32(1)); i32_store(8);
+        local_get(Local(2));
         end;
     });
 
@@ -722,65 +723,65 @@ fn compile_json_parse_at(emitter: &mut WasmEmitter) {
 /// Uses locals: 0=str_ptr, 1=pos, 3=str_len, 4=ch, 7=tmp, 12=num_val(i64), 13=divisor(f64)
 fn emit_parse_exponent(f: &mut Function) {
     // Default multiplier = 1.0 (no exponent)
-    wasm!(f, { f64_const(1.0); local_set(13); });
+    wasm!(f, { f64_const(1.0); local_set(Local(13)); });
 
     // Check if we have e/E
     wasm!(f, {
-        local_get(1); local_get(3); i32_lt_u;
+        local_get(Local(1)); local_get(Local(3)); i32_lt_u;
         if_empty;
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-          i32_load8_u(0); local_set(4);
-          local_get(4); i32_const(ASCII_E_LOWER); i32_eq; // 'e'
-          local_get(4); i32_const(ASCII_E_UPPER); i32_eq;  // 'E'
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+          i32_load8_u(0); local_set(Local(4));
+          local_get(Local(4)); i32_const(Imm32(ASCII_E_LOWER)); i32_eq; // 'e'
+          local_get(Local(4)); i32_const(Imm32(ASCII_E_UPPER)); i32_eq;  // 'E'
           i32_or;
           if_empty;
-            local_get(1); i32_const(1); i32_add; local_set(1);
+            local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
             // exp_sign: check +/-
-            i32_const(1); local_set(7); // exp_sign = 1 (positive)
-            local_get(1); local_get(3); i32_lt_u;
+            i32_const(Imm32(1)); local_set(Local(7)); // exp_sign = 1 (positive)
+            local_get(Local(1)); local_get(Local(3)); i32_lt_u;
             if_empty;
-              local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-              i32_load8_u(0); local_set(4);
-              local_get(4); i32_const(ASCII_MINUS); i32_eq; // '-'
+              local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+              i32_load8_u(0); local_set(Local(4));
+              local_get(Local(4)); i32_const(Imm32(ASCII_MINUS)); i32_eq; // '-'
               if_empty;
-                i32_const(-1); local_set(7);
-                local_get(1); i32_const(1); i32_add; local_set(1);
+                i32_const(Imm32(-1)); local_set(Local(7));
+                local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
               else_;
-                local_get(4); i32_const(ASCII_PLUS); i32_eq; // '+'
+                local_get(Local(4)); i32_const(Imm32(ASCII_PLUS)); i32_eq; // '+'
                 if_empty;
-                  local_get(1); i32_const(1); i32_add; local_set(1);
+                  local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
                 end;
               end;
             end;
             // Parse exponent digits
-            i64_const(0); local_set(12);
+            i64_const(Imm64(0)); local_set(Local(12));
     });
     wasm!(f, {
             block_empty; loop_empty;
-              local_get(1); local_get(3); i32_ge_u; br_if(1);
-              local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-              i32_load8_u(0); local_set(4);
-              local_get(4); i32_const(ASCII_ZERO); i32_lt_u; br_if(1);
-              local_get(4); i32_const(ASCII_NINE); i32_gt_u; br_if(1);
-              local_get(12); i64_const(DECIMAL_RADIX); i64_mul;
-              local_get(4); i32_const(ASCII_ZERO); i32_sub; i64_extend_i32_u;
-              i64_add; local_set(12);
-              local_get(1); i32_const(1); i32_add; local_set(1);
+              local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+              local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+              i32_load8_u(0); local_set(Local(4));
+              local_get(Local(4)); i32_const(Imm32(ASCII_ZERO)); i32_lt_u; br_if(1);
+              local_get(Local(4)); i32_const(Imm32(ASCII_NINE)); i32_gt_u; br_if(1);
+              local_get(Local(12)); i64_const(Imm64(DECIMAL_RADIX)); i64_mul;
+              local_get(Local(4)); i32_const(Imm32(ASCII_ZERO)); i32_sub; i64_extend_i32_u;
+              i64_add; local_set(Local(12));
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
               br(0);
             end; end;
     });
     // Compute multiplier = 10^exp via loop, store in local 13
     wasm!(f, {
-            f64_const(1.0); local_set(13);
+            f64_const(1.0); local_set(Local(13));
             block_empty; loop_empty;
-              local_get(12); i64_eqz; br_if(1);
-              local_get(7); i32_const(0); i32_lt_s;
+              local_get(Local(12)); i64_eqz; br_if(1);
+              local_get(Local(7)); i32_const(Imm32(0)); i32_lt_s;
               if_empty;
-                local_get(13); f64_const(0.1); f64_mul; local_set(13);
+                local_get(Local(13)); f64_const(0.1); f64_mul; local_set(Local(13));
               else_;
-                local_get(13); f64_const(10.0); f64_mul; local_set(13);
+                local_get(Local(13)); f64_const(10.0); f64_mul; local_set(Local(13));
               end;
-              local_get(12); i64_const(1); i64_sub; local_set(12);
+              local_get(Local(12)); i64_const(Imm64(1)); i64_sub; local_set(Local(12));
               br(0);
             end; end;
           end; // if e/E
@@ -788,7 +789,7 @@ fn emit_parse_exponent(f: &mut Function) {
     });
 
     // Push multiplier onto stack
-    wasm!(f, { local_get(13); });
+    wasm!(f, { local_get(Local(13)); });
 }
 
 /// Emit whitespace-skipping loop.
@@ -796,15 +797,15 @@ fn emit_parse_exponent(f: &mut Function) {
 fn emit_skip_ws(f: &mut Function) {
     wasm!(f, {
         block_empty; loop_empty;
-          local_get(1); local_get(3); i32_ge_u; br_if(1);
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-          i32_load8_u(0); local_set(4);
-          local_get(4); i32_const(ASCII_SPACE); i32_eq;
-          local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
-          local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
-          local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
+          local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+          i32_load8_u(0); local_set(Local(4));
+          local_get(Local(4)); i32_const(Imm32(ASCII_SPACE)); i32_eq;
+          local_get(Local(4)); i32_const(Imm32(ASCII_HT)); i32_eq; i32_or;
+          local_get(Local(4)); i32_const(Imm32(ASCII_LF)); i32_eq; i32_or;
+          local_get(Local(4)); i32_const(Imm32(ASCII_CR)); i32_eq; i32_or;
           i32_eqz; br_if(1);
-          local_get(1); i32_const(1); i32_add; local_set(1);
+          local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
           br(0);
         end; end;
     });
@@ -815,19 +816,19 @@ fn emit_skip_ws(f: &mut Function) {
 /// for `\uXXXX` escapes and their low-surrogate continuation (#651). Local 11 is
 /// scratch.
 fn emit_parse_hex4(f: &mut Function, off0: i32, target: u32) {
-    wasm!(f, { i32_const(0); local_set(target); });
+    wasm!(f, { i32_const(Imm32(0)); local_set(Local(target)); });
     for k in off0..off0 + 4 {
         wasm!(f, {
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add; local_get(8); i32_add; i32_const(k); i32_add;
-            i32_load8_u(0); local_set(11);
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(5)); i32_add; local_get(Local(8)); i32_add; i32_const(Imm32(k)); i32_add;
+            i32_load8_u(0); local_set(Local(11));
             // digit = byte < ':' ? byte - '0' : (byte | 0x20) - ('a' - 10)
-            local_get(11); i32_const(ASCII_COLON); i32_lt_u;
+            local_get(Local(11)); i32_const(Imm32(ASCII_COLON)); i32_lt_u;
             if_i32;
-              local_get(11); i32_const(ASCII_ZERO); i32_sub;
+              local_get(Local(11)); i32_const(Imm32(ASCII_ZERO)); i32_sub;
             else_;
-              local_get(11); i32_const(ASCII_LOWER_BIT); i32_or; i32_const(HEX_ALPHA_BIAS); i32_sub;
+              local_get(Local(11)); i32_const(Imm32(ASCII_LOWER_BIT)); i32_or; i32_const(Imm32(HEX_ALPHA_BIAS)); i32_sub;
             end;
-            local_get(target); i32_const(HEX_NIBBLE_SHIFT); i32_shl; i32_add; local_set(target);
+            local_get(Local(target)); i32_const(Imm32(HEX_NIBBLE_SHIFT)); i32_shl; i32_add; local_set(Local(target));
         });
     }
 }
@@ -838,10 +839,10 @@ fn emit_parse_hex4(f: &mut Function, off0: i32, target: u32) {
 /// 1-byte (ASCII) case uses `shift=0, mask=0x7F, high=0`. `out` base is local 6.
 fn emit_utf8_byte(f: &mut Function, shift: i32, mask: i32, high: i32) {
     wasm!(f, {
-        local_get(6); i32_const(string_data_off()); i32_add; local_get(9); i32_add;
-        local_get(10); i32_const(shift); i32_shr_u; i32_const(mask); i32_and; i32_const(high); i32_or;
+        local_get(Local(6)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(9)); i32_add;
+        local_get(Local(10)); i32_const(Imm32(shift)); i32_shr_u; i32_const(Imm32(mask)); i32_and; i32_const(Imm32(high)); i32_or;
         i32_store8(0);
-        local_get(9); i32_const(1); i32_add; local_set(9);
+        local_get(Local(9)); i32_const(Imm32(1)); i32_add; local_set(Local(9));
     });
 }
 
@@ -853,45 +854,45 @@ fn emit_utf8_byte(f: &mut Function, shift: i32, mask: i32, high: i32) {
 /// `u`. Mirrors serde_json's `\u` decoding. #651.
 fn emit_unicode_escape_branch(f: &mut Function) {
     wasm!(f, {
-        local_get(4); i32_const(ASCII_U); i32_eq; // 'u'
+        local_get(Local(4)); i32_const(Imm32(ASCII_U)); i32_eq; // 'u'
         if_empty;
     });
     // codepoint (local 10) from the 4 hex following the `u`.
     emit_parse_hex4(f, 1, 10);
-    wasm!(f, { local_get(8); i32_const(UNICODE_ESCAPE_LEN); i32_add; local_set(8); }); // consumed `u` + 4 hex
+    wasm!(f, { local_get(Local(8)); i32_const(Imm32(UNICODE_ESCAPE_LEN)); i32_add; local_set(Local(8)); }); // consumed `u` + 4 hex
     // Surrogate pair: a high surrogate (D800..DBFF) immediately followed by a
     // "\uYYYY" low surrogate (DC00..DFFF) forms one astral codepoint.
     wasm!(f, {
-        local_get(10); i32_const(SURR_HIGH_START); i32_ge_u;
-        local_get(10); i32_const(SURR_HIGH_END); i32_le_u;
+        local_get(Local(10)); i32_const(Imm32(SURR_HIGH_START)); i32_ge_u;
+        local_get(Local(10)); i32_const(Imm32(SURR_HIGH_END)); i32_le_u;
         i32_and;
         if_empty;
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add; local_get(8); i32_add; i32_load8_u(0); i32_const(ASCII_BACKSLASH); i32_eq;
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add; local_get(8); i32_add; i32_const(1); i32_add; i32_load8_u(0); i32_const(ASCII_U); i32_eq;
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(5)); i32_add; local_get(Local(8)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_BACKSLASH)); i32_eq;
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(5)); i32_add; local_get(Local(8)); i32_add; i32_const(Imm32(1)); i32_add; i32_load8_u(0); i32_const(Imm32(ASCII_U)); i32_eq;
           i32_and;
           if_empty;
     });
     emit_parse_hex4(f, 2, 14); // low surrogate → local 14
     wasm!(f, {
-            local_get(14); i32_const(SURR_LOW_START); i32_ge_u;
-            local_get(14); i32_const(SURR_LOW_END); i32_le_u;
+            local_get(Local(14)); i32_const(Imm32(SURR_LOW_START)); i32_ge_u;
+            local_get(Local(14)); i32_const(Imm32(SURR_LOW_END)); i32_le_u;
             i32_and;
             if_empty;
-              local_get(10); i32_const(SURR_HIGH_START); i32_sub; i32_const(SURR_HIGH_SHIFT); i32_shl;
-              local_get(14); i32_const(SURR_LOW_START); i32_sub; i32_add;
-              i32_const(SURR_PAIR_BASE); i32_add; local_set(10);
-              local_get(8); i32_const(UNICODE_ESCAPE_PAIR_ADV); i32_add; local_set(8); // consumed "\uYYYY"
+              local_get(Local(10)); i32_const(Imm32(SURR_HIGH_START)); i32_sub; i32_const(Imm32(SURR_HIGH_SHIFT)); i32_shl;
+              local_get(Local(14)); i32_const(Imm32(SURR_LOW_START)); i32_sub; i32_add;
+              i32_const(Imm32(SURR_PAIR_BASE)); i32_add; local_set(Local(10));
+              local_get(Local(8)); i32_const(Imm32(UNICODE_ESCAPE_PAIR_ADV)); i32_add; local_set(Local(8)); // consumed "\uYYYY"
             end;
           end;
         end;
     });
     // UTF-8 encode cp(10): 1 byte (<0x80), 2 (<0x800), 3 (<0x10000), else 4.
-    wasm!(f, { local_get(10); i32_const(UTF8_1BYTE_MAX); i32_lt_u; if_empty; });
+    wasm!(f, { local_get(Local(10)); i32_const(Imm32(UTF8_1BYTE_MAX)); i32_lt_u; if_empty; });
     emit_utf8_byte(f, 0, 0x7F, 0x00);
-    wasm!(f, { else_; local_get(10); i32_const(UTF8_2BYTE_MAX); i32_lt_u; if_empty; });
+    wasm!(f, { else_; local_get(Local(10)); i32_const(Imm32(UTF8_2BYTE_MAX)); i32_lt_u; if_empty; });
     emit_utf8_byte(f, 6, 0x1F, 0xC0);
     emit_utf8_byte(f, 0, 0x3F, 0x80);
-    wasm!(f, { else_; local_get(10); i32_const(UTF8_3BYTE_MAX); i32_lt_u; if_empty; });
+    wasm!(f, { else_; local_get(Local(10)); i32_const(Imm32(UTF8_3BYTE_MAX)); i32_lt_u; if_empty; });
     emit_utf8_byte(f, 12, 0x0F, 0xE0);
     emit_utf8_byte(f, 6, 0x3F, 0x80);
     emit_utf8_byte(f, 0, 0x3F, 0x80);
@@ -911,52 +912,52 @@ fn emit_unicode_escape_branch(f: &mut Function) {
 /// Uses locals: 0=str_ptr, 1=pos, 2=result_ptr, 3=str_len, 4=ch, 5=start, 6=value_ptr, 7=tmp, 9=count
 fn emit_parse_string(f: &mut Function, alloc: u32, string_alloc: u32) {
     wasm!(f, {
-        local_get(4); i32_const(ASCII_DQUOTE); i32_eq;
+        local_get(Local(4)); i32_const(Imm32(ASCII_DQUOTE)); i32_eq;
         if_empty;
-          local_get(1); i32_const(1); i32_add; local_set(1);
-          local_get(1); local_set(5);
+          local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
+          local_get(Local(1)); local_set(Local(5));
     });
     // Find closing quote
     wasm!(f, {
           block_empty; loop_empty;
-            local_get(1); local_get(3); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); local_set(7);
-            local_get(7); i32_const(ASCII_DQUOTE); i32_eq; br_if(1);
-            local_get(7); i32_const(ASCII_BACKSLASH); i32_eq;
+            local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+            i32_load8_u(0); local_set(Local(7));
+            local_get(Local(7)); i32_const(Imm32(ASCII_DQUOTE)); i32_eq; br_if(1);
+            local_get(Local(7)); i32_const(Imm32(ASCII_BACKSLASH)); i32_eq;
             if_empty;
-              local_get(1); i32_const(1); i32_add; local_set(1);
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
             end;
-            local_get(1); i32_const(1); i32_add; local_set(1);
+            local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
             br(0);
           end; end;
     });
     // Build string
     wasm!(f, {
-          local_get(1); local_get(5); i32_sub; local_set(7);
-          local_get(7); call(string_alloc); local_set(6);
-          i32_const(0); local_set(9);
+          local_get(Local(1)); local_get(Local(5)); i32_sub; local_set(Local(7));
+          local_get(Local(7)); call(string_alloc); local_set(Local(6));
+          i32_const(Imm32(0)); local_set(Local(9));
     });
     // Copy bytes loop with JSON escape decoding.
     // Locals: 8 = read offset, 9 = write offset, 4 = current byte (reused).
     // Handles \n \t \r \" \\ \/ \b \f. \uXXXX is not yet supported (passes through).
     wasm!(f, {
-          i32_const(0); local_set(8);
-          i32_const(0); local_set(9);
+          i32_const(Imm32(0)); local_set(Local(8));
+          i32_const(Imm32(0)); local_set(Local(9));
           block_empty; loop_empty;
-            local_get(8); local_get(7); i32_ge_u; br_if(1);
+            local_get(Local(8)); local_get(Local(7)); i32_ge_u; br_if(1);
             // byte = in[in_base + read_off]
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add; local_get(8); i32_add;
-            i32_load8_u(0); local_set(4);
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(5)); i32_add; local_get(Local(8)); i32_add;
+            i32_load8_u(0); local_set(Local(4));
             // if byte == 0x5C (backslash): decode next byte
-            local_get(4); i32_const(ASCII_BACKSLASH); i32_eq;
+            local_get(Local(4)); i32_const(Imm32(ASCII_BACKSLASH)); i32_eq;
             if_empty;
               // advance read past backslash
-              local_get(8); i32_const(1); i32_add; local_set(8);
-              local_get(8); local_get(7); i32_ge_u; br_if(2);
+              local_get(Local(8)); i32_const(Imm32(1)); i32_add; local_set(Local(8));
+              local_get(Local(8)); local_get(Local(7)); i32_ge_u; br_if(2);
               // load next byte
-              local_get(0); i32_const(string_data_off()); i32_add; local_get(5); i32_add; local_get(8); i32_add;
-              i32_load8_u(0); local_set(4);
+              local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(5)); i32_add; local_get(Local(8)); i32_add;
+              i32_load8_u(0); local_set(Local(4));
     });
     // \uXXXX decodes to UTF-8 and continues the loop (multi-byte); the simple
     // single-byte escapes below run only when the char is not `u`. #651.
@@ -966,33 +967,33 @@ fn emit_parse_string(f: &mut Function, alloc: u32, string_alloc: u32) {
               // Decoded values (8,9,10,12,13) and idempotent ones (34,47,92) don't
               // collide with the source codes for other escapes (110,116,114,98,102),
               // so a sequential pass is safe.
-              local_get(4); i32_const(ASCII_N); i32_eq; if_empty; i32_const(ASCII_LF); local_set(4); end;  // n
-              local_get(4); i32_const(ASCII_T); i32_eq; if_empty; i32_const(ASCII_HT);  local_set(4); end;  // t
-              local_get(4); i32_const(ASCII_R); i32_eq; if_empty; i32_const(ASCII_CR); local_set(4); end;  // r
-              local_get(4); i32_const(ASCII_B);  i32_eq; if_empty; i32_const(ASCII_BS);  local_set(4); end;  // b
-              local_get(4); i32_const(ASCII_F_LOWER); i32_eq; if_empty; i32_const(ASCII_FF); local_set(4); end;  // f
+              local_get(Local(4)); i32_const(Imm32(ASCII_N)); i32_eq; if_empty; i32_const(Imm32(ASCII_LF)); local_set(Local(4)); end;  // n
+              local_get(Local(4)); i32_const(Imm32(ASCII_T)); i32_eq; if_empty; i32_const(Imm32(ASCII_HT));  local_set(Local(4)); end;  // t
+              local_get(Local(4)); i32_const(Imm32(ASCII_R)); i32_eq; if_empty; i32_const(Imm32(ASCII_CR)); local_set(Local(4)); end;  // r
+              local_get(Local(4)); i32_const(Imm32(ASCII_B));  i32_eq; if_empty; i32_const(Imm32(ASCII_BS));  local_set(Local(4)); end;  // b
+              local_get(Local(4)); i32_const(Imm32(ASCII_F_LOWER)); i32_eq; if_empty; i32_const(Imm32(ASCII_FF)); local_set(Local(4)); end;  // f
               // ", \, /  decode to themselves — no rewrite needed.
             end;
             // out[out_base + write_off] = byte
-            local_get(6); i32_const(string_data_off()); i32_add; local_get(9); i32_add;
-            local_get(4);
+            local_get(Local(6)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(9)); i32_add;
+            local_get(Local(4));
             i32_store8(0);
-            local_get(9); i32_const(1); i32_add; local_set(9);
-            local_get(8); i32_const(1); i32_add; local_set(8);
+            local_get(Local(9)); i32_const(Imm32(1)); i32_add; local_set(Local(9));
+            local_get(Local(8)); i32_const(Imm32(1)); i32_add; local_set(Local(8));
             br(0);
           end; end;
     });
     // Build Value and return — write actual decoded length (write_off)
     wasm!(f, {
-          local_get(6); local_get(9); i32_store(0);
-          local_get(1); i32_const(1); i32_add; local_set(1);
-          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(7);
-          local_get(7); i32_const(VTAG_STRING); i32_store(0);
-          local_get(7); local_get(6); i32_store(4);
-          local_get(2); local_get(7); i32_store(0);
-          local_get(2); local_get(1); i32_store(4);
-          local_get(2); i32_const(0); i32_store(8);
-          local_get(2); return_;
+          local_get(Local(6)); local_get(Local(9)); i32_store(0);
+          local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
+          i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(7));
+          local_get(Local(7)); i32_const(Imm32(VTAG_STRING)); i32_store(0);
+          local_get(Local(7)); local_get(Local(6)); i32_store(4);
+          local_get(Local(2)); local_get(Local(7)); i32_store(0);
+          local_get(Local(2)); local_get(Local(1)); i32_store(4);
+          local_get(Local(2)); i32_const(Imm32(0)); i32_store(8);
+          local_get(Local(2)); return_;
         end;
     });
 }
@@ -1002,60 +1003,60 @@ fn emit_parse_string(f: &mut Function, alloc: u32, string_alloc: u32) {
 fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: u32) {
     // Check if number
     wasm!(f, {
-        local_get(4); i32_const(ASCII_MINUS); i32_eq;
-        local_get(4); i32_const(ASCII_ZERO); i32_ge_u;
-        local_get(4); i32_const(ASCII_NINE); i32_le_u;
+        local_get(Local(4)); i32_const(Imm32(ASCII_MINUS)); i32_eq;
+        local_get(Local(4)); i32_const(Imm32(ASCII_ZERO)); i32_ge_u;
+        local_get(Local(4)); i32_const(Imm32(ASCII_NINE)); i32_le_u;
         i32_and; i32_or;
         if_empty;
           // Save the token start (incl. a leading '-') so a float token can be
           // re-parsed by the correctly-rounded float.parse (#663 / #667).
-          local_get(1); local_set(5);
-          i32_const(1); local_set(11);
-          i64_const(0); local_set(12);
-          local_get(4); i32_const(ASCII_MINUS); i32_eq;
+          local_get(Local(1)); local_set(Local(5));
+          i32_const(Imm32(1)); local_set(Local(11));
+          i64_const(Imm64(0)); local_set(Local(12));
+          local_get(Local(4)); i32_const(Imm32(ASCII_MINUS)); i32_eq;
           if_empty;
-            i32_const(-1); local_set(11);
-            local_get(1); i32_const(1); i32_add; local_set(1);
+            i32_const(Imm32(-1)); local_set(Local(11));
+            local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
           end;
     });
     // Parse integer digits
     wasm!(f, {
           block_empty; loop_empty;
-            local_get(1); local_get(3); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); local_set(4);
-            local_get(4); i32_const(ASCII_ZERO); i32_lt_u; br_if(1);
-            local_get(4); i32_const(ASCII_NINE); i32_gt_u; br_if(1);
-            local_get(12); i64_const(DECIMAL_RADIX); i64_mul;
-            local_get(4); i32_const(ASCII_ZERO); i32_sub; i64_extend_i32_u;
-            i64_add; local_set(12);
-            local_get(1); i32_const(1); i32_add; local_set(1);
+            local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+            i32_load8_u(0); local_set(Local(4));
+            local_get(Local(4)); i32_const(Imm32(ASCII_ZERO)); i32_lt_u; br_if(1);
+            local_get(Local(4)); i32_const(Imm32(ASCII_NINE)); i32_gt_u; br_if(1);
+            local_get(Local(12)); i64_const(Imm64(DECIMAL_RADIX)); i64_mul;
+            local_get(Local(4)); i32_const(Imm32(ASCII_ZERO)); i32_sub; i64_extend_i32_u;
+            i64_add; local_set(Local(12));
+            local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
             br(0);
           end; end;
     });
     // Check for decimal point
     wasm!(f, {
-          local_get(1); local_get(3); i32_lt_u;
+          local_get(Local(1)); local_get(Local(3)); i32_lt_u;
           if_empty;
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+            i32_load8_u(0); i32_const(Imm32(ASCII_DOT)); i32_eq;
             if_empty;
-              local_get(1); i32_const(1); i32_add; local_set(1);
-              f64_const(1.0); local_set(13);
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
+              f64_const(1.0); local_set(Local(13));
     });
     // Parse decimal digits
     wasm!(f, {
               block_empty; loop_empty;
-                local_get(1); local_get(3); i32_ge_u; br_if(1);
-                local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-                i32_load8_u(0); local_set(4);
-                local_get(4); i32_const(ASCII_ZERO); i32_lt_u; br_if(1);
-                local_get(4); i32_const(ASCII_NINE); i32_gt_u; br_if(1);
-                local_get(12); i64_const(DECIMAL_RADIX); i64_mul;
-                local_get(4); i32_const(ASCII_ZERO); i32_sub; i64_extend_i32_u;
-                i64_add; local_set(12);
-                local_get(13); f64_const(10.0); f64_mul; local_set(13);
-                local_get(1); i32_const(1); i32_add; local_set(1);
+                local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+                local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+                i32_load8_u(0); local_set(Local(4));
+                local_get(Local(4)); i32_const(Imm32(ASCII_ZERO)); i32_lt_u; br_if(1);
+                local_get(Local(4)); i32_const(Imm32(ASCII_NINE)); i32_gt_u; br_if(1);
+                local_get(Local(12)); i64_const(Imm64(DECIMAL_RADIX)); i64_mul;
+                local_get(Local(4)); i32_const(Imm32(ASCII_ZERO)); i32_sub; i64_extend_i32_u;
+                i64_add; local_set(Local(12));
+                local_get(Local(13)); f64_const(10.0); f64_mul; local_set(Local(13));
+                local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
                 br(0);
               end; end;
     });
@@ -1067,27 +1068,27 @@ fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: 
     emit_parse_exponent(f);
     wasm!(f, {
               drop;
-              local_get(0); local_get(5); local_get(1); call(str_slice);
-              call(float_parse); local_set(7); // Result[Float, String] ptr; valid JSON ⇒ ok
-              i32_const(PARSE_RESULT_SIZE); call(alloc); local_set(6);
-              local_get(6); i32_const(VTAG_FLOAT); i32_store(0);
-              local_get(6); local_get(7); f64_load(4); f64_store(4);
-              local_get(2); local_get(6); i32_store(0);
-              local_get(2); local_get(1); i32_store(4);
-              local_get(2); i32_const(0); i32_store(8);
-              local_get(2); return_;
+              local_get(Local(0)); local_get(Local(5)); local_get(Local(1)); call(str_slice);
+              call(float_parse); local_set(Local(7)); // Result[Float, String] ptr; valid JSON ⇒ ok
+              i32_const(Imm32(PARSE_RESULT_SIZE)); call(alloc); local_set(Local(6));
+              local_get(Local(6)); i32_const(Imm32(VTAG_FLOAT)); i32_store(0);
+              local_get(Local(6)); local_get(Local(7)); f64_load(4); f64_store(4);
+              local_get(Local(2)); local_get(Local(6)); i32_store(0);
+              local_get(Local(2)); local_get(Local(1)); i32_store(4);
+              local_get(Local(2)); i32_const(Imm32(0)); i32_store(8);
+              local_get(Local(2)); return_;
             end;
           end;
     });
     // Integer path: check for exponent → becomes float
     wasm!(f, {
           // Check for e/E after integer
-          local_get(1); local_get(3); i32_lt_u;
+          local_get(Local(1)); local_get(Local(3)); i32_lt_u;
           if_empty;
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); local_set(4);
-            local_get(4); i32_const(ASCII_E_LOWER); i32_eq; // 'e'
-            local_get(4); i32_const(ASCII_E_UPPER); i32_eq;  // 'E'
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+            i32_load8_u(0); local_set(Local(4));
+            local_get(Local(4)); i32_const(Imm32(ASCII_E_LOWER)); i32_eq; // 'e'
+            local_get(Local(4)); i32_const(Imm32(ASCII_E_UPPER)); i32_eq;  // 'E'
             i32_or;
             if_empty;
               // Integer mantissa with an exponent suffix → a float. Re-parse the
@@ -1096,29 +1097,29 @@ fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: 
     emit_parse_exponent(f);
     wasm!(f, {
               drop;
-              local_get(0); local_get(5); local_get(1); call(str_slice);
-              call(float_parse); local_set(7);
-              i32_const(PARSE_RESULT_SIZE); call(alloc); local_set(6);
-              local_get(6); i32_const(VTAG_FLOAT); i32_store(0);
-              local_get(6); local_get(7); f64_load(4); f64_store(4);
-              local_get(2); local_get(6); i32_store(0);
-              local_get(2); local_get(1); i32_store(4);
-              local_get(2); i32_const(0); i32_store(8);
-              local_get(2); return_;
+              local_get(Local(0)); local_get(Local(5)); local_get(Local(1)); call(str_slice);
+              call(float_parse); local_set(Local(7));
+              i32_const(Imm32(PARSE_RESULT_SIZE)); call(alloc); local_set(Local(6));
+              local_get(Local(6)); i32_const(Imm32(VTAG_FLOAT)); i32_store(0);
+              local_get(Local(6)); local_get(Local(7)); f64_load(4); f64_store(4);
+              local_get(Local(2)); local_get(Local(6)); i32_store(0);
+              local_get(Local(2)); local_get(Local(1)); i32_store(4);
+              local_get(Local(2)); i32_const(Imm32(0)); i32_store(8);
+              local_get(Local(2)); return_;
             end;
           end;
     });
     // Build int Value (no exponent)
     wasm!(f, {
-          i32_const(PARSE_RESULT_SIZE); call(alloc); local_set(6);
-          local_get(6); i32_const(VTAG_INT); i32_store(0);
-          local_get(6);
-          local_get(11); i64_extend_i32_s; local_get(12); i64_mul;
+          i32_const(Imm32(PARSE_RESULT_SIZE)); call(alloc); local_set(Local(6));
+          local_get(Local(6)); i32_const(Imm32(VTAG_INT)); i32_store(0);
+          local_get(Local(6));
+          local_get(Local(11)); i64_extend_i32_s; local_get(Local(12)); i64_mul;
           i64_store(4);
-          local_get(2); local_get(6); i32_store(0);
-          local_get(2); local_get(1); i32_store(4);
-          local_get(2); i32_const(0); i32_store(8);
-          local_get(2); return_;
+          local_get(Local(2)); local_get(Local(6)); i32_store(0);
+          local_get(Local(2)); local_get(Local(1)); i32_store(4);
+          local_get(Local(2)); i32_const(Imm32(0)); i32_store(8);
+          local_get(Local(2)); return_;
         end;
     });
 }
@@ -1126,123 +1127,123 @@ fn emit_parse_number(f: &mut Function, alloc: u32, str_slice: u32, float_parse: 
 /// Parse JSON array.
 fn emit_parse_array(f: &mut Function, alloc: u32, parse_at_fn: u32) {
     wasm!(f, {
-        local_get(4); i32_const(ASCII_LBRACKET); i32_eq;
+        local_get(Local(4)); i32_const(Imm32(ASCII_LBRACKET)); i32_eq;
         if_empty;
-          local_get(1); i32_const(1); i32_add; local_set(1);
+          local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
     });
     // Skip whitespace (inline)
     wasm!(f, {
           block_empty; loop_empty;
-            local_get(1); local_get(3); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); local_set(4);
-            local_get(4); i32_const(ASCII_SPACE); i32_eq;
-            local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
-            local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
-            local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
+            local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+            i32_load8_u(0); local_set(Local(4));
+            local_get(Local(4)); i32_const(Imm32(ASCII_SPACE)); i32_eq;
+            local_get(Local(4)); i32_const(Imm32(ASCII_HT)); i32_eq; i32_or;
+            local_get(Local(4)); i32_const(Imm32(ASCII_LF)); i32_eq; i32_or;
+            local_get(Local(4)); i32_const(Imm32(ASCII_CR)); i32_eq; i32_or;
             i32_eqz; br_if(1);
-            local_get(1); i32_const(1); i32_add; local_set(1);
+            local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
             br(0);
           end; end;
     });
     // Check empty array
     wasm!(f, {
-          local_get(1); local_get(3); i32_lt_u;
+          local_get(Local(1)); local_get(Local(3)); i32_lt_u;
           if_empty;
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); i32_const(ASCII_RBRACKET); i32_eq;
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+            i32_load8_u(0); i32_const(Imm32(ASCII_RBRACKET)); i32_eq;
             if_empty;
-              local_get(1); i32_const(1); i32_add; local_set(1);
-              i32_const(list_hdr()); call(alloc); local_set(8);
-              local_get(8); i32_const(0); i32_store(0);
-              i32_const(VALUE_BOX_SIZE); call(alloc); local_set(6);
-              local_get(6); i32_const(VTAG_ARRAY); i32_store(0);
-              local_get(6); local_get(8); i32_store(4);
-              local_get(2); local_get(6); i32_store(0);
-              local_get(2); local_get(1); i32_store(4);
-              local_get(2); i32_const(0); i32_store(8);
-              local_get(2); return_;
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
+              i32_const(Imm32(list_hdr())); call(alloc); local_set(Local(8));
+              local_get(Local(8)); i32_const(Imm32(0)); i32_store(0);
+              i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(6));
+              local_get(Local(6)); i32_const(Imm32(VTAG_ARRAY)); i32_store(0);
+              local_get(Local(6)); local_get(Local(8)); i32_store(4);
+              local_get(Local(2)); local_get(Local(6)); i32_store(0);
+              local_get(Local(2)); local_get(Local(1)); i32_store(4);
+              local_get(Local(2)); i32_const(Imm32(0)); i32_store(8);
+              local_get(Local(2)); return_;
             end;
           end;
     });
     // Parse elements — growable buffer (local 14 = capacity)
     wasm!(f, {
-          i32_const(INIT_CAPACITY); local_set(14); // initial capacity
-          i32_const(INIT_BUF_BYTES); call(alloc); local_set(8); // list_hdr + INIT_CAPACITY*4
-          i32_const(0); local_set(9); // count = 0
+          i32_const(Imm32(INIT_CAPACITY)); local_set(Local(14)); // initial capacity
+          i32_const(Imm32(INIT_BUF_BYTES)); call(alloc); local_set(Local(8)); // list_hdr + INIT_CAPACITY*4
+          i32_const(Imm32(0)); local_set(Local(9)); // count = 0
           block_empty; loop_empty;
-            local_get(0); local_get(1);
-            call(parse_at_fn); local_set(10);
-            local_get(10); i32_load(8);
+            local_get(Local(0)); local_get(Local(1));
+            call(parse_at_fn); local_set(Local(10));
+            local_get(Local(10)); i32_load(8);
             if_empty;
-              local_get(2); local_get(10); i32_load(0); i32_store(0);
-              local_get(2); i32_const(0); i32_store(4);
-              local_get(2); i32_const(1); i32_store(8);
-              local_get(2); return_;
+              local_get(Local(2)); local_get(Local(10)); i32_load(0); i32_store(0);
+              local_get(Local(2)); i32_const(Imm32(0)); i32_store(4);
+              local_get(Local(2)); i32_const(Imm32(1)); i32_store(8);
+              local_get(Local(2)); return_;
             end;
     });
     // Grow buffer if count >= capacity (uses only locals 14, 15)
     wasm!(f, {
-            local_get(9); local_get(14); i32_ge_u;
+            local_get(Local(9)); local_get(Local(14)); i32_ge_u;
             if_empty;
-              local_get(8); local_set(15); // save old buf
-              local_get(14); i32_const(1); i32_shl; local_set(14); // cap *= 2
-              i32_const(list_hdr()); local_get(14); i32_const(I32_BYTES); i32_mul; i32_add;
-              call(alloc); local_set(8); // new buf → local 8
-              local_get(8); local_get(15);
-              i32_const(list_hdr()); local_get(9); i32_const(I32_BYTES); i32_mul; i32_add;
+              local_get(Local(8)); local_set(Local(15)); // save old buf
+              local_get(Local(14)); i32_const(Imm32(1)); i32_shl; local_set(Local(14)); // cap *= 2
+              i32_const(Imm32(list_hdr())); local_get(Local(14)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+              call(alloc); local_set(Local(8)); // new buf → local 8
+              local_get(Local(8)); local_get(Local(15));
+              i32_const(Imm32(list_hdr())); local_get(Local(9)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
               memory_copy;
             end;
     });
     wasm!(f, {
-            local_get(8); i32_const(list_data_off()); i32_add;
-            local_get(9); i32_const(I32_BYTES); i32_mul; i32_add;
-            local_get(10); i32_load(0); i32_store(0);
-            local_get(10); i32_load(4); local_set(1);
-            local_get(9); i32_const(1); i32_add; local_set(9);
+            local_get(Local(8)); i32_const(Imm32(list_data_off())); i32_add;
+            local_get(Local(9)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+            local_get(Local(10)); i32_load(0); i32_store(0);
+            local_get(Local(10)); i32_load(4); local_set(Local(1));
+            local_get(Local(9)); i32_const(Imm32(1)); i32_add; local_set(Local(9));
     });
     // Skip whitespace after element
     wasm!(f, {
             block_empty; loop_empty;
-              local_get(1); local_get(3); i32_ge_u; br_if(1);
-              local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-              i32_load8_u(0); local_set(4);
-              local_get(4); i32_const(ASCII_SPACE); i32_eq;
-              local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
-              local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
-              local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
+              local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+              local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+              i32_load8_u(0); local_set(Local(4));
+              local_get(Local(4)); i32_const(Imm32(ASCII_SPACE)); i32_eq;
+              local_get(Local(4)); i32_const(Imm32(ASCII_HT)); i32_eq; i32_or;
+              local_get(Local(4)); i32_const(Imm32(ASCII_LF)); i32_eq; i32_or;
+              local_get(Local(4)); i32_const(Imm32(ASCII_CR)); i32_eq; i32_or;
               i32_eqz; br_if(1);
-              local_get(1); i32_const(1); i32_add; local_set(1);
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
               br(0);
             end; end;
     });
     // Check ] or ,
     wasm!(f, {
-            local_get(1); local_get(3); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); local_set(4);
-            local_get(4); i32_const(ASCII_RBRACKET); i32_eq;
+            local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+            i32_load8_u(0); local_set(Local(4));
+            local_get(Local(4)); i32_const(Imm32(ASCII_RBRACKET)); i32_eq;
             if_empty;
-              local_get(1); i32_const(1); i32_add; local_set(1);
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
               br(2);
             end;
-            local_get(4); i32_const(ASCII_COMMA); i32_eq;
+            local_get(Local(4)); i32_const(Imm32(ASCII_COMMA)); i32_eq;
             if_empty;
-              local_get(1); i32_const(1); i32_add; local_set(1);
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
             end;
             br(0);
           end; end;
     });
     // Build result
     wasm!(f, {
-          local_get(8); local_get(9); i32_store(0);
-          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(6);
-          local_get(6); i32_const(VTAG_ARRAY); i32_store(0);
-          local_get(6); local_get(8); i32_store(4);
-          local_get(2); local_get(6); i32_store(0);
-          local_get(2); local_get(1); i32_store(4);
-          local_get(2); i32_const(0); i32_store(8);
-          local_get(2); return_;
+          local_get(Local(8)); local_get(Local(9)); i32_store(0);
+          i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(6));
+          local_get(Local(6)); i32_const(Imm32(VTAG_ARRAY)); i32_store(0);
+          local_get(Local(6)); local_get(Local(8)); i32_store(4);
+          local_get(Local(2)); local_get(Local(6)); i32_store(0);
+          local_get(Local(2)); local_get(Local(1)); i32_store(4);
+          local_get(Local(2)); i32_const(Imm32(0)); i32_store(8);
+          local_get(Local(2)); return_;
         end;
     });
 }
@@ -1250,177 +1251,177 @@ fn emit_parse_array(f: &mut Function, alloc: u32, parse_at_fn: u32) {
 /// Parse JSON object.
 fn emit_parse_object(f: &mut Function, alloc: u32, parse_at_fn: u32) {
     wasm!(f, {
-        local_get(4); i32_const(ASCII_LBRACE); i32_eq;
+        local_get(Local(4)); i32_const(Imm32(ASCII_LBRACE)); i32_eq;
         if_empty;
-          local_get(1); i32_const(1); i32_add; local_set(1);
+          local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
     });
     // Skip whitespace
     wasm!(f, {
           block_empty; loop_empty;
-            local_get(1); local_get(3); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); local_set(4);
-            local_get(4); i32_const(ASCII_SPACE); i32_eq;
-            local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
-            local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
-            local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
+            local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+            i32_load8_u(0); local_set(Local(4));
+            local_get(Local(4)); i32_const(Imm32(ASCII_SPACE)); i32_eq;
+            local_get(Local(4)); i32_const(Imm32(ASCII_HT)); i32_eq; i32_or;
+            local_get(Local(4)); i32_const(Imm32(ASCII_LF)); i32_eq; i32_or;
+            local_get(Local(4)); i32_const(Imm32(ASCII_CR)); i32_eq; i32_or;
             i32_eqz; br_if(1);
-            local_get(1); i32_const(1); i32_add; local_set(1);
+            local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
             br(0);
           end; end;
     });
     // Check empty object
     wasm!(f, {
-          local_get(1); local_get(3); i32_lt_u;
+          local_get(Local(1)); local_get(Local(3)); i32_lt_u;
           if_empty;
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); i32_const(ASCII_RBRACE); i32_eq;
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+            i32_load8_u(0); i32_const(Imm32(ASCII_RBRACE)); i32_eq;
             if_empty;
-              local_get(1); i32_const(1); i32_add; local_set(1);
-              i32_const(list_hdr()); call(alloc); local_set(8);
-              local_get(8); i32_const(0); i32_store(0);
-              i32_const(VALUE_BOX_SIZE); call(alloc); local_set(6);
-              local_get(6); i32_const(VTAG_OBJECT); i32_store(0);
-              local_get(6); local_get(8); i32_store(4);
-              local_get(2); local_get(6); i32_store(0);
-              local_get(2); local_get(1); i32_store(4);
-              local_get(2); i32_const(0); i32_store(8);
-              local_get(2); return_;
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
+              i32_const(Imm32(list_hdr())); call(alloc); local_set(Local(8));
+              local_get(Local(8)); i32_const(Imm32(0)); i32_store(0);
+              i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(6));
+              local_get(Local(6)); i32_const(Imm32(VTAG_OBJECT)); i32_store(0);
+              local_get(Local(6)); local_get(Local(8)); i32_store(4);
+              local_get(Local(2)); local_get(Local(6)); i32_store(0);
+              local_get(Local(2)); local_get(Local(1)); i32_store(4);
+              local_get(Local(2)); i32_const(Imm32(0)); i32_store(8);
+              local_get(Local(2)); return_;
             end;
           end;
     });
     // Parse key-value pairs — growable buffer (local 14 = capacity)
     wasm!(f, {
-          i32_const(INIT_CAPACITY); local_set(14); // initial capacity
-          i32_const(INIT_BUF_BYTES); call(alloc); local_set(8); // list_hdr + INIT_CAPACITY*4
-          i32_const(0); local_set(9);
+          i32_const(Imm32(INIT_CAPACITY)); local_set(Local(14)); // initial capacity
+          i32_const(Imm32(INIT_BUF_BYTES)); call(alloc); local_set(Local(8)); // list_hdr + INIT_CAPACITY*4
+          i32_const(Imm32(0)); local_set(Local(9));
           block_empty; loop_empty;
     });
     // Skip whitespace before key
     wasm!(f, {
             block_empty; loop_empty;
-              local_get(1); local_get(3); i32_ge_u; br_if(1);
-              local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-              i32_load8_u(0); local_set(4);
-              local_get(4); i32_const(ASCII_SPACE); i32_eq;
-              local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
-              local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
-              local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
+              local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+              local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+              i32_load8_u(0); local_set(Local(4));
+              local_get(Local(4)); i32_const(Imm32(ASCII_SPACE)); i32_eq;
+              local_get(Local(4)); i32_const(Imm32(ASCII_HT)); i32_eq; i32_or;
+              local_get(Local(4)); i32_const(Imm32(ASCII_LF)); i32_eq; i32_or;
+              local_get(Local(4)); i32_const(Imm32(ASCII_CR)); i32_eq; i32_or;
               i32_eqz; br_if(1);
-              local_get(1); i32_const(1); i32_add; local_set(1);
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
               br(0);
             end; end;
     });
     // Parse key
     wasm!(f, {
-            local_get(0); local_get(1);
-            call(parse_at_fn); local_set(10);
-            local_get(10); i32_load(8);
+            local_get(Local(0)); local_get(Local(1));
+            call(parse_at_fn); local_set(Local(10));
+            local_get(Local(10)); i32_load(8);
             if_empty;
-              local_get(2); local_get(10); i32_load(0); i32_store(0);
-              local_get(2); i32_const(0); i32_store(4);
-              local_get(2); i32_const(1); i32_store(8);
-              local_get(2); return_;
+              local_get(Local(2)); local_get(Local(10)); i32_load(0); i32_store(0);
+              local_get(Local(2)); i32_const(Imm32(0)); i32_store(4);
+              local_get(Local(2)); i32_const(Imm32(1)); i32_store(8);
+              local_get(Local(2)); return_;
             end;
-            local_get(10); i32_load(0); i32_load(4); local_set(7);
-            local_get(10); i32_load(4); local_set(1);
+            local_get(Local(10)); i32_load(0); i32_load(4); local_set(Local(7));
+            local_get(Local(10)); i32_load(4); local_set(Local(1));
     });
     // Skip whitespace and colon
     wasm!(f, {
             block_empty; loop_empty;
-              local_get(1); local_get(3); i32_ge_u; br_if(1);
-              local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-              i32_load8_u(0); local_set(4);
-              local_get(4); i32_const(ASCII_SPACE); i32_eq;
-              local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
-              local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
-              local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
-              local_get(4); i32_const(ASCII_COLON); i32_eq; i32_or;
+              local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+              local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+              i32_load8_u(0); local_set(Local(4));
+              local_get(Local(4)); i32_const(Imm32(ASCII_SPACE)); i32_eq;
+              local_get(Local(4)); i32_const(Imm32(ASCII_HT)); i32_eq; i32_or;
+              local_get(Local(4)); i32_const(Imm32(ASCII_LF)); i32_eq; i32_or;
+              local_get(Local(4)); i32_const(Imm32(ASCII_CR)); i32_eq; i32_or;
+              local_get(Local(4)); i32_const(Imm32(ASCII_COLON)); i32_eq; i32_or;
               i32_eqz; br_if(1);
-              local_get(1); i32_const(1); i32_add; local_set(1);
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
               br(0);
             end; end;
     });
     // Parse value
     wasm!(f, {
-            local_get(0); local_get(1);
-            call(parse_at_fn); local_set(10);
-            local_get(10); i32_load(8);
+            local_get(Local(0)); local_get(Local(1));
+            call(parse_at_fn); local_set(Local(10));
+            local_get(Local(10)); i32_load(8);
             if_empty;
-              local_get(2); local_get(10); i32_load(0); i32_store(0);
-              local_get(2); i32_const(0); i32_store(4);
-              local_get(2); i32_const(1); i32_store(8);
-              local_get(2); return_;
+              local_get(Local(2)); local_get(Local(10)); i32_load(0); i32_store(0);
+              local_get(Local(2)); i32_const(Imm32(0)); i32_store(4);
+              local_get(Local(2)); i32_const(Imm32(1)); i32_store(8);
+              local_get(Local(2)); return_;
             end;
     });
     // Grow object list buffer if count >= capacity (uses only locals 14, 15)
     wasm!(f, {
-            local_get(9); local_get(14); i32_ge_u;
+            local_get(Local(9)); local_get(Local(14)); i32_ge_u;
             if_empty;
-              local_get(8); local_set(15); // save old buf
-              local_get(14); i32_const(1); i32_shl; local_set(14); // cap *= 2
-              i32_const(list_hdr()); local_get(14); i32_const(I32_BYTES); i32_mul; i32_add;
-              call(alloc); local_set(8); // new buf
-              local_get(8); local_get(15);
-              i32_const(list_hdr()); local_get(9); i32_const(I32_BYTES); i32_mul; i32_add;
+              local_get(Local(8)); local_set(Local(15)); // save old buf
+              local_get(Local(14)); i32_const(Imm32(1)); i32_shl; local_set(Local(14)); // cap *= 2
+              i32_const(Imm32(list_hdr())); local_get(Local(14)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+              call(alloc); local_set(Local(8)); // new buf
+              local_get(Local(8)); local_get(Local(15));
+              i32_const(Imm32(list_hdr())); local_get(Local(9)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
               memory_copy;
             end;
     });
     // Allocate tuple (key_str_ptr, value_ptr) and store pointer in list
     wasm!(f, {
             // Allocate VALUE_BOX_SIZE tuple: [key_str_ptr: i32][value_ptr: i32]
-            i32_const(VALUE_BOX_SIZE); call(alloc); local_set(5); // reuse local 5 as tuple_ptr
-            local_get(5); local_get(7); i32_store(0); // key
-            local_get(5); local_get(10); i32_load(0); i32_store(4); // value
+            i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(5)); // reuse local 5 as tuple_ptr
+            local_get(Local(5)); local_get(Local(7)); i32_store(0); // key
+            local_get(Local(5)); local_get(Local(10)); i32_load(0); i32_store(4); // value
             // Store tuple pointer in list at position count
-            local_get(8); i32_const(list_data_off()); i32_add;
-            local_get(9); i32_const(I32_BYTES); i32_mul; i32_add;
-            local_get(5); i32_store(0);
-            local_get(10); i32_load(4); local_set(1);
-            local_get(9); i32_const(1); i32_add; local_set(9);
+            local_get(Local(8)); i32_const(Imm32(list_data_off())); i32_add;
+            local_get(Local(9)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+            local_get(Local(5)); i32_store(0);
+            local_get(Local(10)); i32_load(4); local_set(Local(1));
+            local_get(Local(9)); i32_const(Imm32(1)); i32_add; local_set(Local(9));
     });
     // Skip whitespace after value
     wasm!(f, {
             block_empty; loop_empty;
-              local_get(1); local_get(3); i32_ge_u; br_if(1);
-              local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-              i32_load8_u(0); local_set(4);
-              local_get(4); i32_const(ASCII_SPACE); i32_eq;
-              local_get(4); i32_const(ASCII_HT); i32_eq; i32_or;
-              local_get(4); i32_const(ASCII_LF); i32_eq; i32_or;
-              local_get(4); i32_const(ASCII_CR); i32_eq; i32_or;
+              local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+              local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+              i32_load8_u(0); local_set(Local(4));
+              local_get(Local(4)); i32_const(Imm32(ASCII_SPACE)); i32_eq;
+              local_get(Local(4)); i32_const(Imm32(ASCII_HT)); i32_eq; i32_or;
+              local_get(Local(4)); i32_const(Imm32(ASCII_LF)); i32_eq; i32_or;
+              local_get(Local(4)); i32_const(Imm32(ASCII_CR)); i32_eq; i32_or;
               i32_eqz; br_if(1);
-              local_get(1); i32_const(1); i32_add; local_set(1);
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
               br(0);
             end; end;
     });
     // Check } or ,
     wasm!(f, {
-            local_get(1); local_get(3); i32_ge_u; br_if(1);
-            local_get(0); i32_const(string_data_off()); i32_add; local_get(1); i32_add;
-            i32_load8_u(0); local_set(4);
-            local_get(4); i32_const(ASCII_RBRACE); i32_eq;
+            local_get(Local(1)); local_get(Local(3)); i32_ge_u; br_if(1);
+            local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(1)); i32_add;
+            i32_load8_u(0); local_set(Local(4));
+            local_get(Local(4)); i32_const(Imm32(ASCII_RBRACE)); i32_eq;
             if_empty;
-              local_get(1); i32_const(1); i32_add; local_set(1);
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
               br(2);
             end;
-            local_get(4); i32_const(ASCII_COMMA); i32_eq;
+            local_get(Local(4)); i32_const(Imm32(ASCII_COMMA)); i32_eq;
             if_empty;
-              local_get(1); i32_const(1); i32_add; local_set(1);
+              local_get(Local(1)); i32_const(Imm32(1)); i32_add; local_set(Local(1));
             end;
             br(0);
           end; end;
     });
     // Build object result
     wasm!(f, {
-          local_get(8); local_get(9); i32_store(0);
-          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(6);
-          local_get(6); i32_const(VTAG_OBJECT); i32_store(0);
-          local_get(6); local_get(8); i32_store(4);
-          local_get(2); local_get(6); i32_store(0);
-          local_get(2); local_get(1); i32_store(4);
-          local_get(2); i32_const(0); i32_store(8);
-          local_get(2); return_;
+          local_get(Local(8)); local_get(Local(9)); i32_store(0);
+          i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(6));
+          local_get(Local(6)); i32_const(Imm32(VTAG_OBJECT)); i32_store(0);
+          local_get(Local(6)); local_get(Local(8)); i32_store(4);
+          local_get(Local(2)); local_get(Local(6)); i32_store(0);
+          local_get(Local(2)); local_get(Local(1)); i32_store(4);
+          local_get(Local(2)); i32_const(Imm32(0)); i32_store(8);
+          local_get(Local(2)); return_;
         end;
     });
 }
@@ -1453,13 +1454,13 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
     // --- Phase 1: Count segments ---
     // Walk path from leaf to root, counting non-root nodes.
     wasm!(f, {
-        i32_const(0); local_set(2);     // seg_count = 0
-        local_get(1); local_set(3);     // cur_path = path
+        i32_const(Imm32(0)); local_set(Local(2));     // seg_count = 0
+        local_get(Local(1)); local_set(Local(3));     // cur_path = path
         block_empty; loop_empty;
-          local_get(3); i32_load(0);    // tag
+          local_get(Local(3)); i32_load(0);    // tag
           i32_eqz; br_if(1);           // tag==0 (root) → done
-          local_get(2); i32_const(1); i32_add; local_set(2);
-          local_get(3); i32_load(4); local_set(3); // cur_path = parent
+          local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
+          local_get(Local(3)); i32_load(4); local_set(Local(3)); // cur_path = parent
           br(0);
         end; end;
     });
@@ -1467,24 +1468,24 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
     // --- Phase 2: Allocate segments array and fill in reverse ---
     // segs_arr = alloc(seg_count * I32_BYTES), each slot is a path node ptr.
     wasm!(f, {
-        local_get(2); i32_eqz;
+        local_get(Local(2)); i32_eqz;
         if_empty;
           // Empty path → return some(value): alloc option box.
           // SHARE: the box holds a second reference to the input tree.
-          i32_const(I32_BYTES); call(alloc); local_set(13);
-          local_get(13); local_get(0); call(emitter.rt.rc_inc); i32_store(0);
-          local_get(13);
+          i32_const(Imm32(I32_BYTES)); call(alloc); local_set(Local(13));
+          local_get(Local(13)); local_get(Local(0)); call(emitter.rt.rc_inc); i32_store(0);
+          local_get(Local(13));
           return_;
         end;
-        local_get(2); i32_const(I32_BYTES); i32_mul; call(alloc); local_set(4); // segs_arr
-        local_get(2); local_set(5); // i = seg_count (fill from end)
-        local_get(1); local_set(3); // cur_path = path (start from leaf)
+        local_get(Local(2)); i32_const(Imm32(I32_BYTES)); i32_mul; call(alloc); local_set(Local(4)); // segs_arr
+        local_get(Local(2)); local_set(Local(5)); // i = seg_count (fill from end)
+        local_get(Local(1)); local_set(Local(3)); // cur_path = path (start from leaf)
         block_empty; loop_empty;
-          local_get(3); i32_load(0); i32_eqz; br_if(1); // root → done
-          local_get(5); i32_const(1); i32_sub; local_set(5); // i--
-          local_get(4); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
-          local_get(3); i32_store(0); // segs_arr[i] = cur_path
-          local_get(3); i32_load(4); local_set(3); // cur_path = parent
+          local_get(Local(3)); i32_load(0); i32_eqz; br_if(1); // root → done
+          local_get(Local(5)); i32_const(Imm32(1)); i32_sub; local_set(Local(5)); // i--
+          local_get(Local(4)); local_get(Local(5)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          local_get(Local(3)); i32_store(0); // segs_arr[i] = cur_path
+          local_get(Local(3)); i32_load(4); local_set(Local(3)); // cur_path = parent
           br(0);
         end; end;
     });
@@ -1492,76 +1493,76 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
     // --- Phase 3: Walk value following segments ---
     // cur_val = value
     wasm!(f, {
-        local_get(0); local_set(8); // cur_val = value
-        i32_const(0); local_set(5); // i = 0
+        local_get(Local(0)); local_set(Local(8)); // cur_val = value
+        i32_const(Imm32(0)); local_set(Local(5)); // i = 0
         block_empty; loop_empty;
-          local_get(5); local_get(2); i32_ge_u; br_if(1); // i >= seg_count → done
+          local_get(Local(5)); local_get(Local(2)); i32_ge_u; br_if(1); // i >= seg_count → done
           // Load segment
-          local_get(4); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
-          i32_load(0); local_set(6); // seg_ptr
-          local_get(6); i32_load(0); local_set(7); // seg_tag
+          local_get(Local(4)); local_get(Local(5)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          i32_load(0); local_set(Local(6)); // seg_ptr
+          local_get(Local(6)); i32_load(0); local_set(Local(7)); // seg_tag
     });
 
     // --- Field segment (tag=1) ---
     wasm!(f, {
-          local_get(7); i32_const(JP_FIELD_TAG); i32_eq;
+          local_get(Local(7)); i32_const(Imm32(JP_FIELD_TAG)); i32_eq;
           if_empty;
             // cur_val must be object (tag=6)
-            local_get(8); i32_load(0); i32_const(VTAG_OBJECT); i32_ne;
-            if_empty; i32_const(0); return_; end; // not object → none
-            local_get(8); i32_load(4); local_set(9); // list (pairs)
-            local_get(9); i32_load(0); local_set(10); // len
-            i32_const(0); local_set(11); // j = 0
-            i32_const(0); local_set(13); // found = 0
+            local_get(Local(8)); i32_load(0); i32_const(Imm32(VTAG_OBJECT)); i32_ne;
+            if_empty; i32_const(Imm32(0)); return_; end; // not object → none
+            local_get(Local(8)); i32_load(4); local_set(Local(9)); // list (pairs)
+            local_get(Local(9)); i32_load(0); local_set(Local(10)); // len
+            i32_const(Imm32(0)); local_set(Local(11)); // j = 0
+            i32_const(Imm32(0)); local_set(Local(13)); // found = 0
             block_empty; loop_empty;
-              local_get(11); local_get(10); i32_ge_u; br_if(1);
-              local_get(9); i32_const(list_data_off()); i32_add;
-              local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
-              i32_load(0); local_set(12); // pair_ptr
-              local_get(12); i32_load(0); // pair key
-              local_get(6); i32_load(8); // segment field name
+              local_get(Local(11)); local_get(Local(10)); i32_ge_u; br_if(1);
+              local_get(Local(9)); i32_const(Imm32(list_data_off())); i32_add;
+              local_get(Local(11)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+              i32_load(0); local_set(Local(12)); // pair_ptr
+              local_get(Local(12)); i32_load(0); // pair key
+              local_get(Local(6)); i32_load(8); // segment field name
               call(str_eq);
               if_empty;
-                local_get(12); i32_load(4); local_set(8); // cur_val = pair value
-                i32_const(1); local_set(13); // found = 1
+                local_get(Local(12)); i32_load(4); local_set(Local(8)); // cur_val = pair value
+                i32_const(Imm32(1)); local_set(Local(13)); // found = 1
                 br(2);
               end;
-              local_get(11); i32_const(1); i32_add; local_set(11);
+              local_get(Local(11)); i32_const(Imm32(1)); i32_add; local_set(Local(11));
               br(0);
             end; end;
-            local_get(13); i32_eqz;
-            if_empty; i32_const(0); return_; end; // key not found → none
+            local_get(Local(13)); i32_eqz;
+            if_empty; i32_const(Imm32(0)); return_; end; // key not found → none
           end;
     });
 
     // --- Index segment (tag=2) ---
     wasm!(f, {
-          local_get(7); i32_const(JP_INDEX_TAG); i32_eq;
+          local_get(Local(7)); i32_const(Imm32(JP_INDEX_TAG)); i32_eq;
           if_empty;
             // cur_val must be array (tag=5)
-            local_get(8); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
-            if_empty; i32_const(0); return_; end; // not array → none
-            local_get(8); i32_load(4); local_set(9); // list
-            local_get(9); i32_load(0); local_set(10); // len
-            local_get(6); i32_load(8); local_set(11); // index value
+            local_get(Local(8)); i32_load(0); i32_const(Imm32(VTAG_ARRAY)); i32_ne;
+            if_empty; i32_const(Imm32(0)); return_; end; // not array → none
+            local_get(Local(8)); i32_load(4); local_set(Local(9)); // list
+            local_get(Local(9)); i32_load(0); local_set(Local(10)); // len
+            local_get(Local(6)); i32_load(8); local_set(Local(11)); // index value
     });
     emit_normalize_neg_index(&mut f, 11, 10); // native: i<0 → len+i
     wasm!(f, {
             // Bounds check (still-negative-after-normalize counts as OOB)
-            local_get(11); i32_const(0); i32_lt_s;
-            local_get(11); local_get(10); i32_ge_s;
+            local_get(Local(11)); i32_const(Imm32(0)); i32_lt_s;
+            local_get(Local(11)); local_get(Local(10)); i32_ge_s;
             i32_or;
-            if_empty; i32_const(0); return_; end; // out of bounds → none
+            if_empty; i32_const(Imm32(0)); return_; end; // out of bounds → none
             // cur_val = list[index]
-            local_get(9); i32_const(list_data_off()); i32_add;
-            local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
-            i32_load(0); local_set(8);
+            local_get(Local(9)); i32_const(Imm32(list_data_off())); i32_add;
+            local_get(Local(11)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+            i32_load(0); local_set(Local(8));
           end;
     });
 
     // --- Next segment ---
     wasm!(f, {
-          local_get(5); i32_const(1); i32_add; local_set(5);
+          local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5));
           br(0);
         end; end;
     });
@@ -1569,9 +1570,9 @@ fn compile_json_get_path(emitter: &mut WasmEmitter) {
     // --- Return some(cur_val): alloc Option box ---
     // SHARE: cur_val is an interior pointer into the surviving input tree.
     wasm!(f, {
-        i32_const(I32_BYTES); call(alloc); local_set(13);
-        local_get(13); local_get(8); call(emitter.rt.rc_inc); i32_store(0);
-        local_get(13);
+        i32_const(Imm32(I32_BYTES)); call(alloc); local_set(Local(13));
+        local_get(Local(13)); local_get(Local(8)); call(emitter.rt.rc_inc); i32_store(0);
+        local_get(Local(13));
         end;
     });
 
@@ -1601,36 +1602,36 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
 
     // --- Phase 1: Count segments ---
     wasm!(f, {
-        i32_const(0); local_set(3);
-        local_get(1); local_set(4);
+        i32_const(Imm32(0)); local_set(Local(3));
+        local_get(Local(1)); local_set(Local(4));
         block_empty; loop_empty;
-          local_get(4); i32_load(0); i32_eqz; br_if(1);
-          local_get(3); i32_const(1); i32_add; local_set(3);
-          local_get(4); i32_load(4); local_set(4);
+          local_get(Local(4)); i32_load(0); i32_eqz; br_if(1);
+          local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(3));
+          local_get(Local(4)); i32_load(4); local_set(Local(4));
           br(0);
         end; end;
     });
 
     // --- Phase 2: Allocate and fill segments array ---
     wasm!(f, {
-        local_get(3); i32_eqz;
+        local_get(Local(3)); i32_eqz;
         if_empty;
           // Empty path → ok(new_val)
-          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(14);
-          local_get(14); i32_const(0); i32_store(0);
-          local_get(14); local_get(2); i32_store(4);
-          local_get(14);
+          i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(14));
+          local_get(Local(14)); i32_const(Imm32(0)); i32_store(0);
+          local_get(Local(14)); local_get(Local(2)); i32_store(4);
+          local_get(Local(14));
           return_;
         end;
-        local_get(3); i32_const(I32_BYTES); i32_mul; call(alloc); local_set(5);
-        local_get(3); local_set(6);
-        local_get(1); local_set(4);
+        local_get(Local(3)); i32_const(Imm32(I32_BYTES)); i32_mul; call(alloc); local_set(Local(5));
+        local_get(Local(3)); local_set(Local(6));
+        local_get(Local(1)); local_set(Local(4));
         block_empty; loop_empty;
-          local_get(4); i32_load(0); i32_eqz; br_if(1);
-          local_get(6); i32_const(1); i32_sub; local_set(6);
-          local_get(5); local_get(6); i32_const(I32_BYTES); i32_mul; i32_add;
-          local_get(4); i32_store(0);
-          local_get(4); i32_load(4); local_set(4);
+          local_get(Local(4)); i32_load(0); i32_eqz; br_if(1);
+          local_get(Local(6)); i32_const(Imm32(1)); i32_sub; local_set(Local(6));
+          local_get(Local(5)); local_get(Local(6)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          local_get(Local(4)); i32_store(0);
+          local_get(Local(4)); i32_load(4); local_set(Local(4));
           br(0);
         end; end;
     });
@@ -1638,18 +1639,18 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
     // --- Phase 3: Walk forward saving values at each depth ---
     // val_stack = alloc((seg_count+1) * I32_BYTES): val_stack[d] = value at depth d
     wasm!(f, {
-        local_get(3); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul;
-        call(alloc); local_set(16); // val_stack
-        local_get(16); local_get(0); i32_store(0); // val_stack[0] = value
-        i32_const(0); local_set(6); // depth = 0
+        local_get(Local(3)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(I32_BYTES)); i32_mul;
+        call(alloc); local_set(Local(16)); // val_stack
+        local_get(Local(16)); local_get(Local(0)); i32_store(0); // val_stack[0] = value
+        i32_const(Imm32(0)); local_set(Local(6)); // depth = 0
         block_empty; loop_empty;
-          local_get(6); local_get(3); i32_const(1); i32_sub; i32_ge_u; br_if(1); // depth >= seg_count-1 → done
-          local_get(5); local_get(6); i32_const(I32_BYTES); i32_mul; i32_add;
-          i32_load(0); local_set(7); // seg_ptr = segs_arr[depth]
-          local_get(7); i32_load(0); local_set(8); // seg_tag
+          local_get(Local(6)); local_get(Local(3)); i32_const(Imm32(1)); i32_sub; i32_ge_u; br_if(1); // depth >= seg_count-1 → done
+          local_get(Local(5)); local_get(Local(6)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          i32_load(0); local_set(Local(7)); // seg_ptr = segs_arr[depth]
+          local_get(Local(7)); i32_load(0); local_set(Local(8)); // seg_tag
           // Load cur_val from val_stack[depth]
-          local_get(16); local_get(6); i32_const(I32_BYTES); i32_mul; i32_add;
-          i32_load(0); local_set(9);
+          local_get(Local(16)); local_get(Local(6)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          i32_load(0); local_set(Local(9));
     });
 
     // Navigate field during forward walk.
@@ -1663,43 +1664,43 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
     // never an Err. The prior `path error: expected object` Err diverged: native
     // autovivifies here instead of failing.
     wasm!(f, {
-          local_get(8); i32_const(JP_FIELD_TAG); i32_eq;
+          local_get(Local(8)); i32_const(Imm32(JP_FIELD_TAG)); i32_eq;
           if_empty;
-            i32_const(0); local_set(17); // found = 0
+            i32_const(Imm32(0)); local_set(Local(17)); // found = 0
             // Only scan pairs when cur_val is actually an object; otherwise it
             // is a non-object that native replaces (autoviv) — leave found = 0.
-            local_get(9); i32_load(0); i32_const(VTAG_OBJECT); i32_eq;
+            local_get(Local(9)); i32_load(0); i32_const(Imm32(VTAG_OBJECT)); i32_eq;
             if_empty;
-              local_get(9); i32_load(4); local_set(10); // pairs list
-              local_get(10); i32_load(0); local_set(11); // len
-              i32_const(0); local_set(12);
+              local_get(Local(9)); i32_load(4); local_set(Local(10)); // pairs list
+              local_get(Local(10)); i32_load(0); local_set(Local(11)); // len
+              i32_const(Imm32(0)); local_set(Local(12));
               block_empty; loop_empty;
-                local_get(12); local_get(11); i32_ge_u; br_if(1);
-                local_get(10); i32_const(list_data_off()); i32_add;
-                local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
-                i32_load(0); local_set(13); // pair
-                local_get(13); i32_load(0);
-                local_get(7); i32_load(8);
+                local_get(Local(12)); local_get(Local(11)); i32_ge_u; br_if(1);
+                local_get(Local(10)); i32_const(Imm32(list_data_off())); i32_add;
+                local_get(Local(12)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                i32_load(0); local_set(Local(13)); // pair
+                local_get(Local(13)); i32_load(0);
+                local_get(Local(7)); i32_load(8);
                 call(str_eq);
                 if_empty;
-                  local_get(16); local_get(6); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul; i32_add;
-                  local_get(13); i32_load(4); i32_store(0);
-                  i32_const(1); local_set(17);
+                  local_get(Local(16)); local_get(Local(6)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                  local_get(Local(13)); i32_load(4); i32_store(0);
+                  i32_const(Imm32(1)); local_set(Local(17));
                   br(2);
                 end;
-                local_get(12); i32_const(1); i32_add; local_set(12);
+                local_get(Local(12)); i32_const(Imm32(1)); i32_add; local_set(Local(12));
                 br(0);
               end; end;
             end;
             // Key absent (or cur_val was a non-object): seed the next depth with
             // a fresh empty object, mirroring native `Object(vec![])`.
-            local_get(17); i32_eqz;
+            local_get(Local(17)); i32_eqz;
             if_empty;
     });
     emit_make_empty_object(&mut f, 17, alloc);
     wasm!(f, {
-              local_get(16); local_get(6); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul; i32_add;
-              local_get(17); i32_store(0);
+              local_get(Local(16)); local_get(Local(6)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+              local_get(Local(17)); i32_store(0);
             end;
           end;
     });
@@ -1719,36 +1720,36 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
         // val_stack[depth+1] = {}  (don't-care value; rebuild discards it here)
         emit_make_empty_object(f, 17, alloc);
         wasm!(f, {
-            local_get(16); local_get(6); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul; i32_add;
-            local_get(17); i32_store(0);
+            local_get(Local(16)); local_get(Local(6)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+            local_get(Local(17)); i32_store(0);
         });
     };
     wasm!(f, {
-          local_get(8); i32_const(JP_INDEX_TAG); i32_eq;
+          local_get(Local(8)); i32_const(Imm32(JP_INDEX_TAG)); i32_eq;
           if_empty;
-            local_get(9); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
+            local_get(Local(9)); i32_load(0); i32_const(Imm32(VTAG_ARRAY)); i32_ne;
             if_empty;
     });
     emit_index_noop_placeholder(&mut f);
     wasm!(f, {
             else_;
-            local_get(9); i32_load(4); local_set(10); // list
-            local_get(10); i32_load(0); local_set(11); // len
-            local_get(7); i32_load(8); local_set(18); // idx
+            local_get(Local(9)); i32_load(4); local_set(Local(10)); // list
+            local_get(Local(10)); i32_load(0); local_set(Local(11)); // len
+            local_get(Local(7)); i32_load(8); local_set(Local(18)); // idx
     });
     emit_normalize_neg_index(&mut f, 18, 11);
     wasm!(f, {
-            local_get(18); i32_const(0); i32_lt_s;
-            local_get(18); local_get(11); i32_ge_s;
+            local_get(Local(18)); i32_const(Imm32(0)); i32_lt_s;
+            local_get(Local(18)); local_get(Local(11)); i32_ge_s;
             i32_or;
             if_empty;
     });
     emit_index_noop_placeholder(&mut f);
     wasm!(f, {
             else_;
-            local_get(16); local_get(6); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul; i32_add;
-            local_get(10); i32_const(list_data_off()); i32_add;
-            local_get(18); i32_const(I32_BYTES); i32_mul; i32_add;
+            local_get(Local(16)); local_get(Local(6)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+            local_get(Local(10)); i32_const(Imm32(list_data_off())); i32_add;
+            local_get(Local(18)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
             i32_load(0); i32_store(0);
             end;
             end;
@@ -1757,7 +1758,7 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
 
     // Next depth in forward walk
     wasm!(f, {
-          local_get(6); i32_const(1); i32_add; local_set(6);
+          local_get(Local(6)); i32_const(Imm32(1)); i32_add; local_set(Local(6));
           br(0);
         end; end;
     });
@@ -1765,103 +1766,103 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
     // --- Phase 4: Rebuild from leaf to root ---
     // cur_built starts as new_val, then we wrap it at each level going backwards.
     wasm!(f, {
-        local_get(2); local_set(9); // cur_built = new_val
-        local_get(3); i32_const(1); i32_sub; local_set(6); // depth = seg_count - 1
+        local_get(Local(2)); local_set(Local(9)); // cur_built = new_val
+        local_get(Local(3)); i32_const(Imm32(1)); i32_sub; local_set(Local(6)); // depth = seg_count - 1
         block_empty; loop_empty;
-          local_get(6); i32_const(0); i32_lt_s; br_if(1);
-          local_get(5); local_get(6); i32_const(I32_BYTES); i32_mul; i32_add;
-          i32_load(0); local_set(7); // seg
-          local_get(7); i32_load(0); local_set(8); // seg_tag
+          local_get(Local(6)); i32_const(Imm32(0)); i32_lt_s; br_if(1);
+          local_get(Local(5)); local_get(Local(6)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          i32_load(0); local_set(Local(7)); // seg
+          local_get(Local(7)); i32_load(0); local_set(Local(8)); // seg_tag
           // orig_val at this depth
-          local_get(16); local_get(6); i32_const(I32_BYTES); i32_mul; i32_add;
-          i32_load(0); local_set(14);
+          local_get(Local(16)); local_get(Local(6)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          i32_load(0); local_set(Local(14));
     });
 
     // Rebuild for field segment
     wasm!(f, {
-          local_get(8); i32_const(JP_FIELD_TAG); i32_eq;
+          local_get(Local(8)); i32_const(Imm32(JP_FIELD_TAG)); i32_eq;
           if_empty;
-            local_get(14); i32_load(0); i32_const(VTAG_OBJECT); i32_eq;
+            local_get(Local(14)); i32_load(0); i32_const(Imm32(VTAG_OBJECT)); i32_eq;
             if_empty;
               // Clone pairs, replacing matching key
-              local_get(14); i32_load(4); local_set(10); // old pairs
-              local_get(10); i32_load(0); local_set(11); // old len
+              local_get(Local(14)); i32_load(4); local_set(Local(10)); // old pairs
+              local_get(Local(10)); i32_load(0); local_set(Local(11)); // old len
               // Check if key exists
-              i32_const(0); local_set(17);
-              i32_const(0); local_set(12);
+              i32_const(Imm32(0)); local_set(Local(17));
+              i32_const(Imm32(0)); local_set(Local(12));
               block_empty; loop_empty;
-                local_get(12); local_get(11); i32_ge_u; br_if(1);
-                local_get(10); i32_const(list_data_off()); i32_add;
-                local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
-                i32_load(0); local_set(13);
-                local_get(13); i32_load(0);
-                local_get(7); i32_load(8);
+                local_get(Local(12)); local_get(Local(11)); i32_ge_u; br_if(1);
+                local_get(Local(10)); i32_const(Imm32(list_data_off())); i32_add;
+                local_get(Local(12)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                i32_load(0); local_set(Local(13));
+                local_get(Local(13)); i32_load(0);
+                local_get(Local(7)); i32_load(8);
                 call(str_eq);
-                if_empty; i32_const(1); local_set(17); end;
-                local_get(12); i32_const(1); i32_add; local_set(12);
+                if_empty; i32_const(Imm32(1)); local_set(Local(17)); end;
+                local_get(Local(12)); i32_const(Imm32(1)); i32_add; local_set(Local(12));
                 br(0);
               end; end;
               // new_len = old_len + (found ? 0 : 1)
-              local_get(11); local_get(17); i32_eqz; i32_add; local_set(18);
+              local_get(Local(11)); local_get(Local(17)); i32_eqz; i32_add; local_set(Local(18));
               // Alloc new pairs list
-              i32_const(list_data_off()); local_get(18); i32_const(I32_BYTES); i32_mul; i32_add;
-              call(alloc); local_set(15);
-              local_get(15); local_get(18); i32_store(0);
+              i32_const(Imm32(list_data_off())); local_get(Local(18)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+              call(alloc); local_set(Local(15));
+              local_get(Local(15)); local_get(Local(18)); i32_store(0);
               // Copy, replacing match
-              i32_const(0); local_set(12);
+              i32_const(Imm32(0)); local_set(Local(12));
               block_empty; loop_empty;
-                local_get(12); local_get(11); i32_ge_u; br_if(1);
-                local_get(10); i32_const(list_data_off()); i32_add;
-                local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
-                i32_load(0); local_set(13);
-                local_get(13); i32_load(0);
-                local_get(7); i32_load(8);
+                local_get(Local(12)); local_get(Local(11)); i32_ge_u; br_if(1);
+                local_get(Local(10)); i32_const(Imm32(list_data_off())); i32_add;
+                local_get(Local(12)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                i32_load(0); local_set(Local(13));
+                local_get(Local(13)); i32_load(0);
+                local_get(Local(7)); i32_load(8);
                 call(str_eq);
                 if_empty;
                   // Replace value — the kept KEY string is shared from the
                   // old pair the source tree still owns: dup.
-                  i32_const(VALUE_BOX_SIZE); call(alloc); local_set(17);
-                  local_get(17); local_get(13); i32_load(0); call(emitter.rt.rc_inc); i32_store(0);
-                  local_get(17); local_get(9); i32_store(4);
-                  local_get(15); i32_const(list_data_off()); i32_add;
-                  local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
-                  local_get(17); i32_store(0);
+                  i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(17));
+                  local_get(Local(17)); local_get(Local(13)); i32_load(0); call(emitter.rt.rc_inc); i32_store(0);
+                  local_get(Local(17)); local_get(Local(9)); i32_store(4);
+                  local_get(Local(15)); i32_const(Imm32(list_data_off())); i32_add;
+                  local_get(Local(12)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                  local_get(Local(17)); i32_store(0);
                 else_;
                   // Unchanged pair: shared between old and new object — dup.
-                  local_get(15); i32_const(list_data_off()); i32_add;
-                  local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
-                  local_get(13); call(emitter.rt.rc_inc); i32_store(0);
+                  local_get(Local(15)); i32_const(Imm32(list_data_off())); i32_add;
+                  local_get(Local(12)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                  local_get(Local(13)); call(emitter.rt.rc_inc); i32_store(0);
                 end;
-                local_get(12); i32_const(1); i32_add; local_set(12);
+                local_get(Local(12)); i32_const(Imm32(1)); i32_add; local_set(Local(12));
                 br(0);
               end; end;
               // Append new pair if key was not found
-              local_get(18); local_get(11); i32_gt_u;
+              local_get(Local(18)); local_get(Local(11)); i32_gt_u;
               if_empty;
-                i32_const(VALUE_BOX_SIZE); call(alloc); local_set(17);
-                local_get(17); local_get(7); i32_load(8); call(emitter.rt.rc_inc); i32_store(0);
-                local_get(17); local_get(9); i32_store(4);
-                local_get(15); i32_const(list_data_off()); i32_add;
-                local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
-                local_get(17); i32_store(0);
+                i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(17));
+                local_get(Local(17)); local_get(Local(7)); i32_load(8); call(emitter.rt.rc_inc); i32_store(0);
+                local_get(Local(17)); local_get(Local(9)); i32_store(4);
+                local_get(Local(15)); i32_const(Imm32(list_data_off())); i32_add;
+                local_get(Local(11)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                local_get(Local(17)); i32_store(0);
               end;
               // Build object
-              i32_const(VALUE_BOX_SIZE); call(alloc); local_set(9);
-              local_get(9); i32_const(VTAG_OBJECT); i32_store(0);
-              local_get(9); local_get(15); i32_store(4);
+              i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(9));
+              local_get(Local(9)); i32_const(Imm32(VTAG_OBJECT)); i32_store(0);
+              local_get(Local(9)); local_get(Local(15)); i32_store(4);
             else_;
               // Not an object → AUTOVIVIFY: replace it with a fresh single-key
               // object {seg_key: cur_built}, mirroring native `set_at_steps`
               // Field-over-non-object (json.rs:288).
-              i32_const(list_hdr() + I32_BYTES); call(alloc); local_set(15); // pairs list: 1 slot
-              local_get(15); i32_const(1); i32_store(0);
-              i32_const(VALUE_BOX_SIZE); call(alloc); local_set(17); // pair [key][val]
-              local_get(17); local_get(7); i32_load(8); call(emitter.rt.rc_inc); i32_store(0);
-              local_get(17); local_get(9); i32_store(4);
-              local_get(15); i32_const(list_data_off()); i32_add; local_get(17); i32_store(0);
-              i32_const(VALUE_BOX_SIZE); call(alloc); local_set(9);
-              local_get(9); i32_const(VTAG_OBJECT); i32_store(0);
-              local_get(9); local_get(15); i32_store(4);
+              i32_const(Imm32(list_hdr() + I32_BYTES)); call(alloc); local_set(Local(15)); // pairs list: 1 slot
+              local_get(Local(15)); i32_const(Imm32(1)); i32_store(0);
+              i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(17)); // pair [key][val]
+              local_get(Local(17)); local_get(Local(7)); i32_load(8); call(emitter.rt.rc_inc); i32_store(0);
+              local_get(Local(17)); local_get(Local(9)); i32_store(4);
+              local_get(Local(15)); i32_const(Imm32(list_data_off())); i32_add; local_get(Local(17)); i32_store(0);
+              i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(9));
+              local_get(Local(9)); i32_const(Imm32(VTAG_OBJECT)); i32_store(0);
+              local_get(Local(9)); local_get(Local(15)); i32_store(4);
             end;
           end;
     });
@@ -1871,50 +1872,50 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
     // So when orig is not an array OR the (normalized) index is OOB, keep the
     // original value as the rebuilt node instead of fabricating an array.
     wasm!(f, {
-          local_get(8); i32_const(JP_INDEX_TAG); i32_eq;
+          local_get(Local(8)); i32_const(Imm32(JP_INDEX_TAG)); i32_eq;
           if_empty;
             // Non-array → no-op: cur_built = orig_val.
-            local_get(14); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
+            local_get(Local(14)); i32_load(0); i32_const(Imm32(VTAG_ARRAY)); i32_ne;
             if_empty;
-              local_get(14); call(emitter.rt.rc_inc); local_set(9);
+              local_get(Local(14)); call(emitter.rt.rc_inc); local_set(Local(9));
             else_;
-              local_get(14); i32_load(4); local_set(10); // old list
-              local_get(10); i32_load(0); local_set(11); // len
-              local_get(7); i32_load(8); local_set(18); // idx
+              local_get(Local(14)); i32_load(4); local_set(Local(10)); // old list
+              local_get(Local(10)); i32_load(0); local_set(Local(11)); // len
+              local_get(Local(7)); i32_load(8); local_set(Local(18)); // idx
     });
     emit_normalize_neg_index(&mut f, 18, 11);
     wasm!(f, {
               // OOB (incl. still-negative) → no-op: cur_built = orig_val.
-              local_get(18); i32_const(0); i32_lt_s;
-              local_get(18); local_get(11); i32_ge_s;
+              local_get(Local(18)); i32_const(Imm32(0)); i32_lt_s;
+              local_get(Local(18)); local_get(Local(11)); i32_ge_s;
               i32_or;
               if_empty;
-                local_get(14); call(emitter.rt.rc_inc); local_set(9);
+                local_get(Local(14)); call(emitter.rt.rc_inc); local_set(Local(9));
               else_;
                 // Clone list replacing at idx
-                i32_const(list_hdr()); local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
-                call(alloc); local_set(15);
-                local_get(15); local_get(11); i32_store(0);
-                i32_const(0); local_set(12);
+                i32_const(Imm32(list_hdr())); local_get(Local(11)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                call(alloc); local_set(Local(15));
+                local_get(Local(15)); local_get(Local(11)); i32_store(0);
+                i32_const(Imm32(0)); local_set(Local(12));
                 block_empty; loop_empty;
-                  local_get(12); local_get(11); i32_ge_u; br_if(1);
-                  local_get(15); i32_const(list_data_off()); i32_add;
-                  local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
-                  local_get(12); local_get(18); i32_eq;
-                  if_i32; local_get(9);
+                  local_get(Local(12)); local_get(Local(11)); i32_ge_u; br_if(1);
+                  local_get(Local(15)); i32_const(Imm32(list_data_off())); i32_add;
+                  local_get(Local(12)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                  local_get(Local(12)); local_get(Local(18)); i32_eq;
+                  if_i32; local_get(Local(9));
                   else_;
                     // Unchanged element: shared between old and new array — dup.
-                    local_get(10); i32_const(list_data_off()); i32_add;
-                    local_get(12); i32_const(I32_BYTES); i32_mul; i32_add;
+                    local_get(Local(10)); i32_const(Imm32(list_data_off())); i32_add;
+                    local_get(Local(12)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
                     i32_load(0); call(emitter.rt.rc_inc);
                   end;
                   i32_store(0);
-                  local_get(12); i32_const(1); i32_add; local_set(12);
+                  local_get(Local(12)); i32_const(Imm32(1)); i32_add; local_set(Local(12));
                   br(0);
                 end; end;
-                i32_const(VALUE_BOX_SIZE); call(alloc); local_set(9);
-                local_get(9); i32_const(VTAG_ARRAY); i32_store(0);
-                local_get(9); local_get(15); i32_store(4);
+                i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(9));
+                local_get(Local(9)); i32_const(Imm32(VTAG_ARRAY)); i32_store(0);
+                local_get(Local(9)); local_get(Local(15)); i32_store(4);
               end;
             end;
           end;
@@ -1922,17 +1923,17 @@ fn compile_json_set_path(emitter: &mut WasmEmitter) {
 
     // Next depth upward
     wasm!(f, {
-          local_get(6); i32_const(1); i32_sub; local_set(6);
+          local_get(Local(6)); i32_const(Imm32(1)); i32_sub; local_set(Local(6));
           br(0);
         end; end;
     });
 
     // Return ok(result)
     wasm!(f, {
-        i32_const(VALUE_BOX_SIZE); call(alloc); local_set(14);
-        local_get(14); i32_const(0); i32_store(0);
-        local_get(14); local_get(9); i32_store(4);
-        local_get(14);
+        i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(14));
+        local_get(Local(14)); i32_const(Imm32(0)); i32_store(0);
+        local_get(Local(14)); local_get(Local(9)); i32_store(4);
+        local_get(Local(14));
         end;
     });
 
@@ -1955,110 +1956,110 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
 
     // --- Phase 1: Count segments ---
     wasm!(f, {
-        i32_const(0); local_set(2);
-        local_get(1); local_set(3);
+        i32_const(Imm32(0)); local_set(Local(2));
+        local_get(Local(1)); local_set(Local(3));
         block_empty; loop_empty;
-          local_get(3); i32_load(0); i32_eqz; br_if(1);
-          local_get(2); i32_const(1); i32_add; local_set(2);
-          local_get(3); i32_load(4); local_set(3);
+          local_get(Local(3)); i32_load(0); i32_eqz; br_if(1);
+          local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
+          local_get(Local(3)); i32_load(4); local_set(Local(3));
           br(0);
         end; end;
     });
 
     // --- Phase 2: Allocate and fill segments array ---
     wasm!(f, {
-        local_get(2); i32_eqz;
+        local_get(Local(2)); i32_eqz;
         if_empty;
           // Empty path → return null (removing root itself)
-          i32_const(I32_BYTES); call(alloc); local_set(16);
-          local_get(16); i32_const(0); i32_store(0);
-          local_get(16);
+          i32_const(Imm32(I32_BYTES)); call(alloc); local_set(Local(16));
+          local_get(Local(16)); i32_const(Imm32(0)); i32_store(0);
+          local_get(Local(16));
           return_;
         end;
-        local_get(2); i32_const(I32_BYTES); i32_mul; call(alloc); local_set(4);
-        local_get(2); local_set(5);
-        local_get(1); local_set(3);
+        local_get(Local(2)); i32_const(Imm32(I32_BYTES)); i32_mul; call(alloc); local_set(Local(4));
+        local_get(Local(2)); local_set(Local(5));
+        local_get(Local(1)); local_set(Local(3));
         block_empty; loop_empty;
-          local_get(3); i32_load(0); i32_eqz; br_if(1);
-          local_get(5); i32_const(1); i32_sub; local_set(5);
-          local_get(4); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
-          local_get(3); i32_store(0);
-          local_get(3); i32_load(4); local_set(3);
+          local_get(Local(3)); i32_load(0); i32_eqz; br_if(1);
+          local_get(Local(5)); i32_const(Imm32(1)); i32_sub; local_set(Local(5));
+          local_get(Local(4)); local_get(Local(5)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          local_get(Local(3)); i32_store(0);
+          local_get(Local(3)); i32_load(4); local_set(Local(3));
           br(0);
         end; end;
     });
 
     // --- Phase 3: Walk forward saving values at each depth (all but last) ---
     wasm!(f, {
-        local_get(2); i32_const(I32_BYTES); i32_mul; call(alloc); local_set(14); // val_stack
-        local_get(14); local_get(0); i32_store(0); // val_stack[0] = value
-        i32_const(0); local_set(5); // depth = 0
+        local_get(Local(2)); i32_const(Imm32(I32_BYTES)); i32_mul; call(alloc); local_set(Local(14)); // val_stack
+        local_get(Local(14)); local_get(Local(0)); i32_store(0); // val_stack[0] = value
+        i32_const(Imm32(0)); local_set(Local(5)); // depth = 0
         block_empty; loop_empty;
-          local_get(5); local_get(2); i32_const(1); i32_sub; i32_ge_u; br_if(1);
-          local_get(4); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
-          i32_load(0); local_set(6);
-          local_get(6); i32_load(0); local_set(7);
-          local_get(14); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
-          i32_load(0); local_set(8);
+          local_get(Local(5)); local_get(Local(2)); i32_const(Imm32(1)); i32_sub; i32_ge_u; br_if(1);
+          local_get(Local(4)); local_get(Local(5)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          i32_load(0); local_set(Local(6));
+          local_get(Local(6)); i32_load(0); local_set(Local(7));
+          local_get(Local(14)); local_get(Local(5)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          i32_load(0); local_set(Local(8));
     });
 
     // Navigate field for walk
     wasm!(f, {
-          local_get(7); i32_const(JP_FIELD_TAG); i32_eq;
+          local_get(Local(7)); i32_const(Imm32(JP_FIELD_TAG)); i32_eq;
           if_empty;
-            local_get(8); i32_load(0); i32_const(VTAG_OBJECT); i32_ne;
-            if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end;
-            local_get(8); i32_load(4); local_set(9);
-            local_get(9); i32_load(0); local_set(10);
-            i32_const(0); local_set(11);
-            i32_const(0); local_set(13);
+            local_get(Local(8)); i32_load(0); i32_const(Imm32(VTAG_OBJECT)); i32_ne;
+            if_empty; local_get(Local(0)); call(emitter.rt.rc_inc); return_; end;
+            local_get(Local(8)); i32_load(4); local_set(Local(9));
+            local_get(Local(9)); i32_load(0); local_set(Local(10));
+            i32_const(Imm32(0)); local_set(Local(11));
+            i32_const(Imm32(0)); local_set(Local(13));
             block_empty; loop_empty;
-              local_get(11); local_get(10); i32_ge_u; br_if(1);
-              local_get(9); i32_const(list_data_off()); i32_add;
-              local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
-              i32_load(0); local_set(12);
-              local_get(12); i32_load(0);
-              local_get(6); i32_load(8);
+              local_get(Local(11)); local_get(Local(10)); i32_ge_u; br_if(1);
+              local_get(Local(9)); i32_const(Imm32(list_data_off())); i32_add;
+              local_get(Local(11)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+              i32_load(0); local_set(Local(12));
+              local_get(Local(12)); i32_load(0);
+              local_get(Local(6)); i32_load(8);
               call(str_eq);
               if_empty;
-                local_get(14); local_get(5); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul; i32_add;
-                local_get(12); i32_load(4); i32_store(0);
-                i32_const(1); local_set(13);
+                local_get(Local(14)); local_get(Local(5)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                local_get(Local(12)); i32_load(4); i32_store(0);
+                i32_const(Imm32(1)); local_set(Local(13));
                 br(2);
               end;
-              local_get(11); i32_const(1); i32_add; local_set(11);
+              local_get(Local(11)); i32_const(Imm32(1)); i32_add; local_set(Local(11));
               br(0);
             end; end;
-            local_get(13); i32_eqz;
-            if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end;
+            local_get(Local(13)); i32_eqz;
+            if_empty; local_get(Local(0)); call(emitter.rt.rc_inc); return_; end;
           end;
     });
 
     // Navigate index for walk
     wasm!(f, {
-          local_get(7); i32_const(JP_INDEX_TAG); i32_eq;
+          local_get(Local(7)); i32_const(Imm32(JP_INDEX_TAG)); i32_eq;
           if_empty;
-            local_get(8); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
-            if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end; // non-array → no-op (orig)
-            local_get(8); i32_load(4); local_set(9);
-            local_get(9); i32_load(0); local_set(10);
-            local_get(6); i32_load(8); local_set(17);
+            local_get(Local(8)); i32_load(0); i32_const(Imm32(VTAG_ARRAY)); i32_ne;
+            if_empty; local_get(Local(0)); call(emitter.rt.rc_inc); return_; end; // non-array → no-op (orig)
+            local_get(Local(8)); i32_load(4); local_set(Local(9));
+            local_get(Local(9)); i32_load(0); local_set(Local(10));
+            local_get(Local(6)); i32_load(8); local_set(Local(17));
     });
     emit_normalize_neg_index(&mut f, 17, 10);
     wasm!(f, {
-            local_get(17); i32_const(0); i32_lt_s;
-            local_get(17); local_get(10); i32_ge_s;
+            local_get(Local(17)); i32_const(Imm32(0)); i32_lt_s;
+            local_get(Local(17)); local_get(Local(10)); i32_ge_s;
             i32_or;
-            if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end; // OOB → no-op (orig)
-            local_get(14); local_get(5); i32_const(1); i32_add; i32_const(I32_BYTES); i32_mul; i32_add;
-            local_get(9); i32_const(list_data_off()); i32_add;
-            local_get(17); i32_const(I32_BYTES); i32_mul; i32_add;
+            if_empty; local_get(Local(0)); call(emitter.rt.rc_inc); return_; end; // OOB → no-op (orig)
+            local_get(Local(14)); local_get(Local(5)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+            local_get(Local(9)); i32_const(Imm32(list_data_off())); i32_add;
+            local_get(Local(17)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
             i32_load(0); i32_store(0);
           end;
     });
 
     wasm!(f, {
-          local_get(5); i32_const(1); i32_add; local_set(5);
+          local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5));
           br(0);
         end; end;
     });
@@ -2066,144 +2067,144 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
     // --- Phase 4: Remove at the last segment ---
     // Load last segment and value at that depth
     wasm!(f, {
-        local_get(4); local_get(2); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add;
-        i32_load(0); local_set(6);
-        local_get(6); i32_load(0); local_set(7);
-        local_get(14); local_get(2); i32_const(1); i32_sub; i32_const(I32_BYTES); i32_mul; i32_add;
-        i32_load(0); local_set(8);
+        local_get(Local(4)); local_get(Local(2)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+        i32_load(0); local_set(Local(6));
+        local_get(Local(6)); i32_load(0); local_set(Local(7));
+        local_get(Local(14)); local_get(Local(2)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+        i32_load(0); local_set(Local(8));
     });
 
     // Remove field from object
     wasm!(f, {
-        local_get(7); i32_const(JP_FIELD_TAG); i32_eq;
+        local_get(Local(7)); i32_const(Imm32(JP_FIELD_TAG)); i32_eq;
         if_empty;
-          local_get(8); i32_load(0); i32_const(VTAG_OBJECT); i32_ne;
-          if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end;
-          local_get(8); i32_load(4); local_set(9);
-          local_get(9); i32_load(0); local_set(10);
+          local_get(Local(8)); i32_load(0); i32_const(Imm32(VTAG_OBJECT)); i32_ne;
+          if_empty; local_get(Local(0)); call(emitter.rt.rc_inc); return_; end;
+          local_get(Local(8)); i32_load(4); local_set(Local(9));
+          local_get(Local(9)); i32_load(0); local_set(Local(10));
           // Alloc new list (worst case same size)
-          i32_const(list_data_off()); local_get(10); i32_const(I32_BYTES); i32_mul; i32_add;
-          call(alloc); local_set(15);
-          i32_const(0); local_set(11); // src
-          i32_const(0); local_set(18); // dst
+          i32_const(Imm32(list_data_off())); local_get(Local(10)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          call(alloc); local_set(Local(15));
+          i32_const(Imm32(0)); local_set(Local(11)); // src
+          i32_const(Imm32(0)); local_set(Local(18)); // dst
           block_empty; loop_empty;
-            local_get(11); local_get(10); i32_ge_u; br_if(1);
-            local_get(9); i32_const(list_data_off()); i32_add;
-            local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
-            i32_load(0); local_set(12);
-            local_get(12); i32_load(0);
-            local_get(6); i32_load(8);
+            local_get(Local(11)); local_get(Local(10)); i32_ge_u; br_if(1);
+            local_get(Local(9)); i32_const(Imm32(list_data_off())); i32_add;
+            local_get(Local(11)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+            i32_load(0); local_set(Local(12));
+            local_get(Local(12)); i32_load(0);
+            local_get(Local(6)); i32_load(8);
             call(str_eq);
             i32_eqz;
             if_empty;
               // Surviving pair: shared with the source object — dup.
-              local_get(15); i32_const(list_data_off()); i32_add;
-              local_get(18); i32_const(I32_BYTES); i32_mul; i32_add;
-              local_get(12); call(emitter.rt.rc_inc); i32_store(0);
-              local_get(18); i32_const(1); i32_add; local_set(18);
+              local_get(Local(15)); i32_const(Imm32(list_data_off())); i32_add;
+              local_get(Local(18)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+              local_get(Local(12)); call(emitter.rt.rc_inc); i32_store(0);
+              local_get(Local(18)); i32_const(Imm32(1)); i32_add; local_set(Local(18));
             end;
-            local_get(11); i32_const(1); i32_add; local_set(11);
+            local_get(Local(11)); i32_const(Imm32(1)); i32_add; local_set(Local(11));
             br(0);
           end; end;
-          local_get(15); local_get(18); i32_store(0); // set actual len
-          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(16);
-          local_get(16); i32_const(VTAG_OBJECT); i32_store(0);
-          local_get(16); local_get(15); i32_store(4);
+          local_get(Local(15)); local_get(Local(18)); i32_store(0); // set actual len
+          i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(16));
+          local_get(Local(16)); i32_const(Imm32(VTAG_OBJECT)); i32_store(0);
+          local_get(Local(16)); local_get(Local(15)); i32_store(4);
         end;
     });
 
     // Remove index from array
     wasm!(f, {
-        local_get(7); i32_const(JP_INDEX_TAG); i32_eq;
+        local_get(Local(7)); i32_const(Imm32(JP_INDEX_TAG)); i32_eq;
         if_empty;
-          local_get(8); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
-          if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end; // non-array → no-op (orig)
-          local_get(8); i32_load(4); local_set(9);
-          local_get(9); i32_load(0); local_set(10);
-          local_get(6); i32_load(8); local_set(17);
+          local_get(Local(8)); i32_load(0); i32_const(Imm32(VTAG_ARRAY)); i32_ne;
+          if_empty; local_get(Local(0)); call(emitter.rt.rc_inc); return_; end; // non-array → no-op (orig)
+          local_get(Local(8)); i32_load(4); local_set(Local(9));
+          local_get(Local(9)); i32_load(0); local_set(Local(10));
+          local_get(Local(6)); i32_load(8); local_set(Local(17));
     });
     emit_normalize_neg_index(&mut f, 17, 10);
     wasm!(f, {
-          local_get(17); i32_const(0); i32_lt_s;
-          local_get(17); local_get(10); i32_ge_s;
+          local_get(Local(17)); i32_const(Imm32(0)); i32_lt_s;
+          local_get(Local(17)); local_get(Local(10)); i32_ge_s;
           i32_or;
-          if_empty; local_get(0); call(emitter.rt.rc_inc); return_; end; // OOB → no-op (orig)
+          if_empty; local_get(Local(0)); call(emitter.rt.rc_inc); return_; end; // OOB → no-op (orig)
           // Alloc new list (len - 1)
-          local_get(10); i32_const(1); i32_sub; local_set(13);
-          i32_const(list_hdr()); local_get(13); i32_const(I32_BYTES); i32_mul; i32_add;
-          call(alloc); local_set(15);
-          local_get(15); local_get(13); i32_store(0);
-          i32_const(0); local_set(11); // src
-          i32_const(0); local_set(18); // dst
+          local_get(Local(10)); i32_const(Imm32(1)); i32_sub; local_set(Local(13));
+          i32_const(Imm32(list_hdr())); local_get(Local(13)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          call(alloc); local_set(Local(15));
+          local_get(Local(15)); local_get(Local(13)); i32_store(0);
+          i32_const(Imm32(0)); local_set(Local(11)); // src
+          i32_const(Imm32(0)); local_set(Local(18)); // dst
           block_empty; loop_empty;
-            local_get(11); local_get(10); i32_ge_u; br_if(1);
-            local_get(11); local_get(17); i32_ne;
+            local_get(Local(11)); local_get(Local(10)); i32_ge_u; br_if(1);
+            local_get(Local(11)); local_get(Local(17)); i32_ne;
             if_empty;
-              local_get(15); i32_const(list_data_off()); i32_add;
-              local_get(18); i32_const(I32_BYTES); i32_mul; i32_add;
-              local_get(9); i32_const(list_data_off()); i32_add;
-              local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
+              local_get(Local(15)); i32_const(Imm32(list_data_off())); i32_add;
+              local_get(Local(18)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+              local_get(Local(9)); i32_const(Imm32(list_data_off())); i32_add;
+              local_get(Local(11)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
               i32_load(0); i32_store(0);
-              local_get(18); i32_const(1); i32_add; local_set(18);
+              local_get(Local(18)); i32_const(Imm32(1)); i32_add; local_set(Local(18));
             end;
-            local_get(11); i32_const(1); i32_add; local_set(11);
+            local_get(Local(11)); i32_const(Imm32(1)); i32_add; local_set(Local(11));
             br(0);
           end; end;
-          i32_const(VALUE_BOX_SIZE); call(alloc); local_set(16);
-          local_get(16); i32_const(VTAG_ARRAY); i32_store(0);
-          local_get(16); local_get(15); i32_store(4);
+          i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(16));
+          local_get(Local(16)); i32_const(Imm32(VTAG_ARRAY)); i32_store(0);
+          local_get(Local(16)); local_get(Local(15)); i32_store(4);
         end;
     });
 
     // --- Phase 5: Rebuild upward from seg_count-2 to 0 ---
     // cur_built is in local 16
     wasm!(f, {
-        local_get(2); i32_const(JP_INDEX_TAG); i32_sub; local_set(5); // depth = seg_count - 2
+        local_get(Local(2)); i32_const(Imm32(JP_INDEX_TAG)); i32_sub; local_set(Local(5)); // depth = seg_count - 2
         block_empty; loop_empty;
-          local_get(5); i32_const(0); i32_lt_s; br_if(1);
-          local_get(4); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
-          i32_load(0); local_set(6);
-          local_get(6); i32_load(0); local_set(7);
-          local_get(14); local_get(5); i32_const(I32_BYTES); i32_mul; i32_add;
-          i32_load(0); local_set(8); // orig val
+          local_get(Local(5)); i32_const(Imm32(0)); i32_lt_s; br_if(1);
+          local_get(Local(4)); local_get(Local(5)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          i32_load(0); local_set(Local(6));
+          local_get(Local(6)); i32_load(0); local_set(Local(7));
+          local_get(Local(14)); local_get(Local(5)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+          i32_load(0); local_set(Local(8)); // orig val
     });
 
     // Rebuild field
     wasm!(f, {
-          local_get(7); i32_const(JP_FIELD_TAG); i32_eq;
+          local_get(Local(7)); i32_const(Imm32(JP_FIELD_TAG)); i32_eq;
           if_empty;
-            local_get(8); i32_load(4); local_set(9);
-            local_get(9); i32_load(0); local_set(10);
-            i32_const(list_data_off()); local_get(10); i32_const(I32_BYTES); i32_mul; i32_add;
-            call(alloc); local_set(15);
-            local_get(15); local_get(10); i32_store(0);
-            i32_const(0); local_set(11);
+            local_get(Local(8)); i32_load(4); local_set(Local(9));
+            local_get(Local(9)); i32_load(0); local_set(Local(10));
+            i32_const(Imm32(list_data_off())); local_get(Local(10)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+            call(alloc); local_set(Local(15));
+            local_get(Local(15)); local_get(Local(10)); i32_store(0);
+            i32_const(Imm32(0)); local_set(Local(11));
             block_empty; loop_empty;
-              local_get(11); local_get(10); i32_ge_u; br_if(1);
-              local_get(9); i32_const(list_data_off()); i32_add;
-              local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
-              i32_load(0); local_set(12);
-              local_get(12); i32_load(0);
-              local_get(6); i32_load(8);
+              local_get(Local(11)); local_get(Local(10)); i32_ge_u; br_if(1);
+              local_get(Local(9)); i32_const(Imm32(list_data_off())); i32_add;
+              local_get(Local(11)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+              i32_load(0); local_set(Local(12));
+              local_get(Local(12)); i32_load(0);
+              local_get(Local(6)); i32_load(8);
               call(str_eq);
               if_empty;
-                i32_const(VALUE_BOX_SIZE); call(alloc); local_set(13);
-                local_get(13); local_get(12); i32_load(0); call(emitter.rt.rc_inc); i32_store(0);
-                local_get(13); local_get(16); i32_store(4);
-                local_get(15); i32_const(list_data_off()); i32_add;
-                local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
-                local_get(13); call(emitter.rt.rc_inc); i32_store(0);
+                i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(13));
+                local_get(Local(13)); local_get(Local(12)); i32_load(0); call(emitter.rt.rc_inc); i32_store(0);
+                local_get(Local(13)); local_get(Local(16)); i32_store(4);
+                local_get(Local(15)); i32_const(Imm32(list_data_off())); i32_add;
+                local_get(Local(11)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                local_get(Local(13)); call(emitter.rt.rc_inc); i32_store(0);
               else_;
-                local_get(15); i32_const(list_data_off()); i32_add;
-                local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
-                local_get(12); call(emitter.rt.rc_inc); i32_store(0);
+                local_get(Local(15)); i32_const(Imm32(list_data_off())); i32_add;
+                local_get(Local(11)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                local_get(Local(12)); call(emitter.rt.rc_inc); i32_store(0);
               end;
-              local_get(11); i32_const(1); i32_add; local_set(11);
+              local_get(Local(11)); i32_const(Imm32(1)); i32_add; local_set(Local(11));
               br(0);
             end; end;
-            i32_const(VALUE_BOX_SIZE); call(alloc); local_set(16);
-            local_get(16); i32_const(VTAG_OBJECT); i32_store(0);
-            local_get(16); local_get(15); i32_store(4);
+            i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(16));
+            local_get(Local(16)); i32_const(Imm32(VTAG_OBJECT)); i32_store(0);
+            local_get(Local(16)); local_get(Local(15)); i32_store(4);
           end;
     });
 
@@ -2212,54 +2213,54 @@ fn compile_json_remove_path(emitter: &mut WasmEmitter) {
     // a non-array here is a defensive no-op; the normalization mirrors the
     // forward walk so a negative intermediate index targets the same slot.
     wasm!(f, {
-          local_get(7); i32_const(JP_INDEX_TAG); i32_eq;
+          local_get(Local(7)); i32_const(Imm32(JP_INDEX_TAG)); i32_eq;
           if_empty;
-            local_get(8); i32_load(0); i32_const(VTAG_ARRAY); i32_ne;
+            local_get(Local(8)); i32_load(0); i32_const(Imm32(VTAG_ARRAY)); i32_ne;
             if_empty;
-              local_get(8); local_set(16); // non-array → keep orig as built node
+              local_get(Local(8)); local_set(Local(16)); // non-array → keep orig as built node
             else_;
-              local_get(8); i32_load(4); local_set(9);
-              local_get(9); i32_load(0); local_set(10);
-              local_get(6); i32_load(8); local_set(17);
+              local_get(Local(8)); i32_load(4); local_set(Local(9));
+              local_get(Local(9)); i32_load(0); local_set(Local(10));
+              local_get(Local(6)); i32_load(8); local_set(Local(17));
     });
     emit_normalize_neg_index(&mut f, 17, 10);
     wasm!(f, {
-              i32_const(list_hdr()); local_get(10); i32_const(I32_BYTES); i32_mul; i32_add;
-              call(alloc); local_set(15);
-              local_get(15); local_get(10); i32_store(0);
-              i32_const(0); local_set(11);
+              i32_const(Imm32(list_hdr())); local_get(Local(10)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+              call(alloc); local_set(Local(15));
+              local_get(Local(15)); local_get(Local(10)); i32_store(0);
+              i32_const(Imm32(0)); local_set(Local(11));
               block_empty; loop_empty;
-                local_get(11); local_get(10); i32_ge_u; br_if(1);
-                local_get(15); i32_const(list_data_off()); i32_add;
-                local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
-                local_get(11); local_get(17); i32_eq;
-                if_i32; local_get(16);
+                local_get(Local(11)); local_get(Local(10)); i32_ge_u; br_if(1);
+                local_get(Local(15)); i32_const(Imm32(list_data_off())); i32_add;
+                local_get(Local(11)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
+                local_get(Local(11)); local_get(Local(17)); i32_eq;
+                if_i32; local_get(Local(16));
                 else_;
                   // Unchanged element: shared between old and new array — dup.
-                  local_get(9); i32_const(list_data_off()); i32_add;
-                  local_get(11); i32_const(I32_BYTES); i32_mul; i32_add;
+                  local_get(Local(9)); i32_const(Imm32(list_data_off())); i32_add;
+                  local_get(Local(11)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add;
                   i32_load(0); call(emitter.rt.rc_inc);
                 end;
                 i32_store(0);
-                local_get(11); i32_const(1); i32_add; local_set(11);
+                local_get(Local(11)); i32_const(Imm32(1)); i32_add; local_set(Local(11));
                 br(0);
               end; end;
-              i32_const(VALUE_BOX_SIZE); call(alloc); local_set(16);
-              local_get(16); i32_const(VTAG_ARRAY); i32_store(0);
-              local_get(16); local_get(15); i32_store(4);
+              i32_const(Imm32(VALUE_BOX_SIZE)); call(alloc); local_set(Local(16));
+              local_get(Local(16)); i32_const(Imm32(VTAG_ARRAY)); i32_store(0);
+              local_get(Local(16)); local_get(Local(15)); i32_store(4);
             end;
           end;
     });
 
     wasm!(f, {
-          local_get(5); i32_const(1); i32_sub; local_set(5);
+          local_get(Local(5)); i32_const(Imm32(1)); i32_sub; local_set(Local(5));
           br(0);
         end; end;
     });
 
     // Return cur_built
     wasm!(f, {
-        local_get(16);
+        local_get(Local(16));
         end;
     });
 

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -8,6 +8,78 @@ use super::rt_string::{string_data_off, string_hdr, string_cap_off, list_data_of
 use wasm_encoder::{ValType};
 use super::TrackedFunction as Function;
 
+// ---------------------------------------------------------------------------
+// Named immediate constants — every non-obvious literal that appears as an
+// argument to a WASM const-emit call is named here.  The grouping follows the
+// subsystem that owns the meaning; sharing a numeric value across subsystems is
+// intentional only when the field/role is truly the same.
+// ---------------------------------------------------------------------------
+
+// WASM memory-page arithmetic (used in the bump-allocator grow check).
+/// WASM page size in bytes minus one; used to round a byte address up to the
+/// next page boundary: `(addr + PAGE_SIZE_MINUS_1) >> PAGE_SHIFT`.
+const WASM_PAGE_SIZE_MINUS_1: i64 = 65535;
+/// Log₂ of the WASM page size (65536 = 2¹⁶); right-shifting by this converts
+/// a byte count to a page count.
+const WASM_PAGE_SHIFT: i64 = 16;
+
+// IOV (iovec) scratch layout used by WASI fd_write calls.
+// The scratch area at address 0 holds one iovec: [buf:i32@0][len:i32@4],
+// and the fd_write nwritten output is written at byte 8.
+/// Byte offset of the `len` field inside one iovec record (4 bytes past `buf`).
+const IOV_LEN_OFF: i32 = 4;
+/// Byte offset at which fd_write writes its `nwritten` result (just past one iovec).
+const NWRITTEN_OFF: i32 = 8;
+
+// WASI file-descriptor numbers.
+/// First preopened directory fd assigned by the WASI host (fds 0–2 are stdio).
+const WASI_FIRST_PREOPEN_FD: i32 = 3;
+
+// Preopened-directory table layout.
+/// Size in bytes of one entry in the preopen table: [fd:i32, path_ptr:i32, path_len:i32].
+const PREOPEN_ENTRY_SIZE: i32 = 12;
+/// Maximum number of preopened directory entries we scan and record.
+const PREOPEN_MAX_ENTRIES: i32 = 16;
+/// Total byte size of the preallocated preopen table (PREOPEN_MAX_ENTRIES × PREOPEN_ENTRY_SIZE).
+const PREOPEN_TABLE_SIZE: i32 = 192; // 16 × 12
+/// Size in bytes of the WASI prestat_t buffer used in fd_prestat_get calls.
+const PRESTAT_BUF_SIZE: i32 = 8;
+
+// ASCII character codes (used in itoa and path resolution).
+/// ASCII code for the digit '0'; used to convert a decimal digit (0..9) to a character.
+const ASCII_ZERO: i32 = 48;
+/// ASCII code for the minus sign '-'; written as the sign byte in negative integers.
+const ASCII_MINUS: i32 = 45;
+/// ASCII code for the forward slash '/'; used to detect and strip absolute path prefixes.
+const ASCII_SLASH: i32 = 47;
+/// ASCII code for the period '.'; used to detect the WASI "." preopened directory.
+const ASCII_DOT: i32 = 46;
+
+// Integer-to-decimal conversion.
+/// Decimal radix; used for both the remainder and the division in the itoa digit loop.
+const DECIMAL_BASE: i64 = 10;
+
+// String capacity growth factor.
+/// Multiplier applied to the current capacity when a string buffer must be grown.
+const STRING_GROW_FACTOR: i32 = 2;
+
+// IEEE-754 half-precision (f16) bit-field constants.
+/// Bit position of the sign bit in a 16-bit f16 word (bit 15).
+const F16_SIGN_SHIFT: i32 = 15;
+/// Bit position of the low exponent bit in a 16-bit f16 word (bits 14..10).
+const F16_EXP_SHIFT: i32 = 10;
+/// The 5-bit exponent field value that signals NaN or infinity in f16.
+const F16_EXP_ALL_ONES: i32 = 31;
+/// 10-bit mantissa mask for f16 (0x3FF = 1023).
+const F16_MANTISSA_MASK: i32 = 1023;
+/// Bias adjustment to convert an f16 biased exponent (bias 15) to an f64 biased
+/// exponent (bias 1023): 1023 − 15 = 1008.  Applied as `exp_f16 + F16_TO_F64_EXP_BIAS_ADJ`
+/// before shifting into the f64 exponent field.
+const F16_TO_F64_EXP_BIAS_ADJ: i32 = 1008;
+/// Number of mantissa bits in an IEEE-754 double (f64); the biased exponent is placed
+/// at bit 52 of the 64-bit representation.
+const F64_MANTISSA_BITS: i64 = 52;
+
 /// Register WASI host imports only. Must be called before any register_func.
 /// After this, callers may register additional imports (e.g. @extern(wasm))
 /// before calling `register_runtime_functions`.
@@ -551,9 +623,9 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
         // Grow memory if needed
         w.gget(heap_ptr);
         w.raw(wasm_encoder::Instruction::I64ExtendI32U);
-        w.raw(wasm_encoder::Instruction::I64Const(65535));
+        w.raw(wasm_encoder::Instruction::I64Const(WASM_PAGE_SIZE_MINUS_1));
         w.raw(wasm_encoder::Instruction::I64Add);
-        w.raw(wasm_encoder::Instruction::I64Const(16));
+        w.raw(wasm_encoder::Instruction::I64Const(WASM_PAGE_SHIFT));
         w.raw(wasm_encoder::Instruction::I64ShrU);
         w.raw(wasm_encoder::Instruction::I32WrapI64);
         w.memory_size().sub().tee(2);
@@ -841,17 +913,17 @@ fn compile_println_str(emitter: &mut WasmEmitter) {
     });
     // iov[0].len = *ptr  (load length)
     wasm!(f, {
-        i32_const(4);
+        i32_const(IOV_LEN_OFF);
         local_get(0);
         i32_load(0);
         i32_store(0);
     });
-    // fd_write(stdout=1, iovs=0, iovs_len=1, nwritten=8)
+    // fd_write(stdout=1, iovs=0, iovs_len=1, nwritten=NWRITTEN_OFF)
     wasm!(f, {
         i32_const(1);
         i32_const(0);
         i32_const(1);
-        i32_const(8);
+        i32_const(NWRITTEN_OFF);
         call(emitter.rt.fd_write);
         drop;
     });
@@ -861,13 +933,13 @@ fn compile_println_str(emitter: &mut WasmEmitter) {
         i32_const(0);
         i32_const(NEWLINE_OFFSET as i32);
         i32_store(0);
-        i32_const(4);
+        i32_const(IOV_LEN_OFF);
         i32_const(1);
         i32_store(0);
         i32_const(1);
         i32_const(0);
         i32_const(1);
-        i32_const(8);
+        i32_const(NWRITTEN_OFF);
         call(emitter.rt.fd_write);
         drop;
         end;
@@ -925,7 +997,7 @@ fn compile_int_to_string(emitter: &mut WasmEmitter) {
         i64_eqz;
         if_empty;
         local_get(1);
-        i32_const(48);
+        i32_const(ASCII_ZERO);
         i32_store8(0);
         local_get(1);
         i32_const(1);
@@ -944,14 +1016,14 @@ fn compile_int_to_string(emitter: &mut WasmEmitter) {
     // mem[$pos] = ($abs_n % 10) + '0'
     wasm!(f, { local_get(1); });
     f.instruction(&wasm_encoder::Instruction::LocalGet(3));
-    f.instruction(&wasm_encoder::Instruction::I64Const(10));
+    f.instruction(&wasm_encoder::Instruction::I64Const(DECIMAL_BASE));
     // UNSIGNED rem: `abs_n = 0 - n` produces the correct unsigned magnitude bits
     // even for i64::MIN (0x8000…0 = 2^63), but a SIGNED rem would read those bits
     // as negative and emit bytes below '0'. Unsigned keeps MIN's digits correct.
     f.instruction(&wasm_encoder::Instruction::I64RemU);
     wasm!(f, {
         i32_wrap_i64;
-        i32_const(48);
+        i32_const(ASCII_ZERO);
         i32_add;
         i32_store8(0);
     });
@@ -965,7 +1037,7 @@ fn compile_int_to_string(emitter: &mut WasmEmitter) {
     // $abs_n /= 10  (UNSIGNED — see the rem note above; keeps i64::MIN correct)
     wasm!(f, {
         local_get(3);
-        i64_const(10);
+        i64_const(DECIMAL_BASE);
         i64_div_u;
         local_set(3);
         br(0);
@@ -979,7 +1051,7 @@ fn compile_int_to_string(emitter: &mut WasmEmitter) {
         local_get(2);
         if_empty;
         local_get(1);
-        i32_const(45);
+        i32_const(ASCII_MINUS);
         i32_store8(0);
         local_get(1);
         i32_const(1);
@@ -1279,7 +1351,7 @@ fn compile_string_append(emitter: &mut WasmEmitter) {
           local_get(0);  // return left (same pointer)
         else_;
           // Grow: alloc new buffer with cap = max(left_cap*2, new_len)
-          local_get(5); i32_const(2); i32_mul; local_set(5); // cap *= 2
+          local_get(5); i32_const(STRING_GROW_FACTOR); i32_mul; local_set(5); // cap *= 2
           local_get(5); local_get(4); i32_lt_u;
           if_empty; local_get(4); local_set(5); end;          // cap = max(cap*2, new_len)
           // Alloc
@@ -1362,12 +1434,12 @@ fn compile_init_preopen_dirs(emitter: &mut WasmEmitter) {
     ]);
 
     wasm!(f, {
-        // Allocate prestat buf (8 bytes) and table (max 16 entries × 12 bytes = 192)
-        i32_const(8); call(emitter.rt.alloc_pinned); local_set(1);
-        i32_const(192); call(emitter.rt.alloc_pinned); local_set(5);
+        // Allocate prestat buf (PRESTAT_BUF_SIZE bytes) and table (PREOPEN_TABLE_SIZE bytes)
+        i32_const(PRESTAT_BUF_SIZE); call(emitter.rt.alloc_pinned); local_set(1);
+        i32_const(PREOPEN_TABLE_SIZE); call(emitter.rt.alloc_pinned); local_set(5);
 
-        // Start from fd=3 (first possible preopened dir)
-        i32_const(3); local_set(0);
+        // Start from fd=WASI_FIRST_PREOPEN_FD (first possible preopened dir)
+        i32_const(WASI_FIRST_PREOPEN_FD); local_set(0);
         i32_const(0); local_set(4);
 
         // Loop: try fd_prestat_get for each fd until it fails
@@ -1391,19 +1463,19 @@ fn compile_init_preopen_dirs(emitter: &mut WasmEmitter) {
         drop;
 
         // Store entry in table: [fd, path_ptr, path_len]
-        local_get(5); local_get(4); i32_const(12); i32_mul; i32_add;
+        local_get(5); local_get(4); i32_const(PREOPEN_ENTRY_SIZE); i32_mul; i32_add;
         local_get(0); i32_store(0);
-        local_get(5); local_get(4); i32_const(12); i32_mul; i32_add;
+        local_get(5); local_get(4); i32_const(PREOPEN_ENTRY_SIZE); i32_mul; i32_add;
         local_get(6); i32_store(4);
-        local_get(5); local_get(4); i32_const(12); i32_mul; i32_add;
+        local_get(5); local_get(4); i32_const(PREOPEN_ENTRY_SIZE); i32_mul; i32_add;
         local_get(3); i32_store(8);
 
         // count++, fd++
         local_get(4); i32_const(1); i32_add; local_set(4);
         local_get(0); i32_const(1); i32_add; local_set(0);
 
-        // Max 16 entries
-        local_get(4); i32_const(16); i32_ge_u; br_if(1);
+        // Max PREOPEN_MAX_ENTRIES entries
+        local_get(4); i32_const(PREOPEN_MAX_ENTRIES); i32_ge_u; br_if(1);
         br(0);
         end; end;
 
@@ -1444,10 +1516,10 @@ fn compile_resolve_path(emitter: &mut WasmEmitter) {
 
     wasm!(f, {
         // Allocate result: [fd, rel_path_ptr, rel_path_len]
-        i32_const(12); call(emitter.rt.alloc_pinned); local_set(2);
+        i32_const(PREOPEN_ENTRY_SIZE); call(emitter.rt.alloc_pinned); local_set(2);
 
-        // Default: fd=3, no prefix match
-        i32_const(3); local_set(4);
+        // Default: fd=WASI_FIRST_PREOPEN_FD, no prefix match
+        i32_const(WASI_FIRST_PREOPEN_FD); local_set(4);
         i32_const(0); local_set(5);
 
         // Loop over preopened dirs to find longest prefix match
@@ -1457,7 +1529,7 @@ fn compile_resolve_path(emitter: &mut WasmEmitter) {
 
         // Load entry [fd, path_ptr, path_len]
         global_get(emitter.preopen_table_global);
-        local_get(3); i32_const(12); i32_mul; i32_add;
+        local_get(3); i32_const(PREOPEN_ENTRY_SIZE); i32_mul; i32_add;
         local_set(6);
         local_get(6); i32_load(0); local_set(7);
         local_get(6); i32_load(4); local_set(8);
@@ -1507,7 +1579,7 @@ fn compile_resolve_path(emitter: &mut WasmEmitter) {
           local_get(1); local_get(5); i32_sub; i32_const(0); i32_gt_u;
           if_empty;
             local_get(0); local_get(5); i32_add; i32_load8_u(0);
-            i32_const(47); i32_eq;
+            i32_const(ASCII_SLASH); i32_eq;
             if_empty;
               local_get(2); local_get(0); local_get(5); i32_add; i32_const(1); i32_add; i32_store(4);
               local_get(2); local_get(1); local_get(5); i32_sub; i32_const(1); i32_sub; i32_store(8);
@@ -1522,25 +1594,25 @@ fn compile_resolve_path(emitter: &mut WasmEmitter) {
           end;
         else_;
           // No prefix match. For relative paths, find "." preopened dir. For absolute, strip '/'.
-          local_get(0); i32_load8_u(0); i32_const(47); i32_eq;
+          local_get(0); i32_load8_u(0); i32_const(ASCII_SLASH); i32_eq;
           if_empty;
-            // Absolute path with no match: strip '/' and use fd=3
-            local_get(2); i32_const(3); i32_store(0);
+            // Absolute path with no match: strip '/' and use WASI_FIRST_PREOPEN_FD
+            local_get(2); i32_const(WASI_FIRST_PREOPEN_FD); i32_store(0);
             local_get(2); local_get(0); i32_const(1); i32_add; i32_store(4);
             local_get(2); local_get(1); i32_const(1); i32_sub; i32_store(8);
           else_;
-            // Relative path: find "." in preopened dirs, fallback to fd=3
-            local_get(2); i32_const(3); i32_store(0); // default fd=3
+            // Relative path: find "." in preopened dirs, fallback to WASI_FIRST_PREOPEN_FD
+            local_get(2); i32_const(WASI_FIRST_PREOPEN_FD); i32_store(0); // default fd
             i32_const(0); local_set(3);
             block_empty; loop_empty;
             local_get(3); global_get(emitter.preopen_count_global); i32_ge_u; br_if(1);
             global_get(emitter.preopen_table_global);
-            local_get(3); i32_const(12); i32_mul; i32_add;
+            local_get(3); i32_const(PREOPEN_ENTRY_SIZE); i32_mul; i32_add;
             local_set(6);
             // Check if entry path is "." (len==1 && byte[0]=='.')
             local_get(6); i32_load(8); i32_const(1); i32_eq;
             if_empty;
-              local_get(6); i32_load(4); i32_load8_u(0); i32_const(46); i32_eq;
+              local_get(6); i32_load(4); i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
               if_empty;
                 local_get(2); local_get(6); i32_load(0); i32_store(0); // use this fd
                 br(3); // break out of search loop
@@ -1582,12 +1654,12 @@ pub(super) fn compile_bytes_f16_to_f64(emitter: &mut WasmEmitter) {
         (2, ValType::F64), // locals 5..=6 f64: sign_f, result
     ]);
     wasm!(f, {
-        // sign = bits >> 15
-        local_get(0); i32_const(15); i32_shr_u; local_set(1);
-        // exp = (bits >> 10) & 0x1f
-        local_get(0); i32_const(10); i32_shr_u; i32_const(31); i32_and; local_set(2);
-        // mant = bits & 0x3ff
-        local_get(0); i32_const(1023); i32_and; local_set(3);
+        // sign = bits >> F16_SIGN_SHIFT
+        local_get(0); i32_const(F16_SIGN_SHIFT); i32_shr_u; local_set(1);
+        // exp = (bits >> F16_EXP_SHIFT) & F16_EXP_ALL_ONES
+        local_get(0); i32_const(F16_EXP_SHIFT); i32_shr_u; i32_const(F16_EXP_ALL_ONES); i32_and; local_set(2);
+        // mant = bits & F16_MANTISSA_MASK
+        local_get(0); i32_const(F16_MANTISSA_MASK); i32_and; local_set(3);
         // sign_f = sign ? -1.0 : 1.0
         local_get(1);
         if_f64; f64_const(-1.0);
@@ -1604,7 +1676,7 @@ pub(super) fn compile_bytes_f16_to_f64(emitter: &mut WasmEmitter) {
             f64_const(5.960464477539063e-8); // 2^-24
             f64_mul;
         else_;
-            local_get(2); i32_const(31); i32_eq;
+            local_get(2); i32_const(F16_EXP_ALL_ONES); i32_eq;
             if_f64;
                 // exp all-ones: mant==0 → ±inf (sign-preserving), mant!=0 → NaN.
                 // Mirrors native f16_bits_to_f64 (runtime/rs/src/bytes.rs): the
@@ -1618,8 +1690,8 @@ pub(super) fn compile_bytes_f16_to_f64(emitter: &mut WasmEmitter) {
             else_;
                 // normal: sign_f * (1 + mant/1024) * 2^(exp-15)
                 // 2^(exp-15) computed as f64 bit pattern:
-                //   f64 exponent bias = 1023, so exp_f64 = exp - 15 + 1023 = exp + 1008
-                //   bits = (exp_f64) << 52
+                //   f64 exponent bias = 1023, so exp_f64 = exp - 15 + 1023 = exp + F16_TO_F64_EXP_BIAS_ADJ
+                //   bits = (exp_f64) << F64_MANTISSA_BITS
                 local_get(5);
                 f64_const(1.0);
                 local_get(3); f64_convert_i32_u;
@@ -1627,8 +1699,8 @@ pub(super) fn compile_bytes_f16_to_f64(emitter: &mut WasmEmitter) {
                 f64_add;
                 f64_mul;
                 // Multiply by 2^(exp - 15): construct that power via i64 bit tricks.
-                local_get(2); i32_const(1008); i32_add; i64_extend_i32_u;
-                i64_const(52); i64_shl;
+                local_get(2); i32_const(F16_TO_F64_EXP_BIAS_ADJ); i32_add; i64_extend_i32_u;
+                i64_const(F64_MANTISSA_BITS); i64_shl;
                 f64_reinterpret_i64;
                 f64_mul;
             end;

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -3,6 +3,7 @@
 //! These are emitted as regular WASM functions, not imports.
 //! Only fd_write is imported from WASI.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::{CompiledFunc, WasmEmitter, SCRATCH_ITOA, NEWLINE_OFFSET};
 use super::rt_string::{string_data_off, string_hdr, string_cap_off, list_data_off, list_hdr};
 use wasm_encoder::{ValType};
@@ -559,11 +560,11 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
         // (e.g. a host-written buffer freed and overwritten — the fs scratch
         // poison class). No free list can have more nodes than 8-byte blocks
         // in the heap, so heap_ptr >> 3 bounds any acyclic walk.
-        w.i32c(0).set(3);                       // prev = null
-        w.gget(free_list).set(4);               // cur = free_list_head
-        w.i32c(0).set(5);                       // steps = 0
+        w.i32c(Imm32(0)).set(Local(3));                       // prev = null
+        w.gget(free_list).set(Local(4));               // cur = free_list_head
+        w.i32c(Imm32(0)).set(Local(5));                       // steps = 0
         w.block(|w| { w.loop_(|w| {
-            w.get(4).eqz().br_if(1);            // cur == null → bump
+            w.get(Local(4)).eqz().br_if(1);            // cur == null → bump
             // steps++; steps > cap → cycle → trap. The cap is ABSOLUTE:
             // a heap-derived bound (heap_ptr >> 3) lets a multi-hundred-MB
             // heap walk tens of millions of steps PER ALLOC before tripping —
@@ -571,8 +572,8 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
             // instead of trapping (observed killing the dev machine). No sane
             // free list approaches a million nodes in this runtime.
             const FREE_LIST_WALK_CAP: i32 = 1 << 20;
-            w.get(5).i32c(1).add().tee(5);
-            w.i32c(FREE_LIST_WALK_CAP);
+            w.get(Local(5)).i32c(Imm32(1)).add().tee(Local(5));
+            w.i32c(Imm32(FREE_LIST_WALK_CAP));
             w.gt_u();
             w.if_void(|w| { w.unreachable_(); }, |_| {});
             // NOTE: a size-sanity bound (cur+hdr+size <= heap_ptr) was tried
@@ -582,69 +583,69 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
             // rc_dec (double-free), and the rc==0 trap in rc_inc
             // (resurrection). Host-clobbered headers (the fs scratch class)
             // are addressed by construction via pinned allocations.
-            w.get(4).emit_load(size_off, size_ty); // cur.size
-            w.get(0).ge_u();                     // >= request_size?
+            w.get(Local(4)).emit_load(size_off, size_ty); // cur.size
+            w.get(Local(0)).ge_u();                     // >= request_size?
             w.if_void(|w| {
                 // Found: unlink
-                w.get(3).eqz();
+                w.get(Local(3)).eqz();
                 w.if_void(|w| {
                     // prev == null → cur is head: head = cur.next
-                    w.get(4).i32c(hdr).add().emit_load(0, MemType::I32);
+                    w.get(Local(4)).i32c(Imm32(hdr)).add().emit_load(0, MemType::I32);
                     w.gset(free_list);
                 }, |w| {
                     // prev.next = cur.next
-                    w.get(3).i32c(hdr).add();
-                    w.get(4).i32c(hdr).add().emit_load(0, MemType::I32);
+                    w.get(Local(3)).i32c(Imm32(hdr)).add();
+                    w.get(Local(4)).i32c(Imm32(hdr)).add().emit_load(0, MemType::I32);
                     w.emit_store(0, MemType::I32);
                 });
                 // RC = 1
-                w.get(4).i32c(1).emit_store(rc_off, rc_ty);
+                w.get(Local(4)).i32c(Imm32(1)).emit_store(rc_off, rc_ty);
                 // Zero-fill reused block's data area to prevent stale data
                 // (critical for Swiss Table tag arrays)
-                w.get(4).i32c(hdr).add();  // data_ptr
-                w.i32c(0);                 // fill value
-                w.get(4).emit_load(size_off, size_ty); // size
+                w.get(Local(4)).i32c(Imm32(hdr)).add();  // data_ptr
+                w.i32c(Imm32(0));                 // fill value
+                w.get(Local(4)).emit_load(size_off, size_ty); // size
                 w.raw(wasm_encoder::Instruction::MemoryFill(0));
                 // Return data ptr
-                w.get(4).i32c(hdr).add().ret();
+                w.get(Local(4)).i32c(Imm32(hdr)).add().ret();
             }, |_| {});
             // Advance: prev = cur, cur = cur.next
-            w.get(4).set(3);
-            w.get(4).i32c(hdr).add().emit_load(0, MemType::I32).set(4);
+            w.get(Local(4)).set(Local(3));
+            w.get(Local(4)).i32c(Imm32(hdr)).add().emit_load(0, MemType::I32).set(Local(4));
             w.br(0);
         }); });
 
         // --- Bump path ---
         // Align heap_ptr to header boundary
         let align_mask = hdr - 1;       // hdr is power of 2 (8) → mask = 7
-        w.gget(heap_ptr).i32c(align_mask).add().i32c(-hdr).and().set(1);
+        w.gget(heap_ptr).i32c(Imm32(align_mask)).add().i32c(Imm32(-hdr)).and().set(Local(1));
         // Advance: ptr + size + header
-        w.get(1).get(0).add().i32c(hdr).add().gset(heap_ptr);
+        w.get(Local(1)).get(Local(0)).add().i32c(Imm32(hdr)).add().gset(heap_ptr);
         // Grow memory if needed
         w.gget(heap_ptr);
         w.raw(wasm_encoder::Instruction::I64ExtendI32U);
-        w.raw(wasm_encoder::Instruction::I64Const(WASM_PAGE_SIZE_MINUS_1));
+        w.i64c(Imm64(WASM_PAGE_SIZE_MINUS_1));
         w.raw(wasm_encoder::Instruction::I64Add);
-        w.raw(wasm_encoder::Instruction::I64Const(WASM_PAGE_SHIFT));
+        w.i64c(Imm64(WASM_PAGE_SHIFT));
         w.raw(wasm_encoder::Instruction::I64ShrU);
         w.raw(wasm_encoder::Instruction::I32WrapI64);
-        w.memory_size().sub().tee(2);
-        w.i32c(0);
+        w.memory_size().sub().tee(Local(2));
+        w.i32c(Imm32(0));
         w.raw(wasm_encoder::Instruction::I32GtS);
         w.if_void(|w| {
-            w.memory_size().get(2);
-            w.memory_size().get(2);
+            w.memory_size().get(Local(2));
+            w.memory_size().get(Local(2));
             w.gt_u();
             w.raw(wasm_encoder::Instruction::Select);
             w.memory_grow();
-            w.i32c(-1).eq();
+            w.i32c(Imm32(-1)).eq();
             w.if_void(|w| { w.unreachable_(); }, |_| {});
         }, |_| {});
         // Write header
-        w.get(1).get(0).emit_store(size_off, size_ty);
-        w.get(1).i32c(1).emit_store(rc_off, rc_ty);
+        w.get(Local(1)).get(Local(0)).emit_store(size_off, size_ty);
+        w.get(Local(1)).i32c(Imm32(1)).emit_store(rc_off, rc_ty);
         // Return data ptr
-        w.get(1).i32c(hdr).add();
+        w.get(Local(1)).i32c(Imm32(hdr)).add();
     }
     f.instruction(&wasm_encoder::Instruction::End);
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.alloc, type_idx, f));
@@ -675,7 +676,7 @@ fn compile_rc_inc(emitter: &mut WasmEmitter) {
         let mut f = Function::new([]);
         {
             let w = &mut WasmBuilder::new(&mut f, &emitter.layout_reg);
-            w.get(0);
+            w.get(Local(0));
         }
         f.instruction(&wasm_encoder::Instruction::End);
         emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.rc_inc, type_idx, f));
@@ -696,30 +697,30 @@ fn compile_rc_inc(emitter: &mut WasmEmitter) {
     {
         let w = &mut WasmBuilder::new(&mut f, &emitter.layout_reg);
         // Data-section constants have no header: pass through.
-        w.get(0).gget(heap_start).lt_u();
-        w.if_void(|w| { w.get(0).ret(); }, |_| {});
+        w.get(Local(0)).gget(heap_start).lt_u();
+        w.if_void(|w| { w.get(Local(0)).ret(); }, |_| {});
         // Dead-zone guard: after __heap_restore moved the frontier DOWN, a
         // stale pointer at/above heap_ptr has no live header — touching it
         // would corrupt whatever gets bump-allocated there next. Skip (the
         // leak direction is the safe one).
-        w.get(0).gget(heap_ptr).ge_u();
-        w.if_void(|w| { w.get(0).ret(); }, |_| {});
+        w.get(Local(0)).gget(heap_ptr).ge_u();
+        w.if_void(|w| { w.get(Local(0)).ret(); }, |_| {});
         // Resurrection tripwire: Inc of a FREED block (rc==0 sentinel) is
         // always a compiler bug — without this trap it silently revives a
         // block already on the free list and the next alloc hands out live
         // memory (observed as silent value corruption, not a crash).
-        w.get(0).i32c(rc_neg).sub().emit_load(0, rc_ty).tee(1);
+        w.get(Local(0)).i32c(Imm32(rc_neg)).sub().emit_load(0, rc_ty).tee(Local(1));
         w.eqz();
         w.if_void(|w| { w.unreachable_(); }, |_| {});
         // PINNED blocks are immortal: pass through untouched (a +1 would
         // creep the sentinel toward wrap/unpin).
-        w.get(1).i32c(PINNED_RC).eq();
-        w.if_void(|w| { w.get(0).ret(); }, |_| {});
+        w.get(Local(1)).i32c(Imm32(PINNED_RC)).eq();
+        w.if_void(|w| { w.get(Local(0)).ret(); }, |_| {});
         // *(ptr - rc_neg) = rc + 1
-        w.get(0).i32c(rc_neg).sub();
-        w.get(1).i32c(1).add();
+        w.get(Local(0)).i32c(Imm32(rc_neg)).sub();
+        w.get(Local(1)).i32c(Imm32(1)).add();
         w.emit_store(0, rc_ty);
-        w.get(0); // return ptr
+        w.get(Local(0)); // return ptr
     }
     f.instruction(&wasm_encoder::Instruction::End);
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.rc_inc, type_idx, f));
@@ -753,35 +754,35 @@ fn compile_rc_dec(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(1, ValType::I32)]); // local 1: $rc
     {
         let w = &mut WasmBuilder::new(&mut f, &emitter.layout_reg);
-        w.get(0).gget(heap_start).lt_u();
+        w.get(Local(0)).gget(heap_start).lt_u();
         w.if_void(|w| { w.ret(); }, |_| {});
         // Dead-zone guard (see compile_rc_inc): a stale pointer at/above the
         // restored bump frontier has no header — freeing it would re-poison
         // the just-reset free list. Skip = bounded leak.
-        w.get(0).gget(heap_ptr_g).ge_u();
+        w.get(Local(0)).gget(heap_ptr_g).ge_u();
         w.if_void(|w| { w.ret(); }, |_| {});
         // rc = *(ptr - rc_neg)
-        w.get(0).i32c(rc_neg).sub().emit_load(0, rc_ty).tee(1);
+        w.get(Local(0)).i32c(Imm32(rc_neg)).sub().emit_load(0, rc_ty).tee(Local(1));
         // PINNED blocks never free (host-written scratch; see __alloc_pinned).
-        w.i32c(PINNED_RC).eq();
+        w.i32c(Imm32(PINNED_RC)).eq();
         w.if_void(|w| { w.ret(); }, |_| {});
-        w.get(1);
-        w.i32c(1).gt_u();
+        w.get(Local(1));
+        w.i32c(Imm32(1)).gt_u();
         w.if_void(|w| {
             // rc > 1: decrement
-            w.get(0).i32c(rc_neg).sub();
-            w.get(1).i32c(1).sub();
+            w.get(Local(0)).i32c(Imm32(rc_neg)).sub();
+            w.get(Local(1)).i32c(Imm32(1)).sub();
             w.emit_store(0, rc_ty);
         }, |w| {
             // rc <= 1: about to free. Sentinel: rc==0 = already freed → trap.
-            w.get(1).eqz();
+            w.get(Local(1)).eqz();
             w.if_void(|w| { w.unreachable_(); }, |_| {});
             // Push to free list for reuse (next ptr lives at data[0]).
-            w.get(0).gget(free_list).emit_store(0, MemType::I32);
-            w.get(0).i32c(hdr).sub().gset(free_list);
+            w.get(Local(0)).gget(free_list).emit_store(0, MemType::I32);
+            w.get(Local(0)).i32c(Imm32(hdr)).sub().gset(free_list);
             // Stamp rc=0 (the sentinel).
-            w.get(0).i32c(rc_neg).sub();
-            w.i32c(0);
+            w.get(Local(0)).i32c(Imm32(rc_neg)).sub();
+            w.i32c(Imm32(0));
             w.emit_store(0, rc_ty);
         });
     }
@@ -821,13 +822,13 @@ fn compile_cow_check(emitter: &mut WasmEmitter) {
         // A data-section ptr (below heap_start) has no alloc header → not a heap
         // object → nothing to clone, return as-is. Uses the immutable heap_start
         // global directly (the rt field is still 0 at this compile point).
-        w.get(0).gget(HEAP_START_GLOBAL_IDX).lt_u();
-        w.if_void(|w| { w.get(0).ret(); }, |_| {});
+        w.get(Local(0)).gget(HEAP_START_GLOBAL_IDX).lt_u();
+        w.if_void(|w| { w.get(Local(0)).ret(); }, |_| {});
         // size = header.SIZE; new = alloc(size); memcpy(new, ptr, size); return new.
-        w.get(0).i32c(size_neg).sub().emit_load(0, size_ty).set(1);
-        w.get(1).call(alloc_fn).set(2);
-        w.get(2).get(0).get(1).memory_copy();
-        w.get(2); // return the fresh clone
+        w.get(Local(0)).i32c(Imm32(size_neg)).sub().emit_load(0, size_ty).set(Local(1));
+        w.get(Local(1)).call(alloc_fn).set(Local(2));
+        w.get(Local(2)).get(Local(0)).get(Local(1)).memory_copy();
+        w.get(Local(2)); // return the fresh clone
     }
     f.instruction(&wasm_encoder::Instruction::End);
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.cow_check, type_idx, f));
@@ -855,14 +856,14 @@ fn compile_heap_restore(emitter: &mut WasmEmitter) {
     // Reset heap pointer (no zero-fill — alloc writes refcount header,
     // and Swiss Table init zeroes tags via bump allocator's fresh pages).
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         global_set(emitter.heap_ptr_global);
         // Forget the free list wholesale: nodes above the restored frontier
         // are dead (the walk's size-sanity tripwire traps on them); nodes
         // below are merely un-remembered — optimization loss, never
         // corruption. Unconditional: a no-op while frees are off, so the
         // emitted bytes stay env-independent here.
-        i32_const(0);
+        i32_const(Imm32(0));
         global_set(emitter.free_list_global);
         end;
     });
@@ -886,11 +887,11 @@ fn compile_alloc_pinned(emitter: &mut WasmEmitter) {
     let mut f = Function::new([(1, ValType::I32)]); // local 1: $ptr
     {
         let w = &mut WasmBuilder::new(&mut f, &emitter.layout_reg);
-        w.get(0).call(emitter.rt.alloc).set(1);
-        w.get(1).i32c(rc_neg).sub();
-        w.i32c(PINNED_RC);
+        w.get(Local(0)).call(emitter.rt.alloc).set(Local(1));
+        w.get(Local(1)).i32c(Imm32(rc_neg)).sub();
+        w.i32c(Imm32(PINNED_RC));
         w.emit_store(0, rc_ty);
-        w.get(1);
+        w.get(Local(1));
     }
     f.instruction(&wasm_encoder::Instruction::End);
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.alloc_pinned, type_idx, f));
@@ -905,41 +906,41 @@ fn compile_println_str(emitter: &mut WasmEmitter) {
     // --- Write the string ---
     // iov[0].buf = ptr + string_data_off()  (skip len+cap header)
     wasm!(f, {
-        i32_const(0);
-        local_get(0);
-        i32_const(emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
+        i32_const(Imm32(0));
+        local_get(Local(0));
+        i32_const(Imm32(emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
         i32_add;
         i32_store(0);
     });
     // iov[0].len = *ptr  (load length)
     wasm!(f, {
-        i32_const(IOV_LEN_OFF);
-        local_get(0);
+        i32_const(Imm32(IOV_LEN_OFF));
+        local_get(Local(0));
         i32_load(0);
         i32_store(0);
     });
     // fd_write(stdout=1, iovs=0, iovs_len=1, nwritten=NWRITTEN_OFF)
     wasm!(f, {
-        i32_const(1);
-        i32_const(0);
-        i32_const(1);
-        i32_const(NWRITTEN_OFF);
+        i32_const(Imm32(1));
+        i32_const(Imm32(0));
+        i32_const(Imm32(1));
+        i32_const(Imm32(NWRITTEN_OFF));
         call(emitter.rt.fd_write);
         drop;
     });
 
     // --- Write newline ---
     wasm!(f, {
-        i32_const(0);
-        i32_const(NEWLINE_OFFSET as i32);
+        i32_const(Imm32(0));
+        i32_const(Imm32(NEWLINE_OFFSET as i32));
         i32_store(0);
-        i32_const(IOV_LEN_OFF);
-        i32_const(1);
+        i32_const(Imm32(IOV_LEN_OFF));
+        i32_const(Imm32(1));
         i32_store(0);
-        i32_const(1);
-        i32_const(0);
-        i32_const(1);
-        i32_const(NWRITTEN_OFF);
+        i32_const(Imm32(1));
+        i32_const(Imm32(0));
+        i32_const(Imm32(1));
+        i32_const(Imm32(NWRITTEN_OFF));
         call(emitter.rt.fd_write);
         drop;
         end;
@@ -968,78 +969,78 @@ fn compile_int_to_string(emitter: &mut WasmEmitter) {
 
     // $pos = scratch_end (write backwards from end of scratch buffer)
     wasm!(f, {
-        i32_const(scratch_end as i32);
-        local_set(1);
+        i32_const(Imm32(scratch_end as i32));
+        local_set(Local(1));
     });
 
     // $is_neg = $n < 0
-    f.instruction(&wasm_encoder::Instruction::LocalGet(0));
-    f.instruction(&wasm_encoder::Instruction::I64Const(0));
+    wasm!(f, { local_get(Local(0)); });
+    wasm!(f, { i64_const(Imm64(0)); });
     f.instruction(&wasm_encoder::Instruction::I64LtS);
-    wasm!(f, { local_set(2); });
+    wasm!(f, { local_set(Local(2)); });
 
     // $abs_n = if $is_neg then -$n else $n
     wasm!(f, {
-        local_get(2);
+        local_get(Local(2));
         if_i64;
-        i64_const(0);
-        local_get(0);
+        i64_const(Imm64(0));
+        local_get(Local(0));
         i64_sub;
         else_;
-        local_get(0);
+        local_get(Local(0));
         end;
-        local_set(3);
+        local_set(Local(3));
     });
 
     // if $abs_n == 0: write '0'
     wasm!(f, {
-        local_get(3);
+        local_get(Local(3));
         i64_eqz;
         if_empty;
-        local_get(1);
-        i32_const(ASCII_ZERO);
+        local_get(Local(1));
+        i32_const(Imm32(ASCII_ZERO));
         i32_store8(0);
-        local_get(1);
-        i32_const(1);
+        local_get(Local(1));
+        i32_const(Imm32(1));
         i32_sub;
-        local_set(1);
+        local_set(Local(1));
         else_;
     });
     // while $abs_n > 0: write digits backwards
     wasm!(f, {
         block_empty;
         loop_empty;
-        local_get(3);
+        local_get(Local(3));
         i64_eqz;
         br_if(1);
     });
     // mem[$pos] = ($abs_n % 10) + '0'
-    wasm!(f, { local_get(1); });
-    f.instruction(&wasm_encoder::Instruction::LocalGet(3));
-    f.instruction(&wasm_encoder::Instruction::I64Const(DECIMAL_BASE));
+    wasm!(f, { local_get(Local(1)); });
+    wasm!(f, { local_get(Local(3)); });
+    wasm!(f, { i64_const(Imm64(DECIMAL_BASE)); });
     // UNSIGNED rem: `abs_n = 0 - n` produces the correct unsigned magnitude bits
     // even for i64::MIN (0x8000…0 = 2^63), but a SIGNED rem would read those bits
     // as negative and emit bytes below '0'. Unsigned keeps MIN's digits correct.
     f.instruction(&wasm_encoder::Instruction::I64RemU);
     wasm!(f, {
         i32_wrap_i64;
-        i32_const(ASCII_ZERO);
+        i32_const(Imm32(ASCII_ZERO));
         i32_add;
         i32_store8(0);
     });
     // $pos -= 1
     wasm!(f, {
-        local_get(1);
-        i32_const(1);
+        local_get(Local(1));
+        i32_const(Imm32(1));
         i32_sub;
-        local_set(1);
+        local_set(Local(1));
     });
     // $abs_n /= 10  (UNSIGNED — see the rem note above; keeps i64::MIN correct)
     wasm!(f, {
-        local_get(3);
-        i64_const(DECIMAL_BASE);
+        local_get(Local(3));
+        i64_const(Imm64(DECIMAL_BASE));
         i64_div_u;
-        local_set(3);
+        local_set(Local(3));
         br(0);
         end;
         end;
@@ -1048,88 +1049,88 @@ fn compile_int_to_string(emitter: &mut WasmEmitter) {
 
     // if $is_neg: write '-'
     wasm!(f, {
-        local_get(2);
+        local_get(Local(2));
         if_empty;
-        local_get(1);
-        i32_const(ASCII_MINUS);
+        local_get(Local(1));
+        i32_const(Imm32(ASCII_MINUS));
         i32_store8(0);
-        local_get(1);
-        i32_const(1);
+        local_get(Local(1));
+        i32_const(Imm32(1));
         i32_sub;
-        local_set(1);
+        local_set(Local(1));
         end;
     });
 
     // $start = $pos + 1
     wasm!(f, {
-        local_get(1);
-        i32_const(1);
+        local_get(Local(1));
+        i32_const(Imm32(1));
         i32_add;
-        local_set(4);
+        local_set(Local(4));
     });
 
     // $len = scratch_end - $pos
     wasm!(f, {
-        i32_const(scratch_end as i32);
-        local_get(1);
+        i32_const(Imm32(scratch_end as i32));
+        local_get(Local(1));
         i32_sub;
-        local_set(5);
+        local_set(Local(5));
     });
 
     // $result = __alloc(string_hdr() + $len)
     // String layout: [len:i32][cap:i32][data@8]
     wasm!(f, {
-        local_get(5);
-        i32_const(emitter.layout_reg.header_size(super::engine::layout::STRING) as i32);
+        local_get(Local(5));
+        i32_const(Imm32(emitter.layout_reg.header_size(super::engine::layout::STRING) as i32));
         i32_add;
         call(emitter.rt.alloc);
-        local_set(6);
+        local_set(Local(6));
     });
 
     // mem32[$result+0] = $len, mem32[$result+4] = $len (cap = len)
     wasm!(f, {
-        local_get(6);
-        local_get(5);
+        local_get(Local(6));
+        local_get(Local(5));
         i32_store(0);
-        local_get(6);
-        local_get(5);
+        local_get(Local(6));
+        local_get(Local(5));
         i32_store(emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32, 0);
     });
 
     // memcpy: copy $len bytes from $start to $result+string_data_off()
     wasm!(f, {
-        i32_const(0);
-        local_set(7);
+        i32_const(Imm32(0));
+        local_set(Local(7));
         block_empty;
         loop_empty;
-        local_get(7);
-        local_get(5);
+        local_get(Local(7));
+        local_get(Local(5));
         i32_ge_u;
         br_if(1);
     });
     // mem[$result + string_data_off() + $i] = mem[$start + $i]
     wasm!(f, {
-        local_get(6);
-        i32_const(emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
+        local_get(Local(6));
+        i32_const(Imm32(emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
         i32_add;
-        local_get(7);
+        local_get(Local(7));
         i32_add;
-        local_get(4);
-        local_get(7);
+        local_get(Local(4));
+        local_get(Local(7));
         i32_add;
         i32_load8_u(0);
         i32_store8(0);
-        local_get(7);
-        i32_const(1);
+        local_get(Local(7));
+        i32_const(Imm32(1));
         i32_add;
-        local_set(7);
+        local_set(Local(7));
         br(0);
         end;
         end;
     });
 
     // return $result
-    wasm!(f, { local_get(6); end; });
+    wasm!(f, { local_get(Local(6)); end; });
 
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.int_to_string, type_idx, f));
 }
@@ -1141,7 +1142,7 @@ fn compile_println_int(emitter: &mut WasmEmitter) {
     let mut f = Function::new([]);
 
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         call(emitter.rt.int_to_string);
         call(emitter.rt.println_str);
         end;
@@ -1165,26 +1166,26 @@ fn compile_concat_str(emitter: &mut WasmEmitter) {
     ]);
 
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         i32_load(0);        // left.len
-        local_set(2);
-        local_get(1);
+        local_set(Local(2));
+        local_get(Local(1));
         i32_load(0);        // right.len
-        local_set(3);
-        local_get(2);
-        local_get(3);
+        local_set(Local(3));
+        local_get(Local(2));
+        local_get(Local(3));
         i32_add;
-        local_set(4);       // new_len = left_len + right_len
-        local_get(4);
-        i32_const(string_hdr());
+        local_set(Local(4));       // new_len = left_len + right_len
+        local_get(Local(4));
+        i32_const(Imm32(string_hdr()));
         i32_add;
         call(emitter.rt.alloc);
-        local_set(5);
-        local_get(5);
-        local_get(4);
+        local_set(Local(5));
+        local_get(Local(5));
+        local_get(Local(4));
         i32_store(0);       // result.len = new_len
-        local_get(5);
-        local_get(4);
+        local_get(Local(5));
+        local_get(Local(4));
         i32_store(string_cap_off() as u32); // result.cap = new_len
     });
 
@@ -1194,38 +1195,38 @@ fn compile_concat_str(emitter: &mut WasmEmitter) {
 
     // Copy right data: dst=result+DATA_OFFSET+left_len, src=right+DATA_OFFSET
     wasm!(f, {
-        i32_const(0);
-        local_set(6);
+        i32_const(Imm32(0));
+        local_set(Local(6));
         block_empty;
         loop_empty;
-        local_get(6);
-        local_get(3);
+        local_get(Local(6));
+        local_get(Local(3));
         i32_ge_u;
         br_if(1);
-        local_get(5);
-        i32_const(string_data_off());
+        local_get(Local(5));
+        i32_const(Imm32(string_data_off()));
         i32_add;
-        local_get(2);
+        local_get(Local(2));
         i32_add;
-        local_get(6);
+        local_get(Local(6));
         i32_add;
-        local_get(1);
-        i32_const(string_data_off());
+        local_get(Local(1));
+        i32_const(Imm32(string_data_off()));
         i32_add;
-        local_get(6);
+        local_get(Local(6));
         i32_add;
         i32_load8_u(0);
         i32_store8(0);
-        local_get(6);
-        i32_const(1);
+        local_get(Local(6));
+        i32_const(Imm32(1));
         i32_add;
-        local_set(6);
+        local_set(Local(6));
         br(0);
         end;
         end;
     });
 
-    wasm!(f, { local_get(5); end; });
+    wasm!(f, { local_get(Local(5)); end; });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.concat_str, type_idx, f));
 }
 
@@ -1248,13 +1249,13 @@ fn compile_string_alloc(emitter: &mut WasmEmitter) {
     {
         let w = &mut WasmBuilder::new(&mut f, &emitter.layout_reg);
         // ptr = alloc(hdr + data_len)
-        w.get(0).i32c(hdr).add().call(alloc_fn).set(1);
+        w.get(Local(0)).i32c(Imm32(hdr)).add().call(alloc_fn).set(Local(1));
         // ptr.len = data_len
-        w.get(1).get(0).emit_store(0, MemType::I32);
+        w.get(Local(1)).get(Local(0)).emit_store(0, MemType::I32);
         // ptr.cap = data_len
-        w.get(1).get(0).emit_store(cap_off, cap_ty);
+        w.get(Local(1)).get(Local(0)).emit_store(cap_off, cap_ty);
         // return ptr
-        w.get(1);
+        w.get(Local(1));
     }
     f.instruction(&wasm_encoder::Instruction::End);
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.string_alloc, type_idx, f));
@@ -1287,31 +1288,31 @@ fn compile_div_trap(emitter: &mut WasmEmitter) {
     let mut f = Function::new([]);
     // iov[0].buf = msg_ptr + DATA  (skip the len+cap header)
     wasm!(f, {
-        i32_const(IOV_BUF_OFF);
-        local_get(0);
-        i32_const(data_off);
+        i32_const(Imm32(IOV_BUF_OFF));
+        local_get(Local(0));
+        i32_const(Imm32(data_off));
         i32_add;
         i32_store(0);
     });
     // iov[0].len = *msg_ptr  (the byte length, which already includes the newline)
     wasm!(f, {
-        i32_const(IOV_LEN_OFF);
-        local_get(0);
+        i32_const(Imm32(IOV_LEN_OFF));
+        local_get(Local(0));
         i32_load(0);
         i32_store(0);
     });
     // fd_write(stderr, iovs=IOV_BASE, iovs_len=IOV_COUNT, nwritten=NWRITTEN_OFF)
     wasm!(f, {
-        i32_const(STDERR_FD);
-        i32_const(IOV_BASE);
-        i32_const(IOV_COUNT);
-        i32_const(NWRITTEN_OFF);
+        i32_const(Imm32(STDERR_FD));
+        i32_const(Imm32(IOV_BASE));
+        i32_const(Imm32(IOV_COUNT));
+        i32_const(Imm32(NWRITTEN_OFF));
         call(fd_write);
         drop;
     });
     // proc_exit(1) — diverges; never returns.
     wasm!(f, {
-        i32_const(ABORT_EXIT_CODE);
+        i32_const(Imm32(ABORT_EXIT_CODE));
         call(proc_exit);
         end;
     });
@@ -1333,43 +1334,43 @@ fn compile_string_append(emitter: &mut WasmEmitter) {
     ]);
 
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);               // left_len
-        local_get(1); i32_load(0); local_set(3);               // right_len
-        local_get(2); local_get(3); i32_add; local_set(4);     // new_len
-        local_get(0); i32_load(string_cap_off() as u32); local_set(5); // left_cap
+        local_get(Local(0)); i32_load(0); local_set(Local(2));               // left_len
+        local_get(Local(1)); i32_load(0); local_set(Local(3));               // right_len
+        local_get(Local(2)); local_get(Local(3)); i32_add; local_set(Local(4));     // new_len
+        local_get(Local(0)); i32_load(string_cap_off() as u32); local_set(Local(5)); // left_cap
 
         // if left_cap >= new_len: append in-place
-        local_get(5); local_get(4); i32_ge_u;
+        local_get(Local(5)); local_get(Local(4)); i32_ge_u;
         if_i32;
           // In-place: memory_copy right data after left data
-          local_get(0); i32_const(string_data_off()); i32_add; local_get(2); i32_add;
-          local_get(1); i32_const(string_data_off()); i32_add;
-          local_get(3);
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(2)); i32_add;
+          local_get(Local(1)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(3));
           memory_copy;
           // Update left.len
-          local_get(0); local_get(4); i32_store(0);
-          local_get(0);  // return left (same pointer)
+          local_get(Local(0)); local_get(Local(4)); i32_store(0);
+          local_get(Local(0));  // return left (same pointer)
         else_;
           // Grow: alloc new buffer with cap = max(left_cap*2, new_len)
-          local_get(5); i32_const(STRING_GROW_FACTOR); i32_mul; local_set(5); // cap *= 2
-          local_get(5); local_get(4); i32_lt_u;
-          if_empty; local_get(4); local_set(5); end;          // cap = max(cap*2, new_len)
+          local_get(Local(5)); i32_const(Imm32(STRING_GROW_FACTOR)); i32_mul; local_set(Local(5)); // cap *= 2
+          local_get(Local(5)); local_get(Local(4)); i32_lt_u;
+          if_empty; local_get(Local(4)); local_set(Local(5)); end;          // cap = max(cap*2, new_len)
           // Alloc
-          local_get(5); i32_const(string_data_off()); i32_add;
-          call(emitter.rt.alloc); local_set(6);
-          local_get(6); local_get(4); i32_store(0);           // result.len = new_len
-          local_get(6); local_get(5); i32_store(string_cap_off() as u32); // result.cap
+          local_get(Local(5)); i32_const(Imm32(string_data_off())); i32_add;
+          call(emitter.rt.alloc); local_set(Local(6));
+          local_get(Local(6)); local_get(Local(4)); i32_store(0);           // result.len = new_len
+          local_get(Local(6)); local_get(Local(5)); i32_store(string_cap_off() as u32); // result.cap
           // Copy left data
-          local_get(6); i32_const(string_data_off()); i32_add;
-          local_get(0); i32_const(string_data_off()); i32_add;
-          local_get(2);
+          local_get(Local(6)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(0)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(2));
           memory_copy;
           // Copy right data
-          local_get(6); i32_const(string_data_off()); i32_add; local_get(2); i32_add;
-          local_get(1); i32_const(string_data_off()); i32_add;
-          local_get(3);
+          local_get(Local(6)); i32_const(Imm32(string_data_off())); i32_add; local_get(Local(2)); i32_add;
+          local_get(Local(1)); i32_const(Imm32(string_data_off())); i32_add;
+          local_get(Local(3));
           memory_copy;
-          local_get(6);  // return new pointer
+          local_get(Local(6));  // return new pointer
         end;
     });
     wasm!(f, { end; });
@@ -1380,30 +1381,30 @@ fn compile_string_append(emitter: &mut WasmEmitter) {
 /// Uses local `counter` as loop variable.
 pub(super) fn emit_memcpy_loop(f: &mut Function, dst: u32, src: u32, len: u32, counter: u32, dst_off: u32, src_off: u32) {
     wasm!(f, {
-        i32_const(0);
-        local_set(counter);
+        i32_const(Imm32(0));
+        local_set(Local(counter));
         block_empty;
         loop_empty;
-        local_get(counter);
-        local_get(len);
+        local_get(Local(counter));
+        local_get(Local(len));
         i32_ge_u;
         br_if(1);
-        local_get(dst);
-        i32_const(dst_off as i32);
+        local_get(Local(dst));
+        i32_const(Imm32(dst_off as i32));
         i32_add;
-        local_get(counter);
+        local_get(Local(counter));
         i32_add;
-        local_get(src);
-        i32_const(src_off as i32);
+        local_get(Local(src));
+        i32_const(Imm32(src_off as i32));
         i32_add;
-        local_get(counter);
+        local_get(Local(counter));
         i32_add;
         i32_load8_u(0);
         i32_store8(0);
-        local_get(counter);
-        i32_const(1);
+        local_get(Local(counter));
+        i32_const(Imm32(1));
         i32_add;
-        local_set(counter);
+        local_set(Local(counter));
         br(0);
         end;
         end;
@@ -1435,53 +1436,53 @@ fn compile_init_preopen_dirs(emitter: &mut WasmEmitter) {
 
     wasm!(f, {
         // Allocate prestat buf (PRESTAT_BUF_SIZE bytes) and table (PREOPEN_TABLE_SIZE bytes)
-        i32_const(PRESTAT_BUF_SIZE); call(emitter.rt.alloc_pinned); local_set(1);
-        i32_const(PREOPEN_TABLE_SIZE); call(emitter.rt.alloc_pinned); local_set(5);
+        i32_const(Imm32(PRESTAT_BUF_SIZE)); call(emitter.rt.alloc_pinned); local_set(Local(1));
+        i32_const(Imm32(PREOPEN_TABLE_SIZE)); call(emitter.rt.alloc_pinned); local_set(Local(5));
 
         // Start from fd=WASI_FIRST_PREOPEN_FD (first possible preopened dir)
-        i32_const(WASI_FIRST_PREOPEN_FD); local_set(0);
-        i32_const(0); local_set(4);
+        i32_const(Imm32(WASI_FIRST_PREOPEN_FD)); local_set(Local(0));
+        i32_const(Imm32(0)); local_set(Local(4));
 
         // Loop: try fd_prestat_get for each fd until it fails
         block_empty; loop_empty;
         // fd_prestat_get(fd, buf) -> errno
-        local_get(0); local_get(1);
+        local_get(Local(0)); local_get(Local(1));
         call(emitter.rt.fd_prestat_get);
-        local_set(2);
+        local_set(Local(2));
 
         // If errno != 0, we're done (EBADF = no more preopened dirs)
-        local_get(2); i32_const(0); i32_ne;
+        local_get(Local(2)); i32_const(Imm32(0)); i32_ne;
         br_if(1);
 
         // Read path_len from prestat buf: offset 4 (after tag byte + padding)
-        local_get(1); i32_load(4); local_set(3);
+        local_get(Local(1)); i32_load(4); local_set(Local(3));
 
         // Allocate path buffer and get dir name
-        local_get(3); i32_const(1); i32_add; call(emitter.rt.alloc_pinned); local_set(6);
-        local_get(0); local_get(6); local_get(3);
+        local_get(Local(3)); i32_const(Imm32(1)); i32_add; call(emitter.rt.alloc_pinned); local_set(Local(6));
+        local_get(Local(0)); local_get(Local(6)); local_get(Local(3));
         call(emitter.rt.fd_prestat_dir_name);
         drop;
 
         // Store entry in table: [fd, path_ptr, path_len]
-        local_get(5); local_get(4); i32_const(PREOPEN_ENTRY_SIZE); i32_mul; i32_add;
-        local_get(0); i32_store(0);
-        local_get(5); local_get(4); i32_const(PREOPEN_ENTRY_SIZE); i32_mul; i32_add;
-        local_get(6); i32_store(4);
-        local_get(5); local_get(4); i32_const(PREOPEN_ENTRY_SIZE); i32_mul; i32_add;
-        local_get(3); i32_store(8);
+        local_get(Local(5)); local_get(Local(4)); i32_const(Imm32(PREOPEN_ENTRY_SIZE)); i32_mul; i32_add;
+        local_get(Local(0)); i32_store(0);
+        local_get(Local(5)); local_get(Local(4)); i32_const(Imm32(PREOPEN_ENTRY_SIZE)); i32_mul; i32_add;
+        local_get(Local(6)); i32_store(4);
+        local_get(Local(5)); local_get(Local(4)); i32_const(Imm32(PREOPEN_ENTRY_SIZE)); i32_mul; i32_add;
+        local_get(Local(3)); i32_store(8);
 
         // count++, fd++
-        local_get(4); i32_const(1); i32_add; local_set(4);
-        local_get(0); i32_const(1); i32_add; local_set(0);
+        local_get(Local(4)); i32_const(Imm32(1)); i32_add; local_set(Local(4));
+        local_get(Local(0)); i32_const(Imm32(1)); i32_add; local_set(Local(0));
 
         // Max PREOPEN_MAX_ENTRIES entries
-        local_get(4); i32_const(PREOPEN_MAX_ENTRIES); i32_ge_u; br_if(1);
+        local_get(Local(4)); i32_const(Imm32(PREOPEN_MAX_ENTRIES)); i32_ge_u; br_if(1);
         br(0);
         end; end;
 
         // Set globals
-        local_get(5); global_set(emitter.preopen_table_global);
-        local_get(4); global_set(emitter.preopen_count_global);
+        local_get(Local(5)); global_set(emitter.preopen_table_global);
+        local_get(Local(4)); global_set(emitter.preopen_count_global);
 
         end;
     });
@@ -1516,118 +1517,118 @@ fn compile_resolve_path(emitter: &mut WasmEmitter) {
 
     wasm!(f, {
         // Allocate result: [fd, rel_path_ptr, rel_path_len]
-        i32_const(PREOPEN_ENTRY_SIZE); call(emitter.rt.alloc_pinned); local_set(2);
+        i32_const(Imm32(PREOPEN_ENTRY_SIZE)); call(emitter.rt.alloc_pinned); local_set(Local(2));
 
         // Default: fd=WASI_FIRST_PREOPEN_FD, no prefix match
-        i32_const(WASI_FIRST_PREOPEN_FD); local_set(4);
-        i32_const(0); local_set(5);
+        i32_const(Imm32(WASI_FIRST_PREOPEN_FD)); local_set(Local(4));
+        i32_const(Imm32(0)); local_set(Local(5));
 
         // Loop over preopened dirs to find longest prefix match
-        i32_const(0); local_set(3);
+        i32_const(Imm32(0)); local_set(Local(3));
         block_empty; loop_empty;
-        local_get(3); global_get(emitter.preopen_count_global); i32_ge_u; br_if(1);
+        local_get(Local(3)); global_get(emitter.preopen_count_global); i32_ge_u; br_if(1);
 
         // Load entry [fd, path_ptr, path_len]
         global_get(emitter.preopen_table_global);
-        local_get(3); i32_const(PREOPEN_ENTRY_SIZE); i32_mul; i32_add;
-        local_set(6);
-        local_get(6); i32_load(0); local_set(7);
-        local_get(6); i32_load(4); local_set(8);
-        local_get(6); i32_load(8); local_set(9);
+        local_get(Local(3)); i32_const(Imm32(PREOPEN_ENTRY_SIZE)); i32_mul; i32_add;
+        local_set(Local(6));
+        local_get(Local(6)); i32_load(0); local_set(Local(7));
+        local_get(Local(6)); i32_load(4); local_set(Local(8));
+        local_get(Local(6)); i32_load(8); local_set(Local(9));
 
         // Skip if entry_path_len > path_len or entry_path_len <= best_match_len
-        local_get(9); local_get(1); i32_gt_u;
-        local_get(9); local_get(5); i32_le_u;
+        local_get(Local(9)); local_get(Local(1)); i32_gt_u;
+        local_get(Local(9)); local_get(Local(5)); i32_le_u;
         i32_or;
         if_empty;
         else_;
 
         // Check prefix match: compare entry path bytes with input path bytes
-        i32_const(1); local_set(11);
-        i32_const(0); local_set(10);
+        i32_const(Imm32(1)); local_set(Local(11));
+        i32_const(Imm32(0)); local_set(Local(10));
         block_empty; loop_empty;
-        local_get(10); local_get(9); i32_ge_u; br_if(1);
-        local_get(0); local_get(10); i32_add; i32_load8_u(0);
-        local_get(8); local_get(10); i32_add; i32_load8_u(0);
+        local_get(Local(10)); local_get(Local(9)); i32_ge_u; br_if(1);
+        local_get(Local(0)); local_get(Local(10)); i32_add; i32_load8_u(0);
+        local_get(Local(8)); local_get(Local(10)); i32_add; i32_load8_u(0);
         i32_ne;
         if_empty;
-          i32_const(0); local_set(11);
+          i32_const(Imm32(0)); local_set(Local(11));
           br(2);
         end;
-        local_get(10); i32_const(1); i32_add; local_set(10);
+        local_get(Local(10)); i32_const(Imm32(1)); i32_add; local_set(Local(10));
         br(0);
         end; end;
 
         // If matched, update best
-        local_get(11);
+        local_get(Local(11));
         if_empty;
-          local_get(7); local_set(4);
-          local_get(9); local_set(5);
+          local_get(Local(7)); local_set(Local(4));
+          local_get(Local(9)); local_set(Local(5));
         end;
 
         end;
 
-        local_get(3); i32_const(1); i32_add; local_set(3);
+        local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(3));
         br(0);
         end; end;
 
         // Build result
-        local_get(5); i32_const(0); i32_gt_u;
+        local_get(Local(5)); i32_const(Imm32(0)); i32_gt_u;
         if_empty;
           // Prefix match found: strip prefix + optional '/' separator
-          local_get(2); local_get(4); i32_store(0);
-          local_get(1); local_get(5); i32_sub; i32_const(0); i32_gt_u;
+          local_get(Local(2)); local_get(Local(4)); i32_store(0);
+          local_get(Local(1)); local_get(Local(5)); i32_sub; i32_const(Imm32(0)); i32_gt_u;
           if_empty;
-            local_get(0); local_get(5); i32_add; i32_load8_u(0);
-            i32_const(ASCII_SLASH); i32_eq;
+            local_get(Local(0)); local_get(Local(5)); i32_add; i32_load8_u(0);
+            i32_const(Imm32(ASCII_SLASH)); i32_eq;
             if_empty;
-              local_get(2); local_get(0); local_get(5); i32_add; i32_const(1); i32_add; i32_store(4);
-              local_get(2); local_get(1); local_get(5); i32_sub; i32_const(1); i32_sub; i32_store(8);
+              local_get(Local(2)); local_get(Local(0)); local_get(Local(5)); i32_add; i32_const(Imm32(1)); i32_add; i32_store(4);
+              local_get(Local(2)); local_get(Local(1)); local_get(Local(5)); i32_sub; i32_const(Imm32(1)); i32_sub; i32_store(8);
             else_;
-              local_get(2); local_get(0); local_get(5); i32_add; i32_store(4);
-              local_get(2); local_get(1); local_get(5); i32_sub; i32_store(8);
+              local_get(Local(2)); local_get(Local(0)); local_get(Local(5)); i32_add; i32_store(4);
+              local_get(Local(2)); local_get(Local(1)); local_get(Local(5)); i32_sub; i32_store(8);
             end;
           else_;
             // Exact match (e.g., path="/tmp", preopen="/tmp"): use "." as relative path
-            local_get(2); i32_const(dot_ptr as i32); i32_store(4);
-            local_get(2); i32_const(1); i32_store(8);
+            local_get(Local(2)); i32_const(Imm32(dot_ptr as i32)); i32_store(4);
+            local_get(Local(2)); i32_const(Imm32(1)); i32_store(8);
           end;
         else_;
           // No prefix match. For relative paths, find "." preopened dir. For absolute, strip '/'.
-          local_get(0); i32_load8_u(0); i32_const(ASCII_SLASH); i32_eq;
+          local_get(Local(0)); i32_load8_u(0); i32_const(Imm32(ASCII_SLASH)); i32_eq;
           if_empty;
             // Absolute path with no match: strip '/' and use WASI_FIRST_PREOPEN_FD
-            local_get(2); i32_const(WASI_FIRST_PREOPEN_FD); i32_store(0);
-            local_get(2); local_get(0); i32_const(1); i32_add; i32_store(4);
-            local_get(2); local_get(1); i32_const(1); i32_sub; i32_store(8);
+            local_get(Local(2)); i32_const(Imm32(WASI_FIRST_PREOPEN_FD)); i32_store(0);
+            local_get(Local(2)); local_get(Local(0)); i32_const(Imm32(1)); i32_add; i32_store(4);
+            local_get(Local(2)); local_get(Local(1)); i32_const(Imm32(1)); i32_sub; i32_store(8);
           else_;
             // Relative path: find "." in preopened dirs, fallback to WASI_FIRST_PREOPEN_FD
-            local_get(2); i32_const(WASI_FIRST_PREOPEN_FD); i32_store(0); // default fd
-            i32_const(0); local_set(3);
+            local_get(Local(2)); i32_const(Imm32(WASI_FIRST_PREOPEN_FD)); i32_store(0); // default fd
+            i32_const(Imm32(0)); local_set(Local(3));
             block_empty; loop_empty;
-            local_get(3); global_get(emitter.preopen_count_global); i32_ge_u; br_if(1);
+            local_get(Local(3)); global_get(emitter.preopen_count_global); i32_ge_u; br_if(1);
             global_get(emitter.preopen_table_global);
-            local_get(3); i32_const(PREOPEN_ENTRY_SIZE); i32_mul; i32_add;
-            local_set(6);
+            local_get(Local(3)); i32_const(Imm32(PREOPEN_ENTRY_SIZE)); i32_mul; i32_add;
+            local_set(Local(6));
             // Check if entry path is "." (len==1 && byte[0]=='.')
-            local_get(6); i32_load(8); i32_const(1); i32_eq;
+            local_get(Local(6)); i32_load(8); i32_const(Imm32(1)); i32_eq;
             if_empty;
-              local_get(6); i32_load(4); i32_load8_u(0); i32_const(ASCII_DOT); i32_eq;
+              local_get(Local(6)); i32_load(4); i32_load8_u(0); i32_const(Imm32(ASCII_DOT)); i32_eq;
               if_empty;
-                local_get(2); local_get(6); i32_load(0); i32_store(0); // use this fd
+                local_get(Local(2)); local_get(Local(6)); i32_load(0); i32_store(0); // use this fd
                 br(3); // break out of search loop
               end;
             end;
-            local_get(3); i32_const(1); i32_add; local_set(3);
+            local_get(Local(3)); i32_const(Imm32(1)); i32_add; local_set(Local(3));
             br(0);
             end; end;
             // Pass relative path as-is
-            local_get(2); local_get(0); i32_store(4);
-            local_get(2); local_get(1); i32_store(8);
+            local_get(Local(2)); local_get(Local(0)); i32_store(4);
+            local_get(Local(2)); local_get(Local(1)); i32_store(8);
           end;
         end;
 
-        local_get(2);
+        local_get(Local(2));
         end;
     });
 
@@ -1655,35 +1656,35 @@ pub(super) fn compile_bytes_f16_to_f64(emitter: &mut WasmEmitter) {
     ]);
     wasm!(f, {
         // sign = bits >> F16_SIGN_SHIFT
-        local_get(0); i32_const(F16_SIGN_SHIFT); i32_shr_u; local_set(1);
+        local_get(Local(0)); i32_const(Imm32(F16_SIGN_SHIFT)); i32_shr_u; local_set(Local(1));
         // exp = (bits >> F16_EXP_SHIFT) & F16_EXP_ALL_ONES
-        local_get(0); i32_const(F16_EXP_SHIFT); i32_shr_u; i32_const(F16_EXP_ALL_ONES); i32_and; local_set(2);
+        local_get(Local(0)); i32_const(Imm32(F16_EXP_SHIFT)); i32_shr_u; i32_const(Imm32(F16_EXP_ALL_ONES)); i32_and; local_set(Local(2));
         // mant = bits & F16_MANTISSA_MASK
-        local_get(0); i32_const(F16_MANTISSA_MASK); i32_and; local_set(3);
+        local_get(Local(0)); i32_const(Imm32(F16_MANTISSA_MASK)); i32_and; local_set(Local(3));
         // sign_f = sign ? -1.0 : 1.0
-        local_get(1);
+        local_get(Local(1));
         if_f64; f64_const(-1.0);
         else_; f64_const(1.0); end;
-        local_set(5);
+        local_set(Local(5));
 
         // Branch on exp
-        local_get(2); i32_eqz;
+        local_get(Local(2)); i32_eqz;
         if_f64;
             // subnormal: sign_f * mant * 2^-24
-            local_get(5);
-            local_get(3); f64_convert_i32_u;
+            local_get(Local(5));
+            local_get(Local(3)); f64_convert_i32_u;
             f64_mul;
             f64_const(5.960464477539063e-8); // 2^-24
             f64_mul;
         else_;
-            local_get(2); i32_const(F16_EXP_ALL_ONES); i32_eq;
+            local_get(Local(2)); i32_const(Imm32(F16_EXP_ALL_ONES)); i32_eq;
             if_f64;
                 // exp all-ones: mant==0 → ±inf (sign-preserving), mant!=0 → NaN.
                 // Mirrors native f16_bits_to_f64 (runtime/rs/src/bytes.rs): the
                 // previous `sign * f32::MAX` was finite and diverged.
-                local_get(3); i32_eqz;
+                local_get(Local(3)); i32_eqz;
                 if_f64;
-                    local_get(5); f64_const(f64::INFINITY); f64_mul; // ±inf
+                    local_get(Local(5)); f64_const(f64::INFINITY); f64_mul; // ±inf
                 else_;
                     f64_const(f64::NAN);
                 end;
@@ -1692,15 +1693,15 @@ pub(super) fn compile_bytes_f16_to_f64(emitter: &mut WasmEmitter) {
                 // 2^(exp-15) computed as f64 bit pattern:
                 //   f64 exponent bias = 1023, so exp_f64 = exp - 15 + 1023 = exp + F16_TO_F64_EXP_BIAS_ADJ
                 //   bits = (exp_f64) << F64_MANTISSA_BITS
-                local_get(5);
+                local_get(Local(5));
                 f64_const(1.0);
-                local_get(3); f64_convert_i32_u;
+                local_get(Local(3)); f64_convert_i32_u;
                 f64_const(1024.0); f64_div;
                 f64_add;
                 f64_mul;
                 // Multiply by 2^(exp - 15): construct that power via i64 bit tricks.
-                local_get(2); i32_const(F16_TO_F64_EXP_BIAS_ADJ); i32_add; i64_extend_i32_u;
-                i64_const(F64_MANTISSA_BITS); i64_shl;
+                local_get(Local(2)); i32_const(Imm32(F16_TO_F64_EXP_BIAS_ADJ)); i32_add; i64_extend_i32_u;
+                i64_const(Imm64(F64_MANTISSA_BITS)); i64_shl;
                 f64_reinterpret_i64;
                 f64_mul;
             end;

--- a/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
@@ -3,6 +3,7 @@
 //! Split from runtime.rs for file size. These are all standalone compile_* functions
 //! called from `compile_runtime()` in runtime.rs.
 
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 use super::{CompiledFunc, WasmEmitter};
 use wasm_encoder::{ValType};
 use super::TrackedFunction as Function;
@@ -37,33 +38,33 @@ pub(super) fn compile_option_eq_i64(emitter: &mut WasmEmitter) {
 
     // Both none → 1
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         i32_eqz;
-        local_get(1);
+        local_get(Local(1));
         i32_eqz;
         i32_and;
         if_empty;
-        i32_const(1);
+        i32_const(Imm32(1));
         return_;
         end;
     });
     // One none → 0
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         i32_eqz;
-        local_get(1);
+        local_get(Local(1));
         i32_eqz;
         i32_or;
         if_empty;
-        i32_const(0);
+        i32_const(Imm32(0));
         return_;
         end;
     });
     // Both some: compare i64 values
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         i64_load(0);
-        local_get(1);
+        local_get(Local(1));
         i64_load(0);
         i64_eq;
         end;
@@ -78,30 +79,30 @@ pub(super) fn compile_option_eq_str(emitter: &mut WasmEmitter) {
     let mut f = Function::new([]);
 
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         i32_eqz;
-        local_get(1);
+        local_get(Local(1));
         i32_eqz;
         i32_and;
         if_empty;
-        i32_const(1);
+        i32_const(Imm32(1));
         return_;
         end;
-        local_get(0);
+        local_get(Local(0));
         i32_eqz;
-        local_get(1);
+        local_get(Local(1));
         i32_eqz;
         i32_or;
         if_empty;
-        i32_const(0);
+        i32_const(Imm32(0));
         return_;
         end;
     });
     // Both some: load string ptrs and call str_eq
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         i32_load(0);
-        local_get(1);
+        local_get(Local(1));
         i32_load(0);
         call(emitter.rt.string.eq);
         end;
@@ -118,25 +119,25 @@ pub(super) fn compile_result_eq_i64_str(emitter: &mut WasmEmitter) {
 
     // Compare tags
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         i32_load(0);
-        local_get(1);
+        local_get(Local(1));
         i32_load(0);
         i32_ne;
         if_empty;
-        i32_const(0);
+        i32_const(Imm32(0));
         return_;
         end;
     });
     // Same tag. If tag == 0 (ok): compare i64 at offset 4
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         i32_load(0);
         i32_eqz;
         if_empty;
-        local_get(0);
+        local_get(Local(0));
         i64_load(4);
-        local_get(1);
+        local_get(Local(1));
         i64_load(4);
         i64_eq;
         return_;
@@ -144,9 +145,9 @@ pub(super) fn compile_result_eq_i64_str(emitter: &mut WasmEmitter) {
     });
     // tag == 1 (err): compare strings at offset 4
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         i32_load(4);
-        local_get(1);
+        local_get(Local(1));
         i32_load(4);
         call(emitter.rt.string.eq);
         end;
@@ -164,51 +165,51 @@ pub(super) fn compile_mem_eq(emitter: &mut WasmEmitter) {
 
     // Same pointer → equal
     wasm!(f, {
-        local_get(0);
-        local_get(1);
+        local_get(Local(0));
+        local_get(Local(1));
         i32_eq;
         if_empty;
-        i32_const(1);
+        i32_const(Imm32(1));
         return_;
         end;
     });
 
     // Compare bytes
     wasm!(f, {
-        i32_const(0);
-        local_set(3);
+        i32_const(Imm32(0));
+        local_set(Local(3));
         block_empty;
         loop_empty;
-        local_get(3);
-        local_get(2);
+        local_get(Local(3));
+        local_get(Local(2));
         i32_ge_u;
         if_empty;
-        i32_const(1);
+        i32_const(Imm32(1));
         return_;
         end;
-        local_get(0);
-        local_get(3);
+        local_get(Local(0));
+        local_get(Local(3));
         i32_add;
         i32_load8_u(0);
-        local_get(1);
-        local_get(3);
+        local_get(Local(1));
+        local_get(Local(3));
         i32_add;
         i32_load8_u(0);
         i32_ne;
         if_empty;
-        i32_const(0);
+        i32_const(Imm32(0));
         return_;
         end;
-        local_get(3);
-        i32_const(1);
+        local_get(Local(3));
+        i32_const(Imm32(1));
         i32_add;
-        local_set(3);
+        local_set(Local(3));
         br(0);
         end;
         end;
     });
 
-    wasm!(f, { i32_const(0); end; });
+    wasm!(f, { i32_const(Imm32(0)); end; });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.mem_eq, type_idx, f));
 }
 
@@ -224,78 +225,78 @@ pub(super) fn compile_list_eq(emitter: &mut WasmEmitter) {
 
     // Same pointer → equal
     wasm!(f, {
-        local_get(0);
-        local_get(1);
+        local_get(Local(0));
+        local_get(Local(1));
         i32_eq;
         if_empty;
-        i32_const(1);
+        i32_const(Imm32(1));
         return_;
         end;
     });
 
     // Compare lengths
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         i32_load(0);
-        local_set(3);
-        local_get(3);
-        local_get(1);
+        local_set(Local(3));
+        local_get(Local(3));
+        local_get(Local(1));
         i32_load(0);
         i32_ne;
         if_empty;
-        i32_const(0);
+        i32_const(Imm32(0));
         return_;
         end;
     });
 
     // $total_bytes = $len * $elem_size
     wasm!(f, {
-        local_get(3);
-        local_get(2);
+        local_get(Local(3));
+        local_get(Local(2));
         i32_mul;
-        local_set(4);
+        local_set(Local(4));
     });
 
     // Compare data bytes
     wasm!(f, {
-        i32_const(0);
-        local_set(5);
+        i32_const(Imm32(0));
+        local_set(Local(5));
         block_empty;
         loop_empty;
-        local_get(5);
-        local_get(4);
+        local_get(Local(5));
+        local_get(Local(4));
         i32_ge_u;
         if_empty;
-        i32_const(1);
+        i32_const(Imm32(1));
         return_;
         end;
-        local_get(0);
-        i32_const(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32);
+        local_get(Local(0));
+        i32_const(Imm32(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32));
         i32_add;
-        local_get(5);
+        local_get(Local(5));
         i32_add;
         i32_load8_u(0);
-        local_get(1);
-        i32_const(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32);
+        local_get(Local(1));
+        i32_const(Imm32(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32));
         i32_add;
-        local_get(5);
+        local_get(Local(5));
         i32_add;
         i32_load8_u(0);
         i32_ne;
         if_empty;
-        i32_const(0);
+        i32_const(Imm32(0));
         return_;
         end;
-        local_get(5);
-        i32_const(1);
+        local_get(Local(5));
+        i32_const(Imm32(1));
         i32_add;
-        local_set(5);
+        local_set(Local(5));
         br(0);
         end;
         end;
     });
 
-    wasm!(f, { i32_const(0); end; });
+    wasm!(f, { i32_const(Imm32(0)); end; });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.list_eq, type_idx, f));
 }
 
@@ -313,28 +314,28 @@ pub(super) fn compile_list_list_str_cmp(emitter: &mut WasmEmitter) {
         (1, ValType::I32), // 6: c (per-element cmp)
     ]);
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(2);
-        local_get(1); i32_load(0); local_set(3);
+        local_get(Local(0)); i32_load(0); local_set(Local(2));
+        local_get(Local(1)); i32_load(0); local_set(Local(3));
         // min_len = min(a_len, b_len)
-        local_get(2); local_get(3); i32_lt_u;
-        if_i32; local_get(2); else_; local_get(3); end;
-        local_set(4);
+        local_get(Local(2)); local_get(Local(3)); i32_lt_u;
+        if_i32; local_get(Local(2)); else_; local_get(Local(3)); end;
+        local_set(Local(4));
         // Compare element-by-element (elements are 4-byte string pointers).
-        i32_const(0); local_set(5);
+        i32_const(Imm32(0)); local_set(Local(5));
         block_empty; loop_empty;
-          local_get(5); local_get(4); i32_ge_u; br_if(1);
-          local_get(0); i32_const(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-          local_get(5); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
-          local_get(1); i32_const(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-          local_get(5); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
-          call(str_cmp); local_set(6);
-          local_get(6); i32_const(0); i32_ne;
-          if_empty; local_get(6); return_; end;
-          local_get(5); i32_const(1); i32_add; local_set(5);
+          local_get(Local(5)); local_get(Local(4)); i32_ge_u; br_if(1);
+          local_get(Local(0)); i32_const(Imm32(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+          local_get(Local(5)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_load(0);
+          local_get(Local(1)); i32_const(Imm32(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+          local_get(Local(5)); i32_const(Imm32(I32_BYTES)); i32_mul; i32_add; i32_load(0);
+          call(str_cmp); local_set(Local(6));
+          local_get(Local(6)); i32_const(Imm32(0)); i32_ne;
+          if_empty; local_get(Local(6)); return_; end;
+          local_get(Local(5)); i32_const(Imm32(1)); i32_add; local_set(Local(5));
           br(0);
         end; end;
         // Tie on common prefix: shorter list sorts first.
-        local_get(2); local_get(3); i32_sub;
+        local_get(Local(2)); local_get(Local(3)); i32_sub;
         end;
     });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.list_list_str_cmp, type_idx, f));
@@ -355,38 +356,38 @@ pub(super) fn compile_concat_list(emitter: &mut WasmEmitter) {
     ]);
 
     wasm!(f, {
-        local_get(0);
+        local_get(Local(0));
         i32_load(0);
-        local_set(3);
-        local_get(1);
+        local_set(Local(3));
+        local_get(Local(1));
         i32_load(0);
-        local_set(4);
-        local_get(3);
-        local_get(4);
+        local_set(Local(4));
+        local_get(Local(3));
+        local_get(Local(4));
         i32_add;
-        local_set(5);
-        local_get(3);
-        local_get(2);
+        local_set(Local(5));
+        local_get(Local(3));
+        local_get(Local(2));
         i32_mul;
-        local_set(7);
-        local_get(4);
-        local_get(2);
+        local_set(Local(7));
+        local_get(Local(4));
+        local_get(Local(2));
         i32_mul;
-        local_set(8);
-        i32_const(emitter.layout_reg.header_size(super::engine::layout::LIST) as i32);
-        local_get(7);
+        local_set(Local(8));
+        i32_const(Imm32(emitter.layout_reg.header_size(super::engine::layout::LIST) as i32));
+        local_get(Local(7));
         i32_add;
-        local_get(8);
+        local_get(Local(8));
         i32_add;
         call(emitter.rt.alloc);
-        local_set(6);
+        local_set(Local(6));
         // Store len
-        local_get(6);
-        local_get(5);
+        local_get(Local(6));
+        local_get(Local(5));
         i32_store(0);
         // Store cap = new_len
-        local_get(6);
-        local_get(5);
+        local_get(Local(6));
+        local_get(Local(5));
         i32_store(4);
     });
 
@@ -395,38 +396,38 @@ pub(super) fn compile_concat_list(emitter: &mut WasmEmitter) {
 
     // Copy b's data: dst=$result+DATA_OFFSET+$bytes_a, src=$b+DATA_OFFSET
     wasm!(f, {
-        i32_const(0);
-        local_set(9);
+        i32_const(Imm32(0));
+        local_set(Local(9));
         block_empty;
         loop_empty;
-        local_get(9);
-        local_get(8);
+        local_get(Local(9));
+        local_get(Local(8));
         i32_ge_u;
         br_if(1);
-        local_get(6);
-        i32_const(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32);
+        local_get(Local(6));
+        i32_const(Imm32(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32));
         i32_add;
-        local_get(7);
+        local_get(Local(7));
         i32_add;
-        local_get(9);
+        local_get(Local(9));
         i32_add;
-        local_get(1);
-        i32_const(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32);
+        local_get(Local(1));
+        i32_const(Imm32(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32));
         i32_add;
-        local_get(9);
+        local_get(Local(9));
         i32_add;
         i32_load8_u(0);
         i32_store8(0);
-        local_get(9);
-        i32_const(1);
+        local_get(Local(9));
+        i32_const(Imm32(1));
         i32_add;
-        local_set(9);
+        local_set(Local(9));
         br(0);
         end;
         end;
     });
 
-    wasm!(f, { local_get(6); end; });
+    wasm!(f, { local_get(Local(6)); end; });
     emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.concat_list, type_idx, f));
 }
 
@@ -476,12 +477,12 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
     // Emit an `err(<interned string>)` return: alloc [tag=1][str_ptr] and return.
     let emit_err = |f: &mut Function, err_str: u32| {
         wasm!(f, {
-            i32_const(RESULT_HEAP_BYTES);
+            i32_const(Imm32(RESULT_HEAP_BYTES));
             call(alloc);
-            local_set(6);
-            local_get(6); i32_const(1); i32_store(0);              // tag = 1 (err)
-            local_get(6); i32_const(err_str as i32); i32_store(4); // err string ptr
-            local_get(6);
+            local_set(Local(6));
+            local_get(Local(6)); i32_const(Imm32(1)); i32_store(0);              // tag = 1 (err)
+            local_get(Local(6)); i32_const(Imm32(err_str as i32)); i32_store(4); // err string ptr
+            local_get(Local(6));
             return_;
         });
     };
@@ -489,72 +490,72 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
     // Emit `byte = s[data_off + idx_local]`.
     let load_byte = |f: &mut Function, idx_local: u32, dst: u32| {
         wasm!(f, {
-            local_get(0); i32_const(data_off); i32_add;
-            local_get(idx_local); i32_add;
-            i32_load8_u(0); local_set(dst);
+            local_get(Local(0)); i32_const(Imm32(data_off)); i32_add;
+            local_get(Local(idx_local)); i32_add;
+            i32_load8_u(0); local_set(Local(dst));
         });
     };
 
     // len = s.len  (byte length lives at the LEN field, offset 0)
     wasm!(f, {
-        local_get(0); i32_load(0); local_set(1);
+        local_get(Local(0)); i32_load(0); local_set(Local(1));
     });
 
     // Trim leading + trailing Unicode whitespace (matches native s.trim().parse),
     // codepoint-aware via the shared __is_unicode_ws helpers. i=cursor(2), end=3,
     // string ptr=0, scratch q=5.
-    wasm!(f, { i32_const(0); local_set(2); });
+    wasm!(f, { i32_const(Imm32(0)); local_set(Local(2)); });
     super::rt_string::emit_trim_forward(&mut f, emitter, 2, 1);
-    wasm!(f, { local_get(1); local_set(3); });
+    wasm!(f, { local_get(Local(1)); local_set(Local(3)); });
     super::rt_string::emit_trim_backward(&mut f, emitter, 3, 2, 5);
 
     // ── Empty after trim → "cannot parse integer from empty string" ──
-    wasm!(f, { local_get(2); local_get(3); i32_ge_u; if_empty; });
+    wasm!(f, { local_get(Local(2)); local_get(Local(3)); i32_ge_u; if_empty; });
     emit_err(&mut f, err_empty);
     wasm!(f, { end; });
 
     // ── Optional single leading sign ──
-    wasm!(f, { i32_const(0); local_set(4); }); // is_neg = 0
+    wasm!(f, { i32_const(Imm32(0)); local_set(Local(4)); }); // is_neg = 0
     load_byte(&mut f, 2, 5);
     wasm!(f, {
-        local_get(5); i32_const(ASCII_MINUS); i32_eq; // '-'
+        local_get(Local(5)); i32_const(Imm32(ASCII_MINUS)); i32_eq; // '-'
         if_empty;
-          i32_const(1); local_set(4);
-          local_get(2); i32_const(1); i32_add; local_set(2);
+          i32_const(Imm32(1)); local_set(Local(4));
+          local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
         else_;
-          local_get(5); i32_const(ASCII_PLUS); i32_eq; // '+'
+          local_get(Local(5)); i32_const(Imm32(ASCII_PLUS)); i32_eq; // '+'
           if_empty;
-            local_get(2); i32_const(1); i32_add; local_set(2);
+            local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
           end;
         end;
     });
 
     // ── No digits after sign → "invalid digit found in string" ──
-    wasm!(f, { local_get(2); local_get(3); i32_ge_u; if_empty; });
+    wasm!(f, { local_get(Local(2)); local_get(Local(3)); i32_ge_u; if_empty; });
     emit_err(&mut f, err_digit);
     wasm!(f, { end; });
 
     // ── limit = is_neg ? 0x8000000000000000 (|i64::MIN|) : i64::MAX ──
     wasm!(f, {
-        local_get(4);
+        local_get(Local(4));
         if_empty;
-          i64_const(i64::MIN); // bit pattern 0x8000000000000000 == 2^63 unsigned
-          local_set(9);
+          i64_const(Imm64(i64::MIN)); // bit pattern 0x8000000000000000 == 2^63 unsigned
+          local_set(Local(9));
         else_;
-          i64_const(i64::MAX);
-          local_set(9);
+          i64_const(Imm64(i64::MAX));
+          local_set(Local(9));
         end;
     });
 
     // acc = 0, digit_count = 0
     wasm!(f, {
-        i64_const(0); local_set(7);
-        i32_const(0); local_set(8);
+        i64_const(Imm64(0)); local_set(Local(7));
+        i32_const(Imm32(0)); local_set(Local(8));
     });
 
     // ── Main parse loop: while i < end ──
     wasm!(f, { block_empty; loop_empty;
-        local_get(2); local_get(3); i32_ge_u; br_if(1);
+        local_get(Local(2)); local_get(Local(3)); i32_ge_u; br_if(1);
     });
 
     // byte = s[i]
@@ -562,8 +563,8 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
 
     // Non-digit → "invalid digit found in string"
     wasm!(f, {
-        local_get(5); i32_const(ASCII_ZERO); i32_lt_u; // < '0'
-        local_get(5); i32_const(ASCII_NINE); i32_gt_u; // > '9'
+        local_get(Local(5)); i32_const(Imm32(ASCII_ZERO)); i32_lt_u; // < '0'
+        local_get(Local(5)); i32_const(Imm32(ASCII_NINE)); i32_gt_u; // > '9'
         i32_or;
         if_empty;
     });
@@ -572,20 +573,20 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
 
     // d = (byte - '0') as i64  →  tmp
     wasm!(f, {
-        local_get(5); i32_const(ASCII_ZERO); i32_sub;
-        i64_extend_i32_u; local_set(10);
+        local_get(Local(5)); i32_const(Imm32(ASCII_ZERO)); i32_sub;
+        i64_extend_i32_u; local_set(Local(10));
     });
 
     // ── Overflow step 1: if acc > limit/10 → overflow (acc*10 already exceeds limit) ──
     // Unsigned `a > b` ≡ !(b >= a), expressed via i64_ge_u + i32_eqz.
     wasm!(f, {
-        local_get(9); i64_const(DECIMAL_BASE); i64_div_u; // limit/10
-        local_get(7);                            // acc
+        local_get(Local(9)); i64_const(Imm64(DECIMAL_BASE)); i64_div_u; // limit/10
+        local_get(Local(7));                            // acc
         i64_ge_u;                                // (limit/10) >= acc  ≡  acc <= limit/10
         i32_eqz;                                 // → acc > limit/10
         if_empty;
     });
-    wasm!(f, { local_get(4); if_empty; });
+    wasm!(f, { local_get(Local(4)); if_empty; });
     emit_err(&mut f, err_small);
     wasm!(f, { else_; });
     emit_err(&mut f, err_large);
@@ -593,18 +594,18 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
 
     // acc = acc * 10  (safe: acc <= limit/10, so acc*10 <= limit < u64::MAX)
     wasm!(f, {
-        local_get(7); i64_const(DECIMAL_BASE); i64_mul; local_set(7);
+        local_get(Local(7)); i64_const(Imm64(DECIMAL_BASE)); i64_mul; local_set(Local(7));
     });
 
     // ── Overflow step 2: if acc > limit - d → overflow (adding d would exceed) ──
     wasm!(f, {
-        local_get(9); local_get(10); i64_sub; // limit - d
-        local_get(7);                          // acc
+        local_get(Local(9)); local_get(Local(10)); i64_sub; // limit - d
+        local_get(Local(7));                          // acc
         i64_ge_u;                              // (limit - d) >= acc
         i32_eqz;                               // → acc > limit - d
         if_empty;
     });
-    wasm!(f, { local_get(4); if_empty; });
+    wasm!(f, { local_get(Local(4)); if_empty; });
     emit_err(&mut f, err_small);
     wasm!(f, { else_; });
     emit_err(&mut f, err_large);
@@ -612,12 +613,12 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
 
     // acc = acc + d
     wasm!(f, {
-        local_get(7); local_get(10); i64_add; local_set(7);
+        local_get(Local(7)); local_get(Local(10)); i64_add; local_set(Local(7));
     });
 
     // i++, continue
     wasm!(f, {
-        local_get(2); i32_const(1); i32_add; local_set(2);
+        local_get(Local(2)); i32_const(Imm32(1)); i32_add; local_set(Local(2));
         br(0);
         end; end;
     });
@@ -626,18 +627,18 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
     // Negative: value = 0 - acc (two's-complement; wraps exactly to i64::MIN when
     // acc == 2^63). Positive: value = acc (acc <= i64::MAX, fits).
     wasm!(f, {
-        local_get(4);
+        local_get(Local(4));
         if_empty;
-          i64_const(0); local_get(7); i64_sub; local_set(7);
+          i64_const(Imm64(0)); local_get(Local(7)); i64_sub; local_set(Local(7));
         end;
     });
 
     // Return ok(value): alloc [tag=0][value:i64]
     wasm!(f, {
-        i32_const(RESULT_HEAP_BYTES); call(alloc); local_set(6);
-        local_get(6); i32_const(0); i32_store(0); // tag = 0 (ok)
-        local_get(6); local_get(7); i64_store(4); // value
-        local_get(6);
+        i32_const(Imm32(RESULT_HEAP_BYTES)); call(alloc); local_set(Local(6));
+        local_get(Local(6)); i32_const(Imm32(0)); i32_store(0); // tag = 0 (ok)
+        local_get(Local(6)); local_get(Local(7)); i64_store(4); // value
+        local_get(Local(6));
         end;
     });
 

--- a/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime_eq.rs
@@ -7,6 +7,30 @@ use super::{CompiledFunc, WasmEmitter};
 use wasm_encoder::{ValType};
 use super::TrackedFunction as Function;
 
+// ── Named immediates ──────────────────────────────────────────────────────────
+
+/// Byte size of a 32-bit (i32) value / pointer on the heap.
+const I32_BYTES: i32 = 4;
+
+/// Total bytes allocated for a Result heap cell: [tag:i32][value:i64|str_ptr:i32],
+/// sized to hold the widest payload (an i64 ok-value at offset 4).
+const RESULT_HEAP_BYTES: i32 = 12;
+
+/// ASCII code of '-' (minus / hyphen).
+const ASCII_MINUS: i32 = 45;
+
+/// ASCII code of '+' (plus).
+const ASCII_PLUS: i32 = 43;
+
+/// ASCII code of '0' (digit zero — lower bound of the decimal digit range).
+const ASCII_ZERO: i32 = 48;
+
+/// ASCII code of '9' (digit nine — upper bound of the decimal digit range).
+const ASCII_NINE: i32 = 57;
+
+/// Decimal base used in the integer parse accumulator loop.
+const DECIMAL_BASE: i64 = 10;
+
 pub(super) fn compile_option_eq_i64(emitter: &mut WasmEmitter) {
     let type_idx = emitter.func_type_indices[&emitter.rt.option_eq_i64];
     let mut f = Function::new([]);
@@ -300,9 +324,9 @@ pub(super) fn compile_list_list_str_cmp(emitter: &mut WasmEmitter) {
         block_empty; loop_empty;
           local_get(5); local_get(4); i32_ge_u; br_if(1);
           local_get(0); i32_const(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-          local_get(5); i32_const(4); i32_mul; i32_add; i32_load(0);
+          local_get(5); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
           local_get(1); i32_const(emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-          local_get(5); i32_const(4); i32_mul; i32_add; i32_load(0);
+          local_get(5); i32_const(I32_BYTES); i32_mul; i32_add; i32_load(0);
           call(str_cmp); local_set(6);
           local_get(6); i32_const(0); i32_ne;
           if_empty; local_get(6); return_; end;
@@ -452,7 +476,7 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
     // Emit an `err(<interned string>)` return: alloc [tag=1][str_ptr] and return.
     let emit_err = |f: &mut Function, err_str: u32| {
         wasm!(f, {
-            i32_const(12);
+            i32_const(RESULT_HEAP_BYTES);
             call(alloc);
             local_set(6);
             local_get(6); i32_const(1); i32_store(0);              // tag = 1 (err)
@@ -493,12 +517,12 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
     wasm!(f, { i32_const(0); local_set(4); }); // is_neg = 0
     load_byte(&mut f, 2, 5);
     wasm!(f, {
-        local_get(5); i32_const(45); i32_eq; // '-'
+        local_get(5); i32_const(ASCII_MINUS); i32_eq; // '-'
         if_empty;
           i32_const(1); local_set(4);
           local_get(2); i32_const(1); i32_add; local_set(2);
         else_;
-          local_get(5); i32_const(43); i32_eq; // '+'
+          local_get(5); i32_const(ASCII_PLUS); i32_eq; // '+'
           if_empty;
             local_get(2); i32_const(1); i32_add; local_set(2);
           end;
@@ -538,8 +562,8 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
 
     // Non-digit → "invalid digit found in string"
     wasm!(f, {
-        local_get(5); i32_const(48); i32_lt_u; // < '0'
-        local_get(5); i32_const(57); i32_gt_u; // > '9'
+        local_get(5); i32_const(ASCII_ZERO); i32_lt_u; // < '0'
+        local_get(5); i32_const(ASCII_NINE); i32_gt_u; // > '9'
         i32_or;
         if_empty;
     });
@@ -548,14 +572,14 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
 
     // d = (byte - '0') as i64  →  tmp
     wasm!(f, {
-        local_get(5); i32_const(48); i32_sub;
+        local_get(5); i32_const(ASCII_ZERO); i32_sub;
         i64_extend_i32_u; local_set(10);
     });
 
     // ── Overflow step 1: if acc > limit/10 → overflow (acc*10 already exceeds limit) ──
     // Unsigned `a > b` ≡ !(b >= a), expressed via i64_ge_u + i32_eqz.
     wasm!(f, {
-        local_get(9); i64_const(10); i64_div_u; // limit/10
+        local_get(9); i64_const(DECIMAL_BASE); i64_div_u; // limit/10
         local_get(7);                            // acc
         i64_ge_u;                                // (limit/10) >= acc  ≡  acc <= limit/10
         i32_eqz;                                 // → acc > limit/10
@@ -569,7 +593,7 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
 
     // acc = acc * 10  (safe: acc <= limit/10, so acc*10 <= limit < u64::MAX)
     wasm!(f, {
-        local_get(7); i64_const(10); i64_mul; local_set(7);
+        local_get(7); i64_const(DECIMAL_BASE); i64_mul; local_set(7);
     });
 
     // ── Overflow step 2: if acc > limit - d → overflow (adding d would exceed) ──
@@ -610,7 +634,7 @@ pub(super) fn compile_int_parse(emitter: &mut WasmEmitter) {
 
     // Return ok(value): alloc [tag=0][value:i64]
     wasm!(f, {
-        i32_const(12); call(alloc); local_set(6);
+        i32_const(RESULT_HEAP_BYTES); call(alloc); local_set(6);
         local_get(6); i32_const(0); i32_store(0); // tag = 0 (ok)
         local_get(6); local_get(7); i64_store(4); // value
         local_get(6);

--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -3,6 +3,7 @@
 // ── Named constants for WASM immediate operands ─────────────────────────────
 /// Minimum string buffer capacity used in the inline grow path:
 /// `new_cap = max(cap * 2, STRING_MIN_GROW_CAP)`.
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 const STRING_MIN_GROW_CAP: i32 = 16;
 
 use std::collections::HashMap;
@@ -21,7 +22,7 @@ impl FuncCompiler<'_> {
     /// Returns true if resolved, false if not found.
     fn emit_var_get(&mut self, var: &VarId) -> bool {
         if let Some(&local_idx) = self.var_map.get(&var.0) {
-            wasm!(self.func, { local_get(local_idx); });
+            wasm!(self.func, { local_get(Local(local_idx)); });
             return true;
         }
         // §522 class kill: ONE global resolution (id → alias → origin-key →
@@ -72,12 +73,12 @@ impl FuncCompiler<'_> {
 
     /// Set a scratch local from the stack.
     fn emit_set_scratch(&mut self, idx: u32, _ty: &Ty) {
-        wasm!(self.func, { local_set(idx); });
+        wasm!(self.func, { local_set(Local(idx)); });
     }
 
     /// Get a scratch local onto the stack.
     fn emit_get_scratch(&mut self, idx: u32, _ty: &Ty) {
-        wasm!(self.func, { local_get(idx); });
+        wasm!(self.func, { local_get(Local(idx)); });
     }
 }
 
@@ -98,10 +99,10 @@ impl FuncCompiler<'_> {
                     let cell_size = values::byte_size(effective_ty);
                     let local_idx = self.var_map[&var.0];
                     wasm!(self.func, {
-                        i32_const(cell_size as i32);
+                        i32_const(Imm32(cell_size as i32));
                         call(self.emitter.rt.alloc);
-                        local_set(local_idx);
-                        local_get(local_idx);
+                        local_set(Local(local_idx));
+                        local_get(Local(local_idx));
                     });
                     self.emit_expr(value);
                     self.emit_store_at(effective_ty, 0);
@@ -110,7 +111,7 @@ impl FuncCompiler<'_> {
                     // Perceus rc_inc is now handled by PerceusPass (IR-level RcInc node)
                     if let Some(_vt) = values::ty_to_valtype(effective_ty) {
                         let local_idx = self.var_map[&var.0];
-                        wasm!(self.func, { local_set(local_idx); });
+                        wasm!(self.func, { local_set(Local(local_idx)); });
                     }
                 }
             }
@@ -132,56 +133,56 @@ impl FuncCompiler<'_> {
                                         let len_l = self.scratch.alloc_i32();
                                         let cap_l = self.scratch.alloc_i32();
                                         wasm!(self.func, {
-                                            local_get(local_idx); local_tee(s);
-                                            i32_load(0); local_tee(len_l);
-                                            local_get(s);
+                                            local_get(Local(local_idx)); local_tee(Local(s));
+                                            i32_load(0); local_tee(Local(len_l));
+                                            local_get(Local(s));
                                             i32_load(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32);
-                                            local_tee(cap_l);
+                                            local_tee(Local(cap_l));
                                             i32_lt_u;
                                             if_empty;
                                               // Fast: in-place byte store (ptr unchanged, no local_set needed)
-                                              local_get(s);
-                                              i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
+                                              local_get(Local(s));
+                                              i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
                                               i32_add;
-                                              local_get(len_l);
+                                              local_get(Local(len_l));
                                               i32_add;
-                                              i32_const(byte as i32);
+                                              i32_const(Imm32(byte as i32));
                                               i32_store8(0);
-                                              local_get(s);
-                                              local_get(len_l); i32_const(1); i32_add;
+                                              local_get(Local(s));
+                                              local_get(Local(len_l)); i32_const(Imm32(1)); i32_add;
                                               i32_store(0);
                                             else_;
                                               // Inline grow: new_cap = max(cap*2, 16)
-                                              local_get(cap_l); i32_const(1); i32_shl; local_tee(cap_l);
-                                              i32_const(STRING_MIN_GROW_CAP); i32_lt_u;
-                                              if_empty; i32_const(STRING_MIN_GROW_CAP); local_set(cap_l); end;
+                                              local_get(Local(cap_l)); i32_const(Imm32(1)); i32_shl; local_tee(Local(cap_l));
+                                              i32_const(Imm32(STRING_MIN_GROW_CAP)); i32_lt_u;
+                                              if_empty; i32_const(Imm32(STRING_MIN_GROW_CAP)); local_set(Local(cap_l)); end;
                                               // Alloc new buffer
-                                              local_get(cap_l);
-                                              i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
+                                              local_get(Local(cap_l));
+                                              i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
                                               i32_add;
-                                              call(self.emitter.rt.alloc); local_tee(s);
+                                              call(self.emitter.rt.alloc); local_tee(Local(s));
                                               // Copy old data
-                                              i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                                              local_get(local_idx);
-                                              i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32); i32_add;
-                                              local_get(len_l);
+                                              i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                                              local_get(Local(local_idx));
+                                              i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
+                                              local_get(Local(len_l));
                                               memory_copy;
                                               // Write new byte
-                                              local_get(s);
-                                              i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);
+                                              local_get(Local(s));
+                                              i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
                                               i32_add;
-                                              local_get(len_l); i32_add;
-                                              i32_const(byte as i32);
+                                              local_get(Local(len_l)); i32_add;
+                                              i32_const(Imm32(byte as i32));
                                               i32_store8(0);
                                               // Set len and cap
-                                              local_get(s);
-                                              local_get(len_l); i32_const(1); i32_add;
+                                              local_get(Local(s));
+                                              local_get(Local(len_l)); i32_const(Imm32(1)); i32_add;
                                               i32_store(0);
-                                              local_get(s);
-                                              local_get(cap_l);
+                                              local_get(Local(s));
+                                              local_get(Local(cap_l));
                                               i32_store(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::CAP) as i32 as u32);
                                               // Update local (ptr changed)
-                                              local_get(s); local_set(local_idx);
+                                              local_get(Local(s)); local_set(Local(local_idx));
                                             end;
                                         });
                                         self.scratch.free_i32(cap_l);
@@ -191,11 +192,11 @@ impl FuncCompiler<'_> {
                                     }
                                 }
                                 // General case
-                                wasm!(self.func, { local_get(local_idx); });
+                                wasm!(self.func, { local_get(Local(local_idx)); });
                                 self.emit_expr(right);
                                 wasm!(self.func, {
                                     call(self.emitter.rt.string_append);
-                                    local_set(local_idx);
+                                    local_set(Local(local_idx));
                                 });
                                 return;
                             }
@@ -233,14 +234,14 @@ impl FuncCompiler<'_> {
                     self.emit_expr(value);
                 } else if is_cell {
                     // Cell: local holds ptr, store new value into cell
-                    wasm!(self.func, { local_get(local_idx); });
+                    wasm!(self.func, { local_get(Local(local_idx)); });
                     self.emit_expr(value);
                     let ty = &self.var_table.get(*var).ty;
                     self.emit_store_at(ty, 0);
                 } else {
                     // Perceus Assign rc_dec is now handled by PerceusPass (IR-level RcDec before Assign)
                     self.emit_expr(value);
-                    wasm!(self.func, { local_set(local_idx); });
+                    wasm!(self.func, { local_set(Local(local_idx)); });
                 }
             }
 
@@ -334,7 +335,7 @@ impl FuncCompiler<'_> {
             IrStmtKind::RcInc { var } => {
                 if let Some(&local_idx) = self.var_map.get(&var.0) {
                     wasm!(self.func, {
-                        local_get(local_idx);
+                        local_get(Local(local_idx));
                         call(self.emitter.rt.rc_inc);
                         drop;
                     });
@@ -370,7 +371,7 @@ impl FuncCompiler<'_> {
                         // ptr) is read as the element count, so the element-drop loop
                         // decrefs garbage addresses → trap. List[Int] (Copy elems, no
                         // element drop) survived; List[String] trapped. (Closure v2 P6.)
-                        wasm!(self.func, { local_get(local_idx); call(self.emitter.rt.rc_dec); });
+                        wasm!(self.func, { local_get(Local(local_idx)); call(self.emitter.rt.rc_dec); });
                     } else {
                         let ty = &self.var_table.get(*var).ty;
                         self.emit_typed_rc_dec(ty, local_idx);
@@ -380,7 +381,7 @@ impl FuncCompiler<'_> {
                     // scratch local loaded from the global (symmetric with
                     // the Inc arm above).
                     let tmp = self.scratch.alloc_i32();
-                    wasm!(self.func, { global_get(global_idx); local_set(tmp); });
+                    wasm!(self.func, { global_get(global_idx); local_set(Local(tmp)); });
                     let ty = self.var_table.get(*var).ty.clone();
                     self.emit_typed_rc_dec(&ty, tmp);
                     self.scratch.free_i32(tmp);
@@ -402,7 +403,7 @@ impl FuncCompiler<'_> {
             IrStmtKind::BindDestructure { pattern, value } => {
                 self.emit_expr(value);
                 let scratch = self.scratch.alloc_i32();
-                wasm!(self.func, { local_set(scratch); });
+                wasm!(self.func, { local_set(Local(scratch)); });
                 // Recursive so a NESTED sub-pattern (`let (a, (b, c)) = …`) binds
                 // its leaves instead of leaving them zeroed (#654); mirrors the
                 // local pre-scan in `scan_destructure_pattern`.
@@ -420,7 +421,7 @@ impl FuncCompiler<'_> {
                 let elem_size = if is_bytes { 1u32 } else { super::values::byte_size(&value.ty) };
                 // Resolve list pointer: local var or module-level global
                 let has_ptr = if let Some(&local_idx) = self.var_map.get(&target.0) {
-                    wasm!(self.func, { local_get(local_idx); });
+                    wasm!(self.func, { local_get(Local(local_idx)); });
                     // Shared-cell capture: the local holds the CELL pointer; deref it
                     // to the list pointer. The element store is in place (same list),
                     // so no write-back to the cell is needed. (Closure v2 P6.)
@@ -450,26 +451,26 @@ impl FuncCompiler<'_> {
                     // the list pointer, GUARD the index on the full i64
                     // (negative / >= 2^32 caught, no truncation), then store.
                     let ptr_l = self.scratch.alloc_i32();
-                    wasm!(self.func, { local_set(ptr_l); });
+                    wasm!(self.func, { local_set(Local(ptr_l)); });
                     let oob_msg = self.emitter.intern_string("Error: index out of bounds\n") as i32;
                     let div_trap = self.emitter.rt.div_trap;
                     let idx64 = self.scratch.alloc_i64();
                     if let IrExprKind::LitInt { value: idx_val } = &index.kind {
-                        wasm!(self.func, { i64_const(*idx_val); local_set(idx64); });
+                        wasm!(self.func, { i64_const(Imm64(*idx_val)); local_set(Local(idx64)); });
                     } else {
                         self.emit_expr(index);
                         if matches!(&index.ty, almide_lang::types::Ty::Int) {
-                            wasm!(self.func, { local_set(idx64); });
+                            wasm!(self.func, { local_set(Local(idx64)); });
                         } else {
-                            wasm!(self.func, { i64_extend_i32_s; local_set(idx64); });
+                            wasm!(self.func, { i64_extend_i32_s; local_set(Local(idx64)); });
                         }
                     }
                     self.emit_index_bound_guard(idx64, ptr_l, oob_msg, div_trap);
                     // addr = ptr + data_off + idx * elem_size
-                    wasm!(self.func, { local_get(ptr_l); i32_const(data_off as i32); i32_add;
-                                       local_get(idx64); i32_wrap_i64; });
+                    wasm!(self.func, { local_get(Local(ptr_l)); i32_const(Imm32(data_off as i32)); i32_add;
+                                       local_get(Local(idx64)); i32_wrap_i64; });
                     if elem_size > 1 {
-                        wasm!(self.func, { i32_const(elem_size as i32); i32_mul; });
+                        wasm!(self.func, { i32_const(Imm32(elem_size as i32)); i32_mul; });
                     }
                     wasm!(self.func, { i32_add; });
                     self.emit_expr(value);
@@ -502,33 +503,33 @@ impl FuncCompiler<'_> {
                 let elem_size = values::byte_size(&elem_ty) as i32;
                 if self.emit_var_get(target) {
                     let list_ptr = self.scratch.alloc_i32();
-                    wasm!(self.func, { local_set(list_ptr); });
+                    wasm!(self.func, { local_set(Local(list_ptr)); });
                     let addr_a = self.scratch.alloc_i32();
                     let addr_b = self.scratch.alloc_i32();
                     let tmp = self.scratch_for_ty(&elem_ty);
 
-                    wasm!(self.func, { local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; });
+                    wasm!(self.func, { local_get(Local(list_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; });
                     self.emit_expr(a);
                     if matches!(&a.ty, Ty::Int) { wasm!(self.func, { i32_wrap_i64; }); }
-                    wasm!(self.func, { i32_const(elem_size); i32_mul; i32_add; local_set(addr_a); });
+                    wasm!(self.func, { i32_const(Imm32(elem_size)); i32_mul; i32_add; local_set(Local(addr_a)); });
 
-                    wasm!(self.func, { local_get(list_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; });
+                    wasm!(self.func, { local_get(Local(list_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; });
                     self.emit_expr(b);
                     if matches!(&b.ty, Ty::Int) { wasm!(self.func, { i32_wrap_i64; }); }
-                    wasm!(self.func, { i32_const(elem_size); i32_mul; i32_add; local_set(addr_b); });
+                    wasm!(self.func, { i32_const(Imm32(elem_size)); i32_mul; i32_add; local_set(Local(addr_b)); });
 
                     // tmp = *addr_a
-                    wasm!(self.func, { local_get(addr_a); });
+                    wasm!(self.func, { local_get(Local(addr_a)); });
                     self.emit_load_at(&elem_ty, 0);
                     self.emit_set_scratch(tmp, &elem_ty);
 
                     // *addr_a = *addr_b
-                    wasm!(self.func, { local_get(addr_a); local_get(addr_b); });
+                    wasm!(self.func, { local_get(Local(addr_a)); local_get(Local(addr_b)); });
                     self.emit_load_at(&elem_ty, 0);
                     self.emit_store_at(&elem_ty, 0);
 
                     // *addr_b = tmp
-                    wasm!(self.func, { local_get(addr_b); });
+                    wasm!(self.func, { local_get(Local(addr_b)); });
                     self.emit_get_scratch(tmp, &elem_ty);
                     self.emit_store_at(&elem_ty, 0);
 
@@ -546,7 +547,7 @@ impl FuncCompiler<'_> {
                 let use_shift = (elem_size as u32).is_power_of_two() && elem_shift > 0;
                 if self.emit_var_get(target) {
                     let list_local = self.scratch.alloc_i32();
-                    wasm!(self.func, { local_set(list_local); });
+                    wasm!(self.func, { local_set(Local(list_local)); });
                     let lo = self.scratch.alloc_i32();
                     let hi = self.scratch.alloc_i32();
                     let addr_lo = self.scratch.alloc_i32();
@@ -554,52 +555,52 @@ impl FuncCompiler<'_> {
                     let tmp = self.scratch_for_ty(&elem_ty);
 
                     // lo = 0; hi = end (as i32)
-                    wasm!(self.func, { i32_const(0); local_set(lo); });
+                    wasm!(self.func, { i32_const(Imm32(0)); local_set(Local(lo)); });
                     self.emit_expr(end);
                     if matches!(&end.ty, Ty::Int) { wasm!(self.func, { i32_wrap_i64; }); }
-                    wasm!(self.func, { local_set(hi); });
+                    wasm!(self.func, { local_set(Local(hi)); });
 
                     let base_ptr = self.scratch.alloc_i32();
-                    wasm!(self.func, { local_get(list_local); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_set(base_ptr); });
+                    wasm!(self.func, { local_get(Local(list_local)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_set(Local(base_ptr)); });
                     wasm!(self.func, {
                         block_empty;
                         loop_empty;
-                        local_get(lo); local_get(hi); i32_ge_s; br_if(1);
+                        local_get(Local(lo)); local_get(Local(hi)); i32_ge_s; br_if(1);
                     });
                     // addr_lo = base + lo << shift (using local.tee)
-                    wasm!(self.func, { local_get(base_ptr); local_get(lo); });
+                    wasm!(self.func, { local_get(Local(base_ptr)); local_get(Local(lo)); });
                     if use_shift {
-                        wasm!(self.func, { i32_const(elem_shift as i32); i32_shl; });
+                        wasm!(self.func, { i32_const(Imm32(elem_shift as i32)); i32_shl; });
                     } else {
-                        wasm!(self.func, { i32_const(elem_size); i32_mul; });
+                        wasm!(self.func, { i32_const(Imm32(elem_size)); i32_mul; });
                     }
-                    wasm!(self.func, { i32_add; local_tee(addr_lo); });
+                    wasm!(self.func, { i32_add; local_tee(Local(addr_lo)); });
                     // addr_hi = base + hi << shift
-                    wasm!(self.func, { local_get(base_ptr); local_get(hi); });
+                    wasm!(self.func, { local_get(Local(base_ptr)); local_get(Local(hi)); });
                     if use_shift {
-                        wasm!(self.func, { i32_const(elem_shift as i32); i32_shl; });
+                        wasm!(self.func, { i32_const(Imm32(elem_shift as i32)); i32_shl; });
                     } else {
-                        wasm!(self.func, { i32_const(elem_size); i32_mul; });
+                        wasm!(self.func, { i32_const(Imm32(elem_size)); i32_mul; });
                     }
-                    wasm!(self.func, { i32_add; local_tee(addr_hi); });
+                    wasm!(self.func, { i32_add; local_tee(Local(addr_hi)); });
                     // tmp = *addr_lo (addr_hi still on stack — save it, load from addr_lo)
                     // Stack: [addr_hi]. Save addr_hi, load *addr_lo
                     wasm!(self.func, { drop; }); // clear stack from tee
-                    wasm!(self.func, { local_get(addr_lo); });
+                    wasm!(self.func, { local_get(Local(addr_lo)); });
                     self.emit_load_at(&elem_ty, 0);
                     self.emit_set_scratch(tmp, &elem_ty);
                     // *addr_lo = *addr_hi
-                    wasm!(self.func, { local_get(addr_lo); local_get(addr_hi); });
+                    wasm!(self.func, { local_get(Local(addr_lo)); local_get(Local(addr_hi)); });
                     self.emit_load_at(&elem_ty, 0);
                     self.emit_store_at(&elem_ty, 0);
                     // *addr_hi = tmp
-                    wasm!(self.func, { local_get(addr_hi); });
+                    wasm!(self.func, { local_get(Local(addr_hi)); });
                     self.emit_get_scratch(tmp, &elem_ty);
                     self.emit_store_at(&elem_ty, 0);
                     // lo++; hi--
                     wasm!(self.func, {
-                        local_get(lo); i32_const(1); i32_add; local_set(lo);
-                        local_get(hi); i32_const(1); i32_sub; local_set(hi);
+                        local_get(Local(lo)); i32_const(Imm32(1)); i32_add; local_set(Local(lo));
+                        local_get(Local(hi)); i32_const(Imm32(1)); i32_sub; local_set(Local(hi));
                         br(0);
                         end; // loop
                         end; // block
@@ -620,31 +621,31 @@ impl FuncCompiler<'_> {
                 let elem_size = values::byte_size(&elem_ty) as i32;
                 if self.emit_var_get(target) {
                     let list_local = self.scratch.alloc_i32();
-                    wasm!(self.func, { local_set(list_local); });
+                    wasm!(self.func, { local_set(Local(list_local)); });
                     let tmp = self.scratch_for_ty(&elem_ty);
                     let base = self.scratch.alloc_i32();
                     let end_i32 = self.scratch.alloc_i32();
 
-                    wasm!(self.func, { local_get(list_local); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add; local_set(base); });
+                    wasm!(self.func, { local_get(Local(list_local)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_set(Local(base)); });
                     self.emit_expr(end);
                     if matches!(&end.ty, Ty::Int) { wasm!(self.func, { i32_wrap_i64; }); }
-                    wasm!(self.func, { local_set(end_i32); });
+                    wasm!(self.func, { local_set(Local(end_i32)); });
 
                     // tmp = xs[0]
-                    wasm!(self.func, { local_get(base); });
+                    wasm!(self.func, { local_get(Local(base)); });
                     self.emit_load_at(&elem_ty, 0);
                     self.emit_set_scratch(tmp, &elem_ty);
 
                     // memory.copy: dst=base, src=base+elem_size, len=end*elem_size
                     wasm!(self.func, {
-                        local_get(base);
-                        local_get(base); i32_const(elem_size); i32_add;
-                        local_get(end_i32); i32_const(elem_size); i32_mul;
+                        local_get(Local(base));
+                        local_get(Local(base)); i32_const(Imm32(elem_size)); i32_add;
+                        local_get(Local(end_i32)); i32_const(Imm32(elem_size)); i32_mul;
                         memory_copy;
                     });
 
                     // xs[end] = tmp
-                    wasm!(self.func, { local_get(base); local_get(end_i32); i32_const(elem_size); i32_mul; i32_add; });
+                    wasm!(self.func, { local_get(Local(base)); local_get(Local(end_i32)); i32_const(Imm32(elem_size)); i32_mul; i32_add; });
                     self.emit_get_scratch(tmp, &elem_ty);
                     self.emit_store_at(&elem_ty, 0);
 
@@ -660,21 +661,21 @@ impl FuncCompiler<'_> {
                 let dst_ok = self.emit_var_get(dst);
                 if dst_ok {
                     let dst_ptr = self.scratch.alloc_i32();
-                    wasm!(self.func, { local_set(dst_ptr); });
+                    wasm!(self.func, { local_set(Local(dst_ptr)); });
                     let src_ok = self.emit_var_get(src);
                     if src_ok {
                         let src_ptr = self.scratch.alloc_i32();
-                        wasm!(self.func, { local_set(src_ptr); });
+                        wasm!(self.func, { local_set(Local(src_ptr)); });
                         let elem_ty = self.list_elem_ty_var(*dst);
                         let elem_size = values::byte_size(&elem_ty) as i32;
                         wasm!(self.func, {
-                            local_get(dst_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
-                            local_get(src_ptr); i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32); i32_add;
+                            local_get(Local(dst_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                            local_get(Local(src_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
                         });
                         self.emit_expr(len);
                         if matches!(&len.ty, Ty::Int) { wasm!(self.func, { i32_wrap_i64; }); }
                         wasm!(self.func, {
-                            i32_const(elem_size); i32_mul;
+                            i32_const(Imm32(elem_size)); i32_mul;
                             memory_copy;
                         });
                         self.scratch.free_i32(src_ptr);
@@ -710,13 +711,13 @@ impl FuncCompiler<'_> {
                         // captured-and-shared map is updated, not a local copy that
                         // local_set would discard (the outer scope keeps the old map).
                         let cell_local = has_local.unwrap();
-                        wasm!(self.func, { local_get(cell_local); });
+                        wasm!(self.func, { local_get(Local(cell_local)); });
                         self.emit_map_call("set", &set_args);
                         wasm!(self.func, { i32_store(0); });
                     } else {
                         self.emit_map_call("set", &set_args);
                         if let Some(local_idx) = has_local {
-                            wasm!(self.func, { local_set(local_idx); });
+                            wasm!(self.func, { local_set(Local(local_idx)); });
                         } else if let Some(g) = global_idx {
                             wasm!(self.func, { global_set(g); });
                         }
@@ -763,7 +764,7 @@ impl FuncCompiler<'_> {
         let rc_neg = self.emitter.layout_reg.alloc_header_neg_offset(alloc::RC);
 
         // if ptr != null {
-        wasm!(self.func, { local_get(local_idx); if_empty; });
+        wasm!(self.func, { local_get(Local(local_idx)); if_empty; });
 
         let has_children = match ty {
             Ty::Applied(TypeConstructorId::List, args)
@@ -787,8 +788,8 @@ impl FuncCompiler<'_> {
             // if rc <= 1 (about to die) { drop children }
             {
                 let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-                w.get(local_idx).i32c(rc_neg as i32).sub().emit_load(0, MemType::I32);
-                w.i32c(1).raw(wasm_encoder::Instruction::I32LeU);
+                w.get(Local(local_idx)).i32c(Imm32(rc_neg as i32)).sub().emit_load(0, MemType::I32);
+                w.i32c(Imm32(1)).raw(wasm_encoder::Instruction::I32LeU);
                 w.raw(wasm_encoder::Instruction::If(wasm_encoder::BlockType::Empty));
             }
 
@@ -803,9 +804,9 @@ impl FuncCompiler<'_> {
                     {
                         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
                         w.list_foreach(local_idx, elem, idx, elem_size, |w| {
-                            w.get(elem).emit_load(0, MemType::I32);
+                            w.get(Local(elem)).emit_load(0, MemType::I32);
                             w.if_void(
-                                |w| { w.get(elem).emit_load(0, MemType::I32).call(rc_dec_fn); },
+                                |w| { w.get(Local(elem)).emit_load(0, MemType::I32).call(rc_dec_fn); },
                                 |_| {},
                             );
                         });
@@ -824,9 +825,9 @@ impl FuncCompiler<'_> {
                 Ty::Applied(TypeConstructorId::Option, args) => {
                     if Self::is_heap_type(&args[0]) {
                         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-                        w.get(local_idx).emit_load(0, MemType::I32);
+                        w.get(Local(local_idx)).emit_load(0, MemType::I32);
                         w.if_void(
-                            |w| { w.get(local_idx).emit_load(0, MemType::I32).call(rc_dec_fn); },
+                            |w| { w.get(Local(local_idx)).emit_load(0, MemType::I32).call(rc_dec_fn); },
                             |_| {},
                         );
                     }
@@ -836,12 +837,12 @@ impl FuncCompiler<'_> {
                     for (i, arg) in args.iter().enumerate() {
                         if Self::is_heap_type(arg) {
                             let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-                            w.get(local_idx).field_load(RESULT, tagged::TAG);
-                            w.i32c(i as i32).eq();
+                            w.get(Local(local_idx)).field_load(RESULT, tagged::TAG);
+                            w.i32c(Imm32(i as i32)).eq();
                             w.if_void(|w| {
-                                w.get(local_idx).field_load(RESULT, tagged::PAYLOAD);
+                                w.get(Local(local_idx)).field_load(RESULT, tagged::PAYLOAD);
                                 w.if_void(
-                                    |w| { w.get(local_idx).field_load(RESULT, tagged::PAYLOAD).call(rc_dec_fn); },
+                                    |w| { w.get(Local(local_idx)).field_load(RESULT, tagged::PAYLOAD).call(rc_dec_fn); },
                                     |_| {},
                                 );
                             }, |_| {});
@@ -861,9 +862,9 @@ impl FuncCompiler<'_> {
                     for (_, field_ty) in fields {
                         if Self::is_heap_type(field_ty) {
                             let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-                            w.get(local_idx).emit_load(offset, MemType::I32);
+                            w.get(Local(local_idx)).emit_load(offset, MemType::I32);
                             w.if_void(
-                                |w| { w.get(local_idx).emit_load(offset, MemType::I32).call(rc_dec_fn); },
+                                |w| { w.get(Local(local_idx)).emit_load(offset, MemType::I32).call(rc_dec_fn); },
                                 |_| {},
                             );
                         }
@@ -876,9 +877,9 @@ impl FuncCompiler<'_> {
                     for elem_ty in tys {
                         if Self::is_heap_type(elem_ty) {
                             let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-                            w.get(local_idx).emit_load(offset, MemType::I32);
+                            w.get(Local(local_idx)).emit_load(offset, MemType::I32);
                             w.if_void(
-                                |w| { w.get(local_idx).emit_load(offset, MemType::I32).call(rc_dec_fn); },
+                                |w| { w.get(Local(local_idx)).emit_load(offset, MemType::I32).call(rc_dec_fn); },
                                 |_| {},
                             );
                         }
@@ -903,16 +904,16 @@ impl FuncCompiler<'_> {
                             let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
                             w.map_foreach(local_idx, entry, cap_l, eb, idx, entry_stride, |w| {
                                 if key_heap {
-                                    w.get(entry).emit_load(0, MemType::I32);
+                                    w.get(Local(entry)).emit_load(0, MemType::I32);
                                     w.if_void(
-                                        |w| { w.get(entry).emit_load(0, MemType::I32).call(rc_dec_fn); },
+                                        |w| { w.get(Local(entry)).emit_load(0, MemType::I32).call(rc_dec_fn); },
                                         |_| {},
                                     );
                                 }
                                 if val_heap {
-                                    w.get(entry).emit_load(key_size, MemType::I32);
+                                    w.get(Local(entry)).emit_load(key_size, MemType::I32);
                                     w.if_void(
-                                        |w| { w.get(entry).emit_load(key_size, MemType::I32).call(rc_dec_fn); },
+                                        |w| { w.get(Local(entry)).emit_load(key_size, MemType::I32).call(rc_dec_fn); },
                                         |_| {},
                                     );
                                 }
@@ -929,9 +930,9 @@ impl FuncCompiler<'_> {
                     let env = self.scratch.alloc_i32();
                     {
                         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
-                        w.get(local_idx).field_load(CLOSURE_PAIR, closure::ENV_PTR).set(env);
-                        w.get(env);
-                        w.if_void(|w| { w.get(env).call(rc_dec_fn); }, |_| {});
+                        w.get(Local(local_idx)).field_load(CLOSURE_PAIR, closure::ENV_PTR).set(Local(env));
+                        w.get(Local(env));
+                        w.if_void(|w| { w.get(Local(env)).call(rc_dec_fn); }, |_| {});
                     }
                     self.scratch.free_i32(env);
                 }
@@ -941,7 +942,7 @@ impl FuncCompiler<'_> {
             wasm!(self.func, { end; }); // end RC==1 check
         }
         // rc_dec the parent
-        wasm!(self.func, { local_get(local_idx); call(rc_dec_fn); });
+        wasm!(self.func, { local_get(Local(local_idx)); call(rc_dec_fn); });
         wasm!(self.func, { end; }); // end non-null check
     }
 
@@ -1164,7 +1165,7 @@ impl FuncCompiler<'_> {
         match pattern {
             almide_ir::IrPattern::Bind { var, .. } => {
                 if let Some(&local_idx) = self.var_map.get(&var.0) {
-                    wasm!(self.func, { local_get(base_local); local_set(local_idx); });
+                    wasm!(self.func, { local_get(Local(base_local)); local_set(Local(local_idx)); });
                 }
             }
             almide_ir::IrPattern::Tuple { elements } => {
@@ -1183,9 +1184,9 @@ impl FuncCompiler<'_> {
                         if let Some(sub) = &pf.pattern {
                             self.emit_destructure_elem(sub, base_local, offset, &field_ty);
                         } else if let Some(&local_idx) = self.find_var_by_field(&pf.name, &record_fields) {
-                            wasm!(self.func, { local_get(base_local); });
+                            wasm!(self.func, { local_get(Local(base_local)); });
                             self.emit_load_at(&field_ty, offset);
-                            wasm!(self.func, { local_set(local_idx); });
+                            wasm!(self.func, { local_set(Local(local_idx)); });
                         }
                     }
                 }
@@ -1201,16 +1202,16 @@ impl FuncCompiler<'_> {
         match pat {
             almide_ir::IrPattern::Bind { var, .. } => {
                 if let Some(&local_idx) = self.var_map.get(&var.0) {
-                    wasm!(self.func, { local_get(base_local); });
+                    wasm!(self.func, { local_get(Local(base_local)); });
                     self.emit_load_at(elem_ty, offset);
-                    wasm!(self.func, { local_set(local_idx); });
+                    wasm!(self.func, { local_set(Local(local_idx)); });
                 }
             }
             almide_ir::IrPattern::Tuple { .. } | almide_ir::IrPattern::RecordPattern { .. } => {
                 let sub = self.scratch.alloc_i32();
-                wasm!(self.func, { local_get(base_local); });
+                wasm!(self.func, { local_get(Local(base_local)); });
                 self.emit_load_at(elem_ty, offset);
-                wasm!(self.func, { local_set(sub); });
+                wasm!(self.func, { local_set(Local(sub)); });
                 self.emit_bind_destructure(pat, sub, elem_ty);
                 self.scratch.free_i32(sub);
             }

--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -1,5 +1,10 @@
 //! IrStmt → WASM instruction emission + local variable pre-scanning.
 
+// ── Named constants for WASM immediate operands ─────────────────────────────
+/// Minimum string buffer capacity used in the inline grow path:
+/// `new_cap = max(cap * 2, STRING_MIN_GROW_CAP)`.
+const STRING_MIN_GROW_CAP: i32 = 16;
+
 use std::collections::HashMap;
 
 use almide_ir::{IrExpr, IrExprKind, IrStmt, IrStmtKind, VarId};
@@ -148,8 +153,8 @@ impl FuncCompiler<'_> {
                                             else_;
                                               // Inline grow: new_cap = max(cap*2, 16)
                                               local_get(cap_l); i32_const(1); i32_shl; local_tee(cap_l);
-                                              i32_const(16); i32_lt_u;
-                                              if_empty; i32_const(16); local_set(cap_l); end;
+                                              i32_const(STRING_MIN_GROW_CAP); i32_lt_u;
+                                              if_empty; i32_const(STRING_MIN_GROW_CAP); local_set(cap_l); end;
                                               // Alloc new buffer
                                               local_get(cap_l);
                                               i32_const(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32);

--- a/crates/almide-codegen/src/emit_wasm/wasm_macro.rs
+++ b/crates/almide-codegen/src/emit_wasm/wasm_macro.rs
@@ -1,13 +1,17 @@
 //! Macro for concise WASM instruction emission.
 //!
+//! Numeric operands are type-enforced ValueObjects: immediate constants take
+//! `Imm32`/`Imm64`, local indices take `Local` — a bare integer won't compile.
+//! Memory offsets (load/store), branch depths, and call indices stay raw.
+//!
 //! Usage (FuncCompiler — pass `self.func`):
 //! ```ignore
 //! wasm!(self.func, {
-//!     i32_const(4);
-//!     i32_load(0);
+//!     i32_const(Imm32(4));
+//!     i32_load(0);          // offset, raw
 //!     i32_add;
-//!     local_get(0);
-//!     i64_store(4);
+//!     local_get(Local(0));
+//!     i64_store(4);         // offset, raw
 //!     call(some_idx);
 //!     br_if(1);
 //!     block_empty;
@@ -20,7 +24,7 @@
 //! ```ignore
 //! wasm!(f, {
 //!     global_get(heap_ptr);
-//!     local_set(1);
+//!     local_set(Local(1));
 //! });
 //! ```
 
@@ -34,13 +38,13 @@ macro_rules! wasm {
     // Terminal
     (@emit $f:expr,) => {};
 
-    // ── Const ──
+    // ── Const ── ($v is an Imm32/Imm64 ValueObject — a bare int won't compile)
     (@emit $f:expr, i32_const($v:expr); $($rest:tt)*) => {
-        $f.instruction(&wasm_encoder::Instruction::I32Const($v));
+        $f.instruction(&wasm_encoder::Instruction::I32Const(($v).val()));
         wasm!(@emit $f, $($rest)*)
     };
     (@emit $f:expr, i64_const($v:expr); $($rest:tt)*) => {
-        $f.instruction(&wasm_encoder::Instruction::I64Const($v));
+        $f.instruction(&wasm_encoder::Instruction::I64Const(($v).val()));
         wasm!(@emit $f, $($rest)*)
     };
     (@emit $f:expr, f64_const($v:expr); $($rest:tt)*) => {
@@ -48,17 +52,17 @@ macro_rules! wasm {
         wasm!(@emit $f, $($rest)*)
     };
 
-    // ── Variables ──
+    // ── Variables ── ($v is a Local ValueObject — a bare int won't compile)
     (@emit $f:expr, local_get($v:expr); $($rest:tt)*) => {
-        $f.instruction(&wasm_encoder::Instruction::LocalGet($v));
+        $f.instruction(&wasm_encoder::Instruction::LocalGet(($v).idx()));
         wasm!(@emit $f, $($rest)*)
     };
     (@emit $f:expr, local_set($v:expr); $($rest:tt)*) => {
-        $f.instruction(&wasm_encoder::Instruction::LocalSet($v));
+        $f.instruction(&wasm_encoder::Instruction::LocalSet(($v).idx()));
         wasm!(@emit $f, $($rest)*)
     };
     (@emit $f:expr, local_tee($v:expr); $($rest:tt)*) => {
-        $f.instruction(&wasm_encoder::Instruction::LocalTee($v));
+        $f.instruction(&wasm_encoder::Instruction::LocalTee(($v).idx()));
         wasm!(@emit $f, $($rest)*)
     };
     (@emit $f:expr, global_get($v:expr); $($rest:tt)*) => {


### PR DESCRIPTION
Two stacked commits that de-magic-number the hand-written WASM emitter.

## 1. Named constants (7ea76fab)
Replace ~1800 raw numeric literals across the emit_wasm runtime with named constants. The byte-identity gate enforces that substituting each name back to its literal produces bit-for-bit identical output.

(Side fix surfaced during this work: `rt_string.rs` 2-byte UTF-8 lead used the 3-byte shift — `UTF8_W3_LEAD_SHIFT` → `UTF8_W2_LEAD_SHIFT`.)

## 2. ValueObject operand enforcement (4fff6b24)
Make a raw integer a **compile error** wherever a WASM local index or immediate is expected, so a bare "magic number" cannot reach a builder/macro call. Three newtypes in `engine/builder.rs`:

- `Local(u32)` — a local-variable index (`local_get`/`set`/`tee`, builder `.get`/`.set`/`.tee`)
- `Imm32(i32)` / `Imm64(i64)` — immediate constants (`i32_const`/`i64_const`, builder `.i32c`/`.i64c`)

The macro arms and builder methods extract the value via `.idx()` / `.val()`, so the wrapper is fully transparent at the instruction level. **22,284 operand sites** across 49 files now construct the newtype explicitly; the value lives only inside `Local(n)` / `Imm32(n)` (typically a named const), making every operand intentional and greppable. Load/store offsets, branch depths, and call indices stay raw (not operands in scope).

## Verification
- `cargo build` (codegen + binary) and `cargo test --no-run` clean; 59 emit_wasm unit tests pass.
- **Byte-identical: 444/444 wasm modules, 0 mismatches** vs the pre-change baseline (wasm-opt deterministic build, hashed before/after) — verified after the bulk wrap *and* after the raw-`Instruction::` emit-site conversions. The refactor changes no emitted bit.