### PR TITLE
LSP: answer every request, decode Windows file URIs, fix test URI construction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,10 +543,13 @@ jobs:
       # DELIBERATELY unarmed (#983 decision): wasmtime is not installed there,
       # so the tool-gated wasm suites skip on Windows by design — Linux
       # (test-rust) and macOS are the armed legs.
-      - name: Cargo tests (workspace)
+      # PROBE ONLY (#1008 evidence run — this branch never merges): run just
+      # the LSP suite, serial and uncaptured, so the Windows hang's server-side
+      # trace lands in this log verbatim.
+      - name: LSP suite only (probe, serial, nocapture)
         env:
-          ALMIDE_EXPECT_TOOLS: ${{ runner.os == 'Windows' && '0' || '1' }}
-        run: cargo test --workspace
+          ALMIDE_EXPECT_TOOLS: "0"
+        run: cargo test --test lsp_test -- --nocapture --test-threads=1
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,13 +543,10 @@ jobs:
       # DELIBERATELY unarmed (#983 decision): wasmtime is not installed there,
       # so the tool-gated wasm suites skip on Windows by design — Linux
       # (test-rust) and macOS are the armed legs.
-      # PROBE ONLY (#1008 evidence run — this branch never merges): run just
-      # the LSP suite, serial and uncaptured, so the Windows hang's server-side
-      # trace lands in this log verbatim.
-      - name: LSP suite only (probe, serial, nocapture)
+      - name: Cargo tests (workspace)
         env:
-          ALMIDE_EXPECT_TOOLS: "0"
-        run: cargo test --test lsp_test -- --nocapture --test-threads=1
+          ALMIDE_EXPECT_TOOLS: ${{ runner.os == 'Windows' && '0' || '1' }}
+        run: cargo test --workspace
 
       - uses: actions/upload-artifact@v7
         with:

--- a/src/cli/lsp.rs
+++ b/src/cli/lsp.rs
@@ -492,17 +492,37 @@ fn handle_notification(notif: Notification, connection: &Connection, documents: 
             }
         }
         "textDocument/didChange" => {
-            if let Ok(params) = serde_json::from_value::<DidChangeTextDocumentParams>(notif.params) {
-                let uri = params.text_document.uri.clone();
-                if let Some(change) = params.content_changes.into_iter().last() {
-                    let source = change.text;
-                    let file_path = uri_to_path(&uri);
-                    let deps = project_deps_for(file_path.as_deref(), dep_cache, false);
-                    let doc = AnalyzedDoc::analyze(&source, file_path.as_deref(), &deps);
-                    publish_diagnostics(connection, &uri, &doc.lsp_diagnostics);
-                    documents.insert(uri.clone(), source);
-                    analyzed.insert(uri, doc);
+            let trace = std::env::var("ALMIDE_LSP_TRACE").is_ok();
+            match serde_json::from_value::<DidChangeTextDocumentParams>(notif.params) {
+                Ok(params) => {
+                    let uri = params.text_document.uri.clone();
+                    if let Some(change) = params.content_changes.into_iter().last() {
+                        let source = change.text;
+                        let file_path = uri_to_path(&uri);
+                        if trace {
+                            eprintln!("[lsp-trace] didChange uri={} path={:?}", uri.as_str(), file_path);
+                        }
+                        let t = std::time::Instant::now();
+                        let deps = project_deps_for(file_path.as_deref(), dep_cache, false);
+                        if trace {
+                            eprintln!("[lsp-trace] didChange deps resolved: {} in {:?}", deps.len(), t.elapsed());
+                        }
+                        let t = std::time::Instant::now();
+                        let doc = AnalyzedDoc::analyze(&source, file_path.as_deref(), &deps);
+                        if trace {
+                            eprintln!("[lsp-trace] didChange analyzed in {:?}", t.elapsed());
+                        }
+                        publish_diagnostics(connection, &uri, &doc.lsp_diagnostics);
+                        documents.insert(uri.clone(), source);
+                        analyzed.insert(uri, doc);
+                    }
                 }
+                // A notification with unparseable params is dropped by design
+                // (no reply channel exists for notifications) — but never
+                // SILENTLY: an undeserializable didChange means the analyzed
+                // map silently stops updating (#1008's hang started life as
+                // an invisible drop like this).
+                Err(e) => eprintln!("[lsp] didChange params failed to parse — dropped: {e}"),
             }
         }
         "textDocument/didClose" => {
@@ -535,12 +555,32 @@ pub fn run_lsp() {
         match msg {
             Message::Request(req) => {
                 if connection.handle_shutdown(&req).unwrap_or(false) { return; }
-                let resp = handle_request(&req, &documents, &analyzed, &workspace_root);
-                if let Some(r) = resp {
-                    connection.sender.send(Message::Response(r)).ok();
+                if std::env::var("ALMIDE_LSP_TRACE").is_ok() {
+                    eprintln!("[lsp-trace] request  {} id={:?}", req.method, req.id);
                 }
+                let resp = handle_request(&req, &documents, &analyzed, &workspace_root);
+                // A REQUEST must always get a response (JSON-RPC). A `None`
+                // here used to be a SILENT DROP — a client blocking on the
+                // reply waited forever, which is how the Windows CI leg burned
+                // 6h runs inside lsp_test since #961 (#1008). Anything the
+                // handler cannot answer (param-parse failure, no analyzed
+                // doc) is an honest empty result, and the drop is LOGGED so
+                // it can never be invisible again.
+                let r = resp.unwrap_or_else(|| {
+                    eprintln!(
+                        "[lsp] request {} id={:?} unanswerable (bad params or no analyzed doc) — replying null (#1008)",
+                        req.method, req.id
+                    );
+                    Response::new_ok(req.id.clone(), serde_json::Value::Null)
+                });
+                connection.sender.send(Message::Response(r)).ok();
             }
-            Message::Notification(notif) => handle_notification(notif, &connection, &mut documents, &mut analyzed, &mut dep_cache),
+            Message::Notification(notif) => {
+                if std::env::var("ALMIDE_LSP_TRACE").is_ok() {
+                    eprintln!("[lsp-trace] notification {}", notif.method);
+                }
+                handle_notification(notif, &connection, &mut documents, &mut analyzed, &mut dep_cache)
+            }
             Message::Response(_) => {}
         }
     }

--- a/src/cli/lsp_code_actions.rs
+++ b/src/cli/lsp_code_actions.rs
@@ -180,8 +180,80 @@ fn collect_almd_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) 
 // Helpers
 // ══════════════════════════════════════════════════════════════
 
+/// `file://` URI → filesystem path, in the three shapes real clients send:
+/// `file:///tmp/x` (POSIX), `file:///C:/x`, and percent-encoded
+/// `file:///c%3A/x` (VS Code on Windows encodes the drive colon). The old
+/// bare `strip_prefix` left the leading slash and the `%3A` intact, so every
+/// real-editor path on Windows failed to resolve (#1008) — the manifest was
+/// never found and per-project analysis silently degraded.
 fn uri_to_path(uri: &Uri) -> Option<String> {
-    uri.as_str().strip_prefix("file://").map(|p| p.to_string())
+    let rest = uri.as_str().strip_prefix("file://")?;
+    let decoded = percent_decode(rest);
+    // `/C:/…` — a POSIX-form absolute path naming a Windows drive → `C:/…`.
+    let b = decoded.as_bytes();
+    if b.len() >= 3 && b[0] == b'/' && b[1].is_ascii_alphabetic() && b[2] == b':' {
+        return Some(decoded[1..].to_string());
+    }
+    Some(decoded)
+}
+
+/// Minimal RFC 3986 percent-decoding (multi-byte UTF-8 sequences decode
+/// byte-wise, then re-validate as a string). Invalid escapes pass through
+/// literally rather than erroring — a path lookup on the raw text then fails
+/// visibly downstream instead of the URI being dropped here.
+fn percent_decode(s: &str) -> String {
+    let b = s.as_bytes();
+    let mut out = Vec::with_capacity(b.len());
+    let mut i = 0;
+    while i < b.len() {
+        if b[i] == b'%' && i + 2 < b.len() {
+            let hex = |c: u8| (c as char).to_digit(16);
+            if let (Some(h), Some(l)) = (hex(b[i + 1]), hex(b[i + 2])) {
+                out.push((h * 16 + l) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(b[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[cfg(test)]
+mod uri_to_path_tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn conv(s: &str) -> Option<String> {
+        uri_to_path(&Uri::from_str(s).unwrap())
+    }
+
+    #[test]
+    fn posix_path() {
+        assert_eq!(conv("file:///tmp/x.almd").as_deref(), Some("/tmp/x.almd"));
+    }
+
+    #[test]
+    fn windows_drive_plain() {
+        assert_eq!(conv("file:///C:/Users/x.almd").as_deref(), Some("C:/Users/x.almd"));
+    }
+
+    #[test]
+    fn windows_drive_percent_encoded_colon() {
+        // The exact shape VS Code sends on Windows.
+        assert_eq!(conv("file:///c%3A/Users/x.almd").as_deref(), Some("c:/Users/x.almd"));
+    }
+
+    #[test]
+    fn percent_encoded_space_and_utf8() {
+        assert_eq!(conv("file:///tmp/a%20b/%E3%81%82.almd").as_deref(), Some("/tmp/a b/あ.almd"));
+    }
+
+    #[test]
+    fn non_file_scheme_is_none() {
+        assert_eq!(conv("untitled:Untitled-1"), None);
+    }
 }
 
 fn publish_diagnostics(connection: &Connection, uri: &Uri, diags: &[Diagnostic]) {

--- a/tests/lsp_test.rs
+++ b/tests/lsp_test.rs
@@ -3,6 +3,7 @@
 //! and verifies responses.
 
 use std::io::{Read, Write, BufRead, BufReader};
+use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::time::Duration;
@@ -14,6 +15,17 @@ use serde_json::{json, Value};
 /// 6h job default would have killed it (#1008). A deadline turns any future
 /// hang into a red naming the wait, in about a minute.
 const RECV_DEADLINE: Duration = Duration::from_secs(60);
+
+/// A CORRECT `file://` URI for a real path on every OS: forward slashes and
+/// the third slash before a Windows drive letter. The old inline
+/// `format!("file://{}", path.display())` produced `file://C:\…` on Windows —
+/// an INVALID URI the server's params deserialization rejected, which is how
+/// the didChange test's hover went unanswered and hung the suite for 6h per
+/// run (#1008).
+fn file_uri(path: &Path) -> String {
+    let s = path.display().to_string().replace('\\', "/");
+    if s.starts_with('/') { format!("file://{s}") } else { format!("file:///{s}") }
+}
 
 struct LspClient {
     child: std::process::Child,
@@ -567,18 +579,13 @@ fn lsp_didchange_never_fetches_or_writes_lock() {
     ).unwrap();
     let file = dir.join("main.almd");
     std::fs::write(&file, "let x = 1\n").unwrap();
-    let uri = format!("file://{}", file.display());
+    let uri = file_uri(&file);
 
     let mut c = LspClient::start();
     // didChange without a prior didOpen: the cache has no entry for this
     // project, and the no-fetch path must resolve against no deps.
     c.did_change(&uri, "let x = 2\n");
     let resp = c.hover(1, &uri, 0, 4);
-    // PROBE ONLY (#1008): dump the exchange even on success so the Windows
-    // leg's log carries the full server-side trace either way.
-    eprintln!("[probe] uri sent: {uri}");
-    eprintln!("[probe] hover response: {resp}");
-    eprintln!("[probe] server stderr:\n{}", c.server_log_tail());
     assert!(resp.get("id").is_some(), "server must answer after didChange");
     assert!(
         !dir.join("almide.lock").exists(),

--- a/tests/lsp_test.rs
+++ b/tests/lsp_test.rs
@@ -20,6 +20,9 @@ struct LspClient {
     /// Parsed server messages, delivered by the reader thread — recv'ing
     /// through a channel is what makes the deadline possible.
     rx: mpsc::Receiver<Value>,
+    /// The server's captured stderr (trace lines, drop notices) — dumped
+    /// into the deadline panic so a hang names its cause (#1008).
+    server_log: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
     /// The `capabilities` object from the initialize response.
     capabilities: Value,
 }
@@ -67,15 +70,26 @@ impl LspClient {
     fn start() -> Self {
         let mut child = Command::new(env!("CARGO_BIN_EXE_almide"))
             .arg("lsp")
+            .env("ALMIDE_LSP_TRACE", "1")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .spawn()
             .expect("failed to start almide lsp");
         let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take().unwrap();
         let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || reader_loop(stdout, tx));
-        let mut client = LspClient { child, rx, capabilities: Value::Null };
+        let server_log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let log = server_log.clone();
+        std::thread::spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines() {
+                let Ok(line) = line else { return };
+                log.lock().unwrap().push(line);
+            }
+        });
+        let mut client = LspClient { child, rx, server_log, capabilities: Value::Null };
         client.initialize();
         client
     }
@@ -94,13 +108,24 @@ impl LspClient {
             Ok(msg) => msg,
             Err(mpsc::RecvTimeoutError::Timeout) => panic!(
                 "no server message within {RECV_DEADLINE:?} — the server is hung \
-                 or fetching (#1008); an unbounded read here previously turned \
-                 this into a 4h+ CI hang"
+                 (#1008); an unbounded read here previously turned this into a \
+                 4h+ CI hang.\nserver stderr (tail):\n{}",
+                self.server_log_tail()
             ),
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                panic!("server pipe closed without a response (server died)")
+                panic!(
+                    "server pipe closed without a response (server died).\nserver stderr (tail):\n{}",
+                    self.server_log_tail()
+                )
             }
         }
+    }
+
+    /// The last lines of the server's captured stderr, for hang forensics.
+    fn server_log_tail(&self) -> String {
+        let log = self.server_log.lock().unwrap();
+        let start = log.len().saturating_sub(40);
+        log[start..].join("\n")
     }
 
     /// Read responses until we find one with the given id.
@@ -549,6 +574,11 @@ fn lsp_didchange_never_fetches_or_writes_lock() {
     // project, and the no-fetch path must resolve against no deps.
     c.did_change(&uri, "let x = 2\n");
     let resp = c.hover(1, &uri, 0, 4);
+    // PROBE ONLY (#1008): dump the exchange even on success so the Windows
+    // leg's log carries the full server-side trace either way.
+    eprintln!("[probe] uri sent: {uri}");
+    eprintln!("[probe] hover response: {resp}");
+    eprintln!("[probe] server stderr:\n{}", c.server_log_tail());
     assert!(resp.get("id").is_some(), "server must answer after didChange");
     assert!(
         !dir.join("almide.lock").exists(),


### PR DESCRIPTION
Fixes #1008. Root cause proven end-to-end by the instrumented evidence run (PR #1010, Windows leg log):

```
[probe] uri sent: file://C:\Users\RUNNER~1\...\main.almd
[lsp] didChange params failed to parse — dropped: unexpected character at index 9
[lsp] request textDocument/hover id=1 unanswerable — replying null (#1008)
test result: ok. 20 passed ... finished in 2.17s     ← was a 6h hang
```

## The causal chain (all three links fixed)

1. **Test bug**: `format!("file://{}", path.display())` produces `file://C:\…` on Windows — an invalid URI. → new `file_uri()` helper builds the correct form on every OS (forward slashes, third slash before a drive letter).
2. **Server bug (the hang)**: `handle_request` returning `None` (bad params / no analyzed doc) sent NO response — a JSON-RPC violation. A client awaiting the reply blocked forever: this burned a **6-hour Windows runner on every develop→main PR since #961** (verified: run 30443590068 sat 10:25→16:25 in `Run cargo test`, killed at GitHub's default limit, invisible because build-cross isn't a required check). Every request now gets a response — null result for the unanswerable, with the drop LOGGED. An undeserializable didChange notification is also logged instead of vanishing.
3. **Server bug (real editors)**: `uri_to_path` was a bare `strip_prefix("file://")` — VS Code on Windows sends `file:///c%3A/Users/…` (percent-encoded drive colon), which resolved to the nonsense path `/c%3A/…`: manifest lookup and per-project analysis silently degraded for every real Windows editor. Now: percent-decoding + POSIX-form drive-path normalization, pinned by 5 new unit tests (POSIX, plain drive, VS Code's encoded form, %20/UTF-8, non-file scheme).

Also kept from the evidence run: `ALMIDE_LSP_TRACE` server tracing, and the test client's server-stderr capture — a future hang's deadline panic (from #1009) now carries the server-side trace naming the cause.

## Verification

| check | result |
|---|---|
| `cargo test --test lsp_test` | 20/20 |
| new `uri_to_path` unit tests | 5/5 |
| Windows leg on the instrumented probe (#1010) | 20/20 in 2.17s (previously 6h hang) |