### PR TITLE
Honor UTF-16 positions across the LSP, keep dep fetching off the keystroke path, drop unscoped rename, and deliver fix-its as code actions

### DIFF
--- a/src/cli/lsp.rs
+++ b/src/cli/lsp.rs
@@ -15,17 +15,22 @@ struct AnalyzedDoc {
     lsp_diagnostics: Vec<Diagnostic>,
 }
 
+/// Dependency source dirs cached per almide.toml, so a keystroke never
+/// re-runs the fetcher (which shells out to git and writes almide.lock).
+type DepCache = HashMap<std::path::PathBuf, Vec<(crate::project::PkgId, std::path::PathBuf)>>;
+
 impl AnalyzedDoc {
-    fn analyze(source: &str, file_path: Option<&str>) -> Self {
+    fn analyze(source: &str, file_path: Option<&str>, deps: &[(crate::project::PkgId, std::path::PathBuf)]) -> Self {
+        let src_lines: Vec<&str> = source.lines().collect();
         let tokens = crate::lexer::Lexer::tokenize(source);
         let mut parser = crate::parser::Parser::new(tokens);
         let (mut program, parse_errors) = match parser.parse() {
             Ok(p) => {
-                let errs: Vec<Diagnostic> = parser.errors.iter().map(|e| diag_from_almide(e)).collect();
+                let errs: Vec<Diagnostic> = parser.errors.iter().map(|e| diag_from_almide(e, &src_lines)).collect();
                 (p, errs)
             }
             Err(_) => {
-                let errs = parser.errors.iter().map(|e| diag_from_almide(e)).collect();
+                let errs = parser.errors.iter().map(|e| diag_from_almide(e, &src_lines)).collect();
                 return AnalyzedDoc {
                     source: source.to_string(),
                     program: empty_program(),
@@ -44,9 +49,10 @@ impl AnalyzedDoc {
             };
         }
 
-        // Cross-file import resolution
+        // Cross-file import resolution against the caller-provided dep list —
+        // analyze itself never fetches.
         let resolved_modules = file_path
-            .map(|fp| resolve_imports_for_lsp(fp, &program))
+            .map(|fp| resolve_imports_cached(fp, &program, deps))
             .unwrap_or_default();
 
         let canon = crate::canonicalize::canonicalize_program(
@@ -68,7 +74,7 @@ impl AnalyzedDoc {
         for d in &check_diags {
             // Suppress E015 (reimpl-lint) for stdlib source files
             if is_stdlib && d.code.as_deref() == Some("E015") { continue; }
-            diags.push(diag_from_almide(d));
+            diags.push(diag_from_almide(d, &src_lines));
         }
 
         AnalyzedDoc {
@@ -312,11 +318,12 @@ fn find_node_usage_lookup(doc: &AnalyzedDoc, word: &str, line: u32) -> Option<Lo
     find_user_ident(doc, word)
 }
 
-fn find_node(doc: &AnalyzedDoc, line: u32, col: u32) -> Option<Located> {
+fn find_node(doc: &AnalyzedDoc, line: u32, col_utf16: u32) -> Option<Located> {
     let source = &doc.source;
     let lines: Vec<&str> = source.lines().collect();
     let line_text = lines.get(line as usize)?;
-    let (word, start, end) = word_at(line_text, col as usize)?;
+    let col = utf16_col_to_byte(line_text, col_utf16);
+    let (word, start, end) = word_at(line_text, col)?;
 
     // 1. Keywords
     if let Some(info) = lookup_keyword_info(word) {
@@ -423,9 +430,18 @@ fn find_ident_in_stmt(stmt: &crate::ast::Stmt, name: &str, type_map: &crate::typ
 // LSP Server
 // ══════════════════════════════════════════════════════════════
 
-/// `run_lsp`'s server-capabilities declaration. Extracted verbatim.
+/// `run_lsp`'s server-capabilities declaration.
+///
+/// `position_encoding` declares UTF-16 explicitly — that is what an LSP
+/// client sends by default, and every position this server reads or emits is
+/// converted through the utf16/char-column helpers rather than sliced as raw
+/// bytes (#927). Rename is deliberately NOT advertised: the old
+/// implementation was an unscoped textual find/replace (renamed matches
+/// inside strings, comments, and shadowed scopes), which silently corrupts
+/// user code. It comes back when it can be binding-aware via the Checker.
 fn lsp_server_capabilities() -> ServerCapabilities {
     ServerCapabilities {
+        position_encoding: Some(PositionEncodingKind::UTF16),
         text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
         hover_provider: Some(HoverProviderCapability::Simple(true)),
         completion_provider: Some(CompletionOptions {
@@ -441,7 +457,6 @@ fn lsp_server_capabilities() -> ServerCapabilities {
             work_done_progress_options: Default::default(),
         }),
         workspace_symbol_provider: Some(OneOf::Left(true)),
-        rename_provider: Some(OneOf::Left(true)),
         code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         ..Default::default()
     }
@@ -456,15 +471,21 @@ fn derive_workspace_root(init: &InitializeParams) -> Option<std::path::PathBuf> 
 }
 
 /// `run_lsp`'s notification dispatch (`didOpen`/`didChange`/`didClose`).
-/// Extracted verbatim.
-fn handle_notification(notif: Notification, connection: &Connection, documents: &mut HashMap<Uri, String>, analyzed: &mut HashMap<Uri, AnalyzedDoc>) {
+///
+/// Dep fetching (git shell-out, almide.lock write) is allowed only on
+/// didOpen — opening a file is a deliberate user action. didChange runs on
+/// every keystroke and serves the dep list cached at open time; a project
+/// never opened in this session analyzes against no deps rather than
+/// touching the network (#927).
+fn handle_notification(notif: Notification, connection: &Connection, documents: &mut HashMap<Uri, String>, analyzed: &mut HashMap<Uri, AnalyzedDoc>, dep_cache: &mut DepCache) {
     match notif.method.as_str() {
         "textDocument/didOpen" => {
             if let Ok(params) = serde_json::from_value::<DidOpenTextDocumentParams>(notif.params) {
                 let uri = params.text_document.uri.clone();
                 let source = params.text_document.text;
                 let file_path = uri_to_path(&uri);
-                let doc = AnalyzedDoc::analyze(&source, file_path.as_deref());
+                let deps = project_deps_for(file_path.as_deref(), dep_cache, true);
+                let doc = AnalyzedDoc::analyze(&source, file_path.as_deref(), &deps);
                 publish_diagnostics(connection, &uri, &doc.lsp_diagnostics);
                 documents.insert(uri.clone(), source);
                 analyzed.insert(uri, doc);
@@ -476,7 +497,8 @@ fn handle_notification(notif: Notification, connection: &Connection, documents: 
                 if let Some(change) = params.content_changes.into_iter().last() {
                     let source = change.text;
                     let file_path = uri_to_path(&uri);
-                    let doc = AnalyzedDoc::analyze(&source, file_path.as_deref());
+                    let deps = project_deps_for(file_path.as_deref(), dep_cache, false);
+                    let doc = AnalyzedDoc::analyze(&source, file_path.as_deref(), &deps);
                     publish_diagnostics(connection, &uri, &doc.lsp_diagnostics);
                     documents.insert(uri.clone(), source);
                     analyzed.insert(uri, doc);
@@ -507,6 +529,7 @@ pub fn run_lsp() {
 
     let mut documents: HashMap<Uri, String> = HashMap::new();
     let mut analyzed: HashMap<Uri, AnalyzedDoc> = HashMap::new();
+    let mut dep_cache: DepCache = HashMap::new();
 
     for msg in &connection.receiver {
         match msg {
@@ -517,7 +540,7 @@ pub fn run_lsp() {
                     connection.sender.send(Message::Response(r)).ok();
                 }
             }
-            Message::Notification(notif) => handle_notification(notif, &connection, &mut documents, &mut analyzed),
+            Message::Notification(notif) => handle_notification(notif, &connection, &mut documents, &mut analyzed, &mut dep_cache),
             Message::Response(_) => {}
         }
     }
@@ -547,7 +570,7 @@ fn handle_request(req: &Request, documents: &HashMap<Uri, String>, analyzed: &Ha
         "textDocument/documentSymbol" => {
             let params: DocumentSymbolParams = serde_json::from_value(req.params.clone()).ok()?;
             let doc = analyzed.get(&params.text_document.uri)?;
-            let symbols = compute_document_symbols(doc);
+            let symbols = compute_document_symbols(doc, &params.text_document.uri);
             let result = serde_json::to_value(DocumentSymbolResponse::Flat(symbols)).ok()?;
             Some(Response::new_ok(req.id.clone(), result))
         }
@@ -582,15 +605,6 @@ fn handle_request(req: &Request, documents: &HashMap<Uri, String>, analyzed: &Ha
             let params: WorkspaceSymbolParams = serde_json::from_value(req.params.clone()).ok()?;
             let symbols = compute_workspace_symbols(&params.query, workspace_root);
             let result = serde_json::to_value(symbols).ok()?;
-            Some(Response::new_ok(req.id.clone(), result))
-        }
-        "textDocument/rename" => {
-            let params: RenameParams = serde_json::from_value(req.params.clone()).ok()?;
-            let uri = &params.text_document_position.text_document.uri;
-            let pos = params.text_document_position.position;
-            let source = documents.get(uri)?;
-            let edit = compute_rename(source, pos, uri, &params.new_name);
-            let result = edit.map(|e| serde_json::to_value(e).unwrap_or(serde_json::Value::Null)).unwrap_or(serde_json::Value::Null);
             Some(Response::new_ok(req.id.clone(), result))
         }
         "textDocument/codeAction" => {

--- a/src/cli/lsp_code_actions.rs
+++ b/src/cli/lsp_code_actions.rs
@@ -42,14 +42,14 @@ fn code_action_for_e006(diag: &Diagnostic, lines: &[&str], uri: &Uri) -> Option<
         if !lt.contains("fn ") || lt.contains("effect fn") {
             continue;
         }
-        let c = lt.find("fn ")?;
+        let c = byte_col_to_utf16(lt, lt.find("fn ")?);
         return Some(CodeActionOrCommand::CodeAction(CodeAction {
             title: "Mark as effect fn".to_string(),
             kind: Some(CodeActionKind::QUICKFIX),
             diagnostics: Some(vec![diag.clone()]),
             edit: Some(WorkspaceEdit {
                 changes: Some(HashMap::from([(uri.clone(), vec![TextEdit {
-                    range: Range { start: Position { line: i as u32, character: c as u32 }, end: Position { line: i as u32, character: c as u32 + 2 } },
+                    range: Range { start: Position { line: i as u32, character: c }, end: Position { line: i as u32, character: c + 2 } },
                     new_text: "effect fn".to_string(),
                 }])])),
                 ..Default::default()
@@ -58,6 +58,36 @@ fn code_action_for_e006(diag: &Diagnostic, lines: &[&str], uri: &Uri) -> Option<
         }));
     }
     None
+}
+
+/// Materialize the compiler's machine-applicable fix (`try_replace_span`,
+/// round-tripped through the diagnostic's `data` field — see
+/// `diag_from_almide`) as a quickfix edit. The stored columns are the
+/// compiler's 1-indexed char offsets; they convert to UTF-16 here, where the
+/// line text is at hand.
+fn code_action_for_try_fix(diag: &Diagnostic, lines: &[&str], uri: &Uri) -> Option<CodeActionOrCommand> {
+    let data = diag.data.as_ref()?;
+    let snippet = data.get("try")?.as_str()?;
+    let line = (data.get("line")?.as_u64()? as usize).checked_sub(1)? as u32;
+    let col = data.get("col")?.as_u64()? as usize;
+    let end_col = data.get("endCol")?.as_u64()? as usize;
+    let line_text = lines.get(line as usize)?;
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Replace with `{}`", snippet),
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diag.clone()]),
+        edit: Some(WorkspaceEdit {
+            changes: Some(HashMap::from([(uri.clone(), vec![TextEdit {
+                range: Range {
+                    start: Position { line, character: char_col_to_utf16(line_text, col) },
+                    end: Position { line, character: char_col_to_utf16(line_text, end_col) },
+                },
+                new_text: snippet.to_string(),
+            }])])),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }))
 }
 
 fn compute_code_actions(source: &str, diagnostics: &[Diagnostic], uri: &Uri) -> Vec<CodeActionOrCommand> {
@@ -72,6 +102,9 @@ fn compute_code_actions(source: &str, diagnostics: &[Diagnostic], uri: &Uri) -> 
             _ => None,
         };
         if let Some(a) = action {
+            actions.push(a);
+        }
+        if let Some(a) = code_action_for_try_fix(diag, &lines, uri) {
             actions.push(a);
         }
     }
@@ -107,7 +140,8 @@ fn collect_workspace_symbols_from_file(file_path: &std::path::Path, query: &str,
         };
         if !query.is_empty() && !name.to_lowercase().contains(query_lower) { continue; }
         let line = span.as_ref().map(|s| s.line.saturating_sub(1) as u32).unwrap_or(0);
-        let col = span.as_ref().map(|s| s.col.saturating_sub(1) as u32).unwrap_or(0);
+        let line_text = source.lines().nth(line as usize).unwrap_or("");
+        let col = span.as_ref().map(|s| char_col_to_utf16(line_text, s.col)).unwrap_or(0);
         #[allow(deprecated)]
         results.push(SymbolInformation {
             name: name.to_string(), kind,
@@ -156,39 +190,72 @@ fn publish_diagnostics(connection: &Connection, uri: &Uri, diags: &[Diagnostic])
     connection.sender.send(Message::Notification(notif)).ok();
 }
 
-fn diag_from_almide(d: &crate::diagnostic::Diagnostic) -> Diagnostic {
+/// Compiler diagnostic → LSP diagnostic. The compiler's line/col are
+/// 1-indexed char offsets; LSP wants 0-based lines and UTF-16 columns, so the
+/// conversion needs the source line text. A machine-applicable fix
+/// (`try_snippet` + `try_replace_span`) rides along in the `data` field —
+/// the client echoes `data` back on `textDocument/codeAction`, where
+/// `code_action_for_try_fix` materializes it as a quickfix edit. Before
+/// this, the already-computed fix-its were dropped here and never reached
+/// the client (#927).
+fn diag_from_almide(d: &crate::diagnostic::Diagnostic, lines: &[&str]) -> Diagnostic {
     let line = d.line.unwrap_or(1).saturating_sub(1) as u32;
-    let col = d.col.unwrap_or(1).saturating_sub(1) as u32;
-    let end_col = d.end_col.map(|c| c as u32).unwrap_or(col + 1);
+    let line_text = lines.get(line as usize).copied().unwrap_or("");
+    let col = char_col_to_utf16(line_text, d.col.unwrap_or(1));
+    let end_col = d.end_col.map(|c| char_col_to_utf16(line_text, c)).unwrap_or(col + 1);
+    let data = match (&d.try_snippet, d.try_replace_span) {
+        (Some(snippet), Some((l, c, ec))) => Some(serde_json::json!({
+            "try": snippet, "line": l, "col": c, "endCol": ec,
+        })),
+        _ => None,
+    };
     Diagnostic {
         range: Range { start: Position { line, character: col }, end: Position { line, character: end_col } },
         severity: Some(if d.level == crate::diagnostic::Level::Error { DiagnosticSeverity::ERROR } else { DiagnosticSeverity::WARNING }),
         code: d.code.as_ref().map(|c| NumberOrString::String(c.to_string())),
         source: Some("almide".to_string()),
         message: if d.hint.is_empty() { d.message.clone() } else { format!("{}\nhint: {}", d.message, d.hint) },
+        data,
         ..Default::default()
     }
 }
 
-fn resolve_imports_for_lsp(file_path: &str, program: &crate::ast::Program) -> Vec<(String, crate::ast::Program, bool)> {
-    let file = std::path::Path::new(file_path);
-    let dep_paths: Vec<(crate::project::PkgId, std::path::PathBuf)> = file.parent()
-        .and_then(|dir| {
-            // Walk up to find almide.toml
-            let mut d = dir;
-            loop {
-                let toml = d.join("almide.toml");
-                if toml.exists() {
-                    let proj = crate::project::parse_toml(&toml).ok()?;
-                    return crate::project_fetch::fetch_all_deps(&proj).ok().map(|deps| {
-                        deps.into_iter().map(|fd| (fd.pkg_id, fd.source_dir)).collect()
-                    });
-                }
-                d = d.parent()?;
-            }
-        })
+/// Walk up from `file_path` to the almide.toml governing it, if any.
+fn find_project_toml(file_path: &str) -> Option<std::path::PathBuf> {
+    let mut dir = std::path::Path::new(file_path).parent()?;
+    loop {
+        let toml = dir.join("almide.toml");
+        if toml.exists() {
+            return Some(toml);
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// Dependency source dirs for the project owning `file_path`, cached per
+/// almide.toml. `allow_fetch` is true only on didOpen: `fetch_all_deps`
+/// shells out to git and writes almide.lock, which must never run on a
+/// keystroke (#927). With `allow_fetch` false a cache miss resolves to no
+/// deps instead of touching the network. A failed fetch caches the empty
+/// list, so one broken manifest cannot re-trigger fetch storms.
+fn project_deps_for(file_path: Option<&str>, cache: &mut DepCache, allow_fetch: bool) -> Vec<(crate::project::PkgId, std::path::PathBuf)> {
+    let Some(toml) = file_path.and_then(find_project_toml) else { return Vec::new() };
+    if let Some(cached) = cache.get(&toml) {
+        return cached.clone();
+    }
+    if !allow_fetch {
+        return Vec::new();
+    }
+    let deps: Vec<(crate::project::PkgId, std::path::PathBuf)> = crate::project::parse_toml(&toml).ok()
+        .and_then(|proj| crate::project_fetch::fetch_all_deps(&proj).ok())
+        .map(|deps| deps.into_iter().map(|fd| (fd.pkg_id, fd.source_dir)).collect())
         .unwrap_or_default();
-    match crate::resolve::resolve_imports_with_deps(file_path, program, &dep_paths) {
+    cache.insert(toml, deps.clone());
+    deps
+}
+
+fn resolve_imports_cached(file_path: &str, program: &crate::ast::Program, deps: &[(crate::project::PkgId, std::path::PathBuf)]) -> Vec<(String, crate::ast::Program, bool)> {
+    match crate::resolve::resolve_imports_with_deps(file_path, program, deps) {
         Ok(r) => r.modules.into_iter().map(|(n, p, _, s)| (n, p, s)).collect(),
         Err(_) => vec![],
     }

--- a/src/cli/lsp_hover_definition.rs
+++ b/src/cli/lsp_hover_definition.rs
@@ -39,10 +39,39 @@ fn compute_hover(doc: &AnalyzedDoc, pos: Position) -> Option<Hover> {
 // Go to Definition — dispatches on Located word, walks AST for declaration
 // ══════════════════════════════════════════════════════════════
 
-/// Extract the identifier word (`[A-Za-z0-9_]+`) touching column `col` in
-/// `line`, plus its `[start, end)` byte range. Shared by `compute_definition`
-/// and `compute_rename`, which had identical copies of this word-boundary
-/// scan.
+/// LSP positions arrive in UTF-16 code units — the encoding this server
+/// declares in its capabilities. Convert one to a byte offset into `line`,
+/// clamping past-EOL positions to the line end. Slicing with the raw
+/// `character` value treated bytes as columns: any non-ASCII text before the
+/// cursor produced wrong offsets, and a cursor past a char boundary or past
+/// EOL panicked the server (#927). The returned offset is always a char
+/// boundary.
+fn utf16_col_to_byte(line: &str, col: u32) -> usize {
+    let mut units = 0u32;
+    for (byte, ch) in line.char_indices() {
+        if units >= col {
+            return byte;
+        }
+        units += ch.len_utf16() as u32;
+    }
+    line.len()
+}
+
+/// 1-indexed char column — the lexer's span/diagnostic convention — to
+/// 0-based UTF-16 code units, for every position this server emits.
+fn char_col_to_utf16(line: &str, char_col: usize) -> u32 {
+    line.chars().take(char_col.saturating_sub(1)).map(|c| c.len_utf16() as u32).sum()
+}
+
+/// Byte offset into `line` to 0-based UTF-16 code units, for emitted
+/// positions derived from byte scans (`str::find` results).
+fn byte_col_to_utf16(line: &str, byte: usize) -> u32 {
+    line[..byte.min(line.len())].chars().map(|c| c.len_utf16() as u32).sum()
+}
+
+/// Extract the identifier word (`[A-Za-z0-9_]+`) touching byte column `col`
+/// in `line`, plus its `[start, end)` byte range. `col` must be a char
+/// boundary (convert LSP positions through `utf16_col_to_byte` first).
 fn word_at(line: &str, col: usize) -> Option<(&str, usize, usize)> {
     if col >= line.len() { return None; }
     let start = line[..col].rfind(|c: char| !c.is_alphanumeric() && c != '_').map(|i| i + 1).unwrap_or(0);
@@ -55,7 +84,7 @@ fn word_at(line: &str, col: usize) -> Option<(&str, usize, usize)> {
 /// `compute_definition`'s first phase: search the current file's own
 /// declarations (fn/type/top-let name, or a variant constructor name) for
 /// a match. Extracted verbatim.
-fn find_decl_definition(program: &crate::ast::Program, word: &str, uri: &Uri) -> Option<Location> {
+fn find_decl_definition(program: &crate::ast::Program, word: &str, uri: &Uri, lines: &[&str]) -> Option<Location> {
     for decl in &program.decls {
         let (name, span) = match decl {
             crate::ast::Decl::Fn { name, span, .. } => (name.as_str(), span),
@@ -64,7 +93,7 @@ fn find_decl_definition(program: &crate::ast::Program, word: &str, uri: &Uri) ->
             _ => continue,
         };
         if name == word {
-            return span_to_location(span, uri);
+            return span_to_location(span, uri, lines);
         }
         // Variant constructors
         if let crate::ast::Decl::Type { ty: crate::ast::TypeExpr::Variant { cases }, span, .. } = decl {
@@ -75,7 +104,7 @@ fn find_decl_definition(program: &crate::ast::Program, word: &str, uri: &Uri) ->
                     crate::ast::VariantCase::Record { name, .. } => name.as_str(),
                 };
                 if case_name == word {
-                    return span_to_location(span, uri);
+                    return span_to_location(span, uri, lines);
                 }
             }
         }
@@ -122,25 +151,25 @@ fn find_stdlib_definition(line: &str, word: &str, start: usize, end: usize) -> O
 fn compute_definition(doc: &AnalyzedDoc, pos: Position, uri: &Uri) -> Option<Location> {
     let lines: Vec<&str> = doc.source.lines().collect();
     let line = lines.get(pos.line as usize)?;
-    let col = pos.character as usize;
+    let col = utf16_col_to_byte(line, pos.character);
     let (word, start, end) = word_at(line, col)?;
 
-    if let Some(loc) = find_decl_definition(&doc.program, word, uri) {
+    if let Some(loc) = find_decl_definition(&doc.program, word, uri, &lines) {
         return Some(loc);
     }
 
     find_stdlib_definition(line, word, start, end)
 }
 
-fn span_to_location(span: &Option<crate::ast::Span>, uri: &Uri) -> Option<Location> {
+fn span_to_location(span: &Option<crate::ast::Span>, uri: &Uri, lines: &[&str]) -> Option<Location> {
     let s = span.as_ref()?;
     let line = s.line.saturating_sub(1) as u32;
-    let col = s.col.saturating_sub(1) as u32;
+    let line_text = lines.get(line as usize).copied().unwrap_or("");
     Some(Location {
         uri: uri.clone(),
         range: Range {
-            start: Position { line, character: col },
-            end: Position { line, character: s.end_col as u32 },
+            start: Position { line, character: char_col_to_utf16(line_text, s.col) },
+            end: Position { line, character: char_col_to_utf16(line_text, s.end_col) },
         },
     })
 }
@@ -152,8 +181,8 @@ fn span_to_location(span: &Option<crate::ast::Span>, uri: &Uri) -> Option<Locati
 fn compute_completions(source: &str, pos: Position) -> Vec<CompletionItem> {
     let lines: Vec<&str> = source.lines().collect();
     let line = match lines.get(pos.line as usize) { Some(l) => *l, None => return vec![] };
-    let col = pos.character as usize;
-    let prefix = &line[..col.min(line.len())];
+    let col = utf16_col_to_byte(line, pos.character);
+    let prefix = &line[..col];
 
     if let Some(dot_pos) = prefix.rfind('.') {
         let module_start = prefix[..dot_pos].rfind(|c: char| !c.is_alphanumeric() && c != '_').map(|i| i + 1).unwrap_or(0);
@@ -189,7 +218,8 @@ fn compute_completions(source: &str, pos: Position) -> Vec<CompletionItem> {
 // Document Symbols
 // ══════════════════════════════════════════════════════════════
 
-fn compute_document_symbols(doc: &AnalyzedDoc) -> Vec<SymbolInformation> {
+fn compute_document_symbols(doc: &AnalyzedDoc, uri: &Uri) -> Vec<SymbolInformation> {
+    let lines: Vec<&str> = doc.source.lines().collect();
     let mut symbols = Vec::new();
     for decl in &doc.program.decls {
         let (name, kind, span) = match decl {
@@ -200,11 +230,12 @@ fn compute_document_symbols(doc: &AnalyzedDoc) -> Vec<SymbolInformation> {
             _ => continue,
         };
         let line = span.as_ref().map(|s| s.line.saturating_sub(1) as u32).unwrap_or(0);
-        let col = span.as_ref().map(|s| s.col.saturating_sub(1) as u32).unwrap_or(0);
+        let line_text = lines.get(line as usize).copied().unwrap_or("");
+        let col = span.as_ref().map(|s| char_col_to_utf16(line_text, s.col)).unwrap_or(0);
         #[allow(deprecated)]
         symbols.push(SymbolInformation {
             name, kind,
-            location: Location { uri: Uri::from_str("file:///").unwrap(), range: Range { start: Position { line, character: col }, end: Position { line, character: col } } },
+            location: Location { uri: uri.clone(), range: Range { start: Position { line, character: col }, end: Position { line, character: col } } },
             tags: None, deprecated: None, container_name: None,
         });
     }
@@ -249,7 +280,7 @@ fn find_active_call(prefix: &str) -> Option<(usize, u32)> {
 fn compute_signature_help(source: &str, pos: Position, doc: Option<&AnalyzedDoc>) -> Option<SignatureHelp> {
     let lines: Vec<&str> = source.lines().collect();
     let line = lines.get(pos.line as usize)?;
-    let prefix = &line[..pos.character as usize];
+    let prefix = &line[..utf16_col_to_byte(line, pos.character)];
 
     let (paren_pos, active_param) = find_active_call(prefix)?;
     let before = prefix[..paren_pos].trim_end();
@@ -297,33 +328,8 @@ fn make_sig_help(prefix: &str, params: &[(crate::intern::Sym, crate::types::Ty)]
     }
 }
 
-// ══════════════════════════════════════════════════════════════
-// Rename
-// ══════════════════════════════════════════════════════════════
-
-fn compute_rename(source: &str, pos: Position, uri: &Uri, new_name: &str) -> Option<WorkspaceEdit> {
-    let lines: Vec<&str> = source.lines().collect();
-    let line = lines.get(pos.line as usize)?;
-    let col = pos.character as usize;
-    let (old_name, _, _) = word_at(line, col)?;
-
-    let mut edits = Vec::new();
-    for (line_idx, line_text) in lines.iter().enumerate() {
-        let mut search_from = 0;
-        while let Some(found) = line_text[search_from..].find(old_name) {
-            let abs = search_from + found;
-            let before_ok = abs == 0 || { let b = line_text.as_bytes()[abs - 1]; !b.is_ascii_alphanumeric() && b != b'_' };
-            let after = abs + old_name.len();
-            let after_ok = after >= line_text.len() || { let b = line_text.as_bytes()[after]; !b.is_ascii_alphanumeric() && b != b'_' };
-            if before_ok && after_ok {
-                edits.push(TextEdit {
-                    range: Range { start: Position { line: line_idx as u32, character: abs as u32 }, end: Position { line: line_idx as u32, character: after as u32 } },
-                    new_text: new_name.to_string(),
-                });
-            }
-            search_from = after;
-        }
-    }
-    if edits.is_empty() { return None; }
-    Some(WorkspaceEdit { changes: Some(HashMap::from([(uri.clone(), edits)])), ..Default::default() })
-}
+// Rename was removed from the advertised capabilities: the previous
+// implementation was an unscoped textual find/replace over the raw buffer —
+// no scope resolution, no shadowing, matches inside string literals and
+// comments, single-file only — which silently corrupts user code (#927).
+// It returns when it can be binding-aware via the Checker.

--- a/tests/lsp_test.rs
+++ b/tests/lsp_test.rs
@@ -9,6 +9,8 @@ use serde_json::{json, Value};
 struct LspClient {
     child: std::process::Child,
     reader: BufReader<std::process::ChildStdout>,
+    /// The `capabilities` object from the initialize response.
+    capabilities: Value,
 }
 
 impl LspClient {
@@ -22,7 +24,7 @@ impl LspClient {
             .expect("failed to start almide lsp");
         let stdout = child.stdout.take().unwrap();
         let reader = BufReader::new(stdout);
-        let mut client = LspClient { child, reader };
+        let mut client = LspClient { child, reader, capabilities: Value::Null };
         client.initialize();
         client
     }
@@ -83,6 +85,7 @@ impl LspClient {
         }));
         let resp = self.recv_response(0);
         assert!(resp.get("result").is_some(), "initialize should succeed");
+        self.capabilities = resp["result"]["capabilities"].clone();
 
         // Send initialized notification
         self.send(&json!({
@@ -155,6 +158,45 @@ impl LspClient {
             "method": "textDocument/documentSymbol",
             "params": {
                 "textDocument": { "uri": uri }
+            }
+        }));
+        self.recv_response(id)
+    }
+
+    fn did_change(&mut self, uri: &str, text: &str) {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+                "textDocument": { "uri": uri, "version": 2 },
+                "contentChanges": [{ "text": text }]
+            }
+        }));
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    fn signature_help(&mut self, id: i64, uri: &str, line: u32, character: u32) -> Value {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "textDocument/signatureHelp",
+            "params": {
+                "textDocument": { "uri": uri },
+                "position": { "line": line, "character": character }
+            }
+        }));
+        self.recv_response(id)
+    }
+
+    fn code_action(&mut self, id: i64, uri: &str, diagnostics: Value) -> Value {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "textDocument/codeAction",
+            "params": {
+                "textDocument": { "uri": uri },
+                "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 0 } },
+                "context": { "diagnostics": diagnostics }
             }
         }));
         self.recv_response(id)
@@ -350,6 +392,150 @@ fn lsp_document_symbols() {
     assert!(names.contains(&"double"), "should contain double: {:?}", names);
     assert!(names.contains(&"Color"), "should contain Color: {:?}", names);
     assert!(names.contains(&"main"), "should contain main: {:?}", names);
+    c.shutdown();
+}
+
+/// UTF-16 code-unit column of `target`'s first occurrence in `line` — the
+/// encoding the server declares and every request position must use.
+fn utf16_col(line: &str, target: &str) -> u32 {
+    let byte = line.find(target).unwrap();
+    line[..byte].chars().map(|c| c.len_utf16() as u32).sum()
+}
+
+#[test]
+fn lsp_capabilities_declare_utf16_and_no_rename() {
+    let mut c = LspClient::start();
+    assert_eq!(
+        c.capabilities["positionEncoding"].as_str(),
+        Some("utf-16"),
+        "server must declare the encoding it honors: {}",
+        c.capabilities
+    );
+    assert!(
+        c.capabilities.get("renameProvider").is_none(),
+        "unscoped textual rename must not be advertised: {}",
+        c.capabilities
+    );
+    c.shutdown();
+}
+
+#[test]
+fn lsp_hover_after_nonascii_text() {
+    let mut c = LspClient::start();
+    // Japanese before the hover target: the UTF-16 column differs from the
+    // byte column, which the old byte-sliced positions either missed or
+    // panicked on.
+    let src = "let greeting = \"world\"\nlet msg = \"こんにちは、\" + greeting\n";
+    c.open_file(TEST_URI, src);
+    let line1 = src.lines().nth(1).unwrap();
+    let resp = c.hover(1, TEST_URI, 1, utf16_col(line1, "greeting"));
+    let val = hover_value(&resp);
+    assert!(val.contains("greeting") && val.contains("String"), "hover after Japanese text: got {}", val);
+    c.shutdown();
+}
+
+#[test]
+fn lsp_position_inside_multibyte_no_panic() {
+    let mut c = LspClient::start();
+    let src = "let msg = \"こんにちは\"\nlet x = 1\n";
+    c.open_file(TEST_URI, src);
+    // A UTF-16 column landing inside the Japanese literal: the old code
+    // sliced the line at that value as a BYTE offset — mid-char — and the
+    // server died of a char-boundary panic.
+    let resp = c.hover(1, TEST_URI, 0, 13);
+    assert!(resp.get("id").is_some(), "server must answer, not die");
+    // And a column far past EOL must clamp, not panic.
+    let resp = c.hover(2, TEST_URI, 0, 10_000);
+    assert!(resp.get("id").is_some(), "past-EOL hover must answer");
+    // The server is still alive and correct afterwards.
+    let line1 = src.lines().nth(1).unwrap();
+    let resp = c.hover(3, TEST_URI, 1, utf16_col(line1, "x"));
+    assert!(hover_value(&resp).contains("Int"), "server still serves after odd positions");
+    c.shutdown();
+}
+
+#[test]
+fn lsp_signature_help_past_eol_no_panic() {
+    let mut c = LspClient::start();
+    let src = "let s = string.len(\"日本語\")\n";
+    c.open_file(TEST_URI, src);
+    // The old code sliced `&line[..pos.character]` with no bound check —
+    // any client cursor past EOL (or inside the multibyte literal) killed
+    // the server.
+    let resp = c.signature_help(1, TEST_URI, 0, 10_000);
+    assert!(resp.get("id").is_some(), "past-EOL signatureHelp must answer");
+    let resp = c.signature_help(2, TEST_URI, 0, utf16_col(src, "\")") + 1);
+    assert!(resp.get("id").is_some(), "signatureHelp near multibyte text must answer");
+    c.shutdown();
+}
+
+#[test]
+fn lsp_document_symbols_carry_real_uri() {
+    let mut c = LspClient::start();
+    c.open_file(TEST_URI, TEST_SOURCE);
+    let resp = c.document_symbols(1, TEST_URI);
+    let symbols = resp["result"].as_array().unwrap();
+    assert!(!symbols.is_empty());
+    for s in symbols {
+        assert_eq!(
+            s["location"]["uri"].as_str(),
+            Some(TEST_URI),
+            "documentSymbol must carry the document's own URI, not a fabricated one: {}",
+            s
+        );
+    }
+    c.shutdown();
+}
+
+#[test]
+fn lsp_didchange_never_fetches_or_writes_lock() {
+    // A project with a dependency manifest: didChange must not shell out to
+    // git or write almide.lock — the old server did both on every keystroke.
+    let dir = std::env::temp_dir().join(format!("almide_lsp_didchange_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("almide.toml"),
+        "[package]\nname = \"lsp_didchange_probe\"\n\n[dependencies]\nnonexistent_pkg = { git = \"https://invalid.invalid/nowhere\", branch = \"main\" }\n",
+    ).unwrap();
+    let file = dir.join("main.almd");
+    std::fs::write(&file, "let x = 1\n").unwrap();
+    let uri = format!("file://{}", file.display());
+
+    let mut c = LspClient::start();
+    // didChange without a prior didOpen: the cache has no entry for this
+    // project, and the no-fetch path must resolve against no deps.
+    c.did_change(&uri, "let x = 2\n");
+    let resp = c.hover(1, &uri, 0, 4);
+    assert!(resp.get("id").is_some(), "server must answer after didChange");
+    assert!(
+        !dir.join("almide.lock").exists(),
+        "didChange must never write almide.lock"
+    );
+    c.shutdown();
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn lsp_try_fix_reaches_client_as_code_action() {
+    let mut c = LspClient::start();
+    // E013 with a close-match suggestion emits a machine-applicable
+    // try_replace fix ("p.name") — it must survive into the published
+    // diagnostic's `data` and come back as a quickfix edit.
+    let src = "type Person = { name: String, age: Int }\nfn get(p: Person) -> String = p.nam\n";
+    c.open_file(TEST_URI, src);
+    let msg = c.recv();
+    let diags = msg["params"]["diagnostics"].clone();
+    let e013 = diags.as_array().unwrap().iter()
+        .find(|d| d["code"].as_str() == Some("E013"))
+        .unwrap_or_else(|| panic!("expected an E013 diagnostic, got {}", diags));
+    assert!(e013.get("data").is_some(), "E013's fix-it must ride in `data`: {}", e013);
+
+    let resp = c.code_action(1, TEST_URI, json!([e013]));
+    let actions = resp["result"].as_array().unwrap();
+    let fix = actions.iter().find(|a| a["title"].as_str().map_or(false, |t| t.contains("p.name")))
+        .unwrap_or_else(|| panic!("expected a quickfix applying `p.name`, got {}", resp["result"]));
+    let edits = &fix["edit"]["changes"][TEST_URI];
+    assert_eq!(edits[0]["newText"].as_str(), Some("p.name"), "quickfix edit text: {}", fix);
     c.shutdown();
 }
 


### PR DESCRIPTION
Fixes #927.

## The three holes, closed

1. **Position encoding.** The server now declares `position_encoding: utf-16` and honors it everywhere. Incoming positions convert through `utf16_col_to_byte` (clamping, always a char boundary) before any slicing — the old byte-sliced positions gave wrong offsets on any non-ASCII line and a char-boundary/past-EOL cursor killed the server. Outgoing positions (diagnostics, definitions, document/workspace symbols, code-action edits) convert from the compiler's 1-indexed char columns via `char_col_to_utf16`.
2. **Rename** is no longer advertised. The implementation was an unscoped textual find/replace — no scope resolution, no shadowing, renamed matches inside strings and comments, single-file only — i.e. it silently corrupted user code. Removed rather than kept broken; it returns when it can be binding-aware via the Checker (issue's sanctioned closure).
3. **didChange side effects.** Dep fetching (`fetch_all_deps`: git shell-outs, almide.lock writes) now runs only on didOpen, cached per almide.toml. A keystroke serves the cached dep list — or resolves against no deps on a cache miss — and can never touch the network or the lockfile.

## Also in the file, per the issue

- `documentSymbol` carries the document's real URI instead of a fabricated `file:///`.
- The compiler's machine-applicable fix-its (`try_replace_span`) were computed and then dropped in `diag_from_almide`; they now ride the diagnostic's `data` field and materialize as quickfix edits in `textDocument/codeAction`.

## Tests (7 new, in tests/lsp_test.rs)

- capabilities declare `utf-16` and do not advertise rename
- hover works at UTF-16 columns after Japanese text (non-ASCII fixture per the closure condition)
- a cursor inside a multibyte char and 10,000 columns past EOL both answer instead of killing the server (both previously fatal)
- signatureHelp past EOL answers (previously an unchecked slice panic)
- documentSymbol URIs are real
- didChange on a project with a dependency manifest writes no almide.lock
- an E013 fix-it survives into `data` and comes back as a `p.name` quickfix edit

All 20 LSP integration tests pass. No new compiler warnings (the pre-existing dead-code warnings in lsp.rs are on develop too).