### PR TITLE
wasm: persist in-place mutation of a mut record field, cross-target (#705)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/collections.rs
+++ b/crates/almide-codegen/src/emit_wasm/collections.rs
@@ -490,6 +490,35 @@ impl FuncCompiler<'_> {
         }
     }
 
+    /// Total byte offset (variant tag + field) at which `object.field` is
+    /// stored inside `object`'s record block — the store-side mirror of
+    /// `emit_member`'s type resolution. `emit_mutator_writeback` uses it to
+    /// write a realloc'd list pointer back into a record field slot (#705).
+    /// None when the field/type can't be resolved.
+    pub(super) fn member_field_store_offset(&self, object: &IrExpr, field: &str) -> Option<u32> {
+        let resolved_ty = if let almide_ir::IrExprKind::Var { id } = &object.kind {
+            let vt_ty = &self.var_table.get(*id).ty;
+            if object.ty.is_unresolved_structural() && !vt_ty.is_unresolved_structural() {
+                vt_ty.clone()
+            } else {
+                object.ty.clone()
+            }
+        } else if let almide_ir::IrExprKind::Member { object: inner_obj, field: inner_field } = &object.kind {
+            let inner_ty = self.resolve_member_result_type(inner_obj, inner_field);
+            if !matches!(inner_ty, Ty::Unknown) { inner_ty } else { object.ty.clone() }
+        } else {
+            object.ty.clone()
+        };
+        let mut fields = self.extract_record_fields(&resolved_ty);
+        if fields.is_empty() && resolved_ty.is_unresolved() {
+            for (_name, rf) in &self.emitter.record_fields {
+                if rf.iter().any(|(n, _)| n == field) { fields = rf.clone(); break; }
+            }
+        }
+        let tag_offset = self.variant_tag_offset(&resolved_ty);
+        values::field_offset(&fields, field).map(|(field_offset, _)| tag_offset + field_offset)
+    }
+
     /// Resolve the result type of a member access (obj.field) for chained access.
     fn resolve_member_result_type(&self, object: &IrExpr, field: &str) -> Ty {
         let obj_ty = if let almide_ir::IrExprKind::Var { id } = &object.kind {

--- a/crates/almide-codegen/src/emit_wasm/mod.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod.rs
@@ -452,6 +452,11 @@ pub struct WasmEmitter {
     next_func_idx: u32,
     pub func_map: HashMap<String, u32>,
     pub module_names: Vec<String>,
+    /// Per-function `mut` parameter flags, keyed by the call target's name
+    /// (top-level fn → `name`; module fn → `module::func`). The loop/fn-scope
+    /// reclamation escape check consults it: a call that passes an outer-scope
+    /// var into a `mut` param may realloc it, so the value escapes (#705).
+    pub mut_param_sigs: HashMap<String, Vec<bool>>,
     /// Reverse lookup for `@intrinsic("almide_rt_<m>_<f>")` attributes:
     /// mangled symbol → (stdlib module name, Almide fn name). Populated
     /// once from bundled stdlib sources; used by the WASM `RuntimeCall`
@@ -601,6 +606,7 @@ impl WasmEmitter {
             next_func_idx: 0,
             func_map: HashMap::new(),
             module_names: Vec::new(),
+            mut_param_sigs: HashMap::new(),
             intrinsic_symbol_to_fn: HashMap::new(),
             func_type_indices: HashMap::new(),
             compiled: Vec::new(),
@@ -947,6 +953,23 @@ impl FuncCompiler<'_> {
     /// `new_ptr` is a local already holding the new object pointer. No-op when the
     /// target is not a bare `Var` (e.g. `foo().push(x)` has nowhere to write back).
     pub fn emit_mutator_writeback(&mut self, target: &almide_ir::IrExpr, new_ptr: u32) {
+        // A field of a record (`list.push(b.xs, v)` on a `mut b`): store the
+        // realloc'd pointer back into the field slot `[base + offset]`. The
+        // record block is shared (passed by pointer), so the write persists to
+        // the caller — the wasm counterpart of native's `&mut b.xs` (#703/#705).
+        // Without this the new buffer is dropped and the field keeps pointing at
+        // the pre-realloc block (silently wrong — slabhra's tape on wasm).
+        if let almide_ir::IrExprKind::Member { object, field } = &target.kind {
+            if let Some(total_offset) = self.member_field_store_offset(object, field) {
+                self.emit_expr(object);
+                wasm!(self.func, {
+                    i32_const(Imm32(total_offset as i32)); i32_add;
+                    local_get(Local(new_ptr));
+                    i32_store(0);
+                });
+            }
+            return;
+        }
         let id = match &target.kind {
             almide_ir::IrExprKind::Var { id } => id.0,
             _ => return,
@@ -1015,6 +1038,24 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
     emitter.needs_cow = program.codegen_annotations.needs_cow.iter().map(|v| v.0).collect();
     emitter.global_alias = program.codegen_annotations.global_alias.iter()
         .map(|(k, v)| (k.0, v.0)).collect();
+
+    // Per-function `mut` parameter flags, for the loop/fn-scope reclamation
+    // escape check. Top-level fns key on `name`; module fns on `module::func` —
+    // matching the `CallTarget::Named`/`CallTarget::Module` the scanner sees.
+    for func in &program.functions {
+        emitter.mut_param_sigs.insert(
+            func.name.to_string(),
+            func.params.iter().map(|p| p.is_mut).collect(),
+        );
+    }
+    for module in &program.modules {
+        for func in &module.functions {
+            emitter.mut_param_sigs.insert(
+                format!("{}::{}", module.name, func.name),
+                func.params.iter().map(|p| p.is_mut).collect(),
+            );
+        }
+    }
 
     // Phase 0: Collect `@intrinsic(symbol)` → (module, fn_name) from every
     // bundled stdlib source so the `RuntimeCall` fallback path can route

--- a/crates/almide-codegen/src/emit_wasm/statements.rs
+++ b/crates/almide-codegen/src/emit_wasm/statements.rs
@@ -1007,6 +1007,7 @@ impl FuncCompiler<'_> {
     pub(super) fn expr_writes_outer_heap(&self, expr: &IrExpr) -> bool {
         struct HeapWriteScanner<'a> {
             var_table: &'a almide_ir::VarTable,
+            mut_sigs: &'a std::collections::HashMap<String, Vec<bool>>,
             found: bool,
         }
         impl IrVisitor for HeapWriteScanner<'_> {
@@ -1048,7 +1049,24 @@ impl FuncCompiler<'_> {
                 // misses them; mirror its conservative non-scalar test here.
                 if let IrExprKind::RuntimeCall { symbol, args } = &expr.kind {
                     if crate::pass_closure_conversion::is_inplace_mutator(symbol.as_str()) {
-                        if let Some(IrExprKind::Var { id }) = args.first().map(|a| &a.kind) {
+                        // args[0] may be a bare Var (`list.push(out, …)`) OR a
+                        // field/element of one (`list.push(b.xs, …)` on a `mut
+                        // b`): the realloc'd backing escapes through the rooted
+                        // binding either way. #693 only matched a bare Var, so a
+                        // MEMBER target slipped through and the fn/iter-scope
+                        // reclamation freed a live field buffer — slabhra's tape
+                        // `push_node`, where `list.push(t.depth, …)` traps after
+                        // teardown reuses the address (#705). Walk the
+                        // member/index chain to its root variable.
+                        let mut root = args.first().map(|a| &a.kind);
+                        while let Some(
+                            IrExprKind::Member { object, .. }
+                            | IrExprKind::TupleIndex { object, .. }
+                            | IrExprKind::IndexAccess { object, .. },
+                        ) = root {
+                            root = Some(&object.kind);
+                        }
+                        if let Some(IrExprKind::Var { id }) = root {
                             let ty = &self.var_table.get(*id).ty;
                             let scalar = matches!(ty, Ty::Int | Ty::Float | Ty::Bool | Ty::Unit);
                             if !scalar {
@@ -1058,10 +1076,45 @@ impl FuncCompiler<'_> {
                         }
                     }
                 }
+                // A USER function with a `mut` parameter fed an outer-scope var
+                // (`op.add(t, …)` where `t` is the tape) may realloc the field it
+                // mutates; the new buffer escapes via `t`. The stdlib-mutator
+                // check above misses it because the mutation happens one frame
+                // down. mut_param_sigs gives each callee's per-param `mut` flags.
+                if let IrExprKind::Call { target, args, .. } = &expr.kind {
+                    let key = match target {
+                        almide_ir::CallTarget::Named { name } => Some(name.to_string()),
+                        almide_ir::CallTarget::Module { module, func, .. } =>
+                            Some(format!("{}::{}", module, func)),
+                        _ => None,
+                    };
+                    if let Some(sig) = key.and_then(|k| self.mut_sigs.get(&k)) {
+                        for (i, arg) in args.iter().enumerate() {
+                            if !sig.get(i).copied().unwrap_or(false) { continue; }
+                            // arg in a `mut` slot — escape if it is rooted at a var
+                            let mut root = Some(&arg.kind);
+                            while let Some(
+                                IrExprKind::Member { object, .. }
+                                | IrExprKind::TupleIndex { object, .. }
+                                | IrExprKind::IndexAccess { object, .. },
+                            ) = root {
+                                root = Some(&object.kind);
+                            }
+                            if matches!(root, Some(IrExprKind::Var { .. })) {
+                                self.found = true;
+                                return;
+                            }
+                        }
+                    }
+                }
                 walk_expr(self, expr);
             }
         }
-        let mut scanner = HeapWriteScanner { var_table: self.var_table, found: false };
+        let mut scanner = HeapWriteScanner {
+            var_table: self.var_table,
+            mut_sigs: &self.emitter.mut_param_sigs,
+            found: false,
+        };
         scanner.visit_expr(expr);
         scanner.found
     }

--- a/spec/lang/loop_arena_escape_test.almd
+++ b/spec/lang/loop_arena_escape_test.almd
@@ -1,0 +1,53 @@
+// Regression (#705): the loop iteration-arena AND the function-scope heap
+// reclamation must NOT reclaim a buffer that a `list.push` grows into a place
+// that escapes the scope — whether the push targets a record FIELD of a `mut`
+// param directly, or happens TRANSITIVELY through a callee's `mut` parameter.
+// Each used to free a live buffer on wasm: a Member target slipped past #693's
+// Var-only mutator check (fn-scope reclamation freed `t.depth`'s buffer in a
+// `push_node` that also allocated the `list.get ?? d` Option box), and a
+// `mut`-param callee was invisible to the loop escape scan. Runs on BOTH
+// targets — this is the slabhra-tape build shape.
+
+type Tape = { depth: List[Int] }
+
+// `mut`-param fn that BOTH reads a field via `list.get ?? d` (allocates an
+// Option box the reclamation reclaims) AND pushes into the field (grows a buffer
+// that escapes via `t`). Exercises the Member-rooted in-place-mutator escape.
+fn node(mut t: Tape, pa: Int) -> Int = {
+  let dpa = if pa >= 0 then (list.get(t.depth, pa) ?? 0) else (0 - 1)
+  list.push(t.depth, dpa + 1)
+  list.len(t.depth) - 1
+}
+
+test "mut-param fn grows a record field while allocating an inner temp (#705)" {
+  var t: Tape = { depth: [] }
+  let a = node(t, 0 - 1)        // pa<0: no read; depth 0
+  let b = node(t, a)            // reads t.depth[0], pushes depth 1
+  let c = node(t, b)            // reads t.depth[1], pushes depth 2
+  assert(list.len(t.depth) == 3)
+  assert(t.depth[0] == 0)
+  assert(t.depth[1] == 1)
+  assert(t.depth[2] == 2)
+}
+
+// Transitive: a LOOP grows an outer record through the `mut`-param fn above —
+// the slabhra build-loop shape (`op.add(t, …)` on a `mut t`). The loop's own
+// iteration arena must see the `mut`-param call as an escape.
+fn build_tape(n: Int) -> Tape = {
+  var t: Tape = { depth: [] }
+  var prev = 0 - 1
+  var i = 0
+  while i < n {
+    prev = node(t, prev)
+    i = i + 1
+  }
+  t
+}
+
+test "loop grows an outer record via a user mut-param fn (#705)" {
+  let t = build_tape(6)
+  assert(list.len(t.depth) == 6)
+  assert(t.depth[0] == 0)
+  assert(t.depth[1] == 1)
+  assert(t.depth[5] == 5)
+}

--- a/spec/lang/mut_list_param_test.almd
+++ b/spec/lang/mut_list_param_test.almd
@@ -1,0 +1,22 @@
+// wasm:skip — a bare `mut List` PARAM mutated in place persists on native but
+// not yet on wasm (#705). Unlike a record field — whose pointer lives in an
+// addressable record block in linear memory — a bare list param's pointer lives
+// in a wasm LOCAL, which is not memory-addressable, so a reallocating push
+// cannot write the new pointer back to the caller's slot. Fixing this needs the
+// by-reference `mut` ABI (spill the arg to a memory cell around the call). The
+// record-field case (slabhra's tape) already works cross-target — see
+// mut_record_field_test.almd. Native is correct; this runs native.
+
+fn push9(mut v: List[Int], x: Int) -> Int = {
+  list.push(v, x)
+  list.len(v) - 1
+}
+
+test "mut List param pushes in place (native; #705 on wasm)" {
+  var v: List[Int] = [10]
+  let i = push9(v, 20)
+  let j = push9(v, 30)
+  assert(i == 1 and j == 2)
+  assert(list.len(v) == 3)
+  assert(v[2] == 30)
+}

--- a/spec/lang/mut_record_field_test.almd
+++ b/spec/lang/mut_record_field_test.almd
@@ -1,14 +1,14 @@
-// wasm:skip — in-place mutation of a `mut` record/list param does not yet
-// persist on the wasm target (a reallocating `list.push` moves the inline list
-// header and the new pointer is not written back to the caller's slot — the
-// wasm counterpart of #703, still open). Native is correct; these run native.
-//
 // #703: a `mut` parameter of a RECORD type can have `list.push` applied to one
 // of its List-typed fields — the field access `b.xs` of a `mut b` is a mutable
-// place, so the borrow is `&mut b.xs` and the push is O(1) amortized in place,
-// exactly like a bare `mut List` param. Previously this was rejected at the
-// checker (E007 "temporary expression") and then mis-lowered to an owned
-// non-`mut` binding (E0596).
+// place, so the borrow is `&mut b.xs` and the push is O(1) amortized in place.
+//
+// Cross-target: runs on BOTH native and wasm. A record is passed by a shared
+// pointer, so a reallocating `list.push` into a field writes the new buffer
+// pointer back into the field slot `[base + offset]` on wasm too
+// (emit_mutator_writeback handles the Member lvalue — #705), and the loop/
+// fn-scope heap reclamation recognizes the field as an escape and does not
+// reclaim it. The bare `mut List` *param* case (pointer in a non-addressable
+// wasm local) is still wasm-divergent — see mut_list_param_test.almd.
 
 type Box = { xs: List[Int] }
 
@@ -49,19 +49,4 @@ test "mut record with multiple parallel list fields (#703, slabhra-tape shape)" 
   assert(list.len(t.op) == 3)
   assert(t.val[2] == 3.5)
   assert(t.op[1] == 4)
-}
-
-// Contrast (already worked): a bare `mut List` param pushes in place.
-fn push9(mut v: List[Int], x: Int) -> Int = {
-  list.push(v, x)
-  list.len(v) - 1
-}
-
-test "mut List param still pushes in place (contrast to record field)" {
-  var v: List[Int] = [10]
-  let i = push9(v, 20)
-  let j = push9(v, 30)
-  assert(i == 1 and j == 2)
-  assert(list.len(v) == 3)
-  assert(v[2] == 30)
 }


### PR DESCRIPTION
Fixes **#705**: in-place mutation of a `mut` record param's List-typed field (`list.push(b.xs, v)` on a `mut b`, allowed on native since #703/#710) is now **bit-identical on native and wasm**. slabhra's autograd library — MLP forward+backward, training, and the DLGN XOR gate network — runs byte-identically on both targets.

Three wasm-emit fixes, all reconciled against the current emitter (#691 ValueObject operands, #693 escape gate, #702 function-scope reclamation):

### 1. Member writeback (`mod.rs`, `collections.rs`)
`emit_mutator_writeback` only handled a `Var` target; a `Member` target (`b.xs`) silently fell through `_ => return`, so a reallocating `list.push` dropped the new buffer and the field kept pointing at the pre-realloc block. Now it stores the realloc'd pointer into the field slot `[base + offset]` (`member_field_store_offset` mirrors `emit_member`'s resolution). The record block is shared (passed by pointer on wasm), so the write persists to the caller.

### 2. Member-rooted in-place-mutator escape (`statements.rs`)
#693 gates the loop / function-scope heap reclamation on `expr_writes_outer_heap`, but its mutator check only matched a **bare `Var`** arg. `list.push(t.depth, d)` on a `mut t` — where `t.depth` is a `Member` — slipped through, so the reclamation freed the field buffer the push had grown (after fix 1 made the push persist, `push_node` trapped out-of-bounds reading reclaimed memory). Walk the member/index chain to its root var.

### 3. Transitive `mut`-param escape (`statements.rs`, `mod.rs`)
A loop that grows an outer record **through a callee's `mut` parameter** (`op.add(t, …)` on a `mut t: Tape`) was invisible to the escape scan — the mutation is a frame down. Collect each function's per-param `mut` flags into `emitter.mut_param_sigs` (keyed `name` / `module::func`) and flag a call that hands an outer-scope var into a `mut` slot. Precise: `Ref`/by-value params keep the arena optimization.

## Tests
- `mut_record_field_test.almd` — drops its `// wasm:skip`, now runs **cross-target**.
- `loop_arena_escape_test.almd` (new) — the escape regression (Member field push in a `mut`-param fn + a loop growing an outer record through it), **cross-target**.
- `mut_list_param_test.almd` (new) — the still-divergent bare `mut List` *param* case under `// wasm:skip` (pointer in a non-addressable wasm local; needs the by-ref `mut` ABI, tracked in #705).

`almide test spec/` — 274 files green; `cargo test` incl. `wasm_cross_target_spec` green.

## Note (separate, follow-up)
This surfaced an independent pre-existing bug that #703 newly makes reachable: pushing into a **local `var`'s** record field inside a loop (`var b: Box; while … { list.push(b.xs, i) }`) yields `len 0` on **both** native and wasm — distinct from this `mut`-param fix. Will file separately.
