### PR TITLE
fix(perceus): RC-process heap temps inside guard-else blocks (#755)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ care about.
 
 ## [Unreleased]
 
+### Fixed — WASM codegen
+
+- **Perceus RC: `guard`-`else` heap temporaries** (#755): a heap local bound
+  inside a `guard … else { … }` block was never reference-count processed on
+  the WASM target. `Guard` is an `IrStmtKind`, so `block_to_fnbody` funnelled
+  it into perceus's `FnBody::Stmt` pass-through arm, which recursed into
+  nothing — the else block's temps got no scope-end `Dec` and WASM RC
+  verification refused the build (`[perceus-belt] LEAK: no RcDec`). The Stmt
+  arm now `perceus_expr`s a Guard's `cond` and `else_`, so the divergent else
+  block is round-tripped and Dec-balanced like any other block.
+
 ## [0.23.3] — 2026-05-24
 
 ### Performance — WASM parity with Rust

--- a/crates/almide-codegen/src/pass_perceus.rs
+++ b/crates/almide-codegen/src/pass_perceus.rs
@@ -327,7 +327,23 @@ fn perceus_fnbody(fb: FnBody, var_table: &mut VarTable) -> FnBody {
                 perceus_expr(&mut expr, var_table);
                 FnBody::Expr { expr, body: Box::new(result) }
             }
-            ChainHead::Stmt { stmt } => FnBody::Stmt { stmt, body: Box::new(result) },
+            ChainHead::Stmt { mut stmt } => {
+                // A `Guard { cond, else_ }` statement reaches perceus NOWHERE
+                // else: `block_to_fnbody` funnels every stmt kind that isn't
+                // Bind/Assign/RcInc/RcDec/Expr into this pass-through arm, so
+                // without recursing here its `cond` and its divergent `else_`
+                // block get ZERO Rc processing — every heap temp inside the
+                // else block leaks (repro: `guard c else { io.print("v${x}"); ok(()) }`,
+                // the interpolation temp is never Dec'd). `perceus_expr` on the
+                // else Block round-trips it through the Block arm, which inserts
+                // the scope-end Decs before its (divergent) Ret, exactly as for
+                // any other block.
+                if let IrStmtKind::Guard { cond, else_ } = &mut stmt.kind {
+                    perceus_expr(cond, var_table);
+                    perceus_expr(else_, var_table);
+                }
+                FnBody::Stmt { stmt, body: Box::new(result) }
+            }
             ChainHead::Inc { var } => FnBody::Inc { var, body: Box::new(result) },
             ChainHead::Dec { var } => FnBody::Dec { var, body: Box::new(result) },
         };

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -168,6 +168,26 @@ fn main() -> Unit = {
 }
 
 #[test]
+fn wasm_guard_else_heap_temp() {
+    // Regression (#755): a heap temp inside a `guard … else { … }` block was
+    // never RC-processed on the WASM target. `Guard` is an `IrStmtKind`, so
+    // `block_to_fnbody` funnelled it into perceus's `FnBody::Stmt`
+    // pass-through arm, which recursed into nothing — the else block's heap
+    // locals got no scope-end Dec and WASM RC verification refused the build
+    // (`[perceus-belt] LEAK: no RcDec`). The else block's temp (`"hi " + w`)
+    // is a fresh heap String here; it must be Dec'd before the guard's
+    // divergent return, exactly as any other block-local.
+    assert_cross_target(r#"
+fn pick(b: Bool) -> Bool = b
+fn main() -> Unit = {
+  let w = "world"
+  guard pick(false) else { let s = "hi " + w; println(s) }
+  println("passed")
+}
+"#);
+}
+
+#[test]
 fn wasm_list_map() {
     assert_cross_target(r#"
 fn main() -> Unit = {


### PR DESCRIPTION
Fixes #755.

## Root cause

`guard … else { … }` lowers to an `IrStmtKind::Guard { cond, else_ }` that is
still a *statement* when the WASM-only Perceus pass runs. `block_to_fnbody`
maps every statement kind it doesn't special-case (Bind/Assign/RcInc/RcDec/Expr)
to `FnBody::Stmt`, and `perceus_fnbody`'s `ChainHead::Stmt` arm was a pure
pass-through. So a `Guard`'s `cond` and its divergent `else_` block received
**zero** reference-count processing: a heap temp bound in the else block (e.g.
a string interpolation or `"a" + b`) never got its scope-end `Dec`. The
Lean-certified RC verifier then correctly refused the WASM build with
`[perceus-belt] LEAK: no RcDec: __anf_N`. The native/Rust target was fine
(RAII drops the temp), so this only surfaced on `--target wasm` — and thus on
`almide test`, whose default target is wasm.

## Fix

`ChainHead::Stmt` now `perceus_expr`s a `Guard`'s `cond` and `else_`. The else
Block round-trips through the Block arm, which inserts the scope-end Decs
before its divergent `Ret` — identical treatment to every other block.

## Verification

- Minimal repro and the original reporter (`almide-ai/manus`) pass the RC gate.
- 16/16 `examples/*.almd` compile clean to wasm (no perceus failures).
- `cargo test -p almide-codegen`: 107 pass; perceus proptests: 28 pass.
- Native runtime output unchanged.
- New cross-target regression test `wasm_guard_else_heap_temp`.
