### PR TITLE
Replace the Rust-style range spellings with Swift's: ..< exclusive and ... inclusive

### DIFF
--- a/crates/almide-interp/tests/eval_test.rs
+++ b/crates/almide-interp/tests/eval_test.rs
@@ -455,16 +455,16 @@ fn main() -> Unit = {
 
 #[test]
 fn for_in_range_exclusive_and_inclusive() {
-    // `1..5` is exclusive (sum 1+2+3+4 = 10); `1..=3` materializes to
+    // `1..<5` is exclusive (sum 1+2+3+4 = 10); `1...3` materializes to
     // [1, 2, 3] when displayed.
     let src = r#"
 fn main() -> Unit = {
   var sum = 0
-  for i in 1..5 {
+  for i in 1..<5 {
     sum = sum + i
   }
   println("${sum}")
-  let r = 1..=3
+  let r = 1...3
   println("${r}")
 }"#;
     expect_out(src, "10\n[1, 2, 3]\n");
@@ -818,7 +818,7 @@ fn huge_range_for_in_is_fuel_bounded_not_oom() {
     // FuelExhausted in O(fuel) steps and O(1) memory — the eager
     // materialization used to allocate the whole range (tens of GB) and
     // abort the process before the first fuel check.
-    let src = "fn main() -> Unit = {\n  var s = 0\n  for i in 0..2000000000 {\n    s = s + 1\n  }\n  println(\"${s}\")\n}";
+    let src = "fn main() -> Unit = {\n  var s = 0\n  for i in 0..<2000000000 {\n    s = s + 1\n  }\n  println(\"${s}\")\n}";
     let ir = lower(src);
     let out = almide_interp::Interpreter::new(&ir).with_fuel(10_000).run_main();
     assert!(

--- a/crates/almide-syntax/src/lexer.rs
+++ b/crates/almide-syntax/src/lexer.rs
@@ -49,9 +49,10 @@ pub enum TokenType {
     Question,         // ?
     QuestionDot,      // ?.
     QuestionQuestion, // ??
-    DotDot,    // ..
-    DotDotEq,  // ..=
-    DotDotDot, // ...
+    DotDot,    // .. — record-rest in patterns/types; RETIRED as a range operator (#966: E033 fix-it → ..<)
+    DotDotEq,  // ..= — RETIRED (#966: E033 fix-it → ...)
+    DotDotDot, // ... — record/list spread (prefix) AND inclusive range (infix)
+    DotDotLt,  // ..< — exclusive range
     At,        // @
     // Whitespace / structure
     Comment, Newline, EOF,
@@ -622,6 +623,7 @@ fn lex_operator(chars: &[char], pos: usize, line: usize, col: usize) -> (Token, 
         // Three-char
         ('.', Some('.'), Some('=')) => (TokenType::DotDotEq, "..=", 3),
         ('.', Some('.'), Some('.')) => (TokenType::DotDotDot, "...", 3),
+        ('.', Some('.'), Some('<')) => (TokenType::DotDotLt, "..<", 3),
         // Two-char
         ('-', Some('>'), _) => (TokenType::Arrow, "->", 2),
         ('=', Some('>'), _) => (TokenType::FatArrow, "=>", 2),

--- a/crates/almide-syntax/src/parser/expressions.rs
+++ b/crates/almide-syntax/src/parser/expressions.rs
@@ -32,8 +32,12 @@ impl Parser {
             | TokenType::LtEq  | TokenType::GtEq
                                         => Some((6,  7)),   // non-assoc (enforced below)
             TokenType::PipeArrow        => Some((8,  25)),  // ★ asymmetric
-            TokenType::DotDot           => Some((10, 10)),  // range
-            TokenType::DotDotEq         => Some((10, 10)),
+            TokenType::DotDotLt         => Some((10, 10)),  // range, end-exclusive (#966)
+            TokenType::DotDotDot        => Some((10, 10)),  // range, end-inclusive — infix only;
+                                                            // prefix `...` is spread, consumed by the
+                                                            // record/list item parsers before this table
+            TokenType::DotDot           => Some((10, 10)),  // RETIRED range spelling → E031 fix-it
+            TokenType::DotDotEq         => Some((10, 10)),  // RETIRED range spelling → E031 fix-it
             TokenType::Plus | TokenType::Minus
             | TokenType::PlusPlus       => Some((12, 13)),  // left-assoc
             TokenType::Star | TokenType::Slash
@@ -45,11 +49,15 @@ impl Parser {
     }
 
     /// All token types that are infix operators (for newline lookahead).
+    /// `DotDotDot` is deliberately ABSENT: a line starting with `...` is a
+    /// spread inside a multiline record/list literal, and joining it to the
+    /// previous item as an inclusive range would rewrite those programs. An
+    /// inclusive range therefore cannot break the line BEFORE its `...`.
     const INFIX_TOKENS: &'static [TokenType] = &[
         TokenType::Or, TokenType::And,
         TokenType::EqEq, TokenType::BangEq, TokenType::LtEq, TokenType::GtEq,
         TokenType::PipeArrow, TokenType::ComposeArrow,
-        TokenType::DotDot, TokenType::DotDotEq,
+        TokenType::DotDot, TokenType::DotDotEq, TokenType::DotDotLt,
         TokenType::Plus, TokenType::Minus, TokenType::PlusPlus,
         TokenType::Star, TokenType::Slash, TokenType::Percent,
         TokenType::Caret,
@@ -93,6 +101,8 @@ impl Parser {
 
             let span = Some(self.current_span());
             let op_value = self.current().value.clone();
+            let (op_line, op_col, op_end_col) =
+                { let t = self.current(); (t.line, t.col, t.end_col) };
             self.advance();
             self.skip_newlines();
 
@@ -128,12 +138,41 @@ impl Parser {
                 TokenType::ComposeArrow => Expr::new(self.next_id(), span, ExprKind::Compose {
                     left: Box::new(left), right: Box::new(right),
                 }),
-                TokenType::DotDot => Expr::new(self.next_id(), span, ExprKind::Range {
+                TokenType::DotDotLt => Expr::new(self.next_id(), span, ExprKind::Range {
                     start: Box::new(left), end: Box::new(right), inclusive: false,
                 }),
-                TokenType::DotDotEq => Expr::new(self.next_id(), span, ExprKind::Range {
+                TokenType::DotDotDot => Expr::new(self.next_id(), span, ExprKind::Range {
                     start: Box::new(left), end: Box::new(right), inclusive: true,
                 }),
+                // #966: the Rust-style range spellings were retired for the
+                // self-describing Swift pair. The range still PARSES — `almide
+                // fix`/`fmt` need the AST to migrate the file, and downstream
+                // sees the program — but the E031 tombstone makes every
+                // compile path fail loudly, with a machine-applicable fix-it
+                // on the operator span.
+                TokenType::DotDot | TokenType::DotDotEq => {
+                    let inclusive = tt == TokenType::DotDotEq;
+                    let new_spelling = if inclusive { "..." } else { "..<" };
+                    let mut d = crate::diagnostic::Diagnostic::error(
+                        format!(
+                            "'{}' was retired: {} ranges are written '{}'",
+                            op_value,
+                            if inclusive { "end-inclusive" } else { "end-exclusive" },
+                            new_spelling,
+                        ),
+                        "run `almide fix` on this file to migrate every range mechanically",
+                        "range expression",
+                    ).with_code("E031")
+                     .with_try_replace(op_line, op_col, op_end_col, new_spelling);
+                    if let Some(f) = &self.file { d.file = Some(f.clone()); }
+                    d.line = Some(op_line);
+                    d.col = Some(op_col);
+                    d.end_col = Some(op_end_col);
+                    self.errors.push(d);
+                    Expr::new(self.next_id(), span, ExprKind::Range {
+                        start: Box::new(left), end: Box::new(right), inclusive,
+                    })
+                }
                 _ => Expr::new(self.next_id(), span, ExprKind::Binary {
                     op: sym(&op_value), left: Box::new(left), right: Box::new(right),
                 }),
@@ -168,7 +207,7 @@ impl Parser {
                 if matches!(start.kind, ExprKind::Range { .. }) || matches!(end.kind, ExprKind::Range { .. }) {
                     let (line, col) = left.span.map(|s| (s.line, s.col)).unwrap_or((0, 0));
                     return Err(format!(
-                        "Chained range operators are not allowed at line {}:{}\n  Hint: A range has one start and one end. Write: 0..2",
+                        "Chained range operators are not allowed at line {}:{}\n  Hint: A range has one start and one end. Write: 0..<2",
                         line, col
                     ));
                 }

--- a/crates/almide-syntax/src/parser/test_expr_precedence.rs
+++ b/crates/almide-syntax/src/parser/test_expr_precedence.rs
@@ -32,7 +32,7 @@ mod tests {
                 format!("(>> {} {})", shape(&left.kind), shape(&right.kind))
             }
             ExprKind::Range { start, end, inclusive } => {
-                let op = if *inclusive { "..=" } else { ".." };
+                let op = if *inclusive { "..." } else { "..<" };
                 format!("({} {} {})", op, shape(&start.kind), shape(&end.kind))
             }
             ExprKind::Unary { op, operand } => {
@@ -130,42 +130,42 @@ mod tests {
     #[test]
     fn r1_range_then_pipe() {
         assert_eq!(
-            parse_shape("0..n |> list.map(f)"),
-            "(|> (.. 0 n) list.map(f))"
+            parse_shape("0..<n |> list.map(f)"),
+            "(|> (..< 0 n) list.map(f))"
         );
     }
 
     #[test]
     fn r2_range_add_then_pipe() {
         assert_eq!(
-            parse_shape("0..n+1 |> list.map(f)"),
-            "(|> (.. 0 (+ n 1)) list.map(f))"
+            parse_shape("0..<n+1 |> list.map(f)"),
+            "(|> (..< 0 (+ n 1)) list.map(f))"
         );
     }
 
     #[test]
     fn r3_range_with_add() {
-        assert_eq!(parse_shape("0..n + 1"), "(.. 0 (+ n 1))");
+        assert_eq!(parse_shape("0..<n + 1"), "(..< 0 (+ n 1))");
     }
 
     #[test]
     fn r4_range_both_add() {
-        assert_eq!(parse_shape("a+1..b+2"), "(.. (+ a 1) (+ b 2))");
+        assert_eq!(parse_shape("a+1..<b+2"), "(..< (+ a 1) (+ b 2))");
     }
 
     #[test]
     fn r5_range_pipe_add() {
         assert_eq!(
-            parse_shape("0..n |> list.map(f) + ys"),
-            "(+ (|> (.. 0 n) list.map(f)) ys)"
+            parse_shape("0..<n |> list.map(f) + ys"),
+            "(+ (|> (..< 0 n) list.map(f)) ys)"
         );
     }
 
     #[test]
     fn r6_range_pipe_chain() {
         assert_eq!(
-            parse_shape("0..10 |> list.filter(p) |> list.map(f)"),
-            "(|> (|> (.. 0 10) list.filter(p)) list.map(f))"
+            parse_shape("0..<10 |> list.filter(p) |> list.map(f)"),
+            "(|> (|> (..< 0 10) list.filter(p)) list.map(f))"
         );
     }
 
@@ -369,8 +369,8 @@ mod tests {
 
     #[test]
     fn k_range_basic() {
-        assert_eq!(parse_shape("0..10"), "(.. 0 10)");
-        assert_eq!(parse_shape("0..=10"), "(..= 0 10)");
+        assert_eq!(parse_shape("0..<10"), "(..< 0 10)");
+        assert_eq!(parse_shape("0...10"), "(... 0 10)");
     }
 
     #[test]

--- a/crates/almide-tools/src/fmt_expr.rs
+++ b/crates/almide-tools/src/fmt_expr.rs
@@ -110,7 +110,7 @@ fn fmt_expr_infix(out: &mut String, expr: &Expr, depth: usize) -> bool {
         ExprKind::Compose { left, right, .. } => joined(left, " >> ", right),
         ExprKind::UnwrapOr { expr: e, fallback, .. } => joined(e, " ?? ", fallback),
         ExprKind::Range { start, end, inclusive, .. } => {
-            joined(start, if *inclusive { "..=" } else { ".." }, end)
+            joined(start, if *inclusive { "..." } else { "..<" }, end)
         }
         ExprKind::Binary { op, left, right, .. } => {
             fmt_expr(out, left, depth);

--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -212,10 +212,10 @@ while i < 10 {
 
 ### Range
 ```
-0..5            // [0, 1, 2, 3, 4]  (exclusive end)
-1..=5           // [1, 2, 3, 4, 5]  (inclusive end)
+0..<5           // [0, 1, 2, 3, 4]  (exclusive end)
+1...5           // [1, 2, 3, 4, 5]  (inclusive end)
 for i in 0..n { ... }    // optimized: no list allocation
-let xs = list.map(0..10, (i) => i * i)   // range as List[Int]
+let xs = list.map(0..<10, (i) => i * i)  // range as List[Int]
 ```
 
 ### Pipe
@@ -383,7 +383,7 @@ effect fn main() -> Unit = {
 Command-line arguments are accessed via `process.args()` (not main parameters).
 
 ## Operators (precedence high→low)
-`. () [] ! ? ?. ??` (postfix) > `not -` (prefix) > `>>` > `^` (power) > `* / %` > `+ -` > `.. ..=` > `|>` > `== != < > <= >=` (non-assoc) > `and` > `or`
+`. () [] ! ? ?. ??` (postfix) > `not -` (prefix) > `>>` > `^` (power) > `* / %` > `+ -` > `..< ...` > `|>` > `== != < > <= >=` (non-assoc) > `and` > `or`
 
 `^` is exponentiation (right-associative, `**` also accepted). `+` is concatenation for strings and lists (overloaded with addition). XOR is available as `int.bxor(a, b)`.
 

--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -95,7 +95,7 @@ lparam      = (IDENT | "_") (":" type)?
             | "(" (IDENT | "_") ("," (IDENT | "_"))* ")"   (* tuple-destructuring param *)
 
 pipe        = expr "|>" expr                               (* also: expr |> match { arms } *)
-range       = expr ".." expr | expr "..=" expr             (* exclusive / inclusive *)
+range       = expr "..<" expr | expr "..." expr            (* exclusive / inclusive *)
 postfix     = primary ( "(" args ")"                       (* call *)
                       | "[" type_args "]" "(" args ")"     (* explicit type args: f[Int](x) *)
                       | "[" expr "]"                       (* index *)
@@ -156,7 +156,7 @@ a parse error (use `and`).
 | 2 | `and` | left |
 | 3 | `==` `!=` `<` `>` `<=` `>=` | non-assoc |
 | 4 | `\|>` | left (asymmetric — see below) |
-| 5 | `..` `..=` | — |
+| 5 | `..<` `...` | — |
 | 6 | `+` `-` | left |
 | 7 | `*` `/` `%` | left |
 | 8 | `^` (alias `**`) power | right |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -103,7 +103,7 @@ local   mod     fan
 ### 1.6 Operators and Delimiters
 
 ```
-Operators:   +  -  *  /  %  ^  ==  !=  <  <=  >  >=  |>  >>  ..  ..=
+Operators:   +  -  *  /  %  ^  ==  !=  <  <=  >  >=  |>  >>  ..<  ...
 Postfix:     !  ?  ?.  ??
 Unary:       -  not
 Logical:     and  or
@@ -114,7 +114,7 @@ Delimiters:  (  )  {  }  [  ]  ,  .  :  ;  |  _  @  ...
 
 - `^` is exponentiation (right-associative). `**` is accepted as an alias
 - `+` is overloaded: addition for numbers, concatenation for strings and lists
-- `..` is exclusive range, `..=` is inclusive range
+- `..<` is exclusive range, `...` is inclusive range (the Rust-style `..`/`..=` are a diagnosed E031 with a mechanical fix-it)
 - `...` is spread (in records)
 - `_` is wildcard (in match patterns) or placeholder (in pipe arguments)
 - `@` is used for extern annotations
@@ -718,7 +718,7 @@ for (k, v) in map.entries(config) {
   println(k + " = " + v)
 }
 
-for i in 0..10 {
+for i in 0..<10 {
   println(int.to_string(i))
 }
 ```
@@ -797,8 +797,8 @@ Resolution: when `x.f(args...)` is called, the compiler looks for `f(x, args...)
 ### 9.12 Range
 
 ```
-0..5            // [0, 1, 2, 3, 4]    exclusive end
-1..=5           // [1, 2, 3, 4, 5]    inclusive end
+0..<5           // [0, 1, 2, 3, 4]    exclusive end
+1...5           // [1, 2, 3, 4, 5]    inclusive end
 for i in 0..n { ... }   // no list allocation (optimized)
 ```
 
@@ -868,7 +868,7 @@ fn optimize(ast: Ast) -> Ast = todo("implement later") // todo with message
 | 2 | `and` | left |
 | 3 | `==` `!=` `<` `<=` `>` `>=` | non-assoc (chaining is an error) |
 | 4 | `\|>` (pipe) | left, asymmetric (see below) |
-| 5 | `..` `..=` (range) | none |
+| 5 | `..<` `...` (range) | none |
 | 6 | `+` `-` (additive) | left |
 | 7 | `*` `/` `%` (multiplicative) | left |
 | 8 | `^` (power; `**` is an alias) | right |
@@ -897,7 +897,7 @@ fn optimize(ast: Ast) -> Ast = todo("implement later") // todo with message
 | `and` `or` `not` | Boolean logic |
 | `\|>` | Pipe |
 | `>>` | Function composition |
-| `..` `..=` | Range (exclusive / inclusive) |
+| `..<` `...` | Range (exclusive / inclusive) |
 | `!` `?` `?.` `??` (postfix) | Unwrap / to-Option / optional chain / fallback |
 
 In Rust codegen, `==`/`!=` emit the `almide_eq!` macro for deep structural equality. In WASM codegen, they emit byte-level comparison.

--- a/docs/diagnostics/E031.md
+++ b/docs/diagnostics/E031.md
@@ -1,0 +1,35 @@
+# E031 — retired range spelling
+
+The Rust-style range operators were replaced by Swift's self-describing pair
+(#966): `..<` is the end-exclusive range and `...` the end-inclusive one. The
+old `..` / `..=` spellings are a diagnosed error with a machine-applicable
+fix-it — the one-character `..` vs `..=` distinction was silently confusable
+in both directions, while `..<` carries its own `<`.
+
+```almide
+fn main() -> Unit = {
+  var s = 0
+  for i in 0 .. 5 { s = s + i }     // ← E031: '..' was retired, write '..<'
+  for j in 1 ..= 3 { s = s + j }    // ← E031: '..=' was retired, write '...'
+  println(int.to_string(s))
+}
+```
+
+## Fix
+
+```almide
+fn main() -> Unit = {
+  var s = 0
+  for i in 0 ..< 5 { s = s + i }    // end-exclusive: 0,1,2,3,4
+  for j in 1 ... 3 { s = s + j }    // end-inclusive: 1,2,3
+  println(int.to_string(s))
+}
+```
+
+Run `almide fix <file>` to migrate every range in a file mechanically — it
+applies exactly the operator rewrites and touches nothing else.
+
+Note the survivors: `..` is still valid as the record-rest marker
+(`{ x, .. }` in patterns and open record types — never in expression
+position), and `...` doubles as the record/list spread (`{ ...base, x: 1 }`)
+— prefix position means spread, infix means inclusive range.

--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -23,6 +23,7 @@ Use `almide explain <code>` to read these from the CLI.
 | [E028](E028.md) | `main()` takes no parameters (use `env.args()`) |
 | [E029](E029.md) | Unknown type name in an annotation or record literal |
 | [E030](E030.md) | Type has no ordering (sort/min/max over Map/Set/Fn or compound Float) |
+| [E031](E031.md) | Retired range spelling (`..`/`..=` → `..<`/`...`, fix-it + `almide fix`) |
 | [E420](E420.md) | Function visibility violation (placeholder code, renumber candidate) |
 
 Codes in the 4-digit range (`E0001` and up) that leak into output

--- a/docs/specs/language.md
+++ b/docs/specs/language.md
@@ -656,7 +656,7 @@ for (k, v) in map.entries(m) {
 Underscore for ignored variable:
 
 ```
-for _ in 0..5 {
+for _ in 0..<5 {
   println("tick")
 }
 ```
@@ -690,14 +690,14 @@ while true {
 ### 5.14 Range
 
 ```
-0..5              // [0, 1, 2, 3, 4]     (exclusive end)
-1..=5             // [1, 2, 3, 4, 5]     (inclusive end)
+0..<5             // [0, 1, 2, 3, 4]     (exclusive end)
+1...5             // [1, 2, 3, 4, 5]     (inclusive end)
 ```
 
 Ranges can be used in for loops (optimized, no list allocation):
 
 ```
-for i in 0..n {
+for i in 0..<n {
   println(int.to_string(i))
 }
 ```
@@ -962,7 +962,7 @@ match pair {
 | 3 | `^` | Right |
 | 4 | `*` `/` `%` | Left |
 | 5 | `+` `-` | Left |
-| 6 | `..` `..=` | Non-associative |
+| 6 | `..<` `...` | Non-associative |
 | 7 | `==` `!=` `<` `>` `<=` `>=` | Non-associative |
 | 8 | `and` | Left |
 | 9 | `or` | Left |

--- a/examples/minesweeper.almd
+++ b/examples/minesweeper.almd
@@ -7,7 +7,7 @@ import io
 // mines: flat List[Bool] (81 cells), returns flat List[Int] (-1 = mine, 0..8 = count)
 fn build_adjacent(mines: List[Bool]) -> List[Int] = {
   var result: List[Int] = []
-  for idx in 0..81 {
+  for idx in 0..<81 {
     let r = idx / 9
     let c = idx % 9
     if mines[idx] then {
@@ -35,7 +35,7 @@ fn build_adjacent(mines: List[Bool]) -> List[Int] = {
 // Place mines randomly, excluding 3x3 zone around (sr, sc)
 effect fn place_mines(sr: Int, sc: Int) -> Result[List[Bool], String] = {
   var mines: List[Bool] = []
-  for _i in 0..81 {
+  for _i in 0..<81 {
     mines = mines + [false]
   }
   var placed = 0
@@ -88,7 +88,7 @@ fn flood_fill(adjacent: List[Int], revealed: List[Bool], start_idx: Int) -> List
 // Count remaining non-mine unrevealed cells
 fn count_unrevealed(adjacent: List[Int], revealed: List[Bool]) -> Int = {
   var count = 0
-  for i in 0..81 {
+  for i in 0..<81 {
     if not revealed[i] and adjacent[i] != -1 then {
       count = count + 1
     } else ()
@@ -99,7 +99,7 @@ fn count_unrevealed(adjacent: List[Int], revealed: List[Bool]) -> Int = {
 // Count flags
 fn count_flags(flagged: List[Bool]) -> Int = {
   var count = 0
-  for i in 0..81 {
+  for i in 0..<81 {
     if flagged[i] then {
       count = count + 1
     } else ()
@@ -111,9 +111,9 @@ fn count_flags(flagged: List[Bool]) -> Int = {
 fn render_board(adjacent: List[Int], revealed: List[Bool], flagged: List[Bool], show_mines: Bool) -> String = {
   var out = "    0 1 2 3 4 5 6 7 8\n"
   out = out + "  +-------------------+\n"
-  for r in 0..9 {
+  for r in 0..<9 {
     var row = int.to_string(r) + " | "
-    for c in 0..9 {
+    for c in 0..<9 {
       let idx = r * 9 + c
       let cell = if show_mines and adjacent[idx] == -1 then "● "
         else if flagged[idx] then "⚑ "
@@ -149,7 +149,7 @@ fn parse_input(input: String) -> Result[{flag: Bool, row: Int, col: Int}, String
 // Initialize a list of 81 false values
 fn make_bools() -> List[Bool] = {
   var xs: List[Bool] = []
-  for _i in 0..81 {
+  for _i in 0..<81 {
     xs = xs + [false]
   }
   xs
@@ -158,7 +158,7 @@ fn make_bools() -> List[Bool] = {
 // Initialize a list of 81 zeros
 fn make_zeros() -> List[Int] = {
   var xs: List[Int] = []
-  for _i in 0..81 {
+  for _i in 0..<81 {
     xs = xs + [0]
   }
   xs

--- a/examples/raytracer.almd
+++ b/examples/raytracer.almd
@@ -174,7 +174,7 @@ fn pixel(px: Int, py: Int, w: Int, h: Int) -> V3 = {
 // Two pixel rows per text row: ▀ with fg = upper pixel, bg = lower pixel.
 fn render_row(py: Int, w: Int, h: Int) -> String = {
   var line = ""
-  for px in 0..w {
+  for px in 0..<w {
     let top = pixel(px, py, w, h)
     let bot = pixel(px, py + 1, w, h)
     let fg = "\x1b[38;2;${int.to_string(channel(top.x))};${int.to_string(channel(top.y))};${int.to_string(channel(top.z))}m"

--- a/llms.txt
+++ b/llms.txt
@@ -180,6 +180,7 @@ let root_i = float.to_int(root_f)    // truncating
 | E028 | `main()` takes no parameters (`fn main(args: List[String])` is not wired on any target) | Read program arguments with `env.args()` inside the body |
 | E029 | Unknown type name in an annotation or record literal (would fail the native build after check accepted) | Declare the type, fix the spelling, or add the missing import |
 | E030 | Type has no ordering — `list.sort/min/max` or a `sort_by` key over Map/Set/Fn or compound-nested Float | Sort by an explicit orderable key (`list.sort_by(xs, (m) => <Int/String key>)`) |
+| E031 | Retired range spelling — `..`/`..=` were replaced by Swift-style `..<` (exclusive) / `...` (inclusive) | Write `0 ..< n` / `1 ... n`, or run `almide fix <file>` to migrate every range mechanically |
 | E420 | Function visibility violation (callee is private) | Make the callee public, or add a public shim |
 
 A rustc 4-digit code (`error[E0XXX]`) leaking through always indicates

--- a/spec/integration/clone_opt_test.almd
+++ b/spec/integration/clone_opt_test.almd
@@ -21,7 +21,7 @@ test "tree check no clone" {
 test "list index int (no clone needed)" {
   let xs = [10, 20, 30, 40, 50]
   var sum = 0
-  for i in 0..5 { sum = sum + xs[i] }
+  for i in 0..<5 { sum = sum + xs[i] }
   assert_eq(sum, 150)
 }
 
@@ -34,7 +34,7 @@ test "list index string (element clone)" {
 // push optimization: xs = xs + [v] → xs.push(v)
 test "push optimization" {
   var xs: List[Int] = []
-  for i in 0..100 {
+  for i in 0..<100 {
     xs = xs + [i]
   }
   assert_eq(list.len(xs), 100)

--- a/spec/integration/codegen_interpolation_test.almd
+++ b/spec/integration/codegen_interpolation_test.almd
@@ -59,7 +59,7 @@ test "many interpolations in one string" {
 
 test "interpolation inside for loop" {
   var lines: List[String] = []
-  for i in 1..=3 {
+  for i in 1...3 {
     lines = lines + ["line ${int.to_string(i)}"]
   }
   assert_eq(lines, ["line 1", "line 2", "line 3"])

--- a/spec/integration/codegen_loop_guard_test.almd
+++ b/spec/integration/codegen_loop_guard_test.almd
@@ -57,7 +57,7 @@ test "do block find smallest factor" {
 
 test "for with guard continue filtering" {
   var odds: List[Int] = []
-  for i in 1..=20 {
+  for i in 1...20 {
     guard i % 2 != 0 else continue
     guard i <= 15 else break
     odds = odds + [i]
@@ -72,7 +72,7 @@ test "do block containing for with guard" {
   var total = 0
   while batch < 3 {
     var batch_sum = 0
-    for i in 1..=5 {
+    for i in 1...5 {
       guard i != 3 else continue
       batch_sum = batch_sum + i
     }
@@ -116,7 +116,7 @@ effect fn power_mod(base: Int, exp: Int, modulus: Int) -> Result[Int, String] = 
   guard modulus > 0 else err("modulus must be positive")
   guard exp >= 0 else err("exponent must be non-negative")
   var result = 1
-  for _i in 0..exp {
+  for _i in 0..<exp {
     result = (result * base) % modulus
   }
   ok(result % modulus)

--- a/spec/integration/licm_test.almd
+++ b/spec/integration/licm_test.almd
@@ -7,7 +7,7 @@ fn add(a: Int, b: Int) -> Int = a + b
 test "list.len hoisted" {
   let xs = [1, 2, 3, 4, 5]
   var total = 0
-  for i in 0..100 {
+  for i in 0..<100 {
     if i < list.len(xs) then total = total + 1
     else total = total
   }
@@ -18,7 +18,7 @@ test "list.len hoisted" {
 test "pure user fn hoisted" {
   let n = 7
   var total = 0
-  for i in 0..10 {
+  for i in 0..<10 {
     total = total + square(n)
   }
   assert_eq(total, 490)
@@ -27,7 +27,7 @@ test "pure user fn hoisted" {
 // Impure: list.push must NOT be hoisted
 test "list.push not hoisted" {
   var xs: List[Int] = []
-  for i in 0..5 {
+  for i in 0..<5 {
     list.push(xs, i)
   }
   assert_eq(list.len(xs), 5)
@@ -38,7 +38,7 @@ test "list.push not hoisted" {
 // Impure: bytes.push must NOT be hoisted
 test "bytes.push not hoisted" {
   var buf = bytes.new(0)
-  for i in 0..3 {
+  for i in 0..<3 {
     bytes.push(buf, 65 + i)
   }
   assert_eq(bytes.len(buf), 3)
@@ -80,7 +80,7 @@ test "nested for loops" {
 test "list.len with loop-modified list" {
   var xs: List[Int] = []
   var lengths: List[Int] = []
-  for i in 0..3 {
+  for i in 0..<3 {
     list.push(xs, i)
     lengths = lengths + [list.len(xs)]
   }

--- a/spec/integration/modules/cross_module_global_state_loop_test.almd
+++ b/spec/integration/modules/cross_module_global_state_loop_test.almd
@@ -16,7 +16,7 @@ test "while-loop cross-module scalar accumulation" {
 
 test "for-loop cross-module list-slot accumulation" {
   gstate.reset()
-  for _ in 0..8 {
+  for _ in 0..<8 {
     gstate.bump_at(1, 0.25)
   }
   assert_eq(gstate.get_at(1), 2.0);

--- a/spec/integration/peephole_test.almd
+++ b/spec/integration/peephole_test.almd
@@ -40,7 +40,7 @@ test "reverse single element" {
 test "rotate left pattern" {
   var xs = [1, 2, 3, 4, 5]
   let p0 = xs[0]
-  for i in 0..4 { xs[i] = xs[i + 1] }
+  for i in 0..<4 { xs[i] = xs[i + 1] }
   xs[4] = p0
   assert_eq(xs, [2, 3, 4, 5, 1])
 }
@@ -48,7 +48,7 @@ test "rotate left pattern" {
 test "rotate left partial" {
   var xs = [10, 20, 30, 40, 50]
   let p0 = xs[0]
-  for i in 0..2 { xs[i] = xs[i + 1] }
+  for i in 0..<2 { xs[i] = xs[i + 1] }
   xs[2] = p0
   assert_eq(xs[0], 20)
   assert_eq(xs[1], 30)
@@ -59,7 +59,7 @@ test "rotate left partial" {
 test "copy pattern" {
   var src = [100, 200, 300, 400]
   var dst = [0, 0, 0, 0]
-  for i in 0..4 { dst[i] = src[i] }
+  for i in 0..<4 { dst[i] = src[i] }
   assert_eq(dst, [100, 200, 300, 400])
 }
 

--- a/spec/lang/closure_nested_capture_test.almd
+++ b/spec/lang/closure_nested_capture_test.almd
@@ -2,8 +2,8 @@
 // captured through multiple lambda levels work correctly.
 
 fn make(n: Int) -> List[List[Int]] =
-  0..2 |> list.map((i) =>
-    0..n |> list.map((j) => i + j)
+  0..<2 |> list.map((i) =>
+    0..<n |> list.map((j) => i + j)
   )
 
 test "nested capture of function param" {
@@ -16,8 +16,8 @@ test "nested capture of function param" {
 }
 
 fn wave(w: Int) -> List[String] =
-  0..3 |> list.map((row) =>
-    0..w |> list.map((col) => {
+  0..<3 |> list.map((row) =>
+    0..<w |> list.map((col) => {
       let v = (row + col) % 4
       if v == 0 then "A" else if v == 1 then "B" else if v == 2 then "C" else "D"
     }) |> list.join("")
@@ -30,8 +30,8 @@ test "nested capture: wave pattern" {
 }
 
 fn grid(rows: Int, cols: Int) -> List[String] =
-  0..rows |> list.map((r) =>
-    0..cols |> list.map((c) => int.to_string(r * cols + c)) |> list.join(",")
+  0..<rows |> list.map((r) =>
+    0..<cols |> list.map((c) => int.to_string(r * cols + c)) |> list.join(",")
   )
 
 test "nested capture: two params" {
@@ -40,9 +40,9 @@ test "nested capture: two params" {
 }
 
 fn triple_nest(n: Int) -> List[List[List[Int]]] =
-  0..2 |> list.map((i) =>
-    0..2 |> list.map((j) =>
-      0..n |> list.map((k) => i + j + k)
+  0..<2 |> list.map((i) =>
+    0..<2 |> list.map((j) =>
+      0..<n |> list.map((k) => i + j + k)
     )
   )
 

--- a/spec/lang/control_flow_test.almd
+++ b/spec/lang/control_flow_test.almd
@@ -124,7 +124,7 @@ test "for in list" {
 
 test "for in range" {
   var sum = 0;
-  for i in 0..5 {
+  for i in 0..<5 {
     sum = sum + i;
   };
   assert_eq(sum, 10)
@@ -132,7 +132,7 @@ test "for in range" {
 
 test "for in inclusive range" {
   var sum = 0;
-  for i in 1..=5 {
+  for i in 1...5 {
     sum = sum + i;
   };
   assert_eq(sum, 15)
@@ -166,8 +166,8 @@ test "for with zip" {
 
 test "nested for" {
   var sum = 0;
-  for i in 0..3 {
-    for j in 0..3 {
+  for i in 0..<3 {
+    for j in 0..<3 {
       sum = sum + 1;
     };
   };
@@ -408,7 +408,7 @@ test "for with index counter var" {
 
 test "for in large range" {
   var sum = 0;
-  for i in 0..100 {
+  for i in 0..<100 {
     sum = sum + 1;
   };
   assert_eq(sum, 100)
@@ -416,8 +416,8 @@ test "for in large range" {
 
 test "for nested with accumulation" {
   var pairs: List[String] = [];
-  for i in 0..3 {
-    for j in 0..3 {
+  for i in 0..<3 {
+    for j in 0..<3 {
       pairs = pairs + [
         "${int.to_string(i)}${int.to_string(j)}"
       ];
@@ -452,7 +452,7 @@ test "do guard with complex condition" {
 
 test "for guard continue skip odds" {
   var evens: List[Int] = [];
-  for x in 1..=10 {
+  for x in 1...10 {
     guard x % 2 == 0 else continue;
     evens = evens + [x];
   };

--- a/spec/lang/edge_cases_test.almd
+++ b/spec/lang/edge_cases_test.almd
@@ -182,7 +182,7 @@ test "deeply nested if expression" {
 
 test "many-element list" {
   var xs: List[Int] = [];
-  for i in 0..50 {
+  for i in 0..<50 {
     xs = xs + [i];
   };
   assert_eq(list.len(xs), 50);

--- a/spec/lang/for_test.almd
+++ b/spec/lang/for_test.almd
@@ -19,7 +19,7 @@ test "for over empty list" {
 
 test "for over range" {
   var sum = 0;
-  for i in 0..5 {
+  for i in 0..<5 {
     sum = sum + i;
   };
   assert_eq(sum, 10)
@@ -45,7 +45,7 @@ test "for over map" {
 
 test "for building a list" {
   var items: List[String] = [];
-  for i in 0..3 {
+  for i in 0..<3 {
     items = items + [
       "item ${i}"
     ];
@@ -55,8 +55,8 @@ test "for building a list" {
 
 test "nested for loops" {
   var count = 0;
-  for _ in 0..4 {
-    for _ in 0..3 {
+  for _ in 0..<4 {
+    for _ in 0..<3 {
       count = count + 1;
     };
   };
@@ -75,7 +75,7 @@ test "for with var mutation" {
 
 test "for with guard continue" {
   var evens: List[Int] = [];
-  for i in 0..10 {
+  for i in 0..<10 {
     guard i % 2 == 0 else continue;
     evens = evens + [i];
   };

--- a/spec/lang/function_test.almd
+++ b/spec/lang/function_test.almd
@@ -269,7 +269,7 @@ test "function call in if condition" {
 
 fn repeat_(f: fn(Int) -> Int, n: Int, x: Int) -> Int = {
   var result = x;
-  for _i in 0..n {
+  for _i in 0..<n {
     result = f(result);
   };
   result

--- a/spec/lang/guard_test.almd
+++ b/spec/lang/guard_test.almd
@@ -62,7 +62,7 @@ test "nested do blocks" {
 
 test "guard with continue in for" {
   var sum = 0;
-  for i in 0..10 {
+  for i in 0..<10 {
     guard i % 2 == 0 else continue;
     sum = sum + i;
   };

--- a/spec/lang/index_access_test.almd
+++ b/spec/lang/index_access_test.almd
@@ -46,7 +46,7 @@ test "bytes index in expression" {
 
 test "bytes range slice" {
   var buf: Bytes = bytes.from_list([10, 20, 30, 40, 50])
-  let sub = buf[1..3]
+  let sub = buf[1..<3]
   assert_eq(bytes.len(sub), 2)
   assert_eq(sub[0], 20)
   assert_eq(sub[1], 30)
@@ -54,7 +54,7 @@ test "bytes range slice" {
 
 test "bytes range inclusive" {
   var buf: Bytes = bytes.from_list([10, 20, 30, 40, 50])
-  let sub = buf[1..=3]
+  let sub = buf[1...3]
   assert_eq(bytes.len(sub), 3)
   assert_eq(sub[0], 20)
   assert_eq(sub[2], 40)
@@ -62,7 +62,7 @@ test "bytes range inclusive" {
 
 test "list range slice" {
   let xs = [10, 20, 30, 40, 50]
-  let sub = xs[1..4]
+  let sub = xs[1..<4]
   assert_eq(list.len(sub), 3)
   assert_eq(sub[0], 20)
   assert_eq(sub[2], 40)
@@ -70,7 +70,7 @@ test "list range slice" {
 
 test "list range inclusive" {
   let xs = [10, 20, 30, 40, 50]
-  let sub = xs[0..=2]
+  let sub = xs[0...2]
   assert_eq(list.len(sub), 3)
   assert_eq(sub[0], 10)
   assert_eq(sub[2], 30)

--- a/spec/lang/member_index_borrow_test.almd
+++ b/spec/lang/member_index_borrow_test.almd
@@ -33,7 +33,7 @@ test "member-container index borrow direct" {
 
 fn pass2(node: Node, line: Line, n: Int) -> Float = {
   var t = 0.0
-  for ii in 0..n {
+  for ii in 0..<n {
     let child = node.children[line.items[ii].idx]
     t = t + child.grow * line.items[ii].basis
   }
@@ -48,7 +48,7 @@ test "chained index-member scalar reads" {
 
 fn sum_items(line: Line, n: Int) -> Float = {
   var t = 0.0
-  for ii in 0..n {
+  for ii in 0..<n {
     t = t + line.items[ii].basis
   }
   t
@@ -61,12 +61,12 @@ test "scalar index through a member-field list" {
 
 fn rebind_read(n: Int) -> Float = {
   var a: List[Float] = []
-  for i in 0..n { a = a + [int.to_float(i) + 1.0] }
+  for i in 0..<n { a = a + [int.to_float(i) + 1.0] }
   var b: List[Float] = []
-  for i in 0..n { b = b + [a[i] * 3.0] }
+  for i in 0..<n { b = b + [a[i] * 3.0] }
   a = b
   var t = 0.0
-  for i in 0..n { t = t + a[i] }
+  for i in 0..<n { t = t + a[i] }
   t
 }
 

--- a/spec/lang/protocol_advanced_test.almd
+++ b/spec/lang/protocol_advanced_test.almd
@@ -150,7 +150,7 @@ type Stamp: Replicable = { mark: String }
 
 fn Stamp.replicate(s: Stamp, n: Int) -> List[String] = {
   var result: List[String] = [];
-  for _ in 0..n {
+  for _ in 0..<n {
     result = result + [
       s.mark
     ];

--- a/spec/lang/range_test.almd
+++ b/spec/lang/range_test.almd
@@ -2,7 +2,7 @@
 // range_test — Range expressions and iteration
 test "basic range in for" {
   var sum = 0;
-  for i in 0..5 {
+  for i in 0..<5 {
     sum = sum + i;
   };
   assert_eq(sum, 10)
@@ -10,7 +10,7 @@ test "basic range in for" {
 
 test "range starts at non-zero" {
   var sum = 0;
-  for i in 3..6 {
+  for i in 3..<6 {
     sum = sum + i;
   };
   assert_eq(sum, 12)
@@ -18,7 +18,7 @@ test "range starts at non-zero" {
 
 test "inclusive range" {
   var count = 0;
-  for _ in 0..=5 {
+  for _ in 0...5 {
     count = count + 1;
   };
   assert_eq(count, 6)
@@ -26,7 +26,7 @@ test "inclusive range" {
 
 test "range zero iterations" {
   var count = 0;
-  for _ in 5..5 {
+  for _ in 5..<5 {
     count = count + 1;
   };
   assert_eq(count, 0)
@@ -34,7 +34,7 @@ test "range zero iterations" {
 
 test "range single iteration" {
   var count = 0;
-  for _ in 0..1 {
+  for _ in 0..<1 {
     count = count + 1;
   };
   assert_eq(count, 1)
@@ -44,7 +44,7 @@ test "range with variable bounds" {
   let start = 2;
   let end = 7;
   var sum = 0;
-  for i in start..end {
+  for i in start..<end {
     sum = sum + i;
   };
   assert_eq(sum, 20)
@@ -52,7 +52,7 @@ test "range with variable bounds" {
 
 test "range collecting to list" {
   var result: List[Int] = [];
-  for i in 0..4 {
+  for i in 0..<4 {
     result = result + [i];
   };
   assert_eq(result, [0, 1, 2, 3])
@@ -60,8 +60,8 @@ test "range collecting to list" {
 
 test "range in nested loop" {
   var count = 0;
-  for _ in 0..3 {
-    for _ in 0..4 {
+  for _ in 0..<3 {
+    for _ in 0..<4 {
       count = count + 1;
     };
   };
@@ -70,7 +70,7 @@ test "range in nested loop" {
 
 test "inclusive range boundary" {
   var last = -1;
-  for i in 0..=0 {
+  for i in 0...0 {
     last = i;
   };
   assert_eq(last, 0)
@@ -78,7 +78,7 @@ test "inclusive range boundary" {
 
 test "range with large step accumulator" {
   var sum = 0;
-  for i in 0..100 {
+  for i in 0..<100 {
     sum = sum + i;
   };
   assert_eq(sum, 4950)

--- a/spec/lang/region_window_test.almd
+++ b/spec/lang/region_window_test.almd
@@ -18,7 +18,7 @@ fn check(tree: Tree) -> Int = match tree {
 // resets between iterations; every tree must count the same).
 fn sum_checks(n: Int, depth: Int) -> Int = {
   var total = 0
-  for _ in 0..n {
+  for _ in 0..<n {
     total = total + check(make(depth))
   }
   total
@@ -52,7 +52,7 @@ test "held tree (no window): the value survives multiple consumers" {
 test "windows interleave with unrelated heap use" {
   var xs: List[Int] = []
   var total = 0
-  for i in 0..3 {
+  for i in 0..<3 {
     total = total + check(make(2))
     list.push(xs, i * 10)
   }
@@ -79,7 +79,7 @@ fn sum_w(t: Weighted) -> Int = match t {
 
 test "region compact: scalar field packs next to handle fields" {
   var total = 0
-  for _ in 0..3 {
+  for _ in 0..<3 {
     total = total + sum_w(make_w(3))
   }
   assert_eq(total, 3 * 11)
@@ -102,7 +102,7 @@ fn count_t(t: Tri) -> Int = match t {
 
 test "region compact: two singletons chain the tag select" {
   var total = 0
-  for _ in 0..3 {
+  for _ in 0..<3 {
     total = total + count_t(make_t(6))
   }
   assert_eq(total, 3 * 21)
@@ -124,7 +124,7 @@ fn sum_f(t: FTree) -> Float = match t {
 
 test "region compact: float payload is bit-exact through the packed slot" {
   var total = 0.0
-  for _ in 0..2 {
+  for _ in 0..<2 {
     total = total + sum_f(make_f(3, 1.5))
   }
   // S(d,x) = x + 2*S(d-1, x+0.25); S(3, 1.5) = 13.0
@@ -144,9 +144,9 @@ test "region window: frontier grow inside one region" {
 // and every tree must still count the same.
 test "region windows interleave with free-list churn" {
   var total = 0
-  for i in 0..50 {
+  for i in 0..<50 {
     var xs: List[Int] = []
-    for j in 0..20 {
+    for j in 0..<20 {
       list.push(xs, i + j)
     }
     total = total + check(make(6)) + xs[19]

--- a/spec/lang/scope_test.almd
+++ b/spec/lang/scope_test.almd
@@ -164,7 +164,7 @@ test "scope in if-else blocks" {
 
 test "var mutation visible after block" {
   var x = 0;
-  for i in 1..=5 {
+  for i in 1...5 {
     x = x + i;
   };
   assert_eq(x, 15);
@@ -175,7 +175,7 @@ test "var mutation visible after block" {
 test "for loop body scope isolation" {
   let prefix = "item";
   var items: List[String] = [];
-  for i in 0..3 {
+  for i in 0..<3 {
     let label = prefix + int.to_string(i);
     items = items + [label];
   };

--- a/spec/lang/variable_test.almd
+++ b/spec/lang/variable_test.almd
@@ -119,7 +119,7 @@ test "multiple vars" {
   var a = 0;
   var b = 0;
   var c = 0;
-  for i in 1..=10 {
+  for i in 1...10 {
     a = a + 1;
     b = b + i;
     c = c + i * i;
@@ -145,7 +145,7 @@ test "let record destructure" {
 
 test "var list build in for" {
   var xs: List[String] = [];
-  for i in 0..5 {
+  for i in 0..<5 {
     xs = xs + [int.to_string(i)];
   };
   assert_eq(xs, ["0", "1", "2", "3", "4"])
@@ -186,7 +186,7 @@ test "var swap pattern" {
 
 test "var string building" {
   var result = "";
-  for i in 1..=5 {
+  for i in 1...5 {
     if i > 1 then {
       result = result + ", ";
     } else { () };
@@ -197,7 +197,7 @@ test "var string building" {
 
 test "var index assign multiple" {
   var xs = [0, 0, 0, 0, 0];
-  for i in 0..5 {
+  for i in 0..<5 {
     xs[i] = i * 10;
   };
   assert_eq(xs, [0, 10, 20, 30, 40])

--- a/spec/stdlib/list_map_range_test.almd
+++ b/spec/stdlib/list_map_range_test.almd
@@ -9,10 +9,10 @@ fn lerp(a: Vec2, b: Vec2, t: Float) -> Vec2 =
   { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t }
 
 test "range map scalar" {
-  assert_eq(0..5 |> list.map((i) => i * i), [0, 1, 4, 9, 16]);
-  assert_eq(1..=3 |> list.map((i) => i * 10), [10, 20, 30]);
-  assert_eq(list.len(3..3 |> list.map((i) => i)), 0);
-  assert_eq(2..6 |> list.map((i) => i + 100), [102, 103, 104, 105])
+  assert_eq(0..<5 |> list.map((i) => i * i), [0, 1, 4, 9, 16]);
+  assert_eq(1...3 |> list.map((i) => i * 10), [10, 20, 30]);
+  assert_eq(list.len(3..<3 |> list.map((i) => i)), 0);
+  assert_eq(2..<6 |> list.map((i) => i + 100), [102, 103, 104, 105])
 }
 
 test "range map record elements with heap captures" {
@@ -21,7 +21,7 @@ test "range map record elements with heap captures" {
   let color = [0.5, 0.6]
   let n = 4
   let nf = int.to_float(n)
-  let segs = 0..n |> list.map((i) => {
+  let segs = 0..<n |> list.map((i) => {
     let t0 = int.to_float(i) / nf
     let t1 = int.to_float(i + 1) / nf
     { p0: lerp(a, b, t0), p1: lerp(a, b, t1), color: color, path_id: 7 }
@@ -34,7 +34,7 @@ test "range map record elements with heap captures" {
 }
 
 test "range map scalar-only record elements" {
-  let pts = 0..3 |> list.map((i) => { px: i, py: i * 2, on: i == 1 })
+  let pts = 0..<3 |> list.map((i) => { px: i, py: i * 2, on: i == 1 })
   let shown = pts
     |> list.map((p) => int.to_string(p.px) + ":" + int.to_string(p.py) + ":" + (if p.on then "T" else "F"))
     |> list.join(",")

--- a/spec/stdlib/random_test.almd
+++ b/spec/stdlib/random_test.almd
@@ -78,7 +78,7 @@ effect fn rand_shuffle_single() -> Result[List[String], String] = {
 
 effect fn rand_int_repeated_in_range() -> Result[Bool, String] = {
   var all_in_range = true;
-  for i in 0..20 {
+  for i in 0..<20 {
     let n = random.int(1, 5);
     if n < 1 or n > 5 then {
       all_in_range = false;

--- a/spec/wasm_cross/bytes_set_value_semantics.almd
+++ b/spec/wasm_cross/bytes_set_value_semantics.almd
@@ -21,7 +21,7 @@ type St = { iv: Bytes }
 
 fn rotate(state: St, n: Int) -> Bytes = {
   var iv = state.iv
-  for _i in 0..n {
+  for _i in 0..<n {
     let first = bytes.read_u8(iv, 0)
     iv = bytes.concat(bytes.slice(iv, 1, 4), bytes.from_list([first + 10]))
   }
@@ -51,7 +51,7 @@ fn main() -> Unit = {
 
   // The fast self-update path still works (fresh, unaliased buffer).
   var buf = bytes.new(4)
-  for i in 0..4 {
+  for i in 0..<4 {
     buf = bytes.set(buf, i, (i + 1) * 3)
   }
   println(bytes.to_list(buf) |> list.map((x) => int.to_string(x)) |> list.join(","))

--- a/spec/wasm_cross/cross_module_spread.almd
+++ b/spec/wasm_cross/cross_module_spread.almd
@@ -41,17 +41,17 @@ fn tw_tick(tw: Tw, dt: Float) -> Tw = {
 
 fn main() -> Unit = {
   var items: List[Tw] = []
-  for i in 0..5 {
+  for i in 0..<5 {
     items = items + [tw_make(0.0, 1.0, 100.0)]
   }
   // tick all
   var out: List[Tw] = []
-  for i in 0..5 {
+  for i in 0..<5 {
     out = out + [tw_tick(items[i], 10.0)]
   }
   // second tick loop (2 for+concat loops = trigger condition)
   var out2: List[Tw] = []
-  for i in 0..5 {
+  for i in 0..<5 {
     out2 = out2 + [tw_tick(out[i], 10.0)]
   }
   println(float.to_string(out2[0].h))

--- a/spec/wasm_cross/heap_arena.almd
+++ b/spec/wasm_cross/heap_arena.almd
@@ -22,7 +22,7 @@ fn arena_round(base: Int) -> Int = {
   let cp = bytes.heap_save()
   // Scratch work whose memory is reclaimable after restore.
   var scratch: List[Int] = []
-  for i in 0..100 { list.push(scratch, base + i) }
+  for i in 0..<100 { list.push(scratch, base + i) }
   var s = 0
   for x in scratch { s = s + x }
   bytes.heap_restore(cp)
@@ -34,14 +34,14 @@ fn main() -> Unit = {
   // ignored (native). Either way the sums must be identical and the heap must
   // stay coherent for the FINAL persistent structure built afterward.
   var acc = 0
-  for r in 0..40 {
+  for r in 0..<40 {
     acc = acc + arena_round(r * 10)
   }
   println(int.to_string(acc))
 
   // After all the save/restore churn, a fresh persistent list must be intact.
   var persist: List[Int] = []
-  for i in 0..50 { list.push(persist, i * i) }
+  for i in 0..<50 { list.push(persist, i * i) }
   var psum = 0
   for x in persist { psum = psum + x }
   println(int.to_string(psum) + " " + int.to_string(persist[7]) + " " + int.to_string(list.len(persist)))
@@ -49,7 +49,7 @@ fn main() -> Unit = {
   // Nested checkpoint/restore: inner restore must not corrupt outer live data.
   let cp_outer = bytes.heap_save()
   var outer_live: List[Int] = []
-  for i in 0..10 { list.push(outer_live, i + 1) }
+  for i in 0..<10 { list.push(outer_live, i + 1) }
   let inner = arena_round(1000)          // takes + restores its own checkpoint
   var ol_sum = 0
   for x in outer_live { ol_sum = ol_sum + x }   // outer must still read 1..10 = 55

--- a/spec/wasm_cross/heap_result_if_record_arm.almd
+++ b/spec/wasm_cross/heap_result_if_record_arm.almd
@@ -7,7 +7,7 @@ fn tl(x: Int) -> { tag: Int, len: Int, hdr: Int } =
   if x < 0x80 then { tag: 1, len: x, hdr: 2 }
   else {
     var len = 0
-    for i in 0..2 { len = len + x }
+    for i in 0..<2 { len = len + x }
     { tag: 1, len: len, hdr: 3 }
   }
 fn main() -> Unit = {

--- a/spec/wasm_cross/list_comprehensive.almd
+++ b/spec/wasm_cross/list_comprehensive.almd
@@ -18,7 +18,7 @@ fn main() -> Unit = {
 
   // push (capacity growth)
   var ys: List[Int] = []
-  for i in 0..25 { list.push(ys, i * 2) }
+  for i in 0..<25 { list.push(ys, i * 2) }
   println(int.to_string(list.len(ys)) + " " + int.to_string(ys[24]))
 
   // pop
@@ -28,7 +28,7 @@ fn main() -> Unit = {
 
   // with_capacity
   var ws = list.with_capacity(32)
-  for i in 0..10 { list.push(ws, i) }
+  for i in 0..<10 { list.push(ws, i) }
   println(int.to_string(ws[9]))
 
   // slice / take / drop

--- a/spec/wasm_cross/list_index_element_append.almd
+++ b/spec/wasm_cross/list_index_element_append.almd
@@ -24,7 +24,7 @@ type P = { x: Float, y: Float, on: Bool }
 fn rotate_from(ps: List[P], start: Int) -> List[P] = {
   let n = list.len(ps)
   var out: List[P] = []
-  for i in 0..n {
+  for i in 0..<n {
     out = out + [ps[(i + start) % n]]
   }
   out
@@ -65,7 +65,7 @@ fn main() -> Unit = {
   // element that is a fresh literal next to an indexed one — the two element
   // shapes side by side in one accumulator.
   var mixed: List[P] = []
-  for i in 0..list.len(ps) {
+  for i in 0..<list.len(ps) {
     mixed = mixed + [ps[i]]
     mixed = mixed + [P { x: 0.0, y: 0.0, on: false }]
   }
@@ -80,10 +80,10 @@ fn main() -> Unit = {
   var k = 0
   while k < 8 {
     var src: List[P] = []
-    for i in 0..3 {
+    for i in 0..<3 {
       src = src + [P { x: int.to_float(k * 10 + i), y: 0.0, on: true }]
     }
-    for i in 0..3 {
+    for i in 0..<3 {
       keep = keep + [src[i]]
     }
     k = k + 1

--- a/spec/wasm_cross/memory_stress.almd
+++ b/spec/wasm_cross/memory_stress.almd
@@ -3,7 +3,7 @@
 
 fn count_matches(xs: List[Int], expected: (Int) -> Int, n: Int) -> Int = {
   var pass = 0
-  for i in 0..n {
+  for i in 0..<n {
     pass = if xs[i] == expected(i) then pass + 1 else pass
   }
   pass
@@ -11,21 +11,21 @@ fn count_matches(xs: List[Int], expected: (Int) -> Int, n: Int) -> Int = {
 
 fn test_push_verify_all() -> String = {
   var xs: List[Int] = []
-  for i in 0..100 { list.push(xs, i * 7 + 3) }
+  for i in 0..<100 { list.push(xs, i * 7 + 3) }
   let pass = count_matches(xs, (i) => i * 7 + 3, 100)
   int.to_string(pass)
 }
 
 fn test_repeat_index_assign_all() -> String = {
   var xs = list.repeat(0, 50)
-  for i in 0..50 { xs[i] = (i + 1) * 11 }
+  for i in 0..<50 { xs[i] = (i + 1) * 11 }
   let pass = count_matches(xs, (i) => (i + 1) * 11, 50)
   int.to_string(pass)
 }
 
 fn test_nested_list() -> String = {
   var outer: List[List[Int]] = []
-  for i in 0..10 {
+  for i in 0..<10 {
     outer = outer + [[i * 100, i * 100 + 1, i * 100 + 2]]
   }
   let v = outer[5]
@@ -34,9 +34,9 @@ fn test_nested_list() -> String = {
 
 fn test_push_pop_integrity() -> String = {
   var xs: List[Int] = []
-  for i in 0..20 { list.push(xs, i) }
-  for _ in 0..10 { list.pop(xs) }
-  for i in 0..10 { list.push(xs, 100 + i) }
+  for i in 0..<20 { list.push(xs, i) }
+  for _ in 0..<10 { list.pop(xs) }
+  for i in 0..<10 { list.push(xs, 100 + i) }
   let a = int.to_string(xs[0]) + " " + int.to_string(xs[9])
   let b = int.to_string(xs[10]) + " " + int.to_string(xs[19])
   a + " " + b
@@ -66,7 +66,7 @@ fn test_forin_with_parallel_push() -> String = {
 
 fn test_many_small_lists() -> String = {
   var lists: List[List[Int]] = []
-  for i in 0..100 {
+  for i in 0..<100 {
     lists = lists + [[i, i + 1, i + 2]]
   }
   let first = lists[0]
@@ -77,13 +77,13 @@ fn test_many_small_lists() -> String = {
 
 fn test_large_string_list() -> String = {
   var xs: List[String] = []
-  for i in 0..30 { list.push(xs, "item_" + int.to_string(i)) }
+  for i in 0..<30 { list.push(xs, "item_" + int.to_string(i)) }
   xs[0] + " " + xs[15] + " " + xs[29] + " " + int.to_string(list.len(xs))
 }
 
 fn test_filter_map_chain() -> String = {
   var ys: List[Int] = []
-  for i in 0..50 { ys = ys + [i] }
+  for i in 0..<50 { ys = ys + [i] }
   let result = ys
     |> list.filter((x) => x % 3 == 0)
     |> list.map((x) => x * x)
@@ -104,7 +104,7 @@ fn test_concurrent_push_11_lists() -> String = {
   var l8: List[Int] = []
   var l9: List[Int] = []
   var l10: List[Int] = []
-  for i in 0..25 {
+  for i in 0..<25 {
     list.push(l0, i)
     list.push(l1, i + 100)
     list.push(l2, i + 200)

--- a/spec/wasm_cross/mg_rebuild_two_phase.almd
+++ b/spec/wasm_cross/mg_rebuild_two_phase.almd
@@ -15,14 +15,14 @@ fn bump(r: Rec, d: Float) -> Rec = { a: r.a + d, b: r.b }
 fn init() -> Unit = {
   count = 3
   items = []
-  for i in 0..count {
+  for i in 0..<count {
     items = items + [{ a: int.to_float(i), b: int.to_float(i) * 2.0 }]
   }
 }
 
 fn tick_a(d: Float) -> Unit = {
   var out: List[Rec] = []
-  for i in 0..count {
+  for i in 0..<count {
     out = out + [bump(items[i], d)]
   }
   items = out
@@ -30,7 +30,7 @@ fn tick_a(d: Float) -> Unit = {
 
 fn tick_b(d: Float) -> Unit = {
   var out: List[Rec] = []
-  for i in 0..count {
+  for i in 0..<count {
     out = out + [bump(items[i], d)]
   }
   items = out

--- a/spec/wasm_cross/nested_scalar_record_append.almd
+++ b/spec/wasm_cross/nested_scalar_record_append.almd
@@ -8,7 +8,7 @@ type P = { x: Int, y: Int, on: Bool }
 
 fn build(n: Int) -> List[P] = {
   var ps: List[P] = []
-  for i in 0..n {
+  for i in 0..<n {
     ps = ps + [{ x: i, y: i * 2, on: i == 1 }]
   }
   ps
@@ -16,7 +16,7 @@ fn build(n: Int) -> List[P] = {
 
 fn groups(n: Int) -> List[List[P]] = {
   var gs: List[List[P]] = []
-  for i in 0..n {
+  for i in 0..<n {
     gs = gs + [build(i)]
   }
   gs

--- a/spec/wasm_cross/random_int_entropy.almd
+++ b/spec/wasm_cross/random_int_entropy.almd
@@ -7,7 +7,7 @@
 import random
 effect fn main() -> Unit = {
   var hits = 0
-  for i in 0..50 {
+  for i in 0..<50 {
     let r = random.int(10, 20)
     if r >= 10 and r <= 20 then hits = hits + 1 else hits = hits
   }

--- a/spec/wasm_cross/rc_alloc_stress.almd
+++ b/spec/wasm_cross/rc_alloc_stress.almd
@@ -20,7 +20,7 @@
 // alloc + realloc growth: push N elements, sum must be exact.
 fn test_growth_sum() -> String = {
   var xs: List[Int] = []
-  for i in 0..1000 { list.push(xs, i) }
+  for i in 0..<1000 { list.push(xs, i) }
   var total = 0
   for x in xs { total = total + x }
   int.to_string(total) + " " + int.to_string(list.len(xs))   // 499500 1000
@@ -29,9 +29,9 @@ fn test_growth_sum() -> String = {
 // string_alloc growth: builder loop with interleaved reads.
 fn test_string_builder() -> String = {
   var s = ""
-  for _ in 0..200 { s = s + "x" }
+  for _ in 0..<200 { s = s + "x" }
   var dots = ""
-  for i in 0..50 { dots = dots + "." + int.to_string(i % 10) }
+  for i in 0..<50 { dots = dots + "." + int.to_string(i % 10) }
   int.to_string(string.len(s)) + " " + int.to_string(string.len(dots)) + " " + string.slice(dots, 0, 6)
 }
 
@@ -39,14 +39,14 @@ fn test_string_builder() -> String = {
 // A refcount imbalance corrupts a later allocation reusing freed blocks.
 fn build_nested(seed: Int) -> List[List[Int]] = {
   var outer: List[List[Int]] = []
-  for i in 0..20 {
+  for i in 0..<20 {
     outer = outer + [[seed + i, seed + i * 2, seed + i * 3]]
   }
   outer
 }
 fn test_rc_churn() -> String = {
   var checksum = 0
-  for round in 0..50 {
+  for round in 0..<50 {
     let nested = build_nested(round * 100)
     let mid = nested[10]
     checksum = checksum + mid[2]      // (round*100 + 30) summed over 50 rounds
@@ -57,9 +57,9 @@ fn test_rc_churn() -> String = {
 // Map insert/lookup churn (alloc/rehash + rc on string keys). map.insert mutates.
 fn test_map_churn() -> String = {
   var hits = 0
-  for round in 0..30 {
+  for round in 0..<30 {
     var m = map.new()
-    for i in 0..40 {
+    for i in 0..<40 {
       map.insert(m, "k" + int.to_string(i), i * round)
     }
     let v = map.get(m, "k20") ?? -1
@@ -71,9 +71,9 @@ fn test_map_churn() -> String = {
 // Set insert/contains churn. set.insert returns a new set.
 fn test_set_churn() -> String = {
   var found = 0
-  for _ in 0..30 {
+  for _ in 0..<30 {
     var s = set.new()
-    for i in 0..40 { s = set.insert(s, i * 2) }
+    for i in 0..<40 { s = set.insert(s, i * 2) }
     found = found + (if set.contains(s, 40) then 1 else 0)
     found = found + (if set.contains(s, 41) then 1 else 0)
   }
@@ -85,7 +85,7 @@ fn sum_to(n: Int) -> Int =
   if n <= 0 then 0 else n + sum_to(n - 1)
 fn test_deep_alloc() -> String = {
   var acc = 0
-  for k in 0..100 {
+  for k in 0..<100 {
     let xs = list.repeat(k, k % 10 + 1)
     var s = 0
     for x in xs { s = s + x }

--- a/spec/wasm_cross/zip_view_shape.almd
+++ b/spec/wasm_cross/zip_view_shape.almd
@@ -24,7 +24,7 @@ fn zipish(view: View, rx: Float, rh: Float, idx: Int) -> Zip = {
     let ih = view._item_height
     frame_h = rh
     let total = list.len(view._children)
-    for i in 0..total {
+    for i in 0..<total {
       let child = view._children[i]
       let cs = child._style
       let iy = rx + int.to_float(i) * ih

--- a/spec/wasm_cross_pkg/main.almd
+++ b/spec/wasm_cross_pkg/main.almd
@@ -8,7 +8,7 @@ fn init() -> Unit = {
   count = 4
   items = []
   let easings = [ease.LINEAR, ease.OUT_CUBIC, ease.IN_OUT_QUAD, ease.OUT_ELASTIC]
-  for i in 0..count {
+  for i in 0..<count {
     let t0 = tw.create(0.0, 1.0, 1200.0)
     let t1 = tw.with_easing(t0, easings[i])
     let t2 = tw.with_delay(t1, int.to_float(i) * 80.0)
@@ -20,7 +20,7 @@ fn init() -> Unit = {
 
 fn tick_a(dt: Float) -> Unit = {
   var out: List[tw.Tween] = []
-  for i in 0..count {
+  for i in 0..<count {
     out = out + [tw.tick(items[i], dt)]
   }
   items = out
@@ -28,7 +28,7 @@ fn tick_a(dt: Float) -> Unit = {
 
 fn tick_b(dt: Float) -> Unit = {
   var out: List[tw.Tween] = []
-  for i in 0..count {
+  for i in 0..<count {
     out = out + [tw.tick(items[i], dt)]
   }
   items = out

--- a/src/cli/fix.rs
+++ b/src/cli/fix.rs
@@ -31,6 +31,7 @@ struct FixReport<'a> {
     imports_added: Vec<String>,
     letin_removed: usize,
     operator_rewrites: usize,
+    range_rewrites: usize,
     return_removed: usize,
     manual_pending: Vec<ManualDiag>,
     /// True if the file was written (or would be, in --dry-run). Harness can
@@ -58,6 +59,7 @@ struct FixOutcome<'a> {
     import_messages: &'a [String],
     imports_added: Vec<String>,
     operator_count: usize,
+    range_count: usize,
     letin_count: usize,
     return_count: usize,
     manual: Vec<ManualDiag>,
@@ -73,6 +75,12 @@ fn print_fix_detail_lines(outcome: &FixOutcome, print: fn(&str)) {
         print(&format!(
             "  Rewrote {} comparison function call(s) to operator form (int.gt/lt/eq/... → > < == ...)",
             outcome.operator_count
+        ));
+    }
+    if outcome.range_count > 0 {
+        print(&format!(
+            "  Migrated {} retired range spelling(s) (`..` -> `..<`, `..=` -> `...`)",
+            outcome.range_count
         ));
     }
     if outcome.letin_count > 0 {
@@ -135,6 +143,7 @@ fn report_fix_result(outcome: FixOutcome, dry_run: bool, json: bool) {
             imports_added: outcome.imports_added,
             letin_removed: outcome.letin_count,
             operator_rewrites: outcome.operator_count,
+            range_rewrites: outcome.range_count,
             return_removed: outcome.return_count,
             manual_pending: outcome.manual,
             changed: outcome.any_change,
@@ -159,10 +168,42 @@ fn report_fix_result(outcome: FixOutcome, dry_run: bool, json: bool) {
     }
 }
 
+/// #966: migrate the retired range spellings (`..` → `..<`, `..=` → `...`)
+/// from the parser's E031 fix-its. Applied textually and span-surgically —
+/// in reverse span order, so earlier spans stay valid as later ones grow the
+/// line by one char — which migrates ONLY the operators and leaves the rest
+/// of the file byte-identical (no reformat). Returns the migrated source and
+/// the number of operators rewritten.
+fn migrate_range_spellings(source: &str, parse_errors: &[crate::diagnostic::Diagnostic]) -> (String, usize) {
+    let mut fixes: Vec<&crate::diagnostic::Diagnostic> = parse_errors.iter()
+        .filter(|d| d.code.as_deref() == Some("E031") && d.try_replace_span.is_some())
+        .collect();
+    fixes.sort_by_key(|d| std::cmp::Reverse(d.try_replace_span.unwrap()));
+    let mut working = source.to_string();
+    let mut n = 0;
+    for d in fixes {
+        if let Some(rewritten) = d.apply_try_to(&working) {
+            working = rewritten;
+            n += 1;
+        }
+    }
+    (working, n)
+}
+
 pub fn cmd_fix(file: &str, dry_run: bool, json: bool) {
-    // `parse_errors` is consumed inside the rule engine (per-rule
-    // re-parse) so we discard it here.
-    let (mut program, source_text, _parse_errors) = parse_file(file);
+    let (parsed_program, disk_source, parse_errors) = parse_file(file);
+
+    // Range migration runs FIRST, on the raw text, so everything after —
+    // auto-imports, the comparison-call rewrite, the formatter — sees the
+    // migrated program instead of tripping on E031's parse errors.
+    let (source_text, range_count) = migrate_range_spellings(&disk_source, &parse_errors);
+    let mut program = if range_count > 0 {
+        let tokens = almide::lexer::Lexer::tokenize(&source_text);
+        let mut parser = almide::parser::Parser::new(tokens);
+        parser.parse().unwrap_or(parsed_program)
+    } else {
+        parsed_program
+    };
 
     let (dep_names, dep_submodules): (Vec<String>, std::collections::HashMap<String, String>) =
         if std::path::Path::new("almide.toml").exists() {
@@ -207,7 +248,7 @@ pub fn cmd_fix(file: &str, dry_run: bool, json: bool) {
     let letin_count = LETIN_REMOVAL.apply(&mut working);
     let return_count = RETURN_REMOVAL.apply(&mut working);
 
-    let any_change = has_import_changes || operator_count > 0 || letin_count > 0 || return_count > 0;
+    let any_change = has_import_changes || operator_count > 0 || letin_count > 0 || return_count > 0 || range_count > 0;
 
     // Extract "Added `import X`" → bare module names for JSON.
     let imports_added: Vec<String> = import_messages.iter()
@@ -226,7 +267,7 @@ pub fn cmd_fix(file: &str, dry_run: bool, json: bool) {
 
     report_fix_result(FixOutcome {
         file, working: &working, import_messages: &import_messages, imports_added,
-        operator_count, letin_count, return_count, manual, any_change,
+        operator_count, range_count, letin_count, return_count, manual, any_change,
     }, dry_run, json);
 }
 

--- a/tests/check_rejects_unbuildable_test.rs
+++ b/tests/check_rejects_unbuildable_test.rs
@@ -102,21 +102,33 @@ fn a_constructor_in_match_arm_position_is_still_accepted() {
 #[test]
 fn a_chained_range_is_rejected() {
     assert_rejected(
-        "fn main() -> Unit = {\n  let xs = 0..1..2\n  println(int.to_string(list.len(xs)))\n}",
+        "fn main() -> Unit = {\n  let xs = 0..<1..<2\n  println(int.to_string(list.len(xs)))\n}",
         "Chained range operators are not allowed",
     );
     assert_rejected(
-        "fn main() -> Unit = {\n  let xs = 0..=1..=2\n  println(int.to_string(list.len(xs)))\n}",
+        "fn main() -> Unit = {\n  let xs = 0...1...2\n  println(int.to_string(list.len(xs)))\n}",
         "Chained range operators are not allowed",
     );
 }
 
 #[test]
+fn retired_range_spellings_are_rejected_with_the_migration_notice() {
+    assert_rejected(
+        "fn main() -> Unit = println(int.to_string(list.len(0..3)))",
+        "'..' was retired",
+    );
+    assert_rejected(
+        "fn main() -> Unit = println(int.to_string(list.len(0..=3)))",
+        "'..=' was retired",
+    );
+}
+
+#[test]
 fn ordinary_ranges_still_parse() {
-    assert_accepted("fn main() -> Unit = println(int.to_string(list.len(0..3)))");
-    assert_accepted("fn main() -> Unit = println(int.to_string(list.len(0..=3)))");
-    assert_accepted("fn main() -> Unit = { for i in 0..3 { println(int.to_string(i)) } }");
+    assert_accepted("fn main() -> Unit = println(int.to_string(list.len(0..<3)))");
+    assert_accepted("fn main() -> Unit = println(int.to_string(list.len(0...3)))");
+    assert_accepted("fn main() -> Unit = { for i in 0..<3 { println(int.to_string(i)) } }");
     // A range whose bounds are themselves expressions must keep working — the
     // rejection looks at the bound's SHAPE, not at the tokens around it.
-    assert_accepted("fn main() -> Unit = { let n = 2\n  println(int.to_string(list.len(n - 1..n + 2)))\n }");
+    assert_accepted("fn main() -> Unit = { let n = 2\n  println(int.to_string(list.len(n - 1..<n + 2)))\n }");
 }

--- a/tests/checker_test.rs
+++ b/tests/checker_test.rs
@@ -298,7 +298,7 @@ fn check_match_with_wildcard() {
 
 #[test]
 fn check_for_in_range() {
-    has_no_errors("effect fn main() -> Result[Unit, String] = {\n  for i in 0..10 {\n    println(int.to_string(i))\n  }\n  ok(())\n}");
+    has_no_errors("effect fn main() -> Result[Unit, String] = {\n  for i in 0..<10 {\n    println(int.to_string(i))\n  }\n  ok(())\n}");
 }
 
 #[test]

--- a/tests/checker_test.rs
+++ b/tests/checker_test.rs
@@ -152,7 +152,7 @@ fn check_pipe_operator() {
 
 #[test]
 fn check_range() {
-    has_no_errors("fn f() -> List[Int] = 0..5");
+    has_no_errors("fn f() -> List[Int] = 0..<5");
 }
 
 #[test]

--- a/tests/diagnostics/e031-range-spelling/broken.almd
+++ b/tests/diagnostics/e031-range-spelling/broken.almd
@@ -1,0 +1,5 @@
+fn main() -> Unit = {
+  var s = 0
+  for i in 0 .. 4 { s = s + i }
+  println(int.to_string(s))
+}

--- a/tests/diagnostics/e031-range-spelling/fixed.almd
+++ b/tests/diagnostics/e031-range-spelling/fixed.almd
@@ -1,0 +1,5 @@
+fn main() -> Unit = {
+  var s = 0
+  for i in 0 ..< 4 { s = s + i }
+  println(int.to_string(s))
+}

--- a/tests/diagnostics/e031-range-spelling/meta.toml
+++ b/tests/diagnostics/e031-range-spelling/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E031"
+expects_error = "'..' was retired"
+hint_substring = "almide fix"

--- a/tests/fmt_test.rs
+++ b/tests/fmt_test.rs
@@ -190,14 +190,24 @@ fn fmt_not() {
 
 #[test]
 fn fmt_range() {
-    let out = roundtrip("fn f() -> List[Int] = 0..10");
-    assert!(out.contains("0..10"));
+    let out = roundtrip("fn f() -> List[Int] = 0..<10");
+    assert!(out.contains("0..<10"));
 }
 
 #[test]
 fn fmt_range_inclusive() {
+    let out = roundtrip("fn f() -> List[Int] = 1...10");
+    assert!(out.contains("1...10"));
+}
+
+// #966: the formatter is the migration path for the retired spellings — an
+// old-syntax file round-trips to the new spellings.
+#[test]
+fn fmt_migrates_retired_range_spellings() {
+    let out = roundtrip("fn f() -> List[Int] = 0..10");
+    assert!(out.contains("0..<10"), "got: {out}");
     let out = roundtrip("fn f() -> List[Int] = 1..=10");
-    assert!(out.contains("1..=10"));
+    assert!(out.contains("1...10"), "got: {out}");
 }
 
 // ---- Result/Option ----

--- a/tests/lower_test.rs
+++ b/tests/lower_test.rs
@@ -234,13 +234,13 @@ fn lower_tuple_literal() {
 
 #[test]
 fn lower_range() {
-    let ir = lower("fn f() -> List[Int] = 0..5");
+    let ir = lower("fn f() -> List[Int] = 0..<5");
     assert!(matches!(ir.functions[0].body.kind, IrExprKind::Range { inclusive: false, .. }));
 }
 
 #[test]
 fn lower_range_inclusive() {
-    let ir = lower("fn f() -> List[Int] = 1..=10");
+    let ir = lower("fn f() -> List[Int] = 1...10");
     assert!(matches!(ir.functions[0].body.kind, IrExprKind::Range { inclusive: true, .. }));
 }
 

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -132,7 +132,7 @@ fn wasm_list_push_basic() {
     assert_cross_target(r#"
 fn main() -> Unit = {
   var xs: List[Int] = []
-  for i in 0..5 { list.push(xs, i * 10) }
+  for i in 0..<5 { list.push(xs, i * 10) }
   println(int.to_string(xs[4]))
 }
 "#);
@@ -143,7 +143,7 @@ fn wasm_list_push_capacity() {
     assert_cross_target(r#"
 fn main() -> Unit = {
   var xs: List[Int] = []
-  for i in 0..20 { list.push(xs, i) }
+  for i in 0..<20 { list.push(xs, i) }
   println(int.to_string(list.len(xs)) + " " + int.to_string(xs[19]))
 }
 "#);
@@ -330,7 +330,7 @@ fn wasm_list_with_capacity() {
     assert_cross_target(r#"
 fn main() -> Unit = {
   var xs = list.with_capacity(16)
-  for i in 0..10 { list.push(xs, i) }
+  for i in 0..<10 { list.push(xs, i) }
   println(int.to_string(list.len(xs)) + " " + int.to_string(xs[9]))
 }
 "#);


### PR DESCRIPTION
Fixes #966 (owner decision recorded there: hard error + fix-it, no deprecation window).

## The language change

| meaning | before | after |
|---|---|---|
| half-open range | `a .. b` | `a ..< b` |
| closed range | `a ..= b` | `a ... b` |

`..<` carries its own `<`, so the exclusive case is self-describing at the call site — the `..` vs `..=` one-character distinction was silently confusable in both directions (the MSR argument). `..` **survives as the record-rest marker** (`{ x, .. }` patterns, open record types) — after this change it simply never appears in expression position. `...` is now BOTH the record/list spread (prefix, consumed by the literal item parsers) and the inclusive range (infix, in the Pratt table) — position disambiguates, never the token; `spec/wasm_cross/cross_module_spread.almd` now exercises both roles in one file.

## The old spellings: E031, machine-migratable

An infix `..`/`..=` still parses to the correct `Range` node (so tooling sees the program) but every compile path fails with:

```
error[E031]: '..' was retired: end-exclusive ranges are written '..<'
  hint: run `almide fix` on this file to migrate every range mechanically
  try:
      ..<
  |
3 |   for i in 0 .. 5 { s = s + i }
  |              ^^
```

`almide fix` applies the fix-its span-surgically in reverse order (only the operators change — zero reformat; new `range_rewrites` field in the JSON report), and the formatter emits the new spellings. One deliberate parser subtlety: `DotDotDot` is **absent from the newline-continuation set**, so a line starting with `...` stays a spread inside a multiline literal instead of being joined to the previous item as a range (comment in `expressions.rs` pins the reasoning).

## Corpus + docs, same train

- 36 corpus files / 137 operators migrated surgically (`spec/`, `examples/`; 1:1 line diff, comments and record-rest untouched).
- `docs/GRAMMAR.md`, `docs/CHEATSHEET.md`, `docs/SPEC.md`, `docs/specs/language.md` — grammar row, precedence tables, every example. The tokio-free `FanLowering` row was left to #965's PR.
- almide-grammar (single source of truth) updated and pushed: `tokens.toml` / `precedence.toml` / `src/mod.almd` (`almide/almide-grammar@8864277`).

## Tests

- `tests/diagnostics/e031-range-spelling/` — the harness proves the fix-it applies cleanly and lands exactly on `fixed.almd` (4/4).
- `check_rejects_unbuildable_test` — chained-range rejection re-pinned on the new spellings (the check is AST-shape-based, so `0..<1..<2` is still refused), plus a new lock that the retired spellings are rejected **with the migration notice** (7/7).
- `fmt_test` — new spellings round-trip; a new lock that old-syntax input round-trips TO the new spellings (fmt is a migration path) (51/51).
- `test_expr_precedence` — the executable precedence truth speaks the new spellings.

## Verification

| gate | result |
|---|---|
| full `cargo test` battery | green (2 pre-existing tests updated, listed above) |
| `almide test` (full spec, migrated corpus) | 323/323 |
| `wasm_cross_target_spec` (byte-identity over all fixtures) | pass (180s) |
| `scripts/check-contracts.sh` | OK — 193 contracts, 322/322 fixtures linked |
| corpus E031 sweep | zero remaining |

## Follow-ups (tracked on #966)

Downstream consumers of the syntax: tree-sitter-almide, vscode-almide highlighting, playground snippets, docs-site guide pages, almide-agents' CHEATSHEET copy, dojo task bank. Each is a small textual sweep once this merges.