### PR TITLE
Native trust spine rung 3: broadened String floor and run --verified wiring

### DIFF
--- a/crates/almide-mir/src/render_native.rs
+++ b/crates/almide-mir/src/render_native.rs
@@ -93,6 +93,51 @@ fn shim(name: &str) -> Option<(&'static [NTy], Option<NTy>, &'static str)> {
             Some(NTy::I64),
             "fn rt_string_len(s: &str) -> i64 { s.chars().count() as i64 }",
         )),
+        // String predicates/transforms: each shim is the EXACT v0 native oracle
+        // expression (runtime/rs/src/string.rs delegates to Rust std the same way),
+        // so the differential gate pins byte-equality, and C-016/C-019/C-020's
+        // full-Unicode discipline carries over unchanged.
+        "string.contains" => Some((
+            &[NTy::Str, NTy::Str],
+            Some(NTy::I64),
+            "fn rt_string_contains(s: &str, sub: &str) -> i64 { s.contains(sub) as i64 }",
+        )),
+        "string.starts_with" => Some((
+            &[NTy::Str, NTy::Str],
+            Some(NTy::I64),
+            "fn rt_string_starts_with(s: &str, p: &str) -> i64 { s.starts_with(p) as i64 }",
+        )),
+        "string.ends_with" => Some((
+            &[NTy::Str, NTy::Str],
+            Some(NTy::I64),
+            "fn rt_string_ends_with(s: &str, p: &str) -> i64 { s.ends_with(p) as i64 }",
+        )),
+        "string.to_upper" => Some((
+            &[NTy::Str],
+            Some(NTy::Str),
+            "fn rt_string_to_upper(s: &str) -> String { s.to_uppercase() }",
+        )),
+        "string.to_lower" => Some((
+            &[NTy::Str],
+            Some(NTy::Str),
+            "fn rt_string_to_lower(s: &str) -> String { s.to_lowercase() }",
+        )),
+        "string.trim" => Some((
+            &[NTy::Str],
+            Some(NTy::Str),
+            "fn rt_string_trim(s: &str) -> String { s.trim().to_string() }",
+        )),
+        "string.repeat" => Some((
+            &[NTy::Str, NTy::I64],
+            Some(NTy::Str),
+            "fn rt_string_repeat(s: &str, n: i64) -> String { s.repeat(n as usize) }",
+        )),
+        "string.cmp" => Some((
+            // Byte-wise lexicographic, -1/0/1 (C-019: rt_string_extra cmp = native oracle).
+            &[NTy::Str, NTy::Str],
+            Some(NTy::I64),
+            "fn rt_string_cmp(a: &str, b: &str) -> i64 {\n    match a.cmp(b) { std::cmp::Ordering::Less => -1, std::cmp::Ordering::Equal => 0, std::cmp::Ordering::Greater => 1 }\n}",
+        )),
         "__chk_div" => Some((
             &[NTy::I64, NTy::I64],
             Some(NTy::I64),

--- a/docs/roadmap/active/native-trust-spine.md
+++ b/docs/roadmap/active/native-trust-spine.md
@@ -33,13 +33,26 @@
       PRECISION WALL in the pipeline — a heap `Repr::Ptr` param/result renders
       as a string only when the DECLARED `Ty` says so, any signature outside
       {Int, Bool, String, Unit-ret} walls before lowering.
-- [ ] Rung 3: `List[Int]` / `List[String]` (`Vec<i64>` / `Vec<String>`), the
-      typed Drop family mapped to scope-end (`DropListStr` etc. erase once the
-      element type is a real Rust type — no recursive free needed natively).
-- [ ] Rung 4: records/variants (native structs/enums), Float (real `f64` — no
+- [x] **Rung 3** (shipped): the String floor broadened to the full boundary
+      surface reachable today — `string.contains` / `starts_with` / `ends_with`
+      / `to_upper` / `to_lower` / `trim` / `repeat` / `cmp` (each shim is the
+      EXACT v0 oracle expression, so C-016/C-019/C-020 discipline carries over)
+      — plus `almide run --verified` native wiring (`compile_to_binary_with`).
+- [ ] **Rung 4 — LISTS (needs a shared-MIR design, coordinate before building)**:
+      the v1 lower materializes list literals as `Alloc{DynList}` + inline
+      `Prim` stores and admits direct `xs[i]` prim loads over materialized
+      lists — the list world is BELOW the prim floor by design, so no
+      boundary-name mapping can reach it natively. Pattern-matching prim idioms
+      in the native renderer is rejected (guessing, not op fidelity). The path:
+      target-neutral list ops (e.g. `Op::ListLit`/`ListGet`/`ListLen`/`ListSet`)
+      that render_wasm lowers to EXACTLY today's prim sequences (byte-identity
+      guarded by the existing gates) and the native leg maps to `Vec` ops. This
+      touches the same `lower/binds*` bricks the ceangal/module-var workstream
+      is actively editing — do it WITH that workstream, not alongside it.
+- [ ] Rung 5: records/variants (native structs/enums), Float (real `f64` — no
       i64-bits convention on native), closures.
-- [ ] Rung 5: `almide run --verified` wiring; org byte-verify sweep column for
-      the native leg; multi-module + top-lets.
+- [ ] Rung 6: org byte-verify sweep column for the native leg; multi-module +
+      top-lets.
 - [ ] Default flip: v1-first native (`--no-verified` opt-out), README memory
       claim updated to the unified statement — closes #764.
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -789,7 +789,7 @@ pub fn cmd_test_json(file: &str, run_filter: Option<&str>) {
     }
 
     for test_file in &test_files {
-        let code = super::cmd_run_inner(test_file, &program_args, false, true, false);
+        let code = super::cmd_run_inner(test_file, &program_args, false, true, false, false);
         // Emit JSON per file
         let status = if code == 0 { "pass" } else { "fail" };
         println!(

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -57,7 +57,30 @@ impl BuildDirLock {
 /// Compile an .almd file to a native binary, returning the path to the executable.
 /// Uses incremental caching: if the generated Rust code hasn't changed, skips cargo build.
 pub fn compile_to_binary(file: &str, no_check: bool, test_mode: bool, release: bool, project_dir_override: Option<&std::path::Path>) -> Result<std::path::PathBuf, String> {
+    compile_to_binary_with(file, no_check, test_mode, release, project_dir_override, false)
+}
+
+/// `compile_to_binary` with the NATIVE trust-spine opt-in (#764): when
+/// `native_verified`, try the v1 MIR renderer first (same Perceus MIR as the
+/// wasm leg; Drop erased to Rust scope-end, ownership verified pre-render) and
+/// fall back to the v0 source on a WALL — a v1-rendered program is never wrong.
+pub fn compile_to_binary_with(file: &str, no_check: bool, test_mode: bool, release: bool, project_dir_override: Option<&std::path::Path>, native_verified: bool) -> Result<std::path::PathBuf, String> {
     let rs_code = try_compile(file, no_check).map_err(|_| "compile failed".to_string())?;
+    let rs_code = if native_verified && !test_mode {
+        let source_text = std::fs::read_to_string(file).unwrap_or_default();
+        match almide_mir::pipeline::try_render_rust_source(&source_text) {
+            Ok(v1_code) => {
+                eprintln!("native: v1 trust-spine render");
+                v1_code
+            }
+            Err(e) => {
+                eprintln!("native: v1 walled ({e:?}) — falling back to v0 codegen");
+                rs_code
+            }
+        }
+    } else {
+        rs_code
+    };
 
     // Scratch dir. A per-call `project_dir_override` (one dir per test file)
     // gives each parallel worker its own `src/main.rs`, so cold rustc builds
@@ -204,8 +227,8 @@ pub fn run_binary(bin: &std::path::Path, program_args: &[String]) -> i32 {
     1
 }
 
-pub fn cmd_run_inner(file: &str, program_args: &[String], no_check: bool, test_mode: bool, release: bool) -> i32 {
-    match compile_to_binary(file, no_check, test_mode, release, None) {
+pub fn cmd_run_inner(file: &str, program_args: &[String], no_check: bool, test_mode: bool, release: bool, native_verified: bool) -> i32 {
+    match compile_to_binary_with(file, no_check, test_mode, release, None, native_verified) {
         Ok(bin) => run_binary(&bin, program_args),
         Err(e) => {
             eprintln!("Compile error:\n{}", e);
@@ -214,10 +237,10 @@ pub fn cmd_run_inner(file: &str, program_args: &[String], no_check: bool, test_m
     }
 }
 
-pub fn cmd_run(file: &str, program_args: &[String], no_check: bool, release: bool, target: Option<&str>, verified: bool) {
+pub fn cmd_run(file: &str, program_args: &[String], no_check: bool, release: bool, target: Option<&str>, verified: bool, native_verified: bool) {
     let code = match target {
         // Default and explicit native target: the cargo/rustc path.
-        None | Some("rust") | Some("native") => cmd_run_inner(file, program_args, no_check, false, release),
+        None | Some("rust") | Some("native") => cmd_run_inner(file, program_args, no_check, false, release, native_verified),
         // WASM target: build the same module `almide build --target wasm`
         // emits, then execute it on the `wasmtime` CLI. Both targets must
         // produce byte-identical stdout/stderr/exit — the cross-target gate.

--- a/src/main.rs
+++ b/src/main.rs
@@ -690,10 +690,10 @@ fn dispatch(cli: Cli) {
         Commands::Init => cli::cmd_init(),
         Commands::Run { file, no_check, release, target, verified, no_verified, program_args } => {
             let file = resolve_file(file);
-            // 0.29.0: v1-first verified wasm is the DEFAULT; `--no-verified` opts out,
-            // `--verified` stays an accepted no-op (org byte-verify gate: 0 V1-MISMATCH).
-            let _ = verified;
-            cli::cmd_run(&file, &program_args, no_check, release, target.as_deref(), !no_verified);
+            // 0.29.0: v1-first verified wasm is the DEFAULT; `--no-verified` opts out.
+            // On the rust target the explicit `--verified` opts IN to the v1 native
+            // trust-spine renderer (#764 ladder; walls fall back to v0).
+            cli::cmd_run(&file, &program_args, no_check, release, target.as_deref(), !no_verified, verified);
         }
         Commands::Build { file, o, target, release, fast, unchecked_index, no_check, repr_c, cdylib, emit_unverified, verified, no_verified } => {
             let file = resolve_file(file);

--- a/tests/native_v1_differential_test.rs
+++ b/tests/native_v1_differential_test.rs
@@ -71,6 +71,10 @@ const CORPUS: &[(&str, &str)] = &[
     ("str_param_fn", "fn shout(s: String) -> String = s + \"!\"\nfn twice(s: String) -> String = shout(s) + shout(s)\n\nfn main() -> Unit = {\n  println(twice(\"hey\"))\n}\n"),
     ("loop_concat", "fn main() -> Unit = {\n  var acc = \"\"\n  var i = 0\n  while i < 5 {\n    acc = acc + int.to_string(i)\n    i = i + 1\n  }\n  println(acc)\n  println(int.to_string(string.len(acc)))\n}\n"),
     ("str_if_value", "fn label(n: Int) -> String = if n > 40 then int.to_string(n) + \"-big\" else \"small\"\n\nfn main() -> Unit = {\n  println(label(42))\n  println(label(7))\n}\n"),
+    // ── Rung 3: broadened String floor (each shim = the v0 oracle expression) ──
+    ("str_predicates", "fn main() -> Unit = {\n  let s = \"pre-\" + int.to_string(42) + \"-post\"\n  if string.contains(s, \"42\") then println(\"c1\") else println(\"c0\")\n  if string.starts_with(s, \"pre\") then println(\"s1\") else println(\"s0\")\n  if string.ends_with(s, \"post\") then println(\"e1\") else println(\"e0\")\n  if string.contains(s, \"x\") then println(\"c1\") else println(\"c0\")\n}\n"),
+    ("str_transforms", "fn main() -> Unit = {\n  let s = \"héllo ßtraße \" + int.to_string(7)\n  println(string.to_upper(s))\n  println(string.to_lower(string.to_upper(s)))\n  println(string.trim(\"  padded  \" + int.to_string(1)))\n  println(string.repeat(\"ab\", 3))\n}\n"),
+    ("str_ordering", "fn main() -> Unit = {\n  let a = int.to_string(41)\n  let b = int.to_string(42)\n  if a < b then println(\"lt\") else println(\"ge\")\n  if b < a then println(\"lt\") else println(\"ge\")\n  if a != b then println(\"ne\") else println(\"eq\")\n}\n"),
 ];
 
 #[test]
@@ -120,7 +124,7 @@ fn out_of_subset_walls_honestly() {
     let walls = [
         ("list", "fn main() -> Unit = {\n  let xs = [1, 2, 3]\n  println(int.to_string(list.len(xs)))\n}\n"),
         ("float", "fn main() -> Unit = {\n  println(float.to_string(1.5))\n}\n"),
-        ("str_contains", "fn main() -> Unit = {\n  if string.contains(\"abc\", \"b\") then println(\"y\") else println(\"n\")\n}\n"),
+        ("str_split", "fn main() -> Unit = {\n  let parts = string.split(\"a,b\", \",\")\n  println(parts[0])\n}\n"),
         ("list_param", "fn head(xs: List[Int]) -> Int = xs[0]\n\nfn main() -> Unit = {\n  println(int.to_string(head([9])))\n}\n"),
     ];
     for (name, src) in walls {


### PR DESCRIPTION
Part of #764 (rung 3 of `docs/roadmap/active/native-trust-spine.md`). Follows rungs 1–2 (#769, #770): honest wall, differential-gate-first.

## What ships

- **String floor broadened to the full boundary surface reachable today**: `string.contains` / `starts_with` / `ends_with` / `to_upper` / `to_lower` / `trim` / `repeat` / `cmp` (byte-wise -1/0/1). Each shim is the **exact v0 oracle expression** (`runtime/rs/src/string.rs` delegates to Rust std the same way), so the C-016/C-019/C-020 full-Unicode discipline carries over unchanged — verified against v0 with Unicode rows (`héllo ßtraße`, casing round-trips) in the differential corpus, now **18 programs, all byte-identical**.
- **`almide run --verified` native wiring** (`compile_to_binary_with`): the run path now tries the v1 renderer with the same wall-and-fallback discipline as `almide build --verified` (rung 1). Test-harness call sites keep v0 explicitly.

## The load-bearing finding: lists need a shared-MIR design (written into the ladder)

Rung 3 was planned as lists. Probing showed the v1 lower materializes list literals as `Alloc{DynList}` + inline `Prim` stores, and admits direct `xs[i]` prim loads over materialized lists — **the list world is below the prim floor by design**, unreachable by boundary-name mapping. Pattern-matching prim idioms in the native renderer is rejected (guessing, not op fidelity). The honest path is target-neutral list ops (`ListLit`/`ListGet`/`ListLen`/`ListSet`) that render_wasm lowers to exactly today's prim sequences and the native leg maps to `Vec` — but that touches the same `lower/binds*` bricks the ceangal/module-var workstream is actively editing, so the ladder now flags it as **coordinate-before-building** (new rung 4). The rung ordering was rebalanced accordingly.

## Verification

- Differential gate: 18/18 byte-identical (stdout/exit; div-zero also stderr); wall cases (`string.split`, lists, floats, `List[Int]` param) decline honestly.
- E2E: `almide run p.almd --verified` → "native: v1 trust-spine render" → output byte-identical to v0 (Unicode casing included).
- Full `cargo test --release`, native `almide test`, and `almide test spec/ --target wasm` (the CI invocation) green.
