### PR TITLE
Reject String [] indexing at check with E026 (fix #558)

### DIFF
--- a/crates/almide-frontend/src/check/infer.rs
+++ b/crates/almide-frontend/src/check/infer.rs
@@ -513,6 +513,20 @@ impl Checker {
                         Ty::Applied(TypeConstructorId::List, args) if args.len() == 1 => args[0].clone(),
                         Ty::Applied(TypeConstructorId::Map, args) if args.len() == 2 => Ty::option(args[1].clone()),
                         Ty::Bytes => Ty::Int,
+                        // A String has no `[]` indexing — it is a UTF-8 codepoint
+                        // sequence, not a byte/char array. Without this arm the
+                        // type fell to `Unknown`, the checker passed, and codegen
+                        // emitted a `[COMPILER BUG] unresolved IndexAccess` blamed
+                        // on the user (#558). Reject at check with a hint to the
+                        // codepoint-indexed stdlib accessors.
+                        Ty::String => {
+                            self.emit(super::err(
+                                "cannot index a String with `[]`",
+                                "a String is a UTF-8 codepoint sequence, not an array — use `string.get(s, i)` (returns `Option[String]`) or `string.char_at(s, i)`",
+                                "string index",
+                            ).with_code("E026"));
+                            Ty::Unknown
+                        }
                         _ => Ty::Unknown,
                     }
                 }

--- a/docs/diagnostics/E026.md
+++ b/docs/diagnostics/E026.md
@@ -1,0 +1,25 @@
+# E026 — cannot index a String with `[]`
+
+A `String` is a sequence of UTF-8 codepoints, not a byte or character array, so
+it has no `[]` element-indexing. Writing `s[i]` used to type-check as `Unknown`
+(the checker had no `String` case for index access), so `check` passed and both
+backends then emitted a `[COMPILER BUG] unresolved IndexAccess` blamed on the
+user. It is now rejected at check time.
+
+```almide
+fn main() -> Unit = {
+  let s = "hello"
+  println(s[1])            // ← E026
+}
+```
+
+## Fix
+
+Use the codepoint-indexed stdlib accessors:
+
+```almide
+let c = string.get(s, 1) ?? ""   // Option[String] — empty if out of range
+let c = string.char_at(s, 1)     // String (one codepoint)
+```
+
+Range slicing is supported and unaffected: `s[0..3]` yields a substring.

--- a/llms.txt
+++ b/llms.txt
@@ -173,6 +173,7 @@ let root_i = float.to_int(root_f)    // truncating
 | E023 | Derived `Codec`/`Ord`/`Hash` not satisfied by a field type | Add `: P` to the offending field type (every field of a `: P` type must itself be `P`) — or hand-write `Type.encode`/`decode` for Codec |
 | E024 | Integer literal out of range for its type (would silently fold to 0) | Use a literal within the type's range; for large magnitudes use `UInt64` (or `Float`, lossy); `-9223372036854775808` (i64::MIN) is valid |
 | E025 | Cannot infer a concrete type — an undecidable type slot (e.g. the error type of a value that is always `ok(...)`) was never pinned | Annotate the binding with its full type (`let r: Result[Int, String] = ...`); an unconstrained slot is an error even if never constructed, never silently defaulted |
+| E026 | `[]` indexing on a String (a UTF-8 codepoint sequence, not a byte/char array) | Use `string.get(s, i)` (returns `Option[String]`) or `string.char_at(s, i)`; range slicing `s[a..b]` is fine |
 | E420 | Function visibility violation (callee is private) | Make the callee public, or add a public shim |
 
 A rustc 4-digit code (`error[E0XXX]`) leaking through always indicates

--- a/tests/diagnostics/e026-string-index/broken.almd
+++ b/tests/diagnostics/e026-string-index/broken.almd
@@ -1,0 +1,9 @@
+// Indexing a String with `[]` is not supported — a String is a UTF-8 codepoint
+// sequence, not a byte/char array. The checker used to type this as `Unknown`
+// (check-clean), and BOTH backends then emitted a `[COMPILER BUG] unresolved
+// IndexAccess` blamed on the user. E026 rejects it at check with a hint to the
+// codepoint-indexed accessors. (#558)
+effect fn main() -> () = {
+  let s = "hello"
+  println(s[1])
+}

--- a/tests/diagnostics/e026-string-index/fixed.almd
+++ b/tests/diagnostics/e026-string-index/fixed.almd
@@ -1,0 +1,5 @@
+// The fix: use the codepoint-indexed stdlib accessor.
+effect fn main() -> () = {
+  let s = "hello"
+  println(string.get(s, 1) ?? "")
+}

--- a/tests/diagnostics/e026-string-index/meta.toml
+++ b/tests/diagnostics/e026-string-index/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E026"
+expects_error = "cannot index a String"
+hint_substring = "string.get"


### PR DESCRIPTION
Closes **#558**. Of the six "checker accepts, the backends fail differently" shapes, **five were already fixed** on develop (verified by repro) and **one remained** — this PR fixes it.

## Verified already fixed (no longer reproduce)
- Named args bound by name vs position — `f(1, c: "boom")` is now caught at check; `f(1, c: 5)` with defaults works (native+wasm = 6).
- UFCS default-arg fill — `5.add()` with `add(a, b: Int = 10)` → 15.
- Calling a non-function value — `let n = 5; n(3)` is now a checker error.
- auto-? exemption for `error.*` — `error.context(inner(3), "ctx")` works cross-target.
- Generic `+` on a TypeVar — `dup[T](x) = x + x` works for String ("abab") and Int (6).

## Fixed here: String `[]` indexing (E026)
`s[i]` on a String typed as `Unknown` in the checker (the IndexAccess inference had List / Map / Bytes arms but no String arm → `Unknown`), so the check passed and **both** backends emitted `[COMPILER BUG] unresolved IndexAccess` — a compiler-internal error blamed on the user.

A String is a UTF-8 codepoint sequence, not a byte/char array, so `[]` indexing has no meaning. Now rejected at check with **E026** + a hint to `string.get(s, i)` / `string.char_at(s, i)`:

```
error[E026]: cannot index a String with `[]`
  hint: a String is a UTF-8 codepoint sequence, not an array —
        use `string.get(s, i)` (returns `Option[String]`) or `string.char_at(s, i)`
```

Range slicing `s[a..b]` is unaffected (it takes the earlier `is_range` branch).

## Tests
`tests/diagnostics/e026-string-index/` (broken + fixed + meta.toml). `almide test spec/` 275 green; the diagnostic harness validates the code/message/hint.
