### PR TITLE
Match nested constructor patterns through a Box on native (fix #610)

### DIFF
--- a/crates/almide-codegen/src/pass_box_deref.rs
+++ b/crates/almide-codegen/src/pass_box_deref.rs
@@ -393,9 +393,8 @@ impl IrVisitor for DerefCollector<'_> {
             };
             if let Some(ref ename) = enum_name {
                 if self.recursive_enums.contains(ename.as_str()) {
-                    let td = self.type_decls.iter().find(|td| *ename == td.name);
                     for arm in arms {
-                        collect_deref_from_pattern(&arm.pattern, self.recursive_enums, td, self.name_to_var, self.deref_vars);
+                        collect_deref_from_pattern(&arm.pattern, self.recursive_enums, self.type_decls, self.name_to_var, self.deref_vars);
                     }
                 }
             }
@@ -415,17 +414,27 @@ fn find_variant_case<'a>(td: Option<&'a IrTypeDecl>, ctor_name: &str) -> Option<
     cases.iter().find(|c| c.name == ctor_name).map(|c| &c.kind)
 }
 
-fn collect_deref_from_pattern(pattern: &IrPattern, recursive: &HashSet<String>, td: Option<&IrTypeDecl>, name_to_var: &std::collections::HashMap<String, Vec<VarId>>, deref_vars: &mut HashSet<VarId>) {
+/// Find the variant type-decl that DECLARES constructor `ctor` — lets a nested
+/// constructor resolve to its OWN enum (which may differ from the outer one under
+/// mutual recursion), so each field's box-ness is judged against the right decl.
+fn find_td_for_ctor<'a>(type_decls: &'a [IrTypeDecl], ctor: &str) -> Option<&'a IrTypeDecl> {
+    type_decls.iter().find(|td| matches!(&td.kind,
+        IrTypeDeclKind::Variant { cases, .. } if cases.iter().any(|c| c.name == ctor)))
+}
+
+fn collect_deref_from_pattern(pattern: &IrPattern, recursive: &HashSet<String>, type_decls: &[IrTypeDecl], name_to_var: &std::collections::HashMap<String, Vec<VarId>>, deref_vars: &mut HashSet<VarId>) {
     match pattern {
         IrPattern::Constructor { name, args } => {
+            let td = find_td_for_ctor(type_decls, name.as_str());
             let Some(IrVariantKind::Tuple { fields }) = find_variant_case(td, name) else { return };
             // A field bound here is Box'd iff it references ANY cycle member, so
             // the deref must use the SAME predicate as the Box-rendering site (#656).
             args.iter().enumerate()
                 .filter(|(i, _)| fields.get(*i).map_or(false, |ft| walker::ty_contains_any_recursive(ft, recursive)))
-                .for_each(|(_, arg)| collect_bind_vars(arg, deref_vars));
+                .for_each(|(_, arg)| mark_boxed_field_pattern(arg, recursive, type_decls, name_to_var, deref_vars));
         }
         IrPattern::RecordPattern { name, fields, .. } => {
+            let td = find_td_for_ctor(type_decls, name.as_str());
             let Some(IrVariantKind::Record { fields: case_fields }) = find_variant_case(td, name) else { return };
             for field_pat in fields {
                 let is_recursive = case_fields.iter()
@@ -434,7 +443,7 @@ fn collect_deref_from_pattern(pattern: &IrPattern, recursive: &HashSet<String>, 
                 if !is_recursive { continue; }
 
                 if let Some(ref p) = field_pat.pattern {
-                    collect_bind_vars(p, deref_vars);
+                    mark_boxed_field_pattern(p, recursive, type_decls, name_to_var, deref_vars);
                 } else if let Some(var_ids) = name_to_var.get(&field_pat.name) {
                     // Shorthand: lookup VarId by name, only if unambiguous
                     if var_ids.len() == 1 {
@@ -447,12 +456,17 @@ fn collect_deref_from_pattern(pattern: &IrPattern, recursive: &HashSet<String>, 
     }
 }
 
-fn collect_bind_vars(pattern: &IrPattern, deref_vars: &mut HashSet<VarId>) {
-    match pattern {
+/// A pattern occupying a BOXED field position. A var bound here aliases the box
+/// itself, so it derefs on use. But a NESTED constructor/record matches THROUGH
+/// the box — its OWN inner fields must be re-gated by their declared types, never
+/// blanket-marked: `Node(Leaf(a), _)`'s `a: Int` is not boxed and must not get a
+/// spurious `*a` (the #610 E0614). Recursing via `collect_deref_from_pattern`
+/// re-applies the box predicate at each level (and re-resolves the enum decl).
+fn mark_boxed_field_pattern(pat: &IrPattern, recursive: &HashSet<String>, type_decls: &[IrTypeDecl], name_to_var: &std::collections::HashMap<String, Vec<VarId>>, deref_vars: &mut HashSet<VarId>) {
+    match pat {
         IrPattern::Bind { var, .. } => { deref_vars.insert(*var); }
-        IrPattern::Constructor { args, .. } => {
-            for a in args { collect_bind_vars(a, deref_vars); }
-        }
+        IrPattern::Constructor { .. } | IrPattern::RecordPattern { .. } =>
+            collect_deref_from_pattern(pat, recursive, type_decls, name_to_var, deref_vars),
         _ => {}
     }
 }

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -540,6 +540,207 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
     }
 }
 
+// ── #610: nested constructor patterns through a `Box` ──
+//
+// Rust cannot pattern-match through a `Box` on stable (box-patterns are
+// unstable). A nested constructor on a BOXED recursive field —
+// `Node(Leaf(a), Leaf(b))` where `Node`'s fields are `Box<Tree>` — used to render
+// `Tree::Node(Tree::Leaf(a), ..)`, which rustc rejects: the field is `Box<Tree>`,
+// not `Tree` (E0308). We rewrite the arm instead:
+//   * each boxed-nested position becomes a fresh `Box` binding in a FLAT pattern,
+//   * a `matches!` shape-guard verifies the nested structure (a non-match falls
+//     through to a later arm — refinement, exactly like the wasm emitter),
+//   * a `let-else` moves the value out of the box in the body and binds the inner
+//     names by value (matching the by-value `*box` convention of simple arms).
+// All stable since 1.65, edition-agnostic, any nesting depth. With no boxed-nested
+// position `unbox_arm_pattern` returns None and the arm renders unchanged.
+
+fn pattern_is_complex(p: &IrPattern) -> bool {
+    matches!(p, IrPattern::Constructor { .. } | IrPattern::RecordPattern { .. })
+}
+
+fn fresh_box_var(counter: &mut usize) -> String {
+    let v = format!("__bx{}", *counter);
+    *counter += 1;
+    v
+}
+
+fn qualify_ctor(ctx: &RenderContext, name: &str, enum_hint: Option<&str>) -> String {
+    let enum_name = enum_hint.map(|s| s.to_string())
+        .or_else(|| ctx.ann.ctor_to_enum.get(name).map(|s| s.to_string()));
+    match enum_name {
+        Some(en) => ctx.templates.render_with("ctor_qualify", None, &[],
+            &[("enum_name", en.as_str()), ("ctor_name", name)])
+            .unwrap_or_else(|| format!("{}::{}", en, name)),
+        None => name.to_string(),
+    }
+}
+
+fn is_boxed_tuple_field(ctx: &RenderContext, ctor: &str, idx: usize) -> bool {
+    ctx.ann.boxed_fields.contains(&(ctor.to_string(), idx.to_string()))
+}
+
+fn is_boxed_record_field(ctx: &RenderContext, ctor: &str, field: &str) -> bool {
+    ctx.ann.boxed_fields.contains(&(ctor.to_string(), field.to_string()))
+}
+
+/// `matches!`-shaped boolean that `access` (a `&Enum`-typed expr) structurally
+/// matches `pat`, deref-ing one box per level. Bindings render as `_`; a deeper
+/// boxed-nested sub-pattern binds a fresh var and recurses through `&**` into the
+/// matches! `if` clause.
+fn box_shape_guard(ctx: &RenderContext, pat: &IrPattern, access: &str, counter: &mut usize) -> String {
+    match pat {
+        IrPattern::Constructor { name, args } => {
+            let qualified = qualify_ctor(ctx, name.as_str(), None);
+            if args.is_empty() {
+                return format!("matches!({}, {})", access, qualified);
+            }
+            let mut shape = Vec::with_capacity(args.len());
+            let mut subs = Vec::new();
+            for (i, arg) in args.iter().enumerate() {
+                if is_boxed_tuple_field(ctx, name.as_str(), i) && pattern_is_complex(arg) {
+                    let g = fresh_box_var(counter);
+                    subs.push(box_shape_guard(ctx, arg, &format!("&**{}", g), counter));
+                    shape.push(g);
+                } else {
+                    shape.push("_".to_string());
+                }
+            }
+            let pat_str = format!("{}({})", qualified, shape.join(", "));
+            if subs.is_empty() {
+                format!("matches!({}, {})", access, pat_str)
+            } else {
+                format!("matches!({}, {} if {})", access, pat_str, subs.join(" && "))
+            }
+        }
+        IrPattern::RecordPattern { name, fields, .. } => {
+            let qualified = qualify_ctor(ctx, name.as_str(), None);
+            let mut shape = Vec::with_capacity(fields.len());
+            let mut subs = Vec::new();
+            for fp in fields {
+                match &fp.pattern {
+                    Some(p) if is_boxed_record_field(ctx, name.as_str(), fp.name.as_str())
+                        && pattern_is_complex(p) =>
+                    {
+                        let g = fresh_box_var(counter);
+                        subs.push(box_shape_guard(ctx, p, &format!("&**{}", g), counter));
+                        shape.push(format!("{}: {}", fp.name, g));
+                    }
+                    _ => shape.push(format!("{}: _", fp.name)),
+                }
+            }
+            let pat_str = format!("{} {{ {}, .. }}", qualified, shape.join(", "));
+            if subs.is_empty() {
+                format!("matches!({}, {})", access, pat_str)
+            } else {
+                format!("matches!({}, {} if {})", access, pat_str, subs.join(" && "))
+            }
+        }
+        // Non-constructor pattern in a boxed position cannot occur (a recursive
+        // field is always a variant); be conservative and impose no constraint.
+        _ => "true".to_string(),
+    }
+}
+
+/// Emit `let <flat pat> = <move_expr> else { unreachable!() };` to move the value
+/// out of its box and bind the inner names by value, recursing for deeper boxes.
+/// The guard has already verified the structure, so `else` is dead.
+fn box_extract(ctx: &RenderContext, pat: &IrPattern, move_expr: &str, binds: &mut Vec<String>, counter: &mut usize) {
+    match pat {
+        IrPattern::Constructor { name, args } => {
+            let qualified = qualify_ctor(ctx, name.as_str(), None);
+            let mut flat = Vec::with_capacity(args.len());
+            let mut deeper: Vec<(String, &IrPattern)> = Vec::new();
+            for (i, arg) in args.iter().enumerate() {
+                if is_boxed_tuple_field(ctx, name.as_str(), i) && pattern_is_complex(arg) {
+                    let e = fresh_box_var(counter);
+                    flat.push(e.clone());
+                    deeper.push((e, arg));
+                } else {
+                    flat.push(render_pattern_hinted(ctx, arg, None));
+                }
+            }
+            let flat_pat = if args.is_empty() { qualified } else { format!("{}({})", qualified, flat.join(", ")) };
+            binds.push(format!("let {} = {} else {{ unreachable!() }};", flat_pat, move_expr));
+            for (e, sub) in deeper {
+                box_extract(ctx, sub, &format!("*{}", e), binds, counter);
+            }
+        }
+        IrPattern::RecordPattern { name, fields, .. } => {
+            let qualified = qualify_ctor(ctx, name.as_str(), None);
+            let mut flat = Vec::with_capacity(fields.len());
+            let mut deeper: Vec<(String, &IrPattern)> = Vec::new();
+            for fp in fields {
+                match &fp.pattern {
+                    Some(p) if is_boxed_record_field(ctx, name.as_str(), fp.name.as_str())
+                        && pattern_is_complex(p) =>
+                    {
+                        let e = fresh_box_var(counter);
+                        flat.push(format!("{}: {}", fp.name, e));
+                        deeper.push((e, p));
+                    }
+                    Some(p) => flat.push(format!("{}: {}", fp.name, render_pattern_hinted(ctx, p, None))),
+                    None => flat.push(fp.name.to_string()),
+                }
+            }
+            binds.push(format!("let {} {{ {}, .. }} = {} else {{ unreachable!() }};", qualified, flat.join(", "), move_expr));
+            for (e, sub) in deeper {
+                box_extract(ctx, sub, &format!("*{}", e), binds, counter);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Rewrite an arm whose top-level variant pattern has a boxed-nested constructor.
+/// Returns `(flat_pattern, shape_guards, body_let_else_binds)` or None if the arm
+/// has no boxed-nested position (the common case → no rewrite).
+fn unbox_arm_pattern(ctx: &RenderContext, pat: &IrPattern, enum_hint: Option<&str>)
+    -> Option<(String, Vec<String>, Vec<String>)>
+{
+    let mut counter = 0usize;
+    let mut guards = Vec::new();
+    let mut binds = Vec::new();
+    let flat = match pat {
+        IrPattern::Constructor { name, args } => {
+            let qualified = qualify_ctor(ctx, name.as_str(), enum_hint);
+            let mut flat = Vec::with_capacity(args.len());
+            for (i, arg) in args.iter().enumerate() {
+                if is_boxed_tuple_field(ctx, name.as_str(), i) && pattern_is_complex(arg) {
+                    let v = fresh_box_var(&mut counter);
+                    guards.push(box_shape_guard(ctx, arg, &format!("&*{}", v), &mut counter));
+                    box_extract(ctx, arg, &format!("*{}", v), &mut binds, &mut counter);
+                    flat.push(v);
+                } else {
+                    flat.push(render_pattern_hinted(ctx, arg, None));
+                }
+            }
+            if args.is_empty() { qualified } else { format!("{}({})", qualified, flat.join(", ")) }
+        }
+        IrPattern::RecordPattern { name, fields, .. } => {
+            let qualified = qualify_ctor(ctx, name.as_str(), enum_hint);
+            let mut flat = Vec::with_capacity(fields.len());
+            for fp in fields {
+                match &fp.pattern {
+                    Some(p) if is_boxed_record_field(ctx, name.as_str(), fp.name.as_str())
+                        && pattern_is_complex(p) =>
+                    {
+                        let v = fresh_box_var(&mut counter);
+                        guards.push(box_shape_guard(ctx, p, &format!("&*{}", v), &mut counter));
+                        box_extract(ctx, p, &format!("*{}", v), &mut binds, &mut counter);
+                        flat.push(format!("{}: {}", fp.name, v));
+                    }
+                    Some(p) => flat.push(format!("{}: {}", fp.name, render_pattern_hinted(ctx, p, None))),
+                    None => flat.push(fp.name.to_string()),
+                }
+            }
+            format!("{} {{ {} }}", qualified, flat.join(", "))
+        }
+        _ => return None,
+    };
+    if guards.is_empty() { None } else { Some((flat, guards, binds)) }
+}
+
 // ── Match arm rendering ──
 
 pub fn render_match_arm(ctx: &RenderContext, arm: &IrMatchArm, match_ty: &almide_lang::types::Ty, subject_ty: &almide_lang::types::Ty) -> String {
@@ -553,22 +754,39 @@ pub fn render_match_arm(ctx: &RenderContext, arm: &IrMatchArm, match_ty: &almide
             => Some(n.as_str()),
         _ => None,
     };
-    let pattern = render_pattern_hinted(ctx, &arm.pattern, enum_hint);
+    // #610: a boxed-nested constructor pattern is rewritten to a flat pattern + a
+    // `matches!` shape-guard + `let-else` box move-outs in the body. None when the
+    // arm has no boxed-nested position (the common case → identical to before).
+    let (pattern, shape_guards, box_binds) = match unbox_arm_pattern(ctx, &arm.pattern, enum_hint) {
+        Some((flat, guards, binds)) => (flat, guards, binds),
+        None => (render_pattern_hinted(ctx, &arm.pattern, enum_hint), Vec::new(), Vec::new()),
+    };
     // err() in a match arm where the match type is NOT Result: early return.
     // This handles `let x: T = match ... { none => err("msg") }` in
     // functions returning Result — the err() doesn't contribute a T value,
     // it exits the function with an error.
-    let body = if matches!(&arm.body.kind, IrExprKind::ResultErr { .. }) && !match_ty.is_result() {
+    let raw_body = if matches!(&arm.body.kind, IrExprKind::ResultErr { .. }) && !match_ty.is_result() {
         format!("return {}", render_expr(ctx, &arm.body))
     } else {
         super::expressions::render_expr_owned(ctx, &arm.body)
     };
-    // Append guard to pattern if present
-    let full_pattern = if let Some(ref guard) = arm.guard {
-        let guard_str = render_expr(ctx, guard);
-        format!("{} if {}", pattern, guard_str)
+    // The box move-outs (`let Tree::Leaf(a) = *__bx0 else …`) run FIRST in the
+    // arm body, then the original body sees the inner bindings.
+    let body = if box_binds.is_empty() {
+        raw_body
     } else {
+        format!("{{ {} {} }}", box_binds.join(" "), raw_body)
+    };
+    // Append guards: the structural shape-guards (which must hold for the rewritten
+    // arm to apply, so a non-match falls through) then any user guard.
+    let mut guard_conds = shape_guards;
+    if let Some(ref guard) = arm.guard {
+        guard_conds.push(render_expr(ctx, guard));
+    }
+    let full_pattern = if guard_conds.is_empty() {
         pattern
+    } else {
+        format!("{} if {}", pattern, guard_conds.join(" && "))
     };
     ctx.templates.render_with("match_arm_inline", None, &[], &[("pattern", full_pattern.as_str()), ("body", body.as_str())])
         .unwrap_or_else(|| format!("_ => _,"))

--- a/spec/lang/nested_boxed_ctor_pattern_test.almd
+++ b/spec/lang/nested_boxed_ctor_pattern_test.almd
@@ -1,0 +1,53 @@
+// Regression (#610): a NESTED constructor pattern on a BOXED recursive-variant
+// field used to emit invalid Rust natively. `Node`'s fields are `Box<Tree>`, so
+// the renderer's `Tree::Node(Tree::Leaf(a), Tree::Leaf(b))` failed rustc — the
+// field is `Box<Tree>`, not `Tree` (E0308) — and box-deref also marked the inner
+// `a: Int` for a spurious `*a` (E0614). `almide check` passed, so it shipped as a
+// native "codegen produced invalid Rust" ICE (wasm was already correct). The arm
+// is now rewritten to a flat pattern + a `matches!` shape-guard + `let-else`
+// box-move-outs, so a non-match still falls through to a later arm. Runs on BOTH
+// targets (native ⇄ wasm must agree).
+
+type Tree = Leaf(Int) | Node(Tree, Tree)
+
+fn sum(t: Tree) -> Int = match t {
+  Leaf(n) => n,
+  Node(Leaf(a), Leaf(b)) => a + b,
+  Node(l, r) => sum(l) + sum(r),
+}
+
+test "nested ctor arm refines, falls through to the general Node arm (#610)" {
+  // direct hit on the nested arm
+  assert(sum(Node(Leaf(5), Leaf(7))) == 12)
+  // left is not a Leaf → falls through to Node(l, r)
+  assert(sum(Node(Node(Leaf(1), Leaf(2)), Leaf(3))) == 6)
+  // both sides non-leaf
+  assert(sum(Node(Node(Leaf(1), Leaf(1)), Node(Leaf(2), Leaf(2)))) == 6)
+  // a bare Leaf
+  assert(sum(Leaf(42)) == 42)
+}
+
+// Depth-2 nesting + a boxed Bind (`r`) inside a nested arm, deref'd on use.
+fn classify(t: Tree) -> String = match t {
+  Node(Leaf(a), Node(Leaf(b), Leaf(c))) => "deep:" + int.to_string(a + b + c),
+  Node(Leaf(a), r) => "left:" + int.to_string(a) + ":" + int.to_string(sum(r)),
+  Leaf(n) => "leaf:" + int.to_string(n),
+  Node(l, r) => "node:" + int.to_string(sum(l) + sum(r)),
+}
+
+test "depth-2 nested pattern and a boxed bind inside a nested arm (#610)" {
+  assert_eq(classify(Leaf(9)), "leaf:9")
+  assert_eq(classify(Node(Leaf(1), Node(Leaf(2), Leaf(3)))), "deep:6")
+  assert_eq(classify(Node(Leaf(4), Leaf(10))), "left:4:10")
+  assert_eq(classify(Node(Node(Leaf(1), Leaf(1)), Leaf(5))), "node:7")
+}
+
+// The pre-existing simple shapes (no nesting) must be untouched.
+fn mirror(t: Tree) -> Tree = match t {
+  Leaf(n) => Leaf(n),
+  Node(l, r) => Node(mirror(r), mirror(l)),
+}
+
+test "non-nested recursive patterns still work (#610 no regression)" {
+  assert(sum(mirror(Node(Leaf(1), Node(Leaf(2), Leaf(3))))) == 6)
+}


### PR DESCRIPTION
## Problem (#610)

A nested constructor pattern on a **boxed recursive-variant field** made `almide build` emit invalid Rust (*"codegen produced invalid Rust"*) on native; `almide check` passed and wasm was already correct.

```almide
type Tree = Leaf(Int) | Node(Tree, Tree)
fn sum(t: Tree) -> Int = match t {
  Leaf(n) => n,
  Node(Leaf(a), Leaf(b)) => a + b,   // ← native: E0308 + E0614
  Node(l, r) => sum(l) + sum(r),
}
```

`Node`'s fields are `Box<Tree>`, so the emitted `Tree::Node(Tree::Leaf(a), Tree::Leaf(b))` failed rustc (field is `Box<Tree>`, not `Tree`: **E0308**), and box-deref also marked the inner `a: Int` for a spurious `*a` (**E0614**).

## Fix — two co-located defects

**(a) box-deref over-marking (E0614)** — `crates/almide-codegen/src/pass_box_deref.rs`. `collect_deref_from_pattern` recursed into a nested constructor's args unconditionally, marking every inner `Bind` for deref. It now re-gates each level by the field type — and re-resolves the constructor's own enum, so mutual recursion is handled — marking a var only when its field is genuinely boxed.

**(b) matching through the box (E0308)** — `crates/almide-codegen/src/walker/statements.rs`. Stable Rust can't pattern-match through a `Box` (box-patterns are unstable). The arm is rewritten to:
- a **flat pattern** `Tree::Node(__bx0, __bx1)` binding the boxes,
- a **`matches!` shape-guard** verifying the nested structure (a non-match falls through to a later arm — refinement, exactly like the wasm emitter),
- a **`let-else`** that moves the value out of the box and binds the inner names.

All stable since 1.65, edition-agnostic (the generated crate is edition 2021), any nesting depth. With no boxed-nested position the rewrite returns `None` and the arm renders unchanged.

## Verification

- Repro + depth-2 nesting (`Node(Leaf(a), Node(Leaf(b), Leaf(c)))`) + a boxed `Bind` inside a nested arm: **native == wasm**, byte-identical.
- `almide test spec/`: **276/276 files green** (new `spec/lang/nested_boxed_ctor_pattern_test.almd`, run on both targets).
- `cargo test -p almide-codegen`: 107/0; **codegen snapshots unchanged (13/13)** — the rewrite fires only for a boxed-nested position, so every other arm is identical.

(Record-variant nested patterns are handled symmetrically in codegen, but are independently gated by a pre-existing frontend reachability check (E014), so the verified path here is tuple variants — the issue's repro.)