### PR TITLE
Skip the copy-on-write clone for a uniquely-owned object on wasm (fix #696, fix #695)

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/runtime.rs
+++ b/crates/almide-codegen/src/emit_wasm/runtime.rs
@@ -830,21 +830,29 @@ fn compile_rc_dec(emitter: &mut WasmEmitter) {
 /// body carries no hardcoded element-size — it works uniformly for List/String/
 /// Map/Record/Bytes/variant blocks, all of which __alloc stamps with their size.
 ///
-/// This clones UNCONDITIONALLY (a data-section pointer, which has no header, is the
-/// only pass-through). It does NOT branch on the refcount: in the current WASM
-/// runtime the rc header guard (rc_inc/rc_dec) is a no-op (a bump-allocate-and-leak
-/// model — see `HEAP_START_GLOBAL_IDX`), so the rc never reflects aliasing and a
-/// `rc>1` test would never fire. Unconditional clone matches the Rust target's
-/// eager `.clone()` at the bind: correct, and the extra copy when the alias is
-/// already dead is the accepted, conservative cost of `needs_cow` marking. The
-/// original block is left untouched (it leaks like every other block today), so no
-/// refcount bookkeeping is needed.
+/// A data-section pointer (no header) is the one pass-through. Otherwise: when
+/// frees are ENABLED (the 0.27.0+ default — a real refcount), a UNIQUELY-owned
+/// object (`rc <= 1`) has no alias to protect, so the mutation is safe in place
+/// and we return `ptr` unchanged; only a genuinely SHARED object (`rc > 1`) is
+/// cloned. This was unconditional under the original bump-allocate-and-leak model
+/// (where rc was a no-op and a `rc>1` test could never fire) — but that left a
+/// `needs_cow` var mutated in a loop (`while … { list.push(merged, …) }` where
+/// `cur = merged` aliases it) cloning the WHOLE list on EVERY push: O(n²) work and
+/// memory churn that trapped on wasm at scale (#696, and the List[String] O(n²)
+/// of #695). With `ALMIDE_WASM_FREES=0` the rc is a no-op, so we keep the
+/// unconditional clone (a `rc<=1` test would always pass and break value
+/// semantics). The shared (`rc>1`) path is unchanged — the original block is left
+/// untouched (it leaks like every other block under the leak model), matching the
+/// Rust target's eager `.clone()` at the bind.
 fn compile_cow_check(emitter: &mut WasmEmitter) {
     use super::engine::{WasmBuilder, layout::*};
     let type_idx = emitter.func_type_indices[&emitter.rt.cow_check];
     let size_neg = emitter.layout_reg.alloc_header_neg_offset(alloc::SIZE) as i32;
     let size_ty = emitter.layout_reg.field(ALLOC_HEADER, alloc::SIZE).ty;
+    let rc_neg = emitter.layout_reg.alloc_header_neg_offset(alloc::RC) as i32;
+    let rc_ty = emitter.layout_reg.field(ALLOC_HEADER, alloc::RC).ty;
     let alloc_fn = emitter.rt.alloc;
+    let frees = wasm_frees_enabled();
 
     // locals: 1 = $size (data byte count), 2 = $new_ptr
     let mut f = Function::new([(2, ValType::I32)]);
@@ -855,6 +863,13 @@ fn compile_cow_check(emitter: &mut WasmEmitter) {
         // global directly (the rt field is still 0 at this compile point).
         w.get(Local(0)).gget(HEAP_START_GLOBAL_IDX).lt_u();
         w.if_void(|w| { w.get(Local(0)).ret(); }, |_| {});
+        if frees {
+            // Uniquely owned (rc <= 1, i.e. rc < 2) → no alias to protect, skip the
+            // clone. (#696/#695) Only a shared object falls through to the copy.
+            w.get(Local(0)).i32c(Imm32(rc_neg)).sub().emit_load(0, rc_ty);
+            w.i32c(Imm32(2)).lt_u();
+            w.if_void(|w| { w.get(Local(0)).ret(); }, |_| {});
+        }
         // size = header.SIZE; new = alloc(size); memcpy(new, ptr, size); return new.
         w.get(Local(0)).i32c(Imm32(size_neg)).sub().emit_load(0, size_ty).set(Local(1));
         w.get(Local(1)).call(alloc_fn).set(Local(2));

--- a/spec/lang/cow_unique_no_clone_test.almd
+++ b/spec/lang/cow_unique_no_clone_test.almd
@@ -1,0 +1,76 @@
+// Regression (#696 / #695): `__cow_check` (the copy-on-write guard emitted at the
+// mutation sites of AliasCowPass-marked vars) used to clone the WHOLE heap object
+// UNCONDITIONALLY — a stale carryover from the pre-0.27.0 bump-allocate-and-leak
+// model where the refcount was a no-op. Once frees became the default the rc is a
+// real count, but the clone stayed unconditional, so a `needs_cow` list mutated in
+// a loop (`while … { list.push(merged, …) }` where `cur = merged` aliases it) was
+// cloned in full on EVERY push: O(n²) work + memory churn that trapped on wasm at
+// n≳8000 (#696) and made a List[String] build quadratic (#695). The guard now
+// skips the clone when the object is uniquely owned (rc ≤ 1) and only copies a
+// genuinely shared one — so value semantics are unchanged but the in-loop mutation
+// is O(1) amortized again. Runs on BOTH targets.
+
+// Value semantics must still hold: a mutation through one alias of a SHARED list
+// must not be visible through the other (the rc > 1 path still clones).
+test "aliased list keeps value semantics under in-place push (#696)" {
+  var a: List[Int] = [1, 2, 3]
+  let b = a
+  list.push(a, 4)
+  assert_eq(list.len(a), 4)
+  assert_eq(list.len(b), 3)
+  assert_eq(b[0], 1)
+  assert_eq(a[3], 4)
+}
+
+// A bottom-up merge sort: `cur = merged` aliases the push-built list across the
+// outer loop, marking `merged` needs_cow. At n≳8000 the per-push full clone made
+// wasm trap with a raw "out of bounds memory access". This must now sort
+// correctly (and not trap) on both targets.
+fn msort(xs: List[Int]) -> List[Int] = {
+  let n = list.len(xs)
+  var cur = list.slice(xs, 0, n)
+  var width = 1
+  while width < n {
+    var merged: List[Int] = []
+    var lo = 0
+    while lo < n {
+      let mid = if lo + width < n then lo + width else n
+      let hi = if lo + 2 * width < n then lo + 2 * width else n
+      var i = lo
+      var j = mid
+      while i < mid and j < hi {
+        if (list.get(cur, i) ?? 0) <= (list.get(cur, j) ?? 0)
+          then { list.push(merged, list.get(cur, i) ?? 0); i = i + 1 }
+          else { list.push(merged, list.get(cur, j) ?? 0); j = j + 1 }
+      }
+      while i < mid { list.push(merged, list.get(cur, i) ?? 0); i = i + 1 }
+      while j < hi { list.push(merged, list.get(cur, j) ?? 0); j = j + 1 }
+      lo = lo + 2 * width
+    }
+    cur = merged
+    width = width * 2
+  }
+  cur
+}
+
+test "bottom-up merge sort of 8000 reversed ints, cross-target (#696)" {
+  var xs: List[Int] = []
+  var i = 0
+  while i < 8000 { list.push(xs, 8000 - i); i = i + 1 }   // [8000, 7999, …, 1]
+  let s = msort(xs)
+  assert_eq(list.len(s), 8000)
+  assert_eq(s[0], 1)
+  assert_eq(s[7999], 8000)
+  assert_eq(s[4000], 4001)
+}
+
+// A List[String] of freshly-allocated strings built by repeated push — the #695
+// shape (the strings are needs_cow alias-marked); must build correctly at scale.
+test "build a List[String] of 4000 fresh strings (#695)" {
+  var ss: List[String] = []
+  var i = 0
+  while i < 4000 { list.push(ss, "v" + int.to_string(i)); i = i + 1 }
+  assert_eq(list.len(ss), 4000)
+  assert_eq(ss[0], "v0")
+  assert_eq(ss[3999], "v3999")
+}


### PR DESCRIPTION
## Problem (#696, #695)

A bottom-up merge sort over `List[Int]` ran correctly on native at 152k but trapped on wasm with a raw `memory access out of bounds` once n ≳ 8000 (#696). Separately, building a `List[String]` by repeated `push` was O(n²) on wasm (#695).

## Root cause

`__cow_check` — the copy-on-write guard emitted at the mutation sites of `AliasCowPass`-marked vars — **cloned the whole heap object unconditionally**. That was correct under the pre-0.27.0 bump-allocate-and-leak model, where the refcount was a no-op so a `rc>1` test could never fire — but **frees (a real refcount) became the default in 0.27.0** and the guard was never updated.

So a `needs_cow` list mutated in a loop — `while … { list.push(merged, …) }` where `cur = merged` aliases it — was cloned in **full on every push**: O(n²) work + memory churn. On wasm the churn trapped at scale (#696); the quadratic copy made the `List[String]` build slow (#695).

## Fix

`__cow_check` now returns the pointer unchanged when the object is **uniquely owned** (`rc ≤ 1`) — no alias to protect, so the in-place mutation is safe — and only copies a genuinely **shared** object (`rc > 1`):

```rust
if frees {
    // rc <= 1 (rc < 2) → unique → skip the clone
    w.get(Local(0)).i32c(Imm32(rc_neg)).sub().emit_load(0, rc_ty);
    w.i32c(Imm32(2)).lt_u();
    w.if_void(|w| { w.get(Local(0)).ret(); }, |_| {});
}
// shared (or ALMIDE_WASM_FREES=0): unchanged unconditional clone
```

With `ALMIDE_WASM_FREES=0` the rc is a no-op, so the unconditional clone is kept (a `rc≤1` test would always pass and break value semantics under the leak model).

## Verification

- **#696** merge sort and **#695** `List[String]` build run in ~0.15 s at 50k / 20k, **byte-identical native ⇄ wasm** (was: trap / O(n²)).
- **Value semantics preserved**: `var b = a; list.push(a, 4)` → `a` len 4, `b` len 3 on both targets (the `rc > 1` path still clones).
- `almide test spec/`: **277/277** files green; the frees churn gate (record / TCO-deep / TCO-loop) green; `cargo test -p almide-codegen` 107/0.
- New regression `spec/lang/cow_unique_no_clone_test.almd` (value semantics + an 8000-element merge sort + a 4000 `List[String]` build, both targets).

Closes #696. Closes #695.