### PR TITLE
Size each parsed JSON string from its own span, not the document remainder

### DIFF
--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -62,6 +62,7 @@ io_write_ordering  out-of-interp-scope capability: io.write
 json_gltf_walk  out-of-interp-scope capability: json.parse
 json_number_unicode  out-of-interp-scope capability: json.parse
 json_path_edges  out-of-interp-scope capability: json.parse
+json_string_span  out-of-interp-scope capability: json.parse
 json_stringify_pretty  out-of-interp-scope capability: json.from_string
 json_value  out-of-interp-scope capability: json.parse
 let_unwrap_propagation  out-of-interp-scope capability: value.str

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -114,7 +114,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-084 | Codec/value decode error messages are byte-identical across targets |  | active | fixture | 1 |
 | C-085 | Float decode widens an integral JSON number to f64 |  | active | fixture | 1 |
 | C-086 | Pass-through stdlib combinators give their result its own reference |  | active | fixture | 1 |
-| C-087 | JSON number and \\u string decoding are byte-identical across targets |  | active | fixture | 1 |
+| C-087 | JSON number and \\u string decoding are byte-identical across targets |  | active | fixture | 2 |
 | C-088 | A Rust-keyword function name compiles on both targets |  | active | fixture | 1 |
 | C-089 | A default parameter referencing an earlier parameter is filled with its argument |  | active | fixture | 1 |
 | C-090 | bytes.from_list on a List[Int] parameter compiles on both targets |  | active | fixture | 1 |

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-64 normative sections; 324 distinct executable fixtures.
+64 normative sections; 325 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -63,7 +63,7 @@
 | ALS-S6 | C-074 | `spec/wasm_cross/r5_wasm_split_replace_iterative.almd` (byte-compare) |
 | ALS-T1 | C-021 | `spec/wasm_cross/string_whitespace.almd` (byte-compare) |
 | ALS-T2 | C-024 | `spec/wasm_cross/float_parse.almd` (byte-compare) |
-| ALS-T3 | C-087 | `spec/wasm_cross/json_number_unicode.almd` (byte-compare) |
+| ALS-T3 | C-087 | `spec/wasm_cross/json_number_unicode.almd` (byte-compare)<br>`spec/wasm_cross/json_string_span.almd` (byte-compare) |
 | ALS-T4 | C-129, C-171 | `spec/wasm_cross/list_chunk_windows.almd` (byte-compare)<br>`spec/wasm_cross/list_chunk_zero.almd` (byte-compare)<br>`spec/wasm_cross/list_windows_zero.almd` (byte-compare)<br>`spec/wasm_cross/list_window_zero.almd` (byte-compare)<br>`spec/wasm_cross/bytes_f16_offset_overflow.almd` (byte-compare) |
 | ALS-T5 | C-020, C-162 | `spec/wasm_cross/string_case_unicode.almd` (byte-compare)<br>`spec/wasm_cross/io_write_ordering.almd` (byte-compare) |
 | ALS-T6 | C-001, C-002, C-047, C-067, C-154, C-155, C-161, C-169, C-184 | `spec/wasm_cross/int_div_by_zero.almd` (byte-compare)<br>`spec/wasm_cross/int_mod_by_zero.almd` (byte-compare)<br>`spec/wasm_cross/int_div_by_zero_literal.almd` (byte-compare)<br>`spec/wasm_cross/int_div_overflow.almd` (byte-compare)<br>`spec/wasm_cross/int_mod_overflow.almd` (byte-compare)<br>`spec/wasm_cross/int8_div_overflow.almd` (byte-compare)<br>`spec/wasm_cross/int_pow_negative_exponent.almd` (byte-compare)<br>`spec/wasm_cross/int_pow_overflow_wraps.almd` (byte-compare)<br>`spec/wasm_cross/int_rotate_nonpositive_width.almd` (byte-compare)<br>`spec/wasm_cross/index_bounds.almd` (byte-compare)<br>`spec/wasm_cross/index_bounds_write_heap.almd` (byte-compare)<br>`spec/wasm_cross/index_bounds_i64.almd` (byte-compare)<br>`spec/wasm_cross/index_bounds_write_only_var.almd` (byte-compare)<br>`spec/wasm_cross/int_clamp_inverted.almd` (byte-compare)<br>`spec/wasm_cross/float_clamp_invalid.almd` (byte-compare)<br>`spec/wasm_cross/to_fixed_domain_abort.almd` (byte-compare)<br>`spec/wasm_cross/to_fixed_domain_abort_hi.almd` (byte-compare)<br>`spec/wasm_cross/to_fixed_wide_precision.almd` (byte-compare)<br>`spec/wasm_cross/matrix_dims_guard.almd` (byte-compare)<br>`spec/wasm_cross/matrix_dims_guard_overflow.almd` (byte-compare)<br>`spec/wasm_cross/list_repeat_size_ceiling.almd` (byte-compare)<br>`spec/wasm_cross/int_pow_operator_negative_base.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -1125,6 +1125,7 @@ statement = "json.parse decodes \\uXXXX escapes (BMP 1/2/3-byte UTF-8 plus high+
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/json_number_unicode.almd", class = "fixture" },
+  { path = "spec/wasm_cross/json_string_span.almd", class = "fixture" },
 ]
 
 [[contract]]

--- a/spec/wasm_cross/json_string_span.almd
+++ b/spec/wasm_cross/json_string_span.almd
@@ -1,0 +1,60 @@
+// @contract: C-087
+// The wasm json parser sizes each decoded string from its OWN span, not from
+// the rest of the document (#939 — sizing by the remainder made parse cost
+// O(strings x document length): a 103 KiB glTF took 708 ms and committed
+// 326 MiB, versus 30 ms / 9 MiB once sized per string).
+//
+// The span pass (`__jp_str_span`) must mirror `__jp_str_fill`'s advance and
+// stop conditions EXACTLY. Advancing less than the fill would under-allocate
+// and let the fill write past the end of the buffer, so every branch where the
+// two could disagree is pinned here — and, because this is a wasm_cross fixture,
+// pinned against the native oracle rather than against itself.
+//
+// The hazard cases are the ones where the fill skips bytes the span might stop
+// on: a `\u` with invalid hex advances 6 unconditionally, so it can step over a
+// quote that would otherwise end the string.
+import json
+
+fn s(text: String) -> String =
+  match json.parse(text) {
+    ok(v) => json.stringify(v),
+    err(e) => "ERR " + e,
+  }
+
+fn main() -> Unit = {
+  // Fill advances 6 past invalid hex — including over a closing quote.
+  println(s("[\"\\uZZZZtail\"]"))
+  println(s("[\"a\\uZZ\"]"))
+
+  // Surrogate handling: a valid pair advances 12, everything else 6.
+  println(s("[\"\\uD83D\\uDE00\"]"))
+  println(s("[\"\\uD83D\\uD83D\"]"))
+  println(s("[\"\\uD83D\"]"))
+  println(s("[\"\\uDC00\"]"))
+  println(s("[\"\\uD83Dxy\"]"))
+
+  // Simple escapes: 2 raw bytes, at most 1 decoded.
+  println(s("[\"a\\nb\\tc\\rd\\be\\ff\"]"))
+  println(s("[\"q\\\"q\",\"s\\\\s\",\"sl\\/sl\"]"))
+
+  // An unknown escape consumes 2 and writes nothing.
+  println(s("[\"x\\qy\"]"))
+
+  // Truncation: the fill yields what it read; the span must stop with it.
+  println(s("[\"abc"))
+  println(s("[\"abc\\"))
+  println(s("[\"abc\\u"))
+
+  // Empty and adjacent strings — a zero-length allocation is legal.
+  println(s("[\"\",\"\",\"a\"]"))
+  println(s("{\"\":\"\"}"))
+
+  // Multi-byte source bytes pass through untouched, 1 raw for 1 decoded.
+  println(s("[\"日本語\",\"emoji \\uD83D\\uDE00 end\"]"))
+
+  // Keys go through the same path as values.
+  println(s("{\"k\\u0041y\":\"v\",\"b\\\\d\":1}"))
+
+  // Many strings in one document: the case whose cost motivated the change.
+  println(s("[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\"]"))
+}

--- a/stdlib/json_parse.almd
+++ b/stdlib/json_parse.almd
@@ -146,19 +146,51 @@ fn __jp_value(base: Int, len: Int, p: Int) -> Result[(Value, Int), String] = {
 }
 
 // ── strings ──
-// One pass: over-allocate (decoded output is never longer than the raw span),
-// write bytes through a cursor, then patch the String's len header — the same
-// write-cursor + len-patch discipline as list.filter. p is at the opening `"`
-// (or whatever byte the object-key path hands it — consumed unconditionally,
-// like the oracle's parse_string).
+// Two passes over THIS string's own bytes: measure an upper bound on the
+// decoded length, allocate exactly that, then write bytes through a cursor and
+// patch the String's len header — the same write-cursor + len-patch discipline
+// as list.filter. p is at the opening `"` (or whatever byte the object-key path
+// hands it — consumed unconditionally, like the oracle's parse_string).
+//
+// The bound must come from the string's own span, NOT from `len - p - 1` (the
+// rest of the document): sizing by the document remainder makes parsing cost
+// O(strings x document length), which timed out on real glTF (#939). The span
+// pass mirrors __jp_str_fill's advance and stop conditions exactly — advancing
+// less would under-allocate and corrupt the heap, so the two must stay in step.
 
 fn __jp_string(base: Int, len: Int, p: Int) -> (String, Int) = {
-  let buf = prim.alloc_str(if len > p + 1 then len - p - 1 else 0)
+  let buf = prim.alloc_str(__jp_str_span(base, len, p + 1, 0))
   let dh = prim.handle(buf) + 12
   let (np, outn) = __jp_str_fill(base, len, p + 1, dh, 0)
   prim.store32(prim.handle(buf) + 4, outn)
   (buf, np)
 }
+
+// An upper bound on the bytes __jp_str_fill will write, walking the same path
+// it does. Per branch: a simple escape consumes 2 and writes at most 1; a
+// \uXXXX consumes 6 and writes at most 3 (any BMP codepoint); a surrogate pair
+// consumes 12 and writes exactly 4; a plain byte is 1 for 1.
+fn __jp_str_span(base: Int, len: Int, p: Int, n: Int) -> Int =
+  if p >= len then n
+  else {
+    let b = prim.load8(base + p)
+    if b == 34 then n
+    else if b == 92 then {
+      let e = if p + 1 < len then prim.load8(base + p + 1) else 0
+      if e == 117 then {
+        let unit = __jp_hex4(base, len, p + 2)
+        if unit >= 55296 and unit <= 56319
+          and p + 8 <= len and prim.load8(base + p + 6) == 92 and prim.load8(base + p + 7) == 117 then {
+          let lo = __jp_hex4(base, len, p + 8)
+          if lo >= 56320 and lo <= 57343 then __jp_str_span(base, len, p + 12, n + 4)
+          else __jp_str_span(base, len, p + 6, n + 3)
+        }
+        else __jp_str_span(base, len, p + 6, n + 3)
+      }
+      else __jp_str_span(base, len, p + 2, n + 1)
+    }
+    else __jp_str_span(base, len, p + 1, n + 1)
+  }
 
 // Returns (position after the closing quote / end, bytes written).
 fn __jp_str_fill(base: Int, len: Int, p: Int, dh: Int, o: Int) -> (Int, Int) =


### PR DESCRIPTION
Fixes the dominant term in #939. A 103 KiB glTF document parses in **30 ms / 9 MiB** instead of **708 ms / 326 MiB** — 24x faster, 38x less memory — with byte-identical results on every case tested.

## The change

`__jp_string` sized its output buffer from `len - p - 1` — the rest of the **document** — for every string it parsed:

```almide
let buf = prim.alloc_str(if len > p + 1 then len - p - 1 else 0)
```

`__jp_str_fill` then wrote the decoded bytes and `prim.store32` patched the length header down, but the allocation had already been made at full size. Parsing therefore committed O(strings × document length) of memory. glTF is string-dense, so a mid-size model degrades sharply and a large one exhausts the heap.

This sizes the buffer from the string's own span instead, via a new `__jp_str_span` pass. The over-allocate-then-patch discipline is unchanged — the span is still an upper bound, just a tight one.

## Keeping the two passes in step

`__jp_str_span` must mirror `__jp_str_fill`'s advance and stop conditions exactly. Advancing **less** would under-allocate and let the fill write past the end of the buffer, so the span mirrors the fill branch for branch:

| input | fill advances | fill writes | span counts |
|---|---|---|---|
| plain byte | 1 | 1 | 1 |
| `\n` `\t` `\r` `\b` `\f` `\"` `\\` `\/` | 2 | 1 | 1 |
| unknown escape | 2 | 0 | 1 |
| `\uXXXX` (BMP or invalid hex) | 6 | ≤3 | 3 |
| `\uXXXX\uXXXX` valid surrogate pair | 12 | 4 | 4 |

The subtle one is invalid hex: `__jp_str_u` advances 6 unconditionally when `__jp_hex4` fails, which can step **over a closing quote**. A span pass that stopped at that quote would under-allocate, so it has to reproduce the same skip.

## Tests

`spec/wasm_cross/json_string_span.almd` pins every branch where the two passes could disagree — invalid `\u` hex before a quote, lone and paired surrogates, unknown escapes, truncation mid-string and mid-escape, empty strings, multi-byte source bytes, and object keys (which take the same path). As a `wasm_cross` fixture it is pinned against the native oracle, not against itself.

I could not build the compiler here to run the suite — the machine has 13 GiB free against a 24 GiB `target/`, and rebuilding would have contended with the running codopsy worktrees. Instead I compiled **both** parser versions — `develop`'s and this one — into a single module with the shipped 0.36.0 compiler and diffed them on identical input. Full suite runs still need doing.

Correctness, 21 cases including all of the above plus the real 103 KiB glTF: **every one agrees**, compared on `json.stringify` of the parse result so a dropped escape or truncated string would show up.

## Numbers

Fresh instance per measurement — running both parsers in one instance contaminates the second, since the first leaves a heap grown to hundreds of MiB:

| document | develop | this branch | |
|---|---|---|---|
| real glTF, 103 KiB | 708 ms / 326 MiB | **30 ms / 9 MiB** | 24x faster, 38x less memory |
| synthetic 40 KiB | 264 ms / 104 MiB | 49 ms / 25 MiB | 5x |
| synthetic 86 KiB | 1858 ms / 436 MiB | 347 ms / 103 MiB | 5x |
| synthetic 178 KiB | 10004 ms / 1817 MiB | 1978 ms / 425 MiB | 5x |

## What this does not fix

Parsing is **still superlinear** after this change — roughly 4x per doubling at the top of that table. The remaining term is `acc + [v]` in `__jp_array` / `__jp_object`, which accumulate `List[Value]` and `List[(String, Value)]`.

That is a known gap rather than a new finding: `spec/wasm_cross/append_accumulator_heap.almd` (C-105) says so outright — *"the concat is the rc-incrementing `__list_concat_rc` … (O(n^2) copy like v0; n kept small.)"*. Scalar element lists got amortized doubling; heap-element lists did not. Measured on this compiler:

|    n | `List[Int]` | `List[String]` | `List[(String,Int)]` |
|-----:|------------:|---------------:|---------------------:|
|  500 |      0.1 ms |         0.9 ms |               0.9 ms |
| 4000 |      0.4 ms |        52.6 ms |              97.4 ms |

~2x per doubling for scalars, ~4-5x for heap elements. Closing that would take the parser the rest of the way, and belongs with #910 rather than here.
