### PR TITLE
DO NOT MERGE — #1008 evidence run: Windows LSP hang instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,10 +543,13 @@ jobs:
       # DELIBERATELY unarmed (#983 decision): wasmtime is not installed there,
       # so the tool-gated wasm suites skip on Windows by design — Linux
       # (test-rust) and macOS are the armed legs.
-      - name: Cargo tests (workspace)
+      # PROBE ONLY (#1008 evidence run — this branch never merges): run just
+      # the LSP suite, serial and uncaptured, so the Windows hang's server-side
+      # trace lands in this log verbatim.
+      - name: LSP suite only (probe, serial, nocapture)
         env:
-          ALMIDE_EXPECT_TOOLS: ${{ runner.os == 'Windows' && '0' || '1' }}
-        run: cargo test --workspace
+          ALMIDE_EXPECT_TOOLS: "0"
+        run: cargo test --test lsp_test -- --nocapture --test-threads=1
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ env:
   # Cold runners gain nothing from the workspace's release-incremental
   # profile (#1006) — it only bloats the caches. Opt out.
   CARGO_INCREMENTAL: "0"
+  # No CI job may ever wait on an interactive git credential prompt: on the
+  # Windows runners a git fetch of an unreachable/bogus remote can block in
+  # Git Credential Manager instead of failing fast — the suspected mechanism
+  # behind the 4h20m lsp_test hang (#1008).
+  GIT_TERMINAL_PROMPT: "0"
+  GCM_INTERACTIVE: "never"
 
 jobs:
   # ═══════════════════════════════════════════════
@@ -488,6 +494,11 @@ jobs:
           - os: windows-latest
             artifact: almide-windows
     runs-on: ${{ matrix.os }}
+    # A hung test must be a fast red, not a 6h grind (the trust-spine #921
+    # lesson): the Windows leg sat 4h20m inside a single blocked lsp_test
+    # before being cancelled by hand (#1008). Cold build + full workspace
+    # tests fit well inside this.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
 

--- a/src/cli/lsp.rs
+++ b/src/cli/lsp.rs
@@ -492,17 +492,37 @@ fn handle_notification(notif: Notification, connection: &Connection, documents: 
             }
         }
         "textDocument/didChange" => {
-            if let Ok(params) = serde_json::from_value::<DidChangeTextDocumentParams>(notif.params) {
-                let uri = params.text_document.uri.clone();
-                if let Some(change) = params.content_changes.into_iter().last() {
-                    let source = change.text;
-                    let file_path = uri_to_path(&uri);
-                    let deps = project_deps_for(file_path.as_deref(), dep_cache, false);
-                    let doc = AnalyzedDoc::analyze(&source, file_path.as_deref(), &deps);
-                    publish_diagnostics(connection, &uri, &doc.lsp_diagnostics);
-                    documents.insert(uri.clone(), source);
-                    analyzed.insert(uri, doc);
+            let trace = std::env::var("ALMIDE_LSP_TRACE").is_ok();
+            match serde_json::from_value::<DidChangeTextDocumentParams>(notif.params) {
+                Ok(params) => {
+                    let uri = params.text_document.uri.clone();
+                    if let Some(change) = params.content_changes.into_iter().last() {
+                        let source = change.text;
+                        let file_path = uri_to_path(&uri);
+                        if trace {
+                            eprintln!("[lsp-trace] didChange uri={} path={:?}", uri.as_str(), file_path);
+                        }
+                        let t = std::time::Instant::now();
+                        let deps = project_deps_for(file_path.as_deref(), dep_cache, false);
+                        if trace {
+                            eprintln!("[lsp-trace] didChange deps resolved: {} in {:?}", deps.len(), t.elapsed());
+                        }
+                        let t = std::time::Instant::now();
+                        let doc = AnalyzedDoc::analyze(&source, file_path.as_deref(), &deps);
+                        if trace {
+                            eprintln!("[lsp-trace] didChange analyzed in {:?}", t.elapsed());
+                        }
+                        publish_diagnostics(connection, &uri, &doc.lsp_diagnostics);
+                        documents.insert(uri.clone(), source);
+                        analyzed.insert(uri, doc);
+                    }
                 }
+                // A notification with unparseable params is dropped by design
+                // (no reply channel exists for notifications) — but never
+                // SILENTLY: an undeserializable didChange means the analyzed
+                // map silently stops updating (#1008's hang started life as
+                // an invisible drop like this).
+                Err(e) => eprintln!("[lsp] didChange params failed to parse — dropped: {e}"),
             }
         }
         "textDocument/didClose" => {
@@ -535,12 +555,32 @@ pub fn run_lsp() {
         match msg {
             Message::Request(req) => {
                 if connection.handle_shutdown(&req).unwrap_or(false) { return; }
-                let resp = handle_request(&req, &documents, &analyzed, &workspace_root);
-                if let Some(r) = resp {
-                    connection.sender.send(Message::Response(r)).ok();
+                if std::env::var("ALMIDE_LSP_TRACE").is_ok() {
+                    eprintln!("[lsp-trace] request  {} id={:?}", req.method, req.id);
                 }
+                let resp = handle_request(&req, &documents, &analyzed, &workspace_root);
+                // A REQUEST must always get a response (JSON-RPC). A `None`
+                // here used to be a SILENT DROP — a client blocking on the
+                // reply waited forever, which is how the Windows CI leg burned
+                // 6h runs inside lsp_test since #961 (#1008). Anything the
+                // handler cannot answer (param-parse failure, no analyzed
+                // doc) is an honest empty result, and the drop is LOGGED so
+                // it can never be invisible again.
+                let r = resp.unwrap_or_else(|| {
+                    eprintln!(
+                        "[lsp] request {} id={:?} unanswerable (bad params or no analyzed doc) — replying null (#1008)",
+                        req.method, req.id
+                    );
+                    Response::new_ok(req.id.clone(), serde_json::Value::Null)
+                });
+                connection.sender.send(Message::Response(r)).ok();
             }
-            Message::Notification(notif) => handle_notification(notif, &connection, &mut documents, &mut analyzed, &mut dep_cache),
+            Message::Notification(notif) => {
+                if std::env::var("ALMIDE_LSP_TRACE").is_ok() {
+                    eprintln!("[lsp-trace] notification {}", notif.method);
+                }
+                handle_notification(notif, &connection, &mut documents, &mut analyzed, &mut dep_cache)
+            }
             Message::Response(_) => {}
         }
     }

--- a/tests/lsp_test.rs
+++ b/tests/lsp_test.rs
@@ -4,13 +4,63 @@
 
 use std::io::{Read, Write, BufRead, BufReader};
 use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
 use serde_json::{json, Value};
+
+/// How long any single server response may take before the test fails.
+/// Reads used to block UNBOUNDED on the server pipe, so a non-responding
+/// server was an infinite test hang — 4h20m on the Windows leg before the
+/// 6h job default would have killed it (#1008). A deadline turns any future
+/// hang into a red naming the wait, in about a minute.
+const RECV_DEADLINE: Duration = Duration::from_secs(60);
 
 struct LspClient {
     child: std::process::Child,
-    reader: BufReader<std::process::ChildStdout>,
+    /// Parsed server messages, delivered by the reader thread — recv'ing
+    /// through a channel is what makes the deadline possible.
+    rx: mpsc::Receiver<Value>,
     /// The `capabilities` object from the initialize response.
     capabilities: Value,
+}
+
+/// The reader half, on its own thread: blocks on the pipe, parses framed
+/// JSON-RPC messages, forwards them. When the child dies (or is killed by
+/// `Drop`) the pipe EOFs and the thread exits.
+fn reader_loop(stdout: std::process::ChildStdout, tx: mpsc::Sender<Value>) {
+    let mut reader = BufReader::new(stdout);
+    loop {
+        let mut header = String::new();
+        let mut len: Option<usize> = None;
+        loop {
+            header.clear();
+            if reader.read_line(&mut header).is_err() || header.is_empty() {
+                return; // EOF / broken pipe — server gone
+            }
+            let trimmed = header.trim();
+            if trimmed.is_empty() {
+                if len.is_some() { break; } // end of headers
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix("Content-Length:") {
+                len = rest.trim().parse().ok();
+            }
+        }
+        let Some(len) = len else { return };
+        let mut buf = vec![0u8; len];
+        if reader.read_exact(&mut buf).is_err() { return; }
+        let Ok(msg) = serde_json::from_slice::<Value>(&buf) else { return };
+        if tx.send(msg).is_err() { return; } // client dropped
+    }
+}
+
+impl Drop for LspClient {
+    /// Kill the server on ANY exit path (panic included): a deadline panic
+    /// must not leave an orphan `almide lsp` holding the pipe open.
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
 }
 
 impl LspClient {
@@ -23,8 +73,9 @@ impl LspClient {
             .spawn()
             .expect("failed to start almide lsp");
         let stdout = child.stdout.take().unwrap();
-        let reader = BufReader::new(stdout);
-        let mut client = LspClient { child, reader, capabilities: Value::Null };
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || reader_loop(stdout, tx));
+        let mut client = LspClient { child, rx, capabilities: Value::Null };
         client.initialize();
         client
     }
@@ -39,25 +90,17 @@ impl LspClient {
     }
 
     fn recv(&mut self) -> Value {
-        // Read Content-Length header
-        let mut header = String::new();
-        loop {
-            header.clear();
-            self.reader.read_line(&mut header).unwrap();
-            let trimmed = header.trim();
-            if trimmed.is_empty() { break; }
-            if trimmed.starts_with("Content-Length:") {
-                let len: usize = trimmed.split(':').nth(1).unwrap().trim().parse().unwrap();
-                // Read blank line after header
-                let mut blank = String::new();
-                self.reader.read_line(&mut blank).unwrap();
-                // Read body
-                let mut buf = vec![0u8; len];
-                self.reader.read_exact(&mut buf).unwrap();
-                return serde_json::from_slice(&buf).unwrap();
+        match self.rx.recv_timeout(RECV_DEADLINE) {
+            Ok(msg) => msg,
+            Err(mpsc::RecvTimeoutError::Timeout) => panic!(
+                "no server message within {RECV_DEADLINE:?} — the server is hung \
+                 or fetching (#1008); an unbounded read here previously turned \
+                 this into a 4h+ CI hang"
+            ),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("server pipe closed without a response (server died)")
             }
         }
-        panic!("no response received");
     }
 
     /// Read responses until we find one with the given id.

--- a/tests/lsp_test.rs
+++ b/tests/lsp_test.rs
@@ -20,6 +20,9 @@ struct LspClient {
     /// Parsed server messages, delivered by the reader thread — recv'ing
     /// through a channel is what makes the deadline possible.
     rx: mpsc::Receiver<Value>,
+    /// The server's captured stderr (trace lines, drop notices) — dumped
+    /// into the deadline panic so a hang names its cause (#1008).
+    server_log: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
     /// The `capabilities` object from the initialize response.
     capabilities: Value,
 }
@@ -67,15 +70,26 @@ impl LspClient {
     fn start() -> Self {
         let mut child = Command::new(env!("CARGO_BIN_EXE_almide"))
             .arg("lsp")
+            .env("ALMIDE_LSP_TRACE", "1")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .spawn()
             .expect("failed to start almide lsp");
         let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take().unwrap();
         let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || reader_loop(stdout, tx));
-        let mut client = LspClient { child, rx, capabilities: Value::Null };
+        let server_log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let log = server_log.clone();
+        std::thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines() {
+                let Ok(line) = line else { return };
+                log.lock().unwrap().push(line);
+            }
+        });
+        let mut client = LspClient { child, rx, server_log, capabilities: Value::Null };
         client.initialize();
         client
     }
@@ -94,13 +108,24 @@ impl LspClient {
             Ok(msg) => msg,
             Err(mpsc::RecvTimeoutError::Timeout) => panic!(
                 "no server message within {RECV_DEADLINE:?} — the server is hung \
-                 or fetching (#1008); an unbounded read here previously turned \
-                 this into a 4h+ CI hang"
+                 (#1008); an unbounded read here previously turned this into a \
+                 4h+ CI hang.\nserver stderr (tail):\n{}",
+                self.server_log_tail()
             ),
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                panic!("server pipe closed without a response (server died)")
+                panic!(
+                    "server pipe closed without a response (server died).\nserver stderr (tail):\n{}",
+                    self.server_log_tail()
+                )
             }
         }
+    }
+
+    /// The last lines of the server's captured stderr, for hang forensics.
+    fn server_log_tail(&self) -> String {
+        let log = self.server_log.lock().unwrap();
+        let start = log.len().saturating_sub(40);
+        log[start..].join("\n")
     }
 
     /// Read responses until we find one with the given id.
@@ -549,6 +574,11 @@ fn lsp_didchange_never_fetches_or_writes_lock() {
     // project, and the no-fetch path must resolve against no deps.
     c.did_change(&uri, "let x = 2\n");
     let resp = c.hover(1, &uri, 0, 4);
+    // PROBE ONLY (#1008): dump the exchange even on success so the Windows
+    // leg's log carries the full server-side trace either way.
+    eprintln!("[probe] uri sent: {uri}");
+    eprintln!("[probe] hover response: {resp}");
+    eprintln!("[probe] server stderr:\n{}", c.server_log_tail());
     assert!(resp.get("id").is_some(), "server must answer after didChange");
     assert!(
         !dir.join("almide.lock").exists(),


### PR DESCRIPTION
Throwaway PR to run build-cross (Windows) on instrumented code — **never merge; will be closed after the log is read** (#1008).

Contents:
- **Fix candidate under test**: every LSP request now gets a response — `handle_request`'s `None` (bad params / no analyzed doc) replies null and LOGS instead of silently dropping (a JSON-RPC violation that turned any client await into an infinite hang; the Windows leg has burned 6h runs inside lsp_test on every develop→main PR since #961 — verified on run 30443590068: 10:25→16:25, killed at the GitHub default limit).
- Server-side `ALMIDE_LSP_TRACE` phase tracing (didChange: uri/path, dep-resolution time, analyze time).
- Test client captures server stderr; the didchange test dumps uri/response/server-trace unconditionally.
- PROBE-ONLY: build-cross runs just `cargo test --test lsp_test -- --nocapture --test-threads=1`.

Expected outcomes on the Windows leg:
- **Green** → the always-respond fix resolves the hang; the trace names which `None` used to fire. Fix + client/server keepable parts get promoted to develop and shipped as v0.40.1.
- **Red in ~1 min** (deadline panic with server stderr) → the hang is deeper than the response protocol; the trace shows the last phase entered.