### PR TITLE
Name and bound the equivalence law's one exemption

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,17 @@ almide run hello.almd
 
 **Every program that compiles for both targets produces byte-identical observable output — stdout, stderr, exit code — whether it runs as a native binary or as WebAssembly.** Native is the oracle; `native == wasm` is a hard invariant, not a "target difference" to be documented around.
 
-The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-identical" means the execution output, not the compiled artifacts; inherently nondeterministic sources certify deterministic *invariants* instead of exact bytes; and APIs not yet implemented on wasm are compile- or run-time *refusals* — never wrong bytes.
+The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-identical" means the execution output, not the compiled artifacts; inherently nondeterministic sources certify deterministic *invariants* instead of exact bytes; APIs not yet implemented on wasm are compile- or run-time *refusals* — never wrong bytes; and exactly two fns are exempt because their job is to report the host — `env.os()` and `env.temp_dir()`, bounded by C-189, since making them agree across targets would be the defect rather than the guarantee.
 
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI) so this section cannot drift from what the gates actually verify:
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> **Ledger: 188 contracts — 188 active, 0 flagged-for-revision.**
+> **Ledger: 189 contracts — 189 active, 0 flagged-for-revision.**
 >
-> **Exceptions: none.** Every contract in the ledger is `active`, carrying
-> executable evidence of class ≥ `fixture`.
+> **Divergences awaiting a fix: none.** Every contract in the ledger is
+> `active`, carrying executable evidence of class >= `fixture`. The one
+> by-design carve-out in the law — the platform-reporting fns `env.os`
+> and `env.temp_dir` — is bounded by C-189.
 <!-- claims:generated:end -->
 
 Full scope, ledger mechanics, and the evidence stack (contract ledger, cross-target fixture gate, differential fuzz, emit-time Σ-probes, Lean belt, org-wide byte-verify sweep): **[docs/EQUIVALENCE.md](./docs/EQUIVALENCE.md)**.

--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -35,6 +35,7 @@ empty_from_list_mono  out-of-interp-scope capability: map.from_list
 encoding_base64  out-of-interp-scope capability: base64.encode
 env_args  out-of-interp-scope capability: env.args
 env_get  out-of-interp-scope capability: env.get
+env_platform_reporting  out-of-interp-scope capability: env.os
 fan_any_allfail  out-of-interp-scope capability: fan.any
 fan_any_early_winner  out-of-interp-scope capability: fan.any
 fan_deterministic  out-of-interp-scope capability: fan.map

--- a/docs/EQUIVALENCE.md
+++ b/docs/EQUIVALENCE.md
@@ -11,6 +11,7 @@ The guarantee is **continuous, with an explicit scope** — held by gates that r
 - **In scope**: everything the program lets you observe — stdout, stderr, exit code — on every program that compiles for both targets.
 - **Inherently nondeterministic sources** are ledger-managed, not waved away: their contracts certify the *deterministic invariant* (e.g. every `random.int(lo, hi)` draw stays in range — C-112) instead of exact bytes, and the sole wall-clock stdlib surface was removed outright (C-006) rather than documented around.
 - **APIs not yet implemented on wasm** are compile- or run-time *refusals*: the program never runs far enough to emit wrong bytes — an honest wall, not a silent divergence.
+- **Platform-reporting fns are the one exemption, and it is closed**: `env.os()` and `env.temp_dir()` report the host they run on, so native answers the real OS name and temp directory while the wasm leg answers the WASI sandbox. Making them agree would be the defect. C-189 bounds the carve-out to exactly those two and certifies the invariant that *is* identical (the platform set is closed; the temp path is non-empty and absolute), so a third exempt fn cannot appear without amending the contract and its fixture.
 
 ## The contract ledger
 

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-188 contracts
+189 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -216,4 +216,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-186 | Appending an inline index read to a list accumulator lowers and runs on both targets | 0.37.0 | active | fixture | 1 |
 | C-187 | An in-place mutator writing through a module-level `var` buffer behaves identically on both targets | 0.37.0 | active | fixture | 2 |
 | C-188 | A scalar `if` arm executes its statement effects — global writes land and outer-var reassignments hit the stable local | 0.37.0 | active | fixture | 1 |
+| C-189 | env.os / env.temp_dir report the HOST — the equivalence law's only exemption, and it is closed | 0.37.0 | active | fixture | 1 |
 

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-64 normative sections; 326 distinct executable fixtures.
+64 normative sections; 327 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -53,7 +53,7 @@
 | ALS-R2 | C-008, C-009, C-010, C-011 | `spec/wasm_cross/compound_repr_interp.almd` (byte-compare)<br>`spec/wasm_cross/repr_parity_pin.almd` (byte-compare)<br>`spec/wasm_cross/compound_repr_records_interp.almd` (byte-compare)<br>`spec/wasm_cross/compound_repr_recursive_interp.almd` (byte-compare)<br>`spec/wasm_cross/recursive_generic_repr_interp.almd` (byte-compare)<br>`spec/wasm_cross/float_concrete.almd` (byte-compare)<br>`spec/wasm_cross/num_edge_to_string.almd` (byte-compare)<br>`spec/wasm_cross/int_float_ops.almd` (byte-compare)<br>`spec/wasm_cross/float_interp_forms.almd` (byte-compare) |
 | ALS-R3 | C-004, C-005, C-006 | `spec/wasm_cross/fan_deterministic.almd` (byte-compare)<br>`spec/wasm_cross/fan_map_inline_lambda.almd` (byte-compare)<br>`spec/wasm_cross/fan_pure_thunks.almd` (byte-compare)<br>`spec/wasm_cross/fan_var_thunk_list.almd` (byte-compare)<br>`spec/wasm_cross/fan_map_err.almd` (byte-compare)<br>`spec/wasm_cross/fan_map_inline_err.almd` (byte-compare)<br>`spec/wasm_cross/fan_any_allfail.almd` (byte-compare)<br>`spec/wasm_cross/fan_race_err.almd` (byte-compare)<br>`spec/wasm_cross/option_none_unwrap_term.almd` (byte-compare)<br>`tests/diagnostics/e027-fan-timeout-removed/broken.almd` (checker)<br>`tests/diagnostic_harness_test.rs` (cargo gate) |
 | ALS-R4 | C-012 | `spec/wasm_cross/const_fold_nonfinite_float.almd` (byte-compare) |
-| ALS-R5 | C-096, C-112, C-118, C-133 | `spec/wasm_cross/process_args.almd` (byte-compare)<br>`spec/wasm_cross/random_int_entropy.almd` (byte-compare)<br>`spec/wasm_cross/env_args.almd` (byte-compare)<br>`spec/wasm_cross/env_get.almd` (byte-compare) |
+| ALS-R5 | C-096, C-112, C-118, C-133, C-189 | `spec/wasm_cross/process_args.almd` (byte-compare)<br>`spec/wasm_cross/random_int_entropy.almd` (byte-compare)<br>`spec/wasm_cross/env_args.almd` (byte-compare)<br>`spec/wasm_cross/env_get.almd` (byte-compare)<br>`spec/wasm_cross/env_platform_reporting.almd` (byte-compare) |
 | ALS-R6 | C-042, C-137 | `spec/wasm_cross/fs_preopen_resolve.almd` (byte-compare)<br>`spec/wasm_cross/fs_relative_path.almd` (byte-compare)<br>`spec/stdlib/fs_stat_test.almd` (both-target test) |
 | ALS-S1 | C-016, C-065 | `spec/wasm_cross/string_codepoint.almd` (byte-compare)<br>`spec/wasm_cross/string_ops.almd` (byte-compare)<br>`spec/wasm_cross/string_codepoint_index.almd` (byte-compare)<br>`spec/wasm_cross/string_lines.almd` (byte-compare) |
 | ALS-S2 | C-017 | `spec/wasm_cross/string_empty_pattern.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -5,9 +5,11 @@
 # Each [[contract]] is a NORMATIVE, observable promise the compiler keeps on
 # BOTH backends (native Rust and wasm32). "Observable" = stdout, stderr, exit
 # code. Native is the oracle; native == wasm is a hard invariant, NOT a "target
-# difference". This ledger is the human-readable + machine-checkable index of
-# every such promise, with a TRACEABLE link to the executable evidence that
-# certifies it.
+# difference". The ONE exemption is the platform-reporting pair `env.os` /
+# `env.temp_dir`, which must report the host they run on and are bounded by
+# C-189; a divergence anywhere else is a compiler bug. This ledger is the
+# human-readable + machine-checkable index of every such promise, with a
+# TRACEABLE link to the executable evidence that certifies it.
 #
 # WHY THIS EXISTS
 # ---------------
@@ -33,7 +35,15 @@
 #   statement (string, REQUIRED)  the normative behaviour, <= 3 sentences. When a
 #                                 table / longer prose is needed, the statement is
 #                                 a 1-line summary and `doc` points at the prose.
-#   since     (string, REQUIRED)  version the contract became normative.
+#   since     (string, REQUIRED)  the release in which the BEHAVIOUR became
+#                                 normative — the first version a user can rely
+#                                 on it. When a contract is written RETROACTIVELY
+#                                 over behaviour that already shipped (C-099..C-115
+#                                 documented fixtures that had accumulated since
+#                                 0.27.6), `since` is the behaviour's release, NOT
+#                                 the release the ledger entry landed in. Those two
+#                                 coincide whenever the contract ships alongside the
+#                                 change it certifies, which is the normal case.
 #   status    (enum,   REQUIRED)  "active" | "flagged-for-revision".
 #   doc       (string, OPTIONAL)  basename of a docs/contracts/*.md prose file.
 #   evidence  (array,  REQUIRED)  >= 1 inline-table entries; each:
@@ -131,7 +141,7 @@ evidence  = [
 id        = "C-006"
 spec      = "ALS-R3"
 title     = "fan.timeout does not exist — wall-clock deadlines live at the host boundary"
-statement = "`fan.timeout` was removed in 0.29.0: a wall-clock timeout has no portable cross-target meaning (wasm has no clock, scheduler, or threads), and it was the sole stdlib surface whose result was not a function of the program + its inputs — the deadline firing depended on machine load, even native-to-native. Referencing it is a check-time tombstone error (E027) with a host-boundary migration hint, identical on both targets since type check precedes the target split. This retired the ledger's LAST flagged-for-revision entry — the equivalence claim carries no exceptions clause."
+statement = "`fan.timeout` was removed in 0.29.0: a wall-clock timeout has no portable cross-target meaning (wasm has no clock, scheduler, or threads), and it was the sole stdlib surface whose result was not a function of the program + its inputs — the deadline firing depended on machine load, even native-to-native. Referencing it is a check-time tombstone error (E027) with a host-boundary migration hint, identical on both targets since type check precedes the target split. This retired the ledger's LAST flagged-for-revision entry: the ratchet stands at zero, so the equivalence claim carries no clause for divergences awaiting a fix. It is not exception-free in the absolute sense — the platform-reporting fns `env.os` / `env.temp_dir` differ by design and are exempt under C-189, which bounds that carve-out to exactly those two."
 since     = "0.29.0"
 status    = "active"
 doc       = "C-006-fan-timeout-removed.md"
@@ -2352,4 +2362,16 @@ since     = "0.37.0"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/scalar_if_arm_effects.almd", class = "fixture" },
+]
+
+# ── PLATFORM-REPORTING EXEMPTION (the equivalence law's ONLY carve-out) ─
+[[contract]]
+id        = "C-189"
+spec      = "ALS-R5"
+title     = "env.os / env.temp_dir report the HOST — the equivalence law's only exemption, and it is closed"
+statement = "`env.os()` and `env.temp_dir()` are the ONLY stdlib observables whose bytes may differ between native and wasm, and they differ BY DESIGN: both report the host they are running on, so native answers the real OS name and the real temp directory while the wasm leg answers the WASI sandbox (\"wasi\", \"/tmp\"). Agreeing across targets would be the defect — a program asking which platform it is on must be told the truth. The exemption is bounded, not open: the certified observable is the deterministic INVARIANT that holds identically on both legs (os is a member of the closed platform set {macos, linux, windows, wasi}; temp_dir is non-empty and absolute on every posix host), the same technique C-112 uses for random.int's nondeterministic draw. Every other fn in the process-environment surface stays byte-identical — env.args (C-096), env.get (C-118), random.int's range (C-112) — and `env.cwd` is not an exemption but a diagnosed wall on wasm. Adding a third exempt fn REQUIRES amending this statement and its fixture, which is what keeps the carve-out from widening silently."
+since     = "0.37.0"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/env_platform_reporting.almd", class = "fixture" },
 ]

--- a/docs/specs/als/runtime.md
+++ b/docs/specs/als/runtime.md
@@ -46,7 +46,16 @@ Contracts: C-012。
 観測し、存在すれば some(値)、無ければ none を両ターゲットで同一バイトで
 返す（wasm は WASI environ + ランナーの環境継承）。`random.int(a, b)` は
 WASI entropy 下でも常に [a, b] 範囲内。
-Contracts: C-096, C-112, C-118, C-133。
+
+`env.os()` と `env.temp_dir()` は等価性則の**唯一の適用除外**である。両者は
+実行中のホストを報告するため、native は実 OS 名と実 temp ディレクトリを、
+wasm レグは WASI サンドボックス（`wasi` / `/tmp`）を返す。両ターゲットで
+一致させることこそが欠陥であり、「今どのプラットフォームか」を問う
+プログラムには真を返さねばならない。除外は無制限ではなく、両レグで同一の
+決定的不変量（os は閉じた集合 {macos, linux, windows, wasi} の要素、
+temp_dir は非空かつ posix ホストでは絶対パス）が証明対象となる。第三の関数を
+除外に加えるには C-189 の statement とその fixture の改訂を要する。
+Contracts: C-096, C-112, C-118, C-133, C-189。
 
 ## ALS-R6 ファイルシステムのパス解決
 

--- a/scripts/gen-claims.sh
+++ b/scripts/gen-claims.sh
@@ -49,10 +49,18 @@ awk '
     printf "> **Ledger: %d contracts — %d active, %d flagged-for-revision.**\n", total, active, nflag
     print ">"
     if (nflag == 0) {
-      print "> **Exceptions: none.** Every contract in the ledger is `active`, carrying"
-      print "> executable evidence of class ≥ `fixture`."
+      # "Divergences awaiting a fix", not "Exceptions" — this block sits directly
+      # under the equivalence claim, and the ratchet counts contracts flagged for
+      # revision, NOT carve-outs in the law itself. The one by-design carve-out
+      # (platform-reporting env.os / env.temp_dir, C-189) is active, not flagged,
+      # so a bare "Exceptions: none" read as covering it would be false.
+      # NOTE: this awk program is single-quoted — no apostrophes in these strings.
+      print "> **Divergences awaiting a fix: none.** Every contract in the ledger is"
+      print "> `active`, carrying executable evidence of class >= `fixture`. The one"
+      print "> by-design carve-out in the law — the platform-reporting fns `env.os`"
+      print "> and `env.temp_dir` — is bounded by C-189."
     } else {
-      printf "> **Exceptions (%d)** — contracts flagged for revision; the ratchet says this list may only shrink:\n", nflag
+      printf "> **Divergences awaiting a fix (%d)** — contracts flagged for revision; the ratchet says this list may only shrink:\n", nflag
       print ">"
       for (k = 1; k <= nflag; k++) {
         link = (fdoc[k] != "") ? "docs/contracts/" fdoc[k] : "docs/contracts/contracts.toml"

--- a/spec/wasm_cross/env_platform_reporting.almd
+++ b/spec/wasm_cross/env_platform_reporting.almd
@@ -16,6 +16,11 @@
 // Everything else in the process-environment surface stays byte-identical:
 // env.args (C-096), env.get (C-118), random.int's range (C-112). If a third
 // fn ever needs an exemption, it belongs in C-189's statement and here.
+//
+// The reference interpreter ABSTAINS on this fixture (ledgered alongside
+// env_args / env_get). It is a third leg that is neither native nor the WASI
+// sandbox, so "which platform is the interpreter" needs its own deliberate
+// answer rather than one inherited from whatever host it happens to run on.
 import env
 
 effect fn main() -> Unit = {

--- a/spec/wasm_cross/env_platform_reporting.almd
+++ b/spec/wasm_cross/env_platform_reporting.almd
@@ -1,0 +1,32 @@
+// @contract: C-189
+// env.os / env.temp_dir — the ONLY stdlib observables exempt from the
+// native == wasm law, and the fixture that keeps that exemption CLOSED.
+//
+// Both fns REPORT THE HOST they are running on: native answers the real OS
+// name and the real temp directory, the wasm leg answers the WASI sandbox
+// ("wasi", "/tmp"). Reporting the same platform on both legs would be the
+// DEFECT — a program asking "where am I" must be told the truth.
+//
+// The raw value therefore differs by target by design, so — exactly like
+// C-112, where random.int's draw is nondeterministic — the certified
+// observable is the deterministic INVARIANT that holds identically on both:
+// os is a member of the closed platform set, and temp_dir is a non-empty
+// path that is absolute on every posix host. Both legs print the same bytes.
+//
+// Everything else in the process-environment surface stays byte-identical:
+// env.args (C-096), env.get (C-118), random.int's range (C-112). If a third
+// fn ever needs an exemption, it belongs in C-189's statement and here.
+import env
+
+effect fn main() -> Unit = {
+  let os = env.os()
+  let known = os == "macos" or os == "linux" or os == "windows" or os == "wasi"
+  if known then println("os:known") else println("os:UNKNOWN")
+
+  // Non-empty on every host; absolute everywhere except Windows, whose temp
+  // dir is a drive path. Checking both keeps the assertion true on all three
+  // native platforms AND on the WASI leg without weakening it to "non-empty".
+  let tmp = env.temp_dir()
+  let shaped = string.len(tmp) > 0 and (os == "windows" or string.starts_with(tmp, "/"))
+  if shaped then println("temp_dir:shaped") else println("temp_dir:MALFORMED")
+}


### PR DESCRIPTION
Closes #948.

The ledger says the equivalence claim has no exceptions. It has one, and it was undocumented:

```
$ almide run probe.almd --target native   $ almide run probe.almd --target wasm
macos                                     wasi
/var/folders/q3/…/T/                      /tmp
```

`env.os()` and `env.temp_dir()` report the host they run on. **This is correct behaviour** — a program asking which platform it is on must be told the truth, and making the two legs agree would be the defect. The problem was that the one place a reader goes to learn the exact shape of the guarantee did not mention the only fns that intentionally break it, while stating in three places that no such fns exist.

## The exempt set is exactly two

Determined by running the process-environment surface on both targets rather than by reading code:

| fn | native | wasm | verdict |
|---|---|---|---|
| `env.os()` | `macos` | `wasi` | **exempt** |
| `env.temp_dir()` | `/var/folders/…/T/` | `/tmp` | **exempt** |
| `env.get("HOME")` | `/Users/o6lvl4` | `/Users/o6lvl4` | identical — wasmtime forwards the host env |
| `env.args()` | `0` | `0` | identical (C-096) |
| `env.cwd()` | path | diagnosed wall | not a divergence — an honest refusal |

## C-189

Follows C-112's shape. Where random.int cannot certify a value because the draw is nondeterministic, it certifies the *range*; where these two cannot certify bytes because the host differs, they certify the invariant that is identical on both legs — os is a member of the closed set `{macos, linux, windows, wasi}`, temp_dir is non-empty and absolute on every posix host. `spec/wasm_cross/env_platform_reporting.almd` prints the derived result, so it passes the byte-identity gate like every other fixture (verified: `wasm_cross_target_spec` green, 318 fixtures).

That is what makes the carve-out *closed* rather than open-ended: a third exempt fn cannot appear without amending C-189's statement and its fixture.

## The three overclaims corrected

- `contracts.toml` header — "native == wasm is a hard invariant, NOT a 'target difference'" now names the exemption and keeps the rest absolute.
- **C-006** — "the equivalence claim carries no exceptions clause" was conflating two things. The ratchet of divergences *awaiting a fix* is genuinely zero; that is not the same as the law being exception-free. Split into both statements.
- **README + `docs/EQUIVALENCE.md`** — the scope list had three carve-outs (output not artifacts / nondeterministic sources certify invariants / unimplemented APIs refuse). Platform-reporting is a fourth and was missing, directly under a bold universal claim.

`scripts/gen-claims.sh` emitted **"Exceptions: none"** immediately below that claim. It counts contracts flagged for revision, so it was accurate about *status* and misleading about *scope*. Now emits "Divergences awaiting a fix: none" plus a pointer to C-189 — same fact, no longer readable as covering the carve-out.

## Also in here

`docs/contracts/contracts.toml`'s schema defined `since` as "version the contract became normative", which is ambiguous, and the ledger uses both readings. I originally reported C-099/C-100 as factually wrong for declaring `0.27.6` when `v0.27.6` was tagged ten days before their entries landed. **That was my error** — all 17 contracts in that batch (C-099..C-115) declare `0.27.6` uniformly, which is a deliberate choice: the commit contracted fixtures that had accumulated during the 0.27.6 cycle, so `since` is the *behaviour's* release, not the paperwork's. That is also the more useful reading for anyone asking "from which version can I rely on this?". The values stay; the schema now says which reading it means, so the next entry does not inherit the ambiguity. (The 32 values backfilled in #942 are unaffected — each of those contracts shipped alongside the behaviour it certifies, so both readings give the same release.)

## Verification

- `wasm_cross_target_spec` green — 318 fixtures including the new one, byte-identical on both legs
- contract gate green — 189 contracts, `--check` on the claims block green
- `cargo build --release` clean
- README/conformance/claims all regenerated

## Found while probing, filed separately

`println("os=${env.os()}")` walls on the wasm renderer: `non-lowerable string interpolation in a call-argument position (would borrow an empty deferred String)`. The same expression with a plain `println(env.os())` compiles. The wall message asks for an issue, so one is coming.

---

## Added after the first CI run

`Build & Test (Linux)` failed on `interp_abstain_ledger`: the reference interpreter cannot evaluate the new fixture (`out-of-interp-scope capability: env.os`), and an unledgered abstention fails the gate by design.

The gate offers two paths and prefers widening the interp glue. I took the other one, deliberately: the interpreter is a **third leg** that is neither the native target nor the WASI sandbox, so "which platform is the interpreter running as" needs its own defined answer. Inheriting whatever host it happens to execute on would make a platform-reporting fixture silently host-dependent, and that is a decision about the interpreter's capability surface — not something to settle as a side effect of a PR documenting an exemption.

Recording it is also consistent with what is already there: `env_args` and `env_get` abstain for the same reason, and the new line sits directly between them.

```
 env_args  out-of-interp-scope capability: env.args
 env_get  out-of-interp-scope capability: env.get
+env_platform_reporting  out-of-interp-scope capability: env.os
```

The reasoning is recorded in the fixture header so the next reader does not have to reconstruct it, and re-widening the interpreter later stays open — the gate fails on a *stale* entry too, so if `env.os` ever becomes evaluable this line has to come out.

Re-verified after the change: `interp_abstain_ledger` green (318 fixtures, 176 evaluated, 143 ledgered), `wasm_cross_target_spec` green, contract gate green.