### PR TITLE
Bump wasm tooling to 0.253, lsp-server to 0.9, insta to 1.48, checkout to v7, cache to v6

### DIFF
--- a/.github/workflows/almide-pkg-ci.yml
+++ b/.github/workflows/almide-pkg-ci.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Almide
         run: |

--- a/.github/workflows/ci-cross-target.yml
+++ b/.github/workflows/ci-cross-target.yml
@@ -27,13 +27,13 @@ jobs:
     name: Cross-Target (Rust vs WASM)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -46,7 +46,7 @@ jobs:
         run: cargo build --release
 
       - name: Cache wasmtime tarball
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: wasmtime-v42.0.1-x86_64-linux.tar.xz
           key: wasmtime-v42.0.1-x86_64-linux

--- a/.github/workflows/ci-feature.yml
+++ b/.github/workflows/ci-feature.yml
@@ -31,13 +31,13 @@ jobs:
     name: Build & Test (Linux)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,13 @@ jobs:
     name: Build (Linux)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -66,7 +66,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/download-artifact@v8
         with:
@@ -81,7 +81,7 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Cache wasmtime tarball
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: wasmtime-v42.0.1-x86_64-linux.tar.xz
           key: wasmtime-v42.0.1-x86_64-linux
@@ -158,13 +158,13 @@ jobs:
     # cannot see an excluded package). No `needs: build` — it tests only the kernel.
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -187,7 +187,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/download-artifact@v8
         with:
@@ -198,7 +198,7 @@ jobs:
         run: chmod +x /tmp/almide-bin/almide
 
       - name: Cache wasmtime tarball
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: wasmtime-v42.0.1-x86_64-linux.tar.xz
           key: wasmtime-v42.0.1-x86_64-linux
@@ -242,7 +242,7 @@ jobs:
     if: github.server_url == 'https://github.com'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -256,7 +256,7 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -267,7 +267,7 @@ jobs:
           restore-keys: wasmgen-${{ env.RUST_TOOLCHAIN }}-
 
       - name: Cache wasmtime tarball
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: wasmtime-v42.0.1-x86_64-linux.tar.xz
           key: wasmtime-v42.0.1-x86_64-linux
@@ -304,7 +304,7 @@ jobs:
     name: Lean Proofs (0 sorry)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Two complementary checks — both are required for the "proven" claim:
       # 1. grep for `sorry`: `lake build` only WARNS on sorry, so the grep is what
@@ -320,7 +320,7 @@ jobs:
           echo "✓ 0 sorry in Lean proofs"
 
       - name: Cache elan + Lean toolchain
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.elan
           key: elan-${{ runner.os }}-${{ hashFiles('crates/almide-perceus-belt/lean-toolchain') }}
@@ -361,7 +361,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/download-artifact@v8
         with:
@@ -413,13 +413,13 @@ jobs:
             artifact: almide-windows
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -460,7 +460,7 @@ jobs:
             binary: almide-bin/almide.exe
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -40,13 +40,13 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -65,7 +65,7 @@ jobs:
         run: cargo build --release
 
       - name: Cache wasmtime tarball
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: wasmtime-v42.0.1-x86_64-linux.tar.xz
           key: wasmtime-v42.0.1-x86_64-linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,14 @@ jobs:
             archive: almide-windows-x86_64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: ${{ matrix.target }}
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -96,7 +96,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/trust-spine.yml
+++ b/.github/workflows/trust-spine.yml
@@ -53,7 +53,7 @@ jobs:
     name: Coq proofs + axiom audit + PCC gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # ── Rust toolchain + cargo cache (almide-mir pulls in the frontend) ──
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "toml",
- "wasm-encoder 0.252.0",
+ "wasm-encoder 0.253.0",
  "wat",
 ]
 
@@ -71,8 +71,8 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
- "wasm-encoder 0.252.0",
- "wasmparser 0.252.0",
+ "wasm-encoder 0.253.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -654,9 +654,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lsp-server"
-version = "0.7.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6ada348dbc2703cbe7637b2dda05cff84d3da2819c24abcb305dd613e0ba2e"
+checksum = "62e55c013e58520c3471c904b6a4b95367acb73f20e718e1a0026d4297c9fc8e"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -1256,12 +1256,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+checksum = "59972d6cd272259de647b7c1f1912e45e289c75ffd4be04e10695507cd7e1b59"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.252.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
@@ -1290,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+checksum = "19db11f87d2486580e1e8b6f494c54df7e0566b87d0b599db843c24019667339"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.17.1",
@@ -1303,22 +1303,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "252.0.0"
+version = "253.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
+checksum = "d3264542f8965c5d84fb1085d924bfba9a6314bb228eff13a2de14d7627664d0"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.252.0",
+ "wasm-encoder 0.253.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.252.0"
+version = "1.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
+checksum = "4bfc5ce906144200c972ec617470aa35bd847472e170b26dde3e80541c674055"
 dependencies = [
  "wast",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 semver = "1"
 toml = "1.1"
-wasm-encoder = "0.252"
+wasm-encoder = "0.253"
 lasso = { version = "0.7", features = ["multi-threaded"] }
-lsp-server = "0.7"
+lsp-server = "0.9"
 lsp-types = "0.97"
 
 # Cross-platform advisory file lock (flock / LockFileEx) for the shared build

--- a/crates/almide-codegen/Cargo.toml
+++ b/crates/almide-codegen/Cargo.toml
@@ -11,8 +11,8 @@ almide-lang = { path = "../almide-lang" }
 almide-ir = { path = "../almide-ir" }
 almide-egg-lab = { path = "../almide-egg-lab" }
 egg = "0.11"
-wasm-encoder = "0.252"
-wasmparser = "0.252"
+wasm-encoder = "0.253"
+wasmparser = "0.253"
 toml = "1.1"
 serde_json = "1"
 

--- a/src/cli/lsp.rs
+++ b/src/cli/lsp.rs
@@ -447,7 +447,7 @@ fn handle_request(req: &Request, documents: &HashMap<Uri, String>, analyzed: &Ha
             let doc = analyzed.get(uri)?;
             let hover = compute_hover(doc, pos);
             let result = hover.map(|h| serde_json::to_value(h).unwrap()).unwrap_or(serde_json::Value::Null);
-            Some(Response { id: req.id.clone(), result: Some(result), error: None })
+            Some(Response::new_ok(req.id.clone(), result))
         }
         "textDocument/completion" => {
             let params: CompletionParams = serde_json::from_value(req.params.clone()).ok()?;
@@ -456,21 +456,21 @@ fn handle_request(req: &Request, documents: &HashMap<Uri, String>, analyzed: &Ha
             let source = documents.get(uri)?;
             let items = compute_completions(source, pos);
             let result = serde_json::to_value(CompletionResponse::Array(items)).unwrap();
-            Some(Response { id: req.id.clone(), result: Some(result), error: None })
+            Some(Response::new_ok(req.id.clone(), result))
         }
         "textDocument/documentSymbol" => {
             let params: DocumentSymbolParams = serde_json::from_value(req.params.clone()).ok()?;
             let doc = analyzed.get(&params.text_document.uri)?;
             let symbols = compute_document_symbols(doc);
             let result = serde_json::to_value(DocumentSymbolResponse::Flat(symbols)).unwrap();
-            Some(Response { id: req.id.clone(), result: Some(result), error: None })
+            Some(Response::new_ok(req.id.clone(), result))
         }
         "textDocument/formatting" => {
             let params: DocumentFormattingParams = serde_json::from_value(req.params.clone()).ok()?;
             let doc = analyzed.get(&params.text_document.uri)?;
             let edits = compute_formatting(doc);
             let result = serde_json::to_value(edits).unwrap();
-            Some(Response { id: req.id.clone(), result: Some(result), error: None })
+            Some(Response::new_ok(req.id.clone(), result))
         }
         "textDocument/definition" => {
             let params: GotoDefinitionParams = serde_json::from_value(req.params.clone()).ok()?;
@@ -480,7 +480,7 @@ fn handle_request(req: &Request, documents: &HashMap<Uri, String>, analyzed: &Ha
             let loc = compute_definition(doc, pos, uri);
             let result = loc.map(|l| serde_json::to_value(GotoDefinitionResponse::Scalar(l)).unwrap())
                 .unwrap_or(serde_json::Value::Null);
-            Some(Response { id: req.id.clone(), result: Some(result), error: None })
+            Some(Response::new_ok(req.id.clone(), result))
         }
         "textDocument/signatureHelp" => {
             let params: SignatureHelpParams = serde_json::from_value(req.params.clone()).ok()?;
@@ -490,13 +490,13 @@ fn handle_request(req: &Request, documents: &HashMap<Uri, String>, analyzed: &Ha
             let doc = analyzed.get(uri);
             let help = compute_signature_help(source, pos, doc);
             let result = help.map(|h| serde_json::to_value(h).unwrap()).unwrap_or(serde_json::Value::Null);
-            Some(Response { id: req.id.clone(), result: Some(result), error: None })
+            Some(Response::new_ok(req.id.clone(), result))
         }
         "workspace/symbol" => {
             let params: WorkspaceSymbolParams = serde_json::from_value(req.params.clone()).ok()?;
             let symbols = compute_workspace_symbols(&params.query, workspace_root);
             let result = serde_json::to_value(symbols).unwrap();
-            Some(Response { id: req.id.clone(), result: Some(result), error: None })
+            Some(Response::new_ok(req.id.clone(), result))
         }
         "textDocument/rename" => {
             let params: RenameParams = serde_json::from_value(req.params.clone()).ok()?;
@@ -505,7 +505,7 @@ fn handle_request(req: &Request, documents: &HashMap<Uri, String>, analyzed: &Ha
             let source = documents.get(uri)?;
             let edit = compute_rename(source, pos, uri, &params.new_name);
             let result = edit.map(|e| serde_json::to_value(e).unwrap()).unwrap_or(serde_json::Value::Null);
-            Some(Response { id: req.id.clone(), result: Some(result), error: None })
+            Some(Response::new_ok(req.id.clone(), result))
         }
         "textDocument/codeAction" => {
             let params: CodeActionParams = serde_json::from_value(req.params.clone()).ok()?;
@@ -513,7 +513,7 @@ fn handle_request(req: &Request, documents: &HashMap<Uri, String>, analyzed: &Ha
             let source = documents.get(uri)?;
             let actions = compute_code_actions(source, &params.context.diagnostics, uri);
             let result = serde_json::to_value(actions).unwrap();
-            Some(Response { id: req.id.clone(), result: Some(result), error: None })
+            Some(Response::new_ok(req.id.clone(), result))
         }
         _ => None,
     }


### PR DESCRIPTION
Batches the 7 open dependabot PRs (#760 #761 #762 #763 #745 #742 #735) into one CI run.

- wat 1.252 → 1.253, wasmparser/wasm-encoder 0.252 → 0.253 (lockstep family)
- lsp-server 0.7.9 → 0.9.0 — `Response { result, error }` became `ResponseKind`; the 9 struct-literal sites in `src/cli/lsp.rs` now use the `Response::new_ok` constructor (wire format unchanged)
- insta 1.47.2 → 1.48.0
- actions/checkout v6 → v7, actions/cache v5 → v6 (all workflows)

Dependabot will auto-close its PRs once this lands.