### PR TITLE
Carry source spans through wall errors and render them with a caret

### DIFF
--- a/crates/almide-base/src/span.rs
+++ b/crates/almide-base/src/span.rs
@@ -1,6 +1,6 @@
 use serde::{Serialize, Deserialize};
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Span {
     pub line: usize,
     pub col: usize,

--- a/crates/almide-ir/src/lib.rs
+++ b/crates/almide-ir/src/lib.rs
@@ -13,7 +13,7 @@
 
 use std::collections::HashSet;
 use serde::{Serialize, Deserialize};
-use almide_base::Span;
+pub use almide_base::Span;
 use almide_base::intern::Sym;
 use almide_lang::types::Ty;
 

--- a/crates/almide-mir/examples/classify_corpus_parts/classify_corpus_c.rs
+++ b/crates/almide-mir/examples/classify_corpus_parts/classify_corpus_c.rs
@@ -200,7 +200,9 @@ fn classify_lower_one_fn(
                 file_mirs.push((mir.name.clone(), mir));
             }
         }
-        Ok(Err(almide_mir::lower::LowerError::Unsupported(reason))) => {
+        Ok(Err(wall_err)) => {
+            let reason = wall_err.reason().to_string();
+            let reason = &reason;
             // Categorize the wall: NATIVE-FFI (structural, excluded) iff this function is
             // in the transitive native-FFI closure; else REAL (a lowering gap to close).
             // A name absent from the node map (an inline_mutual_tail_recursion-synthesized

--- a/crates/almide-mir/src/lower/binds_p2.rs
+++ b/crates/almide-mir/src/lower/binds_p2.rs
@@ -258,11 +258,11 @@ impl LowerCtx {
             // Outside the executable subset a Const-0 would silently pick a wrong
             // arm — WALL (the discipline: an unfaithful variant match rejects, never
             // emits a deferred 0).
-            return Err(LowerError::Unsupported(
+            return Err(LowerError::at(
+                subject.span,
                 "variant (Option/Result) match bound to a let/var outside the \
                  executable subset cannot be faithfully computed (a Const-0 would \
-                 silently pick a wrong arm) not in this brick"
-                    .into(),
+                 silently pick a wrong arm) not in this brick",
             ));
         }
         Ok(false)

--- a/crates/almide-mir/src/lower/binds_p2_c.rs
+++ b/crates/almide-mir/src/lower/binds_p2_c.rs
@@ -441,11 +441,11 @@ impl LowerCtx {
             self.ops.truncate(mark);
             self.live_heap_handles.truncate(lhh_mark);
         }
-        Err(LowerError::Unsupported(
+        Err(LowerError::at(
+            value.span,
             "heap-result `match` bound to a let/var cannot be faithfully \
              computed in this brick (would bind an empty deferred heap value); \
-             the merged result has no sound scope-end drop in the flat certificate"
-                .into(),
+             the merged result has no sound scope-end drop in the flat certificate",
         ))
     }
 
@@ -513,11 +513,11 @@ impl LowerCtx {
                 }
             }
         }
-        Err(LowerError::Unsupported(
+        Err(LowerError::at(
+            value.span,
             "heap-result `if` bound to a let/var cannot be faithfully \
              computed in this brick (would bind an empty deferred heap value); \
-             the merged result has no sound scope-end drop in the flat certificate"
-                .into(),
+             the merged result has no sound scope-end drop in the flat certificate",
         ))
     }
 

--- a/crates/almide-mir/src/lower/calls.rs
+++ b/crates/almide-mir/src/lower/calls.rs
@@ -110,9 +110,9 @@ impl LowerCtx {
         // producer funnels here (#958's C-195 fixture, `classify` mir 6 > ir 5).
         if crate::lower::is_identity_int_widening(module, func, args) {
             return self.lower_scalar_value(&args[0]).ok_or_else(|| {
-                LowerError::Unsupported(
-                    "identity int-widening operand outside the scalar subset not in this brick"
-                        .into(),
+                LowerError::at(
+                    args[0].span,
+                    "identity int-widening operand outside the scalar subset not in this brick",
                 )
             });
         }
@@ -120,8 +120,9 @@ impl LowerCtx {
         // counter-alignment reasoning as the widening above.
         if crate::lower::is_float_from_int_prim(module, func, args) {
             let v = self.lower_scalar_value(&args[0]).ok_or_else(|| {
-                LowerError::Unsupported(
-                    "float.from_int operand outside the scalar subset not in this brick".into(),
+                LowerError::at(
+                    args[0].span,
+                    "float.from_int operand outside the scalar subset not in this brick",
                 )
             })?;
             let dst = self.fresh_value();

--- a/crates/almide-mir/src/lower/calls_arg_b.rs
+++ b/crates/almide-mir/src/lower/calls_arg_b.rs
@@ -194,12 +194,12 @@ impl LowerCtx {
             Some(v) => CallArg::Scalar(v),
             None => {
                 self.ops.truncate(mark);
-                return Err(LowerError::Unsupported(
+                return Err(LowerError::at(
+                    a.span,
                     "scalar-result match over a heap subject in a call-argument \
                      position outside the executable subset cannot be faithfully \
                      computed (a Const-0 would silently pick a wrong arm) not in \
-                     this brick"
-                        .into(),
+                     this brick",
                 ));
             }
         }))

--- a/crates/almide-mir/src/lower/calls_p2.rs
+++ b/crates/almide-mir/src/lower/calls_p2.rs
@@ -652,10 +652,10 @@ impl LowerCtx {
                 Ok(())
             }
             Some(ArgOutcome::Pushed) => Ok(()),
-            None => Err(LowerError::Unsupported(format!(
-                "call argument {} not in this brick",
-                kind_name(&a.kind)
-            ))),
+            None => Err(LowerError::at(
+                a.span,
+                format!("call argument {} not in this brick", kind_name(&a.kind)),
+            )),
         }
     }
 }

--- a/crates/almide-mir/src/lower/control_while.rs
+++ b/crates/almide-mir/src/lower/control_while.rs
@@ -13,11 +13,13 @@ impl LowerCtx {
         // `try_lower_scalar_while` already declined both shapes and rolled back.)
         self.wall_break_over_heap_frame(body, "while", self.live_heap_handles.len())?;
         if body_reassigns_heap(body) {
-            return Err(LowerError::Unsupported(
+            // The span points at the CONDITION — the nearest node the `while`
+            // itself carries; the accumulator sits in the body it heads (#931).
+            return Err(LowerError::at(
+                cond.span,
                 "while body with a heap-accumulator reassignment cannot be faithfully lowered \
                  (the model-one-iteration fallback defers the reassignment, dropping the \
-                 accumulation) not in this brick"
-                    .into(),
+                 accumulation) not in this brick",
             ));
         }
         self.record_elided_calls(cond);

--- a/crates/almide-mir/src/lower/mod.rs
+++ b/crates/almide-mir/src/lower/mod.rs
@@ -31,6 +31,42 @@ use std::collections::{HashMap, HashSet};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LowerError {
     Unsupported(String),
+    /// A wall carrying the SOURCE SPAN of the construct that walled (#931):
+    /// line/col/end_col in the lexer's 1-indexed char convention, straight off
+    /// the nearest IR node. Construct via [`LowerError::at`] — every NEW wall
+    /// site must use it (the spanless count is ratcheted by
+    /// `spanless_wall_count_only_goes_down`), so the CLI can render the wall
+    /// through the Diagnostic machinery with the source line and a caret
+    /// instead of a bare sentence.
+    UnsupportedAt { reason: String, span: almide_ir::Span },
+}
+
+impl LowerError {
+    /// Span-carrying wall constructor — pass the nearest IR node's span.
+    /// Falls back to the spanless form when the node carries none, so callers
+    /// never have to branch.
+    pub fn at(span: Option<almide_ir::Span>, reason: impl Into<String>) -> LowerError {
+        match span {
+            Some(span) => LowerError::UnsupportedAt { reason: reason.into(), span },
+            None => LowerError::Unsupported(reason.into()),
+        }
+    }
+
+    /// The wall reason, span or not — what every ledger/notice prints.
+    pub fn reason(&self) -> &str {
+        match self {
+            LowerError::Unsupported(reason) => reason,
+            LowerError::UnsupportedAt { reason, .. } => reason,
+        }
+    }
+
+    /// The source span, when the construction site had one to give.
+    pub fn span(&self) -> Option<almide_ir::Span> {
+        match self {
+            LowerError::Unsupported(_) => None,
+            LowerError::UnsupportedAt { span, .. } => Some(*span),
+        }
+    }
 }
 
 /// The USER-FACING rendering: the reason, bare. The `Debug` form wraps it in
@@ -42,9 +78,7 @@ pub enum LowerError {
 /// formats through THIS, so the reason reads as one sentence at any depth.
 impl std::fmt::Display for LowerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LowerError::Unsupported(reason) => f.write_str(reason),
-        }
+        f.write_str(self.reason())
     }
 }
 

--- a/crates/almide-mir/src/lower/tail.rs
+++ b/crates/almide-mir/src/lower/tail.rs
@@ -82,10 +82,10 @@ impl LowerCtx {
             return Ok(owned);
         }
         let container = extraction_container(expr).ok_or_else(|| {
-            LowerError::Unsupported(format!(
-                "{} is not a field/element extraction",
-                kind_name(&expr.kind)
-            ))
+            LowerError::at(
+                expr.span,
+                format!("{} is not a field/element extraction", kind_name(&expr.kind)),
+            )
         })?;
         let src = match &container.kind {
             IrExprKind::Var { id } if is_heap_ty(&container.ty) => self.value_or_global(*id)?,

--- a/crates/almide-mir/src/pipeline_b.rs
+++ b/crates/almide-mir/src/pipeline_b.rs
@@ -556,7 +556,7 @@ fn lower_main_and_sibling_fns(
     layouts: &PipelineLayouts,
     total_ir_fn_count: usize,
     verbose: bool,
-    fn_walls: &mut std::collections::HashMap<String, String>,
+    fn_walls: &mut std::collections::HashMap<String, crate::lower::LowerError>,
 ) -> Vec<crate::MirFunction> {
     let mut functions = Vec::new();
     let mut walled = Vec::new();
@@ -581,8 +581,8 @@ fn lower_main_and_sibling_fns(
                 // cause into one unattributable bucket — a third of the fuzzer's
                 // wall histogram (#812). An exported `pub fn` declines the module
                 // the same way, so it reads its reason out of here too (#906).
-                fn_walls.insert(func.name.as_str().to_string(), format!("{e}"));
                 walled.push(format!("{}: {e:?}", func.name.as_str()));
+                fn_walls.insert(func.name.as_str().to_string(), e);
             }
         }
     }
@@ -636,10 +636,10 @@ fn lower_main_and_sibling_fns(
             // with the cause discarded one frame down — the same mis-attribution
             // #906 fixed for exports and #904 for qualified type names (#943).
             Err(e) => {
-                fn_walls.insert(func.name.as_str().to_string(), format!("{e}"));
                 if verbose {
                     eprintln!("[v1-wall] module sibling {}: {e:?}", func.name.as_str());
                 }
+                fn_walls.insert(func.name.as_str().to_string(), e);
             }
         }
     }

--- a/crates/almide-mir/src/pipeline_c.rs
+++ b/crates/almide-mir/src/pipeline_c.rs
@@ -280,7 +280,7 @@ fn try_render_wasm_source_impl_rest(
 
     repair_and_substitute_globals(ir, &mut inlined_fns, &mut module_fn_sibs, &layouts, &all_fns);
 
-    let mut fn_walls: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let mut fn_walls: std::collections::HashMap<String, crate::lower::LowerError> = std::collections::HashMap::new();
     let mut functions = lower_main_and_sibling_fns(
         &inlined_fns,
         &module_fn_sibs,
@@ -414,10 +414,17 @@ fn try_render_wasm_source_impl_rest(
         // most common wall, and reporting it as "main is outside the subset"
         // collapsed every distinct reason into one bucket that no burn-down
         // could act on (#812).
-        return Err(LowerError::Unsupported(match &main_wall {
-            Some(reason) => format!("main is outside the MIR-lowering subset: {reason}"),
-            None => "main is outside the MIR-lowering subset (no main in the IR)".into(),
-        }));
+        // The wrapper PRESERVES the inner wall's span (#931): nesting adds
+        // context to the reason, never strips the location.
+        return Err(match &main_wall {
+            Some(inner) => LowerError::at(
+                inner.span(),
+                format!("main is outside the MIR-lowering subset: {inner}"),
+            ),
+            None => LowerError::Unsupported(
+                "main is outside the MIR-lowering subset (no main in the IR)".into(),
+            ),
+        });
     }
 
     // `pub fn` EXPORT roots (#457): a Public non-test MAIN-program fn must be a named wasm
@@ -467,17 +474,22 @@ fn try_render_wasm_source_impl_rest(
                 // burned the search on the export machinery — the same
                 // mis-attribution class as #904, reported as #906. `main` has
                 // carried its inner reason since #812; an export now does too.
-                return Err(LowerError::Unsupported(match fn_walls.get(n) {
-                    Some(reason) => format!(
-                        "exported `pub fn {n}` is outside the MIR-lowering subset \
-                         (the wasm module must carry its export): {reason}"
+                // Like the main wrapper: the nesting adds context, the inner
+                // wall's SPAN survives (#931).
+                return Err(match fn_walls.get(n) {
+                    Some(inner) => LowerError::at(
+                        inner.span(),
+                        format!(
+                            "exported `pub fn {n}` is outside the MIR-lowering subset \
+                             (the wasm module must carry its export): {inner}"
+                        ),
                     ),
-                    None => format!(
+                    None => LowerError::Unsupported(format!(
                         "exported `pub fn {n}` is outside the MIR-lowering subset (the wasm \
                          module must carry its export; no per-function wall was recorded — \
                          it was dropped before lowering)"
-                    ),
-                }));
+                    )),
+                });
             }
         }
     }
@@ -512,7 +524,7 @@ fn try_render_wasm_source_impl_rest(
 /// user module that is sitting right there in the package (#943).
 fn attribute_unlinked_calls(
     e: LowerError,
-    fn_walls: &std::collections::HashMap<String, String>,
+    fn_walls: &std::collections::HashMap<String, crate::lower::LowerError>,
 ) -> LowerError {
     let LowerError::Unsupported(msg) = &e else { return e };
     let Some(rest) = msg.strip_prefix("unlinked stdlib/runtime call(s) with no wasm definition: ")

--- a/crates/almide-mir/tests/wall_span_ratchet.rs
+++ b/crates/almide-mir/tests/wall_span_ratchet.rs
@@ -1,0 +1,49 @@
+//! The spanless-wall RATCHET (#931).
+//!
+//! `LowerError::at(span, reason)` is the constructor every NEW wall site must
+//! use: it carries the source span of the construct that walled, so the CLI
+//! renders the wall through the Diagnostic machinery — source line, caret —
+//! instead of a bare sentence. The legacy spanless `LowerError::Unsupported(…)`
+//! sites are grandfathered at the count below, which may only go DOWN (the
+//! same ratchet discipline as the walled-real count and the skip ledger):
+//! migrating a site lowers it, adding a spanless site trips this test.
+//!
+//! Counted TEXTUALLY over crates/almide-mir/src — constructions and the few
+//! frozen pattern-matches alike — so any new mention of the spanless form
+//! (either kind) shows up and gets reviewed.
+
+const BASELINE: usize = 193;
+
+#[test]
+fn spanless_wall_count_only_goes_down() {
+    let src_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut count = 0usize;
+    let mut stack = vec![src_root];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("read src dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                let text = std::fs::read_to_string(&path).expect("read source");
+                count += text.matches("LowerError::Unsupported(").count();
+            }
+        }
+    }
+    assert!(
+        count <= BASELINE,
+        "{count} spanless `LowerError::Unsupported(` mentions (baseline {BASELINE}) — \
+         new wall sites must use `LowerError::at(<node>.span, reason)` so the wall \
+         renders with a source location (#931)"
+    );
+    assert!(
+        count >= 1,
+        "sanity: the scan found {count} mentions — did the source layout move?"
+    );
+    if count < BASELINE {
+        eprintln!(
+            "spanless wall count is {count}, below the {BASELINE} baseline — \
+             lower BASELINE in this test to lock in the progress"
+        );
+    }
+}

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -515,15 +515,35 @@ fn render_wasm_module(source_text: &str, v1_self_modules: &[(String, almide_lang
             // The reason renders through `LowerError`'s Display — one readable
             // sentence, however deep the wall nested — never the `{:?}` form,
             // whose per-level `Unsupported("…")` wrappers and escaped quotes
-            // were the worst diagnostic in the compiler (#931).
-            err(&format!(
-                "error: this program shape is not yet supported by the verified wasm renderer\n\n  \
-                 {e}\n\n  \
-                 The unverified v0 wasm emitter was retired (#782): a wall is an honest error\n  \
-                 instead of a silent fallback. If this names a missing capability, please file\n  \
-                 it with the source shape that triggered it:\n  \
-                 https://github.com/almide/almide/issues"
-            ));
+            // were the worst diagnostic in the compiler (#931). A wall whose
+            // construction site had a span renders through the Diagnostic
+            // machinery — source line, caret, the works — so the user sees
+            // WHERE the shape lives, not just what it is.
+            if let Some(span) = e.span() {
+                let mut d = crate::diagnostic::Diagnostic::error(
+                    e.reason().to_string(),
+                    "the unverified v0 wasm emitter was retired (#782): a wall is an honest \
+                     error instead of a silent fallback. If this names a missing capability, \
+                     please file it with the source shape that triggered it: \
+                     https://github.com/almide/almide/issues",
+                    "the verified wasm render (v1 trust spine) — this shape is not yet in its subset",
+                );
+                d.line = Some(span.line);
+                d.col = Some(span.col);
+                if span.end_col > span.col {
+                    d.end_col = Some(span.end_col);
+                }
+                err(&format!("{}", crate::diagnostic_render::display_with_source(&d, source_text)));
+            } else {
+                err(&format!(
+                    "error: this program shape is not yet supported by the verified wasm renderer\n\n  \
+                     {e}\n\n  \
+                     The unverified v0 wasm emitter was retired (#782): a wall is an honest error\n  \
+                     instead of a silent fallback. If this names a missing capability, please file\n  \
+                     it with the source shape that triggered it:\n  \
+                     https://github.com/almide/almide/issues"
+                ));
+            }
             Err(())
         }
     }


### PR DESCRIPTION
Refs #931 — the structural half (span + rendering + ratchet). The remaining checkbox on the issue is the WallShape enum with per-shape rewrite hints.

## What the user sees now

`almide build examples/minesweeper.almd --target wasm` — the issue's own example, before: a bare sentence with no location; after:

```
error: main is outside the MIR-lowering subset: while body with a heap-accumulator reassignment cannot be faithfully lowered (…) not in this brick
  at line 181
  here: while not game_over {
  hint: the unverified v0 wasm emitter was retired (#782): …file it with the source shape…
    |
181 |   while not game_over {
    |         ^^^
```

## How

- **`LowerError::UnsupportedAt { reason, span }`** + `LowerError::at(span, reason)` / `.reason()` / `.span()`. Spans are the lexer's 1-indexed char convention, straight off the nearest IR node (`Span` gains `PartialEq/Eq`; `almide-ir` re-exports it).
- **Nesting preserves the span**: `fn_walls` (the per-fn wall ledger) now stores the `LowerError` itself instead of a pre-rendered string, so the `main is outside the subset: …` and `exported pub fn … : …` wrappers carry the INNER wall's span up — nesting adds context, never strips location.
- **CLI rendering** (`render_wasm_module`'s wall arm): a span-carrying wall renders through the Diagnostic machinery — source line, caret, hint — with the reason as the headline; a spanless wall keeps the previous prose form.
- **The ratchet** (`crates/almide-mir/tests/wall_span_ratchet.rs`): spanless `LowerError::Unsupported(` mentions in almide-mir are frozen at **193** and may only go down — a new spanless site trips the test and points at `LowerError::at`. Same discipline as the walled-real count and the skip ledger.
- **9 sites migrated** in this PR, chosen by hit-rate: the while heap-accumulator wall (the single most-reported wall — the issue's example), the value-position variant match wall, both heap-result bind walls (`match`/`if`), the two call-argument walls (including the generic `call argument … not in this brick`), the tail field-extraction wall, and the two elision walls from #969.

## Verification

| gate | result |
|---|---|
| ratchet test | 1/1 (193 baseline) |
| minesweeper wall render | line 181 + caret (above) |
| `almide test` (full spec) | 323/323 |
| `cargo test --workspace --no-fail-fast` | green (two CLI-shelling suites raced the release-binary rebuild inside the battery; both pass standalone) |