### PR TITLE
Cache cargo registry and target in the Test Rust job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,20 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
+      # This job was the ONE heavy job with no cargo cache: every PR run
+      # downloaded the registry and cold-built the whole workspace's dev-profile
+      # test targets (~15 of its ~22 minutes) before a single test ran. Same
+      # shape as fuzz-nightly's cache — registry + git + target, keyed on
+      # Cargo.lock, prefix restore so a lockfile bump still warm-starts.
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: test-rust-cargo-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: test-rust-cargo-${{ env.RUST_TOOLCHAIN }}-
+
       - name: Cache wasmtime tarball
         uses: actions/cache@v6
         with:


### PR DESCRIPTION
The `Test Rust` job was the one heavy CI job with no cargo cache: every PR run downloaded the whole registry and cold-built the workspace's dev-profile test targets — ~15 of its ~22 minutes spent before a single test ran (visible in any run log: the job opens with a full `Downloaded …` storm). Every other heavy job already caches (`build`: registry+git; `WASM host-arch determinism`: registry+git+harness targets; fuzz-nightly: the full registry+git+target shape).

This adds the fuzz-nightly cache shape to `test-rust` — registry + git + `target`, keyed on `Cargo.lock` with a prefix restore key so a lockfile bump still warm-starts. Expected effect: the ~22-minute job drops to a few minutes on a warm cache, which is the long pole of every PR's time-to-green today.

First run on this PR is the cold seed (unchanged duration); runs after merge inherit the cache.