### PR TITLE
Reap child process groups and bound output in the nightly fuzz harness

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -96,15 +96,27 @@ jobs:
           STATUS=${PIPESTATUS[0]}
           set -e
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+      # Count findings in a SEPARATE always()-step. The campaign writes
+      # each finding to disk as it is discovered, so its findings survive
+      # even if the campaign step itself is killed mid-run (an OOM, or the
+      # job timeout). Computing the count here — not inside the campaign
+      # step — is what lets the upload/issue steps still fire after a
+      # crash, instead of silently discarding a night's worth of repros.
+      - name: Collect findings
+        id: collect
+        if: always()
+        run: |
           FINDINGS_DIR="tools/xtarget-fuzz/findings"
           COUNT=0
           if [ -d "$FINDINGS_DIR" ]; then
             COUNT=$(find "$FINDINGS_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
           fi
           echo "findings=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Recorded $COUNT unique finding(s)."
 
       - name: Upload findings
-        if: steps.campaign.outputs.findings != '0'
+        if: always() && steps.collect.outputs.findings != '0'
         uses: actions/upload-artifact@v7
         with:
           name: fuzz-findings-${{ github.run_id }}
@@ -114,11 +126,11 @@ jobs:
           retention-days: 30
 
       - name: Open / update tracking issue
-        if: steps.campaign.outputs.findings != '0'
+        if: always() && steps.collect.outputs.findings != '0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          COUNT="${{ steps.campaign.outputs.findings }}"
+          COUNT="${{ steps.collect.outputs.findings }}"
           TITLE="Nightly fuzz: $COUNT cross-target finding(s)"
           # Summarize the finding kinds for the issue body.
           SUMMARY=$(find tools/xtarget-fuzz/findings -name meta.txt -exec cat {} \; \

--- a/tools/xtarget-fuzz/Cargo.lock
+++ b/tools/xtarget-fuzz/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.27.3"
+version = "0.27.10"
 dependencies = [
  "almide-base",
  "almide-codegen",
@@ -999,6 +999,7 @@ name = "xtarget-fuzz"
 version = "0.0.0"
 dependencies = [
  "almide",
+ "libc",
  "serde_json",
 ]
 

--- a/tools/xtarget-fuzz/Cargo.toml
+++ b/tools/xtarget-fuzz/Cargo.toml
@@ -31,5 +31,15 @@ almide = { path = "../.." }
 # minimizer paths need to build those literal values directly.
 serde_json = "1"
 
+[target.'cfg(unix)'.dependencies]
+# Process-group teardown. A hung child (e.g. `almide run` waiting on a
+# generated native binary that loops forever) spawns grandchildren that
+# inherit our captured stdout pipe; killing only the direct child leaves
+# them alive holding the pipe, so the reader thread never sees EOF and
+# the worker wedges (the nightly campaign's exit-143 stall). We spawn
+# each child as its own process-group leader and `kill(-pgid)` the whole
+# tree on timeout — which needs `libc::kill`.
+libc = "0.2"
+
 [profile.release]
 opt-level = 2

--- a/tools/xtarget-fuzz/src/oracle/ladder.rs
+++ b/tools/xtarget-fuzz/src/oracle/ladder.rs
@@ -144,6 +144,18 @@ pub fn run_ladder(
             wasm: None,
         });
     }
+    if native.output_overflow {
+        // A finite generated program that floods stdout past the capture
+        // cap is a runaway (effectively non-terminating output) — bucket
+        // it with hangs, not with build failures.
+        return Outcome::Finding(Finding {
+            rung: Rung::Run,
+            kind: FindingKind::Hang,
+            summary: "native run produced unbounded output (runaway)".into(),
+            native: Some(RunEvidence::from(&native)),
+            wasm: None,
+        });
+    }
     if !native.success() {
         // Distinguish a build/codegen failure from a legitimate runtime
         // error. Both surface as non-zero exit; the generated programs
@@ -191,6 +203,24 @@ pub fn run_ladder(
     // Compare observable behaviour: stdout, exit code, and run-success.
     let nat_ev = RunEvidence::from(&native);
     let wasm_ev = RunEvidence::from(&wasm);
+
+    if wasm.output_overflow && !native.output_overflow {
+        // The classic wasm string-codegen failure: native prints a small
+        // finite result while wasm dumps linear memory unbounded. The cap
+        // already tore it down; record it as the divergence it is rather
+        // than a generic run failure.
+        return Outcome::Finding(Finding {
+            rung: Rung::Run,
+            kind: FindingKind::OutputDivergence,
+            summary: format!(
+                "wasm emitted excessive output ({}B captured, native {}B) — likely a linear-memory dump",
+                wasm_ev.stdout.len(),
+                nat_ev.stdout.len()
+            ),
+            native: Some(nat_ev),
+            wasm: Some(wasm_ev),
+        });
+    }
 
     if !wasm.success() {
         // Native ran cleanly but WASM did not — a run-failure divergence.
@@ -259,7 +289,9 @@ fn parse_then_format(src: &str) -> Option<String> {
 }
 
 /// Build a short, scannable description of an output divergence —
-/// the first line that differs.
+/// the first line that differs. Each side is truncated so a pathological
+/// line (e.g. a wasm memory dump) cannot bloat the log, the dedup key, or
+/// the findings artifact.
 fn divergence_summary(native: &RunEvidence, wasm: &RunEvidence) -> String {
     if native.exit_code != wasm.exit_code {
         return format!(
@@ -269,7 +301,11 @@ fn divergence_summary(native: &RunEvidence, wasm: &RunEvidence) -> String {
     }
     for (n, w) in native.stdout.lines().zip(wasm.stdout.lines()) {
         if n != w {
-            return format!("stdout differs: native={n:?} wasm={w:?}");
+            return format!(
+                "stdout differs: native={:?} wasm={:?}",
+                clip(n),
+                clip(w)
+            );
         }
     }
     format!(
@@ -277,4 +313,15 @@ fn divergence_summary(native: &RunEvidence, wasm: &RunEvidence) -> String {
         native.stdout.len(),
         wasm.stdout.len()
     )
+}
+
+/// Clip one side of a divergence to a bounded prefix (by `char`, so the
+/// boundary is always valid UTF-8), appending an elision marker when cut.
+fn clip(s: &str) -> String {
+    const MAX: usize = 160;
+    if s.chars().count() <= MAX {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(MAX).collect();
+    format!("{head}…(+{} more chars)", s.chars().count() - MAX)
 }

--- a/tools/xtarget-fuzz/src/oracle/runner.rs
+++ b/tools/xtarget-fuzz/src/oracle/runner.rs
@@ -10,11 +10,44 @@
 //! passed to `almide run`/`build` via `ALMIDE_RUN_PROJECT_DIR`, so the
 //! native cargo build caches do not contend on the shared-`/tmp` flock.
 //! Workers therefore scale across cores.
+//!
+//! ## Surviving pathological children
+//!
+//! Generated programs can hang or emit an unbounded volume of output (a
+//! wasm string-codegen bug dumping linear memory, say). The spawn path
+//! is hardened against both so a single bad program cannot wedge a worker
+//! or OOM the whole campaign — the failure mode behind the nightly run's
+//! exit-143 stall:
+//!
+//! * **Process-group teardown.** `almide run` executes the compiled
+//!   native binary with `Command::status()`, which lets that binary
+//!   *inherit* our captured stdout pipe. If it loops forever, killing
+//!   only the direct `almide` child leaves the grandchild alive holding
+//!   the pipe write end — the reader thread then blocks in `read_to_end`
+//!   forever. We spawn each child as its own process-group leader and
+//!   `kill(-pgid)` the entire tree on timeout, so every pipe write end
+//!   closes and the readers drain to EOF.
+//! * **Bounded capture.** Each stream is captured up to
+//!   [`MAX_CAPTURE_BYTES`]; past the cap the reader flags an overflow and
+//!   keeps draining (so the child never blocks on a full pipe) while the
+//!   poll loop tears the group down. The captured head is enough to
+//!   classify the divergence; the cap keeps memory and the findings
+//!   artifact bounded.
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+/// Maximum bytes captured per stream. A finite generated program that
+/// emits more than this is pathological; we keep the head, flag the
+/// overflow, and tear the child down so it cannot OOM the campaign. The
+/// cap is far above any legitimate finding's diff (the widest real output
+/// — a fully expanded subnormal float — is ~330 bytes), so no genuine
+/// divergence is truncated in practice.
+const MAX_CAPTURE_BYTES: usize = 4 * 1024 * 1024; // 4 MiB / stream
 
 /// The captured result of running a child process to completion (or
 /// timing it out).
@@ -30,11 +63,29 @@ pub struct ProcResult {
     /// `true` if the binary could not be spawned at all (e.g. `wasmtime`
     /// not installed). The ladder treats this as a *skip*, not a finding.
     pub spawn_failed: bool,
+    /// `true` if either stream hit [`MAX_CAPTURE_BYTES`] — the child
+    /// emitted a pathological volume of output and was torn down. The
+    /// captured bytes are the head of the stream.
+    pub output_overflow: bool,
 }
 
 impl ProcResult {
     pub fn success(&self) -> bool {
-        self.exit_code == Some(0) && !self.timed_out && !self.spawn_failed
+        self.exit_code == Some(0)
+            && !self.timed_out
+            && !self.spawn_failed
+            && !self.output_overflow
+    }
+
+    fn spawn_failure(msg: String) -> Self {
+        ProcResult {
+            stdout: Vec::new(),
+            stderr: msg.into_bytes(),
+            exit_code: None,
+            timed_out: false,
+            spawn_failed: true,
+            output_overflow: false,
+        }
     }
 }
 
@@ -98,65 +149,68 @@ impl Toolchain {
 
     /// Spawn a command, capture stdout/stderr on dedicated reader
     /// threads (so a child that fills a pipe buffer never deadlocks),
-    /// and enforce the timeout by polling, killing on overrun.
+    /// and enforce the timeout by polling, tearing the whole process
+    /// group down on overrun or output overflow.
     fn spawn_timed(&self, mut cmd: Command) -> ProcResult {
         cmd.stdin(Stdio::null());
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
+        // Run the child in its own process group so a timeout can reap
+        // the entire tree — including grandchildren that inherited our
+        // pipes (see the module docs).
+        set_own_process_group(&mut cmd);
 
         let mut child = match cmd.spawn() {
             Ok(c) => c,
-            Err(e) => {
-                return ProcResult {
-                    stdout: Vec::new(),
-                    stderr: format!("spawn failed: {e}").into_bytes(),
-                    exit_code: None,
-                    timed_out: false,
-                    spawn_failed: true,
-                };
-            }
+            Err(e) => return ProcResult::spawn_failure(format!("spawn failed: {e}")),
         };
 
         // Drain both pipes concurrently on threads. A blocked writer in
         // the child (full 64 KiB pipe buffer) would otherwise deadlock
-        // the timeout poll — these readers keep the pipes flowing.
-        let out_pipe = child.stdout.take();
-        let err_pipe = child.stderr.take();
-        let out_handle = out_pipe.map(|mut o| {
-            std::thread::spawn(move || {
-                let mut buf = Vec::new();
-                let _ = o.read_to_end(&mut buf);
-                buf
-            })
+        // the timeout poll — these readers keep the pipes flowing. The
+        // capture is capped; an overflow is surfaced so the poll loop can
+        // tear the child down promptly.
+        let out_overflow = Arc::new(AtomicBool::new(false));
+        let err_overflow = Arc::new(AtomicBool::new(false));
+        let out_handle = child.stdout.take().map(|p| {
+            let flag = Arc::clone(&out_overflow);
+            std::thread::spawn(move || drain_capped(p, &flag))
         });
-        let err_handle = err_pipe.map(|mut e| {
-            std::thread::spawn(move || {
-                let mut buf = Vec::new();
-                let _ = e.read_to_end(&mut buf);
-                buf
-            })
+        let err_handle = child.stderr.take().map(|p| {
+            let flag = Arc::clone(&err_overflow);
+            std::thread::spawn(move || drain_capped(p, &flag))
         });
 
         let deadline = Instant::now() + self.timeout;
         let poll_interval = Duration::from_millis(POLL_INTERVAL_MS);
 
-        let timed_out = loop {
+        let mut timed_out = false;
+        let mut overflowed = false;
+        loop {
             match child.try_wait() {
-                Ok(Some(_status)) => break false,
+                Ok(Some(_status)) => break,
                 Ok(None) => {
+                    if out_overflow.load(Ordering::Relaxed)
+                        || err_overflow.load(Ordering::Relaxed)
+                    {
+                        overflowed = true;
+                        kill_group(&mut child);
+                        break;
+                    }
                     if Instant::now() >= deadline {
-                        let _ = child.kill();
-                        let _ = child.wait();
-                        break true;
+                        timed_out = true;
+                        kill_group(&mut child);
+                        break;
                     }
                     std::thread::sleep(poll_interval);
                 }
-                Err(_) => break false,
+                Err(_) => break,
             }
-        };
+        }
 
-        // Join the readers (they finish once the child's pipe ends close,
-        // which the kill above guarantees).
+        // Join the readers. The group kill above closes every inherited
+        // pipe write end, so `read` returns EOF and the threads finish
+        // even when a grandchild was holding the pipe.
         let stdout = out_handle.and_then(|h| h.join().ok()).unwrap_or_default();
         let stderr = err_handle.and_then(|h| h.join().ok()).unwrap_or_default();
         let exit_code = child.wait().ok().and_then(|s| s.code());
@@ -167,10 +221,152 @@ impl Toolchain {
             exit_code,
             timed_out,
             spawn_failed: false,
+            output_overflow: overflowed,
         }
     }
+}
+
+/// Read a pipe into a buffer capped at [`MAX_CAPTURE_BYTES`]. Past the
+/// cap the bytes are discarded (so the child never blocks on a full pipe)
+/// and `overflow` is set, signalling the poll loop to tear the child
+/// down. Returns the captured head.
+fn drain_capped(mut pipe: impl Read, overflow: &AtomicBool) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 64 * 1024];
+    loop {
+        match pipe.read(&mut chunk) {
+            Ok(0) => break, // EOF
+            Ok(n) => {
+                if buf.len() < MAX_CAPTURE_BYTES {
+                    let room = MAX_CAPTURE_BYTES - buf.len();
+                    buf.extend_from_slice(&chunk[..n.min(room)]);
+                    if buf.len() >= MAX_CAPTURE_BYTES {
+                        overflow.store(true, Ordering::Relaxed);
+                    }
+                }
+                // Past the cap: keep reading to drain the pipe (so the
+                // child does not block) but discard. The poll loop kills
+                // the group on seeing the overflow flag, which ends this.
+            }
+            Err(_) => break,
+        }
+    }
+    buf
+}
+
+/// Mark `cmd` to spawn in a fresh process group (its PID becomes the
+/// PGID), so `kill(-pgid)` later reaps the whole subtree.
+#[cfg(unix)]
+fn set_own_process_group(cmd: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    cmd.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn set_own_process_group(_cmd: &mut Command) {}
+
+/// Kill the child's entire process group (the child plus every
+/// grandchild that inherited its group), then reap the direct child.
+#[cfg(unix)]
+fn kill_group(child: &mut Child) {
+    // The child leads its own group (`process_group(0)`), so its PGID
+    // equals its PID. SIGKILL to `-PID` hits the whole tree.
+    let pid = child.id() as libc::pid_t;
+    unsafe {
+        libc::kill(-pid, libc::SIGKILL);
+    }
+    let _ = child.wait();
+}
+
+#[cfg(not(unix))]
+fn kill_group(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 /// Polling granularity while waiting on a child. Small enough that a
 /// hung program is killed promptly, large enough not to busy-spin.
 const POLL_INTERVAL_MS: u64 = 10;
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    fn toolchain(timeout: Duration) -> Toolchain {
+        Toolchain {
+            almide: PathBuf::from("/nonexistent"),
+            wasmtime: PathBuf::from("/nonexistent"),
+            scratch: std::env::temp_dir(),
+            timeout,
+        }
+    }
+
+    /// Regression for the nightly exit-143 stall: a child that spawns a
+    /// grandchild which inherits the stdout pipe and then outlives the
+    /// parent must NOT wedge the reader. `sh -c 'sleep 30 & ...'` leaves
+    /// the `sleep` holding the pipe after the shell waits; group teardown
+    /// must kill it so `spawn_timed` returns within the timeout. Without
+    /// the `kill(-pgid)`, the reader blocks in `read_to_end` for 30s and
+    /// this test would hang past its own deadline.
+    #[test]
+    fn timeout_reaps_pipe_holding_grandchild() {
+        let tc = toolchain(Duration::from_millis(300));
+        let mut cmd = Command::new("sh");
+        // Background a long sleeper that inherits stdout, print, then the
+        // shell blocks on `wait` — so the direct child hangs AND a
+        // grandchild keeps the pipe open.
+        cmd.args(["-c", "sleep 30 & echo holding; wait"]);
+
+        let start = Instant::now();
+        let r = tc.spawn_timed(cmd);
+        let elapsed = start.elapsed();
+
+        assert!(r.timed_out, "expected a timeout finding");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "spawn_timed wedged on a pipe-holding grandchild: took {elapsed:?}"
+        );
+        assert!(
+            String::from_utf8_lossy(&r.stdout).contains("holding"),
+            "should still capture the head before teardown"
+        );
+    }
+
+    /// A child that floods stdout must be capped, flagged, and torn down
+    /// rather than buffered without bound (the OOM half of exit-143).
+    #[test]
+    fn excessive_output_is_capped_and_flagged() {
+        let tc = toolchain(Duration::from_secs(20));
+        let mut cmd = Command::new("sh");
+        // `yes` streams "y\n" forever; cap must trip well before OOM.
+        cmd.args(["-c", "yes"]);
+
+        let r = tc.spawn_timed(cmd);
+
+        assert!(r.output_overflow, "expected the capture cap to trip");
+        assert!(!r.timed_out, "overflow should fire before the 20s timeout");
+        assert!(
+            r.stdout.len() <= MAX_CAPTURE_BYTES + 64 * 1024,
+            "captured {} bytes, expected ~{}",
+            r.stdout.len(),
+            MAX_CAPTURE_BYTES
+        );
+    }
+
+    /// The happy path still works: a quick, well-behaved child is
+    /// captured exactly with a zero exit and no false overflow/timeout.
+    #[test]
+    fn clean_child_is_captured_verbatim() {
+        let tc = toolchain(Duration::from_secs(10));
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "printf 'hello\\n'"]);
+
+        let r = tc.spawn_timed(cmd);
+
+        assert!(r.success());
+        assert_eq!(r.exit_code, Some(0));
+        assert!(!r.timed_out);
+        assert!(!r.output_overflow);
+        assert_eq!(r.stdout, b"hello\n");
+    }
+}


### PR DESCRIPTION
## Why

The nightly differential fuzz [run #723](https://github.com/almide/almide/actions/runs/27897273202) went red with **exit 143 (SIGTERM)** at ~25 min — not because of the 478 native↔wasm divergences it found (those don't fail the step), but because the **fuzz harness itself wedged**, and the crash then **skipped `Upload findings` / `Open issue`, discarding all 478 repros**.

Root cause: `almide run` executes the generated native binary with `Command::status()`, so that binary **inherits the fuzzer's captured stdout pipe**. When a generated program hangs, the per-program timeout kills only the direct `almide` child — the grandchild survives holding the pipe, so the reader thread blocks forever in `read_to_end`. Unbounded capture of multi-MB wasm memory dumps is a second OOM vector.

## What

- **`oracle/runner.rs`** — spawn each child in its own process group (`process_group(0)`) and `kill(-pgid, SIGKILL)` the whole tree on timeout, so hung grandchildren die and the readers drain to EOF. Cap each stream at **4 MiB**, flag overflow, and tear the child down (bounds memory + the findings artifact). Adds 3 regression tests (pipe-holding grandchild / runaway output / clean child).
- **`oracle/ladder.rs`** — classify overflow (native runaway → `Hang`, wasm dump → `OutputDivergence`) and clip divergence summaries so a pathological line can't bloat the log, dedup key, or artifact.
- **`.github/workflows/fuzz-nightly.yml`** — count findings + upload + open-issue moved to `if: always()` steps, so a campaign crash/timeout no longer silently throws away the night's findings.

## Validation

- `cargo test --release` in `tools/xtarget-fuzz`: 16/16 pass (incl. the 3 new regression tests).
- A real 1-minute campaign completes cleanly (dedup works, findings recorded, summary printed — no wedge).
- Replaying captured findings is fast (~2.8s) with bounded summaries.
- Diff is scoped to the fuzzer harness + workflow only — no codegen/spec changes.

The 478 codegen divergences are tracked separately for the wasm-codegen burndown (dominated by wasm string-representation bugs).