### PR TITLE
Cut the interp cross-target gate from 710s to 126s, and fix the flake it exposed

### DIFF
--- a/crates/almide-interp/tests/interp_cross_target_test.rs
+++ b/crates/almide-interp/tests/interp_cross_target_test.rs
@@ -79,6 +79,31 @@ fn spec_dir() -> PathBuf {
 }
 
 // ── Leg 1: native backend (compile to a binary, then run it) ──
+/// ONE build scratch for the whole test process.
+///
+/// `almide build` (native) compiles the generated Rust inside
+/// `$TMPDIR/almide-build` and reuses that Cargo target dir across builds. This
+/// harness used to hand every fixture a FRESH `TMPDIR`, which made the scratch
+/// cold every time — all ~318 fixtures paid a full dependency build instead of
+/// an incremental one. Measured on a 5-build loop: 0.97s shared vs 14.71s
+/// isolated, a 15x cliff, and it is why this gate ran ~4x longer than the 2-way
+/// `wasm_cross_target_spec` that does the SAME native+wasm builds (595s vs 140s)
+/// despite the interp leg itself being cheap.
+///
+/// Isolation from OTHER test processes still has to hold, and it does: the
+/// system-temp `almide-build` is shared and guarded only by an advisory flock
+/// held through build+copy, so a concurrently-running gate cross-contaminated
+/// `src/main.rs` + `target/` (observed: `inff64`, `Box<Tree>` leaking between
+/// fixtures). A per-PROCESS root keeps this harness off that shared dir while
+/// letting its own fixtures share one warm scratch — the isolation was never
+/// needed per fixture, only per process.
+fn build_scratch() -> &'static std::path::Path {
+    static SCRATCH: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+    SCRATCH
+        .get_or_init(|| tempfile::tempdir().expect("failed to create build scratch"))
+        .path()
+}
+
 // Identical shape to wasm_runtime_test.rs::run_native_capture: build to a binary
 // FIRST (compiler diagnostics discarded), then run it, so the captured stderr is
 // the PROGRAM's runtime stderr — not the compiler's warnings — matching the wasm
@@ -90,17 +115,10 @@ fn run_native_capture(source: &str) -> (i32, String, String) {
     let bin_path = dir.path().join("test_native_bin");
     std::fs::write(&src_path, source).unwrap();
     let build = Command::new(almide_bin())
-        // ISOLATE the native build scratch dir. `almide build` (native) compiles
-        // generated Rust inside `std::env::temp_dir().join("almide-build")` — a
-        // SHARED dir guarded only by a cross-process flock held through
-        // build+copy. When other test processes (e.g. the 2-way
-        // `wasm_cross_target_spec` gate) run `almide build` in parallel, the
-        // shared `src/main.rs`+`target/` can get cross-contaminated and a fixture
-        // spuriously fails to compile with another fixture's types (observed:
-        // `inff64`, `Box<Tree>` leaking across fixtures). Pointing `TMPDIR` at a
-        // unique per-invocation dir gives this build its own scratch, removing
-        // the race so the third judge is deterministic.
-        .env("TMPDIR", dir.path())
+        // Keep this build off the shared system-temp scratch that other test
+        // processes race on — but on ONE dir for the whole process, so the Cargo
+        // target dir stays warm across fixtures. See `build_scratch`.
+        .env("TMPDIR", build_scratch())
         .args([
             "build",
             src_path.to_str().unwrap(),
@@ -135,10 +153,10 @@ fn run_wasm_capture(source: &str) -> Option<(i32, String, String)> {
     let wasm_path = dir.path().join("test.wasm");
     std::fs::write(&src_path, source).unwrap();
     let build = Command::new(almide_bin())
-        // Isolate scratch (see run_native_capture). The wasm path uses bare
-        // rustc into the output dir, but pinning TMPDIR keeps any incidental
-        // temp use off the shared dir too.
-        .env("TMPDIR", dir.path())
+        // Isolate scratch (see run_native_capture / build_scratch). The wasm
+        // path uses bare rustc into the output dir, but pinning TMPDIR keeps any
+        // incidental temp use off the shared dir too.
+        .env("TMPDIR", build_scratch())
         .args([
             "build",
             src_path.to_str().unwrap(),

--- a/crates/almide-mir/src/lower/mod.rs
+++ b/crates/almide-mir/src/lower/mod.rs
@@ -399,13 +399,56 @@ fn try_lower_extern_wasm(func: &IrFunction) -> Result<Option<MirFunction>, Lower
 /// when set, every lowering site that would fall back to `Op::Const` (the
 /// deferred ZERO whose only legitimate consumer is the caps-counting
 /// classifier) REFUSES instead — a walled function can never print a silently
-/// wrong value (the `prim.handle(<literal>)` → address-0 class). Set ONCE by
-/// the render/output entrypoints (render_program); the classifier and the
-/// in-process unit tests keep the permissive caps-counting behavior.
-pub static STRICT_VALUES: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+/// wrong value (the `prim.handle(<literal>)` → address-0 class). Set by the
+/// render/output entrypoints (render_program); the classifier and the in-process
+/// unit tests keep the permissive caps-counting behavior.
+///
+/// THREAD-LOCAL, for the same reason [`mod_p2::NEVER_ERR_LIFTED_FNS`] is:
+/// lowering runs single-threaded per program, so per-thread state carries the
+/// mode faithfully on the real render path. A process-global `AtomicBool` did
+/// not: `cargo test` runs a crate's unit tests as many threads in ONE process,
+/// so a test that enabled strict mode leaked it into every test that ran after
+/// it on any thread. `lower::tests::scalar_loop_with_break_walls` asserts a
+/// break/continue wall and intermittently saw a STRICT-mode wall instead —
+/// order-dependent, invisible when the test ran alone, and the doc-comment above
+/// claimed the opposite ("the in-process unit tests keep the permissive
+/// behavior") while nothing enforced it.
+pub fn set_strict_values(on: bool) {
+    STRICT_VALUES.with(|s| s.set(on));
+}
+
+/// Enable strict mode for a scope and restore the previous value on drop.
+///
+/// Prefer this over the bare setter. Thread-locality alone is not enough: it
+/// isolates the PARALLEL test runner (libtest gives each test its own thread),
+/// but `--test-threads=1` runs every test on the same thread, where an
+/// unrestored setter leaks exactly as the process-global did. It also matters
+/// outside tests — a long-lived process that compiles more than one program
+/// (the playground, the language server) would otherwise have the first strict
+/// render pin the mode for everything after it.
+#[must_use = "the guard restores the previous mode when dropped; binding it to `_` restores immediately"]
+pub struct StrictValuesGuard(bool);
+
+impl StrictValuesGuard {
+    pub fn set(on: bool) -> Self {
+        let prev = strict_values();
+        set_strict_values(on);
+        Self(prev)
+    }
+}
+
+impl Drop for StrictValuesGuard {
+    fn drop(&mut self) {
+        set_strict_values(self.0);
+    }
+}
+
+thread_local! {
+    static STRICT_VALUES: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 pub(crate) fn strict_values() -> bool {
-    STRICT_VALUES.load(std::sync::atomic::Ordering::Relaxed)
+    STRICT_VALUES.with(|s| s.get())
 }
 
 pub(crate) fn strict_const_wall(what: &str) -> LowerError {

--- a/crates/almide-mir/src/pipeline.rs
+++ b/crates/almide-mir/src/pipeline.rs
@@ -555,7 +555,7 @@ fn build_ir_with_drops(
 ) -> Result<almide_ir::IrProgram, LowerError> {
     // STRICT VALUE MODE: this is an OUTPUT path — a deferred Const-0 must never be executable
     // (flight-evidence-gaps F2, the prim.handle literal address-0 class).
-    crate::lower::STRICT_VALUES.store(true, std::sync::atomic::Ordering::Relaxed);
+    let _strict = crate::lower::StrictValuesGuard::set(true);
 
     let ir = source_to_ir_with(source, self_modules)?;
     // ADT brick 5b: GENERATE the recursive-drop fns (`__drop_<T>`) for nested-variant types and

--- a/crates/almide-mir/src/pipeline_c.rs
+++ b/crates/almide-mir/src/pipeline_c.rs
@@ -483,7 +483,7 @@ fn try_render_wasm_source_impl_rest(
 /// Debug probe: dump the lowered MIR ops of every non-test fn (walls listed
 /// per fn). Used by examples/probe_native.rs during rung development.
 pub fn debug_dump_mir(source: &str) -> Result<String, LowerError> {
-    crate::lower::STRICT_VALUES.store(true, std::sync::atomic::Ordering::Relaxed);
+    let _strict = crate::lower::StrictValuesGuard::set(true);
     let ir = source_to_ir_with(source, &[])?;
     let globals = std::collections::HashMap::new();
     let global_inits = std::collections::HashMap::new();
@@ -513,7 +513,7 @@ pub fn debug_dump_mir(source: &str) -> Result<String, LowerError> {
 }
 
 pub fn try_render_rust_source(source: &str) -> Result<String, LowerError> {
-    crate::lower::STRICT_VALUES.store(true, std::sync::atomic::Ordering::Relaxed);
+    let _strict = crate::lower::StrictValuesGuard::set(true);
     let ir = source_to_ir_with(source, &[])?;
     // Rung-5 records slab: the layout registries the wasm leg threads — without
     // them a record literal lowers as an Opaque skeleton and every field read

--- a/crates/almide-mir/src/render_wasm/tests_part1.rs
+++ b/crates/almide-mir/src/render_wasm/tests_part1.rs
@@ -297,7 +297,7 @@
         // Match the PRODUCTION condition (render_program sets strict values): the
         // deferred-Const fallback is retired on real render paths, so the tests pin
         // the same lowering the shipped pipeline runs.
-        crate::lower::STRICT_VALUES.store(true, std::sync::atomic::Ordering::Relaxed);
+        let _strict = crate::lower::StrictValuesGuard::set(true);
         use almide_frontend::check::Checker;
         use almide_frontend::lower::lower_program;
         use almide_frontend::{canonicalize, ir_link};


### PR DESCRIPTION
Two independent fixes, one commit each.

The starting question was why `Test Rust` takes ~30 min in CI. Measuring it produced a different answer than the obvious one, and then exposed a real order-dependence bug.

## 1. The gate rebuilt its dependencies 318 times (`2d5e0a93`)

`Test Rust` is 93.5% one step, and `interp_cross_target_test` is most of it. The obvious suspect — CI runs `cargo test --workspace` in **debug**, and the interpreter is Rust — turned out to be wrong:

| | |
|---|---|
| debug | 710s |
| `--release` | 595s |

16%. Not it. Adding `--release` to CI would have been a change made on a wrong theory.

The real cause: `run_native_capture` gave every fixture a **fresh `TMPDIR`**. `almide build` compiles its generated Rust in `$TMPDIR/almide-build` and reuses that Cargo target dir, so a fresh TMPDIR meant a cold target dir and a full dependency build — 318 times. Measured directly on a 5-build loop:

```
shared TMPDIR    0.97s
isolated TMPDIR  14.71s     15x
```

That also explains a discrepancy sitting in plain sight: the 2-way `wasm_cross_target_spec` does the **same** native+wasm builds over the **same** 318 fixtures in 140s, against this gate's 595s.

The isolation itself is load-bearing — the comment records real cross-contamination (`inff64`, `Box<Tree>` leaking between fixtures) when another test process races on the shared system-temp scratch. But that hazard is **per-process, not per-fixture**. One `OnceLock<TempDir>` for the process keeps this harness off the shared dir while letting its own fixtures share a warm scratch.

**710s → 126s (5.6x)**, with the gate's accounting bit-for-bit unchanged: 318 fixtures, 176 `interp==native==wasm`, 142 ledgered abstains, 0 backend-split, 0 interp-dissent.

## 2. `STRICT_VALUES` was a process-global that tests leaked through (`71b669c8`)

The faster run surfaced a failure in `lower::tests::scalar_loop_with_break_walls`: it asserts a `break/continue` wall but got

```
scalar for-in loop variable outside the value subset cannot be faithfully computed
in this brick (... STRICT value mode refuses instead of risking a silently wrong value)
```

`lower::STRICT_VALUES` was a `pub static AtomicBool` — **process-global**. `cargo test` runs a crate's unit tests as many threads in one process, so `render_wasm::tests::lower_source` setting strict mode leaked into every concurrently-running test. The doc comment asserted the opposite ("the in-process unit tests keep the permissive caps-counting behavior") with nothing enforcing it.

Not caused by this PR — reproduced on unmodified develop:

| | develop | this branch |
|---|---|---|
| `--test-threads=16`, repeated | **1 failure in 6 runs** | 0 in 8 |
| `-p almide-mir --lib` alone | 597/597 | 597/597 |

(The speedup changed thread interleaving, which is why a latent flake started showing.)

Fixed in two layers, because thread-locality alone is not enough:

- **`thread_local!`** — kills the cross-thread leak. Correct by construction: lowering has no parallelism (`grep rayon|par_iter|thread::spawn` over `almide-mir/src` is empty), and the neighbouring `NEVER_ERR_LIFTED_FNS` already uses this pattern for the same stated reason.
- **`StrictValuesGuard` (RAII)** — restores the previous value on drop. Needed because `--test-threads=1` runs every test on the **same** thread, where an unrestored setter leaks exactly as the global did. Single-threaded happens to pass today only because `lower::` sorts before `render_wasm::`; that is luck, not a property.

The guard matters outside tests too: a process that compiles more than one program — the playground, the language server — would otherwise have the first strict render pin the mode for everything after it. All four call sites now take the guard.

## Verification

- `cargo test --workspace` (the CI command): 0 failures
- `-p almide-mir --lib`: 597/597 — parallel, `--test-threads=1` (145s), and 8 consecutive runs at 16 threads
- `interp_cross_target_test`: 2/2, same fixture accounting as before
- strict mode still reaches the real render path — the 21 wall tests pass, and a native/wasm compile agrees byte-for-byte

## Not done

The 2-way and 3-way gates still build all 318 fixtures for **both** targets independently — after this, 140s and 126s of near-duplicate work. Merging them into one pass with three legs is the next real win, but it crosses a crate boundary (`almide-interp`'s harness vs the root `tests/`) and belongs in its own change.

CI `cargo test --workspace` stays on debug: `--release` buys 16% and costs a second full compile.