### PR TITLE
Treat a guest exit 127 as a comparable observable and never return green mid-corpus from the wasm gates

### DIFF
--- a/tests/semantic_laws_test.rs
+++ b/tests/semantic_laws_test.rs
@@ -115,12 +115,14 @@ fn run_wasm_capture(source: &str) -> Option<(i32, String, String)> {
         ));
     }
     match Command::new("wasmtime").arg("--dir=/").arg(wasm_path.to_str().unwrap()).output() {
-        Ok(o) if o.status.code() != Some(127) => Some((
+        // A 127 guest exit is a comparable observable, not wasmtime-absence
+        // (#991) — only a spawn error means the tool is missing.
+        Ok(o) => Some((
             o.status.code().unwrap_or(-1),
             String::from_utf8_lossy(&o.stdout).trim().to_string(),
             String::from_utf8_lossy(&o.stderr).trim().to_string(),
         )),
-        _ => None, // wasmtime not installed → skip the wasm leg
+        Err(_) => None, // wasmtime not installed → skip the wasm leg
     }
 }
 

--- a/tests/wasm_opt_parity_test.rs
+++ b/tests/wasm_opt_parity_test.rs
@@ -34,12 +34,14 @@ fn build_and_run(src_path: &Path, dir: &Path, wasm_opt: bool) -> Option<(i32, St
     assert!(build.status.success(), "wasm build failed ({}):\n{}", if wasm_opt { "--wasm-opt" } else { "plain" }, String::from_utf8_lossy(&build.stderr));
 
     match Command::new("wasmtime").arg("--dir=/").arg("-S").arg("inherit-env=y").arg(&wasm_path).output() {
-        Ok(o) if o.status.code() != Some(127) => Some((
+        // A 127 guest exit is a comparable observable, not wasmtime-absence
+        // (#991) — only a spawn error means the tool is gone.
+        Ok(o) => Some((
             o.status.code().unwrap_or(-1),
             String::from_utf8_lossy(&o.stdout).trim().to_string(),
             String::from_utf8_lossy(&o.stderr).trim().to_string(),
         )),
-        _ => None,
+        Err(_) => None,
     }
 }
 
@@ -69,14 +71,23 @@ fn wasm_opt_parity_spec() {
         let name = path.file_stem().unwrap().to_str().unwrap().to_string();
         let dir = tempfile::tempdir().unwrap();
 
+        // A mid-corpus spawn failure is this fixture's failure — never
+        // `return` from inside the loop, which dropped the remaining corpus
+        // and the accumulated failures as a green pass (#991).
         let plain = match std::panic::catch_unwind(|| build_and_run(&path, dir.path(), false)) {
             Ok(Some(r)) => r,
-            Ok(None) => return, // wasmtime unavailable mid-run → skip the gate
+            Ok(None) => {
+                failed.push(format!("{name}: wasmtime could not be spawned mid-run (plain)"));
+                continue;
+            }
             Err(_) => { failed.push(format!("{name}: plain build/run panicked")); continue; }
         };
         let opt = match std::panic::catch_unwind(|| build_and_run(&path, dir.path(), true)) {
             Ok(Some(r)) => r,
-            Ok(None) => return,
+            Ok(None) => {
+                failed.push(format!("{name}: wasmtime could not be spawned mid-run (--wasm-opt)"));
+                continue;
+            }
             Err(_) => { failed.push(format!("{name}: --wasm-opt build/run panicked")); continue; }
         };
 

--- a/tests/wasm_runtime_test_parts/p2.rs
+++ b/tests/wasm_runtime_test_parts/p2.rs
@@ -43,7 +43,14 @@ fn wasm_cross_target_spec() {
         let (rc, rout, rerr) = run_native_capture(&source);
         let wasm = match std::panic::catch_unwind(|| run_wasm_capture(&source)) {
             Ok(Some(w)) => w,
-            Ok(None) => return, // wasmtime unavailable mid-run → skip the gate
+            // A spawn failure mid-corpus (wasmtime WAS probed at entry) is
+            // this fixture's failure — never `return` from inside the loop:
+            // that discarded the rest of the corpus and every accumulated
+            // failure as a green pass (#991).
+            Ok(None) => {
+                failed.push(format!("{name}: wasmtime could not be spawned mid-run"));
+                continue;
+            }
             Err(_) => { failed.push(format!("{name}: WASM build/run panicked")); continue; }
         };
         let (wc, wout, werr) = wasm;
@@ -131,8 +138,10 @@ fn assert_cross_target_project(files: &[(&str, &str)]) {
         .arg("out.wasm")
         .output()
     {
-        Ok(o) if o.status.code() != Some(127) => o,
-        _ => return, // wasmtime unavailable
+        // A 127 guest exit flows into the success assertion below as an
+        // honest failure; only a spawn error means wasmtime is absent (#991).
+        Ok(o) => o,
+        Err(_) => return, // wasmtime unavailable
     };
     assert!(
         w.status.success(),

--- a/tests/wasm_runtime_test_parts/p3.rs
+++ b/tests/wasm_runtime_test_parts/p3.rs
@@ -379,7 +379,11 @@ fn run_native_capture(source: &str) -> (i32, String, String) {
 }
 
 /// Compile to wasm + run via wasmtime; return (exit_code, stdout, stderr).
-/// `None` if wasmtime is unavailable (the assertion is then skipped).
+/// `None` ONLY when wasmtime itself cannot be spawned. A guest exit of 127 is
+/// an ordinary comparable observable (#991): the old `!= Some(127)` guard
+/// conflated it with wasmtime-absence, and the corpus gate `return`ed green
+/// mid-run on the first such fixture — discarding every remaining fixture AND
+/// every failure already accumulated.
 fn run_wasm_capture(source: &str) -> Option<(i32, String, String)> {
     let dir = tempfile::tempdir().unwrap();
     let src_path = dir.path().join("test.almd");
@@ -391,12 +395,12 @@ fn run_wasm_capture(source: &str) -> Option<(i32, String, String)> {
         .expect("failed to build wasm");
     assert!(build.status.success(), "wasm build failed:\n{}", String::from_utf8_lossy(&build.stderr));
     match Command::new("wasmtime").arg("--dir=/").arg("-S").arg("inherit-env=y").arg(wasm_path.to_str().unwrap()).output() {
-        Ok(o) if o.status.code() != Some(127) => Some((
+        Ok(o) => Some((
             o.status.code().unwrap_or(-1),
             String::from_utf8_lossy(&o.stdout).trim().to_string(),
             String::from_utf8_lossy(&o.stderr).trim().to_string(),
         )),
-        _ => None,
+        Err(_) => None,
     }
 }
 


### PR DESCRIPTION
Fixes #991.

## The two conflations, removed

1. **`run_wasm_capture` (both copies: `tests/wasm_runtime_test_parts/p3.rs`, `tests/wasm_opt_parity_test.rs`, plus the verbatim helper in `tests/semantic_laws_test.rs`)** — the `Ok(o) if o.status.code() != Some(127) => …, _ => None` guard mapped a GUEST exit of 127 to "wasmtime unavailable". A missing wasmtime is `Err` at spawn (and is anyway excluded by the `--version` probe at gate entry), so the 127 arm could only ever hide a real guest observable. Now: `Ok(o)` always returns the observable (127 included — native and wasm should agree on it), `Err` alone means the tool is absent.
2. **The corpus loops (`wasm_cross_target_spec`, `wasm_opt_parity_spec`)** — `Ok(None) => return` exited the WHOLE gate green mid-corpus, discarding every remaining fixture AND every failure already accumulated in the vector. Now a mid-run spawn failure is recorded as that fixture's failure and the loop continues; there is no early `return` inside either loop. Same fix for the second p2.rs site (single-fixture helper): a 127 guest now flows into the success assertion as an honest failure.

## Verification (real tools, locally — wasmtime 47 + binaryen 131)

| suite | result |
|---|---|
| `wasm_runtime_test` (incl. `wasm_cross_target_spec`, 72 tests) | 72/72, 171s |
| `wasm_opt_parity_test` | pass, 99s (the corpus actually ran under wasm-opt) |
| `semantic_laws_test` | 3/3 |

The remaining `!= Some(127)` occurrences in one-shot skip guards (libm_*, regex_fuzz, nested_effect_unwrap, wasm_runtime_test.rs:73, float_to_fixed) are single-assertion skips without accumulated state — same cosmetic conflation, none can discard failures; left for a follow-up if desired.