### PR TITLE
Escape free-form strings emitted by fmt

### DIFF
--- a/crates/almide-tools/src/fmt.rs
+++ b/crates/almide-tools/src/fmt.rs
@@ -7,6 +7,28 @@ use std::fmt::Write;
 use almide_lang::ast::*;
 use almide_base::intern::Sym;
 
+// Escapes a raw string for emission inside a double-quoted literal. `Decl::Test`
+// names are stored (post-parse) as the raw, already-unescaped description text —
+// unlike `ExprKind::String` (see fmt_p2.rs), which fmt_expr escapes correctly,
+// this had no escaping at all, so a test name containing a literal `"` (e.g.
+// `test "decide_pick(\"big\") ..."`) round-tripped through fmt into a broken,
+// prematurely-closed string literal — not idempotent, and not even valid on
+// the first pass. Same rule set as fmt_expr's ExprKind::String double-quote arm.
+pub(crate) fn escape_dquoted(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
 fn join_syms(syms: &[Sym], sep: &str) -> String {
     syms.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(sep)
 }
@@ -447,8 +469,8 @@ fn fmt_decl(out: &mut String, decl: &Decl, depth: usize) {
             out.push_str(" = "); fmt_expr(out, value, depth);
         }
         Decl::Fn { name, effect, r#async, visibility, params, return_type, body, extern_attrs, export_attrs, attrs, generics, .. } => {
-            for a in extern_attrs { wln!(out, "{i}@extern({}, \"{}\", \"{}\")", a.target, a.module, a.function); }
-            for a in export_attrs { wln!(out, "{i}@export({}, \"{}\")", a.target, a.symbol); }
+            for a in extern_attrs { wln!(out, "{i}@extern({}, \"{}\", \"{}\")", a.target, escape_dquoted(a.module.as_str()), escape_dquoted(a.function.as_str())); }
+            for a in export_attrs { wln!(out, "{i}@export({}, \"{}\")", a.target, escape_dquoted(a.symbol.as_str())); }
             for a in attrs { wln!(out, "{i}{}", format_attribute(a)); }
             out.push_str(&i); fmt_vis(out, visibility);
             if matches!(effect, Some(true)) { out.push_str("effect "); }
@@ -469,7 +491,7 @@ fn fmt_decl(out: &mut String, decl: &Decl, depth: usize) {
         Decl::Test { name, body, where_clauses, .. } => {
             // `where` clauses are the test's data — dropping them deleted
             // the bindings the body reads (E003 after formatting).
-            w!(out, "{i}test \"{name}\"");
+            w!(out, "{i}test \"{}\"", escape_dquoted(name));
             let cases: Vec<&TestWhere> = where_clauses.iter()
                 .filter(|wc| matches!(wc, TestWhere::Case { .. })).collect();
             let binds: Vec<&TestWhere> = where_clauses.iter()
@@ -579,7 +601,7 @@ fn fmt_type(out: &mut String, ty: &TypeExpr, depth: usize) {
 /// wire key), and silently deleting them broke round-tripped sources.
 fn fmt_field_type(out: &mut String, f: &FieldType, depth: usize) {
     w!(out, "{}", f.name);
-    if let Some(alias) = &f.alias { w!(out, " as \"{}\"", alias); }
+    if let Some(alias) = &f.alias { w!(out, " as \"{}\"", escape_dquoted(alias.as_str())); }
     out.push_str(": ");
     fmt_type(out, &f.ty, depth);
     if let Some(d) = &f.default { out.push_str(" = "); fmt_expr(out, d, depth); }

--- a/crates/almide-tools/src/fmt_p2.rs
+++ b/crates/almide-tools/src/fmt_p2.rs
@@ -33,7 +33,7 @@ fn fmt_expr(out: &mut String, expr: &Expr, depth: usize) {
         ExprKind::None => out.push_str("none"),
         ExprKind::Hole | ExprKind::Placeholder => out.push('_'),
         ExprKind::Error => out.push_str("/* error */"),
-        ExprKind::Todo { message, .. } => if message.is_empty() { out.push_str("todo"); } else { w!(out, "todo(\"{message}\")"); },
+        ExprKind::Todo { message, .. } => if message.is_empty() { out.push_str("todo"); } else { w!(out, "todo(\"{}\")", crate::fmt::escape_dquoted(message)); },
         ExprKind::Some { expr: e, .. } => { out.push_str("some("); fmt_expr(out, e, depth); out.push(')'); }
         ExprKind::Ok { expr: e, .. } => { out.push_str("ok("); fmt_expr(out, e, depth); out.push(')'); }
         ExprKind::Err { expr: e, .. } => { out.push_str("err("); fmt_expr(out, e, depth); out.push(')'); }
@@ -274,7 +274,7 @@ fn fmt_test_where_bare(out: &mut String, wc: &TestWhere, depth: usize) {
             fmt_expr(out, response, depth);
         }
         TestWhere::Case { name, bindings } => {
-            w!(out, "\"{}\" [", name);
+            w!(out, "\"{}\" [", crate::fmt::escape_dquoted(name));
             comma_sep(out, bindings, |out, b| fmt_test_where_bare(out, b, depth));
             out.push(']');
         }


### PR DESCRIPTION
## Summary
- `almide fmt` emitted 4 classes of free-form strings (test names, `@extern`/`@export` module/function/symbol, field-alias `as "..."`, `todo("...")` messages, test-case labels) with no escaping.
- A string containing `"`, `\`, or a newline (e.g. `test "decide_pick(\"big\") ..."`) round-tripped into a broken, prematurely-closed string literal on the very first format pass — not idempotent.
- Adds `escape_dquoted()` (same escape rule set as `fmt_expr`'s `ExprKind::String` arm) and applies it at all 4 emission sites.

## Test plan
- [x] `almide test` — 288/288 files pass, 0 failed
- [x] `cargo build --release` clean