### PR TITLE
Document brace record construction as canonical, paren form as alias

### DIFF
--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -208,10 +208,14 @@ xs |> filter(_, (x) => x > 0)      // _ = placeholder for piped value
 ```
 { name: "alice", age: 30 }
 { ...base, name: "bob" }
-User { name: "alice" }     // named record construction (brace form)
-User(name: "alice")        // same thing — paren-NAMED is normalized to the brace form
+User { name: "alice" }     // named record construction — canonical form
+User(name: "alice")        // alias: named-argument call syntax, normalized to the brace form
 User("alice")              // WRONG: records take named fields, not positional (E021)
 ```
+The paren alias also works for matching a plain record type (`User(name) => ...`).
+It does **not** work for a variant's record-payload case — `Circle { radius }` (a
+case of `type Shape = Circle { radius: Float } | ...`) only matches as
+`Circle { radius }`, never `Circle(radius)` (E021).
 
 ### List
 ```

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -497,10 +497,15 @@ connect(host: "localhost", secure: true)
 Named arguments after positional ones are allowed. Positional arguments after named ones are not.
 
 A call of a **record type** (or record-payload variant case) with all-named
-arguments is record construction: `Cfg(name: "x")` is normalized to
-`Cfg { name: "x" }` and validated identically (unknown / duplicate /
-missing-without-default fields are E021). Positional arguments on a record,
-and named arguments on a tuple constructor, are rejected (E021).
+arguments is record construction: `Cfg(name: "x")` is an alias, normalized to
+the canonical `Cfg { name: "x" }` and validated identically (unknown /
+duplicate / missing-without-default fields are E021). Positional arguments on
+a record, and named arguments on a tuple constructor, are rejected (E021).
+
+The paren alias also matches a plain record type in patterns (`Cfg(name) =>
+...`). It does **not** match a variant's record-payload case — only the brace
+form does there (`Circle { radius } => ...`, never `Circle(radius) => ...`,
+E021: "use a record pattern").
 
 ### 7.4 Predicate Functions
 

--- a/docs/diagnostics/E021.md
+++ b/docs/diagnostics/E021.md
@@ -6,8 +6,12 @@ from **positional arguments** — mixing the two, or naming a field that does no
 exist, silently corrupted the value before this check existed (the arguments
 were dropped on the floor and the targets disagreed on what happened next).
 
-The paren spelling with named fields is **accepted and normalized**:
-`Cfg(name: "x")` means exactly `Cfg { name: "x" }`.
+`Cfg { name: "x" }` (brace) is the canonical spelling. `Cfg(name: "x")` (paren,
+named-argument call syntax) is an accepted **alias**, normalized to exactly
+the same construction — but only for construction and only for a plain
+record type. A variant's record-payload case (`Circle { radius: Float }` as
+one arm of `type Shape = Circle { radius: Float } | ...`) only ever matches
+as a brace pattern, never `Circle(radius)` — see the last example below.
 
 ## Common cases
 


### PR DESCRIPTION
## Summary
Docs-only change, no compiler behavior affected.

- `docs/CHEATSHEET.md`, `docs/SPEC.md`, `docs/diagnostics/E021.md`: reframe `Cfg(name: "x")` as an explicit **alias** for the canonical `Cfg { name: "x" }` (mirrors how `**` is documented as an alias for `^`), rather than presenting both as equally primary.
- Document the one real asymmetry precisely (verified against the compiler): the paren alias works for both construction *and* pattern matching on a plain record type, but a variant's record-payload case only ever matches as a brace pattern — never `Circle(radius)`, always `Circle { radius }` (E021).

## Test plan
- [x] `almide docs-gen --check` — no drift
- [x] Every code example in the diff verified against the built compiler before writing