### PR TITLE
Sweep the stale paths out of the specs, contracts doc, stdlib README, and active roadmap

### DIFF
--- a/docs/contracts/C-033-cow-truth-table.md
+++ b/docs/contracts/C-033-cow-truth-table.md
@@ -5,7 +5,8 @@
 > 2026-06-06): the truth table below is now byte-identical on both targets,
 > locked by `spec/wasm_cross/alias_cow.almd`. The history below was ported from
 > the formerly-grandfathered `cow_check` note in
-> [crates/almide-codegen/rt-oracle-registry.toml](../../crates/almide-codegen/rt-oracle-registry.toml).
+> `crates/almide-codegen/rt-oracle-registry.toml` (retired with the v0 emitter, #782 —
+> see git history; the live gates are spec/wasm_cross + the interp oracle).
 > This is the SOLE doc-only contract — it records a real, currently-unfixable
 > native<->wasm divergence, not a behaviour we can yet certify.
 

--- a/docs/roadmap/active/closure-architecture-v2.md
+++ b/docs/roadmap/active/closure-architecture-v2.md
@@ -123,7 +123,7 @@ A recognizer pass that runs **before** lifting. A closure may be inlined iff a
 - **(a) the use site**: the closure is *anonymous* (not the RHS of any `Bind`),
   *single-use*, and does not escape its scope; **and**
 - **(b) the sink**: the callee is on a curated allowlist of *consume-only*
-  combinators carrying `@fn_arg_consumed(idx)` in `stdlib/defs`, verified once
+  combinators carrying `@fn_arg_consumed(idx)` in the stdlib `.almd` sources (the stdlib/defs TOML pipeline is gone), verified once
   against the runtime impl — so the closure cannot escape *through* the call (a
   `fold` whose reducer captures the fn into the accumulator would otherwise
   escape it).
@@ -302,7 +302,7 @@ effect fn main() -> Unit = {
 ```
 
 **True root cause (frontend, *not* Perceus or the `Try` emit — the earlier hypothesis
-in this doc was wrong).** `lower_call_target` (`almide-frontend/src/lower/calls.rs`)
+in this doc was wrong).** `lower_call_target` (`crates/almide-frontend/src/lower/calls_target.rs`)
 decided `Named` vs `Computed` for `add5(10)` by reading the **`var_table` snapshot
 type** of `add5` and checking `matches!(.., Ty::Fn)`. In an effect fn the effect-`?`
 unwrap rewrite (`auto_try`) runs *after* lowering, so at the call site `add5`'s stored
@@ -419,5 +419,5 @@ The capture-*cell* architecture is complete. A later adversarial cross-target sw
 adjacent divergences in how closures are *typed / parsed / stored* (string mutators on WASM,
 closure-in-tuple, list-index call, typed params, closure-in-map, non-Copy-element IndexAssign) —
 orthogonal to capture cells. Those are tracked separately in
-[Closure Codegen Cross-Target Gaps](closure-codegen-cross-target-gaps.md) (5 fixed via #334; 2 deep
+[Closure Codegen Cross-Target Gaps](../done/closure-codegen-cross-target-gaps.md) (5 fixed via #334; 2 deep
 ones root-caused and open).

--- a/docs/roadmap/active/correctness-guarantee-gaps.md
+++ b/docs/roadmap/active/correctness-guarantee-gaps.md
@@ -157,7 +157,7 @@ Quick wins first (small effort, high leverage):
     現状 `hard_fail = cfg!(debug_assertions)`（pass.rs:248）。release では
     print のみで素通り。注意: そのまま hard error 化すると、下記
     under-constrained のような「今 warning で通っているプログラム」が
-    全て compile error になる破壊的変更。先に spec/exercises 全量で
+    全て compile error になる破壊的変更。先に spec/ 全量で
     影響件数を測ること。
   - **under-constrained を明確に拒否**: `ok([])` を fold init にし err 値が
     一度も現れないケースは err 型 `E` が原理的に未制約 → 現状

--- a/docs/roadmap/active/cross-target-completeness.md
+++ b/docs/roadmap/active/cross-target-completeness.md
@@ -26,7 +26,7 @@ RC) — makes no equivalence claim at all.
 |---|---|
 | Cross-target gate (`tests/wasm_runtime_test.rs::wasm_cross_target_spec`) | 65+ corpus files, byte-compared, **0 @xt-allow** |
 | Documented divergence list | **N = 0** (`fan.timeout`, the last entry, was removed from the language in 0.29.0 — C-006 flipped to active) |
-| Oracle-pairing registry (`crates/almide-codegen/rt-oracle-registry.toml`, gate = `scripts/check-rt-oracle-registry.sh`) | 118 routines: **76 verified / 42 grandfathered** (was 48; drain in progress) |
+| Oracle-pairing registry — RETIRED with the v0 emitter (#782); `scripts/check-rt-oracle-registry.sh` is a tombstone | superseded by spec/wasm_cross + the interp 3-way oracle (final v0 tally: 76 verified / 42 grandfathered) |
 | By-construction tables (Σ-probe derived from Rust std at emit time + all-scalar CI locks) | case folding, whitespace, UTF-8 classification, Unicode properties (Alphabetic/Alphanumeric/Uppercase/Lowercase) |
 | Lean kernel-check in CI | 41 theorems (Perceus RC / closure env / heap) — `lake build`, not just a sorry-grep |
 | Other ratchets | fmt round-trip property (no skips), host-arch-deterministic emit, snapshot suite |
@@ -55,7 +55,7 @@ A new divergence must evade ALL of these to exist:
    targets run the same source (the "two implementations drift" tap closes), shrinking
    the proof surface to ~30 IR ops + RC + layout; prove those (per-op theorems).
    **Selfhost is parked here by decision (2026-06-05) — roadmap-only until called.**
-   See `research/selfhost/` probes.
+   See `research/spike/v1-mir/` (the former `research/selfhost/` probes were removed).
 
 ## Live drain queue (all enumerated, coordinates known)
 

--- a/docs/roadmap/active/effect-system-capability.md
+++ b/docs/roadmap/active/effect-system-capability.md
@@ -102,9 +102,9 @@ Layer 1 catches bugs. Layer 2 catches compiler bugs. Layer 3 catches everything 
    - Pure `fn` → zero capabilities (unchanged)
 
 **Files to modify**:
-- `stdlib/defs/*.toml` — add `capability = "FS.read"` field to each function def
+- stdlib `.almd` sources — declare the capability on each function (the stdlib/defs TOML pipeline is gone; per-fn metadata lives in the .almd bodies)
 - `crates/almide-frontend/src/check/` — capability checking pass
-- `crates/almide-frontend/src/resolve.rs` — parse [permissions] from almide.toml
+- `src/resolve.rs` (root crate) — parse [permissions] from almide.toml
 - `crates/almide-base/src/` — CapabilitySet type (u16 bitset)
 
 **Test**: Write an agent test that compiles with `allow = ["FS.read"]` and fails with `fs.write_text` call.
@@ -137,8 +137,8 @@ Layer 1 catches bugs. Layer 2 catches compiler bugs. Layer 3 catches everything 
    Orchestrator reads this before loading the WASM binary — verify capabilities match policy.
 
 **Files to modify**:
-- `crates/almide-codegen/src/emit_wasm/mod.rs` — conditional WASI import emission
-- `crates/almide-codegen/src/emit_wasm/runtime.rs` — WASI import registration
+- `crates/almide-mir/src/render_wasm*` — conditional WASI import emission (this plan predates #782; v0's emit_wasm/ is deleted)
+- `crates/almide-types/src/self_host_registry.rs` — WASI import registration (v0 path deleted, #782)
 - `src/cli/build.rs` — emit manifest.json
 
 **Test**: Build with `allow = ["IO.stdout"]` → verify WASM binary has no `path_open` import.
@@ -185,9 +185,9 @@ Fn { params: Vec<Ty>, ret: Box<Ty>, effects: CapabilitySet }
 This is the most invasive change (touches Ty enum, unification, inference) but enables precise tracking through HOFs.
 
 **Files to modify**:
-- `crates/almide-types/src/types.rs` — CapabilitySet field on Ty::Fn
+- `crates/almide-types/src/types/mod.rs` — CapabilitySet field on Ty::Fn
 - `crates/almide-frontend/src/check/infer.rs` — effect propagation through HOFs
-- `crates/almide-frontend/src/check/unify.rs` — CapabilitySet unification
+- `crates/almide-types/src/types/unify.rs` — CapabilitySet unification
 
 ### Phase 5: MCP Server Stdlib Module
 

--- a/docs/roadmap/active/flight-profile.md
+++ b/docs/roadmap/active/flight-profile.md
@@ -124,7 +124,7 @@ counted range のみ・no-alloc-in-loop・static pool ── これは **DO-178C
   - **Almide → Rust 翻訳忠実性** = `rust_pattern` 表 + per-build V。`Translation.v` の
     **eager instance は既に証明済み**(`eager_translation_refines_safety`)で、同じ shape。
     綺麗なマッピング(`Dup→.clone()` / `Drop→scope-end` / `Consume→move` /
-    `MakeUnique→no-op`)は `render_rust.rs:1-21` に「§3.2 faithful-renderer 契約」
+    `MakeUnique→no-op`)は `render_native.rs:1-21` に「§3.2 faithful-renderer 契約」
     として既に書かれている。
   - **Rust ソース → 機械語** = **Ferrocene に信頼**(ISO 26262 ASIL D / IEC 61508 資格化)。
     SCADE KCG 型で、`certification-grade.md:135` が既にこのアナロジーを書いている。
@@ -137,7 +137,7 @@ counted range のみ・no-alloc-in-loop・static pool ── これは **DO-178C
 
 Rust 経路が**2本に分裂**している:
 
-- **綺麗な所有権保存マッピング** = `crates/almide-mir/src/render_rust.rs`(368行のデモ)。
+- **綺麗な所有権保存マッピング** = `crates/almide-mir/src/render_native.rs`(368行のデモ)。
   だが Vec<i64> 一律・CLI 未接続・`v0`/`v1` 番号ローカルで**レビュー不可グレード**。
 - **本番 Rust** = `crates/almide-codegen/src/walker/` + `codegen/templates/rust.toml`
   (v0/legacy)。イディオマティックで**レビュー可・DO-178C「ソースは可読」を満たす**が、

--- a/docs/roadmap/active/interp-is-desugar-to-tostring.md
+++ b/docs/roadmap/active/interp-is-desugar-to-tostring.md
@@ -22,7 +22,7 @@ The desugar landed (commit f81a93a0, develop-v1) in the **v1 lowering**
 (`crates/almide-mir/src/lower/mod.rs` `desugar_string_interp`), NOT the shared frontend. This
 deliberately defers the frontend desugar (layer 1) to keep v0 risk at zero. Evidence: the step-2
 diff touches only `almide-mir` (+ a new `stdlib/bool.almd`); `git diff crates/almide-frontend` is
-EMPTY; v0's `emit_string_interp` (in `crates/almide-codegen/src/emit_wasm/calls_string.rs`) is
+EMPTY; v0's `emit_string_interp` (in `emit_wasm/calls_string.rs`, deleted with #782 — git history) was
 unchanged. What was retired is the v1-internal `interp_str_lowerable` predicate — NOT the v0 oracle.
 The dual-oracle is fully intact and IS the gate: v1's desugar output is byte-compared against v0's
 output (corpus-wall (a)=250 interps byte-match v0; + independent goldens: Int/String/Bool/edge

--- a/docs/roadmap/active/post-0.29-improvement-sweep.md
+++ b/docs/roadmap/active/post-0.29-improvement-sweep.md
@@ -45,4 +45,4 @@
 ## 関連
 
 - flight ladder は別建て: [#586](https://github.com/almide/almide/issues/586)（#776 リファレンスアプリ / #777 lowering 信頼基底縮小 / #569 WCET 更新済み）
-- [v1-release-path](v1-release-path.md) / [v1-org-byte-verification](v1-org-byte-verification.md) / [code-health-codopsy](code-health-codopsy.md)
+- [v1-release-path](v1-release-path.md) / [v1-org-byte-verification](v1-org-byte-verification.md) / [code-health-codopsy](../done/code-health-codopsy.md)

--- a/docs/roadmap/active/receipt-logic.md
+++ b/docs/roadmap/active/receipt-logic.md
@@ -147,7 +147,7 @@ C-SAFE は**ソース不要・成果物だけで検証できる最強の型**。
    スコープを明記)。capability Phase 1-2 が前提。
 2. **Receipt v2**(+ C-FAITHFUL): CG-1 oracle 反転 + 性質台帳の公開と拡張。
 3. **Receipt v3**(T4 対応): 再現ビルド → 2 バックエンドを使った DDC 型
-   相互検証 → selfhost(`research/selfhost/`)。rustc そのものへの攻撃は
+   相互検証 → selfhost(旧 `research/selfhost/`、現 `research/spike/v1-mir/`)。rustc そのものへの攻撃は
    v1/v2 完了後に初めて意味を持つ。
 
 ## trust-layer.md への反映(追補 4 点)

--- a/docs/roadmap/active/v0-unwrap-early-return-leak.md
+++ b/docs/roadmap/active/v0-unwrap-early-return-leak.md
@@ -16,7 +16,7 @@ For an `effect fn`, `x!` (`IrExprKind::Unwrap`), the effect-fn auto-`?`
 RETURN. The v0 **wasm** emitter renders that Err path as a bare early return:
 
 ```
-// crates/almide-codegen/src/emit_wasm/expressions.rs
+// v0's emit_wasm/expressions.rs (deleted with #782 — read via git history)
 //   Unwrap/Result : 846   local_get(scratch); return_;
 //   Unwrap/Option : 826   ... return_;
 //   Try           : 786   ... local_get(res); return_;
@@ -26,7 +26,7 @@ RETURN. The v0 **wasm** emitter renders that Err path as a bare early return:
 
 The function's per-heap-local `rc_dec` frees are inserted by the Perceus pass
 ONLY at the terminal `Ret`/`Nop`
-(`crates/almide-codegen/src/pass_perceus.rs:389-441 insert_decs_before_ret`).
+(v0's `pass_perceus.rs:389-441 insert_decs_before_ret` — deleted with #782; see git history).
 The early `return_` is an unconditional control transfer to the function end that
 jumps PAST all of those decs. So any heap local already bound and still live at
 the early-return point is LEAKED on the Err path.

--- a/docs/roadmap/active/v1-adt-brick5-goal.md
+++ b/docs/roadmap/active/v1-adt-brick5-goal.md
@@ -48,7 +48,7 @@ corpus-wall after each.
   `bind_variant_arm` (scalar binds only), `emit_variant_arm_chain` / `emit_variant_unit_chain`.
   Wired at: tail.rs (scalar+heap), binds.rs (let-bind), calls.rs (operand/arg + ctor construct
   in arg position), control.rs:~122 (unit statement).
-- v0 reference layout: `crates/almide-codegen/src/emit_wasm/collections.rs::emit_record`,
+- v0 reference layout (deleted with #782 — read via git history): `emit_wasm/collections.rs::emit_record`,
   `equality.rs::{variant_alloc_size,find_variant_tag_by_ctor}`, `mod.rs` variant registration.
   (v1 uses its OWN uniform-i64-slot block — tag@slot0, fields@slot1.., padded to slot_count —
   NOT v0's byte-packed layout. Only the observable stdout must match v0.)

--- a/docs/roadmap/active/v1-kgi-kpi.md
+++ b/docs/roadmap/active/v1-kgi-kpi.md
@@ -144,7 +144,7 @@
   (c)runtime を Almide 化(Phase 3、v1-mir-architecture.md §4 / #575/#576)。
 
   PUNCH-LIST(順): (1) MIR op 集合をプリミティブ(alloc/RC + 不可分)へ定義、Push/Print 等
-  を runtime fn Call に置換、(2) 最小 stdlib を **Almide で書く**(`research/selfhost/` の
+  を runtime fn Call に置換、(2) 最小 stdlib を **Almide で書く**(旧 `research/selfhost/`、現 `research/spike/v1-mir/` の
   方向)→ render_program で program+runtime を v1 コンパイル → v0 と byte 一致、
   (3) faithful Module/Computed call の実行 → 制御フロー → closure → nested heap。
   ※ self-host 設計は骨太 ―― 疲労下で詰め込まず、fresh session で(検証ワークフローで

--- a/docs/roadmap/active/v1-mir-architecture.md
+++ b/docs/roadmap/active/v1-mir-architecture.md
@@ -104,7 +104,7 @@ MIR に小ステップ操作的意味論を与える(自分の IR だから出�
 
 ## 4. self-host runtime
 
-`runtime/rs`(native)と emit_wasm の ~136 routine(wasm)の二重実装が、ownership 以外の drift(~72%の本体: `string.lines`/regex/libm/json…)の源。v1 では **ランタイムを Almide で書く** → 同じ Core→MIR→target を通って全ターゲットへ。drift クラスごと消滅し、dogfooding にもなる(`research/selfhost/` の方向)。alloc/RC の最小プリミティブだけ MIR 組み込み、残りは Almide。ブートストラップは段階的に(Phase 3)。
+`runtime/rs`(native)と emit_wasm の ~136 routine(wasm)の二重実装が、ownership 以外の drift(~72%の本体: `string.lines`/regex/libm/json…)の源。v1 では **ランタイムを Almide で書く** → 同じ Core→MIR→target を通って全ターゲットへ。drift クラスごと消滅し、dogfooding にもなる(旧 `research/selfhost/`、現 `research/spike/v1-mir/` の方向)。alloc/RC の最小プリミティブだけ MIR 組み込み、残りは Almide。ブートストラップは段階的に(Phase 3)。
 
 ### 4.1 wasm emit の理想形 = 手書き wasm 表面を極小化して証明可能にする
 

--- a/docs/roadmap/active/v1-phase1-mir-core.md
+++ b/docs/roadmap/active/v1-phase1-mir-core.md
@@ -20,7 +20,7 @@ Grounding: 既存コンパイラの所有権/レイアウト決定を6コンポ�
 
 精読で確定した最重要事実: **高 IR は既に「半 MIR」である。**
 
-- `IrStmtKind::RcInc/RcDec` は**既に IR ノード**(almide-ir/lib.rs:723)。Perceus が IR レベルで dup/drop を置いている。§2.2 の「dup→__rc_inc / drop→__rc_dec」行は文字通り `emit_wasm/statements.rs:329/358`。
+- `IrStmtKind::RcInc/RcDec` は**既に IR ノード**(crates/almide-ir/src/lib.rs:723)。Perceus が IR レベルで dup/drop を置いている。§2.2 の「dup→__rc_inc / drop→__rc_dec」行は文字通り v0 の `emit_wasm/statements.rs:329/358`(#782 で削除済み — git history 参照)。
 - `engine/layout.rs` の `LayoutRegistry`(:77)は**既に §2.1 Repr テーブルそのもの** — STRING/LIST/SWISS_MAP/SET/VARIANT/OPTION/RESULT を field offset(Fixed/AfterDynamic)+ MemType width + header_size で持ち、**このモジュール外にマジックナンバー0**(`list_layout.rs` は薄いアクセサ)。
 
 → Phase 1 は「ゼロから新 IR を建てる」のではなく、**既に中央化された事実を MIR 値に昇格し、散在する決定を1パスに畳む**作業。

--- a/docs/roadmap/active/v1-spine-correctness-holes.md
+++ b/docs/roadmap/active/v1-spine-correctness-holes.md
@@ -1,7 +1,7 @@
 <!-- description: Adversarial sweep of the v1 trust spine (2026-06-27) and the correctness holes it surfaced -->
 # v1 trust-spine correctness holes (adversarial sweep 2026-06-27)
 
-Found by a systematic adversarial sweep of render_program (v1 spine) vs native, probing shape-space the v0 corpus does NOT cover. All **verified reproducing in render_program** (not legacy emit_wasm). The corpus-wall (checks certs, not wat-validity) + output-parity (124 files) structurally miss these. Root hints below are the SWEEP agents' guesses (several cite legacy paths — the real site is the v1 spine crates/almide-mir/render_wasm\*; re-derive when fixing).
+Found by a systematic adversarial sweep of render_program (v1 spine) vs native, probing shape-space the v0 corpus does NOT cover. All **verified reproducing in render_program** (not legacy emit_wasm). The corpus-wall (checks certs, not wat-validity) + output-parity (124 files) structurally miss these. Root hints below are the SWEEP agents' guesses (several cite legacy paths — the real site is the v1 spine crates/almide-mir/src/render_wasm\*; re-derive when fixing).
 
 **30 confirmed holes.** Fix = lower correctly, OR narrowly wall (never emit invalid wasm / never miscompile) WITHOUT regressing the working corpus variant.
 

--- a/docs/roadmap/active/v1-v0-parity.md
+++ b/docs/roadmap/active/v1-v0-parity.md
@@ -191,7 +191,7 @@ phase 単位で goal 設定するのが回しやすい。例：
 ```
 DBG_DESUGAR_FN=<fn名> [DBG_DESUGAR_RAW=1] almide/render_program <file>   # eprintln に desugared IR
 ```
-`crates/almide-mir/src/lower/mod_p6.rs::dump_ir` / `dump_desugared_ir`、呼び出しは
+`crates/almide-mir/src/lower/desugar.rs::dump_ir` / `dump_desugared_ir`、呼び出しは
 `lower_function_all_impl`（mod.rs）。
 
 **発見**: man6（`type Basic: Codec` + 手書き effect-fn `dec` の両方を含む単一ファイル）で

--- a/docs/roadmap/active/v1-value-model.md
+++ b/docs/roadmap/active/v1-value-model.md
@@ -152,7 +152,7 @@ yaml's remaining 22 v1 walls are dominated by the dynamic `Value` model: `value.
    - tag == 6 (Object): payload = the key/value store (match v0's Object layout — `Vec<(String, Value)>`). `for each pair: rc_dec(key String); $__drop_value(value)`; then `rc_dec(store)`; then `rc_dec(p)`.
    The cert sees ONE `d` (an `Op::DropValue`, opaque). The recursion is the trusted routine — verified by the rt-oracle-registry DIFFERENTIAL test (a `value.stringify` round-trip fixture proves no leak/no double-free vs v0). A `value_elem_lists` List drops via a sibling `$__drop_list_value` (loop `$__drop_value` per element + free list).
 
-3. **`value.array`/`value.object` self-host** (value_core.almd): `alloc_value`, `store32(h+4, 5/6)`, `store64(h+12, <list/store handle>)` — MOVE the items in (v0 does `Array(items.clone())`, so a DEEP COPY: the self-host either copies items or takes ownership; match v0's bytes via the stringify round-trip). Register in render_wasm/registry.rs.
+3. **`value.array`/`value.object` self-host** (value_core.almd): `alloc_value`, `store32(h+4, 5/6)`, `store64(h+12, <list/store handle>)` — MOVE the items in (v0 does `Array(items.clone())`, so a DEEP COPY: the self-host either copies items or takes ownership; match v0's bytes via the stringify round-trip). Register in crates/almide-types/src/self_host_registry.rs (`self_host_runtime()`).
 
 4. **`value.as_array`/`value.as_object`** — read tag; tag 5/6 → `Ok(payload list/store)` (BINDS the heap payload — yaml:249), else `Err`. A heap-Ok Result (cap-as-tag, like value.as_string — reuse the str-result machinery from commit 7b24ef8f).
 

--- a/docs/roadmap/active/wasm-ownership-emit-mechanization.md
+++ b/docs/roadmap/active/wasm-ownership-emit-mechanization.md
@@ -143,7 +143,7 @@ churn fixture を追加。推測パッチは新たな leak/regression を生む�
 `almide_rt_error_context`(`r.clone().map_err(|e| format!("{ctx}: {e}"))`)を
 **実 wasm runtime routine 化**して rt-oracle 登録すること(上の
 `emit_extract_owned` 集約と同じ「手書き emit をオラクル準拠の単一実装に
-寄せる」方針)。`spec/wasm_cross/error_context.almd` で固定。
+寄せる」方針)。固定用 fixture `spec/wasm_cross/error_context.almd` は未追加(要作成 — 現状この主張を pin する fixture は存在しない)。
 
 ## 提案: emit 層の所有権を単一ヘルパーに集約する
 
@@ -177,7 +177,7 @@ IR レベルの `PerceusVerify` は emit 層の借用/所有権を見られな�
 ## 段階
 
 1. **#643 を runtime トレースで確定 → 単発修正** (emit 層 or pass_perceus、
-   設計意図「leak 優先」に合わせる)。+ `spec/wasm_cross/option_fallback_rc.almd`
+   設計意図「leak 優先」に合わせる)。+ `spec/wasm_cross/option_fallback_rc.almd`(未追加 — 要作成)
    回帰固定 + contract。
 2. `emit_extract_owned` ヘルパー抽出 + 全 payload-取り出しサイトを移行。
 3. `spec/churn/` owned-extract fixture + (将来) rc-count 差分ハーネス。

--- a/docs/specs/codegen.md
+++ b/docs/specs/codegen.md
@@ -374,12 +374,12 @@ The wasm binary is produced by the v1 MIR trust-spine, not by almide-codegen:
 `almide-mir` lowers the linked IR through MIR (Perceus ownership, layout) to
 WAT text; the CLI assembles it with the `wat` crate and keeps only function
 names in the name section. Stdlib calls are satisfied by self-hosted pure-Almide
-implementations (`stdlib/*.almd` via `render_wasm/registry.rs`); an unlinked
+implementations (`stdlib/*.almd` via `crates/almide-types/src/self_host_registry.rs`); an unlinked
 call is a wall — a hard, diagnosed error. The v0 direct emitter that this
 section used to describe was retired in #782.
 
 Details: [../WASM-OUTPUT.md](../WASM-OUTPUT.md),
-[../ARCHITECTURE.md](../ARCHITECTURE.md), `crates/almide-mir/CLAUDE.md`.
+[../ARCHITECTURE.md](../ARCHITECTURE.md), [crates/CLAUDE.md](../../crates/CLAUDE.md).
 
 ## 8. CodegenOptions
 

--- a/docs/specs/effect-fn-call-semantics.md
+++ b/docs/specs/effect-fn-call-semantics.md
@@ -127,6 +127,5 @@ spec/lang/effect_fn_test.almd
 spec/lang/effect_assign_unwrap_test.almd
 spec/lang/effect_if_branch_unwrap_test.almd
 spec/lang/effect_result_arg_test.almd
-spec/lang/match_arm_effect_unify_test.almd
 spec/integration/codegen_effect_fn_test.almd
 ```

--- a/docs/specs/effect-system.md
+++ b/docs/specs/effect-system.md
@@ -250,7 +250,7 @@ effect fn fetch() -> Result[String, String] = http.get("https://example.com")
 - **Layer 2** (implemented): `[permissions].allow` in almide.toml -- restricts stdlib capabilities per package
 - **Layer 3** (future): Consumer restricts dependency capabilities
 
-Test: Effect inference unit tests in `src/codegen/pass_effect_inference.rs` (`#[cfg(test)]` module)
+Test: Effect inference unit tests in `crates/almide-codegen/src/pass_effect_inference.rs` (`#[cfg(test)]` module)
 
 ## 9. Error Codes
 

--- a/docs/specs/language.md
+++ b/docs/specs/language.md
@@ -267,8 +267,8 @@ Other attribute names (`@pure`, `@schedule`, `@rewrite`,
 `@wasm_intrinsic`) parse without error and are preserved in the AST,
 but carry no semantic behavior yet. They are reserved for later
 sub-phases of the Stdlib Declarative Unification and MLIR Backend
-arcs (see `docs/roadmap/active/stdlib-declarative-unification.md` and
-`docs/roadmap/active/mlir-backend-adoption.md`). Writing them in user
+arcs (see `docs/roadmap/done/stdlib-declarative-unification.md` and
+`docs/roadmap/on-hold/mlir-backend-adoption.md`). Writing them in user
 code today is legal syntax but the compiler ignores them.
 
 テスト: `crates/almide-syntax/src/parser/test_attributes.rs` (13

--- a/docs/specs/type-system.md
+++ b/docs/specs/type-system.md
@@ -567,15 +567,15 @@ Source (.almd)
 
 ### Key Data Structures
 
-- **`Ty` enum** (`src/types/mod.rs`): Internal type representation. 17 variants covering all types.
-- **`TypeEnv`** (`src/types/env.rs`): The type environment. Holds type declarations, function signatures, scopes, protocol definitions, and conformance tracking.
-- **`FnSig`** (`src/types/mod.rs`): Function signature with params, return type, generics, structural bounds, and protocol bounds.
-- **`TypeConstructorId`** (`src/types/constructor.rs`): Identifies type constructors (List, Option, Result, Map, Set, user-defined). Used by the `Applied` variant of `Ty`.
-- **`Kind`** (`src/types/constructor.rs`): The "type of a type constructor" — `*`, `* -> *`, `* -> * -> *`.
-- **`UnionFind`** (`src/check/types.rs`): Disjoint-set structure for inference variable equivalence. Union-by-rank with path compression.
-- **`Checker`** (`src/check/mod.rs`): Orchestrates the three-pass type checking pipeline.
+- **`Ty` enum** (`crates/almide-types/src/types/mod.rs`): Internal type representation. 17 variants covering all types.
+- **`TypeEnv`** (`crates/almide-frontend/src/type_env.rs`): The type environment. Holds type declarations, function signatures, scopes, protocol definitions, and conformance tracking.
+- **`FnSig`** (`crates/almide-types/src/types/mod.rs`): Function signature with params, return type, generics, structural bounds, and protocol bounds.
+- **`TypeConstructorId`** (`crates/almide-types/src/types/constructor.rs`): Identifies type constructors (List, Option, Result, Map, Set, user-defined). Used by the `Applied` variant of `Ty`.
+- **`Kind`** (`crates/almide-types/src/types/constructor.rs`): The "type of a type constructor" — `*`, `* -> *`, `* -> * -> *`.
+- **`UnionFind`** (`crates/almide-frontend/src/check/types.rs`): Disjoint-set structure for inference variable equivalence. Union-by-rank with path compression.
+- **`Checker`** (`crates/almide-frontend/src/check/mod.rs`): Orchestrates the three-pass type checking pipeline.
 
-### Unification (`src/types/unify.rs`)
+### Unification (`crates/almide-types/src/types/unify.rs`)
 
 The `unify` function matches a signature type against a concrete type, collecting `TypeVar` bindings:
 
@@ -587,7 +587,7 @@ The `unify` function matches a signature type against a concrete type, collectin
 
 `substitute` replaces bound `TypeVar`s in a type with their bindings.
 
-### Type Constructor Registry (`src/types/constructor.rs`)
+### Type Constructor Registry (`crates/almide-types/src/types/constructor.rs`)
 
 Every type constructor is registered with its kind and algebraic laws. The registry enables uniform operations across all container types and supports stream fusion optimizations:
 

--- a/stdlib/README.md
+++ b/stdlib/README.md
@@ -17,8 +17,8 @@ stdlib/<module>_<part>.almd     Split files: pure-Almide implementations used
         │     bundled_source(): include_str! of module bodies.
         │     The frontend extracts FnSigs; codegen extracts @inline_rust.
         │
-        ├─▶ crates/almide-mir/src/render_wasm/registry.rs
-        │     (include_str!(<file>), [(impl_fn, "module.fn")]) registrations:
+        ├─▶ crates/almide-types/src/self_host_registry.rs
+        │     self_host_runtime(): (SRC_<STEM>, [(impl_fn, "module.fn")]) registrations:
         │     pure-Almide impls compiled to WAT alongside user code.
         │     An unlinked stdlib call is a wall (hard error) in the renderer.
         │
@@ -32,7 +32,7 @@ stdlib/<module>_<part>.almd     Split files: pure-Almide implementations used
 1. **Implement in Almide** — add the function to `stdlib/<module>.almd` (or a
    new `stdlib/<module>_<part>.almd` split file for the WASM path).
 2. **WASM/v1 coverage** — register the split file in
-   `crates/almide-mir/src/render_wasm/registry.rs`; adjust
+   `crates/almide-types/src/self_host_registry.rs` (`self_host_runtime()`); adjust
    `crates/almide-mir/src/purity.rs` if the function's purity matters to
    lowering.
 3. **Native intrinsic (only when pure Almide won't do)** — implement


### PR DESCRIPTION
Fixes #992. (The config half — wasmgen cache key, Makefile help text, ci-cross-target comment — landed in #995.)

Every replacement was existence-verified against the tree; `docs/roadmap/done/` untouched as historical record. Policy per class:

- **Action items pointing at deleted locations** → repointed at the live ones: `render_wasm/registry.rs` → `crates/almide-types/src/self_host_registry.rs` (specs/codegen.md, stdlib/README.md ×2 incl. the pipeline diagram, v1-value-model.md); `stdlib/defs/*.toml` modify-targets → the `.almd` sources (effect-system-capability.md, closure-architecture-v2.md).
- **Deleted v0 reference material cited as things to READ** → annotated "deleted with #782 — read via git history" instead of silently repointed (v1-adt-brick5-goal.md, v0-unwrap-early-return-leak.md, interp-is-desugar-to-tostring.md, v1-phase1-mir-core.md).
- **Moved/renamed files** → corrected: the whole pre-workspace "Key Data Structures" block in type-system.md (9 paths — `TypeEnv` moved crate AND filename to `almide-frontend/src/type_env.rs`), effect-system.md's flat-layout path, `render_rust.rs` → `render_native.rs` (flight-profile.md), `mod_p6.rs::dump_ir` → `desugar.rs` (v1-v0-parity.md), `lower/calls.rs::lower_call_target` → `calls_target.rs` (closure-architecture-v2.md), `research/selfhost/` → noted removed, pointed at `research/spike/v1-mir/` (4 files).
- **Claims of nonexistent evidence** → made honest: C-033's 404 link to the retired registry is now a retirement note; effect-fn-call-semantics.md no longer lists `match_arm_effect_unify_test.almd` among EXISTING conformance tests; wasm-ownership-emit-mechanization.md's two "pinned by fixture X" claims now say the fixtures are yet to be created; cross-target-completeness.md's registry status row states the retirement instead of presenting a live 76/42 gate.
- **Dead corpora** → `spec/exercises` → `spec/` (correctness-guarantee-gaps.md); dead roadmap cross-links repointed at `done/`/`on-hold/` (language.md ×2, closure-architecture-v2.md, post-0.29-improvement-sweep.md).

Verified: the stale patterns grep clean outside removed-notes; `scripts/check-contracts.sh` green (195 contracts, 324/324 fixtures) after the C-033 doc edit.