### PR TITLE
Enforce the contract ledger's required scalars and stop citing the retired emit_wasm tree

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -94,38 +94,38 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-064 | The effect-fn Result auto-unwrap rule is identical across binding positions and type-directed, byte-identical on both targets | 0.26.20 | active | fixture | 1 |
 | C-065 | The string position API is codepoint-indexed end-to-end on both targets | 0.26.20 | active | fixture | 2 |
 | C-066 | WASM heap is reclaimed by default (true Perceus) | 0.27.0 | active | fixture | 4 |
-| C-067 | The xs[i] index syntax aborts on out-of-bounds (read and write) |  | active | fixture | 4 |
-| C-068 | Auto-? is target-directed in construction positions |  | active | fixture | 2 |
-| C-069 | Effect-fn tail self-recursion loop-converts to O(1) stack on both targets |  | active | fixture | 1 |
-| C-070 | Nested constructor patterns match and bind identically on both targets |  | active | fixture | 2 |
-| C-071 | Single-part interpolation RC balance |  | active | fixture | 1 |
-| C-072 | Inferred named-record repr parity |  | active | fixture | 1 |
-| C-073 | Tuple pattern testing a variant constructor |  | active | fixture | 1 |
-| C-074 | Iterative split/replace on large inputs |  | active | fixture | 1 |
-| C-075 | lowmisc round-5 cluster: borrowed-param owning binding, effect-Option auto-try strip, matching-error ! passthrough |  | active | fixture | 1 |
-| C-076 | Producer-side in-module variant construction is target-stable |  | active | fixture | 1 |
-| C-077 | Cross-module heap-global init order is dependency-respecting |  | active | fixture | 1 |
-| C-078 | Phantom record generic param is stripped on the Rust target |  | active | fixture | 1 |
-| C-079 | Variant cases with distinct anonymous-record payloads are target-stable |  | active | fixture | 1 |
-| C-080 | Empty map.from_list / set.from_list resolves its element from the result type |  | active | fixture | 1 |
-| C-081 | Generic fn in an inferred-param lambda resolves its type parameter |  | active | fixture | 1 |
-| C-082 | Calling a closure-typed lambda parameter yields the call result, not the closure |  | active | fixture | 1 |
-| C-083 | A negated i64::MIN literal is representable, not folded to zero |  | active | fixture | 1 |
-| C-084 | Codec/value decode error messages are byte-identical across targets |  | active | fixture | 1 |
-| C-085 | Float decode widens an integral JSON number to f64 |  | active | fixture | 1 |
-| C-086 | Pass-through stdlib combinators give their result its own reference |  | active | fixture | 1 |
-| C-087 | JSON number and \\u string decoding are byte-identical across targets |  | active | fixture | 1 |
-| C-088 | A Rust-keyword function name compiles on both targets |  | active | fixture | 1 |
-| C-089 | A default parameter referencing an earlier parameter is filled with its argument |  | active | fixture | 1 |
-| C-090 | bytes.from_list on a List[Int] parameter compiles on both targets |  | active | fixture | 1 |
-| C-091 | A nested sub-pattern in let-destructuring binds every leaf |  | active | fixture | 1 |
-| C-092 | A generic record field is sized by its instantiated type at construction |  | active | fixture | 1 |
-| C-093 | Mutually-recursive variant types compile on both targets |  | active | fixture | 1 |
-| C-094 | A protocol-method UFCS call on an inferred lambda param resolves the element type |  | active | fixture | 1 |
-| C-095 | json.stringify_pretty is byte-identical indented output across targets |  | active | fixture | 1 |
-| C-096 | process.args works on WASM and matches native |  | active | fixture | 1 |
-| C-097 | generic + on a type parameter concatenates strings/lists identically across targets |  | active | fixture | 1 |
-| C-098 | cross-module derived Codec methods dispatch on WASM and match native |  | active | fixture | 0 |
+| C-067 | The xs[i] index syntax aborts on out-of-bounds (read and write) | 0.27.4 | active | fixture | 4 |
+| C-068 | Auto-? is target-directed in construction positions | 0.27.4 | active | fixture | 2 |
+| C-069 | Effect-fn tail self-recursion loop-converts to O(1) stack on both targets | 0.27.4 | active | fixture | 1 |
+| C-070 | Nested constructor patterns match and bind identically on both targets | 0.27.6 | active | fixture | 2 |
+| C-071 | Single-part interpolation RC balance | 0.27.6 | active | fixture | 1 |
+| C-072 | Inferred named-record repr parity | 0.27.6 | active | fixture | 1 |
+| C-073 | Tuple pattern testing a variant constructor | 0.27.6 | active | fixture | 1 |
+| C-074 | Iterative split/replace on large inputs | 0.27.6 | active | fixture | 1 |
+| C-075 | lowmisc round-5 cluster: borrowed-param owning binding, effect-Option auto-try strip, matching-error ! passthrough | 0.27.6 | active | fixture | 1 |
+| C-076 | Producer-side in-module variant construction is target-stable | 0.27.6 | active | fixture | 1 |
+| C-077 | Cross-module heap-global init order is dependency-respecting | 0.27.6 | active | fixture | 1 |
+| C-078 | Phantom record generic param is stripped on the Rust target | 0.27.6 | active | fixture | 1 |
+| C-079 | Variant cases with distinct anonymous-record payloads are target-stable | 0.27.6 | active | fixture | 1 |
+| C-080 | Empty map.from_list / set.from_list resolves its element from the result type | 0.27.6 | active | fixture | 1 |
+| C-081 | Generic fn in an inferred-param lambda resolves its type parameter | 0.27.6 | active | fixture | 1 |
+| C-082 | Calling a closure-typed lambda parameter yields the call result, not the closure | 0.27.6 | active | fixture | 1 |
+| C-083 | A negated i64::MIN literal is representable, not folded to zero | 0.27.6 | active | fixture | 1 |
+| C-084 | Codec/value decode error messages are byte-identical across targets | 0.27.6 | active | fixture | 1 |
+| C-085 | Float decode widens an integral JSON number to f64 | 0.27.6 | active | fixture | 1 |
+| C-086 | Pass-through stdlib combinators give their result its own reference | 0.27.6 | active | fixture | 1 |
+| C-087 | JSON number and \\u string decoding are byte-identical across targets | 0.27.6 | active | fixture | 1 |
+| C-088 | A Rust-keyword function name compiles on both targets | 0.27.6 | active | fixture | 1 |
+| C-089 | A default parameter referencing an earlier parameter is filled with its argument | 0.27.6 | active | fixture | 1 |
+| C-090 | bytes.from_list on a List[Int] parameter compiles on both targets | 0.27.6 | active | fixture | 1 |
+| C-091 | A nested sub-pattern in let-destructuring binds every leaf | 0.27.6 | active | fixture | 1 |
+| C-092 | A generic record field is sized by its instantiated type at construction | 0.27.6 | active | fixture | 1 |
+| C-093 | Mutually-recursive variant types compile on both targets | 0.27.6 | active | fixture | 1 |
+| C-094 | A protocol-method UFCS call on an inferred lambda param resolves the element type | 0.27.6 | active | fixture | 1 |
+| C-095 | json.stringify_pretty is byte-identical indented output across targets | 0.27.6 | active | fixture | 1 |
+| C-096 | process.args works on WASM and matches native | 0.27.6 | active | fixture | 1 |
+| C-097 | generic + on a type parameter concatenates strings/lists identically across targets | 0.27.6 | active | fixture | 1 |
+| C-098 | cross-module derived Codec methods dispatch on WASM and match native | 0.27.6 | active | fixture | 0 |
 | C-099 | comparison/equality operators byte-match native across all operand types on the v1 wasm path | 0.27.6 | active | fixture | 9 |
 | C-100 | Self-hosted String classification/transform ops byte-match native on wasm | 0.27.6 | active | fixture | 4 |
 | C-101 | List ops over heap elements (String/Value) byte-match native and are leak/double-free free | 0.27.6 | active | fixture | 11 |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -483,7 +483,7 @@ evidence  = [
 id        = "C-034"
 spec      = "ALS-C4"
 title     = "Out-of-range list ops clamp / no-op gracefully (no OOB heap access)"
-statement = "Out-of-range `list.insert` clamps the index to the end (`min(i, len)`), `list.remove_at` / `list.swap` with an index >= len are no-ops, `list.slice` clamps past-the-end indices (end -> len, start >= effective_end -> []), and `list.with_capacity(n)` starts empty without header corruption for any n — all byte-identical native == wasm with no OOB heap read/write. `with_capacity` is TOTAL on both targets: capacity is an unobservable hint whose EAGER reservation is clamped to the SAME named byte ceiling (`MAX_WITH_CAPACITY_PREALLOC_BYTES` = 64 MiB, runtime/rs/src/list.rs == emit_wasm/calls_list.rs), so a huge request neither aborts native (`Vec::with_capacity(i32::MAX)` over a 24-byte element = ~51.5 GB, machine-dependent) nor corrupts the wasm header (the data byte count is computed in i64 so `hdr + bytes` never overflows i32); `push` grows past the clamped reservation normally. Native (runtime/rs/src/list.rs) is the oracle for each. On the v1 leg `list.slice` routes by ELEMENT repr like take/drop: String elements ride the deep-copying `list.slice_str` twin (same clamp edges), other heap elements wall — the Int twin's raw i64 element copy aliased String handles un-owned, a scope-end double free after correct output (differential-fuzz seed 20260718 index 680)."
+statement = "Out-of-range `list.insert` clamps the index to the end (`min(i, len)`), `list.remove_at` / `list.swap` with an index >= len are no-ops, `list.slice` clamps past-the-end indices (end -> len, start >= effective_end -> []), and `list.with_capacity(n)` starts empty without header corruption for any n — all byte-identical native == wasm with no OOB heap read/write. `with_capacity` is TOTAL on both targets: capacity is an unobservable hint, so a huge request neither aborts native nor corrupts the wasm header. Native clamps its EAGER reservation to a named byte ceiling (`MAX_WITH_CAPACITY_PREALLOC_BYTES` = 64 MiB, runtime/rs/src/list.rs), so `Vec::with_capacity(i32::MAX)` over a 24-byte element (~51.5 GB, machine-dependent) cannot abort; the v1 wasm self-host (stdlib/list_make.almd) reserves NOTHING — `list_with_capacity` returns a fresh EMPTY list and ignores `cap` — which is byte-equivalent precisely because the reservation is unobservable (there is no self-host `push` to observe it through). `push` grows normally on both legs. Native (runtime/rs/src/list.rs) is the oracle for each. On the v1 leg `list.slice` routes by ELEMENT repr like take/drop: String elements ride the deep-copying `list.slice_str` twin (same clamp edges), other heap elements wall — the Int twin's raw i64 element copy aliased String handles un-owned, a scope-end double free after correct output (differential-fuzz seed 20260718 index 680)."
 since     = "0.24.0"
 status    = "active"
 evidence  = [
@@ -917,6 +917,7 @@ id        = "C-067"
 spec      = "ALS-T6"
 title     = "The xs[i] index syntax aborts on out-of-bounds (read and write)"
 statement = "The index-operator path `xs[i]` (both read `xs[i]` and write `xs[i] = v`) is the ASSERT-in-bounds form: an out-of-bounds, negative, or >= 2^32 index ABORTS with the unified `Error: index out of bounds\n` + exit 1, byte-identical native == wasm — distinct from the stdlib `list.get`/`set` ops (C-054) which take native's no-op / default path. The check runs on the FULL i64 before the wasm i32 narrowing (so an index >= 2^32 can never truncate into range and read/write the wrong slot) and applies to the WRITE path too (previously wasm had no write-path bounds check — an OOB `xs[i] = v` was a silent heap write into adjacent allocator memory, exit 0; native panicked exit 101). Native routes through the `almide_index!`/`almide_index_set!` macros, wasm through `emit_index_bound_guard` + the unified `div_trap`, so neither a native panic (exit 101) nor a wasm `unreachable` trap (exit 134) is observable."
+since     = "0.27.4"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/index_bounds.almd", class = "fixture" },
@@ -930,6 +931,7 @@ id        = "C-068"
 spec      = "ALS-M4"
 title     = "Auto-? is target-directed in construction positions"
 statement = "An effect-fn call in a CONSTRUCTION position — a record field, list element, tuple slot, or map value — whose declared TARGET type is `Result[T, E]` KEEPS its Result (the auto-inserted `?` is stripped), exactly like the binding-statement arms (let/assign/index-assign/field-assign). The implicit Result-lift of an effect call plus an unconditional unwrap previously produced invalid native Rust (E0308: a `?` against a Result-typed slot) while wasm RAN and stored a SILENTLY WRONG value (the unwrapped i64 0 instead of the Result). Now byte-identical native == wasm: the Result is preserved at every construction position."
+since     = "0.27.4"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/autotry_construction.almd", class = "fixture" },
@@ -941,6 +943,7 @@ id        = "C-069"
 spec      = "ALS-M4"
 title     = "Effect-fn tail self-recursion loop-converts to O(1) stack on both targets"
 statement = "A self-recursive `effect fn` whose recursive call is in tail position runs in O(1) native/wasm stack (loop-converted), identically to the non-effect equivalent — not O(n) frames that overflow at ~1e5 depth. The auto-? desugar moved into the frontend (cc70ebc4), so the tail self-call reaches TailCallOpt already wrapped as `Try{Call self}` (Rust arm) or `Ok(Try(Call self))` (wasm arm, where ResultPropagation precedes TCO); TCO sees through both wrappers — the `?` is subsumed by the loop (an Err can only originate at a base case) and the `Ok` propagation wrapper is tail-transparent for effect fns. The Err short-circuit at a base case still fires. Before the fix every implicitly-lifted recursive effect fn crashed at ~1e5 depth (native stack overflow exit, wasm call-stack-exhausted trap) while the identical non-effect fn was O(1). The v1 leg's OWN loop rewrite must ALSO see through the wrapper: tco_collect classified `Try{Call self}` as the recursive arm but tco_rewrite lacked the twin arm, so an err-CAPABLE effect fn's recursive arm compiled to 'exit with the last base's kind' — a carried accumulator delivered its INITIAL value, and `checked(n - 0)` terminated with ok(0) where native spins (fuzz seed-20260718 index 946)."
+since     = "0.27.4"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/effect_tco.almd", class = "fixture" },
@@ -951,6 +954,7 @@ id        = "C-070"
 spec      = "ALS-M1"
 title     = "Nested constructor patterns match and bind identically on both targets"
 statement = "A NESTED pattern as the argument of a user-defined constructor pattern — `Wrap(A(n))`, `Box(Some(n))`, `Held(Circle { r })`, `Node(Leaf(a), Leaf(b))` — emits the inner discriminant test(s) into the arm guard and binds the inner payload(s) recursively, byte-identical native == wasm. The wasm match backend's constructor arm-binding loop previously handled only top-level `Bind`/`Literal` args: a nested ctor / Some / None / variant-record arg got NO inner discriminant test and bound garbage (0), so wasm SILENTLY took the wrong arm (exit 0) while native was correct (and a nested ctor on a recursive boxed variant additionally emitted invalid Rust). Now `emit_arg_tests` recurses the discriminant tests into the guard and `bind_arg` recurses the binding through nested ctor / Some / variant-record payloads. The NATIVE side of the same promise (#757): the `matches!` shape-guard the #610 box rewrite synthesizes must carry EVERY refutable constraint of the boxed inner pattern — the inner variant tag and inner literals, at any depth — so a non-matching value REFINES to the next arm. Erasing them to `_` admitted the value past the guard and panicked at the body's `let-else unreachable!()` (exit 101) while wasm refined correctly."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/nested_ctor_pattern.almd", class = "fixture" },
@@ -962,6 +966,7 @@ id        = "C-071"
 spec      = "ALS-I1"
 title     = "Single-part interpolation RC balance"
 statement = "A degenerate one-part interpolation `\"${e}\"` that the WASM emitter short-circuits to return `e`'s pointer directly does not double-free `e`'s heap buffer at teardown: when `e` is a heap-String alias the binding acquires its own reference, so native and WASM both produce the value and exit 0 (no 'unreachable' trap). Literal, non-String, surrounded, and multi-fragment interpolations stay genuinely fresh."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/r5_wasm_interp_alias_rc.almd", class = "fixture" },
@@ -972,6 +977,7 @@ id        = "C-072"
 spec      = "ALS-M2"
 title     = "Inferred named-record repr parity"
 statement = "A record literal inferred without a type annotation reprs identically on native and WASM: when its field set matches a declared record type, both print `TypeName { ... }` in the type's DECLARATION field order with correct values even when the literal is written out of declaration order; a truly anonymous record prints prefix-less in sorted field-name order on both targets."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/r5_wasm_inferred_record_repr.almd", class = "fixture" },
@@ -982,6 +988,7 @@ id        = "C-073"
 spec      = "ALS-M1"
 title     = "Tuple pattern testing a variant constructor"
 statement = "A tuple match arm that tests a variant constructor in any element position (nullary in pos 1/2 or both, or a payload-carrying constructor whose binder is captured) compiles and runs byte-identically on native and WASM; the WASM module passes structural validation (no 'expected i32 but nothing on stack')."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/r5_wasm_tuple_variant_pattern.almd", class = "fixture" },
@@ -992,6 +999,7 @@ id        = "C-074"
 spec      = "ALS-S6"
 title     = "Iterative split/replace on large inputs"
 statement = "string.split and string.replace produce byte-identical results on native and WASM for large inputs (5000+ segments, 6000+ occurrences) and exit 0 with no 'call stack exhausted' trap; an empty `from` pattern inserts the replacement at every codepoint boundary (Rust `str::replace` parity)."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/r5_wasm_split_replace_iterative.almd", class = "fixture" },
@@ -1002,6 +1010,7 @@ id        = "C-075"
 spec      = "ALS-I3"
 title     = "lowmisc round-5 cluster: borrowed-param owning binding, effect-Option auto-try strip, matching-error ! passthrough"
 statement = "Binding a borrow-rendered param (List &[T] / Map &AlmideMap) to a local converts to the owned type; an effect-fn Option[T] bound to a let and consumed by ?? strips the effect Result first leaving Option[T]; and `!` propagation whose source error type equals the enclosing fn's declared error type carries the custom variant error through `?` unchanged (no Debug stringify). All three compile and run byte-identically on native Rust and wasm32: stdout 'list=[7, 8]' / 'map_len=2' / 'miss=999' / 'hit=42' / 'fetch=item', exit 0."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/r5_lowmisc_param_try_err.almd", class = "fixture" },
@@ -1012,6 +1021,7 @@ id        = "C-076"
 spec      = "ALS-M3"
 title     = "Producer-side in-module variant construction is target-stable"
 statement = "A producer function declared inside the submodule that owns a variant type, constructing the variant via the bare constructor (tuple `Circle(r)` or record-variant `Circle { radius: r }`) and returning it, compiles and runs byte-identically on native Rust and wasm32 (stdout, stderr, exit). The construction expression's type is pinned to the owner-qualified `mod.Type`, so the #433 name-pinning verifier never fires on a valid in-module construction."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/r5_mod_producer_variant.almd", class = "fixture" },
@@ -1022,6 +1032,7 @@ id        = "C-077"
 spec      = "ALS-T7"
 title     = "Cross-module heap-global init order is dependency-respecting"
 statement = "An importing module's top-level let that reads an imported module's heap global (string/list/etc.), directly or through a function call, observes the imported global already initialized on both native Rust and wasm32 (byte-identical stdout, stderr, exit). WASM eager top-let init runs in a dependency-respecting order computed interprocedurally; native's lazy/forced init agrees (C-007)."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/r5_mod_global_init_order.almd", class = "fixture" },
@@ -1032,6 +1043,7 @@ id        = "C-078"
 spec      = "ALS-M2"
 title     = "Phantom record generic param is stripped on the Rust target"
 statement = "A record type with a generic param used by no field (a phantom param) compiles and runs byte-identical native == wasm. Rust forbids an unused type param (error[E0392]), so the Rust struct and every reference to it are emitted without generics; the param carries no runtime data (codegen erases types), so distinct instantiations share one representation — matching wasm, which already erases type params."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/phantom_type_param.almd", class = "fixture" },
@@ -1042,6 +1054,7 @@ id        = "C-079"
 spec      = "ALS-M3"
 title     = "Variant cases with distinct anonymous-record payloads are target-stable"
 statement = "A variant whose cases carry anonymous-record payloads with different field-name sets compiles and runs byte-identical native == wasm, including for a payload type that appears only in the declaration (never constructed). The anonymous-record collector scans declaration field/payload types, so every payload lowers to its generated struct (`AlmdRec_<fields>`) instead of native falling back to the bare field name as a type (rustc E0425)."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/anon_record_variant_payloads.almd", class = "fixture" },
@@ -1052,6 +1065,7 @@ id        = "C-080"
 spec      = "ALS-M5"
 title     = "Empty map.from_list / set.from_list resolves its element from the result type"
 statement = "`map.from_list([])` / `set.from_list([])` with an annotated result type compiles and runs byte-identical native == wasm. The empty-list argument's element type flows only through the generic call's return (Map[K,V] from List[(K,V)], Set[E] from List[E]); the checker can leave it an unresolved List slot, which native tolerates but the WASM concretization gate refuses. ConcretizeTypes derives the argument element from the call's resolved Map/Set type — matching both the Module-call and the lowered RuntimeCall (`almide_rt_map_from_entries`) forms — pinning the empty list (and its ANF temp) before the gate."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/empty_from_list_mono.almd", class = "fixture" },
@@ -1062,6 +1076,7 @@ id        = "C-081"
 spec      = "ALS-M5"
 title     = "Generic fn in an inferred-param lambda resolves its type parameter"
 statement = "A generic function called inside a `list.map` (or similar HOF) lambda whose parameter type is inferred from the collection element compiles and runs byte-identical native == wasm. The generic's type parameter, which flows in only via the HOF's `(A)->B` slot after the lambda body is inferred, is fresh-instantiated before back-propagation instead of leaking its literal name into the union-find, so it resolves to the concrete element type. Verified at two instantiations (Int and String element types)."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/generic_fn_in_inferred_lambda.almd", class = "fixture" },
@@ -1072,6 +1087,7 @@ id        = "C-082"
 spec      = "ALS-M5"
 title     = "Calling a closure-typed lambda parameter yields the call result, not the closure"
 statement = "A lambda whose body CALLS one of its parameters — `(f) => f(10)` over a `List[(Int)->Int]` via `list.map` — compiles and runs byte-identical native == wasm. When the called parameter's type is an unresolved inference var at the call site, the call constrains it to `(args)->?ret` and yields `?ret` (resolved from context), not the parameter's own closure type — so the HOF result is `List[?ret]`, not a list of closures. Verified for Int and String closure element types."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/call_closure_lambda_param.almd", class = "fixture" },
@@ -1082,6 +1098,7 @@ id        = "C-083"
 spec      = "ALS-M8"
 title     = "A negated i64::MIN literal is representable, not folded to zero"
 statement = "The literal `-9223372036854775808` (and its underscored/hex forms) compiles to a real `i64::MIN` and runs byte-identical native == wasm. The magnitude 9223372036854775808 overflows a signed `i64` parse, which previously clamped to 0 so the unary minus produced 0; lowering now folds the leading minus INTO the integer-literal parse (`-<digits>`) for decimal, hex, octal, and binary, so the whole negative value is parsed in range."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/i64_min_literal.almd", class = "fixture" },
@@ -1092,6 +1109,7 @@ id        = "C-084"
 spec      = "ALS-D6"
 title     = "Codec/value decode error messages are byte-identical across targets"
 statement = "value.as_* type mismatches and Codec decode failures produce the SAME error string on both backends. The WASM emitter mirrors the native oracle (runtime/rs/src/value.rs): type errors name the Value variant (`expected Float`, `expected Int`, `expected Str`, `expected Bool`, `expected Object`, `expected Array`) and a missing required field interpolates its name (`missing field '<key>'`, built at runtime via __concat_str), replacing the prior lowercase / `key not found` placeholders."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/codec_decode_errors.almd", class = "fixture" },
@@ -1102,6 +1120,7 @@ id        = "C-085"
 spec      = "ALS-D6"
 title     = "Float decode widens an integral JSON number to f64"
 statement = "Because a JSON number has no int/float distinction, value.as_float, json.as_float, and Codec Float-field decode (required, Option, and defaulted) all accept an integer JSON value and widen it to f64 — matching the native oracle (which already coerces in json.as_float/get_float and now in value.as_float) and serde. This keeps Codec roundtrips total when a Float value serializes without a decimal point. Verified byte-identical native == wasm for required, Option, and defaulted Float fields plus direct value.as_float / json.as_float."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/codec_float_int.almd", class = "fixture" },
@@ -1112,6 +1131,7 @@ id        = "C-086"
 spec      = "ALS-I1"
 title     = "Pass-through stdlib combinators give their result its own reference"
 statement = "Combinators that return an INPUT cell unchanged — option.filter (some), option.or_else (some), option.flatten, result.map_err (ok), result.map (err), result.flat_map (err) — SHARE a +1 onto the returned cell on the pass-through path (like list.get's some-box), so the let-bound result owns its own reference. Without it the result and the input aliased one cell and both scope-end Decs double-freed it: a __rc_dec trap, or a SILENT wrong value read from the freed cell through a longer combinator chain. Verified byte-identical native == wasm across all six combinators, a four-stage find|>map|>filter|>flat_map chain, and an OOB-defaulted loop lookahead (list.get(xs, i+1) ?? default)."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/alias_combinator_rc.almd", class = "fixture" },
@@ -1122,6 +1142,7 @@ id        = "C-087"
 spec      = "ALS-T3"
 title     = "JSON number and \\u string decoding are byte-identical across targets"
 statement = "json.parse decodes \\uXXXX escapes (BMP 1/2/3-byte UTF-8 plus high+low surrogate pairs to astral code points) and numbers identically on both backends. The WASM parser hands every float token to the same correctly-rounded parser float.parse uses (__dec2flt) instead of an ad-hoc digits/divisor * 10^exp, fixing the dropped -0.0 sign (#663) and the one-ULP exponent error (#667); its \\u decoder UTF-8-encodes the code point (#651). The native oracle's BMP-only \\u decoder gained the same surrogate-pair joining so emoji and other astral escapes round-trip. Integers keep their exact i64 path."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/json_number_unicode.almd", class = "fixture" },
@@ -1132,6 +1153,7 @@ id        = "C-088"
 spec      = "ALS-M7"
 title     = "A Rust-keyword function name compiles on both targets"
 statement = "A user function whose name is a Rust keyword (box, move, dyn, unsafe, …) compiles and runs byte-identical native == wasm. The Rust emitter raw-escapes the name (box → r#box) at BOTH its definition and every call site, driven by one shared keyword predicate (is_rust_keyword) — an incomplete per-site list previously left the definition or the call unescaped, producing invalid Rust. WASM identifiers have no keyword conflict."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/reserved_keyword_fn.almd", class = "fixture" },
@@ -1142,6 +1164,7 @@ id        = "C-089"
 spec      = "ALS-M5"
 title     = "A default parameter referencing an earlier parameter is filled with its argument"
 statement = "A default parameter value that references an earlier parameter (fn rect(w, h: Int = w)) compiles and runs byte-identical native == wasm. Defaults are inlined at the call site, so emitting the callee-local parameter name referenced a binding absent there (rustc E0425); lowering now substitutes each earlier parameter with its actual argument (chaining through earlier-filled defaults) before lowering the default expression."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/default_param_ref.almd", class = "fixture" },
@@ -1152,6 +1175,7 @@ id        = "C-090"
 spec      = "ALS-D7"
 title     = "bytes.from_list on a List[Int] parameter compiles on both targets"
 statement = "bytes.from_list applied to a List[Int] function parameter compiles and runs byte-identical native == wasm. A List[Int] parameter renders as &[i64], which the native runtime rejected when it took &Vec<i64> (rustc E0308). The runtime now takes a slice &[i64] — the parameter passes directly and a local Vec<i64> still deref-coerces."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/bytes_from_list_param.almd", class = "fixture" },
@@ -1162,6 +1186,7 @@ id        = "C-091"
 spec      = "ALS-M1"
 title     = "A nested sub-pattern in let-destructuring binds every leaf"
 statement = "A let-destructuring pattern containing a nested tuple (or record) sub-pattern binds every leaf, byte-identical native == wasm. The WASM emit handled only a flat Bind element and skipped nested sub-patterns — their leaves stayed zeroed; it now recurses, loading each sub-aggregate pointer and binding through it, mirroring the local pre-scan that already allocated those leaf locals."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/nested_tuple_destructure.almd", class = "fixture" },
@@ -1172,6 +1197,7 @@ id        = "C-092"
 spec      = "ALS-M2"
 title     = "A generic record field is sized by its instantiated type at construction"
 statement = "A generic record field is allocated and laid out by its instantiated type, byte-identical native == wasm. The WASM record emit sized the block from the DECLARED field list, so a generic field (value: T) used the unresolved param's default size (4 bytes); a trailing concrete heap field then wrote past the under-allocated block and read back empty, corrupting both the record and any spread of it. Construction now derives size and field order from the concrete (generic-substituted) layout of the result type."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/generic_record_field_size.almd", class = "fixture" },
@@ -1182,6 +1208,7 @@ id        = "C-093"
 spec      = "ALS-M3"
 title     = "Mutually-recursive variant types compile on both targets"
 statement = "Variant types forming a recursion cycle across two or more types (type A = A(B); type B = B(A)) compile and run byte-identical native == wasm. The native enum emit boxed a variant field only when it named the ENCLOSING type, so a mutual cycle emitted both enums without indirection and rustc rejected them as infinitely sized (E0072). Recursion detection is now cycle-based (a type that can reach itself through variant-field references), and the Box-rendering, pattern-deref, and boxed-fields-annotation sites all box a field that references ANY cycle member."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/mutual_recursive_types.almd", class = "fixture" },
@@ -1192,6 +1219,7 @@ id        = "C-094"
 spec      = "ALS-M5"
 title     = "A protocol-method UFCS call on an inferred lambda param resolves the element type"
 statement = "A higher-order call whose lambda argument has an UNANNOTATED parameter used as a protocol-method receiver (`list.map(xs, (e) => e.name())` where `xs: List[T]`, `T: Labelled`) compiles and runs byte-identical native == wasm. The checker resolves the callee signature up front and pins the lambda's inferred param to the expected element type (carrying its protocol bound) before inferring the body, so `e.name()` resolves via the protocol path instead of collapsing `e` into a closure type (which native rendered as `Rc<dyn Fn() -> String>`, rustc E0308). Verified for a stdlib HOF and a user-defined HOF."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/protocol_ufcs_inferred_lambda.almd", class = "fixture" },
@@ -1202,6 +1230,7 @@ id        = "C-095"
 spec      = "ALS-D6"
 title     = "json.stringify_pretty is byte-identical indented output across targets"
 statement = "json.stringify_pretty produces the same indented JSON on both backends. The WASM arm was a stub (compact output plus a stray newline); it now has a real recursive pretty-printer (__json_stringify_pretty) mirroring the native oracle (json.rs stringify_value): two-space indent per depth, one array element / object member per line, comma-then-newline separators, and inline [] / {} for empty containers. Scalars match the compact form. String quoting is the canonical 5-escape rule (backslash, quote, \\n, \\r, \\t; everything else raw UTF-8) — the SAME rule the compact stringify and the wasm __json_quote use. Previously the native pretty printer used Rust's {:?} (escape_debug), which escaped combining marks as `\\u{301}` — not valid JSON escaping and a byte divergence against the wasm leg (differential-fuzz: a `cafe` + U+0301 key). Verified byte-identical native == wasm over a nested object/array document, a top-level array, a top-level scalar, and combining-mark strings/keys."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/json_stringify_pretty.almd", class = "fixture" },
@@ -1212,6 +1241,7 @@ id        = "C-096"
 spec      = "ALS-R5"
 title     = "process.args works on WASM and matches native"
 statement = "process.args() runs on the WASM target (previously an emit ICE) and agrees with native. It maps to std::env::args() — argv[0] (the program path) followed by program args — built on WASM from the WASI args_sizes_get / args_get imports into the same List[String] layout native produces. The result List and each inner String are framed with the canonical 8-byte [len][cap][data] header (a 4-byte header made every element/byte read at the wrong offset — #645). Verified byte-identical native == wasm on the argument COUNT and on an argv[0]-independent content invariant (string.len of element 0 is non-zero), which reads the list at index 0 and walks element 0's UTF-8 data, exercising both the list and string header."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/process_args.almd", class = "fixture" },
@@ -1222,6 +1252,7 @@ id        = "C-097"
 spec      = "ALS-M5"
 title     = "generic + on a type parameter concatenates strings/lists identically across targets"
 statement = "A `+` whose operand is a type parameter T lowers to the default AddInt; when T instantiates to String or List, monomorphization re-dispatches it to ConcatStr / ConcatList (mirroring lowering's own type dispatch). A `fn dup[T](x: T) -> T = x + x` therefore concatenates for String and List and adds for Int, byte-identical native == wasm. A genuinely non-concatenable instantiation (e.g. a record) stays AddInt and is still rejected by the IR-verify gate."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/generic_concat.almd", class = "fixture" },
@@ -1232,6 +1263,7 @@ id        = "C-098"
 spec      = "ALS-D6"
 title     = "cross-module derived Codec methods dispatch on WASM and match native"
 statement = "A derived Codec method whose subject or element type is defined in another module (mod.Type.encode/decode, direct field, List[mod.Type], Option[mod.Type]) now dispatches on the WASM target instead of an emit ICE, and roundtrips byte-identically to native. The call site carries only Type.method (the subject type has no module) while the fn is registered under its module_origin-qualified name mod.Type.method; the WASM dispatcher resolves it by a unique func_map suffix match, and a __decode_list_mod.Type codec helper is routed before the dotted-name split that used to mis-parse the embedded dot. Native is unaffected (the #411-B BuiltinLoweringPass already flattens the name, but it is Rust-only)."
+since     = "0.27.6"
 status    = "active"
 evidence  = [
   { path = "tests/crossmod_matrix_test.rs", name = "crossmod_shape_matrix", class = "fixture" },
@@ -1506,7 +1538,7 @@ evidence  = [
 id        = "C-118"
 spec      = "ALS-R5"
 title     = "env.args works on WASM and matches native (argv[0] skipped)"
-statement = "env.args() runs on the WASM target (previously a stub that always returned the empty list) and agrees with native. It maps to almide_rt_env_args = std::env::args() with argv[0] (the binary name) SKIPPED — only the real program args. On WASM it is built from the WASI args_sizes_get / args_get imports by the SAME builder process.args uses (emit_wasm/calls_process.rs::emit_wasi_argv_list), parameterized by a leading-argv skip count: env.args passes skip=1 (drop argv[0]); process.args passes skip=0 (full argv). The result List and each inner String are framed with the canonical 8-byte [len][cap][data] header. Verified byte-identical native == wasm on the argument COUNT: with no extra program args the underlying argv is [program] on both legs, so after the skip env.args() is the empty list (length 0) on both — an argv[0]-content-independent invariant, since argv[0] itself differs between a temp binary path and the wasm module path."
+statement = "env.args() runs on the WASM target (previously a stub that always returned the empty list) and agrees with native. It maps to almide_rt_env_args = std::env::args() with argv[0] (the binary name) SKIPPED — only the real program args. On WASM it is built from the WASI args_sizes_get / args_get imports by the SAME builder process.args uses (crates/almide-mir/src/render_wasm_p3.rs), parameterized by a leading-argv skip count: env.args passes skip=1 (drop argv[0]); process.args passes skip=0 (full argv). The result List and each inner String are framed with the canonical 8-byte [len][cap][data] header. Verified byte-identical native == wasm on the argument COUNT: with no extra program args the underlying argv is [program] on both legs, so after the skip env.args() is the empty list (length 0) on both — an argv[0]-content-independent invariant, since argv[0] itself differs between a temp binary path and the wasm module path."
 since     = "0.27.8"
 status    = "active"
 evidence  = [
@@ -1712,7 +1744,7 @@ evidence  = [
 id        = "C-134"
 spec      = "ALS-T10"
 title     = "Vendored-libm atan / tanh are byte-identical cross-target"
-statement = "`math.atan` and `math.tanh` route through the SAME vendored musl-libm reference on both targets (native runtime/rs/src/libm_p4.rs — atan/expm1/tanh; wasm emit_wasm/rt_numeric.rs + rt_libm_p4.rs), so every result is byte-identical — printed via the (itself byte-identical) Dragon4 `float.to_string`. Native previously carried a PLATFORM `f64::atan` (dead code, never exposed in stdlib); it now runs the vendored fn. Every atan subrange (7/16, 11/16, 19/16, 39/16, 2^-27 tiny, 2^66 huge) and every tanh/expm1 range split (log(5/3)/2, log(3)/2, |x|>20, subnormal, k = 0/±1/>56 scaling) is exercised; identities atan(1) = pi/4, atan(inf) = pi/2 and the upstream expm1(1.1) sanity vector hold. Differential fuzz certifies the continuous input space."
+statement = "`math.atan` and `math.tanh` route through the SAME vendored musl-libm reference on both targets (native runtime/rs/src/libm_p4.rs — atan/expm1/tanh; wasm stdlib/math_atan.almd + stdlib/math_tanh.almd, self-hosted transcriptions of the same reference), so every result is byte-identical — printed via the (itself byte-identical) Dragon4 `float.to_string`. Native previously carried a PLATFORM `f64::atan` (dead code, never exposed in stdlib); it now runs the vendored fn. Every atan subrange (7/16, 11/16, 19/16, 39/16, 2^-27 tiny, 2^66 huge) and every tanh/expm1 range split (log(5/3)/2, log(3)/2, |x|>20, subnormal, k = 0/±1/>56 scaling) is exercised; identities atan(1) = pi/4, atan(inf) = pi/2 and the upstream expm1(1.1) sanity vector hold. Differential fuzz certifies the continuous input space."
 since     = "0.30.0"
 status    = "active"
 evidence  = [

--- a/scripts/check-contracts.sh
+++ b/scripts/check-contracts.sh
@@ -27,13 +27,16 @@
 #   (d) a fixture<->contract link is not symmetric (header names a contract that
 #       does not list the fixture as evidence, or vice-versa);
 #   (e) a schema violation (bad id / duplicate id / bad status / bad class /
-#       fuzz without n / missing doc file);
+#       fuzz without n / missing doc file / a missing REQUIRED scalar —
+#       title, statement, or since — or a since that is not MAJOR.MINOR.PATCH);
 #   (f) a coverage gap (C-001..C-NNN must be contiguous) or the flagged-contract
 #       ratchet ceiling is exceeded;
 #   (g) the README claims block (equivalence-claim numbers + exceptions clause)
 #       is stale relative to the ledger (scripts/gen-claims.sh --check, #766);
 #   (h) docs/contracts/README.md — the generated index — is stale relative to
-#       the ledger (the same diff CI's "Emit & Format" job runs).
+#       the ledger (the same diff CI's "Emit & Format" job runs);
+#   (j) a source path cited in a contract statement or a fixture header lives
+#       under a directory that no longer exists (a retired subsystem — #941).
 set -uo pipefail
 cd "$(dirname "$0")/.." || { echo "::error::cannot cd to repo root"; exit 2; }
 
@@ -67,20 +70,31 @@ err() { fail=1; echo "::error::$*"; }
 # side can group by id. The `statement` field uses ''' triple-quote when multi-
 # line; a sentinel skips its body. Single-line scalars parse exactly like the
 # registry's awk. Output schema (one per line, TAB-delimited):
-#   META<TAB>id<TAB>status<TAB>doc
+#   META<TAB>id<TAB>status<TAB>doc<TAB>title<TAB>statement<TAB>since
 #   EV<TAB>id<TAB>path<TAB>class<TAB>name<TAB>n
-# (empty name/n render as the literal "-")
+# (empty name/n render as the literal "-"; title/statement are presence flags
+# 0|1, since is the literal value or "" when the key is absent)
 parse_ledger() {
   awk '
-    function emit_meta() { if (id != "") print "META\t" id "\t" status "\t" doc }
-    BEGIN { id=""; status=""; doc=""; in_stmt=0 }
-    # triple-quote sentinel: toggle, and swallow everything between
-    /'"'"''"'"''"'"'/ { in_stmt = !in_stmt; next }
+    # Empty optional scalars render as "-": TAB is IFS whitespace, so bash `read`
+    # COLLAPSES adjacent tabs and an empty field would shift every later column.
+    function emit_meta() {
+      if (id != "") print "META\t" id "\t" status "\t" (doc == "" ? "-" : doc) "\t" title "\t" stmt "\t" (since == "" ? "-" : since)
+    }
+    function reset() { id=""; status=""; doc=""; title=0; stmt=0; since="" }
+    BEGIN { reset(); in_stmt=0 }
+    # triple-quote sentinel: toggle, and swallow everything between. A
+    # `statement = ""..."` opening line is consumed HERE, so the presence flag
+    # has to be set on the opening toggle — the /^statement/ rule never sees it.
+    /'"'"''"'"''"'"'/ { in_stmt = !in_stmt; if (in_stmt) stmt=1; next }
     in_stmt { next }
-    /^\[\[contract\]\]/ { emit_meta(); id=""; status=""; doc=""; next }
+    /^\[\[contract\]\]/ { emit_meta(); reset(); next }
     /^id[ \t]*=/      { v=$0; sub(/^id[ \t]*=[ \t]*"/,"",v); sub(/".*$/,"",v); id=v; next }
     /^status[ \t]*=/  { v=$0; sub(/^status[ \t]*=[ \t]*"/,"",v); sub(/".*$/,"",v); status=v; next }
     /^doc[ \t]*=/     { v=$0; sub(/^doc[ \t]*=[ \t]*"/,"",v); sub(/".*$/,"",v); doc=v; next }
+    /^title[ \t]*=/     { title=1; next }
+    /^statement[ \t]*=/ { stmt=1; next }
+    /^since[ \t]*=/   { v=$0; sub(/^since[ \t]*=[ \t]*"/,"",v); sub(/".*$/,"",v); since=v; next }
     # an evidence inline-table line: { path = "...", class = "...", name = "...", n = N }
     /path[ \t]*=[ \t]*"/ {
       line=$0
@@ -102,13 +116,26 @@ EV="$(printf '%s\n' "$LEDGER_RECORDS" | grep '^EV' || true)"
 ALL_IDS="$(printf '%s\n' "$META" | cut -f2 | grep . || true)"
 
 # ── (e) SCHEMA: id shape + uniqueness, status enum, doc file exists ──────────
-while IFS=$'\t' read -r _tag id status doc; do
+# Every REQUIRED scalar is checked here. `since` used to be documented REQUIRED
+# but unenforced, so 32 contracts (C-067..C-098) shipped without it and the
+# generated README published 32 blank Since cells (#938). A field the schema
+# calls required and the gate never reads is a field that silently goes missing.
+while IFS=$'\t' read -r _tag id status doc title stmt since; do
   [ -z "$id" ] && continue
+  [ "$doc" = "-" ] && doc=""
+  [ "$since" = "-" ] && since=""
   printf '%s\n' "$id" | grep -qE '^C-[0-9]{3}$' || err "bad contract id '$id' (must match ^C-[0-9]{3}\$)"
   case "$status" in
     active|flagged-for-revision) ;;
     *) err "$id: status '$status' is not one of {active, flagged-for-revision}" ;;
   esac
+  [ "$title" = "1" ] || err "$id: REQUIRED key 'title' is missing"
+  [ "$stmt"  = "1" ] || err "$id: REQUIRED key 'statement' is missing"
+  if [ -z "$since" ]; then
+    err "$id: REQUIRED key 'since' is missing (the version the contract became normative)"
+  elif ! printf '%s\n' "$since" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    err "$id: since='$since' is not a MAJOR.MINOR.PATCH version"
+  fi
   if [ "$doc" != "" ] && [ ! -f "$DOC_DIR/$doc" ]; then
     err "$id: doc='$doc' does not exist under $DOC_DIR/"
   fi
@@ -225,6 +252,33 @@ if [ -n "$only_rev" ]; then
     err "$base declares $id but $id does not list $base as evidence (link must be symmetric)"
   done <<< "$only_rev"
 fi
+
+# ── (j) CITED SOURCE PATHS MUST NOT NAME A RETIRED SUBSYSTEM ────────────────
+# `evidence.path` is already checked to exist. But contract STATEMENTS and
+# fixture HEADERS also point the reader at the implementation ("the WASM runtime
+# `emit_wasm/rt_dragon.rs` must match it"), and nothing read those. When the v0
+# wasm emitter was retired (c71eff7b deleted 115 files under
+# crates/almide-codegen/src/emit_wasm/), 16 such citations rotted in place and
+# the ledger kept sending readers to code that no longer existed (#941).
+#
+# The rule is deliberately narrow: flag a cited path only when its PARENT
+# DIRECTORY is gone. That is exactly the retired-subsystem signature, and it
+# cannot fire on an illustrative filename inside a live directory — statements
+# legitimately contain examples like `fs.stat("spec/x.almd")`. A single deleted
+# file inside a surviving directory is NOT caught; that is the price of zero
+# false positives, and the evidence-path check above covers the paths that
+# actually certify a contract.
+dead_paths=0
+while IFS= read -r cited; do
+  [ -z "$cited" ] && continue
+  [ -e "$cited" ] && continue
+  parent="$(dirname "$cited")"
+  [ -d "$parent" ] && continue
+  err "cited path '$cited' lives under '$parent', which does not exist (retired subsystem?)"
+  dead_paths=$((dead_paths + 1))
+done <<< "$(grep -rhoE '(crates|runtime|stdlib|spec|tests|scripts|proofs)/[A-Za-z0-9_.-]+(/[A-Za-z0-9_.-]+)*\.(rs|almd|lean|toml|sh)' \
+              "$LEDGER" "$FIXTURE_DIR"/*.almd 2>/dev/null | sort -u)"
+[ "$dead_paths" -eq 0 ] && echo "cited-paths: every source path named in a statement or fixture header resolves to a live directory."
 
 # ── (f) COVERAGE: ids must be contiguous C-001..C-NNN, no gaps ──────────────
 sorted_ids="$(printf '%s\n' "$ALL_IDS" | sort -u)"
@@ -355,3 +409,7 @@ echo "  fixtures: $n_with_header/$n_fixtures carry a // @contract: header; bidir
 #   (7) hand-edit a number inside README's claims markers  -> (g) stale-claims.
 #   (8) add a contract without regenerating the index      -> (h) stale-index.
 #   (9) cite a new section without regenerating conformance -> (i) stale-report.
+#  (10) delete a `since = ` line from any contract         -> (e) missing-required.
+#  (11) point a fixture header back at emit_wasm/rt_*.rs   -> (j) dead-path.
+# (10) and (11) were verified by hand against C-067 and spec/wasm_cross/
+# float_parse.almd: each flips the gate red alone and green again on restore.

--- a/spec/wasm_cross/bytes_f16.almd
+++ b/spec/wasm_cross/bytes_f16.almd
@@ -1,8 +1,8 @@
 // @contract: C-037
 // Cross-target differential fixture: bytes.read_f16_le (IEEE-754 half → f64).
 //
-// Native oracle `runtime/rs/src/bytes.rs::f16_bits_to_f64`. The WASM expander
-// `emit_wasm/runtime.rs::compile_bytes_f16_to_f64` must match it; the regression
+// Native oracle `runtime/rs/src/bytes.rs::f16_bits_to_f64`. The self-hosted
+// WASM leg `stdlib/bytes_f16.almd` must match it; the regression
 // was the exp-all-ones path rendering ±inf as the FINITE ±f32::MAX instead of
 // ±inf / NaN. Covers ±inf, NaN (zero and nonzero mantissa), ±0, the smallest
 // subnormal, a few normals, and the largest finite half.

--- a/spec/wasm_cross/encoding_base64.almd
+++ b/spec/wasm_cross/encoding_base64.almd
@@ -2,8 +2,9 @@
 // Cross-target differential fixture: base64 encode/decode (standard + URL-safe).
 //
 // Native `runtime/rs/src/base64.rs` is the oracle (RFC 4648, canonical padded
-// form for BOTH alphabets); the WASM runtime `emit_wasm/rt_encoding.rs` must
-// produce byte-identical output, including the decode error strings:
+// form for BOTH alphabets); the self-hosted WASM leg `stdlib/base64_encode.almd`
+// (encode AND decode) must produce byte-identical output, including the decode
+// error strings:
 //   - "invalid base64 character"
 //   - "invalid base64 length: <orig_len>"
 // Drains the rt-oracle-registry compile_base64_{encode,decode} entries, and

--- a/spec/wasm_cross/float_parse.almd
+++ b/spec/wasm_cross/float_parse.almd
@@ -3,8 +3,8 @@
 // (Rust `s.trim().parse::<f64>()`), i.e. correctly-rounded round-to-nearest-even.
 // The old WASM parser accumulated the mantissa in f64 (`acc*10+digit`, `*10^exp`),
 // which is NOT correctly rounded: "0.3" → 0.30000000000000004, long mantissas drift,
-// subnormals collapse to 0. The runtime now uses Clinger AlgorithmM with exact
-// big-integer arithmetic (crates/almide-codegen/src/emit_wasm/rt_dec2flt.rs),
+// subnormals collapse to 0. The WASM leg now uses Clinger AlgorithmM with exact
+// big-integer arithmetic in SELF-HOSTED Almide (stdlib/float_parse.almd),
 // reusing the Dragon4 bignum. Each parse is printed via the (shortest-round-trip)
 // float.to_string so any 1-ULP error would show as different bytes.
 effect fn main() -> Unit = {

--- a/spec/wasm_cross/float_shortest_roundtrip.almd
+++ b/spec/wasm_cross/float_shortest_roundtrip.almd
@@ -1,8 +1,9 @@
 // @contract: C-023
 // Regression: WASM float.to_string must produce the SAME bytes as native —
 // Rust's f64 Display (shortest round-tripping decimal, fixed notation) plus the
-// ".0" integer suffix. The WASM runtime implements Dragon4 with exact
-// big-integer arithmetic (crates/almide-codegen/src/emit_wasm/rt_dragon.rs).
+// ".0" integer suffix. The WASM leg implements Dragon4 with exact big-integer
+// arithmetic in SELF-HOSTED Almide (stdlib/float_to_string.almd), transcribed
+// from v0's Rust emitter (emit_wasm/rt_dragon.rs, retired in c71eff7b).
 // Previously WASM emitted fixed-precision digits (native 0.30000000000000004 vs
 // wasm 0.3) AND trapped via i64_trunc for |x| >= 2^63.
 effect fn main() -> Unit = {

--- a/spec/wasm_cross/heap_arena.almd
+++ b/spec/wasm_cross/heap_arena.almd
@@ -1,14 +1,16 @@
 // @contract: C-041
-// Cross-target drain fixture for the arena checkpoint primitives in
-// emit_wasm/runtime.rs: compile_heap_save, compile_heap_restore.
+// Cross-target drain fixture for the arena checkpoint surface
+// (stdlib/bytes_core.almd: bytes_heap_save, bytes_heap_restore).
 //
 // Exposed as bytes.heap_save() -> Int (an OPAQUE checkpoint) and
 // bytes.heap_restore(checkpoint) -> Unit. On native these are intentionally
 // trivial (runtime/rs/src/bytes.rs: heap_save() = 0, heap_restore() = no-op,
-// since the Rust allocator manages memory); on WASM they save/reset the bump
-// pointer to reclaim everything allocated since the checkpoint. The CONTRACT is
-// the same on both: take a checkpoint, allocate scratch, restore, and subsequent
-// work must produce identical results.
+// since the Rust allocator manages memory). v0's WASM leg saved/reset a bump
+// pointer to reclaim everything allocated since the checkpoint; v1's RC
+// discipline reclaims scratch deterministically at scope end, so the self-host
+// is trivial on BOTH legs. The CONTRACT is unchanged either way: take a
+// checkpoint, allocate scratch, restore, and subsequent work must produce
+// identical results.
 //
 // The checkpoint value itself is target-specific (0 vs a real pointer) and is
 // NEVER printed — only the post-restore observable results, which must match.

--- a/spec/wasm_cross/int_from_hex.almd
+++ b/spec/wasm_cross/int_from_hex.almd
@@ -3,8 +3,8 @@
 //
 // Native oracle (runtime/rs/src/int.rs):
 //   i64::from_str_radix(s.trim().trim_start_matches("0x"), 16).map_err(|e| e.to_string())
-// The WASM runtime `emit_wasm/rt_numeric.rs::compile_int_from_hex` must mirror
-// it exactly, INCLUDING the native quirks (see contract_notes):
+// The self-hosted WASM leg `stdlib/int_hex.almd` must mirror it exactly,
+// INCLUDING the native quirks (see contract_notes):
 //   - "0X10" → Err (the "0x" strip is lowercase-only / case-sensitive)
 //   - "0x0xff" → Ok(255) (trim_start_matches strips "0x" REPEATEDLY)
 //   - "f_f" → Err (NO underscore skipping)

--- a/spec/wasm_cross/json_path_edges.almd
+++ b/spec/wasm_cross/json_path_edges.almd
@@ -2,7 +2,8 @@
 // Cross-target differential fixture: json get/set/remove_path edge cases.
 //
 // Native `runtime/rs/src/json.rs` path ops are the INFALLIBLE oracle. The WASM
-// `emit_wasm/rt_value.rs` path walkers had 8 divergences this locks down:
+// path walkers (v0's `emit_wasm/rt_value.rs`, now self-hosted in
+// `stdlib/json_path.almd`) had 8 divergences this locks down:
 //   1. get_path negative Index normalizes (len + i); WASM returned None.
 //   2. set_path negative Index normalizes (top + nested); WASM left unchanged.
 //   3. set_path Index over an OBJECT → no-op; WASM read pairs as an array (garbage).

--- a/spec/wasm_cross/math_atan_tanh.almd
+++ b/spec/wasm_cross/math_atan_tanh.almd
@@ -3,8 +3,8 @@
 // tanh rides on).
 //
 // Both targets run the SAME vendored musl-libm reference (native:
-// runtime/rs/src/libm_p4.rs, wasm: emit_wasm/rt_numeric.rs +
-// emit_wasm/rt_libm_p4.rs), so every result must be byte-identical. Printed
+// runtime/rs/src/libm_p4.rs, wasm: self-hosted stdlib/math_atan.almd +
+// stdlib/math_tanh.almd), so every result must be byte-identical. Printed
 // via float.to_string (Dragon4, itself byte-identical cross-target), so any
 // diff the gate catches is the MATH. Covers:
 //   - every atan subrange (|x| < 7/16, the three reduction intervals, |x| >= 2^66)

--- a/spec/wasm_cross/math_explog.almd
+++ b/spec/wasm_cross/math_explog.almd
@@ -2,7 +2,8 @@
 // Cross-target equivalence for math.exp / log / log2 / log10.
 //
 // Both targets run the SAME vendored musl-libm reference (native:
-// runtime/rs/src/libm.rs, wasm: emit_wasm/rt_libm.rs), so every result must be
+// runtime/rs/src/libm.rs, wasm: self-hosted stdlib/math_exp.almd +
+// stdlib/math_log.almd), so every result must be
 // byte-identical. Printed via float.to_string (Dragon4, itself byte-identical
 // cross-target), so any diff the gate catches is the MATH. Covers the headline
 // values AND the sweep-confirmed special cases:

--- a/spec/wasm_cross/rc_alloc_stress.almd
+++ b/spec/wasm_cross/rc_alloc_stress.almd
@@ -1,6 +1,7 @@
 // @contract: C-041
-// Cross-target drain fixture for the heap/RC primitives in emit_wasm/runtime.rs:
-//   compile_alloc, compile_rc_inc, compile_rc_dec, compile_string_alloc.
+// Cross-target drain fixture for the wasm heap/RC primitives — alloc, rc_inc,
+// rc_dec, string alloc — emitted by the v1 renderer
+// (crates/almide-mir/src/render_wasm_p2.rs, render_wasm_p2_b.rs).
 //
 // These have no directly-callable surface; their oracle is "any program whose
 // allocation / refcount / growth behavior is observable must produce the same

--- a/spec/wasm_cross/string_case_unicode.almd
+++ b/spec/wasm_cross/string_case_unicode.almd
@@ -5,7 +5,8 @@
 // (±32 byte loop), so every non-ASCII case op diverged: accents, Greek, Cyrillic,
 // the length-CHANGING maps (ß -> SS), and the context-sensitive Greek sigma
 // (Final_Sigma: word-final ς vs medial σ). The runtime now embeds oracle-derived
-// Unicode case tables (crates/almide-codegen/src/emit_wasm/rt_string_case.rs) and
+// Unicode case tables in SELF-HOSTED Almide (stdlib/string_to_upper.almd,
+// stdlib/string_to_lower.almd, stdlib/string_capitalize.almd) and
 // resolves Final_Sigma at runtime — byte-identical to native for ALL scalars.
 effect fn main() -> Unit = {
   // ── ASCII (the old fast path; still correct) ──

--- a/spec/wasm_cross/string_ops_drain.almd
+++ b/spec/wasm_cross/string_ops_drain.almd
@@ -8,8 +8,9 @@
 // native and wasm and asserts byte-identical stdout. Native is the oracle.
 //
 // Probe matrix is aimed at the STRUCTURAL differences between the std-backed
-// native runtime (runtime/rs/src/string.rs) and the hand-written wasm bytes
-// (crates/almide-codegen/src/emit_wasm/rt_string_extra.rs):
+// native runtime (runtime/rs/src/string.rs) and the self-hosted wasm leg
+// (stdlib/string_replace.almd, string_first_last.almd, string_is_digit.almd,
+// string_cmp.almd):
 //   - cmp is BYTE-lexicographic with a length tiebreak, NOT codepoint order
 //     ("ä" > "z" because 0xC3 > 0x7A; "apple" > "Apple" because 'a' > 'A').
 //   - replace_first with an EMPTY pattern: native find("") = Some(0), so `to`

--- a/spec/wasm_cross/trig_libm.almd
+++ b/spec/wasm_cross/trig_libm.almd
@@ -2,7 +2,7 @@
 // Cross-target equivalence for the vendored-libm trig (math.sin/cos/tan).
 //
 // Both targets run the SAME musl-libm algorithm (native: runtime/rs/src/libm.rs,
-// wasm: emit_wasm/rt_libm.rs), so every result must be byte-identical. Printed via
+// wasm: self-hosted stdlib/math_trig.almd), so every result must be byte-identical. Printed via
 // float.to_string (Dragon4), which is itself byte-identical cross-target, so any
 // diff the gate catches is the MATH. The point set deliberately hits each rem_pio2
 // path: small (|x|<pi/4), the small/medium pi/2-quadrant branches, and the


### PR DESCRIPTION
Closes #938. Closes #941.

The ledger's selling point is that the link between a promise and its evidence is machine-enforced rather than maintained by hand. Two of its fields were not: a REQUIRED key nothing read, and the source paths its prose points readers at. Both had rotted.

## `since` was declared REQUIRED and never checked (#938)

`scripts/check-contracts.sh` never mentioned `since` (`grep -c since` → 0), so 32 contracts shipped without it and the generated, publicly-served README published 32 blank **Since** cells.

Backfilled C-067…C-098. Picking the values needed care, because the existing declarations follow two different conventions:

- **version in `Cargo.toml` at the introducing commit** — matches C-066 / C-099 / C-100, off by one patch for C-129 / C-165
- **first release tag containing the commit** — matches C-066 / C-129 / C-165, differs for C-099 / C-100

The tie-breaker: **`v0.27.5` was never tagged.** The Cargo.toml rule assigns C-097 / C-098 a version that was never released, so it cannot be the intended meaning. Every value here is the first release tag containing the introducing commit — C-067…C-069 → `0.27.4`, C-070…C-098 → `0.27.6`.

That leaves no room for the other reading either: all 18 introducing commits carry the behaviour change alongside the contract (2–25 non-ledger files each), so "the release the contract became normative" and "the release the behaviour started holding" are the same release for all 32.

## Contract statements and fixture headers pointed at deleted code (#941)

`c71eff7b` retired the v0 wasm emitter, deleting 115 files under `crates/almide-codegen/src/emit_wasm/`. 17 citations in the ledger (3) and in `spec/wasm_cross/*.almd` headers (13) kept sending readers there — including C-023's "the wasm runtime implements Dragon4 … (rt_dragon.rs)", whose fixture is the first thing a reader of the docs site's cross-target guarantee is pointed at.

Repointed each at its live home. The implementations did not move — they were **rewritten as self-hosted Almide** under `stdlib/`, so the citations now name e.g. `stdlib/float_to_string.almd` rather than a Rust file. Deliberately historical references are kept and marked as past ("v0's `emit_wasm/rt_value.rs`, now self-hosted in …").

Two citations were wrong about **behaviour**, not just location:

- **C-034** claimed both legs clamp an eager reservation to a shared 64 MiB ceiling. The v1 wasm self-host (`stdlib/list_make.almd`) ignores `cap` entirely and returns an empty list — the clamp is native-only now. The observable contract (capacity is an unobservable hint, `with_capacity` is total) is unchanged; the stated mechanism was not.
- **`heap_arena.almd`** described the wasm leg as saving/resetting a bump pointer. v1's RC discipline reclaims scratch at scope end, so the self-host is trivial on both legs — as `stdlib/bytes_core.almd` already documented correctly.

## Gate

Two new checks, both mutation-tested by hand (each flips the gate red alone, green again on restore):

- **(e) required scalars** — `title`, `statement`, `since` must be present, and `since` must be `MAJOR.MINOR.PATCH`. Verified against C-067.
- **(j) dead citations** — a source path named in a statement or fixture header must not live under a directory that no longer exists. Verified by pointing `float_parse.almd` back at `emit_wasm/rt_dec2flt.rs`.

Check (j) is deliberately narrow: it fires only when the **parent directory** is gone. That is the retired-subsystem signature, and it cannot trip on an illustrative filename inside a live directory — statements legitimately contain examples like `fs.stat("spec/x.almd")`. A single deleted file inside a surviving directory is not caught; that is the price of zero false positives, and `evidence.path` (already checked to exist) covers the paths that actually certify a contract.

Implementation note: the parser emits `META` as TAB-separated fields and bash reads them with `IFS=$'\t'`. TAB is IFS **whitespace**, so adjacent tabs collapse and an empty optional field shifts every later column — which is why the `EV` records already used a `-` placeholder. `doc` and `since` now follow the same convention.

## Verification

- gate green: 188 contracts, 315 fixtures, 0 blank Since cells, 0 dead citations
- all 13 edited fixtures pass `almide check` (they are compiled sources, not just comments)
- `docs/contracts/README.md` regenerated

## Not in this PR

The same drift exists in ~27 source comments under `stdlib/` and `runtime/rs/` (e.g. `stdlib/float.almd` still says "WASM dispatch stays on `emit_wasm/calls_float.rs`"). Those mix live claims with deliberate v0 provenance notes and need per-site judgment from someone who knows the migration, so they are left out rather than bulk-edited here.

Separately: C-099 and C-100 declare `since = "0.27.6"`, but `v0.27.6` was tagged 2026-06-13 and their contract lines landed 2026-06-23 — they first shipped in `0.28.0`. Left alone, since changing an existing declared value is a maintainer's call rather than a backfill.