### PR TITLE
Make the embedded-size ratchet measure again: pattern-discovered embed sites, blind-scan floor, missing-file hard error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ almide test
 
 When adding or modifying stdlib functions (the stdlib is self-hosted — `stdlib/defs/*.toml` and `runtime/rust/` no longer exist):
 - Write the implementation in pure Almide in `stdlib/<module>[_<part>].almd`
-- For WASM/v1 coverage, register it in `crates/almide-mir/src/render_wasm/registry.rs` (`include_str!` + `(impl_fn, "module.fn")` mapping); adjust `purity.rs` if needed. Unlinked stdlib calls are a wall error in the wasm renderer
+- For WASM/v1 coverage, register it in `crates/almide-types/src/self_host_registry.rs` (add `(crate::embedded::SRC_<STEM>, &[("impl_fn", "module.fn")])` to `self_host_runtime()`); adjust `crates/almide-mir/src/purity.rs` if needed. Unlinked stdlib calls are a wall error in the wasm renderer
 - Only if a native intrinsic is required: implement `almide_rt_*` in `runtime/rs/src/<module>.rs` and declare it with `@intrinsic("almide_rt_*")` in the module's `.almd`
 - New modules: update `STDLIB_MODULES` / `BUNDLED_MODULES` / `bundled_source()` (and `AUTO_IMPORT_BUNDLED` if auto-imported) in `crates/almide-types/src/stdlib_info.rs`
 - Write a test in `spec/stdlib/` (as `*_test.almd` or inline `test` block); add the almide-interp bridge glue so the 3-way oracle covers it

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -56,6 +56,6 @@ so it shares no codegen pass with either backend. See
 ## When Adding a New Feature
 
 - **New syntax** → almide-syntax (parser) → almide-frontend (checker + lowering) → almide-codegen (passes + templates)
-- **New stdlib function** → pure-Almide impl in `stdlib/<module>[_<part>].almd`; register for WASM in `almide-mir/src/render_wasm/registry.rs`; native intrinsics (only when needed) in `runtime/rs/src/<module>.rs` + `@intrinsic` declaration. To keep the 3-way oracle covering it (instead of skipping it), also add the glue to almide-interp's bridge — it is hand-maintained, NOT auto-generated. See [almide-interp/CLAUDE.md](./almide-interp/CLAUDE.md#coverage-model--does-a-new-stdlib-fn-get-covered-automatically).
+- **New stdlib function** → pure-Almide impl in `stdlib/<module>[_<part>].almd`; register for WASM + interp in `almide-types/src/self_host_registry.rs` (`self_host_runtime()`); native intrinsics (only when needed) in `runtime/rs/src/<module>.rs` + `@intrinsic` declaration. To keep the 3-way oracle covering it (instead of skipping it), also add the glue to almide-interp's bridge — it is hand-maintained, NOT auto-generated. See [almide-interp/CLAUDE.md](./almide-interp/CLAUDE.md#coverage-model--does-a-new-stdlib-fn-get-covered-automatically).
 - **New type** → almide-types (Ty variant) → almide-frontend (inference rules) → almide-ir (IR nodes) → almide-codegen (emission)
 - **New codegen target** → almide-codegen (pass pipeline + TOML template + target entry)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -141,8 +141,9 @@ The wasm backend is the v1 MIR pipeline in `almide-mir`:
   name section.
 - Ownership/RC follows Perceus; the crate forbids `unsafe`.
 - Stdlib calls are *self-hosted*: pure-Almide implementations from
-  `stdlib/*.almd` are registered in `render_wasm/registry.rs` and compiled
-  along with user code. An unlinked stdlib call is a wall (hard error).
+  `stdlib/*.almd` are registered in `almide-types/src/self_host_registry.rs`
+  and compiled along with user code. An unlinked stdlib call is a wall (hard
+  error).
 - `wasmparser::validate` guards the test harness; `almide test --target wasm`
   falls back to native execution on a wall.
 
@@ -156,7 +157,8 @@ The stdlib is self-hosted: every function lives in `stdlib/<module>[_part].almd`
   codegen extracts `@inline_rust` templates. `@intrinsic("almide_rt_*")`
   declarations dispatch to hand-written Rust in `runtime/rs/src/<module>.rs`.
 - **WASM** — pure-Almide implementations registered in
-  `almide-mir/src/render_wasm/registry.rs` are compiled to WAT with user code.
+  `almide-types/src/self_host_registry.rs` (shared with the interp oracle)
+  are compiled to WAT with user code.
 
 Auto-import is the union of the seed list in
 `almide-frontend/src/import_table.rs` and `AUTO_IMPORT_BUNDLED` in

--- a/docs/HIDDEN_OPERATIONS.md
+++ b/docs/HIDDEN_OPERATIONS.md
@@ -88,7 +88,7 @@ fn load() -> Result<String, String> {
 ### WASM target
 
 外部ランタイムは存在しない。stdlib は self-hosted な純 Almide 実装
-（`stdlib/*.almd` → `crates/almide-mir/src/render_wasm/registry.rs`）が
+（`stdlib/*.almd` → `crates/almide-types/src/self_host_registry.rs`）が
 ユーザコードと一緒に WAT へコンパイルされ、少数の手書き WAT プリアンブルと
 共にモジュールへ埋め込まれる。詳細: [WASM-OUTPUT.md](./WASM-OUTPUT.md)。
 

--- a/docs/roadmap/active/v1-adt-brick5-goal.md
+++ b/docs/roadmap/active/v1-adt-brick5-goal.md
@@ -133,7 +133,7 @@ WIRING:
 1. `Op::DropVariant { v, ty }` in MIR — cert = ONE `d` (lib.rs + certificate.rs, alongside the
    other Drop* ops). Render → `(call $__drop_<ty> (local.get v))`.
 2. GENERATE the `__drop_<ty>` Almide source per recursive variant type at program assembly and
-   auto-link it (the cleanest hook is alongside `self_host_runtime()` in render_wasm/registry.rs
+   auto-link it (the cleanest hook is alongside `self_host_runtime()` in almide-types/src/self_host_registry.rs
    — but that registry is `include_str!` of fixed files, so add a DYNAMIC generated-source path:
    produce the source string from the `VariantLayouts`, run it through the same frontend feeder
    `lower_source` uses, rename its fn to `__drop_<ty>`, add to the program functions). Both

--- a/docs/roadmap/active/v1-records-svg.md
+++ b/docs/roadmap/active/v1-records-svg.md
@@ -78,7 +78,7 @@ records. Concrete pieces:
    this, but the recursion is shallow per-level).
 
 3. **`__drop_map_ss`** (generic `Map[String,String]` free, self-host once in `stdlib/value_core.almd`
-   + register in `render_wasm/registry.rs`): the Map is a DynListStr of `2*len` String slots (key,val
+   + register in `almide-types/src/self_host_registry.rs`): the Map is a DynListStr of `2*len` String slots (key,val
    pairs) — rc_dec each of `2 * load32(h+4)` slots, then rc_dec the block. (NOTE: a flat `DropListStr`
    is WRONG here — it uses len@4 = entry count = n, not 2n, leaking the values.)
 
@@ -124,7 +124,7 @@ records. Concrete pieces:
 - `crates/almide-mir/src/lib.rs` — `Op::DropVariant` (258) + the Drop family.
 - `crates/almide-mir/examples/render_program.rs` (~217) + `crates/almide-mir/src/render_wasm/tests_part1.rs`
   (~217) — where `generate_variant_drop_sources` is appended + linked.
-- `stdlib/value_core.almd` + `crates/almide-mir/src/render_wasm/registry.rs` — `__drop_map_ss`.
+- `stdlib/value_core.almd` + `crates/almide-types/src/self_host_registry.rs` — `__drop_map_ss`.
 - svg source: `/Users/o6lvl4/workspace/github.com/almide/svg/src/mod.almd` (Element @ line 11, el @ 44,
   doc @ 47, group @ 97, render_el @ ~205).
 

--- a/scripts/check-embedded-size.sh
+++ b/scripts/check-embedded-size.sh
@@ -1,19 +1,26 @@
 #!/usr/bin/env bash
 # EMBEDDED-PAYLOAD SIZE RATCHET (#878).
 #
-# The compiler embeds the self-hosted stdlib verbatim: every `include_str!` in
-# `crates/almide-mir/src/render_wasm/registry.rs` (the wasm self-host registry)
-# and in `crates/almide-types/src/stdlib_info.rs` (the bundled-module sources)
+# The compiler embeds the self-hosted stdlib verbatim: every `SRC_<STEM>`
+# const `crates/almide-types/build.rs` generates (referenced from
+# `stdlib_info.rs`'s bundled sources and `self_host_registry.rs`'s wasm
+# self-host registry) plus every direct `include_str!(".../stdlib/*.almd")`
 # lands in the binary's DATA section. That section was 2.04MB of the 5.8MB
 # size-first playground build — the half of the footprint this repo owns and
 # can watch. The 6x growth over four months went unnoticed because nothing
 # watched it; this is the watch.
 #
 # What it checks: the total bytes of the DISTINCT stdlib sources reachable
-# through those two embed sites, against `scripts/embedded-size-baseline.txt`.
+# through those embed sites, against `scripts/embedded-size-baseline.txt`.
 # Growth beyond the budget fails. Adding stdlib is normal and expected — the
 # gate is not "never grow", it is "grow on purpose": raise the baseline in the
 # SAME change, so the number is a reviewed decision instead of a drift.
+#
+# The embed sites are DISCOVERED by pattern over crates/, not named by path:
+# the previous version grepped a hard-coded file that was later deleted in a
+# reorganization, its grep error was swallowed, and the gate spent its life
+# measuring "0 bytes over 0 sources" — green forever (#976). Discovery plus
+# the hard floor below make that failure mode loud instead of silent.
 #
 # The other half (the 3.76MB code section) is a twiggy audit + feature gating,
 # tracked in #878; it needs the wasm build, which lives in the playground repo.
@@ -23,15 +30,22 @@ cd "$(git rev-parse --show-toplevel)"
 BASELINE_FILE="scripts/embedded-size-baseline.txt"
 # Percent the total may exceed the baseline before this fails.
 BUDGET_PCT="${EMBEDDED_SIZE_BUDGET_PCT:-10}"
+# The scan must find at least this many sources or it has gone blind (#976):
+# the bundled list alone names ~40 modules, so a result under the floor means
+# the discovery pattern no longer matches the embed sites, not a small stdlib.
+SOURCE_FLOOR=30
 
 sources() {
-  # Distinct stdlib stems named by either embed site (`SRC_<STEM>`, the consts
-  # `crates/almide-types/build.rs` generates). `sort -u` makes the total a real
-  # footprint rather than a sum with duplicates.
+  # Distinct stdlib stems named by any embed site: `SRC_<STEM>` references
+  # anywhere in almide-types (build.rs generates one per stdlib/<stem>.almd),
+  # plus direct `include_str!` of a stdlib file anywhere in crates/. `sort -u`
+  # makes the total a real footprint rather than a sum with duplicates.
   {
-    grep -o 'SRC_[A-Z0-9_]*' crates/almide-mir/src/render_wasm/registry.rs
-    grep -o 'SRC_[A-Z0-9_]*' crates/almide-types/src/stdlib_info.rs
-  } | sort -u | sed 's/^SRC_//' | tr 'A-Z' 'a-z' | sed 's|^|stdlib/|; s|$|.almd|'
+    grep -rho 'SRC_[A-Z0-9_]*' crates/almide-types/src/ \
+      | sed 's/^SRC_//' | tr 'A-Z' 'a-z' | sed 's|^|stdlib/|; s|$|.almd|'
+    grep -rho 'include_str!("[^"]*stdlib/[^"]*\.almd")' crates/ \
+      | sed 's|.*stdlib/|stdlib/|; s|")$||'
+  } | sort -u
 }
 
 # Count what SHIPS, not what the repo holds: the embed blanks whole-line
@@ -41,11 +55,24 @@ sources() {
 total=0
 count=0
 while read -r f; do
-  [ -f "$f" ] || continue
+  if [ ! -f "$f" ]; then
+    echo "::error::embedded-size: $f is named by an embed site but does not exist —"
+    echo "a SRC_ const or include_str! references a deleted stdlib source. Fix the"
+    echo "reference (or restore the file); the gate does not skip what it cannot see."
+    exit 1
+  fi
   n=$(awk '{ if ($0 ~ /^[[:space:]]*\/\//) print ""; else print }' "$f" | wc -c | tr -d ' ')
   total=$((total + n))
   count=$((count + 1))
 done < <(sources)
+
+if [ "$count" -lt "$SOURCE_FLOOR" ]; then
+  echo "::error::embedded-size: only $count embedded sources discovered (floor $SOURCE_FLOOR)"
+  echo "— the scan went blind (#976): the embed sites moved and the discovery pattern"
+  echo "in sources() no longer matches them. Point it at the current registry; do not"
+  echo "lower the floor to make this pass."
+  exit 1
+fi
 
 if [ ! -f "$BASELINE_FILE" ]; then
   echo "embedded-size: no baseline; writing $BASELINE_FILE ($total bytes over $count sources)"


### PR DESCRIPTION
Fixes #976.

## The failure

`scripts/check-embedded-size.sh` grepped the hard-coded path `crates/almide-mir/src/render_wasm/registry.rs`. That file was deleted in 3292fd8d (the registry moved to `crates/almide-types/src/self_host_registry.rs`), the grep's failure was swallowed by the pipeline, and the #878 payload ratchet has been reporting `0 bytes over 0 sources` — green forever. Same broken-gate class as #919's `fmt --check`.

## The fix

- **Discovery over hard-coding**: `sources()` now derives the embedded set by pattern — every `SRC_<STEM>` reference in `crates/almide-types/src/` (the consts `build.rs` generates, referenced by `stdlib_info.rs` and `self_host_registry.rs`) plus every direct `include_str!("…stdlib/*.almd")` anywhere in `crates/` (catches the two pipeline embeds of `value_core`/`print_str`). A file rename or split cannot silently blind it again.
- **Blind-scan floor**: fewer than 30 discovered sources is a hard error naming #976 — "0 sources" can never read as green again. Verified by simulation: breaking the discovery patterns makes the gate exit 1 with the floor message.
- **Missing-file hard error**: a stem named by an embed site that doesn't exist on disk used to be silently skipped; now it fails loudly (a `SRC_` const for a deleted stdlib file is drift, not noise).
- **Docs de-staled**: `CLAUDE.md`, `crates/CLAUDE.md`, `docs/ARCHITECTURE.md`, `docs/HIDDEN_OPERATIONS.md`, and the two active roadmap files still pointed new-stdlib work at the deleted `render_wasm/registry.rs`; all now name `almide-types/src/self_host_registry.rs` (`self_host_runtime()`). Historical `docs/roadmap/done/` records are left as records.

## The number, re-measured

```
embedded-size: 842156 bytes over 286 stdlib sources (baseline 819637, ceiling 901600, +10%)
```

The growth accrued while the gate was blind is +2.7% over the last reviewed baseline — inside the +10% budget, so the baseline stands and the gate passes honestly. No re-baseline needed.