### PR TITLE
Fill in missing roadmap tags and fix stale cross-links

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -6,26 +6,26 @@
 
 ## Active
 
-65 items
+66 items
 
 | Item | Description |
 |------|-------------|
 | [AlmidePerceusBelt](active/almide-perceus-belt.md) | AlmidePerceusBelt — formal memory safety guarantee for Almide |
 | [Behavioral Contract — 機械生成コードの「機能正しさ」を、王者の土俵を避けて取る層](active/behavioral-contract.md) | 機能正しさを王者(Dafny/F*/SPARK/Lean)の土俵を避けて取る層。C-FAITHFUL の上に C-PRESERVED(差分保存)と C-ASSERTED(批准性質)を積む。仕様の出所を機械生成レジームへずらす戦略。 |
 | [Build Speed: Runtime rlib + Hot-Fn Inlining](active/build-speed-runtime-rlib.md) | Native build-speed — precompiled almide_rt runtime rlib, and recovering the shipping-build inlining gap with #[inline] |
-| [Certificate Format v1 — design](active/certificate-format-v1.md) |  |
+| [Certificate Format v1 — design](active/certificate-format-v1.md) | v1 trust-spine certificate format design — ownership alphabet (i/a/d/m), per-call-site caps, branch-agreement encoding, and the kernel-as-oracle gate |
 | [Certification-Grade Hardening — 認証級への硬化](active/certification-grade.md) | Certification-grade hardening — adopt the mechanisms of DO-178C / ISO 26262 / IEC 61508 (spec, traceability, coverage, tool qualification, dossier) for the machine-written-software trust layer |
-| [CI Warnings Cleanup](active/ci-warnings-cleanup.md) |  |
+| [CI Warnings Cleanup](active/ci-warnings-cleanup.md) | Clean up CI warnings and non-fatal ICE messages on Windows/macOS CI |
 | [Closure Architecture v2](active/closure-architecture-v2.md) | Closure Architecture v2 — one identity, one capture-set, lifting is lowering; separates closure REPRESENTATION from the inlining OPTIMIZATION |
-| [Closure cross-target completeness](active/closure-cross-target-completeness.md) |  |
+| [Closure cross-target completeness](active/closure-cross-target-completeness.md) | Eliminate native/WASM closure-codegen divergence classes by construction, backed by a permanent CI differential gate |
 | [Code Health: Codopsy-Driven File Splits and Function Decomposition](active/code-health-codopsy.md) | Codopsy-driven code health: split 1000+ line files, decompose cog>100 fns |
-| [Codegen traversal totality](active/codegen-traversal-totality.md) |  |
-| [Completeness by Construction](active/completeness-by-construction.md) |  |
-| [Correctness Guarantee Gaps](active/correctness-guarantee-gaps.md) |  |
+| [Codegen traversal totality](active/codegen-traversal-totality.md) | Make a codegen pass forgetting to recurse into a node kind a compile error or CI failure, never a silent native/WASM divergence |
+| [Completeness by Construction](active/completeness-by-construction.md) | Make compiler correctness structural (by construction) rather than convention-enforced, extending the Perceus/borrow-checker completeness pattern compiler-wide |
+| [Correctness Guarantee Gaps](active/correctness-guarantee-gaps.md) | Audit of the well-typed-source-to-correct-binary chain — which layers have mechanical/mathematical proof and which don't, with per-layer milestones |
 | [Cross-Target Completeness (the Lid)](active/cross-target-completeness.md) | Cross-target completeness lid — the staged path from "all known divergences fixed + byte-diff gate" to structural equivalence (drain → interpreter+fuzz → selfhost → kernel proofs), with the live drain queue |
 | [The Determinism / Purity Belt](active/determinism-belt.md) | Determinism/Purity Belt — a Perceus-analog that makes the compiler deterministic & target-portable by construction |
 | [Capability-Based Effect System](active/effect-system-capability.md) | Capability-based effect system for sandboxed AI agent containers |
-| [Blueprint — making the ~27 effectful / raw-pointer stdlib fns FUNCTIONAL in v1](active/effectful-27-blueprint.md) |  |
+| [Blueprint — making the ~27 effectful / raw-pointer stdlib fns FUNCTIONAL in v1](active/effectful-27-blueprint.md) | Design blueprint for making the ~27 effectful/raw-pointer stdlib functions FUNCTIONAL on v1, tiered by verification ceiling |
 | [Flight Evidence Gaps — 実地監査所見台帳](active/flight-evidence-gaps.md) | Hands-on internal audit findings (2026-07-03) — the measured distance between DAL-A philosophy and DAL-A evidence, as 7 findings with corrective work items and acceptance criteria |
 | [Flight Profile — 航空品質への接地分析と2つのキーストーン](active/flight-profile.md) | Flight-grade (DO-178C/DO-333/DO-330) gap analysis for the v1 trust spine — the 6 pillars, what the PCC spine already nails, and the two engineering-closeable keystones (lift loops into Coq for WCET-bounding; productionize MIR→Rust to bind the cert to a Ferrocene-qualified flight target) that converge on one flight stack |
 | [Flight Qualification — DO-178C/DO-330/DO-333 マッピング + 資格化キット(G-F5 + G-F6)](active/flight-qualification.md) | Flight gates G-F5 + G-F6 — how the PCC certificate/receipt maps to DO-178C Table A objectives, the DO-330 "prove-the-checker" tool-qualification argument (compiler→TQL-5 output-verified, checker→qualified-by-proof), the DO-333 formal-methods credit per proven property, and the G-F6 qualification kit as a product (AbsInt/SCADE-KCG model): what's in the kit, the boundary (kit provides vs customer's domain process), and the customer integration story. |
@@ -33,47 +33,48 @@
 | [Flight Keystone (い) — v1 MIR → Rust → Ferrocene(忠実性束縛)](active/flight-rust-ferrocene.md) | Concrete implementation design for flight keystone (い) — G-F3: a production v1 MIR→Rust renderer + a rust_pattern faithfulness layer, making Rust→Ferrocene the flight target. The proof is cheap (~75% of the spine is target-agnostic; the faithfulness theorem is `exact eager_copy_refines_safety`); the real cost is the production renderer (~5x render_wasm). Ferrocene owns Rust→machine, so the flight path bypasses the hardest wasm byte-binding proof (Gap 1). |
 | [Almide Flight Profile — 規範仕様(Normative Subset)](active/flight-subset-spec.md) | The normative Almide Flight Profile — the SPARK/Ravenscar-class language subset for flight-grade code, machine-enforced by the per-build certificate (by proof, not review). Feature IN/OUT/RESTRICTED classification, the resolved keystone open questions (Dup-in-loop IN, break/continue OUT, recursion=acyclicity-reject, nested loops IN), the @flight enforcement architecture, the MISRA/Ravenscar mapping, and honest language residuals. |
 | [Flight Keystone (あ) — Counted Loops + Bounded Allocation(WCET-by-construction)](active/flight-wcet-loops.md) | Concrete implementation design for flight keystone (あ) — G-F1/G-F2: counted-loop flight subset + lifting loops into Coq to prove bounded allocation (WCET-by-construction). The counted loop is a SEPARATE structural witness (preserving the flat-fold RC invariant), two Subset.v-shaped properties prove it, and try_lower_scalar_for_range already knows the trip count. |
-| [StringInterp is NOT special syntax — desugar it to `concat + to_string(part)`](active/interp-is-desugar-to-tostring.md) |  |
-| [Issue Ledger Burn-down — 完全性キャンペーンの残量計](active/issue-ledger-burndown.md) |  |
+| [Fuzz Findings Triage: Re-green the Nightly Differential Gate](active/fuzz-findings-triage.md) | Fuzz (nightly) is red — triage the differential findings to zero and re-green the workflow |
+| [StringInterp is NOT special syntax — desugar it to `concat + to_string(part)`](active/interp-is-desugar-to-tostring.md) | Desugar StringInterp into a concat + to_string(part) chain instead of treating it as special syntax |
+| [Issue Ledger Burn-down — 完全性キャンペーンの残量計](active/issue-ledger-burndown.md) | Issue-ledger burn-down tracker for the completeness campaign — GitHub open-issue count as the completeness residual |
 | [LLM-first Language](active/llm-first-language.md) | Plan to make Almide the language LLMs write most accurately, measured by dojo MSR |
-| [Map / Set data-structure roadmap](active/map-data-structure-roadmap.md) |  |
-| [native: nested ctor/literal pattern at a Box'd (recursive-variant) field](active/native-boxed-pattern-lowering.md) |  |
-| [Native Trust Spine — Perceus as the single memory model (#764)](active/native-trust-spine.md) |  |
+| [Map / Set data-structure roadmap](active/map-data-structure-roadmap.md) | Design decision and roadmap for Map[K,V]/Set[T]: an O(1) insertion-ordered hash map (compact-ordered-dict) |
+| [native: nested ctor/literal pattern at a Box'd (recursive-variant) field](active/native-boxed-pattern-lowering.md) | Fix native (Rust) codegen for nested ctor/literal patterns on a Box'd recursive-variant field (#610) |
+| [Native Trust Spine — Perceus as the single memory model (#764)](active/native-trust-spine.md) | Route almide build --target rust through the same v1 Perceus MIR as the wasm leg, certified per build by verify_ownership (#764) |
 | [Post-0.29 Improvement Sweep](active/post-0.29-improvement-sweep.md) | Post-0.29.0 improvement sweep — every open gap issue-ized and ordered, from face-fixes to the v0 wasm retirement |
 | [Protocols: declared conformance + opt-in `any P`](active/protocol-any-existentials.md) | Declared conformance + opt-in `any P` existentials — take Go's interface-value ergonomics without its implicit-satisfaction and nil-interface traps; the one Swift idea worth stealing, none of the rest |
 | [Receipt Logic — 受領書の論理](active/receipt-logic.md) | Formal foundation for the trust layer — receipt logic: claim types, threat model, trust bases, falsification procedures, completeness relative to use-case |
 | [reconciliation follow-up — v0.28.0 で見送った develop 側の残件](active/reconciliation-followup.md) | v0.28.0 reconciliation follow-up: deferred develop commits for 0.28.1 |
 | [Trust Layer — 機械が書くソフトウェアの信頼層](active/trust-layer.md) | Category strategy — winning "the trust layer for machine-written software": MWS Trust Levels, receipts, critical path |
 | [Type Where Constraints](active/type-where-constraints.md) | where clauses on type/fn definitions for type constraints |
-| [v0 wasm codegen: Try/Unwrap/Fan early-return heap leak](active/v0-unwrap-early-return-leak.md) |  |
-| [GOAL PROMPT — finish ADT brick 5 (heap-field bind + recursive drop) to the #1 lever](active/v1-adt-brick5-goal.md) |  |
-| [v1 ① — custom ADT (variant) as a first-class value](active/v1-adt-value-model.md) |  |
+| [v0 wasm codegen: Try/Unwrap/Fan early-return heap leak](active/v0-unwrap-early-return-leak.md) | v0 wasm codegen: fix the Try/Unwrap/Fan early-return heap leak (emitter-side emit_early_return_decs) |
+| [GOAL PROMPT — finish ADT brick 5 (heap-field bind + recursive drop) to the #1 lever](active/v1-adt-brick5-goal.md) | Goal prompt: finish v1 ADT brick 5 (heap-field bind + recursive drop) to close the #1 cross-repo wall lever |
+| [v1 ① — custom ADT (variant) as a first-class value](active/v1-adt-value-model.md) | v1: make custom ADT (variant) values first-class, closing the #1 cross-repo wall lever (~41 walls, recursive to_string/pretty-print over user variants) |
 | [V1 Backlog — trust spine の残件一覧（優先度付き）](active/v1-backlog.md) | The v1 trust-spine backlog — soundness, drop completeness, self-host surface, walls |
 | [v1 Bolt Backlog(AI-DLC 管理)](active/v1-bolt-backlog.md) | AI-DLC Bolt backlog for the v1 climb — the camps/steps roadmap expressed as intent-driven, time-boxed Bolts (each with intent / Definition-of-Done / gate / deps / status). The construction guardrails are the goal-prompt discipline; each Bolt's exit gate is independent review (reviewer agent + Trust Spine CI + unbiased dual-oracle corpus); humans (Mob) decide at the marked forks. Tracks "あと何 Bolt" to each summit. |
 | [v1 → develop Reflow Strategy](active/v1-develop-reflow.md) | Strategy for flowing the develop-v1 trust spine back into develop — what moves, in what order, and what stays branch-local until its gate exists |
-| [v1 heap-result `if`/`match` execution — design (DE-RISKED: no Coq change)](active/v1-heap-result-control-flow.md) |  |
+| [v1 heap-result `if`/`match` execution — design (DE-RISKED: no Coq change)](active/v1-heap-result-control-flow.md) | v1: design for heap-result if/match execution — de-risked, no Coq change required |
 | [v1 KGI / KPI スコアボード](active/v1-kgi-kpi.md) | v1 KGI/KPI scoreboard — the terminal goal indicators (trust + writability), the guard invariants that must never degrade (checker size, TB purity, axiom cleanliness, zero claim-drift), and the progress KPIs toward each gap. Weekly fill-in. |
-| [v1 heap-loop-carried ownership — option C (cert-spine extension), the COMPLETENESS fix](active/v1-loop-ownership-cert.md) |  |
-| [Almide v1: MIR を唯一の真とする単一意味論アーキテクチャ](active/v1-mir-architecture.md) |  |
+| [v1 heap-loop-carried ownership — option C (cert-spine extension), the COMPLETENESS fix](active/v1-loop-ownership-cert.md) | v1: teach the proven ownership checker to reason about loop-carried heap accumulators (option C), the completeness fix for the remaining yaml walls |
+| [Almide v1: MIR を唯一の真とする単一意味論アーキテクチャ](active/v1-mir-architecture.md) | Almide v1: MIR as the single source of semantic truth — greenfield + dual-oracle architecture, mission-first surface language |
 | [Org byte-verification — every repo's own vectors on both targets](active/v1-org-byte-verification.md) | Org-wide v0==wasm byte-verification sweep and the wasm bug classes it flushed out |
-| [v1 — the parser-TCO lever (the real "heap-result-expr" cross-repo lever)](active/v1-parser-tco-lever.md) |  |
-| [Almide v1 Phase 1: MIR コア + 二レンダラ — 実装設計](active/v1-phase1-mir-core.md) |  |
+| [v1 — the parser-TCO lever (the real "heap-result-expr" cross-repo lever)](active/v1-parser-tco-lever.md) | v1: the parser-TCO lever — TCO over a match returning Result, the cross-repo lever blocking base64/toml decode |
+| [Almide v1 Phase 1: MIR コア + 二レンダラ — 実装設計](active/v1-phase1-mir-core.md) | Almide v1 Phase 1: MIR core + dual renderer — implementation design following the Phase 0 decision gate |
 | [v1 Proof Architecture — 構想(着地形)](active/v1-proof-architecture.md) | v1 vision — the landed proof architecture: untrusted compiler + two tiny qualified checkers, ALS as normative semantics, single Coq trust base, per-build receipts. Self-contained, terminal-state. |
 | [v1 Proof Spine — #31 progress (全V / leak-freedom / 推移的caps / 抽出穴)](active/v1-proof-spine-progress.md) | v1 proof-spine progress — what of task #31 (全V / leak-freedom / 推移的caps / 抽出穴) is PROVEN vs the honest remaining. Records the CapabilityReach.v transitive-caps theorem (2026-06-21). |
-| [v1 — records feature: svg FULL CONQUEST (goal prompt)](active/v1-records-svg.md) |  |
+| [v1 — records feature: svg FULL CONQUEST (goal prompt)](active/v1-records-svg.md) | v1 records feature: full conquest of the svg org repo on the WASM trust spine (construct, field read, spread, recursive nested ownership) |
 | [v1 リリース路線 — 段階リリース計画](active/v1-release-path.md) | v1 リリース路線 — opt-in 検証 codegen(v0 fallback) を beachhead に、カバレッジ→証明書 emit→flight-grade へ段階リリースする計画。4案のメリデメと選定理由、各段の受入基準。 |
-| [v1 stdlib self-host — the machinery phase (Option / List-building / closures)](active/v1-selfhost-machinery.md) |  |
-| [v1 self-host print floor — the ③ observability keystone](active/v1-selfhost-print-floor.md) |  |
-| [v1 trust-spine correctness holes (adversarial sweep 2026-06-27)](active/v1-spine-correctness-holes.md) |  |
+| [v1 stdlib self-host — the machinery phase (Option / List-building / closures)](active/v1-selfhost-machinery.md) | v1 stdlib self-host machinery phase (Option / list-building / closures) — self-hosting all ~381 v0 stdlib fns to execute byte-for-byte |
+| [v1 self-host print floor — the ③ observability keystone](active/v1-selfhost-print-floor.md) | v1 self-host print floor — the observability keystone for the first self-host slice |
+| [v1 trust-spine correctness holes (adversarial sweep 2026-06-27)](active/v1-spine-correctness-holes.md) | v1 trust-spine correctness holes found by an adversarial sweep of render_program vs native (30 confirmed holes) |
 | [v1 System Map — 全体像(mermaid)](active/v1-system-map.md) | v1 system map — mermaid diagrams of the whole trust architecture: each component's what / why / which area it secures, the PCC trust flow, the trust base, the three pillars, the threat model, and the maturity ladder. |
-| [v1 TCO — self-recursive tail calls → scalar-state loop (the yaml parser keystone)](active/v1-tco-self-recursion.md) |  |
+| [v1 TCO — self-recursive tail calls → scalar-state loop (the yaml parser keystone)](active/v1-tco-self-recursion.md) | v1 TCO for self-recursive tail calls to a scalar-state loop — the yaml-parser keystone |
 | [V1 → V0 Parity — the completion plan](active/v1-v0-parity.md) | The completion plan to bring the v1 MIR trust-spine to full v0 parity |
-| [v1 dynamic Value model — the yaml keystone (path A: self-host + ONE trusted recursive-drop routine)](active/v1-value-model.md) |  |
-| [柱C extension: bring Value rc into the certified region](active/value-rc-cert.md) |  |
-| [Almide WASM Engine — Complete Redesign](active/wasm-engine-redesign.md) |  |
-| [WASM Reference-Count Frees: the Ownership-Discipline Drain](active/wasm-frees-ownership-discipline.md) |  |
-| [WASM Optimization Roadmap](active/wasm-optimization-roadmap.md) |  |
-| [WASM 所有権 emit 層の機械化 (Perceus drift の構造的封じ込め)](active/wasm-ownership-emit-mechanization.md) |  |
+| [v1 dynamic Value model — the yaml keystone (path A: self-host + ONE trusted recursive-drop routine)](active/v1-value-model.md) | v1 dynamic Value model — the yaml keystone: self-hosted constructors/extractors/serializer with one trusted recursive-drop routine (path A) |
+| [柱C extension: bring Value rc into the certified region](active/value-rc-cert.md) | Bring Value refcount ops into the certified ownership region (柱C extension) — closing the prim.handle-fed rc blind spot |
+| [Almide WASM Engine — Complete Redesign](active/wasm-engine-redesign.md) | Complete redesign of the hand-written WASM emitter into a type-aware, layout-safe, stack-verified compiler (WASM 3.0/Component Model ready) |
+| [WASM Reference-Count Frees: the Ownership-Discipline Drain](active/wasm-frees-ownership-discipline.md) | Drain the WASM reference-count-frees ownership discipline gap toward the two-gate green |
+| [WASM Optimization Roadmap](active/wasm-optimization-roadmap.md) | WASM emitter performance roadmap — closing wins/ties/losses against rustc+LLVM across benchmarks |
+| [WASM 所有権 emit 層の機械化 (Perceus drift の構造的封じ込め)](active/wasm-ownership-emit-mechanization.md) | Mechanize the WASM ownership emit layer to structurally contain Perceus drift (#643) |
 | [WASM Platform Frontier — beyond core Wasm 3.0](active/wasm-platform-frontier.md) | Post-Wasm-3.0 platform tracking — WASI 0.3 / Component Model, stack switching, shared-everything-threads |
 
 ## On Hold
@@ -133,27 +134,45 @@
 | 2026-06-05 | [Perceus Void Block Stack Balance — CI Blocker](done/wasm-perceus-void-block.md) | StackBalancePass — void-context blocks never leak stack values (wasmtime 45+ strict validation) |
 | 2026-06-02 | [Closure Codegen Cross-Target Gaps](done/closure-codegen-cross-target-gaps.md) | Cross-target (native vs wasm) closure-codegen divergences found by the adversarial differential sweep — all 8 fixed |
 | 2026-05-29 | [WASM Component Model](done/wasm-component-model.md) | WebAssembly Component Model support with WIT bindings |
+| 2026-05-25 | [Cross-crate stdlib struct injection — DONE](done/cross-crate-struct-injection.md) | Fix ProcessStatus struct missing in cross-crate codegen — blocks almai dependency usage |
+| 2026-05-25 | [Cross-crate default field codegen](done/cross-crate-default-fields.md) | Fix cross-crate codegen for types with default field values |
+| 2026-05-25 | [Cross-crate anonymous record collision](done/cross-crate-anon-record-collision.md) | Anonymous record struct IDs collide across crates |
+| 2026-05-25 | [Cross-crate SSE runtime functions](done/cross-crate-sse-runtime.md) | SSE runtime functions missing in cross-crate codegen — http module needs sse dependency |
+| 2026-05-23 | [Test Where Syntax](done/test-where.md) | test where syntax — unified value/type/mock/table-driven test context |
+| 2026-05-22 | [Package Native Dispatch](done/package-native-dispatch.md) | First-class @inline_rust for packages, remove bundled-only walls |
+| 2026-05-22 | [Indexing Mutation Syntax](done/indexing-mutation.md) | buf[i] = val indexing syntax for bytes and list mutation |
+| 2026-05-22 | [Borrow Read Hoisting](done/borrow-read-hoist.md) | Auto-hoist reads from mut args to avoid Rust borrow conflicts |
+| 2026-05-21 | [Separate Compilation](done/separate-compilation.md) | Separate compilation with unified IR linker for all targets |
+| 2026-05-20 | [REPL](done/repl.md) | Interactive REPL — `almide` with no args starts an interactive session |
+| 2026-05-19 | [`mut` Parameter Modifier](done/mut-parameter-modifier.md) | mut parameter modifier for in-place mutation (Swift inout / Mojo mut) |
+| 2026-05-15 | [VarStorage Refactor — Unified Variable Classification](done/var-storage-refactor.md) | Unify module-var / local-COW variable classification into a single VarStorage model, removing duplicated if-else mutation chains |
+| 2026-05-14 | [Name Resolution Pass — Unified Cross-Package Symbol Resolution](done/name-resolution-pass.md) | Unified cross-package symbol resolution via DefId/DefTable, replacing ad-hoc name lookup |
+| 2026-05-11 | [Almide vs Mojo: Capability Parity Assessment](done/mojo-parity-assessment.md) | Almide vs Mojo capability parity assessment (Mojo = 100) |
+| 2026-04-20 | [`almide docs-gen` — llms.txt Auto-Generation](done/llms-txt-autogen.md) | Auto-generate llms.txt from canonical sources (CHEATSHEET, diagnostics, stdlib) |
 | 2026-04-20 | [Whisper in Pure Almide](done/whisper-almide.md) | Whisper speech recognition implemented entirely in Almide |
 | 2026-04-20 | [Variant Exhaustiveness Refinement](done/variant-exhaustiveness-refinement.md) | Non-exhaustive match suggests missing arm code; unreachable arms become hard errors |
 | 2026-04-20 | [Unify Diagnostic Emission with Docs](done/diagnostic-emit-doc-unification.md) | Unify diagnostic emission sites with their docs/diagnostics/*.md files |
 | 2026-04-20 | [Stdlib Symmetry Audit](done/stdlib-symmetry-audit.md) | Symmetry audit and lint for stdlib Option/Result/List/Set/Map to remove naming drift |
 | 2026-04-20 | [Stdlib Defs / Runtime Consistency Check](done/stdlib-defs-runtime-consistency.md) | CI check that stdlib/defs/*.toml declared types match runtime/rs/src/*.rs signatures |
 | 2026-04-20 | [Reimpl Lint: Signature-Match Detection of Stdlib Reimplementations](done/reimpl-lint.md) | Detect user fns whose signature matches a stdlib fn, suggest delegation |
-| 2026-04-20 | [DX & Codegen Papercuts](done/dx-codegen-papercuts.md) | Codegen bugs (effect fn unification) + DX papercuts — A/C landed, B spun off |
 | 2026-04-20 | [Diagnostics: Here / Try / Hint Format](done/diagnostics-here-try-hint.md) | Standardize diagnostics to Here/Try/Hint three-part format with CI-verified hint correctness |
-| 2026-04-20 | [`almide docs-gen` — llms.txt Auto-Generation](done/llms-txt-autogen.md) | Auto-generate llms.txt from canonical sources (CHEATSHEET, diagnostics, stdlib) |
+| 2026-04-20 | [DX: `almide test` stderr & `almide explain`](done/dx-testing-explain.md) | almide test stderr passthrough + almide explain <code> subcommand |
+| 2026-04-20 | [DX & Codegen Papercuts](done/dx-codegen-papercuts.md) | Codegen bugs (effect fn unification) + DX papercuts — A/C landed, B spun off |
+| 2026-04-19 | [bytes: unify bounds-check semantics](done/bytes-bounds-check.md) | Unify bounds checking across bytes accessors with Option/Result returns |
+| 2026-04-19 | [`cargo test --all` Cache Race](done/cargo-test-cache-race.md) | Fix parallel-cargo-test cache race in fix_test/run_test that masks real failures |
 | 2026-04-19 | [VarTable Unification](done/var-table-unification.md) | Unify program/module var_tables into a single program-level table |
 | 2026-04-19 | [Stdlib Declarative Unification — Toward a Single Source of Truth](done/stdlib-declarative-unification.md) | Drive stdlib toward a single source-of-truth: `.almd` + multi-target ABI attributes |
 | 2026-04-19 | [Sized Numeric Types](done/sized-numeric-types.md) | Swift-style Int8/Int32/UInt32/Float32 scalar types; unblocks bytes redesign + Matrix[T] dtype |
 | 2026-04-19 | [Dispatch Unification Plan (S3 Phase 1e)](done/dispatch-unification-plan.md) | Unify Rust + WASM stdlib dispatch via IR-level RuntimeCall; attributes become sugar |
 | 2026-04-19 | [Compiler Version Pin](done/compiler-version-pin.md) | minimum compiler version pinning in almide.toml (Cargo rust-version style) |
 | 2026-04-19 | [Codegen Ideal Form](done/codegen-ideal-form.md) | WASM codegen redesign toward declarative dispatch and explicit symbol resolution |
-| 2026-04-19 | [bytes: unify bounds-check semantics](done/bytes-bounds-check.md) | Unify bounds checking across bytes accessors with Option/Result returns |
-| 2026-04-19 | [`cargo test --all` Cache Race](done/cargo-test-cache-race.md) | Fix parallel-cargo-test cache race in fix_test/run_test that masks real failures |
 | 2026-04-17 | [Option/Result Bundled `.almd` — Not Cosmetic After All](done/option-result-bundled-cleanup.md) | Bundled option/result are signature-override layer; pick a path to consolidate |
 | 2026-04-17 | [Bundled-Almide Stdlib — Ideal Form](done/bundled-almide-ideal-form.md) | Ideal form for bundled-Almide stdlib: one dispatch path, no patch-layer special cases |
 | 2026-04-16 | [Cut v0.14.6 Release](done/release-0.14.6.md) | Cut v0.14.6 release from llm-first-phase2 branch |
 | 2026-04-16 | [Bundled-Almide Dispatch for Stdlib Modules](done/bundled-almide-dispatch.md) | Let stdlib/<module>.almd extend TOML modules (codegen dispatch fix) |
+| 2026-04-12 | [lumen — Pure Graphics Math](done/lumen-graphics-math.md) | lumen — pure graphics math library (vec3, mat4, color), used by webgl/canvas/obsid |
+| 2026-04-12 | [almai — Multi-Provider LLM Client](done/almai-llm-client.md) | almai — multi-provider LLM client library, 8 providers shipped |
+| 2026-04-12 | [Almide Dojo — Continuous MSR Measurement](done/almide-dojo.md) | Daily automated MSR loop — 30 tasks, Claude 100%, Llama 61%, almai integration |
 | 2026-04-09 | [Distribution UX](done/distribution-ux.md) | GitHub Release binaries, one-line installer, and almide self-update |
 | 2026-04-09 | [Custom WASM Host Imports](done/wasm-host-imports.md) | Allow WASM target to import functions from custom host modules |
 | 2026-04-08 | [WASM Closure Mutable Capture](done/wasm-closure-mutable-capture.md) | WASM closure mutable capture via heap cell for var mutation in lambdas |
@@ -171,11 +190,12 @@
 | 2026-04-03 | [Type Inference Unification for Generic Functions](done/type-inference-unification.md) | Unify inference variables with named TypeVars in generic function bodies |
 | 2026-04-03 | [Test Block Result Semantics](done/test-block-result-semantics.md) | Remove auto-unwrap of effect fn results in test blocks |
 | 2026-04-03 | [Flexible Error Types](done/flexible-error-types.md) | User-defined error types in Result, and test block Result visibility |
+| 2026-04-03 | [Fan Concurrency — Next Generation](done/fan-concurrency-next.md) | fan as a language-level concurrency primitive with rush/spawn/link/cancel |
+| 2026-04-02 | [`import self` in Dependency Packages Bug](done/import-self-in-dependency-bug.md) | Fix import self resolution in dependency packages (blocks almide-lander) |
 | 2026-04-02 | [Versioned Module Codegen Bug](done/versioned-module-codegen-bug.md) | Fix versioned module name mismatch in codegen for package dependencies |
 | 2026-04-02 | [UFCS Resolution in Dependency Modules](done/ufcs-in-dependency-modules.md) | UFCS method calls fail type resolution in dependency module context |
 | 2026-04-02 | [Pipe Operator Precedence Redesign](done/pipe-operator-precedence.md) | Pipe |> precedence conflicts with + (list concat) and .. (range) |
 | 2026-04-02 | [Almide Native cdylib — Scaffold in Almide, Not Rust](done/almide-native-cdylib.md) | Build .so/.dylib from pure Almide, eliminating Rust scaffolding from lander |
-| 2026-04-02 | [`import self` in Dependency Packages Bug](done/import-self-in-dependency-bug.md) | Fix import self resolution in dependency packages (blocks almide-lander) |
 | 2026-04-01 | [WASM Remaining FS Operations](done/wasm-remaining-fs.md) | Implement remaining filesystem operations for the WASM target |
 | 2026-04-01 | [Typed AST Cache](done/typed-ast-cache.md) | Cache type annotations on AST nodes to eliminate re-inference in lowering |
 | 2026-04-01 | [Type Expressiveness: Business Scenario Comparison](done/type-expressiveness-scenarios.md) | Business scenario comparison of type expressiveness across languages |
@@ -221,14 +241,14 @@
 | 2026-03-20 | [Stdlib Additions — Complete](done/stdlib-additions.md) | Stdlib module additions (set expanded to 20 functions) |
 | 2026-03-20 | [HKT Foundation — Complete](done/hkt-foundation.md) | Higher-kinded type foundation - all phases complete |
 | 2026-03-20 | [Compiler Bugs and Gaps — Status](done/compiler-bugs.md) | Codegen bugs and runtime gaps found while writing 400+ test blocks |
+| 2026-03-19 | [fan.map Concurrency Limit](done/fan-map-limit.md) | Add concurrency limit parameter to fan.map |
 | 2026-03-19 | [Test Architecture Redesign](done/test-architecture-redesign.md) | Separate effect permission from Result auto-unwrap in test infra |
 | 2026-03-19 | [Streaming — WebSocket, SSE, Stream](done/streaming.md) | WebSocket, SSE, and streaming data support |
 | 2026-03-19 | [HKT Foundation — Phase 1-4 + Stream Fusion (All 6 Laws)](done/hkt-foundation-phase1.md) | HKT foundation phases 1-4 with type constructors and algebraic laws |
-| 2026-03-19 | [fan.map Concurrency Limit](done/fan-map-limit.md) | Add concurrency limit parameter to fan.map |
 | 2026-03-19 | [Effect System — Phase 1-2](done/effect-system-phase1-2.md) | Effect inference engine with 7 categories and checker integration |
 | 2026-03-18 | [UFCS for External Libraries](done/ufcs-external.md) | Extend UFCS resolution to external library functions |
-| 2026-03-18 | [TS Edge-Native Deployment](done/ts-edge-native.md) | Native TS output for edge runtimes (Workers, Deno Deploy, Vercel) |
 | 2026-03-18 | [Tooling [ON HOLD — items split to active]](done/tooling.md) | Tooling roadmap (LSP, REPL, doc gen, bench) split to active |
+| 2026-03-18 | [TS Edge-Native Deployment](done/ts-edge-native.md) | Native TS output for edge runtimes (Workers, Deno Deploy, Vercel) |
 | 2026-03-18 | [Stdlib Strategy](done/stdlib-strategy.md) | Stdlib expansion strategy via Rust ecosystem wrapping |
 | 2026-03-18 | [Stdlib Architecture: 3-Layer Design](done/stdlib-architecture-3-layer-design.md) | Three-layer stdlib design (core/platform/external) for WASM parity |
 | 2026-03-18 | [Stdlib API Surface Reform](done/stdlib-verb-system.md) | Unified verb system across all stdlib container types |
@@ -260,6 +280,7 @@
 | 2026-03-18 | [Built-in Protocols](done/trait-impl.md) | Built-in protocols (Eq, Hash, Repr, From) with automatic derivation |
 | 2026-03-18 | [Anonymous Record Codegen Fix](done/anon-record-codegen.md) | Fix Rust codegen emitting invalid type for anonymous records |
 | 2026-03-18 | [Almide Runtime](done/almide-runtime.md) | Runtime design targeting best-in-class compiler performance |
+| 2026-03-17 | [almide.lock [DONE — 1.0 Phase III]](done/lockfile.md) | Dependency lockfile with git-based resolution and reproducible builds |
 | 2026-03-17 | [Stdlib Runtime Architecture Reform](done/stdlib-self-hosted-redesign.md) | Self-hosted stdlib with .almd-first design and @extern for host deps |
 | 2026-03-17 | [Stability Contract [DONE — 1.0 Phase II]](done/stability-contract.md) | Backward compatibility policy, edition system, and API freeze |
 | 2026-03-17 | [Runtime Layout Unification](done/runtime-layout.md) | Unify Rust and TS runtime file layout and management |
@@ -271,20 +292,19 @@
 | 2026-03-17 | [Effect Isolation (Security Layer 1)](done/effect-isolation.md) | Static verification that pure functions cannot perform I/O |
 | 2026-03-17 | [CLI-First](done/cli-first.md) | Enable comfortable CLI tool authoring with run, build, and WASM targets |
 | 2026-03-17 | [Borrow/Clone Gaps](done/borrow-clone-gaps.md) | Fix cases where Rust codegen fails to insert necessary clones |
-| 2026-03-17 | [almide.lock [DONE — 1.0 Phase III]](done/lockfile.md) | Dependency lockfile with git-based resolution and reproducible builds |
 | 2026-03-17 | [2026 Ergonomics Roadmap](done/2026-ergonomics.md) | Ergonomics issues found via self-tooling, evaluated against design principles |
 | 2026-03-16 | [Type System Theory Upgrade — HM Integration Plan](done/type-system-theory-upgrade.md) | Hindley-Milner integration plan (type schemes, let-polymorphism) |
 | 2026-03-16 | [TS Target: Result Maintenance (Erasure to Object)](done/ts-result-maintenance.md) | Replace TS Result erasure (throw/catch) with Result objects |
 | 2026-03-16 | [Recursive Type Box Insertion](done/recursive-type-box.md) | Auto-insert Box for recursive type members in Rust codegen |
 | 2026-03-16 | [Open Record / Row Polymorphism — Implementation Guide](done/open-record-structural-typing.md) | Open record / row polymorphism implementation for structural typing |
-| 2026-03-16 | [Let-Polymorphism (Algorithm W)](done/let-polymorphism.md) |  |
+| 2026-03-16 | [Let-Polymorphism (Algorithm W)](done/let-polymorphism.md) | Generalize let bindings to type schemes (Algorithm W) instead of monomorphic let inference |
 | 2026-03-16 | [Higher-Order Function Type Inference](done/higher-order-fn-inference.md) | Type inference for higher-order functions returning closures |
 | 2026-03-16 | [Guard `ok(value)` Value Loss in Effect Do-Block](done/guard-ok-value-loss.md) | Fix ok(value) being lost in guard expressions within effect do-blocks |
 | 2026-03-15 | [Unused Variable Warnings](done/unused-variable-warnings.md) | Warn on unused variables and imports, suppressible with _ prefix |
 | 2026-03-15 | [Type System Soundness](done/type-system-soundness.md) | Type system soundness fixes (Unknown propagation, unification, occurs) |
 | 2026-03-15 | [Type System Extensions](done/type-system.md) | Type system extensions (generics migration, inference improvements) |
-| 2026-03-15 | [TS/JS Codegen Rewrite](done/ts-codegen-rewrite.md) | Rewrite TS codegen to two-stage pipeline (IR to TsIR to String) |
 | 2026-03-15 | [Tail Call Optimization](done/tail-call-optimization.md) | Self-recursive tail call to labeled loop transformation |
+| 2026-03-15 | [TS/JS Codegen Rewrite](done/ts-codegen-rewrite.md) | Rewrite TS codegen to two-stage pipeline (IR to TsIR to String) |
 | 2026-03-15 | [Syntax Sugar](done/syntax-sugar.md) | Syntax sugar (ranges, exhaustiveness check, lambda shorthand) |
 | 2026-03-15 | [RustIR: Rust Codegen Intermediate Representation](done/rust-ir.md) | Two-stage Rust codegen pipeline via RustIR intermediate repr |
 | 2026-03-15 | [Pattern Exhaustiveness Check](done/pattern-exhaustiveness-check.md) | Static exhaustiveness checking for match expressions |
@@ -309,22 +329,24 @@
 | 2026-03-15 | [Clone Reduction Phase 4](done/clone-reduction.md) | Phase 4 clone reduction targeting field-level borrow analysis |
 | 2026-03-15 | [Architecture Hardening](done/architecture-hardening.md) | Fix structural weaknesses in compiler architecture |
 | 2026-03-15 | [--emit-ir: IR JSON Export](done/emit-ir.md) | Export typed IR as JSON via --emit-ir flag |
+| 2026-03-14 | [almide scaffold & Module Proliferation Pipeline [MERGED]](done/scaffold-and-proliferation.md) | Scaffold command and LLM module proliferation pipeline |
 | 2026-03-14 | [UFCS Type Resolution for Ambiguous Methods](done/ufcs-type-resolution.md) | Fix UFCS resolution for ambiguous methods on complex expressions |
 | 2026-03-14 | [Trailing Lambda / Builder DSL [WON'T DO]](done/trailing-lambda-builder.md) | Trailing lambda / builder DSL exploration (rejected) |
 | 2026-03-14 | [Structured Concurrency](done/structured-concurrency.md) | Async model with async fn, await, and async let constructs |
+| 2026-03-14 | [LSP Server](done/lsp.md) | Language Server Protocol for editor completion, diagnostics, and navigation |
 | 2026-03-14 | [LLM Developer Experience [DONE / MERGED]](done/llm-developer-experience.md) | UFCS and almide init improvements for LLM-assisted development |
 | 2026-03-14 | [JSON Builder API [SUPERSEDED]](done/json-builder-api.md) | Superseded JSON builder API, replaced by Codec Protocol |
 | 2026-03-14 | [Function Reference Passing [WON'T DO]](done/function-reference-passing.md) | Rejected: direct function reference passing deemed not worth complexity |
+| 2026-03-14 | [Elm-Grade Error Experience](done/error-fix-db.md) | Elm-grade compiler error experience — hospitality, not hostility |
 | 2026-03-14 | [Codegen Optimization [IN PROGRESS]](done/codegen-optimization.md) | Reduce clone overhead for heap types without exposing ownership |
 | 2026-03-14 | [Codegen IR Redesign](done/ir-redesign.md) | Self-contained typed IR so codegen never references AST |
 | 2026-03-14 | [Bidirectional Type Inference for Lambda Parameters](done/lambda-type-inference.md) | Bidirectional type inference for lambda parameters via two-pass checker |
-| 2026-03-14 | [almide scaffold & Module Proliferation Pipeline [MERGED]](done/scaffold-and-proliferation.md) | Scaffold command and LLM module proliferation pipeline |
+| 2026-03-13 | [`import self` — Package Entry Point Access](done/import-self-entry.md) | Allow main.almd to access pub functions from same-package mod.almd |
 | 2026-03-13 | [Module System v2](done/module-system-v2.md) | File-based module system with visibility controls and mod.almd |
 | 2026-03-13 | [Map Literal Syntax](done/map-literal.md) | Map literal syntax with Swift-style [:] empty map notation |
 | 2026-03-13 | [Hint System Architecture [P0]](done/hint-system.md) | Decouple hint generation from parser into a dedicated system |
 | 2026-03-13 | [Error Recovery](done/error-recovery.md) | Report all errors at once instead of stopping at the first one |
 | 2026-03-13 | [Eq Protocol](done/eq-protocol.md) | Automatic deep equality for all value types without deriving |
-| 2026-03-13 | [`import self` — Package Entry Point Access](done/import-self-entry.md) | Allow main.almd to access pub functions from same-package mod.almd |
 | 2026-03-12 | [While Loop](done/while-loop.md) | Dedicated while loop syntax replacing do-block guard pattern |
 | 2026-03-12 | [Variant Record Fields](done/variant-record-fields.md) | Named fields for enum variants (like Rust struct variants) |
 | 2026-03-12 | [Typed IR](done/typed-ir.md) | Typed intermediate representation between checker and emitters |
@@ -336,19 +358,19 @@
 | 2026-03-12 | [Language Test Coverage (`almide test`)](done/test-coverage.md) | Almide language-level test coverage targets (1500+ cases) |
 | 2026-03-12 | [Default Field Values](done/default-field-values.md) | Default values for record fields to eliminate sentinel value patterns |
 | 2026-03-12 | [Compiler Bugs Found by Test Expansion](done/compiler-bugs-from-tests.md) | Seven compiler bugs discovered during test coverage expansion |
+| 2026-03-11 | [stdin / Interactive I/O](done/stdin-io.md) | stdin reading and interactive I/O via io module |
+| 2026-03-11 | [npm Package Target](done/npm-package-target-target-npm.md) | Compile Almide to publish-ready npm packages via --target npm |
 | 2026-03-11 | [Tuple & Record](done/tuple-record.md) | Named record construction and tuple index access |
 | 2026-03-11 | [String Handling](done/string-handling.md) | Heredoc multi-line strings and raw string literals |
 | 2026-03-11 | [Stdlib Self-Hosting](done/stdlib-self-hosting.md) | Write stdlib in Almide for automatic multi-target support |
 | 2026-03-11 | [Stdlib Gaps](done/stdlib-gaps.md) | Reduce AI-generated boilerplate via new stdlib functions |
 | 2026-03-11 | [Stdlib Completeness](done/stdlib-completeness.md) | Fill stdlib gaps in int, string, list, and map modules |
-| 2026-03-11 | [stdin / Interactive I/O](done/stdin-io.md) | stdin reading and interactive I/O via io module |
 | 2026-03-11 | [Proliferation Blockers](done/proliferation-blockers.md) | Compiler bugs that blocked LLM module generation (all resolved) |
 | 2026-03-11 | [Playground Repair Turn](done/playground-repair.md) | Playground AI-powered error repair and type checker integration |
-| 2026-03-11 | [npm Package Target](done/npm-package-target-target-npm.md) | Compile Almide to publish-ready npm packages via --target npm |
-| 2026-03-11 | [LLM and Immutable Data Structures](done/llm-immutable-patterns.md) | Mitigations for LLM failures with immutable data patterns |
 | 2026-03-11 | [Literal Syntax Gaps](done/literal-syntax-gaps.md) | Cross-language comparison of numeric and collection literal syntax |
 | 2026-03-11 | [List Stdlib Gaps](done/list-stdlib-gaps.md) | Cross-language comparison of missing list module operations |
 | 2026-03-11 | [Language Test Suite](done/language-test-suite.md) | Systematic language feature test suite for regression detection |
+| 2026-03-11 | [LLM and Immutable Data Structures](done/llm-immutable-patterns.md) | Mitigations for LLM failures with immutable data patterns |
 | 2026-03-11 | [HTTP Module](done/http.md) | HTTP server and client module with multithreading support |
 | 2026-03-11 | [Generics](done/generics.md) | Generic functions, records, variants, and recursive generics |
 | 2026-03-11 | [Error Diagnostics](done/error-diagnostics.md) | LLM-critical diagnostics including lost mutation and type mismatch |

--- a/docs/roadmap/active/certificate-format-v1.md
+++ b/docs/roadmap/active/certificate-format-v1.md
@@ -1,3 +1,4 @@
+<!-- description: v1 trust-spine certificate format design — ownership alphabet (i/a/d/m), per-call-site caps, branch-agreement encoding, and the kernel-as-oracle gate -->
 # Certificate Format v1 — design
 
 > Status: **design accepted; bricks 1–2 and 5 shipped** (ownership alphabet

--- a/docs/roadmap/active/ci-warnings-cleanup.md
+++ b/docs/roadmap/active/ci-warnings-cleanup.md
@@ -1,3 +1,4 @@
+<!-- description: Clean up CI warnings and non-fatal ICE messages on Windows/macOS CI -->
 # CI Warnings Cleanup
 
 > **Status**: Active

--- a/docs/roadmap/active/closure-cross-target-completeness.md
+++ b/docs/roadmap/active/closure-cross-target-completeness.md
@@ -1,3 +1,4 @@
+<!-- description: Eliminate native/WASM closure-codegen divergence classes by construction, backed by a permanent CI differential gate -->
 # Closure cross-target completeness
 
 **Goal:** make native (Rust) and WASM agree on *every* closure program — not by passing more

--- a/docs/roadmap/active/codegen-traversal-totality.md
+++ b/docs/roadmap/active/codegen-traversal-totality.md
@@ -1,3 +1,4 @@
+<!-- description: Make a codegen pass forgetting to recurse into a node kind a compile error or CI failure, never a silent native/WASM divergence -->
 # Codegen traversal totality
 
 **Goal:** make "a pass forgot to recurse into a node kind" a **compile error or a CI failure**, never

--- a/docs/roadmap/active/completeness-by-construction.md
+++ b/docs/roadmap/active/completeness-by-construction.md
@@ -1,3 +1,4 @@
+<!-- description: Make compiler correctness structural (by construction) rather than convention-enforced, extending the Perceus/borrow-checker completeness pattern compiler-wide -->
 # Completeness by Construction
 
 > Perceus や Rust の borrow checker が持つ「機械的に完全性を担保する」性質を、

--- a/docs/roadmap/active/correctness-guarantee-gaps.md
+++ b/docs/roadmap/active/correctness-guarantee-gaps.md
@@ -1,3 +1,4 @@
+<!-- description: Audit of the well-typed-source-to-correct-binary chain — which layers have mechanical/mathematical proof and which don't, with per-layer milestones -->
 # Correctness Guarantee Gaps
 
 > "well-typed source -> correct binary" chain: layers that lack mechanical/mathematical proof

--- a/docs/roadmap/active/effectful-27-blueprint.md
+++ b/docs/roadmap/active/effectful-27-blueprint.md
@@ -1,3 +1,4 @@
+<!-- description: Design blueprint for making the ~27 effectful/raw-pointer stdlib functions FUNCTIONAL on v1, tiered by verification ceiling -->
 # Blueprint — making the ~27 effectful / raw-pointer stdlib fns FUNCTIONAL in v1
 
 Design-only (the PLAN, not a build). Produced by a 6-agent design fan-out + adversarial

--- a/docs/roadmap/active/interp-is-desugar-to-tostring.md
+++ b/docs/roadmap/active/interp-is-desugar-to-tostring.md
@@ -1,3 +1,4 @@
+<!-- description: Desugar StringInterp into a concat + to_string(part) chain instead of treating it as special syntax -->
 # StringInterp is NOT special syntax — desugar it to `concat + to_string(part)`
 
 The ideal end-state (set 2026-06-17). Supersedes the per-position interp-lowering approach.

--- a/docs/roadmap/active/issue-ledger-burndown.md
+++ b/docs/roadmap/active/issue-ledger-burndown.md
@@ -1,3 +1,4 @@
+<!-- description: Issue-ledger burn-down tracker for the completeness campaign — GitHub open-issue count as the completeness residual -->
 # Issue Ledger Burn-down — 完全性キャンペーンの残量計
 
 > 2026-06-11 時点。台帳→tracker の単射は完成済み: **GitHub の open issue 数 =

--- a/docs/roadmap/active/map-data-structure-roadmap.md
+++ b/docs/roadmap/active/map-data-structure-roadmap.md
@@ -1,3 +1,4 @@
+<!-- description: Design decision and roadmap for Map[K,V]/Set[T]: an O(1) insertion-ordered hash map (compact-ordered-dict) -->
 # Map / Set data-structure roadmap
 
 How `Map[K,V]` (and `Set[T]`) are represented, and where they should go.

--- a/docs/roadmap/active/native-boxed-pattern-lowering.md
+++ b/docs/roadmap/active/native-boxed-pattern-lowering.md
@@ -1,3 +1,4 @@
+<!-- description: Fix native (Rust) codegen for nested ctor/literal patterns on a Box'd recursive-variant field (#610) -->
 # native: nested ctor/literal pattern at a Box'd (recursive-variant) field
 
 Status: active — analyzed, ready to implement (#610)

--- a/docs/roadmap/active/native-trust-spine.md
+++ b/docs/roadmap/active/native-trust-spine.md
@@ -1,3 +1,4 @@
+<!-- description: Route almide build --target rust through the same v1 Perceus MIR as the wasm leg, certified per build by verify_ownership (#764) -->
 # Native Trust Spine — Perceus as the single memory model (#764)
 
 > Goal: `almide build --target rust` flows through the SAME v1 Perceus MIR as the

--- a/docs/roadmap/active/v0-unwrap-early-return-leak.md
+++ b/docs/roadmap/active/v0-unwrap-early-return-leak.md
@@ -1,3 +1,4 @@
+<!-- description: v0 wasm codegen: fix the Try/Unwrap/Fan early-return heap leak (emitter-side emit_early_return_decs) -->
 # v0 wasm codegen: Try/Unwrap/Fan early-return heap leak
 
 **Status**: IMPLEMENTED + verified (emitter-side `emit_early_return_decs`); v1 wall LIFTED, -59 recovered (in-profile 4083). Leak-free (100k-err-loop completes) + double-free-free (260-file wasm corpus green).

--- a/docs/roadmap/active/v1-adt-brick5-goal.md
+++ b/docs/roadmap/active/v1-adt-brick5-goal.md
@@ -1,3 +1,4 @@
+<!-- description: Goal prompt: finish v1 ADT brick 5 (heap-field bind + recursive drop) to close the #1 cross-repo wall lever -->
 # GOAL PROMPT — finish ADT brick 5 (heap-field bind + recursive drop) to the #1 lever
 
 You are continuing the v1 trust-spine ADT value-model work on branch **`develop-v1`**. Bricks

--- a/docs/roadmap/active/v1-adt-value-model.md
+++ b/docs/roadmap/active/v1-adt-value-model.md
@@ -1,3 +1,4 @@
+<!-- description: v1: make custom ADT (variant) values first-class, closing the #1 cross-repo wall lever (~41 walls, recursive to_string/pretty-print over user variants) -->
 # v1 ① — custom ADT (variant) as a first-class value
 
 The cross-repo wall lever #1 (~41 walls: recursive `to_string`/pretty-print over `type Expr = Lit(Int)

--- a/docs/roadmap/active/v1-heap-result-control-flow.md
+++ b/docs/roadmap/active/v1-heap-result-control-flow.md
@@ -1,3 +1,4 @@
+<!-- description: v1: design for heap-result if/match execution — de-risked, no Coq change required -->
 # v1 heap-result `if`/`match` execution — design (DE-RISKED: no Coq change)
 
 Status: **`if` with literal arms IMPLEMENTED (commit 126921e6), adversarially

--- a/docs/roadmap/active/v1-loop-ownership-cert.md
+++ b/docs/roadmap/active/v1-loop-ownership-cert.md
@@ -1,3 +1,4 @@
+<!-- description: v1: teach the proven ownership checker to reason about loop-carried heap accumulators (option C), the completeness fix for the remaining yaml walls -->
 # v1 heap-loop-carried ownership — option C (cert-spine extension), the COMPLETENESS fix
 
 **CEO chose C ("C一択", 2026-06-20): close the proof spine's completeness gap at the ROOT — teach the

--- a/docs/roadmap/active/v1-mir-architecture.md
+++ b/docs/roadmap/active/v1-mir-architecture.md
@@ -1,3 +1,4 @@
+<!-- description: Almide v1: MIR as the single source of semantic truth — greenfield + dual-oracle architecture, mission-first surface language -->
 # Almide v1: MIR を唯一の真とする単一意味論アーキテクチャ
 
 Status: active — Phase 0 決定ゲート合格(5/5, §8.1)。**完全グリーンフィールド + 二重オラクル**で実装(§6)、言語表層は **mission-first**(§10)で確定(2026-06-13)。手術前の網2枚(意味法則 oracle / compound-drop churn)敷設・緑。

--- a/docs/roadmap/active/v1-parser-tco-lever.md
+++ b/docs/roadmap/active/v1-parser-tco-lever.md
@@ -1,3 +1,4 @@
+<!-- description: v1: the parser-TCO lever — TCO over a match returning Result, the cross-repo lever blocking base64/toml decode -->
 # v1 — the parser-TCO lever (the real "heap-result-expr" cross-repo lever)
 
 ## ⭐ decode_chunks ONION — FULLY MAPPED (2026-06-22, turn 5, effort=max). The remaining "base64 decode / toml" frontier is ONE coherent slice: **TCO over a `match` whose result is a `Result`**, with an ownership-critical core. The unwrap-`!` desugar turns `let x = f(p)!; recurse(.., acc+[x])` into `match f(p) { ok(x) => recurse(.., acc+[x]), err(e) => err(e) }` — recursion inside a match arm, returning `Result[heap, String]`. To lower it (verified, repro `umr` = a 1-unwrap version; build it first, it is the unit test for the whole slice):

--- a/docs/roadmap/active/v1-phase1-mir-core.md
+++ b/docs/roadmap/active/v1-phase1-mir-core.md
@@ -1,3 +1,4 @@
+<!-- description: Almide v1 Phase 1: MIR core + dual renderer — implementation design following the Phase 0 decision gate -->
 # Almide v1 Phase 1: MIR コア + 二レンダラ — 実装設計
 
 Status: active — 設計(design-first)。Phase 0 決定ゲート合格(5/5)を受けた本体設計。実装着手前のレビュー対象。

--- a/docs/roadmap/active/v1-records-svg.md
+++ b/docs/roadmap/active/v1-records-svg.md
@@ -1,3 +1,4 @@
+<!-- description: v1 records feature: full conquest of the svg org repo on the WASM trust spine (construct, field read, spread, recursive nested ownership) -->
 # v1 — records feature: svg FULL CONQUEST (goal prompt)
 
 ## BIG-PICTURE GOAL

--- a/docs/roadmap/active/v1-selfhost-machinery.md
+++ b/docs/roadmap/active/v1-selfhost-machinery.md
@@ -1,3 +1,4 @@
+<!-- description: v1 stdlib self-host machinery phase (Option / list-building / closures) — self-hosting all ~381 v0 stdlib fns to execute byte-for-byte -->
 # v1 stdlib self-host — the machinery phase (Option / List-building / closures)
 
 Status: **~28 functions self-hosted + executing = v0 (corpus-wall ACCEPT 13139/4083/3582

--- a/docs/roadmap/active/v1-selfhost-print-floor.md
+++ b/docs/roadmap/active/v1-selfhost-print-floor.md
@@ -1,3 +1,4 @@
+<!-- description: v1 self-host print floor — the observability keystone for the first self-host slice -->
 # v1 self-host print floor — the ③ observability keystone
 
 **Status**: design (2026-06-14). Synthesized from a 5-agent design workflow

--- a/docs/roadmap/active/v1-spine-correctness-holes.md
+++ b/docs/roadmap/active/v1-spine-correctness-holes.md
@@ -1,3 +1,4 @@
+<!-- description: v1 trust-spine correctness holes found by an adversarial sweep of render_program vs native (30 confirmed holes) -->
 # v1 trust-spine correctness holes (adversarial sweep 2026-06-27)
 
 Found by a systematic adversarial sweep of render_program (v1 spine) vs native, probing shape-space the v0 corpus does NOT cover. All **verified reproducing in render_program** (not legacy emit_wasm). The corpus-wall (checks certs, not wat-validity) + output-parity (124 files) structurally miss these. Root hints below are the SWEEP agents' guesses (several cite legacy paths — the real site is the v1 spine crates/almide-mir/render_wasm\*; re-derive when fixing).

--- a/docs/roadmap/active/v1-tco-self-recursion.md
+++ b/docs/roadmap/active/v1-tco-self-recursion.md
@@ -1,3 +1,4 @@
+<!-- description: v1 TCO for self-recursive tail calls to a scalar-state loop — the yaml-parser keystone -->
 # v1 TCO — self-recursive tail calls → scalar-state loop (the yaml parser keystone)
 
 **Status: DESIGN (2026-06-19). Soundness-critical → design-first, implement fresh + adversarial, verify against the proven checker before shipping. NEVER ship a checker-rejected witness.**

--- a/docs/roadmap/active/v1-value-model.md
+++ b/docs/roadmap/active/v1-value-model.md
@@ -1,3 +1,4 @@
+<!-- description: v1 dynamic Value model — the yaml keystone: self-hosted constructors/extractors/serializer with one trusted recursive-drop routine (path A) -->
 # v1 dynamic Value model — the yaml keystone (path A: self-host + ONE trusted recursive-drop routine)
 
 **Status: DESIGN (2026-06-19). CEO chose path A ("Aでいくぞ"): keep the trusted base minimal, PROVE the Value model (constructors/extractors/serializer self-hosted in .almd, cert-verified), with the recursive free as the ONE trusted runtime routine (like `DropListStr` already is). Coq-free; byte-match-verified vs v0 `runtime/rs/src/value.rs` per brick.**

--- a/docs/roadmap/active/value-rc-cert.md
+++ b/docs/roadmap/active/value-rc-cert.md
@@ -1,3 +1,4 @@
+<!-- description: Bring Value refcount ops into the certified ownership region (柱C extension) — closing the prim.handle-fed rc blind spot -->
 # 柱C extension: bring Value rc into the certified region
 
 **Status: Brick 1+2 LANDED — carrier rc is CERTIFIED (verify_ownership + ownership_certificate, atomic, agree). 2026-06-24.**

--- a/docs/roadmap/active/wasm-engine-redesign.md
+++ b/docs/roadmap/active/wasm-engine-redesign.md
@@ -1,3 +1,4 @@
+<!-- description: Complete redesign of the hand-written WASM emitter into a type-aware, layout-safe, stack-verified compiler (WASM 3.0/Component Model ready) -->
 # Almide WASM Engine — Complete Redesign
 
 > **Status**: Design phase — foundation (LayoutRegistry + WasmIR + WasmBuilder) exists, full recreate planned

--- a/docs/roadmap/active/wasm-frees-ownership-discipline.md
+++ b/docs/roadmap/active/wasm-frees-ownership-discipline.md
@@ -1,3 +1,4 @@
+<!-- description: Drain the WASM reference-count-frees ownership discipline gap toward the two-gate green -->
 # WASM Reference-Count Frees: the Ownership-Discipline Drain
 
 **Status:** in progress (2026-06-07). Branch `perceus-belt-hard-error`, worktree

--- a/docs/roadmap/active/wasm-optimization-roadmap.md
+++ b/docs/roadmap/active/wasm-optimization-roadmap.md
@@ -1,3 +1,4 @@
+<!-- description: WASM emitter performance roadmap — closing wins/ties/losses against rustc+LLVM across benchmarks -->
 # WASM Optimization Roadmap
 
 > Almide's WASM emitter: 336B hello world. **Current: 3 wins / 2 ties / 6 losses vs Rust+LLVM

--- a/docs/roadmap/active/wasm-ownership-emit-mechanization.md
+++ b/docs/roadmap/active/wasm-ownership-emit-mechanization.md
@@ -1,3 +1,4 @@
+<!-- description: Mechanize the WASM ownership emit layer to structurally contain Perceus drift (#643) -->
 # WASM 所有権 emit 層の機械化 (Perceus drift の構造的封じ込め)
 
 Status: active — 提案 + #643 の精密分析

--- a/docs/roadmap/done/almai-llm-client.md
+++ b/docs/roadmap/done/almai-llm-client.md
@@ -1,4 +1,5 @@
 <!-- description: almai — multi-provider LLM client library, 8 providers shipped -->
+<!-- done: 2026-04-12 -->
 # almai — Multi-Provider LLM Client
 
 ## Status

--- a/docs/roadmap/done/almide-dojo.md
+++ b/docs/roadmap/done/almide-dojo.md
@@ -1,4 +1,5 @@
 <!-- description: Daily automated MSR loop — 30 tasks, Claude 100%, Llama 61%, almai integration -->
+<!-- done: 2026-04-12 -->
 # Almide Dojo — Continuous MSR Measurement
 
 ## Motivation

--- a/docs/roadmap/done/anon-record-codegen.md
+++ b/docs/roadmap/done/anon-record-codegen.md
@@ -68,5 +68,5 @@ In `emit_rust/`'s empty list codegen, the anonymous record type mapping is missi
 
 ## Related
 
-- [design-debt.md #2](../on-hold/design-debt.md) — Fundamental anonymous record design
+- [design-debt.md #2](../done/design-debt.md) — Fundamental anonymous record design
 - Grammar Lab [optional-handling REPORT](../../../research/grammar-lab/experiments/optional-handling/REPORT.md)

--- a/docs/roadmap/done/borrow-read-hoist.md
+++ b/docs/roadmap/done/borrow-read-hoist.md
@@ -1,4 +1,5 @@
 <!-- description: Auto-hoist reads from mut args to avoid Rust borrow conflicts -->
+<!-- done: 2026-05-22 -->
 # Borrow Read Hoisting
 
 > **Target: v0.22**

--- a/docs/roadmap/done/codegen-optimization.md
+++ b/docs/roadmap/done/codegen-optimization.md
@@ -88,7 +88,7 @@ A calls B with param `x`. Whether `x` escapes in A depends on B's classification
 
 ### Next: Phase 4
 
-Remaining clone reduction opportunities identified in [clone-reduction.md](../active/clone-reduction.md):
+Remaining clone reduction opportunities identified in [clone-reduction.md](../done/clone-reduction.md):
 - For-in unconditional clone
 - List/tuple element clone (use-count aware)
 - Member access clone (single-use awareness)
@@ -96,7 +96,7 @@ Remaining clone reduction opportunities identified in [clone-reduction.md](../ac
 - Record spread clone (single-use move)
 - Field-level borrow analysis
 
-Additional codegen refinements in [codegen-refinement.md](../active/codegen-refinement.md):
+Additional codegen refinements in [codegen-refinement.md](../done/codegen-refinement.md):
 - let mut → let refinement
 - `#[inline]` hints
 - Constant folding

--- a/docs/roadmap/done/codegen-v3-architecture.md
+++ b/docs/roadmap/done/codegen-v3-architecture.md
@@ -136,4 +136,4 @@ Go/Python targets are post-1.0. Architecture is ready (only TOML + pass addition
 - [x] walker `is_rust()` zero
 - [x] walker `ctx.target ==` branches zero
 - [x] Existing codegen fully replaced
-- Go target → [on-hold](../on-hold/go-target.md)
+- Go target → on-hold, later removed as obsolete

--- a/docs/roadmap/done/cross-crate-anon-record-collision.md
+++ b/docs/roadmap/done/cross-crate-anon-record-collision.md
@@ -1,4 +1,5 @@
 <!-- description: Anonymous record struct IDs collide across crates -->
+<!-- done: 2026-05-25 -->
 # Cross-crate anonymous record collision
 
 > **Priority: high** — blocks mc-bot-cli (deep dependency chain) from compiling.

--- a/docs/roadmap/done/cross-crate-default-fields.md
+++ b/docs/roadmap/done/cross-crate-default-fields.md
@@ -1,4 +1,5 @@
 <!-- description: Fix cross-crate codegen for types with default field values -->
+<!-- done: 2026-05-25 -->
 # Cross-crate default field codegen
 
 > **Priority: high** — blocks almai Message type from being used across crates.

--- a/docs/roadmap/done/cross-crate-sse-runtime.md
+++ b/docs/roadmap/done/cross-crate-sse-runtime.md
@@ -1,4 +1,5 @@
 <!-- description: SSE runtime functions missing in cross-crate codegen — http module needs sse dependency -->
+<!-- done: 2026-05-25 -->
 # Cross-crate SSE runtime functions
 
 > **Priority: high** — blocks almai from being used as a dependency.

--- a/docs/roadmap/done/cross-crate-struct-injection.md
+++ b/docs/roadmap/done/cross-crate-struct-injection.md
@@ -1,4 +1,5 @@
 <!-- description: Fix ProcessStatus struct missing in cross-crate codegen — blocks almai dependency usage -->
+<!-- done: 2026-05-25 -->
 # Cross-crate stdlib struct injection — DONE
 
 ## Problem

--- a/docs/roadmap/done/diagnostic-secondary-spans.md
+++ b/docs/roadmap/done/diagnostic-secondary-spans.md
@@ -22,4 +22,4 @@ Activated secondary spans (displaying declaration sites that caused the error).
 ### JSON diagnostics
 - Added `end_col` and `secondary` fields to `to_json()`
 
-## Remaining → [active/diagnostic-end-col.md](../active/diagnostic-end-col.md)
+## Remaining → [done/diagnostic-end-col.md](../done/diagnostic-end-col.md)

--- a/docs/roadmap/done/dx-codegen-papercuts.md
+++ b/docs/roadmap/done/dx-codegen-papercuts.md
@@ -6,7 +6,7 @@
 
 このロードマップの 5 課題のうち、Codegen 系 (A-1/A-2) と Module-system spec 系
 (C-1/C-2/B-3) は **v0.15.0 で全て解決**。残る DX 系 2 件 (B-1 / B-2) は別 arc
-[`active/dx-testing-explain.md`](../active/dx-testing-explain.md) に切り出した。
+[`done/dx-testing-explain.md`](../done/dx-testing-explain.md) に切り出した。
 
 ### A-1 / A-2 (effect fn と built-in 混在) — 既に動作
 
@@ -56,7 +56,7 @@ nominal record / anonymous record / variant 全てが Rust と WASM 両方で cr
 
 B-1 (`almide test` stderr passthrough) と B-2 (`almide explain E003`) は純粋な DX
 項目で、effect fn codegen や module system とは独立。
-[`active/dx-testing-explain.md`](../active/dx-testing-explain.md) として再スタート。
+[`done/dx-testing-explain.md`](../done/dx-testing-explain.md) として再スタート。
 
 ## 学び
 

--- a/docs/roadmap/done/dx-testing-explain.md
+++ b/docs/roadmap/done/dx-testing-explain.md
@@ -1,4 +1,5 @@
 <!-- description: almide test stderr passthrough + almide explain <code> subcommand -->
+<!-- done: 2026-04-20 -->
 # DX: `almide test` stderr & `almide explain`
 
 [`dx-codegen-papercuts.md`](../done/dx-codegen-papercuts.md) の A / C 系は

--- a/docs/roadmap/done/eq-protocol.md
+++ b/docs/roadmap/done/eq-protocol.md
@@ -22,4 +22,4 @@ fn same_color(a: Color, b: Color) -> Bool = a == b  // just works
 - **Rust**: `almide_eq!` macro for deep structural equality
 - **TS**: `__deep_eq` runtime function
 
-See [Built-in Protocols](../on-hold/trait-impl.md) for remaining protocols (Show, Hash).
+See [Built-in Protocols](../done/trait-impl.md) for remaining protocols (Show, Hash).

--- a/docs/roadmap/done/error-fix-db.md
+++ b/docs/roadmap/done/error-fix-db.md
@@ -1,4 +1,5 @@
 <!-- description: Elm-grade compiler error experience — hospitality, not hostility -->
+<!-- done: 2026-03-14 -->
 # Elm-Grade Error Experience
 
 > **Status: Done** — Phase 1-2 shipped. Phase 3-4 (tone/teaching) deferred — current style is accurate, LLM-friendly, and sufficient.

--- a/docs/roadmap/done/fan-concurrency-next.md
+++ b/docs/roadmap/done/fan-concurrency-next.md
@@ -1,4 +1,5 @@
 <!-- description: fan as a language-level concurrency primitive with rush/spawn/link/cancel -->
+<!-- done: 2026-04-03 -->
 # Fan Concurrency — Next Generation
 
 ## Vision

--- a/docs/roadmap/done/hkt-foundation.md
+++ b/docs/roadmap/done/hkt-foundation.md
@@ -26,5 +26,5 @@
 
 ## Follow-up (on-hold, 2.x)
 
-- [Effect Type Integration](../on-hold/effect-type-integration.md) — Add EffectSet to FnType
-- [Trait System](../on-hold/trait-system.md) — Protocol/Interface on the HKT foundation
+- [Effect System (capability-based)](../active/effect-system-capability.md) — consolidates the earlier EffectSet-on-FnType proposal
+- [Built-in Protocols](../done/trait-impl.md) — Protocol/Interface on the HKT foundation (trait-system.md was folded in as redundant)

--- a/docs/roadmap/done/indexing-mutation.md
+++ b/docs/roadmap/done/indexing-mutation.md
@@ -1,4 +1,5 @@
 <!-- description: buf[i] = val indexing syntax for bytes and list mutation -->
+<!-- done: 2026-05-22 -->
 # Indexing Mutation Syntax
 
 > **Target: v0.22**

--- a/docs/roadmap/done/json-builder-api.md
+++ b/docs/roadmap/done/json-builder-api.md
@@ -2,7 +2,7 @@
 <!-- done: 2026-03-14 -->
 # JSON Builder API [SUPERSEDED]
 
-> **Note**: This roadmap has been superseded by [Codec Protocol & JSON](../active/codec-and-json.md) (merged into Phase 1).
+> **Note**: This roadmap has been superseded by [Codec Protocol & JSON](../done/codec-and-json.md) (merged into Phase 1).
 
 ## Problem
 

--- a/docs/roadmap/done/let-polymorphism.md
+++ b/docs/roadmap/done/let-polymorphism.md
@@ -1,3 +1,4 @@
+<!-- description: Generalize let bindings to type schemes (Algorithm W) instead of monomorphic let inference -->
 <!-- done: 2026-03-16 -->
 # Let-Polymorphism (Algorithm W)
 

--- a/docs/roadmap/done/llm-developer-experience.md
+++ b/docs/roadmap/done/llm-developer-experience.md
@@ -2,7 +2,7 @@
 <!-- done: 2026-03-14 -->
 # LLM Developer Experience [DONE / MERGED]
 
-> UFCS: done. Remaining items (`almide init` config) merged into [LLM Integration](../active/llm-integration.md).
+> UFCS: done. Remaining items (`almide init` config) merged into [LLM Integration](../on-hold/llm-integration.md).
 
 ### `almide init` CLAUDE.md generation
 

--- a/docs/roadmap/done/lsp.md
+++ b/docs/roadmap/done/lsp.md
@@ -1,4 +1,5 @@
 <!-- description: Language Server Protocol for editor completion, diagnostics, and navigation -->
+<!-- done: 2026-03-14 -->
 # LSP Server
 
 > **Status: Done** (v0.19.0).

--- a/docs/roadmap/done/lumen-graphics-math.md
+++ b/docs/roadmap/done/lumen-graphics-math.md
@@ -1,4 +1,5 @@
 <!-- description: lumen — pure graphics math library (vec3, mat4, color), used by webgl/canvas/obsid -->
+<!-- done: 2026-04-12 -->
 # lumen — Pure Graphics Math
 
 ## Status

--- a/docs/roadmap/done/mojo-parity-assessment.md
+++ b/docs/roadmap/done/mojo-parity-assessment.md
@@ -1,4 +1,5 @@
 <!-- description: Almide vs Mojo capability parity assessment (Mojo = 100) -->
+<!-- done: 2026-05-11 -->
 # Almide vs Mojo: Capability Parity Assessment
 
 > Mojo = 100 as baseline. Scored per axis based on feature completeness,

--- a/docs/roadmap/done/mut-parameter-modifier.md
+++ b/docs/roadmap/done/mut-parameter-modifier.md
@@ -1,4 +1,5 @@
 <!-- description: mut parameter modifier for in-place mutation (Swift inout / Mojo mut) -->
+<!-- done: 2026-05-19 -->
 # `mut` Parameter Modifier
 
 > **Status: Done** — shipped in v0.18.0.

--- a/docs/roadmap/done/name-resolution-pass.md
+++ b/docs/roadmap/done/name-resolution-pass.md
@@ -1,3 +1,5 @@
+<!-- description: Unified cross-package symbol resolution via DefId/DefTable, replacing ad-hoc name lookup -->
+<!-- done: 2026-05-14 -->
 # Name Resolution Pass — Unified Cross-Package Symbol Resolution
 
 ## Status: Done (Phase 1-3 shipped in v0.18.1, Phase 4 cleanup deferred to cross-package builds)

--- a/docs/roadmap/done/package-native-dispatch.md
+++ b/docs/roadmap/done/package-native-dispatch.md
@@ -1,4 +1,5 @@
 <!-- description: First-class @inline_rust for packages, remove bundled-only walls -->
+<!-- done: 2026-05-22 -->
 # Package Native Dispatch
 
 > **Shipped: v0.22.1**

--- a/docs/roadmap/done/repl.md
+++ b/docs/roadmap/done/repl.md
@@ -1,4 +1,5 @@
 <!-- description: Interactive REPL — `almide` with no args starts an interactive session -->
+<!-- done: 2026-05-20 -->
 # REPL
 
 > **Status: Done** — shipped in v0.19.0.

--- a/docs/roadmap/done/scaffold-and-proliferation.md
+++ b/docs/roadmap/done/scaffold-and-proliferation.md
@@ -2,7 +2,7 @@
 <!-- done: 2026-03-14 -->
 # almide scaffold & Module Proliferation Pipeline [MERGED]
 
-> Merged into [LLM Integration](../active/llm-integration.md) as `almide forge`.
+> Merged into [LLM Integration](../on-hold/llm-integration.md) as `almide forge`.
 
 Infrastructure for mass-producing Almide modules. Enables LLMs to autonomously generate, verify, and publish modules — the core loop of AI proliferation.
 

--- a/docs/roadmap/done/separate-compilation.md
+++ b/docs/roadmap/done/separate-compilation.md
@@ -1,4 +1,5 @@
 <!-- description: Separate compilation with unified IR linker for all targets -->
+<!-- done: 2026-05-21 -->
 # Separate Compilation
 
 > **Target: v0.21 (Phase 1-4 shipped), Phase 5 future**

--- a/docs/roadmap/done/stdlib-self-hosted-redesign.md
+++ b/docs/roadmap/done/stdlib-self-hosted-redesign.md
@@ -926,7 +926,7 @@ regex:   new, is_match, find, find_all, replace, split, captures
 
 - [Stdlib Strategy](stdlib-strategy.md) Strategy 1 (TOML + runtime) and Strategy 2 (@extern)
   - Strategy 3 (self-host) and Strategy 4 (x/ packages) remain valid
-- [Stdlib Architecture: 3-Layer Design](../on-hold/stdlib-architecture-3-layer-design.md) internal implementation approach
+- [Stdlib Architecture: 3-Layer Design](../done/stdlib-architecture-3-layer-design.md) internal implementation approach
 
 ## Files
 ```

--- a/docs/roadmap/done/stdlib-strategy.md
+++ b/docs/roadmap/done/stdlib-strategy.md
@@ -378,7 +378,7 @@ Include LLM-era languages in the collection targets:
 
 ## Related Roadmap
 
-- [Stdlib Architecture: 3-Layer Design](../on-hold/stdlib-architecture-3-layer-design.md) — Detailed layer separation design
+- [Stdlib Architecture: 3-Layer Design](../done/stdlib-architecture-3-layer-design.md) — Detailed layer separation design
 - [Package Registry](../on-hold/package-registry.md) — Distribution infrastructure for x/ packages
-- [Rainbow FFI Gate](../on-hold/rainbow-gate.md) — Multi-language FFI (evolution of @extern)
-- [Codec Protocol & JSON](active/codec-and-json.md) — Next format support beyond JSON
+- [Rainbow FFI Gate](../done/rainbow-gate.md) — Multi-language FFI (evolution of @extern)
+- [Codec Protocol & JSON](../done/codec-and-json.md) — Next format support beyond JSON

--- a/docs/roadmap/done/test-where.md
+++ b/docs/roadmap/done/test-where.md
@@ -1,4 +1,5 @@
 <!-- description: test where syntax — unified value/type/mock/table-driven test context -->
+<!-- done: 2026-05-23 -->
 # Test Where Syntax
 
 > **Target: v0.23.0**

--- a/docs/roadmap/done/tooling.md
+++ b/docs/roadmap/done/tooling.md
@@ -6,8 +6,8 @@ Most items from this roadmap have been promoted to dedicated active roadmaps:
 
 ## Promoted to Active
 
-- **LSP** → [lsp.md](../active/lsp.md) — P0 priority, editor integration
-- **REPL** → [repl.md](../active/repl.md) — interactive evaluation
+- **LSP** → [lsp.md](../done/lsp.md) — P0 priority, editor integration
+- **REPL** → [repl.md](../done/repl.md) — interactive evaluation
 
 ## Remaining (ON HOLD)
 

--- a/docs/roadmap/done/trait-impl.md
+++ b/docs/roadmap/done/trait-impl.md
@@ -2,7 +2,7 @@
 <!-- done: 2026-03-18 -->
 # Built-in Protocols
 
-> **Note**: Eq and Hash are implemented. Repr is still pending. The overall type system design has moved to [Type System Extensions](../active/type-system.md), which covers container protocols (Mappable, Chainable, etc.) and `deriving`-based conformance. This document records the initial design limited to the Eq/Hash/Repr built-in protocols.
+> **Note**: Eq and Hash are implemented. Repr is still pending. The overall type system design has moved to [Type System Extensions](../done/type-system.md), which covers container protocols (Mappable, Chainable, etc.) and `deriving`-based conformance. This document records the initial design limited to the Eq/Hash/Repr built-in protocols.
 
 ## Design Principle
 

--- a/docs/roadmap/done/var-storage-refactor.md
+++ b/docs/roadmap/done/var-storage-refactor.md
@@ -1,3 +1,5 @@
+<!-- description: Unify module-var / local-COW variable classification into a single VarStorage model, removing duplicated if-else mutation chains -->
+<!-- done: 2026-05-15 -->
 # VarStorage Refactor — Unified Variable Classification
 
 ## Status: Complete

--- a/docs/roadmap/done/wasm-fs-io.md
+++ b/docs/roadmap/done/wasm-fs-io.md
@@ -27,4 +27,4 @@ Implemented file I/O for the WASM target via WASI preview1.
 - Implemented `env.unix_timestamp()`, `env.millis()` via WASI `clock_time_get`
 - Implemented `env.args()` via WASI `args_sizes_get`/`args_get`
 
-## Remaining → [active/wasm-remaining-fs.md](../active/wasm-remaining-fs.md)
+## Remaining → [done/wasm-remaining-fs.md](../done/wasm-remaining-fs.md)

--- a/docs/roadmap/on-hold/supervision-and-actors.md
+++ b/docs/roadmap/on-hold/supervision-and-actors.md
@@ -207,7 +207,7 @@ Receiver.try_receive() -> Result[T, Empty]
 ## Dependencies
 
 - Layer 1 (`async fn` / `await`) — DONE
-- Layer 2 (structured concurrency) — required for concurrent actor patterns (see [Structured Concurrency](../active/structured-concurrency.md). `concurrent` block syntax is TBD)
+- Layer 2 (structured concurrency) — required for concurrent actor patterns (see [Structured Concurrency](../done/structured-concurrency.md). `concurrent` block syntax is TBD)
 - Async streams (`Stream[T]` type) — required for `Actor.receive()` and `Channel.receive()`
 
 ## References


### PR DESCRIPTION
## Summary
`docs/roadmap/README.md` is auto-generated from `<!-- description: -->` / `<!-- done: YYYY-MM-DD -->` header tags on each roadmap doc (`docs/roadmap/generate-readme.sh`). An audit found two silent-omission bugs:

- **31 `active/*.md` files** had no `<!-- description: -->` tag → rendered with a blank description cell in the table.
- **20 `done/*.md` files** had no `<!-- done: -->` tag → the generator's `[ -z "$date" ] && continue` guard **silently dropped them from the Done table entirely** (present on disk, invisible in the index). Dates were backfilled from each file's git "added to `done/`" commit date; `let-polymorphism.md`/`name-resolution-pass.md`/`var-storage-refactor.md` were also missing the description tag.
- **18 stale internal cross-links** — prose references like `[lsp.md](../active/lsp.md)` pointing at the old `active/`/`on-hold/` location of a doc that has since moved to `done/` (or, for `go-target.md`/`trait-system.md`, was removed outright as obsolete/redundant — those two are now de-linked to plain text; `effect-type-integration.md` was consolidated into `active/effect-system-capability.md`, retargeted accordingly).

`docs/roadmap/README.md` regenerated via `bash docs/roadmap/generate-readme.sh`.

## Test plan
- [x] `almide test` — 300/300 files pass, 0 failed (unrelated to this change; docs-only)
- [x] scripted check: zero broken links, zero orphan files in `active/`/`on-hold/`/`done/` after the fix