### PR TITLE
Wire native/*.rs and [native-deps] into the cdylib build (fix #719)

### DIFF
--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -50,34 +50,12 @@ pub fn cmd_build(file: &str, output: Option<&str>, target: Option<&str>, release
         return;
     }
 
-    // cdylib target: build shared library (.dylib/.so)
-    if cdylib {
-        let use_release = release || fast;
-        let project_dir = std::env::temp_dir().join("almide-build-cdylib");
-        // Strip fn main() from the code — cdylib has no entry point
-        let lib_code = rs_code.replace("fn main()", "fn __almide_unused_main()");
-        // Serialize across processes: the shared scratch dir's src + target
-        // would otherwise be corrupted by a concurrent `almide build`.
-        let _ = std::fs::create_dir_all(&project_dir);
-        let _flock = super::run::BuildDirLock::acquire(&project_dir)
-            .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
-        match super::cargo_build_cdylib(&lib_code, &project_dir, &output, use_release) {
-            Ok(lib_path) => {
-                eprintln!("Built {}", lib_path.display());
-            }
-            Err(e) => {
-                eprintln!("Compile error:\n{}", e);
-                std::process::exit(1);
-            }
-        }
-        return;
-    }
-
-    // Native target: use cargo to resolve rustls/webpki-roots for HTTPS support
+    // Load native deps from almide.toml (search in input file's directory, then
+    // CWD). BOTH the cdylib and bin paths need them: a cdylib with a `native/*.rs`
+    // shim or a `[native-deps]` crate must wire them in exactly like a bin, or it
+    // fails with "cannot find module" / a missing dep (#719). source_root is the
+    // directory containing almide.toml (where native/ lives).
     let use_release = release || fast;
-    let project_dir = std::env::temp_dir().join("almide-build");
-    // Load native deps from almide.toml (search in input file's directory, then CWD).
-    // source_root is the directory containing almide.toml (where native/ lives).
     let file_dir = std::path::Path::new(file).parent()
         .map(|p| if p.as_os_str().is_empty() { std::path::PathBuf::from(".") } else { p.to_path_buf() })
         .unwrap_or_else(|| std::path::PathBuf::from("."));
@@ -94,6 +72,31 @@ pub fn cmd_build(file: &str, output: Option<&str>, target: Option<&str>, release
         .unwrap_or_else(|| std::path::PathBuf::from("."));
     let has_deps = parsed.as_ref().map_or(false, |p| !p.dependencies.is_empty());
     let source_root = if !native_deps.is_empty() || has_deps { Some(toml_dir.as_path()) } else { None };
+
+    // cdylib target: build shared library (.dylib/.so)
+    if cdylib {
+        let project_dir = std::env::temp_dir().join("almide-build-cdylib");
+        // Strip fn main() from the code — cdylib has no entry point
+        let lib_code = rs_code.replace("fn main()", "fn __almide_unused_main()");
+        // Serialize across processes: the shared scratch dir's src + target
+        // would otherwise be corrupted by a concurrent `almide build`.
+        let _ = std::fs::create_dir_all(&project_dir);
+        let _flock = super::run::BuildDirLock::acquire(&project_dir)
+            .unwrap_or_else(|e| { eprintln!("{}", e); std::process::exit(1); });
+        match super::cargo_build_cdylib(&lib_code, &project_dir, &output, use_release, native_deps, source_root) {
+            Ok(lib_path) => {
+                eprintln!("Built {}", lib_path.display());
+            }
+            Err(e) => {
+                eprintln!("Compile error:\n{}", e);
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
+    // Native target: use cargo to resolve rustls/webpki-roots for HTTPS support
+    let project_dir = std::env::temp_dir().join("almide-build");
     // Serialize across processes: the shared scratch dir's src + target would
     // otherwise be corrupted by a concurrent `almide build`. Held through the
     // copy-out below so the generated binary can't be overwritten between

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -275,10 +275,15 @@ fn append_cargo_dep(cargo: &mut String, name: &str, spec: &str) {
 }
 
 /// Build generated Rust code as a cdylib shared library (.dylib/.so).
-fn cargo_build_cdylib(rs_code: &str, project_dir: &std::path::Path, lib_name: &str, release: bool) -> Result<std::path::PathBuf, String> {
+fn cargo_build_cdylib(rs_code: &str, project_dir: &std::path::Path, lib_name: &str, release: bool, native_deps: &[crate::project::NativeDep], source_root: Option<&std::path::Path>) -> Result<std::path::PathBuf, String> {
     let src_dir = project_dir.join("src");
     std::fs::create_dir_all(&src_dir).map_err(|e| format!("failed to create {}: {}", src_dir.display(), e))?;
-    let cargo_toml = format!(r#"[package]
+    // Base manifest for a cdylib; `build_cargo_toml` folds in `[native-deps]` and
+    // `inject_dep_natives` appends any dependency-package native deps below — so a
+    // cdylib wires native crates exactly like the bin path (#719). Previously this
+    // wrote a dep-free manifest and `rs_code` verbatim, so `@extern(rust, …)`
+    // modules were undeclared (E0433) and `[native-deps]` never reached cargo.
+    let cdylib_base = format!(r#"[package]
 name = "almide-cdylib"
 version = "0.1.0"
 edition = "2021"
@@ -297,9 +302,17 @@ opt-level = 3
 lto = true
 codegen-units = 1
 "#, lib_name.replace('-', "_"));
+    let cargo_toml = build_cargo_toml(&cdylib_base, native_deps);
     std::fs::write(project_dir.join("Cargo.toml"), &cargo_toml)
         .map_err(|e| format!("failed to write Cargo.toml: {}", e))?;
-    std::fs::write(src_dir.join("lib.rs"), rs_code)
+
+    // Copy `native/*.rs` shims into src/ + inject `mod <stem>;`, then pull native
+    // modules + `[native-deps]` from dependency packages — same wiring as
+    // `cargo_build_generated_with_native`.
+    let mut lib_code = rs_code.to_string();
+    inject_native_modules(&mut lib_code, source_root, &src_dir)?;
+    inject_dep_natives(&mut lib_code, source_root, &src_dir, project_dir)?;
+    std::fs::write(src_dir.join("lib.rs"), &lib_code)
         .map_err(|e| format!("failed to write lib.rs: {}", e))?;
 
     let mut cmd = std::process::Command::new("cargo");


### PR DESCRIPTION
## Problem (#719)

`almide build --cdylib` silently **ignored `native/*.rs` shims and `[native-deps]`**. A project that builds fine as a binary failed as a cdylib with `error[E0433]: cannot find module or crate <name>` for every `@extern(rust, "<name>", …)`, and the `[native-deps]` crates were absent from the generated `Cargo.toml` — so a C-ABI shared library (`@export(c, …)`) couldn't bind a native FFI shim.

## Root cause

The cdylib and bin paths diverged. The bin path (`cargo_build_generated_with_native`) builds the manifest with `build_cargo_toml(base, native_deps)` and calls `inject_native_modules` + `inject_dep_natives` (copy `native/*.rs` into `src/`, inject `mod <stem>;`, fold deps into `Cargo.toml`). `cargo_build_cdylib` did **none** of this — it wrote a hardcoded dep-free manifest and the generated Rust verbatim.

## Fix

`cargo_build_cdylib` now goes through the same native wiring:
- its cdylib base manifest is folded through `build_cargo_toml(base, native_deps)`,
- `inject_native_modules` + `inject_dep_natives` run before `src/lib.rs` is written.

The native-config (`parsed` almide.toml, `native_deps`, `source_root`) is computed **once** before the cdylib/bin split in `cmd_build` and shared, so both paths get identical wiring (and the duplicated bin-path computation is removed).

## Verification (end-to-end)

A `--cdylib --repr-c` project with `native/foo.rs` that *uses* a `[native-deps]` crate:

```toml
# almide.toml
[native-deps]
libloading = "0.8"
```
```almide
@extern(rust, "foo", "foo_answer") fn foo_answer() -> Int = _
@export(c, "answer")
fn answer() -> Int = foo_answer()
```

- **Before:** `error[E0433]: cannot find module or crate foo` (and `libloading` absent).
- **After:** builds — generated `Cargo.toml` has `libloading = "0.8"` under `[dependencies]`, `mod foo;` is injected at the top of `src/lib.rs`, `foo.rs` is copied into `src/`, and `nm` shows the exported `_answer` symbol in the `.dylib`.
- The **bin** build of the same project is unchanged; `@extern` integration tests and the common (dep-free, rlib-fast-path) build still pass.

(No automated regression test: the existing suite has no harness for a cdylib/native-dep cargo build; verified manually as above.)