### PR TITLE
Remove documented unsafe block, fix deriving wording, document mut parameters

### DIFF
--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -44,7 +44,7 @@ type Color: Eq, Repr = Red | Green | Blue   // convention after type name with :
 
 **Variant serialization — recommended pattern.** When a variant type
 crosses a serialization boundary (JSON / file IO / dojo fixtures),
-use `deriving Codec` to auto-generate `Type.encode` / `Type.decode`
+declare `: Codec` to auto-generate `Type.encode` / `Type.decode`
 instead of hand-writing `match` ladders. The auto-derived Codec emits
 tagged-JSON with the ctor name as the tag and payload fields under
 `value`:
@@ -53,7 +53,7 @@ type Event: Codec = | Click(Int, Int) | Scroll{dy: Int}
 // Event.encode(Click(10, 20)) → {"tag": "Click", "value": [10, 20]}
 // Event.encode(Scroll { dy: 5 }) → {"tag": "Scroll", "value": {"dy": 5}}
 ```
-Skip the `deriving Codec` only for variants that never serialize
+Skip `: Codec` only for variants that never serialize
 (internal enums like `Endian` in `stdlib/bytes.almd`). Every other
 variant should opt in — the roundtrip code is LLM-error prone when
 hand-written.
@@ -83,6 +83,16 @@ effect fn name(x: Type) -> Result[T, E] = expr       // has side effects
 fn parse(text: String) -> Ast = _                     // hole (type-checked stub)
 fn optimize(ast: Ast) -> Ast = todo("implement later") // todo with message
 ```
+
+### Mutable parameters
+```
+fn incr(mut x: Int) -> Unit = { x = x + 1 }
+var n = 5
+incr(n)          // n is now 6 -- mutated in place, not returned
+```
+Caller must pass a `var` binding (`let` or a temporary is E007). `mut` can be
+on any parameter, any position. This is how in-place stdlib ops work
+(`list.push`, `list.pop`, `list.clear`, …).
 
 ## Built-in Protocols
 Eq and Hash are automatic (compiler-derived from type structure). No annotation needed.
@@ -414,8 +424,8 @@ Full function signatures: [docs/stdlib/](stdlib/)
 - The stdlib functions listed above are exhaustive — no other functions exist
 - Use `for x in xs { ... }` for iteration
 - **No nested functions.** All `fn` must be at the top level. Use lambdas for local helpers
-- **No `mut` keyword.** Use `var` for mutable bindings, not `let mut`
-- Almide is NOT Rust. No `&`, `mut`, `trait` (use `protocol`), `impl` (use convention methods: `fn Type.method(...)`), `pub`, `mod` (as declaration)
+- **No `let mut`.** Use `var` for mutable bindings. `mut` itself is a real keyword, but only as a parameter modifier (`fn f(mut x: Int)`) — see Functions
+- Almide is NOT Rust. No `&`, `trait` (use `protocol`), `impl` (use convention methods: `fn Type.method(...)`), `pub`, `mod` (as declaration)
 
 ## Naming conventions across stdlib
 
@@ -436,7 +446,7 @@ Full function signatures: [docs/stdlib/](stdlib/)
 - `println(x)` where x is Int → **WRONG**. Write `println(int.to_string(x))`. No implicit conversion
 - `1 :: 2 :: []` → **WRONG**. Write `[1, 2]`. There is no cons operator `::`
 - `fn foo<T>(x: T)` → **WRONG**. Write `fn foo[T](x: T)`. Use `[]` for generics, not `<>`
-- `let mut x = 1` → **WRONG**. Write `var x = 1`. No `mut` keyword
+- `let mut x = 1` → **WRONG**. Write `var x = 1`. `mut` is only a parameter modifier (`fn f(mut x: Int)`), not a binding modifier
 - Nested `fn` inside a function → **WRONG**. All `fn` must be top-level. Use `let helper = (x) => ...` for local functions
 - `match x { ... pattern => expr }` with `...` → **WRONG**. No spread in patterns
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -95,14 +95,14 @@ Numeric literals support `_` as a visual separator (e.g., `1_000_000`).
 
 Block comments nest: `/* outer /* inner */ still outer */` is valid.
 
-### 1.5 Keywords (34)
+### 1.5 Keywords (35)
 
 ```
 module  import  type    protocol for     in      fn      let
-var     if      then    else     match   ok      err     some
-none    todo    true    false    not     and     or      strict
-pub     effect  test    guard    break   continue while   local
-mod     fan
+var     mut     if      then     else    match   ok      err
+some    none    todo    true     false   not     and     or
+strict  pub     effect  test     guard   break   continue while
+local   mod     fan
 ```
 
 ### 1.6 Operators and Delimiters
@@ -181,7 +181,7 @@ Expr      ::= Literal | Name | InterpolatedStr
             | ForInExpr | WhileExpr | FanExpr
             | BlockExpr | LambdaExpr
             | HoleExpr | TodoExpr
-            | RangeExpr | TupleExpr | UnsafeExpr
+            | RangeExpr | TupleExpr
             | "(" Expr ")"
 ```
 
@@ -454,7 +454,7 @@ FnDecl ::= Visibility? "effect"? "fn" Name GenericParams?
 
 Visibility ::= "local" | "mod"        // default is public
 ParamList  ::= Param ( "," Param )*
-Param      ::= Identifier ":" TypeExpr ( "=" Expr )?   // default value optional
+Param      ::= "mut"? Identifier ":" TypeExpr ( "=" Expr )?   // default value optional
 ```
 
 Modifier order: `[local|mod]? effect? fn`
@@ -546,6 +546,29 @@ For FFI bindings to target-specific functions:
 @extern(ts, "fs", "readFileSync")
 effect fn read_text(path: String) -> Result[String, String] = _
 ```
+
+### 7.8 Mutable Parameters
+
+`mut` on a parameter passes it by mutable reference: an assignment to the
+parameter inside the function is visible to the caller after the call
+returns, in place — there is no return value carrying the new state back.
+
+```
+fn incr(mut x: Int) -> Unit = { x = x + 1 }
+
+fn main() -> Unit = {
+  var n = 5
+  incr(n)
+  println(int.to_string(n))   // 6
+}
+```
+
+The call site must pass a `var` binding — a `let` binding or a temporary
+expression is rejected (E007), since there is nothing to write the mutation
+back into. `mut` may appear on any parameter, not only the first. This is how
+in-place stdlib operations are written (`list.push`, `list.pop`,
+`list.clear`, …) — not via a hidden receiver convention, just an ordinary
+parameter marked `mut`.
 
 ---
 
@@ -834,15 +857,6 @@ fn optimize(ast: Ast) -> Ast = todo("implement later") // todo with message
 ```
 
 `_` (hole) and `todo(msg)` accept any expected type. The compiler reports the expected type, available variables, and suggestions.
-
-### 9.19 unsafe Block
-
-```
-fn technically_pure(x: Int) -> Int =
-  unsafe { fs.read_text(cache_path) }    // bypass effect boundary
-```
-
-`unsafe` surfaces "normal rules are being broken here."
 
 ---
 


### PR DESCRIPTION
## Summary
Docs-only change, no compiler behavior affected.

- **Removed `unsafe { }` from SPEC.md §9.19.** It was an explicitly removed dead keyword (`0ab01bf1`, same commit as `async`/`await`/`try`/`deriving`) — `docs/roadmap/active/trust-layer.md` even states "no unsafe in user space" as a design decision — but the docs kept describing it as real syntax. Confirmed dead: `unsafe { 1 + 1 }` → `undefined variable 'unsafe'`.
- **Fixed stale `deriving` wording in CHEATSHEET.md.** The prose said "use `deriving Codec`" right above a code example that actually used `: Codec` — `deriving` was removed in the same commit as `unsafe`. Reworded to match the real syntax.
- **Documented `mut` parameters** (SPEC.md new §7.8, CHEATSHEET.md new subsection). This is a real, working feature — used 12x in stdlib (`list.push`, `list.pop`, `list.clear`, …) for in-place mutation — that had zero documentation anywhere, while CHEATSHEET.md actively claimed "No `mut` keyword" (three separate spots). Fixed all three claims and added the missing documentation.
- **Fixed the keyword count**: 34 → 35. Earlier develop work correctly removed `impl` (35→34) but didn't notice `mut` was *also* missing from that same list — net effect should have been 35→34→35 (swap, not just a removal).

## Test plan
- [x] `almide docs-gen --check` — no drift
- [x] Every code example verified against the built compiler before writing (including `unsafe`/`deriving` failing exactly as claimed)