### PR TITLE
Publish the ledger-derived equivalence claim in the README with a drift gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,39 @@ almide run hello.almd
 - **Built-in testing** — `test "name" { assert_eq(a, b) }` with `almide test`
 - **Actionable diagnostics** — Every error includes file:line, context, and a concrete fix suggestion
 
+## The Equivalence Claim — Byte-Identical Across Targets
+
+**Every program that compiles for both targets produces byte-identical observable output — stdout, stderr, exit code — whether it runs as a native binary or as WebAssembly.** Native is the oracle; `native == wasm` is a hard invariant, not a "target difference" to be documented around.
+
+"Byte-identical" means the *execution output*, not the compiled artifacts — a native binary and a `.wasm` module are different bytes by construction; what must not differ is anything the program lets you observe.
+
+This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI) so this section cannot drift from what the gates actually verify:
+
+<!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
+> **Ledger: 132 contracts — 131 active, 1 flagged-for-revision.**
+>
+> **Exceptions (1)** — contracts flagged for revision; the ratchet says this list may only shrink:
+>
+> - [C-006 — fan.timeout is the SOLE documented wall-clock divergence (wasm warns)](docs/contracts/C-006-fan-timeout-divergence.md)
+<!-- claims:generated:end -->
+
+| Evidence layer | What it locks |
+|---|---|
+| [Contract ledger](docs/contracts/) | every promise is a named `C-NNN`; an `active` contract must carry evidence of class ≥ `fixture` |
+| [Cross-target fixture gate](tests/wasm_runtime_test.rs) | every `spec/wasm_cross/*.almd` fixture runs on both targets; outputs byte-compared (`wasm_cross_target_spec`) |
+| [Differential fuzz](tests/regex_fuzz_test.rs) | randomized programs and inputs, native vs wasm outputs compared |
+| Emit-time Σ-probes | wasm Unicode/case tables exhaustively probed against Rust `std` over the full scalar domain at emit time |
+| [Lean 4 belt](crates/almide-perceus-belt/) | RC-insertion correctness machine-checked by the Lean kernel |
+| [Org byte-verify sweep](scripts/org-byte-verify.sh) | every runnable repo in the almide org executed on both targets, stdout + exit byte-compared |
+
 ## Memory Safety — Formally Verified
 
-Almide uses [Perceus](https://www.microsoft.com/en-us/research/publication/perceus-garbage-free-reference-counting-with-reuse/) reference counting for automatic memory management. No GC, no manual free, no pauses.
+You write no ownership annotations, no lifetimes, no `free` — memory management is fully automatic, garbage-collector-free, pause-free. The mechanism is per-target today:
+
+- **WebAssembly** — the compiler inserts [Perceus](https://www.microsoft.com/en-us/research/publication/perceus-garbage-free-reference-counting-with-reuse/) reference counting: precise, compiler-placed RC with no GC. This is the path the Lean proofs below certify.
+- **Native (Rust)** — the compiler emits ownership-idiomatic Rust, inserting borrows and clones for you; every heap value is freed by Rust's own scope-end drops.
+
+Making Perceus the *single* memory model on both targets — native rendered from the same IR discipline, with the Drop-erasure machine-checked — is tracked in [#764](https://github.com/almide/almide/issues/764).
 
 Where Rust gives you *zero-cost* abstraction (paid for in ownership annotations), Almide gives you **zero-annotation** abstraction: you write none, and every heap free is machine-proven — *write none, prove all.*
 
@@ -106,7 +136,7 @@ theorem perceus_all_heap_freed (fb : FnBody) :
     allHeapFreed (perceusTransform fb)
 ```
 
-**For any program, the compiler produces code where every heap allocation is freed on all execution paths.** 22 theorems, 0 sorry — verified by the Lean 4 kernel.
+**For any program, the compiler produces code where every heap allocation is freed on all execution paths** — by Rust's own drop semantics on native, and by the proven Perceus transform on wasm. 22 theorems, 0 sorry — verified by the Lean 4 kernel.
 
 This is connected to the actual compiler (not a separate paper proof):
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,8 +7,8 @@ pre-commit:
       glob: "{crates/almide-codegen/src/emit_wasm/*.rs,crates/almide-codegen/rt-oracle-registry.toml,scripts/check-rt-oracle-registry.sh,scripts/lib/contract-classes.txt}"
       run: scripts/check-rt-oracle-registry.sh
     contracts:
-      glob: "{docs/contracts/contracts.toml,docs/contracts/*.md,spec/wasm_cross/*.almd,crates/almide-codegen/rt-oracle-registry.toml,scripts/check-contracts.sh,scripts/lib/contract-classes.txt}"
-      run: scripts/check-contracts.sh && bash docs/contracts/generate-readme.sh > docs/contracts/README.md && git add docs/contracts/README.md
+      glob: "{docs/contracts/contracts.toml,docs/contracts/*.md,spec/wasm_cross/*.almd,crates/almide-codegen/rt-oracle-registry.toml,scripts/check-contracts.sh,scripts/lib/contract-classes.txt,scripts/gen-claims.sh,README.md}"
+      run: bash scripts/gen-claims.sh && git add README.md && scripts/check-contracts.sh && bash docs/contracts/generate-readme.sh > docs/contracts/README.md && git add docs/contracts/README.md
     ratchet-separation:
       run: scripts/check-ratchet-separation.sh
     semantics-manifest:

--- a/scripts/check-contracts.sh
+++ b/scripts/check-contracts.sh
@@ -29,7 +29,9 @@
 #   (e) a schema violation (bad id / duplicate id / bad status / bad class /
 #       fuzz without n / missing doc file);
 #   (f) a coverage gap (C-001..C-NNN must be contiguous) or the flagged-contract
-#       ratchet ceiling is exceeded.
+#       ratchet ceiling is exceeded;
+#   (g) the README claims block (equivalence-claim numbers + exceptions clause)
+#       is stale relative to the ledger (scripts/gen-claims.sh --check, #766).
 set -uo pipefail
 cd "$(dirname "$0")/.." || { echo "::error::cannot cd to repo root"; exit 2; }
 
@@ -307,6 +309,12 @@ if [ -d "$ALS_DIR" ]; then
   [ "$n_orphan" -eq 0 ] && echo "spec-coverage: every normative ALS section is cited by >=1 contract."
 fi
 
+# ── (g) README claims block (#766) ───────────────────────────────────────────
+# The equivalence-claim numbers and the exceptions clause quoted in README.md
+# are DERIVED from this ledger by scripts/gen-claims.sh. A stale or hand-edited
+# block is a public claim drifting from what the gates verify — red.
+bash scripts/gen-claims.sh --check || fail=1
+
 if [ "$fail" -ne 0 ]; then
   echo "::error::contract-ledger gate FAILED — see messages above."
   exit 1
@@ -321,3 +329,4 @@ echo "  fixtures: $n_with_header/$n_fixtures carry a // @contract: header; bidir
 #   (4) typo a class                                       -> (e) bad-class.
 #   (5) flag a 3rd contract                                -> (f) ratchet.
 #   (6) renumber a contract to leave a gap                 -> (f) coverage.
+#   (7) hand-edit a number inside README's claims markers  -> (g) stale-claims.

--- a/scripts/gen-claims.sh
+++ b/scripts/gen-claims.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# gen-claims.sh — regenerate the machine-derived claims block in README.md
+# from docs/contracts/contracts.toml (#766).
+#
+# The README's "Equivalence Claim" section quotes ledger numbers (contract
+# count, active/flagged split) and the exceptions clause (the list of
+# flagged-for-revision contracts). Those must be DERIVED, never hand-written:
+# this script rewrites everything between the claims markers, and
+# scripts/check-contracts.sh runs `--check` in CI so a drifted block is red.
+#
+#   bash scripts/gen-claims.sh          # rewrite README.md in place
+#   bash scripts/gen-claims.sh --check  # exit 1 if the block is stale
+#
+# Pure shell/awk, no deps — same discipline as docs/contracts/generate-readme.sh.
+set -euo pipefail
+cd "$(dirname "$0")/.." || exit 2
+
+LEDGER="docs/contracts/contracts.toml"
+README="README.md"
+START="<!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->"
+END="<!-- claims:generated:end -->"
+
+[ -f "$LEDGER" ] || { echo "::error::$LEDGER not found (run from repo root)"; exit 2; }
+[ -f "$README" ] || { echo "::error::$README not found (run from repo root)"; exit 2; }
+grep -qxF "$START" "$README" || { echo "::error::claims start marker missing from $README"; exit 2; }
+grep -qxF "$END" "$README"   || { echo "::error::claims end marker missing from $README"; exit 2; }
+
+# Walk the ledger with the same block parser as generate-readme.sh: line-start
+# anchors skip schema comments, the ''' toggle skips multi-line statements.
+blockfile="$(mktemp)"
+trap 'rm -f "$blockfile"' EXIT
+awk '
+  function flush() {
+    if (id == "") return
+    total++
+    if (status == "active") active++
+    else { nflag++; fid[nflag] = id; ftitle[nflag] = title; fdoc[nflag] = doc }
+    id = ""; title = ""; status = ""; doc = ""
+  }
+  /'"'"''"'"''"'"'/ { in_stmt = !in_stmt; next }
+  in_stmt { next }
+  /^\[\[contract\]\]/ { flush(); next }
+  /^id[ \t]*=/     { v = $0; sub(/^id[ \t]*=[ \t]*"/, "", v); sub(/".*$/, "", v); id = v; next }
+  /^title[ \t]*=/  { v = $0; sub(/^title[ \t]*=[ \t]*"/, "", v); sub(/".*$/, "", v); title = v; next }
+  /^status[ \t]*=/ { v = $0; sub(/^status[ \t]*=[ \t]*"/, "", v); sub(/".*$/, "", v); status = v; next }
+  /^doc[ \t]*=/    { v = $0; sub(/^doc[ \t]*=[ \t]*"/, "", v); sub(/".*$/, "", v); doc = v; next }
+  END {
+    flush()
+    printf "> **Ledger: %d contracts — %d active, %d flagged-for-revision.**\n", total, active, nflag
+    print ">"
+    if (nflag == 0) {
+      print "> **Exceptions: none.** Every contract in the ledger is `active`, carrying"
+      print "> executable evidence of class ≥ `fixture`."
+    } else {
+      printf "> **Exceptions (%d)** — contracts flagged for revision; the ratchet says this list may only shrink:\n", nflag
+      print ">"
+      for (k = 1; k <= nflag; k++) {
+        link = (fdoc[k] != "") ? "docs/contracts/" fdoc[k] : "docs/contracts/contracts.toml"
+        printf "> - [%s — %s](%s)\n", fid[k], ftitle[k], link
+      }
+    }
+  }
+' "$LEDGER" > "$blockfile"
+
+rendered="$(awk -v start="$START" -v end="$END" -v bf="$blockfile" '
+  $0 == start { print; while ((getline line < bf) > 0) print line; skip = 1; next }
+  $0 == end   { skip = 0; print; next }
+  !skip { print }
+' "$README")"
+
+if [ "${1:-}" = "--check" ]; then
+  if [ "$rendered" != "$(cat "$README")" ]; then
+    echo "::error::README.md claims block is stale — run: bash scripts/gen-claims.sh"
+    exit 1
+  fi
+  exit 0
+fi
+
+printf '%s\n' "$rendered" > "$README"


### PR DESCRIPTION
Closes #766.

## What

Adds a first-class **"The Equivalence Claim — Byte-Identical Across Targets"** section to the README, with its numbers machine-derived from the contract ledger so the public claim can never drift from what the gates verify.

- **Precise claim**: byte-identical = observable *execution* output (stdout, stderr, exit code), explicitly not the compiled artifacts. Native is the oracle.
- **Machine-derived block**: `scripts/gen-claims.sh` (pure shell/awk, same discipline as `docs/contracts/generate-readme.sh`) regenerates the contract counts and the exceptions clause between `claims:generated` markers from `contracts.toml`. Today it renders: 132 contracts — 131 active, 1 flagged (C-006). When #765 retires C-006, regenerating flips it to **"Exceptions: none."** automatically.
- **Evidence index**: one row per layer — contract ledger, cross-target fixture gate (`wasm_cross_target_spec`), differential fuzz, emit-time Σ-probes, Lean 4 belt, org byte-verify sweep.
- **Target-precise memory wording**: the Memory Safety section now states the per-target mechanism (wasm = compiler-inserted Perceus RC, the path the Lean proofs certify; native = ownership-idiomatic Rust with compiler-inserted borrows/clones) and links #764 for unifying the model.

## Enforcement

- `scripts/check-contracts.sh` gains check **(g)**: `gen-claims.sh --check` — a stale or hand-edited claims block fails the gate (CI `checks` job + lefthook, no new wiring needed).
- lefthook `contracts` hook auto-fixes: runs `gen-claims.sh && git add README.md` before the gate; glob extended with `README.md` and `scripts/gen-claims.sh`.
- Mutation-testability entry (7) added: hand-editing a number inside the markers flips the gate green→red (verified locally, both directions, plus idempotence of the generator).

## Verification

- `bash scripts/check-contracts.sh` green end-to-end (132 contracts, 242/242 fixtures linked).
- Generator idempotent; `--check` green on fresh, red on mutated block, self-heals on rerun.
