### PR TITLE
Copy the ok payload in error.context on WASM so it never aliases args[0] (fix #591)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/calls.rs
+++ b/crates/almide-codegen/src/emit_wasm/calls.rs
@@ -651,17 +651,43 @@ impl FuncCompiler<'_> {
                     }
                     ("error", "context") => {
                         // error.context(result, msg) → Result[T, String]
-                        // If err: wrap error message with context. If ok: pass through.
+                        // err branch: wrap the message with context. ok branch: COPY
+                        // the payload into a FRESH Result. Returning args[0]'s pointer
+                        // directly would alias a box the caller still owns and Decs;
+                        // Perceus then drops BOTH the arg temp and this result (the
+                        // same pointer on the ok path) — a double-free that a later
+                        // `??`/`match` reads as garbage (#591). A fresh copy makes the
+                        // two Decs free two distinct allocations, exactly as the err
+                        // branch already does. A heap ok payload is rc_inc'd so it
+                        // survives the arg temp's recursive free.
+                        let ok_ty = args[0].ty.result_ok_ty().unwrap_or(Ty::Int);
+                        let ok_has_val = values::ty_to_valtype(&ok_ty).is_some();
+                        let ok_is_heap = crate::pass_perceus::is_heap_type(&ok_ty);
+                        let ok_alloc = 4 + values::byte_size(&ok_ty) as i32;
                         let s = self.scratch.alloc_i32();
                         let s1 = self.scratch.alloc_i32();
                         let s2 = self.scratch.alloc_i32();
                         let s3 = self.scratch.alloc_i32();
+                        let nw = self.scratch.alloc_i32();
                         self.emit_expr(&args[0]);
                         wasm!(self.func, {
                             local_set(Local(s));
                             local_get(Local(s)); i32_load(0); i32_eqz; // tag == 0 (ok)?
                             if_i32;
-                              local_get(Local(s)); // pass ok through
+                              // ok: fresh [tag=0][payload] copy — never alias args[0]
+                              i32_const(Imm32(ok_alloc)); call(self.emitter.rt.alloc); local_set(Local(nw));
+                              local_get(Local(nw)); i32_const(Imm32(0)); i32_store(0);
+                        });
+                        if ok_has_val {
+                            wasm!(self.func, { local_get(Local(nw)); local_get(Local(s)); });
+                            self.emit_load_at(&ok_ty, 4);
+                            if ok_is_heap {
+                                wasm!(self.func, { call(self.emitter.rt.rc_inc); });
+                            }
+                            self.emit_store_at(&ok_ty, 4);
+                        }
+                        wasm!(self.func, {
+                              local_get(Local(nw)); // return the fresh ok copy
                             else_;
                               // Build new err with context: "msg: original_err"
                               local_get(Local(s)); i32_load(4); local_set(Local(s1)); // original err string
@@ -686,6 +712,7 @@ impl FuncCompiler<'_> {
                               local_get(Local(s));
                             end;
                         });
+                        self.scratch.free_i32(nw);
                         self.scratch.free_i32(s3);
                         self.scratch.free_i32(s2);
                         self.scratch.free_i32(s1);

--- a/spec/stdlib/error_extra_test.almd
+++ b/spec/stdlib/error_extra_test.almd
@@ -33,3 +33,46 @@ test "error.context on ok" {
   let r2 = error.context(r, "loading config");
   assert_eq(r2.unwrap_or(0), 42)
 }
+
+// ── #591: error.context on ok must COPY, not alias args[0] ──
+// The WASM emit used to return args[0]'s pointer on the ok branch. With a
+// function-produced Result, Perceus owns and Decs that arg temp right after
+// the call, so the aliased result was a freed pointer — `??` read garbage
+// (native `3`, wasm a giant int + trap). A fresh copy fixes it. The literal
+// `ok(42)` case above missed this: its value survived in the freed block.
+fn ctx_inner(x: Int) -> Result[Int, String] = ok(x)
+fn ctx_load(s: String) -> Result[String, String] = ok("<" + s + ">")
+
+test "error.context ok via ?? on a function-produced Result (#591)" {
+  let m: Result[Int, String] = error.context(ctx_inner(3), "loading");
+  assert_eq(m ?? 99, 3)
+}
+
+test "error.context ok via match on a function-produced Result (#591)" {
+  let v = match error.context(ctx_inner(7), "loading") {
+    ok(n) => n,
+    err(_) => -1,
+  };
+  assert_eq(v, 7)
+}
+
+test "error.context ok with a heap payload survives (#591)" {
+  let r: Result[String, String] = error.context(ctx_load("data"), "ctx");
+  assert_eq(r ?? "none", "<data>");
+  let v = match error.context(ctx_load("x"), "ctx") {
+    ok(s) => s,
+    err(_) => "",
+  };
+  assert_eq(v, "<x>")
+}
+
+test "error.context ok accumulates in a loop without leaking (#591)" {
+  var i = 0;
+  var total = 0;
+  while i < 50 {
+    let r: Result[Int, String] = error.context(ctx_inner(i), "iter");
+    total = total + (r ?? 0);
+    i = i + 1;
+  };
+  assert_eq(total, 1225)
+}


### PR DESCRIPTION
## Problem (#591)

On WASM, `error.context(r, msg)` produced wrong/garbled output when `r` was `ok(...)` and the result was read with `??`:

```almide
import error
fn inner(x: Int) -> Result[Int, String] = ok(x)
effect fn main() -> Unit = {
  let m: Result[Int, String] = error.context(inner(3), "loading")
  println(int.to_string(m ?? 99))   // native: 3 | wasm: garbage int + trap
}
```

`match` happened to read the value correctly, but `??` returned garbage (e.g. `219043332097`) and then trapped (`failed to run main module`).

## Root cause

The WASM emit returned **args[0]'s pointer directly** on the ok branch (`local_get(s)` — a pass-through). With a function-produced Result, Perceus owns that arg temp and inserts its `Dec` right after the call. On the ok path the returned result *is* that same pointer, so Perceus emits **two drops of one allocation** (the arg temp, then the result) — a double-free. The freed block is then read by `??` as garbage.

The existing `error.context on ok` spec test missed this because it used a literal `ok(42)` whose value survived in the freed block; only a function-produced Result (a distinct heap temp Perceus eagerly frees) exposes the use-after-free.

## Fix (WASM-codegen only)

The ok branch now **copies the payload into a fresh `Result`**, exactly as the err branch already builds a fresh one — so the two Decs free two distinct allocations. A heap ok payload is `rc_inc`'d so it survives the arg temp's recursive free. No Perceus changes.

## Verification

- Repro + `match`/`??` + heap-payload (`Result[String,String]`) + a 1000-iteration loop: **native == wasm, byte-identical**.
- The strict **Perceus RC gate** passes on both ok and err paths (loops build without `--emit-unverified` — no leak, no double-free).
- `almide test spec/`: **275/275 files green** via WASM.
- New regression cases in `spec/stdlib/error_extra_test.almd` covering the exact `??`-on-function-produced-Result shape, a heap payload, and a loop.
- `cargo test -p almide-codegen`: 107/0.