### PR TITLE
fix(#433): let a local type shadow a dependency's same-name type

### DIFF
--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -708,15 +708,25 @@ pub fn register_type_decl(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, 
     // equal and not flagged.
     if matches!(resolved, Ty::Record { .. } | Ty::OpenRecord { .. } | Ty::Variant { .. }) {
         let canonical_key = prefixed_key(prefix, name);
-        if let Some(existing) = env.types.get(&sym(&canonical_key)) {
-            if existing != &resolved
-                && matches!(existing, Ty::Record { .. } | Ty::OpenRecord { .. } | Ty::Variant { .. })
-            {
-                diagnostics.push(err(
-                    format!("type '{}' is declared more than once with different structures", name),
-                    format!("Two distinct types share the name '{}' within the same module. Rename one so the name is unique.", name),
-                    format!("type {}", name),
-                ).with_code("E020"));
+        // A LOCAL type (main program, no prefix) is allowed to SHADOW a
+        // dependency's bare-name dual-registration rather than collide with it
+        // (#433): the existing bare `Persona` mirrors some `dep.Persona`, and a
+        // local `type Persona` should win for unqualified use (the dep stays
+        // reachable via `dep.Persona`). Only flag E020 for a genuine duplicate —
+        // another type registered under the SAME canonical key that is NOT just a
+        // dependency's bare alias being shadowed by a local.
+        let shadows_dep_alias = prefix.is_none() && env.prefixed_bare_aliases.contains(&sym(&canonical_key));
+        if !shadows_dep_alias {
+            if let Some(existing) = env.types.get(&sym(&canonical_key)) {
+                if existing != &resolved
+                    && matches!(existing, Ty::Record { .. } | Ty::OpenRecord { .. } | Ty::Variant { .. })
+                {
+                    diagnostics.push(err(
+                        format!("type '{}' is declared more than once with different structures", name),
+                        format!("Two distinct types share the name '{}' within the same module. Rename one so the name is unique.", name),
+                        format!("type {}", name),
+                    ).with_code("E020"));
+                }
             }
         }
     }
@@ -746,7 +756,14 @@ pub fn register_type_decl(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, 
     }
     env.types.insert(sym(&key), resolved.clone());
     if prefix.is_some() {
+        // Bare-name dual-registration of a prefixed type, for unqualified access.
+        // Record it so a local same-name type may shadow it (#433).
         env.types.insert(sym(name), resolved);
+        env.prefixed_bare_aliases.insert(sym(name));
+    } else {
+        // A local type owns the bare name now — it is no longer a dependency
+        // alias, so a later genuine local duplicate is still caught by E020.
+        env.prefixed_bare_aliases.remove(&sym(name));
     }
     if let Some(derives) = deriving {
         register_derive_sigs(env, derives, name, prefix);

--- a/crates/almide-frontend/src/canonicalize/resolve.rs
+++ b/crates/almide-frontend/src/canonicalize/resolve.rs
@@ -52,6 +52,27 @@ pub fn canonical_user_type_sym(name: &str, types: &HashMap<Sym, Ty>, cur_mod: Op
         }
     }
     if !name.contains('.') {
+        // A LOCAL (main-program, unprefixed) type registered under the bare name
+        // shadows a dependency's same-name type for unqualified use (#433). Prefer
+        // the bare entry when it is structurally DISTINCT from every qualified
+        // `<pkg>.name` owner — i.e. it is a genuine local type, not merely the
+        // dependency's bare alias (which mirrors its qualified entry exactly).
+        // Only for the main program (`cur_mod` is None); a user module's own types
+        // are already qualified and handled by the first block above.
+        if cur_mod.is_none() {
+            if let Some(bare) = types.get(&sym(name)) {
+                if matches!(bare, Ty::Record { .. } | Ty::Variant { .. }) {
+                    let is_alias_of_a_qualified = types.iter().any(|(k, v)| {
+                        k.as_str().rsplit_once('.').map_or(false, |(p, base)| {
+                            base == name && !almide_lang::stdlib_info::is_bundled_module(p)
+                        }) && v == bare
+                    });
+                    if !is_alias_of_a_qualified {
+                        return Some(sym(name));
+                    }
+                }
+            }
+        }
         let mut owners = types.iter().filter(|(k, v)| {
             k.as_str().rsplit_once('.').map_or(false, |(p, base)| {
                 base == name && !almide_lang::stdlib_info::is_bundled_module(p)

--- a/crates/almide-frontend/src/type_env.rs
+++ b/crates/almide-frontend/src/type_env.rs
@@ -75,6 +75,13 @@ pub struct TypeEnv {
     /// same-name ctors across types union their sets (#413 corner — the
     /// worst case is a suppressed missing-field error, never wrong code).
     pub ctor_field_defaults: std::collections::HashMap<Sym, std::collections::HashSet<Sym>>,
+    /// Bare type names that are currently a dual-registration of a PREFIXED
+    /// (dependency / submodule) type — i.e. `env.types["Persona"]` mirrors
+    /// `env.types["fizz_persona.Persona"]` for unqualified access. A LOCAL type
+    /// (main program, no prefix) with the same name is allowed to shadow this
+    /// bare alias instead of colliding with it (#433): unqualified use resolves
+    /// to the local type, the dependency's stays reachable via its qualified key.
+    pub prefixed_bare_aliases: std::collections::HashSet<Sym>,
     /// Types that implement the Eq protocol (via `deriving Eq`)
     pub eq_types: std::collections::HashSet<Sym>,
     /// Structural bounds for generic type parameters: TypeVar name → OpenRecord constraint
@@ -145,6 +152,7 @@ impl TypeEnv {
             param_vars: std::collections::HashSet::new(),
             var_decl_locs: std::collections::HashMap::new(),
             top_lets: std::collections::HashMap::new(),
+            prefixed_bare_aliases: std::collections::HashSet::new(),
             eq_types: std::collections::HashSet::new(),
             structural_bounds: std::collections::HashMap::new(),
             generic_protocol_bounds: std::collections::HashMap::new(),


### PR DESCRIPTION
Addresses the remaining frontend half of #433.

A dependency's type is dual-registered under both its qualified key (`dep.Persona`) and the bare name (`Persona`). A main-program `type Persona` then (a) tripped the E020 duplicate-structure check against the dep's bare alias, and (b) had its constructions resolved against the dep's fields (E021) because `canonical_user_type_sym` scanned qualified owners and ignored the local bare entry.

Fix:
- Track which bare names are dependency aliases (`prefixed_bare_aliases`); a local (unprefixed) type may shadow such an alias (skip E020, overwrite the bare entry), so a genuine local duplicate is still caught.
- In `canonical_user_type_sym`, for the main program prefer the bare entry when it is structurally distinct from every qualified `<pkg>.name` owner. The dependency stays reachable via `dep.Type`.

Verified on a real consumer (a local `type Persona` colliding with a dependency's `Persona`). Build + spec green (stdlib/lang/integration).