### PR TITLE
fix(codegen): Ok-wrap bare-value intrinsic effect fns in tail position (#758)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ care about.
   arm now `perceus_expr`s a Guard's `cond` and `else_`, so the divergent else
   block is round-tripped and Dec-balanced like any other block.
 
+### Fixed — Rust codegen
+
+- **Bare-value `@intrinsic` effect fns in tail position** (#758): a tail call
+  to an intrinsic effect fn whose runtime returns a plain value (`io.print →
+  Unit`, `io.read_line → String`, `fs.exists → Bool`, `env.get → Option`) was
+  wrongly exempted from the Result tail-wrap — the exemption set held *every*
+  `@intrinsic` effect fn, not just the runtime-`Result` ones — leaving a bare
+  `()`/value tail in the auto-`Result`-wrapped fn (invalid Rust, E0308). The
+  set is now built from intrinsics that actually return `Result` (declared
+  `-> Result[...]`, plus `http.serve`, whose runtime returns `Result<(),
+  String>` under a `-> Unit` declaration), so bare-value intrinsic tails get
+  their `Ok(...)` like any other tail.
+
 ## [0.23.3] — 2026-05-24
 
 ### Performance — WASM parity with Rust

--- a/crates/almide-codegen/src/pass_result_propagation.rs
+++ b/crates/almide-codegen/src/pass_result_propagation.rs
@@ -85,17 +85,35 @@ impl NanoPass for ResultPropagationPass {
         // wrongly `Ok(...)`-wrap it, double-wrapping the Result (#434, E0308).
         // Collect their runtime symbols so the tail-wrap can recognize them.
         let intrinsic_effect_syms: HashSet<String> = if wrap_non_result {
-            use almide_lang::ast::{AttrValue, Decl};
+            use almide_lang::ast::{AttrValue, Decl, TypeExpr};
+            // Only intrinsic effect fns whose RUNTIME returns `Result<_, String>`
+            // belong in the tail exemption below: their tail `RuntimeCall` IS the
+            // Result this fn returns, so Ok-wrapping it double-wraps (#434). That
+            // is exactly the ones DECLARED `-> Result[...]`, plus the rare
+            // intrinsic whose runtime returns Result under a non-Result
+            // declaration — currently only `http.serve` (declared `-> Unit`, but
+            // `almide_rt_http_serve -> Result<(), String>`; its runtime wrapper
+            // composes the Result internally).
+            //
+            // A BARE-value intrinsic must NOT be exempted: `io.print -> Unit`,
+            // `io.read_line -> String`, `fs.exists -> Bool`, `env.get -> Option`
+            // all return a plain value from the runtime, so a tail call to one
+            // still needs `Ok(...)`. Exempting them left a bare `()`/value tail
+            // in a `-> Result<_, String>` fn (#758, E0308).
+            const RUNTIME_RESULT_NONRESULT_DECL: &[&str] = &["almide_rt_http_serve"];
             let mut set = HashSet::new();
             for &mod_name in almide_lang::stdlib_info::BUNDLED_MODULES {
                 let Some(source) = almide_lang::stdlib_info::bundled_source(mod_name) else { continue };
                 let Some(parsed) = almide_lang::parse_cached(source) else { continue };
                 for decl in &parsed.decls {
-                    let Decl::Fn { effect, attrs, .. } = decl else { continue };
+                    let Decl::Fn { effect, attrs, return_type, .. } = decl else { continue };
                     if *effect != Some(true) { continue; }
                     let Some(attr) = attrs.iter().find(|a| a.name.as_str() == "intrinsic") else { continue };
                     let Some(first) = attr.args.first() else { continue };
-                    if let AttrValue::String { value: symbol } = &first.value {
+                    let AttrValue::String { value: symbol } = &first.value else { continue };
+                    let declared_result = matches!(return_type,
+                        TypeExpr::Generic { name, .. } if name.as_str() == "Result");
+                    if declared_result || RUNTIME_RESULT_NONRESULT_DECL.contains(&symbol.as_str()) {
                         set.insert(symbol.to_string());
                     }
                 }

--- a/spec/lang/effect_intrinsic_tail_test.almd
+++ b/spec/lang/effect_intrinsic_tail_test.almd
@@ -8,11 +8,28 @@
 // They are now recognized and left un-wrapped. http.serve blocks forever, so it
 // is never started here — `_serve_demo` exists only to keep that codegen path
 // compiling (it is emitted, not eliminated).
+//
+// The counterpart (#758): a tail call to a BARE-VALUE @intrinsic effect fn
+// (`io.print -> Unit`, `io.read_line -> String`) must NOT be exempted — its
+// runtime returns a plain value, not a Result, so the tail still needs an
+// `Ok(...)`. Exempting it (the exemption set formerly held every intrinsic
+// effect fn regardless of runtime return type) emitted a bare `()`/value tail
+// in a `-> Result<_, String>` fn — invalid Rust (E0308). These two fns pin
+// both sides of the exemption decision. All three are emitted, not eliminated;
+// none is run (http.serve blocks forever, io.read_line would read stdin).
 import http
+import io
 
 effect fn _serve_demo() -> Unit = {
   http.serve(8080, (req) => http.response(200, http.req_path(req)))
 }
+
+effect fn _print_tail() -> Unit = {
+  let s = "hello"
+  io.print(s)
+}
+
+effect fn _read_tail() -> String = io.read_line()
 
 test "effect-fn tail call to an intrinsic effect fn compiles" {
   assert_eq(1, 1)


### PR DESCRIPTION
Fixes #758.

## Root cause

The Result-propagation pass exempts a tail `RuntimeCall` to a `@intrinsic`
effect fn from the `Ok(...)` tail-wrap, because such an intrinsic's runtime
returns `Result<_, String>` — it *is* the Result the fn returns, so wrapping
double-wraps (#434). But `intrinsic_effect_syms` was built from **every**
intrinsic effect fn, not only the runtime-`Result` ones. A bare-value
intrinsic (`io.print → Unit`, `io.read_line → String`, `fs.exists → Bool`,
`env.get → Option`) returns a plain value from its runtime, so exempting its
tail left a bare `()`/value as the last expr of the auto-`Result`-wrapped fn —
invalid Rust (`E0308: expected Result<(), String>, found ()`). `println` was
unaffected because it lowers to a `RustMacro`, not a `RuntimeCall`.

## Fix

Build the exemption set from intrinsics that actually return `Result`: those
declared `-> Result[...]`, plus the one runtime-`Result`-under-`-> Unit` case,
`http.serve` (`almide_rt_http_serve -> Result<(), String>`). Bare-value
intrinsic tails then fall through to the general `Ok(...)` wrap.

## Verification

- `effect fn main() -> Unit = { let s = "hello"; io.print(s) }` and the
  non-trivial-arg / `io.read_line`-tail variants compile & run.
- #434 regression (`http.serve` tail, `effect_intrinsic_tail_test`) still clean.
- 16/16 `examples/*.almd` wasm-build; `cargo test -p almide-codegen` 107 pass.
- `effect_intrinsic_tail_test.almd` extended to pin both sides of the decision.