### PR TITLE
Recompute if/match/block type after auto-? unwraps an effect branch (fix #717)

### DIFF
--- a/crates/almide-frontend/src/lower/auto_try.rs
+++ b/crates/almide-frontend/src/lower/auto_try.rs
@@ -485,7 +485,23 @@ fn insert_try(expr: IrExpr, in_match_subject: bool, ctx: &mut TryCtx) -> IrExpr 
         other => other,
     };
 
-    let mut result = IrExpr { kind, ty: ty.clone(), span, def_id: None };
+    // #717: an `if`/`match`/tail-`block` YIELDS its branch type. The checker
+    // lifts an effect-fn-call branch to `Result[T, String]`, so the whole node
+    // inherits that Result type — but `insert_try` above just auto-?'d those
+    // branches down to `T`. Recompute the node type from the (now-unwrapped)
+    // branches so a `let pick = if c then eff() else pure()` binding gets `T`,
+    // not the stale `Result[T]` (which then emitted `Result<T>` = `?`-branches,
+    // an E0308 type mismatch). Pure / genuinely-Result branches are unchanged:
+    // their branch types already equal the original node type.
+    let node_ty = match &kind {
+        IrExprKind::If { then, else_, .. } if then.ty == else_.ty => then.ty.clone(),
+        IrExprKind::Match { arms, .. }
+            if !arms.is_empty() && arms.iter().all(|a| a.body.ty == arms[0].body.ty)
+            => arms[0].body.ty.clone(),
+        IrExprKind::Block { expr: Some(tail), .. } => tail.ty.clone(),
+        _ => ty.clone(),
+    };
+    let mut result = IrExpr { kind, ty: node_ty, span, def_id: None };
 
     if should_wrap {
         let inner_ty = match &ty {
@@ -537,11 +553,14 @@ fn insert_try_stmt(stmt: IrStmt, ctx: &mut TryCtx) -> IrStmt {
                         span, def_id: None,
                     };
                 }
-                let new_ty = if matches!(&new_value.kind, IrExprKind::Try { .. }) {
-                    new_value.ty.clone()
-                } else {
-                    ty
-                };
+                // The binding type IS the value's type. A top-level Try unwraps
+                // Result→T; an `if`/`match`/block whose effect branches were just
+                // auto-?'d likewise now yields T (its node type was recomputed
+                // above, #717). Either way `new_value.ty` is authoritative — the
+                // old `else { ty }` kept the stale effect-lifted `Result[T]` for
+                // those non-Try forms, emitting `Result<T>` over `?`-branches.
+                let _ = ty;
+                let new_ty = new_value.ty.clone();
                 // Keep the var table in sync with the unwrap: a later
                 // `v = effectCall()` reads this entry to decide its own
                 // wrap/strip, so a stale Result type would invert that rule.

--- a/spec/lang/effect_if_value_test.almd
+++ b/spec/lang/effect_if_value_test.almd
@@ -1,0 +1,93 @@
+// Regression (#717): an effect-fn call inside an `if`/`match` expression that is
+// USED AS A VALUE (bound by `let`) inside an EFFECT FN must lower correctly. The
+// checker lifts an effect-call branch to `Result[T, String]`, so the whole
+// `if`/`match` inherited that Result type; auto-? then unwrapped the branches to
+// `T` but left the node (and its `let` binding) typed `Result[T]`. Native emitted
+// `let x: Result<T, String> = if c { (eff())? } else { pure() }` — a `?`-over-Vec
+// vs Result<Vec> mismatch (E0308, "codegen produced invalid Rust"). The node type
+// is now recomputed from the unwrapped branches. (auto-? runs in effect fns, not
+// `test` blocks, so the pattern lives in effect fns the tests call.) BOTH targets.
+
+fn pure_one() -> List[Int] = [1, 1]
+effect fn eff_two() -> List[Int] = [2, 2, 2]
+effect fn eff_three() -> List[Int] = [3, 3, 3, 3]
+
+// effect call + pure branch, if-value bound by let
+effect fn pick_mixed(cond: Bool) -> Result[Int, String] = {
+  let pick = if cond then eff_two() else pure_one()
+  ok(list.len(pick))
+}
+
+// effect calls on BOTH branches
+effect fn pick_both(cond: Bool) -> Result[Int, String] = {
+  let pick = if cond then eff_two() else eff_three()
+  ok(list.len(pick))
+}
+
+// effect call in a match-value bound by let
+effect fn pick_match(n: Int) -> Result[Int, String] = {
+  let pick = match n {
+    2 => eff_two(),
+    _ => pure_one(),
+  }
+  ok(list.len(pick))
+}
+
+// effect call in a block-tail if bound by let
+effect fn pick_block(cond: Bool) -> Result[Int, String] = {
+  let pick = {
+    let _warm = pure_one()
+    if cond then eff_two() else eff_three()
+  }
+  ok(list.len(pick))
+}
+
+test "effect call in if-value bound by let, mixed with a pure branch (#717)" {
+  assert_eq(pick_mixed(true), ok(3))
+  assert_eq(pick_mixed(false), ok(2))
+}
+
+test "effect calls on BOTH if branches bound by let (#717)" {
+  assert_eq(pick_both(true), ok(3))
+  assert_eq(pick_both(false), ok(4))
+}
+
+test "effect call in a match-value bound by let (#717)" {
+  assert_eq(pick_match(2), ok(3))
+  assert_eq(pick_match(9), ok(2))
+}
+
+test "effect call in a block-tail if bound by let (#717)" {
+  assert_eq(pick_block(true), ok(3))
+  assert_eq(pick_block(false), ok(4))
+}
+
+// Error propagation through the if-value must still short-circuit `err` out of
+// the enclosing effect fn (the auto-? on the chosen branch stays load-bearing).
+effect fn boom(x: Int) -> Result[Int, String] =
+  if x < 0 then err("neg") else ok(x)
+
+effect fn via_if(x: Int) -> Result[Int, String] = {
+  let v = if x > 10 then boom(x) else boom(0 - 1)
+  ok(v + 100)
+}
+
+test "effect propagation through an if-value still short-circuits err (#717)" {
+  assert_eq(via_if(20), ok(120))
+  assert_eq(via_if(5), err("neg"))
+}
+
+// An explicitly Result-annotated binding must KEEP its Result (not be unwrapped
+// by the node-type recompute) — guards against over-correction.
+effect fn annotated(cond: Bool) -> Result[Int, String] = {
+  let r: Result[Int, String] = if cond then ok(7) else err("x")
+  match r {
+    ok(v) => ok(v),
+    err(e) => err(e),
+  }
+}
+
+test "annotated Result binding over an if stays a Result (#717)" {
+  assert_eq(annotated(true), ok(7))
+  assert_eq(annotated(false), err("x"))
+}


### PR DESCRIPTION
## Problem (#717)

An `effect fn` call used as a **value** inside an `if`/`match` expression bound by `let` made `almide build` emit invalid Rust (*"codegen produced invalid Rust — this is an Almide bug"*):

```almide
fn pure_one() -> List[Int] = [1]
effect fn eff_two() -> List[Int] = [2]
effect fn main() -> Unit = {
  let cond = true
  let pick = if cond then eff_two() else pure_one()
  println(int.to_string(list.len(pick)))
}
```

```rust
// generated:
let pick: Result<Vec<i64>, String> = if cond { (eff_two())? } else { (pure_one()) };
// error[E0308]: `?` operator has incompatible types — Result<Vec> vs Vec
```

## Root cause

The checker types an effect-fn call as `Result[T, String]`, so the whole `if`/`match` node inherited that Result type. `insert_auto_try` then wrapped the effect branches in `Try` — unwrapping each to `T` — but left the **node** (and the `let` binding that reads it) typed `Result[T]`. So the binding annotation said `Result<Vec>` while the value (the `if` with `?`-unwrapped branches) was `Vec`.

## Fix (frontend `auto_try`, lowering)

After `insert_auto_try` processes the branches:

1. An `if`/`match`/tail-`block` node **recomputes its type from its (now-unwrapped) branches**, so it reflects the value it actually yields.
2. A non-`Try` `let` binding takes the **value's** type rather than the stale checker type.

Both only change a type when a branch was actually unwrapped — pure branches and genuinely-`Result` branches keep their type.

## Verification

- Repro + all-effect-branches + `match`-value + block-tail forms: **native == wasm**.
- Error propagation through the branch still short-circuits `err` out of the enclosing effect fn.
- An explicitly `Result`-annotated binding over an `if` still stays a `Result` (no over-unwrap).
- **All 13 codegen snapshots unchanged** — existing effect-fn codegen is untouched.
- `almide test spec/`: **276/276 files green** (new `spec/lang/effect_if_value_test.almd`); `cargo test -p almide-frontend` green.