### PR TITLE
Shard the Test Rust job four ways and gate that the shards cover every target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,67 @@ jobs:
   # Target tests — all run on every develop/main PR
   # ═══════════════════════════════════════════════
 
-  test-rust:
-    name: Test Rust
+  shard-coverage:
+    # THE GATE that makes sharding safe. A partition that drops a target does
+    # not fail — it goes GREEN, faster, with less tested. That failure mode is
+    # invisible by construction, so it gets its own job: assert the four shards'
+    # union is exactly the full target set, with nothing missing and nothing run
+    # twice. Cheap (no tests run, just enumeration) and it gates the same commit
+    # the shards run on.
+    name: Test shards cover every target
     needs: build
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Union of shards == full target set
+        run: |
+          set -euo pipefail
+          bash scripts/ci-test-shard.sh --list-all | sort > /tmp/all.txt
+          : > /tmp/union.txt
+          for i in 0 1 2 3; do
+            bash scripts/ci-test-shard.sh --list "$i" 4 >> /tmp/union.txt
+          done
+          sort /tmp/union.txt > /tmp/union_sorted.txt
+          dupes=$(sort /tmp/union.txt | uniq -d | wc -l | tr -d ' ')
+          if [ "$dupes" -ne 0 ]; then
+            echo "SHARD GATE FAIL: $dupes target(s) assigned to more than one shard:" >&2
+            sort /tmp/union.txt | uniq -d >&2
+            exit 1
+          fi
+          if ! diff -u /tmp/all.txt /tmp/union_sorted.txt; then
+            echo "SHARD GATE FAIL: the shards' union is not the full target set — a" >&2
+            echo "target above with '-' is enumerated but NEVER RUN (a green build" >&2
+            echo "that tests less), one with '+' is run twice." >&2
+            exit 1
+          fi
+          echo "shard coverage OK: $(wc -l < /tmp/all.txt | tr -d ' ') target(s), each in exactly one shard"
+      - name: Balance report (informational — imbalance costs time, not coverage)
+        run: |
+          for i in 0 1 2 3; do
+            printf '  shard %s: %s target(s)\n' "$i" "$(bash scripts/ci-test-shard.sh --list "$i" 4 | wc -l | tr -d ' ')"
+          done
+
+  test-rust:
+    # SHARDED (4 ways). The suite's 30 minutes are TEST EXECUTION, not
+    # compilation — 29 of them are `finished in` time — so caching cannot touch
+    # it, and neither can a bigger runner: nearly every test shells out to
+    # `almide`, and each `almide` compile takes a GLOBAL exclusive flock on the
+    # shared build dir (src/cli/run.rs::BuildDirLock), which serializes the whole
+    # suite inside one machine. Separate JOBS each get their own build dir and
+    # therefore their own lock — that is where the parallelism comes from.
+    #
+    # 4, not more: the load is extremely skewed (the top 4 targets are half the
+    # total) and `wasm_runtime_test` alone is ~270s, so past 4 shards the
+    # longest target IS the floor and extra jobs buy nothing.
+    name: Test Rust (shard ${{ matrix.shard }}/4)
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v7
 
@@ -163,11 +220,14 @@ jobs:
         env:
           ALMIDE_BIN: /tmp/almide-bin/almide
           ALMIDE_EXPECT_TOOLS: "1"
-        # --workspace: a bare `cargo test` at the root tests only the ROOT
-        # package — the member crates' suites (almide-interp's abstain-ledger
-        # gate, frontend/codegen/tools unit tests) silently never ran in CI.
-        # Trust Spine covers almide-mir; this covers everything.
-        run: cargo test --workspace
+        # The script enumerates every workspace test target from cargo's own
+        # JSON (root package AND member crates — a bare `cargo test` at the root
+        # tests only the root, and the members' suites silently never ran in CI
+        # before `--workspace`), packs them heaviest-first into balanced shards,
+        # and runs this shard's share. `shard-coverage` below proves the four
+        # shards' union is the whole set, so a partition bug reads as a RED
+        # build rather than a fast green one.
+        run: bash scripts/ci-test-shard.sh --run ${{ matrix.shard }} 4
 
       - name: Generated runtime registry matches committed sources (regenerate and diff)
         # crates/almide-codegen/src/generated/{rust_runtime,runtime_fn_modes}.rs

--- a/scripts/ci-test-shard.sh
+++ b/scripts/ci-test-shard.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Partition `cargo test --workspace` across N CI jobs.
+#
+# WHY: the suite's wall clock is TEST EXECUTION, not compilation — 29 of the
+# step's 30 minutes are `finished in` time. It cannot be fixed by caching, and
+# it does not shrink with cores: almost every test shells out to `almide`, and
+# each `almide` compile takes a GLOBAL exclusive flock on the shared build dir
+# (`src/cli/run.rs::BuildDirLock`), so the whole suite serializes inside one
+# machine no matter how wide it is. Separate JOBS each get their own build dir,
+# and therefore their own lock — which is where the parallelism has to come
+# from.
+#
+# The load is extremely skewed (measured: the top 4 targets are half the total,
+# the top 9 are 80%), so a modulo split would leave one shard carrying the two
+# giants. Targets are packed heaviest-first into the least-loaded shard, using
+# measured weights from `scripts/ci-test-weights.txt`; an unlisted target gets
+# DEFAULT_WEIGHT, which costs balance but never coverage.
+#
+# VALIDATED 2026-08-08: `cargo test --workspace` reported 1979 passed / 0
+# failed, and the four shards together reported 1979 passed / 0 failed — the
+# partition runs the same tests, not merely the same target NAMES. The CI gate
+# below re-checks the name set on every commit; this count equality was the
+# one-time proof that the name set is the right thing to gate on.
+#
+# COVERAGE IS GATED, NOT ASSUMED: `--list` prints this shard's targets and
+# `--list-all` prints every target, so CI can assert that the shards' union is
+# the whole set. A partition that silently drops a target would read as a
+# faster green build — the exact failure this script must not enable.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+DEFAULT_WEIGHT=5     # seconds; the median target is a few seconds
+WEIGHTS="scripts/ci-test-weights.txt"
+
+enumerate() {
+  cargo test --workspace --no-run --message-format=json 2>/dev/null | python3 -c '
+import sys, json
+out = []
+for line in sys.stdin:
+    try:
+        m = json.loads(line)
+    except ValueError:
+        continue
+    if m.get("reason") != "compiler-artifact":
+        continue
+    if not m.get("profile", {}).get("test"):
+        continue
+    t = m["target"]
+    pkg = m["package_id"].split("#")[-1].split("@")[0]
+    # package_id shapes differ across cargo versions; recover the NAME.
+    if pkg[0].isdigit():
+        pkg = m["package_id"].split("#")[0].rstrip("/").split("/")[-1].split("@")[0]
+    kind = t["kind"][0]
+    out.append("%s\t%s\t%s" % (pkg, kind, t["name"]))
+for line in sorted(set(out)):
+    print(line)
+'
+}
+
+partition() { # shard total  (empty shard = print every target)
+  local shard="${1:-}" total="${2:-}"
+  enumerate | python3 -c '
+import sys, os
+shard = os.environ.get("SHARD", "")
+total = os.environ.get("TOTAL", "")
+default = int(os.environ["DEFAULT_WEIGHT"])
+weights = {}
+path = os.environ["WEIGHTS"]
+if os.path.exists(path):
+    for line in open(path):
+        line = line.split("#")[0].strip()
+        if not line:
+            continue
+        name, w = line.rsplit(None, 1)
+        weights[name.strip()] = int(w)
+rows = [l.rstrip("\n").split("\t") for l in sys.stdin if l.strip()]
+if not shard:
+    for pkg, kind, name in rows:
+        print("%s\t%s\t%s" % (pkg, kind, name))
+    sys.exit(0)
+shard, total = int(shard), int(total)
+# Longest-processing-time-first: pack the giants before the gravel.
+rows.sort(key=lambda r: (-weights.get(r[2], default), r[2]))
+load = [0] * total
+bins = [[] for _ in range(total)]
+for r in rows:
+    i = load.index(min(load))
+    bins[i].append(r)
+    load[i] += weights.get(r[2], default)
+for pkg, kind, name in bins[shard]:
+    print("%s\t%s\t%s" % (pkg, kind, name))
+'
+}
+
+case "${1:-}" in
+  --list-all) SHARD="" TOTAL="" DEFAULT_WEIGHT=$DEFAULT_WEIGHT WEIGHTS=$WEIGHTS partition ;;
+  --list)     SHARD="$2" TOTAL="$3" DEFAULT_WEIGHT=$DEFAULT_WEIGHT WEIGHTS=$WEIGHTS partition ;;
+  --run)
+    shard="$2"; total="$3"
+    mapfile -t rows < <(SHARD="$shard" TOTAL="$total" DEFAULT_WEIGHT=$DEFAULT_WEIGHT WEIGHTS=$WEIGHTS partition)
+    if [ "${#rows[@]}" -eq 0 ]; then
+      echo "shard $shard/$total: no targets — a partition that runs nothing is a bug, not a fast build" >&2
+      exit 1
+    fi
+    echo "== shard $shard/$total: ${#rows[@]} target(s) =="
+    # ONE cargo invocation PER PACKAGE, not one for the whole shard: `--lib`
+    # cannot be repeated ("the argument '--lib' cannot be used multiple times"),
+    # and a single flat arg list silently means something else anyway — cargo
+    # takes the UNION of -p and the UNION of --test rather than pairing them, so
+    # one bad list can run the wrong set while still exiting 0. Grouping by
+    # package keeps each invocation's selection unambiguous.
+    declare -A pkg_args=()
+    for row in "${rows[@]}"; do
+      IFS=$'\t' read -r pkg kind name <<<"$row"
+      case "$kind" in
+        lib)  pkg_args["$pkg"]+=" --lib" ;;
+        bin)  pkg_args["$pkg"]+=" --bin $name" ;;
+        *)    pkg_args["$pkg"]+=" --test $name" ;;
+      esac
+    done
+    rc=0
+    for pkg in "${!pkg_args[@]}"; do
+      echo "-- $pkg:${pkg_args[$pkg]}"
+      # shellcheck disable=SC2086
+      cargo test -p "$pkg" ${pkg_args[$pkg]} || rc=1
+    done
+    exit $rc
+    ;;
+  *)
+    echo "usage: $0 --run <shard> <total> | --list <shard> <total> | --list-all" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/ci-test-weights.txt
+++ b/scripts/ci-test-weights.txt
@@ -1,0 +1,18 @@
+# Measured test-target durations (seconds) — used ONLY to balance the CI shards
+# (scripts/ci-test-shard.sh). A target missing here still RUNS; it just gets the
+# default weight, so a stale file costs balance, never coverage. Coverage is
+# gated separately (the shard job asserts the union is the whole target set).
+#
+# Measured 2026-08-08 on an M-series laptop. CI runners are ~1.5x slower but the
+# packing only needs the RATIOS. Refresh when the shard job's balance report
+# shows one shard consistently trailing.
+wasm_runtime_test            268
+native_v1_differential_test  134
+examples_parity_test          68
+fmt_test                      47
+wasm_gc_test                  32
+codegen_snapshot_test         32
+diagnostic_test               31
+crossmod_matrix_test          28
+semantic_laws_test            26
+wasm_dispatch_coverage_test   25


### PR DESCRIPTION
## What the wait actually is

The wait a developer feels is **40m50s**, and one workflow sets it:

```
CI               40m50s  ← the critical path
  └ Test Rust    38m35s  (94%)
      └ cargo test  30m30s
Cross-Target CI  16m18s   ← finishes long before
Trust Spine       9m20s   ← finishes long before
```

Those 30 minutes are **test EXECUTION, not compilation**: the sum of the
`finished in` values is 1755s against a 1830s step. So caching cannot touch it.

Neither can a wider machine. Nearly every test shells out to `almide`, and each
`almide` compile takes a **global exclusive flock** on the shared build dir
(`src/cli/run.rs::BuildDirLock`), so the suite serializes inside one machine no
matter how many cores it has — measured locally at 14 cores with a load average
of 1.9 and an hour on the clock.

**Parallelism has to come from separate JOBS**, each with its own build dir and
therefore its own lock.

## Why four

The load is extremely skewed (top 4 targets are half the total, top 9 are 80%,
and `wasm_runtime_test` alone is ~270s), so a modulo split drops both giants in
one shard. Targets are packed heaviest-first instead:

| N | per-shard load |
|---|---|
| 3 | 388 / 389 / 389 |
| **4** | **293 / 289 / 293 / 291** |
| 6 | 268 / 179 / 183 / 178 / 178 / 180 |

Past 4, the longest single target IS the floor and extra jobs buy nothing.

## Proving nothing was dropped

A partition bug does not fail — it goes **green, faster, with less tested**.
That failure mode is invisible by construction, so it gets two checks.

**A CI gate, every commit.** The new `shard-coverage` job asserts the four
shards' union is exactly the full 105-target set: a missing target prints with
`-`, a duplicated one with `+`, and the job fails. It runs no tests, so it is
cheap (measured at 1m45s).

**A one-time count check.** A matching set of target NAMES still does not prove
the same tests ran, so the counts were compared directly:

```
cargo test --workspace : 1979 passed / 0 failed
the four shards        : 1979 passed / 0 failed
```

## Measured result

| | before | after |
|---|---|---|
| CI workflow | 40m50s | **19m45s** |
| slowest job | Test Rust 38m35s | Test Rust shard 2 **17m26s** |

**The balance is worse than the local numbers predicted, and that is a known
follow-up.** Shard 0 was the heaviest locally and is nearly the lightest on CI
(853s vs shard 2's 1046s) — the weights file only carries five measured targets
and everything else takes a default, and CI adds each shard's own compile. A
perfectly balanced split would put the floor at ~884s (14m45s), where
`WASM host-arch determinism` (14m20s) takes over as the critical path. That is
a matter of refreshing the weights with CI-measured numbers, independent of
this change.

## About the weights file

`scripts/ci-test-weights.txt` affects **balance only**. An unlisted target still
runs, at a default weight, so a stale file costs evenness and never coverage —
coverage is the gate's job, not the file's.
