### PR TITLE
Record each fuzz night as a structured verdict line and add a track-record scorer for the closure streaks

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -182,53 +182,23 @@ jobs:
       # numbers — indistinguishable from a real finding, and #796's "two
       # consecutive green nights" had nothing to read.
       #
-      # The `=== campaign summary ===` block only prints when the campaign loop
-      # exits on its own (time or program budget), so its PRESENCE is the
-      # budget_completed signal — a reclaimed runner cannot fake it. The
-      # `fuzz-night:` line is the per-night record #924 asks for: programs,
-      # elapsed, throughput, findings — one greppable line in the log and the
-      # step summary, so a throughput regression is visible across nights.
-      # A truncated night still reports its last progress line. The streaks the
-      # closure conditions read (#924: 14 full-budget nights, #796: 2 green)
-      # are scored from step conclusions by scripts/fuzz-track-record.sh.
+      # The rendering lives in scripts/fuzz-night-verdict.sh (testable locally,
+      # unlike inline YAML bash): it emits the markdown verdict on stdout and
+      # the greppable `fuzz-night:` record line — programs, elapsed, throughput,
+      # findings, budget_completed — on stderr, so a throughput regression is
+      # visible across nights in the job logs. budget_completed is read from
+      # the fuzzer's own `=== campaign summary ===` block, which only prints
+      # when the campaign loop exits on its own — a reclaimed runner cannot
+      # fake it. The streaks the closure conditions read (#924: 14 full-budget
+      # nights, #796: 2 green) are scored from step conclusions by
+      # scripts/fuzz-track-record.sh.
       - name: Campaign verdict
         if: always()
         run: |
-          MINUTES="${{ github.event.inputs.minutes || env.FUZZ_MINUTES }}"
-          FINDINGS="${{ steps.campaign.outputs.findings || '?' }}"
-          echo "## Nightly fuzz verdict" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ ! -s fuzz-output.txt ]; then
-            echo "The campaign produced no output — it was killed before it started." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          # The campaign header pads its columns ("seed     = N"), so the
-          # separator is `space*=space*`, not a single "= ".
-          SEED=$(grep -oE "seed += +[0-9]+" fuzz-output.txt | tr -s ' ' | head -1 || true)
-          if grep -q "^=== campaign summary ===" fuzz-output.txt; then
-            ELAPSED=$(awk '/^  elapsed /{print $3; exit}' fuzz-output.txt)
-            GENERATED=$(awk '/^  generated /{print $3; exit}' fuzz-output.txt)
-            THROUGHPUT=$(awk '/^  throughput /{print $3; exit}' fuzz-output.txt)
-            LINE="fuzz-night: budget_completed=true minutes=$MINUTES elapsed=$ELAPSED generated=$GENERATED throughput=${THROUGHPUT}prog/min findings=$FINDINGS"
-          else
-            LAST=$(grep -E "^ *\[ *[0-9]+s\]" fuzz-output.txt | tail -1 || true)
-            LINE="fuzz-night: budget_completed=false minutes=$MINUTES last_progress=\"${LAST:-<none>}\" findings=$FINDINGS"
-          fi
-          echo "$LINE"
-          {
-            echo '```'
-            echo "$LINE"
-            echo '```'
-            echo ""
-            echo "Campaign ${SEED:-seed unknown} — replay a finding with"
-            echo '`xtarget-fuzz replay --seed S --index I`'
-            if grep -q "^=== campaign summary ===" fuzz-output.txt; then
-              echo ""
-              echo '```'
-              sed -n '/^=== campaign summary ===/,$p' fuzz-output.txt | head -25
-              echo '```'
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          bash scripts/fuzz-night-verdict.sh fuzz-output.txt \
+            "${{ github.event.inputs.minutes || env.FUZZ_MINUTES }}" \
+            "${{ steps.campaign.outputs.findings || '?' }}" \
+            >> "$GITHUB_STEP_SUMMARY" || true
           exit 0
 
       - name: Upload findings

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -180,25 +180,55 @@ jobs:
       # reclaimed mid-run. A `exit 143` kill skips every conditional step, so
       # before this the only trace of a truncated night was a red X with no
       # numbers — indistinguishable from a real finding, and #796's "two
-      # consecutive green nights" had nothing to read. The last progress line
-      # the fuzzer printed is the verdict: it carries generated / clean /
-      # findings / walls, so a truncated night still says whether it found
-      # anything in the time it got.
+      # consecutive green nights" had nothing to read.
+      #
+      # The `=== campaign summary ===` block only prints when the campaign loop
+      # exits on its own (time or program budget), so its PRESENCE is the
+      # budget_completed signal — a reclaimed runner cannot fake it. The
+      # `fuzz-night:` line is the per-night record #924 asks for: programs,
+      # elapsed, throughput, findings — one greppable line in the log and the
+      # step summary, so a throughput regression is visible across nights.
+      # A truncated night still reports its last progress line. The streaks the
+      # closure conditions read (#924: 14 full-budget nights, #796: 2 green)
+      # are scored from step conclusions by scripts/fuzz-track-record.sh.
       - name: Campaign verdict
         if: always()
         run: |
+          MINUTES="${{ github.event.inputs.minutes || env.FUZZ_MINUTES }}"
+          FINDINGS="${{ steps.campaign.outputs.findings || '?' }}"
           echo "## Nightly fuzz verdict" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ -s fuzz-output.txt ]; then
-            LAST=$(grep -E "^ *\[ *[0-9]+s\]" fuzz-output.txt | tail -1 || true)
-            SEED=$(grep -oE "seed = [0-9]+" fuzz-output.txt | head -1 || true)
-            echo "Last progress line: ${LAST:-<none>}" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Campaign ${SEED:-seed unknown} — replay a finding with" >> "$GITHUB_STEP_SUMMARY"
-            echo "xtarget-fuzz replay --seed S --index I" >> "$GITHUB_STEP_SUMMARY"
-          else
+          if [ ! -s fuzz-output.txt ]; then
             echo "The campaign produced no output — it was killed before it started." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
+          # The campaign header pads its columns ("seed     = N"), so the
+          # separator is `space*=space*`, not a single "= ".
+          SEED=$(grep -oE "seed += +[0-9]+" fuzz-output.txt | tr -s ' ' | head -1 || true)
+          if grep -q "^=== campaign summary ===" fuzz-output.txt; then
+            ELAPSED=$(awk '/^  elapsed /{print $3; exit}' fuzz-output.txt)
+            GENERATED=$(awk '/^  generated /{print $3; exit}' fuzz-output.txt)
+            THROUGHPUT=$(awk '/^  throughput /{print $3; exit}' fuzz-output.txt)
+            LINE="fuzz-night: budget_completed=true minutes=$MINUTES elapsed=$ELAPSED generated=$GENERATED throughput=${THROUGHPUT}prog/min findings=$FINDINGS"
+          else
+            LAST=$(grep -E "^ *\[ *[0-9]+s\]" fuzz-output.txt | tail -1 || true)
+            LINE="fuzz-night: budget_completed=false minutes=$MINUTES last_progress=\"${LAST:-<none>}\" findings=$FINDINGS"
+          fi
+          echo "$LINE"
+          {
+            echo '```'
+            echo "$LINE"
+            echo '```'
+            echo ""
+            echo "Campaign ${SEED:-seed unknown} — replay a finding with"
+            echo '`xtarget-fuzz replay --seed S --index I`'
+            if grep -q "^=== campaign summary ===" fuzz-output.txt; then
+              echo ""
+              echo '```'
+              sed -n '/^=== campaign summary ===/,$p' fuzz-output.txt | head -25
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
           exit 0
 
       - name: Upload findings

--- a/scripts/fuzz-night-verdict.sh
+++ b/scripts/fuzz-night-verdict.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# NIGHTLY FUZZ VERDICT RENDERER (#924)
+# ====================================
+#
+# Renders one night's campaign output into (a) a markdown verdict for
+# $GITHUB_STEP_SUMMARY on stdout and (b) the greppable per-night record line
+# on stderr, so it lands in the job log even with stdout redirected:
+#
+#   fuzz-night: budget_completed=true minutes=5 elapsed=300.1s generated=1052
+#               throughput=210.3prog/min findings=0
+#
+# budget_completed is read from the presence of the fuzzer's own
+# `=== campaign summary ===` block: print_summary (tools/xtarget-fuzz) only
+# runs after the campaign loop exits on its own (time or program budget), so
+# a reclaimed runner cannot fake it. A truncated night reports its last
+# progress line instead.
+#
+# Lives in a file, not workflow YAML, so it can be run and tested locally.
+# Division of labour: scripts/fuzz-track-record.sh scores nights ACROSS runs
+# from step conclusions; this renders the numbers WITHIN one night.
+#
+# Usage: fuzz-night-verdict.sh <fuzz-output.txt> <minutes> <findings>
+
+set -euo pipefail
+
+OUT="${1:?usage: fuzz-night-verdict.sh <fuzz-output.txt> <minutes> <findings>}"
+MINUTES="${2:?minutes}"
+FINDINGS="${3:?findings}"
+
+echo "## Nightly fuzz verdict"
+echo ""
+
+if [ ! -s "$OUT" ]; then
+  echo "The campaign produced no output — it was killed before it started."
+  exit 0
+fi
+
+# The campaign header pads its columns ("seed     = N"), so the separator is
+# `space*=space*`, not a single "= ".
+SEED=$(grep -oE "seed += +[0-9]+" "$OUT" | tr -s ' ' | head -1 || true)
+
+if grep -q "^=== campaign summary ===" "$OUT"; then
+  ELAPSED=$(awk '/^  elapsed /{print $3; exit}' "$OUT")
+  GENERATED=$(awk '/^  generated /{print $3; exit}' "$OUT")
+  THROUGHPUT=$(awk '/^  throughput /{print $3; exit}' "$OUT")
+  LINE="fuzz-night: budget_completed=true minutes=$MINUTES elapsed=$ELAPSED generated=$GENERATED throughput=${THROUGHPUT}prog/min findings=$FINDINGS"
+else
+  LAST=$(grep -E "^ *\[ *[0-9]+s\]" "$OUT" | tail -1 || true)
+  LINE="fuzz-night: budget_completed=false minutes=$MINUTES last_progress=\"${LAST:-<none>}\" findings=$FINDINGS"
+fi
+
+echo "$LINE" >&2
+
+echo '```'
+echo "$LINE"
+echo '```'
+echo ""
+echo "Campaign ${SEED:-seed unknown} — replay a finding with"
+echo '`xtarget-fuzz replay --seed S --index I`'
+
+if grep -q "^=== campaign summary ===" "$OUT"; then
+  echo ""
+  echo '```'
+  sed -n '/^=== campaign summary ===/,$p' "$OUT" | head -25
+  echo '```'
+fi

--- a/scripts/fuzz-track-record.sh
+++ b/scripts/fuzz-track-record.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# NIGHTLY FUZZ TRACK RECORD (#924 / #796)
+# =======================================
+#
+# Scores the last N *scheduled* fuzz-nightly runs into one verdict per night,
+# read from the same job/step conclusions the workflow itself produces:
+#
+#   GREEN       run concluded success — full budget, zero findings
+#   FINDINGS    the campaign completed its budget and the fuzzer recorded
+#               finding(s): the instrument working, not an infra failure
+#   TRUNCATED   the campaign step never concluded success (runner reclaimed,
+#               build failure, or a pre-split night with a different job shape)
+#
+# "Completed its budget" is read from the "Run fuzz campaign" step conclusion:
+# that step's script only reaches its exit after the campaign returns, so a
+# reclaimed runner cannot leave it `success`. The per-night numbers (programs,
+# throughput) live on the `fuzz-night:` line in each run's step summary/log.
+#
+# Closure conditions this makes checkable with one command:
+#   #924 — 14 consecutive full-budget nights (GREEN or FINDINGS)
+#   #796 —  2 consecutive green nights       (GREEN)
+#
+# Reporting tool, NOT a CI gate: needs `gh` auth and network.
+#
+# Usage: scripts/fuzz-track-record.sh [N]    (default: 20 nights)
+
+set -euo pipefail
+
+REPO="${FUZZ_REPO:-almide/almide}"
+N="${1:-20}"
+
+FUZZ_JOB="Generative differential fuzz"
+CAMPAIGN_STEP="Run fuzz campaign"
+
+runs=$(gh api "repos/$REPO/actions/workflows/fuzz-nightly.yml/runs?event=schedule&per_page=$N" \
+  --jq '.workflow_runs[] | [.id, (.conclusion // .status), .created_at] | @tsv')
+
+full_streak=0
+green_streak=0
+full_done=0
+green_done=0
+
+printf '%-12s %-13s %-11s %s\n' "date" "run" "conclusion" "verdict"
+
+while IFS=$'\t' read -r id conclusion created; do
+  date="${created%%T*}"
+
+  if [ "$conclusion" = "in_progress" ] || [ "$conclusion" = "queued" ]; then
+    printf '%-12s %-13s %-11s %s\n' "$date" "$id" "$conclusion" "IN PROGRESS (not scored)"
+    continue
+  fi
+
+  step=$(gh api "repos/$REPO/actions/runs/$id/jobs" --jq \
+    "[.jobs[] | select(.name == \"$FUZZ_JOB\") | .steps[] \
+      | select(.name == \"$CAMPAIGN_STEP\") | .conclusion][0] // \"absent\"")
+
+  if [ "$conclusion" = "success" ]; then
+    verdict="GREEN"
+  elif [ "$step" = "success" ]; then
+    verdict="FINDINGS (full budget, red on findings)"
+  else
+    verdict="TRUNCATED (campaign step: $step)"
+  fi
+
+  case "$verdict" in
+    GREEN)
+      if [ "$green_done" -eq 0 ]; then green_streak=$((green_streak + 1)); fi
+      if [ "$full_done" -eq 0 ]; then full_streak=$((full_streak + 1)); fi
+      ;;
+    FINDINGS*)
+      green_done=1
+      if [ "$full_done" -eq 0 ]; then full_streak=$((full_streak + 1)); fi
+      ;;
+    *)
+      green_done=1
+      full_done=1
+      ;;
+  esac
+
+  printf '%-12s %-13s %-11s %s\n' "$date" "$id" "$conclusion" "$verdict"
+done <<<"$runs"
+
+echo
+echo "full-budget streak: $full_streak/14  (#924 closes at 14)"
+echo "green streak:       $green_streak/2   (#796 needs 2 consecutive)"


### PR DESCRIPTION
Refs #924 (does not close it — closure needs 14 consecutive full-budget nights).

## What

Implements the remaining piece of #924's option 3: **record programs/night so throughput regressions are visible**, and make both closure streaks checkable with one command.

- **`Campaign verdict` step**: parses the fuzzer's own `=== campaign summary ===` block into one greppable line per night:
  `fuzz-night: budget_completed=true minutes=5 elapsed=300.1s generated=1052 throughput=210.3prog/min findings=0`
  The summary block only prints when the campaign loop exits on its own, so its presence IS the budget-completed signal — a reclaimed runner cannot fake it. A truncated night still reports its last progress line, now marked `budget_completed=false`. The full summary block (including the wall-reason histogram) is echoed into the step summary.
- **`scripts/fuzz-track-record.sh`**: scores the last N scheduled nights from step conclusions (`Run fuzz campaign` = success ⇔ full budget) into GREEN / FINDINGS / TRUNCATED and prints the two streaks: #924 closes at full-budget ≥ 14, #796 needs green ≥ 2.
- Fixes the seed extraction in the verdict step — the campaign header pads its columns (`seed     = N`), so the old `grep "seed = "` never matched.

## Current track record (live run of the scorer)

```
2026-07-28  30332337014  failure  FINDINGS (full budget, red on findings)
2026-07-27 … 2026-07-14  all TRUNCATED (runner reclaimed, pre-split)

full-budget streak: 1/14  (#924 closes at 14)
green streak:       0/2   (#796 needs 2 consecutive)
```

The infra fix (`aad0d635`, build split + lifetime-sized budget) is holding: 7/28 was the first night where the red X means "the fuzzer found something" instead of "the runner died". Both 7/28 findings were triaged and fixed same-day (`f9b0d264`, `6ac44503`).

## Verification

- Scorer run against the live run history (output above); job/step names confirmed against the Actions API for run 30332337014.
- Both verdict branches (full-budget and truncated) exercised against a simulated `fuzz-output.txt` matching `tools/xtarget-fuzz/src/main.rs` output byte shapes.
- Workflow YAML validated; `bash -n` on the script.