### PR TITLE
Give walls a shape: per-shape headline and rewrite hint, raw reason demoted to a note

### DIFF
--- a/crates/almide-mir/src/lower/binds_p2.rs
+++ b/crates/almide-mir/src/lower/binds_p2.rs
@@ -258,8 +258,9 @@ impl LowerCtx {
             // Outside the executable subset a Const-0 would silently pick a wrong
             // arm — WALL (the discipline: an unfaithful variant match rejects, never
             // emits a deferred 0).
-            return Err(LowerError::at(
+            return Err(LowerError::shaped(
                 subject.span,
+                WallShape::VariantValueMatch,
                 "variant (Option/Result) match bound to a let/var outside the \
                  executable subset cannot be faithfully computed (a Const-0 would \
                  silently pick a wrong arm) not in this brick",

--- a/crates/almide-mir/src/lower/binds_p2_c.rs
+++ b/crates/almide-mir/src/lower/binds_p2_c.rs
@@ -441,8 +441,9 @@ impl LowerCtx {
             self.ops.truncate(mark);
             self.live_heap_handles.truncate(lhh_mark);
         }
-        Err(LowerError::at(
+        Err(LowerError::shaped(
             value.span,
+            WallShape::HeapResultBind,
             "heap-result `match` bound to a let/var cannot be faithfully \
              computed in this brick (would bind an empty deferred heap value); \
              the merged result has no sound scope-end drop in the flat certificate",
@@ -513,8 +514,9 @@ impl LowerCtx {
                 }
             }
         }
-        Err(LowerError::at(
+        Err(LowerError::shaped(
             value.span,
+            WallShape::HeapResultBind,
             "heap-result `if` bound to a let/var cannot be faithfully \
              computed in this brick (would bind an empty deferred heap value); \
              the merged result has no sound scope-end drop in the flat certificate",

--- a/crates/almide-mir/src/lower/calls.rs
+++ b/crates/almide-mir/src/lower/calls.rs
@@ -110,8 +110,9 @@ impl LowerCtx {
         // producer funnels here (#958's C-195 fixture, `classify` mir 6 > ir 5).
         if crate::lower::is_identity_int_widening(module, func, args) {
             return self.lower_scalar_value(&args[0]).ok_or_else(|| {
-                LowerError::at(
+                LowerError::shaped(
                     args[0].span,
+                    WallShape::CallArgument,
                     "identity int-widening operand outside the scalar subset not in this brick",
                 )
             });
@@ -120,8 +121,9 @@ impl LowerCtx {
         // counter-alignment reasoning as the widening above.
         if crate::lower::is_float_from_int_prim(module, func, args) {
             let v = self.lower_scalar_value(&args[0]).ok_or_else(|| {
-                LowerError::at(
+                LowerError::shaped(
                     args[0].span,
+                    WallShape::CallArgument,
                     "float.from_int operand outside the scalar subset not in this brick",
                 )
             })?;

--- a/crates/almide-mir/src/lower/calls_arg_b.rs
+++ b/crates/almide-mir/src/lower/calls_arg_b.rs
@@ -194,8 +194,9 @@ impl LowerCtx {
             Some(v) => CallArg::Scalar(v),
             None => {
                 self.ops.truncate(mark);
-                return Err(LowerError::at(
+                return Err(LowerError::shaped(
                     a.span,
+                    WallShape::VariantValueMatch,
                     "scalar-result match over a heap subject in a call-argument \
                      position outside the executable subset cannot be faithfully \
                      computed (a Const-0 would silently pick a wrong arm) not in \

--- a/crates/almide-mir/src/lower/calls_p2.rs
+++ b/crates/almide-mir/src/lower/calls_p2.rs
@@ -652,8 +652,9 @@ impl LowerCtx {
                 Ok(())
             }
             Some(ArgOutcome::Pushed) => Ok(()),
-            None => Err(LowerError::at(
+            None => Err(LowerError::shaped(
                 a.span,
+                WallShape::CallArgument,
                 format!("call argument {} not in this brick", kind_name(&a.kind)),
             )),
         }

--- a/crates/almide-mir/src/lower/control_while.rs
+++ b/crates/almide-mir/src/lower/control_while.rs
@@ -15,8 +15,9 @@ impl LowerCtx {
         if body_reassigns_heap(body) {
             // The span points at the CONDITION — the nearest node the `while`
             // itself carries; the accumulator sits in the body it heads (#931).
-            return Err(LowerError::at(
+            return Err(LowerError::shaped(
                 cond.span,
+                WallShape::WhileHeapAccumulator,
                 "while body with a heap-accumulator reassignment cannot be faithfully lowered \
                  (the model-one-iteration fallback defers the reassignment, dropping the \
                  accumulation) not in this brick",

--- a/crates/almide-mir/src/lower/mod.rs
+++ b/crates/almide-mir/src/lower/mod.rs
@@ -25,6 +25,89 @@ use almide_ir::{
 use almide_lang::types::Ty;
 use std::collections::{HashMap, HashSet};
 
+/// The KNOWN wall shapes (#931): a coarse classification of the constructs
+/// the verified renderer most often refuses. Each known shape carries a
+/// plain-language headline and the documented rewrite (the CHEATSHEET idioms)
+/// that takes the program back inside the subset — so the CLI can lead with
+/// what the USER wrote and how to change it, keeping the compiler-internal
+/// reason string for a trailing `note:`. `Other` is every wall with no
+/// specific rewrite; it renders as before (reason as the headline).
+/// `wall_shape_hints.rs` gates that every non-`Other` shape has both texts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WallShape {
+    /// A `while` body reassigning a heap accumulator (`s = s + x`).
+    WhileHeapAccumulator,
+    /// A `match`/`if` producing a heap value, bound to a `let`/`var`.
+    HeapResultBind,
+    /// An Option/Result match bound to a `let`/`var` outside the executable
+    /// (scalar-payload) subset.
+    VariantValueMatch,
+    /// A call argument (or scalar-call operand) whose shape the lowering
+    /// cannot admit.
+    CallArgument,
+    /// A tail-position expression that is not a supported field/element
+    /// extraction.
+    TailExtraction,
+    /// No specific rewrite known — the reason string is the whole story.
+    Other,
+}
+
+impl WallShape {
+    /// What the user wrote, in surface-language vocabulary — the diagnostic
+    /// headline. `None` for [`WallShape::Other`].
+    pub fn headline(&self) -> Option<&'static str> {
+        match self {
+            WallShape::WhileHeapAccumulator => Some(
+                "this `while` body grows a heap value (String/List) across iterations \
+                 — not yet in the verified wasm subset",
+            ),
+            WallShape::HeapResultBind => Some(
+                "this `match`/`if` produces a heap value (String/List/record) and is \
+                 bound to a let/var — not yet in the verified wasm subset",
+            ),
+            WallShape::VariantValueMatch => Some(
+                "this Option/Result match binds a payload shape that is not yet in \
+                 the verified wasm subset",
+            ),
+            WallShape::CallArgument => Some(
+                "this call argument's shape is not yet in the verified wasm subset",
+            ),
+            WallShape::TailExtraction => Some(
+                "this return expression's shape is not yet in the verified wasm subset",
+            ),
+            WallShape::Other => None,
+        }
+    }
+
+    /// The documented rewrite that takes the program back inside the subset
+    /// (the CHEATSHEET/CLAUDE.md idioms). `None` for [`WallShape::Other`].
+    pub fn rewrite_hint(&self) -> Option<&'static str> {
+        match self {
+            WallShape::WhileHeapAccumulator => Some(
+                "hoist the accumulator into a recursive helper fn (prefer recursion \
+                 over var + while), or build the value with a list combinator \
+                 (map / filter / join)",
+            ),
+            WallShape::HeapResultBind => Some(
+                "move the `match`/`if` into tail position: return it from a small \
+                 helper fn instead of binding it to a let/var",
+            ),
+            WallShape::VariantValueMatch => Some(
+                "scalar payloads (Int/Float/Bool) execute directly; for heap payloads \
+                 match in tail position via a helper fn, or collapse the value first \
+                 with `??`",
+            ),
+            WallShape::CallArgument => Some(
+                "hoist the argument into its own `let` binding and pass the name",
+            ),
+            WallShape::TailExtraction => Some(
+                "bind the expression to a `let` and return the binding",
+            ),
+            WallShape::Other => None,
+        }
+    }
+}
+
 /// A lowering could not proceed because the input is outside this brick's
 /// subset (or violates a precondition such as concrete types). Carrying the
 /// reason keeps the pass TOTAL — no case is silently skipped.
@@ -37,8 +120,10 @@ pub enum LowerError {
     /// site must use it (the spanless count is ratcheted by
     /// `spanless_wall_count_only_goes_down`), so the CLI can render the wall
     /// through the Diagnostic machinery with the source line and a caret
-    /// instead of a bare sentence.
-    UnsupportedAt { reason: String, span: almide_ir::Span },
+    /// instead of a bare sentence. Sites matching a known [`WallShape`]
+    /// construct via [`LowerError::shaped`] instead, which additionally buys
+    /// the per-shape headline and rewrite hint.
+    UnsupportedAt { reason: String, span: almide_ir::Span, shape: WallShape },
 }
 
 impl LowerError {
@@ -47,8 +132,26 @@ impl LowerError {
     /// never have to branch.
     pub fn at(span: Option<almide_ir::Span>, reason: impl Into<String>) -> LowerError {
         match span {
-            Some(span) => LowerError::UnsupportedAt { reason: reason.into(), span },
+            Some(span) => {
+                LowerError::UnsupportedAt { reason: reason.into(), span, shape: WallShape::Other }
+            }
             None => LowerError::Unsupported(reason.into()),
+        }
+    }
+
+    /// Shape-carrying wall constructor (#931): [`LowerError::at`] plus the
+    /// known [`WallShape`], so the CLI headlines the construct and hints its
+    /// documented rewrite. Spanless input falls back exactly as `at` does —
+    /// the shape is dropped, because the hint machinery renders only through
+    /// the span path.
+    pub fn shaped(
+        span: Option<almide_ir::Span>,
+        shape: WallShape,
+        reason: impl Into<String>,
+    ) -> LowerError {
+        match span {
+            Some(span) => LowerError::UnsupportedAt { reason: reason.into(), span, shape },
+            None => LowerError::at(None, reason),
         }
     }
 
@@ -65,6 +168,15 @@ impl LowerError {
         match self {
             LowerError::Unsupported(_) => None,
             LowerError::UnsupportedAt { span, .. } => Some(*span),
+        }
+    }
+
+    /// The wall's shape — [`WallShape::Other`] when the site recorded none
+    /// (every spanless wall, and every `at`-constructed site).
+    pub fn shape(&self) -> WallShape {
+        match self {
+            LowerError::UnsupportedAt { shape, .. } => *shape,
+            _ => WallShape::Other,
         }
     }
 }

--- a/crates/almide-mir/src/lower/tail.rs
+++ b/crates/almide-mir/src/lower/tail.rs
@@ -82,8 +82,9 @@ impl LowerCtx {
             return Ok(owned);
         }
         let container = extraction_container(expr).ok_or_else(|| {
-            LowerError::at(
+            LowerError::shaped(
                 expr.span,
+                WallShape::TailExtraction,
                 format!("{} is not a field/element extraction", kind_name(&expr.kind)),
             )
         })?;

--- a/crates/almide-mir/src/pipeline_c.rs
+++ b/crates/almide-mir/src/pipeline_c.rs
@@ -417,8 +417,9 @@ fn try_render_wasm_source_impl_rest(
         // The wrapper PRESERVES the inner wall's span (#931): nesting adds
         // context to the reason, never strips the location.
         return Err(match &main_wall {
-            Some(inner) => LowerError::at(
+            Some(inner) => LowerError::shaped(
                 inner.span(),
+                inner.shape(),
                 format!("main is outside the MIR-lowering subset: {inner}"),
             ),
             None => LowerError::Unsupported(
@@ -477,8 +478,9 @@ fn try_render_wasm_source_impl_rest(
                 // Like the main wrapper: the nesting adds context, the inner
                 // wall's SPAN survives (#931).
                 return Err(match fn_walls.get(n) {
-                    Some(inner) => LowerError::at(
+                    Some(inner) => LowerError::shaped(
                         inner.span(),
+                        inner.shape(),
                         format!(
                             "exported `pub fn {n}` is outside the MIR-lowering subset \
                              (the wasm module must carry its export): {inner}"

--- a/crates/almide-mir/tests/wall_shape_hints.rs
+++ b/crates/almide-mir/tests/wall_shape_hints.rs
@@ -1,0 +1,64 @@
+//! The WallShape hint matrix gate (#931).
+//!
+//! Every KNOWN wall shape must carry BOTH texts — the plain-language headline
+//! and the documented rewrite hint — or the CLI's shape-aware rendering
+//! silently degrades to the reason-as-headline form for that shape. `Other`
+//! must carry NEITHER: it is the "no specific rewrite" bucket, and giving it
+//! texts would stamp a generic hint onto walls it does not fit. Point-wise
+//! drift (a new shape added without its texts) fails here, not in the field.
+
+use almide_mir::lower::WallShape;
+
+const KNOWN_SHAPES: &[WallShape] = &[
+    WallShape::WhileHeapAccumulator,
+    WallShape::HeapResultBind,
+    WallShape::VariantValueMatch,
+    WallShape::CallArgument,
+    WallShape::TailExtraction,
+];
+
+#[test]
+fn every_known_shape_carries_headline_and_rewrite_hint() {
+    for shape in KNOWN_SHAPES {
+        assert!(
+            shape.headline().is_some(),
+            "{shape:?} has no headline — the CLI would fall back to the raw reason"
+        );
+        assert!(
+            shape.rewrite_hint().is_some(),
+            "{shape:?} has no rewrite hint — the wall would offer no way forward"
+        );
+    }
+}
+
+#[test]
+fn other_carries_neither_text() {
+    assert_eq!(WallShape::Other.headline(), None);
+    assert_eq!(WallShape::Other.rewrite_hint(), None);
+}
+
+#[test]
+fn shape_survives_construction_and_nesting() {
+    let span = almide_ir::Span { line: 3, col: 5, end_col: 8 };
+    let inner = almide_mir::lower::LowerError::shaped(
+        Some(span),
+        WallShape::WhileHeapAccumulator,
+        "while body with a heap-accumulator reassignment",
+    );
+    // The wrapper pattern pipeline_c uses: nesting adds context to the reason
+    // but preserves the inner wall's span AND shape.
+    let wrapped = almide_mir::lower::LowerError::shaped(
+        inner.span(),
+        inner.shape(),
+        format!("main is outside the MIR-lowering subset: {inner}"),
+    );
+    assert_eq!(wrapped.span(), Some(span));
+    assert_eq!(wrapped.shape(), WallShape::WhileHeapAccumulator);
+    // `at` (no known shape) and the spanless legacy form both read as Other.
+    let at = almide_mir::lower::LowerError::at(Some(span), "reason");
+    assert_eq!(at.shape(), WallShape::Other);
+    assert_eq!(at.span(), Some(span));
+    let spanless = almide_mir::lower::LowerError::at(None, "reason");
+    assert_eq!(spanless.shape(), WallShape::Other);
+    assert_eq!(spanless.span(), None);
+}

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -518,14 +518,31 @@ fn render_wasm_module(source_text: &str, v1_self_modules: &[(String, almide_lang
             // were the worst diagnostic in the compiler (#931). A wall whose
             // construction site had a span renders through the Diagnostic
             // machinery — source line, caret, the works — so the user sees
-            // WHERE the shape lives, not just what it is.
+            // WHERE the shape lives, not just what it is. A KNOWN WallShape
+            // additionally headlines the construct in surface-language
+            // vocabulary and hints its documented rewrite; the raw reason —
+            // compiler-internal vocabulary and all — moves to a trailing
+            // `note:` where it still serves a bug report.
             if let Some(span) = e.span() {
+                let shape = e.shape();
+                let (message, hint, reason_note) =
+                    match (shape.headline(), shape.rewrite_hint()) {
+                        (Some(headline), Some(rewrite)) => {
+                            (headline.to_string(), rewrite.to_string(), Some(e.reason()))
+                        }
+                        _ => (
+                            e.reason().to_string(),
+                            "the unverified v0 wasm emitter was retired (#782): a wall is an \
+                             honest error instead of a silent fallback. If this names a missing \
+                             capability, please file it with the source shape that triggered it: \
+                             https://github.com/almide/almide/issues"
+                                .to_string(),
+                            None,
+                        ),
+                    };
                 let mut d = crate::diagnostic::Diagnostic::error(
-                    e.reason().to_string(),
-                    "the unverified v0 wasm emitter was retired (#782): a wall is an honest \
-                     error instead of a silent fallback. If this names a missing capability, \
-                     please file it with the source shape that triggered it: \
-                     https://github.com/almide/almide/issues",
+                    message,
+                    hint,
                     "the verified wasm render (v1 trust spine) — this shape is not yet in its subset",
                 );
                 d.line = Some(span.line);
@@ -533,7 +550,16 @@ fn render_wasm_module(source_text: &str, v1_self_modules: &[(String, almide_lang
                 if span.end_col > span.col {
                     d.end_col = Some(span.end_col);
                 }
-                err(&format!("{}", crate::diagnostic_render::display_with_source(&d, source_text)));
+                let mut rendered =
+                    crate::diagnostic_render::display_with_source(&d, source_text);
+                if let Some(reason) = reason_note {
+                    rendered.push_str(&format!(
+                        "\n  note: {reason}\n  note: if the rewrite does not apply, file the \
+                         source shape that triggered this: \
+                         https://github.com/almide/almide/issues"
+                    ));
+                }
+                err(&rendered);
             } else {
                 err(&format!(
                     "error: this program shape is not yet supported by the verified wasm renderer\n\n  \

--- a/tests/wall_shape_rendering_test.rs
+++ b/tests/wall_shape_rendering_test.rs
@@ -1,0 +1,125 @@
+//! A known-shape wall renders as headline + rewrite hint + caret + note (#931).
+//!
+//! The closure condition's rendering half: for a wall whose site stamped a
+//! `WallShape`, the CLI diagnostic leads with a surface-language headline,
+//! hints the documented rewrite (the while-heap-accumulator wall's hint is
+//! the recursion idiom), points at the source with a caret, and demotes the
+//! raw compiler-internal reason string to a trailing `note:`. Before, the
+//! reason WAS the headline and the hint was only the file-an-issue pointer.
+//!
+//! Skips cleanly when the `almide` binary is unavailable (CI builds it in the
+//! build step; locally run `cargo build --release` first).
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn tool_available() -> bool {
+    Command::new(almide_bin()).arg("--version").output().is_ok()
+}
+
+/// The single most-reported wall (#931's own example class), reduced from
+/// `examples/minesweeper.almd` by ddmin: a `while` body reassigning a heap
+/// accumulator in a nested arm, past what the scalar-state loop admits. (The
+/// simple `s = s + "x"` loop now EXECUTES — the subset absorbed it — so the
+/// fixture needs the effect-call let + nested reassignment to still wall. If
+/// the subset absorbs this shape too, the first assertion below fails: pick
+/// the next still-walled shape from the skip ledger and update the fixture.)
+const WHILE_HEAP_ACCUMULATOR: &str = r#"import io
+
+effect fn pick() -> Result[List[Int], String] = ok([1, 2])
+
+fn grow(xs: List[Int], n: Int) -> List[Int] = xs + [n]
+
+effect fn main() -> Unit = {
+  var adj: List[Int] = []
+  var first = true
+  var game_over = false
+  while not game_over {
+    let input = io.read_line()
+    match int.parse(input) {
+      err(msg) => {},
+      ok(n) => {
+        if n > 0 then {
+          if first then {
+            let mines = pick()
+            adj = grow(mines, n)
+            first = false
+          } else ()
+        } else {
+          game_over = true
+        }
+      },
+    }
+  }
+  println(int.to_string(list.len(adj)))
+}
+"#;
+
+#[test]
+fn while_heap_accumulator_wall_renders_headline_hint_caret_and_note() {
+    if !tool_available() {
+        eprintln!("skipping: almide binary not available");
+        return;
+    }
+    let dir = std::env::temp_dir().join(format!("almide-wall-shape-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let src = dir.join("wall.almd");
+    std::fs::write(&src, WHILE_HEAP_ACCUMULATOR).unwrap();
+
+    let output = Command::new(almide_bin())
+        .args([
+            "build",
+            src.to_str().unwrap(),
+            "--target",
+            "wasm",
+            "-o",
+            dir.join("wall.wasm").to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to spawn almide");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    std::fs::remove_dir_all(&dir).ok();
+
+    assert!(
+        !output.status.success(),
+        "a walled build must fail (v0 was retired; a wall is an honest error), got success.\nstderr: {stderr}"
+    );
+    // Headline: what the user wrote, surface vocabulary — not the raw reason.
+    assert!(
+        stderr.contains("grows a heap value"),
+        "headline missing from:\n{stderr}"
+    );
+    // Hint: the documented rewrite, not (only) the file-an-issue pointer.
+    assert!(
+        stderr.contains("hoist the accumulator into a recursive helper"),
+        "rewrite hint missing from:\n{stderr}"
+    );
+    // The caret gutter points into the source.
+    assert!(stderr.contains("^"), "caret missing from:\n{stderr}");
+    assert!(stderr.contains("while"), "source line missing from:\n{stderr}");
+    // The raw reason survives as a note (it still serves a bug report), and
+    // is no longer the headline.
+    assert!(
+        stderr.contains("note: ") && stderr.contains("model-one-iteration"),
+        "raw-reason note missing from:\n{stderr}"
+    );
+    let headline_line = stderr
+        .lines()
+        .find(|l| l.contains("error"))
+        .unwrap_or_default();
+    assert!(
+        !headline_line.contains("model-one-iteration"),
+        "the raw reason leaked back into the headline:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Fixes #931 — the remaining half after #973 (span + caret + ratchet).

## Closure condition → where it landed

| condition | status |
|---|---|
| `WallShape` enum of known shapes on the error | this PR — `WhileHeapAccumulator` / `HeapResultBind` / `VariantValueMatch` / `CallArgument` / `TailExtraction` / `Other`, stamped on all 9 span-carrying sites via the new `LowerError::shaped`; the two nesting wrappers (`main is outside…`, `exported pub fn…`) carry the INNER wall's shape through, same discipline as the span |
| CLI renders source line + caret + per-shape rewrite hint | #973 rendered the caret; this PR adds the shape texts. The while-heap-accumulator hint is the issue's own: "hoist the accumulator into a recursive helper" (the CHEATSHEET recursion idiom) |
| raw reason moves to a `note:` | this PR — for a known shape the headline is surface-language ("this `while` body grows a heap value (String/List) across iterations"), and the compiler-internal reason ("model-one-iteration fallback… not in this brick") trails as `note:` where it still serves a bug report. `Other`-shaped walls render as before |
| new spanless wall sites fail a lint | #973's ratchet, untouched — still 193, textual count unchanged by this PR |
| native fallback prints a one-line notice by default | already on develop (`render_v1_native_or_fallback`: "the fallback is SILENT no more") |

## What the user sees now (`almide build examples/minesweeper.almd --target wasm`)

```
error: this `while` body grows a heap value (String/List) across iterations — not yet in the verified wasm subset
  at line 181
  in the verified wasm render (v1 trust spine) — this shape is not yet in its subset
  here: while not game_over {
  hint: hoist the accumulator into a recursive helper fn (prefer recursion over var + while), or build the value with a list combinator (map / filter / join)
    |
181 |   while not game_over {
    |         ^^^
  note: main is outside the MIR-lowering subset: while body with a heap-accumulator reassignment cannot be faithfully lowered (the model-one-iteration fallback defers the reassignment, dropping the accumulation) not in this brick
  note: if the rewrite does not apply, file the source shape that triggered this: https://github.com/almide/almide/issues
```

## Tests

- `crates/almide-mir/tests/wall_shape_hints.rs` — the shape matrix gate: every non-`Other` shape carries BOTH texts, `Other` carries neither, and shape+span survive the pipeline_c nesting wrappers.
- `tests/wall_shape_rendering_test.rs` — CLI integration on a ddmin-reduced minesweeper wall (the simple `s = s + "x"` loop now EXECUTES — the subset absorbed it — so the fixture needs the effect-call let + nested reassignment): asserts headline, rewrite hint, caret, source line, the reason note, and that the raw reason no longer leaks into the headline.
- Ratchet untouched: `wall_span_ratchet` still passes at baseline 193.

## Verification

| gate | result |
|---|---|
| `cargo test --workspace --release --no-fail-fast` | green |
| `almide test` (full spec) | 323/323 |
| minesweeper wall rendering (above) | exit 1, new form |