### PR TITLE
Reinitialize module globals before every wasm test for native isolation parity

### DIFF
--- a/crates/almide-codegen/src/emit_wasm/mod_p3.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod_p3.rs
@@ -671,8 +671,15 @@ pub(crate) fn emit(program: &IrProgram) -> Vec<u8> {
         almide_ir::IrExprKind::LitInt { .. } | almide_ir::IrExprKind::LitFloat { .. } |
         almide_ir::IrExprKind::LitBool { .. }
     );
+    // TEST mode re-inits globals before EVERY test (native thread_local
+    // isolation parity — see compile_test_runner), so a test module with ANY
+    // top-let needs the init fn even when all initializers are constants: a
+    // constant-init `var` mutated by one test must reset for the next.
+    let has_any_top_let = !program.top_lets.is_empty()
+        || program.modules.iter().any(|m| !m.top_lets.is_empty());
     let needs_init = program.top_lets.iter().any(is_dyn)
-        || program.modules.iter().any(|m| m.top_lets.iter().any(is_dyn));
+        || program.modules.iter().any(|m| m.top_lets.iter().any(is_dyn))
+        || (!has_main && !test_func_indices.is_empty() && has_any_top_let);
     let init_globals_idx: Option<u32> = if needs_init {
         let void_ty = emitter.register_type(vec![], vec![]);
         let idx = emitter.register_func("__init_globals", void_ty);

--- a/crates/almide-codegen/src/emit_wasm/mod_p4.rs
+++ b/crates/almide-codegen/src/emit_wasm/mod_p4.rs
@@ -395,12 +395,17 @@ fn compile_test_runner(emitter: &mut WasmEmitter, tests: &[(u32, String)], init_
     let void_type = emitter.register_type(vec![], vec![]);
     let mut f = TrackedFunction::new([]);
 
-    // Initialize globals if needed
-    if let Some(init_idx) = init_globals {
-        f.instruction(&wasm_encoder::Instruction::Call(init_idx));
-    }
-
     for (func_idx, test_name) in tests {
+        // Re-initialize module globals before EVERY test: the native harness
+        // stores module `var`s in `thread_local!`s and libtest runs each test
+        // on its own thread, so each native test sees PRISTINE module state.
+        // A single shared init here would leak one test's global mutations
+        // into the next — an isolation (and order-sensitivity) divergence
+        // from native (module_var_index_test's cross-test corruption class).
+        if let Some(init_idx) = init_globals {
+            f.instruction(&wasm_encoder::Instruction::Call(init_idx));
+        }
+
         // Print test name
         let name_str = emitter.intern_string(&format!("test: {} ... ", test_name));
         f.instruction(&wasm_encoder::Instruction::I32Const(name_str as i32));

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-132 contracts
+133 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -160,4 +160,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-130 | option/map combinators hand back OWNED heap results (no bare pass-through handles) | 0.28.5 | active | fixture | 2 |
 | C-131 | Loop-rebuilt buffers are O(n): COW guards only LIVE aliases, and LICM never hoists heap allocations | 0.28.6 | active | fixture | 1 |
 | C-132 | mut parameters of reallocating containers persist to the caller at every call position | 0.28.6 | active | fixture | 1 |
+| C-133 | env.get observes the host environment identically on native and wasm | 0.29.0 | active | fixture | 1 |
 


### PR DESCRIPTION
Fixes the red `Test WASM` job on develop (`spec/lang/module_var_index_test.almd`).

## Root cause

The wasm test runner called `__init_globals` ONCE before all tests, so one test's module-`var` mutations leaked into the next. The native harness stores module `var`s in `thread_local!`s and libtest runs each test on its own thread — every native test sees PRISTINE module state. With the runner executing tests in a different order than declaration, the leaked state broke `module var index-assign through fn`: the preceding `let-bind` test left `speeds[0] = 4.5`, failing the test's `get_speed(0) == 0.0`.

## Fix

- `compile_test_runner` calls `__init_globals` before EVERY test (isolation parity with native; order sensitivity eliminated).
- Test mode forces the init fn even when all module-var initializers are constants — a constant-init `var` mutated by one test must reset for the next.

## Verification

- `almide test spec/ --target wasm` (the exact CI invocation): **271 passed, 0 failed, 14 skipped** — was 270/1/14.
- Full `cargo test --release` (45 binaries, 878 tests) and native `almide test` (285 files): green.