### PR TITLE
Describe fan as the deterministic list-order surface it is and count the fan block into C-004's interleaving exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ almide run hello.almd
 - **Bidirectional type inference** — Type annotations flow into expressions (`let xs: List[Int] = []`)
 - **Codec system** — `Type.decode(value)` / `Type.encode(value)` convention with auto-derive
 - **Map literals** — `["key": value]` syntax with `m[key]` access and `for (k, v) in m` iteration
-- **Fan concurrency** — `fan { a(); b() }`, `fan.map`, `fan.race`, `fan.any`, `fan.settle`
+- **Fan** — structured concurrency surface: `fan { a(); b() }` and `fan.settle` run on real threads natively (sequential on wasm); `fan.map` / `fan.race` / `fan.any` are deterministic by list order on both targets
 - **Top-level constants** — `let PI = 3.14` at module scope, compile-time evaluated
 - **Pipeline operator** — `data |> transform |> output`
 - **Module system** — Packages, sub-namespaces, visibility control, diamond dependency resolution

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -48,9 +48,9 @@ Almide keeps concurrency boring on purpose: explicit fork, explicit join, automa
 
 One keyword, three forms:
 
-- **`fan { a(); b() }`** — run expressions concurrently, wait for all, return results as a tuple
-- **`fan.map(xs, fn)`** — parallel map over a collection, return results as a list
-- **`fan.race(thunks)`** — run thunks concurrently, return the first to complete, cancel the rest
+- **`fan { a(); b() }`** — run expressions as one scoped unit (real threads on native, sequential on wasm), wait for all, return results as a tuple in declaration order
+- **`fan.map(xs, fn)`** — map over a collection through the fan surface — deterministic, sequential in list order on both targets (C-004)
+- **`fan.race(thunks)`** — settle on the first thunk in LIST ORDER, deterministic rather than wall-clock; fan thunks are pure, so not running the rest is unobservable (C-004)
 
 The rules are minimal:
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -463,7 +463,7 @@ Modifier order: `[local|mod]? effect? fn`
 - Return type is required
 - The body is a single expression (after `=`)
 - `effect fn` marks functions with side effects
-- `fan { }` for concurrent execution (only inside `effect fn`)
+- `fan { }` for scoped concurrent execution — native threads, sequential on wasm (only inside `effect fn`)
 
 ```
 fn add(x: Int, y: Int) -> Int = x + y
@@ -751,7 +751,7 @@ Rules:
 - No `var` capture from outer scope (prevents data races)
 
 Library forms:
-- `fan.map(xs, f)` -- parallel map over a collection
+- `fan.map(xs, f)` -- map over a collection via the fan surface (deterministic, sequential in list order)
 - `fan.race(thunks)` -- first to complete wins, rest cancelled
 
 ### 9.10 Pipe
@@ -984,7 +984,7 @@ When a hole is found, the compiler returns:
 
 ### 13.1 fan Block
 
-`fan { }` runs expressions concurrently. Only valid inside `effect fn`.
+`fan { }` runs expressions as one scoped unit — real threads on native, sequential in declaration order on wasm; results are identical either way. Only valid inside `effect fn`.
 
 ```
 effect fn main() -> Result[Unit, String] = {
@@ -1002,7 +1002,7 @@ Results are returned as a tuple. If any expression returns `Err`, the entire `fa
 ### 13.2 fan.map / fan.race
 
 ```
-let results = fan.map(urls, (url) => fetch(url))   // parallel map
+let results = fan.map(urls, (url) => fetch(url))   // deterministic, list order
 let first = fan.race([task_a, task_b])              // first to complete wins
 ```
 
@@ -1228,7 +1228,7 @@ Target source code
 4. StdlibLowering -- module calls to named calls with arg decoration
 5. ResultPropagation -- insert `?` for effect fn calls
 6. BuiltinLowering -- assert_eq, println, etc. to Rust macros
-7. FanLowering -- fan blocks to tokio::join!/spawn
+7. FanLowering -- fan blocks to scoped threads (`std::thread::scope`)
 
 Templates are defined in TOML files (`codegen/templates/*.toml`), separating syntax from semantics.
 
@@ -1242,7 +1242,7 @@ Templates are defined in TOML files (`codegen/templates/*.toml`), separating syn
 | `==` / `!=` | `almide_eq!` macro (deep) | Byte comparison |
 | `+` on String | `format!` / owned concat | `string_concat` runtime |
 | `+` on List | `[...a, ...b]` | `list_concat` runtime |
-| `fan { }` | `tokio::join!` | Sequential (single-threaded) |
+| `fan { }` | `std::thread::scope` | Sequential (single-threaded) |
 
 ---
 

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -112,7 +112,7 @@ evidence  = [
 id        = "C-004"
 spec      = "ALS-R3"
 title     = "fan.race / fan.any / fan.map / fan.settle are deterministic by list order"
-statement = "`fan.race` returns thunk[0]'s settled result in LIST ORDER (Ok or Err), NOT wall-clock fastest. `fan.any` tries thunks in list order and returns the first Ok. `fan.map` runs element fns sequentially in list order; `fan.settle` returns results in list order. All are byte-identical native == wasm. (race takes thunk[0] even on Err; any skips failures to find an Ok.) EXCEPTION: fan.settle THUNK side-effect interleaving is wall-clock on native (real threads) and sequential on wasm — settle pins its RESULT list order only."
+statement = "`fan.race` returns thunk[0]'s settled result in LIST ORDER (Ok or Err), NOT wall-clock fastest. `fan.any` tries thunks in list order and returns the first Ok. `fan.map` runs element fns sequentially in list order; `fan.settle` returns results in list order. All are byte-identical native == wasm. (race takes thunk[0] even on Err; any skips failures to find an Ok.) EXCEPTION: side-effect INTERLEAVING inside `fan { }` block arms and `fan.settle` thunks is wall-clock on native (both run on real threads) and sequential on wasm — they pin their RESULT (tuple / list) order only. The block was an undercount here until #915's audit: it spawns per-arm scoped threads on native, the same interleaving class as settle."
 since     = "0.24.0"
 status    = "active"
 evidence  = [


### PR DESCRIPTION
Fixes #915 (the de-advertise closure option, which is the one the ledger already chose).

## Why de-advertise rather than implement threads

C-004 pinned `fan.race`/`fan.any`/`fan.map`/`fan.settle` as **deterministic by list order** back in 0.24.0, and C-006 removed `fan.timeout` precisely because wall-clock behavior has no portable cross-target meaning. Making `fan.race` actually race on native would reintroduce wall-clock nondeterminism the ledger explicitly rejects — the docs were advertising semantics the language deliberately does not have. The runtime's doc comments already explain this; the user-facing docs never caught up.

## What changed

- **docs/DESIGN.md** — `fan{}` described as scoped unit (native threads / wasm sequential, identical results); `fan.map` and `fan.race` described as deterministic list-order, citing C-004, instead of "parallel map" and "run concurrently, cancel the rest".
- **docs/SPEC.md** — the `FanLowering -- tokio::join!/spawn` pass description and the `fan { } | tokio::join!` cross-target table row replaced with the real `std::thread::scope` lowering (no tokio dependency exists); "parallel map" mentions rewritten.
- **README.md** — the "Fan concurrency" feature bullet now states the execution model honestly: threads for `fan{}`/`fan.settle` on native, deterministic list order for the combinators.
- **C-004's EXCEPTION clause** now also names the `fan { }` block: it spawns per-arm scoped threads on native (walker `render_fan` → `__s.spawn`), so its side-effect interleaving is the same wall-clock-on-native/sequential-on-wasm class as `fan.settle`'s — the clause previously undercounted the exception by one construct. Statement-only amendment; no behavior change; `check-contracts.sh` green (193 contracts, 322/322 fixtures linked).

The stale docs-site page (almide/docs `guide/concurrency.md`: "Parallel map" summary row and an "avoid fan.any on wasm" warning for the long-since-fixed #900) is fixed in a companion PR on that repo.