### PR TITLE
Fix #643: in-place mutation of a loop-outer binding wrongly reclaimed by iter-scope

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -1031,6 +1031,27 @@ impl FuncCompiler<'_> {
             }
             fn visit_expr(&mut self, expr: &IrExpr) {
                 if self.found { return; }
+                // In-place stdlib mutators (`list.push`, `map.insert`,
+                // `string.push`, bytes builders) reallocate `args[0]`'s heap
+                // backing through its shared pointer. When the mutated binding
+                // is declared OUTSIDE the loop, that fresh backing is allocated
+                // in the iteration arena yet escapes it — a heap_restore then
+                // reclaims a live object and the next allocation reuses its
+                // address (a spurious double-free at teardown, #643). These are
+                // CALLS, not assignment statements, so the stmt scan above
+                // misses them; mirror its conservative non-scalar test here.
+                if let IrExprKind::RuntimeCall { symbol, args } = &expr.kind {
+                    if crate::pass_closure_conversion::is_inplace_mutator(symbol.as_str()) {
+                        if let Some(IrExprKind::Var { id }) = args.first().map(|a| &a.kind) {
+                            let ty = &self.var_table.get(*id).ty;
+                            let scalar = matches!(ty, Ty::Int | Ty::Float | Ty::Bool | Ty::Unit);
+                            if !scalar {
+                                self.found = true;
+                                return;
+                            }
+                        }
+                    }
+                }
                 walk_expr(self, expr);
             }
         }

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -93,7 +93,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-063 | Parsing a heterogeneous-nested glTF/JSON document and walking its arrays by element is byte-identical on both targets | 0.26.19 | active | fixture | 1 |
 | C-064 | The effect-fn Result auto-unwrap rule is identical across binding positions and type-directed, byte-identical on both targets | 0.26.20 | active | fixture | 1 |
 | C-065 | The string position API is codepoint-indexed end-to-end on both targets | 0.26.20 | active | fixture | 2 |
-| C-066 | WASM heap is reclaimed by default (true Perceus) | 0.27.0 | active | fixture | 3 |
+| C-066 | WASM heap is reclaimed by default (true Perceus) | 0.27.0 | active | fixture | 4 |
 | C-067 | The xs[i] index syntax aborts on out-of-bounds (read and write) |  | active | fixture | 1 |
 | C-068 | Auto-? is target-directed in construction positions |  | active | fixture | 2 |
 | C-069 | Effect-fn tail self-recursion loop-converts to O(1) stack on both targets |  | active | fixture | 1 |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -556,13 +556,14 @@ evidence  = [
 [[contract]]
 id        = "C-066"
 title     = "WASM heap is reclaimed by default (true Perceus)"
-statement = "Since 0.27.0 the wasm target frees by default: construct-and-drop churn reuses freed blocks (free-list) and loop iterations whose heap values do not escape reclaim wholesale (region reset incl. the free list), so steady-state churn runs in O(1) memory instead of the pre-0.27 bump-allocate-and-leak model. Observable values stay byte-identical native == wasm under churn. `ALMIDE_WASM_FREES=0` is the opt-out back to the leak model (env-conditional emission is declared behavior under the host-determinism gates). Known bounded exceptions, tracked in docs/roadmap/active/wasm-frees-ownership-discipline.md: TCO self-call loops leak per iteration until the Stage C redesign lands, and a stored-field over-count leaks one reference per construct-from-temp outside reclaimed regions."
+statement = "Since 0.27.0 the wasm target frees by default: construct-and-drop churn reuses freed blocks (free-list) and loop iterations whose heap values do not escape reclaim wholesale (region reset incl. the free list), so steady-state churn runs in O(1) memory instead of the pre-0.27 bump-allocate-and-leak model. The escape test counts an in-place stdlib mutator (`list.push`/`string.push`/`map.insert`) on a binding declared OUTSIDE the loop as an escape — its reallocated backing lives in the iteration arena but is reachable after the loop, so the region reset must not roll the frontier back over it (#643: the scan formerly inspected assignment STATEMENTS only and missed the mutator CALL, producing a spurious double-free trap at teardown). Observable values stay byte-identical native == wasm under churn. `ALMIDE_WASM_FREES=0` is the opt-out back to the leak model (env-conditional emission is declared behavior under the host-determinism gates). Known bounded exceptions, tracked in docs/roadmap/active/wasm-frees-ownership-discipline.md: TCO self-call loops leak per iteration until the Stage C redesign lands, and a stored-field over-count leaks one reference per construct-from-temp outside reclaimed regions."
 since     = "0.27.0"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/rc_reclaim_churn.almd", class = "fixture" },
   { path = "spec/wasm_cross/assign_alias_rc.almd", class = "fixture" },
   { path = "spec/wasm_cross/container_alias_return.almd", class = "fixture" },
+  { path = "spec/wasm_cross/loop_outer_inplace_mutate_rc.almd", class = "fixture" },
   { path = "spec/churn/record_churn.almd", class = "by-construction" },
   { path = "spec/churn/tco_loop_churn.almd", class = "by-construction" },
 ]

--- a/spec/wasm_cross/loop_outer_inplace_mutate_rc.almd
+++ b/spec/wasm_cross/loop_outer_inplace_mutate_rc.almd
@@ -1,0 +1,40 @@
+
+// @contract: C-066
+// #643: an in-place stdlib mutator (`list.push`, `string.push`, `map.insert`)
+// applied to a binding declared OUTSIDE the loop reallocates that binding's
+// heap backing in the per-iteration arena, yet the binding escapes the
+// iteration. The iter-scope heap_restore must NOT reclaim that backing: it is
+// reachable after the loop. Before the fix, `expr_writes_outer_heap` only
+// scanned assignment STATEMENTS and missed the mutator CALL, so the reclamation
+// rolled the frontier back over `out`'s reallocated backing; the next
+// allocation reused its address and a spurious second __rc_dec at teardown hit
+// the rc==0 sentinel (an `unreachable` trap on wasm — exit 134 — while native
+// printed the correct value). The trigger needs the in-loop allocations that an
+// OOB-defaulted lookahead (`list.get(xs, i+1) ?? ""`) and the slice/join temps
+// supply, so the freed-then-reused address lands on a live block. Byte-identical
+// native == wasm, exit 0, no trap.
+effect fn main() -> Unit = {
+  // 1. list.push onto a loop-outer var, with the list.get ?? lookahead that
+  //    shapes the heap layout into the colliding case.
+  let cs = ["a", " "];
+  var out: List[String] = [];
+  var i = 0;
+  while i < 2 {
+    let nx = list.get(cs, i + 1) ?? "";
+    if nx == "x" then { list.push(out, "p") } else {
+      list.push(out, list.slice(cs, i, i + 1) |> list.join(""))
+    };
+    i = i + 1;
+  };
+  println(out |> list.join(","));
+  // 2. string.push onto a loop-outer var (a different in-place mutator on the
+  //    same escape path).
+  var acc: String = "";
+  var j = 0;
+  while j < 3 {
+    let piece = list.get(cs, j) ?? "z";
+    string.push(acc, piece);
+    j = j + 1;
+  };
+  println(acc)
+}


### PR DESCRIPTION
Closes #643. WASM-only double-free trap (exit 134) on a loop that `list.push`es onto a binding declared outside the loop, while native printed the correct value.

## Root cause
The while-loop `iter_scope` optimization (`emit_wasm/expressions.rs`) saves the heap frontier at iteration start and rolls it back at iteration end — reclaiming per-iteration heap and resetting the free list — gated by `!expr_writes_outer_heap(body)`. That escape check only scanned assignment **statements** (`Assign`/`MapInsert`/`IndexAssign`/`FieldAssign`) and missed in-place mutator **calls**: `list.push(out, …)` reallocates `out`'s backing through its shared pointer, and when `out` is declared outside the loop the fresh backing lives in the iteration arena yet escapes it. The reclamation rolled the frontier back over `out`'s reallocated backing; the next allocation reused that address, and a spurious second `__rc_dec` at teardown hit the `rc==0` sentinel — an `unreachable` trap on wasm.

## Diagnosis
A non-allocating binary alloc/free tracer captured the exact address timeline. `out`'s backing (e.g. addr 4264) was DEC'd twice: once when the join-result string — which had reused the reclaimed address — was freed, then again at teardown (`rc==0` → trap). The `?? ""` lookahead (`list.get` Some-box) only shaped the heap layout into the colliding case, which is why four prior "remove one dec" patches all missed it: there is no single spurious dec node; the over-dec is a layout-dependent address collision created by reclaiming live, escaping heap.

## Fix
Extend `expr_writes_outer_heap`'s scanner to also flag in-place mutator calls (`is_inplace_mutator`: `list.push`/`string.push`/`map.insert`/`list.pop`/bytes-builders/…) whose `args[0]` is a non-scalar var, mirroring the existing conservative type-based test for assignment targets. Such loops skip `iter_scope`, so the escaping backing is never reclaimed; ordinary RC + free-list reclaim memory correctly. Pure ops (`list.set`/`insert`) return a new value and flow through `out = …` — already covered by the statement scan. 21 lines, emit-wasm only (does not run for native codegen).

## Evidence
- Repro now byte-identical native == wasm (`a, `), exit 0 (was wasm exit 134).
- New regression fixture `spec/wasm_cross/loop_outer_inplace_mutate_rc.almd` (`list.push` + `string.push` cases), linked to contract **C-066** (statement updated to spell out the in-place-mutator escape).
- Full `spec/` suite 270/270 green.