### PR TITLE
Render integer type ranges in diagnostics with the Swift-style inclusive spelling

### DIFF
--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -357,7 +357,9 @@ pub(crate) fn classify_int_literal(raw: &str, ty: &Ty, negated: bool) -> Literal
     }
 }
 
-/// The inclusive range `ty` accepts, as written in a diagnostic — `0..=255`.
+/// The inclusive range `ty` accepts, as written in a diagnostic — `0...255`
+/// (the Swift-style inclusive spelling, #966 — a diagnostic quoting the
+/// retired `..=` would teach the very syntax E031 rejects).
 ///
 /// Rust states this range in a note on its out-of-range literal error, and it
 /// is the difference between a hint a reader can act on and one they have to go
@@ -366,9 +368,9 @@ pub(crate) fn classify_int_literal(raw: &str, ty: &Ty, negated: bool) -> Literal
 pub(crate) fn int_type_range(ty: &Ty) -> Option<String> {
     let (signed, bits) = int_type_signed_bits(ty)?;
     Some(if signed {
-        format!("-{}..={}", 1u128 << (bits - 1), (1u128 << (bits - 1)) - 1)
+        format!("-{}...{}", 1u128 << (bits - 1), (1u128 << (bits - 1)) - 1)
     } else {
-        format!("0..={}", (1u128 << bits) - 1)
+        format!("0...{}", (1u128 << bits) - 1)
     })
 }
 


### PR DESCRIPTION
Refs #966 (a downstream of the range-syntax switch found during the sweep).

`int_type_range` — the E024 out-of-range hint's "its range is …" renderer — still spelled type ranges Rust-style (`-128..=127`, `0..=255`): a diagnostic teaching the very syntax E031 now rejects. It renders `-128...127` / `0...255` now, and the docs-site page quoting the hint was updated to match (`almide/docs@dbc792a`).

Verification: `cargo test --workspace --no-fail-fast` green (no test asserted the old rendering); no other user-facing diagnostic text carries the retired spellings (`grep '\.\.='` over the frontend's format strings — the remaining hits are Rust `0..=n` loops).