### PR TITLE
Win WASM perf vs rustc: q1_0/transpose/fold SIMD, function-scope heap reclamation, bulk string append

### DIFF
--- a/crates/almide-codegen/rt-oracle-registry.toml
+++ b/crates/almide-codegen/rt-oracle-registry.toml
@@ -137,6 +137,24 @@ note = "spec/wasm_cross/rc_alloc_stress.almd: 1000-element list growth (sum=4995
 
 [[routine]]
 file = "runtime.rs"
+routine = "compile_alloc_variant"
+status = "verified"
+class = "fixture"
+oracle = "no native counterpart — the parameterized body shared by compile_alloc and compile_alloc_nozero (the `zero_on_reuse` flag selects whether a recycled free-list block is zero-filled before return); same observable-correctness oracle as compile_alloc"
+test = "tests/wasm_runtime_test.rs::wasm_cross_target_spec"
+note = "Not a distinct runtime routine: compile_alloc / compile_alloc_nozero both delegate here, so spec/wasm_cross/rc_alloc_stress.almd exercises it on every allocation. Refactored out of compile_alloc to express the zero-fill choice once instead of duplicating the allocator. The BUMP path never zeros (fresh wasm pages are zero); reclaimed-then-rebumped memory IS dirty, but the one read-before-write caller that can land there — variant construction — zeros its own payload tail (calls.rs::emit_zero_variant_tail), and map/set tags can't reach a reclaimed block (their in-place-mutator builders disable reclamation)."
+
+[[routine]]
+file = "runtime.rs"
+routine = "compile_alloc_nozero"
+status = "verified"
+class = "fixture"
+oracle = "no native counterpart — bump allocator variant that SKIPS the free-list-reuse zero-fill; sound only for callers that overwrite the whole returned buffer (every read is bounded by a length/cap they also write). Oracle is the same observable correctness as compile_alloc: a caller that reads an un-written byte would diverge from native."
+test = "tests/wasm_runtime_test.rs::wasm_cross_target_spec"
+note = "Routed from emit_list_alloc (list_layout.rs — pre-sized list data is written in full by map/filter/range/collect, reads bounded by len) and the string-append grow path (expressions.rs try_emit_string_append_loop — old prefix copied, the rest filled). spec/wasm_cross/rc_alloc_stress.almd churns exactly these list allocations byte-identically: an unsound skip would surface an un-zeroed reused block as a wrong checksum. Maps keep compile_alloc (Swiss/COD tag arrays depend on the reuse zero-fill); variants keep compile_alloc and additionally zero their own payload tail at construction."
+
+[[routine]]
+file = "runtime.rs"
 routine = "compile_rc_inc"
 status = "verified"
 class = "fixture"

--- a/crates/almide-codegen/src/emit_wasm/calls.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls.rs
@@ -8,6 +8,7 @@ use wasm_encoder::ValType;
 
 use super::FuncCompiler;
 use super::values;
+use super::equality::VARIANT_TAG_SIZE;
 
 // ---------------------------------------------------------------------------
 // Named immediate constants used in inline WASM emission below.
@@ -71,6 +72,31 @@ fn sized_type_info(name: &str) -> Option<(SizedKind, u32)> {
 use super::wasm_macro::wasm;
 
 impl FuncCompiler<'_> {
+    /// Zero a variant value's unwritten payload tail `[written_end, total_size)`.
+    ///
+    /// A constructor writes only its own tag + payload, but variant `==` lowers
+    /// to `mem_eq` over the FULL max-payload span (so any two values of the type
+    /// compare with one fixed width). A never-touched wasm page reads zero, so
+    /// the unwritten tail used to compare equal by luck — until heap reclamation
+    /// (function-scope / iter_scope) began rolling the bump pointer back over
+    /// live-then-freed memory: a re-bumped variant then carries stale tail bytes,
+    /// and two otherwise-equal values diverge there, trapping the `assert_eq`
+    /// (spec/lang/variant_mixed_eq_test, regression_v0_11_test). The constructor
+    /// clears its own tail rather than `__alloc` zeroing every bump — the latter
+    /// taxed all map/list allocation (precise_all map_insert 0.67x → 1.06x), and
+    /// map/set tags (the only other read-before-write region) can't reach a
+    /// reclaimed block: their in-place-mutator builders trip `expr_writes_outer_heap`
+    /// and disable reclamation.
+    fn emit_zero_variant_tail(&mut self, scratch: u32, written_end: u32, total_size: u32) {
+        if total_size <= written_end { return; }
+        wasm!(self.func, {
+            local_get(Local(scratch)); i32_const(Imm32(written_end as i32)); i32_add;
+            i32_const(Imm32(0));
+            i32_const(Imm32((total_size - written_end) as i32));
+            memory_fill;
+        });
+    }
+
     /// Fallback for module dispatch: when `emit_<module>_call` has no arm
     /// for `func` (often a mono-specialized `filter__Int_String`), try
     /// `func_map["almide_rt_<module>_<func>"]` — the name ResolveCalls
@@ -350,8 +376,11 @@ impl FuncCompiler<'_> {
                                     local_get(Local(scratch));
                                     i32_const(Imm32(tag as i32));
                                     i32_store(0);
-                                    local_get(Local(scratch));
                                 });
+                                // The constructor wrote only the tag; zero the rest
+                                // of the max-payload span it leaves untouched.
+                                self.emit_zero_variant_tail(scratch, VARIANT_TAG_SIZE, variant_size);
+                                wasm!(self.func, { local_get(Local(scratch)); });
                                 self.scratch.free_i32(scratch);
                                 return;
                             } else if !is_unit {
@@ -377,13 +406,16 @@ impl FuncCompiler<'_> {
                                 // dup), the same rule emit_record uses; a
                                 // bare emit_expr stored a payload the source
                                 // binding still owned and later Dec'd.
-                                let mut offset = 4u32;
+                                let mut offset = VARIANT_TAG_SIZE;
                                 for arg in args {
                                     wasm!(self.func, { local_get(Local(scratch)); });
                                     self.emit_stored_field(arg);
                                     self.emit_store_at(&arg.ty, offset);
                                     offset += values::byte_size(&arg.ty);
                                 }
+                                // This constructor's payload may be shorter than the
+                                // type's max; zero the unwritten span up to total_size.
+                                self.emit_zero_variant_tail(scratch, offset, total_size);
                                 wasm!(self.func, { local_get(Local(scratch)); });
                                 self.scratch.free_i32(scratch);
                                 return;

--- a/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_closure2.rs
@@ -19,6 +19,22 @@ use almide_ir::{BinOp, IrExpr, IrExprKind};
 use almide_lang::types::Ty;
 use wasm_encoder::ValType;
 
+// ── SIMD reduction/map geometry (derived so the relationships stay visible) ──
+/// i64 / f64 element size in bytes.
+const F64_BYTES: i32 = 8;
+/// 64-bit SIMD lanes in a v128 (i64x2 / f64x2).
+const SIMD_LANES_64: i32 = 2;
+/// Bytes spanned by one v128 register.
+const V128_BYTES: i32 = SIMD_LANES_64 * F64_BYTES;
+/// v128 loads issued per unrolled SIMD iteration.
+const SIMD_UNROLL: i32 = 4;
+/// 64-bit elements consumed per SIMD iteration (unroll × lanes).
+const SIMD_GROUP: i32 = SIMD_UNROLL * SIMD_LANES_64;
+/// Bytes advanced per SIMD iteration (unroll × v128 bytes).
+const SIMD_STRIDE_BYTES: i32 = SIMD_UNROLL * V128_BYTES;
+/// Mask that rounds an element count down to a whole SIMD group (`& ~(GROUP-1)`).
+const SIMD_GROUP_MASK: i32 = !(SIMD_GROUP - 1);
+
 /// A pipeline stage for stream fusion.
 enum PipelineStage<'a> {
     Map(&'a IrExpr),    // lambda expr
@@ -1031,6 +1047,19 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(src);
             }
             "fold" => {
+                // SIMD fast path: `xs |> fold(init, (a, x) => a + x)` over a borrowed
+                // Int list with no fused pipeline — i64x2 reduction instead of a scalar
+                // accumulate loop (rustc autovectorizes the same sum). Falls through to
+                // the general fold below for any other shape.
+                if matches!(&args[0].kind, IrExprKind::Var { .. })
+                    && self.detect_pipeline(&args[0]).is_empty()
+                    && matches!(self.resolve_list_elem(&args[0], None), Ty::Int)
+                    && matches!(&args[1].ty, Ty::Int)
+                    && Self::is_simd_fold_sum(&args[2])
+                {
+                    self.emit_simd_fold_sum(&args[0], &args[1], list_data_off);
+                    return true;
+                }
                 // fold(list, init, fn(acc, elem) → acc)
                 // Resolve types from closure Fn signature when available
                 // Derive element type from the input list (most reliable source)
@@ -1641,5 +1670,78 @@ impl FuncCompiler<'_> {
         } else {
             None
         }
+    }
+
+    /// Detect `(acc, elem) => acc + elem` — a SIMD-vectorizable Int sum reduction.
+    fn is_simd_fold_sum(fn_arg: &IrExpr) -> bool {
+        if let IrExprKind::Lambda { params, body, .. } = &fn_arg.kind {
+            let (Some((p0, _)), Some((p1, _))) = (params.first(), params.get(1)) else { return false };
+            if let IrExprKind::BinOp { op: BinOp::AddInt, left, right } = &body.kind {
+                if let (IrExprKind::Var { id: l }, IrExprKind::Var { id: r }) = (&left.kind, &right.kind) {
+                    return (l.0 == p0.0 && r.0 == p1.0) || (l.0 == p1.0 && r.0 == p0.0);
+                }
+            }
+        }
+        false
+    }
+
+    /// SIMD i64 sum reduction for `xs |> fold(init, (a, x) => a + x)`. Accumulates
+    /// into an i64x2 (8 i64 per iteration, 4× v128) then horizontal-adds the two
+    /// lanes and finishes a scalar tail. rustc autovectorizes the same reduction;
+    /// the scalar fold loop did not, leaving it ~2.5× behind. The source list is a
+    /// borrowed Var (read, never freed here), so no RC handling is needed.
+    fn emit_simd_fold_sum(&mut self, list_arg: &IrExpr, init_arg: &IrExpr, list_data_off: i32) {
+        let list_ptr = self.scratch.alloc_i32();
+        let src_ptr = self.scratch.alloc_i32();
+        let end_ptr = self.scratch.alloc_i32();
+        let simd_end = self.scratch.alloc_i32();
+        let acc = self.scratch.alloc_i64();
+        let acc_v = self.scratch.alloc_v128();
+        self.emit_expr(list_arg);
+        wasm!(self.func, { local_set(Local(list_ptr)); });
+        self.emit_expr(init_arg);
+        wasm!(self.func, {
+            local_set(Local(acc));
+            // src_ptr = &xs[0]; end_ptr = src_ptr + len * F64_BYTES
+            local_get(Local(list_ptr)); i32_const(Imm32(list_data_off)); i32_add; local_set(Local(src_ptr));
+            local_get(Local(src_ptr));
+            local_get(Local(list_ptr)); i32_load(0); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; local_set(Local(end_ptr));
+            // simd_end = src_ptr + (len & ~(GROUP-1)) * F64_BYTES  (whole SIMD groups)
+            local_get(Local(src_ptr));
+            local_get(Local(list_ptr)); i32_load(0); i32_const(Imm32(SIMD_GROUP_MASK)); i32_and; i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; local_set(Local(simd_end));
+            // acc_v = i64x2(0, 0)
+            i64_const(Imm64(0)); i64x2_splat; local_set(Local(acc_v));
+            // SIMD loop: SIMD_GROUP i64 (SIMD_UNROLL × v128) per iteration into the lane-pair accumulator
+            block_empty; loop_empty;
+              local_get(Local(src_ptr)); local_get(Local(simd_end)); i32_ge_u; br_if(1);
+              local_get(Local(acc_v));
+              local_get(Local(src_ptr)); v128_load(0); i64x2_add;
+              local_get(Local(src_ptr)); v128_load(V128_BYTES as u64); i64x2_add;
+              local_get(Local(src_ptr)); v128_load((2 * V128_BYTES) as u64); i64x2_add;
+              local_get(Local(src_ptr)); v128_load((3 * V128_BYTES) as u64); i64x2_add;
+              local_set(Local(acc_v));
+              local_get(Local(src_ptr)); i32_const(Imm32(SIMD_STRIDE_BYTES)); i32_add; local_set(Local(src_ptr));
+              br(0);
+            end; end;
+            // acc += acc_v.lane0 + acc_v.lane1
+            local_get(Local(acc));
+            local_get(Local(acc_v)); i64x2_extract_lane(0);
+            local_get(Local(acc_v)); i64x2_extract_lane(1);
+            i64_add; i64_add; local_set(Local(acc));
+            // scalar tail (remaining < SIMD_GROUP elements)
+            block_empty; loop_empty;
+              local_get(Local(src_ptr)); local_get(Local(end_ptr)); i32_ge_u; br_if(1);
+              local_get(Local(acc)); local_get(Local(src_ptr)); i64_load(0); i64_add; local_set(Local(acc));
+              local_get(Local(src_ptr)); i32_const(Imm32(F64_BYTES)); i32_add; local_set(Local(src_ptr));
+              br(0);
+            end; end;
+            local_get(Local(acc));
+        });
+        self.scratch.free_v128(acc_v);
+        self.scratch.free_i64(acc);
+        self.scratch.free_i32(simd_end);
+        self.scratch.free_i32(end_ptr);
+        self.scratch.free_i32(src_ptr);
+        self.scratch.free_i32(list_ptr);
     }
 }

--- a/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_list_helpers.rs
@@ -619,104 +619,128 @@ impl FuncCompiler<'_> {
             local_get(Local(xs_ptr)); i32_load(0); local_set(Local(len));
             // alloc dst
             i32_const(Imm32(self.emitter.layout_reg.header_size(LIST) as i32)); local_get(Local(len)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
-            call(self.emitter.rt.alloc); local_set(Local(dst));
+            // dst's data area is written in full by every path below (bulk/reverse
+            // copy, or the merge's initial src→dst copy), so skip the reuse zero-fill.
+            call(self.emitter.rt.alloc_nozero); local_set(Local(dst));
             local_get(Local(dst)); local_get(Local(len)); i32_store(0);
         });
 
-        // 2. Pre-scan SOURCE (xs_ptr) for asc/desc before copying.
-        let is_asc = self.scratch.alloc_i32();
-        let is_desc = self.scratch.alloc_i32();
+        // 2. Pre-scan SOURCE (xs_ptr) for an existing run, then copy in one pass.
+        //    Pick the direction from the FIRST pair and scan that one way — a
+        //    single comparison per element — exactly as Rust's .sort() run
+        //    detection does. (The old scan tested ascending AND descending every
+        //    step: two comparisons and four loads per element, which was the bulk
+        //    of the cost on the fully-reversed input this benchmarks.)
+        let dir_desc = self.scratch.alloc_i32();
+        let sorted = self.scratch.alloc_i32();
         let scan_done = self.scratch.alloc_i32();
+        let data_off = self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32;
         wasm!(self.func, {
+            // Default to the merge path; a fully-ordered run overrides this.
+            // (scratch locals are reused, so an explicit reset is required.)
+            i32_const(Imm32(0)); local_set(Local(scan_done));
             local_get(Local(len)); i32_const(Imm32(SORT_MIN_LEN)); i32_lt_u;
             if_empty;
-              // len < 2: nothing to sort, but still copy the 0/1 source elements
-              // to dst. The sort-proper path (scan_done==0) copies src→dst, but
-              // this short-circuit skipped it — so dst's data stayed the zeroed
-              // alloc and a singleton sort returned a zeroed element.
-              local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
-              local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
+              // len < 2: nothing to order, but still copy the 0/1 source elements
+              // (the sort-proper path is skipped, so dst would stay uninitialized).
+              local_get(Local(dst)); i32_const(Imm32(data_off)); i32_add;
+              local_get(Local(xs_ptr)); i32_const(Imm32(data_off)); i32_add;
               local_get(Local(len)); i32_const(Imm32(es as i32)); i32_mul;
               memory_copy;
               i32_const(Imm32(1)); local_set(Local(scan_done));
             else_;
-              i32_const(Imm32(1)); local_set(Local(is_asc));
-              i32_const(Imm32(1)); local_set(Local(is_desc));
+              // dir_desc = NOT (xs[0] <= xs[1]); sorted optimistically true.
+              local_get(Local(xs_ptr)); i32_const(Imm32(data_off)); i32_add;
+        });
+        kind.emit_load(&mut self.func); // xs[0]
+        wasm!(self.func, {
+              local_get(Local(xs_ptr)); i32_const(Imm32(data_off)); i32_add; i32_const(Imm32(es as i32)); i32_add;
+        });
+        kind.emit_load(&mut self.func); // xs[1]
+        self.emit_sort_le_cmp(&kind); // xs[0] <= xs[1]
+        wasm!(self.func, {
+              i32_eqz; local_set(Local(dir_desc));
+              i32_const(Imm32(1)); local_set(Local(sorted));
               i32_const(Imm32(0)); local_set(Local(i));
-              block_empty; loop_empty;
-                local_get(Local(i)); local_get(Local(len)); i32_const(Imm32(1)); i32_sub; i32_ge_u; br_if(1);
-                // Load xs[i] and xs[i+1]
-                local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
-                local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
-        });
-        kind.emit_load(&mut self.func); // xs[i]
-        wasm!(self.func, {
-                local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
-                local_get(Local(i)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(es as i32)); i32_mul; i32_add;
-        });
-        kind.emit_load(&mut self.func); // xs[i+1]
-        // Check: if dst[i] > dst[i+1] → not ascending
-        // We need both values for two comparisons. Duplicate via locals.
-        // Actually, emit_le_cmp consumes both. Let me do two separate scans? No, too slow.
-        // Simpler: just check dst[i] <= dst[i+1] for ascending.
-        self.emit_sort_le_cmp(&kind); // dst[i] <= dst[i+1]
-        wasm!(self.func, {
-                i32_eqz;
-                if_empty; i32_const(Imm32(0)); local_set(Local(is_asc)); end;
-                // Check descending: xs[i] >= xs[i+1]
-                local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
-                local_get(Local(i)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(es as i32)); i32_mul; i32_add;
-        });
-        kind.emit_load(&mut self.func); // xs[i+1]
-        wasm!(self.func, {
-                local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
-                local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
-        });
-        kind.emit_load(&mut self.func); // xs[i]
-        self.emit_sort_le_cmp(&kind); // dst[i+1] <= dst[i]
-        wasm!(self.func, {
-                i32_eqz;
-                if_empty; i32_const(Imm32(0)); local_set(Local(is_desc)); end;
-                // Early exit if neither
-                local_get(Local(is_asc)); local_get(Local(is_desc)); i32_or; i32_eqz;
-                br_if(1); // break scan loop
-                local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i)); br(0);
-              end; end;
-              // Determine result
-              local_get(Local(is_asc));
+              local_get(Local(dir_desc));
               if_empty;
-                // Already sorted: just bulk copy
-                local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
-                local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
-                local_get(Local(len)); i32_const(Imm32(es as i32)); i32_mul;
-                memory_copy;
-                i32_const(Imm32(1)); local_set(Local(scan_done));
-              else_;
-                local_get(Local(is_desc));
-                if_empty;
-                  // Reverse copy: dst[i] = src[len-1-i] (1 pass, no swap)
-                  i32_const(Imm32(0)); local_set(Local(i));
-                  block_empty; loop_empty;
-                    local_get(Local(i)); local_get(Local(len)); i32_ge_u; br_if(1);
-                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
-                    local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
-                    local_get(Local(xs_ptr)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(LIST, ll::DATA) as i32)); i32_add;
-                    local_get(Local(len)); i32_const(Imm32(1)); i32_sub; local_get(Local(i)); i32_sub;
-                    i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                // ── descending: verify and reverse-write in a single pass ──
+                // While xs[i+1] <= xs[i] holds, place dst[len-1-i] = xs[i]. The
+                // first violation bails to the merge below, which recopies xs→dst
+                // and so discards these speculative writes; a complete pass then
+                // drops in the final (smallest) element and skips the merge. Fusing
+                // the run check with the reverse keeps xs hot in cache instead of
+                // re-reading all of it in a separate reverse pass.
+                block_empty; loop_empty;
+                  local_get(Local(i)); local_get(Local(len)); i32_const(Imm32(1)); i32_sub; i32_ge_u; br_if(1);
+                  local_get(Local(xs_ptr)); i32_const(Imm32(data_off)); i32_add;
+                  local_get(Local(i)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(es as i32)); i32_mul; i32_add;
+        });
+        kind.emit_load(&mut self.func); // xs[i+1]
+        wasm!(self.func, {
+                  local_get(Local(xs_ptr)); i32_const(Imm32(data_off)); i32_add;
+                  local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+        });
+        kind.emit_load(&mut self.func); // xs[i]
+        self.emit_sort_le_cmp(&kind); // xs[i+1] <= xs[i]
+        wasm!(self.func, {
+                  // first out-of-order pair → bail straight to the merge below
+                  i32_eqz; if_empty; i32_const(Imm32(0)); local_set(Local(sorted)); br(2); end;
+                  // dst[len-1-i] = xs[i]
+                  local_get(Local(dst)); i32_const(Imm32(data_off)); i32_add;
+                  local_get(Local(len)); i32_const(Imm32(1)); i32_sub; local_get(Local(i)); i32_sub; i32_const(Imm32(es as i32)); i32_mul; i32_add;
+                  local_get(Local(xs_ptr)); i32_const(Imm32(data_off)); i32_add;
+                  local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
         });
         kind.emit_copy_one(&mut self.func);
         wasm!(self.func, {
-                    local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i)); br(0);
-                  end; end;
+                  local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i)); br(0);
+                end; end;
+                // fully descending (exited via the bound, sorted still 1): place
+                // the final, smallest element dst[0] = xs[len-1].
+                local_get(Local(sorted));
+                if_empty;
+                  local_get(Local(dst)); i32_const(Imm32(data_off)); i32_add;
+                  local_get(Local(xs_ptr)); i32_const(Imm32(data_off)); i32_add;
+                  local_get(Local(len)); i32_const(Imm32(1)); i32_sub; i32_const(Imm32(es as i32)); i32_mul; i32_add;
+        });
+        kind.emit_copy_one(&mut self.func);
+        wasm!(self.func, {
                   i32_const(Imm32(1)); local_set(Local(scan_done));
-                else_;
-                  i32_const(Imm32(0)); local_set(Local(scan_done));
+                end;
+              else_;
+                // ── ascending run: every step must keep xs[i] <= xs[i+1] ──
+                block_empty; loop_empty;
+                  local_get(Local(i)); local_get(Local(len)); i32_const(Imm32(1)); i32_sub; i32_ge_u; br_if(1);
+                  local_get(Local(xs_ptr)); i32_const(Imm32(data_off)); i32_add;
+                  local_get(Local(i)); i32_const(Imm32(es as i32)); i32_mul; i32_add;
+        });
+        kind.emit_load(&mut self.func); // xs[i]
+        wasm!(self.func, {
+                  local_get(Local(xs_ptr)); i32_const(Imm32(data_off)); i32_add;
+                  local_get(Local(i)); i32_const(Imm32(1)); i32_add; i32_const(Imm32(es as i32)); i32_mul; i32_add;
+        });
+        kind.emit_load(&mut self.func); // xs[i+1]
+        self.emit_sort_le_cmp(&kind); // xs[i] <= xs[i+1]
+        wasm!(self.func, {
+                  // first out-of-order pair → bail straight to the merge below
+                  i32_eqz; if_empty; i32_const(Imm32(0)); local_set(Local(sorted)); br(2); end;
+                  local_get(Local(i)); i32_const(Imm32(1)); i32_add; local_set(Local(i)); br(0);
+                end; end;
+                local_get(Local(sorted));
+                if_empty;
+                  // already ascending → bulk copy
+                  local_get(Local(dst)); i32_const(Imm32(data_off)); i32_add;
+                  local_get(Local(xs_ptr)); i32_const(Imm32(data_off)); i32_add;
+                  local_get(Local(len)); i32_const(Imm32(es as i32)); i32_mul;
+                  memory_copy;
+                  i32_const(Imm32(1)); local_set(Local(scan_done));
                 end;
               end;
             end;
         });
-        self.scratch.free_i32(is_desc);
-        self.scratch.free_i32(is_asc);
+        self.scratch.free_i32(sorted);
+        self.scratch.free_i32(dir_desc);
 
         // 3. Bottom-up merge sort (only if scan_done == 0).
         wasm!(self.func, {
@@ -728,7 +752,8 @@ impl FuncCompiler<'_> {
             local_get(Local(len)); i32_const(Imm32(es as i32)); i32_mul;
             memory_copy;
             local_get(Local(len)); i32_const(Imm32(es as i32)); i32_mul;
-            call(self.emitter.rt.alloc); local_set(Local(tmp));
+            // tmp is fully written by each merge pass before it is read back.
+            call(self.emitter.rt.alloc_nozero); local_set(Local(tmp));
             i32_const(Imm32(1)); local_set(Local(width));
             block_empty; loop_empty;
               local_get(Local(width)); local_get(Local(len)); i32_ge_u; br_if(1);

--- a/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls_matrix.rs
@@ -6,8 +6,19 @@
 // ── Named immediates ──────────────────────────────────────────────────────────
 // Element widths / byte sizes
 /// Bytes per f64 matrix element.
-use crate::emit_wasm::engine::{Imm32, Local};
+use crate::emit_wasm::engine::{Imm32, Imm64, Local};
 const F64_BYTES: i32 = 8;
+/// i8x16.shuffle byte selectors for the in-register 2×2 f64 transpose. Inputs a,b
+/// hold rows (src[r][c..c+2], src[r+1][c..c+2]); LO gathers both lane-0 f64s
+/// (→ dst[c][r..r+2]), HI both lane-1 f64s (→ dst[c+1][r..r+2]). Bytes 0–15 = a,
+/// 16–31 = b. LLVM cannot synthesise this shuffle network from a scalar transpose.
+const TRANSPOSE_SHUF_LO: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23];
+const TRANSPOSE_SHUF_HI: [u8; 16] = [8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31];
+/// Edge of the in-register transpose tile: a v128 holds 2 f64, so each shuffle
+/// step transposes a 2×2 element block.
+const TRANSPOSE_BLOCK: i32 = 2;
+/// Mask rounding a dimension down to a whole transpose block (`& ~(BLOCK-1)`).
+const TRANSPOSE_BLOCK_MASK: i32 = !(TRANSPOSE_BLOCK - 1);
 /// Bytes per f32 element (to_bytes_f32_le / from_bytes_f32_le).
 const F32_BYTES: i32 = 4;
 /// Bytes per i32 pointer slot in a list-of-pointers.
@@ -30,6 +41,14 @@ const Q1_0_BLOCK_BYTES: i32 = 18;
 const Q1_0_SCALE_BYTES: i32 = 2;
 /// SIMD pairs per Q1_0 block (Q1_0_BLOCK_SIZE / SIMD_F64_LANES).
 const Q1_0_PAIRS_PER_BLOCK: i32 = 64;
+/// Weights packed per sign byte (8 sign bits = 8 weights).
+const Q1_0_WEIGHTS_PER_SIGN_BYTE: i32 = 8;
+/// Sign bytes per Q1_0 block (128 weights / 8 per byte = 16).
+const Q1_0_SIGN_BYTES_PER_BLOCK: i32 = Q1_0_BLOCK_SIZE / Q1_0_WEIGHTS_PER_SIGN_BYTE;
+/// Weights carried by one f64x2 lane-pair (= the two sign bits decoded together).
+const Q1_0_WEIGHTS_PER_PAIR: i32 = 2;
+/// f64x2 pairs packed per sign byte (8 weights / 2 lanes = 4).
+const PAIRS_PER_SIGN_BYTE: i32 = Q1_0_WEIGHTS_PER_SIGN_BYTE / Q1_0_WEIGHTS_PER_PAIR;
 /// log2(PAIRS_PER_BYTE): each byte holds 4 (2-bit-wide) pairs; used as right-shift.
 const LOG2_PAIRS_PER_BYTE: i32 = 2;
 /// Bitmask for within-byte pair position (4 pairs per byte → mask = 3).
@@ -60,6 +79,9 @@ const FP16_MANT_TO_F32_SHIFT: i32 = 13;
 const F32_SIGN_SHIFT: i32 = 31;
 /// Exponent bias difference between f32 (127) and fp16 (15): 127 - 15 = 112.
 const FP16_EXP_BIAS_DIFF: i32 = 112;
+/// f64 sign bit position (bit 63). XOR-ing a lane with `1 << 63` flips its sign,
+/// the branchless ±x trick used in the Q1_0 quantized-linear inner loop.
+const F64_SIGN_BIT_POS: i64 = 63;
 
 // conv1d constant
 /// Number of sides that padding is applied to in conv1d (left + right = 2).
@@ -237,8 +259,18 @@ impl FuncCompiler<'_> {
                 let dst = self.scratch.alloc_i32();
                 let r = self.scratch.alloc_i32();
                 let c = self.scratch.alloc_i32();
+                let rows_even = self.scratch.alloc_i32();
+                let cols_even = self.scratch.alloc_i32();
+                let src_data = self.scratch.alloc_i32();
+                let dst_data = self.scratch.alloc_i32();
+                let cols_bytes = self.scratch.alloc_i32();
+                let rows_stride = self.scratch.alloc_i32();
+                let src_ptr = self.scratch.alloc_i32();
+                let dst_ptr = self.scratch.alloc_i32();
                 let rows = self.scratch.alloc_i32();
                 let cols = self.scratch.alloc_i32();
+                let va = self.scratch.alloc_v128();
+                let vb = self.scratch.alloc_v128();
                 self.emit_expr(&args[0]);
                 wasm!(self.func, {
                     local_set(Local(src));
@@ -247,36 +279,95 @@ impl FuncCompiler<'_> {
                     // alloc dst: [cols, rows, data...]
                     local_get(Local(cols)); local_get(Local(rows)); i32_mul; i32_const(Imm32(F64_BYTES)); i32_mul;
                     i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
-                    call(self.emitter.rt.alloc); local_set(Local(dst));
+                    call(self.emitter.rt.alloc_nozero); local_set(Local(dst));
                     local_get(Local(dst)); local_get(Local(cols)); i32_store(0);
                     local_get(Local(dst)); local_get(Local(rows)); i32_store(4);
-                    // loop: dst[c][r] = src[r][c]
+                    // SIMD 2×2 transpose. A v128 holds two adjacent columns of one row;
+                    // loading rows r and r+1 then i8x16.shuffle gathers the two lane-0 f64s
+                    // (→ contiguous dst[c][r..r+2]) and the two lane-1 f64s (→ dst[c+1][r..r+2]),
+                    // converting a strided scalar transpose into contiguous v128 loads/stores +
+                    // an in-register shuffle network LLVM cannot synthesise from scalar code.
+                    // Odd row/col edges fall to two scalar tails.
+                    local_get(Local(src)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_set(Local(src_data));
+                    local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add; local_set(Local(dst_data));
+                    local_get(Local(cols)); i32_const(Imm32(F64_BYTES)); i32_mul; local_set(Local(cols_bytes));
+                    local_get(Local(rows)); i32_const(Imm32(F64_BYTES)); i32_mul; local_set(Local(rows_stride));
+                    // rows_even = rows & ~1 ; cols_even = cols & ~1
+                    local_get(Local(rows)); i32_const(Imm32(TRANSPOSE_BLOCK_MASK)); i32_and; local_set(Local(rows_even));
+                    local_get(Local(cols)); i32_const(Imm32(TRANSPOSE_BLOCK_MASK)); i32_and; local_set(Local(cols_even));
+                    // for r in (0..rows_even).step(2)
                     i32_const(Imm32(0)); local_set(Local(r));
+                    block_empty; loop_empty;
+                      local_get(Local(r)); local_get(Local(rows_even)); i32_ge_u; br_if(1);
+                      // for c in (0..cols_even).step(2)
+                      i32_const(Imm32(0)); local_set(Local(c));
+                      block_empty; loop_empty;
+                        local_get(Local(c)); local_get(Local(cols_even)); i32_ge_u; br_if(1);
+                        // src_ptr = &src[r][c]; va = src[r][c..c+2], vb = src[r+1][c..c+2]
+                        local_get(Local(src_data)); local_get(Local(r)); local_get(Local(cols_bytes)); i32_mul; i32_add;
+                        local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; local_set(Local(src_ptr));
+                        local_get(Local(src_ptr)); v128_load(0); local_set(Local(va));
+                        local_get(Local(src_ptr)); local_get(Local(cols_bytes)); i32_add; v128_load(0); local_set(Local(vb));
+                        // dst_ptr = &dst[c][r] = dst_data + c*rows_stride + r*8
+                        local_get(Local(dst_data)); local_get(Local(c)); local_get(Local(rows_stride)); i32_mul; i32_add;
+                        local_get(Local(r)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add; local_set(Local(dst_ptr));
+                        // dst[c][r..r+2] = (va.lane0, vb.lane0)
+                        local_get(Local(dst_ptr)); local_get(Local(va)); local_get(Local(vb)); i8x16_shuffle(TRANSPOSE_SHUF_LO); v128_store(0);
+                        // dst[c+1][r..r+2] = (va.lane1, vb.lane1)  at dst_ptr + rows_stride
+                        local_get(Local(dst_ptr)); local_get(Local(rows_stride)); i32_add;
+                        local_get(Local(va)); local_get(Local(vb)); i8x16_shuffle(TRANSPOSE_SHUF_HI); v128_store(0);
+                        local_get(Local(c)); i32_const(Imm32(TRANSPOSE_BLOCK)); i32_add; local_set(Local(c));
+                        br(0);
+                      end; end;
+                      local_get(Local(r)); i32_const(Imm32(TRANSPOSE_BLOCK)); i32_add; local_set(Local(r));
+                      br(0);
+                    end; end;
+                    // scalar tail 1: last row(s) r in [rows_even, rows), every c
+                    local_get(Local(rows_even)); local_set(Local(r));
                     block_empty; loop_empty;
                       local_get(Local(r)); local_get(Local(rows)); i32_ge_u; br_if(1);
                       i32_const(Imm32(0)); local_set(Local(c));
                       block_empty; loop_empty;
                         local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
-                        // dst offset: 8 + (c * rows + r) * 8
-                        local_get(Local(dst)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
-                        local_get(Local(c)); local_get(Local(rows)); i32_mul; local_get(Local(r)); i32_add;
-                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
-                        // src offset: 8 + (r * cols + c) * 8
-                        local_get(Local(src)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
-                        local_get(Local(r)); local_get(Local(cols)); i32_mul; local_get(Local(c)); i32_add;
-                        i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
-                        f64_load(0);
-                        f64_store(0);
+                        local_get(Local(dst_data)); local_get(Local(c)); local_get(Local(rows_stride)); i32_mul; i32_add; local_get(Local(r)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(src_data)); local_get(Local(r)); local_get(Local(cols_bytes)); i32_mul; i32_add; local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        f64_load(0); f64_store(0);
                         local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
                         br(0);
                       end; end;
                       local_get(Local(r)); i32_const(Imm32(1)); i32_add; local_set(Local(r));
                       br(0);
                     end; end;
+                    // scalar tail 2: last col(s) c in [cols_even, cols), r in [0, rows_even)
+                    local_get(Local(cols_even)); local_set(Local(c));
+                    block_empty; loop_empty;
+                      local_get(Local(c)); local_get(Local(cols)); i32_ge_u; br_if(1);
+                      i32_const(Imm32(0)); local_set(Local(r));
+                      block_empty; loop_empty;
+                        local_get(Local(r)); local_get(Local(rows_even)); i32_ge_u; br_if(1);
+                        local_get(Local(dst_data)); local_get(Local(c)); local_get(Local(rows_stride)); i32_mul; i32_add; local_get(Local(r)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        local_get(Local(src_data)); local_get(Local(r)); local_get(Local(cols_bytes)); i32_mul; i32_add; local_get(Local(c)); i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                        f64_load(0); f64_store(0);
+                        local_get(Local(r)); i32_const(Imm32(1)); i32_add; local_set(Local(r));
+                        br(0);
+                      end; end;
+                      local_get(Local(c)); i32_const(Imm32(1)); i32_add; local_set(Local(c));
+                      br(0);
+                    end; end;
                     local_get(Local(dst));
                 });
                 self.scratch.free_i32(cols);
                 self.scratch.free_i32(rows);
+                self.scratch.free_v128(vb);
+                self.scratch.free_v128(va);
+                self.scratch.free_i32(dst_ptr);
+                self.scratch.free_i32(src_ptr);
+                self.scratch.free_i32(rows_stride);
+                self.scratch.free_i32(cols_bytes);
+                self.scratch.free_i32(dst_data);
+                self.scratch.free_i32(src_data);
+                self.scratch.free_i32(cols_even);
+                self.scratch.free_i32(rows_even);
                 self.scratch.free_i32(c);
                 self.scratch.free_i32(r);
                 self.scratch.free_i32(dst);
@@ -1946,13 +2037,13 @@ impl FuncCompiler<'_> {
                 // matrix.linear_q1_0_row_no_bias(x, w_bytes, w_offset, w_rows, w_cols) -> Matrix
                 // y[i, j] = Σ_k x[i, k] * W[j, k]; W packed Q1_0.
                 //
-                // SIMD inner loop: process 2 weights per iteration using
-                // f64x2. The 128-weight block is now 64 pair iterations,
-                // each packing {w0,w1} as a v128 from 2 sign-bits (same
-                // byte — pair_idx*2 aligns to even lane positions so the
-                // two bits always live within one byte). Accumulator is
-                // v128 across all blocks for (i,j), reduced to scalar once
-                // at the end.
+                // Hot path beats rustc's wasm output (~1.35× at 1×2048×256). Two f64
+                // weights per f64x2 lane; the weight sign is applied branchlessly by
+                // XOR-ing x with a 1<<63 sign mask (no select, no ±scale multiply), and
+                // `scale` is factored out to one multiply per block. The 128-weight block
+                // (16 sign bytes × 4 pairs) is FULLY UNROLLED at emit time so every bit
+                // shift and x offset is a constant folded into the shift / v128.load
+                // immediate; even/odd pairs feed two accumulators to overlap the reductions.
                 let x = self.scratch.alloc_i32();
                 let w_bytes = self.scratch.alloc_i32();
                 let w_off = self.scratch.alloc_i32();
@@ -1965,7 +2056,6 @@ impl FuncCompiler<'_> {
                 let i = self.scratch.alloc_i32();
                 let j = self.scratch.alloc_i32();
                 let b = self.scratch.alloc_i32();
-                let pair_idx = self.scratch.alloc_i32();
                 let block_start = self.scratch.alloc_i32();
                 let bits_start = self.scratch.alloc_i32();
                 let scale_raw = self.scratch.alloc_i32();
@@ -1973,17 +2063,18 @@ impl FuncCompiler<'_> {
                 let expv = self.scratch.alloc_i32();
                 let mant = self.scratch.alloc_i32();
                 let f32bits = self.scratch.alloc_i32();
-                let byte_idx = self.scratch.alloc_i32();
                 let byte_val = self.scratch.alloc_i32();
-                let bit_shift = self.scratch.alloc_i32();
                 let bit0 = self.scratch.alloc_i32();
                 let bit1 = self.scratch.alloc_i32();
+                let x_block_base = self.scratch.alloc_i32();
                 let scale = self.scratch.alloc_f64();
-                let neg_scale = self.scratch.alloc_f64();
-                let w0 = self.scratch.alloc_f64();
-                let w1 = self.scratch.alloc_f64();
                 let sum_v = self.scratch.alloc_v128();
-                let w_v = self.scratch.alloc_v128();
+                // Two block accumulators broken out so the per-pair f64x2_add does
+                // not form one serial reduction chain across all 64 pairs — the two
+                // independent chains overlap in the pipeline (what LLVM does by
+                // unrolling). They are summed once at the end of each block.
+                let block_acc_v = self.scratch.alloc_v128();
+                let block_acc_v2 = self.scratch.alloc_v128();
                 let x_v = self.scratch.alloc_v128();
 
                 self.emit_expr(&args[0]);
@@ -2060,61 +2151,57 @@ impl FuncCompiler<'_> {
                           end;
                           local_get(Local(f32bits)); f32_reinterpret_i32; f64_promote_f32;
                           local_set(Local(scale));
-                          f64_const(0.0); local_get(Local(scale)); f64_sub; local_set(Local(neg_scale));
                           local_get(Local(block_start)); i32_const(Imm32(Q1_0_SCALE_BYTES)); i32_add; local_set(Local(bits_start));
-                          // for pair_idx in 0..64
-                          i32_const(Imm32(0)); local_set(Local(pair_idx));
-                          block_empty; loop_empty;
-                            local_get(Local(pair_idx)); i32_const(Imm32(Q1_0_PAIRS_PER_BLOCK)); i32_ge_u; br_if(1);
-                            // byte_idx = pair_idx >> 2  (each byte holds 4 pairs = 8 bits)
-                            local_get(Local(pair_idx)); i32_const(Imm32(LOG2_PAIRS_PER_BYTE)); i32_shr_u;
-                            local_set(Local(byte_idx));
-                            // bit_shift = (pair_idx & 3) << 1
-                            local_get(Local(pair_idx)); i32_const(Imm32(PAIRS_PER_BYTE_MASK)); i32_and;
-                            i32_const(Imm32(1)); i32_shl;
-                            local_set(Local(bit_shift));
-                            // byte_val = block[bits_start + byte_idx]
-                            local_get(Local(bits_start)); local_get(Local(byte_idx)); i32_add;
-                            i32_load8_u(0);
-                            local_set(Local(byte_val));
-                            // bit0 = (byte_val >> bit_shift) & 1
-                            local_get(Local(byte_val)); local_get(Local(bit_shift)); i32_shr_u;
-                            i32_const(Imm32(1)); i32_and;
-                            local_set(Local(bit0));
-                            // bit1 = (byte_val >> (bit_shift + 1)) & 1
-                            local_get(Local(byte_val));
-                            local_get(Local(bit_shift)); i32_const(Imm32(1)); i32_add; i32_shr_u;
-                            i32_const(Imm32(1)); i32_and;
-                            local_set(Local(bit1));
-                            // w0 = bit0 ? scale : neg_scale
-                            local_get(Local(bit0));
-                            if_f64; local_get(Local(scale)); else_; local_get(Local(neg_scale)); end;
-                            local_set(Local(w0));
-                            // w1 = bit1 ? scale : neg_scale
-                            local_get(Local(bit1));
-                            if_f64; local_get(Local(scale)); else_; local_get(Local(neg_scale)); end;
-                            local_set(Local(w1));
-                            // w_v = f64x2{w0, w1}
-                            local_get(Local(w0)); f64x2_splat;
-                            local_get(Local(w1)); f64x2_replace_lane(1);
-                            local_set(Local(w_v));
-                            // x_addr = x + 8 + (i*n_in + b*128 + pair_idx*2) * 8
-                            local_get(Local(x)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
-                            local_get(Local(i)); local_get(Local(n_in)); i32_mul;
-                            local_get(Local(b)); i32_const(Imm32(Q1_0_BLOCK_SIZE)); i32_mul; i32_add;
-                            local_get(Local(pair_idx)); i32_const(Imm32(1)); i32_shl; i32_add;
-                            i32_const(Imm32(F64_BYTES)); i32_mul;
-                            i32_add;
-                            v128_load(0);
-                            local_set(Local(x_v));
-                            // sum_v = sum_v + x_v * w_v
-                            local_get(Local(sum_v));
-                            local_get(Local(x_v)); local_get(Local(w_v)); f64x2_mul;
-                            f64x2_add;
-                            local_set(Local(sum_v));
-                            local_get(Local(pair_idx)); i32_const(Imm32(1)); i32_add; local_set(Local(pair_idx));
-                            br(0);
-                          end; end;
+                          // x_block_base = x + DATA + (i*n_in + b*128) * 8 — block-invariant base
+                          // address; the unrolled pairs add a constant f64 offset to it.
+                          local_get(Local(x)); i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::LIST, super::engine::layout::list::DATA) as i32)); i32_add;
+                          local_get(Local(i)); local_get(Local(n_in)); i32_mul;
+                          local_get(Local(b)); i32_const(Imm32(Q1_0_BLOCK_SIZE)); i32_mul; i32_add;
+                          i32_const(Imm32(F64_BYTES)); i32_mul; i32_add;
+                          local_set(Local(x_block_base));
+                          // Reset both accumulators; ±x is summed branchlessly (XOR) into
+                          // two independent chains, then ×scale once at the end of the block.
+                          f64_const(0.0); f64x2_splat; local_set(Local(block_acc_v));
+                          f64_const(0.0); f64x2_splat; local_set(Local(block_acc_v2));
+                          });
+                          // Inner loop FULLY UNROLLED: 16 sign bytes × 4 pairs = 64 pairs. Bit
+                          // shifts and x offsets are compile-time constants folded into the
+                          // i32.shr / v128.load immediates (zero per-pair index or address
+                          // arithmetic and no loop branch). Each sign byte is loaded once for its
+                          // 4 pairs; even/odd pairs feed two independent accumulators so the
+                          // f64x2_add reduction chains overlap in the pipeline.
+                          for byte_i in 0..Q1_0_SIGN_BYTES_PER_BLOCK {
+                              wasm!(self.func, {
+                                  local_get(Local(bits_start)); i32_load8_u(byte_i as u64); local_set(Local(byte_val));
+                              });
+                              for p in 0..PAIRS_PER_SIGN_BYTE {
+                                  let shift = p * Q1_0_WEIGHTS_PER_PAIR;
+                                  let weight_idx = byte_i * Q1_0_WEIGHTS_PER_SIGN_BYTE + p * Q1_0_WEIGHTS_PER_PAIR;
+                                  let x_off = weight_idx as u64 * F64_BYTES as u64;
+                                  let acc = if (byte_i * PAIRS_PER_SIGN_BYTE + p) % 2 == 0 { block_acc_v } else { block_acc_v2 };
+                                  wasm!(self.func, {
+                                      // bit0/bit1 at constant shifts within the already-loaded byte
+                                      local_get(Local(byte_val)); i32_const(Imm32(shift)); i32_shr_u; i32_const(Imm32(1)); i32_and; local_set(Local(bit0));
+                                      local_get(Local(byte_val)); i32_const(Imm32(shift + 1)); i32_shr_u; i32_const(Imm32(1)); i32_and; local_set(Local(bit1));
+                                      // x_v = load 2 f64 at x_block_base + constant offset
+                                      local_get(Local(x_block_base)); v128_load(x_off); local_set(Local(x_v));
+                                      // acc += x_v XOR mask{(bit0^1)<<63, (bit1^1)<<63} (branchless ±x)
+                                      local_get(Local(acc));
+                                      local_get(Local(x_v));
+                                      local_get(Local(bit0)); i32_const(Imm32(1)); i32_xor; i64_extend_i32_u; i64_const(Imm64(F64_SIGN_BIT_POS)); i64_shl; i64x2_splat;
+                                      local_get(Local(bit1)); i32_const(Imm32(1)); i32_xor; i64_extend_i32_u; i64_const(Imm64(F64_SIGN_BIT_POS)); i64_shl; i64x2_replace_lane(1);
+                                      v128_xor; f64x2_add; local_set(Local(acc));
+                                  });
+                              }
+                          }
+                          wasm!(self.func, {
+                          // sum_v += (block_acc_v + block_acc_v2) * scale — scale once per block
+                          // (distributive: Σ ±x · scale = scale · Σ ±x), not once per pair.
+                          local_get(Local(sum_v));
+                          local_get(Local(block_acc_v)); local_get(Local(block_acc_v2)); f64x2_add;
+                          local_get(Local(scale)); f64x2_splat; f64x2_mul;
+                          f64x2_add;
+                          local_set(Local(sum_v));
                           local_get(Local(b)); i32_const(Imm32(1)); i32_add; local_set(Local(b));
                           br(0);
                         end; end;
@@ -2137,17 +2224,14 @@ impl FuncCompiler<'_> {
                     local_get(Local(dst));
                 });
                 self.scratch.free_v128(x_v);
-                self.scratch.free_v128(w_v);
+                self.scratch.free_v128(block_acc_v2);
+                self.scratch.free_v128(block_acc_v);
                 self.scratch.free_v128(sum_v);
-                self.scratch.free_f64(w1);
-                self.scratch.free_f64(w0);
-                self.scratch.free_f64(neg_scale);
                 self.scratch.free_f64(scale);
+                self.scratch.free_i32(x_block_base);
                 self.scratch.free_i32(bit1);
                 self.scratch.free_i32(bit0);
-                self.scratch.free_i32(bit_shift);
                 self.scratch.free_i32(byte_val);
-                self.scratch.free_i32(byte_idx);
                 self.scratch.free_i32(f32bits);
                 self.scratch.free_i32(mant);
                 self.scratch.free_i32(expv);
@@ -2155,7 +2239,6 @@ impl FuncCompiler<'_> {
                 self.scratch.free_i32(scale_raw);
                 self.scratch.free_i32(bits_start);
                 self.scratch.free_i32(block_start);
-                self.scratch.free_i32(pair_idx);
                 self.scratch.free_i32(b);
                 self.scratch.free_i32(j);
                 self.scratch.free_i32(i);

--- a/crates/almide-codegen/src/emit_wasm/equality.rs
+++ b/crates/almide-codegen/src/emit_wasm/equality.rs
@@ -9,6 +9,11 @@ use std::collections::BTreeMap;
 // Named constants for raw WASM immediate values used in this module.
 /// Position of the sign bit in an i64 (used by the f64 total-order key transform).
 const I64_SIGN_BIT_POS: i64 = 63;
+/// Bytes of a variant's discriminant tag, stored at offset 0 ahead of the
+/// payload. A variant value is laid out `[tag: i32][payload…]`, padded to the
+/// max payload across the type's constructors so `mem_eq` can compare any two
+/// by a single fixed-width span.
+pub(super) const VARIANT_TAG_SIZE: u32 = 4;
 
 use super::FuncCompiler;
 use super::VariantCase;
@@ -1280,10 +1285,10 @@ impl FuncCompiler<'_> {
                 let max_payload = cases.iter()
                     .map(|c| super::values::record_size(&c.fields))
                     .max().unwrap_or(0);
-                return 4 + max_payload; // tag + max payload
+                return VARIANT_TAG_SIZE + max_payload; // tag + max payload
             }
         }
-        4 // fallback: tag only
+        VARIANT_TAG_SIZE // fallback: tag only
     }
 
     /// Find the variant tag for a constructor name, searching variant_info by subject type.

--- a/crates/almide-codegen/src/emit_wasm/expressions.rs
+++ b/crates/almide-codegen/src/emit_wasm/expressions.rs
@@ -1757,6 +1757,66 @@ impl FuncCompiler<'_> {
         let str_local = match self.var_map.get(&str_var.0) { Some(&v) => v, None => return false };
         let counter_local = match self.var_map.get(&counter_var.0) { Some(&v) => v, None => return false };
 
+        // BULK fast path: `while counter < BOUND { s = s + CONST_CHAR; counter += 1 }`
+        // appends (BOUND - counter) identical bytes, so the entire loop collapses to one
+        // capacity reservation + memory.fill. rustc lowers the equivalent push-loop
+        // char-by-char and LLVM will not coalesce it into a memset — a decisive idiom win.
+        // Restricted to a side-effect-free bound (literal / variable) so evaluating it once
+        // (instead of per iteration) is sound.
+        if let IrExprKind::BinOp { op: BinOp::Lt, left, right } = &cond.kind {
+            if matches!(&left.kind, IrExprKind::Var { id } if *id == counter_var)
+                && matches!(&right.kind, IrExprKind::LitInt { .. } | IrExprKind::Var { .. })
+            {
+                use super::engine::layout::{STRING, string};
+                let data_off = self.emitter.layout_reg.fixed_offset(STRING, string::DATA) as i32;
+                let cap_off = self.emitter.layout_reg.fixed_offset(STRING, string::CAP) as i32 as u32;
+                // Almide `Int` is an i64 on wasm: bound and the counter are i64; the byte
+                // run length and string len/cap are i32.
+                let bound = self.scratch.alloc_i64();
+                let run = self.scratch.alloc_i32();
+                let s = self.scratch.alloc_i32();
+                let len = self.scratch.alloc_i32();
+                let new_len = self.scratch.alloc_i32();
+                self.emit_expr(right);
+                wasm!(self.func, {
+                    local_set(Local(bound));
+                    // run = (bound - counter) wrapped to i32; only proceed when positive
+                    local_get(Local(bound)); local_get(Local(counter_local)); i64_sub; i32_wrap_i64; local_set(Local(run));
+                    local_get(Local(run)); i32_const(Imm32(0)); i32_gt_s;
+                    if_empty;
+                      local_get(Local(str_local)); local_set(Local(s));
+                      local_get(Local(s)); i32_load(0); local_set(Local(len));
+                      local_get(Local(len)); local_get(Local(run)); i32_add; local_set(Local(new_len));
+                      // grow the backing buffer iff new_len exceeds capacity
+                      local_get(Local(new_len)); local_get(Local(s)); i32_load(cap_off); i32_gt_u;
+                      if_empty;
+                        local_get(Local(new_len)); i32_const(Imm32(data_off)); i32_add;
+                        call(self.emitter.rt.alloc_nozero); local_set(Local(s));
+                        local_get(Local(s)); i32_const(Imm32(data_off)); i32_add;
+                        local_get(Local(str_local)); i32_const(Imm32(data_off)); i32_add;
+                        local_get(Local(len)); memory_copy;
+                        local_get(Local(s)); local_get(Local(new_len)); i32_store(cap_off);
+                      end;
+                      // fill the appended run with the constant byte, in one shot
+                      local_get(Local(s)); i32_const(Imm32(data_off)); i32_add; local_get(Local(len)); i32_add;
+                      i32_const(Imm32(byte_val as i32));
+                      local_get(Local(run));
+                      memory_fill;
+                      // finalize: len = new_len, counter = bound, rebind s
+                      local_get(Local(s)); local_get(Local(new_len)); i32_store(0);
+                      local_get(Local(s)); local_set(Local(str_local));
+                      local_get(Local(bound)); local_set(Local(counter_local));
+                    end;
+                });
+                self.scratch.free_i32(new_len);
+                self.scratch.free_i32(len);
+                self.scratch.free_i32(s);
+                self.scratch.free_i32(run);
+                self.scratch.free_i64(bound);
+                return true;
+            }
+        }
+
         // Emit optimized loop with hoisted len/cap
         let s = self.scratch.alloc_i32();
         let len = self.scratch.alloc_i32();
@@ -1805,7 +1865,9 @@ impl FuncCompiler<'_> {
               local_get(Local(cap));
               i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32));
               i32_add;
-              call(self.emitter.rt.alloc); local_tee(Local(s));
+              // Grow buffer is overwritten in full (old prefix via memory.copy below,
+              // the rest by subsequent appends, reads bounded by len) → skip reuse-zeroing.
+              call(self.emitter.rt.alloc_nozero); local_tee(Local(s));
               // Copy old data
               i32_const(Imm32(self.emitter.layout_reg.fixed_offset(super::engine::layout::STRING, super::engine::layout::string::DATA) as i32)); i32_add;
               local_get(Local(str_local));

--- a/crates/almide-codegen/src/emit_wasm/functions.rs
+++ b/crates/almide-codegen/src/emit_wasm/functions.rs
@@ -6,6 +6,7 @@ use wasm_encoder::{Function, ValType};
 use almide_ir::{IrFunction, IrExpr, IrExprKind, IrStmt, IrStmtKind, VarTable};
 
 use super::{CompiledFunc, FuncCompiler, WasmEmitter};
+use super::engine::{Imm32, Local};
 use super::statements::collect_locals;
 
 /// Check if a function body uses stdlib calls, closures, or complex operations
@@ -160,7 +161,45 @@ fn compile_function_inner(
         wasm!(compiler.func, { call(compiler.emitter.rt.init_preopen_dirs); });
     }
 
+    // Function-scope heap reclamation (the non-loop analog of iter_scope). When a
+    // function returns a SCALAR (no heap escapes through the return), allocates
+    // heap, and never writes outer heap, roll the bump pointer back to entry on
+    // exit. Sequential calls then bump into the just-reclaimed WARM region instead
+    // of growing into cold (page-faulting) pages — this is what made `data |>
+    // list.map` ~4× slower than rustc when called once per benchmark: the result
+    // leaked and every call hit fresh memory, while a loop's iter_scope already
+    // recovered it. The scalar result sits on the wasm value stack, untouched by
+    // the global resets. The escape guard (`expr_writes_outer_heap`, hardened in
+    // #643) keeps any in-place-mutated / outer-stored heap out of the rollback.
+    let fn_scope = matches!(
+        func.ret_ty,
+        almide_lang::types::Ty::Int
+            | almide_lang::types::Ty::Bool
+            | almide_lang::types::Ty::Float
+            | almide_lang::types::Ty::Unit
+    ) && compiler.expr_allocates_heap(&func.body)
+        && !compiler.expr_writes_outer_heap(&func.body);
+    let fn_scope_local = if fn_scope {
+        let sl = compiler.scratch.alloc_i32();
+        wasm!(compiler.func, { global_get(compiler.emitter.heap_ptr_global); local_set(Local(sl)); });
+        Some(sl)
+    } else {
+        None
+    };
+
     compiler.emit_expr(&func.body);
+
+    // Restore the bump frontier + forget the free list (every node freed in the
+    // body points into the region being reclaimed — the same wholesale-forget the
+    // loop iter_scope relies on). Global sets do not disturb the stacked result.
+    if let Some(sl) = fn_scope_local {
+        wasm!(compiler.func, {
+            local_get(Local(sl));
+            global_set(compiler.emitter.heap_ptr_global);
+            i32_const(Imm32(0));
+            global_set(compiler.emitter.free_list_global);
+        });
+    }
 
     // Perceus function-exit rc_dec is now handled by PerceusPass (IR-level RcDec nodes)
 

--- a/crates/almide-codegen/src/emit_wasm/functions.rs
+++ b/crates/almide-codegen/src/emit_wasm/functions.rs
@@ -121,11 +121,22 @@ fn compile_function_inner(
     // (#417) and falls back to the native build. These margins cover realistic
     // functions; the exact fix is a two-pass emit that sizes caps to the measured
     // high-water mark. Unused scratch locals are zero-cost declarations.
+    //
+    // Function-scope heap reclamation (below) draws ONE i32 scratch slot that
+    // stays live across the entire body (it holds the entry heap frontier), so it
+    // is NOT freed before the body's own temporaries are allocated. Reserve that
+    // slot on top of the body budget in BOTH branches — otherwise a body that
+    // already peaks at the minimal i32 cap overflows by exactly one once the
+    // reclamation slot is taken first (codegen_borrow_test / protocol_stress_test:
+    // body needs 4, +1 frontier slot = 5 > 4). The reserve is unconditional because
+    // eligibility is decided after the compiler is built; an unused extra i32 local
+    // is a zero-cost declaration.
+    const FN_SCOPE_FRONTIER_SLOTS: usize = 1;
     let (scratch_i32_cap, scratch_i64_cap, scratch_f64_cap, scratch_v128_cap) = if needs_full_scratch {
-        (64usize, 48usize, 48usize, 8usize)
+        (64 + FN_SCOPE_FRONTIER_SLOTS, 48usize, 48usize, 8usize)
     } else {
         // Minimal: enough for basic match/if temporaries
-        (4usize, 2usize, 2usize, 0usize)
+        (4 + FN_SCOPE_FRONTIER_SLOTS, 2usize, 2usize, 0usize)
     };
     let scratch_i32_base = param_count + local_decls.len() as u32;
     for _ in 0..scratch_i32_cap { local_decls.push((1, ValType::I32)); }

--- a/crates/almide-codegen/src/emit_wasm/list_layout.rs
+++ b/crates/almide-codegen/src/emit_wasm/list_layout.rs
@@ -43,10 +43,18 @@ impl FuncCompiler<'_> {
     }
 
     /// Allocate list for `len_local` elements. Returns scratch local with ptr.
+    ///
+    /// Uses `__alloc_nozero`: a pre-sized list's data area is written in full by
+    /// its producer (map/filter/range/collect), and `len` bounds every read, so a
+    /// recycled free-list block need not be zeroed first. On a warm repeated
+    /// allocation (the common `data |> list.map` loop) this is the difference
+    /// between touching 8 MB once vs twice — list combinators were ~4× off rustc
+    /// purely from the redundant reuse-zeroing, not the (already SIMD) inner loop.
+    /// (Swiss-Table maps DO need the zero-fill — they keep using `__alloc`.)
     pub fn emit_list_alloc(&mut self, len_local: u32, elem_size: u32) -> u32 {
         use super::engine::{WasmBuilder, layout::LIST};
         let dst = self.scratch.alloc_i32();
-        let alloc_fn = self.emitter.rt.alloc;
+        let alloc_fn = self.emitter.rt.alloc_nozero;
         let mut w = WasmBuilder::new(&mut self.func, &self.emitter.layout_reg);
         w.alloc_collection(LIST, len_local, elem_size, dst, alloc_fn);
         dst

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -322,6 +322,11 @@ pub struct RuntimeFuncs {
     /// block had its free-list `next` clobbered by the host (the C-042
     /// poison class). Pinning makes fs scratch immortal BY CONSTRUCTION.
     pub alloc_pinned: u32,
+    /// `__alloc_nozero(size)` — like `__alloc` but skips zeroing a recycled
+    /// free-list block, for callers (matrix transpose/matmul/zeros) that
+    /// immediately overwrite the whole data area. Avoids a redundant full-block
+    /// fill that dominated those ops' wall time.
+    pub alloc_nozero: u32,
     /// Global index holding the heap start address (immutable).
     /// Pointers below this are in the data section and must NOT be rc_dec'd.
     pub heap_start_global: u32,
@@ -607,7 +612,7 @@ impl WasmEmitter {
             case_table_bytes: 0,
             rt: RuntimeFuncs {
                 fd_write: 0, alloc: 0, rc_inc: 0, rc_dec: 0, cow_check: 0,
-                heap_save: 0, heap_restore: 0, alloc_pinned: 0, heap_start_global: 0,
+                heap_save: 0, heap_restore: 0, alloc_pinned: 0, alloc_nozero: 0, heap_start_global: 0,
                 println_str: 0, println_int: 0,
                 int_to_string: 0, float_to_string: 0,
                 float_parse: 0, float_to_fixed: 0, float_pow: 0,

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -253,6 +253,9 @@ pub fn register_runtime_functions(emitter: &mut WasmEmitter) {
     let alloc_pinned_ty = emitter.register_type(vec![ValType::I32], vec![ValType::I32]);
     emitter.rt.alloc_pinned = emitter.register_func("__alloc_pinned", alloc_pinned_ty);
 
+    // __alloc_nozero(size: i32) -> i32 — like __alloc, no zeroing on free-list reuse
+    emitter.rt.alloc_nozero = emitter.register_func("__alloc_nozero", alloc_ty);
+
     // __println_str(ptr: i32) -> ()
     let println_ty = emitter.register_type(vec![ValType::I32], vec![]);
     emitter.rt.println_str = emitter.register_func("__println_str", println_ty);
@@ -464,6 +467,7 @@ pub fn compile_runtime(emitter: &mut WasmEmitter) {
     compile_heap_save(emitter);
     compile_heap_restore(emitter);
     compile_alloc_pinned(emitter);
+    compile_alloc_nozero(emitter);
     compile_println_str(emitter);
     compile_int_to_string(emitter);
     // float.to_string driver (Dragon4 shortest-decimal). Registered early, so
@@ -531,8 +535,24 @@ pub fn compile_runtime(emitter: &mut WasmEmitter) {
 /// All returned pointers are guaranteed to be 8-byte aligned, matching wasi-libc
 /// and Emscripten conventions. This ensures i64 loads/stores never trap on alignment.
 fn compile_alloc(emitter: &mut WasmEmitter) {
+    let idx = emitter.rt.alloc;
+    compile_alloc_variant(emitter, idx, true);
+}
+/// `__alloc_nozero`: identical to `__alloc` but does NOT zero a reused free-list
+/// block. For callers that immediately overwrite the entire data area (matrix
+/// transpose / matmul / zeros), the reuse-zeroing in `__alloc` is pure waste —
+/// at 512×512 f64 it was ~70% of a transpose's wall time (a fresh 2 MB fill per
+/// call). Bump-path blocks come from fresh wasm pages (already zero), so only the
+/// reuse path differs.
+fn compile_alloc_nozero(emitter: &mut WasmEmitter) {
+    let idx = emitter.rt.alloc_nozero;
+    compile_alloc_variant(emitter, idx, false);
+}
+/// Shared body for the `__alloc` family. `zero_on_reuse` controls whether a
+/// recycled free-list block has its data area cleared before return.
+fn compile_alloc_variant(emitter: &mut WasmEmitter, func_idx: u32, zero_on_reuse: bool) {
     use super::engine::{WasmBuilder, layout::*};
-    let type_idx = emitter.func_type_indices[&emitter.rt.alloc];
+    let type_idx = emitter.func_type_indices[&func_idx];
     let hdr = emitter.layout_reg.header_size(ALLOC_HEADER) as i32;
     let rc_off = emitter.layout_reg.fixed_offset(ALLOC_HEADER, alloc::RC);
     let size_off = emitter.layout_reg.fixed_offset(ALLOC_HEADER, alloc::SIZE);
@@ -600,12 +620,15 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
                 });
                 // RC = 1
                 w.get(Local(4)).i32c(Imm32(1)).emit_store(rc_off, rc_ty);
-                // Zero-fill reused block's data area to prevent stale data
-                // (critical for Swiss Table tag arrays)
-                w.get(Local(4)).i32c(Imm32(hdr)).add();  // data_ptr
-                w.i32c(Imm32(0));                 // fill value
-                w.get(Local(4)).emit_load(size_off, size_ty); // size
-                w.raw(wasm_encoder::Instruction::MemoryFill(0));
+                if zero_on_reuse {
+                    // Zero-fill reused block's data area to prevent stale data
+                    // (critical for Swiss Table tag arrays). Skipped by
+                    // __alloc_nozero, whose callers overwrite the whole block.
+                    w.get(Local(4)).i32c(Imm32(hdr)).add();  // data_ptr
+                    w.i32c(Imm32(0));                 // fill value
+                    w.get(Local(4)).emit_load(size_off, size_ty); // size
+                    w.raw(wasm_encoder::Instruction::MemoryFill(0));
+                }
                 // Return data ptr
                 w.get(Local(4)).i32c(Imm32(hdr)).add().ret();
             }, |_| {});
@@ -648,7 +671,7 @@ fn compile_alloc(emitter: &mut WasmEmitter) {
         w.get(Local(1)).i32c(Imm32(hdr)).add();
     }
     f.instruction(&wasm_encoder::Instruction::End);
-    emitter.add_compiled(CompiledFunc::tracked_for(emitter.rt.alloc, type_idx, f));
+    emitter.add_compiled(CompiledFunc::tracked_for(func_idx, type_idx, f));
 }
 
 /// Whether this emission activates real reference-count frees — the DEFAULT

--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -664,6 +664,14 @@ fn compile_alloc_variant(emitter: &mut WasmEmitter, func_idx: u32, zero_on_reuse
             w.i32c(Imm32(-1)).eq();
             w.if_void(|w| { w.unreachable_(); }, |_| {});
         }, |_| {});
+        // Bump path does NOT zero: a never-touched wasm page is already zero, and
+        // the only callers that read before they write — variant payload tails —
+        // zero their own tail at construction (calls.rs), because whole-block
+        // zeroing here taxed every map/list bump (precise_all map_insert 0.67x →
+        // 1.06x). Reclaimed-then-rebumped memory IS dirty, but map/set tags (the
+        // other read-before-write region) never land in a reclaimed region: their
+        // builders use in-place mutators, which trip `expr_writes_outer_heap` and
+        // disable iter_scope / function-scope reclamation.
         // Write header
         w.get(Local(1)).get(Local(0)).emit_store(size_off, size_ty);
         w.get(Local(1)).i32c(Imm32(1)).emit_store(rc_off, rc_ty);

--- a/crates/almide-codegen/src/emit_wasm/wasm_macro.rs
+++ b/crates/almide-codegen/src/emit_wasm/wasm_macro.rs
@@ -638,6 +638,18 @@ macro_rules! wasm {
     (@emit $f:expr, i64x2_splat; $($rest:tt)*) => {
         $f.instruction(&wasm_encoder::Instruction::I64x2Splat); wasm!(@emit $f, $($rest)*)
     };
+    (@emit $f:expr, i64x2_extract_lane($lane:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::I64x2ExtractLane($lane)); wasm!(@emit $f, $($rest)*)
+    };
+    (@emit $f:expr, i64x2_replace_lane($lane:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::I64x2ReplaceLane($lane)); wasm!(@emit $f, $($rest)*)
+    };
+    (@emit $f:expr, v128_xor; $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::V128Xor); wasm!(@emit $f, $($rest)*)
+    };
+    (@emit $f:expr, i8x16_shuffle($lanes:expr); $($rest:tt)*) => {
+        $f.instruction(&wasm_encoder::Instruction::I8x16Shuffle($lanes)); wasm!(@emit $f, $($rest)*)
+    };
 }
 
 pub(super) use wasm;


### PR DESCRIPTION
## WASM perf sweep: Almide-emitted wasm now wins or ties rustc-wasm on every measured op

Closes the gap where Almide's `--target wasm` output lost to `rustc`'s wasm on most allocation- and SIMD-heavy operations. Measured with the stdlib precision benchmark (faithful Rust twins, `wasm32-wasip1 --release`, wasmtime, interleaved min-of-15).

### Scoreboard (precise_all 11-op)

| | before | after |
|---|---|---|
| **WIN / TIE / LOSS** | 2 / 3 / 6 | **7 / 4 / 0** |

Highlights: `list_map` 4.75×→1.00× (tie), `list_filter` 2.65×→0.83×, `list_fold` 2.50×→0.80×, `map_insert` 1.51×→0.69×, `map_get` 1.12×→0.44×, `str_concat` 2.14×→**~0× (one memory.fill)**. Plus, outside the suite: `linear_q1_0` 0.45×→**1.30×** vs Rust+simd128, dense `transpose` 0.55×→**1.62×** vs default Rust.

### What changed

**Commit 1 — allocation/reclamation infrastructure**
- **Function-scope heap reclamation** (`functions.rs`): the non-loop analogue of `iter_scope`. When a function returns a scalar (no heap escapes via the return), allocates heap, and never writes outer heap, save the bump pointer at entry and restore it (+ reset the free list) at exit. Sequential calls then bump into the just-reclaimed *warm* region instead of growing into cold, page-faulting pages. This was the dominant fix: non-loop transient heap was leaking (reclamation was loop-only), so a one-shot `data |> list.map` hit fresh 8 MB pages (~4× slower) while rustc reused warm memory. The scalar-return guard avoids any materialize-recovery; the escape guard (`expr_writes_outer_heap`, #643-hardened) keeps in-place-mutated/outer-stored heap out of the rollback.
- **`__alloc_nozero`** (`runtime.rs`, `mod.rs`): an allocator variant that skips zeroing a recycled free-list block, for callers that overwrite the whole buffer. Routed list allocation (`list_layout.rs`) to it (Swiss-Table maps keep the zeroing `__alloc`).

**Commit 2 — SIMD emit + bulk string append**
- **q1_0 full-unroll** (`calls_matrix.rs`): branchless XOR sign + scale-hoist + emit-time unroll folding bit shifts and x offsets into the shift/`v128.load` immediates (56→20 ms).
- **transpose** (`calls_matrix.rs`): in-register 2×2 `i8x16.shuffle` transpose, contiguous v128 loads/stores.
- **SIMD i64x2 fold reduction** (`calls_list_closure2.rs`): `xs |> fold(init, (a,x) => a + x)` over a borrowed Int list → i64x2 accumulate + horizontal add + scalar tail.
- **bulk string append** (`expressions.rs`): `while i < N { s = s + CONST_CHAR }` collapses to one capacity reserve + `memory.fill` (rustc lowers the push-loop char-by-char and LLVM won't memset it). Routes the string-grow allocation to `__alloc_nozero`.
- New `wasm!` macro arms: `v128_xor`, `i64x2_replace_lane`, `i64x2_extract_lane`, `i8x16_shuffle`. All raw operand values replaced with derived named constants.

### Correctness & tests

- `cargo test --workspace --exclude almide-interp`: **35 binaries, 0 failures**.
- Cross-target oracle (`interp_cross_target_spec`): **0 backend-split** — native and wasm agree on every evaluated fixture, i.e. these changes introduce no native↔wasm divergence.
- Per-op correctness verified directly (q1_0 mixed-sign vs an independent Rust reference; transpose non-square + odd; fold edge sizes; string content/empty/large; escape-path battery for function-scope reclamation), plus the wasm spec corpus.

The two locally-red `almide-interp` tests (`interp_abstain_ledger`, `interp_cross_target_spec`'s 1 interp-dissent) are **pre-existing** drift in the in-progress reference-interpreter infrastructure (untouched here — they fail on the `json.parse`/`bytes.from_list`/`process.args` capabilities the interpreter abstains on) and **self-skip on CI**.
