### PR TITLE
LICM: don't hoist a stdlib in-place mutator's receiver out of a loop (fix #712)

### DIFF
--- a/crates/almide-codegen/src/pass_licm.rs
+++ b/crates/almide-codegen/src/pass_licm.rs
@@ -374,20 +374,61 @@ fn collect_defined_vars_expr(expr: &IrExpr, defined: &mut HashSet<VarId>, mm: &M
         // caller-side Var as defined so LICM doesn't wrongly hoist
         // something that depends on it.
         IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. } => {
+            // A mutated arg's heap backing is written in place; if that arg (or a
+            // place rooted at it) is hoisted out of the loop as a CLONE, the
+            // mutation is lost. Two mutator sources:
+            //   - user fns: per-param `mut` flags in the MutationMap (`mm`).
+            //   - stdlib in-place mutators (`list.push`, `map.insert`, …): args[0],
+            //     keyed by the mangled runtime symbol — the MutationMap only
+            //     covers user fns, so without this `list.push(b.xs, …)` had `b.xs`
+            //     hoisted to a clone and never grew `b.xs` (#712, after #703 made
+            //     a `var`/`mut` record field a legal mutator target).
+            let stdlib_sym = format!("almide_rt_{}_{}", module.as_str(), func.as_str());
+            let stdlib_mutates_arg0 =
+                crate::pass_closure_conversion::is_inplace_mutator(&stdlib_sym);
             for (i, arg) in args.iter().enumerate() {
-                if let IrExprKind::Var { id } = &arg.kind {
-                    if mm.get(&(*module, *func)).map_or(false, |mp| mp.contains(&i)) {
+                let mutated = (i == 0 && stdlib_mutates_arg0)
+                    || mm.get(&(*module, *func)).map_or(false, |mp| mp.contains(&i));
+                if mutated {
+                    // Mark the ROOT var (bare `out`, or `b` in `b.xs` / `b[i]`)
+                    // loop-variant so LICM never hoists an expression depending
+                    // on it.
+                    let mut root = &arg.kind;
+                    while let IrExprKind::Member { object, .. }
+                        | IrExprKind::TupleIndex { object, .. }
+                        | IrExprKind::IndexAccess { object, .. } = root {
+                        root = &object.kind;
+                    }
+                    if let IrExprKind::Var { id } = root {
                         defined.insert(*id);
                     }
                 }
             }
         }
-        // Explicit-preserve: only the scopes/loops/mutating-Module-calls above
-        // define variables relevant to LICM. Every other node (including Call
-        // with a non-Module target) defines nothing. Listing each variant
-        // turns a new IrExprKind into a compile error instead of a silent miss.
+        // The wasm pipeline lowers `list.push` etc. to RuntimeCall BEFORE LICM,
+        // so the Module arm above never sees them — handle the same stdlib
+        // in-place-mutator escape here (#712 wasm: without it `b.xs` was hoisted
+        // to a clone and the push never grew `b.xs`, so the loop read len 0).
+        IrExprKind::RuntimeCall { symbol, args } => {
+            if crate::pass_closure_conversion::is_inplace_mutator(symbol.as_str()) {
+                if let Some(arg0) = args.first() {
+                    let mut root = &arg0.kind;
+                    while let IrExprKind::Member { object, .. }
+                        | IrExprKind::TupleIndex { object, .. }
+                        | IrExprKind::IndexAccess { object, .. } = root {
+                        root = &object.kind;
+                    }
+                    if let IrExprKind::Var { id } = root {
+                        defined.insert(*id);
+                    }
+                }
+            }
+        }
+        // Explicit-preserve: only the scopes/loops/mutating calls above define
+        // variables relevant to LICM. Every other node (including Call with a
+        // non-Module target) defines nothing. Listing each variant turns a new
+        // IrExprKind into a compile error instead of a silent miss.
         IrExprKind::Call { .. } | IrExprKind::TailCall { .. }
-        | IrExprKind::RuntimeCall { .. }
         | IrExprKind::LitInt { .. } | IrExprKind::LitFloat { .. }
         | IrExprKind::LitStr { .. } | IrExprKind::LitBool { .. }
         | IrExprKind::Unit | IrExprKind::Var { .. } | IrExprKind::FnRef { .. }

--- a/spec/lang/loop_localvar_field_push_test.almd
+++ b/spec/lang/loop_localvar_field_push_test.almd
@@ -1,0 +1,49 @@
+// Regression (#712): `list.push` into a LOCAL `var`'s record field inside a loop
+// must accumulate. LICM treated the member access `b.xs` as loop-invariant and
+// hoisted it out as a CLONE (`let __licm = b.xs.clone()`), so the push grew the
+// discarded clone and `b.xs` stayed empty (`len 0`) — on BOTH targets. The push
+// receiver is a stdlib in-place mutator's args[0]; LICM now marks its root var
+// loop-variant (in both the Module-call and wasm RuntimeCall forms), so the
+// member is never hoisted. This became reachable after #703 made a `var`/`mut`
+// record field a legal `list.push` target. Runs on BOTH targets.
+
+type Box = { xs: List[Int] }
+
+fn build(n: Int) -> Box = {
+  var b: Box = { xs: [] }
+  var i = 0
+  while i < n {
+    list.push(b.xs, i * i)
+    i = i + 1
+  }
+  b
+}
+
+test "list.push into a local var's record field accumulates across a loop (#712)" {
+  let b = build(5)
+  assert(list.len(b.xs) == 5)
+  assert(b.xs[0] == 0)
+  assert(b.xs[2] == 4)
+  assert(b.xs[4] == 16)
+}
+
+// Two parallel fields grown in the same loop (a record arena shape).
+type Pair = { a: List[Int], b: List[Int] }
+
+fn build_pair(n: Int) -> Pair = {
+  var p: Pair = { a: [], b: [] }
+  var i = 0
+  while i < n {
+    list.push(p.a, i)
+    list.push(p.b, n - i)
+    i = i + 1
+  }
+  p
+}
+
+test "two local-var record fields grown in one loop (#712)" {
+  let p = build_pair(4)
+  assert(list.len(p.a) == 4 and list.len(p.b) == 4)
+  assert(p.a[0] == 0 and p.a[3] == 3)
+  assert(p.b[0] == 4 and p.b[3] == 1)
+}


### PR DESCRIPTION
Fixes **#712**: `list.push` into a LOCAL `var`'s record field inside a loop dropped every element — `list.len` read **0** — on **both** native and wasm.

```almide
type Box = { xs: List[Int] }
effect fn main() -> () = {
  var b: Box = { xs: [] }
  var i = 0
  while i < 5 { list.push(b.xs, i); i = i + 1 }
  println(int.to_string(list.len(b.xs)))   // was 0, expected 5
}
```

## Root cause

LICM treated the member access `b.xs` as loop-invariant and hoisted it out as a **clone**:

```rust
let mut __licm = b.xs.clone();     // hoisted
while … { almide_rt_list_push(&mut __licm, i); … }   // grows the discarded clone
… list.len(&b.xs) …                // b.xs still empty → 0
```

LICM's `collect_defined_vars` marks a *mutated* call argument's root var as loop-variant so dependent expressions aren't hoisted — but it only did so for **bare-`Var`** args via the `MutationMap`, and the `MutationMap` is built from **user fns only**. A stdlib mutator's **member** arg (`b.xs`) was invisible: not a bare Var, and `list.push` isn't in the map. So `b` was never marked variant and `b.xs` got hoisted.

(Reachable only since #703 made a `var`/`mut` record field a legal `list.push` target — before that the checker rejected `list.push(b.xs, …)`.)

## Fix

Recognize stdlib in-place mutators by their runtime symbol (`is_inplace_mutator`) and mark `args[0]`'s **root var** loop-variant — walking the member/index chain to the root — in **both** call forms:

- **Module call** (`CallTarget::Module { "list", "push" }`) — the native pipeline's form at LICM time.
- **RuntimeCall** (`almide_rt_list_push`) — the wasm pipeline lowers `list.push` to a RuntimeCall *before* LICM, so the Module arm never saw it (this is why the first cut fixed native but not wasm).

Conservative — it only **adds** vars to the loop-variant set, forgoing a hoist; never incorrect.

## Tests

`spec/lang/loop_localvar_field_push_test.almd` (new) — local-var record-field push in a loop, plus two parallel fields grown in one loop; **cross-target**. `almide test spec/` (274) green; `cargo test -p almide-codegen` (107 LICM/codegen) green.
